### PR TITLE
fix(FR-2627): forward api_version/date/endpoint to token_login

### DIFF
--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -746,6 +746,12 @@ const eduAppExtraParamSpec = {
   shmem: parseAsString,
   'cuda-shares': parseAsString,
   'cuda-device': parseAsString,
+  // LMS signing envelope: the upstream launcher URL carries these alongside
+  // `sToken` and the manager-side auth hook validates the signature against
+  // them. Dropping any of them causes token_login to reject as tampered.
+  api_version: parseAsString,
+  date: parseAsString,
+  endpoint: parseAsString,
 };
 
 /**


### PR DESCRIPTION
Follow-up to #6864 (FR-2627).

## Summary

The `eduAppExtraParamSpec` nuqs allowlist in `react/src/routes.tsx` was missing three keys that the pre-migration `EduAppLauncher._token_login` used to forward as part of the body:

- `api_version`
- `date`
- `endpoint`

The old implementation iterated every `URLSearchParams` entry and forwarded everything except `sToken`/`stoken`. The nuqs migration replaced that with an explicit allowlist and silently dropped these unlisted keys, so `POST /server/token-login` went out with a body that only contained `{ sToken, app, session_id, ... }` — no signing envelope.

Backend.AI Manager auth hooks that validate the LMS-signed launcher URL against these fields would then reject the request as tampered, breaking sToken entry into `/edu-applauncher` and `/applauncher`.

## Fix

Add `api_version`, `date`, `endpoint` to `eduAppExtraParamSpec` with a comment explaining why these must stay in the spec.

## Test plan

- [x] `bash scripts/verify.sh` → `ALL PASS`
- [ ] Manual: launch from LMS URL `/edu-applauncher?sToken=<signed>&app=jupyterlab&api_version=...&date=...&endpoint=...&session_id=...` and confirm `POST /server/token-login` body includes all five extra keys
- [ ] Verify E2E regression PR #6865 scenarios still pass on top of this fix