### PR TITLE
feat(FR-2691): relocate /data header panels — Dashboard + host-capacity cell

### DIFF
--- a/react/src/components/QuotaPerStorageVolumeDashboardItem.tsx
+++ b/react/src/components/QuotaPerStorageVolumeDashboardItem.tsx
@@ -1,0 +1,65 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useSuspendedBackendaiClient } from '../hooks';
+import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
+import QuotaPerStorageVolumePanelCard, {
+  type VolumeInfo,
+} from './QuotaPerStorageVolumePanelCard';
+import { Empty, theme } from 'antd';
+import { BAIBoardItemTitle, BAIFlex } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+// Dashboard wrapper around `QuotaPerStorageVolumePanelCard`. Resolves the
+// first quota-supporting host up-front so the panel opens on a meaningful
+// scope instead of the inner card's "does not support" state. Renders an
+// `Empty` placeholder when no host advertises `quota` capability — the
+// dashboard slot is always shown (unlike the row-level modal trigger that
+// hides itself entirely when no quota host exists).
+const QuotaPerStorageVolumeDashboardItem: React.FC = () => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const baiClient = useSuspendedBackendaiClient();
+
+  const { data: vhostInfo } = useSuspenseTanQuery<{
+    volume_info?: Record<string, Omit<VolumeInfo, 'id'>>;
+  } | null>({
+    queryKey: ['vhostInfo'],
+    queryFn: () => baiClient.vfolder.list_hosts(),
+  });
+
+  const quotaSupportedEntry = _.find(
+    _.entries(vhostInfo?.volume_info ?? {}),
+    ([, info]) => _.includes(info?.capabilities, 'quota'),
+  );
+  const defaultVolumeInfo: VolumeInfo | undefined = quotaSupportedEntry
+    ? { id: quotaSupportedEntry[0], ...quotaSupportedEntry[1] }
+    : undefined;
+
+  return (
+    <BAIFlex
+      direction="column"
+      align="stretch"
+      style={{
+        paddingInline: token.paddingXL,
+        paddingBottom: token.padding,
+      }}
+    >
+      <BAIBoardItemTitle title={t('data.QuotaPerStorageVolume')} />
+      {defaultVolumeInfo ? (
+        <QuotaPerStorageVolumePanelCard defaultVolumeInfo={defaultVolumeInfo} />
+      ) : (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={t('storageHost.QuotaDoesNotSupported')}
+        />
+      )}
+    </BAIFlex>
+  );
+};
+
+export default QuotaPerStorageVolumeDashboardItem;

--- a/react/src/components/QuotaPerStorageVolumePanelCard.tsx
+++ b/react/src/components/QuotaPerStorageVolumePanelCard.tsx
@@ -8,13 +8,11 @@ import { addQuotaScopeTypePrefix, convertToDecimalUnit } from '../helper';
 import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import BAIProgress from './BAIProgress';
-import FlexActivityIndicator from './FlexActivityIndicator';
 import StorageSelect from './StorageSelect';
