### PR TITLE
docs(FR-2603): add health check SVG diagrams for all 4 languages, replace ASCII art

### DIFF
--- a/packages/backend.ai-webui-docs/src/en/images/health_check_app_proxy.svg
+++ b/packages/backend.ai-webui-docs/src/en/images/health_check_app_proxy.svg
@@ -1,0 +1,85 @@
+<svg id="d1e" viewBox="0 0 960 500" xmlns="http://www.w3.org/2000/svg" font-size="14" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="a1e" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <marker id="a1ge" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#16a34a"/>
+    </marker>
+    <marker id="a1re" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#dc2626"/>
+    </marker>
+    <marker id="a1be" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#60a5fa"/>
+    </marker>
+    <filter id="s1e" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Manager -->
+  <g filter="url(#s1e)">
+    <rect x="245" y="30" width="280" height="84" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="385" y="64" text-anchor="middle" font-size="16" font-weight="600" fill="#0f172a">Manager</text>
+    <text x="385" y="86" text-anchor="middle" font-size="12" fill="#64748b">Syncs only Active · HEALTHY routes</text>
+    <text x="385" y="104" text-anchor="middle" font-size="12" fill="#64748b">to AppProxy</text>
+  </g>
+
+  <!-- Manager → AppProxy sync arrow -->
+  <line x1="385" y1="114" x2="385" y2="178" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#a1be)"/>
+  <text x="400" y="150" font-size="12" fill="#1e40af" font-weight="500">sync</text>
+
+  <!-- User -->
+  <g filter="url(#s1e)">
+    <circle cx="80" cy="290" r="42" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="80" y="286" text-anchor="middle" font-size="14" font-weight="600" fill="#0f172a">User</text>
+    <text x="80" y="304" text-anchor="middle" font-size="11" fill="#64748b">traffic</text>
+  </g>
+
+  <!-- User → AppProxy arrow -->
+  <line x1="124" y1="290" x2="173" y2="290" stroke="#334155" stroke-width="2" marker-end="url(#a1e)"/>
+  <text x="148" y="280" text-anchor="middle" font-size="12" fill="#0f172a" font-weight="500">request</text>
+
+  <!-- AppProxy box -->
+  <g filter="url(#s1e)">
+    <rect x="175" y="180" width="420" height="280" rx="14" fill="#eff6ff" stroke="#2563eb" stroke-width="1.5"/>
+    <text x="385" y="212" text-anchor="middle" font-size="18" font-weight="700" fill="#1e3a8a">AppProxy</text>
+    <line x1="205" y1="226" x2="565" y2="226" stroke="#bfdbfe" stroke-width="1"/>
+
+    <!-- Health Checker -->
+    <rect x="200" y="252" width="170" height="80" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+    <text x="285" y="284" text-anchor="middle" font-size="14" font-weight="600" fill="#1e40af">Health Checker</text>
+    <text x="285" y="304" text-anchor="middle" font-size="11" fill="#3b82f6">replica probe</text>
+
+    <!-- Active Pool -->
+    <rect x="395" y="252" width="170" height="80" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+    <text x="480" y="284" text-anchor="middle" font-size="14" font-weight="600" fill="#1e40af">Active Pool</text>
+    <text x="480" y="304" text-anchor="middle" font-size="11" fill="#3b82f6">healthy only</text>
+
+    <line x1="372" y1="292" x2="393" y2="292" stroke="#60a5fa" stroke-width="1.3" marker-end="url(#a1be)"/>
+
+    <text x="385" y="430" text-anchor="middle" font-size="12" fill="#1e40af" font-weight="500">→ routes to healthy replicas only</text>
+  </g>
+
+  <!-- Replicas -->
+  <g filter="url(#s1e)">
+    <rect x="680" y="204" width="220" height="72" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+    <text x="790" y="234" text-anchor="middle" font-size="15" font-weight="600" fill="#14532d">replica A</text>
+    <text x="790" y="256" text-anchor="middle" font-size="12" fill="#16a34a">✓ in pool</text>
+  </g>
+  <g filter="url(#s1e)">
+    <rect x="680" y="296" width="220" height="72" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+    <text x="790" y="326" text-anchor="middle" font-size="15" font-weight="600" fill="#14532d">replica B</text>
+    <text x="790" y="348" text-anchor="middle" font-size="12" fill="#16a34a">✓ in pool</text>
+  </g>
+  <g filter="url(#s1e)">
+    <rect x="680" y="388" width="220" height="72" rx="12" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="6 4"/>
+    <text x="790" y="418" text-anchor="middle" font-size="15" font-weight="600" fill="#7f1d1d">replica C</text>
+    <text x="790" y="440" text-anchor="middle" font-size="12" fill="#dc2626">✗ excluded from pool</text>
+  </g>
+
+  <!-- AppProxy → Replicas -->
+  <line x1="597" y1="240" x2="678" y2="240" stroke="#16a34a" stroke-width="1.8" marker-end="url(#a1ge)"/>
+  <line x1="597" y1="332" x2="678" y2="332" stroke="#16a34a" stroke-width="1.8" marker-end="url(#a1ge)"/>
+  <line x1="597" y1="424" x2="678" y2="424" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#a1re)"/>
+</svg>

