### PR TITLE
feat(FR-2629): extend tokenLogin helper with optional extraParams

### DIFF
--- a/react/src/helper/loginSessionAuth.ts
+++ b/react/src/helper/loginSessionAuth.ts
@@ -171,14 +171,35 @@ export async function connectViaGQL(
 
 /**
  * Perform token-based login (SSO).
+ *
+ * `extraParams` are forwarded to `client.token_login` alongside the `sToken`
+ * argument. Callers typically collect these from URL query parameters (for
+ * example, EduAppLauncher forwards `app`, `session_id`, resource hints) for
+ * the server-side token handler. LoginView callers that do not need to
+ * forward anything can omit the argument.
+ *
+ * Reserved keys (`sToken`, `stoken`) are stripped from `extraParams` before
+ * forwarding so that the explicit `sToken` argument always wins, regardless
+ * of whether a caller accidentally (or maliciously) included the token in
+ * the forwarded query parameters. `client.token_login` merges `extraParams`
+ * into the request body via `Object.assign`, so an unsanitized map would
+ * otherwise overwrite the authenticated token field.
  */
 export async function tokenLogin(
   client: any,
   sToken: string,
   cfg: LoginConfigState,
   endpoints: string[],
+  extraParams?: Record<string, string>,
 ): Promise<string[]> {
-  const loginSuccess = await client.token_login(sToken);
+  const sanitizedExtraParams = extraParams
+    ? Object.fromEntries(
+        Object.entries(extraParams).filter(
+          ([key]) => key !== 'sToken' && key !== 'stoken',
+        ),
+      )
+    : {};
+  const loginSuccess = await client.token_login(sToken, sanitizedExtraParams);
   if (!loginSuccess) {
     throw new Error('Cannot authorize session by token.');
   }


### PR DESCRIPTION
Resolves FR-2629 (sub-task of Epic [FR-2616](https://lablup.atlassian.net/browse/FR-2616))

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

## Stack

This PR is part of the Story 1 stack for Epic FR-2616 (Extract sToken login flow into reusable boundary component). See the [dev plan](../blob/main/.specs/draft-stoken-login-boundary/dev-plan.md) for the full scope. The Story 1 PR stack is #6850 → #6851 → #6852 → #6853 → #6854 → #6855 → #6856 on top of spec PR #6828.

[FR-2616]: https://lablup.atlassian.net/browse/FR-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