### PR TITLE
feat(FR-2634): add CI grep rule forbidding URL APIs in STokenLoginBoundary

### DIFF
--- a/scripts/check-stoken-login-boundary-url-free.sh
+++ b/scripts/check-stoken-login-boundary-url-free.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Enforce the URL-API prohibition invariant for STokenLoginBoundary (FR-2616).
+#
+# The boundary component must not read or mutate URL state on its own — the
+# `sToken` value is supplied by callers via prop (sourced through `useSToken`
+# or equivalent nuqs-based hook). See
+# `.specs/draft-stoken-login-boundary/spec.md` section "URL 파라미터 파싱 규약
+# (nuqs)" and the file-header comment in `STokenLoginBoundary.tsx`.
+#
+# This script greps the component source and any sibling files under a
+# future `STokenLoginBoundary/` subdirectory for the forbidden tokens.
+# Matches cause a non-zero exit so `verify.sh` / CI fails the build.
+#
+# Run from the repo root:
+#   bash scripts/check-stoken-login-boundary-url-free.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGETS=()
+
+if [ -f "$ROOT/react/src/components/STokenLoginBoundary.tsx" ]; then
+  TARGETS+=("$ROOT/react/src/components/STokenLoginBoundary.tsx")
+fi
+
+if [ -d "$ROOT/react/src/components/STokenLoginBoundary" ]; then
+  while IFS= read -r file; do
+    TARGETS+=("$file")
+  done < <(find "$ROOT/react/src/components/STokenLoginBoundary" -type f \
+    \( -name '*.ts' -o -name '*.tsx' \))
+fi
+
+if [ ${#TARGETS[@]} -eq 0 ]; then
+  echo "no STokenLoginBoundary source found — nothing to check"
+  exit 0
+fi
+
+# Patterns that indicate direct URL-state access. Comments are stripped
+# from source before grepping, so documentation of the rule in the
+# file-header comment does not trigger a false match.
+FORBIDDEN='window\.location|window\.history|document\.location|\bURLSearchParams\b'
+
+FAIL=0
+for file in "${TARGETS[@]}"; do
+  # Strip block comments and line comments before grepping so the header
+  # documentation does not match. Use a short awk pipeline.
+  CLEANED="$(awk '
+    BEGIN { in_block = 0 }
+    {
+      line = $0
+      if (in_block) {
+        idx = index(line, "*/")
+        if (idx > 0) {
+          line = substr(line, idx + 2)
+          in_block = 0
+        } else {
+          next
+        }
+      }
+      while (match(line, /\/\*.*\*\//)) {
+        line = substr(line, 1, RSTART - 1) substr(line, RSTART + RLENGTH)
+      }
+      start = index(line, "/*")
+      if (start > 0) {
+        line = substr(line, 1, start - 1)
+        in_block = 1
+      }
+      sub(/\/\/.*/, "", line)
+      print line
+    }
+  ' "$file")"
+
+  if echo "$CLEANED" | grep -Eq "$FORBIDDEN"; then
+    echo "ERROR: forbidden URL API reference in $file"
+    echo "$CLEANED" | grep -En "$FORBIDDEN" || true
+    FAIL=1
+  fi
+done
+
+if [ $FAIL -ne 0 ]; then
+  echo ""
+  echo "STokenLoginBoundary must not reference window.location, window.history,"
+  echo "document.location, or URLSearchParams. Callers supply sToken via nuqs."
+  exit 1
+fi
+
+echo "ok: no forbidden URL APIs in STokenLoginBoundary source"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -24,6 +24,7 @@ run_check "Relay" pnpm run relay
 run_check "Lint" pnpm run lint
 run_check "Format" pnpm run format
 run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit
+run_check "STokenLoginBoundary URL-free" bash scripts/check-stoken-login-boundary-url-free.sh
 
 if [ $FAIL -eq 0 ]; then
   echo "=== ALL PASS ==="


### PR DESCRIPTION
Resolves FR-2634 (sub-task of Epic [FR-2616](https://lablup.atlassian.net/browse/FR-2616))

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

## Stack

This PR is part of the Story 1 stack for Epic FR-2616 (Extract sToken login flow into reusable boundary component). See the [dev plan](../blob/main/.specs/draft-stoken-login-boundary/dev-plan.md) for the full scope. The Story 1 PR stack is #6850 → #6851 → #6852 → #6853 → #6854 → #6855 → #6856 on top of spec PR #6828.

[FR-2616]: https://lablup.atlassian.net/browse/FR-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