### PR TITLE
feat(FR-2664): add /deployments + /admin-deployments routes with legacy fallbacks

### DIFF
--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -1,0 +1,16 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import React from 'react';
+
+// TODO(needs-backend): FR-2672 — Admin deployment list page.
+// This is a placeholder stub introduced by FR-2664 so that the new
+// /admin-deployments route can be wired before the real page lands in
+// Phase 5.
+const AdminDeploymentListPage: React.FC = () => {
+  'use memo';
+  return <div>TODO: AdminDeploymentListPage — FR-2672</div>;
+};
+
+export default AdminDeploymentListPage;

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -1,0 +1,16 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import React from 'react';
+
+// TODO(needs-backend): FR-2681 — Deployment detail page.
+// This is a placeholder stub introduced by FR-2664 so that the new
+// /deployments/:deploymentId route can be wired before the real page
+// lands in Phase 4.
+const DeploymentDetailPage: React.FC = () => {
+  'use memo';
+  return <div>TODO: DeploymentDetailPage — FR-2681</div>;
+};
+
+export default DeploymentDetailPage;

--- a/react/src/pages/DeploymentLauncherPage.tsx
+++ b/react/src/pages/DeploymentLauncherPage.tsx
@@ -1,0 +1,16 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import React from 'react';
+
+// TODO(needs-backend): FR-2675 — Deployment launcher page (create + edit).
+// This is a placeholder stub introduced by FR-2664 so that the new
+// /deployments/new and /deployments/:deploymentId/edit routes can be
+// wired before the real page lands in Phase 3.
+const DeploymentLauncherPage: React.FC = () => {
+  'use memo';
+  return <div>TODO: DeploymentLauncherPage — FR-2675</div>;
+};
+
+export default DeploymentLauncherPage;

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -1,0 +1,15 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import React from 'react';
+
+// TODO(needs-backend): FR-2671 — Deployment list page (user view).
+// This is a placeholder stub introduced by FR-2664 so that the new
+// /deployments route can be wired before the real page lands in Phase 3.
+const DeploymentListPage: React.FC = () => {
+  'use memo';
+  return <div>TODO: DeploymentListPage — FR-2671</div>;
+};
+
+export default DeploymentListPage;

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -22,20 +22,16 @@ import { useWebUIMenuItems } from './hooks/useWebUIMenuItems';
 import ComputeSessionListPage from './pages/ComputeSessionListPage';
 import LegacyModelStoreListPage from './pages/LegacyModelStoreListPage';
 import Page404 from './pages/Page404';
-import ServingPage from './pages/ServingPage';
 import VFolderNodeListPage from './pages/VFolderNodeListPage';
 import { Skeleton, theme } from 'antd';
 import { BAIFlex, BAICard } from 'backend.ai-ui';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { RouteObject, useLocation } from 'react-router-dom';
+import { RouteObject, useLocation, useParams } from 'react-router-dom';
 
 const LoginViewLazy = React.lazy(() => import('./components/LoginView'));
 
 const Information = React.lazy(() => import('./components/Information'));
