### PR TITLE
feat(FR-2616): handle totp and concurrent-session inline in STokenLoginBoundary

### DIFF
--- a/e2e/auth/stoken-login.spec.ts
+++ b/e2e/auth/stoken-login.spec.ts
@@ -13,9 +13,95 @@
  *   - URL preservation on error: the boundary only strips `sToken`
  *     after a successful login, so an invalid token remains in the URL
  *     and the user's Retry can still pick it up.
+ *
+ * Additionally, this file mocks `/server/token-login` to exercise the
+ * interactive paths that do not require a customer-specific auth plugin
+ * to reproduce:
+ *   - `require-totp-authentication` → inline OTP form
+ *   - `active-login-session-exists` → "Logged in elsewhere" + Login
+ *   - sticky retries fold both `otp` and `force: true` into the same
+ *     body when the user satisfies both challenges in sequence.
  */
 import { webuiEndpoint } from '../utils/test-util';
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Mock webserver version response returned by the boundary's
+ * `get_manager_version()` probe. Needed so the ping step passes and the
+ * sequence actually reaches `token_login` where the test-specific
+ * response is fulfilled.
+ */
+const MOCK_SERVER_VERSION = {
+  manager: '25.0.0',
+  version: 'v6.20220615',
+  'backend.ai': '25.0.0',
+};
+
+/** Not-logged-in envelope for the fast-path session probe. */
+const MOCK_LOGIN_CHECK_NOT_AUTHED = { authenticated: false };
+
+const TOTP_REQUIRED_RESPONSE = {
+  authenticated: false,
+  data: {
+    type: 'https://api.backend.ai/probs/require-totp-authentication',
+    title: 'Two-Factor Authentication needed.',
+    details: 'You must authenticate using Two-Factor Authentication.',
+  },
+};
+
+const CONCURRENT_SESSION_RESPONSE = {
+  authenticated: false,
+  data: {
+    type: 'https://api.backend.ai/probs/active-login-session-exists',
+    title: 'Too many concurrent login sessions for this user.',
+    details: 'Internal server error',
+  },
+};
+
+const AUTH_FAILED_INERT_RESPONSE = {
+  authenticated: false,
+  data: {
+    type: 'https://api.backend.ai/probs/auth-failed',
+    title: 'stub',
+    details: 'stub',
+  },
+};
+
+/**
+ * Fixture JWT-shaped sToken used to exercise the interactive flows.
+ * It never actually authenticates — the tests mock `/server/token-login`
+ * — but using a realistic shape ensures no assumptions about length,
+ * URL-encoding safety, or signed-section format accidentally leak into
+ * the classifier or cookie-writing code.
+ */
+const FIXTURE_STOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3Nfa2V5IjoiQUtJQUlPU0ZPRE5ON0VYQU1QTEUiLCJzZWNyZXRfa2V5Ijoid0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWSJ9.BC4eXVHEG0_HhYknddlUo8NlUnr0aY99qpXAO5FfN5g';
+
+/**
+ * Install the ping + existing-session probes once so the boundary reaches
+ * `token_login`. Individual tests register `**\/server/token-login` on
+ * top of this to drive the flow they care about.
+ */
+async function installBoundaryProbeMocks(page: Page): Promise<void> {
+  await page.route('**/func/', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_SERVER_VERSION),
+    });
+  });
+  await page.route('**/server/login-check', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_LOGIN_CHECK_NOT_AUTHED),
+    });
+  });
+}
 
 test.describe(
   'sToken login boundary (LoginView routes)',
@@ -71,6 +157,190 @@ test.describe(
       await expect(page.getByRole('button', { name: /retry/i })).toBeVisible({
         timeout: 15_000,
       });
+    });
+  },
+);
+
+test.describe(
+  'sToken login boundary (interactive flows)',
+  { tag: ['@regression', '@auth', '@functional'] },
+  () => {
+    /**
+     * Critical: the webserver signals `authenticated: false` with a 200
+     * status. `client.token_login` only routes into the `{ fail_reason,
+     * fail_type }` branch when `_wrapWithPromise` resolves; any non-2xx
+     * is rethrown as a generic "no manager found" and misclassified as
+     * `token-invalid`. Every mock below therefore returns 200 regardless
+     * of the authentication outcome.
+     */
+
+    test('TOTP-required response swaps the action area for an OTP form (no Retry button)', async ({
+      page,
+    }) => {
+      await installBoundaryProbeMocks(page);
+      await page.route('**/server/token-login', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(TOTP_REQUIRED_RESPONSE),
+        });
+      });
+
+      await page.goto(`${webuiEndpoint}/?sToken=${FIXTURE_STOKEN}`);
+
+      // Inline OTP input + Submit, per design "no separate modal, only
+      // the lower half of the card changes". Input.OTP exposes an
+      // aria-label on its root; individual slots are queryable via
+      // `locator('input')`.
+      await expect(page.getByLabel(/authenticator code/i)).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(
+        page.getByRole('button', { name: /^submit$/i }),
+      ).toBeVisible();
+      // The OTP kind replaces Retry — it must NOT co-exist with the
+      // generic retry button (would be a design regression).
+      await expect(
+        page.getByRole('button', { name: /retry/i }),
+      ).not.toBeVisible();
+    });
+
+    test('submitting the OTP folds `otp` into the next token_login body', async ({
+      page,
+    }) => {
+      await installBoundaryProbeMocks(page);
+
+      let callIndex = 0;
+      const bodies: Array<Record<string, unknown> | null> = [];
+      await page.route('**/server/token-login', async (route) => {
+        bodies.push(route.request().postDataJSON() ?? null);
+        callIndex += 1;
+        // First call: demand TOTP. Second call (after submit): inert
+        // failure so the test stays focused on the request body.
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(
+            callIndex === 1
+              ? TOTP_REQUIRED_RESPONSE
+              : AUTH_FAILED_INERT_RESPONSE,
+          ),
+        });
+      });
+
+      await page.goto(`${webuiEndpoint}/?sToken=${FIXTURE_STOKEN}`);
+
+      const otpGroup = page.getByLabel(/authenticator code/i);
+      await expect(otpGroup).toBeVisible({ timeout: 15_000 });
+      // Input.OTP distributes a multi-char string pasted into a single
+      // slot across the remaining slots; `fill` dispatches the same
+      // input event.
+      await otpGroup.locator('input').first().fill('123456');
+      await page.getByRole('button', { name: /^submit$/i }).click();
+
+      await expect
+        .poll(() => bodies.length, { timeout: 10_000 })
+        .toBeGreaterThanOrEqual(2);
+      expect(bodies[0]).not.toHaveProperty('otp');
+      expect(bodies[1]).toMatchObject({ otp: '123456' });
+    });
+
+    test('concurrent-session response renders the Login confirm (no Retry) and sends `force: true`', async ({
+      page,
+    }) => {
+      await installBoundaryProbeMocks(page);
+
+      let callIndex = 0;
+      const bodies: Array<Record<string, unknown> | null> = [];
+      await page.route('**/server/token-login', async (route) => {
+        bodies.push(route.request().postDataJSON() ?? null);
+        callIndex += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(
+            callIndex === 1
+              ? CONCURRENT_SESSION_RESPONSE
+              : AUTH_FAILED_INERT_RESPONSE,
+          ),
+        });
+      });
+
+      await page.goto(`${webuiEndpoint}/?sToken=${FIXTURE_STOKEN}`);
+
+      // The concurrent-session card uses the LoginView-aligned copy:
+      // "Logged in elsewhere" title with a Login confirm button.
+      await expect(
+        page.getByText('Logged in elsewhere', { exact: true }),
+      ).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(
+        page.getByRole('button', { name: /^login$/i }),
+      ).toBeVisible();
+      // Retry button must NOT appear — this kind replaces it entirely.
+      await expect(
+        page.getByRole('button', { name: /retry/i }),
+      ).not.toBeVisible();
+
+      await page.getByRole('button', { name: /^login$/i }).click();
+
+      await expect
+        .poll(() => bodies.length, { timeout: 10_000 })
+        .toBeGreaterThanOrEqual(2);
+      expect(bodies[0]).not.toHaveProperty('force');
+      expect(bodies[1]).toMatchObject({ force: true });
+    });
+
+    test('OTP-then-concurrent sequence keeps both `otp` and `force: true` sticky on the final body', async ({
+      page,
+    }) => {
+      await installBoundaryProbeMocks(page);
+
+      let callIndex = 0;
+      const bodies: Array<Record<string, unknown> | null> = [];
+      await page.route('**/server/token-login', async (route) => {
+        bodies.push(route.request().postDataJSON() ?? null);
+        callIndex += 1;
+        let body: unknown;
+        if (callIndex === 1) {
+          body = TOTP_REQUIRED_RESPONSE;
+        } else if (callIndex === 2) {
+          // After the OTP submission, the server discovers an existing
+          // active session. This is the sticky-OTP scenario the bug
+          // report uncovered.
+          body = CONCURRENT_SESSION_RESPONSE;
+        } else {
+          body = AUTH_FAILED_INERT_RESPONSE;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(body),
+        });
+      });
+
+      await page.goto(`${webuiEndpoint}/?sToken=${FIXTURE_STOKEN}`);
+
+      // Step 1: supply OTP.
+      const otpGroup = page.getByLabel(/authenticator code/i);
+      await expect(otpGroup).toBeVisible({ timeout: 15_000 });
+      await otpGroup.locator('input').first().fill('999111');
+      await page.getByRole('button', { name: /^submit$/i }).click();
+
+      // Step 2: confirm force-login.
+      await expect(
+        page.getByText('Logged in elsewhere', { exact: true }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+      await page.getByRole('button', { name: /^login$/i }).click();
+
+      await expect
+        .poll(() => bodies.length, { timeout: 10_000 })
+        .toBeGreaterThanOrEqual(3);
+      // Final body must carry BOTH factors the user satisfied.
+      expect(bodies[2]).toMatchObject({ otp: '999111', force: true });
     });
   },
 );

