### PR TITLE
fix(FR-2606): replace `global.packageVersion` with `globalThis.packageVersion` in WebUISider

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -346,7 +346,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
                 style={{ fontSize: token.sizeXS }}
               >
                 {/* @ts-ignore */}
-                {`${global.packageVersion}.${globalThis.buildNumber}`}
+                {`${globalThis.packageVersion}.${globalThis.buildNumber}`}
               </small>
             </address>
           </Typography.Text>


### PR DESCRIPTION
Resolves #6809(FR-2606)

## Summary

Runtime error found after logging into the app with the Vite build:

```
ReferenceError: global is not defined
  at WebUISider (WebUISider.tsx:349:21)
```

Triggered the error boundary, blanked the sidebar footer area. **One-line fix.**

**Root cause**: `WebUISider.tsx:349` read `global.packageVersion`. Under CRA/Webpack, `global` was auto-aliased to `window` in browser builds, so the reference worked by coincidence. Vite intentionally leaves `global` undefined in the browser (`nodePolyfills({ globals: { global: false } })` in `vite.config.ts`), so the same reference now throws.

The value is actually written to `globalThis.packageVersion` in the root `index.html` inline script — switching the read site to `globalThis` matches the writer and works under any bundler.

## Verification

- [x] `grep -r 'global\.' react/src` → only test-file usages remain (where `global === globalThis` in node/jsdom env)
- [x] Started dev server, logged in as admin, confirmed sidebar renders `26.4.0-alpha.0.<buildNumber>` with no `ReferenceError` in console
- [x] Error boundary no longer activates on the start page

## Stack

Logically belongs to FR-2606 (Vite parity work). Sits above the PWA manifest fix.