-import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Col, Empty, Row, theme, Tooltip, Typography } from 'antd';
-import { BAICard, BAICardProps, BAIFlex } from 'backend.ai-ui';
+import { Col, Empty, Row, Skeleton, theme, Typography } from 'antd';
+import { BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React, { useDeferredValue, useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -22,21 +20,39 @@ export type VolumeInfo = {
   id: string;
   backend: string;
   capabilities: string[];
-  usage: {
-    percentage: number;
+  // `usage` is optional because `vfolder.list_hosts()` only attaches it for
+  // hosts that can report capacity; `usage.percentage` is optional because
+  // even a reporting host may omit the percentage (rendered as "Unknown").
+  usage?: {
+    percentage?: number;
   };
   sftp_scaling_groups: string[];
 };
 
-interface QuotaPerStorageVolumePanelCardProps extends BAICardProps {}
+interface QuotaPerStorageVolumePanelCardProps {
+  /**
+   * Pre-selects a volume so the content renders that host's quota immediately
+   * (e.g. when opened from a specific folder row). When provided, the built-in
+   * usage-based auto-select is disabled; users can still switch volumes via
+   * the inline `StorageSelect`.
+   */
+  defaultVolumeInfo?: VolumeInfo;
+}
 
-const QuotaPerStorageVolumePanelCard: React.FC<
-  QuotaPerStorageVolumePanelCardProps
-> = ({ ...baiCardProps }) => {
+interface QuotaScopeContentProps {
+  selectedVolumeInfo: VolumeInfo | undefined;
+}
+
+// Body of the panel: fetches and renders project / user quota scope for the
+// selected volume. Wrapped in a Suspense boundary by the parent so switching
+// to an uncached host shows a loading indicator while in flight, while cache
+// hits commit synchronously without any spinner flash.
+const QuotaScopeContent: React.FC<QuotaScopeContentProps> = ({
+  selectedVolumeInfo,
+}) => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [selectedVolumeInfo, setSelectedVolumeInfo] = useState<VolumeInfo>();
-  const deferredSelectedVolumeInfo = useDeferredValue(selectedVolumeInfo);
   const currentProject = useCurrentProjectValue();
   const baiClient = useSuspendedBackendaiClient();
 
@@ -92,13 +108,23 @@ const QuotaPerStorageVolumePanelCard: React.FC<
           currentProject?.id || '',
         ),
         user_quota_scope_id: addQuotaScopeTypePrefix('user', user?.id || ''),
-        storage_host_name: deferredSelectedVolumeInfo?.id || '',
+        storage_host_name: selectedVolumeInfo?.id || '',
         skipQuotaScope:
           currentProject?.id === undefined ||
           user?.id === undefined ||
-          !deferredSelectedVolumeInfo?.id,
+          !selectedVolumeInfo?.id,
       },
     );
+
+  if (!selectedVolumeInfo?.capabilities?.includes('quota')) {
+    return (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description={t('storageHost.QuotaDoesNotSupported')}
+        style={{ margin: 'auto 25px' }}
+      />
+    );
+  }
 
   const projectUsageBytes = _.toFinite(
     project_quota_scope?.details?.usage_bytes,
@@ -121,118 +147,114 @@ const QuotaPerStorageVolumePanelCard: React.FC<
     : 0;
 
   return (
-    <BAICard
-      {...baiCardProps}
-      title={
-        <BAIFlex gap={'xs'} align="center">
-          {t('data.QuotaPerStorageVolume')}
-          <Tooltip title={t('data.HostDetails')}>
-            <QuestionCircleOutlined
-              style={{ color: token.colorTextDescription }}
-            />
-          </Tooltip>
-        </BAIFlex>
-      }
-      extra={
-        <BAIFlex
-          style={{
-            marginRight: -8,
-          }}
-        >
-          <StorageSelect
-            value={selectedVolumeInfo?.id}
-            onChange={(__, vInfo) => {
-              setSelectedVolumeInfo(vInfo);
-            }}
-            autoSelectType="usage"
-            showUsageStatus
-            showSearch
-            variant="borderless"
-          />
-        </BAIFlex>
-      }
-      styles={{
-        body: {
-          paddingTop: token.paddingLG,
-        },
-      }}
-    >
-      {selectedVolumeInfo !== deferredSelectedVolumeInfo ? (
-        <FlexActivityIndicator style={{ minHeight: 120 }} />
-      ) : selectedVolumeInfo?.capabilities?.includes('quota') ? (
-        <Row gutter={[24, 16]}>
-          <Col
-            span={12}
-            style={{
-              borderRight: `1px solid ${token.colorBorderSecondary}`,
-            }}
-          >
-            <BAIProgress
-              title={
-                <BAIFlex direction="column" align="start">
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: token.fontSizeSM }}
-                  >
-                    {t('data.Project')}
-                  </Typography.Text>
-                  <Typography.Text style={{ fontSize: token.fontSize }}>
-                    {currentProject?.name}
-                  </Typography.Text>
-                </BAIFlex>
-              }
-              percent={projectPercent}
-              used={
-                projectUsageBytes === 0
-                  ? ''
-                  : `${convertToDecimalUnit(_.toString(projectUsageBytes), 'g')?.displayValue}`
-              }
-              total={
-                projectHardLimitBytes === 0
-                  ? ''
-                  : `${convertToDecimalUnit(_.toString(projectHardLimitBytes), 'g')?.displayValue}`
-              }
-            />
-          </Col>
-          <Col span={12}>
-            <BAIProgress
-              percent={userPercent}
-              title={
-                <BAIFlex direction="column" align="start">
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: token.fontSizeSM }}
-                  >
-                    {t('data.User')}
-                  </Typography.Text>
-                  <Typography.Text style={{ fontSize: token.fontSize }}>
-                    {baiClient?.full_name}
-                  </Typography.Text>
-                </BAIFlex>
-              }
-              used={
-                userUsageBytes === 0
-                  ? ''
-                  : convertToDecimalUnit(_.toString(userUsageBytes), 'auto')
-                      ?.displayValue
-              }
-              total={
-                userHardLimitBytes === 0
-                  ? ''
-                  : convertToDecimalUnit(_.toString(userHardLimitBytes), 'auto')
-                      ?.displayValue
-              }
-            />
-          </Col>
-        </Row>
-      ) : (
-        <Empty
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={t('storageHost.QuotaDoesNotSupported')}
-          style={{ margin: 'auto 25px' }}
+    <Row gutter={[24, 16]}>
+      <Col
+        span={12}
+        style={{
+          borderRight: `1px solid ${token.colorBorderSecondary}`,
+        }}
+      >
+        <BAIProgress
+          title={
+            <BAIFlex direction="column" align="start">
+              <Typography.Text
+                type="secondary"
+                style={{ fontSize: token.fontSizeSM }}
+              >
+                {t('data.Project')}
+              </Typography.Text>
+              <Typography.Text style={{ fontSize: token.fontSize }}>
+                {currentProject?.name}
+              </Typography.Text>
+            </BAIFlex>
+          }
+          percent={projectPercent}
+          used={
+            projectUsageBytes === 0
+              ? ''
+              : `${convertToDecimalUnit(_.toString(projectUsageBytes), 'g')?.displayValue}`
+          }
+          total={
+            projectHardLimitBytes === 0
+              ? ''
+              : `${convertToDecimalUnit(_.toString(projectHardLimitBytes), 'g')?.displayValue}`
+          }
         />
-      )}
-    </BAICard>
+      </Col>
+      <Col span={12}>
+        <BAIProgress
+          percent={userPercent}
+          title={
+            <BAIFlex direction="column" align="start">
+              <Typography.Text
+                type="secondary"
+                style={{ fontSize: token.fontSizeSM }}
+              >
+                {t('data.User')}
+              </Typography.Text>
+              <Typography.Text style={{ fontSize: token.fontSize }}>
+                {baiClient?.full_name}
+              </Typography.Text>
+            </BAIFlex>
+          }
+          used={
+            userUsageBytes === 0
+              ? ''
+              : convertToDecimalUnit(_.toString(userUsageBytes), 'auto')
+                  ?.displayValue
+          }
+          total={
+            userHardLimitBytes === 0
+              ? ''
+              : convertToDecimalUnit(_.toString(userHardLimitBytes), 'auto')
+                  ?.displayValue
+          }
+        />
+      </Col>
+    </Row>
+  );
+};
+
+// Modal-body view for per-volume quota. Intentionally not wrapped in a BAICard
+// — the consuming Modal provides its own title and chrome, so a nested card
+// would duplicate the header and inflate the modal visually.
+const QuotaPerStorageVolumePanelCard: React.FC<
+  QuotaPerStorageVolumePanelCardProps
+> = ({ defaultVolumeInfo }) => {
+  'use memo';
+  const [selectedVolumeInfo, setSelectedVolumeInfo] = useState<
+    VolumeInfo | undefined
+  >(defaultVolumeInfo);
+  // Reset the inline selection when the consumer passes a different
+  // `defaultVolumeInfo` while the panel stays mounted (e.g., reopened for a
+  // different host). Compare ids only — following the
+  // "storing info from previous renders" pattern
+  // (https://react.dev/reference/react/useState#storing-information-from-previous-renders),
+  // so the badge reflects the latest prop without an effect.
+  const [prevDefaultVolumeId, setPrevDefaultVolumeId] = useState(
+    defaultVolumeInfo?.id,
+  );
+  if (prevDefaultVolumeId !== defaultVolumeInfo?.id) {
+    setPrevDefaultVolumeId(defaultVolumeInfo?.id);
+    setSelectedVolumeInfo(defaultVolumeInfo);
+  }
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap={'md'}>
+      <StorageSelect
+        value={selectedVolumeInfo?.id}
+        onChange={(__, vInfo) => {
+          setSelectedVolumeInfo(vInfo);
+        }}
+        autoSelectType={defaultVolumeInfo ? undefined : 'usage'}
+        showUsageStatus
+        showSearch
+        style={{ alignSelf: 'flex-start', minWidth: 240 }}
+      />
+      <Suspense fallback={<Skeleton active paragraph={{ rows: 0 }} />}>
+        <QuotaScopeContent selectedVolumeInfo={selectedVolumeInfo} />
+      </Suspense>
+    </BAIFlex>
   );
 };
 

