### PR TITLE
feat(FR-2618): add sToken login boundary component spec

### DIFF
--- a/.specs/draft-stoken-login-boundary/dev-plan.md
+++ b/.specs/draft-stoken-login-boundary/dev-plan.md
@@ -1,0 +1,272 @@
+# sToken Login Boundary — Dev Plan
+
+## Parent References
+
+| Item | Key | Link |
+|---|---|---|
+| Epic | **FR-2616** | https://lablup.atlassian.net/browse/FR-2616 |
+| Spec Task | **FR-2618** | https://lablup.atlassian.net/browse/FR-2618 |
+| Spec PR (draft) | **#6828** | branch `04-21-feat_add_stoken_login_boundary_component_spec_draft_` |
+| Spec document | — | `.specs/draft-stoken-login-boundary/spec.md` (Korean) |
+
+> This plan is English per CLAUDE.md. Sub-task acceptance references cite Korean spec section headings verbatim as stable anchors.
+
+## Resolved Open Questions
+
+Decisions locked for implementation. Each picks the spec's own recommendation where one exists, and defers a small set to explicit verification sub-tasks.
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| Q1 | `tokenLogin` helper: extend vs. bypass | **(a) Extend** `helper/loginSessionAuth.ts:tokenLogin` with optional 5th arg `extraParams?: Record<string, string>`; pass through to `client.token_login(sToken, extraParams)` | Spec-recommended. Keeps `connectViaGQL` responsibility inside helper, LoginView callers unaffected. |
+| Q2 | Include `loadConfigFromWebServer` in boundary? | **Exclude** | Matches current LoginView sToken path behavior. If a caller needs webserver config merge it can invoke it inside `onSuccess`. Keeps boundary narrowly focused on authentication. |
+| Q3 | Endpoint resolve hook name | **(a) Rename** `useEduAppApiEndpoint` → `useResolvedApiEndpoint`; update both callers | Cosmetic debt is cheaper to pay once; avoids long-lived "Edu" prefix on a now-general hook. |
+| Q4 | `errorFallback` fallthrough policy for `endpoint-unresolved` | **`errorFallback` wins for all error kinds when provided** | Predictable and simpler; EduAppLauncher needs its stepper-integrated UI even for `endpoint-unresolved`. |
+| Q5 | Cookie encoding backend compatibility | **Add verification sub-task under Story 1** (read webserver source; confirm or flip default) | Not a blocker; result is "confirm current encoding choice or fall back to raw value". |
+| Q6 | `concurrent-session` detection signal | **Defer**: do not attempt detection in first pass; emit `{ kind: 'unknown' }` with TODO pointing to `.specs/draft-concurrent-login-guard/` | Signal shape depends on unresolved sibling spec; premature detection risks inconsistency. |
+| Q7 | `useSToken` helper hook adoption | **(a) Add the hook in Story 1**, use in both LoginView and EduAppLauncher routes | Two callers share `sToken`/`stoken` fallback + deprecation warning; the hook pays for itself immediately. |
+| Q8 | EduAppLauncher sToken reuse (line 631 `get_user_credential`) | **(a) Route reads sToken, passes via prop to `EduAppLauncher`** — but first a Story 3 verification sub-task checks whether `get_user_credential` is dead code (option (d) kills plumbing entirely if so) | Verify before designing plumbing. Minimal change if dead; clean prop path if live. |
+
+## Story Overview
+
+| Story | Key | PR stack branch | Depends on | Parallelizable |
+|---|---|---|---|---|
+| 1. Introduce `STokenLoginBoundary` | **FR-2625** | `feat/stoken-login-boundary-story-1-component` | — | — |
+| 2. Migrate `LoginView` sToken path | **FR-2626** | `feat/stoken-login-boundary-story-2-loginview` | FR-2625 | with Story 3 |
+| 3. Migrate `EduAppLauncher` sToken path | **FR-2627** | `feat/stoken-login-boundary-story-3-eduapplauncher` | FR-2625 | with Story 2 |
+
+Dependency graph:
+
+```
+Story 1 ──blocks──→ Story 2
+Story 1 ──blocks──→ Story 3
+(Story 2 ↔ Story 3 independent)
+```
+
+---
+
+## Story 1 — Introduce `STokenLoginBoundary` component
+
+**Jira Story**: **FR-2625**
+**PR stack branch**: `feat/stoken-login-boundary-story-1-component`
+**Goal**: Land the new boundary component, supporting hook(s), helper extension, and unit tests. No existing caller is migrated in this story.
+
+### Sub-tasks
+
+#### 1.1 Generalize endpoint resolve hook
+- **Key**: **FR-2628**
+- **Files**: `react/src/hooks/useEduAppApiEndpoint.ts` → `react/src/hooks/useResolvedApiEndpoint.ts`; update all import sites (`react/src/components/EduAppLauncher*` and any stories/tests).
+- **Approach**: Rename file + export, strip "Edu-only" wording from JSDoc, keep `cachedEndpoint` / `inflightPromise` module-scope caching behavior unchanged.
+- **Acceptance mapping**: spec "엔드포인트 resolve 훅", Acceptance Criteria "엔드포인트 resolve" bullets.
+- **Dependencies**: none.
+- **Review complexity**: Low (mechanical rename).
+
+#### 1.2 Extend `tokenLogin` helper with optional `extraParams`
+- **Key**: **FR-2629**
+- **Files**: `react/src/helper/loginSessionAuth.ts`
+- **Approach**: Change signature to `tokenLogin(client, sToken, cfg, endpoints, extraParams?: Record<string, string>)`. Pass `extraParams ?? {}` to `client.token_login`. Existing LoginView caller remains valid (fifth arg defaults).
+- **Acceptance mapping**: spec "Risks & Open Questions" Q1 resolution; component Acceptance Criteria "`extraParams`가 `client.token_login`의 두 번째 인자로 그대로 전달된다".
+- **Dependencies**: none.
+- **Review complexity**: Low.
+
+#### 1.3 Add `useSToken` helper hook (nuqs)
+- **Key**: **FR-2630**
+- **Files**: `react/src/hooks/useSToken.ts` (new)
+- **Approach**: Follow spec section "공용 helper hook 제안" literally — `useQueryState('sToken', parseAsString)` + `useQueryState('stoken', parseAsString)`, prefer canonical key, emit `useBAILogger` `.warn` once per session when only `stoken` provided, return `[effective, clear]` tuple where `clear` nulls both keys.
+- **Acceptance mapping**: spec "URL 파라미터 파싱 규약 (nuqs)"; acceptance "호출자 코드(`routes.tsx` 또는 페이지 컴포넌트)가 nuqs로 `sToken`을 읽고, `onSuccess` 콜백에서 setter로 URL에서 `sToken`을 제거한다".
+- **Dependencies**: none.
+- **Review complexity**: Low.
+
+#### 1.4 Implement `STokenLoginBoundary` component (core)
+- **Key**: **FR-2631**
+- **Files**: `react/src/components/STokenLoginBoundary.tsx` (new)
+- **Approach**: Follow spec "컴포넌트 설계" and "내부 동작 시퀀스" strictly: Props API exactly as in spec, state machine `idle → resolving-endpoint → cookie → client → ping → token-login → gql → success` (internal naming flexible); use `useResolvedApiEndpoint` (1.1); call the extended `tokenLogin` (1.2) + `connectViaGQL`; dispatch `backend-ai-connected` exactly once on final success; guard StrictMode double-fire with `useRef` started flag; do NOT import `useLoginOrchestration`. No `window.location` / `URLSearchParams` / `window.history` / `document.location` references anywhere in the file. `errorFallback` wins for all kinds when provided (Q4). `concurrent-session` not detected in first pass (Q6) — generic errors map to `{ kind: 'unknown' }`. Use `'use memo'` directive.
+- **Acceptance mapping**: spec "컴포넌트 설계", "내부 동작 시퀀스", "멱등성과 재시도", Acceptance Criteria "컴포넌트 자체" + "URL 파싱 금지 불변 조건".
+- **Dependencies**: 1.1 (blocks), 1.2 (blocks).
+- **Review complexity**: **High** (novel async control flow + StrictMode/race invariants).
+
+#### 1.5 Default fallback and error card UI
+- **Key**: **FR-2632**
+- **Files**: `react/src/components/STokenLoginBoundary.tsx` (same file as 1.4, staged separately), `resources/i18n/*.json` (per i18n skill), `packages/backend.ai-ui/src/locale/*.json` only if a BAI-UI primitive is extended
+- **Approach**: Use `BAICard` (prefer BAI components over Ant Design). Retry button uses `BAIButton` with `action` prop (auto loading state). Copy-details button serializes `{ kind, cause }` to JSON and writes to clipboard. i18n keys grouped under `component.STokenLoginBoundary.*`. Fallback "connecting" card also renders through `BAICard` for visual consistency.
+- **Acceptance mapping**: spec "에러 처리 & 기본 에러 카드 UI".
+- **Dependencies**: 1.4 (blocks).
+- **Review complexity**: Medium (new UI + i18n, straightforward patterns).
+
+#### 1.6 Unit tests — state transitions, event-once, URL-free
+- **Key**: **FR-2633**
+- **Files**: `react/src/components/__tests__/STokenLoginBoundary.test.tsx` (new)
+- **Approach**: Mock `globalThis.BackendAIClient` / `BackendAIClientConfig`, mock `useResolvedApiEndpoint`. Assert:
+  - Each `STokenLoginError.kind` transition (inject failure at each stage).
+  - `document.dispatchEvent('backend-ai-connected')` called exactly once across success path; zero times across failure; still exactly once after retry-then-success sequence.
+  - Cookie value is `encodeURIComponent(sToken)`.
+  - Retry invokes the sequence again without duplicate events.
+  - Children never mount until success; use render spy.
+  - No `window.location` / `URLSearchParams` / `window.history` mocking needed (grep test below enforces this is possible).
+- **Acceptance mapping**: Acceptance Criteria "컴포넌트 자체" + "URL 파싱 금지 불변 조건".
+- **Dependencies**: 1.4 (blocks), 1.5 (blocks — to assert error card renders).
+- **Review complexity**: Medium.
+
+#### 1.7 CI grep rule: forbid URL-related APIs in boundary
+- **Key**: **FR-2634**
+- **Files**: `scripts/verify.sh` or a small dedicated script under `scripts/`; optional ESLint custom rule if simpler
+- **Approach**: Add a step that greps `react/src/components/STokenLoginBoundary.tsx` (and any sub-module under `STokenLoginBoundary/` if extracted) for forbidden tokens: `window.location`, `window.history`, `document.location`, `URLSearchParams`. Fail the build on match. Document the rule near the top of the boundary file with a comment referencing the spec.
+- **Acceptance mapping**: Acceptance "grep / ESLint custom rule로 검증 가능".
+- **Dependencies**: 1.4 (blocks).
+- **Review complexity**: Low.
+
+#### 1.8 Verify Manager/Webserver cookie decoding (Q5)
+- **Key**: **FR-2635**
+- **Files**: No code change expected. Findings captured in sub-task Jira comment and, if a policy flip is needed, rolled into a follow-up under 1.4.
+- **Approach**: Read Backend.AI Manager / Webserver source (external repo) to confirm the `sToken` cookie value is `decodeURIComponent`-ed before comparison / lookup. If it is NOT, revise 1.4 to set the cookie unencoded and update the spec's Pitfall #3. If it is, close the sub-task with a comment citing the file/line.
+- **Acceptance mapping**: spec Pitfall #3, Open Question 5.
+- **Dependencies**: can run in parallel with 1.4, must complete before Story 2/3 merge.
+- **Review complexity**: Low (investigation only).
+
+### Story 1 internal dependency graph
+
+```
+1.1 ─┐
+     ├─→ 1.4 ─→ 1.5 ─→ 1.6
+1.2 ─┘          └─→ 1.7
+1.3 (parallel)
+1.8 (investigation, parallel)
+```
+
+---
+
+## Story 2 — Migrate `LoginView` sToken path
+
+**Jira Story**: **FR-2626**
+**PR stack branch**: `feat/stoken-login-boundary-story-2-loginview`
+**Goal**: Route `/` and `/interactive-login` wrap their subtrees with `STokenLoginBoundary` when `sToken` is present; delete the duplicated sToken branch inside `LoginView`.
+
+### Sub-tasks
+
+#### 2.1 Wrap `/` and `/interactive-login` routes with `STokenLoginBoundary`
+- **Key**: **FR-2636**
+- **Files**: `react/src/routes.tsx`
+- **Approach**: In the `Component` of `/` and `/interactive-login`, call `useSToken()`; conditionally wrap the existing `DefaultProvidersForReactRoot` subtree with `STokenLoginBoundary` only when `sToken` is truthy (scenario A in spec "사용 패턴"). `errorFallback` not supplied — built-in card is correct for LoginView. Pass an `onSuccess` placeholder that is fleshed out in 2.2.
+- **Acceptance mapping**: spec 사용 패턴 시나리오 A.
+- **Dependencies**: Story 1 (blocks).
+- **Review complexity**: Medium (route-level plumbing, shell wrapping).
+
+#### 2.2 Move `postConnectSetup` side effects to route-level `onSuccess`
+- **Key**: **FR-2637**
+- **Files**: `react/src/routes.tsx` (same route `Component` as 2.1), `react/src/components/LoginView.tsx` (only where `postConnectSetup` was exported from; keep function usable for non-sToken path)
+- **Approach**: Extract or call into `postConnectSetup(client)` from the `onSuccess` callback: `last_login` / `login_attempt` counters, `clearSavedLoginInfo`, `setPluginApiEndpoint`, localStorage `backendaiwebui.api_endpoint` persistence using `client._config.endpoint` (spec Pitfall #8), `main-layout-ready` wait + panel close, finally `clear()` from `useSToken()` to strip `sToken`/`stoken` from URL. Do NOT import `useLoginOrchestration` into the route Component.
+- **Acceptance mapping**: spec "마이그레이션 계획 Story 2", Pitfall #8.
+- **Dependencies**: 2.1 (blocks).
+- **Review complexity**: **High** (state ordering, Pitfall #8 closure rule, main-layout-ready signal).
+
+#### 2.3 Remove `connectUsingSession` sToken branch in `LoginView`
+- **Key**: **FR-2638**
+- **Files**: `react/src/components/LoginView.tsx` (current lines 455–490 range — verify exact range at implementation time; line numbers drift)
+- **Approach**: Delete the sToken branch inside `connectUsingSession()` and any internal URL parsing specific to sToken. The normal ID/PW path remains unchanged. `useLoginOrchestration` continues to own multi-tab / auto-logout / config gating for the non-sToken path.
+- **Acceptance mapping**: Acceptance "마이그레이션 후 `LoginView.tsx`에서 `connectUsingSession()` 내 sToken 분기가 제거되며…".
+- **Dependencies**: 2.1 (blocks), 2.2 (blocks — so onSuccess captures all side effects first).
+- **Review complexity**: Medium (deletion, but must confirm no hidden callers).
+
+#### 2.4 E2E regression — LoginView sToken entry
+- **Key**: **FR-2639**
+- **Files**: `e2e/` (add or extend existing sToken entry scenario — confirm presence first)
+- **Approach**: Playwright scenario: visit `/?sToken=<valid>`; assert login completes, URL no longer contains `sToken` after success, MainLayout renders. Add negative case: `/?sToken=<invalid>` shows error card with Retry.
+- **Acceptance mapping**: Acceptance "Story 2 적용 후 LoginView의 sToken 진입 시나리오가 기존 E2E 테스트…를 통과한다".
+- **Dependencies**: 2.1, 2.2, 2.3 (blocks).
+- **Review complexity**: Medium.
+
+### Story 2 internal dependency graph
+
+```
+2.1 ─→ 2.2 ─→ 2.3 ─→ 2.4
+```
+
+---
+
+## Story 3 — Migrate `EduAppLauncher` sToken path
+
+**Jira Story**: **FR-2627**
+**PR stack branch**: `feat/stoken-login-boundary-story-3-eduapplauncher`
+**Goal**: Route `/edu-applauncher` and `/applauncher` always wrap their subtree with `STokenLoginBoundary`; delete `_token_login` and manual `backend-ai-connected` dispatch; handle Pitfall #8 (`get_user_credential(sToken)` at line 631) via the resolved strategy.
+
+### Sub-tasks
+
+#### 3.1 Verify `get_user_credential(sToken)` liveness (Q8 prerequisite)
+- **Key**: **FR-2640**
+- **Files**: Investigation only; findings captured in Jira sub-task comment.
+- **Approach**: Check whether `backendaiclient.eduApp.get_user_credential` is implemented in the backend.ai client library (`src/lib/backend.ai-client-esm.ts` or equivalent) AND whether any Backend.AI Manager endpoint currently responds. If method is missing or routinely 404s, the code at `react/src/components/EduAppLauncher.tsx:631` is dead — switch plan to **option (d)**: delete the call entirely in 3.3 and skip the sToken prop plumbing. If live, proceed with **option (a)**: pass sToken as prop to `EduAppLauncher` in 3.2.
+- **Acceptance mapping**: spec Pitfall #8, Open Question 8.
+- **Dependencies**: Story 1 (blocks — needs the decision before 3.2/3.3 scope).
+- **Review complexity**: Low (investigation).
+
+#### 3.2 Wrap `/edu-applauncher` and `/applauncher` routes with `STokenLoginBoundary`
+- **Key**: **FR-2641**
+- **Files**: `react/src/routes.tsx`, `react/src/components/EduAppLauncher.tsx` (small surface: accept optional `sToken` prop if 3.1 resolves to option (a))
+- **Approach**: Always wrap (scenario B). Read `sToken` via `useSToken()`, collect `extraParams` with `useQueryStates` (exclude `sToken`/`stoken`), pass both to `STokenLoginBoundary`. Provide `errorFallback` that renders a stepper-integrated error step (reuse existing `EduAppErrorStep` or equivalent). `onSuccess` clears `sToken`/`stoken` from URL only (other keys preserved — spec Pitfall #7). If 3.1 resolved to option (a), pass `sToken` prop through to `EduAppLauncher`; if option (d), skip the prop.
+- **Acceptance mapping**: spec 사용 패턴 시나리오 B.
+- **Dependencies**: 3.1 (blocks), Story 1 (blocks).
+- **Review complexity**: **High** (stepper UI integration, Q8 branch).
+
+#### 3.3 Remove `_token_login` and manual `backend-ai-connected` dispatch
+- **Key**: **FR-2642**
+- **Files**: `react/src/components/EduAppLauncher.tsx`
+- **Approach**: Delete `_token_login()` method (current lines 201–237). Delete the manual `document.dispatchEvent(new CustomEvent('backend-ai-connected'...))` call (current ~line 787 — verify). Delete URL parsing for `sToken`/`stoken` inside the component. If 3.1 resolved to option (d), also delete the `get_user_credential(sToken)` block (currently lines ~628–644) — confirm tests/fixtures don't reference the call.
+- **Acceptance mapping**: Acceptance "`EduAppLauncher.tsx`에서 `_token_login()` 메서드와 수동 `backend-ai-connected` 디스패치가 제거된다".
+- **Dependencies**: 3.2 (blocks).
+- **Review complexity**: Medium.
+
+#### 3.4 E2E regression — EduApp entry with / without `session_id`
+- **Key**: **FR-2643**
+- **Files**: `e2e/` (extend existing EduApp scenarios)
+- **Approach**: Two scenarios: `/edu-applauncher?sToken=<valid>&app=jupyter&session_id=<existing>` (session reuse path) and `/edu-applauncher?sToken=<valid>&app=jupyter` (session create path). Both must succeed with no regression. **URL retention**: the sToken stays in the URL after success (no behavior change vs. old impl on this axis — intentional, so `_createEduSession.get_user_credential(sToken)` keeps working). Negative: invalid sToken surfaces the stepper-integrated error step.
+- **Acceptance mapping**: Acceptance "Story 3 적용 후 EduAppLauncher의 sToken 진입 시나리오(세션 ID 있음·없음)가 회귀 없이 통과한다".
+- **Dependencies**: 3.2 (blocks), 3.3 (blocks).
+- **Review complexity**: Medium.
+
+### Story 3 internal dependency graph
+
+```
+3.1 ─→ 3.2 ─→ 3.3 ─→ 3.4
+```
+
+---
+
+## Full Dependency Graph (cross-story)
+
+```
+Story 1
+ ├─ 1.1 ─┐
+ │       ├─→ 1.4 ─→ 1.5 ─→ 1.6
+ ├─ 1.2 ─┘          └─→ 1.7
+ ├─ 1.3 (parallel)
+ └─ 1.8 (investigation, parallel to 1.4)
+        │
+        ▼
+Story 2 (blocked by Story 1)
+ 2.1 ─→ 2.2 ─→ 2.3 ─→ 2.4
+
+Story 3 (blocked by Story 1; parallel with Story 2)
+ 3.1 ─→ 3.2 ─→ 3.3 ─→ 3.4
+```
+
+Wave estimate for `/batch-implement`:
+- **Wave 1** (Story 1): 1.1, 1.2, 1.3, 1.8 in parallel; then 1.4; then 1.5 and 1.7 in parallel; then 1.6.
+- **Wave 2** (Story 2 and Story 3 in parallel): 2.1 → 2.2 → 2.3 → 2.4, and 3.1 → 3.2 → 3.3 → 3.4.
+
+## Risks & Notes
+
+- **Pitfall #8 closure discipline**: 2.2's `onSuccess` must read `client._config.endpoint` (not a captured `apiEndpoint` closure) when writing localStorage. Reviewer should grep the diff for `apiEndpoint` / `endpoint` identifiers in the onSuccess body.
+- **StrictMode double-fire**: 1.4's internal `useRef` started flag must survive React 19 StrictMode dev double-effect. Unit test in 1.6 should render under StrictMode wrapper and assert event-once holds.
+- **Concurrent-session deferred**: When the sibling `.specs/draft-concurrent-login-guard/` lands, a follow-up sub-task will extend `STokenLoginError` with the real `concurrent-session` detection. Not in scope here.
+- **URL handling differs between Story 2 and Story 3**: LoginView (`/`, `/interactive-login`) strips the sToken from the URL on success (security — the URL is a generic web entry point and a stale token could leak via history / referer). EduAppLauncher (`/edu-applauncher`, `/applauncher`) retains the URL verbatim because `_createEduSession` re-reads sToken via the prop (customer-specific `get_user_credential` call) and the `app` / `session_id` / resource-hint params drive the downstream Relay loader. The EduApp token URL is issued by the integrating LMS, so leaving it in the browser history is an accepted trade-off.
+- **Q5 verification outcome risks re-work on 1.4**: If Manager/Webserver expects raw cookie values, 1.4's `encodeURIComponent` becomes incorrect and must be flipped before Story 2/3 merge. 1.8 is the gate.
+- **`useSToken` logger choice**: Use `useBAILogger` per React instructions; do not use `console.*`.
+- **`loadConfigFromWebServer` not included (Q2)**: If a future SSO entry point requires it, the caller can invoke it from `onSuccess`. Document this in the component's JSDoc so it's discoverable.
+
+## Out of Scope
+
+- `useLoginOrchestration` responsibilities (multi-tab sync, auto-logout, config gating) stay in `LoginView`.
+- Normal ID/PW login extraction.
+- `concurrent-session` detection and its modal UX (tracked in `.specs/draft-concurrent-login-guard/`).
+- Storybook stories for the new component (can be added as a follow-up).
+- Directory rename `.specs/draft-stoken-login-boundary/` → `.specs/FR-2616-stoken-login-boundary/` (follow-up per metadata.json `notes`).
+- Backend.AI Manager server changes.

--- a/.specs/draft-stoken-login-boundary/metadata.json
+++ b/.specs/draft-stoken-login-boundary/metadata.json
@@ -1,0 +1,82 @@
+{
+  "epicKey": "FR-2616",
+  "epicUrl": "https://lablup.atlassian.net/browse/FR-2616",
+  "specTaskKey": "FR-2618",
+  "specTaskUrl": "https://lablup.atlassian.net/browse/FR-2618",
+  "devPlanPath": ".specs/draft-stoken-login-boundary/dev-plan.md",
+  "jiraFilingPending": false,
+  "proposedEpicTitle": "Extract sToken login flow into reusable boundary component",
+  "proposedSpecTaskTitle": "Define sToken login boundary component spec",
+  "slug": "stoken-login-boundary",
+  "stories": [
+    {
+      "key": "FR-2625",
+      "url": "https://lablup.atlassian.net/browse/FR-2625",
+      "title": "Story 1: Introduce STokenLoginBoundary component",
+      "prStackBranch": "feat/stoken-login-boundary-story-1-component",
+      "subtasks": [
+        { "key": "FR-2628", "title": "[1.1] Rename useEduAppApiEndpoint to useResolvedApiEndpoint" },
+        { "key": "FR-2629", "title": "[1.2] Extend tokenLogin helper with optional extraParams" },
+        { "key": "FR-2630", "title": "[1.3] Add useSToken hook (nuqs) with stoken fallback and deprecation warning" },
+        { "key": "FR-2631", "title": "[1.4] Implement STokenLoginBoundary component core" },
+        { "key": "FR-2632", "title": "[1.5] Default fallback and error card UI" },
+        { "key": "FR-2633", "title": "[1.6] Unit tests for STokenLoginBoundary state transitions and invariants" },
+        { "key": "FR-2634", "title": "[1.7] CI grep rule forbidding URL APIs in STokenLoginBoundary" },
+        { "key": "FR-2635", "title": "[1.8] Verify Manager/Webserver cookie decoding for sToken (Q5)" }
+      ]
+    },
+    {
+      "key": "FR-2626",
+      "url": "https://lablup.atlassian.net/browse/FR-2626",
+      "title": "Story 2: Migrate LoginView sToken path to STokenLoginBoundary",
+      "prStackBranch": "feat/stoken-login-boundary-story-2-loginview",
+      "blockedBy": ["FR-2625"],
+      "subtasks": [
+        { "key": "FR-2636", "title": "[2.1] Wrap / and /interactive-login routes with STokenLoginBoundary conditionally" },
+        { "key": "FR-2637", "title": "[2.2] Move postConnectSetup side effects into route-level onSuccess" },
+        { "key": "FR-2638", "title": "[2.3] Remove connectUsingSession sToken branch and URL parsing in LoginView" },
+        { "key": "FR-2639", "title": "[2.4] E2E regression for LoginView sToken entry" }
+      ]
+    },
+    {
+      "key": "FR-2627",
+      "url": "https://lablup.atlassian.net/browse/FR-2627",
+      "title": "Story 3: Migrate EduAppLauncher sToken path to STokenLoginBoundary",
+      "prStackBranch": "feat/stoken-login-boundary-story-3-eduapplauncher",
+      "blockedBy": ["FR-2625"],
+      "subtasks": [
+        { "key": "FR-2640", "title": "[3.1] Investigate get_user_credential(sToken) liveness (Q8)" },
+        { "key": "FR-2641", "title": "[3.2] Wrap /edu-applauncher and /applauncher routes with STokenLoginBoundary" },
+        { "key": "FR-2642", "title": "[3.3] Remove _token_login and manual backend-ai-connected dispatch in EduAppLauncher" },
+        { "key": "FR-2643", "title": "[3.4] E2E regression for EduApp sToken entry with and without session_id" }
+      ]
+    }
+  ],
+  "proposedStories": [
+    {
+      "title": "Introduce STokenLoginBoundary component",
+      "summary": "New component, generalized endpoint-resolve hook, extend tokenLogin helper with extraParams (pending Open Question 1), default fallback + error card UI, unit tests."
+    },
+    {
+      "title": "Migrate LoginView sToken path to STokenLoginBoundary",
+      "summary": "Replace connectUsingSession sToken branch (lines 455–490 of LoginView.tsx) with boundary wrapping; move post-login side effects to onSuccess callback."
+    },
+    {
+      "title": "Migrate EduAppLauncher sToken path to STokenLoginBoundary",
+      "summary": "Remove _token_login and manual backend-ai-connected dispatch; wrap stepper auth step with boundary; supply errorFallback for stepper-integrated error UI; strip sToken from URL (behavior change)."
+    }
+  ],
+  "resolvedOpenQuestions": {
+    "Q1_tokenLogin_extension": "extend (option a) — add optional extraParams arg to tokenLogin helper",
+    "Q2_loadConfigFromWebServer": "exclude — caller may invoke inside onSuccess if needed",
+    "Q3_endpoint_hook_name": "rename useEduAppApiEndpoint to useResolvedApiEndpoint (option a)",
+    "Q4_errorFallback_fallthrough": "errorFallback wins for all kinds when provided",
+    "Q5_cookie_encoding_verification": "verification sub-task FR-2635 under Story 1",
+    "Q6_concurrent_session_detection": "defer — emit unknown kind with TODO",
+    "Q7_useSToken_hook": "adopt in Story 1 as FR-2630",
+    "Q8_eduapp_sToken_reuse": "default option (a) prop-threading; FR-2640 first verifies if option (d) deletion applies"
+  },
+  "sourceIssues": [],
+  "createdAt": "2026-04-21T00:00:00Z",
+  "notes": "Epic FR-2616 filed. Spec Task FR-2618 created as sub-issue under the Epic. Spec PR #6828 resolves FR-2618. Dev plan landed on same PR stack. 3 Stories + 16 sub-tasks created; see stories[] for keys. Directory still uses draft- prefix; rename to FR-2616-stoken-login-boundary as a follow-up."
+}

--- a/.specs/draft-stoken-login-boundary/spec.md
+++ b/.specs/draft-stoken-login-boundary/spec.md
@@ -1,0 +1,518 @@
+# sToken 로그인 경계 컴포넌트 (sToken Login Boundary)
+
+## 개요
+
+URL 쿼리 파라미터 `sToken`을 통해 Backend.AI에 SSO 방식으로 로그인하는 플로우를, 재사용 가능한 단일 React 컴포넌트로 추출한다. 현재 동일한 sToken 인증 로직이 `LoginView.tsx`와 `EduAppLauncher.tsx` 두 곳에 각각 다른 형태로 복제되어 있어, 쿠키 인코딩, URL 파라미터 대소문자 처리, `backend-ai-connected` 이벤트 디스패치 시점 등이 서로 다르게 구현되어 있다. 이 불일치는 향후 외부 플랫폼 통합(교육·파트너·SSO 엔트리 포인트 추가)이 늘어날 때마다 동일한 버그와 보안 고려사항을 반복해서 해결해야 하는 문제를 만든다.
+
+본 스펙은 이 플로우를 에러 바운더리와 유사한 "로그인 경계 컴포넌트"로 추출하여, 자식 트리가 마운트되기 전 sToken 인증을 완료하고 Relay 환경이 안전하게 동작할 수 있는 상태를 보장하는 것을 목표로 한다.
+
+## 문제 정의
+
+### 현재 상태의 중복과 불일치
+
+현재 sToken 기반 로그인 로직은 다음 두 호출 지점에 독립적으로 구현되어 있다.
+
+**1. `react/src/components/LoginView.tsx` — `connectUsingSession()` (lines 405–490)**
+
+- URL 파라미터는 `sToken`만 인식 (`urlParams.get('sToken')`, 대소문자 구분)
+- 쿠키 값을 **인코딩하지 않음**: `document.cookie = sToken=${sToken}; ...`
+- `helper/loginSessionAuth.ts:175`의 `tokenLogin(client, sToken, cfg, endpoints)` 헬퍼 사용 (extraParams 전달 경로 없음)
+- 성공 시 `postConnectSetup(client)` 실행 — `last_login` 카운터, `clearSavedLoginInfo`, `backend-ai-connected` 이벤트 디스패치, 엔드포인트 localStorage 저장, `main-layout-ready` 대기 후 패널 닫기
+- 성공 시 `window.history.replaceState({}, '', '/')` 로 URL에서 sToken 제거
+- 멀티탭/자동 로그아웃/config 게이팅은 `useLoginOrchestration()` 훅이 담당
+
+**2. `react/src/components/EduAppLauncher.tsx` — `_token_login()` (lines 201–237)**
+
+- URL 파라미터는 `sToken`과 `stoken` **둘 다 허용** (대소문자 혼용)
+- 쿠키 값을 `encodeURIComponent(sToken)`으로 **인코딩**
+- 다른 URL 파라미터를 모두 `extraParams`로 수집하여 `client.token_login(sToken, extraParams)`로 전달
+- URL에서 sToken을 **제거하지 않음** (URL이 그대로 브라우저 히스토리에 남음)
+- `backend-ai-connected` 이벤트를 `_launch()` 내부 별도 위치(line 787)에서 수동 디스패치하며, `LoginView`를 경유하지 않음
+- 자체 상태 머신(`idle → auth → session → launching → done/error`) 관리
+
+### 이 중복이 만드는 구체적 위험
+
+1. **Relay 환경 race**: `RelayEnvironment.ts`의 `waitForBAIClient()`는 `'backend-ai-connected'` 이벤트를 기다려야만 해제된다. 두 호출 지점에서 이벤트 디스패치 순서가 다르기 때문에, 새로운 진입 지점을 추가할 때마다 Relay 쿼리 블로킹 규칙을 재학습해야 한다.
+2. **URL sToken 유출**: EduAppLauncher 경로에서는 sToken이 URL에 남아 브라우저 히스토리·referer·공유 링크를 통해 유출될 위험이 있다.
+3. **쿠키 인코딩 불일치**: 한쪽은 인코딩하고 다른 쪽은 하지 않아, 백엔드 쿠키 파서가 두 형식 모두를 허용한다는 암묵적 가정에 의존하고 있다.
+4. **파라미터 이름 규칙 부재**: `sToken` vs `stoken` 허용 여부가 경로별로 다르며, 외부 플랫폼 문서화 없이 내부 코드 관찰로만 알 수 있다.
+5. **유지보수 비용**: 신규 SSO 진입점을 추가할 때마다 두 구현 중 하나를 모방하게 되며, 모방 대상에 따라 보안·UX 기본값이 달라진다.
+
+## 목표 / 비목표
+
+### 목표
+
+- sToken 기반 로그인 흐름을 재사용 가능한 React 컴포넌트 하나로 추출한다.
+- 컴포넌트의 API는 호출자가 부가적인 후처리(패널 닫기, 멀티탭 상태, `last_login` 카운터 등)를 자유롭게 수행할 수 있도록 **최소한의 책임**만 갖는다.
+- `LoginView`와 `EduAppLauncher` 양쪽을 새 컴포넌트로 마이그레이션하여 중복 로직을 제거한다.
+- 마이그레이션은 **각 호출 지점마다 독립된 PR**로 분리하여 스택 기반으로 진행한다.
+- 쿠키 인코딩, URL 정리, 파라미터 이름 규칙을 컴포넌트 내부에 **단일 표준**으로 고정한다.
+
+### 비목표 (Out of Scope)
+
+- `useLoginOrchestration`이 담당하는 멀티탭 동기화, 자동 로그아웃, config 게이팅은 컴포넌트 범위에 포함하지 않는다. LoginView가 계속 담당한다.
+- 일반 세션 로그인(ID/PW) 플로우의 추출은 이 스펙에 포함하지 않는다. 본 컴포넌트는 **sToken 경로 전용**이다.
+- 동시 로그인 세션(Concurrent Login) 모달 UI는 이 컴포넌트가 제공하지 않는다. 에러 종류로만 노출하며, 처리는 `.specs/draft-concurrent-login-guard/spec.md`를 따른다.
+- `last_login` 카운터, `clearSavedLoginInfo`, `localStorage('backendaiwebui.api_endpoint')` 저장, `setPluginApiEndpoint`, `main-layout-ready` 대기, 로그인 패널 닫기 등 **호출자 고유의 후처리**는 컴포넌트가 수행하지 않는다. 호출자가 `onSuccess` 콜백에서 처리한다.
+- Backend.AI Manager 서버 측 변경은 포함하지 않는다.
+- Storybook 스토리 작성은 이 스펙의 필수 항목이 아니다 (후속 dev-plan에서 결정).
+
+## 사용자 시나리오
+
+### 시나리오 1: `LoginView`를 통한 sToken URL 진입
+
+1. 외부 시스템이 `https://webui.example.com/?sToken=...`로 사용자를 리다이렉트한다.
+2. `LoginView`가 마운트되면서 경계 컴포넌트로 자식 트리를 감싼다.
+3. 경계 컴포넌트가 URL에서 `sToken`을 읽고, 기본 fallback(연결 중 카드)을 표시한다.
+4. 쿠키 설정 → 엔드포인트 resolve → 클라이언트 생성 → `client.token_login(sToken)` → `globalThis.backendaiclient` 설정 → `'backend-ai-connected'` 이벤트 디스패치 → URL에서 sToken 제거 순으로 수행한다.
+5. 성공 시 `onSuccess(client)` 콜백이 호출되며, `LoginView`는 기존 `postConnectSetup` 로직(패널 닫기, `last_login` 카운터, localStorage 저장 등)을 실행한다.
+6. 자식 트리(메인 레이아웃)가 마운트되고, 내부 Relay 쿼리가 정상적으로 인증된 클라이언트로 수행된다.
+
+### 시나리오 2: `EduAppLauncher`를 통한 sToken URL 진입
+
+1. 외부 교육 플랫폼이 `https://webui.example.com/eduapi?sToken=...&app=jupyter&session_id=...`로 사용자를 리다이렉트한다.
+2. `EduAppLauncherPage`가 엔드포인트 resolve 후 `EduAppLauncher`를 렌더하며, `EduAppLauncher`는 자신의 스테퍼 UI 내부에서 경계 컴포넌트로 자식 트리를 감싼다.
+3. 경계 컴포넌트가 URL에서 `sToken`/`stoken`을 읽고 나머지 파라미터를 `extraParams`로 전달받아 `client.token_login(sToken, extraParams)`를 호출한다.
+4. `extraParams`(app, session_id, cpu, mem 등)은 그대로 백엔드에 전달되어 기존 동작을 유지한다.
+5. 성공 후 `EduAppLauncher`는 `onSuccess` 콜백에서 기존 `_prepareProjectInformation` → 세션 조회/생성 → 앱 런칭 스텝을 이어서 진행한다.
+6. URL은 **그대로 유지된다** — `sToken`도 제거하지 않는다. EduAppLauncher의 `_createEduSession`이 customer-specific `eduApp.get_user_credential(sToken)` 호출에서 원본 token을 다시 사용해야 하고, `app` / `session_id` / 리소스 힌트 같은 다른 파라미터도 후속 스텝에서 계속 참조되기 때문이다. 교육용 진입 URL은 LMS가 발급하므로 브라우저 히스토리에 남는 것이 허용 가능한 트레이드오프로 본다.
+
+### 시나리오 3: 미래의 제3 SSO 엔트리 포인트 (비전, 이 스펙 범위 밖)
+
+- 향후 추가될 수 있는 파트너 통합·이메일 매직 링크 등의 진입점은 경계 컴포넌트를 그대로 재사용하여 Relay 환경 초기화 race와 URL 정리·쿠키 인코딩 등 기본 보안 요구를 자동으로 만족한다. 이 스펙은 그 기반을 제공하는 것이 목표이다.
+
+## 컴포넌트 설계
+
+### 이름과 배치
+
+**이름**: `STokenLoginBoundary`
+
+**근거**: 사용자 요청에서 "에러 바운더리 이런 식으로"라고 표현된 비유를 따른다. React의 ErrorBoundary가 자식 트리 렌더링 중 발생하는 에러를 경계에서 차단·처리하듯, 이 컴포넌트는 자식 트리 마운트 전에 sToken 인증이라는 **전제 조건**을 해결한다. 인증이 완료되기 전에는 자식을 렌더하지 않는다는 점에서 "boundary"라는 명명이 의미적으로 맞다.
+
+**배치**: `react/src/components/STokenLoginBoundary.tsx` — 다른 주요 컴포넌트들과 동일한 경로. 관련 타입(`STokenLoginError`)은 동일 파일에서 export하거나, 파일이 커지면 `react/src/components/STokenLoginBoundary/` 디렉터리로 분리한다.
+
+### Props API
+
+```tsx
+interface STokenLoginBoundaryProps {
+  // 필수 — 호출자가 nuqs로 URL 쿼리에서 읽어 넘긴다.
+  // 컴포넌트는 내부에서 URL을 직접 파싱하지 않는다 (URL 파라미터 파싱 규약 섹션 참조).
+  sToken: string;
+  children: React.ReactNode;
+
+  // client.token_login에 두 번째 인자로 그대로 전달되는 추가 파라미터.
+  // 호출자가 nuqs로 수집하거나 정적 객체로 구성해 넘긴다.
+  extraParams?: Record<string, string>;
+
+  // 생명주기 훅 — 호출자가 자신의 후처리를 수행 (패널 닫기, last_login 카운터,
+  // nuqs setter로 URL에서 sToken 제거 등).
+  onSuccess?: (client: BackendAIClient) => void;
+  onError?: (error: STokenLoginError) => void;
+
+  // 렌더 슬롯 — 둘 다 선택, 기본 UI 제공
+  fallback?: React.ReactNode;
+  errorFallback?: (error: STokenLoginError, retry: () => void) => React.ReactNode;
+}
+```
+
+**주의**
+
+- **`apiEndpoint` prop은 제공하지 않는다.** 엔드포인트는 컴포넌트 내부에서 config.toml 기반 훅으로 resolve한다. 테스트용 override는 첫 이터레이션에 포함하지 않으며, 필요해질 경우 후속 이슈에서 결정한다.
+- **`sToken`은 prop으로만 받는다.** 컴포넌트는 `window.location`, `URLSearchParams`, `window.history` 등 URL 관련 API를 **일절 참조하지 않는다**. URL 파싱 책임은 전적으로 호출자에게 있으며 라이브러리는 `nuqs`를 사용한다 (다음 섹션 참조).
+- **`sToken`이 빈 문자열이거나 유효하지 않은 값인 경우**에도 컴포넌트는 이를 URL에서 재조회하지 않는다. `{ kind: 'missing-token' }` 에러 상태로 전이한다.
+
+### 에러 분류 (`STokenLoginError`)
+
+```tsx
+type STokenLoginError =
+  | { kind: 'missing-token' }                          // URL·prop 모두에서 sToken을 찾지 못함
+  | { kind: 'endpoint-unresolved'; cause: unknown }     // config.toml fetch/parse 실패 또는 엔드포인트 빈 문자열
+  | { kind: 'server-unreachable'; cause: unknown }      // get_manager_version 등 사전 확인 실패
+  | { kind: 'token-invalid'; cause: unknown }           // token_login이 false 반환 또는 인증 실패 예외
+  | { kind: 'concurrent-session'; cause: unknown }      // 서버가 동시 세션 상태를 반환한 경우 (상세는 concurrent-login-guard 스펙 참조)
+  | { kind: 'unknown'; cause: unknown };                // 상기 분류에 해당하지 않는 기타 예외
+```
+
+각 분류는 `onError`로 전달되며, 기본 에러 카드 UI도 분류별 메시지를 표시한다. `cause`는 원본 예외를 보존한다.
+
+### 내부 동작 시퀀스
+
+경계 컴포넌트는 성공 상태가 되기 전까지 **절대 자식을 렌더하지 않는다**. 동작 순서는 다음과 같다.
+
+1. **마운트**: 컴포넌트가 마운트되면 내부 로컬 상태를 `pending`으로 두고 `fallback`(기본: 연결 중 카드)을 렌더한다. 단, 엔드포인트 resolve 훅이 render 중 promise를 throw해 Suspense 경계에 걸리는 구간은 **호출자가 배치한 바깥쪽 `<Suspense fallback={...}>`가 처리**한다(아래 "사용 패턴 (라우트 통합 예시)" 섹션 참조). 경계 컴포넌트 자신의 `fallback`은 훅 resolve가 끝난 이후 token_login·connectViaGQL 등 **로컬 상태로 진행되는 pending 구간**에서 렌더된다.
+2. **sToken 검증**: prop으로 받은 `sToken`을 그대로 사용한다. URL 파싱은 수행하지 않는다 (호출자가 nuqs로 이미 파싱해 넘긴 값이다). 값이 빈 문자열 또는 `null`/`undefined`(타입 시스템이 막지 못한 경우에 대한 방어)이면 `{ kind: 'missing-token' }` 에러 상태로 전이.
+3. **엔드포인트 resolve**: 공용 엔드포인트 resolve 훅을 사용하여 config.toml에서 엔드포인트를 얻는다 (#엔드포인트-resolve-훅 섹션 참조). 실패 시 `{ kind: 'endpoint-unresolved', cause }`.
+4. **쿠키 설정**: `document.cookie = sToken=${encodeURIComponent(sToken)}; path=/; Secure; SameSite=Lax`로 설정. 세션 쿠키로 유지하기 위해 `Expires`/`Max-Age`는 지정하지 않으며, 값은 **항상 인코딩**한다.
+5. **클라이언트 생성**: `createBackendAIClient('', '', endpoint, 'SESSION')`로 Backend.AI 클라이언트 인스턴스를 만들고 `globalThis.backendaiclient`에 할당한다.
+6. **서버 ping (선택적 방어 단계)**: `client.get_manager_version()`을 호출하여 서버 도달 가능 여부를 사전 확인. 실패 시 `{ kind: 'server-unreachable', cause }`.
+7. **토큰 로그인**: `await client.token_login(sToken, extraParams ?? {})`. 반환이 falsy거나 예외 발생 시 `{ kind: 'token-invalid', cause }` 또는 서버 응답으로부터 동시 세션이 감지되면 `{ kind: 'concurrent-session', cause }`로 분류.
+8. **GQL 연결**: `connectViaGQL(client, loginConfig, endpoints)`를 호출해 사용자 정보 및 리소스 정책을 로드.
+9. **이벤트 디스패치**: `document.dispatchEvent(new CustomEvent('backend-ai-connected', { detail: client }))`를 **정확히 한 번** 디스패치한다. 이 이벤트는 `RelayEnvironment.ts`의 `waitForBAIClient()`를 해제하는 핵심 신호이다.
+10. **성공 콜백**: `onSuccess?.(client)` 호출. 호출자는 이 시점에서 자신의 후처리(패널 닫기, `last_login` 등)를 수행한다. URL 정리(nuqs setter로 sToken 제거)는 **호출자의 선택 사항**이다 — 범용 `/` / `/interactive-login` 진입점은 보안상 제거하고, EduAppLauncher처럼 `sToken`이 이후 스텝에서 재사용되는 플로우는 URL을 그대로 두는 식으로 경로별로 다르게 결정한다 (다음 섹션 참조).
+11. **자식 렌더**: 성공 상태 전이 후 `children`을 렌더.
+
+컴포넌트 본체에는 `window.location`, `URLSearchParams`, `window.history.replaceState`, `document.location` 등 **URL 관련 API를 일절 참조하지 않는다**. 이는 코드 리뷰와 단위 테스트로 강제한다.
+
+### 멱등성과 재시도
+
+- Retry 동작은 내부 상태를 초기 상태(idle)로 되돌린 뒤 위 시퀀스를 재실행한다.
+- 쿠키 재설정은 동일 값으로 덮어쓰므로 문제가 없다.
+- `'backend-ai-connected'` 이벤트는 **성공한 최종 시도에서만 1회 디스패치**되어야 한다. 재시도 과정에서 이전 실패 시에 이벤트가 누출되지 않도록 한다.
+- `globalThis.backendaiclient`는 성공 시점에 최신 client 인스턴스로 할당한다.
+
+## 에러 처리 & 기본 에러 카드 UI
+
+호출자가 자체 에러 UI를 제공하지 않을 경우, 컴포넌트는 **기본 내장 에러 카드**를 렌더한다. 사용자가 "무언가를 할 수 있는" 카드여야 하며, 단순 텍스트 에러 메시지로는 불충분하다.
+
+### 요구 사항
+
+- 에러 카드는 `BAICard` 기반으로 구성한다 (프로젝트 컴포넌트 컨벤션 따름).
+- 카드 헤더에는 에러 분류(`STokenLoginError.kind`)에 맞춘 i18n 제목을 표시한다.
+- 카드 본문에는 사람이 읽을 수 있는 설명 + 원본 예외 메시지를 접힘/펼침 가능한 영역에 표시한다.
+- 카드 액션은 최소 두 개를 제공한다:
+  - **Retry** (`BAIButton`의 `action` prop 사용 — 비동기 재시도 중 자동 로딩 상태 표시)
+  - **Copy error details** (에러 분류 + cause의 JSON 직렬화 결과를 클립보드에 복사, 지원 문의 시 사용)
+- `errorFallback` prop이 주어지면 기본 카드 대신 호출자 정의 렌더를 사용한다. 이 경우 `retry` 함수가 두 번째 인자로 전달되며, 호출자가 원하는 UI에서 이를 트리거한다.
+- EduAppLauncher는 자체 스테퍼 UI와 통합된 에러 표시가 필요하므로 `errorFallback`을 사용한다.
+
+### 에러 분류별 UX 원칙 (참고)
+
+| kind | 기본 UX | 커스텀 UX 예시 |
+|------|---------|----------------|
+| `missing-token` | "토큰이 URL에 포함되지 않았습니다" + Retry(새로고침과 동일) | LoginView: 경계 컴포넌트를 감싸지 않고 sToken 존재 시에만 렌더하도록 분기 |
+| `endpoint-unresolved` | "서버 설정을 불러오지 못했습니다" + Retry + Copy | 관리자 안내 문구 추가 |
+| `server-unreachable` | "서버에 연결할 수 없습니다" + Retry + Copy | — |
+| `token-invalid` | "토큰이 만료되었거나 유효하지 않습니다" + Retry 없음/있음(정책 결정) | 외부 플랫폼으로 돌아가는 링크 노출 |
+| `concurrent-session` | 기본 카드에 간단한 안내만, 상세 처리는 호출자 책임 (LoginView의 모달) | LoginView: 기존 동시 세션 확인 다이얼로그 |
+| `unknown` | 일반 에러 메시지 + Retry + Copy | — |
+
+## 엔드포인트 resolve 훅
+
+### 결정
+
+`react/src/hooks/useEduAppApiEndpoint.ts`의 `useEduAppApiEndpoint`가 이미 config.toml을 Suspense-friendly하게 resolve하는 선례다. 이 훅의 책임은 본질적으로 "config.toml → `general.apiEndpoint` → localStorage fallback" 순의 resolution이며 EduAppLauncher 전용이라는 스코프 제한은 코멘트상의 의도일 뿐 로직 자체는 범용이다.
+
+본 스펙은 이 훅을 일반화하여 **`useResolvedApiEndpoint`**(이름은 dev-plan 단계에서 최종 확정)로 이름을 바꾸거나, `useEduAppApiEndpoint`를 그대로 재사용하되 이름의 "Edu"를 제거한 wrapper를 둔다. 선택은 dev-plan 단계에서 결정하며, 본 스펙은 다음을 요구한다.
+
+- 훅은 Suspense-compatible 하게 동작한다 (promise throw 후 결과 캐싱).
+- 훅은 `config.toml → localStorage('backendaiwebui.api_endpoint')` 순서로 endpoint를 resolve한다.
+- 빈 문자열 반환 시 컴포넌트는 `{ kind: 'endpoint-unresolved' }` 에러로 전이한다.
+- `loginConfigState` atom과의 관계: LoginView 경로에서는 이미 atom에 endpoint가 설정되어 있을 수 있으나, 경계 컴포넌트는 **atom에 의존하지 않는다**. LoginView 경로에서는 `LoginView`가 이미 endpoint를 알고 있지만, 경계 컴포넌트가 atom에 관여하기 시작하면 두 플로우 간 결합이 생기므로 파일·config.toml을 단일 source of truth로 고정한다.
+
+### 리팩토링 시 고려사항
+
+- `useEduAppApiEndpoint`는 모듈 스코프에 `cachedEndpoint`와 `inflightPromise`를 보관한다. 일반화 시 동일한 캐시가 여러 호출자를 만족시킬 수 있는지 점검해야 한다 (보통 page lifetime 동안 endpoint는 바뀌지 않으므로 안전하다).
+- LoginView 경로에서 `useResolvedApiEndpoint`로 통합할지 여부는 **이 스펙의 story 1에서 결정**하거나 Open Question으로 둔다.
+
+## URL 파라미터 파싱 규약 (nuqs)
+
+### 원칙
+
+경계 컴포넌트는 **자체적으로 URL을 파싱하지 않는다**. URL 쿼리 파라미터 read/write는 호출자가 [`nuqs`](https://nuqs.47ng.com/)를 사용해 수행하며, 컴포넌트는 순수하게 prop으로 전달된 값만 다룬다. 이 규약은 다음을 보장한다.
+
+- **관심사 분리**: 인증 로직과 URL 상태 관리가 분리되어 단위 테스트에서 URL을 모킹할 필요가 없다.
+- **라우트 수준 제어**: 호출자가 `sToken`의 존재 여부에 따라 컴포넌트를 조건부로 마운트할 수 있다 (예: LoginView 경로는 sToken이 있을 때만 경계를 감싼다).
+- **일관된 URL 상태**: 컴포넌트와 호출자가 URL을 각자 건드리면 race가 발생할 수 있다. nuqs로 단일 소스를 유지한다.
+- **프로젝트 컨벤션 일치**: 현재 프로젝트에서 URL 쿼리 파라미터는 대부분 `nuqs`의 `useQueryState` / `useQueryStates`로 다루고 있다 (예: `AgentList.tsx`, `UserManagement.tsx`, `FairShareItems/*` 등).
+
+### 의존성
+
+- `nuqs` — `react/package.json`에 `^2.8.9`로 이미 존재. 추가 설치 불필요.
+- 라우트 Component 함수 또는 그 상위에서 `NuqsAdapter`가 이미 구성되어 있다고 가정한다 (현재 프로젝트 전반에 적용됨). 별도 provider 추가는 필요 없다.
+
+### 호출자 코드 규약
+
+1. **읽기**: `useQueryState('sToken', parseAsString)`으로 canonical 키를 읽는다.
+2. **`stoken`(소문자) fallback**: 하위 호환을 위해 `stoken`도 함께 읽어야 하는 경우, 호출자 또는 공용 helper hook에서 fallback을 처리한다. `stoken`이 값을 제공한 경우 `logger.warn`을 1회 호출해 deprecation을 남긴다.
+3. **정리 (경로별 선택)**: 보안이 중요한 범용 진입점(`/`, `/interactive-login`)은 `onSuccess` 콜백에서 setter로 `null`을 전달해 URL의 sToken을 제거한다. EduAppLauncher(`/edu-applauncher`, `/applauncher`)처럼 `sToken`이 이후 스텝(`get_user_credential` 등)에서 재사용되는 경로는 URL을 **그대로 둔다**. 어느 쪽이든 다른 쿼리 파라미터는 자동으로 보존된다.
+4. **항상 감싸기 (권장) / 조건부 렌더 (대안)**: 경계 컴포넌트가 session cookie만으로도 success 상태로 전이하므로(`check_login` fast-path) `sToken` 유무와 관계없이 항상 감싸는 것이 단순하다 (EduApp 경로 패턴). 다만 `/` 같은 범용 로그인 페이지는 sToken이 없을 때 `missing-token` 카드 대신 평범한 로그인 폼을 즉시 보여주는 것이 UX 상 낫기 때문에, 조건부 렌더로 sToken이 있을 때만 감싸는 접근도 허용한다 (LoginView 경로 패턴).
+
+### 공용 helper hook 제안 (선택, Open Question)
+
+하위 호환 fallback을 여러 호출자가 중복 구현하지 않도록, 경계 컴포넌트 배포와 함께 helper hook을 제공하는 것을 권장한다. 최종 도입 여부와 이름은 dev-plan에서 결정한다.
+
+```tsx
+// react/src/hooks/useSToken.ts (제안)
+export const useSToken = (): [string | null, (next: string | null) => void] => {
+  const [sToken, setSToken] = useQueryState('sToken', parseAsString);
+  const [stoken, setStoken] = useQueryState('stoken', parseAsString);
+
+  const effective = sToken ?? stoken;
+  if (stoken && !sToken) {
+    logger.warn('Query param `stoken` (lowercase) is deprecated; use `sToken`.');
+  }
+
+  const clear = useCallback((next: string | null) => {
+    setSToken(next);
+    setStoken(null); // deprecated 키도 함께 정리
+  }, [setSToken, setStoken]);
+
+  return [effective, clear];
+};
+```
+
+## 사용 패턴 (라우트 통합 예시)
+
+프로젝트의 다른 페이지 라우트가 `BAIErrorBoundary`로 감싸는 관용을 따른다. 경계 컴포넌트도 동일한 컨테이너 위치에서 wrapping한다.
+
+### 관용 (참고: 기존 다른 라우트)
+
+```tsx
+// 기존 라우트 패턴 — 참고용
+{
+  path: '/dashboard',
+  handle: { labelKey: 'webui.menu.Dashboard' },
+  Component: () => (
+    <BAIErrorBoundary>
+      <Suspense fallback={<Skeleton active />}>
+        <DashboardPage />
+      </Suspense>
+    </BAIErrorBoundary>
+  ),
+}
+```
+
+### sToken 진입이 가능한 라우트 (이 스펙)
+
+경계 컴포넌트는 `BAIErrorBoundary`와 `Suspense` 사이에 위치시킨다. `BAIErrorBoundary`가 React 렌더링 에러를 처리하고, `STokenLoginBoundary`가 sToken 인증 전제조건을 해결하며, `Suspense`가 자식 트리의 비동기 경계를 담당한다.
+
+#### 시나리오 A — LoginView 경로 (`/`, `/interactive-login`): 조건부 wrapping
+
+`/`와 `/interactive-login`은 sToken 없이도 정상 동작해야 한다(일반 로그인 폼 렌더). 따라서 `useSToken` 결과가 존재할 때만 경계를 감싼다.
+
+```tsx
+// pseudo-code — 실제 구조는 story 2에서 확정
+{
+  path: '/',
+  Component: () => {
+    const [sToken, setSToken] = useSToken(); // helper hook 가정
+    const content = (
+      <>
+        <LoginView />
+        <MainLayout />
+      </>
+    );
+    return (
+      <BAIErrorBoundary>
+        <DefaultProvidersForReactRoot>
+          {sToken ? (
+            <STokenLoginBoundary
+              sToken={sToken}
+              onSuccess={(client) => {
+                setSToken(null); // URL에서 제거 (nuqs setter)
+                // 기타 postConnectSetup 책임: last_login, clearSavedLoginInfo,
+                // api_endpoint localStorage 저장, main-layout-ready 대기 등
+              }}
+            >
+              <Suspense fallback={<Skeleton active />}>{content}</Suspense>
+            </STokenLoginBoundary>
+          ) : (
+            <Suspense fallback={<Skeleton active />}>{content}</Suspense>
+          )}
+        </DefaultProvidersForReactRoot>
+      </BAIErrorBoundary>
+    );
+  },
+  children: mainLayoutChildRoutes,
+}
+```
+
+#### 시나리오 B — EduAppLauncher 경로 (`/edu-applauncher`, `/applauncher`): 항상 wrapping
+
+EduAppLauncher는 sToken URL 진입이 기본이지만, 유효한 session cookie만으로도 (URL에 sToken 없이) 진입 가능하다. 경계 컴포넌트의 `check_login` fast-path가 이를 처리하므로 sToken 유무와 상관없이 **항상 감싸는** 것이 단순하다. URL의 `sToken`은 **그대로 유지**한다 (`_createEduSession`의 `get_user_credential(sToken)` 재사용).
+
+```tsx
+// pseudo-code — 실제 구조는 story 3에서 확정
+{
+  path: '/edu-applauncher',
+  Component: () => {
+    'use memo';
+    const [sToken] = useSToken(); // setter 사용 안 함 (URL 유지)
+    const [rawExtraParams] = useQueryStates({
+      app: parseAsString, session_id: parseAsString,
+      // ... cpu, mem, shmem, cuda-shares, cuda-device, session_template 등
+    });
+    const extraParams = Object.fromEntries(
+      Object.entries(rawExtraParams).filter(([, v]) => v !== null),
+    ) as Record<string, string>;
+
+    return (
+      <BAIErrorBoundary>
+        <DefaultProvidersForReactRoot>
+          <STokenLoginBoundary
+            sToken={sToken ?? ''}
+            extraParams={extraParams}
+            // URL은 의도적으로 제거하지 않는다 (교육용 LMS-issued token,
+            // get_user_credential 재사용 — 시나리오 설명 참조).
+            onSuccess={persistPostLoginState}
+          >
+            <Suspense fallback={null}>
+              <EduAppLauncherPage sToken={sToken} extraParams={extraParams} />
+            </Suspense>
+          </STokenLoginBoundary>
+        </DefaultProvidersForReactRoot>
+      </BAIErrorBoundary>
+    );
+  },
+}
+```
+
+### 주의
+
+- 위 예시는 **라우트 구조의 예시**이지 확정된 구현이 아니다. 최종 구조는 각 마이그레이션 story에서 결정한다.
+- `handle`, `DefaultProvidersForReactRoot`, 기타 shell wrapping은 기존 라우트와 동일하게 유지한다.
+- 라우트 수준 wrapping이 어려운 경우 (예: 조건부 wrapping 로직이 복잡해질 때) 페이지 컴포넌트 최상위에서 wrapping해도 무방하다. 컴포넌트 자체가 라우트·페이지 어느 계층에서든 동작해야 한다.
+
+## 마이그레이션 계획
+
+본 스펙은 **세 개의 스택된 PR**로 구현된다. 각 PR은 이전 PR을 기반으로 한다.
+
+### Story 1: `STokenLoginBoundary` 컴포넌트 도입
+
+- 새 파일 `react/src/components/STokenLoginBoundary.tsx` 작성. **URL 관련 API를 일절 참조하지 않음**을 ESLint 규칙 또는 grep CI 검증으로 강제.
+- (선택) `react/src/hooks/useSToken.ts` 공용 helper hook 추가 — nuqs `useQueryState` 기반으로 `sToken`/`stoken`(deprecated) fallback + 경고.
+- 엔드포인트 resolve 훅을 일반화 (이름 확정 포함).
+- `helper/loginSessionAuth.ts`의 `tokenLogin` 헬퍼가 `extraParams`를 받을 수 있도록 확장하거나, 경계 컴포넌트가 `client.token_login` + `connectViaGQL`을 직접 호출하는 경로를 새로 구성한다 ([Open Question 1] 참조).
+- 기본 fallback·error card UI 작성.
+- 단위 테스트: 각 에러 분류 전이, Retry 멱등성, `backend-ai-connected` 이벤트 1회 발행. URL 모킹 없이 prop만으로 전 시나리오 재현 가능할 것.
+- 기존 호출자는 변경하지 않는다 (Story 2·3에서 순차 마이그레이션).
+
+### Story 2: `LoginView` 마이그레이션
+
+- `react/src/routes.tsx`의 `/`와 `/interactive-login` 라우트 `Component`에서 nuqs로 `sToken`을 읽고, 존재 시에만 `STokenLoginBoundary`로 `LoginView`/`MainLayout` 트리를 감싼다 (#사용-패턴-라우트-통합-예시 섹션의 시나리오 A 참조).
+- `LoginView.tsx`의 `connectUsingSession()` sToken 분기(현재 lines 455–490)를 제거. `LoginView` 내부에서 `sToken` 관련 URL 파싱 코드를 제거.
+- 라우트 `Component`의 `onSuccess` 콜백에서 기존 `postConnectSetup`의 책임을 수행: `last_login`/`login_attempt` 카운터, `clearSavedLoginInfo`, `setPluginApiEndpoint`, localStorage endpoint 저장, `main-layout-ready` 대기 후 패널 닫기, nuqs setter로 URL에서 sToken 제거.
+- `useLoginOrchestration`과는 **무관하게** 동작하도록 유지한다. 경계 컴포넌트는 orchestration 훅을 import하지 않는다.
+- E2E: 기존 sToken 진입 시나리오가 회귀 없이 통과. 성공 후 URL에 `sToken`이 남지 않는지 추가 검증.
+
+### Story 3: `EduAppLauncher` 마이그레이션
+
+- `react/src/routes.tsx`의 `/edu-applauncher`와 `/applauncher` 라우트 `Component`에서 nuqs로 `sToken`·`extraParams` 후보 키를 읽고, `STokenLoginBoundary`로 `EduAppLauncherPage`를 감싼다 (#사용-패턴-라우트-통합-예시 섹션의 시나리오 B 참조).
+- `EduAppLauncher.tsx`의 `_token_login()` 메서드와 수동 `backend-ai-connected` 디스패치(line 787)를 제거. URL 파싱 코드도 제거.
+- `errorFallback` prop으로 스테퍼 UI와 통합된 에러 표시 제공 (기존 `transition({ name: 'error', step: 'auth', ... })` 로직 재사용).
+- **URL 유지 결정**: EduApp 경로에서는 성공 후 URL의 `sToken`을 **제거하지 않는다**. 경계 컴포넌트의 `onSuccess`는 `persistPostLoginState(client)`만 호출하며 `useSToken`의 `clear` setter는 사용하지 않는다. 이유:
+  1. `EduAppLauncher._createEduSession`이 customer-specific `eduApp.get_user_credential(sToken)`에서 원본 token을 다시 사용한다. URL을 제거하면 prop으로 흘러온 `sToken`이 다음 렌더에서 `null`이 되어 해당 호출이 깨진다.
+  2. 교육용 진입 URL은 LMS가 발급하므로 브라우저 히스토리 / referer에 sToken이 남는 것이 허용 가능한 트레이드오프이다 (LoginView의 범용 `/` 경로와 성격이 다름).
+  3. `app` / `session_id` / 리소스 힌트는 `nuqs useQueryStates`로 prop으로도 전달하지만, URL 자체에도 남겨 Relay loader의 자식 단계가 동일하게 참조 가능하다.
+- **쿠키 인코딩**: 기존과 동일 (`encodeURIComponent`).
+- 내부 상태 머신(idle → auth → session → launching → done/error)은 유지하되, "auth" 단계는 경계 컴포넌트의 상태로 대체.
+- `_createEduSession`의 `get_user_credential(sToken)` 호출은 Pitfall #8(sToken 재사용)의 해결 전략을 적용한다 — URL 유지 결정으로 자연스럽게 해결됨.
+- E2E: 기존 EduApp 진입 시나리오(세션 ID 있음/없음) 모두 회귀 없이 통과.
+
+## 수락 기준 (Acceptance Criteria)
+
+각 기준은 테스트 가능해야 한다.
+
+### 컴포넌트 자체
+
+- [ ] 컴포넌트가 success 상태가 되기 전까지는 `children` 내부의 Relay 쿼리가 실행되지 않는다. (단위 테스트에서 Relay network spy 또는 mock으로 검증)
+- [ ] `'backend-ai-connected'` 이벤트는 성공 시 **정확히 한 번** 디스패치된다. 재시도 중 이전 실패 시에는 발행되지 않는다.
+- [ ] 성공 시 `globalThis.backendaiclient`가 새 클라이언트 인스턴스로 설정된다.
+- [ ] `sToken` prop이 빈 문자열 또는 nullish인 경우 `{ kind: 'missing-token' }` 에러가 `onError`로 전달되고 기본 에러 카드가 렌더된다.
+- [ ] `extraParams`가 `client.token_login`의 두 번째 인자로 그대로 전달된다 (prop으로 전달한 객체와 동일한 키·값이 전달됨).
+- [ ] 쿠키 `sToken=...`이 설정될 때 값은 `encodeURIComponent(sToken)` 결과와 정확히 일치한다.
+- [ ] Retry 재시도 시 쿠키는 동일 값으로 재설정되며, `'backend-ai-connected'` 이벤트는 최종 성공 시점에서만 1회 디스패치된다.
+- [ ] `errorFallback`이 제공되면 기본 카드 대신 호출자의 렌더가 사용되며, `retry` 함수 호출 시 인증 시퀀스가 초기 상태부터 재실행된다.
+- [ ] Retry 실행 중에는 fallback UI가 다시 표시된다 (또는 `errorFallback` 사용 시 호출자의 로딩 UX로 위임).
+
+### URL 파싱 금지 불변 조건 (nuqs 규약)
+
+- [ ] `react/src/components/STokenLoginBoundary.tsx` 및 하위 모듈에서 `window.location`, `window.history`, `document.location`, `URLSearchParams` 등 URL 접근 API의 직접 참조가 **한 건도 발견되지 않는다**. (grep / ESLint custom rule로 검증 가능)
+- [ ] 컴포넌트 단위 테스트는 URL을 모킹하지 않고 prop만 전달하여 모든 시나리오를 재현할 수 있다.
+- [ ] 호출자 코드(`routes.tsx` 또는 페이지 컴포넌트)가 nuqs (`useQueryState` 또는 helper hook)로 `sToken`을 읽고, `onSuccess` 콜백에서 setter로 URL에서 `sToken`을 제거한다.
+- [ ] 마이그레이션 후 E2E에서 경로별 URL 정리 정책이 검증된다: `/` / `/interactive-login`은 success 시 `window.location.search`에 `sToken`이 남지 않고, `/edu-applauncher` / `/applauncher`는 그대로 유지된다 (`_createEduSession`의 `get_user_credential(sToken)` 재사용을 위해). 이 검증은 호출자 책임 영역이며, 컴포넌트의 acceptance는 아니다.
+
+### 엔드포인트 resolve
+
+- [ ] 엔드포인트 resolve 훅이 config.toml의 `general.apiEndpoint`를 반환한다.
+- [ ] config.toml fetch 실패 시 localStorage `backendaiwebui.api_endpoint` fallback이 동작한다.
+- [ ] 두 source 모두 비어 있으면 `{ kind: 'endpoint-unresolved' }` 에러로 전이한다.
+
+### 마이그레이션
+
+- [ ] Story 2 적용 후 LoginView의 sToken 진입 시나리오가 기존 E2E 테스트(또는 수동 회귀 절차)를 통과한다.
+- [ ] Story 3 적용 후 EduAppLauncher의 sToken 진입 시나리오(세션 ID 있음·없음)가 회귀 없이 통과한다.
+- [ ] 두 호출 지점 모두에서 `useLoginOrchestration`을 경계 컴포넌트가 import하지 않는다 (grep 가능 검증).
+- [ ] 마이그레이션 후 `LoginView.tsx`에서 `connectUsingSession()` 내 sToken 분기가 제거되며, `EduAppLauncher.tsx`에서 `_token_login()` 메서드와 수동 `backend-ai-connected` 디스패치가 제거된다.
+
+## Pitfalls 및 유의사항
+
+1. **Relay 환경 초기화 race**: `'backend-ai-connected'` 이벤트 디스패치 이전에 자식 트리를 마운트하면 내부 Relay 쿼리가 영원히 대기한다. 컴포넌트는 이벤트 디스패치 완료 후에만 `children`을 렌더해야 한다 (testable invariant).
+2. **`useLoginOrchestration`과의 경계**: 멀티탭 동기화, 자동 로그아웃, config 게이팅은 경계 컴포넌트의 책임이 아니다. 이 부분은 LoginView가 계속 소유한다.
+3. **쿠키 인코딩 백엔드 호환성**: `encodeURIComponent(sToken)`으로 설정한 쿠키를 Manager/Webserver가 정상 파싱하는지 **검증이 필요**하다. 대부분의 웹서버는 쿠키 값을 자동으로 `decodeURIComponent` 하지만, Backend.AI 측 구현을 코드 단에서 한 번 확인해야 한다.
+4. **`stoken`(소문자) deprecation 경로**: 본 스펙은 인식만 유지하고 경고만 출력한다. 하드 제거 시점은 외부 플랫폼 공지 후 별도 이슈에서 결정한다. 경고 로깅은 컴포넌트가 아닌 **호출자(또는 공용 `useSToken` helper hook)의 책임**이다. 컴포넌트는 URL을 보지 않으므로 어느 이름으로 들어온 값인지 알 수 없다.
+5. **concurrent-session 에러와 동시 로그인 스펙 연계**: `{ kind: 'concurrent-session' }` 에러의 상세 처리(모달, 기존 세션 종료 확인 등)는 `.specs/draft-concurrent-login-guard/`의 LoginView 측 대응과 연계되어야 한다. sToken 플로우에서는 외부 리다이렉트 주체가 모달을 띄우기 어렵기 때문에, 이 에러 분류를 어떻게 surface할지는 dev-plan 단계에서 LoginView의 모달 로직과 함께 설계한다.
+6. **Retry 멱등성**: 중복 쿠키 설정은 안전하나, 중복 이벤트 디스패치는 하위 구독자(예: proxy URL 설정, 플러그인 초기화)가 여러 번 실행되어 사이드이펙트를 낳을 수 있다. 구현 단계에서 "이벤트는 최종 성공 시 1회"를 엄격히 지킨다.
+7. **URL 정리는 경로별로 다름**: LoginView 계열(`/`, `/interactive-login`)은 `onSuccess`에서 `clearSToken(null)`로 `sToken` / `stoken` 키만 제거한다. 다른 쿼리 키는 nuqs가 그대로 보존한다. EduAppLauncher 계열(`/edu-applauncher`, `/applauncher`)은 URL을 **전혀 건드리지 않는다** — `_createEduSession`이 `eduApp.get_user_credential(sToken)`에서 원본 token을 재사용해야 하고, `app` / `session_id` / 리소스 힌트는 후속 Relay loader에서 읽기 때문이다.
+8. **`backendaiclient._config.endpoint` 스테일 closure**: `LoginView`의 기존 `postConnectSetup`은 `apiEndpoint` closure 대신 client의 `_config.endpoint`를 읽어 최신 값을 취한다. 경계 컴포넌트 마이그레이션 시에도 `onSuccess(client)`에서 `client._config.endpoint`를 참조하여 localStorage에 저장해야 한다.
+9. **StrictMode 이펙트 2회 실행**: dev StrictMode에서 effect가 2회 실행되는 문제를 guard하기 위해 `useRef` 플래그 또는 key 기반 재마운트를 사용한다. 특히 쿠키 설정·서버 ping·token_login이 중복 수행되지 않도록 `started` flag를 둔다.
+10. **Webserver config 병합**: 기존 `loadConfigFromWebServer`는 `apiEndpoint`와 현재 origin이 다를 때 원격 config.toml을 병합하는 단계를 수행한다. 경계 컴포넌트가 이 단계를 포함해야 하는지는 dev-plan에서 결정한다. 포함하지 않으면 호출자가 `onSuccess` 이후 수행할 수도 있다 ([Open Question 2]).
+
+## Risks & Open Questions
+
+1. **`tokenLogin` 헬퍼 확장 vs 우회**: `helper/loginSessionAuth.ts:175`의 `tokenLogin(client, sToken, cfg, endpoints)`는 현재 `client.token_login(sToken)`만 호출한다 (extraParams 전달 경로 없음). 경계 컴포넌트는 두 가지 중 하나를 선택한다.
+   - (a) 헬퍼를 `tokenLogin(client, sToken, cfg, endpoints, extraParams?)`로 확장하고 내부에서 `client.token_login(sToken, extraParams)`를 호출하도록 변경. LoginView는 extraParams 없이 호출, EduAppLauncher는 URL 파라미터를 extraParams로 전달.
+   - (b) 경계 컴포넌트가 헬퍼를 우회하여 `client.token_login` + `connectViaGQL`을 직접 호출하고, LoginView의 기존 헬퍼 호출 경로는 제거.
+   **추천**: (a). 기존 헬퍼의 `connectViaGQL` 호출 책임이 유용하며, extraParams를 optional 파라미터로 추가하는 변경은 기존 LoginView 호출자에 영향이 없다. 최종 결정은 Story 1 dev-plan에서 확정.
+
+2. **`loadConfigFromWebServer` 포함 여부**: LoginView의 일반 로그인 경로는 login 후 webserver config를 병합한다. sToken 경로가 동일하게 병합해야 하는지, 외부 플랫폼 시나리오에서 이것이 관찰되는 동작인지 확인 필요.
+
+3. **엔드포인트 resolve 훅 이름**: `useEduAppApiEndpoint`를 `useResolvedApiEndpoint`로 rename할지, 새 이름의 wrapper를 두고 기존 것을 유지할지는 dev-plan 단계에서 결정.
+
+4. **`errorFallback`으로 처리하지 못하는 치명적 에러**: 예를 들어 `endpoint-unresolved`가 발생한 상태에서는 EduAppLauncher의 스테퍼 UI 자체가 의미 있게 렌더되지 못할 수 있다. 이 경우에도 `errorFallback`이 우선되는지, 아니면 기본 카드로 fall through하는지 정책을 dev-plan에서 확정한다.
+
+5. **쿠키 인코딩 백엔드 호환성**: Manager/Webserver에 실제로 `decodeURIComponent` 파싱 동작이 존재하는지 코드 확인 필요. 만약 서버가 raw 값을 기대한다면 기존 LoginView 동작이 맞고, 이 스펙의 표준이 뒤집힌다.
+
+6. **concurrent-session 에러 감지 신호**: 서버가 이 상태를 어떤 필드로 응답하는지는 `.specs/draft-concurrent-login-guard/`의 Open Question 1에 달려 있다. 본 스펙은 에러 분류만 정의하고 실제 감지 규칙은 concurrent-login 스펙 결정에 위임한다.
+
+7. **`useSToken` helper hook 도입 여부**: `stoken`(소문자) fallback과 deprecation 경고를 모든 호출자가 각자 구현하게 두는 대신, `react/src/hooks/useSToken.ts`로 통일하는 것이 권장되지만 반드시 필수는 아니다. Story 1 또는 Story 2 dev-plan에서 결정한다. 도입하지 않을 경우 각 호출자는 nuqs로 `sToken`/`stoken`을 독립적으로 읽고 deprecation 경고도 각자 관리한다.
+
+8. **EduAppLauncher의 post-login sToken 재사용**: `EduAppLauncher._createEduSession`은 세션 생성 단계에서 `eduApp.get_user_credential(sToken)`(line 631)을 호출하기 위해 URL에서 sToken을 **두 번째**로 읽는다. 경계 컴포넌트가 로그인 성공 즉시 URL에서 sToken을 제거하면 이 호출이 `null` sToken을 받게 된다. 해결 옵션: (a) 라우트 또는 페이지 상위에서 읽은 sToken을 React state/context로 하위 컴포넌트에 전달, (b) `onSuccess`에서 URL 정리를 지연하고 `_createEduSession` 완료 후에 정리, (c) sessionStorage에 임시 보관. Story 3 dev-plan에서 확정한다.
+
+## 테스트 전략
+
+### 단위 테스트 (Jest + React Testing Library)
+
+- 각 에러 분류로의 상태 전이 (mock된 client로 각 단계 실패 주입)
+- Retry 호출 후 재실행되며 이벤트는 1회만 발행되는지
+- URL 정리: `window.history.replaceState` 호출 시 argument 검증
+- `stoken`(소문자) warn 호출 검증
+- `extraParams`가 `client.token_login`에 그대로 전달되는지
+- 기본 에러 카드의 Copy details 버튼이 클립보드에 JSON을 복사하는지
+
+### 통합 테스트
+
+- Relay 환경 mock 하에서 children 내부의 쿼리가 경계 컴포넌트 success 이전에는 suspended, 이후에는 resolved 되는지 확인
+- `'backend-ai-connected'` 이벤트 디스패치 전에 children이 마운트되지 않음을 DOM observer 또는 render spy로 검증
+
+### E2E 테스트 (Playwright, 기존 인프라)
+
+- LoginView sToken 진입 시나리오 (story 2 머지 후 회귀 없음 확인)
+- EduAppLauncher sToken 진입 시나리오 — 세션 ID 있음·없음 두 경로 모두 (story 3 머지 후)
+- 각 경로에서 성공 시 URL에 `sToken`이 남지 않는지 확인
+- 잘못된/만료된 sToken으로 진입 시 에러 카드가 표시되고 Retry가 동작하는지
+
+## 영향 받는 컴포넌트 (기존 코드 참조)
+
+| 파일 | 역할 | 변경 예상 |
+|------|------|-----------|
+| `react/src/components/STokenLoginBoundary.tsx` | (신규) sToken 경계 컴포넌트 | 신규 작성. URL 관련 API 직접 참조 금지 |
+| `react/src/hooks/useSToken.ts` | (신규, 선택) nuqs 기반 sToken 조회 helper hook | `sToken`/`stoken` 읽기·정리 + deprecation 경고 통합 (Open Question 참조) |
+| `react/src/routes.tsx` | React Router 라우트 테이블 | `/`, `/interactive-login`, `/edu-applauncher`, `/applauncher` 라우트 `Component`에서 nuqs로 sToken 읽고 `STokenLoginBoundary` wrapping 추가 |
+| `react/src/components/LoginView.tsx` | 로그인 플로우 오케스트레이션 | `connectUsingSession` sToken 분기 제거. 라우트 레이어가 wrapping을 담당하므로 LoginView 내부에서는 sToken 관련 URL 파싱 로직을 제거 |
+| `react/src/components/EduAppLauncher.tsx` | 교육용 앱 런처 | `_token_login` 제거, 수동 `backend-ai-connected` 디스패치 제거, URL 파싱 제거. 경계 컴포넌트는 라우트 또는 페이지 최상위에서 래핑 |
+| `react/src/helper/loginSessionAuth.ts` | 로그인 세션 유틸 | `tokenLogin`에 `extraParams` 지원 추가 (Open Question 1 채택 시) |
+| `react/src/hooks/useEduAppApiEndpoint.ts` | EduApp 엔드포인트 resolve | 일반화 또는 새 wrapper 훅 추가 |
+| `react/src/RelayEnvironment.ts` | GQL 네트워크 레이어 | 변경 없음 (기존 `waitForBAIClient`를 그대로 의존) |
+| `resources/i18n/*.json` | 다국어 번역 파일 | 새 메시지 키 추가 (에러 카드 제목/본문, Retry/Copy 버튼) |
+
+## 관련 스펙
+
+- `.specs/draft-concurrent-login-guard/spec.md` — 동시 로그인 세션 제어. 본 스펙의 `concurrent-session` 에러 분류가 이 스펙의 모달/확인 다이얼로그와 연계된다.
+- `.specs/FR-2470-edu-applauncher-refactor/spec.md` — EduAppLauncher React 정식 지원 리팩토링. 본 스펙의 story 3(EduAppLauncher 마이그레이션)가 이 스펙과 겹칠 수 있으며, 머지 순서에 따라 조정 필요.
+
+## 관련 이슈
+
+- (Jira 미등록) Epic 제안: "Extract sToken login flow into reusable boundary component"
+- (Jira 미등록) Spec Task 제안: "Define sToken login boundary component spec"
+- 원본 맥락: 사용자와의 설계 논의에서 도출 (외부 issue 없음)


### PR DESCRIPTION
Resolves FR-2618 (sub-issue of Epic [FR-2616](https://lablup.atlassian.net/browse/FR-2616))

## Summary

- Add feature spec for a reusable `STokenLoginBoundary` React component that extracts the duplicated sToken login logic from `LoginView.tsx` and `EduAppLauncher.tsx` into a single, Error-Boundary-style component.
- Stories planned under Epic FR-2616: 3 (new component + endpoint-hook generalization; LoginView migration; EduAppLauncher migration).

## Jira

- Epic: [FR-2616 — Extract sToken login flow into reusable boundary component](https://lablup.atlassian.net/browse/FR-2616)
- Spec Task (this PR): [FR-2618 — Define sToken login boundary component spec](https://lablup.atlassian.net/browse/FR-2618)

## Scope of this PR

- Spec documents only. No production code (LoginView, EduAppLauncher) is touched.
- Files added:
  - `.specs/draft-stoken-login-boundary/spec.md` (Korean)
  - `.specs/draft-stoken-login-boundary/metadata.json`

## Follow-up

- [ ] Rename directory from `draft-stoken-login-boundary` to `FR-2616-stoken-login-boundary` (after this PR merges).
- [ ] Run `/fw:dev-plan FR-2616` to break the spec into the three planned stories.

## Test plan

- [ ] Spec file renders correctly on GitHub (Korean content).
- [ ] Acceptance criteria are testable and map 1:1 to the three planned stories.
- [ ] Open Questions are explicitly marked for resolution in dev-plan.

[FR-2616]: https://lablup.atlassian.net/browse/FR-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