-const EndpointDetailPage = React.lazy(
-  () => import('./pages/EndpointDetailPage'),
-);
 const StartPage = React.lazy(() => import('./pages/StartPage'));
 const DashboardPage = React.lazy(() => import('./pages/DashboardPage'));
 const AdminDashboardPage = React.lazy(
@@ -68,6 +64,21 @@ const ServiceLauncherCreatePage = React.lazy(
 );
 const ServiceLauncherUpdatePage = React.lazy(
   () => import('./pages/ServiceLauncherPage'),
+);
+// FR-2664 — Deployment UI migration (Phase 1: Foundation).
+// These pages are currently stub placeholders and will be implemented in
+// Phase 3/4/5 (FR-2671 / FR-2675 / FR-2681 / FR-2672).
+const DeploymentListPage = React.lazy(
+  () => import('./pages/DeploymentListPage'),
+);
+const DeploymentLauncherPage = React.lazy(
+  () => import('./pages/DeploymentLauncherPage'),
+);
+const DeploymentDetailPage = React.lazy(
+  () => import('./pages/DeploymentDetailPage'),
+);
+const AdminDeploymentListPage = React.lazy(
+  () => import('./pages/AdminDeploymentListPage'),
 );
 const InteractiveLoginPage = React.lazy(
   () => import('./pages/InteractiveLoginPage'),
@@ -105,7 +116,6 @@ const RBACManagementPage = React.lazy(
   () => import('./pages/RBACManagementPage'),
 );
 const AdminSessionPage = React.lazy(() => import('./pages/AdminSessionPage'));
-const AdminServingPage = React.lazy(() => import('./pages/AdminServingPage'));
 const AdminVFolderNodeListPage = React.lazy(
   () => import('./pages/AdminVFolderNodeListPage'),
 );
@@ -249,8 +259,9 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     ],
   },
   {
-    path: '/serving',
-
+    // FR-2664 — New Deployment UI routes. Replaces the legacy /serving
+    // routes (see fallback redirects below).
+    path: '/deployments',
     handle: { labelKey: 'webui.menu.Serving' },
     children: [
       {
@@ -262,19 +273,79 @@ export const mainLayoutChildRoutes: RouteObject[] = [
             <Suspense
               fallback={<BAICard title={t('webui.menu.Serving')} loading />}
             >
-              <ServingPage />
+              <DeploymentListPage />
             </Suspense>
           );
         },
       },
       {
-        path: '/serving/:serviceId',
+        path: 'new',
+        handle: { labelKey: 'modelService.StartNewService' },
         element: (
-          <Suspense fallback={<Skeleton active />}>
-            <EndpointDetailPage />
+          <Suspense
+            fallback={
+              <BAIFlex direction="column" style={{ maxWidth: 700 }}>
+                <Skeleton active />
+              </BAIFlex>
+            }
+          >
+            <DeploymentLauncherPage />
           </Suspense>
         ),
+      },
+      {
+        path: ':deploymentId',
         handle: { labelKey: 'modelService.RoutingInfo' },
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <DeploymentDetailPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: ':deploymentId/edit',
+        handle: { labelKey: 'modelService.UpdateService' },
+        element: (
+          <Suspense
+            fallback={
+              <BAIFlex direction="column" style={{ maxWidth: 700 }}>
+                <Skeleton active />
+              </BAIFlex>
+            }
+          >
+            <DeploymentLauncherPage />
+          </Suspense>
+        ),
+      },
+    ],
+  },
+  {
+    // FR-2664 — Legacy /serving fallback. Transient redirect; remove once
+    // all internal links + external references have been migrated.
+    path: '/serving',
+    handle: { labelKey: 'webui.menu.Serving' },
+    children: [
+      {
+        path: '',
+        Component: () => {
+          const location = useLocation();
+          return (
+            <WebUINavigate to={'/deployments' + location.search} replace />
+          );
+        },
+      },
+      {
+        path: ':serviceId',
+        Component: () => {
+          const { serviceId } = useParams<{ serviceId: string }>();
+          const location = useLocation();
+          return (
+            <WebUINavigate
+              to={`/deployments/${serviceId}${location.search}`}
+              replace
+            />
+          );
+        },
       },
     ],
   },
@@ -284,7 +355,7 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     children: [
       {
         path: '',
-        element: <WebUINavigate to="/serving" replace />,
+        element: <WebUINavigate to="/deployments" replace />,
       },
       {
         path: 'start',
@@ -315,6 +386,34 @@ export const mainLayoutChildRoutes: RouteObject[] = [
             <ServiceLauncherUpdatePage />
           </Suspense>
         ),
+      },
+      {
+        // FR-2664 — Legacy fallback: /service/:endpointId → /deployments/:deploymentId
+        path: ':endpointId',
+        Component: () => {
+          const { endpointId } = useParams<{ endpointId: string }>();
+          const location = useLocation();
+          return (
+            <WebUINavigate
+              to={`/deployments/${endpointId}${location.search}`}
+              replace
+            />
+          );
+        },
+      },
+      {
+        // FR-2664 — Legacy fallback: /service/:endpointId/edit → /deployments/:deploymentId/edit
+        path: ':endpointId/edit',
+        Component: () => {
+          const { endpointId } = useParams<{ endpointId: string }>();
+          const location = useLocation();
+          return (
+            <WebUINavigate
+              to={`/deployments/${endpointId}/edit${location.search}`}
+              replace
+            />
+          );
+        },
       },
     ],
   },
