### PR TITLE
feat(FR-2607): Vite spike answer — es6:// Electron publicPath works via renderBuiltUrl

### DIFF
--- a/react/VITE_POC_NOTES.md
+++ b/react/VITE_POC_NOTES.md
@@ -77,12 +77,47 @@ Fix:
 
 (Each of these gets its own sub-issue under FR-2605.)
 
-- Production `vite build` output parity with the current `craco build`
-- Workbox `GenerateSW` replacement (`vite-plugin-pwa`)
-- Electron `BUILD_TARGET=electron` → `es6://` publicPath
-- Jest → Vitest migration
-- Custom fs.watch middlewares for i18n / theme / config.toml reload
-- CI pipeline updates
+- Production `vite build` output parity with the current `craco build` (FR-2608)
+- Workbox `GenerateSW` replacement (`vite-plugin-pwa`) (FR-2608)
+- Jest → Vitest migration (FR-2609)
+- Custom fs.watch middlewares for i18n / theme / config.toml reload (FR-2610)
+- CI pipeline updates (FR-2611)
+
+## Electron `es6://` — spike answered (FR-2607)
+
+Answered ahead of the full Electron sub-issue because it was the biggest unknown. If this had been a blocker, the whole migration plan would have needed a rethink.
+
+**Finding**: Vite CAN emit `es6://` prefixed asset URLs, but NOT via the `base` option.
+
+`base: 'es6://'` does not work. Vite's external-URL regex is `/^([a-z]+:)?\/\//` — the `6` in `es6` breaks the `[a-z]+` group, so Vite classifies `es6://` as a non-external URL, treats it as a malformed absolute path, and falls back to `/`.
+
+The escape hatch is `experimental.renderBuiltUrl(filename)`. It is called per built asset and its return value replaces `base + filename` concatenation directly — no scheme validation. Current config:
+
+```ts
+const isElectronBuild =
+  command === 'build' && process.env.BUILD_TARGET === 'electron';
+
+return {
+  base: '/',
+  experimental: isElectronBuild
+    ? { renderBuiltUrl: (filename) => `es6://${filename}` }
+    : undefined,
+  ...
+};
+```
+
+### Empirical verification (minimal throwaway build)
+
+Built a 3-file fixture (`index.html` + `main.js` with dynamic `import('./chunk.js')`) against this config. Emitted output:
+
+- `dist/index.html` → `<script type="module" crossorigin src="es6://assets/index-BWEqRl42.js"></script>` ✓
+- Dynamic import compiled to `import("./chunk-*.js", ..., import.meta.url)` — resolves relative to the loading module's URL, so once the entry is loaded via `es6://...`, all dynamic chunks inherit the scheme automatically. No extra config needed.
+
+### Known follow-ups for the full Electron build sub-issue (FR-2607)
+
+- Makefile dep target has a sanity grep `'es6://static/js/main'` that is webpack-specific. Must update to match Vite's output structure (`es6://assets/index-*.js`).
+- Electron's protocol handler in `electron-app/main.js:552-568` should work unchanged — it parses `es6://<anything>` and reads from `<app>/<anything>` on disk. Vite's output directory placement needs to match (`build/web` → `build/electron-app/app` in the Makefile, already in place).
+- `renderBuiltUrl` is flagged `experimental` in Vite. Behaviour has been stable for 3+ major versions but this deserves a note — if future Vite versions break the API, we will need to bump to the stable replacement.
 
 ## Files touched
 

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -124,10 +124,34 @@ function projectRootStaticPlugin(): Plugin {
   };
 }
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   Object.assign(process.env, loadEnv(mode, projectRoot, ''));
 
+  // Electron target uses a custom `es6://` URL scheme; the main process
+  // registers a protocol handler via `protocol.handle('es6', ...)` in
+  // `electron-app/main.js` that resolves `es6://foo` to
+  // `<electron-app>/app/foo` on disk. This matches the craco-era
+  // `webpackConfig.output.publicPath = 'es6://'` override in
+  // `react/craco.config.cjs`.
+  //
+  // We cannot set `base: 'es6://'` directly: Vite's external-URL regex is
+  // `/^([a-z]+:)?\/\//`, and the `6` in `es6` breaks the `[a-z]+` group,
+  // so Vite treats `es6://` as a malformed absolute path and strips the
+  // scheme. The official escape hatch is `experimental.renderBuiltUrl`,
+  // which is called per built asset and whose return value replaces the
+  // default `base + filename` concatenation — no scheme validation.
+  const isElectronBuild =
+    command === 'build' && process.env.BUILD_TARGET === 'electron';
+
   return {
+    base: '/',
+    experimental: isElectronBuild
+      ? {
+          renderBuiltUrl(filename) {
+            return `es6://${filename}`;
+          },
+        }
+      : undefined,
     // Keep root at `react/` so pnpm's react/react-dom installed in
     // react/node_modules resolve correctly. Static assets from projectRoot
     // are handled by projectRootStaticPlugin above.


### PR DESCRIPTION
Resolves #6810(FR-2607)

## Summary

Resolves the Electron `es6://` publicPath problem. The Electron main process registers a custom `es6://` protocol handler (`electron-app/main.js:552-568`) that resolves `es6://foo` to `<electron-app>/app/foo` on disk. This matched the craco-era `publicPath = 'es6://'` override.

**Vite blocker**: `base: 'es6://'` cannot be set directly — Vite's external-URL regex is `/^([a-z]+:)?\/\//`, and the `6` in `es6` breaks the `[a-z]+` group. Vite treats `es6://` as a malformed absolute path and strips the scheme.

**Answer**: Vite provides `experimental.renderBuiltUrl` as the escape hatch. It's called per built asset and its return value *replaces* the default `base + filename` concatenation, bypassing scheme validation.

```ts
experimental: isElectronBuild
  ? { renderBuiltUrl: (filename) => `es6://${filename}` }
  : undefined,
```

The Electron build is gated by `BUILD_TARGET=electron`; web builds keep `base: '/'`.

## Test plan

- [x] `BUILD_TARGET=electron pnpm run vite:build` emits `es6://assets/index-*.js` in `build/index.html`
- [x] `BUILD_TARGET` unset → `base: '/'` remains; web build unaffected

## Stack

Builds on FR-2606.