### PR TITLE
fix(FR-2646): align RoleDetailDrawer queries with updated schema

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -260,7 +260,7 @@ type AdminGetSSHKeypairPayload
 }
 
 """
-Added in UNRELEASED. Payload for admin bulk revision refresh mutation result.
+Added in 26.4.3. Payload for admin bulk revision refresh mutation result.
 """
 type AdminRefreshDeploymentRevisionsPayload
   @join__type(graph: STRAWBERRY)
@@ -1682,7 +1682,7 @@ type AutoScalingRule implements Node
   lastTriggeredAt: DateTime
 
   """
-  Added in UNRELEASED. The Prometheus query preset used for metric-based auto-scaling.
+  Added in 26.4.3. The Prometheus query preset used for metric-based auto-scaling.
   """
   queryPreset: QueryDefinition
 }
@@ -4669,6 +4669,26 @@ input DeploymentFilter
   openToPublic: Boolean = null
   tags: StringFilter = null
   endpointUrl: StringFilter = null
+
+  """Added in 26.4.3. Filter by domain name."""
+  domainName: StringFilter = null
+
+  """Added in 26.4.3. Filter by project ID."""
+  projectId: UUIDFilter = null
+
+  """Added in 26.4.3. Filter by resource group name."""
+  resourceGroup: StringFilter = null
+
+  """Added in 26.4.3. Filter by the user who created the deployment."""
+  createdUserId: UUIDFilter = null
+
+  """Added in 26.4.3. Filter by deployment creation datetime."""
+  createdAt: DateTimeFilter = null
+
+  """
+  Added in 26.4.3. Filter by deployment destruction datetime. Supports IS NULL / IS NOT NULL.
+  """
+  destroyedAt: NullableDateTimeFilter = null
   AND: [DeploymentFilter!] = null
   OR: [DeploymentFilter!] = null
   NOT: [DeploymentFilter!] = null
@@ -4693,7 +4713,7 @@ type DeploymentHistory implements Node
   createdAt: DateTime!
   updatedAt: DateTime!
 
-  """Added in UNRELEASED. The deployment this history record belongs to."""
+  """Added in 26.4.3. The deployment this history record belongs to."""
   deployment: ModelDeployment
 }
 
