### PR TITLE
feat(FR-2632): add default fallback and error card UI for STokenLoginBoundary

### DIFF
--- a/react/src/components/STokenLoginBoundary.tsx
+++ b/react/src/components/STokenLoginBoundary.tsx
@@ -20,8 +20,8 @@ import {
 import { useResolvedApiEndpoint } from '../hooks/useResolvedApiEndpoint';
 import { loginConfigState } from '../hooks/useWebUIConfig';
 import { jotaiStore } from './DefaultProviders';
-import { Alert, Button, Card } from 'antd';
-import { BAIFlex, useBAILogger } from 'backend.ai-ui';
+import { App, Spin, Typography } from 'antd';
+import { BAIButton, BAICard, BAIFlex, useBAILogger } from 'backend.ai-ui';
 import { useAtomValue } from 'jotai';
 import {
   Suspense,
@@ -261,8 +261,21 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
 };
 
 /**
- * Placeholder connecting card. FR-2632 replaces this with the polished
- * BAICard-based version + i18n keys.
+ * Map an error kind to its PascalCase i18n key suffix. The i18n schema
+ * restricts message keys to a flat two-level shape (`module.Key`) where
+ * `Key` must begin with an uppercase letter, so kinds like
+ * `missing-token` cannot appear verbatim in the key.
+ */
+const kindToI18nKey = (kind: STokenLoginError['kind']): string =>
+  kind
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+
+/**
+ * Connecting card shown while the authentication sequence is in flight.
+ * The card is visually subdued so reviewers can tell the app is still
+ * working but hasn't failed.
  */
 const DefaultFallback: React.FC = () => {
   const { t } = useTranslation();
@@ -271,21 +284,73 @@ const DefaultFallback: React.FC = () => {
       direction="column"
       align="center"
       justify="center"
-      style={{ minHeight: '60vh' }}
+      style={{ minHeight: '60vh', padding: 24 }}
     >
-      <Card>{t('login.ConnectingToCluster')}</Card>
+      <BAICard
+        style={{ maxWidth: 480, width: '100%', textAlign: 'center' }}
+        bordered
+      >
+        <BAIFlex direction="column" align="center" gap="md">
+          <Spin size="large" />
+          <Typography.Title level={5} style={{ margin: 0 }}>
+            {t('sTokenLoginBoundary.AuthenticatingTitle')}
+          </Typography.Title>
+          <Typography.Text type="secondary">
+            {t('sTokenLoginBoundary.AuthenticatingDescription')}
+          </Typography.Text>
+        </BAIFlex>
+      </BAICard>
     </BAIFlex>
   );
 };
 
 /**
- * Placeholder error card. FR-2632 replaces this with the full BAICard +
- * BAIButton UI (Retry with async loading state, Copy error details).
+ * Built-in error card rendered when `errorFallback` is not provided.
+ * Offers two actions: Retry (runs the sequence again via BAIButton's
+ * async `action` prop so the loading state appears automatically) and
+ * Copy details (serializes the `{ kind, cause }` payload to JSON and
+ * writes it to the clipboard for support follow-up).
  */
 const DefaultErrorCard: React.FC<{
   error: STokenLoginError;
   onRetry: () => void;
 }> = ({ error, onRetry }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const { logger } = useBAILogger();
+
+  const kindKey = kindToI18nKey(error.kind);
+  const title = t(`sTokenLoginBoundary.Error${kindKey}Title`);
+  const description = t(`sTokenLoginBoundary.Error${kindKey}Description`);
+  const causeDetail =
+    'cause' in error && error.cause
+      ? String((error.cause as Error)?.message ?? error.cause)
+      : null;
+
+  const handleRetry = useCallback(async () => {
+    // Wrap in a Promise so BAIButton.action triggers its async loading
+    // state; the synchronous state reset completes before the next
+    // render, which is visually indistinguishable from the live
+    // sequence restart.
+    await Promise.resolve();
+    onRetry();
+  }, [onRetry]);
+
+  const handleCopy = useCallback(async () => {
+    const payload = {
+      kind: error.kind,
+      cause: causeDetail,
+    };
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+      message.success(t('sTokenLoginBoundary.ErrorDetailsCopied'));
+    } catch (copyError) {
+      logger.warn('[STokenLoginBoundary] clipboard write failed', copyError);
+      message.error(t('sTokenLoginBoundary.ErrorDetailsCopyFailed'));
+    }
+  }, [error, causeDetail, message, t, logger]);
+
   return (
     <BAIFlex
       direction="column"
@@ -293,19 +358,33 @@ const DefaultErrorCard: React.FC<{
       justify="center"
       style={{ minHeight: '60vh', padding: 24 }}
     >
-      <Alert
-        type="error"
-        title={`sToken login failed: ${error.kind}`}
-        description={
-          'cause' in error && error.cause
-            ? String((error.cause as Error)?.message ?? error.cause)
-            : undefined
-        }
-        style={{ maxWidth: 520, marginBottom: 16 }}
-      />
-      <Button type="primary" onClick={onRetry}>
-        Retry
-      </Button>
+      <BAICard
+        status="error"
+        title={title}
+        style={{ maxWidth: 520, width: '100%' }}
+      >
+        <BAIFlex direction="column" gap="md" align="stretch">
+          <Typography.Paragraph style={{ margin: 0 }}>
+            {description}
+          </Typography.Paragraph>
+          {causeDetail && (
+            <Typography.Paragraph
+              type="secondary"
+              style={{ margin: 0, fontSize: 12, whiteSpace: 'pre-wrap' }}
+            >
+              {causeDetail}
+            </Typography.Paragraph>
+          )}
+          <BAIFlex direction="row" gap="sm" justify="end">
+            <BAIButton action={handleCopy}>
+              {t('sTokenLoginBoundary.CopyErrorDetails')}
+            </BAIButton>
+            <BAIButton type="primary" action={handleRetry}>
+              {t('sTokenLoginBoundary.Retry')}
+            </BAIButton>
+          </BAIFlex>
+        </BAIFlex>
+      </BAICard>
     </BAIFlex>
   );
 };

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2071,6 +2071,26 @@
     "SharedMemory": "Gemeinsamer Speicher",
     "Updated": "Ressourcenvoreinstellung aktualisiert"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Geben Sie die Modell-ID ein. (z. B.: openai/gpt-oss-20b)",
     "EnterAVersion": "Geben Sie die Version ein. (Standard: main)",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2069,6 +2069,26 @@
     "SharedMemory": "Κοινόχρηστη μνήμη",
     "Updated": "Η προεπιλογή πόρων ενημερώθηκε"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Εισαγάγετε το ID του μοντέλου. (π.χ.: openai/gpt-oss-20b)",
     "EnterAVersion": "Εισαγάγετε την έκδοση. (Προεπιλογή: main)",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2079,6 +2079,26 @@
     "SharedMemory": "Shared Memory",
     "Updated": "Resource preset updated"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Enter a model ID. (e.g. openai/gpt-oss-20b)",
     "EnterAVersion": "Enter a version. (default: main)",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2069,6 +2069,26 @@
     "SharedMemory": "Memoria compartida",
     "Updated": "Preajuste de recursos actualizado"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Introduzca el ID del modelo. (p. ej.: openai/gpt-oss-20b)",
     "EnterAVersion": "Introduzca la versión. (Predeterminado: main)",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2069,6 +2069,26 @@
     "SharedMemory": "Jaettu muisti",
     "Updated": "Resurssien esiasetus päivitetty"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Syötä mallin tunnus (esim. openai/gpt-oss-20b)",
     "EnterAVersion": "Syötä versio. (Oletus: main)",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2071,6 +2071,26 @@
     "SharedMemory": "Mémoire partagée",
     "Updated": "Préréglage de ressource mis à jour"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Saisissez l'ID du modèle. (ex : openai/gpt-oss-20b)",
     "EnterAVersion": "Saisissez la version. (Par défaut : main)",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2072,6 +2072,26 @@
     "SharedMemory": "Memori bersama",
     "Updated": "Preset sumber daya diperbarui"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Masukkan ID model. (Contoh: openai/gpt-oss-20b)",
     "EnterAVersion": "Masukkan versi. (Nilai bawaan: main)",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2069,6 +2069,26 @@
     "SharedMemory": "Memoria condivisa",
     "Updated": "Preimpostazione delle risorse aggiornata"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Inserisci l'ID del modello. (es.: openai/gpt-oss-20b)",
     "EnterAVersion": "Inserisci la versione. (Predefinito: main)",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2071,6 +2071,26 @@
     "SharedMemory": "共有メモリ",
     "Updated": "リソースプリセットが更新されました"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "モデルIDを入力してください。（例：openai/gpt-oss-20b）",
     "EnterAVersion": "バージョンを入力してください（デフォルト: main）",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2081,6 +2081,26 @@
     "SharedMemory": "공유 메모리",
     "Updated": "자원 프리셋이 수정되었습니다"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "싱글 사인온 토큰으로 로그인하고 있습니다. 잠시만 기다려 주세요.",
+    "AuthenticatingTitle": "로그인 중",
+    "CopyErrorDetails": "오류 세부 정보 복사",
+    "ErrorConcurrentSessionDescription": "다른 곳에서 이미 로그인되어 있습니다. 해당 세션을 종료한 뒤 다시 시도해 주세요.",
+    "ErrorConcurrentSessionTitle": "이미 다른 세션에서 로그인된 상태입니다.",
+    "ErrorDetailsCopied": "오류 세부 정보가 클립보드에 복사되었습니다.",
+    "ErrorDetailsCopyFailed": "오류 세부 정보를 복사하지 못했습니다. 페이지에서 직접 복사해 주세요.",
+    "ErrorEndpointUnresolvedDescription": "구성 파일에서 Backend.AI 서버 주소를 확인하지 못했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.",
+    "ErrorEndpointUnresolvedTitle": "서버 설정을 불러올 수 없습니다.",
+    "ErrorMissingTokenDescription": "요청에 로그인 토큰이 포함되어 있지 않습니다. 원래 링크를 다시 열거나 관리자에게 문의하세요.",
+    "ErrorMissingTokenTitle": "로그인 토큰이 없습니다.",
+    "ErrorServerUnreachableDescription": "초기 연결에 서버가 응답하지 않았습니다. 네트워크 상태를 확인한 뒤 다시 시도하세요.",
+    "ErrorServerUnreachableTitle": "Backend.AI 서버에 연결할 수 없습니다.",
+    "ErrorTokenInvalidDescription": "로그인 토큰이 만료되었거나 해지되었을 수 있습니다. 원래 애플리케이션에서 로그인 절차를 다시 시작해 주세요.",
+    "ErrorTokenInvalidTitle": "로그인 토큰이 유효하지 않습니다.",
+    "ErrorUnknownDescription": "로그인 중 알 수 없는 오류가 발생했습니다. 다시 시도해 주시고, 문제가 계속되면 아래 오류 세부 정보를 복사해 전달해 주세요.",
+    "ErrorUnknownTitle": "로그인 중 예기치 않은 오류가 발생했습니다.",
+    "Retry": "다시 시도"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "모델 ID를 입력하십시오. (예 : openai/gpt-oss-20b)",
     "EnterAVersion": "버전을 입력하십시오. (기본값 : main)",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2070,6 +2070,26 @@
     "SharedMemory": "Хуваалцсан санах ой",
     "Updated": "Нөөцийн урьдчилан тохируулалтыг шинэчилсэн"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Моделийн ID-г оруулна уу. (Жишээ: openai/gpt-oss-20b)",
     "EnterAVersion": "Хувилбарыг оруулна уу. (Анхдагч: main)",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2069,6 +2069,26 @@
     "SharedMemory": "Memori bersama",
     "Updated": "Pratetap sumber dikemas kini"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Sila masukkan ID model. (Contoh: openai/gpt-oss-20b)",
     "EnterAVersion": "Masukkan versi. (lalai: main)",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2071,6 +2071,26 @@
     "SharedMemory": "Udostępniona pamięć",
     "Updated": "Zaktualizowano wstępne ustawienia zasobów"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Wprowadź ID modelu. (np.: openai/gpt-oss-20b)",
     "EnterAVersion": "Wprowadź wersję. (Domyślnie: main)",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2069,6 +2069,26 @@
     "SharedMemory": "Memória compartilhada",
     "Updated": "Predefinição de recurso atualizada"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Digite o ID do modelo. (Ex.: openai/gpt-oss-20b)",
     "EnterAVersion": "Insira a versão. (Padrão: main)",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2071,6 +2071,26 @@
     "SharedMemory": "Memória compartilhada",
     "Updated": "Predefinição de recurso atualizada"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Insira o ID do modelo. (ex.: openai/gpt-oss-20b)",
     "EnterAVersion": "Insira a versão. (Padrão: main)",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2069,6 +2069,26 @@
     "SharedMemory": "Общая память",
     "Updated": "Предустановка ресурса обновлена"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Введите ID модели. (например: openai/gpt-oss-20b)",
     "EnterAVersion": "Введите версию. (По умолчанию: main)",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2071,6 +2071,26 @@
     "SharedMemory": "หน่วยความจำที่ใช้ร่วมกัน",
     "Updated": "อัปเดตค่าที่กำหนดไว้ล่วงหน้าของทรัพยากรแล้ว"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "กรุณาใส่ ID ของโมเดล (เช่น: openai/gpt-oss-20b)",
     "EnterAVersion": "กรุณาใส่เวอร์ชัน (ค่าเริ่มต้น: main)",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2069,6 +2069,26 @@
     "SharedMemory": "Paylaşılan Bellek",
     "Updated": "Kaynak ön ayarı güncellendi"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Model kimliğini girin. (örn: openai/gpt-oss-20b)",
     "EnterAVersion": "Sürümü girin. (Varsayılan: main)",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2071,6 +2071,26 @@
     "SharedMemory": "Bộ nhớ chia sẻ",
     "Updated": "Đã cập nhật cài đặt trước tài nguyên"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Vui lòng nhập ID mô hình. (Ví dụ: openai/gpt-oss-20b)",
     "EnterAVersion": "Nhập phiên bản. (Mặc định: main)",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2071,6 +2071,26 @@
     "SharedMemory": "共享内存",
     "Updated": "资源预设已更新"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "请输入模型 ID。（例如：openai/gpt-oss-20b）",
     "EnterAVersion": "请输入版本（默认：main）",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2073,6 +2073,26 @@
     "SharedMemory": "共享內存",
     "Updated": "資源預設已更新"
   },
