### PR TITLE
chore(FR-2698): remove deprecated @types/uuid stub

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1006,9 +1006,6 @@ importers:
       '@types/relay-test-utils':
         specifier: 'catalog:'
         version: 19.0.0
-      '@types/uuid':
-        specifier: ^11.0.0
-        version: 11.0.0
       babel-jest:
         specifier: 'catalog:'
         version: 30.3.0(@babel/core@7.29.0)
@@ -5340,10 +5337,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@11.0.0':
-    resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
-    deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -19369,10 +19362,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@11.0.0':
-    dependencies:
-      uuid: 13.0.0
 
   '@types/ws@8.18.1':
     dependencies:

--- a/react/package.json
+++ b/react/package.json
@@ -133,7 +133,6 @@
     "@types/react-test-renderer": "^19.1.0",
     "@types/relay-runtime": "catalog:",
     "@types/relay-test-utils": "catalog:",
-    "@types/uuid": "^11.0.0",
     "babel-jest": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
     "babel-plugin-relay": "^20.1.1",


### PR DESCRIPTION
Resolves FR-2698

## Summary

Running `pnpm run build` at the repo root fails at the root `tsc` step with:

```
error TS2688: Cannot find type definition file for 'uuid'.
  The file is in the program because:
    Entry point for implicit type library 'uuid'
```

## Root cause

`react/package.json` pinned `@types/uuid@^11.0.0`, which is a **deprecated stub**:

```json
{ "name": "@types/uuid", "version": "11.0.0", "main": "",
  "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed." }
```

The `uuid` package itself has shipped its own declarations since `uuid@10`, so the stub has no `index.d.ts`. Because the root `tsconfig.json` has `typeRoots: ["./src/types", "./node_modules/@types"]`, pnpm's hoisted `node_modules/@types/uuid/` directory is discovered as an implicit type library during the root `tsc` pass — and fails to resolve its entry file.

## Fix

Drop `@types/uuid` from `react/package.json` dev dependencies and refresh `pnpm-lock.yaml`. The single consumer — `react/src/hooks/useBAINotification.tsx` (`import { v4 as uuidv4 } from 'uuid'`) — picks up its types straight from the runtime `uuid` package.

## Verification

- [x] After the change, `pnpm install` no longer hoists `@types/uuid` into `node_modules/@types/`.
- [x] Root `tsc` no longer emits `TS2688` for `uuid`.
- [x] `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript all green).

## Not in scope

- The root `tsc` pass has other pre-existing unrelated errors (e.g. `@types/d3-dispatch/index.d.ts` parse errors) that reproduce on `main`. Those belong to a separate cleanup of the root `typeRoots` configuration and are out of scope here.

**Checklist:**

- [ ] Documentation — not applicable
- [ ] Minimum required manager version — not applicable
- [ ] Specific setting for review — none
- [ ] Minimum requirements to check during review — run `pnpm install` fresh, confirm no `node_modules/@types/uuid/` hoisted
- [ ] Test case(s) — see Verification above