@@ -4768,7 +4788,11 @@ enum DeploymentOrderField
 {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
-  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+  DESTROYED_AT @join__enumValue(graph: STRAWBERRY)
+  DOMAIN @join__enumValue(graph: STRAWBERRY)
+  PROJECT @join__enumValue(graph: STRAWBERRY)
+  RESOURCE_GROUP @join__enumValue(graph: STRAWBERRY)
+  TAG @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in 25.19.0. Deployment policy configuration."""
@@ -4844,7 +4868,7 @@ type DeploymentRevisionPreset implements Node
   """Timestamp of the last modification to this deployment preset."""
   updatedAt: DateTime
 
-  """Added in UNRELEASED. The runtime variant this preset is designed for."""
+  """Added in 26.4.3. The runtime variant this preset is designed for."""
   runtimeVariant: RuntimeVariant
 
   """Added in 26.4.2. Resource slot allocations for this preset."""
@@ -6144,7 +6168,7 @@ type EntityRef implements Node
   entity: EntityNode
 
   """
-  Added in UNRELEASED. The resolved scope object in which the entity is registered.
+  Added in 26.4.3. The resolved scope object in which the entity is registered.
   """
   scope: EntityNode
 }
@@ -7346,7 +7370,7 @@ type KernelV2 implements Node
   """Added in 26.2.0. The agent running this kernel."""
   agent: AgentV2
 
-  """Added in UNRELEASED. The image used by this kernel."""
+  """Added in 26.4.3. The image used by this kernel."""
   image: ImageV2
 
   """Added in 26.2.0. The user who owns this kernel."""
@@ -7674,7 +7698,7 @@ type KeyPairGQL implements Node
   """UUID of the user who owns this keypair."""
   userId: UUID!
 
-  """Added in UNRELEASED. The user who owns this keypair."""
+  """Added in 26.4.3. The user who owns this keypair."""
   user: UserV2
 }
 
@@ -8168,10 +8192,10 @@ type LoginHistoryV2 implements Node
   """Timestamp when the login attempt occurred."""
   createdAt: DateTime!
 
-  """Added in UNRELEASED. The user who attempted to log in."""
+  """Added in 26.4.3. The user who attempted to log in."""
   user: UserV2
 
-  """Added in UNRELEASED. The domain at the time of the login attempt."""
+  """Added in 26.4.3. The domain at the time of the login attempt."""
   domain: DomainV2
 }
 
@@ -8282,7 +8306,7 @@ type LoginSessionV2 implements Node
   """Timestamp when the session was invalidated."""
   invalidatedAt: DateTime
 
-  """Added in UNRELEASED. The user who owns this login session."""
+  """Added in 26.4.3. The user who owns this login session."""
   user: UserV2
 }
 
@@ -8506,13 +8530,13 @@ type ModelCardV2 implements Node
   """
   vfolder: VFolder
 
-  """Added in UNRELEASED. The domain this model card belongs to."""
+  """Added in 26.4.3. The domain this model card belongs to."""
   domain: DomainV2
 
-  """Added in UNRELEASED. The project this model card belongs to."""
+  """Added in 26.4.3. The project this model card belongs to."""
   project: ProjectV2
 
-  """Added in UNRELEASED. The user who created this model card."""
+  """Added in 26.4.3. The user who created this model card."""
   creator: UserV2
 
   """
@@ -8706,17 +8730,17 @@ type ModelDeployment implements Node
   createdUserId: ID!
 
   """
-  Added in UNRELEASED. The current active revision of this deployment, resolved via DataLoader.
+  Added in 26.4.3. The current active revision of this deployment, resolved via DataLoader.
   """
   currentRevision: ModelRevision
 
   """
-  Added in UNRELEASED. The revision currently being deployed (in progress, not yet active), resolved via DataLoader.
+  Added in 26.4.3. The revision currently being deployed (in progress, not yet active), resolved via DataLoader.
   """
   deployingRevision: ModelRevision
 
   """
-  Added in UNRELEASED. The user who created this deployment, resolved via DataLoader.
+  Added in 26.4.3. The user who created this deployment, resolved via DataLoader.
   """
   creator: UserV2
 
@@ -8769,7 +8793,7 @@ type ModelDeploymentMetadata
   project: GroupNode! @deprecated(reason: "Use project_v2 instead.")
 
   """
-  Added in UNRELEASED. The project this deployment belongs to, resolved via DataLoader.
+  Added in 26.4.3. The project this deployment belongs to, resolved via DataLoader.
   """
   projectV2: ProjectV2
 
@@ -8777,7 +8801,7 @@ type ModelDeploymentMetadata
   domain: DomainNode! @deprecated(reason: "Use domain_v2 instead.")
 
   """
-  Added in UNRELEASED. The domain this deployment belongs to, resolved via DataLoader.
+  Added in 26.4.3. The domain this deployment belongs to, resolved via DataLoader.
   """
   domainV2: DomainV2
   projectId: ID!
@@ -9006,7 +9030,7 @@ type ModelReplica implements Node
   session: ComputeSessionNode! @deprecated(reason: "Use session_v2 instead.")
 
   """
-  Added in UNRELEASED. The compute session running this replica, resolved via DataLoader.
+  Added in 26.4.3. The compute session running this replica, resolved via DataLoader.
   """
   sessionV2: SessionV2
 
@@ -9078,7 +9102,7 @@ type ModelRevision implements Node
   image: ImageNode! @deprecated(reason: "Use image_v2 instead.")
 
   """
-  Added in UNRELEASED. The container image used by this revision, resolved via DataLoader.
+  Added in 26.4.3. The container image used by this revision, resolved via DataLoader.
   """
   imageV2: ImageV2
 
@@ -9115,6 +9139,21 @@ input ModelRevisionFilter
 {
   revisionNumber: IntFilter = null
   deploymentId: ID = null
+
+  """Added in 26.4.3. Filter by container image ID."""
+  imageId: UUIDFilter = null
+
+  """Added in 26.4.3. Filter by model VFolder ID."""
+  modelVfolderId: UUIDFilter = null
+
+  """Added in 26.4.3. Filter by resource group name."""
+  resourceGroup: StringFilter = null
+
+  """Added in 26.4.3. Filter by cluster mode (SINGLE_NODE / MULTI_NODE)."""
+  clusterMode: StringFilter = null
+
+  """Added in 26.4.3. Filter by revision creation datetime."""
+  createdAt: DateTimeFilter = null
   AND: [ModelRevisionFilter!] = null
   OR: [ModelRevisionFilter!] = null
   NOT: [ModelRevisionFilter!] = null
@@ -9134,6 +9173,9 @@ enum ModelRevisionOrderField
 {
   REVISION_NUMBER @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  RESOURCE_GROUP @join__enumValue(graph: STRAWBERRY)
+  CLUSTER_MODE @join__enumValue(graph: STRAWBERRY)
+  RUNTIME_VARIANT @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -10199,7 +10241,7 @@ type Mutation
   addModelRevision(input: AddRevisionInput!, options: AddRevisionOptions = null): AddRevisionPayload! @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. Rebuild and activate a fresh revision for every active deployment (superadmin). Used to repair deployments whose current revision has stale or missing model_definition after backing store migrations.
+  Added in 26.4.3. Rebuild and activate a fresh revision for every active deployment (superadmin). Used to repair deployments whose current revision has stale or missing model_definition after backing store migrations.
   """
   adminRefreshDeploymentRevisions: AdminRefreshDeploymentRevisionsPayload! @join__field(graph: STRAWBERRY)
 
@@ -10762,6 +10804,11 @@ type Mutation
   """Added in 26.4.2. Permanently purge a virtual folder."""
   purgeVfolderV2(vfolderId: UUID!): PurgeVFolderV2Payload! @join__field(graph: STRAWBERRY)
 
+  """
+  Added in UNRELEASED. Restore a trashed virtual folder. RBAC enforced via scope chain.
+  """
+  restoreVFolder(vfolderId: UUID!): RestoreVFolderPayload! @join__field(graph: STRAWBERRY)
+
   """Added in 26.4.2. Deploy a deployment directly from a model VFolder."""
   deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload! @join__field(graph: STRAWBERRY)
 
@@ -11084,7 +11131,7 @@ input NotificationRuleTypeFilter
 }
 
 """
-Added in UNRELEASED. Filter for nullable datetime fields with IS NULL / IS NOT NULL support.
+Added in 26.4.3. Filter for nullable datetime fields with IS NULL / IS NOT NULL support.
 """
 input NullableDateTimeFilter
   @join__type(graph: STRAWBERRY)
