### PR TITLE
feat(FR-1416): add Endpoint → Deployment UI migration feature spec

### DIFF
--- a/.claude/rules/graphite-workflow.md
+++ b/.claude/rules/graphite-workflow.md
@@ -1,0 +1,38 @@
+# Graphite PR Workflow Rules
+
+## Single PR per Spec / Feature
+
+When working on a spec or feature, **never create additional branches or PRs without explicit user instruction**.
+
+- Do NOT use `gt create` to add commits to an existing branch — `gt create` ALWAYS creates a new branch
+- All incremental changes (spec updates, fixes, additions) go into the **existing branch** via `gt modify` (`gt m`)
+- If the current branch already has a PR open, use `gt modify` to amend — do not create a sibling or child branch
+
+## Correct Flow for Updating an Existing PR
+
+```bash
+# Stage changes
+git add <files>
+
+# Amend the current branch's commit (gt m = gt modify)
+gt modify --commit -m "feat(ISSUE): update description"
+# or: gt m --commit -m "feat(ISSUE): update description"
+
+# Push to update the existing PR
+gt submit --no-interactive --publish
+```
+
+## Wrong Flow (Do NOT do this)
+
+```bash
+# ❌ ALWAYS creates a new branch — never use this to update an existing PR
+gt create -m "some update"   # creates a new branch + new PR automatically
+gt submit                    # results in a new unwanted PR
+```
+
+## Why
+
+`gt create` unconditionally creates a new branch and commit on top of the current stack.
+`gt modify` (alias `gt m`) amends the **current** branch's tip commit in place.
+
+Using `gt create` to update an existing PR creates extra branches and PRs, clutters the PR list, and requires manual cleanup (fold, close, comment). One spec = one PR.

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ e2e/.agent-output/
 
 
 e2e/recordings/
+
+# Spec-driven workflow local cache (see spec-driven-workflow skill)
+.specs/**/.context/

--- a/.specs/FR-1368-endpoint-deployment-migration/dev-plan.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/dev-plan.md
@@ -1,0 +1,302 @@
+# Endpoint → Deployment UI Migration Dev Plan
+
+## Spec Reference
+
+`.specs/FR-1368-endpoint-deployment-migration/spec.md`
+
+## Epic
+
+- **FR-1368** — Model deployment & Revision #1 ([Jira](https://lablup.atlassian.net/browse/FR-1368))
+- **Spec Task**: FR-1416 — Transition from Serving page to Deployment page
+
+## Stories and Sub-tasks
+
+Six Stories map directly to the implementation phases declared in the spec (§구현 단계 계획 Phase 1-5 + Flow 7).
+Each Story forms one PR stack on Graphite; sub-tasks inside a Story are generally sequential.
+
+---
+
+### Story 1: Deployment UI Phase 1 — Foundation — FR-2657
+
+> Spec section: §Feature Flag, §URL 경로 변경 + Fallback 리디렉션, §i18n 키 추가
+> PR Stack: `feat/endpoint-deployment-migration-foundation`
+
+Foundation layer. Must land first because every downstream story consumes routes, menu keys, i18n keys, or the feature flag.
+
+#### 1.1 Add `model-deployment-extended-filter` feature flag (26.4.3+) — FR-2663
+
+- **Parent Story**: FR-2657
+- **Changed files**: `src/lib/backend.ai-client-esm.ts`
+- **Dependencies**: None
+- **Review complexity**: Low
+
+#### 1.2 Add routes for `/deployments` + `/admin-deployments` with legacy fallbacks — FR-2664
+
+- **Parent Story**: FR-2657
+- **Changed files**: `react/src/routes.tsx`, stub page files under `react/src/pages/`
+- **Dependencies**: None (parallel with 1.1, 1.3)
+- **Review complexity**: Medium
+
+#### 1.3 Update sidebar menu: Serving → Deployments — FR-2665
+
+- **Parent Story**: FR-2657
+- **Changed files**: `react/src/hooks/useWebUIMenuItems.tsx`
+- **Dependencies**: None (parallel with 1.1, 1.2)
+- **Review complexity**: Low
+
+#### 1.4 Add Deployment i18n keys (en.json) + propagate to 21 languages — FR-2666
+
+- **Parent Story**: FR-2657
+- **Changed files**: `resources/i18n/*.json` (22 files)
+- **Dependencies**: None (parallel with 1.1, 1.2, 1.3)
+- **Review complexity**: Low (mechanical translation tier, can batch together)
+
+---
+
+### Story 2: Deployment UI Phase 2 — Shared status/owner components — FR-2658
+
+> Spec section: §ReplicaStatusTag 컴포넌트, §Flow 1, §Flow 6
+> PR Stack: `feat/endpoint-deployment-migration-shared-components`
+
+Shared presentational components consumed by list and detail stories.
+
+#### 2.1 Add `ReplicaStatusTag` component + Storybook story — FR-2667
+
+- **Parent Story**: FR-2658
+- **Changed files**: `react/src/components/ReplicaStatusTag.tsx`, `react/src/components/ReplicaStatusTag.stories.tsx`
+- **Dependencies**: 1.4 (FR-2666) — needs tooltip i18n keys
+- **Review complexity**: Medium
+
+#### 2.2 Add `DeploymentStatusTag` component — FR-2668
+
+- **Parent Story**: FR-2658
+- **Changed files**: `react/src/components/DeploymentStatusTag.tsx`
+- **Dependencies**: 1.4 (FR-2666) — needs label i18n keys
+- **Review complexity**: Low
+
+#### 2.3 Add `DeploymentOwnerInfo` component — FR-2669
+
+- **Parent Story**: FR-2658
+- **Changed files**: `react/src/components/DeploymentOwnerInfo.tsx`
+- **Dependencies**: 1.4 (FR-2666)
+- **Review complexity**: Low-Medium
+
+---
+
+### Story 3: Deployment UI Phase 3 — Deployment list pages (user + admin) — FR-2659
+
+> Spec section: §Flow 1, §Flow 6
+> PR Stack: `feat/endpoint-deployment-migration-list-pages`
+
+#### 3.1 Add `DeploymentList` fragment-receiving table (server-side filter/sort/paginate) — FR-2670
+
+- **Parent Story**: FR-2659
+- **Changed files**: `react/src/components/DeploymentList.tsx`
+- **Dependencies**: 2.1 (FR-2667), 2.2 (FR-2668)
+- **Review complexity**: High (new pattern — server-side pagination with nuqs URL state, BAIGraphQLPropertyFilter wiring)
+
+#### 3.2 Add `DeploymentListPage` (user) — owns `myDeployments` query — FR-2671
+
+- **Parent Story**: FR-2659
+- **Changed files**: `react/src/pages/DeploymentListPage.tsx`
+- **Dependencies**: 3.1 (FR-2670), 1.2 (FR-2664)
+- **Review complexity**: Medium
+
+#### 3.3 Add `AdminDeploymentListPage` + admin-only filters/columns (26.4.3+) — FR-2672
+
+- **Parent Story**: FR-2659
+- **Changed files**: `react/src/pages/AdminDeploymentListPage.tsx`, extends `DeploymentList` admin mode
+- **Dependencies**: 3.1 (FR-2670), 2.3 (FR-2669), 1.2 (FR-2664)
+- **Review complexity**: Medium
+
+#### 3.4 Remove legacy `ServingPage` and `EndpointList` / `EndpointStatusTag` — FR-2673
+
+- **Parent Story**: FR-2659
+- **Changed files (delete)**: `react/src/pages/ServingPage.tsx`, `react/src/components/EndpointList.tsx`, `react/src/components/EndpointStatusTag.tsx`
+- **Dependencies**: 3.2 (FR-2671), 3.3 (FR-2672) — must wait until both new pages are live
+- **Review complexity**: Low (mechanical deletion)
+
+---
+
+### Story 4: Deployment UI Phase 4 — Deployment Launcher (create + edit) — FR-2660
+
+> Spec section: §Flow 2, §Flow 4, §폼 필드 매핑
+> PR Stack: `feat/endpoint-deployment-migration-launcher`
+
+#### 4.1 Add `DeploymentLauncherPageContent` — multi-step form body — FR-2674
+
+- **Parent Story**: FR-2660
+- **Changed files**: `react/src/components/DeploymentLauncherPageContent.tsx`
+- **Dependencies**: 1.4 (FR-2666) transitively via Phase 1
+- **Review complexity**: High (new multi-step form, nuqs URL sync, antd v6 Steps API)
+
+#### 4.2 Add `DeploymentLauncherPage` (create/edit entry) + GQL mutations — FR-2675
+
+- **Parent Story**: FR-2660
+- **Changed files**: `react/src/pages/DeploymentLauncherPage.tsx`; delete `react/src/pages/ServiceLauncherPage.tsx`, `react/src/components/ServiceLauncherPageContent.tsx`
+- **Dependencies**: 4.1 (FR-2674), 1.2 (FR-2664)
+- **Review complexity**: High
+
+---
+
+### Story 5: Deployment UI Phase 5 — Detail page with tabs, Drawer, and Rollback — FR-2661
+
+> Spec section: §Flow 3, §Flow 5
+> PR Stack: `feat/endpoint-deployment-migration-detail-page`
+
+#### 5.1 Add `DeploymentConfigurationSection` (Overview card + Edit button) — FR-2676
+
+- **Parent Story**: FR-2661
+- **Changed files**: `react/src/components/DeploymentConfigurationSection.tsx`
+- **Dependencies**: None internal; *related to* 4.2 (FR-2675) because the Edit button target must exist
+- **Review complexity**: Medium
+
+#### 5.2 Add `DeploymentReplicasTab` + Replica detail Drawer — FR-2677
+
+- **Parent Story**: FR-2661
+- **Changed files**: `react/src/components/DeploymentReplicasTab.tsx`
+- **Dependencies**: 2.1 (FR-2667)
+- **Review complexity**: High
+
+#### 5.3 Add `DeploymentRevisionHistoryTab` + Rollback flow — FR-2678
+
+- **Parent Story**: FR-2661
+- **Changed files**: `react/src/components/DeploymentRevisionHistoryTab.tsx`
+- **Dependencies**: None internal
+- **Review complexity**: Medium
+
+#### 5.4 Add `DeploymentAccessTokensTab` (list + create + delete) — FR-2679
+
+- **Parent Story**: FR-2661
+- **Changed files**: `react/src/components/DeploymentAccessTokensTab.tsx`
+- **Dependencies**: None internal
+- **Review complexity**: Medium
+
+#### 5.5 Add `DeploymentAutoScalingTab` (wrap existing `AutoScalingRuleList`) — FR-2680
+
+- **Parent Story**: FR-2661
+- **Changed files**: `react/src/components/DeploymentAutoScalingTab.tsx`
+- **Dependencies**: None internal
+- **Review complexity**: Low
+
+#### 5.6 Add `DeploymentDetailPage` (header + Overview + 4 tabs + URL tab sync) — FR-2681
+
+- **Parent Story**: FR-2661
+- **Changed files**: `react/src/pages/DeploymentDetailPage.tsx`
+- **Dependencies**: 5.1 (FR-2676), 5.2 (FR-2677), 5.3 (FR-2678), 5.4 (FR-2679), 5.5 (FR-2680), 2.2 (FR-2668), 1.2 (FR-2664)
+- **Review complexity**: High
+
+#### 5.7 Remove legacy `EndpointDetailPage` + related Endpoint components — FR-2682
+
+- **Parent Story**: FR-2661
+- **Changed files (delete)**: `react/src/pages/EndpointDetailPage.tsx`, `react/src/components/EndpointOwnerInfo.tsx`, `EndpointDiagnosticsSection.tsx`, `EndpointTokenGenerationModal.tsx`
+- **Dependencies**: 5.6 (FR-2681)
+- **Review complexity**: Low
+
+---
+
+### Story 6: Flow 7 — Quick Deploy from model folder (`useDeploymentLauncher`) — FR-2662
+
+> Spec section: §Flow 7
+> PR Stack: `feat/endpoint-deployment-migration-quick-deploy`
+
+#### 6.1 Add `useDeploymentLauncher` hook (GQL-based Quick Deploy) — FR-2683
+
+- **Parent Story**: FR-2662
+- **Changed files**: `react/src/hooks/useDeploymentLauncher.ts`
+- **Dependencies**: 1.1 (FR-2663) — needs feature flag for version gating
+- **Review complexity**: High
+
+#### 6.2 Migrate Deploy button sites to `[Deploy | ▼]` split button using `useDeploymentLauncher` — FR-2684
+
+- **Parent Story**: FR-2662
+- **Changed files**: Every call site of `useModelServiceLauncher` (hunt with `rg`), likely model card / model folder components
+- **Dependencies**: 6.1 (FR-2683), 4.2 (FR-2675) — launcher page must accept `?model=` pre-fill param, 1.2 (FR-2664) — new route
+- **Review complexity**: Medium
+
+---
+
+## PR Stack Strategy
+
+Six PR stacks — one per Story — most of which can run in parallel once Story 1 lands.
+
+| Stack | Story | Sub-tasks (sequential within stack) | Runs after |
+|-------|-------|-------------------------------------|------------|
+| 1 | Foundation | 1.1 · 1.2 · 1.3 · 1.4 (can all be one PR if reviewer OK — mechanical tier) | — |
+| 2 | Shared Components | 2.1 · 2.2 · 2.3 | Stack 1 |
+| 3 | List Pages | 3.1 · 3.2 · 3.3 · 3.4 | Stack 2 |
+| 4 | Launcher | 4.1 · 4.2 | Stack 1 (parallel with Stack 2/3) |
+| 5 | Detail Page | 5.1 · 5.2 · 5.3 · 5.4 · 5.5 · 5.6 · 5.7 | Stack 2 |
+| 6 | Quick Deploy | 6.1 · 6.2 | Stack 1; 6.2 blocked by Stack 4 (4.2) |
+
+Within Stack 5, subtasks 5.1 – 5.5 can each be separate PRs or folded into 5.6 depending on reviewer preference; current decomposition keeps them as independent sub-tasks so reviewers can approve tab-by-tab.
+
+## Dependency Graph
+
+```
+                        ┌────────────────────────────────────────────────┐
+                        │   Story 1 — Foundation (FR-2657)               │
+                        │   FR-2663 (flag) · FR-2664 (routes) ·          │
+                        │   FR-2665 (menu) · FR-2666 (i18n)              │
+                        └────────────┬──────────────┬────────────────────┘
+                                     │              │
+                          ┌──────────┘              └──────────────────┐
+                          ▼                                            ▼
+                ┌─────────────────────┐                       ┌──────────────────────┐
+                │ Story 2 — Shared    │                       │ Story 6.1 (FR-2683)  │
+                │ (FR-2667, 2668,     │                       │ useDeploymentLauncher│
+                │  2669)              │                       └──────────┬───────────┘
+                └──────┬─────┬────────┘                                  │
+                       │     │                                           │
+           ┌───────────┘     └────────────────────┐                      │
+           ▼                                      ▼                      │
+ ┌───────────────────────┐             ┌───────────────────────┐         │
+ │ Story 3 — List Pages  │             │ Story 5 — Detail      │         │
+ │ FR-2670 (list table)  │             │ FR-2676 (Overview)    │         │
+ │ │                     │             │ FR-2677 (Replicas)    │         │
+ │ ├──► FR-2671 (user)   │             │ FR-2678 (History)     │         │
+ │ └──► FR-2672 (admin)  │             │ FR-2679 (Tokens)      │         │
+ │         │             │             │ FR-2680 (AutoScaling) │         │
+ │         ▼             │             │         │             │         │
+ │      FR-2673 cleanup  │             │         ▼             │         │
+ └───────────────────────┘             │ FR-2681 (page)        │         │
+                                       │         │             │         │
+                                       │         ▼             │         │
+                                       │ FR-2682 cleanup       │         │
+                                       └───────────────────────┘         │
+                                                                         │
+                                       ┌───────────────────────┐         │
+                                       │ Story 4 — Launcher    │         │
+                                       │ FR-2674 (content)     │         │
+                                       │         │             │         │
+                                       │         ▼             │         │
+                                       │ FR-2675 (page) ───────┼─────────┤
+                                       └───────────────────────┘         │
+                                                                         ▼
+                                                            ┌───────────────────────┐
+                                                            │ Story 6.2 (FR-2684)   │
+                                                            │ Split-button callers  │
+                                                            └───────────────────────┘
+```
+
+### Execution waves (for `/batch-implement`)
+
+Assuming all sub-tasks in a story can be stacked in one PR stack and waves represent sequential gating:
+
+- **Wave 1 (no blockers)**: FR-2663, FR-2664, FR-2665, FR-2666 — Foundation parallel batch.
+- **Wave 2**: FR-2667, FR-2668, FR-2669 (shared components) — parallel. FR-2674 (launcher content) — parallel with wave 2. FR-2683 (Quick Deploy hook) — parallel with wave 2.
+- **Wave 3**: FR-2670 (list table), FR-2675 (launcher page), FR-2676-2680 (detail sub-components).
+- **Wave 4**: FR-2671 (user list page), FR-2672 (admin list page), FR-2681 (detail page).
+- **Wave 5**: FR-2673 (list cleanup), FR-2682 (detail cleanup), FR-2684 (split-button migration).
+
+## Open Questions / Risks
+
+1. **Legacy `useModelServiceLauncher` during migration window**: Spec §Flow 7 says "keep old hook as fallback for <26.4.2 backends". Current plan treats 26.4.2+ as hard minimum (§개요). Need to confirm whether fallback is actually required, or if we can delete the old hook immediately after 6.2. **Defer to user confirmation in Story 6.**
+2. **Stub pages in Sub-task 1.2**: Creating temporary stub pages so the route PR is mergeable introduces a transient "blank page" state on `/deployments` until Phase 3 lands. If that's unacceptable, 1.2 should be merged together with 3.2 and 5.6 in a single mega-PR — but that violates "single focus per PR". Current plan favors merge-ability; reviewers should be aware.
+3. **Access Tokens tab (5.4) scope**: Spec says "reference old EndpointTokenGenerationModal logic, re-implement fresh". If the new GQL schema for `accessTokens` mutations is still in flux, this sub-task may need a spike first. **Flag for investigation before work starts.**
+4. **AutoScalingRuleList reuse (5.5)**: Spec §범위 외 says existing `AutoScalingRuleList` is already Deployment-API based. Quick verification pass needed to confirm — if any adjustment is required, 5.5 grows in scope.
+5. **DOMAIN/PROJECT/RESOURCE_GROUP sorters (Story 3.3)**: Available only on 26.4.3+. Confirm gating UI is acceptable (sort arrows disappear) vs. always-on (compat error). Spec leans toward feature-flag gate via `baiClient.supports('model-deployment-extended-filter')`.
+
+## Change Log
+
+- 2026-04-22: Initial dev plan generated from spec (post PR-review feedback). 22 sub-tasks across 6 stories created in Jira with dependency links.

--- a/.specs/FR-1368-endpoint-deployment-migration/metadata.json
+++ b/.specs/FR-1368-endpoint-deployment-migration/metadata.json
@@ -1,0 +1,9 @@
+{
+  "epic": "FR-1368",
+  "epicTitle": "Model deployment & Revision #1",
+  "specTask": "FR-1416",
+  "specTaskTitle": "Transition from Serving page to Deployment page",
+  "githubIssue": "https://github.com/lablup/backend.ai-webui/issues/4198",
+  "slug": "endpoint-deployment-migration",
+  "specFile": ".specs/FR-1368-endpoint-deployment-migration/spec.md"
+}