+  "sTokenLoginBoundary": {
+    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingTitle": "Signing you in",
+    "CopyErrorDetails": "Copy error details",
+    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
+    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorDetailsCopied": "Error details copied to clipboard.",
+    "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
+    "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
+    "ErrorEndpointUnresolvedTitle": "Server configuration is unavailable.",
+    "ErrorMissingTokenDescription": "The sign-in token is missing from the request. Try opening the link again from your original source, or contact your administrator.",
+    "ErrorMissingTokenTitle": "No sign-in token was provided.",
+    "ErrorServerUnreachableDescription": "The server did not respond to the initial connection. Check your network and try again.",
+    "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
+    "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
+    "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
+    "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
+    "Retry": "Retry"
+  },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "請輸入模型 ID（例如：openai/gpt-oss-20b）",
     "EnterAVersion": "請輸入版本（預設：main）",


### PR DESCRIPTION
Resolves FR-2632 (sub-task of Epic [FR-2616](https://lablup.atlassian.net/browse/FR-2616))

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

## Stack

This PR is part of the Story 1 stack for Epic FR-2616 (Extract sToken login flow into reusable boundary component). See the [dev plan](../blob/main/.specs/draft-stoken-login-boundary/dev-plan.md) for the full scope. The Story 1 PR stack is #6850 → #6851 → #6852 → #6853 → #6854 → #6855 → #6856 on top of spec PR #6828.

[FR-2616]: https://lablup.atlassian.net/browse/FR-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