--- a/packages/backend.ai-webui-docs/src/en/images/health_check_state_machine.svg
+++ b/packages/backend.ai-webui-docs/src/en/images/health_check_state_machine.svg
@@ -1,0 +1,80 @@
+<svg id="d2e" viewBox="0 0 900 800" xmlns="http://www.w3.org/2000/svg" font-size="14" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="a2e" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <filter id="s2e" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- NOT_CHECKED -->
+  <g filter="url(#s2e)">
+    <ellipse cx="450" cy="100" rx="110" ry="44" fill="#f8fafc" stroke="#475569" stroke-width="1.5"/>
+    <text x="450" y="96" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">NOT_CHECKED</text>
+    <text x="450" y="116" text-anchor="middle" font-size="11" fill="#64748b">initial_delay · pending check</text>
+  </g>
+
+  <!-- HEALTHY -->
+  <g filter="url(#s2e)">
+    <ellipse cx="450" cy="320" rx="110" ry="44" fill="#f0fdf4" stroke="#16a34a" stroke-width="2"/>
+    <text x="450" y="316" text-anchor="middle" font-size="15" font-weight="700" fill="#14532d">HEALTHY</text>
+    <text x="450" y="336" text-anchor="middle" font-size="11" fill="#16a34a">active · routing target</text>
+  </g>
+
+  <!-- UNHEALTHY -->
+  <g filter="url(#s2e)">
+    <ellipse cx="200" cy="560" rx="110" ry="44" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="200" y="556" text-anchor="middle" font-size="15" font-weight="700" fill="#7f1d1d">UNHEALTHY</text>
+    <text x="200" y="576" text-anchor="middle" font-size="11" fill="#dc2626">confirmed consecutive failures</text>
+  </g>
+
+  <!-- DEGRADED -->
+  <g filter="url(#s2e)">
+    <ellipse cx="700" cy="560" rx="110" ry="44" fill="#fffbeb" stroke="#d97706" stroke-width="1.5"/>
+    <text x="700" y="556" text-anchor="middle" font-size="15" font-weight="700" fill="#78350f">DEGRADED</text>
+    <text x="700" y="576" text-anchor="middle" font-size="11" fill="#b45309">check unavailable · deferred</text>
+  </g>
+
+  <!-- TERMINATING (double border for terminal) -->
+  <g filter="url(#s2e)">
+    <ellipse cx="200" cy="740" rx="114" ry="44" fill="#f1f5f9" stroke="#334155" stroke-width="1.5"/>
+    <ellipse cx="200" cy="740" rx="106" ry="36" fill="none" stroke="#334155" stroke-width="1.5"/>
+    <text x="200" y="736" text-anchor="middle" font-size="14" font-weight="700" fill="#1e293b">TERMINATING</text>
+    <text x="200" y="754" text-anchor="middle" font-size="11" fill="#475569">terminal · routing ended</text>
+  </g>
+
+  <!-- NOT_CHECKED → HEALTHY -->
+  <line x1="450" y1="144" x2="450" y2="276" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2e)"/>
+  <text x="466" y="198" font-size="13" fill="#0f172a" font-weight="500">on first success</text>
+  <text x="466" y="216" font-size="11" fill="#64748b">(even during initial_delay)</text>
+
+  <!-- NOT_CHECKED self loop -->
+  <path d="M 345 88 C 265 55 255 135 342 118" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2e)"/>
+  <text x="238" y="88" text-anchor="end" font-size="11" fill="#64748b">failures ignored</text>
+  <text x="238" y="104" text-anchor="end" font-size="11" fill="#64748b">stays NOT_CHECKED</text>
+
+  <!-- HEALTHY → UNHEALTHY -->
+  <path d="M 368 358 Q 240 470 228 520" fill="none" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2e)"/>
+  <text x="232" y="408" text-anchor="end" font-size="12" fill="#0f172a" font-weight="500">N consecutive failures</text>
+
+  <!-- UNHEALTHY → HEALTHY -->
+  <path d="M 272 522 Q 370 460 418 360" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2e)"/>
+  <text x="346" y="450" text-anchor="start" font-size="12" fill="#334155">recovery on success</text>
+
+  <!-- HEALTHY → DEGRADED -->
+  <path d="M 532 358 Q 660 470 672 520" fill="none" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2e)"/>
+  <text x="668" y="408" font-size="12" fill="#0f172a" font-weight="500">check unavailable</text>
+
+  <!-- DEGRADED → HEALTHY -->
+  <path d="M 628 522 Q 530 460 482 360" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2e)"/>
+  <text x="554" y="484" text-anchor="end" font-size="12" fill="#334155">check returns + success</text>
+
+  <!-- DEGRADED → UNHEALTHY -->
+  <path d="M 590 560 Q 450 528 310 560" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2e)"/>
+  <text x="450" y="524" text-anchor="middle" font-size="12" fill="#0f172a" font-weight="500">consecutive failures after check returns</text>
+
+  <!-- UNHEALTHY → TERMINATING -->
+  <line x1="200" y1="604" x2="200" y2="696" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2e)"/>
+  <text x="216" y="654" font-size="12" fill="#0f172a" font-weight="500">eviction</text>
+</svg>

--- a/packages/backend.ai-webui-docs/src/en/model_serving/model_serving.md
+++ b/packages/backend.ai-webui-docs/src/en/model_serving/model_serving.md
@@ -142,58 +142,13 @@ Fields without "(Required)" mark are optional.
 The health check system monitors individual model service containers and automatically
 manages traffic routing based on their health status.
 
-```
-Container Created
-│
-▼
-┌─────────────────────────────────┐
-│  Wait for initial_delay (60s)   │  ← Model loading, GPU init, warmup
-│  Status: NOT_CHECKED            │
-│  No health checks during this   │
-└─────────────────────────────────┘
-│
-▼
-Start Health Check Cycle
-│
-▼
-┌─────────────────────────────────┐
-│  Every interval (10s):          │
-│  HTTP GET → path ("/health")    │
-└─────────────────────────────────┘
-│
-▼
-Wait up to max_wait_time (15s)
-│
-┌──────────┴──────────┐
-▼                     ▼
-Response              Timeout/Error
-│                     │
-▼                     │
-Status ==             │
-expected?             │
-│                     │
-┌──┴──┐               │
-▼     ▼               │
-Y     N               │
-│     │               │
-│     └───────┬───────┘
-│             ▼
-│        Consecutive
-│        failures +1
-│             │
-▼             ▼
-HEALTHY       Failures > max_retries?
-(reset                │
-failures)       ┌─────┴─────┐
-                ▼           ▼
-               Yes          No
-                │           │
-                ▼           ▼
-            UNHEALTHY    Keep current
-            (removed     status
-            from traffic
-            internally)
-```
+**① AppProxy: Traffic Routing Control**
+
+![](../images/health_check_app_proxy.svg)
+
+**② Manager: Health State Management and Eviction**
+
+![](../images/health_check_state_machine.svg)
 
 :::note
 The internal health status (used for traffic routing) may not be immediately

