### PR TITLE
feat(FR-2630): add useSToken hook with nuqs and stoken deprecation warning

### DIFF
--- a/react/src/hooks/useSToken.ts
+++ b/react/src/hooks/useSToken.ts
@@ -1,0 +1,69 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useBAILogger } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+
+/**
+ * Read and clear the sToken URL query parameter using nuqs.
+ *
+ * The `STokenLoginBoundary` component (Epic FR-2616) intentionally does not
+ * read from `window.location` on its own — callers must source `sToken` via
+ * nuqs and pass it as a prop. This hook centralizes that lookup so the two
+ * call sites (LoginView route wrapper, EduAppLauncher route wrapper) and any
+ * future token URL entry point share the same canonical-vs-deprecated
+ * handling.
+ *
+ * Resolution:
+ *   1. `?sToken=...` (canonical key) takes precedence.
+ *   2. `?stoken=...` (deprecated lowercase alias) is accepted as a fallback.
+ *      A single deprecation warning is logged per hook instance when only
+ *      `stoken` is present.
+ *
+ * The returned setter writes the canonical `sToken` key and always nulls
+ * the deprecated `stoken` fallback. Passing `null` therefore clears both
+ * keys (the common case, called from `STokenLoginBoundary`'s `onSuccess`
+ * to strip the token from the URL); passing a non-null value overwrites
+ * the canonical key while still erasing the lowercase alias, which keeps
+ * `stoken`-only query strings from lingering alongside the canonical form.
+ */
+
+export const useSToken = (): [
+  string | null,
+  (next: string | null) => Promise<URLSearchParams>,
+] => {
+  'use memo';
+  const { logger } = useBAILogger();
+  const [sToken, setSToken] = useQueryState('sToken', parseAsString);
+  const [stoken, setStoken] = useQueryState('stoken', parseAsString);
+  const hasWarnedRef = useRef(false);
+
+  const logDeprecationIfNeeded = useEffectEvent(() => {
+    if (stoken && !sToken && !hasWarnedRef.current) {
+      hasWarnedRef.current = true;
+      logger.warn(
+        'Query parameter `stoken` (lowercase) is deprecated; use `sToken`.',
+      );
+    }
+  });
+
+  useEffect(() => {
+    logDeprecationIfNeeded();
+  }, [sToken, stoken]);
+
+  const clear = useCallback(
+    async (next: string | null) => {
+      // Clear both keys; callers typically pass `null` after a successful
+      // login to strip the token from the URL. Return the final search
+      // params from the last setter to match nuqs' Promise contract.
+      await setSToken(next);
+      return setStoken(null);
+    },
+    [setSToken, setStoken],
+  );
+
+  const effective = sToken ?? stoken;
+  return [effective, clear];
+};


### PR DESCRIPTION
Resolves FR-2630 (sub-task of Epic [FR-2616](https://lablup.atlassian.net/browse/FR-2616))

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

## Stack

This PR is part of the Story 1 stack for Epic FR-2616 (Extract sToken login flow into reusable boundary component). See the [dev plan](../blob/main/.specs/draft-stoken-login-boundary/dev-plan.md) for the full scope. The Story 1 PR stack is #6850 → #6851 → #6852 → #6853 → #6854 → #6855 → #6856 on top of spec PR #6828.

[FR-2616]: https://lablup.atlassian.net/browse/FR-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