### PR TITLE
chore(FR-2644): hide react-grab toolbar in development mode

### DIFF
--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -19,13 +19,22 @@ import ReactDOM from 'react-dom/client';
 // It's advisable to ignore these frequent logs in development mode.
 if (process.env.NODE_ENV === 'development') {
   // Enable react-grab for AI agent element inspection during development
-  import('react-grab').catch((error) => {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Failed to load react-grab devtool. AI agent element inspection will be disabled.',
-      error,
-    );
-  });
+  import('react-grab')
+    .then(() => {
+      window.__REACT_GRAB__?.registerPlugin({
+        name: 'hide-toolbar',
+        theme: {
+          toolbar: { enabled: false },
+        },
+      });
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Failed to load react-grab devtool. AI agent element inspection will be disabled.',
+        error,
+      );
+    });
 
   // eslint-disable-next-line no-console
   const originalConsoleError = console.error;


### PR DESCRIPTION
Resolves #6862 ([FR-2644](https://lablup.atlassian.net/browse/FR-2644))

## Summary

- Register a `react-grab` plugin that disables the default toolbar overlay in development mode.
- The react-grab element inspection feature remains available via the long-press `Cmd+C` shortcut.
- No change to production behavior — react-grab is still only loaded when `NODE_ENV === 'development'`.

## Test plan

- [ ] Run `pnpm run dev` and confirm the floating react-grab toolbar no longer appears at the bottom of the app.
- [ ] Long-press `Cmd+C` in development and verify react-grab element inspection still activates.
- [ ] Build a production bundle and confirm no regressions (react-grab should remain excluded).

[FR-2644]: https://lablup.atlassian.net/browse/FR-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