--- a/packages/backend.ai-webui-docs/src/ja/images/health_check_app_proxy.svg
+++ b/packages/backend.ai-webui-docs/src/ja/images/health_check_app_proxy.svg
@@ -1,0 +1,85 @@
+<svg id="d1j" viewBox="0 0 960 500" xmlns="http://www.w3.org/2000/svg" font-size="14" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="a1j" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <marker id="a1gj" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#16a34a"/>
+    </marker>
+    <marker id="a1rj" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#dc2626"/>
+    </marker>
+    <marker id="a1bj" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#60a5fa"/>
+    </marker>
+    <filter id="s1j" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Manager -->
+  <g filter="url(#s1j)">
+    <rect x="245" y="30" width="280" height="84" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="385" y="64" text-anchor="middle" font-size="16" font-weight="600" fill="#0f172a">Manager</text>
+    <text x="385" y="86" text-anchor="middle" font-size="12" fill="#64748b">Active · HEALTHY route のみ</text>
+    <text x="385" y="104" text-anchor="middle" font-size="12" fill="#64748b">AppProxy に sync</text>
+  </g>
+
+  <!-- Manager → AppProxy sync arrow -->
+  <line x1="385" y1="114" x2="385" y2="178" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#a1bj)"/>
+  <text x="400" y="150" font-size="12" fill="#1e40af" font-weight="500">sync</text>
+
+  <!-- User -->
+  <g filter="url(#s1j)">
+    <circle cx="80" cy="290" r="42" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="80" y="286" text-anchor="middle" font-size="14" font-weight="600" fill="#0f172a">User</text>
+    <text x="80" y="304" text-anchor="middle" font-size="11" fill="#64748b">traffic</text>
+  </g>
+
+  <!-- User → AppProxy arrow -->
+  <line x1="124" y1="290" x2="173" y2="290" stroke="#334155" stroke-width="2" marker-end="url(#a1j)"/>
+  <text x="148" y="280" text-anchor="middle" font-size="12" fill="#0f172a" font-weight="500">リクエスト</text>
+
+  <!-- AppProxy box -->
+  <g filter="url(#s1j)">
+    <rect x="175" y="180" width="420" height="280" rx="14" fill="#eff6ff" stroke="#2563eb" stroke-width="1.5"/>
+    <text x="385" y="212" text-anchor="middle" font-size="18" font-weight="700" fill="#1e3a8a">AppProxy</text>
+    <line x1="205" y1="226" x2="565" y2="226" stroke="#bfdbfe" stroke-width="1"/>
+
+    <!-- Health Checker -->
+    <rect x="200" y="252" width="170" height="80" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+    <text x="285" y="284" text-anchor="middle" font-size="14" font-weight="600" fill="#1e40af">Health Checker</text>
+    <text x="285" y="304" text-anchor="middle" font-size="11" fill="#3b82f6">replica probe</text>
+
+    <!-- Active Pool -->
+    <rect x="395" y="252" width="170" height="80" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+    <text x="480" y="284" text-anchor="middle" font-size="14" font-weight="600" fill="#1e40af">Active Pool</text>
+    <text x="480" y="304" text-anchor="middle" font-size="11" fill="#3b82f6">healthy のみ維持</text>
+
+    <line x1="372" y1="292" x2="393" y2="292" stroke="#60a5fa" stroke-width="1.3" marker-end="url(#a1bj)"/>
+
+    <text x="385" y="430" text-anchor="middle" font-size="12" fill="#1e40af" font-weight="500">→ healthy replica のみにルーティング</text>
+  </g>
+
+  <!-- Replicas -->
+  <g filter="url(#s1j)">
+    <rect x="680" y="204" width="220" height="72" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+    <text x="790" y="234" text-anchor="middle" font-size="15" font-weight="600" fill="#14532d">replica A</text>
+    <text x="790" y="256" text-anchor="middle" font-size="12" fill="#16a34a">✓ pool に含む</text>
+  </g>
+  <g filter="url(#s1j)">
+    <rect x="680" y="296" width="220" height="72" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+    <text x="790" y="326" text-anchor="middle" font-size="15" font-weight="600" fill="#14532d">replica B</text>
+    <text x="790" y="348" text-anchor="middle" font-size="12" fill="#16a34a">✓ pool に含む</text>
+  </g>
+  <g filter="url(#s1j)">
+    <rect x="680" y="388" width="220" height="72" rx="12" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="6 4"/>
+    <text x="790" y="418" text-anchor="middle" font-size="15" font-weight="600" fill="#7f1d1d">replica C</text>
+    <text x="790" y="440" text-anchor="middle" font-size="12" fill="#dc2626">✗ pool から除外</text>
+  </g>
+
+  <!-- AppProxy → Replicas -->
+  <line x1="597" y1="240" x2="678" y2="240" stroke="#16a34a" stroke-width="1.8" marker-end="url(#a1gj)"/>
+  <line x1="597" y1="332" x2="678" y2="332" stroke="#16a34a" stroke-width="1.8" marker-end="url(#a1gj)"/>
+  <line x1="597" y1="424" x2="678" y2="424" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#a1rj)"/>
+</svg>

