### PR TITLE
fix(FR-2608): disable vite-plugin-pwa auto-manifest to preserve existing manifest.json

### DIFF
--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -439,6 +439,14 @@ export default defineConfig(({ command, mode }) => {
         strategies: 'generateSW',
         filename: 'sw.js',
         injectRegister: false,
+        // The repo ships its own `manifest.json` under the project root (with
+        // the real Backend.AI icons, name, and colors) and `copyresource`
+        // copies it into `build/web/`. Disable the plugin's auto-generated
+        // `manifest.webmanifest` to avoid shipping two conflicting manifests
+        // — the auto one picks up react/package.json metadata (wrong name,
+        // wrong theme color, no icons) and also injects its own `<link rel=
+        // "manifest">` tag that competes with the existing one in index.html.
+        manifest: false,
         // Stay silent during dev — the registration happens only in prod.
         devOptions: { enabled: false },
         workbox: {


### PR DESCRIPTION
Resolves #6811(FR-2608)

## Summary

Follow-up fix for FR-2608. Discovered while verifying the end-to-end production build in FR-2611.

**Bug**: `vite-plugin-pwa` generates a `manifest.webmanifest` from `react/package.json` metadata and auto-injects `<link rel="manifest" href="/manifest.webmanifest">` into `index.html`. That competes with the repo's own `manifest.json` (already copied into `build/web/` by `copyresource`) — the auto one has:
- wrong `name`: `"backend-ai-webui-react"` (react package name, not product)
- wrong `theme_color`: `"#42b883"` (Vue green, pulled from some default)
- **no icons**

Whichever manifest the browser picks first can leave PWA installs with bogus metadata.

**Fix**: one-line `manifest: false` option in the VitePWA plugin config. The plugin now only emits the service worker and leaves manifest handling to the existing `copyresource` pipeline.

## Verification

- [x] `pnpm run build` produces only `build/web/manifest.json` (the real one); no `manifest.webmanifest`
- [x] Built `index.html` references only `href="manifest.json"`

## Stack

Sits above FR-2611; logically resolves an issue introduced in FR-2608 but couldn't be amended there without invasive rebase.