### PR TITLE
chore(FR-2712): add .watchmanconfig to ignore heavy directories

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,12 @@
+{
+  "ignore_dirs": [
+    "node_modules",
+    ".git",
+    "build",
+    "react/build",
+    "react/.craco-cache",
+    "packages/backend.ai-ui/dist",
+    "packages/backend.ai-ui/storybook-static",
+    ".pnpm-store"
+  ]
+}


### PR DESCRIPTION
Resolves #6990 (FR-2712)

## Problem

Watchman accumulates a very large number of inotify watches on the project root because there is no `.watchmanconfig` to exclude heavy directories. On a freshly running dev environment a single watchman root was holding ~432k watches, taking the system to ~82% of `fs.inotify.max_user_watches` (524,288). Once VS Code Remote attaches and tries to register its own file watcher, the kernel returns `ENOSPC` and the editor surfaces the well-known [*"Visual Studio Code is unable to watch for file changes in this large workspace"*](https://code.visualstudio.com/docs/setup/linux#_visual-studio-code-is-unable-to-watch-for-file-changes-in-this-large-workspace-error-enospc) error.

## Root cause

Without `.watchmanconfig`, watchman recurses into directories that should never be watched: `node_modules`, build outputs (`build/`, `react/build/`, `packages/backend.ai-ui/dist`, `storybook-static`), Craco/Vite caches, `.git`, and `.pnpm-store`. Relay's compiler watch (`pnpm run relay:watch`) and Jest both invoke watchman, so any contributor running the dev environment hits this.

## Fix

Add a project-level `.watchmanconfig` listing `ignore_dirs` for the directories above. Watchman picks this up automatically the next time it watches the project root (e.g. on the next `relay:watch` or jest run); contributors who already have a stale watchman session can pick it up with:

```bash
watchman watch-del $(pwd)
watchman shutdown-server
```

## Verification

Measured on the same machine, before and after applying the config (and resetting watchman):

```
# Before
Total active inotify watches: 432,761 / 524,288  (~82%)

# After
Total active inotify watches:     271 / 524,288  (~0.05%)
```

VS Code Remote no longer raises ENOSPC after the reset.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after