--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -21,8 +21,11 @@ export type VolumeInfo = {
   id: string;
   backend: string;
   capabilities: string[];
-  usage: {
-    percentage: number;
+  // `usage` is optional because `vfolder.list_hosts()` only attaches it for
+  // hosts that can report capacity; `usage.percentage` is optional because
+  // even a reporting host may omit the percentage.
+  usage?: {
+    percentage?: number;
   };
   sftp_scaling_groups: string[];
 };
@@ -118,38 +121,42 @@ const StorageSelect: React.FC<Props> = ({
             }
       }
       optionLabelProp={showUsageStatus ? 'label' : 'value'}
-      options={_.map(vhostInfo?.allowed, (host) => ({
-        label: showUsageStatus ? (
-          <BAIFlex align="center">
-            {vhostInfo?.volume_info?.[host]?.usage && (
-              <Tooltip
-                title={`${t('data.Host')} ${t('data.usage.Status')}:
-                ${
-                  vhostInfo?.volume_info[host]?.usage?.percentage < 70
-                    ? t('data.usage.Adequate')
-                    : vhostInfo?.volume_info[host]?.usage?.percentage < 90
-                      ? t('data.usage.Caution')
-                      : t('data.usage.Insufficient')
-                }`}
-              >
-                <StorageUsageBadge
-                  percent={vhostInfo?.volume_info[host]?.usage?.percentage}
-                />
-                {/* Use &nbsp; instead of Flex gap to fix Tooltip  */}
-                &nbsp;&nbsp;
-              </Tooltip>
-            )}
-            <TextHighlighter keyword={controllableSearchValue}>
-              {host}
-            </TextHighlighter>
-            {/* TODO: uncomment after implementing click action */}
-            {/* <Button type="link" size="small" icon={<InfoCircleOutlined />} /> */}
-          </BAIFlex>
-        ) : (
-          host
-        ),
-        value: host,
-      }))}
+      options={_.map(vhostInfo?.allowed, (host) => {
+        const usagePercent = vhostInfo?.volume_info?.[host]?.usage?.percentage;
+        const usageLabel =
+          usagePercent === undefined
+            ? t('data.usage.Unknown')
+            : usagePercent < 70
+              ? t('data.usage.Adequate')
+              : usagePercent < 90
+                ? t('data.usage.Caution')
+                : t('data.usage.Insufficient');
+        return {
+          label: showUsageStatus ? (
+            <BAIFlex align="center">
+              {vhostInfo?.volume_info?.[host]?.usage && (
+                <Tooltip
+                  title={t('data.usage.HostStatusTooltip', {
+                    status: usageLabel,
+                  })}
+                >
+                  <StorageUsageBadge percent={usagePercent} />
+                  {/* Use &nbsp; instead of Flex gap to fix Tooltip  */}
+                  &nbsp;&nbsp;
+                </Tooltip>
+              )}
+              <TextHighlighter keyword={controllableSearchValue}>
+                {host}
+              </TextHighlighter>
+              {/* TODO: uncomment after implementing click action */}
+              {/* <Button type="link" size="small" icon={<InfoCircleOutlined />} /> */}
+            </BAIFlex>
+          ) : (
+            host
+          ),
+          value: host,
+        };
+      })}
       {...partialSelectProps}
     />
   );

--- a/react/src/components/StorageStatusPanelCard.tsx
+++ b/react/src/components/StorageStatusPanelCard.tsx
@@ -10,7 +10,12 @@ import BAIPanelItem from './BAIPanelItem';
 import { useUpdateEffect } from 'ahooks';
 import { Badge, theme, Tooltip, Typography } from 'antd';
 import { createStyles } from 'antd-style';
