### PR TITLE
fix(FR-2606): replace webpackIgnore with @vite-ignore in dynamic plugin imports

### DIFF
--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -190,7 +190,11 @@ const LoginView: React.FC<{
     if (!sanitizedPlugin || sanitizedPlugin !== loginPlugin) return;
 
     import(
-      /* webpackIgnore: true */
+      // `@vite-ignore` = Vite's equivalent of webpack's `webpackIgnore`.
+      // The path interpolates a user-config'd plugin name at runtime and
+      // sits OUTSIDE react/src — Vite would otherwise warn about the
+      // un-analyzable specifier on every dev rebuild.
+      /* @vite-ignore */
       `../../../src/plugins/${sanitizedPlugin}`
     ).catch(() => {
       setLoginError({ message: t('error.LoginFailed') });

--- a/react/src/components/PluginLoader.tsx
+++ b/react/src/components/PluginLoader.tsx
@@ -107,7 +107,10 @@ function PluginLoader() {
               : `/dist/plugins/${sanitizedPage}.js`;
 
           try {
-            await import(/* webpackIgnore: true */ pluginUrl);
+            // `@vite-ignore` = Vite's equivalent of webpack's `webpackIgnore`.
+            // pluginUrl is a runtime-computed path outside the module graph,
+            // so we opt out of static analysis entirely.
+            await import(/* @vite-ignore */ pluginUrl);
 
             const pageItem = document.createElement(page) as PluginPageElement;
             pageItem.classList.add('page');


### PR DESCRIPTION
Resolves #6809(FR-2606)

## Summary

Dev-server warning spam noticed after the Vite cutover:

```
[vite] (client) warning:
  .../PluginLoader.tsx:75
    await import(/* webpackIgnore: true */ pluginUrl);
  The above dynamic import cannot be analyzed by Vite.
```

Two dynamic-import call sites loaded a runtime-computed URL and tagged it with `/* webpackIgnore: true */`, the CRA/Webpack magic comment that opted out of static analysis. Vite doesn't recognise it, so it defaults to "can't analyse" and warns on every dev rebuild (plus wastes cycles trying to pre-bundle a spec it can't resolve).

**Fix**: replace `/* webpackIgnore: true */` with `/* @vite-ignore */` (Vite's equivalent). Runtime behaviour is unchanged — plugins still load fine.

**Sites fixed**:
- `react/src/components/PluginLoader.tsx`: page-plugin loader for paths under `/dist/plugins/*.js`
- `react/src/components/LoginView.tsx`: login-plugin loader that pulls from `../../../src/plugins/<name>`

## Verification

- [x] `grep -r 'webpackIgnore' react/src` → zero value-level hits; only comments that explain the rename
- [x] `vite:dev` no longer warns about un-analysable dynamic imports from these files
- [x] Plugin loading still works at runtime

## Stack

Top of the stack. This is the final fix bundled from end-to-end verification; reviewing this PR gives a good summary of the whole Vite migration series (the "Stack" section above in the PR lists all 11 PRs in order).