### PR TITLE
test(FR-2633): add unit tests for STokenLoginBoundary

### DIFF
--- a/.specs/draft-stoken-login-boundary/metadata.json
+++ b/.specs/draft-stoken-login-boundary/metadata.json
@@ -15,14 +15,55 @@
       "title": "Story 1: Introduce STokenLoginBoundary component",
       "prStackBranch": "feat/stoken-login-boundary-story-1-component",
       "subtasks": [
-        { "key": "FR-2628", "title": "[1.1] Rename useEduAppApiEndpoint to useResolvedApiEndpoint" },
-        { "key": "FR-2629", "title": "[1.2] Extend tokenLogin helper with optional extraParams" },
-        { "key": "FR-2630", "title": "[1.3] Add useSToken hook (nuqs) with stoken fallback and deprecation warning" },
-        { "key": "FR-2631", "title": "[1.4] Implement STokenLoginBoundary component core" },
-        { "key": "FR-2632", "title": "[1.5] Default fallback and error card UI" },
-        { "key": "FR-2633", "title": "[1.6] Unit tests for STokenLoginBoundary state transitions and invariants" },
-        { "key": "FR-2634", "title": "[1.7] CI grep rule forbidding URL APIs in STokenLoginBoundary" },
-        { "key": "FR-2635", "title": "[1.8] Verify Manager/Webserver cookie decoding for sToken (Q5)" }
+        {
+          "key": "FR-2628",
+          "title": "[1.1] Rename useEduAppApiEndpoint to useResolvedApiEndpoint",
+          "prNumber": 6850,
+          "prUrl": "https://github.com/lablup/backend.ai-webui/pull/6850"
+        },
+        {
+          "key": "FR-2629",
+          "title": "[1.2] Extend tokenLogin helper with optional extraParams",
+          "prNumber": 6851,
+          "prUrl": "https://github.com/lablup/backend.ai-webui/pull/6851"
+        },
+        {
+          "key": "FR-2630",
+          "title": "[1.3] Add useSToken hook (nuqs) with stoken fallback and deprecation warning",
+          "prNumber": 6852,
+          "prUrl": "https://github.com/lablup/backend.ai-webui/pull/6852"
+        },
+        {
+          "key": "FR-2631",
+          "title": "[1.4] Implement STokenLoginBoundary component core",
+          "prNumber": 6853,
+          "prUrl": "https://github.com/lablup/backend.ai-webui/pull/6853"
+        },
+        {
+          "key": "FR-2632",
+          "title": "[1.5] Default fallback and error card UI",
+          "prNumber": 6855,
+          "prUrl": "https://github.com/lablup/backend.ai-webui/pull/6855"
+        },
+        {
+          "key": "FR-2633",
+          "title": "[1.6] Unit tests for STokenLoginBoundary state transitions and invariants",
+          "prNumber": 6856,
+          "prUrl": "https://github.com/lablup/backend.ai-webui/pull/6856"
+        },
+        {
+          "key": "FR-2634",
+          "title": "[1.7] CI grep rule forbidding URL APIs in STokenLoginBoundary",
+          "prNumber": 6854,
+          "prUrl": "https://github.com/lablup/backend.ai-webui/pull/6854"
+        },
+        {
+          "key": "FR-2635",
+          "title": "[1.8] Verify Manager/Webserver cookie decoding for sToken (Q5)",
+          "prNumber": null,
+          "prUrl": null,
+          "note": "investigation only; no PR; Jira comment with findings"
+        }
       ]
     },
     {
@@ -30,12 +71,26 @@
       "url": "https://lablup.atlassian.net/browse/FR-2626",
       "title": "Story 2: Migrate LoginView sToken path to STokenLoginBoundary",
       "prStackBranch": "feat/stoken-login-boundary-story-2-loginview",
-      "blockedBy": ["FR-2625"],
+      "blockedBy": [
+        "FR-2625"
+      ],
       "subtasks": [
-        { "key": "FR-2636", "title": "[2.1] Wrap / and /interactive-login routes with STokenLoginBoundary conditionally" },
-        { "key": "FR-2637", "title": "[2.2] Move postConnectSetup side effects into route-level onSuccess" },
-        { "key": "FR-2638", "title": "[2.3] Remove connectUsingSession sToken branch and URL parsing in LoginView" },
-        { "key": "FR-2639", "title": "[2.4] E2E regression for LoginView sToken entry" }
+        {
+          "key": "FR-2636",
+          "title": "[2.1] Wrap / and /interactive-login routes with STokenLoginBoundary conditionally"
+        },
+        {
+          "key": "FR-2637",
+          "title": "[2.2] Move postConnectSetup side effects into route-level onSuccess"
+        },
+        {
+          "key": "FR-2638",
+          "title": "[2.3] Remove connectUsingSession sToken branch and URL parsing in LoginView"
+        },
+        {
+          "key": "FR-2639",
+          "title": "[2.4] E2E regression for LoginView sToken entry"
+        }
       ]
     },
     {
@@ -43,12 +98,26 @@
       "url": "https://lablup.atlassian.net/browse/FR-2627",
       "title": "Story 3: Migrate EduAppLauncher sToken path to STokenLoginBoundary",
       "prStackBranch": "feat/stoken-login-boundary-story-3-eduapplauncher",
-      "blockedBy": ["FR-2625"],
+      "blockedBy": [
+        "FR-2625"
+      ],
       "subtasks": [
-        { "key": "FR-2640", "title": "[3.1] Investigate get_user_credential(sToken) liveness (Q8)" },
-        { "key": "FR-2641", "title": "[3.2] Wrap /edu-applauncher and /applauncher routes with STokenLoginBoundary" },
-        { "key": "FR-2642", "title": "[3.3] Remove _token_login and manual backend-ai-connected dispatch in EduAppLauncher" },
-        { "key": "FR-2643", "title": "[3.4] E2E regression for EduApp sToken entry with and without session_id" }
+        {
+          "key": "FR-2640",
+          "title": "[3.1] Investigate get_user_credential(sToken) liveness (Q8)"
+        },
+        {
+          "key": "FR-2641",
+          "title": "[3.2] Wrap /edu-applauncher and /applauncher routes with STokenLoginBoundary"
+        },
+        {
+          "key": "FR-2642",
+          "title": "[3.3] Remove _token_login and manual backend-ai-connected dispatch in EduAppLauncher"
+        },
+        {
+          "key": "FR-2643",
+          "title": "[3.4] E2E regression for EduApp sToken entry with and without session_id"
+        }
       ]
     }
   ],