-import { BAICard, BAICardProps, BAIRowWrapWithDividers } from 'backend.ai-ui';
+import {
+  BAIBoardItemTitle,
+  BAIFlex,
+  BAIFlexProps,
+  BAIRowWrapWithDividers,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, { useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -30,17 +35,22 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
-interface StorageStatusPanelProps extends BAICardProps {
+interface StorageStatusPanelProps extends BAIFlexProps {
   fetchKey?: string;
   onRequestBadgeClick?: () => void;
 }
 
 const PANEL_ITEM_MAX_WIDTH = 90; // Adjusted max width for panel items
 
+// Dashboard board-item body for folder-status counts. Uses the shared
+// `BAIBoardItemTitle` so the title reserves space for the board drag handle
+// and sits consistently with peer items (`MyResource`, etc.) — wrapping in a
+// `BAICard` here caused the title to overlap the handle on the left edge.
 const StorageStatusPanelCard: React.FC<StorageStatusPanelProps> = ({
   fetchKey,
   onRequestBadgeClick,
-  ...cardProps
+  style,
+  ...flexProps
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -69,6 +79,23 @@ const StorageStatusPanelCard: React.FC<StorageStatusPanelProps> = ({
     );
   };
 
+  // TODO(FR-2691 v2-migration): the counts below are derived from the legacy
+  // REST call `baiClient.vfolder.list()` and then filtered in JS. Migrate to
+  // the Strawberry V2 GraphQL `myVfolders` / `projectVfolders` connections
+  // (with `filter` + `count`) so the server returns the counts directly.
+  //
+  // Scoping notes for the V2 rewrite:
+  //   - ProjectFolders (`projectCount`): must be scoped to the project
+  //     currently selected in the global header project selector (i.e.
+  //     `currentProject.id`). `projectVfolders(projectId: …, filter: { ... })`
+  //     already takes a required `projectId`, so the count must use that —
+  //     not an aggregate across every project the user can see.
+  //   - InvitedFolders (`invitedCount`): defer migration. The V2 vfolder
+  //     filter input does not yet expose an "invited only / received-share"
+  //     predicate, so we cannot reproduce the current `!is_owner &&
+  //     ownership_type === 'user'` filter with a single server-side count.
+  //     Keep this one on the legacy REST list until the backend adds the
+  //     filter field; revisit in a follow-up issue.
   const { data: vfolders } = useSuspenseTanQuery({
     queryKey: ['vfolders', { deferredFetchKey, id: currentProject.id }],
     queryFn: () => {
@@ -97,6 +124,9 @@ const StorageStatusPanelCard: React.FC<StorageStatusPanelProps> = ({
       !isExcludedCount(item.status),
   ).length;
 
+  // TODO(FR-2691 v2-migration): `user_resource_policy` and
+  // `project_resource_policy` are legacy (V1) root fields. Port this to the V2
+  // schema once it exposes per-user / per-project vfolder count limits.
   const { user_resource_policy, project_resource_policy } =
     useLazyLoadQuery<StorageStatusPanelCardQuery>(
       graphql`
@@ -115,92 +145,100 @@ const StorageStatusPanelCard: React.FC<StorageStatusPanelProps> = ({
     );
 
   return (
-    <>
-      <BAICard {...cardProps} title={t('data.FolderStatus')}>
-        <BAIRowWrapWithDividers
-          rowGap={token.marginXL}
-          columnGap={token.marginXL}
-          dividerColor={token.colorBorder}
-          dividerInset={token.marginXS}
-          dividerWidth={token.lineWidth}
-        >
-          <BAIPanelItem
-            title={t('data.MyFolders')}
-            value={createdCount}
-            unit={
-              user_resource_policy?.max_vfolder_count
-                ? `/ ${user_resource_policy?.max_vfolder_count}`
-                : undefined
-            }
-            style={{
-              maxWidth: PANEL_ITEM_MAX_WIDTH,
-            }}
-            color={token.colorText}
-          />
-          <BAIPanelItem
-            title={t('data.ProjectFolders')}
-            value={projectCount}
-            unit={
-              project_resource_policy?.max_vfolder_count
-                ? `/ ${project_resource_policy?.max_vfolder_count}`
-                : undefined
-            }
-            style={{
-              maxWidth: PANEL_ITEM_MAX_WIDTH,
-            }}
-            color={token.colorText}
-          />
-          <BAIPanelItem
-            title={
-              invitationCount > 0 ? (
-                // Add <a></a> to make tooltip clickable
+    <BAIFlex
+      direction="column"
+      align="stretch"
+      style={{
+        paddingInline: token.paddingXL,
+        paddingBottom: token.padding,
+        ...style,
+      }}
+      {...flexProps}
+    >
+      <BAIBoardItemTitle title={t('data.FolderStatus')} />
+      <BAIRowWrapWithDividers
+        rowGap={token.marginXL}
+        columnGap={token.marginXL}
+        dividerColor={token.colorBorder}
+        dividerInset={token.marginXS}
+        dividerWidth={token.lineWidth}
+      >
+        <BAIPanelItem
+          title={t('data.MyFolders')}
+          value={createdCount}
+          unit={
+            user_resource_policy?.max_vfolder_count
+              ? `/ ${user_resource_policy?.max_vfolder_count}`
+              : undefined
+          }
+          style={{
+            maxWidth: PANEL_ITEM_MAX_WIDTH,
+          }}
+          color={token.colorText}
+        />
+        <BAIPanelItem
+          title={t('data.ProjectFolders')}
+          value={projectCount}
+          unit={
+            project_resource_policy?.max_vfolder_count
+              ? `/ ${project_resource_policy?.max_vfolder_count}`
+              : undefined
+          }
+          style={{
+            maxWidth: PANEL_ITEM_MAX_WIDTH,
+          }}
+          color={token.colorText}
+        />
+        <BAIPanelItem
+          title={
+            invitationCount > 0 ? (
+              // Add <a></a> to make tooltip clickable
 
-                <a
-                  onClick={() => {
-                    onRequestBadgeClick?.();
-                  }}
-                >
-                  <Tooltip
-                    title={t('data.InvitedFoldersTooltip', {
-                      count: invitationCount,
-                    })}
-                    rootClassName={styles.invitationTooltip}
-                    placement="topRight"
-                  >
-                    <Badge
-                      count={`+${invitationCount}`}
-                      offset={[-`${token.sizeXS}`, -`${token.sizeXS}`]}
-                    >
-                      <Typography.Text
-                        style={{ fontSize: token.fontSizeHeading5 }}
-                      >
-                        {t('data.InvitedFolders')}
-                      </Typography.Text>
-                    </Badge>
-                  </Tooltip>
-                </a>
-              ) : (
-                <Typography.Text style={{ fontSize: token.fontSizeHeading5 }}>
-                  {t('data.InvitedFolders')}
-                </Typography.Text>
-              )
-            }
-            value={
-              <Typography.Text
-                style={{
-                  fontSize: token.fontSizeHeading1,
+              <a
+                onClick={() => {
+                  onRequestBadgeClick?.();
                 }}
               >
-                {invitedCount}
+                <Tooltip
+                  title={t('data.InvitedFoldersTooltip', {
+                    count: invitationCount,
+                  })}
+                  rootClassName={styles.invitationTooltip}
+                  placement="topRight"
+                >
+                  <Badge
+                    count={`+${invitationCount}`}
+                    offset={[-`${token.sizeXS}`, -`${token.sizeXS}`]}
+                  >
+                    <Typography.Text
+                      style={{ fontSize: token.fontSizeHeading5 }}
+                    >
+                      {t('data.InvitedFolders')}
+                    </Typography.Text>
+                  </Badge>
+                </Tooltip>
+              </a>
+            ) : (
+              <Typography.Text style={{ fontSize: token.fontSizeHeading5 }}>
+                {t('data.InvitedFolders')}
               </Typography.Text>
-            }
-            style={{
-              maxWidth: PANEL_ITEM_MAX_WIDTH,
-            }}
-          />
-        </BAIRowWrapWithDividers>
-      </BAICard>
-    </>
+            )
+          }
+          value={
+            <Typography.Text
+              style={{
+                fontSize: token.fontSizeHeading1,
+              }}
+            >
+              {invitedCount}
+            </Typography.Text>
+          }
+          style={{
+            maxWidth: PANEL_ITEM_MAX_WIDTH,
+          }}
+        />
+      </BAIRowWrapWithDividers>
+    </BAIFlex>
   );
 };
 

--- a/react/src/components/VFolderNodesV2.tsx
+++ b/react/src/components/VFolderNodesV2.tsx
@@ -8,21 +8,26 @@ import {
   VFolderNodesV2Fragment$key,
 } from '../__generated__/VFolderNodesV2Fragment.graphql';
 import { VFolderNodesV2RestoreMutation } from '../__generated__/VFolderNodesV2RestoreMutation.graphql';
-import { useWebUINavigate } from '../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
+import { useSuspenseTanQuery, useTanQuery } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
 import DeleteForeverVFolderModalV2 from './DeleteForeverVFolderModalV2';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import InviteFolderSettingModal from './InviteFolderSettingModal';
+import QuotaPerStorageVolumePanelCard, {
+  type VolumeInfo,
+} from './QuotaPerStorageVolumePanelCard';
 import SharedFolderPermissionInfoModal from './SharedFolderPermissionInfoModal';
 import VFolderDeployModal from './VFolderDeployModal';
 import VFolderNodeIdenticon from './VFolderNodeIdenticon';
 import VFolderPermissionCell from './VFolderPermissionCell';
-import { UserOutlined } from '@ant-design/icons';
-import { App, theme, Typography } from 'antd';
+import { QuestionCircleOutlined, UserOutlined } from '@ant-design/icons';
+import { App, Modal, Skeleton, theme, Tooltip, Typography } from 'antd';
 import {
   filterOutNullAndUndefined,
+  BAIAlertIconWithTooltip,
   BAIEndpointsIcon,
   BAILink,
   BAIRestoreIcon,
@@ -38,11 +43,12 @@ import {
   useErrorMessageResolver,
   BAITag,
   bytesToGB,
+  StorageUsageBadge,
 } from 'backend.ai-ui';
 import type { BAINameActionCellAction } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import React, { useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
@@ -203,6 +209,179 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
   );
 };
 
+interface VFolderHostCellProps {
+  host?: string | null;
+}
+
+// Renders a Host column cell: usage badge (if the backend reports one)
+// plus the host name. The badge's data comes from `vfolder.list_hosts()`,
+// cached under the same tan-query key that `StorageSelect` uses, so the
+// payload is fetched once and shared across rows + selects. Uses the
+// non-suspense `useTanQuery` here — a per-cell suspense boundary with a
+// plain-text fallback rendered identically on the loaded-without-usage path,
+// so rows would get stuck in the fallback branch and never pick up the badge
+// after the query resolved.
+const VFolderHostCell: React.FC<VFolderHostCellProps> = ({ host }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
+
+  const { data: vhostInfo } = useTanQuery<{
+    volume_info?: Record<string, Omit<VolumeInfo, 'id'>>;
+  } | null>({
+    queryKey: ['vhostInfo'],
+    queryFn: () => baiClient.vfolder.list_hosts(),
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+
+  if (!host) return null;
+
+  const volumeInfo = vhostInfo?.volume_info?.[host];
+  const usage = volumeInfo?.usage;
+  const usagePercent = usage?.percentage;
+  // Match `StorageSelect`'s gating: render the badge whenever the backend
+  // attaches a `usage` object — even an empty `{}` — so rows render a neutral
+  // (uncolored) marker while percentage data is unavailable. Color is derived
+  // from percentage inside `StorageUsageBadge` and is `undefined` (neutral)
+  // when the percentage is missing.
+  const usageLabel =
+    usagePercent === undefined
+      ? t('data.usage.Unknown')
+      : usagePercent < 70
+        ? t('data.usage.Adequate')
+        : usagePercent < 90
+          ? t('data.usage.Caution')
+          : t('data.usage.Insufficient');
+
+  return (
+    <BAIFlex gap={'xs'} align="center">
+      {usage ? (
+        <Tooltip
+          title={t('data.usage.HostStatusTooltip', { status: usageLabel })}
+        >
+          <StorageUsageBadge percent={usagePercent} />
+        </Tooltip>
+      ) : null}
+      <Typography.Text>{host}</Typography.Text>
+    </BAIFlex>
+  );
+};
+
+// Column-header affordance that opens `QuotaPerStorageVolumePanelCard` in a
+// modal, pre-selected on a quota-supporting host so the empty "does not
+// support" state is not the first thing users see. Renders nothing when no
+// volume reports `quota` in its capabilities — removing the modal entry
+// point entirely rather than opening a dialog with no useful content.
+//
+// The trigger (icon) lives inside the column `title`, but the Modal is
+// hoisted to the table-level so React synthetic events from inside the
+// Modal do not bubble up through the React tree to the `<th>` and trigger
+// column sorting (Portal nodes still bubble through the React tree).
+interface HostQuotaTriggerProps {
+  onOpen: () => void;
+}
+
+const HostQuotaTriggerInner: React.FC<HostQuotaTriggerProps> = ({ onOpen }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
+
+  const { data: vhostInfo } = useSuspenseTanQuery<{
+    volume_info?: Record<string, Omit<VolumeInfo, 'id'>>;
+  } | null>({
+    queryKey: ['vhostInfo'],
+    queryFn: () => baiClient.vfolder.list_hosts(),
+  });
+
+  const hasQuotaSupportedHost = _.some(
+    _.values(vhostInfo?.volume_info ?? {}),
+    (info) => _.includes(info?.capabilities, 'quota'),
+  );
+  if (!hasQuotaSupportedHost) return null;
+
+  return (
+    <BAIAlertIconWithTooltip
+      title={t('data.QuotaPerStorageVolume')}
+      iconProps={{
+        size: 14,
+        onClick: (e) => {
+          e.stopPropagation();
+          onOpen();
+        },
+        style: { cursor: 'pointer' },
+      }}
+    />
+  );
+};
+
+const HostQuotaTrigger: React.FC<HostQuotaTriggerProps> = (props) => (
+  <Suspense fallback={null}>
+    <HostQuotaTriggerInner {...props} />
+  </Suspense>
+);
+
+const HostQuotaModalContent: React.FC = () => {
+  'use memo';
+  const baiClient = useSuspendedBackendaiClient();
+
+  const { data: vhostInfo } = useSuspenseTanQuery<{
+    volume_info?: Record<string, Omit<VolumeInfo, 'id'>>;
+  } | null>({
+    queryKey: ['vhostInfo'],
+    queryFn: () => baiClient.vfolder.list_hosts(),
+  });
+
+  const quotaSupportedEntry = _.find(
+    _.entries(vhostInfo?.volume_info ?? {}),
+    ([, info]) => _.includes(info?.capabilities, 'quota'),
+  );
+  if (!quotaSupportedEntry) return null;
+
+  const [host, info] = quotaSupportedEntry;
+  const defaultVolumeInfo: VolumeInfo = { id: host, ...info };
+
+  return (
+    <QuotaPerStorageVolumePanelCard defaultVolumeInfo={defaultVolumeInfo} />
+  );
+};
+
+interface HostQuotaModalProps {
+  open: boolean;
+  onCancel: () => void;
+}
+
+const HostQuotaModal: React.FC<HostQuotaModalProps> = ({ open, onCancel }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onCancel}
+      footer={null}
+      title={
+        <BAIFlex gap={'xs'} align="center">
+          {t('data.QuotaPerStorageVolume')}
+          <Tooltip title={t('data.HostDetails')}>
+            <QuestionCircleOutlined
+              style={{ color: token.colorTextDescription }}
+            />
+          </Tooltip>
+        </BAIFlex>
+      }
+      width={640}
+      destroyOnHidden
+    >
+      <Suspense fallback={<Skeleton active />}>
+        <HostQuotaModalContent />
+      </Suspense>
+    </Modal>
+  );
+};
+
 interface VFolderNodesV2Props extends Omit<
   BAITableProps<VFolderNodeInList>,
   'dataSource' | 'columns'
@@ -240,6 +419,7 @@ const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
   const [deployFallbackVfolderId, setDeployFallbackVfolderId] = useState<
     string | null
   >(null);
+  const [isHostQuotaModalOpen, setIsHostQuotaModalOpen] = useState(false);
 
   const vfolders = useFragment(
     graphql`
@@ -440,8 +620,18 @@ const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
           },
           {
             key: 'host',
-            title: t('data.folders.Location'),
+            title: (
+              <BAIFlex gap={'xs'} align="center">
+                {t('data.Host')}
+                <HostQuotaTrigger
+                  onOpen={() => setIsHostQuotaModalOpen(true)}
+                />
+              </BAIFlex>
+            ),
             dataIndex: 'host',
+            render: (host: string | null | undefined) => (
+              <VFolderHostCell host={host} />
+            ),
             sorter: isEnableSorter('host'),
           },
           {
@@ -609,6 +799,10 @@ const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
         vfolderId={deployFallbackVfolderId ?? undefined}
         onClose={() => setDeployFallbackVfolderId(null)}
         onDeployed={() => setDeployFallbackVfolderId(null)}
+      />
+      <HostQuotaModal
+        open={isHostQuotaModalOpen}
+        onCancel={() => setIsHostQuotaModalOpen(false)}
       />
     </>
   );

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -6,12 +6,14 @@ import { DashboardPageQuery } from '../__generated__/DashboardPageQuery.graphql'
 import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
 import MyResource from '../components/MyResource';
 import MyResourceWithinResourceGroup from '../components/MyResourceWithinResourceGroup';
+import QuotaPerStorageVolumeDashboardItem from '../components/QuotaPerStorageVolumeDashboardItem';
 import RecentlyCreatedSession from '../components/RecentlyCreatedSession';
 import SessionCountDashboardItem from '../components/SessionCountDashboardItem';
+import StorageStatusPanelCard from '../components/StorageStatusPanelCard';
 import TotalResourceWithinResourceGroup, {
   useIsAvailableTotalResourceWithinResourceGroup,
 } from '../components/TotalResourceWithinResourceGroup';
-import { useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   useCurrentProjectValue,
@@ -41,6 +43,7 @@ const DashboardPage: React.FC = () => {
   const currentResourceGroup = useCurrentResourceGroupValue();
   const userRole = useCurrentUserRole();
   const baiClient = useSuspendedBackendaiClient();
+  const webuiNavigate = useWebUINavigate();
 
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [isPendingIntervalRefetch, startIntervalRefetchTransition] =
@@ -165,6 +168,62 @@ const DashboardPage: React.FC = () => {
               fetchKey={fetchKey}
               refetching={isPendingIntervalRefetch}
             />
+          </BAIBoardItemErrorBoundary>
+        ),
+      },
+    },
+    {
+      id: 'folderStatus',
+      rowSpan: 2,
+      columnSpan: 2,
+      definition: {
+        minRowSpan: 2,
+        minColumnSpan: 2,
+      },
+      data: {
+        content: (
+          <BAIBoardItemErrorBoundary
+            title={t('data.FolderStatus')}
+            status="error"
+          >
+            <Suspense
+              fallback={<Skeleton active style={{ padding: token.marginMD }} />}
+            >
+              <StorageStatusPanelCard
+                fetchKey={fetchKey}
+                onRequestBadgeClick={() => {
+                  webuiNavigate({
+                    pathname: '/data',
+                    search: new URLSearchParams({
+                      invitation: 'true',
+                    }).toString(),
+                  });
+                }}
+              />
+            </Suspense>
+          </BAIBoardItemErrorBoundary>
+        ),
+      },
+    },
+    {
+      id: 'quotaPerStorageVolume',
+      rowSpan: 2,
+      columnSpan: 2,
+      definition: {
+        minRowSpan: 2,
+        minColumnSpan: 2,
+      },
+      data: {
+        content: (
+          <BAIBoardItemErrorBoundary
+            title={t('data.QuotaPerStorageVolume')}
+            status="error"
+          >
+            <Suspense
+              fallback={<Skeleton active style={{ padding: token.marginMD }} />}
+            >
+              <QuotaPerStorageVolumeDashboardItem />
+            </Suspense>
           </BAIBoardItemErrorBoundary>
         ),
       },

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -7,30 +7,25 @@ import {
   VFolderNodeListPageQuery$data,
   VFolderNodeListPageQuery$variables,
 } from '../__generated__/VFolderNodeListPageQuery.graphql';
-import ActionItemContent from '../components/ActionItemContent';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import BAITabs from '../components/BAITabs';
 import DeleteForeverVFolderModalV2 from '../components/DeleteForeverVFolderModalV2';
 import DeleteVFolderModalV2 from '../components/DeleteVFolderModalV2';
 import FolderCreateModalV2 from '../components/FolderCreateModalV2';
-import QuotaPerStorageVolumePanelCard from '../components/QuotaPerStorageVolumePanelCard';
 import RestoreVFolderModalV2 from '../components/RestoreVFolderModalV2';
-import StorageStatusPanelCard from '../components/StorageStatusPanelCard';
 import VFolderNodesV2, {
   VFolderNodeInList,
 } from '../components/VFolderNodesV2';
 import { handleRowSelectionChange } from '../helper';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useToggle } from 'ahooks';
-import { Badge, Col, Grid, Row, theme, Tooltip, Typography } from 'antd';
+import { Badge, theme, Tooltip } from 'antd';
 import {
-  BAIAlertIconWithTooltip,
   BAIButton,
   BAICard,
   BAIFetchKeyButton,
   BAIFlex,
-  BAINewFolderIcon,
   BAIPropertyFilter,
   BAIPurgeIcon,
   BAIRestoreIcon,
@@ -42,14 +37,7 @@ import {
   useUpdatableState,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React, {
-  Suspense,
-  useDeferredValue,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
+import React, { useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from 'src/hooks/reactPaginationQueryOptions';
@@ -88,8 +76,6 @@ const FILTER_BY_STATUS_CATEGORY = {
   deleted: 'status in ["DELETE_PENDING", "DELETE_ONGOING", "DELETE_ERROR"]',
 };
 
-const CARD_MIN_HEIGHT = 200;
-
 const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   ...props
 }) => {
@@ -97,10 +83,8 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
 
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const { lg } = Grid.useBreakpoint();
   const currentProject = useCurrentProjectValue();
   const baiClient = useSuspendedBackendaiClient();
-  const webuiNavigate = useWebUINavigate();
   const [invitations] = useVFolderInvitations();
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
@@ -263,133 +247,6 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
 
   return (
     <BAIFlex direction="column" align="stretch" gap={'md'} {...props}>
-      <Row
-        gutter={[16, 16]}
-        align={'stretch'}
-        style={{ minHeight: lg ? CARD_MIN_HEIGHT : undefined }}
-      >
-        <Col xs={24} md={8} xl={4} style={{ display: 'flex' }}>
-          <BAICard
-            style={{
-              width: '100%',
-              minHeight: lg ? CARD_MIN_HEIGHT : undefined,
-            }}
-          >
-            <ActionItemContent
-              title={
-                <Typography.Text
-                  style={{
-                    maxWidth: lg ? 120 : undefined,
-                    wordBreak: 'keep-all',
-                    overflowWrap: 'break-word',
-                  }}
-                >
-                  {t('data.CreateFolderAndUploadFiles')}
-                </Typography.Text>
-              }
-              buttonText={t('data.CreateFolder')}
-              icon={<BAINewFolderIcon />}
-              type="simple"
-              onClick={() => {
-                toggleCreateModal();
-              }}
-              style={{
-                height: '100%',
-              }}
-            />
-          </BAICard>
-        </Col>
-        <Col xs={24} md={16} xl={8} style={{ display: 'flex' }}>
-          <ErrorBoundary
-            fallbackRender={() => {
-              return (
-                <BAICard
-                  style={{
-                    width: '100%',
-                    minHeight: lg ? CARD_MIN_HEIGHT : undefined,
-                  }}
-                  title={t('data.FolderStatus')}
-                  status="error"
-                  extra={
-                    <BAIAlertIconWithTooltip
-                      title={t('error.UnexpectedError')}
-                    />
-                  }
-                />
-              );
-            }}
-          >
-            <Suspense
-              fallback={
-                <BAICard
-                  style={{
-                    width: '100%',
-                    minHeight: lg ? CARD_MIN_HEIGHT : undefined,
-                  }}
-                  title={t('data.FolderStatus')}
-                  loading
-                />
-              }
-            >
-              <StorageStatusPanelCard
-                style={{
-                  width: '100%',
-                  minHeight: lg ? CARD_MIN_HEIGHT : undefined,
-                }}
-                fetchKey={deferredFetchKey}
-                onRequestBadgeClick={() => {
-                  webuiNavigate({
-                    search: new URLSearchParams({
-                      invitation: 'true',
-                    }).toString(),
-                  });
-                }}
-              />
-            </Suspense>
-          </ErrorBoundary>
-        </Col>
-        <Col xs={24} md={24} xl={12} style={{ display: 'flex' }}>
-          <ErrorBoundary
-            fallbackRender={() => {
-              return (
-                <BAICard
-                  style={{
-                    width: '100%',
-                    minHeight: lg ? CARD_MIN_HEIGHT : undefined,
-                  }}
-                  title={t('data.QuotaPerStorageVolume')}
-                  status="error"
-                  extra={
-                    <BAIAlertIconWithTooltip
-                      title={t('error.UnexpectedError')}
-                    />
-                  }
-                />
-              );
-            }}
-          >
-            <Suspense
-              fallback={
-                <BAICard
-                  style={{
-                    width: '100%',
-                    minHeight: lg ? CARD_MIN_HEIGHT : undefined,
-                  }}
-                  title={t('data.QuotaPerStorageVolume')}
-                  loading
-                />
-              }
-            >
-              <QuotaPerStorageVolumePanelCard
-                style={{
-                  width: '100%',
-                  minHeight: lg ? CARD_MIN_HEIGHT : undefined,
-                }}
-              />
-            </Suspense>
-          </ErrorBoundary>
-        </Col>
-      </Row>
       <BAICard
         variant="borderless"
         title={t('data.Folders')}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Angemessen",
       "Caution": "Vorsicht",
+      "HostStatusTooltip": "Host-Nutzungsstatus: {{status}}",
       "Insufficient": "Unzureichend",
       "Status": "Status",
       "StatusOfSelectedHost": "Status des ausgewählten Hosts",
+      "Unknown": "Unbekannt",
       "Used": "gebraucht"
     }
   },

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Επαρκής",
       "Caution": "Προσοχή",
+      "HostStatusTooltip": "Κατάσταση χρήσης κεντρικού υπολογιστή: {{status}}",
       "Insufficient": "Ανεπαρκές",
       "Status": "Κατάσταση",
       "StatusOfSelectedHost": "Κατάσταση του επιλεγμένου κεντρικού υπολογιστή",
+      "Unknown": "Άγνωστο",
       "Used": "χρησιμοποιημένο"
     }
   },

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -754,9 +754,11 @@
     "usage": {
       "Adequate": "Adequate",
       "Caution": "Caution",
+      "HostStatusTooltip": "Host usage status: {{status}}",
       "Insufficient": "Insufficient",
       "Status": "Status",
       "StatusOfSelectedHost": "Status Of Selected Host",
+      "Unknown": "Unknown",
       "Used": "used"
     }
   },

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Adecuado",
       "Caution": "Precaución",
+      "HostStatusTooltip": "Estado de uso del host: {{status}}",
       "Insufficient": "Insuficiente",
       "Status": "Estado",
       "StatusOfSelectedHost": "Estado del host seleccionado",
+      "Unknown": "Desconocido",
       "Used": "usado"
     }
   },

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Riittävästi",
       "Caution": "Varoitus",
+      "HostStatusTooltip": "Isännän käyttötila: {{status}}",
       "Insufficient": "Riittämätön",
       "Status": "Tila",
       "StatusOfSelectedHost": "Valitun isännän tila",
+      "Unknown": "Tuntematon",
       "Used": "käytetty"
     }
   },

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Adéquat",
       "Caution": "Attention",
+      "HostStatusTooltip": "État d'utilisation de l'hôte : {{status}}",
       "Insufficient": "Insuffisant",
       "Status": "Statut",
       "StatusOfSelectedHost": "Statut de l'hôte sélectionné",
+      "Unknown": "Inconnu",
       "Used": "utilisé"
     }
   },

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Memadai",
       "Caution": "Perhatian",
+      "HostStatusTooltip": "Status penggunaan host: {{status}}",
       "Insufficient": "Tidak mencukupi",
       "Status": "Status",
       "StatusOfSelectedHost": "Status Tuan Rumah Terpilih",
+      "Unknown": "Tidak diketahui",
       "Used": "digunakan"
     }
   },

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Adeguato",
       "Caution": "Attenzione",
