### PR TITLE
refactor(FR-2628): rename useEduAppApiEndpoint to useResolvedApiEndpoint

### DIFF
--- a/react/src/components/EduAppLauncher.tsx
+++ b/react/src/components/EduAppLauncher.tsx
@@ -167,7 +167,7 @@ const EduAppLauncher: React.FC<EduAppLauncherProps> = ({
    * Initialize the backend.ai client with session-based auth mode.
    *
    * The caller (`EduAppLauncherPage`) is responsible for providing a
-   * non-empty endpoint via `useEduAppApiEndpoint()`, which reads from
+   * non-empty endpoint via `useResolvedApiEndpoint()`, which reads from
    * `config.toml` and suspends until resolved. If the endpoint is still
    * empty here, client initialization will be rejected and the outer
    * catch in `_launch` will surface the error via notification.

--- a/react/src/hooks/useResolvedApiEndpoint.ts
+++ b/react/src/hooks/useResolvedApiEndpoint.ts
@@ -5,31 +5,26 @@
 import { fetchAndParseConfig } from './useWebUIConfig';
 
 /**
- * Resolve the Backend.AI API endpoint for the EduAppLauncher page.
+ * Resolve the Backend.AI API endpoint from `config.toml` and fallbacks.
  *
- * Unlike the main app flow, the EduAppLauncher page is entered via a token URL
- * and never goes through `LoginView` or `useInitializeConfig`. As a result,
- * neither `localStorage('backendaiwebui.api_endpoint')` nor the `loginConfigState`
- * atom are populated, and the shared `useApiEndpoint()` hook returns an empty
- * string.
- *
- * This hook resolves the endpoint from `config.toml` directly (the same file
- * `LoginView` would have parsed), with the existing sources kept as fallbacks
- * for any rare pre-populated case. It is intentionally scoped to the Edu page
- * only; see FR-2483 for rationale (other independent pages may share the
- * pattern but a broader `useApiEndpoint` refactor is explicitly out of scope).
+ * Intended for pages and components that are entered outside of the normal
+ * `LoginView` → `useInitializeConfig` flow (e.g. token URL entry points like
+ * `EduAppLauncher` or the sToken login boundary) where neither
+ * `localStorage('backendaiwebui.api_endpoint')` nor the `loginConfigState`
+ * atom have been populated yet. The shared `useApiEndpoint()` hook would
+ * return an empty string in those cases.
  *
  * Resolution order:
  *   1. `config.toml` → `general.apiEndpoint`
  *   2. `localStorage('backendaiwebui.api_endpoint')`
- *   3. Empty string (the page should display an error in this case)
+ *   3. Empty string (the caller should display an error in this case)
  *
  * Implementation note: this function suspends by throwing a promise so the
  * caller can gate rendering with `<Suspense>` until endpoint resolution
- * completes. By the time `EduAppLauncher` mounts, the hook returns the
- * resolved endpoint string, which may still be an empty string if every
+ * completes. The resolved value may still be an empty string if every
  * fallback source is unavailable — downstream code is responsible for
- * surfacing that failure (for example, via an error notification).
+ * surfacing that failure (for example, via an error notification or an
+ * `endpoint-unresolved` error state).
  */
 
 let cachedEndpoint: string | null = null;
@@ -62,7 +57,7 @@ const resolveEndpoint = async (): Promise<string> => {
  * Throws a promise on first call so the component tree suspends until the
  * config.toml fetch completes; subsequent calls return the cached value.
  */
-export const useEduAppApiEndpoint = (): string => {
+export const useResolvedApiEndpoint = (): string => {
   if (cachedEndpoint !== null) {
     return cachedEndpoint;
   }

--- a/react/src/pages/EduAppLauncherPage.tsx
+++ b/react/src/pages/EduAppLauncherPage.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { CSSTokenVariables } from '../components/MainLayout/MainLayout';
-import { useEduAppApiEndpoint } from '../hooks/useEduAppApiEndpoint';
+import { useResolvedApiEndpoint } from '../hooks/useResolvedApiEndpoint';
 import React, { Suspense } from 'react';
 
 const EduAppLauncherLazy = React.lazy(
@@ -16,7 +16,7 @@ const EduAppLauncherLazy = React.lazy(
  *
  * Because this page is entered via a token URL and never goes through
  * LoginView, it resolves the API endpoint directly from `config.toml`
- * via `useEduAppApiEndpoint()`. The Suspense boundary below gates
+ * via `useResolvedApiEndpoint()`. The Suspense boundary below gates
  * EduAppLauncher rendering until endpoint resolution completes; the
  * resolved value may still be an empty string if every fallback source
  * is unavailable, in which case `EduAppLauncher._initClient` throws and
@@ -43,7 +43,7 @@ const EduAppLauncherPage: React.FC = () => {
 
 const EduAppLauncherPageContent: React.FC = () => {
   'use memo';
-  const apiEndpoint = useEduAppApiEndpoint();
+  const apiEndpoint = useResolvedApiEndpoint();
 
   return <EduAppLauncherLazy apiEndpoint={apiEndpoint} active={true} />;
 };


### PR DESCRIPTION
Resolves FR-2628 (sub-task of Epic [FR-2616](https://lablup.atlassian.net/browse/FR-2616))

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

## Stack

This PR is part of the Story 1 stack for Epic FR-2616 (Extract sToken login flow into reusable boundary component). See the [dev plan](../blob/main/.specs/draft-stoken-login-boundary/dev-plan.md) for the full scope. The Story 1 PR stack is #6850 → #6851 → #6852 → #6853 → #6854 → #6855 → #6856 on top of spec PR #6828.

[FR-2616]: https://lablup.atlassian.net/browse/FR-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