--- a/react/src/components/STokenLoginBoundary.tsx
+++ b/react/src/components/STokenLoginBoundary.tsx
@@ -20,7 +20,7 @@ import {
 import { useResolvedApiEndpoint } from '../hooks/useResolvedApiEndpoint';
 import { loginConfigState } from '../hooks/useWebUIConfig';
 import { jotaiStore } from './DefaultProviders';
-import { App, Spin, Typography } from 'antd';
+import { App, Form, Input, Spin, Typography } from 'antd';
 import { BAIButton, BAICard, BAIFlex, useBAILogger } from 'backend.ai-ui';
 import { useAtomValue } from 'jotai';
 import {
@@ -43,8 +43,120 @@ export type STokenLoginError =
   | { kind: 'endpoint-unresolved'; cause?: unknown }
   | { kind: 'server-unreachable'; cause: unknown }
   | { kind: 'token-invalid'; cause: unknown }
+  /**
+   * Webserver responded `require-totp-authentication` (or the equivalent
+   * legacy detail string). The default error card swaps its action area
+   * for an inline OTP input; submitting retries `token_login` with
+   * `{ otp }` folded into `extraParams`. `invalidOtp` is set true when the
+   * retry itself returned a TOTP rejection, so the card can show an
+   * invalid-code hint above the input without re-classifying the error.
+   */
+  | { kind: 'totp-required'; cause: unknown; invalidOtp?: boolean }
+  /**
+   * Webserver reported an existing active session for this user
+   * (`active-login-session-exists`). The default error card swaps its
+   * action area for a "terminate previous session?" confirm pair;
+   * confirming retries `token_login` with `force: true` folded into
+   * `extraParams` (sticky for subsequent retries within the same mount,
+   * mirroring LoginView's `forceLoginApprovedRef`).
+   */
   | { kind: 'concurrent-session'; cause: unknown }
   | { kind: 'unknown'; cause: unknown };
+
+/**
+ * Extract the trailing segment of a Backend.AI problem type URL.
+ * e.g. "https://api.backend.ai/probs/active-login-session-exists"
+ *      → "active-login-session-exists"
+ *
+ * Mirrors `LoginView.extractErrorType` so both entry points normalize the
+ * authenticated-probe type the same way before switching on it.
+ */
+const extractErrorType = (typeUrl: string | null | undefined): string => {
+  if (!typeUrl) return '';
+  const parts = typeUrl.split('/');
+  return parts[parts.length - 1] || '';
+};
+
+/**
+ * Classify a `tokenLogin` failure into the appropriate `STokenLoginError`
+ * kind.
+ *
+ * Uses duck-typed field extraction (not `instanceof TokenLoginFailedError`)
+ * so error objects crossing module boundaries — Jest mocked imports, HMR
+ * reloads where two copies of the helper module coexist — classify the
+ * same as direct throws.
+ *
+ * Primary signal: the authenticated-probe `type` surfaced by
+ * `client.token_login` and propagated through `TokenLoginFailedError.failType`.
+ * Strings are a safety net only, for older webservers that omit the
+ * `type` field on the failure envelope.
+ */
+const classifyTokenLoginFailure = (
+  err: unknown,
+  submittedOtp: string | null,
+): STokenLoginError => {
+  const bag =
+    typeof err === 'object' && err !== null
+      ? (err as Record<string, unknown>)
+      : {};
+  const failReason =
+    typeof bag.failReason === 'string'
+      ? bag.failReason
+      : typeof (err as Error | undefined)?.message === 'string'
+        ? (err as Error).message
+        : '';
+  const failType =
+    typeof bag.failType === 'string' ? extractErrorType(bag.failType) : '';
+
+  // Primary: switch on the structured authenticated-probe type.
+  switch (failType) {
+    case 'require-totp-authentication':
+    case 'require-totp-registration':
+      return {
+        kind: 'totp-required',
+        cause: err,
+        invalidOtp: !!submittedOtp,
+      };
+    case 'active-login-session-exists':
+      return { kind: 'concurrent-session', cause: err };
+    case 'rejected-by-hook':
+      // The hook rejection envelope piggybacks on `details` for the real
+      // classification. Currently only TOTP-code validation errors need
+      // special handling — see LoginView.
+      if (
+        failReason.includes('Invalid TOTP code provided') ||
+        failReason.includes('Failed to validate OTP')
+      ) {
+        return { kind: 'totp-required', cause: err, invalidOtp: true };
+      }
+      break;
+  }
+
+  // Fallback: older backends that omit `type`. Substring set matches
+  // LoginView's legacy fallback so both code paths classify identically.
+  const needle = failReason;
+  if (
+    needle.includes('You must authenticate using Two-Factor Authentication') ||
+    needle.includes('OTP not provided')
+  ) {
+    return {
+      kind: 'totp-required',
+      cause: err,
+      invalidOtp: !!submittedOtp,
+    };
+  }
+  if (
+    needle.includes('Invalid TOTP code provided') ||
+    needle.includes('Failed to validate OTP')
+  ) {
+    return { kind: 'totp-required', cause: err, invalidOtp: true };
+  }
+  if (needle.includes('existing active login session')) {
+    return { kind: 'concurrent-session', cause: err };
+  }
+
+  return { kind: 'token-invalid', cause: err };
+};
 
 export interface STokenLoginBoundaryProps {
   /**
@@ -95,6 +207,17 @@ type Phase =
   | { name: 'error'; error: STokenLoginError };
 
 /**
+ * Sub-phase tracked while `phase === 'pending'`. Drives the description
+ * on the default loading card so the user sees progress instead of a
+ * single static "signing you in" line during the (potentially
+ * multi-second) token exchange.
+ *
+ *   - `connecting`:     endpoint resolve, manager ping, existing-session check
+ *   - `authenticating`: `token_login` + profile/GQL bootstrap
+ */
+type PendingStep = 'connecting' | 'authenticating';
+
+/**
  * sToken-based login boundary. Authenticates via `client.token_login` using
  * the caller-supplied `sToken`, dispatches `backend-ai-connected` exactly
  * once on success, and only then renders `children`. See spec section
@@ -126,7 +249,13 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
   const loginConfig = useAtomValue(loginConfigState);
 
   const [phase, setPhase] = useState<Phase>({ name: 'pending' });
+  const [pendingStep, setPendingStep] = useState<PendingStep>('connecting');
   const [retryKey, setRetryKey] = useState(0);
+  // Drives the inline confirm/submit button loading state. Flipped on by
+  // `retryInline` and cleared deterministically at every terminal point of
+  // `runLoginSequence` (success + every `surfaceError` path) so the button
+  // never outlives the retry it initiated.
+  const [isInlineRetrying, setIsInlineRetrying] = useState(false);
 
   // Guard against React StrictMode's dev double-invoke of effects. Once the
   // sequence has started for a given retryKey, a second fire is ignored.
@@ -136,9 +265,23 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
   // most once per successful login; downstream subscribers (Relay, plugin
   // endpoint wiring) assume idempotency does not hold for them.
   const eventDispatchedRef = useRef(false);
-
+  // Sticky OTP across retries within this mount. Mirrors LoginView, which
+  // keeps the value in its Form field until the user explicitly changes it
+  // — the same OTP must be replayed if a later retry kind (e.g. force-
+  // login confirmation) happens between the original TOTP submit and the
+  // eventual success. The ref is overwritten on each `retryWithOtp(otp)`
+  // (so the TOTP input always wins over the previous value) and stale
+  // codes self-correct via the server's invalid-OTP response → the card
+  // surfaces the invalid hint and the user types a fresh one.
+  const submittedOtpRef = useRef<string | null>(null);
+  // Sticky force-login approval: once the user confirms "terminate previous
+  // session", every subsequent retry in this mount includes `force: true`
+  // (mirrors LoginView's `forceLoginApprovedRef` so a TOTP challenge that
+  // follows a force approval does not silently drop the force flag).
+  const forceApprovedRef = useRef(false);
   const surfaceError = useEffectEvent((error: STokenLoginError) => {
     setPhase({ name: 'error', error });
+    setIsInlineRetrying(false);
     onError?.(error);
   });
 
@@ -199,6 +342,24 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
         globalThis as { backendaioptions?: { get: (k: string) => unknown } }
       ).backendaioptions?.get('endpoints') as string[] | undefined) ?? [];
 
+    // Both `submittedOtpRef` and `forceApprovedRef` are sticky for the
+    // lifetime of this mount so that an interactive sequence (e.g. TOTP
+    // submit followed by a concurrent-session force confirmation) carries
+    // every accumulated factor into the single `token_login` call the
+    // server validates. Clearing is left to component unmount.
+    const submittedOtp = submittedOtpRef.current;
+    const effectiveParams: Record<string, string | boolean> = {
+      ...extraParams,
+      ...(submittedOtp ? { otp: submittedOtp } : {}),
+      ...(forceApprovedRef.current ? { force: true } : {}),
+    };
+
+    // Connectivity/session probe above is done; we're now committing to
+    // either the token exchange path or the pre-authenticated GQL
+    // bootstrap. Either way the card description shifts from
+    // "connecting" to "authenticating".
+    setPendingStep('authenticating');
+
     try {
       if (alreadyLoggedIn) {
         // Session already exists — wire up the GraphQL client / groups /
@@ -208,16 +369,11 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
         // fast-path.
         await connectViaGQL(client, cfg, endpoints);
       } else {
-        await tokenLogin(client, sToken!, cfg, endpoints, extraParams);
+        await tokenLogin(client, sToken!, cfg, endpoints, effectiveParams);
       }
     } catch (cause) {
-      // `concurrent-session` detection is deferred (spec Q6); all
-      // `token_login` failures map to `token-invalid` for now, with a TODO
-      // pointing at the sibling concurrent-login-guard spec.
-      // TODO(FR-2616 Q6): classify `concurrent-session` once the backend
-      // signal from `.specs/draft-concurrent-login-guard/` lands.
       logger.error('[STokenLoginBoundary] token_login failed', cause);
-      surfaceError({ kind: 'token-invalid', cause });
+      surfaceError(classifyTokenLoginFailure(cause, submittedOtp));
       return;
     }
 
@@ -229,6 +385,7 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
     }
 
     setPhase({ name: 'success' });
+    setIsInlineRetrying(false);
     onSuccess?.(client);
   });
 
@@ -242,22 +399,61 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
 
   const retry = () => {
     setPhase({ name: 'pending' });
+    // Any retry restarts the sequence from scratch, so the sub-phase
+    // also resets to the initial "connecting" label.
+    setPendingStep('connecting');
+    setIsInlineRetrying(false);
     setRetryKey((k) => k + 1);
+  };
+
+  // Inline retry used by the TOTP submit and force-login confirm paths.
+  // Unlike `retry`, this leaves `phase === 'error'` untouched so the
+  // current error card stays on screen; `isInlineRetrying` drives the
+  // confirm button's loading state and is cleared at every
+  // `runLoginSequence` terminal (success + every `surfaceError` path).
+  const retryInline = () => {
+    setIsInlineRetrying(true);
+    setRetryKey((k) => k + 1);
+  };
+
+  // Fold a user-supplied OTP into the next retry. Overwrites the sticky
+  // value so the TOTP form's latest submission wins. Called from the
+  // inline TOTP form inside `DefaultErrorCard`.
+  const retryWithOtp = (otp: string) => {
+    submittedOtpRef.current = otp;
+    retryInline();
+  };
+
+  // Approve force-login for all subsequent retries in this mount and
+  // immediately retry. Called from the inline concurrent-session confirm.
+  const retryWithForce = () => {
+    forceApprovedRef.current = true;
+    retryInline();
   };
 
   if (phase.name === 'error') {
     if (errorFallback) {
       return <>{errorFallback(phase.error, retry)}</>;
     }
-    return <DefaultErrorCard error={phase.error} onRetry={retry} />;
+    return (
+      <DefaultErrorCard
+        error={phase.error}
+        isInlineRetrying={isInlineRetrying}
+        onRetry={retry}
+        onSubmitOtp={retryWithOtp}
+        onConfirmForce={retryWithForce}
+      />
+    );
   }
 
   if (phase.name === 'success') {
     return <>{children}</>;
   }
 
-  // pending — show fallback while the sequence runs.
-  return <>{fallback ?? <DefaultFallback />}</>;
+  // pending — show fallback while the sequence runs. Caller-supplied
+  // `fallback` is rendered as-is; the built-in `DefaultFallback` gets the
+  // current sub-phase so its description line reflects progress.
+  return <>{fallback ?? <DefaultFallback step={pendingStep} />}</>;
 };
 
 /**
@@ -276,10 +472,23 @@ const kindToI18nKey = (kind: STokenLoginError['kind']): string =>
  * Connecting card shown while the authentication sequence is in flight.
  * The card is visually subdued so reviewers can tell the app is still
  * working but hasn't failed.
+ *
+ * `step` drives the description line so the user can see which phase is
+ * currently running — mostly relevant on slower networks where
+ * `get_manager_version` and `token_login` together take a few seconds.
+ * The outer Suspense boundary (during endpoint resolution) renders this
+ * without a `step` prop, which defaults to `connecting` — the same label
+ * the inner component starts with on mount.
  */
-const DefaultFallback: React.FC = () => {
+const DefaultFallback: React.FC<{ step?: PendingStep }> = ({
+  step = 'connecting',
+}) => {
   'use memo';
   const { t } = useTranslation();
+  const descriptionKey =
+    step === 'authenticating'
+      ? 'sTokenLoginBoundary.AuthenticatingDescription'
+      : 'sTokenLoginBoundary.ConnectingDescription';
   return (
     <BAIFlex
       direction="column"
@@ -294,7 +503,7 @@ const DefaultFallback: React.FC = () => {
             {t('sTokenLoginBoundary.AuthenticatingTitle')}
           </Typography.Title>
           <Typography.Text type="secondary">
-            {t('sTokenLoginBoundary.AuthenticatingDescription')}
+            {t(descriptionKey)}
           </Typography.Text>
         </BAIFlex>
       </BAICard>
@@ -304,15 +513,30 @@ const DefaultFallback: React.FC = () => {
 
 /**
  * Built-in error card rendered when `errorFallback` is not provided.
- * Offers two actions: Retry (runs the sequence again via BAIButton's
- * async `action` prop so the loading state appears automatically) and
- * Copy details (serializes the `{ kind, cause }` payload to JSON and
- * writes it to the clipboard for support follow-up).
+ *
+ * For most error kinds the card shows a description + {Copy details,
+ * Retry} action pair. Two kinds swap the action area inline (per design:
+ * no separate modal — the user stays on the same card layout and only
+ * the lower half changes):
+ *
+ *   - `totp-required`       → OTP input + Submit button; on submit the
+ *                             parent retries `token_login` with the `otp`
+ *                             folded into `extraParams`.
+ *   - `concurrent-session`  → "terminate previous session?" confirm pair;
+ *                             Login button retries with `force: true`.
+ *
+ * Both kinds keep the card mounted through the retry; `isInlineRetrying`
+ * drives the confirm button's loading state deterministically (cleared
+ * at every `runLoginSequence` terminal). No status badge for these kinds
+ * — only genuine terminal failures get the `error` tint.
  */
 const DefaultErrorCard: React.FC<{
   error: STokenLoginError;
+  isInlineRetrying: boolean;
   onRetry: () => void;
-}> = ({ error, onRetry }) => {
+  onSubmitOtp: (otp: string) => void;
+  onConfirmForce: () => void;
+}> = ({ error, isInlineRetrying, onRetry, onSubmitOtp, onConfirmForce }) => {
   'use memo';
   const { t } = useTranslation();
   const { message } = App.useApp();
@@ -325,6 +549,9 @@ const DefaultErrorCard: React.FC<{
     'cause' in error && error.cause
       ? String((error.cause as Error)?.message ?? error.cause)
       : null;
+
+  const isInteractiveKind =
+    error.kind === 'totp-required' || error.kind === 'concurrent-session';
 
   // Wrap in a Promise so BAIButton.action triggers its async loading
   // state; the synchronous state reset completes before the next render,
@@ -356,7 +583,7 @@ const DefaultErrorCard: React.FC<{
       style={{ minHeight: '60vh', padding: 24 }}
     >
       <BAICard
-        status="error"
+        status={isInteractiveKind ? 'default' : 'error'}
         title={title}
         style={{ maxWidth: 520, width: '100%' }}
       >
@@ -364,7 +591,7 @@ const DefaultErrorCard: React.FC<{
           <Typography.Paragraph style={{ margin: 0 }}>
             {description}
           </Typography.Paragraph>
-          {causeDetail && (
+          {causeDetail && error.kind !== 'totp-required' && (
             <Typography.Paragraph
               type="secondary"
               style={{ margin: 0, fontSize: 12, whiteSpace: 'pre-wrap' }}
@@ -372,16 +599,104 @@ const DefaultErrorCard: React.FC<{
               {causeDetail}
             </Typography.Paragraph>
           )}
-          <BAIFlex direction="row" gap="sm" justify="end">
-            <BAIButton action={handleCopy}>
-              {t('sTokenLoginBoundary.CopyErrorDetails')}
-            </BAIButton>
-            <BAIButton type="primary" action={handleRetry}>
-              {t('sTokenLoginBoundary.Retry')}
-            </BAIButton>
-          </BAIFlex>
+          {error.kind === 'totp-required' ? (
+            <TotpInlineForm
+              invalidOtp={!!error.invalidOtp}
+              isSubmitting={isInlineRetrying}
+              onSubmit={onSubmitOtp}
+            />
+          ) : error.kind === 'concurrent-session' ? (
+            <BAIFlex direction="row" gap="sm" justify="end">
+              <BAIButton action={handleCopy} disabled={isInlineRetrying}>
+                {t('sTokenLoginBoundary.CopyErrorDetails')}
+              </BAIButton>
+              <BAIButton
+                type="primary"
+                loading={isInlineRetrying}
+                disabled={isInlineRetrying}
+                onClick={onConfirmForce}
+              >
+                {t('login.Login')}
+              </BAIButton>
+            </BAIFlex>
+          ) : (
+            <BAIFlex direction="row" gap="sm" justify="end">
+              <BAIButton action={handleCopy}>
+                {t('sTokenLoginBoundary.CopyErrorDetails')}
+              </BAIButton>
+              <BAIButton type="primary" action={handleRetry}>
+                {t('sTokenLoginBoundary.Retry')}
+              </BAIButton>
+            </BAIFlex>
+          )}
         </BAIFlex>
       </BAICard>
     </BAIFlex>
+  );
+};
+
+/**
+ * Inline OTP input + Submit button rendered inside `DefaultErrorCard`
+ * when the boundary classifies the failure as `totp-required`. Trimmed
+ * locally — the webserver ignores whitespace but users routinely paste a
+ * code with trailing spaces from authenticator apps.
+ *
+ * `isSubmitting` is owned by the parent (`isInlineRetrying`) so the
+ * loading state tracks the real lifecycle of `runLoginSequence`, not a
+ * local boolean that could desync if the form unmounts mid-retry.
+ */
+const TotpInlineForm: React.FC<{
+  invalidOtp: boolean;
+  isSubmitting: boolean;
+  onSubmit: (otp: string) => void;
+}> = ({ invalidOtp, isSubmitting, onSubmit }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const [form] = Form.useForm<{ otp: string }>();
+  return (
+    <Form
+      form={form}
+      layout="vertical"
+      onFinish={(values) => {
+        const trimmed = (values.otp ?? '').trim();
+        if (!trimmed) return;
+        onSubmit(trimmed);
+      }}
+    >
+      <Form.Item
+        name="otp"
+        label={t('sTokenLoginBoundary.TotpPlaceholder')}
+        rules={[
+          {
+            required: true,
+            message: t('sTokenLoginBoundary.ErrorTotpRequiredMessage'),
+          },
+          {
+            pattern: /^\d{6}$/,
+            message: t('sTokenLoginBoundary.ErrorTotpInvalidHint'),
+          },
+        ]}
+        validateStatus={invalidOtp ? 'error' : undefined}
+        help={invalidOtp ? t('sTokenLoginBoundary.ErrorTotpInvalidHint') : null}
+        style={{ marginBottom: 12 }}
+      >
+        <Input.OTP
+          length={6}
+          size="large"
+          disabled={isSubmitting}
+          aria-label={t('sTokenLoginBoundary.TotpPlaceholder')}
+        />
+      </Form.Item>
+      <BAIFlex direction="row" gap="sm" justify="end">
+        <BAIButton
+          type="primary"
+          htmlType="submit"
+          loading={isSubmitting}
+          disabled={isSubmitting}
+        >
+          {t('sTokenLoginBoundary.SubmitOtp')}
+        </BAIButton>
+      </BAIFlex>
+    </Form>
   );
 };

--- a/react/src/helper/loginSessionAuth.ts
+++ b/react/src/helper/loginSessionAuth.ts
@@ -170,13 +170,46 @@ export async function connectViaGQL(
 }
 
 /**
+ * Structured error thrown by `tokenLogin` when the webserver reports
+ * `authenticated === false`. Carries the raw `fail_reason` string and the
+ * authenticated-probe `type` when available so callers (the
+ * `STokenLoginBoundary` classifier) can discriminate `require-totp-*`,
+ * `active-login-session-exists`, and generic invalid-token cases without
+ * string-matching the user-visible message.
+ *
+ * The prior implementation collapsed every non-success result into a
+ * generic `Error('Cannot authorize session by token.')`, which silently
+ * broke for `{ fail_reason }` returns (`client.token_login` returns an
+ * object in that case — truthy, so the old `!loginSuccess` check passed
+ * through and `connectViaGQL` ran against an unauthenticated client).
+ */
+export class TokenLoginFailedError extends Error {
+  readonly failReason: string | null;
+  readonly failType: string | null;
+  readonly raw: unknown;
+  constructor(
+    failReason: string | null,
+    failType: string | null,
+    raw: unknown,
+  ) {
+    super(failReason ?? 'Cannot authorize session by token.');
+    this.name = 'TokenLoginFailedError';
+    this.failReason = failReason;
+    this.failType = failType;
+    this.raw = raw;
+  }
+}
+
+/**
  * Perform token-based login (SSO).
  *
- * `extraParams` are forwarded to `client.token_login` alongside the `sToken`
- * argument. Callers typically collect these from URL query parameters (for
- * example, EduAppLauncher forwards `app`, `session_id`, resource hints) for
- * the server-side token handler. LoginView callers that do not need to
- * forward anything can omit the argument.
+ * `extraParams` are forwarded to `client.token_login` alongside the explicit
+ * `sToken` argument. Callers typically collect these from URL query parameters
+ * (for example, EduAppLauncher forwards `app`, `session_id`, resource hints)
+ * for the server-side token handler. The `STokenLoginBoundary` also folds
+ * interactive inputs (`otp`, `force`) into this object when retrying after a
+ * TOTP or concurrent-session challenge. LoginView callers that do not need
+ * to forward anything can omit the argument.
  *
  * Reserved keys (`sToken`, `stoken`) are stripped from `extraParams` before
  * forwarding so that the explicit `sToken` argument always wins, regardless
@@ -190,7 +223,7 @@ export async function tokenLogin(
   sToken: string,
   cfg: LoginConfigState,
   endpoints: string[],
-  extraParams?: Record<string, string>,
+  extraParams?: Record<string, string | boolean>,
 ): Promise<string[]> {
   const sanitizedExtraParams = extraParams
     ? Object.fromEntries(
@@ -199,9 +232,27 @@ export async function tokenLogin(
         ),
       )
     : {};
-  const loginSuccess = await client.token_login(sToken, sanitizedExtraParams);
-  if (!loginSuccess) {
-    throw new Error('Cannot authorize session by token.');
+  const result = await client.token_login(sToken, sanitizedExtraParams);
+  // `client.token_login` returns:
+  //   - truthy check_login result object                       → authenticated
+  //   - `{ fail_reason: string, fail_type: string }`           → authenticated: false
+  //   - `false`                                                → authenticated: false, no envelope
+  // Only the first is a successful login.
+  const failed =
+    result === false ||
+    result == null ||
+    (typeof result === 'object' &&
+      ('fail_reason' in result || 'fail_type' in result));
+  if (failed) {
+    const envelope =
+      typeof result === 'object' && result
+        ? (result as { fail_reason?: string; fail_type?: string })
+        : null;
+    throw new TokenLoginFailedError(
+      envelope?.fail_reason ?? null,
+      envelope?.fail_type ?? null,
+      result,
+    );
   }
   return connectViaGQL(client, cfg, endpoints);
 }

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2072,11 +2072,12 @@
     "Updated": "Ressourcenvoreinstellung aktualisiert"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Ihr Anmelde-Token wird verifiziert…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Verbindung mit dem Backend.AI-Server wird hergestellt…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Sie sind bereits an einem anderen Ort angemeldet. Möchten Sie die bestehende Anmeldung beenden und sich hier anmelden?",
+    "ErrorConcurrentSessionTitle": "An anderer Stelle angemeldet",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2087,9 +2088,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Der eingegebene Code wurde nicht akzeptiert. Bitte versuchen Sie es erneut.",
+    "ErrorTotpRequiredDescription": "Geben Sie den Code aus Ihrer Authentifizierungs-App ein, um fortzufahren.",
+    "ErrorTotpRequiredTitle": "Zwei-Faktor-Authentifizierung erforderlich",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Bestätigen",
+    "TotpPlaceholder": "Authentifizierungscode"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Geben Sie die Modell-ID ein. (z. B.: openai/gpt-oss-20b)",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2070,11 +2070,12 @@
     "Updated": "Η προεπιλογή πόρων ενημερώθηκε"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Το διακριτικό σύνδεσής σας επαληθεύεται…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Σύνδεση με τον διακομιστή Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Έχετε ήδη συνδεθεί αλλού. Θέλετε να τερματίσετε την υπάρχουσα σύνδεση και να συνδεθείτε εδώ;",
+    "ErrorConcurrentSessionTitle": "Συνδεδεμένος/η από άλλη τοποθεσία",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2085,9 +2086,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Ο κωδικός που εισαγάγατε δεν έγινε αποδεκτός. Παρακαλώ δοκιμάστε ξανά.",
+    "ErrorTotpRequiredDescription": "Εισαγάγετε τον κωδικό από την εφαρμογή ελέγχου ταυτότητας για να συνεχίσετε.",
+    "ErrorTotpRequiredTitle": "Απαιτείται έλεγχος ταυτότητας δύο παραγόντων",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Υποβολή",
+    "TotpPlaceholder": "Κωδικός αυθεντικοποίησης"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Εισαγάγετε το ID του μοντέλου. (π.χ.: openai/gpt-oss-20b)",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2080,11 +2080,12 @@
     "Updated": "Resource preset updated"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+    "AuthenticatingDescription": "Verifying your sign-in token…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Connecting to the Backend.AI server…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "You are already logged in elsewhere. Would you like to end the existing session and log in here?",
+    "ErrorConcurrentSessionTitle": "Logged in elsewhere",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2095,9 +2096,16 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "The code you entered was not accepted. Please try again.",
+    "ErrorTotpRequiredDescription": "Enter the code from your authenticator app to continue.",
+    "ErrorTotpRequiredMessage": "Please enter your authenticator code.",
+    "ErrorTotpRequiredTitle": "Two-factor authentication required",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "ForceLogin": "Sign in anyway",
+    "Retry": "Retry",
+    "SubmitOtp": "Submit",
+    "TotpPlaceholder": "Authenticator code"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Enter a model ID. (e.g. openai/gpt-oss-20b)",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2070,11 +2070,12 @@
     "Updated": "Preajuste de recursos actualizado"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Verificando su token de inicio de sesión…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Conectando al servidor Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Ya ha iniciado sesión en otro lugar. ¿Desea cerrar la sesión existente e iniciar sesión aquí?",
+    "ErrorConcurrentSessionTitle": "Sesión iniciada en otro lugar",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2085,9 +2086,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "El código introducido no fue aceptado. Por favor, inténtelo de nuevo.",
+    "ErrorTotpRequiredDescription": "Ingrese el código de su aplicación de autenticación para continuar.",
+    "ErrorTotpRequiredTitle": "Se requiere autenticación de dos factores",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Enviar",
+    "TotpPlaceholder": "Código de autenticación"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Introduzca el ID del modelo. (p. ej.: openai/gpt-oss-20b)",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2070,11 +2070,12 @@
     "Updated": "Resurssien esiasetus päivitetty"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Kirjautumistunnistettasi varmennetaan…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Yhdistetään Backend.AI-palvelimeen…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Olet jo kirjautunut sisään toisessa paikassa. Haluatko lopettaa nykyisen istunnon ja kirjautua sisään täällä?",
+    "ErrorConcurrentSessionTitle": "Kirjautunut muualta",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2085,9 +2086,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Antamasi koodi ei kelpaa. Yritä uudelleen.",
+    "ErrorTotpRequiredDescription": "Syötä koodi todennussovelluksestasi jatkaaksesi.",
+    "ErrorTotpRequiredTitle": "Kaksivaiheinen todennus vaaditaan",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Lähetä",
+    "TotpPlaceholder": "Todennuskoodi"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Syötä mallin tunnus (esim. openai/gpt-oss-20b)",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2072,11 +2072,12 @@
     "Updated": "Préréglage de ressource mis à jour"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Vérification de votre jeton de connexion…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Connexion au serveur Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Vous êtes déjà connecté ailleurs. Voulez-vous déconnecter la session existante et vous connecter ici ?",
+    "ErrorConcurrentSessionTitle": "Connecté ailleurs",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2087,9 +2088,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Le code saisi n'a pas été accepté. Veuillez réessayer.",
+    "ErrorTotpRequiredDescription": "Saisissez le code de votre application d'authentification pour continuer.",
+    "ErrorTotpRequiredTitle": "Authentification à deux facteurs requise",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Valider",
+    "TotpPlaceholder": "Code d'authentification"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Saisissez l'ID du modèle. (ex : openai/gpt-oss-20b)",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2073,11 +2073,12 @@
     "Updated": "Preset sumber daya diperbarui"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Memverifikasi token masuk Anda…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Menghubungkan ke server Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Anda sudah masuk di tempat lain. Ingin mengakhiri sesi yang ada dan masuk di sini?",
+    "ErrorConcurrentSessionTitle": "Sedang masuk di tempat lain",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2088,9 +2089,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Kode yang Anda masukkan tidak diterima. Silakan coba lagi.",
+    "ErrorTotpRequiredDescription": "Masukkan kode dari aplikasi autentikasi Anda untuk melanjutkan.",
+    "ErrorTotpRequiredTitle": "Autentikasi dua faktor diperlukan",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Kirim",
+    "TotpPlaceholder": "Kode autentikasi"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Masukkan ID model. (Contoh: openai/gpt-oss-20b)",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2070,11 +2070,12 @@
     "Updated": "Preimpostazione delle risorse aggiornata"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Verifica del token di accesso in corso…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Connessione al server Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Sei già connesso altrove. Vuoi terminare la sessione esistente e accedere qui?",
+    "ErrorConcurrentSessionTitle": "Accesso da un altro dispositivo",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2085,9 +2086,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Il codice inserito non è stato accettato. Riprova.",
+    "ErrorTotpRequiredDescription": "Inserisci il codice dell'app di autenticazione per continuare.",
+    "ErrorTotpRequiredTitle": "Autenticazione a due fattori richiesta",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Invia",
+    "TotpPlaceholder": "Codice di autenticazione"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Inserisci l'ID del modello. (es.: openai/gpt-oss-20b)",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2072,11 +2072,12 @@
     "Updated": "リソースプリセットが更新されました"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "ログイントークンを確認しています…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Backend.AIサーバーに接続しています…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "別の場所で既にログインしています。既存のログインを終了して、こちらでログインしますか？",
+    "ErrorConcurrentSessionTitle": "別の場所でログイン中",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2087,9 +2088,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "入力されたコードは受け付けられませんでした。もう一度お試しください。",
+    "ErrorTotpRequiredDescription": "続行するには、認証アプリのコードを入力してください。",
+    "ErrorTotpRequiredTitle": "二要素認証が必要です",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "送信",
+    "TotpPlaceholder": "認証コード"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "モデルIDを入力してください。（例：openai/gpt-oss-20b）",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2082,11 +2082,12 @@
     "Updated": "자원 프리셋이 수정되었습니다"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "싱글 사인온 토큰으로 로그인하고 있습니다. 잠시만 기다려 주세요.",
+    "AuthenticatingDescription": "로그인 토큰을 확인하고 있습니다…",
     "AuthenticatingTitle": "로그인 중",
+    "ConnectingDescription": "Backend.AI 서버에 연결 중…",
     "CopyErrorDetails": "오류 세부 정보 복사",
-    "ErrorConcurrentSessionDescription": "다른 곳에서 이미 로그인되어 있습니다. 해당 세션을 종료한 뒤 다시 시도해 주세요.",
-    "ErrorConcurrentSessionTitle": "이미 다른 세션에서 로그인된 상태입니다.",
+    "ErrorConcurrentSessionDescription": "다른 곳에서 이미 로그인되어 있습니다. 기존 로그인을 종료하고 여기에서 로그인하시겠습니까?",
+    "ErrorConcurrentSessionTitle": "다른 곳에서 로그인 중",
     "ErrorDetailsCopied": "오류 세부 정보가 클립보드에 복사되었습니다.",
     "ErrorDetailsCopyFailed": "오류 세부 정보를 복사하지 못했습니다. 페이지에서 직접 복사해 주세요.",
     "ErrorEndpointUnresolvedDescription": "구성 파일에서 Backend.AI 서버 주소를 확인하지 못했습니다. 잠시 후 다시 시도하거나 관리자에게 문의하세요.",
@@ -2097,9 +2098,16 @@
     "ErrorServerUnreachableTitle": "Backend.AI 서버에 연결할 수 없습니다.",
     "ErrorTokenInvalidDescription": "로그인 토큰이 만료되었거나 해지되었을 수 있습니다. 원래 애플리케이션에서 로그인 절차를 다시 시작해 주세요.",
     "ErrorTokenInvalidTitle": "로그인 토큰이 유효하지 않습니다.",
+    "ErrorTotpInvalidHint": "입력하신 코드가 올바르지 않습니다. 다시 시도해 주세요.",
+    "ErrorTotpRequiredDescription": "인증기 앱에 표시된 코드를 입력해 계속 진행하세요.",
+    "ErrorTotpRequiredMessage": "인증기 앱의 코드를 입력해 주세요.",
+    "ErrorTotpRequiredTitle": "2단계 인증이 필요합니다",
     "ErrorUnknownDescription": "로그인 중 알 수 없는 오류가 발생했습니다. 다시 시도해 주시고, 문제가 계속되면 아래 오류 세부 정보를 복사해 전달해 주세요.",
     "ErrorUnknownTitle": "로그인 중 예기치 않은 오류가 발생했습니다.",
-    "Retry": "다시 시도"
+    "ForceLogin": "그래도 로그인",
+    "Retry": "다시 시도",
+    "SubmitOtp": "확인",
+    "TotpPlaceholder": "인증 코드"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "모델 ID를 입력하십시오. (예 : openai/gpt-oss-20b)",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2071,11 +2071,12 @@
     "Updated": "Нөөцийн урьдчилан тохируулалтыг шинэчилсэн"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Нэвтрэх токеныг шалгаж байна…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Backend.AI серверт холбогдож байна…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Та аль хэдийн өөр газар нэвтэрсэн байна. Одоогийн нэвтрэлтийг дуусгаж энд нэвтрэх үү?",
+    "ErrorConcurrentSessionTitle": "Өөр газраас нэвтэрсэн байна",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2086,9 +2087,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Оруулсан код хүлээн зөвшөөрөгдсөнгүй. Дахин оролдоно уу.",
+    "ErrorTotpRequiredDescription": "Үргэлжлүүлэхийн тулд баталгаажуулагч програмын кодыг оруулна уу.",
+    "ErrorTotpRequiredTitle": "Хоёр хүчин зүйлийн баталгаажуулалт шаардлагатай",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Илгээх",
+    "TotpPlaceholder": "Баталгаажуулагч код"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Моделийн ID-г оруулна уу. (Жишээ: openai/gpt-oss-20b)",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2070,11 +2070,12 @@
     "Updated": "Pratetap sumber dikemas kini"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Token log masuk anda sedang disahkan…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Menyambung ke pelayan Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Anda sudah log masuk di tempat lain. Adakah anda mahu menamatkan sesi log masuk sedia ada dan log masuk di sini?",
+    "ErrorConcurrentSessionTitle": "Sedang log masuk dari tempat lain",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2085,9 +2086,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Kod yang anda masukkan tidak diterima. Sila cuba lagi.",
+    "ErrorTotpRequiredDescription": "Masukkan kod daripada aplikasi pengesah anda untuk meneruskan.",
+    "ErrorTotpRequiredTitle": "Pengesahan dua faktor diperlukan",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Hantar",
+    "TotpPlaceholder": "Kod pengesah"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Sila masukkan ID model. (Contoh: openai/gpt-oss-20b)",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2072,11 +2072,12 @@
     "Updated": "Zaktualizowano wstępne ustawienia zasobów"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Trwa weryfikacja tokenu logowania…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Łączenie z serwerem Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Jesteś już zalogowany gdzie indziej. Zakończyć poprzednią sesję i zalogować się tutaj?",
+    "ErrorConcurrentSessionTitle": "Zalogowano gdzie indziej",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2087,9 +2088,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Wprowadzony kod nie został zaakceptowany. Spróbuj ponownie.",
+    "ErrorTotpRequiredDescription": "Wprowadź kod z aplikacji uwierzytelniającej, aby kontynuować.",
+    "ErrorTotpRequiredTitle": "Wymagane uwierzytelnianie dwuskładnikowe",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Wyślij",
+    "TotpPlaceholder": "Kod uwierzytelniający"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Wprowadź ID modelu. (np.: openai/gpt-oss-20b)",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2070,11 +2070,12 @@
     "Updated": "Predefinição de recurso atualizada"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Verificando seu token de login…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Conectando ao servidor Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Você já está conectado em outro local. Deseja encerrar a sessão existente e fazer login aqui?",
+    "ErrorConcurrentSessionTitle": "Sessão ativa em outro local",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2085,9 +2086,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "O código inserido não foi aceito. Por favor, tente novamente.",
+    "ErrorTotpRequiredDescription": "Insira o código do seu aplicativo de autenticação para continuar.",
+    "ErrorTotpRequiredTitle": "Autenticação de dois fatores necessária",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Enviar",
+    "TotpPlaceholder": "Código de autenticação"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Digite o ID do modelo. (Ex.: openai/gpt-oss-20b)",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2072,11 +2072,12 @@
     "Updated": "Predefinição de recurso atualizada"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "A verificar o seu token de início de sessão…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "A ligar ao servidor Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Você já está conectado em outro local. Deseja encerrar a sessão existente e entrar aqui?",
+    "ErrorConcurrentSessionTitle": "Conectado em outro local",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2087,9 +2088,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "O código introduzido não foi aceite. Por favor, tente novamente.",
+    "ErrorTotpRequiredDescription": "Introduza o código da sua aplicação de autenticação para continuar.",
+    "ErrorTotpRequiredTitle": "Autenticação de dois fatores necessária",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Enviar",
+    "TotpPlaceholder": "Código de autenticação"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Insira o ID do modelo. (ex.: openai/gpt-oss-20b)",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2070,11 +2070,12 @@
     "Updated": "Предустановка ресурса обновлена"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Выполняется проверка токена входа…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Подключение к серверу Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Вы уже вошли в другом месте. Завершить предыдущую сессию и войти здесь?",
+    "ErrorConcurrentSessionTitle": "Выполняется вход в другом месте",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2085,9 +2086,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Введённый код не был принят. Пожалуйста, попробуйте ещё раз.",
+    "ErrorTotpRequiredDescription": "Введите код из приложения-аутентификатора для продолжения.",
+    "ErrorTotpRequiredTitle": "Требуется двухфакторная аутентификация",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Отправить",
+    "TotpPlaceholder": "Код аутентификатора"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Введите ID модели. (например: openai/gpt-oss-20b)",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2072,11 +2072,12 @@
     "Updated": "อัปเดตค่าที่กำหนดไว้ล่วงหน้าของทรัพยากรแล้ว"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "กำลังตรวจสอบโทเคนการเข้าสู่ระบบของคุณ…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "กำลังเชื่อมต่อกับเซิร์ฟเวอร์ Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "มีการเข้าสู่ระบบจากที่อื่นอยู่แล้ว ต้องการยุติการเข้าสู่ระบบเดิมและเข้าสู่ระบบที่นี่หรือไม่?",
+    "ErrorConcurrentSessionTitle": "กำลังเข้าสู่ระบบจากที่อื่น",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2087,9 +2088,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "รหัสที่คุณป้อนไม่ถูกต้อง กรุณาลองอีกครั้ง",
+    "ErrorTotpRequiredDescription": "กรุณาป้อนรหัสจากแอปยืนยันตัวตนของคุณเพื่อดำเนินการต่อ",
+    "ErrorTotpRequiredTitle": "จำเป็นต้องยืนยันตัวตนสองขั้นตอน",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "ส่ง",
+    "TotpPlaceholder": "รหัสยืนยันตัวตน"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "กรุณาใส่ ID ของโมเดล (เช่น: openai/gpt-oss-20b)",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2070,11 +2070,12 @@
     "Updated": "Kaynak ön ayarı güncellendi"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Oturum açma jetonunuz doğrulanıyor…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Backend.AI sunucusuna bağlanılıyor…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Başka bir yerde zaten oturum açılmış. Mevcut oturumu sonlandırıp burada oturum açmak ister misiniz?",
+    "ErrorConcurrentSessionTitle": "Başka bir yerden giriş yapılıyor",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2085,9 +2086,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Girilen kod kabul edilmedi. Lütfen tekrar deneyin.",
+    "ErrorTotpRequiredDescription": "Devam etmek için kimlik doğrulama uygulamanızdaki kodu girin.",
+    "ErrorTotpRequiredTitle": "İki faktörlü kimlik doğrulama gerekli",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Gönder",
+    "TotpPlaceholder": "Kimlik doğrulama kodu"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Model kimliğini girin. (örn: openai/gpt-oss-20b)",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2072,11 +2072,12 @@
     "Updated": "Đã cập nhật cài đặt trước tài nguyên"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "Đang xác minh token đăng nhập của bạn…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "Đang kết nối đến máy chủ Backend.AI…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "Bạn đã đăng nhập ở nơi khác. Bạn có muốn kết thúc phiên đăng nhập hiện tại và đăng nhập ở đây không?",
+    "ErrorConcurrentSessionTitle": "Đang đăng nhập ở nơi khác",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2087,9 +2088,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "Mã bạn nhập không được chấp nhận. Vui lòng thử lại.",
+    "ErrorTotpRequiredDescription": "Nhập mã từ ứng dụng xác thực của bạn để tiếp tục.",
+    "ErrorTotpRequiredTitle": "Yêu cầu xác thực hai yếu tố",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "Gửi",
+    "TotpPlaceholder": "Mã xác thực"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "Vui lòng nhập ID mô hình. (Ví dụ: openai/gpt-oss-20b)",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2072,11 +2072,12 @@
     "Updated": "资源预设已更新"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "正在验证您的登录令牌…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "正在连接 Backend.AI 服务器…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "您已在其他地方登录。要结束现有会话并在此登录吗？",
+    "ErrorConcurrentSessionTitle": "已在其他地方登录",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2087,9 +2088,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "您输入的验证码未被接受。请重试。",
+    "ErrorTotpRequiredDescription": "请输入您的身份验证器应用程序中的验证码以继续。",
+    "ErrorTotpRequiredTitle": "需要双因素认证",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "提交",
+    "TotpPlaceholder": "身份验证码"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "请输入模型 ID。（例如：openai/gpt-oss-20b）",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2074,11 +2074,12 @@
     "Updated": "資源預設已更新"
   },
   "sTokenLoginBoundary": {
-    "AuthenticatingDescription": "Authenticating with your single sign-on token. This usually takes only a moment.",
+"AuthenticatingDescription": "正在驗證您的登入權杖…",
     "AuthenticatingTitle": "Signing you in",
+    "ConnectingDescription": "正在連線至 Backend.AI 伺服器…",
     "CopyErrorDetails": "Copy error details",
-    "ErrorConcurrentSessionDescription": "This account is already signed in somewhere else. Please close the other session and try again.",
-    "ErrorConcurrentSessionTitle": "Another active session was detected.",
+    "ErrorConcurrentSessionDescription": "您已在其他地方登入。是否要終止現有登入並在此登入？",
+    "ErrorConcurrentSessionTitle": "已在其他地方登入",
     "ErrorDetailsCopied": "Error details copied to clipboard.",
     "ErrorDetailsCopyFailed": "Failed to copy error details. Please copy them manually from the page.",
     "ErrorEndpointUnresolvedDescription": "The Backend.AI server address could not be resolved from the configuration file. Please try again in a moment or contact your administrator.",
@@ -2089,9 +2090,14 @@
     "ErrorServerUnreachableTitle": "Cannot reach the Backend.AI server.",
     "ErrorTokenInvalidDescription": "The sign-in token may have expired or been revoked. Please restart the sign-in flow from your original application.",
     "ErrorTokenInvalidTitle": "Your sign-in token is not valid.",
+    "ErrorTotpInvalidHint": "您輸入的驗證碼未被接受。請重試。",
+    "ErrorTotpRequiredDescription": "請輸入您的身份驗證器應用程式中的驗證碼以繼續。",
+    "ErrorTotpRequiredTitle": "需要雙因素驗證",
     "ErrorUnknownDescription": "An unexpected error occurred while signing in. Please try again, and copy the error details below if the problem persists.",
     "ErrorUnknownTitle": "Sign-in failed unexpectedly.",
-    "Retry": "Retry"
+    "Retry": "Retry",
+    "SubmitOtp": "送出",
+    "TotpPlaceholder": "身份驗證碼"
   },
   "scanArtifactModelsFromHuggingFaceModal": {
     "EnterAModelID": "請輸入模型 ID（例如：openai/gpt-oss-20b）",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -1095,8 +1095,16 @@ class Client {
         // check_login() calls don't confuse it with a live session.
         // Mirrors the regular login() failure-path behavior.
         localStorage.removeItem('backendaiwebui.sessionid');
-        if (result.data && result.data.details) {
-          return Promise.resolve({ fail_reason: result.data.details });
+        if (result.data) {
+          // Surface both `details` (free-text) and `type` (problem URL) so
+          // the webui can classify the failure (`active-login-session-exists`,
+          // `require-totp-authentication`, etc.) without string-matching
+          // the user-visible message. Consumers read the last path segment
+          // of `fail_type` the same way LoginView's `extractErrorType` does.
+          return Promise.resolve({
+            fail_reason: result.data.details,
+            fail_type: result.data.type,
+          });
         } else {
           return Promise.resolve(false);
         }


### PR DESCRIPTION
Follow-up feature on top of Epic [FR-2616](https://lablup.atlassian.net/browse/FR-2616). Jira ticket to be filed.

## Summary

Extends `STokenLoginBoundary` to handle two interactive auth challenges inline, without a modal and without splitting into separate components — the existing `DefaultErrorCard` layout stays, only its action area swaps per error kind.

### UX

| Error kind | Card status | Description | Actions |
|---|---|---|---|
| `totp-required` *(new)* | `warning` | "Enter the 6-digit code from your authenticator app…" | Inline OTP `<Input>` + **Submit** |
| `concurrent-session` *(activated)* | `warning` | "This account is already signed in somewhere else. Do you want to end the other session and continue here?" | **Copy details** · **Sign in anyway** |
| all other kinds | `error` | (unchanged) | **Copy details** · **Retry** |

On **Submit**, `STokenLoginBoundary` folds `otp: <entered>` into `extraParams` and replays the auth sequence. A failed retry re-renders the OTP card with an invalid-code hint above the input; the OTP itself is single-use (cleared after every retry).

On **Sign in anyway**, the boundary sets a sticky `forceApprovedRef` and replays the sequence with `force: true` folded in. Sticky matches LoginView's `forceLoginApprovedRef` — a TOTP challenge that arrives *after* a force approval keeps the force flag on the subsequent retries.

### Why

- `token_login` previously had a latent bug: `client.token_login` returns `{ fail_reason }` on `authenticated: false`, which is truthy, so the old `!loginSuccess` guard passed through and `connectViaGQL` ran against an unauthenticated client. Introducing `TokenLoginFailedError` fixes this at the helper layer before the classifier inspects it.
- Classification uses duck-typed field extraction (`err.failReason`, `err.failType`) rather than `instanceof TokenLoginFailedError` so cross-module-instance errors (Jest mocks, HMR reloads) classify identically to direct throws.
- String-match detection mirrors `LoginView.handleLoginError`'s legacy fallback so both entry points classify the same until the webserver surfaces the probe `type` through `client.token_login` (tracked by `TODO(user-tunable)`).

## Changes

- `react/src/helper/loginSessionAuth.ts`
  - `TokenLoginFailedError` class and structured throw from `tokenLogin`.
  - `extraParams` type widened to `Record<string, string | boolean>` so `force: true` can pass through alongside string URL params.
- `react/src/components/STokenLoginBoundary.tsx`
  - `STokenLoginError` union: `totp-required` added, `concurrent-session` wired up end-to-end.
  - `pendingOtpRef` (single-use) + `forceApprovedRef` (sticky) retry state.
  - `retryWithOtp` / `retryWithForce` handlers; existing `retry()` preserved for non-interactive kinds.
  - `DefaultErrorCard` gains `onSubmitOtp` / `onConfirmForce` plumbing and kind-branched action area. Card `status` shifts to `warning` for the two interactive kinds.
  - New `TotpInlineForm` subcomponent (kept co-located in the same file, per scope request).
- `resources/i18n/en.json`, `resources/i18n/ko.json`
  - `ErrorTotpRequiredTitle` / `ErrorTotpRequiredDescription` / `ErrorTotpInvalidHint` / `TotpPlaceholder` / `SubmitOtp` / `ForceLogin`.
  - `ErrorConcurrentSessionDescription` updated to match the new force-confirm UX.

## Test plan

- [x] `bash scripts/verify.sh` → `ALL PASS`
- [x] `pnpm --dir react jest src/components/STokenLoginBoundary.test.tsx` → 9 passed
- [ ] Manual: navigate `/?sToken=<TOTP-required>` → card shows OTP input, submit retries with `otp=…`. Wrong code surfaces invalid hint; right code proceeds.
- [ ] Manual: navigate with an active second-session setup → card offers "Sign in anyway"; confirming retries with `force=true`.
- [ ] Manual (combined): sToken where the server first issues `active-login-session-exists` then `require-totp-authentication` on the force retry → force flag stays on while OTP is submitted.

## Follow-ups

- File a Jira sub-task under Epic FR-2616 for this feature.
- Swap string-match classifier for strict `type` equality once `client.token_login` surfaces the probe `type` to the caller. `TokenLoginFailedError.failType` is already reserved.
- Translations for the 20 non-en/ko locales via the `fw:i18n` skill.

[FR-2616]: https://lablup.atlassian.net/browse/FR-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