--- a/packages/backend.ai-webui-docs/src/ja/images/health_check_state_machine.svg
+++ b/packages/backend.ai-webui-docs/src/ja/images/health_check_state_machine.svg
@@ -1,0 +1,80 @@
+<svg id="d2j" viewBox="0 0 900 800" xmlns="http://www.w3.org/2000/svg" font-size="14" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="a2j" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <filter id="s2j" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- NOT_CHECKED -->
+  <g filter="url(#s2j)">
+    <ellipse cx="450" cy="100" rx="110" ry="44" fill="#f8fafc" stroke="#475569" stroke-width="1.5"/>
+    <text x="450" y="96" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">NOT_CHECKED</text>
+    <text x="450" y="116" text-anchor="middle" font-size="11" fill="#64748b">initial_delay · 未判定</text>
+  </g>
+
+  <!-- HEALTHY -->
+  <g filter="url(#s2j)">
+    <ellipse cx="450" cy="320" rx="110" ry="44" fill="#f0fdf4" stroke="#16a34a" stroke-width="2"/>
+    <text x="450" y="316" text-anchor="middle" font-size="15" font-weight="700" fill="#14532d">HEALTHY</text>
+    <text x="450" y="336" text-anchor="middle" font-size="11" fill="#16a34a">アクティブ · ルーティング対象</text>
+  </g>
+
+  <!-- UNHEALTHY -->
+  <g filter="url(#s2j)">
+    <ellipse cx="200" cy="560" rx="110" ry="44" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="200" y="556" text-anchor="middle" font-size="15" font-weight="700" fill="#7f1d1d">UNHEALTHY</text>
+    <text x="200" y="576" text-anchor="middle" font-size="11" fill="#dc2626">連続失敗確定</text>
+  </g>
+
+  <!-- DEGRADED -->
+  <g filter="url(#s2j)">
+    <ellipse cx="700" cy="560" rx="110" ry="44" fill="#fffbeb" stroke="#d97706" stroke-width="1.5"/>
+    <text x="700" y="556" text-anchor="middle" font-size="15" font-weight="700" fill="#78350f">DEGRADED</text>
+    <text x="700" y="576" text-anchor="middle" font-size="11" fill="#b45309">チェック不可 · 判定猶予</text>
+  </g>
+
+  <!-- TERMINATING (double border for terminal) -->
+  <g filter="url(#s2j)">
+    <ellipse cx="200" cy="740" rx="114" ry="44" fill="#f1f5f9" stroke="#334155" stroke-width="1.5"/>
+    <ellipse cx="200" cy="740" rx="106" ry="36" fill="none" stroke="#334155" stroke-width="1.5"/>
+    <text x="200" y="736" text-anchor="middle" font-size="14" font-weight="700" fill="#1e293b">TERMINATING</text>
+    <text x="200" y="754" text-anchor="middle" font-size="11" fill="#475569">terminal · ルーティング終了</text>
+  </g>
+
+  <!-- NOT_CHECKED → HEALTHY -->
+  <line x1="450" y1="144" x2="450" y2="276" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2j)"/>
+  <text x="466" y="198" font-size="13" fill="#0f172a" font-weight="500">初回成功時に即時</text>
+  <text x="466" y="216" font-size="11" fill="#64748b">(initial_delay 中でも)</text>
+
+  <!-- NOT_CHECKED self loop -->
+  <path d="M 345 88 C 265 55 255 135 342 118" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2j)"/>
+  <text x="238" y="88" text-anchor="end" font-size="11" fill="#64748b">失敗は無視</text>
+  <text x="238" y="104" text-anchor="end" font-size="11" fill="#64748b">NOT_CHECKED 維持</text>
+
+  <!-- HEALTHY → UNHEALTHY -->
+  <path d="M 368 358 Q 240 470 228 520" fill="none" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2j)"/>
+  <text x="232" y="408" text-anchor="end" font-size="12" fill="#0f172a" font-weight="500">N回連続失敗</text>
+
+  <!-- UNHEALTHY → HEALTHY -->
+  <path d="M 272 522 Q 370 460 418 360" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2j)"/>
+  <text x="346" y="450" text-anchor="start" font-size="12" fill="#334155">成功時に即時復旧</text>
+
+  <!-- HEALTHY → DEGRADED -->
+  <path d="M 532 358 Q 660 470 672 520" fill="none" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2j)"/>
+  <text x="668" y="408" font-size="12" fill="#0f172a" font-weight="500">チェック不可</text>
+
+  <!-- DEGRADED → HEALTHY -->
+  <path d="M 628 522 Q 530 460 482 360" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2j)"/>
+  <text x="554" y="484" text-anchor="end" font-size="12" fill="#334155">チェック復帰 + 成功</text>
+
+  <!-- DEGRADED → UNHEALTHY -->
+  <path d="M 590 560 Q 450 528 310 560" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2j)"/>
+  <text x="450" y="524" text-anchor="middle" font-size="12" fill="#0f172a" font-weight="500">チェック復帰後に連続失敗</text>
+
+  <!-- UNHEALTHY → TERMINATING -->
+  <line x1="200" y1="604" x2="200" y2="696" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2j)"/>
+  <text x="216" y="654" font-size="12" fill="#0f172a" font-weight="500">eviction</text>
+</svg>

--- a/packages/backend.ai-webui-docs/src/ja/model_serving/model_serving.md
+++ b/packages/backend.ai-webui-docs/src/ja/model_serving/model_serving.md
@@ -127,58 +127,13 @@ models:
 
 ヘルスチェックシステムは、個々のモデルサービスコンテナを監視し、ヘルスステータスに基づいてトラフィックルーティングを自動的に管理します。
 
-```
-Container Created
-│
-▼
-┌─────────────────────────────────┐
-│  Wait for initial_delay (60s)   │  ← Model loading, GPU init, warmup
-│  Status: NOT_CHECKED            │
-│  No health checks during this   │
-└─────────────────────────────────┘
-│
-▼
-Start Health Check Cycle
-│
-▼
-┌─────────────────────────────────┐
-│  Every interval (10s):          │
-│  HTTP GET → path ("/health")    │
-└─────────────────────────────────┘
-│
-▼
-Wait up to max_wait_time (15s)
-│
-┌──────────┴──────────┐
-▼                     ▼
-Response              Timeout/Error
-│                     │
-▼                     │
-Status ==             │
-expected?             │
-│                     │
-┌──┴──┐               │
-▼     ▼               │
-Y     N               │
-│     │               │
-│     └───────┬───────┘
-│             ▼
-│        Consecutive
-│        failures +1
-│             │
-▼             ▼
-HEALTHY       Failures > max_retries?
-(reset                │
-failures)       ┌─────┴─────┐
-                ▼           ▼
-               Yes          No
-                │           │
-                ▼           ▼
-            UNHEALTHY    Keep current
-            (removed     status
-            from traffic
-            internally)
-```
+**① AppProxy: トラフィックルーティング制御**
+
+![](../images/health_check_app_proxy.svg)
+
+**② Manager: ヘルス状態管理と eviction**
+
+![](../images/health_check_state_machine.svg)
 
 :::note
 内部ヘルスステータス（トラフィックルーティングに使用）は、ユーザーインターフェースに