--- a/.specs/FR-1368-endpoint-deployment-migration/metadata.json
+++ b/.specs/FR-1368-endpoint-deployment-migration/metadata.json
@@ -1,9 +1,84 @@
 {
   "epic": "FR-1368",
+  "epicKey": "FR-1368",
+  "epicUrl": "https://lablup.atlassian.net/browse/FR-1368",
   "epicTitle": "Model deployment & Revision #1",
   "specTask": "FR-1416",
+  "specTaskKey": "FR-1416",
   "specTaskTitle": "Transition from Serving page to Deployment page",
   "githubIssue": "https://github.com/lablup/backend.ai-webui/issues/4198",
   "slug": "endpoint-deployment-migration",
-  "specFile": ".specs/FR-1368-endpoint-deployment-migration/spec.md"
+  "specFile": ".specs/FR-1368-endpoint-deployment-migration/spec.md",
+  "stories": [
+    {
+      "key": "FR-2657",
+      "title": "Deployment UI Phase 1 — Foundation (feature flag, routes, menu, i18n)",
+      "specSection": "§Feature Flag, §URL 경로 변경 + Fallback 리디렉션, §i18n 키 추가",
+      "prStack": "feat/endpoint-deployment-migration-foundation",
+      "subtasks": [
+        { "key": "FR-2663", "title": "Add model-deployment-extended-filter feature flag (26.4.3+)" },
+        { "key": "FR-2664", "title": "Add routes for /deployments + /admin-deployments with legacy fallbacks" },
+        { "key": "FR-2665", "title": "Update sidebar menu: Serving → Deployments" },
+        { "key": "FR-2666", "title": "Add Deployment i18n keys (en.json) + propagate to 21 languages" }
+      ]
+    },
+    {
+      "key": "FR-2658",
+      "title": "Deployment UI Phase 2 — Shared status/owner components",
+      "specSection": "§ReplicaStatusTag 컴포넌트, §Flow 1, §Flow 6",
+      "prStack": "feat/endpoint-deployment-migration-shared-components",
+      "subtasks": [
+        { "key": "FR-2667", "title": "Add ReplicaStatusTag component + Storybook story" },
+        { "key": "FR-2668", "title": "Add DeploymentStatusTag component" },
+        { "key": "FR-2669", "title": "Add DeploymentOwnerInfo component" }
+      ]
+    },
+    {
+      "key": "FR-2659",
+      "title": "Deployment UI Phase 3 — Deployment list pages (user + admin)",
+      "specSection": "§Flow 1, §Flow 6",
+      "prStack": "feat/endpoint-deployment-migration-list-pages",
+      "subtasks": [
+        { "key": "FR-2670", "title": "Add DeploymentList fragment-receiving table component (server-side filter/sort/paginate)" },
+        { "key": "FR-2671", "title": "Add DeploymentListPage (user) — owns myDeployments query" },
+        { "key": "FR-2672", "title": "Add AdminDeploymentListPage + admin-only filters/columns (26.4.3+)" },
+        { "key": "FR-2673", "title": "Remove legacy ServingPage and EndpointList / EndpointStatusTag" }
+      ]
+    },
+    {
+      "key": "FR-2660",
+      "title": "Deployment UI Phase 4 — Deployment Launcher (create + edit)",
+      "specSection": "§Flow 2, §Flow 4, §폼 필드 매핑",
+      "prStack": "feat/endpoint-deployment-migration-launcher",
+      "subtasks": [
+        { "key": "FR-2674", "title": "Add DeploymentLauncherPageContent — multi-step form body" },
+        { "key": "FR-2675", "title": "Add DeploymentLauncherPage (create/edit entry) + GQL mutations" }
+      ]
+    },
+    {
+      "key": "FR-2661",
+      "title": "Deployment UI Phase 5 — Detail page with tabs, Drawer, and Rollback",
+      "specSection": "§Flow 3, §Flow 5",
+      "prStack": "feat/endpoint-deployment-migration-detail-page",
+      "subtasks": [
+        { "key": "FR-2676", "title": "Add DeploymentConfigurationSection (Overview card + Edit button)" },
+        { "key": "FR-2677", "title": "Add DeploymentReplicasTab + Replica detail Drawer" },
+        { "key": "FR-2678", "title": "Add DeploymentRevisionHistoryTab + Rollback flow" },
+        { "key": "FR-2679", "title": "Add DeploymentAccessTokensTab (list + create + delete)" },
+        { "key": "FR-2680", "title": "Add DeploymentAutoScalingTab (wrap existing AutoScalingRuleList)" },
+        { "key": "FR-2681", "title": "Add DeploymentDetailPage (header + Overview + 4 tabs + URL tab sync)" },
+        { "key": "FR-2682", "title": "Remove legacy EndpointDetailPage + related Endpoint components" }
+      ]
+    },
+    {
+      "key": "FR-2662",
+      "title": "Deployment UI Flow 7 — Quick Deploy from model folder (useDeploymentLauncher)",
+      "specSection": "§Flow 7",
+      "prStack": "feat/endpoint-deployment-migration-quick-deploy",
+      "subtasks": [
+        { "key": "FR-2683", "title": "Add useDeploymentLauncher hook (GQL-based Quick Deploy)" },
+        { "key": "FR-2684", "title": "Migrate Deploy button sites to [Deploy | ▼] split button using useDeploymentLauncher" }
+      ]
+    }
+  ]
 }

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -43,7 +43,7 @@
 | 5 | Active Pool 위치 | Deployment 상세 페이지 **Overview 섹션** (메인 본문 상단)에 배치 |
 | 6 | 최소 백엔드 버전 | **26.4.2** |
 | 7 | 구버전 컴포넌트 처리 | 구버전 Graphene 기반 페이지/컴포넌트는 **그대로 유지** (fallback 라우팅용). 신규 컴포넌트는 처음부터 새로 작성 |
-| 8 | 편집 = 새 Revision | 설정 변경 시 덮어쓰기 없음. `addModelRevision` mutation으로 새 Revision 스냅샷 생성 |
+| 8 | 편집 = 새 리비전 | 설정 변경 시 덮어쓰기 없음. `addModelRevision` mutation으로 새 리비전 스냅샷 생성 |
 
 ---
 
@@ -105,7 +105,7 @@ ModelReplica (Strawberry GQL 타입)
 - 내부 `RoutingRow` 하나 = `SessionRow` 하나 = **UI상 Replica 하나**
 - Route는 내부 구현 세부사항. **UI에서는 Replicas 탭으로만 노출**
 - `healthStatus` / `trafficStatus`는 각 Replica의 속성으로 표시 (별도 Routes 탭 없음)
-- 1개 Revision에 N개 Replica가 있어 카나리/블루-그린 배포(트래픽 분산)를 지원
+- 1개 리비전에 N개 Replica가 있어 카나리/블루-그린 배포(트래픽 분산)를 지원
 
 ---
 
@@ -159,7 +159,7 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
         │                │ (배포 편집)              │
         │                │ /deployments/:id/edit  │
         │                └────────────────────────┘
-        │                         │ 편집 성공 (새 Revision 생성)
+        │                         │ 편집 성공 (새 리비전 생성)
         ▼                         ▼
         └──────────────→ DeploymentDetailPage (복귀)
 
@@ -231,7 +231,7 @@ DeploymentDetailPage (동일)
 
 폼 상단 또는 Step 1에 **"기존 배포에서 가져오기"** 버튼 제공:
 1. 버튼 클릭 → 최근 배포 목록 드로어/모달 열기
-2. 목록에서 배포 선택 → 해당 배포의 현재 Revision 설정으로 폼 전체 pre-fill
+2. 목록에서 배포 선택 → 해당 배포의 현재 리비전 설정으로 폼 전체 pre-fill
 3. 이름 필드는 자동으로 초기화 (새 이름 입력 유도), 나머지 설정은 유지
 4. 사용자가 각 필드를 자유롭게 수정 후 제출
 
@@ -266,6 +266,10 @@ DeploymentDetailPage (동일)
   - `myDeploymentsV2` query로 최근 배포 목록 로드
   - 선택 시 `currentRevision` 기반으로 폼 전체 pre-fill
   - 이름 필드 초기화
+- [ ] **URL 상태 동기화** (`nuqs` `useQueryStates` 사용): 새로고침 후에도 폼 상태 유지
+  - `step`: 현재 단계 번호 (`parseAsInteger.withDefault(1)`)
+  - `formValues`: 핵심 폼 값 JSON (`parseAsJson` 또는 `JsonParam`, `withDefault({})`)
+  - 기존 `ServiceLauncherPageContent`의 `useQueryParams` 패턴 참조
 - [ ] 성공 후 상세 페이지로 이동
 
 관련 이슈: FR-2419 (Add 'Import from existing spec' feature in ModelService creation)
@@ -320,7 +324,7 @@ DeploymentDetailPage (동일)
 - 각 리비전에 "Rollback" 버튼 표시 → Flow 5
 
 **Settings 탭**:
-- 현재 Active Revision의 설정 요약 (읽기 전용)
+- 현재 Active 리비전의 설정 요약 (읽기 전용)
 - "Edit Configuration" 버튼 → Flow 4 (편집 페이지)
 
 **Access Tokens 탭**:
@@ -343,6 +347,13 @@ DeploymentDetailPage (동일)
 - [ ] `DeploymentAutoScalingTab.tsx` 신규 생성 (Auto-scaling 탭)
 - [ ] `DeploymentOwnerInfo.tsx` 신규 생성 (소유자 정보, 기존 `EndpointOwnerInfo` 로직 참조하여 새로 구현)
 - [ ] Replica 상세 Drawer 구현 (Replicas 탭 내)
+- [ ] **활성 탭 URL 동기화** (`nuqs` `useQueryStates` 사용): 새로고침·공유 후에도 탭 위치 유지
+  ```ts
+  const tabValues = ['replicas', 'revision-history', 'settings', 'access-tokens', 'auto-scaling'] as const;
+  const [{ tab }, setTab] = useQueryStates({
+    tab: parseAsStringLiteral(tabValues).withDefault('replicas'),
+  });
+  ```
 - [ ] 페이지 자동 갱신 (`fetchKey` 기반 polling 또는 refetch)
 
 ---
@@ -355,18 +366,17 @@ DeploymentDetailPage (동일)
 
 사용자 경험:
 - Flow 2와 동일한 다단계 폼 (`DeploymentLauncherPageContent` 재사용)
-- 현재 Active Revision의 데이터로 폼 pre-fill
-- 폼 상단에 **안내 배너** 표시: "설정을 변경하면 새 Revision이 생성됩니다. 이전 Revision은 보존됩니다."
+- 현재 Active 리비전의 데이터로 폼 pre-fill
+- 폼 상단에 **안내 배너** 표시: "설정을 변경하면 새 리비전이 생성됩니다. 이전 리비전은 보존됩니다."
 
 제출 흐름:
-- `addModelRevision` mutation 호출 (새 Revision 생성, 이전 Revision 보존)
+- `addModelRevision` mutation 호출 (새 리비전 생성, 이전 리비전 보존)
 - 성공 → `/deployments/:id` 상세 페이지로 복귀
 
 구현 요구사항:
 - [ ] `DeploymentLauncherPage`가 create/edit 모드 모두 처리 (URL param으로 구분)
 - [ ] 편집 모드: `deployment(id: $deploymentId)` + `currentRevision` 데이터로 폼 pre-fill
-- [ ] 편집 모드 안내 배너 표시 (새 Revision 생성 안내)
-- [ ] 제출 전 확인 다이얼로그 표시
+- [ ] 편집 모드 안내 배너 표시 (새 리비전 생성 안내)
 - [ ] `addModelRevision` mutation 연동
 - [ ] 성공 후 상세 페이지로 복귀
 
@@ -374,13 +384,13 @@ DeploymentDetailPage (동일)
 
 #### Flow 5: Rollback
 
-사용자가 Revision History 탭에서 이전 Revision의 "Rollback" 버튼을 클릭합니다.
+사용자가 리비전 히스토리 탭에서 이전 리비전의 "Rollback" 버튼을 클릭합니다.
 
 사용자 경험:
 1. "Rollback" 버튼 클릭
-2. 확인 다이얼로그: "Revision #N으로 롤백하시겠습니까? 현재 Revision이 교체됩니다."
+2. 확인 다이얼로그: "리비전 #N으로 롤백하시겠습니까? 현재 리비전이 교체됩니다."
 3. 확인 → `activateRevision` mutation 호출
-4. 성공 → 상세 페이지 갱신, Active Revision 변경 표시
+4. 성공 → 상세 페이지 갱신, Active 리비전 변경 표시
 
 구현 요구사항:
 - [ ] `DeploymentRevisionHistoryTab` 내 Rollback 버튼 구현
@@ -465,7 +475,7 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
 
 #### i18n 키 추가
 
-신규 추가 키 (`resources/i18n/en.json`):
+신규 추가 키를 `resources/i18n/en.json`에 추가한 뒤, `/fw:i18n` 스킬로 22개 지원 언어 전체에 번역을 자동 생성합니다.
 
 ```json
 {
@@ -731,14 +741,14 @@ type ModelDeployment {
 11. `DeploymentLauncherPageContent.tsx` 신규 생성 (다단계 폼, create/edit 통합)
 12. `DeploymentLauncherPage.tsx` 신규 생성
 13. `createModelDeployment` + `addModelRevision` mutation 연동
-14. 편집 모드: `deployment.currentRevision` 기반 pre-fill + 안내 배너 + 확인 다이얼로그
+14. 편집 모드: `deployment.currentRevision` 기반 pre-fill + 안내 배너 (새 리비전 생성 안내)
 15. Relay 컴파일 + `__generated__` 파일 확인
 
 ### Phase 5 — 배포 상세 페이지
 
 16. `DeploymentActivePoolSection.tsx` 신규 생성 (Active Pool 시각화)
 17. `DeploymentReplicasTab.tsx` 신규 생성 (Replica 목록 + 상세 Drawer)
-18. `DeploymentRevisionHistoryTab.tsx` 신규 생성 (Revision 목록 + Rollback)
+18. `DeploymentRevisionHistoryTab.tsx` 신규 생성 (리비전 목록 + Rollback)
 19. `DeploymentSettingsTab.tsx` 신규 생성
 20. `DeploymentAccessTokensTab.tsx` 신규 생성
 21. `DeploymentAutoScalingTab.tsx` 신규 생성

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -654,7 +654,7 @@ react/src/components/
 ## 범위 외 (Out of Scope)
 
 - 백엔드 API 변경 — `RouteHealthStatus`, `ModelReplica`, `LivenessStatus` 등 스키마는 이미 구현됨
-- 오토스케일링 규칙 변경 — `draft-auto-scaling-rule-ux`에서 별도 추적
+- 오토스케일링 규칙 UI — `AutoScalingRuleEditorModal`, `AutoScalingRuleList` 모두 이미 Deployment API(`modelDeploymentId`, `deploymentId`) 기반으로 구현됨. 추가 변경 불필요
 - Chat 페이지의 Endpoint 관련 컴포넌트 (`EndpointSelect.tsx`, `EndpointTokenSelect.tsx`)
 - API 클라이언트 레벨의 `useApiEndpoint.ts`, `useEduAppApiEndpoint.ts` (다른 의미의 "endpoint")
 

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -568,7 +568,6 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
 ### 선택 구현 (Nice to Have)
 
 - [ ] **Route 상태 필터**: Replicas 탭에서 `healthStatus`(NOT_CHECKED, HEALTHY, UNHEALTHY, DEGRADED)로 필터링
-- [ ] **Traffic Status 토글**: Route의 `trafficStatus`를 ACTIVE/INACTIVE로 수동 전환 (백엔드 지원 필요 — FR-2591 TODO 확인)
 - [ ] **배포 전략 시각화**: Canary/Blue-Green 배포 시 트래픽 비율을 Bar 또는 퍼센트로 시각 표시
 - [ ] **배포 목록 실시간 헬스 갱신**: 목록 테이블에서 헬스 요약 컬럼 자동 갱신
 
@@ -648,7 +647,7 @@ react/src/components/
 | `endpoint.model_definition_path` | `revision.modelDefinition.modelDefinitionPath` |
 | `endpoint.extra_mounts` | `revision.modelDefinition.extraMounts` |
 | `endpoint.open_to_public` | `deployment.networkAccess.isPublic` |
-| `endpoint.cluster_mode`, `endpoint.cluster_size` | revision 설정 내 해당 필드 |
+| `endpoint.cluster_mode`, `endpoint.cluster_size` | `revision.clusterConfig.mode`, `revision.clusterConfig.size` (`ClusterConfig` 타입) |
 
 ---
 

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -357,7 +357,6 @@ DeploymentDetailPage (동일)
 - Flow 2와 동일한 다단계 폼 (`DeploymentLauncherPageContent` 재사용)
 - 현재 Active Revision의 데이터로 폼 pre-fill
 - 폼 상단에 **안내 배너** 표시: "설정을 변경하면 새 Revision이 생성됩니다. 이전 Revision은 보존됩니다."
-- 제출 시 확인 다이얼로그: "새 Revision이 생성됩니다. 계속하시겠습니까?"
 
 제출 흐름:
 - `addModelRevision` mutation 호출 (새 Revision 생성, 이전 Revision 보존)

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -143,6 +143,9 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
   this._features['model-deployment-strawberry'] = true;
   this._features['model-replica'] = true;
 }
+if (this.isManagerVersionCompatibleWith('26.4.3')) {
+  this._features['model-deployment-extended-filter'] = true;
+}
 ```
 
 ---
@@ -470,18 +473,18 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
 
   | 필드 | GQL 타입 | 버전 조건 | 비고 |
   |------|----------|-----------|------|
-  | `domainName` | `StringFilter` | 26.4.3+ | `baiClient.isManagerVersionCompatibleWith('26.4.3')` |
+  | `domainName` | `StringFilter` | 26.4.3+ | `baiClient.supports('model-deployment-extended-filter')` |
   | `resourceGroup` | `StringFilter` | 26.4.3+ | 동일 |
   | `createdAt` | `DateTimeFilter` | 26.4.3+ | datetime picker 사용 |
 
   ```ts
-  const is26_4_3 = baiClient.isManagerVersionCompatibleWith('26.4.3');
+  const isExtendedFilter = baiClient.supports('model-deployment-extended-filter');
   filterProperties={filterOutEmpty([
     { key: 'name', ... },          // 항상 노출
     { key: 'status', ... },        // 항상 노출
-    is26_4_3 && { key: 'domainName', propertyLabel: t('...'), type: 'string' },
-    is26_4_3 && { key: 'resourceGroup', propertyLabel: t('...'), type: 'string' },
-    is26_4_3 && { key: 'createdAt', propertyLabel: t('...'), type: 'datetime' },
+    isExtendedFilter && { key: 'domainName', propertyLabel: t('...'), type: 'string' },
+    isExtendedFilter && { key: 'resourceGroup', propertyLabel: t('...'), type: 'string' },
+    isExtendedFilter && { key: 'createdAt', propertyLabel: t('...'), type: 'datetime' },
   ])}
   ```
 
@@ -711,7 +714,7 @@ react/src/components/
 |----------|---------|
 | `react/src/routes.tsx` | URL 경로 변경, fallback 리디렉션 추가, 신규 페이지 import, 버전 분기 라우팅 |
 | `react/src/hooks/useWebUIMenuItems.tsx` | 메뉴 경로 및 레이블 업데이트 |
-| `src/lib/backend.ai-client-esm.ts` | `model-deployment-strawberry`, `model-replica` feature flag 추가 |
+| `src/lib/backend.ai-client-esm.ts` | `model-deployment-strawberry`, `model-replica`, `model-deployment-extended-filter` feature flag 추가 |
 | `resources/i18n/en.json` | 신규 i18n 키 추가 (22개 언어 번역 필요) |
 
 ---