@@ -13082,7 +13129,7 @@ type Query
   projectSessionsV2(scope: ProjectSessionV2Scope!, filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection! @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. Query a single session by ID. Returns an error if not found.
+  Added in 26.4.3. Query a single session by ID. Returns an error if not found.
   """
   sessionV2(id: UUID!): SessionV2 @join__field(graph: STRAWBERRY)
 
@@ -13555,7 +13602,7 @@ type QueryDefinition implements Node
   """Last update timestamp."""
   updatedAt: DateTime!
 
-  """Added in UNRELEASED. Resolved category entity."""
+  """Added in 26.4.3. Resolved category entity."""
   category: QueryPresetCategory
 }
 
@@ -14387,7 +14434,7 @@ type ResourcePresetV2 implements Node
   """Resource group name. Null means global preset."""
   resourceGroupName: String
 
-  """Added in UNRELEASED. The resource group this preset belongs to."""
+  """Added in 26.4.3. The resource group this preset belongs to."""
   resourceGroup: ResourceGroup
 }
 
@@ -14597,7 +14644,17 @@ type RestoreArtifactsPayload
 }
 
 """
-Added in UNRELEASED. Per-deployment result of an admin bulk revision refresh.
+Added in UNRELEASED. Payload returned after restoring a virtual folder from trash.
+"""
+type RestoreVFolderPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """ID of the restored virtual folder"""
+  id: UUID!
+}
+
+"""
+Added in 26.4.3. Per-deployment result of an admin bulk revision refresh.
 """
 type RevisionRefreshResult
   @join__type(graph: STRAWBERRY)
@@ -14784,7 +14841,7 @@ type RoleAssignment implements Node
   """The assigned user."""
   user: UserV2
 
-  """Added in UNRELEASED. The user who granted this role assignment."""
+  """Added in 26.4.3. The user who granted this role assignment."""
   grantedByUser: UserV2
 }
 
@@ -14815,7 +14872,7 @@ type RoleAssignmentEdge
 input RoleAssignmentFilter
   @join__type(graph: STRAWBERRY)
 {
-  roleId: UUID = null
+  roleId: UUIDFilter = null
   role: RoleAssignmentRoleNestedFilter = null
   permission: PermissionNestedFilter = null
   username: StringFilter = null
@@ -15013,7 +15070,7 @@ type Route implements Node
   session: ID @deprecated(reason: "Use session_v2 instead.")
 
   """
-  Added in UNRELEASED. The compute session associated with this route, resolved via DataLoader.
+  Added in 26.4.3. The compute session associated with this route, resolved via DataLoader.
   """
   sessionV2: SessionV2
 
@@ -15089,10 +15146,10 @@ type RouteHistory implements Node
   createdAt: DateTime!
   updatedAt: DateTime!
 
-  """Added in UNRELEASED. The route this history record belongs to."""
+  """Added in 26.4.3. The route this history record belongs to."""
   route: Route
 
-  """Added in UNRELEASED. The deployment this history record belongs to."""
+  """Added in 26.4.3. The deployment this history record belongs to."""
   deployment: ModelDeployment
 }
 
@@ -16036,7 +16093,7 @@ type SessionSchedulingHistory implements Node
   createdAt: DateTime!
   updatedAt: DateTime!
 
-  """Added in UNRELEASED. The session this history record belongs to."""
+  """Added in 26.4.3. The session this history record belongs to."""
   session: SessionV2
 }
 
@@ -16163,7 +16220,7 @@ type SessionV2 implements Node
   resourceGroup: ResourceGroup
 
   """
-  Added in UNRELEASED. The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
+  Added in 26.4.3. The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
   """
   images: ImageV2Connection!
 

--- a/react/src/components/RoleAssignmentTab.tsx
+++ b/react/src/components/RoleAssignmentTab.tsx
@@ -207,7 +207,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
       refetch(
         {
           filter: {
-            roleId,
+            roleId: { equals: roleId },
             ...(overrides?.filter !== undefined
               ? overrides.filter
               : queryParams.filter),

--- a/react/src/components/RoleDetailDrawer.tsx
+++ b/react/src/components/RoleDetailDrawer.tsx
@@ -121,7 +121,7 @@ const RoleDetailDrawerInner: React.FC<RoleDetailDrawerInnerProps> = ({
     `,
     {
       id: localRoleId,
-      assignmentFilter: { roleId: localRoleId },
+      assignmentFilter: { roleId: { equals: localRoleId } },
       permissionFilter: { roleId: localRoleId },
       scopeFilter: null,
       scopeOrderBy: null,


### PR DESCRIPTION
Resolves [FR-2646](https://lablup.atlassian.net/browse/FR-2646) — GraphQL schema update broke `RoleDetailDrawer`.

## Summary

The backend schema update changed `RoleAssignmentFilter.roleId` from `UUID` to `UUIDFilter`. This:
1. Broke TypeScript compile in `RoleDetailDrawer.tsx` (`error TS2559`).
2. Introduced a latent runtime failure in `RoleAssignmentTab.tsx` refetch path (TypeScript missed it because `GraphQLFilter` is typed `[key: string]: any`).
3. Surfaced a related server-side validation error when loading the role detail drawer: `Fields "adminRole" conflict because they have differing arguments.` — caused by `RoleScopeTabFragment` and the parent query both calling `adminRole(id: …)` at the top level.

## Changes

- **`data/schema.graphql`** — sync with backend 26.4.3+ (`RoleAssignmentFilter.roleId` → `UUIDFilter`, plus new `projectId`/`createdUserId`/`imageId`/`modelVfolderId` filter fields on unrelated inputs).
- **`react/src/components/RoleDetailDrawer.tsx`** — wrap `roleId` in `{ equals: localRoleId }` so it conforms to the new `UUIDFilter` type.
- **`react/src/components/RoleAssignmentTab.tsx`** — same wrap in the refetch path.
- **`react/src/components/RoleScopeTab.tsx`** — alias the inner `adminRole(id: $roleId)` to `scopeRole: adminRole(id: $roleId)` so the server validator stops flagging it as conflicting with the outer `adminRole(id: $id)` call. Two data-access sites (`data.adminRole` → `data.scopeRole`) updated accordingly.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- Relay compile regenerates `RoleDetailDrawerQuery` with the two calls differentiated: outer `adminRole(id: $id)` and inner `scopeRole: adminRole(id: $id)`.
- Role detail drawer opens without the `"Fields adminRole conflict"` validation error from the backend.

## Checklist

- [x] Documentation: N/A (bug fix, no user-facing behavior change)
- [x] Minimum required manager version: needs manager exposing the updated schema (26.4.3+)
- [x] Specific setting for review: open any role in `/rbac` and verify the detail drawer loads
- [x] Minimum requirements to check during review: TypeScript passes; role detail drawer loads without GraphQL validation error
- [x] Test case(s): existing `e2e/rbac/rbac-role-detail.spec.ts` (currently `test.fixme`d pending separate work) exercises this flow

[FR-2646]: https://lablup.atlassian.net/browse/FR-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