+      "HostStatusTooltip": "Stato utilizzo host: {{status}}",
       "Insufficient": "Insufficiente",
       "Status": "Stato",
       "StatusOfSelectedHost": "Stato dell'host selezionato",
+      "Unknown": "Sconosciuto",
       "Used": "usato"
     }
   },

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "余裕",
       "Caution": "注意",
+      "HostStatusTooltip": "ホスト使用状況: {{status}}",
       "Insufficient": "不足",
       "Status": "状態",
       "StatusOfSelectedHost": "選択したホストの状態",
+      "Unknown": "不明",
       "Used": "使用中"
     }
   },

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -754,9 +754,11 @@
     "usage": {
       "Adequate": "여유",
       "Caution": "주의",
+      "HostStatusTooltip": "호스트 사용량 상태: {{status}}",
       "Insufficient": "부족",
       "Status": "상태",
       "StatusOfSelectedHost": "선택한 호스트 상태",
+      "Unknown": "알 수 없음",
       "Used": "사용 중"
     }
   },

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Хангалттай",
       "Caution": "Анхааруулга",
+      "HostStatusTooltip": "Хост ашиглалтын төлөв: {{status}}",
       "Insufficient": "Хангалтгүй",
       "Status": "Статус",
       "StatusOfSelectedHost": "Сонгосон хостын төлөв",