--- a/packages/backend.ai-webui-docs/src/ko/images/health_check_app_proxy.svg
+++ b/packages/backend.ai-webui-docs/src/ko/images/health_check_app_proxy.svg
@@ -1,0 +1,85 @@
+<svg viewBox="0 0 960 500" xmlns="http://www.w3.org/2000/svg" font-size="14" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="p1a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <marker id="p1g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#16a34a"/>
+    </marker>
+    <marker id="p1r" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#dc2626"/>
+    </marker>
+    <marker id="p1b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#60a5fa"/>
+    </marker>
+    <filter id="p1s" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Manager -->
+  <g filter="url(#p1s)">
+    <rect x="245" y="30" width="280" height="84" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="385" y="64" text-anchor="middle" font-size="16" font-weight="600" fill="#0f172a">Manager</text>
+    <text x="385" y="86" text-anchor="middle" font-size="12" fill="#64748b">Syncs only Active · HEALTHY routes</text>
+    <text x="385" y="104" text-anchor="middle" font-size="12" fill="#64748b">to AppProxy</text>
+  </g>
+
+  <!-- Manager → AppProxy sync arrow -->
+  <line x1="385" y1="114" x2="385" y2="178" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#p1b)"/>
+  <text x="400" y="150" font-size="12" fill="#1e40af" font-weight="500">sync</text>
+
+  <!-- User -->
+  <g filter="url(#p1s)">
+    <circle cx="80" cy="290" r="42" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="80" y="286" text-anchor="middle" font-size="14" font-weight="600" fill="#0f172a">User</text>
+    <text x="80" y="304" text-anchor="middle" font-size="11" fill="#64748b">traffic</text>
+  </g>
+
+  <!-- User → AppProxy arrow -->
+  <line x1="124" y1="290" x2="173" y2="290" stroke="#334155" stroke-width="2" marker-end="url(#p1a)"/>
+  <text x="148" y="280" text-anchor="middle" font-size="12" fill="#0f172a" font-weight="500">request</text>
+
+  <!-- AppProxy box -->
+  <g filter="url(#p1s)">
+    <rect x="175" y="180" width="420" height="280" rx="14" fill="#eff6ff" stroke="#2563eb" stroke-width="1.5"/>
+    <text x="385" y="212" text-anchor="middle" font-size="18" font-weight="700" fill="#1e3a8a">AppProxy</text>
+    <line x1="205" y1="226" x2="565" y2="226" stroke="#bfdbfe" stroke-width="1"/>
+
+    <!-- Health Checker -->
+    <rect x="200" y="252" width="170" height="80" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+    <text x="285" y="284" text-anchor="middle" font-size="14" font-weight="600" fill="#1e40af">Health Checker</text>
+    <text x="285" y="304" text-anchor="middle" font-size="11" fill="#3b82f6">replica probe</text>
+
+    <!-- Active Pool -->
+    <rect x="395" y="252" width="170" height="80" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+    <text x="480" y="284" text-anchor="middle" font-size="14" font-weight="600" fill="#1e40af">Active Pool</text>
+    <text x="480" y="304" text-anchor="middle" font-size="11" fill="#3b82f6">healthy only</text>
+
+    <line x1="372" y1="292" x2="393" y2="292" stroke="#60a5fa" stroke-width="1.3" marker-end="url(#p1b)"/>
+
+    <text x="385" y="430" text-anchor="middle" font-size="12" fill="#1e40af" font-weight="500">→ routes to healthy replicas only</text>
+  </g>
+
+  <!-- Replicas -->
+  <g filter="url(#p1s)">
+    <rect x="680" y="204" width="220" height="72" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+    <text x="790" y="234" text-anchor="middle" font-size="15" font-weight="600" fill="#14532d">replica A</text>
+    <text x="790" y="256" text-anchor="middle" font-size="12" fill="#16a34a">✓ in pool</text>
+  </g>
+  <g filter="url(#p1s)">
+    <rect x="680" y="296" width="220" height="72" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+    <text x="790" y="326" text-anchor="middle" font-size="15" font-weight="600" fill="#14532d">replica B</text>
+    <text x="790" y="348" text-anchor="middle" font-size="12" fill="#16a34a">✓ in pool</text>
+  </g>
+  <g filter="url(#p1s)">
+    <rect x="680" y="388" width="220" height="72" rx="12" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="6 4"/>
+    <text x="790" y="418" text-anchor="middle" font-size="15" font-weight="600" fill="#7f1d1d">replica C</text>
+    <text x="790" y="440" text-anchor="middle" font-size="12" fill="#dc2626">✗ excluded from pool</text>
+  </g>
+
+  <!-- AppProxy → Replicas -->
+  <line x1="597" y1="240" x2="678" y2="240" stroke="#16a34a" stroke-width="1.8" marker-end="url(#p1g)"/>
+  <line x1="597" y1="332" x2="678" y2="332" stroke="#16a34a" stroke-width="1.8" marker-end="url(#p1g)"/>
+  <line x1="597" y1="424" x2="678" y2="424" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#p1r)"/>
+</svg>