@@ -78,5 +147,5 @@
   },
   "sourceIssues": [],
   "createdAt": "2026-04-21T00:00:00Z",
-  "notes": "Epic FR-2616 filed. Spec Task FR-2618 created as sub-issue under the Epic. Spec PR #6828 resolves FR-2618. Dev plan landed on same PR stack. 3 Stories + 16 sub-tasks created; see stories[] for keys. Directory still uses draft- prefix; rename to FR-2616-stoken-login-boundary as a follow-up."
+  "notes": "Epic FR-2616 filed. Spec Task FR-2618 created as sub-issue under the Epic. Spec PR #6828 resolves FR-2618. Dev plan landed on same PR stack. Story 1 implementation PRs #6850-#6856 submitted (FR-2628-FR-2634 + test). FR-2635 closed as investigation-only (comment on issue). Directory still uses draft- prefix; rename to FR-2616-stoken-login-boundary as a follow-up."
 }

--- a/react/src/components/STokenLoginBoundary.test.tsx
+++ b/react/src/components/STokenLoginBoundary.test.tsx
@@ -1,0 +1,319 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Tests for STokenLoginBoundary (Epic FR-2616).
+ *
+ * Focus areas mapped to spec acceptance criteria:
+ * - Children only render after the authentication sequence succeeds.
+ * - `backend-ai-connected` fires exactly once per successful login, even
+ *   across a retry-then-success sequence (invariant from spec Pitfall #6).
+ * - Error classification surfaced via `onError` for each branch the test
+ *   can provoke without network (missing-token, endpoint-unresolved,
+ *   server-unreachable, token-invalid).
+ * - `errorFallback` prop replaces the built-in card for every kind (Q4).
+ * - Source file does not reference forbidden URL APIs — this is the
+ *   CI-enforced gate for the spec FR-2616 "URL 파라미터 파싱 규약" rule.
+ *
+ * The helper module is mocked entirely because the real
+ * `createBackendAIClient` instantiates a global `BackendAIClient` that is
+ * only available at runtime in the browser bundle.
+ */
+import '../../__test__/matchMedia.mock.js';
+import {
+  connectViaGQL,
+  createBackendAIClient,
+  tokenLogin,
+} from '../helper/loginSessionAuth';
+import * as endpointModule from '../hooks/useResolvedApiEndpoint';
+import {
+  STokenLoginBoundary,
+  type STokenLoginError,
+} from './STokenLoginBoundary';
+import { render, screen, waitFor } from '@testing-library/react';
+import fs from 'fs';
+import { Provider as JotaiProvider, createStore } from 'jotai';
+import path from 'path';
+import React from 'react';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('./DefaultProviders', () => ({
+  __esModule: true,
+  jotaiStore: { get: () => null, set: () => {} },
+}));
+
+jest.mock('../hooks/useWebUIConfig', () => ({
+  __esModule: true,
+  loginConfigState: { toString: () => 'loginConfigState' },
+}));
+
+jest.mock('../hooks/useResolvedApiEndpoint', () => {
+  const state: { endpoint: string } = { endpoint: 'https://api.example.com' };
+  return {
+    __esModule: true,
+    useResolvedApiEndpoint: jest.fn(() => state.endpoint),
+    __endpointState: state,
+  };
+});
+
+jest.mock('../helper/loginSessionAuth', () => ({
+  __esModule: true,
+  createBackendAIClient: jest.fn(),
+  tokenLogin: jest.fn(),
+  connectViaGQL: jest.fn(),
+}));
+
+jest.mock('backend.ai-ui', () => {
+  const actual = jest.requireActual('backend.ai-ui');
+  return {
+    ...actual,
+    useBAILogger: () => ({
+      logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+    }),
+  };
+});
+
+// Mock Jotai's useAtomValue to return null (no config in test env).
+jest.mock('jotai', () => {
+  const actual = jest.requireActual('jotai');
+  return {
+    ...actual,
+    useAtomValue: () => null,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const mockedCreateBackendAIClient =
+  createBackendAIClient as jest.MockedFunction<typeof createBackendAIClient>;
+const mockedTokenLogin = tokenLogin as jest.MockedFunction<typeof tokenLogin>;
+const mockedConnectViaGQL = connectViaGQL as jest.MockedFunction<
+  typeof connectViaGQL
+>;
+const endpointState = (
+  endpointModule as unknown as { __endpointState: { endpoint: string } }
+).__endpointState;
+const setEndpoint = (next: string) => {
+  endpointState.endpoint = next;
+};
+
+type FakeClient = {
+  get_manager_version: jest.Mock;
+  check_login: jest.Mock;
+  token_login: jest.Mock;
+};
+
+const buildFakeClient = (overrides: Partial<FakeClient> = {}): FakeClient => ({
+  get_manager_version: jest.fn().mockResolvedValue('1.0'),
+  check_login: jest.fn().mockResolvedValue(false),
+  token_login: jest.fn().mockResolvedValue(true),
+  ...overrides,
+});
+
+const renderBoundary = (
+  overrides: Partial<{
+    sToken: string;
+    onSuccess: (client: unknown) => void;
+    onError: (error: STokenLoginError) => void;
+    errorFallback: (
+      error: STokenLoginError,
+      retry: () => void,
+    ) => React.ReactNode;
+  }>,
+  children: React.ReactNode = <div>children-rendered</div>,
+) => {
+  const store = createStore();
+  return render(
+    <JotaiProvider store={store}>
+      <STokenLoginBoundary
+        sToken={overrides.sToken ?? 'fake-token'}
+        onSuccess={overrides.onSuccess}
+        onError={overrides.onError}
+        errorFallback={overrides.errorFallback}
+      >
+        {children}
+      </STokenLoginBoundary>
+    </JotaiProvider>,
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Event spy
+// ---------------------------------------------------------------------------
+
+let connectedEventCount = 0;
+const connectedEventHandler = () => {
+  connectedEventCount += 1;
+};
+
+beforeEach(() => {
+  connectedEventCount = 0;
+  document.addEventListener('backend-ai-connected', connectedEventHandler);
+  setEndpoint('https://api.example.com');
+  mockedCreateBackendAIClient.mockImplementation(() => ({
+    client: buildFakeClient(),
+    clientConfig: {},
+  }));
+  mockedTokenLogin.mockResolvedValue([]);
+  mockedConnectViaGQL.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  document.removeEventListener('backend-ai-connected', connectedEventHandler);
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('STokenLoginBoundary', () => {
+  test('renders children after the login sequence succeeds', async () => {
+    const onSuccess = jest.fn();
+    renderBoundary({ onSuccess });
+
+    await waitFor(() => {
+      expect(screen.getByText('children-rendered')).toBeInTheDocument();
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(tokenLogin).toHaveBeenCalledTimes(1);
+  });
+
+  test('dispatches backend-ai-connected exactly once on success', async () => {
+    renderBoundary({});
+
+    await waitFor(() => {
+      expect(screen.getByText('children-rendered')).toBeInTheDocument();
+    });
+    expect(connectedEventCount).toBe(1);
+  });
+
+  test('reports missing-token when sToken prop is empty', async () => {
+    const onError = jest.fn();
+    renderBoundary({ sToken: '', onError });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith({ kind: 'missing-token' });
+    });
+    expect(tokenLogin).not.toHaveBeenCalled();
+    expect(connectedEventCount).toBe(0);
+  });
+
+  test('reports endpoint-unresolved when the resolver returns empty', async () => {
+    const onError = jest.fn();
+    setEndpoint('');
+    renderBoundary({ onError });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith({ kind: 'endpoint-unresolved' });
+    });
+    expect(tokenLogin).not.toHaveBeenCalled();
+    expect(connectedEventCount).toBe(0);
+  });
+
+  test('reports server-unreachable when get_manager_version rejects', async () => {
+    const serverErr = new Error('network down');
+    mockedCreateBackendAIClient.mockImplementation(() => ({
+      client: {
+        get_manager_version: jest.fn().mockRejectedValue(serverErr),
+        token_login: jest.fn(),
+      },
+      clientConfig: {},
+    }));
+    const onError = jest.fn();
+    renderBoundary({ onError });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith({
+        kind: 'server-unreachable',
+        cause: serverErr,
+      });
+    });
+    expect(tokenLogin).not.toHaveBeenCalled();
+    expect(connectedEventCount).toBe(0);
+  });
+
+  test('reports token-invalid when tokenLogin throws', async () => {
+    const tokenErr = new Error('bad token');
+    mockedTokenLogin.mockRejectedValue(tokenErr);
+    const onError = jest.fn();
+    renderBoundary({ onError });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith({
+        kind: 'token-invalid',
+        cause: tokenErr,
+      });
+    });
+    expect(connectedEventCount).toBe(0);
+  });
+
+  test('skips token_login when the browser already holds a valid session', async () => {
+    // Reuse the existing session: check_login resolves truthy.
+    const client = buildFakeClient({
+      check_login: jest.fn().mockResolvedValue(true),
+    });
+    mockedCreateBackendAIClient.mockImplementation(() => ({
+      client,
+      clientConfig: {},
+    }));
+    const onSuccess = jest.fn();
+    renderBoundary({ onSuccess });
+
+    await waitFor(() => {
+      expect(screen.getByText('children-rendered')).toBeInTheDocument();
+    });
+    // Fast-path assertions: no re-authentication was attempted, but the
+    // GQL wiring still ran and the connected event fired exactly once so
+    // Relay and plugin subscribers unblock.
+    expect(mockedTokenLogin).not.toHaveBeenCalled();
+    expect(mockedConnectViaGQL).toHaveBeenCalledTimes(1);
+    expect(connectedEventCount).toBe(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test('errorFallback replaces the built-in card for every kind', async () => {
+    const tokenErr = new Error('bad token');
+    mockedTokenLogin.mockRejectedValue(tokenErr);
+    const errorFallback = jest.fn((error: STokenLoginError) => (
+      <div>custom-{error.kind}</div>
+    ));
+    renderBoundary({ errorFallback });
+
+    await waitFor(() => {
+      expect(screen.getByText('custom-token-invalid')).toBeInTheDocument();
+    });
+    expect(errorFallback).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL-API prohibition invariant
+// ---------------------------------------------------------------------------
+
+describe('STokenLoginBoundary source', () => {
+  test('does not reference any URL-state APIs', () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, 'STokenLoginBoundary.tsx'),
+      'utf8',
+    );
+    // Strip block comments and line comments so the rule documentation in
+    // the file header (which intentionally names the forbidden APIs) is
+    // not flagged.
+    const stripped = source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .map((line) => line.replace(/\/\/.*$/, ''))
+      .join('\n');
+    expect(stripped).not.toMatch(/window\.location/);
+    expect(stripped).not.toMatch(/window\.history/);
+    expect(stripped).not.toMatch(/document\.location/);
+    expect(stripped).not.toMatch(/\bURLSearchParams\b/);
+  });
+});

--- a/react/src/components/STokenLoginBoundary.tsx
+++ b/react/src/components/STokenLoginBoundary.tsx
@@ -286,10 +286,7 @@ const DefaultFallback: React.FC = () => {
       justify="center"
       style={{ minHeight: '60vh', padding: 24 }}
     >
-      <BAICard
-        style={{ maxWidth: 480, width: '100%', textAlign: 'center' }}
-        bordered
-      >
+      <BAICard style={{ maxWidth: 480, width: '100%', textAlign: 'center' }}>
         <BAIFlex direction="column" align="center" gap="md">
           <Spin size="large" />
           <Typography.Title level={5} style={{ margin: 0 }}>


### PR DESCRIPTION
Resolves FR-2633 (sub-task of Epic [FR-2616](https://lablup.atlassian.net/browse/FR-2616))

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

## Stack

This PR is part of the Story 1 stack for Epic FR-2616 (Extract sToken login flow into reusable boundary component). See the [dev plan](../blob/main/.specs/draft-stoken-login-boundary/dev-plan.md) for the full scope. The Story 1 PR stack is #6850 → #6851 → #6852 → #6853 → #6854 → #6855 → #6856 on top of spec PR #6828.

[FR-2616]: https://lablup.atlassian.net/browse/FR-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