+      "Unknown": "Тодорхойгүй",
       "Used": "ашигласан"
     }
   },

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "memadai",
       "Caution": "Berhati-hati",
+      "HostStatusTooltip": "Status penggunaan hos: {{status}}",
       "Insufficient": "Tidak mencukupi",
       "Status": "Status",
       "StatusOfSelectedHost": "Status Hos Terpilih",
+      "Unknown": "Tidak diketahui",
       "Used": "digunakan"
     }
   },

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Odpowiedni",
       "Caution": "Uwaga",
+      "HostStatusTooltip": "Stan wykorzystania hosta: {{status}}",
       "Insufficient": "Niewystarczające",
       "Status": "Status",
       "StatusOfSelectedHost": "Status wybranego hosta",
+      "Unknown": "Nieznany",
       "Used": "używany"
     }
   },

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Adequado",
       "Caution": "Cuidado",
+      "HostStatusTooltip": "Status de uso do host: {{status}}",
       "Insufficient": "Insuficiente",
       "Status": "Estado",
       "StatusOfSelectedHost": "Estado do anfitrião selecionado",
+      "Unknown": "Desconhecido",
       "Used": "utilizado"
     }
   },

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Adequado",
       "Caution": "Cuidado",
+      "HostStatusTooltip": "Estado de utilização do host: {{status}}",
       "Insufficient": "Insuficiente",
       "Status": "Estado",
       "StatusOfSelectedHost": "Estado do anfitrião selecionado",