--- a/packages/backend.ai-webui-docs/src/ko/images/health_check_state_machine.svg
+++ b/packages/backend.ai-webui-docs/src/ko/images/health_check_state_machine.svg
@@ -1,0 +1,80 @@
+<svg id="d2" viewBox="0 0 900 800" xmlns="http://www.w3.org/2000/svg" font-size="14" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="a2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <filter id="s2" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- NOT_CHECKED -->
+  <g filter="url(#s2)">
+    <ellipse cx="450" cy="100" rx="110" ry="44" fill="#f8fafc" stroke="#475569" stroke-width="1.5"/>
+    <text x="450" y="96" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">NOT_CHECKED</text>
+    <text x="450" y="116" text-anchor="middle" font-size="11" fill="#64748b">initial_delay · 미판정</text>
+  </g>
+
+  <!-- HEALTHY -->
+  <g filter="url(#s2)">
+    <ellipse cx="450" cy="320" rx="110" ry="44" fill="#f0fdf4" stroke="#16a34a" stroke-width="2"/>
+    <text x="450" y="316" text-anchor="middle" font-size="15" font-weight="700" fill="#14532d">HEALTHY</text>
+    <text x="450" y="336" text-anchor="middle" font-size="11" fill="#16a34a">활성 · 라우팅 대상</text>
+  </g>
+
+  <!-- UNHEALTHY -->
+  <g filter="url(#s2)">
+    <ellipse cx="200" cy="560" rx="110" ry="44" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="200" y="556" text-anchor="middle" font-size="15" font-weight="700" fill="#7f1d1d">UNHEALTHY</text>
+    <text x="200" y="576" text-anchor="middle" font-size="11" fill="#dc2626">연속 실패 확정</text>
+  </g>
+
+  <!-- DEGRADED -->
+  <g filter="url(#s2)">
+    <ellipse cx="700" cy="560" rx="110" ry="44" fill="#fffbeb" stroke="#d97706" stroke-width="1.5"/>
+    <text x="700" y="556" text-anchor="middle" font-size="15" font-weight="700" fill="#78350f">DEGRADED</text>
+    <text x="700" y="576" text-anchor="middle" font-size="11" fill="#b45309">체크 불가 · 판정 유예</text>
+  </g>
+
+  <!-- TERMINATING (double border for terminal) -->
+  <g filter="url(#s2)">
+    <ellipse cx="200" cy="740" rx="114" ry="44" fill="#f1f5f9" stroke="#334155" stroke-width="1.5"/>
+    <ellipse cx="200" cy="740" rx="106" ry="36" fill="none" stroke="#334155" stroke-width="1.5"/>
+    <text x="200" y="736" text-anchor="middle" font-size="14" font-weight="700" fill="#1e293b">TERMINATING</text>
+    <text x="200" y="754" text-anchor="middle" font-size="11" fill="#475569">terminal · 라우팅 종료</text>
+  </g>
+
+  <!-- NOT_CHECKED → HEALTHY -->
+  <line x1="450" y1="144" x2="450" y2="276" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2)"/>
+  <text x="466" y="198" font-size="13" fill="#0f172a" font-weight="500">첫 성공 시 즉시</text>
+  <text x="466" y="216" font-size="11" fill="#64748b">(initial_delay 중이어도)</text>
+
+  <!-- NOT_CHECKED self loop -->
+  <path d="M 345 88 C 265 55 255 135 342 118" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2)"/>
+  <text x="238" y="88" text-anchor="end" font-size="11" fill="#64748b">실패는 무시</text>
+  <text x="238" y="104" text-anchor="end" font-size="11" fill="#64748b">NOT_CHECKED 유지</text>
+
+  <!-- HEALTHY → UNHEALTHY -->
+  <path d="M 368 358 Q 240 470 228 520" fill="none" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2)"/>
+  <text x="232" y="408" text-anchor="end" font-size="12" fill="#0f172a" font-weight="500">N회 연속 실패</text>
+
+  <!-- UNHEALTHY → HEALTHY -->
+  <path d="M 272 522 Q 370 460 418 360" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2)"/>
+  <text x="346" y="450" text-anchor="start" font-size="12" fill="#334155">성공 즉시 복구</text>
+
+  <!-- HEALTHY → DEGRADED -->
+  <path d="M 532 358 Q 660 470 672 520" fill="none" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2)"/>
+  <text x="668" y="408" font-size="12" fill="#0f172a" font-weight="500">체크 불가</text>
+
+  <!-- DEGRADED → HEALTHY -->
+  <path d="M 628 522 Q 530 460 482 360" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2)"/>
+  <text x="554" y="484" text-anchor="end" font-size="12" fill="#334155">체크 복귀 + 성공</text>
+
+  <!-- DEGRADED → UNHEALTHY -->
+  <path d="M 590 560 Q 450 528 310 560" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2)"/>
+  <text x="450" y="524" text-anchor="middle" font-size="12" fill="#0f172a" font-weight="500">체크 복귀 후 연속 실패</text>
+
+  <!-- UNHEALTHY → TERMINATING -->
+  <line x1="200" y1="604" x2="200" y2="696" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2)"/>
+  <text x="216" y="654" font-size="12" fill="#0f172a" font-weight="500">eviction</text>
+</svg>

--- a/packages/backend.ai-webui-docs/src/ko/model_serving/model_serving.md
+++ b/packages/backend.ai-webui-docs/src/ko/model_serving/model_serving.md
@@ -127,58 +127,13 @@ models:
 
 상태 확인 시스템은 개별 모델 서비스 컨테이너를 모니터링하고, 상태에 따라 트래픽 라우팅을 자동으로 관리합니다.
 
-```
-Container Created
-│
-▼
-┌─────────────────────────────────┐
-│  Wait for initial_delay (60s)   │  ← Model loading, GPU init, warmup
-│  Status: NOT_CHECKED            │
-│  No health checks during this   │
-└─────────────────────────────────┘
-│
-▼
-Start Health Check Cycle
-│
-▼
-┌─────────────────────────────────┐
-│  Every interval (10s):          │
-│  HTTP GET → path ("/health")    │
-└─────────────────────────────────┘
-│
-▼
-Wait up to max_wait_time (15s)
-│
-┌──────────┴──────────┐
-▼                     ▼
-Response              Timeout/Error
-│                     │
-▼                     │
-Status ==             │
-expected?             │
-│                     │
-┌──┴──┐               │
-▼     ▼               │
-Y     N               │
-│     │               │
-│     └───────┬───────┘
-│             ▼
-│        Consecutive
-│        failures +1
-│             │
-▼             ▼
-HEALTHY       Failures > max_retries?
-(reset                │
-failures)       ┌─────┴─────┐
-                ▼           ▼
-               Yes          No
-                │           │
-                ▼           ▼
-            UNHEALTHY    Keep current
-            (removed     status
-            from traffic
-            internally)
-```
+**① AppProxy: 트래픽 라우팅 제어**
+
+![](../images/health_check_app_proxy.svg)
+
+**② Manager: 상태 관리 및 eviction**
+
+![](../images/health_check_state_machine.svg)
 
 :::note
 내부 상태 정보(트래픽 라우팅에 사용됨)는 사용자 인터페이스에 표시되는