@@ -854,7 +857,7 @@ adminDeployments(filter: DeploymentFilter, orderBy: [DeploymentOrderBy!], limit:
 
 ### Phase 1 — 기반 작업
 
-1. `backend.ai-client-esm.ts`에 `model-deployment-strawberry`, `model-replica` feature flag 추가
+1. `backend.ai-client-esm.ts`에 `model-deployment-strawberry`, `model-replica`, `model-deployment-extended-filter` feature flag 추가
 2. `routes.tsx`: URL 경로 변경 + fallback 리디렉션 + 버전 분기 라우팅 골격
 3. `useWebUIMenuItems.tsx`: 메뉴 레이블 및 경로 업데이트
 4. i18n 신규 키 추가 (`en.json`)

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -265,6 +265,32 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 
 **페이지: `DeploymentLauncherPage` (`/deployments/create`)**
 
+**레이아웃 — 세션 런처(`SessionLauncherPage`)와 동일한 구조**
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  New Deployment                         [Recent Deployments]   ✕     │
+├────────────────────────────────────────────────┬─────────────────────┤
+│                                                │  1. Basic Info      │
+│  (폼 본문 — 현재 step 내용)                    │     ●               │
+│                                                │  2. Model & Runtime │
+│                                                │     ○               │
+│                                                │  3. Resources       │
+│                                                │     ○               │
+│                                                │  4. Review & Create │
+│                                                │     ○               │
+├────────────────────────────────────────────────┴─────────────────────┤
+│  [← Previous]  [Next →]  [Skip to Review »]                          │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- **우측 Steps 패널**: `<Steps size="small" orientation="vertical" current={currentStep} />` — `screens.lg`(lg breakpoint 이상) 일 때만 표시, sticky 포지션 (`SessionLauncherPage` 참조)
+- **하단 네비게이션** (매 step 공통):
+  - `← Previous` — currentStep > 0 일 때 표시
+  - `Next →` — 마지막 step 전까지 표시 (primary ghost)
+  - `Skip to Review »` — 마지막 step 전까지 표시, 클릭 시 Review step으로 즉시 이동 (`session.launcher.SkipToConfirmAndLaunch` 패턴 참조)
+  - Review step에서는 `Next`/`Skip to Review` 대신 **`Create Deployment`** (primary) 버튼 표시
+
 **기본 진입 — 빈 폼으로 바로 시작**
 1. Step 1 — **기본 정보**: 배포 이름, 공개 여부 (`open_to_public`)
 2. Step 2 — **모델 & 런타임**: 모델 폴더(VFolder), 런타임 변형(`vllm` / `sglang` / `custom` 등), 컨테이너 이미지, 실행 커맨드(custom일 때만 표시)
@@ -273,17 +299,7 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 
 **오른쪽 상단 버튼 — 기존 배포에서 가져오기 (FR-2419)**
 
-런처 폼 헤더 오른쪽 상단에 **"Recent Deployments"** 버튼을 배치합니다 (세션 런처의 "Recent History" 버튼과 동일한 패턴):
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│  New Deployment                  [Recent Deployments]  ✕    │
-├─────────────────────────────────────────────────────────────┤
-│  Step 1  Step 2  Step 3  Step 4                             │
-│                                                             │
-│  (빈 폼)                                                    │
-└─────────────────────────────────────────────────────────────┘
-```
+런처 폼 헤더 오른쪽 상단에 **"Recent Deployments"** 버튼을 배치합니다 (세션 런처의 "Recent History" 버튼과 동일한 패턴).
 
 "Recent Deployments" 버튼 클릭 시 모달(세션 런처의 Recent History 모달과 동일한 형태)을 열어 최근 배포 목록 표시:
 
@@ -321,7 +337,14 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 구현 요구사항:
 - [ ] `DeploymentLauncherPage.tsx` 신규 생성 (생성/편집 통합 진입점)
 - [ ] `DeploymentLauncherPageContent.tsx` 신규 생성 (다단계 폼 본문)
-- [ ] Step 1~4 단계형 폼 레이아웃 구현
+- [ ] **레이아웃**: 좌측 폼 + 우측 세로 Steps 패널 (`SessionLauncherPage` 구조 참조)
+  - 우측 `<Steps size="small" orientation="vertical" />` — lg breakpoint 이상일 때만 표시, sticky
+  - `antd` `useBreakpoint` (`screens.lg`) 으로 조건부 렌더링
+- [ ] **하단 네비게이션** 구현
+  - `← Previous`: currentStep > 0 일 때 표시
+  - `Next →`: 마지막 step 전까지 표시 (primary ghost)
+  - `Skip to Review »`: 마지막 step 전까지 표시, Review step으로 즉시 이동
+  - Review step: `Create Deployment` (primary) 버튼
 - [ ] `createModelDeployment` + `addModelRevision` GQL mutation 연동
 - [ ] 폼 헤더 오른쪽 상단에 **"Recent Deployments"** 버튼 배치 (세션 런처 `SessionLauncherPage`의 Recent History 버튼 패턴 참조)
 - [ ] **Recent Deployments 모달** 구현 (FR-2419)

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -7,7 +7,7 @@
 ## 개요
 
 모델 서빙 UI의 용어와 아키텍처를 "Endpoint" 중심에서 "Deployment" 중심으로 전면 재구축합니다.  
-백엔드의 신규 Strawberry GraphQL API(`ModelDeployment`, `Route`, `ModelReplica`)와 정합성을 맞추며, 배포 라이프사이클과 레플리카 헬스 상태를 사용자가 한눈에 파악할 수 있도록 AWS ECS / Vercel 수준의 Deployment UX를 새로 설계합니다.
+백엔드의 신규 Strawberry GraphQL API(`ModelDeployment`, `Route`, `ModelReplica`)와 정합성을 맞추며, 배포 라이프사이클과 레플리카 헬스 상태를 사용자가 한눈에 파악할 수 있는 Deployment UX를 새로 설계합니다.
 
 **최소 지원 백엔드 버전**: 26.4.2 (Strawberry API 지원 시작)  
 구버전(26.4.2 미만)은 라우팅 레벨에서 기존 Graphene 기반 Serving/Endpoint UI로 전달됩니다.
@@ -140,23 +140,23 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
         ▼
 ┌─────────────────────┐
 │  DeploymentListPage  │  /deployments
-│  (배포 목록)         │
+│  (배포 목록)          │
 └─────────────────────┘
         │                         │
         │ "New Deployment" 클릭   │ 행 클릭
         ▼                         ▼
 ┌────────────────────────┐  ┌──────────────────────┐
-│ DeploymentLauncherPage │  │ DeploymentDetailPage  │
-│ (새 배포 생성)          │  │ (배포 상세)            │
-│ /deployments/create    │  │ /deployments/:id      │
+│ DeploymentLauncherPage │  │ DeploymentDetailPage │
+│ (새 배포 생성)            │  │ (배포 상세)            │
+│ /deployments/create    │  │ /deployments/:id     │
 └────────────────────────┘  └──────────────────────┘
         │                         │  "Edit" 버튼 클릭
         │ 생성 성공                │
         │                         ▼
         │                ┌────────────────────────┐
-        │                │ DeploymentLauncherPage  │
+        │                │ DeploymentLauncherPage │
         │                │ (배포 편집)              │
-        │                │ /deployments/:id/edit   │
+        │                │ /deployments/:id/edit  │
         │                └────────────────────────┘
         │                         │ 편집 성공 (새 Revision 생성)
         ▼                         ▼
@@ -168,7 +168,7 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
         ▼
 ┌──────────────────────────┐
 │ AdminDeploymentListPage  │  /admin/deployments
-│ (전체 배포 목록)           │
+│ (전체 배포 목록)            │
 └──────────────────────────┘
         │ 행 클릭
         ▼
@@ -240,7 +240,7 @@ DeploymentDetailPage (동일)
 
 #### Flow 3: 배포 상세 (Deployment Detail)
 
-사용자가 목록에서 배포를 클릭하면 상세 페이지로 이동합니다. AWS ECS 콘솔처럼 배포의 현재 상태, 레플리카 헬스, 리비전 히스토리를 한 페이지에서 파악할 수 있어야 합니다.
+사용자가 목록에서 배포를 클릭하면 상세 페이지로 이동합니다. 배포의 현재 상태, 레플리카 헬스, 리비전 히스토리를 한 페이지에서 파악할 수 있어야 합니다.
 
 **페이지: `DeploymentDetailPage` (`/deployments/:id`)**
 
@@ -252,12 +252,12 @@ DeploymentDetailPage (동일)
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  Active Pool                           [2 / 3 Healthy]      │
-│  AppProxy가 트래픽을 전달하는 레플리카 목록입니다.            │
+│  AppProxy가 트래픽을 전달하는 레플리카 목록입니다.                    │
 ├─────────────────────────────────────────────────────────────┤
 │  [● Replica 1]  HEALTHY   Rev. abc123  Traffic: 50%         │
 │  [● Replica 2]  HEALTHY   Rev. abc123  Traffic: 50%         │
-│  [○ Replica 3]  UNHEALTHY Rev. abc123  (트래픽 차단)  red   │
-│  [○ Replica 4]  DEGRADED  Rev. abc123  (유예 중)     amber  │
+│  [○ Replica 3]  UNHEALTHY Rev. abc123  (트래픽 차단)  red      │
+│  [○ Replica 4]  DEGRADED  Rev. abc123  (유예 중)     amber    │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -480,6 +480,49 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
 
 ---
 
+---
+
+#### Flow 7: 모델 폴더에서 바로 배포 (Quick Deploy)
+
+모델 폴더 목록 또는 모델 카드에서 "Deploy" 버튼을 클릭하면 폼 없이 즉시 배포를 생성합니다.
+
+**진입점**: 모델 폴더 목록, 모델 카드, Model Store 등 (`useDeploymentLauncher` hook 사용)
+
+사용자 경험:
+1. "Deploy" 버튼 클릭
+2. 즉시 배포 생성 시작 — 별도 폼 없음
+3. 백그라운드 알림으로 진행 상황 표시: "배포를 시작하는 중..."
+4. 준비 완료 → 알림에 "/chat으로 이동" 링크 표시
+5. 준비 실패(타임아웃) → 알림에 배포 상세 페이지(`/deployments/:id`) 링크 표시
+
+배포 설정 소스:
+- 런타임: `custom` 고정
+- 이미지/리소스/커맨드 등: 모델 폴더 내 **`deployment-config.yaml`** 파일에서 읽음
+  - (현재 코드는 `service-definition.toml` 참조 중 → `deployment-config.yaml`로 전환 예정)
+
+제출 흐름:
+- `createModelDeployment` mutation → `deploymentId` 반환
+- `addModelRevision` mutation (minimal config, `deployment-config.yaml` 기반)
+- 백그라운드에서 레플리카 준비 상태 폴링 (신규 API: `GET /v2/deployments/:id` 또는 GQL `deployment.activeReplicas` 확인)
+- 기존: `GET /services/:endpoint_id` active_routes 폴링 → 신규 API로 교체
+
+구현 요구사항:
+- [ ] `useDeploymentLauncher.ts` 신규 생성 (기존 `useModelServiceLauncher.ts` 대체)
+  - `createServiceInput` → `createDeploymentInput` (vfolderId, resourceGroup → minimal deployment config)
+  - `mutationToCreateService` (`POST /services`) → `createModelDeployment` + `addModelRevision` GQL mutation
+  - `mutationToClone` (vfolder clone) 유지
+  - 폴링 로직: `GET /services/:id` → 신규 Deployment API로 교체
+  - 알림 링크: `/serving/:id` → `/deployments/:id`
+- [ ] `useModelServiceLauncher.ts` — `useDeploymentLauncher` 지원 후 제거 또는 deprecated 처리
+- [ ] **`deployment-config.yaml` 지원**: 모델 폴더에서 `deployment-config.yaml` 읽기 (기존 `service-definition.toml` 대체)
+- [ ] 26.4.2 미만 백엔드: 기존 `useModelServiceLauncher` 유지 (fallback)
+
+**URL pre-fill 경로** (폼 경유 빠른 시작):
+- `/deployments/create?model=<vfolderId>` — 풀 폼(Flow 2)을 열되 모델 폴더를 pre-fill
+- 기존: `/service/start?model=<vfolderId>` → fallback 리디렉션 추가
+
+---
+
 ### 선택 구현 (Nice to Have)
 
 - [ ] **Route 상태 필터**: Replicas 탭에서 `healthStatus`(NOT_CHECKED, HEALTHY, UNHEALTHY, DEGRADED)로 필터링
@@ -499,6 +542,9 @@ react/src/pages/
   AdminDeploymentListPage.tsx      # Flow 6: 관리자 배포 목록
   DeploymentDetailPage.tsx         # Flow 3: 배포 상세
   DeploymentLauncherPage.tsx       # Flow 2 & 4: 생성/편집 통합 진입점
+
+react/src/hooks/
+  useDeploymentLauncher.ts         # Flow 7: 모델 폴더에서 바로 배포 (useModelServiceLauncher 대체)
 
 react/src/components/
   DeploymentList.tsx                   # 배포 목록 테이블
@@ -687,6 +733,7 @@ type ModelDeployment {
   - Active Pool 섹션: 메인 본문 배치
   - 최소 백엔드 버전: 26.4.2
 - 2026-04-21: ServiceLauncherPage/ServiceLauncherPageContent 마이그레이션 범위 추가
+- 2026-04-21: Flow 7 추가 — 모델 폴더에서 바로 배포 (useDeploymentLauncher, deployment-config.yaml 기반)
 - 2026-04-21: 요구사항 전면 재구조화 — User Flow 중심으로 재작성
   - US-1~US-8 구조 → Flow 1~6 사용자 흐름 중심으로 전환
   - 신규 컴포넌트 처음부터 새로 작성 (기존 컴포넌트 rename/patch 방식 폐기)

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -39,7 +39,7 @@
 | 1 | URL 경로 | `/deployments`로 변경. 기존 `/serving` → `/deployments` 리디렉션 fallback 유지 |
 | 2 | API 호환성 | 26.4.2 이상: 신규 Strawberry API 사용. 미만: 기존 Graphene UI 라우팅. **버전 분기는 라우팅 레벨에서만 처리, 컴포넌트 내 dual-support 없음** |
 | 3 | 헬스 색상 구분 | UNHEALTHY → **red/error**, DEGRADED → **amber/warning** |
-| 4 | Route vs Replica | Route 1개 = Replica 1개 (1:1). 상세 페이지에서 단일 목록으로 표시 |
+| 4 | Route vs Replica | Route는 내부 구현 개념. UI에서는 **Replicas**로만 노출. 헬스/트래픽 상태는 각 Replica의 속성으로 표시 |
 | 5 | Active Pool 위치 | Deployment 상세 페이지 **Overview 섹션** (메인 본문 상단)에 배치 |
 | 6 | 최소 백엔드 버전 | **26.4.2** |
 | 7 | 구버전 컴포넌트 처리 | 구버전 Graphene 기반 페이지/컴포넌트는 **그대로 유지** (fallback 라우팅용). 신규 컴포넌트는 처음부터 새로 작성 |
@@ -56,13 +56,13 @@ Manager ──(HEALTHY 라우트 동기화)──→ AppProxy
                                         ├── Health Checker (레플리카 프로브)
                                         └── Active Pool (HEALTHY 레플리카만 포함)
                                                 │
-                                    사용자 ────→ Route A (HEALTHY ✓) — 트래픽 수신
-                                                 Route B (HEALTHY ✓) — 트래픽 수신
-                                                 Route C (UNHEALTHY ✗) — 트래픽 차단
-                                                 Route D (DEGRADED  ~) — 유예 중, 차단
+                                    사용자 ────→ Replica A (HEALTHY ✓) — 트래픽 수신
+                                                 Replica B (HEALTHY ✓) — 트래픽 수신
+                                                 Replica C (UNHEALTHY ✗) — 트래픽 차단
+                                                 Replica D (DEGRADED  ~) — 유예 중, 차단
 ```
 
-`healthStatus = HEALTHY` AND `trafficStatus = ACTIVE`인 Route만 AppProxy Active Pool에 포함되어 실제 사용자 트래픽을 수신합니다.
+`healthStatus = HEALTHY` AND `trafficStatus = ACTIVE`인 Replica만 AppProxy Active Pool에 포함되어 실제 사용자 트래픽을 수신합니다.
 
 ### Route 헬스 상태 머신
 
@@ -90,21 +90,22 @@ DEGRADED                           ↓
 
 > **주의**: `RouteHealthStatus`는 `NOT_CHECKED | HEALTHY | UNHEALTHY | DEGRADED` 4가지 값을 가지며, TERMINATING은 `RouteStatus.TERMINATING`으로 별도 표현됩니다.
 
-### Route vs ModelReplica 관계
+### 내부 Route 구조와 UI Replica의 관계
 
 ```
 DeploymentRevisionRow
     └── routings (1:N)
-            └── RoutingRow (= 단일 Route)
+            └── RoutingRow (내부 Route, 단일 Replica 슬롯)
                     └── session (FK → SessionRow, 1:1)
 
 ModelReplica (Strawberry GQL 타입)
-    └── Route 데이터를 감싼 래퍼
+    └── RoutingRow를 감싼 사용자 노출용 래퍼
 ```
 
-- `RoutingRow` 하나 = `SessionRow` 하나 = UI상 Replica 하나
-- 1개 Revision에 N개 Route가 있어 카나리/블루-그린 배포(트래픽 분산)를 지원
-- UI에서 **Route 목록 = Replica 목록** (같은 데이터를 컨텍스트에 따라 다른 레이블로 표시)
+- 내부 `RoutingRow` 하나 = `SessionRow` 하나 = **UI상 Replica 하나**
+- Route는 내부 구현 세부사항. **UI에서는 Replicas 탭으로만 노출**
+- `healthStatus` / `trafficStatus`는 각 Replica의 속성으로 표시 (별도 Routes 탭 없음)
+- 1개 Revision에 N개 Replica가 있어 카나리/블루-그린 배포(트래픽 분산)를 지원
 
 ---
 
@@ -334,7 +335,7 @@ DeploymentDetailPage (동일)
 구현 요구사항:
 - [ ] `DeploymentDetailPage.tsx` 신규 생성 (Strawberry API 기반)
 - [ ] `DeploymentActivePoolSection.tsx` 신규 생성 (Overview 섹션 내 Active Pool 시각화)
-- [ ] `ReplicaStatusTag.tsx` 신규 생성 (Route 헬스 상태 태그, 아래 별도 스펙 참조)
+- [ ] `ReplicaStatusTag.tsx` 신규 생성 (Replica 헬스 상태 태그, 아래 별도 스펙 참조)
 - [ ] `DeploymentReplicasTab.tsx` 신규 생성 (Replicas 탭)
 - [ ] `DeploymentRevisionHistoryTab.tsx` 신규 생성 (Revision History 탭)
 - [ ] `DeploymentSettingsTab.tsx` 신규 생성 (Settings 탭)

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -149,46 +149,23 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
 
 ## 페이지 간 내비게이션 흐름
 
-```
-사이드바 "Deployments" 클릭
-        │
-        ▼
-┌─────────────────────┐
-│  DeploymentListPage  │  /deployments
-│  (배포 목록)          │
-└─────────────────────┘
-        │                         │
-        │ "New Deployment" 클릭   │ 행 클릭
-        ▼                         ▼
-┌────────────────────────┐  ┌──────────────────────┐
-│ DeploymentLauncherPage │  │ DeploymentDetailPage │
-│ (새 배포 생성)            │  │ (배포 상세)            │
-│ /deployments/create    │  │ /deployments/:id     │
-└────────────────────────┘  └──────────────────────┘
-        │                         │  "Edit Configuration" 클릭
-        │ 생성 성공                │
-        │                         ▼
-        │                ┌────────────────────────┐
-        │                │ DeploymentLauncherPage │
-        │                │ (배포 편집)              │
-        │                │ /deployments/:id/edit  │
-        │                └────────────────────────┘
-        │                         │ 편집 성공 (새 리비전 생성)
-        ▼                         ▼
-        └──────────────→ DeploymentDetailPage (복귀)
+**사용자 경로**
 
+| 단계 | 진입 | 페이지 | URL |
+|------|------|--------|-----|
+| 1 | 사이드바 "Deployments" 클릭 | `DeploymentListPage` (배포 목록) | `/deployments` |
+| 2a | 목록에서 "New Deployment" 클릭 | `DeploymentLauncherPage` (새 배포 생성) | `/deployments/create` |
+| 2b | 생성 성공 | `DeploymentDetailPage` (배포 상세) | `/deployments/:deploymentId` |
+| 3 | 목록에서 행 클릭 | `DeploymentDetailPage` (배포 상세) | `/deployments/:deploymentId` |
+| 4a | 상세 페이지의 "Edit Configuration" 클릭 | `DeploymentLauncherPage` (배포 편집) | `/deployments/:deploymentId/edit` |
+| 4b | 편집 성공 (새 리비전 생성) | `DeploymentDetailPage` (복귀) | `/deployments/:deploymentId` |
 
-관리자 사이드바 "Deployments" 클릭
-        │
-        ▼
-┌──────────────────────────┐
-│ AdminDeploymentListPage  │  /admin-deployments
-│ (전체 배포 목록)            │
-└──────────────────────────┘
-        │ 행 클릭
-        ▼
-DeploymentDetailPage (동일)
-```
+**관리자 경로**
+
+| 단계 | 진입 | 페이지 | URL |
+|------|------|--------|-----|
+| 1 | 관리자 사이드바 "Deployments" 클릭 | `AdminDeploymentListPage` (전체 배포 목록) | `/admin-deployments` |
+| 2 | 행 클릭 | `DeploymentDetailPage` (사용자 화면과 동일) | `/deployments/:deploymentId` |
 
 ---
 
@@ -223,7 +200,7 @@ DeploymentDetailPage (동일)
 - [ ] `DeploymentStatusTag.tsx` 신규 생성 (배포 라이프사이클 상태 표시)
 - [ ] 레플리카 헬스 요약 (`activeReplicas / replicas Healthy`) 컬럼 표시
 - [ ] "New Deployment" 버튼 → `/deployments/create`로 이동
-- [ ] 행 클릭 → `/deployments/:id`로 이동
+- [ ] 행 클릭 → `/deployments/:deploymentId`로 이동
 
 ---
 
@@ -251,14 +228,14 @@ DeploymentDetailPage (동일)
 
 ```
 ┌────────────────────────────────────────────────────────┐
-│  새 배포 생성                                            │
+│  새 배포 생성                                             │
 │                                                        │
-│  [기존 배포에서 가져오기 ▾]   또는 빈 폼으로 시작         │
+│  [기존 배포에서 가져오기 ▾]   또는 빈 폼으로 시작                │
 │                                                        │
-│  최근 배포                                              │
-│  ○ my-llama-service    vllm · A100 x2 · 2 replicas    │
-│  ○ gpt-sglang-prod     sglang · A100 x1 · 1 replica   │
-│  ○ custom-model-v3     custom · H100 x4 · 3 replicas  │
+│  최근 배포                                               │
+│  ○ my-llama-service    vllm · A100 x2 · 2 replicas     │
+│  ○ gpt-sglang-prod     sglang · A100 x1 · 1 replica    │
+│  ○ custom-model-v3     custom · H100 x4 · 3 replicas   │
 └────────────────────────────────────────────────────────┘
 ```
 
@@ -294,7 +271,7 @@ DeploymentDetailPage (동일)
 
 사용자가 목록에서 배포를 클릭하면 상세 페이지로 이동합니다. 배포의 현재 상태, 레플리카 헬스, 리비전 히스토리를 한 페이지에서 파악할 수 있어야 합니다.
 
-**페이지: `DeploymentDetailPage` (`/deployments/:id`)**
+**페이지: `DeploymentDetailPage` (`/deployments/:deploymentId`)**
 
 사용자 경험:
 - 헤더: 배포 이름, 상태 배지, Endpoint URL 복사 버튼, "Delete" 버튼
@@ -383,7 +360,7 @@ DeploymentDetailPage (동일)
 
 사용자가 Overview 섹션의 "Edit Configuration" 버튼을 클릭합니다.
 
-**페이지: `DeploymentLauncherPage` (`/deployments/:id/edit`)**
+**페이지: `DeploymentLauncherPage` (`/deployments/:deploymentId/edit`)**
 
 사용자 경험:
 - Flow 2와 동일한 다단계 폼 (`DeploymentLauncherPageContent` 재사용)
@@ -392,7 +369,7 @@ DeploymentDetailPage (동일)
 
 제출 흐름:
 - `addModelRevision` mutation 호출 (새 리비전 생성, 이전 리비전 보존)
-- 성공 → `/deployments/:id` 상세 페이지로 복귀
+- 성공 → `/deployments/:deploymentId` 상세 페이지로 복귀
 
 구현 요구사항:
 - [ ] `DeploymentLauncherPage`가 create/edit 모드 모두 처리 (URL param으로 구분)
@@ -561,7 +538,7 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
 2. 즉시 배포 생성 시작 — 별도 폼 없음
 3. 백그라운드 알림으로 진행 상황 표시: "배포를 시작하는 중..."
 4. 준비 완료 → 알림에 "/chat으로 이동" 링크 표시
-5. 준비 실패(타임아웃) → 알림에 배포 상세 페이지(`/deployments/:id`) 링크 표시
+5. 준비 실패(타임아웃) → 알림에 배포 상세 페이지(`/deployments/:deploymentId`) 링크 표시
 
 배포 설정 소스:
 - 런타임: `custom` 고정
@@ -579,7 +556,7 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
   - `createServiceInput` → `createDeploymentInput` (vfolderId, resourceGroup → minimal deployment config)
   - `mutationToCreateService` (`POST /services`) → `createModelDeployment` + `addModelRevision` GQL mutation
   - 폴링 로직: `GET /services/:id` → 신규 Deployment API로 교체
-  - 알림 링크: `/serving/:id` → `/deployments/:id`
+  - 알림 링크: `/serving/:endpointId` → `/deployments/:deploymentId`
 - [ ] `useModelServiceLauncher.ts` — `useDeploymentLauncher` 지원 후 제거 또는 deprecated 처리
 - [ ] **`deployment-config.yaml` 지원**: 모델 폴더에서 `deployment-config.yaml` 읽기 (기존 `service-definition.toml` 대체)
 - [ ] 26.4.2 미만 백엔드: 기존 `useModelServiceLauncher` 유지 (fallback)

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -553,7 +553,6 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
 - [ ] `useDeploymentLauncher.ts` 신규 생성 (기존 `useModelServiceLauncher.ts` 대체)
   - `createServiceInput` → `createDeploymentInput` (vfolderId, resourceGroup → minimal deployment config)
   - `mutationToCreateService` (`POST /services`) → `createModelDeployment` + `addModelRevision` GQL mutation
-  - `mutationToClone` (vfolder clone) 유지
   - 폴링 로직: `GET /services/:id` → 신규 Deployment API로 교체
   - 알림 링크: `/serving/:id` → `/deployments/:id`
 - [ ] `useModelServiceLauncher.ts` — `useDeploymentLauncher` 지원 후 제거 또는 deprecated 처리

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -41,7 +41,7 @@
 | 3 | 헬스 색상 구분 | UNHEALTHY → **red/error**, DEGRADED → **amber/warning** |
 | 4 | Route vs Replica | Route는 내부 구현 개념. UI에서는 **Replicas**로만 노출. 헬스/트래픽 상태는 각 Replica의 속성으로 표시 |
 | 5 | Active Pool 위치 | Deployment 상세 페이지 **Overview 섹션** (메인 본문 상단)에 배치 |
-| 6 | 최소 백엔드 버전 | **26.4.2** |
+| 6 | 최소 백엔드 버전 | **26.4.2**. `sessionV2`(26.4.3+) 같은 상위 버전 필드는 optional 처리하고 `@since` 디렉티브 또는 런타임 가드로 감싼다 |
 | 7 | 구버전 컴포넌트 처리 | 구버전 Graphene 기반 페이지/컴포넌트는 **그대로 유지** (fallback 라우팅용). 신규 컴포넌트는 처음부터 새로 작성 |
 | 8 | 편집 = 새 리비전 | 설정 변경 시 덮어쓰기 없음. `addModelRevision` mutation으로 새 리비전 스냅샷 생성 |
 
@@ -109,6 +109,20 @@ ModelReplica (Strawberry GQL 타입)
 
 ---
 
+## ID 명명 규칙
+
+스펙 전반에서 배포 식별자를 명확히 구분합니다.
+
+| 용도 | 이름 | 타입 | 설명 |
+|------|------|------|------|
+| URL 경로 파라미터 | `:deploymentId` | UUID (문자열) | `ModelDeployment.endpointId` 값 (사용자에게 노출되는 안정된 식별자, 기존 endpoint UUID와 동일) |
+| GraphQL 쿼리/뮤테이션 입력 | `$deploymentId` | `ID!` (GlobalID) | `toGlobalId('ModelDeployment', uuid)`로 UUID를 Relay GlobalID로 변환하여 전달 |
+| 레거시 리디렉션 소스 | `:endpointId` / `:serviceId` | UUID | 기존 URL의 파라미터 이름 유지 (리디렉션 대상에서도 같은 UUID 값을 `:deploymentId`로 매핑) |
+
+**일관성 원칙**: 신규 URL에서는 항상 `:deploymentId`를 사용하고, 레거시 리디렉션 코드에서도 파라미터 값을 그대로 `:deploymentId` 자리에 넣는다.
+
+---
+
 ## API 버전 분기 전략
 
 버전 분기는 **라우팅 레벨에서만** 처리합니다. 개별 컴포넌트 내에서 dual-support하지 않습니다.
@@ -151,7 +165,7 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
 │ (새 배포 생성)            │  │ (배포 상세)            │
 │ /deployments/create    │  │ /deployments/:id     │
 └────────────────────────┘  └──────────────────────┘
-        │                         │  "Edit" 버튼 클릭
+        │                         │  "Edit Configuration" 클릭
         │ 생성 성공                │
         │                         ▼
         │                ┌────────────────────────┐
@@ -168,7 +182,7 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
         │
         ▼
 ┌──────────────────────────┐
-│ AdminDeploymentListPage  │  /admin/deployments
+│ AdminDeploymentListPage  │  /admin-deployments
 │ (전체 배포 목록)            │
 └──────────────────────────┘
         │ 행 클릭
@@ -283,7 +297,8 @@ DeploymentDetailPage (동일)
 **페이지: `DeploymentDetailPage` (`/deployments/:id`)**
 
 사용자 경험:
-- 헤더: 배포 이름, 상태 배지, Endpoint URL 복사 버튼, "Edit" 버튼, "Delete" 버튼
+- 헤더: 배포 이름, 상태 배지, Endpoint URL 복사 버튼, "Delete" 버튼
+  > "Edit" 진입점은 Overview 섹션의 **"Edit Configuration"** 버튼 하나로 통일. 헤더에는 별도 Edit 버튼 없음
 
 **Overview 섹션** (메인 본문 상단, 탭 밖):
 
@@ -297,12 +312,24 @@ DeploymentDetailPage (동일)
 │  [○ Replica 3]  UNHEALTHY Rev. abc123  (트래픽 차단)  red      │
 │  [○ Replica 4]  DEGRADED  Rev. abc123  (유예 중)     amber    │
 └─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  Configuration                       [Edit Configuration]   │
+├─────────────────────────────────────┬───────────────────────┤
+│  Image                              │  vllm:latest          │
+│  Model                              │  my-llama-model       │
+│  Cluster Mode / Size                │  single / 1           │
+│  Replicas                           │  3                    │
+│  Resource Group                     │  default              │
+│  Resources                          │  GPU 1, CPU 4, 16 GiB │
+└─────────────────────────────────────┴───────────────────────┘
 ```
 
 - `healthStatus = HEALTHY` AND `trafficStatus = ACTIVE`인 레플리카: Active Pool 포함, 정상 표시
 - 그 외 레플리카: "트래픽 미수신" 시각적 표시 (점선 테두리 또는 dim)
 - DEGRADED: amber 경고 표시 (유예 중, 트래픽 차단)
 - UNHEALTHY: red 오류 표시 (확정 비정상, 트래픽 차단)
+- Configuration 카드: 현재 Active 리비전의 설정 요약 (읽기 전용). "Edit Configuration" 버튼 → Flow 4
 
 **탭 구성**:
 
@@ -310,22 +337,17 @@ DeploymentDetailPage (동일)
 |----|------|
 | Replicas | 전체 레플리카 목록 + 헬스 상태 |
 | Revision History | 리비전 목록 + Rollback 버튼 |
-| Settings | 현재 설정 요약 + "Edit Configuration" 버튼 |
 | Access Tokens | 토큰 목록 + 생성/삭제 |
 | Auto-scaling | 규칙 목록 + 생성/편집/삭제 |
 
 **Replicas 탭**:
 - 각 행: `replicaId`, `healthStatus` (`ReplicaStatusTag`), `trafficStatus`, `trafficRatio`, `revision`, `createdAt`
 - 행 클릭 시 Replica 상세 Drawer 오픈
-- Drawer 내용: `livenessStatus`, `readinessStatus`, `activenessStatus`, `sessionId` (Session 링크), `revisionId`, `createdAt`
+- Drawer 내용: `readinessStatus`, `livenessStatus`, `activenessStatus`, `sessionId` (Session 링크), `revisionId`, `createdAt`
 
 **Revision History 탭**:
 - 리비전 목록: 번호, 생성일, 이미지, 리소스 요약
 - 각 리비전에 "Rollback" 버튼 표시 → Flow 5
-
-**Settings 탭**:
-- 현재 Active 리비전의 설정 요약 (읽기 전용)
-- "Edit Configuration" 버튼 → Flow 4 (편집 페이지)
 
 **Access Tokens 탭**:
 - 토큰 목록 표시
@@ -338,18 +360,17 @@ DeploymentDetailPage (동일)
 
 구현 요구사항:
 - [ ] `DeploymentDetailPage.tsx` 신규 생성 (Strawberry API 기반)
-- [ ] `DeploymentActivePoolSection.tsx` 신규 생성 (Overview 섹션 내 Active Pool 시각화)
+- [ ] `DeploymentActivePoolSection.tsx` 신규 생성 (Overview 섹션 — Active Pool 시각화 + Configuration 카드 + "Edit Configuration" 버튼)
 - [ ] `ReplicaStatusTag.tsx` 신규 생성 (Replica 헬스 상태 태그, 아래 별도 스펙 참조)
 - [ ] `DeploymentReplicasTab.tsx` 신규 생성 (Replicas 탭)
 - [ ] `DeploymentRevisionHistoryTab.tsx` 신규 생성 (Revision History 탭)
-- [ ] `DeploymentSettingsTab.tsx` 신규 생성 (Settings 탭)
 - [ ] `DeploymentAccessTokensTab.tsx` 신규 생성 (Access Tokens 탭, 기존 `EndpointTokenGenerationModal` 로직 참조하여 새로 구현)
 - [ ] `DeploymentAutoScalingTab.tsx` 신규 생성 (Auto-scaling 탭)
 - [ ] `DeploymentOwnerInfo.tsx` 신규 생성 (소유자 정보, 기존 `EndpointOwnerInfo` 로직 참조하여 새로 구현)
 - [ ] Replica 상세 Drawer 구현 (Replicas 탭 내)
 - [ ] **활성 탭 URL 동기화** (`nuqs` `useQueryStates` 사용): 새로고침·공유 후에도 탭 위치 유지
   ```ts
-  const tabValues = ['replicas', 'revision-history', 'settings', 'access-tokens', 'auto-scaling'] as const;
+  const tabValues = ['replicas', 'revision-history', 'access-tokens', 'auto-scaling'] as const;
   const [{ tab }, setTab] = useQueryStates({
     tab: parseAsStringLiteral(tabValues).withDefault('replicas'),
   });
@@ -360,7 +381,7 @@ DeploymentDetailPage (동일)
 
 #### Flow 4: 배포 설정 편집 (Edit Deployment)
 
-사용자가 상세 페이지의 "Edit" 버튼 또는 Settings 탭의 "Edit Configuration" 버튼을 클릭합니다.
+사용자가 Overview 섹션의 "Edit Configuration" 버튼을 클릭합니다.
 
 **페이지: `DeploymentLauncherPage` (`/deployments/:id/edit`)**
 
@@ -402,7 +423,7 @@ DeploymentDetailPage (동일)
 
 #### Flow 6: 관리자 배포 목록 (Admin Deployments)
 
-**페이지: `AdminDeploymentListPage` (`/admin/deployments`)**
+**페이지: `AdminDeploymentListPage` (`/admin-deployments`)**
 
 사용자 경험:
 - 전체 사용자/프로젝트의 배포 목록 표시
@@ -410,7 +431,7 @@ DeploymentDetailPage (동일)
 - Flow 1과 동일한 테이블 구조 + 관리자용 추가 컬럼
 
 구현 요구사항:
-- [ ] `AdminDeploymentListPage.tsx` 신규 생성 (`/admin/deployments` 경로)
+- [ ] `AdminDeploymentListPage.tsx` 신규 생성 (`/admin-deployments` 경로, 기존 `/admin-serving`, `/admin-session` 컨벤션과 일치)
 - [ ] `adminDeploymentsV2` query 사용
 - [ ] 소유자 정보 표시 (`DeploymentOwnerInfo` 컴포넌트)
 
@@ -419,7 +440,7 @@ DeploymentDetailPage (동일)
 #### URL 경로 변경 + Fallback 리디렉션
 
 - [ ] URL 경로 `/serving` → `/deployments`로 변경
-- [ ] `/serving/:serviceId` → `/deployments/:serviceId`로 변경
+- [ ] `/serving/:serviceId` → `/deployments/:deploymentId`로 변경 (값은 동일 UUID, 파라미터 이름만 통일)
 - [ ] 기존 경로 fallback 리디렉션 추가 (북마크/외부 링크 호환성 유지)
   ```tsx
   { path: '/serving', Component: () => <WebUINavigate to="/deployments" replace /> },
@@ -428,15 +449,19 @@ DeploymentDetailPage (동일)
       return <WebUINavigate to={`/deployments/${serviceId}`} replace />;
   }},
   ```
-- [ ] `/admin-serving` → `/admin-deployments`로 변경 (동일 패턴 fallback 유지)
+- [ ] `/admin-serving` → `/admin-deployments`로 변경 (하이픈 컨벤션 유지)
+  ```tsx
+  { path: '/admin-serving', Component: () => <WebUINavigate to="/admin-deployments" replace /> },
+  ```
 - [ ] Launcher URL 변경:
   - Create: `/service/start` → `/deployments/create`
-  - Edit: `/service/update/:endpointId` → `/deployments/:deploymentId/edit`
+  - Edit: `/service/update/:endpointId` → `/deployments/:deploymentId/edit` (값은 동일 UUID)
   - 기존 경로 fallback 리디렉션 추가:
     ```tsx
     { path: '/service/start', Component: () => <WebUINavigate to="/deployments/create" replace /> },
     { path: '/service/update/:endpointId', Component: () => {
         const { endpointId } = useParams();
+        // 기존 endpoint UUID를 신규 :deploymentId 자리에 그대로 전달
         return <WebUINavigate to={`/deployments/${endpointId}/edit`} replace />;
     }},
     ```
@@ -487,7 +512,7 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
   "modelService": {
     "DeploymentId": "Deployment ID",
     "DeploymentName": "Deployment Name",
-    "StartNewDeployment": "New Deployment",
+    "NewDeployment": "New Deployment",
     "Deployments": "Deployments",
     "DeploymentDetail": "Deployment Detail",
     "Replicas": "Replicas",
@@ -509,7 +534,7 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
     "RollbackConfirm": "Are you sure you want to rollback to Revision #{{revisionNumber}}? The current revision will be replaced.",
     "RollbackSuccess": "Rollback to Revision #{{revisionNumber}} has been requested.",
     "TrafficSplit": "Traffic Split",
-    "CreateNewDeployment": "Create New Deployment",
+    "EditConfiguration": "Edit Configuration",
     "EditDeployment": "Edit Deployment",
     "NewRevisionWillBeCreated": "Saving will create a new Revision. The previous Revision will be preserved.",
     "NewRevisionWillBeCreatedConfirm": "A new Revision will be created. Continue?",
@@ -546,8 +571,8 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
 제출 흐름:
 - `createModelDeployment` mutation → `deploymentId` 반환
 - `addModelRevision` mutation (minimal config, `deployment-config.yaml` 기반)
-- 백그라운드에서 레플리카 준비 상태 폴링 (신규 API: `GET /v2/deployments/:id` 또는 GQL `deployment.activeReplicas` 확인)
-- 기존: `GET /services/:endpoint_id` active_routes 폴링 → 신규 API로 교체
+- 백그라운드에서 레플리카 준비 상태 폴링 (GQL `deployment { activeReplicas replicas }` 필드 사용)
+- 기존: `GET /services/:endpoint_id` active_routes 폴링 → GQL 폴링으로 교체
 
 구현 요구사항:
 - [ ] `useDeploymentLauncher.ts` 신규 생성 (기존 `useModelServiceLauncher.ts` 대체)
@@ -595,7 +620,6 @@ react/src/components/
   DeploymentActivePoolSection.tsx      # Active Pool 시각화 섹션
   DeploymentReplicasTab.tsx            # Replicas 탭
   DeploymentRevisionHistoryTab.tsx     # Revision History 탭
-  DeploymentSettingsTab.tsx            # Settings 탭
   DeploymentAccessTokensTab.tsx        # Access Tokens 탭
   DeploymentAutoScalingTab.tsx         # Auto-scaling 탭
   DeploymentOwnerInfo.tsx              # 소유자 정보
@@ -674,7 +698,7 @@ type Route {
   createdAt: DateTime
   errorData: JSON
   deployment: ModelDeployment!
-  sessionV2: SessionV2              # since 26.4.3
+  sessionV2: SessionV2              # since 26.4.3 — optional, @since gate required in UI
   revision: ModelRevision
 }
 ```
@@ -690,7 +714,7 @@ type ModelReplica {
   livenessStatus: LivenessStatus!      # NOT_CHECKED | HEALTHY | UNHEALTHY | DEGRADED
   activenessStatus: ActivenessStatus!  # ACTIVE | INACTIVE
   createdAt: DateTime!
-  sessionV2: SessionV2                 # since 26.4.3
+  sessionV2: SessionV2                 # since 26.4.3 — optional, @since gate required in UI
   revision: ModelRevision!
 }
 ```
@@ -744,13 +768,12 @@ type ModelDeployment {
 
 ### Phase 5 — 배포 상세 페이지
 
-16. `DeploymentActivePoolSection.tsx` 신규 생성 (Active Pool 시각화)
+16. `DeploymentActivePoolSection.tsx` 신규 생성 (Active Pool + Configuration 카드 포함 Overview 섹션)
 17. `DeploymentReplicasTab.tsx` 신규 생성 (Replica 목록 + 상세 Drawer)
 18. `DeploymentRevisionHistoryTab.tsx` 신규 생성 (리비전 목록 + Rollback)
-19. `DeploymentSettingsTab.tsx` 신규 생성
-20. `DeploymentAccessTokensTab.tsx` 신규 생성
-21. `DeploymentAutoScalingTab.tsx` 신규 생성
-22. `DeploymentDetailPage.tsx` 신규 생성 (모든 섹션/탭 조합)
+19. `DeploymentAccessTokensTab.tsx` 신규 생성
+20. `DeploymentAutoScalingTab.tsx` 신규 생성
+21. `DeploymentDetailPage.tsx` 신규 생성 (Overview 섹션 + 4탭 조합)
 
 ---
 
@@ -765,6 +788,7 @@ type ModelDeployment {
 
 ## 변경 이력
 
+- 2026-04-21: Settings 탭 제거 → Overview 섹션의 Configuration 카드로 통합. 탭 5개 → 4개
 - 2026-04-21: 초기 초안 작성 (아키텍처 다이어그램 + 코드베이스 분석 기반)
 - 2026-04-21: 사용자 확인 사항 6개 반영하여 한국어로 전면 재작성
   - URL: `/deployments` 변경 + `/serving` fallback 리디렉션
@@ -777,7 +801,7 @@ type ModelDeployment {
 - 2026-04-21: Flow 7 추가 — 모델 폴더에서 바로 배포 (useDeploymentLauncher, deployment-config.yaml 기반)
 - 2026-04-21: Flow 2에 "기존 배포에서 가져오기" 추가 (FR-2419 반영)
 - 2026-04-21: 요구사항 전면 재구조화 — User Flow 중심으로 재작성
-  - US-1~US-8 구조 → Flow 1~6 사용자 흐름 중심으로 전환
+  - US-1~US-8 구조 → Flow 1~7 사용자 흐름 중심으로 전환
   - 신규 컴포넌트 처음부터 새로 작성 (기존 컴포넌트 rename/patch 방식 폐기)
   - 구버전 컴포넌트는 라우팅 fallback 전용으로 유지 (수정 없음)
   - 페이지 간 내비게이션 다이어그램 추가

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -1,0 +1,696 @@
+# Endpoint → Deployment UI 마이그레이션 스펙
+
+> **상태**: DRAFT — 사용자 최종 승인 대기 중
+
+---
+
+## 개요
+
+모델 서빙 UI의 용어와 아키텍처를 "Endpoint" 중심에서 "Deployment" 중심으로 전면 재구축합니다.  
+백엔드의 신규 Strawberry GraphQL API(`ModelDeployment`, `Route`, `ModelReplica`)와 정합성을 맞추며, 배포 라이프사이클과 레플리카 헬스 상태를 사용자가 한눈에 파악할 수 있도록 AWS ECS / Vercel 수준의 Deployment UX를 새로 설계합니다.
+
+**최소 지원 백엔드 버전**: 26.4.2 (Strawberry API 지원 시작)  
+구버전(26.4.2 미만)은 라우팅 레벨에서 기존 Graphene 기반 Serving/Endpoint UI로 전달됩니다.
+
+---
+
+## 문제 정의
+
+백엔드는 단순한 `Endpoint` 개념에서 다음과 같은 더 풍부한 모델로 발전했습니다:
+
+- **ModelDeployment** — 서빙 최상위 단위 (기존 "Endpoint"에 대응)
+- **Route** — 배포 내 단일 레플리카 슬롯. 독립된 생명주기와 헬스 상태 보유 (`RouteStatus` + `RouteHealthStatus`)
+- **ModelReplica** — Route를 감싼 GQL 타입. Route와 1:1 관계
+
+현재 WebUI(`EndpointDetailPage`, `EndpointList`, `EndpointStatusTag` 등)는 구버전 Graphene API 기준으로 구현되어 있으며, 다음 사항이 반영되어 있지 않습니다:
+
+1. **AppProxy Active Pool** 개념 — HEALTHY 상태의 Route만 트래픽을 수신함
+2. **Route 헬스 상태 머신 전체** — `NOT_CHECKED → HEALTHY/UNHEALTHY/DEGRADED → TERMINATING`
+3. **레플리카 단위 헬스 세분화** — `readinessStatus`, `livenessStatus`, `activenessStatus`
+4. **UNHEALTHY(확정 실패, red)와 DEGRADED(체크 불가 유예, amber)의 색상 구분 미흡**
+5. **Revision History 및 Rollback** — 설정 변경 이력 추적, 이전 상태로 롤백
+
+---
+
+## 주요 결정 사항
+
+| # | 항목 | 결정 내용 |
+|---|------|-----------|
+| 1 | URL 경로 | `/deployments`로 변경. 기존 `/serving` → `/deployments` 리디렉션 fallback 유지 |
+| 2 | API 호환성 | 26.4.2 이상: 신규 Strawberry API 사용. 미만: 기존 Graphene UI 라우팅. **버전 분기는 라우팅 레벨에서만 처리, 컴포넌트 내 dual-support 없음** |
+| 3 | 헬스 색상 구분 | UNHEALTHY → **red/error**, DEGRADED → **amber/warning** |
+| 4 | Route vs Replica | Route 1개 = Replica 1개 (1:1). 상세 페이지에서 단일 목록으로 표시 |
+| 5 | Active Pool 위치 | Deployment 상세 페이지 **Overview 섹션** (메인 본문 상단)에 배치 |
+| 6 | 최소 백엔드 버전 | **26.4.2** |
+| 7 | 구버전 컴포넌트 처리 | 구버전 Graphene 기반 페이지/컴포넌트는 **그대로 유지** (fallback 라우팅용). 신규 컴포넌트는 처음부터 새로 작성 |
+| 8 | 편집 = 새 Revision | 설정 변경 시 덮어쓰기 없음. `addModelRevision` mutation으로 새 Revision 스냅샷 생성 |
+
+---
+
+## 아키텍처 컨텍스트
+
+### AppProxy 라우팅 구조
+
+```
+Manager ──(HEALTHY 라우트 동기화)──→ AppProxy
+                                        ├── Health Checker (레플리카 프로브)
+                                        └── Active Pool (HEALTHY 레플리카만 포함)
+                                                │
+                                    사용자 ────→ Route A (HEALTHY ✓) — 트래픽 수신
+                                                 Route B (HEALTHY ✓) — 트래픽 수신
+                                                 Route C (UNHEALTHY ✗) — 트래픽 차단
+                                                 Route D (DEGRADED  ~) — 유예 중, 차단
+```
+
+`healthStatus = HEALTHY` AND `trafficStatus = ACTIVE`인 Route만 AppProxy Active Pool에 포함되어 실제 사용자 트래픽을 수신합니다.
+
+### Route 헬스 상태 머신
+
+```
+NOT_CHECKED
+    │ (첫 번째 성공 시)
+    ↓
+HEALTHY ──(N회 연속 실패)──→ UNHEALTHY
+    │                              │
+    │                         (성공 시 회복)
+    ↓                              │
+DEGRADED                           ↓
+(체크 불가 유예 중)              HEALTHY
+    │
+    └──(연속 실패)──→ UNHEALTHY ──(축출)──→ TERMINATING(RouteStatus)
+```
+
+| 상태 | 의미 | UI 색상 | Active Pool 포함 여부 |
+|------|------|---------|----------------------|
+| NOT_CHECKED | 초기 지연 기간, 판정 미결 | gray/default | 미포함 |
+| HEALTHY | 정상, 트래픽 수신 중 | green/success | 포함 |
+| UNHEALTHY | N회 연속 실패로 비정상 확정 | **red/error** | 미포함 |
+| DEGRADED | 헬스체커 도달 불가 유예 | **amber/warning** | 미포함 |
+| TERMINATING | `RouteStatus`로 표현 (종료 중) | — | 미포함 |
+
+> **주의**: `RouteHealthStatus`는 `NOT_CHECKED | HEALTHY | UNHEALTHY | DEGRADED` 4가지 값을 가지며, TERMINATING은 `RouteStatus.TERMINATING`으로 별도 표현됩니다.
+
+### Route vs ModelReplica 관계
+
+```
+DeploymentRevisionRow
+    └── routings (1:N)
+            └── RoutingRow (= 단일 Route)
+                    └── session (FK → SessionRow, 1:1)
+
+ModelReplica (Strawberry GQL 타입)
+    └── Route 데이터를 감싼 래퍼
+```
+
+- `RoutingRow` 하나 = `SessionRow` 하나 = UI상 Replica 하나
+- 1개 Revision에 N개 Route가 있어 카나리/블루-그린 배포(트래픽 분산)를 지원
+- UI에서 **Route 목록 = Replica 목록** (같은 데이터를 컨텍스트에 따라 다른 레이블로 표시)
+
+---
+
+## API 버전 분기 전략
+
+버전 분기는 **라우팅 레벨에서만** 처리합니다. 개별 컴포넌트 내에서 dual-support하지 않습니다.
+
+### 라우팅 분기 원칙
+
+```tsx
+// routes.tsx에서
+const DetailPage = baiClient.supports('model-deployment-strawberry')
+  ? DeploymentDetailPage    // 신규 컴포넌트 (26.4.2+)
+  : EndpointDetailPage;     // 기존 컴포넌트 유지 (fallback)
+```
+
+### Feature Flag 추가 (backend.ai-client-esm.ts)
+
+```ts
+if (this.isManagerVersionCompatibleWith('26.4.2')) {
+  this._features['model-deployment-strawberry'] = true;
+  this._features['model-replica'] = true;
+}
+```
+
+---
+
+## 페이지 간 내비게이션 흐름
+
+```
+사이드바 "Deployments" 클릭
+        │
+        ▼
+┌─────────────────────┐
+│  DeploymentListPage  │  /deployments
+│  (배포 목록)         │
+└─────────────────────┘
+        │                         │
+        │ "New Deployment" 클릭   │ 행 클릭
+        ▼                         ▼
+┌────────────────────────┐  ┌──────────────────────┐
+│ DeploymentLauncherPage │  │ DeploymentDetailPage  │
+│ (새 배포 생성)          │  │ (배포 상세)            │
+│ /deployments/create    │  │ /deployments/:id      │
+└────────────────────────┘  └──────────────────────┘
+        │                         │  "Edit" 버튼 클릭
+        │ 생성 성공                │
+        │                         ▼
+        │                ┌────────────────────────┐
+        │                │ DeploymentLauncherPage  │
+        │                │ (배포 편집)              │
+        │                │ /deployments/:id/edit   │
+        │                └────────────────────────┘
+        │                         │ 편집 성공 (새 Revision 생성)
+        ▼                         ▼
+        └──────────────→ DeploymentDetailPage (복귀)
+
+
+관리자 사이드바 "Deployments" 클릭
+        │
+        ▼
+┌──────────────────────────┐
+│ AdminDeploymentListPage  │  /admin/deployments
+│ (전체 배포 목록)           │
+└──────────────────────────┘
+        │ 행 클릭
+        ▼
+DeploymentDetailPage (동일)
+```
+
+---
+
+## 요구사항
+
+### 필수 구현 (Must Have)
+
+---
+
+#### Flow 1: 배포 목록 (Deployments List)
+
+사용자가 사이드바에서 "Deployments"를 클릭하면 `/deployments` 페이지로 이동합니다.
+
+**페이지: `DeploymentListPage`**
+
+사용자 경험:
+1. 배포 목록 테이블 표시
+2. 각 행에서 배포의 핵심 상태를 즉시 파악 가능
+3. 행 클릭 → Flow 3 (상세 페이지)
+4. "New Deployment" 버튼 클릭 → Flow 2 (생성 페이지)
+
+테이블 컬럼:
+- 배포 이름
+- 상태 (`DeploymentStatusTag`)
+- 레플리카 요약 (`2 / 3 Healthy` 형태, 헬스 배지)
+- Endpoint URL (복사 버튼 포함)
+- 생성일
+
+구현 요구사항:
+- [ ] `DeploymentListPage.tsx` 신규 생성 (`/deployments` 경로)
+- [ ] `DeploymentList.tsx` 신규 생성 (Strawberry `deploymentsV2` 또는 `modelDeployments` query 기반)
+- [ ] `DeploymentStatusTag.tsx` 신규 생성 (배포 라이프사이클 상태 표시)
+- [ ] 레플리카 헬스 요약 (`activeReplicas / replicas Healthy`) 컬럼 표시
+- [ ] "New Deployment" 버튼 → `/deployments/create`로 이동
+- [ ] 행 클릭 → `/deployments/:id`로 이동
+
+---
+
+#### Flow 2: 새 배포 생성 (Create Deployment)
+
+사용자가 "New Deployment"를 클릭하면 다단계 생성 폼으로 이동합니다.
+
+**페이지: `DeploymentLauncherPage` (`/deployments/create`)**
+
+사용자 경험:
+1. Step 1 — **기본 정보**: 배포 이름, 공개 여부 (`open_to_public`)
+2. Step 2 — **모델 & 런타임**: 모델 폴더(VFolder), 런타임 변형(`vllm` / `sglang` / `custom` 등), 컨테이너 이미지, 실행 커맨드(custom일 때만 표시)
+3. Step 3 — **리소스**: GPU/CPU/메모리, 레플리카 수, 리소스 그룹, 클러스터 모드
+4. Step 4 — **검토 & 생성**: 입력 내용 요약 확인 후 제출
+
+제출 흐름:
+- `createModelDeployment` mutation → `deploymentId` 반환
+- `addModelRevision` mutation으로 배포 설정 적용 (image, model, resources, environ 등)
+- 성공 → `/deployments/:deploymentId` 상세 페이지로 이동
+
+구현 요구사항:
+- [ ] `DeploymentLauncherPage.tsx` 신규 생성 (생성/편집 통합 진입점)
+- [ ] `DeploymentLauncherPageContent.tsx` 신규 생성 (다단계 폼 본문)
+- [ ] Step 1~4 단계형 폼 레이아웃 구현
+- [ ] `createModelDeployment` + `addModelRevision` GQL mutation 연동
+- [ ] 성공 후 상세 페이지로 이동
+
+---
+
+#### Flow 3: 배포 상세 (Deployment Detail)
+
+사용자가 목록에서 배포를 클릭하면 상세 페이지로 이동합니다. AWS ECS 콘솔처럼 배포의 현재 상태, 레플리카 헬스, 리비전 히스토리를 한 페이지에서 파악할 수 있어야 합니다.
+
+**페이지: `DeploymentDetailPage` (`/deployments/:id`)**
+
+사용자 경험:
+- 헤더: 배포 이름, 상태 배지, Endpoint URL 복사 버튼, "Edit" 버튼, "Delete" 버튼
+
+**Overview 섹션** (메인 본문 상단, 탭 밖):
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Active Pool                           [2 / 3 Healthy]      │
+│  AppProxy가 트래픽을 전달하는 레플리카 목록입니다.            │
+├─────────────────────────────────────────────────────────────┤
+│  [● Replica 1]  HEALTHY   Rev. abc123  Traffic: 50%         │
+│  [● Replica 2]  HEALTHY   Rev. abc123  Traffic: 50%         │
+│  [○ Replica 3]  UNHEALTHY Rev. abc123  (트래픽 차단)  red   │
+│  [○ Replica 4]  DEGRADED  Rev. abc123  (유예 중)     amber  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- `healthStatus = HEALTHY` AND `trafficStatus = ACTIVE`인 레플리카: Active Pool 포함, 정상 표시
+- 그 외 레플리카: "트래픽 미수신" 시각적 표시 (점선 테두리 또는 dim)
+- DEGRADED: amber 경고 표시 (유예 중, 트래픽 차단)
+- UNHEALTHY: red 오류 표시 (확정 비정상, 트래픽 차단)
+
+**탭 구성**:
+
+| 탭 | 내용 |
+|----|------|
+| Replicas | 전체 레플리카 목록 + 헬스 상태 |
+| Revision History | 리비전 목록 + Rollback 버튼 |
+| Settings | 현재 설정 요약 + "Edit Configuration" 버튼 |
+| Access Tokens | 토큰 목록 + 생성/삭제 |
+| Auto-scaling | 규칙 목록 + 생성/편집/삭제 |
+
+**Replicas 탭**:
+- 각 행: `replicaId`, `healthStatus` (`ReplicaStatusTag`), `trafficStatus`, `trafficRatio`, `revision`, `createdAt`
+- 행 클릭 시 Replica 상세 Drawer 오픈
+- Drawer 내용: `livenessStatus`, `readinessStatus`, `activenessStatus`, `sessionId` (Session 링크), `revisionId`, `createdAt`
+
+**Revision History 탭**:
+- 리비전 목록: 번호, 생성일, 이미지, 리소스 요약
+- 각 리비전에 "Rollback" 버튼 표시 → Flow 5
+
+**Settings 탭**:
+- 현재 Active Revision의 설정 요약 (읽기 전용)
+- "Edit Configuration" 버튼 → Flow 4 (편집 페이지)
+
+**Access Tokens 탭**:
+- 토큰 목록 표시
+- 신규 토큰 생성 버튼
+- 토큰 삭제
+
+**Auto-scaling 탭**:
+- 오토스케일링 규칙 목록
+- 규칙 생성/편집/삭제
+
+구현 요구사항:
+- [ ] `DeploymentDetailPage.tsx` 신규 생성 (Strawberry API 기반)
+- [ ] `DeploymentActivePoolSection.tsx` 신규 생성 (Overview 섹션 내 Active Pool 시각화)
+- [ ] `ReplicaStatusTag.tsx` 신규 생성 (Route 헬스 상태 태그, 아래 별도 스펙 참조)
+- [ ] `DeploymentReplicasTab.tsx` 신규 생성 (Replicas 탭)
+- [ ] `DeploymentRevisionHistoryTab.tsx` 신규 생성 (Revision History 탭)
+- [ ] `DeploymentSettingsTab.tsx` 신규 생성 (Settings 탭)
+- [ ] `DeploymentAccessTokensTab.tsx` 신규 생성 (Access Tokens 탭, 기존 `EndpointTokenGenerationModal` 로직 참조하여 새로 구현)
+- [ ] `DeploymentAutoScalingTab.tsx` 신규 생성 (Auto-scaling 탭)
+- [ ] `DeploymentOwnerInfo.tsx` 신규 생성 (소유자 정보, 기존 `EndpointOwnerInfo` 로직 참조하여 새로 구현)
+- [ ] Replica 상세 Drawer 구현 (Replicas 탭 내)
+- [ ] 페이지 자동 갱신 (`fetchKey` 기반 polling 또는 refetch)
+
+---
+
+#### Flow 4: 배포 설정 편집 (Edit Deployment)
+
+사용자가 상세 페이지의 "Edit" 버튼 또는 Settings 탭의 "Edit Configuration" 버튼을 클릭합니다.
+
+**페이지: `DeploymentLauncherPage` (`/deployments/:id/edit`)**
+
+사용자 경험:
+- Flow 2와 동일한 다단계 폼 (`DeploymentLauncherPageContent` 재사용)
+- 현재 Active Revision의 데이터로 폼 pre-fill
+- 폼 상단에 **안내 배너** 표시: "설정을 변경하면 새 Revision이 생성됩니다. 이전 Revision은 보존됩니다."
+- 제출 시 확인 다이얼로그: "새 Revision이 생성됩니다. 계속하시겠습니까?"
+
+제출 흐름:
+- `addModelRevision` mutation 호출 (새 Revision 생성, 이전 Revision 보존)
+- 성공 → `/deployments/:id` 상세 페이지로 복귀
+
+구현 요구사항:
+- [ ] `DeploymentLauncherPage`가 create/edit 모드 모두 처리 (URL param으로 구분)
+- [ ] 편집 모드: `deployment(id: $deploymentId)` + `currentRevision` 데이터로 폼 pre-fill
+- [ ] 편집 모드 안내 배너 표시 (새 Revision 생성 안내)
+- [ ] 제출 전 확인 다이얼로그 표시
+- [ ] `addModelRevision` mutation 연동
+- [ ] 성공 후 상세 페이지로 복귀
+
+---
+
+#### Flow 5: Rollback
+
+사용자가 Revision History 탭에서 이전 Revision의 "Rollback" 버튼을 클릭합니다.
+
+사용자 경험:
+1. "Rollback" 버튼 클릭
+2. 확인 다이얼로그: "Revision #N으로 롤백하시겠습니까? 현재 Revision이 교체됩니다."
+3. 확인 → `activateRevision` mutation 호출
+4. 성공 → 상세 페이지 갱신, Active Revision 변경 표시
+
+구현 요구사항:
+- [ ] `DeploymentRevisionHistoryTab` 내 Rollback 버튼 구현
+- [ ] 확인 다이얼로그 표시
+- [ ] `activateRevision` mutation 연동
+- [ ] 성공 후 페이지 refetch
+
+---
+
+#### Flow 6: 관리자 배포 목록 (Admin Deployments)
+
+**페이지: `AdminDeploymentListPage` (`/admin/deployments`)**
+
+사용자 경험:
+- 전체 사용자/프로젝트의 배포 목록 표시
+- 소유자(사용자, 프로젝트) 정보 컬럼 포함
+- Flow 1과 동일한 테이블 구조 + 관리자용 추가 컬럼
+
+구현 요구사항:
+- [ ] `AdminDeploymentListPage.tsx` 신규 생성 (`/admin/deployments` 경로)
+- [ ] `adminDeploymentsV2` query 사용
+- [ ] 소유자 정보 표시 (`DeploymentOwnerInfo` 컴포넌트)
+
+---
+
+#### URL 경로 변경 + Fallback 리디렉션
+
+- [ ] URL 경로 `/serving` → `/deployments`로 변경
+- [ ] `/serving/:serviceId` → `/deployments/:serviceId`로 변경
+- [ ] 기존 경로 fallback 리디렉션 추가 (북마크/외부 링크 호환성 유지)
+  ```tsx
+  { path: '/serving', Component: () => <WebUINavigate to="/deployments" replace /> },
+  { path: '/serving/:serviceId', Component: () => {
+      const { serviceId } = useParams();
+      return <WebUINavigate to={`/deployments/${serviceId}`} replace />;
+  }},
+  ```
+- [ ] `/admin-serving` → `/admin-deployments`로 변경 (동일 패턴 fallback 유지)
+- [ ] Launcher URL 변경:
+  - Create: `/service/start` → `/deployments/create`
+  - Edit: `/service/update/:endpointId` → `/deployments/:deploymentId/edit`
+  - 기존 경로 fallback 리디렉션 추가:
+    ```tsx
+    { path: '/service/start', Component: () => <WebUINavigate to="/deployments/create" replace /> },
+    { path: '/service/update/:endpointId', Component: () => {
+        const { endpointId } = useParams();
+        return <WebUINavigate to={`/deployments/${endpointId}/edit`} replace />;
+    }},
+    ```
+- [ ] `routes.tsx`의 `handle.labelKey` 업데이트: `'webui.menu.Serving'` → `'webui.menu.Deployments'`
+
+---
+
+#### ReplicaStatusTag 컴포넌트
+
+신규 컴포넌트: `react/src/components/ReplicaStatusTag.tsx`
+
+- `RouteHealthStatus` (`NOT_CHECKED | HEALTHY | UNHEALTHY | DEGRADED`) 및 `LivenessStatus` 표시
+- `BAITag` props 확장 (`component-props-extension.md` 규칙 준수)
+- 색상 매핑:
+  - `NOT_CHECKED` → gray/default
+  - `HEALTHY` → green/success
+  - `UNHEALTHY` → **red/error** (확정 비정상)
+  - `DEGRADED` → **amber/warning** (체크 불가 유예)
+- 각 상태에 상태 의미를 설명하는 Tooltip 포함
+- Storybook 스토리 필요
+
+```tsx
+export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
+  status: RouteHealthStatus | LivenessStatus;
+  showTooltip?: boolean;
+}
+```
+
+상태별 툴팁 텍스트:
+- `NOT_CHECKED`: "초기 지연 기간 중. 첫 번째 헬스체크 전 상태입니다."
+- `HEALTHY`: "정상. AppProxy Active Pool에 포함되어 트래픽을 수신 중입니다."
+- `UNHEALTHY`: "비정상 확정. 연속 실패 횟수 초과로 Active Pool에서 제외되었습니다."
+- `DEGRADED`: "헬스체커 도달 불가 유예 상태. Active Pool에서 임시 제외되었습니다."
+
+---
+
+#### i18n 키 추가
+
+신규 추가 키 (`resources/i18n/en.json`):
+
+```json
+{
+  "webui": {
+    "menu": {
+      "Deployments": "Deployments"
+    }
+  },
+  "modelService": {
+    "DeploymentId": "Deployment ID",
+    "DeploymentName": "Deployment Name",
+    "StartNewDeployment": "New Deployment",
+    "Deployments": "Deployments",
+    "DeploymentDetail": "Deployment Detail",
+    "Replicas": "Replicas",
+    "ReplicaId": "Replica ID",
+    "ReplicaDetail": "Replica Detail",
+    "ActivePool": "Active Pool",
+    "ActivePoolDescription": "Replicas currently receiving traffic through AppProxy",
+    "HealthySummary": "{{healthy}} / {{total}} Healthy",
+    "NotChecked": "Not Checked",
+    "Healthy": "Healthy",
+    "Unhealthy": "Unhealthy",
+    "Degraded": "Degraded",
+    "ReplicaHealthStatus": "Replica Health Status",
+    "LivenessStatus": "Liveness Status",
+    "ReadinessStatus": "Readiness Status",
+    "ActivenessStatus": "Activeness Status",
+    "RevisionHistory": "Revision History",
+    "Rollback": "Rollback",
+    "RollbackConfirm": "Are you sure you want to rollback to Revision #{{revisionNumber}}? The current revision will be replaced.",
+    "RollbackSuccess": "Rollback to Revision #{{revisionNumber}} has been requested.",
+    "TrafficSplit": "Traffic Split",
+    "CreateNewDeployment": "Create New Deployment",
+    "EditDeployment": "Edit Deployment",
+    "NewRevisionWillBeCreated": "Saving will create a new Revision. The previous Revision will be preserved.",
+    "NewRevisionWillBeCreatedConfirm": "A new Revision will be created. Continue?",
+    "DeploymentUpdated": "Deployment has been updated.",
+    "DeploymentCreated": "Deployment has been created.",
+    "FailedToUpdateDeployment": "Failed to update deployment.",
+    "FailedToCreateDeployment": "Failed to create deployment."
+  }
+}
+```
+
+---
+
+### 선택 구현 (Nice to Have)
+
+- [ ] **Route 상태 필터**: Replicas 탭에서 `healthStatus`(NOT_CHECKED, HEALTHY, UNHEALTHY, DEGRADED)로 필터링
+- [ ] **Traffic Status 토글**: Route의 `trafficStatus`를 ACTIVE/INACTIVE로 수동 전환 (백엔드 지원 필요 — FR-2591 TODO 확인)
+- [ ] **배포 전략 시각화**: Canary/Blue-Green 배포 시 트래픽 비율을 Bar 또는 퍼센트로 시각 표시
+- [ ] **배포 목록 실시간 헬스 갱신**: 목록 테이블에서 헬스 요약 컬럼 자동 갱신
+
+---
+
+## 컴포넌트 아키텍처
+
+### 신규 생성 파일
+
+```
+react/src/pages/
+  DeploymentListPage.tsx           # Flow 1: 배포 목록
+  AdminDeploymentListPage.tsx      # Flow 6: 관리자 배포 목록
+  DeploymentDetailPage.tsx         # Flow 3: 배포 상세
+  DeploymentLauncherPage.tsx       # Flow 2 & 4: 생성/편집 통합 진입점
+
+react/src/components/
+  DeploymentList.tsx                   # 배포 목록 테이블
+  DeploymentStatusTag.tsx              # 배포 상태 태그
+  DeploymentLauncherPageContent.tsx    # 생성/편집 다단계 폼 본문
+  ReplicaStatusTag.tsx                 # 레플리카 헬스 상태 태그
+  DeploymentActivePoolSection.tsx      # Active Pool 시각화 섹션
+  DeploymentReplicasTab.tsx            # Replicas 탭
+  DeploymentRevisionHistoryTab.tsx     # Revision History 탭
+  DeploymentSettingsTab.tsx            # Settings 탭
+  DeploymentAccessTokensTab.tsx        # Access Tokens 탭
+  DeploymentAutoScalingTab.tsx         # Auto-scaling 탭
+  DeploymentOwnerInfo.tsx              # 소유자 정보
+```
+
+### 구버전 컴포넌트 (라우팅 fallback 전용, 변경 없이 유지)
+
+26.4.2 미만 백엔드 접속 시 라우팅 레벨에서 아래 기존 페이지로 전달합니다. 이 파일들은 수정하지 않습니다.
+
+```
+react/src/pages/
+  ServingPage.tsx                  # 구버전 fallback 유지
+  EndpointDetailPage.tsx           # 구버전 fallback 유지
+  ServiceLauncherPage.tsx          # 구버전 fallback 유지
+
+react/src/components/
+  EndpointList.tsx                 # 구버전 fallback 유지
+  EndpointStatusTag.tsx            # 구버전 fallback 유지
+  EndpointDiagnosticsSection.tsx   # 구버전 fallback 유지
+  EndpointOwnerInfo.tsx            # 구버전 fallback 유지
+  EndpointTokenGenerationModal.tsx # 구버전 fallback 유지
+  ServiceLauncherPageContent.tsx   # 구버전 fallback 유지
+```
+
+### 변경 필요 파일
+
+| 파일 경로 | 변경 내용 |
+|----------|---------|
+| `react/src/routes.tsx` | URL 경로 변경, fallback 리디렉션 추가, 신규 페이지 import, 버전 분기 라우팅 |
+| `react/src/hooks/useWebUIMenuItems.tsx` | 메뉴 경로 및 레이블 업데이트 |
+| `src/lib/backend.ai-client-esm.ts` | `model-deployment-strawberry`, `model-replica` feature flag 추가 |
+| `resources/i18n/en.json` | 신규 i18n 키 추가 (22개 언어 번역 필요) |
+
+---
+
+## 폼 필드 매핑 (편집 폼 pre-fill 참조)
+
+| 기존 Graphene 필드 | 신규 Strawberry 필드 |
+|-------------------|---------------------|
+| `endpoint.name` | `deployment.name` |
+| `endpoint.replicas` | `revision.replicaCount` |
+| `endpoint.resource_slots` | `revision.resourceSlots` |
+| `endpoint.resource_group` / `scaling_group` | revision 설정 내 해당 필드 |
+| `endpoint.environ` | `revision.modelDefinition.environ` |
+| `endpoint.runtime_variant.name` | `revision.modelDefinition.runtimeVariant` |
+| `endpoint.image_object` | `revision.modelDefinition.image` |
+| `endpoint.model` (vfolder ID) | `revision.modelDefinition.model` |
+| `endpoint.model_mount_destination` | `revision.modelDefinition.modelMountDestination` |
+| `endpoint.model_definition_path` | `revision.modelDefinition.modelDefinitionPath` |
+| `endpoint.extra_mounts` | `revision.modelDefinition.extraMounts` |
+| `endpoint.open_to_public` | `deployment.networkAccess.isPublic` |
+| `endpoint.cluster_mode`, `endpoint.cluster_size` | revision 설정 내 해당 필드 |
+
+---
+
+## 범위 외 (Out of Scope)
+
+- 백엔드 API 변경 — `RouteHealthStatus`, `ModelReplica`, `LivenessStatus` 등 스키마는 이미 구현됨
+- 오토스케일링 규칙 변경 — `draft-auto-scaling-rule-ux`에서 별도 추적
+- Chat 페이지의 Endpoint 관련 컴포넌트 (`EndpointSelect.tsx`, `EndpointTokenSelect.tsx`)
+- API 클라이언트 레벨의 `useApiEndpoint.ts`, `useEduAppApiEndpoint.ts` (다른 의미의 "endpoint")
+
+---
+
+## 핵심 GQL 스키마 참조
+
+### Route (Strawberry, `routes` 쿼리)
+
+```graphql
+type Route {
+  id: ID!
+  status: RouteStatus!              # PROVISIONING | RUNNING | TERMINATING | TERMINATED | FAILED_TO_START
+  healthStatus: RouteHealthStatus!  # NOT_CHECKED | HEALTHY | UNHEALTHY | DEGRADED  (since 26.4.0)
+  trafficStatus: RouteTrafficStatus! # ACTIVE | INACTIVE
+  trafficRatio: Float!
+  createdAt: DateTime
+  errorData: JSON
+  deployment: ModelDeployment!
+  sessionV2: SessionV2              # since 26.4.3
+  revision: ModelRevision
+}
+```
+
+### ModelReplica (Strawberry, `replicas` 쿼리 on ModelDeployment)
+
+```graphql
+type ModelReplica {
+  id: ID!
+  sessionId: ID!
+  revisionId: ID!
+  readinessStatus: ReadinessStatus!    # NOT_CHECKED | HEALTHY | UNHEALTHY
+  livenessStatus: LivenessStatus!      # NOT_CHECKED | HEALTHY | UNHEALTHY | DEGRADED
+  activenessStatus: ActivenessStatus!  # ACTIVE | INACTIVE
+  createdAt: DateTime!
+  sessionV2: SessionV2                 # since 26.4.3
+  revision: ModelRevision!
+}
+```
+
+### ModelDeployment (Strawberry)
+
+```graphql
+type ModelDeployment {
+  id: GlobalID!
+  endpointId: UUID!
+  name: String!
+  status: EndpointLifecycle!
+  replicas: Int!
+  activeReplicas: Int!
+  currentRevision: ModelRevision
+  routes(filter: RouteFilter, order: RouteOrder, offset: Int, first: Int): RouteConnection!
+  replicas_: ModelReplicaConnection! # (ModelReplica alias)
+}
+```
+
+---
+
+## 구현 단계 계획
+
+### Phase 1 — 기반 작업
+
+1. `backend.ai-client-esm.ts`에 `model-deployment-strawberry`, `model-replica` feature flag 추가
+2. `routes.tsx`: URL 경로 변경 + fallback 리디렉션 + 버전 분기 라우팅 골격
+3. `useWebUIMenuItems.tsx`: 메뉴 레이블 및 경로 업데이트
+4. i18n 신규 키 추가 (`en.json`)
+
+### Phase 2 — 공통 컴포넌트
+
+5. `ReplicaStatusTag.tsx` 신규 생성 + Storybook 스토리
+6. `DeploymentStatusTag.tsx` 신규 생성
+7. `DeploymentOwnerInfo.tsx` 신규 생성
+
+### Phase 3 — 배포 목록 페이지
+
+8. `DeploymentList.tsx` 신규 생성 (Strawberry API 기반)
+9. `DeploymentListPage.tsx` 신규 생성
+10. `AdminDeploymentListPage.tsx` 신규 생성
+
+### Phase 4 — 배포 생성/편집 페이지 (Launcher)
+
+11. `DeploymentLauncherPageContent.tsx` 신규 생성 (다단계 폼, create/edit 통합)
+12. `DeploymentLauncherPage.tsx` 신규 생성
+13. `createModelDeployment` + `addModelRevision` mutation 연동
+14. 편집 모드: `deployment.currentRevision` 기반 pre-fill + 안내 배너 + 확인 다이얼로그
+15. Relay 컴파일 + `__generated__` 파일 확인
+
+### Phase 5 — 배포 상세 페이지
+
+16. `DeploymentActivePoolSection.tsx` 신규 생성 (Active Pool 시각화)
+17. `DeploymentReplicasTab.tsx` 신규 생성 (Replica 목록 + 상세 Drawer)
+18. `DeploymentRevisionHistoryTab.tsx` 신규 생성 (Revision 목록 + Rollback)
+19. `DeploymentSettingsTab.tsx` 신규 생성
+20. `DeploymentAccessTokensTab.tsx` 신규 생성
+21. `DeploymentAutoScalingTab.tsx` 신규 생성
+22. `DeploymentDetailPage.tsx` 신규 생성 (모든 섹션/탭 조합)
+
+---
+
+## 관련 이슈
+
+- FR-2591: Route trafficStatus 수동 전환 (BAIRouteNodes의 TODO)
+- FR-2300: Diagnostics 시스템 (EndpointDiagnosticsSection 원본)
+- `draft-auto-scaling-rule-ux`: 오토스케일링 규칙 UX 개선
+- FR-2581: 이전 모델 서비스 UI 수정
+
+---
+
+## 변경 이력
+
+- 2026-04-21: 초기 초안 작성 (아키텍처 다이어그램 + 코드베이스 분석 기반)
+- 2026-04-21: 사용자 확인 사항 6개 반영하여 한국어로 전면 재작성
+  - URL: `/deployments` 변경 + `/serving` fallback 리디렉션
+  - API: 26.4.2 기준 버전 분기, 별도 파일 관리
+  - 색상: UNHEALTHY(red) vs DEGRADED(amber) 명확 구분
+  - Route = Replica 1:1 관계 확인 및 반영
+  - Active Pool 섹션: 메인 본문 배치
+  - 최소 백엔드 버전: 26.4.2
+- 2026-04-21: ServiceLauncherPage/ServiceLauncherPageContent 마이그레이션 범위 추가
+- 2026-04-21: 요구사항 전면 재구조화 — User Flow 중심으로 재작성
+  - US-1~US-8 구조 → Flow 1~6 사용자 흐름 중심으로 전환
+  - 신규 컴포넌트 처음부터 새로 작성 (기존 컴포넌트 rename/patch 방식 폐기)
+  - 구버전 컴포넌트는 라우팅 fallback 전용으로 유지 (수정 없음)
+  - 페이지 간 내비게이션 다이어그램 추가
+  - 컴포넌트 아키텍처 섹션 신설 (신규/유지/변경 파일 명확 구분)
+  - Phase 계획을 신규 빌드 중심으로 재편

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -9,8 +9,8 @@
 모델 서빙 UI의 용어와 아키텍처를 "Endpoint" 중심에서 "Deployment" 중심으로 전면 재구축합니다.  
 백엔드의 신규 Strawberry GraphQL API(`ModelDeployment`, `Route`, `ModelReplica`)와 정합성을 맞추며, 배포 라이프사이클과 레플리카 헬스 상태를 사용자가 한눈에 파악할 수 있는 Deployment UX를 새로 설계합니다.
 
-**최소 지원 백엔드 버전**: 26.4.2 (Strawberry API 지원 시작)  
-구버전(26.4.2 미만)은 라우팅 레벨에서 기존 Graphene 기반 Serving/Endpoint UI로 전달됩니다.
+**최소 지원 백엔드 버전**: 26.4.x (최신 LTS)  
+구버전 호환성 fallback 없음. 신규 Strawberry API 전용으로 구현하며, 구버전 Graphene 기반 Endpoint 컴포넌트는 삭제합니다.
 
 ---
 
@@ -37,12 +37,12 @@
 | # | 항목 | 결정 내용 |
 |---|------|-----------|
 | 1 | URL 경로 | `/deployments`로 변경. 기존 `/serving` → `/deployments` 리디렉션 fallback 유지 |
-| 2 | API 호환성 | 26.4.2 이상: 신규 Strawberry API 사용. 미만: 기존 Graphene UI 라우팅. **버전 분기는 라우팅 레벨에서만 처리, 컴포넌트 내 dual-support 없음** |
+| 2 | API 호환성 | 최신 LTS 26.4.x만 지원. 구버전 Graphene API 대응 없음. 신규 Strawberry API 전용으로 구현 |
 | 3 | 헬스 색상 구분 | UNHEALTHY → **red/error**, DEGRADED → **amber/warning** |
 | 4 | Route vs Replica | Route는 내부 구현 개념. UI에서는 **Replicas**로만 노출. 헬스/트래픽 상태는 각 Replica의 속성으로 표시 |
-| 5 | Active Pool 위치 | Deployment 상세 페이지 **Overview 섹션** (메인 본문 상단)에 배치 |
-| 6 | 최소 백엔드 버전 | **26.4.2**. `sessionV2`(26.4.3+) 같은 상위 버전 필드는 optional 처리하고 `@since` 디렉티브 또는 런타임 가드로 감싼다 |
-| 7 | 구버전 컴포넌트 처리 | 구버전 Graphene 기반 페이지/컴포넌트는 **그대로 유지** (fallback 라우팅용). 신규 컴포넌트는 처음부터 새로 작성 |
+| 5 | Active Pool 위치 | **Replicas 탭**에서 확인 (Overview 섹션에 배치하지 않음 — 중복) |
+| 6 | 최소 백엔드 버전 | **26.4.x** (최신 LTS). `sessionV2`(26.4.3+) 같은 상위 버전 필드는 optional 처리하고 `@since` 디렉티브 또는 런타임 가드로 감싼다 |
+| 7 | 구버전 컴포넌트 처리 | 구버전 Graphene 기반 페이지/컴포넌트는 **삭제**. 신규 Deployment 컴포넌트로 완전 교체 |
 | 8 | 편집 = 새 리비전 | 설정 변경 시 덮어쓰기 없음. `addModelRevision` mutation으로 새 리비전 스냅샷 생성 |
 
 ---
@@ -123,30 +123,15 @@ ModelReplica (Strawberry GQL 타입)
 
 ---
 
-## API 버전 분기 전략
-
-버전 분기는 **라우팅 레벨에서만** 처리합니다. 개별 컴포넌트 내에서 dual-support하지 않습니다.
-
-### 라우팅 분기 원칙
-
-```tsx
-// routes.tsx에서
-const DetailPage = baiClient.supports('model-deployment-strawberry')
-  ? DeploymentDetailPage    // 신규 컴포넌트 (26.4.2+)
-  : EndpointDetailPage;     // 기존 컴포넌트 유지 (fallback)
-```
-
-### Feature Flag 추가 (backend.ai-client-esm.ts)
+## Feature Flag (backend.ai-client-esm.ts)
 
 ```ts
-if (this.isManagerVersionCompatibleWith('26.4.2')) {
-  this._features['model-deployment-strawberry'] = true;
-  this._features['model-replica'] = true;
-}
 if (this.isManagerVersionCompatibleWith('26.4.3')) {
   this._features['model-deployment-extended-filter'] = true;
 }
 ```
+
+- `model-deployment-extended-filter`: 26.4.3+ 조건부 필터 필드 노출 여부 (관리자 전용 `domainName`, `resourceGroup`, `createdAt` 등)
 
 ---
 
@@ -199,7 +184,7 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 
 구현 요구사항:
 - [ ] `DeploymentListPage.tsx` 신규 생성 (`/deployments` 경로)
-- [ ] `DeploymentList.tsx` 신규 생성 — `useRefetchableFragment` 패턴, `myDeployments` query 기반
+- [ ] `DeploymentList.tsx` 신규 생성 — Relay 복수형 fragment를 받는 Table 컴포넌트 (`myDeployments` query 소유는 `DeploymentListPage`, `DeploymentList`는 `fragmentRef` 수신)
 - [ ] `DeploymentStatusTag.tsx` 신규 생성 (배포 라이프사이클 상태 표시)
 - [ ] 레플리카 헬스 요약 (`activeReplicas / replicas Healthy`) 컬럼 표시
 - [ ] "New Deployment" 버튼 → `/deployments/create`로 이동
@@ -269,7 +254,7 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
-│  New Deployment                         [Recent Deployments]         │
+│  New Deployment                                                       │
 ├────────────────────────────────────────────────┬─────────────────────┤
 │                                                │  1. Basic Info      │
 │  (폼 본문 — 현재 step 내용)                    │     ●               │
@@ -297,37 +282,7 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 3. Step 3 — **리소스**: GPU/CPU/메모리, 레플리카 수, 리소스 그룹, 클러스터 모드
 4. Step 4 — **검토 & 생성**: 입력 내용 요약 확인 후 제출
 
-**오른쪽 상단 버튼 — 기존 배포에서 가져오기 (FR-2419)**
-
-런처 폼 헤더 오른쪽 상단에 **"Recent Deployments"** 버튼을 배치합니다 (세션 런처의 "Recent History" 버튼과 동일한 패턴).
-
-"Recent Deployments" 버튼 클릭 시 모달(세션 런처의 Recent History 모달과 동일한 형태)을 열어 최근 배포 목록 표시:
-
-```
-┌────────────────────────────────────────────────────────────┐
-│  Recent Deployments                                    ✕   │
-├────────────────────────────────────────────────────────────┤
-│  These are your recent deployments. Click a name to        │
-│  pre-fill the form.                                        │
-│                                                            │
-│  Name              Runtime    Resources        CreatedAt   │
-│  ─────────────────────────────────────────────────────     │
-│  my-llama-service  vllm       A100 x2, 2 rep  2026-04-01   │
-│  gpt-sglang-prod   sglang     A100 x1, 1 rep  2026-03-28   │
-│  custom-model-v3   custom     H100 x4, 3 rep  2026-03-15   │
-│                                                            │
-│  (No data — empty state if no previous deployments)        │
-└────────────────────────────────────────────────────────────┘
-```
-
-모달에서 배포 선택 시:
-1. 해당 배포의 `currentRevision` 설정으로 폼 전체 pre-fill
-2. 이름 필드는 자동으로 초기화 (새 이름 입력 유도), 나머지 설정은 유지
-3. 모달 닫힘 → 사용자가 각 필드를 자유롭게 수정 후 제출
-
-데이터 소스:
-- `myDeploymentsV2` query로 최근 배포 목록 조회 (최대 10개, `createdAt` 내림차순)
-- 선택된 배포의 `currentRevision` 필드에서 설정 전체 읽기
+> **범위 외 (별도 spec)**: "기존 배포에서 가져오기" (Recent Deployments pre-fill) 기능은 FR-2419로 완전 별도 진행. 이 스펙에 포함하지 않음.
 
 제출 흐름:
 - `createModelDeployment` mutation → `deploymentId` 반환
@@ -346,19 +301,11 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
   - `Skip to Review »`: 마지막 step 전까지 표시, Review step으로 즉시 이동
   - Review step: `Create Deployment` (primary) 버튼
 - [ ] `createModelDeployment` + `addModelRevision` GQL mutation 연동
-- [ ] 폼 헤더 오른쪽 상단에 **"Recent Deployments"** 버튼 배치 (세션 런처 `SessionLauncherPage`의 Recent History 버튼 패턴 참조)
-- [ ] **Recent Deployments 모달** 구현 (FR-2419)
-  - `myDeploymentsV2` query로 최근 배포 목록 로드
-  - 선택 시 `currentRevision` 기반으로 폼 전체 pre-fill
-  - 이름 필드 초기화
-  - 빈 상태(no data) 처리
 - [ ] **URL 상태 동기화** (`nuqs` `useQueryStates` 사용): 새로고침 후에도 폼 상태 유지
   - `step`: 현재 단계 번호 (`parseAsInteger.withDefault(1)`)
   - `formValues`: 핵심 폼 값 JSON (`parseAsJson` 또는 `JsonParam`, `withDefault({})`)
   - 기존 `ServiceLauncherPageContent`의 `useQueryParams` 패턴 참조
 - [ ] 성공 후 상세 페이지로 이동
-
-관련 이슈: FR-2419 (Add 'Import from existing spec' feature in ModelService creation)
 
 ---
 
@@ -374,17 +321,9 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 
 **Overview 섹션** (메인 본문 상단, 탭 밖):
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  Active Pool                           [2 / 3 Healthy]      │
-│  AppProxy가 트래픽을 전달하는 레플리카 목록입니다.                    │
-├─────────────────────────────────────────────────────────────┤
-│  [● Replica 1]  HEALTHY   Rev. abc123  Traffic: 50%         │
-│  [● Replica 2]  HEALTHY   Rev. abc123  Traffic: 50%         │
-│  [○ Replica 3]  UNHEALTHY Rev. abc123  (트래픽 차단)  red      │
-│  [○ Replica 4]  DEGRADED  Rev. abc123  (유예 중)     amber    │
-└─────────────────────────────────────────────────────────────┘
+> **Active Pool은 Overview에서 제거.** 첫 번째 탭(Replicas)에서 이미 레플리카 상태를 전체 확인할 수 있으므로 중복. Configuration 카드만 Overview에 배치.
 
+```
 ┌─────────────────────────────────────────────────────────────┐
 │  Configuration                       [Edit Configuration]   │
 ├─────────────────────────────────────┬───────────────────────┤
@@ -397,10 +336,6 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 └─────────────────────────────────────┴───────────────────────┘
 ```
 
-- `healthStatus = HEALTHY` AND `trafficStatus = ACTIVE`인 레플리카: Active Pool 포함, 정상 표시
-- 그 외 레플리카: "트래픽 미수신" 시각적 표시 (점선 테두리 또는 dim)
-- DEGRADED: amber 경고 표시 (유예 중, 트래픽 차단)
-- UNHEALTHY: red 오류 표시 (확정 비정상, 트래픽 차단)
 - Configuration 카드: 현재 Active 리비전의 설정 요약 (읽기 전용). "Edit Configuration" 버튼 → Flow 4
 
 **탭 구성**:
@@ -432,7 +367,7 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 
 구현 요구사항:
 - [ ] `DeploymentDetailPage.tsx` 신규 생성 (Strawberry API 기반)
-- [ ] `DeploymentActivePoolSection.tsx` 신규 생성 (Overview 섹션 — Active Pool 시각화 + Configuration 카드 + "Edit Configuration" 버튼)
+- [ ] `DeploymentConfigurationSection.tsx` 신규 생성 (Overview 섹션 — Configuration 카드 + "Edit Configuration" 버튼)
 - [ ] `ReplicaStatusTag.tsx` 신규 생성 (Replica 헬스 상태 태그, 아래 별도 스펙 참조)
 - [ ] `DeploymentReplicasTab.tsx` 신규 생성 (Replicas 탭)
 - [ ] `DeploymentRevisionHistoryTab.tsx` 신규 생성 (Revision History 탭)
@@ -656,12 +591,16 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
 
 #### Flow 7: 모델 폴더에서 바로 배포 (Quick Deploy)
 
-모델 폴더 목록 또는 모델 카드에서 "Deploy" 버튼을 클릭하면 폼 없이 즉시 배포를 생성합니다.
+모델 폴더 목록 또는 모델 카드에서 배포를 시작합니다.
 
-**진입점**: 모델 폴더 목록, 모델 카드, Model Store 등 (`useDeploymentLauncher` hook 사용)
+**진입점**: 모델 폴더 목록, 모델 카드, Model Store 등
 
-사용자 경험:
-1. "Deploy" 버튼 클릭
+**버튼 구성** (`[Deploy | ▼]` 분할 버튼):
+- **`Deploy` (메인 버튼)**: 폼 없이 즉시 배포 생성 (기존 Quick Deploy 동작)
+- **`▼` (드롭다운 버튼)** → `세부 설정 후 배포하기` 메뉴 → `DeploymentLauncherPage` preview 단계(Step 2 또는 Step 1)로 이동, 모델 폴더 pre-fill
+
+**`Deploy` 버튼 Quick Deploy 사용자 경험:**
+1. "Deploy" 클릭
 2. 즉시 배포 생성 시작 — 별도 폼 없음
 3. 백그라운드 알림으로 진행 상황 표시: "배포를 시작하는 중..."
 4. 준비 완료 → 알림에 "/chat으로 이동" 링크 표시
@@ -721,7 +660,7 @@ react/src/components/
   DeploymentStatusTag.tsx              # 배포 상태 태그
   DeploymentLauncherPageContent.tsx    # 생성/편집 다단계 폼 본문
   ReplicaStatusTag.tsx                 # 레플리카 헬스 상태 태그
-  DeploymentActivePoolSection.tsx      # Active Pool 시각화 섹션
+  DeploymentConfigurationSection.tsx   # Overview 섹션 — Configuration 카드
   DeploymentReplicasTab.tsx            # Replicas 탭
   DeploymentRevisionHistoryTab.tsx     # Revision History 탭
   DeploymentAccessTokensTab.tsx        # Access Tokens 탭
@@ -729,32 +668,32 @@ react/src/components/
   DeploymentOwnerInfo.tsx              # 소유자 정보
 ```
 
-### 구버전 컴포넌트 (라우팅 fallback 전용, 변경 없이 유지)
+### 구버전 컴포넌트 (삭제 대상)
 
-26.4.2 미만 백엔드 접속 시 라우팅 레벨에서 아래 기존 페이지로 전달합니다. 이 파일들은 수정하지 않습니다.
+신규 Deployment 컴포넌트로 완전 교체하므로 아래 파일들을 삭제합니다.
 
 ```
 react/src/pages/
-  ServingPage.tsx                  # 구버전 fallback 유지
-  EndpointDetailPage.tsx           # 구버전 fallback 유지
-  ServiceLauncherPage.tsx          # 구버전 fallback 유지
+  ServingPage.tsx                  # 삭제
+  EndpointDetailPage.tsx           # 삭제
+  ServiceLauncherPage.tsx          # 삭제
 
 react/src/components/
-  EndpointList.tsx                 # 구버전 fallback 유지
-  EndpointStatusTag.tsx            # 구버전 fallback 유지
-  EndpointDiagnosticsSection.tsx   # 구버전 fallback 유지
-  EndpointOwnerInfo.tsx            # 구버전 fallback 유지
-  EndpointTokenGenerationModal.tsx # 구버전 fallback 유지
-  ServiceLauncherPageContent.tsx   # 구버전 fallback 유지
+  EndpointList.tsx                 # 삭제
+  EndpointStatusTag.tsx            # 삭제
+  EndpointDiagnosticsSection.tsx   # 삭제
+  EndpointOwnerInfo.tsx            # 삭제
+  EndpointTokenGenerationModal.tsx # 삭제
+  ServiceLauncherPageContent.tsx   # 삭제
 ```
 
 ### 변경 필요 파일
 
 | 파일 경로 | 변경 내용 |
 |----------|---------|
-| `react/src/routes.tsx` | URL 경로 변경, fallback 리디렉션 추가, 신규 페이지 import, 버전 분기 라우팅 |
+| `react/src/routes.tsx` | URL 경로 변경, fallback 리디렉션 추가, 신규 Deployment 페이지 import, 구버전 Endpoint 페이지 제거 |
 | `react/src/hooks/useWebUIMenuItems.tsx` | 메뉴 경로 및 레이블 업데이트 |
-| `src/lib/backend.ai-client-esm.ts` | `model-deployment-strawberry`, `model-replica`, `model-deployment-extended-filter` feature flag 추가 |
+| `src/lib/backend.ai-client-esm.ts` | `model-deployment-extended-filter` feature flag 추가 (26.4.3+ 조건부 필터용) |
 | `resources/i18n/en.json` | 신규 i18n 키 추가 (22개 언어 번역 필요) |
 
 ---
@@ -763,7 +702,7 @@ react/src/components/
 
 | 기존 Graphene 필드 | 신규 Strawberry 필드 |
 |-------------------|---------------------|
-| `endpoint.name` | `deployment.name` |
+| `endpoint.name` | `deployment.metadata.name` |
 | `endpoint.replicas` | `revision.replicaCount` |
 | `endpoint.resource_slots` | `revision.resourceSlots` |
 | `endpoint.resource_group` / `scaling_group` | revision 설정 내 해당 필드 |
@@ -774,7 +713,7 @@ react/src/components/
 | `endpoint.model_mount_destination` | `revision.modelDefinition.modelMountDestination` |
 | `endpoint.model_definition_path` | `revision.modelDefinition.modelDefinitionPath` |
 | `endpoint.extra_mounts` | `revision.modelDefinition.extraMounts` |
-| `endpoint.open_to_public` | `deployment.networkAccess.isPublic` |
+| `endpoint.open_to_public` | `deployment.networkAccess.openToPublic` |
 | `endpoint.cluster_mode`, `endpoint.cluster_size` | `revision.clusterConfig.mode`, `revision.clusterConfig.size` (`ClusterConfig` 타입) |
 
 ---
@@ -897,8 +836,8 @@ adminDeployments(filter: DeploymentFilter, orderBy: [DeploymentOrderBy!], limit:
 
 ### Phase 1 — 기반 작업
 
-1. `backend.ai-client-esm.ts`에 `model-deployment-strawberry`, `model-replica`, `model-deployment-extended-filter` feature flag 추가
-2. `routes.tsx`: URL 경로 변경 + fallback 리디렉션 + 버전 분기 라우팅 골격
+1. `backend.ai-client-esm.ts`에 `model-deployment-extended-filter` feature flag 추가 (26.4.3+ 조건부 필터용)
+2. `routes.tsx`: URL 경로 변경 + fallback 리디렉션 (신규 Deployment 페이지로 직접 라우팅)
 3. `useWebUIMenuItems.tsx`: 메뉴 레이블 및 경로 업데이트
 4. i18n 신규 키 추가 (`en.json`)
 
@@ -933,6 +872,14 @@ adminDeployments(filter: DeploymentFilter, orderBy: [DeploymentOrderBy!], limit:
 
 ---
 
+## 향후 작업 (이 스펙 이후)
+
+- **배포 지표 탭**: deployment에서 표시할 만한 지표가 있으면 상세 페이지에 별도 탭으로 추가
+- **상태 히스토리**: 배포의 상태 변경 이력을 UI에서 확인할 수 있도록 히스토리 뷰 제공
+- **기존 배포에서 가져오기** (FR-2419): 별도 spec으로 진행. Deployment 전반 구현 완료 후 단독 스펙 작성
+
+---
+
 ## 관련 이슈
 
 - FR-2591: Route trafficStatus 수동 전환 (BAIRouteNodes의 TODO)
@@ -944,6 +891,13 @@ adminDeployments(filter: DeploymentFilter, orderBy: [DeploymentOrderBy!], limit:
 
 ## 변경 이력
 
+- 2026-04-22: PR 리뷰 피드백 반영
+  - 구버전 Endpoint 컴포넌트 "유지" → "삭제 대상"으로 변경 (26.4.x LTS만 지원, fallback 제거)
+  - `DeploymentList.tsx` 패턴 수정: `useRefetchableFragment` → 복수형 fragment-receiving Table 컴포넌트
+  - "Recent Deployments" (FR-2419) 이 스펙에서 제거 → 완전 별도 spec으로 분리
+  - Overview 섹션에서 Active Pool 제거 (Replicas 탭과 중복), Configuration 카드만 유지
+  - Flow 7 Quick Deploy UX 변경: `[Deploy | ▼]` 분할 버튼 — `▼` 드롭다운에 "세부 설정 후 배포하기" 추가 → launcher preview 진입
+  - 향후 작업 섹션 추가 (배포 지표 탭, 상태 히스토리)
 - 2026-04-22: Flow 2 UX 변경 — 기본 진입을 빈 폼으로, "Recent Deployments" 버튼을 오른쪽 상단에 배치하여 모달로 기존 배포 선택 (세션 런처 Recent History 패턴)
 - 2026-04-21: 서버사이드 페이지네이션/필터/정렬 패턴 명세 추가 (DeploymentFilter, DeploymentOrderBy, isEnableSorter, convertToOrderBy, nuqs URL 직렬화)
 - 2026-04-21: Settings 탭 제거 → Overview 섹션의 Configuration 카드로 통합. 탭 5개 → 4개

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -219,10 +219,37 @@ DeploymentDetailPage (동일)
 **페이지: `DeploymentLauncherPage` (`/deployments/create`)**
 
 사용자 경험:
+
+**진입 방식 A — 빈 폼으로 시작**
 1. Step 1 — **기본 정보**: 배포 이름, 공개 여부 (`open_to_public`)
 2. Step 2 — **모델 & 런타임**: 모델 폴더(VFolder), 런타임 변형(`vllm` / `sglang` / `custom` 등), 컨테이너 이미지, 실행 커맨드(custom일 때만 표시)
 3. Step 3 — **리소스**: GPU/CPU/메모리, 레플리카 수, 리소스 그룹, 클러스터 모드
 4. Step 4 — **검토 & 생성**: 입력 내용 요약 확인 후 제출
+
+**진입 방식 B — 기존 배포에서 가져오기 (Import from existing, FR-2419)**
+
+폼 상단 또는 Step 1에 **"기존 배포에서 가져오기"** 버튼 제공:
+1. 버튼 클릭 → 최근 배포 목록 드로어/모달 열기
+2. 목록에서 배포 선택 → 해당 배포의 현재 Revision 설정으로 폼 전체 pre-fill
+3. 이름 필드는 자동으로 초기화 (새 이름 입력 유도), 나머지 설정은 유지
+4. 사용자가 각 필드를 자유롭게 수정 후 제출
+
+```
+┌────────────────────────────────────────────────────────┐
+│  새 배포 생성                                            │
+│                                                        │
+│  [기존 배포에서 가져오기 ▾]   또는 빈 폼으로 시작         │
+│                                                        │
+│  최근 배포                                              │
+│  ○ my-llama-service    vllm · A100 x2 · 2 replicas    │
+│  ○ gpt-sglang-prod     sglang · A100 x1 · 1 replica   │
+│  ○ custom-model-v3     custom · H100 x4 · 3 replicas  │
+└────────────────────────────────────────────────────────┘
+```
+
+데이터 소스:
+- `myDeploymentsV2` query로 최근 배포 목록 조회 (최대 10개, `createdAt` 내림차순)
+- 선택된 배포의 `currentRevision` 필드에서 설정 전체 읽기
 
 제출 흐름:
 - `createModelDeployment` mutation → `deploymentId` 반환
@@ -234,7 +261,13 @@ DeploymentDetailPage (동일)
 - [ ] `DeploymentLauncherPageContent.tsx` 신규 생성 (다단계 폼 본문)
 - [ ] Step 1~4 단계형 폼 레이아웃 구현
 - [ ] `createModelDeployment` + `addModelRevision` GQL mutation 연동
+- [ ] **"기존 배포에서 가져오기"** 버튼 및 최근 배포 선택 UI 구현 (FR-2419)
+  - `myDeploymentsV2` query로 최근 배포 목록 로드
+  - 선택 시 `currentRevision` 기반으로 폼 전체 pre-fill
+  - 이름 필드 초기화
 - [ ] 성공 후 상세 페이지로 이동
+
+관련 이슈: FR-2419 (Add 'Import from existing spec' feature in ModelService creation)
 
 ---
 
@@ -734,6 +767,7 @@ type ModelDeployment {
   - 최소 백엔드 버전: 26.4.2
 - 2026-04-21: ServiceLauncherPage/ServiceLauncherPageContent 마이그레이션 범위 추가
 - 2026-04-21: Flow 7 추가 — 모델 폴더에서 바로 배포 (useDeploymentLauncher, deployment-config.yaml 기반)
+- 2026-04-21: Flow 2에 "기존 배포에서 가져오기" 추가 (FR-2419 반영)
 - 2026-04-21: 요구사항 전면 재구조화 — User Flow 중심으로 재작성
   - US-1~US-8 구조 → Flow 1~6 사용자 흐름 중심으로 전환
   - 신규 컴포넌트 처음부터 새로 작성 (기존 컴포넌트 rename/patch 방식 폐기)

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -269,7 +269,7 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
-│  New Deployment                         [Recent Deployments]   ✕     │
+│  New Deployment                         [Recent Deployments]         │
 ├────────────────────────────────────────────────┬─────────────────────┤
 │                                                │  1. Basic Info      │
 │  (폼 본문 — 현재 step 내용)                    │     ●               │

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -196,11 +196,63 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
 
 구현 요구사항:
 - [ ] `DeploymentListPage.tsx` 신규 생성 (`/deployments` 경로)
-- [ ] `DeploymentList.tsx` 신규 생성 (Strawberry `deploymentsV2` 또는 `modelDeployments` query 기반)
+- [ ] `DeploymentList.tsx` 신규 생성 — `useRefetchableFragment` 패턴, `myDeployments` query 기반
 - [ ] `DeploymentStatusTag.tsx` 신규 생성 (배포 라이프사이클 상태 표시)
 - [ ] 레플리카 헬스 요약 (`activeReplicas / replicas Healthy`) 컬럼 표시
 - [ ] "New Deployment" 버튼 → `/deployments/create`로 이동
 - [ ] 행 클릭 → `/deployments/:deploymentId`로 이동
+
+**서버사이드 필터 / 정렬 / 페이지네이션 요구사항** (DeploymentList.tsx):
+
+- [ ] `BAIGraphQLPropertyFilter` 연동 — `DeploymentFilter` 지원 필드만 노출:
+
+  | 필드 | GQL 타입 | 버전 | 비고 |
+  |------|----------|------|------|
+  | `name` | `StringFilter` | 26.4.2+ | 항상 노출 |
+  | `status` | `DeploymentStatusFilter` | 26.4.2+ | `equals` 고정, `PENDING/SCALING/DEPLOYING/READY/STOPPING/STOPPED` 선택 |
+  | `endpointUrl` | `StringFilter` | 26.4.2+ | 항상 노출 |
+  | `tags` | `StringFilter` | 26.4.2+ | 항상 노출 |
+  | `openToPublic` | `Boolean` | 26.4.2+ | `valueMode: 'scalar'`, boolean 타입 |
+
+  필터 객체는 `nuqs`의 `parseAsJson<DeploymentFilter>`로 URL 직렬화:
+  ```ts
+  filter: parseAsJson<DeploymentFilter>((v) => v as DeploymentFilter)
+  ```
+
+- [ ] `BAITable` `order` / `onChangeOrder` 연동 — 서버에서 지원하는 필드에만 `sorter: true` 부여 (`isEnableSorter` 패턴):
+
+  ```ts
+  // DeploymentOrderField 기준으로 지원 여부 결정
+  const SORTABLE_KEYS = ['name', 'createdAt'] as const;
+  const isEnableSorter = (key: string) => SORTABLE_KEYS.includes(key as any);
+  ```
+
+  | 컬럼 | sorter | DeploymentOrderField 매핑 |
+  |------|--------|--------------------------|
+  | 배포 이름 (`name`) | ✅ | `NAME` |
+  | 상태 (`status`) | ❌ | 미지원 |
+  | 레플리카 요약 | ❌ | 미지원 |
+  | Endpoint URL | ❌ | 미지원 |
+  | 생성일 (`createdAt`) | ✅ | `CREATED_AT` |
+
+  BAITable의 `order` 문자열(`"name"` / `"-createdAt"` 등)을 `convertToOrderBy<DeploymentOrderBy>()` 헬퍼로 변환하여 query 변수에 전달:
+  ```ts
+  import { convertToOrderBy } from '../helper';
+  // "−createdAt" → [{ field: "CREATED_AT", direction: "DESC" }]
+  orderBy: convertToOrderBy<DeploymentOrderBy>(queryParams.order)
+  ```
+
+- [ ] URL 상태 (`nuqs` `useQueryStates`) — `urlKeyPrefix` 파라미터로 복수 인스턴스 충돌 방지:
+  ```ts
+  const [queryParams, setQueryParams] = useQueryStates({
+    current:  parseAsInteger.withDefault(1),
+    pageSize: parseAsInteger.withDefault(20),
+    order:    parseAsStringLiteral(deploymentSortableFields),
+    filter:   parseAsJson<DeploymentFilter>(...),
+  }, { history: 'replace', urlKeys: { current: 'dPage', pageSize: 'dSize', order: 'dOrder', filter: 'dFilter' } });
+  ```
+
+- [ ] 서버사이드 pagination: `myDeployments(limit, offset, ...)` — `count` 필드를 `BAITable.pagination.total`에 전달
 
 ---
 
@@ -409,8 +461,32 @@ if (this.isManagerVersionCompatibleWith('26.4.2')) {
 
 구현 요구사항:
 - [ ] `AdminDeploymentListPage.tsx` 신규 생성 (`/admin-deployments` 경로, 기존 `/admin-serving`, `/admin-session` 컨벤션과 일치)
-- [ ] `adminDeploymentsV2` query 사용
+- [ ] `adminDeployments` query 사용 (Flow 1의 `myDeployments` 대신)
 - [ ] 소유자 정보 표시 (`DeploymentOwnerInfo` 컴포넌트)
+
+**서버사이드 필터 / 정렬 / 페이지네이션 요구사항** (AdminDeploymentList 또는 DeploymentList에 `mode="admin"` prop):
+
+- [ ] Flow 1 필터에 추가되는 관리자 전용 필드 (26.4.3+ 조건부 노출):
+
+  | 필드 | GQL 타입 | 버전 조건 | 비고 |
+  |------|----------|-----------|------|
+  | `domainName` | `StringFilter` | 26.4.3+ | `baiClient.isManagerVersionCompatibleWith('26.4.3')` |
+  | `resourceGroup` | `StringFilter` | 26.4.3+ | 동일 |
+  | `createdAt` | `DateTimeFilter` | 26.4.3+ | datetime picker 사용 |
+
+  ```ts
+  const is26_4_3 = baiClient.isManagerVersionCompatibleWith('26.4.3');
+  filterProperties={filterOutEmpty([
+    { key: 'name', ... },          // 항상 노출
+    { key: 'status', ... },        // 항상 노출
+    is26_4_3 && { key: 'domainName', propertyLabel: t('...'), type: 'string' },
+    is26_4_3 && { key: 'resourceGroup', propertyLabel: t('...'), type: 'string' },
+    is26_4_3 && { key: 'createdAt', propertyLabel: t('...'), type: 'datetime' },
+  ])}
+  ```
+
+- [ ] 관리자 전용 컬럼 추가: `domainName`, `projectName`, 소유자(createdBy)
+- [ ] 정렬: Flow 1과 동일 + `DOMAIN`, `PROJECT`, `RESOURCE_GROUP` sorter 추가 (26.4.3+)
 
 ---
 
@@ -518,7 +594,15 @@ export interface ReplicaStatusTagProps extends Omit<BAITagProps, 'color'> {
     "DeploymentUpdated": "Deployment has been updated.",
     "DeploymentCreated": "Deployment has been created.",
     "FailedToUpdateDeployment": "Failed to update deployment.",
-    "FailedToCreateDeployment": "Failed to create deployment."
+    "FailedToCreateDeployment": "Failed to create deployment.",
+    "FilterByName": "Name",
+    "FilterByStatus": "Status",
+    "FilterByEndpointUrl": "Endpoint URL",
+    "FilterByTags": "Tags",
+    "FilterByOpenToPublic": "Public",
+    "FilterByDomainName": "Domain",
+    "FilterByResourceGroup": "Resource Group",
+    "FilterByCreatedAt": "Created At"
   }
 }
 ```
@@ -700,17 +784,69 @@ type ModelReplica {
 
 ```graphql
 type ModelDeployment {
-  id: GlobalID!
-  endpointId: UUID!
+  id: ID!                          # GlobalID (Relay)
+  metadata: ModelDeploymentMetadata!
+  networkAccess: ModelDeploymentNetworkAccess!
+  replicaState: ReplicaState!      # { desiredReplicaCount: Int! }
+  currentRevision: ModelRevision   # since 26.4.3
+  creator: UserV2                  # since 26.4.3
+  replicas(filter, orderBy, limit, offset): ModelReplicaConnection!
+  revisionHistory(filter, orderBy, limit, offset): ModelRevisionConnection!
+  autoScalingRules(filter, orderBy, limit, offset): AutoScalingRuleConnection!
+  accessTokens(filter, orderBy, limit, offset): AccessTokenConnection!
+}
+
+type ModelDeploymentMetadata {
   name: String!
-  status: EndpointLifecycle!
-  replicas: Int!
-  activeReplicas: Int!
-  currentRevision: ModelRevision
-  routes(filter: RouteFilter, order: RouteOrder, offset: Int, first: Int): RouteConnection!
-  replicas_: ModelReplicaConnection! # (ModelReplica alias)
+  status: DeploymentStatus!        # PENDING | SCALING | DEPLOYING | READY | STOPPING | STOPPED
+  tags: [String!]!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  projectId: ID!
+  domainName: String!
+}
+
+type ModelDeploymentNetworkAccess {
+  endpointUrl: String
+  openToPublic: Boolean!
+}
+
+type ReplicaState {
+  desiredReplicaCount: Int!
 }
 ```
+
+### DeploymentFilter / DeploymentOrderBy
+
+```graphql
+input DeploymentFilter {
+  name: StringFilter           # 26.4.2+
+  status: DeploymentStatusFilter
+  openToPublic: Boolean
+  tags: StringFilter
+  endpointUrl: StringFilter
+  domainName: StringFilter     # 26.4.3+
+  projectId: UUIDFilter        # 26.4.3+
+  resourceGroup: StringFilter  # 26.4.3+
+  createdUserId: UUIDFilter    # 26.4.3+
+  createdAt: DateTimeFilter    # 26.4.3+
+  AND/OR/NOT: [DeploymentFilter!]
+}
+
+input DeploymentOrderBy {
+  field: DeploymentOrderField!  # NAME | CREATED_AT | DESTROYED_AT | DOMAIN | PROJECT | RESOURCE_GROUP | TAG
+  direction: OrderDirection! = DESC
+}
+```
+
+쿼리 시그니처:
+```graphql
+myDeployments(filter: DeploymentFilter, orderBy: [DeploymentOrderBy!], limit: Int, offset: Int): ModelDeploymentConnection!
+projectDeployments(scope: ProjectDeploymentScope!, filter: ..., orderBy: ..., limit: Int, offset: Int): ModelDeploymentConnection!
+adminDeployments(filter: DeploymentFilter, orderBy: [DeploymentOrderBy!], limit: Int, offset: Int): ModelDeploymentConnection!
+```
+
+`convertToOrderBy<DeploymentOrderBy>(orderString)` 헬퍼(`react/src/helper/index.tsx`)로 BAITable 문자열 포맷(`"-createdAt"`) → `[{ field: "CREATED_AT", direction: "DESC" }]` 변환.
 
 ---
 
@@ -765,6 +901,7 @@ type ModelDeployment {
 
 ## 변경 이력
 
+- 2026-04-21: 서버사이드 페이지네이션/필터/정렬 패턴 명세 추가 (DeploymentFilter, DeploymentOrderBy, isEnableSorter, convertToOrderBy, nuqs URL 직렬화)
 - 2026-04-21: Settings 탭 제거 → Overview 섹션의 Configuration 카드로 통합. 탭 5개 → 4개
 - 2026-04-21: 초기 초안 작성 (아키텍처 다이어그램 + 코드베이스 분석 기반)
 - 2026-04-21: 사용자 확인 사항 6개 반영하여 한국어로 전면 재작성

--- a/.specs/FR-1368-endpoint-deployment-migration/spec.md
+++ b/.specs/FR-1368-endpoint-deployment-migration/spec.md
@@ -261,38 +261,53 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 
 #### Flow 2: 새 배포 생성 (Create Deployment)
 
-사용자가 "New Deployment"를 클릭하면 다단계 생성 폼으로 이동합니다.
+사용자가 "New Deployment"를 클릭하면 **즉시 빈 런처 폼으로 진입**합니다. 세션 런처와 동일한 UX 패턴을 따릅니다.
 
 **페이지: `DeploymentLauncherPage` (`/deployments/create`)**
 
-사용자 경험:
-
-**진입 방식 A — 빈 폼으로 시작**
+**기본 진입 — 빈 폼으로 바로 시작**
 1. Step 1 — **기본 정보**: 배포 이름, 공개 여부 (`open_to_public`)
 2. Step 2 — **모델 & 런타임**: 모델 폴더(VFolder), 런타임 변형(`vllm` / `sglang` / `custom` 등), 컨테이너 이미지, 실행 커맨드(custom일 때만 표시)
 3. Step 3 — **리소스**: GPU/CPU/메모리, 레플리카 수, 리소스 그룹, 클러스터 모드
 4. Step 4 — **검토 & 생성**: 입력 내용 요약 확인 후 제출
 
-**진입 방식 B — 기존 배포에서 가져오기 (Import from existing, FR-2419)**
+**오른쪽 상단 버튼 — 기존 배포에서 가져오기 (FR-2419)**
 
-폼 상단 또는 Step 1에 **"기존 배포에서 가져오기"** 버튼 제공:
-1. 버튼 클릭 → 최근 배포 목록 드로어/모달 열기
-2. 목록에서 배포 선택 → 해당 배포의 현재 리비전 설정으로 폼 전체 pre-fill
-3. 이름 필드는 자동으로 초기화 (새 이름 입력 유도), 나머지 설정은 유지
-4. 사용자가 각 필드를 자유롭게 수정 후 제출
+런처 폼 헤더 오른쪽 상단에 **"Recent Deployments"** 버튼을 배치합니다 (세션 런처의 "Recent History" 버튼과 동일한 패턴):
 
 ```
-┌────────────────────────────────────────────────────────┐
-│  새 배포 생성                                             │
-│                                                        │
-│  [기존 배포에서 가져오기 ▾]   또는 빈 폼으로 시작                │
-│                                                        │
-│  최근 배포                                               │
-│  ○ my-llama-service    vllm · A100 x2 · 2 replicas     │
-│  ○ gpt-sglang-prod     sglang · A100 x1 · 1 replica    │
-│  ○ custom-model-v3     custom · H100 x4 · 3 replicas   │
-└────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│  New Deployment                  [Recent Deployments]  ✕    │
+├─────────────────────────────────────────────────────────────┤
+│  Step 1  Step 2  Step 3  Step 4                             │
+│                                                             │
+│  (빈 폼)                                                    │
+└─────────────────────────────────────────────────────────────┘
 ```
+
+"Recent Deployments" 버튼 클릭 시 모달(세션 런처의 Recent History 모달과 동일한 형태)을 열어 최근 배포 목록 표시:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Recent Deployments                                    ✕   │
+├────────────────────────────────────────────────────────────┤
+│  These are your recent deployments. Click a name to        │
+│  pre-fill the form.                                        │
+│                                                            │
+│  Name              Runtime    Resources        CreatedAt   │
+│  ─────────────────────────────────────────────────────     │
+│  my-llama-service  vllm       A100 x2, 2 rep  2026-04-01   │
+│  gpt-sglang-prod   sglang     A100 x1, 1 rep  2026-03-28   │
+│  custom-model-v3   custom     H100 x4, 3 rep  2026-03-15   │
+│                                                            │
+│  (No data — empty state if no previous deployments)        │
+└────────────────────────────────────────────────────────────┘
+```
+
+모달에서 배포 선택 시:
+1. 해당 배포의 `currentRevision` 설정으로 폼 전체 pre-fill
+2. 이름 필드는 자동으로 초기화 (새 이름 입력 유도), 나머지 설정은 유지
+3. 모달 닫힘 → 사용자가 각 필드를 자유롭게 수정 후 제출
 
 데이터 소스:
 - `myDeploymentsV2` query로 최근 배포 목록 조회 (최대 10개, `createdAt` 내림차순)
@@ -308,10 +323,12 @@ if (this.isManagerVersionCompatibleWith('26.4.3')) {
 - [ ] `DeploymentLauncherPageContent.tsx` 신규 생성 (다단계 폼 본문)
 - [ ] Step 1~4 단계형 폼 레이아웃 구현
 - [ ] `createModelDeployment` + `addModelRevision` GQL mutation 연동
-- [ ] **"기존 배포에서 가져오기"** 버튼 및 최근 배포 선택 UI 구현 (FR-2419)
+- [ ] 폼 헤더 오른쪽 상단에 **"Recent Deployments"** 버튼 배치 (세션 런처 `SessionLauncherPage`의 Recent History 버튼 패턴 참조)
+- [ ] **Recent Deployments 모달** 구현 (FR-2419)
   - `myDeploymentsV2` query로 최근 배포 목록 로드
   - 선택 시 `currentRevision` 기반으로 폼 전체 pre-fill
   - 이름 필드 초기화
+  - 빈 상태(no data) 처리
 - [ ] **URL 상태 동기화** (`nuqs` `useQueryStates` 사용): 새로고침 후에도 폼 상태 유지
   - `step`: 현재 단계 번호 (`parseAsInteger.withDefault(1)`)
   - `formValues`: 핵심 폼 값 JSON (`parseAsJson` 또는 `JsonParam`, `withDefault({})`)
@@ -904,6 +921,7 @@ adminDeployments(filter: DeploymentFilter, orderBy: [DeploymentOrderBy!], limit:
 
 ## 변경 이력
 
+- 2026-04-22: Flow 2 UX 변경 — 기본 진입을 빈 폼으로, "Recent Deployments" 버튼을 오른쪽 상단에 배치하여 모달로 기존 배포 선택 (세션 런처 Recent History 패턴)
 - 2026-04-21: 서버사이드 페이지네이션/필터/정렬 패턴 명세 추가 (DeploymentFilter, DeploymentOrderBy, isEnableSorter, convertToOrderBy, nuqs URL 직렬화)
 - 2026-04-21: Settings 탭 제거 → Overview 섹션의 Configuration 카드로 통합. 탭 5개 → 4개
 - 2026-04-21: 초기 초안 작성 (아키텍처 다이어그램 + 코드베이스 분석 기반)


### PR DESCRIPTION
Resolves #4198 (FR-1416)

## Summary
- Add feature spec for Endpoint → Deployment UI migration
- Epic: FR-1368 (Model deployment & Revision #1)
- Reference docs: `docs/deployment-migration-guide.md`, AppProxy Route Health diagram

## Spec Highlights

- **7 User Flows**: Deployment list / Create / Detail (tabs) / Edit / Rollback / Admin list / Quick Deploy from model folder
- **ID naming convention**: URL param `:deploymentId` (UUID) vs GraphQL `$deploymentId` (GlobalID via `toGlobalId`)
- **Version branching**: `baiClient.supports('model-deployment-strawberry')` (≥26.4.2) — handled at routing level only, no dual-support inside components
- **Health state machine**: NOT_CHECKED(gray) / HEALTHY(green) / UNHEALTHY(red) / DEGRADED(amber)
- **Detail page Overview section**: Active Pool visualization + Configuration card (Settings tab removed, merged into Overview)
- **Detail page 4 tabs**: Replicas / Revision History / Access Tokens / Auto-scaling
- **Edit = new Revision**: `addModelRevision` mutation — no in-place overwrite; confirmation dialog shown before submit
- **Legacy fallback**: `/serving` → `/deployments` redirect + old Graphene-based components kept untouched as routing fallback