### PR TITLE
fix(FR-2699): prevent duplicate VFolder creation on rapid button clicks

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIButton.tsx
+++ b/packages/backend.ai-ui/src/components/BAIButton.tsx
@@ -1,5 +1,5 @@
 import { Button, type ButtonProps } from 'antd';
-import React, { useTransition } from 'react';
+import React, { useRef, useTransition } from 'react';
 
 export interface BAIButtonProps extends ButtonProps {
   action?: () => Promise<void>;
@@ -7,14 +7,21 @@ export interface BAIButtonProps extends ButtonProps {
 
 const BAIButton: React.FC<BAIButtonProps> = ({ action, ...props }) => {
   const [isPending, startTransition] = useTransition();
+  const isRunningRef = useRef(false);
   return (
     <Button
       {...props}
       loading={isPending || props.loading}
-      onClick={async (e) => {
+      onClick={(e) => {
         if (action) {
+          if (isRunningRef.current) return;
+          isRunningRef.current = true;
           startTransition(async () => {
-            await action();
+            try {
+              await action();
+            } finally {
+              isRunningRef.current = false;
+            }
           });
         }
         props.onClick?.(e);


### PR DESCRIPTION
Resolves #6963 (FR-2699)

## Summary
- Add a synchronous `useRef` guard in `BAIButton` that flips on the first click and is cleared after the `action` promise resolves, preventing any subsequent clicks from firing before the first one completes.
- Remove the per-call-site `isPending` guard from `FolderCreateModal.handleOk` — `BAIButton` now owns this protection for all `action` prop usages project-wide.

## Root Cause
`BAIButton` uses `useTransition` for its loading state, but `startTransition` schedules the `isPending → true` re-render **asynchronously**. Combined with Ant Design's `loading={true}` not blocking pointer events until that re-render commits, a rapid second click could reach `onClick` before the loading state was visually committed — resulting in two `mutateAsync` calls and two folders with the same name.

A `useRef` flag bypasses the re-render cycle entirely: it flips synchronously inside the click handler, so any second click within the same event loop is blocked immediately.

## Test plan
- [ ] Open the data page (VFolderNodeListPage) and rapidly double-click the Create button after filling out a folder name → only one folder is created
- [ ] Verify the same behavior on other entry points: StartPage, VFolderMountFormItem, VFolderSelect, ImportArtifactRevisionToFolderModal, AdminModelCardSettingModal, VFolderTable
- [ ] Confirm the modal still closes on success and shows the success notification
- [ ] Confirm error handling still shows the error message on failure

[FR-2699]: https://lablup.atlassian.net/browse/FR-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