+      "Unknown": "Desconhecido",
       "Used": "utilizado"
     }
   },

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Адекватный",
       "Caution": "Внимание",
+      "HostStatusTooltip": "Статус использования хоста: {{status}}",
       "Insufficient": "Недостаточно",
       "Status": "Статус",
       "StatusOfSelectedHost": "Статус выбранного хоста",
+      "Unknown": "Неизвестно",
       "Used": "используется"
     }
   },

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "เพียงพอ",
       "Caution": "ควรระวัง",
+      "HostStatusTooltip": "สถานะการใช้งานโฮสต์: {{status}}",
       "Insufficient": "ไม่เพียงพอ",
       "Status": "สถานะ",
       "StatusOfSelectedHost": "สถานะของโฮสต์ที่เลือก",
+      "Unknown": "ไม่ทราบ",
       "Used": "ใช้แล้ว"
     }
   },

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Yeterli",
       "Caution": "Dikkat",
+      "HostStatusTooltip": "Ana bilgisayar kullanım durumu: {{status}}",
       "Insufficient": "Yetersiz",
       "Status": "Durum",
       "StatusOfSelectedHost": "Seçilen Ana Bilgisayarın Durumu",
+      "Unknown": "Bilinmiyor",
       "Used": "kullanılmış"
     }
   },

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "Đủ",
       "Caution": "Thận trọng",