--- a/packages/backend.ai-webui-docs/src/th/images/health_check_app_proxy.svg
+++ b/packages/backend.ai-webui-docs/src/th/images/health_check_app_proxy.svg
@@ -1,0 +1,85 @@
+<svg id="d1t" viewBox="0 0 960 500" xmlns="http://www.w3.org/2000/svg" font-size="14" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="a1t" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <marker id="a1gt" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#16a34a"/>
+    </marker>
+    <marker id="a1rt" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#dc2626"/>
+    </marker>
+    <marker id="a1bt" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#60a5fa"/>
+    </marker>
+    <filter id="s1t" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Manager -->
+  <g filter="url(#s1t)">
+    <rect x="245" y="30" width="280" height="84" rx="12" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="385" y="64" text-anchor="middle" font-size="16" font-weight="600" fill="#0f172a">Manager</text>
+    <text x="385" y="86" text-anchor="middle" font-size="12" fill="#64748b">ซิงค์เฉพาะ route Active · HEALTHY</text>
+    <text x="385" y="104" text-anchor="middle" font-size="12" fill="#64748b">ไปยัง AppProxy</text>
+  </g>
+
+  <!-- Manager → AppProxy sync arrow -->
+  <line x1="385" y1="114" x2="385" y2="178" stroke="#2563eb" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#a1bt)"/>
+  <text x="400" y="150" font-size="12" fill="#1e40af" font-weight="500">sync</text>
+
+  <!-- User -->
+  <g filter="url(#s1t)">
+    <circle cx="80" cy="290" r="42" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="80" y="286" text-anchor="middle" font-size="14" font-weight="600" fill="#0f172a">User</text>
+    <text x="80" y="304" text-anchor="middle" font-size="11" fill="#64748b">traffic</text>
+  </g>
+
+  <!-- User → AppProxy arrow -->
+  <line x1="124" y1="290" x2="173" y2="290" stroke="#334155" stroke-width="2" marker-end="url(#a1t)"/>
+  <text x="148" y="280" text-anchor="middle" font-size="12" fill="#0f172a" font-weight="500">คำขอ</text>
+
+  <!-- AppProxy box -->
+  <g filter="url(#s1t)">
+    <rect x="175" y="180" width="420" height="280" rx="14" fill="#eff6ff" stroke="#2563eb" stroke-width="1.5"/>
+    <text x="385" y="212" text-anchor="middle" font-size="18" font-weight="700" fill="#1e3a8a">AppProxy</text>
+    <line x1="205" y1="226" x2="565" y2="226" stroke="#bfdbfe" stroke-width="1"/>
+
+    <!-- Health Checker -->
+    <rect x="200" y="252" width="170" height="80" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+    <text x="285" y="284" text-anchor="middle" font-size="14" font-weight="600" fill="#1e40af">Health Checker</text>
+    <text x="285" y="304" text-anchor="middle" font-size="11" fill="#3b82f6">replica probe</text>
+
+    <!-- Active Pool -->
+    <rect x="395" y="252" width="170" height="80" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+    <text x="480" y="284" text-anchor="middle" font-size="14" font-weight="600" fill="#1e40af">Active Pool</text>
+    <text x="480" y="304" text-anchor="middle" font-size="11" fill="#3b82f6">เฉพาะ healthy</text>
+
+    <line x1="372" y1="292" x2="393" y2="292" stroke="#60a5fa" stroke-width="1.3" marker-end="url(#a1bt)"/>
+
+    <text x="385" y="430" text-anchor="middle" font-size="12" fill="#1e40af" font-weight="500">→ กำหนดเส้นทางไปยัง replica healthy เท่านั้น</text>
+  </g>
+
+  <!-- Replicas -->
+  <g filter="url(#s1t)">
+    <rect x="680" y="204" width="220" height="72" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+    <text x="790" y="234" text-anchor="middle" font-size="15" font-weight="600" fill="#14532d">replica A</text>
+    <text x="790" y="256" text-anchor="middle" font-size="12" fill="#16a34a">✓ อยู่ใน pool</text>
+  </g>
+  <g filter="url(#s1t)">
+    <rect x="680" y="296" width="220" height="72" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+    <text x="790" y="326" text-anchor="middle" font-size="15" font-weight="600" fill="#14532d">replica B</text>
+    <text x="790" y="348" text-anchor="middle" font-size="12" fill="#16a34a">✓ อยู่ใน pool</text>
+  </g>
+  <g filter="url(#s1t)">
+    <rect x="680" y="388" width="220" height="72" rx="12" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="6 4"/>
+    <text x="790" y="418" text-anchor="middle" font-size="15" font-weight="600" fill="#7f1d1d">replica C</text>
+    <text x="790" y="440" text-anchor="middle" font-size="12" fill="#dc2626">✗ ไม่อยู่ใน pool</text>
+  </g>
+
+  <!-- AppProxy → Replicas -->
+  <line x1="597" y1="240" x2="678" y2="240" stroke="#16a34a" stroke-width="1.8" marker-end="url(#a1gt)"/>
+  <line x1="597" y1="332" x2="678" y2="332" stroke="#16a34a" stroke-width="1.8" marker-end="url(#a1gt)"/>
+  <line x1="597" y1="424" x2="678" y2="424" stroke="#dc2626" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#a1rt)"/>
+</svg>

