### PR TITLE
fix(FR-2620): load fallback URL when config.toml parse fails

### DIFF
--- a/configs/debug.toml
+++ b/configs/debug.toml
@@ -31,7 +31,7 @@ maxFileUploadSize = 4294967296 # 4GB. 4294967296
 #allowlist = ""
 
 [server]
-webServerURL =
+webServerURL = ""
 
 [plugin]
 #login = "signup-cloud.js"

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -34,7 +34,7 @@ maxFileUploadSize = 4294967296 # 4GB. 4294967296
 #allowlist = ""
 
 [server]
-webServerURL =
+webServerURL = ""
 
 [plugin]
 #login = "signup-cloud.js"

--- a/configs/main.toml
+++ b/configs/main.toml
@@ -32,7 +32,7 @@ maxFileUploadSize = 68719476736 # 64GB.
 #allowlist = ""
 
 [server]
-webServerURL =
+webServerURL = ""
 
 [plugin]
 #login = "signup-cloud.js"

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -382,10 +382,19 @@ function createWindow() {
     mainWindow.loadURL(endpoint);
   } else {
     // Load HTML into new Window (file-based serving)
+    const loadFallbackIndex = () => {
+      mainURL = url.format({
+        pathname: path.join(mainIndex),
+        protocol: 'file',
+        slashes: true,
+      });
+      mainWindow.loadURL(mainURL);
+    };
     nfs.readFile(path.join(es6Path, 'config.toml'), 'utf-8', (err, data) => {
       console.log('Running on build-resource debug mode...');
       if (err) {
         console.log('No configuration file found.');
+        loadFallbackIndex();
         return;
       }
       try {
@@ -404,16 +413,13 @@ function createWindow() {
           config.server.webServerURL != '""'
         ) {
           mainURL = config.server.webServerURL;
+          mainWindow.loadURL(mainURL);
         } else {
-          mainURL = url.format({
-            pathname: path.join(mainIndex),
-            protocol: 'file',
-            slashes: true,
-          });
+          loadFallbackIndex();
         }
-        mainWindow.loadURL(mainURL);
       } catch (parseErr) {
         console.error('config.toml parse error:', parseErr);
+        loadFallbackIndex();
       }
     });
   }


### PR DESCRIPTION
Resolves #6835 ([FR-2620](https://lablup.atlassian.net/browse/FR-2620))

## Summary

Two independent defects combined to produce a blank screen on Electron app launch:

- **`electron-app/main.js`**: When `smol-toml` throws while parsing `config.toml`, the `catch` branch previously only logged the error and returned without calling `mainWindow.loadURL`, leaving the renderer on an empty page. Now it falls back to loading the packaged `file:///app/index.html`.
- **`configs/{main,default,debug}.toml`**: `webServerURL =` (key with no value) is invalid TOML under `smol-toml` (a prior parser was lenient). Changed to `webServerURL = ""` so the shipped configs parse cleanly.

## Test plan

- [x] `make compile && FORCE_DEP_ELECTRON=1 make mac_arm64` produces a DMG that launches to the login/connection-setup screen.
- [x] Intentionally break `config.toml` (e.g., malformed TOML) → app still loads the packaged `index.html` instead of a blank screen.
- [ ] Windows/Linux desktop builds launch normally.

[FR-2620]: https://lablup.atlassian.net/browse/FR-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