@@ -403,32 +502,56 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     ),
   },
   {
+    // FR-2664 — New admin deployment list route. Replaces the legacy
+    // /admin-serving route (see fallback redirect below).
+    path: '/admin-deployments',
+    handle: { labelKey: 'webui.menu.Serving' },
+    Component: () => {
+      const { t } = useTranslation();
+      return (
+        <BAIErrorBoundary>
+          <Suspense
+            fallback={<BAICard title={t('webui.menu.Serving')} loading />}
+          >
+            <AdminDeploymentListPage />
+          </Suspense>
+        </BAIErrorBoundary>
+      );
+    },
+  },
+  {
+    // FR-2664 — Legacy /admin-serving fallback. Transient redirect; remove
+    // once all internal links + external references have been migrated.
     path: '/admin-serving',
     handle: { labelKey: 'webui.menu.Serving' },
     children: [
       {
         index: true,
         Component: () => {
-          const { t } = useTranslation();
+          const location = useLocation();
           return (
-            <BAIErrorBoundary>
-              <Suspense
-                fallback={<BAICard title={t('webui.menu.Serving')} loading />}
-              >
-                <AdminServingPage />
-              </Suspense>
-            </BAIErrorBoundary>
+            <WebUINavigate
+              to={'/admin-deployments' + location.search}
+              replace
+            />
           );
         },
       },
       {
+        // /admin-deployments has no nested detail route — the deployment
+        // detail page is shared at /deployments/:deploymentId regardless
+        // of the viewer's role.
         path: ':serviceId',
-        element: (
-          <Suspense fallback={<Skeleton active />}>
-            <EndpointDetailPage />
-          </Suspense>
-        ),
-        handle: { labelKey: 'modelService.RoutingInfo' },
+        Component: () => {
+          const { serviceId } = useParams<{ serviceId: string }>();
+          const location = useLocation();
+          return (
+            <WebUINavigate
+              to={`/deployments/${serviceId}${location.search}`}
+              replace
+            />
+          );
+        },
       },
     ],
   },


### PR DESCRIPTION
Resolves FR-2664 (parent story: FR-2657; epic: FR-1368)

## Summary

Phase 1 / Foundation step for migrating the Endpoint UI to the new Deployment UI. This PR wires the new route surface and legacy fallbacks so subsequent phases (FR-2671 list, FR-2675 launcher, FR-2681 detail, FR-2672 admin list) can land against a stable URL contract.

### New routes

- `/deployments` -> `DeploymentListPage` (user view)
- `/deployments/new` -> `DeploymentLauncherPage` (create)
- `/deployments/:deploymentId` -> `DeploymentDetailPage`
- `/deployments/:deploymentId/edit` -> `DeploymentLauncherPage` (edit)
- `/admin-deployments` -> `AdminDeploymentListPage`

All four pages are stub placeholders rendering `TODO: ...PageName — FR-XXXX` so the routes are mergeable before the real implementations land. Each stub carries a `TODO(needs-backend)` marker (well, needs-page) referencing the phase ticket.

### Legacy fallbacks (transient redirects)

| Old path | New path |
|---|---|
| `/serving` | `/deployments` |
| `/serving/:serviceId` | `/deployments/:serviceId` |
| `/admin-serving` | `/admin-deployments` |
| `/admin-serving/:serviceId` | `/deployments/:serviceId` (shared detail page) |
| `/service/:endpointId` | `/deployments/:endpointId` |
| `/service/:endpointId/edit` | `/deployments/:endpointId/edit` |

Query strings are preserved through the redirects via `useLocation().search`. These fallbacks are documented in the code as transient and scheduled for removal once internal links and external references have migrated.

`/service/start` and `/service/update/:endpointId` are intentionally left untouched — those are live launcher paths still in use until the Deployment Launcher (FR-2675) lands.

### Misc

- Removed now-unused `ServingPage`, `EndpointDetailPage`, `AdminServingPage` imports from `routes.tsx`. The underlying page files are kept on disk for the Phase 3/4/5 implementations to reference.

## Verification

```
bash scripts/verify.sh
=== Relay ===  PASS
=== Lint ===   PASS
=== Format === PASS
=== TypeScript === PASS
=== ALL PASS ===
```

## Checklist

- [x] TypeScript / Relay / Lint / Format all pass
- [x] `TODO(needs-backend)` style markers placed on stub pages with phase ticket refs
- [x] Query strings preserved through all legacy-path redirects
- [x] No unrelated scope creep (only routes.tsx + 4 new stub pages)