--- a/packages/backend.ai-webui-docs/src/th/images/health_check_state_machine.svg
+++ b/packages/backend.ai-webui-docs/src/th/images/health_check_state_machine.svg
@@ -1,0 +1,80 @@
+<svg id="d2t" viewBox="0 0 900 800" xmlns="http://www.w3.org/2000/svg" font-size="14" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="a2t" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#64748b"/>
+    </marker>
+    <filter id="s2t" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- NOT_CHECKED -->
+  <g filter="url(#s2t)">
+    <ellipse cx="450" cy="100" rx="110" ry="44" fill="#f8fafc" stroke="#475569" stroke-width="1.5"/>
+    <text x="450" y="96" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">NOT_CHECKED</text>
+    <text x="450" y="116" text-anchor="middle" font-size="11" fill="#64748b">initial_delay · ยังไม่ตัดสิน</text>
+  </g>
+
+  <!-- HEALTHY -->
+  <g filter="url(#s2t)">
+    <ellipse cx="450" cy="320" rx="110" ry="44" fill="#f0fdf4" stroke="#16a34a" stroke-width="2"/>
+    <text x="450" y="316" text-anchor="middle" font-size="15" font-weight="700" fill="#14532d">HEALTHY</text>
+    <text x="450" y="336" text-anchor="middle" font-size="11" fill="#16a34a">ทำงาน · เป้าหมายการกำหนดเส้นทาง</text>
+  </g>
+
+  <!-- UNHEALTHY -->
+  <g filter="url(#s2t)">
+    <ellipse cx="200" cy="560" rx="110" ry="44" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="200" y="556" text-anchor="middle" font-size="15" font-weight="700" fill="#7f1d1d">UNHEALTHY</text>
+    <text x="200" y="576" text-anchor="middle" font-size="11" fill="#dc2626">ล้มเหลวต่อเนื่องยืนยันแล้ว</text>
+  </g>
+
+  <!-- DEGRADED -->
+  <g filter="url(#s2t)">
+    <ellipse cx="700" cy="560" rx="110" ry="44" fill="#fffbeb" stroke="#d97706" stroke-width="1.5"/>
+    <text x="700" y="556" text-anchor="middle" font-size="15" font-weight="700" fill="#78350f">DEGRADED</text>
+    <text x="700" y="576" text-anchor="middle" font-size="11" fill="#b45309">ตรวจสอบไม่ได้ · ผ่อนผัน</text>
+  </g>
+
+  <!-- TERMINATING (double border for terminal) -->
+  <g filter="url(#s2t)">
+    <ellipse cx="200" cy="740" rx="114" ry="44" fill="#f1f5f9" stroke="#334155" stroke-width="1.5"/>
+    <ellipse cx="200" cy="740" rx="106" ry="36" fill="none" stroke="#334155" stroke-width="1.5"/>
+    <text x="200" y="736" text-anchor="middle" font-size="14" font-weight="700" fill="#1e293b">TERMINATING</text>
+    <text x="200" y="754" text-anchor="middle" font-size="11" fill="#475569">terminal · สิ้นสุดการกำหนดเส้นทาง</text>
+  </g>
+
+  <!-- NOT_CHECKED → HEALTHY -->
+  <line x1="450" y1="144" x2="450" y2="276" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2t)"/>
+  <text x="466" y="198" font-size="13" fill="#0f172a" font-weight="500">เมื่อสำเร็จครั้งแรกทันที</text>
+  <text x="466" y="216" font-size="11" fill="#64748b">(แม้ระหว่าง initial_delay)</text>
+
+  <!-- NOT_CHECKED self loop -->
+  <path d="M 345 88 C 265 55 255 135 342 118" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2t)"/>
+  <text x="238" y="88" text-anchor="end" font-size="11" fill="#64748b">ความล้มเหลวถูกละเว้น</text>
+  <text x="238" y="104" text-anchor="end" font-size="11" fill="#64748b">คงอยู่ใน NOT_CHECKED</text>
+
+  <!-- HEALTHY → UNHEALTHY -->
+  <path d="M 368 358 Q 240 470 228 520" fill="none" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2t)"/>
+  <text x="232" y="408" text-anchor="end" font-size="12" fill="#0f172a" font-weight="500">ล้มเหลว N ครั้งติดต่อกัน</text>
+
+  <!-- UNHEALTHY → HEALTHY -->
+  <path d="M 272 522 Q 370 460 418 360" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2t)"/>
+  <text x="346" y="450" text-anchor="start" font-size="12" fill="#334155">กู้คืนทันทีเมื่อสำเร็จ</text>
+
+  <!-- HEALTHY → DEGRADED -->
+  <path d="M 532 358 Q 660 470 672 520" fill="none" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2t)"/>
+  <text x="668" y="408" font-size="12" fill="#0f172a" font-weight="500">ตรวจสอบไม่ได้</text>
+
+  <!-- DEGRADED → HEALTHY -->
+  <path d="M 628 522 Q 530 460 482 360" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2t)"/>
+  <text x="554" y="484" text-anchor="end" font-size="12" fill="#334155">ตรวจสอบกลับมา + สำเร็จ</text>
+
+  <!-- DEGRADED → UNHEALTHY -->
+  <path d="M 590 560 Q 450 528 310 560" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#a2t)"/>
+  <text x="450" y="524" text-anchor="middle" font-size="12" fill="#0f172a" font-weight="500">ล้มเหลวต่อเนื่องหลังตรวจสอบกลับมา</text>
+
+  <!-- UNHEALTHY → TERMINATING -->
+  <line x1="200" y1="604" x2="200" y2="696" stroke="#64748b" stroke-width="1.6" marker-end="url(#a2t)"/>
+  <text x="216" y="654" font-size="12" fill="#0f172a" font-weight="500">eviction</text>
+</svg>

--- a/packages/backend.ai-webui-docs/src/th/model_serving/model_serving.md
+++ b/packages/backend.ai-webui-docs/src/th/model_serving/model_serving.md
@@ -129,58 +129,13 @@ models:
 
 ระบบการตรวจสอบสุขภาพจะตรวจสอบคอนเทนเนอร์บริการโมเดลแต่ละตัวและจัดการการเส้นทางการรับส่งข้อมูลโดยอัตโนมัติตามสถานะสุขภาพ
 
-```
-Container Created
-│
-▼
-┌─────────────────────────────────┐
-│  Wait for initial_delay (60s)   │  ← Model loading, GPU init, warmup
-│  Status: NOT_CHECKED            │
-│  No health checks during this   │
-└─────────────────────────────────┘
-│
-▼
-Start Health Check Cycle
-│
-▼
-┌─────────────────────────────────┐
-│  Every interval (10s):          │
-│  HTTP GET → path ("/health")    │
-└─────────────────────────────────┘
-│
-▼
-Wait up to max_wait_time (15s)
-│
-┌──────────┴──────────┐
-▼                     ▼
-Response              Timeout/Error
-│                     │
-▼                     │
-Status ==             │
-expected?             │
-│                     │
-┌──┴──┐               │
-▼     ▼               │
-Y     N               │
-│     │               │
-│     └───────┬───────┘
-│             ▼
-│        Consecutive
-│        failures +1
-│             │
-▼             ▼
-HEALTHY       Failures > max_retries?
-(reset                │
-failures)       ┌─────┴─────┐
-                ▼           ▼
-               Yes          No
-                │           │
-                ▼           ▼
-            UNHEALTHY    Keep current
-            (removed     status
-            from traffic
-            internally)
-```
+**① AppProxy: การควบคุมการกำหนดเส้นทาง Traffic**
+
+![](../images/health_check_app_proxy.svg)
+
+**② Manager: การจัดการสถานะสุขภาพและ Eviction**
+
+![](../images/health_check_state_machine.svg)
 
 :::note
 สถานะสุขภาพภายใน (ใช้สำหรับการเส้นทางการรับส่งข้อมูล) อาจไม่ถูก


### PR DESCRIPTION
Resolves part of FR-2603

## Summary
- Recover and add health check SVG diagrams (health_check_app_proxy.svg, health_check_state_machine.svg) for all 4 languages (en/ko/ja/th)
- Replace ASCII art flow diagrams in model_serving.md with the two SVG images across all languages:
  - **① AppProxy**: Traffic routing control diagram (960×500)
  - **② Manager**: Health state machine diagram (900×800)
- KO keeps original Korean-labeled SVGs; EN/JA/TH use translated versions