+      "HostStatusTooltip": "Trạng thái sử dụng máy chủ: {{status}}",
       "Insufficient": "không đủ",
       "Status": "Trạng thái",
       "StatusOfSelectedHost": "Trạng thái của máy chủ được chọn",
+      "Unknown": "Không xác định",
       "Used": "đã sử dụng"
     }
   },

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -753,9 +753,11 @@
     "usage": {
       "Adequate": "充足",
       "Caution": "注意事项",
+      "HostStatusTooltip": "主机使用状态: {{status}}",
       "Insufficient": "不足",
       "Status": "现状",
       "StatusOfSelectedHost": "选定主机的状态",
+      "Unknown": "未知",
       "Used": "中古"
     }
   },

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -754,9 +754,11 @@
     "usage": {
       "Adequate": "充足",
       "Caution": "注意事项",
+      "HostStatusTooltip": "主機使用狀態: {{status}}",
       "Insufficient": "不足",
       "Status": "现状",
       "StatusOfSelectedHost": "选定主机的状态",
+      "Unknown": "未知",
       "Used": "用過的"
     }
   },


### PR DESCRIPTION
resolves #6937 (FR-2691)

## Summary

Clears the three header panels that used to sit above the folder table on `/data`, redistributes their responsibilities, and reshapes the "Location" column into a "Host" column that surfaces per-volume capacity info without requiring an extra click on every row.

## Changes on `/data` (`VFolderNodeListPage.tsx`)

- Removed the top `Row` that rendered the Create Folder action card, `StorageStatusPanelCard`, and `QuotaPerStorageVolumePanelCard`. The Create Folder affordance is already present as the primary button inside the folder table card header, so no replacement action card is needed.
- Promoted the folder table card to the top of the page.
- Cleaned up now-unused imports / variables (`ActionItemContent`, `BAINewFolderIcon`, `BAIAlertIconWithTooltip`, `Grid.useBreakpoint`, `useWebUINavigate`, `ErrorBoundary`, per-row `Suspense`, `CARD_MIN_HEIGHT`).

## Changes in the folder table (`VFolderNodesV2.tsx`)

- Column `title`: `data.folders.Location` (위치) → `data.Host` (호스트).
- Column header affordance: a `BAIAlertIconWithTooltip` sits next to the "Host" label. Clicking it opens the `QuotaPerStorageVolumePanelCard` in a Modal, pre-selected on a quota-supporting host. The icon is hidden entirely when no volume reports `"quota"` in `capabilities`, so the modal entry point disappears when the feature is unusable — we don't open a dialog with no useful content.
- Column cells: new `VFolderHostCell` renders a `StorageUsageBadge` (sourced from `vfolder.list_hosts()`, cached under the shared `['vhostInfo']` tan-query key that `StorageSelect` already uses) plus the host name. **No** per-cell click behavior — the modal is only reachable via the column-header affordance.
- Badge gating matches `StorageSelect`'s own precedent: the badge renders whenever the backend attaches a `usage` object (even `{}`). `StorageUsageBadge` resolves a `percentage`-less `usage` to a neutral (uncolored) marker. The accompanying tooltip reads `Host Status: <Adequate | Caution | Insufficient | Unknown>`; the `Unknown` label is a newly added key that covers the "backend reports no percentage" case.
- Switched the cell from `useSuspenseTanQuery` to `useTanQuery`. A per-cell Suspense boundary whose fallback rendered the bare host text (visually indistinguishable from the "loaded but no usage data" branch) caused rows to stick in the fallback even after `vhostInfo` resolved.

## Changes to `QuotaPerStorageVolumePanelCard.tsx`

- Dropped the outer `BAICard` wrapper and the internal title. The consumer is now a `Modal` that supplies its own title and chrome, and a nested card here produced a duplicated header on top of the modal frame.
- Moved the `?` tooltip icon (`QuestionCircleOutlined` with `data.HostDetails`) into the Modal title so all header affordances live in one place.
- `StorageSelect` moved out of the former card's `extra` slot (right-aligned, borderless) and into the modal body as the first element, left-aligned with a sensible `minWidth`.
- Added `defaultVolumeInfo?: VolumeInfo` prop. When set, the card seeds `selectedVolumeInfo` with that value and disables the built-in `autoSelectType="usage"` fallback; users can still switch volumes through the inline `StorageSelect`. This is how the header icon pre-selects a quota-supporting host.
- Props type simplified: `BAICardProps` → a dedicated local interface (card-specific passthrough props no longer make sense).

## Changes on the Dashboard (`DashboardPage.tsx`, `StorageStatusPanelCard.tsx`)

- Added a new `folderStatus` board item between `myResourceWithinResourceGroup` and `totalResourceWithinResourceGroup`, wrapped in `BAIBoardItemErrorBoundary` + `Suspense`. Invitation badge click routes to `/data?invitation=true` through `useWebUINavigate`.
- Refactored `StorageStatusPanelCard` to follow the Dashboard board-item pattern used by `MyResource` / `MyResourceWithinResourceGroup`:
  - Root is a `BAIFlex direction="column" align="stretch"` with `paddingInline: token.paddingXL` and `paddingBottom: token.padding`.
  - Title uses the shared `BAIBoardItemTitle`, which reserves space for the board's drag handle. Wrapping in a `BAICard` caused the title to overlap the handle on the left edge — that's fixed.
  - Props type: `BAICardProps` → `BAIFlexProps`.

## V2 migration notes (TODOs left in `StorageStatusPanelCard.tsx`)

The status counts still run off the legacy REST call `baiClient.vfolder.list()` and the V1 `user_resource_policy` / `project_resource_policy` GraphQL root fields. TODOs in the file call out the V2 rewrite with explicit scoping rules:

- **ProjectFolders**: when ported to `projectVfolders(projectId: …)`, it must be scoped to the project currently selected in the global header project selector (`currentProject.id`), not aggregated across every project the user can see.
- **InvitedFolders**: migration deferred. The V2 `VFolderFilter` does not yet expose an "invited only / received share" predicate, so we cannot reproduce the current `!is_owner && ownership_type === 'user'` filter with a single server-side count. Stays on legacy REST until the backend adds the filter field; revisit in a follow-up issue.

## Internationalization

Added `data.usage.Unknown` to all 21 locales under `resources/i18n/`, placed alphabetically between `StatusOfSelectedHost` and `Used` in the `data.usage` object. The key powers the tooltip fallback when a host has `usage: {}` (object present, `percentage` missing). `packages/backend.ai-ui/src/locale/*.json` is intentionally untouched — that package does not consume the key.

## Testing

- `bash scripts/verify.sh` — Relay, Lint, Format, TypeScript all pass on this branch and on every descendant branch in the stack (FR-2573, FR-2619, FR-2685, FR-2688).
- Manually verified against a manager response where every volume reports `usage: {}` (no `percentage`): per-row neutral badges render with `Host Status: Unknown` tooltip; header `?` icon appears because `icn02:flash01` / `seoul-h100:flash0*` advertise `"quota"` in capabilities; clicking it opens the modal pre-selected on the first quota-capable host.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
