### PR TITLE
feat(FR-2713): F1 site entry and multilingual routing

### DIFF
--- a/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
+++ b/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
@@ -429,3 +429,108 @@ image = rendered brand SVG (or none), no absolute URLs, no sitemap.
 The PDF pipeline reads ONLY `book.config.yaml`, not the `og` key in
 `docs-toolkit.config.yaml`. Adding an `og` block has zero effect on
 PDF output. `pnpm run pdf:en` is unchanged by F2.
+
+## F1 — Site entry & multilingual routing
+
+### Title normalization rule (mandatory)
+
+`book.config.yaml` may write the document title as a YAML block scalar:
+
+```yaml
+title: |
+  Backend.AI WebUI
+  User Guide
+```
+
+The shared loader `book-config.ts` always exposes two derived values:
+
+| Field             | Form              | Used by                                                                                              |
+|-------------------|-------------------|------------------------------------------------------------------------------------------------------|
+| `title`           | single-line       | HTML `<title>`, sidebar header, console output, PDF filename templates, language-picker page         |
+| `titleMultiline`  | original (multi)  | **Only** the PDF cover page (where line breaks are part of the visual layout)                        |
+
+`title` is computed as `raw.title.replace(/\s+/g, " ").trim()` — runs of any whitespace (including newlines) collapse to a single space. `titleMultiline` is `raw.title.trimEnd()` so trailing blank lines are dropped but author-intended line breaks survive for the cover.
+
+**Rules**
+
+1. All call sites that need the title for an HTML `<title>` element, a sidebar header, a log line, or a filename template must use `bookConfig.title`.
+2. Only `html-builder.ts`'s cover renderer (`buildCoverHtml`) reads `metadata.titleMultiline`, with a fallback to `metadata.title` for callers that did not pass it.
+3. The PDF `<head>` `<title>` element keeps a defensive `.trim().replace(/\n/g, " ")` to remain idempotent — but the input is already normalized, so the regex is a safety net rather than a hot path.
+4. New pipelines that read `book.config.yaml` must use `loadBookConfig()` instead of `parseYaml(...).title` to avoid reintroducing the regression.
+
+### Site root and language picker
+
+The website generator emits **one** site-root file outside any language subtree:
+
+```
+dist/web/
+  index.html              ← language picker (this file)
+  favicon.ico             ← from F5
+  apple-touch-icon.png    ← from F5
+  site.webmanifest        ← from F5
+  assets/
+  en/
+  ja/
+  ko/
+  th/
+```
+
+`buildLanguagePickerPage` (in `website-builder.ts`) builds a tiny standalone HTML page (≤ 5 KB total) that:
+
+- Renders a static `<ul>` of language choices (works without JavaScript)
+- Includes an inline `<script>` (no CDN, no external file) that, on first load:
+  1. Reads `localStorage.lang` if it matches a supported language
+  2. Falls back to `navigator.languages` / `navigator.language`, accepting both full tags (`ko-KR`) and primary subtags (`ko`)
+  3. Falls back to `en` (or the first supported language) when no signal matches
+- Uses `location.replace` to avoid polluting the back-button history
+- **Loop-safety**: the script is gated on the URL pathname matching `/(?:^|\/)(?:index\.html)?$/` AND not containing any `/<lang>/` segment, so even if the script were accidentally re-included on a per-language page it would not redirect
+
+`localStorage.lang` is set only when the user clicks one of the visible picker links (the click handler captures `data-lang`). It is never written by the auto-detect path, so a user who lands on the picker once and uses the `<a>` link gets a sticky preference; one who lets the auto-detect fire still re-evaluates `navigator.language` on subsequent root visits.
+
+### Per-page header (language switcher slot)
+
+Every per-page HTML now opens with a `<header class="page-header-bar">` block above the chapter content. F1 occupies it with a single `lang-switcher` group:
+
+```html
+<header class="page-header-bar">
+  <nav class="page-header-nav" aria-label="Page header controls">
+    <div class="lang-switcher" role="group" aria-label="Language switcher">
+      <a class="lang-switcher__item lang-switcher__item--current"   …>English</a>
+      <a class="lang-switcher__item lang-switcher__item--available" …>한국어</a>
+      …
+    </div>
+  </nav>
+</header>
+```
+
+The `<nav class="page-header-nav">` region is intentionally a flex container so future buckets can drop in siblings without reflowing layout: F4 will add a "Copy" toggle, F6 will add a version-selector dropdown.
+
+### Cross-language link resolution
+
+Slugs differ per language because they derive from the localized chapter title (`slugify(nav.title)`). The path is the only stable join key across languages, so the generator builds a per-language `Map<navPath, slug>` once at build time and uses it to resolve switcher hrefs:
+
+- Source: `book.config.yaml`'s `navigation.<lang>[].path` (e.g., `quickstart.md`)
+- Lookup: `slugByPathPerLang[peerLang].get(currentPath)` → peer slug
+- Result href: `../{peerLang}/{peerSlug}.html`
+- Missing peer (chapter not translated): falls back to `../{peerLang}/index.html` and the link is marked `lang-switcher__item--unavailable`
+
+The same lookup also drives `<link rel="alternate" hreflang="…">` in the `<head>`, plus an `x-default` pointing at the English version of the same page (or the first available language when English is absent).
+
+### Files touched
+
+| File                                      | Role                                                                                                  |
+|-------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| `src/book-config.ts` (new)                | Single read site for `book.config.yaml`; exposes `title` (normalized) + `titleMultiline` (raw)        |
+| `src/website-builder.ts`                  | Adds `LanguagePeer`, `buildLanguagePickerPage`, `buildPageHeader`; emits `hreflang` link tags         |
+| `src/website-generator.ts`                | Builds per-language nav-path → slug map; writes `dist/web/index.html`; passes `peers` per page         |
+| `src/styles-web.ts`                       | New `.page-header-bar` / `.lang-switcher` block (sits above the chapter content)                       |
+| `src/html-builder.ts`                     | `DocMetadata.titleMultiline` (optional); cover renderer prefers it when present                       |
+| `src/generate-pdf.ts`                     | Reads via `loadBookConfig`; passes both `title` and `titleMultiline` into the PDF builder             |
+| `src/preview-server*.ts`                  | All three switched to `loadBookConfig` for parity with the production pipelines                       |
+| `src/index.ts`                            | Re-exports the new public types/functions for downstream consumers                                    |
+
+### Constraints honoured
+
+- **Air-gapped** — the language picker script is inline; no CDN, no fetch, no eval.
+- **JS budget** — the picker script is a few hundred bytes; the per-page switcher adds zero JS (links are plain `<a>`).
+- **PDF non-regression** — the cover page still receives the multi-line title via `titleMultiline`; the `<title>` element remains single-line via the existing `.trim().replace(/\n/g, " ")` safety net.

--- a/packages/backend.ai-docs-toolkit/src/book-config.ts
+++ b/packages/backend.ai-docs-toolkit/src/book-config.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared loader for `book.config.yaml`.
+ *
+ * Both the PDF and the web pipelines read the same `book.config.yaml`. The
+ * raw YAML is permissive enough that authors often write `title:` as a YAML
+ * block scalar (`title: |`) so the cover page can render the title across
+ * multiple lines. That same value is also surfaced as `<title>`, the sidebar
+ * header, and the PDF metadata — places where embedded newlines render as
+ * literal `\n` glyphs and look broken.
+ *
+ * F1 introduces a single read site for the book config so both pipelines
+ * agree on what `title` means:
+ *
+ *   - `title`           — single-line, whitespace-collapsed; safe for HTML
+ *                         `<title>`, sidebar headers, console logs, and
+ *                         PDF filename templates.
+ *   - `titleMultiline`  — the original (possibly multi-line) form, preserved
+ *                         only for the PDF cover page where line breaks are
+ *                         load-bearing for visual layout.
+ *
+ * Callers that need the layout-friendly multi-line form (currently only the
+ * PDF cover renderer) should opt into `titleMultiline`. Everything else
+ * should use `title`.
+ */
+
+import fs from "fs";
+import path from "path";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Raw shape of `book.config.yaml`. Kept intentionally minimal — pipelines
+ * that care about extra fields cast through `Record<string, unknown>` from
+ * the same parsed object.
+ */
+export interface RawBookConfig {
+  title: string;
+  description?: string;
+  languages: string[];
+  navigation: Record<string, Array<{ title: string; path: string }>>;
+}
+
+/**
+ * Normalized book config used by the build pipelines.
+ *
+ * `titleMultiline` always equals the raw value (post-`trim`, with newlines
+ * preserved) so pipelines that need the visual line breaks have a stable
+ * field to read. `title` is always single-line.
+ */
+export interface NormalizedBookConfig {
+  /** Single-line, whitespace-collapsed. Safe for `<title>` and headers. */
+  title: string;
+  /** Raw multi-line form. Use only where line breaks are part of the design. */
+  titleMultiline: string;
+  description: string;
+  languages: string[];
+  navigation: Record<string, Array<{ title: string; path: string }>>;
+}
+
+/**
+ * Collapse runs of whitespace (including newlines) into a single space and
+ * trim the result. Idempotent — calling twice gives the same output.
+ */
+export function normalizeTitle(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Read `book.config.yaml` from the language-source root and return both the
+ * normalized title (used everywhere except the PDF cover) and the original
+ * multi-line title (used by the PDF cover renderer).
+ */
+export function loadBookConfig(srcDir: string): NormalizedBookConfig {
+  const configPath = path.join(srcDir, "book.config.yaml");
+  const raw = parseYaml(fs.readFileSync(configPath, "utf-8")) as RawBookConfig;
+
+  const titleMultiline = (raw.title ?? "").trimEnd();
+  const title = normalizeTitle(titleMultiline);
+
+  return {
+    title,
+    titleMultiline,
+    description: raw.description ?? "",
+    languages: raw.languages ?? [],
+    navigation: raw.navigation ?? {},
+  };
+}

--- a/packages/backend.ai-docs-toolkit/src/generate-pdf.ts
+++ b/packages/backend.ai-docs-toolkit/src/generate-pdf.ts
@@ -1,20 +1,13 @@
 import fs from 'fs';
 import path from 'path';
-import { parse as parseYaml } from 'yaml';
 import { chromium } from 'playwright';
 import { processMarkdownFiles } from './markdown-processor.js';
 import { buildFullDocument } from './html-builder.js';
 import { renderPdf } from './pdf-renderer.js';
 import { loadTheme } from './theme.js';
 import { getDocVersion } from './version.js';
+import { loadBookConfig } from './book-config.js';
 import type { ResolvedDocConfig } from './config.js';
-
-interface BookConfig {
-  title: string;
-  description: string;
-  languages: string[];
-  navigation: Record<string, Array<{ title: string; path: string }>>;
-}
 
 export interface GeneratePdfOptions {
   lang: string;
@@ -65,10 +58,11 @@ export async function generatePdf(
 ): Promise<void> {
   const args = options ?? parseArgs(process.argv.slice(2));
 
-  const configPath = path.join(config.srcDir, 'book.config.yaml');
-  const bookConfig: BookConfig = parseYaml(
-    fs.readFileSync(configPath, 'utf-8'),
-  );
+  // Single-line `title` is used for `<title>`, console output, filename
+  // templates. The PDF cover renderer reads `titleMultiline` so the visual
+  // line breaks the author intended (`title: |` block scalar) survive on
+  // the cover page.
+  const bookConfig = loadBookConfig(config.srcDir);
 
   const theme = loadTheme(args.theme ?? 'default');
   const { display: version, filename: versionForFilename } = getDocVersion(
@@ -76,11 +70,11 @@ export async function generatePdf(
     config.version,
   );
   const title = bookConfig.title;
+  const titleMultiline = bookConfig.titleMultiline;
   const availableLanguages = bookConfig.languages;
 
   const langArg = args.lang ?? 'all';
-  const languages =
-    langArg === 'all' ? availableLanguages : [langArg];
+  const languages = langArg === 'all' ? availableLanguages : [langArg];
 
   // Validate requested language
   for (const lang of languages) {
@@ -176,7 +170,7 @@ export async function generatePdf(
     console.log(`[${lang}] Building HTML...`);
     const html = buildFullDocument(
       chapters,
-      { title, version, lang, note: args.note },
+      { title, titleMultiline, version, lang, note: args.note },
       config,
       theme,
     );

--- a/packages/backend.ai-docs-toolkit/src/html-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/html-builder.ts
@@ -1,12 +1,19 @@
-import fs from 'fs';
-import type { Chapter } from './markdown-processor.js';
-import type { PdfTheme } from './theme.js';
-import { defaultTheme } from './theme.js';
-import { generatePdfStyles } from './styles.js';
-import type { ResolvedDocConfig } from './config.js';
+import fs from "fs";
+import type { Chapter } from "./markdown-processor.js";
+import type { PdfTheme } from "./theme.js";
+import { defaultTheme } from "./theme.js";
+import { generatePdfStyles } from "./styles.js";
+import type { ResolvedDocConfig } from "./config.js";
 
 export interface DocMetadata {
+  /** Single-line title — used for the document `<title>` element. */
   title: string;
+  /**
+   * Optional multi-line title — used **only** for the PDF cover page where
+   * line breaks are part of the visual layout (`title: |` block scalar in
+   * `book.config.yaml`). When omitted, the cover falls back to `title`.
+   */
+  titleMultiline?: string;
   version: string;
   lang: string;
   note?: string;
@@ -14,25 +21,25 @@ export interface DocMetadata {
 
 function escapeHtml(text: string): string {
   return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/\n/g, '<br>');
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/\n/g, "<br>");
 }
 
 function getFormattedDate(lang: string): string {
   const now = new Date();
   const year = now.getFullYear();
   const month = now.toLocaleString(
-    lang === 'th'
-      ? 'th-TH'
-      : lang === 'ja'
-        ? 'ja-JP'
-        : lang === 'ko'
-          ? 'ko-KR'
-          : 'en-US',
-    { month: 'long' },
+    lang === "th"
+      ? "th-TH"
+      : lang === "ja"
+        ? "ja-JP"
+        : lang === "ko"
+          ? "ko-KR"
+          : "en-US",
+    { month: "long" },
   );
   return `${month} ${year}`;
 }
@@ -43,18 +50,24 @@ function buildCoverHtml(
   config: ResolvedDocConfig,
 ): string {
   const langLabel = config.languageLabels[metadata.lang] || metadata.lang;
-  const strings = config.localizedStrings[metadata.lang] || config.localizedStrings['en'];
+  const strings =
+    config.localizedStrings[metadata.lang] || config.localizedStrings["en"];
   const date = getFormattedDate(metadata.lang);
 
+  // Cover prefers the multi-line form so author-intended line breaks
+  // (`title: |` in book.config.yaml) survive as `<br>` on the cover. Falls
+  // back to the normalized single-line title when `titleMultiline` is not
+  // provided.
+  const coverTitleSource = metadata.titleMultiline ?? metadata.title;
   return `
 <section class="cover-page" id="cover-page">
   <div class="cover-logo">
     ${logoSvg}
   </div>
-  <h1 class="cover-title">${metadata.title.trim().replace(/\n/g, "<br>")}</h1>
+  <h1 class="cover-title">${coverTitleSource.trim().replace(/\n/g, "<br>")}</h1>
   <!-- TODO(html-builder): Subtitle temporarily disabled for cover layout.
        Re-enable when a cover subtitle is needed.
-       <p class="cover-subtitle">${strings?.userGuide ?? 'User Guide'}</p>
+       <p class="cover-subtitle">${strings?.userGuide ?? "User Guide"}</p>
   -->
   <hr class="cover-divider" />
   <div class="cover-meta">
@@ -62,13 +75,18 @@ function buildCoverHtml(
     <p class="company">${config.company}</p>
     <p class="date">${date}</p>
     <p class="lang">${langLabel}</p>
-  </div>${metadata.note ? `\n  <div class="cover-note">${escapeHtml(metadata.note)}</div>` : ''}
+  </div>${metadata.note ? `\n  <div class="cover-note">${escapeHtml(metadata.note)}</div>` : ""}
 </section>
 `;
 }
 
-function buildTocHtml(chapters: Chapter[], lang: string, config: ResolvedDocConfig): string {
-  const strings = config.localizedStrings[lang] || config.localizedStrings['en'];
+function buildTocHtml(
+  chapters: Chapter[],
+  lang: string,
+  config: ResolvedDocConfig,
+): string {
+  const strings =
+    config.localizedStrings[lang] || config.localizedStrings["en"];
   const tocItems = chapters
     .map((chapter, index) => {
       const num = index + 1;
@@ -76,24 +94,24 @@ function buildTocHtml(chapters: Chapter[], lang: string, config: ResolvedDocConf
       const chapterLink = `<a href="#${anchorId}"><span class="toc-text">${num}. ${chapter.title}</span><span class="toc-pagenum" data-toc-target="${anchorId}"></span></a>`;
 
       const subsections = chapter.headings.filter((h) => h.level === 2);
-      let subsectionHtml = '';
+      let subsectionHtml = "";
       if (subsections.length > 0) {
         const subItems = subsections
           .map(
             (h) =>
               `<li><a href="#${h.id}"><span class="toc-text">${h.text}</span><span class="toc-pagenum" data-toc-target="${h.id}"></span></a></li>`,
           )
-          .join('\n');
+          .join("\n");
         subsectionHtml = `\n<ol class="toc-sections">\n${subItems}\n</ol>`;
       }
 
       return `<li class="toc-chapter">${chapterLink}${subsectionHtml}</li>`;
     })
-    .join('\n');
+    .join("\n");
 
   return `
 <section class="toc-section" id="toc-section">
-  <h1 class="toc-heading">${strings?.tableOfContents ?? 'Table of Contents'}</h1>
+  <h1 class="toc-heading">${strings?.tableOfContents ?? "Table of Contents"}</h1>
   <ol class="toc-list">
     ${tocItems}
   </ol>
@@ -103,23 +121,21 @@ function buildTocHtml(chapters: Chapter[], lang: string, config: ResolvedDocConf
 
 function buildContentHtml(chapters: Chapter[]): string {
   return chapters
-    .map(
-      (chapter, index) => {
-        const chapterNum = index + 1;
-        const chapterTitle = chapter.title;
-        return (
-          `<section class="chapter" id="chapter-${chapter.slug}" data-chapter-num="${chapterNum}" data-chapter-title="${chapterTitle}">\n` +
-          `<a id="${chapter.slug}"></a>\n` +
-          `<div class="chapter-title-page">\n` +
-          `  <div class="chapter-number">Chapter ${chapterNum}</div>\n` +
-          `  <div class="chapter-title-text">${chapterTitle}</div>\n` +
-          `  <div class="chapter-title-divider"></div>\n` +
-          `</div>\n` +
-          `${chapter.htmlContent}\n</section>`
-        );
-      },
-    )
-    .join('\n');
+    .map((chapter, index) => {
+      const chapterNum = index + 1;
+      const chapterTitle = chapter.title;
+      return (
+        `<section class="chapter" id="chapter-${chapter.slug}" data-chapter-num="${chapterNum}" data-chapter-title="${chapterTitle}">\n` +
+        `<a id="${chapter.slug}"></a>\n` +
+        `<div class="chapter-title-page">\n` +
+        `  <div class="chapter-number">Chapter ${chapterNum}</div>\n` +
+        `  <div class="chapter-title-text">${chapterTitle}</div>\n` +
+        `  <div class="chapter-title-divider"></div>\n` +
+        `</div>\n` +
+        `${chapter.htmlContent}\n</section>`
+      );
+    })
+    .join("\n");
 }
 
 /**
@@ -133,7 +149,7 @@ export function buildFullDocument(
 ): string {
   let logoSvg: string;
   if (config.logoPath && fs.existsSync(config.logoPath)) {
-    logoSvg = fs.readFileSync(config.logoPath, 'utf-8');
+    logoSvg = fs.readFileSync(config.logoPath, "utf-8");
   } else {
     logoSvg = config.logoFallbackHtml;
   }
@@ -148,7 +164,7 @@ export function buildFullDocument(
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>${metadata.title.trim().replace(/\n/g, ' ')} (${metadata.lang})</title>
+  <title>${metadata.title.trim().replace(/\n/g, " ")} (${metadata.lang})</title>
   <style>${styles}</style>
 </head>
 <body>

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -79,13 +79,24 @@ export { buildFullDocument } from "./html-builder.js";
 export type { WebDocMetadata } from "./html-builder-web.js";
 export { buildWebDocument } from "./html-builder-web.js";
 export type {
+  LanguagePeer,
+  LanguagePickerPageOptions,
+  PageAssets,
+  PageSeoContext,
+  PageVersionContext,
   WebPageContext,
   WebsiteMetadata,
-  PageAssets,
-  PageVersionContext,
-  PageSeoContext,
 } from "./website-builder.js";
-export { buildWebPage, buildIndexPage } from "./website-builder.js";
+export {
+  applyImageAttributes,
+  buildIndexPage,
+  buildLanguagePickerPage,
+  buildWebPage,
+} from "./website-builder.js";
+
+// ── Book Config (shared loader for book.config.yaml) ────────────
+export type { NormalizedBookConfig, RawBookConfig } from "./book-config.js";
+export { loadBookConfig, normalizeTitle } from "./book-config.js";
 
 // ── SEO (F2) ────────────────────────────────────────────────────
 export type { OgTagOptions, TwitterCardOptions, JsonLdOptions } from "./seo.js";

--- a/packages/backend.ai-docs-toolkit/src/preview-server-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/preview-server-web.ts
@@ -4,37 +4,43 @@
  * Live-reload on file changes.
  */
 
-import fs from 'fs';
-import http from 'http';
-import path from 'path';
-import { parse as parseYaml } from 'yaml';
-import { processMarkdownFilesForWeb, processCatalogMarkdownForWeb } from './markdown-processor-web.js';
-import { buildWebDocument } from './html-builder-web.js';
-import { getDocVersion } from './version.js';
-import type { ResolvedDocConfig } from './config.js';
+import fs from "fs";
+import http from "http";
+import path from "path";
+import {
+  processMarkdownFilesForWeb,
+  processCatalogMarkdownForWeb,
+} from "./markdown-processor-web.js";
+import { buildWebDocument } from "./html-builder-web.js";
+import { getDocVersion } from "./version.js";
+import type { ResolvedDocConfig } from "./config.js";
+import { loadBookConfig } from "./book-config.js";
 // getCatalogMarkdown is dynamically imported in catalog mode for hot-reload support
 
-interface BookConfig {
-  title: string;
-  description: string;
-  languages: string[];
-  navigation: Record<string, Array<{ title: string; path: string }>>;
-}
 
 export interface HtmlPreviewOptions {
   lang: string;
   port: number;
-  mode: 'document' | 'catalog';
+  mode: "document" | "catalog";
 }
 
 function parseArgs(argv: string[]): HtmlPreviewOptions {
-  let lang = 'en';
+  let lang = "en";
   let port = 3457;
-  let mode: 'document' | 'catalog' = 'document';
+  let mode: "document" | "catalog" = "document";
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--lang' && argv[i + 1]) { lang = argv[i + 1]; i++; }
-    if (argv[i] === '--port' && argv[i + 1]) { port = parseInt(argv[i + 1], 10); i++; }
-    if (argv[i] === '--mode' && argv[i + 1]) { mode = argv[i + 1] as 'document' | 'catalog'; i++; }
+    if (argv[i] === "--lang" && argv[i + 1]) {
+      lang = argv[i + 1];
+      i++;
+    }
+    if (argv[i] === "--port" && argv[i + 1]) {
+      port = parseInt(argv[i + 1], 10);
+      i++;
+    }
+    if (argv[i] === "--mode" && argv[i + 1]) {
+      mode = argv[i + 1] as "document" | "catalog";
+      i++;
+    }
   }
   return { lang, port, mode };
 }
@@ -45,23 +51,28 @@ export async function startHtmlPreviewServer(
 ): Promise<void> {
   const args = { ...parseArgs(process.argv.slice(2)), ...options };
 
-  const configPath = path.join(config.srcDir, 'book.config.yaml');
-  const bookConfig: BookConfig = parseYaml(fs.readFileSync(configPath, 'utf-8'));
-  const { display: version } = getDocVersion(config.versionSource, config.version);
-  const isCatalog = args.mode === 'catalog';
-  const title = isCatalog ? 'Style Catalog' : bookConfig.title;
+  const configPath = path.join(config.srcDir, "book.config.yaml");
+  const bookConfig = loadBookConfig(config.srcDir);
+  const { display: version } = getDocVersion(
+    config.versionSource,
+    config.version,
+  );
+  const isCatalog = args.mode === "catalog";
+  const title = isCatalog ? "Style Catalog" : bookConfig.title;
 
   if (!isCatalog) {
     const navigation = bookConfig.navigation[args.lang];
     if (!navigation) {
       console.error(`No navigation found for language: ${args.lang}`);
-      console.error(`Available: ${Object.keys(bookConfig.navigation).join(', ')}`);
+      console.error(
+        `Available: ${Object.keys(bookConfig.navigation).join(", ")}`,
+      );
       process.exit(1);
     }
   }
 
   let currentEtag = Date.now().toString(36);
-  let cachedHtml = '';
+  let cachedHtml = "";
 
   async function generateHtml(): Promise<string> {
     const start = Date.now();
@@ -70,21 +81,37 @@ export async function startHtmlPreviewServer(
     if (isCatalog) {
       // Dynamic import with cache-busting to pick up file changes at runtime
       const cacheBuster = `?t=${Date.now()}`;
-      const { getCatalogMarkdown } = await import(`./sample-content-markdown.js${cacheBuster}`);
+      const { getCatalogMarkdown } = await import(
+        `./sample-content-markdown.js${cacheBuster}`
+      );
       chapters = await processCatalogMarkdownForWeb(getCatalogMarkdown());
     } else {
       const navigation = bookConfig.navigation[args.lang];
-      chapters = await processMarkdownFilesForWeb(args.lang, navigation, config.srcDir, version, config);
+      chapters = await processMarkdownFilesForWeb(
+        args.lang,
+        navigation,
+        config.srcDir,
+        version,
+        config,
+      );
     }
 
-    const html = buildWebDocument(chapters, { title, version, lang: args.lang }, config);
+    const html = buildWebDocument(
+      chapters,
+      { title, version, lang: args.lang },
+      config,
+    );
     const elapsed = Date.now() - start;
-    console.log(`  HTML generated in ${elapsed}ms (${chapters.length} ${isCatalog ? 'sections' : 'chapters'})`);
+    console.log(
+      `  HTML generated in ${elapsed}ms (${chapters.length} ${isCatalog ? "sections" : "chapters"})`,
+    );
     return html;
   }
 
   // Initial build
-  console.log(`  Generating initial HTML (${isCatalog ? 'catalog' : 'document'} mode)...`);
+  console.log(
+    `  Generating initial HTML (${isCatalog ? "catalog" : "document"} mode)...`,
+  );
   cachedHtml = await generateHtml();
 
   // Debounced rebuild
@@ -95,12 +122,14 @@ export async function startHtmlPreviewServer(
     if (rebuildTimer) clearTimeout(rebuildTimer);
     rebuildTimer = setTimeout(async () => {
       rebuildTimer = null;
-      console.log(`  File changed: ${path.relative(config.projectRoot, changedFile)}`);
+      console.log(
+        `  File changed: ${path.relative(config.projectRoot, changedFile)}`,
+      );
       try {
         cachedHtml = await generateHtml();
         currentEtag = Date.now().toString(36);
       } catch (err) {
-        console.error('  Rebuild failed:', err);
+        console.error("  Rebuild failed:", err);
       }
     }, debounceMs);
   }
@@ -109,7 +138,7 @@ export async function startHtmlPreviewServer(
   if (isCatalog) {
     const sampleContentPath = path.resolve(
       path.dirname(new URL(import.meta.url).pathname),
-      'sample-content-markdown.js',
+      "sample-content-markdown.js",
     );
     const watchDir = path.dirname(sampleContentPath);
     const targetFile = path.basename(sampleContentPath);
@@ -126,7 +155,7 @@ export async function startHtmlPreviewServer(
     if (fs.existsSync(srcLangDir)) {
       fs.watch(srcLangDir, { recursive: true }, (_event, filename) => {
         const name = filename?.toString();
-        if (name && (name.endsWith('.md') || name.endsWith('.yaml'))) {
+        if (name && (name.endsWith(".md") || name.endsWith(".yaml"))) {
           scheduleRebuild(path.join(srcLangDir, name));
         }
       });
@@ -134,38 +163,46 @@ export async function startHtmlPreviewServer(
   }
 
   // Watch config
-  fs.watch(configPath, () => { scheduleRebuild(configPath); });
+  fs.watch(configPath, () => {
+    scheduleRebuild(configPath);
+  });
 
   // MIME types for static files
   const MIME_TYPES: Record<string, string> = {
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.gif': 'image/gif',
-    '.svg': 'image/svg+xml',
-    '.webp': 'image/webp',
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".svg": "image/svg+xml",
+    ".webp": "image/webp",
   };
 
   // HTTP server
   const server = http.createServer((req, res) => {
-    const url = new URL(req.url || '/', `http://localhost:${args.port}`);
+    const url = new URL(req.url || "/", `http://localhost:${args.port}`);
 
     // Live-reload polling endpoint
-    if (url.pathname === '/__reload') {
-      res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' });
+    if (url.pathname === "/__reload") {
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+      });
       res.end(JSON.stringify({ etag: currentEtag }));
       return;
     }
 
     // Serve main HTML page
-    if (url.pathname === '/' || url.pathname === '/index.html') {
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      res.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "no-cache",
+      });
       res.end(cachedHtml);
       return;
     }
 
     // Serve static image files from src/{lang}/
-    const safePath = path.normalize(url.pathname).replace(/^\/+/, '');
+    const safePath = path.normalize(url.pathname).replace(/^\/+/, "");
     const baseDir = path.resolve(config.srcDir, args.lang);
     const resolved = path.resolve(baseDir, safePath);
     if (
@@ -177,31 +214,40 @@ export async function startHtmlPreviewServer(
       const ext = path.extname(resolved).toLowerCase();
       const mimeType = MIME_TYPES[ext];
       if (mimeType) {
-        res.writeHead(200, { 'Content-Type': mimeType, 'Cache-Control': 'max-age=60' });
+        res.writeHead(200, {
+          "Content-Type": mimeType,
+          "Cache-Control": "max-age=60",
+        });
         fs.createReadStream(resolved).pipe(res);
         return;
       }
     }
 
-    res.writeHead(404, { 'Content-Type': 'text/plain' });
-    res.end('Not found');
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Not found");
   });
 
   server.listen(args.port, () => {
     const productName = config.productName;
-    console.log('');
-    console.log(`  ${productName} - HTML Preview [${isCatalog ? 'CATALOG' : 'DOCUMENT'}]`);
+    console.log("");
+    console.log(
+      `  ${productName} - HTML Preview [${isCatalog ? "CATALOG" : "DOCUMENT"}]`,
+    );
     if (!isCatalog) {
       console.log(`  Language:  ${args.lang}`);
     }
     console.log(`  URL:       http://localhost:${args.port}`);
-    console.log('');
+    console.log("");
     if (isCatalog) {
-      console.log('  Editing sample-content-markdown will auto-reload the page.');
+      console.log(
+        "  Editing sample-content-markdown will auto-reload the page.",
+      );
     } else {
-      console.log(`  Editing src/${args.lang}/**/*.md will auto-reload the page.`);
+      console.log(
+        `  Editing src/${args.lang}/**/*.md will auto-reload the page.`,
+      );
     }
-    console.log('  Press Ctrl+C to stop.');
-    console.log('');
+    console.log("  Press Ctrl+C to stop.");
+    console.log("");
   });
 }

--- a/packages/backend.ai-docs-toolkit/src/preview-server-website.ts
+++ b/packages/backend.ai-docs-toolkit/src/preview-server-website.ts
@@ -6,16 +6,10 @@
 import fs from "fs";
 import http from "http";
 import path from "path";
-import { parse as parseYaml } from "yaml";
 import { generateWebsite } from "./website-generator.js";
 import type { ResolvedDocConfig } from "./config.js";
+import { loadBookConfig } from "./book-config.js";
 
-interface BookConfig {
-  title: string;
-  description: string;
-  languages: string[];
-  navigation: Record<string, Array<{ title: string; path: string }>>;
-}
 
 export interface WebsitePreviewOptions {
   lang: string;
@@ -63,9 +57,7 @@ export async function startWebsitePreviewServer(
   const args = { ...parseArgs(process.argv.slice(2)), ...options };
 
   const configPath = path.join(config.srcDir, "book.config.yaml");
-  const bookConfig: BookConfig = parseYaml(
-    fs.readFileSync(configPath, "utf-8"),
-  );
+  const bookConfig = loadBookConfig(config.srcDir);
 
   const navigation = bookConfig.navigation[args.lang];
   if (!navigation) {

--- a/packages/backend.ai-docs-toolkit/src/preview-server.ts
+++ b/packages/backend.ai-docs-toolkit/src/preview-server.ts
@@ -1,28 +1,25 @@
-import fs from 'fs';
-import http from 'http';
-import path from 'path';
-import { parse as parseYaml } from 'yaml';
-import { processMarkdownFiles, processCatalogMarkdownForPdf } from './markdown-processor.js';
-import { buildFullDocument } from './html-builder.js';
-import { renderPdf } from './pdf-renderer.js';
-import { loadTheme } from './theme.js';
-import { buildThemeInfoChapter } from './sample-content.js';
-import { getDocVersion } from './version.js';
-import type { ResolvedDocConfig } from './config.js';
+import fs from "fs";
+import http from "http";
+import path from "path";
+import {
+  processMarkdownFiles,
+  processCatalogMarkdownForPdf,
+} from "./markdown-processor.js";
+import { buildFullDocument } from "./html-builder.js";
+import { renderPdf } from "./pdf-renderer.js";
+import { loadTheme } from "./theme.js";
+import { buildThemeInfoChapter } from "./sample-content.js";
+import { getDocVersion } from "./version.js";
+import type { ResolvedDocConfig } from "./config.js";
+import { loadBookConfig } from "./book-config.js";
 
-interface BookConfig {
-  title: string;
-  description: string;
-  languages: string[];
-  navigation: Record<string, Array<{ title: string; path: string }>>;
-}
 
-type PreviewMode = 'catalog' | 'document' | 'sample';
+type PreviewMode = "catalog" | "document" | "sample";
 
 const MODE_LABELS: Record<PreviewMode, string> = {
-  catalog: 'Style Catalog (theme reference + sample elements)',
-  sample: 'Sample content (fast)',
-  document: 'Full document (real markdown)',
+  catalog: "Style Catalog (theme reference + sample elements)",
+  sample: "Sample content (fast)",
+  document: "Full document (real markdown)",
 };
 
 export interface PreviewServerOptions {
@@ -33,15 +30,27 @@ export interface PreviewServerOptions {
 }
 
 function parseArgs(argv: string[]): PreviewServerOptions {
-  let lang = 'en';
-  let theme = 'default';
+  let lang = "en";
+  let theme = "default";
   let port = 3456;
-  let mode: PreviewMode = 'sample';
+  let mode: PreviewMode = "sample";
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--lang' && argv[i + 1]) { lang = argv[i + 1]; i++; }
-    if (argv[i] === '--theme' && argv[i + 1]) { theme = argv[i + 1]; i++; }
-    if (argv[i] === '--port' && argv[i + 1]) { port = parseInt(argv[i + 1], 10); i++; }
-    if (argv[i] === '--mode' && argv[i + 1]) { mode = argv[i + 1] as PreviewMode; i++; }
+    if (argv[i] === "--lang" && argv[i + 1]) {
+      lang = argv[i + 1];
+      i++;
+    }
+    if (argv[i] === "--theme" && argv[i + 1]) {
+      theme = argv[i + 1];
+      i++;
+    }
+    if (argv[i] === "--port" && argv[i + 1]) {
+      port = parseInt(argv[i + 1], 10);
+      i++;
+    }
+    if (argv[i] === "--mode" && argv[i + 1]) {
+      mode = argv[i + 1] as PreviewMode;
+      i++;
+    }
   }
   return { lang, theme, port, mode };
 }
@@ -191,9 +200,12 @@ export async function startPreviewServer(
 ): Promise<void> {
   const args = { ...parseArgs(process.argv.slice(2)), ...options };
 
-  const configPath = path.join(config.srcDir, 'book.config.yaml');
-  const bookConfig: BookConfig = parseYaml(fs.readFileSync(configPath, 'utf-8'));
-  const { display: version } = getDocVersion(config.versionSource, config.version);
+  const configPath = path.join(config.srcDir, "book.config.yaml");
+  const bookConfig = loadBookConfig(config.srcDir);
+  const { display: version } = getDocVersion(
+    config.versionSource,
+    config.version,
+  );
   const theme = loadTheme(args.theme);
   const title = bookConfig.title;
 
@@ -201,7 +213,10 @@ export async function startPreviewServer(
   let isBuilding = false;
 
   fs.mkdirSync(config.distDir, { recursive: true });
-  const previewPdfPath = path.join(config.distDir, `preview_${args.mode}_${args.lang}.pdf`);
+  const previewPdfPath = path.join(
+    config.distDir,
+    `preview_${args.mode}_${args.lang}.pdf`,
+  );
 
   /**
    * Generate preview PDF using the actual Playwright pipeline.
@@ -212,15 +227,24 @@ export async function startPreviewServer(
     const start = Date.now();
 
     let html: string;
-    if (args.mode === 'catalog' || args.mode === 'sample') {
+    if (args.mode === "catalog" || args.mode === "sample") {
       // Dynamic import with cache-busting to pick up file changes at runtime
       const cacheBuster = `?t=${Date.now()}`;
-      const { getCatalogMarkdown } = await import(`./sample-content-markdown.js${cacheBuster}`);
-      const sampleChapters = await processCatalogMarkdownForPdf(getCatalogMarkdown());
-      const chapters = args.mode === 'catalog'
-        ? [buildThemeInfoChapter(theme), ...sampleChapters]
-        : sampleChapters;
-      html = buildFullDocument(chapters, { title, version, lang: args.lang }, config, theme);
+      const { getCatalogMarkdown } = await import(
+        `./sample-content-markdown.js${cacheBuster}`
+      );
+      const sampleChapters =
+        await processCatalogMarkdownForPdf(getCatalogMarkdown());
+      const chapters =
+        args.mode === "catalog"
+          ? [buildThemeInfoChapter(theme), ...sampleChapters]
+          : sampleChapters;
+      html = buildFullDocument(
+        chapters,
+        { title, version, lang: args.lang },
+        config,
+        theme,
+      );
     } else {
       // Document mode: real markdown content
       const navigation = bookConfig.navigation[args.lang];
@@ -229,11 +253,22 @@ export async function startPreviewServer(
         isBuilding = false;
         return;
       }
-      const chapters = await processMarkdownFiles(args.lang, navigation, config.srcDir, version, config);
-      html = buildFullDocument(chapters, { title, version, lang: args.lang }, config, theme);
+      const chapters = await processMarkdownFiles(
+        args.lang,
+        navigation,
+        config.srcDir,
+        version,
+        config,
+      );
+      html = buildFullDocument(
+        chapters,
+        { title, version, lang: args.lang },
+        config,
+        theme,
+      );
     }
 
-    console.log('  Rendering PDF via Playwright...');
+    console.log("  Rendering PDF via Playwright...");
     await renderPdf({
       html,
       outputPath: previewPdfPath,
@@ -275,7 +310,7 @@ export async function startPreviewServer(
       try {
         await generatePreviewPdf();
       } catch (err) {
-        console.error('  Rebuild failed:', err);
+        console.error("  Rebuild failed:", err);
         isBuilding = false;
       } finally {
         currentBuild = null;
@@ -290,19 +325,21 @@ export async function startPreviewServer(
     if (rebuildTimer) clearTimeout(rebuildTimer);
     rebuildTimer = setTimeout(() => {
       rebuildTimer = null;
-      console.log(`  File changed: ${path.relative(config.projectRoot, changedFile)}`);
+      console.log(
+        `  File changed: ${path.relative(config.projectRoot, changedFile)}`,
+      );
       pendingRebuild = true;
       runSerializedBuild();
     }, debounceMs);
   }
 
   // For document mode, watch markdown files
-  if (args.mode === 'document') {
+  if (args.mode === "document") {
     const srcLangDir = path.join(config.srcDir, args.lang);
     if (fs.existsSync(srcLangDir)) {
       fs.watch(srcLangDir, { recursive: true }, (_event, filename) => {
         const name = filename?.toString();
-        if (name && (name.endsWith('.md') || name.endsWith('.yaml'))) {
+        if (name && (name.endsWith(".md") || name.endsWith(".yaml"))) {
           scheduleRebuild(path.join(srcLangDir, name));
         }
       });
@@ -311,12 +348,12 @@ export async function startPreviewServer(
   }
 
   // For sample/catalog modes, watch the sample content source
-  if (args.mode === 'sample' || args.mode === 'catalog') {
+  if (args.mode === "sample" || args.mode === "catalog") {
     // Watch the toolkit's own sample-content-markdown if running from source,
     // or watch project root for custom sample content
     const sampleContentPath = path.resolve(
       path.dirname(new URL(import.meta.url).pathname),
-      'sample-content-markdown.js',
+      "sample-content-markdown.js",
     );
     const watchDir = path.dirname(sampleContentPath);
     const targetFile = path.basename(sampleContentPath);
@@ -332,10 +369,12 @@ export async function startPreviewServer(
   }
 
   // Always watch config
-  fs.watch(configPath, () => { scheduleRebuild(configPath); });
+  fs.watch(configPath, () => {
+    scheduleRebuild(configPath);
+  });
 
   // Watch theme directory for changes
-  const themesDir = path.join(config.projectRoot, 'themes');
+  const themesDir = path.join(config.projectRoot, "themes");
   if (fs.existsSync(themesDir)) {
     fs.watch(themesDir, { recursive: true }, (_event, filename) => {
       const name = filename?.toString();
@@ -345,77 +384,87 @@ export async function startPreviewServer(
 
   // HTTP server
   const server = http.createServer(async (req, res) => {
-    const url = new URL(req.url || '/', `http://localhost:${args.port}`);
+    const url = new URL(req.url || "/", `http://localhost:${args.port}`);
 
     // Live-reload polling endpoint
-    if (url.pathname === '/__reload') {
-      res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' });
+    if (url.pathname === "/__reload") {
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+      });
       res.end(JSON.stringify({ etag: currentEtag, building: isBuilding }));
       return;
     }
 
     // All modes: / serves viewer, /preview.pdf serves actual PDF
-    if (url.pathname === '/' || url.pathname === '/index.html') {
+    if (url.pathname === "/" || url.pathname === "/index.html") {
       const viewerHtml = buildPdfViewerPage(title, args.mode);
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
+      res.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "no-cache",
+      });
       res.end(viewerHtml);
       return;
     }
 
-    if (url.pathname === '/preview.pdf') {
+    if (url.pathname === "/preview.pdf") {
       if (fs.existsSync(previewPdfPath)) {
         const stat = fs.statSync(previewPdfPath);
         res.writeHead(200, {
-          'Content-Type': 'application/pdf',
-          'Content-Length': stat.size,
-          'Cache-Control': 'no-cache',
+          "Content-Type": "application/pdf",
+          "Content-Length": stat.size,
+          "Cache-Control": "no-cache",
         });
         fs.createReadStream(previewPdfPath).pipe(res);
       } else {
-        res.writeHead(503, { 'Content-Type': 'text/plain' });
-        res.end('PDF is being generated...');
+        res.writeHead(503, { "Content-Type": "text/plain" });
+        res.end("PDF is being generated...");
       }
       return;
     }
 
     // Serve static files (images) from src/{lang}/
-    const safePath = path.normalize(url.pathname).replace(/^\/+/, '');
+    const safePath = path.normalize(url.pathname).replace(/^\/+/, "");
     const filePath = path.join(config.srcDir, args.lang, safePath);
     if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
       const ext = path.extname(filePath).toLowerCase();
       const mimeTypes: Record<string, string> = {
-        '.png': 'image/png',
-        '.jpg': 'image/jpeg',
-        '.jpeg': 'image/jpeg',
-        '.gif': 'image/gif',
-        '.svg': 'image/svg+xml',
-        '.webp': 'image/webp',
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".svg": "image/svg+xml",
+        ".webp": "image/webp",
       };
-      res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
+      res.writeHead(200, {
+        "Content-Type": mimeTypes[ext] || "application/octet-stream",
+      });
       fs.createReadStream(filePath).pipe(res);
       return;
     }
 
-    res.writeHead(404, { 'Content-Type': 'text/plain' });
-    res.end('Not found');
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Not found");
   });
 
   server.listen(args.port, () => {
     const productName = config.productName;
-    console.log('');
+    console.log("");
     console.log(`  ${productName} Preview Server`);
     console.log(`  Mode:      ${args.mode} — ${MODE_LABELS[args.mode]}`);
     console.log(`  Theme:     ${theme.name}`);
     console.log(`  Language:  ${args.lang}`);
     console.log(`  URL:       http://localhost:${args.port}`);
     console.log(`  PDF:       http://localhost:${args.port}/preview.pdf`);
-    console.log('');
-    if (args.mode === 'document') {
-      console.log(`  Editing src/${args.lang}/**/*.md will regenerate the PDF.`);
+    console.log("");
+    if (args.mode === "document") {
+      console.log(
+        `  Editing src/${args.lang}/**/*.md will regenerate the PDF.`,
+      );
     } else {
       console.log(`  Editing sample-content-markdown will regenerate the PDF.`);
     }
-    console.log('');
+    console.log("");
     console.log(`  Press Ctrl+C to stop.`);
   });
 }

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -697,6 +697,76 @@ details > :last-child {
   color: var(--ifm-color-emphasis-600);
 }
 
+/* ==========================================================================
+   Page Header Bar (website mode) — F1: language switcher slot.
+   F4 (Copy button toggle) and F6 (version selector) will hang off the same
+   <nav class="page-header-nav"> region.
+   ========================================================================== */
+.page-header-bar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin: 0 0 1.5rem 0;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.page-header-nav {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.lang-switcher {
+  display: inline-flex;
+  gap: 0.25rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.4rem;
+  padding: 0.15rem;
+  background: var(--ifm-color-emphasis-0);
+}
+
+.lang-switcher__item {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.8rem;
+  line-height: 1.2;
+  border-radius: 0.25rem;
+  color: var(--ifm-color-emphasis-700);
+  text-decoration: none;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.lang-switcher__item:hover,
+.lang-switcher__item:focus {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-900);
+  text-decoration: none;
+}
+
+.lang-switcher__item--current {
+  background: var(--ifm-color-primary);
+  color: #fff;
+  cursor: default;
+}
+
+.lang-switcher__item--current:hover,
+.lang-switcher__item--current:focus {
+  background: var(--ifm-color-primary-dark);
+  color: #fff;
+}
+
+.lang-switcher__item--unavailable {
+  color: var(--ifm-color-emphasis-500);
+}
+
+.lang-switcher__item--unavailable:hover,
+.lang-switcher__item--unavailable:focus {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-700);
+}
+
 /* Pagination Navigation */
 .pagination-nav {
   display: flex;

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -33,6 +33,13 @@ export interface WebPageContext {
   /** Hashed asset filenames keyed by logical name (e.g. "styles.css" → "styles.deadbeef.css"). */
   assets: PageAssets;
   /**
+   * Per-language switcher links for this exact chapter. Always contains one
+   * entry per language declared in `book.config.yaml` (including the current
+   * language). Languages where the chapter is missing are still listed but
+   * marked `available: false`.
+   */
+  peers: LanguagePeer[];
+  /**
    * Versioned-docs context (F6). Optional — only set when the build is
    * running in versioned mode (`versions` declared in config). Drives
    * the header version selector and the "is this the latest?" hint
@@ -96,6 +103,26 @@ export interface WebsiteMetadata {
   title: string;
   version: string;
   lang: string;
+  /**
+   * All languages declared in `book.config.yaml`. Used to emit
+   * `<link rel="alternate" hreflang="…">` tags and to render the language
+   * switcher control in the page header (F1).
+   */
+  availableLanguages: string[];
+}
+
+/**
+ * One entry in the per-page language switcher. The `href` is page-relative
+ * (`../<peerLang>/<slug>.html`) so the link works for any deployment path.
+ * `available: false` indicates the chapter is not present in the peer
+ * language and the link falls back to that language's index page; the
+ * switcher uses this signal to render a disabled state.
+ */
+export interface LanguagePeer {
+  lang: string;
+  label: string;
+  href: string;
+  available: boolean;
 }
 
 /**
@@ -321,6 +348,7 @@ function buildHeadAssetTags(
   assets: PageAssets,
   prefix: string,
   seo: PageSeoContext | undefined,
+  peers: LanguagePeer[],
 ): string {
   const lines: string[] = [
     `<meta charset="utf-8" />`,
@@ -414,6 +442,24 @@ function buildHeadAssetTags(
         url: pageUrlAbs,
         imageUrl: ogImageAbs,
       }),
+    );
+  }
+
+  // hreflang alternates (F1). One per peer language plus an `x-default`
+  // pointing at English (when present) — search engines use `x-default` to
+  // pick a target for users whose preferred language is not listed.
+  for (const peer of peers) {
+    lines.push(
+      `<link rel="alternate" hreflang="${escapeHtml(peer.lang)}" href="${escapeHtml(peer.href)}" />`,
+    );
+  }
+  const xDefault =
+    peers.find((p) => p.lang === "en" && p.available) ??
+    peers.find((p) => p.available) ??
+    peers[0];
+  if (xDefault) {
+    lines.push(
+      `<link rel="alternate" hreflang="x-default" href="${escapeHtml(xDefault.href)}" />`,
     );
   }
 
@@ -580,11 +626,58 @@ export function applyImageAttributes(
 }
 
 /**
+ * Build the in-page header bar. Currently hosts the language switcher (F1).
+ * F4 (code-block copy) and F6 (version selector) will add additional
+ * controls into the same `<header class="page-header-bar">`; the
+ * `<nav class="page-header-nav">` slots them as siblings of the language
+ * switcher so they can extend without reflowing the layout.
+ */
+function buildPageHeader(
+  metadata: WebsiteMetadata,
+  peers: LanguagePeer[],
+): string {
+  const items = peers
+    .map((peer) => {
+      const isCurrent = peer.lang === metadata.lang;
+      const ariaCurrent = isCurrent ? ' aria-current="true"' : "";
+      const classes = [
+        "lang-switcher__item",
+        isCurrent ? "lang-switcher__item--current" : "",
+        peer.available
+          ? "lang-switcher__item--available"
+          : "lang-switcher__item--unavailable",
+      ]
+        .filter(Boolean)
+        .join(" ");
+      const titleAttr = peer.available
+        ? ""
+        : ' title="This page is not available in this language; goes to that language\'s index instead."';
+      return `<a class="${classes}" href="${escapeHtml(peer.href)}" hreflang="${escapeHtml(peer.lang)}" lang="${escapeHtml(peer.lang)}"${ariaCurrent}${titleAttr}>${escapeHtml(peer.label)}</a>`;
+    })
+    .join("");
+  return `
+<header class="page-header-bar">
+  <nav class="page-header-nav" aria-label="Page header controls">
+    <div class="lang-switcher" role="group" aria-label="Language switcher">
+      ${items}
+    </div>
+  </nav>
+</header>`;
+}
+
+/**
  * Build a complete HTML page for a single chapter in the static website.
  */
 export function buildWebPage(context: WebPageContext): string {
-  const { chapter, allChapters, currentIndex, metadata, config, assets } =
-    context;
+  const {
+    chapter,
+    allChapters,
+    currentIndex,
+    metadata,
+    config,
+    assets,
+    peers,
+  } = context;
 
   const prefix = rootPrefix(context);
 
@@ -594,7 +687,8 @@ export function buildWebPage(context: WebPageContext): string {
     metadata,
     config,
   );
-  const content = buildPageContent(chapter);
+  const pageHeader = buildPageHeader(metadata, peers);
+  const innerContent = buildPageContent(chapter);
   const metadataBar = buildPageMetadata(context);
   const pagination = buildPaginationNav(
     allChapters,
@@ -612,6 +706,7 @@ export function buildWebPage(context: WebPageContext): string {
     assets,
     prefix,
     context.seo,
+    context.peers,
   );
   const headerBar = buildPageHeaderBar(context);
   const searchScript = buildSearchScriptTag(assets, prefix);
@@ -627,7 +722,8 @@ ${headerBar}
 <div class="doc-page">
   ${sidebar}
   <main class="doc-main">
-    ${content}
+    ${pageHeader}
+    ${innerContent}
     <div class="page-footer">
       ${metadataBar}
       ${pagination}
@@ -657,6 +753,151 @@ export function buildIndexPage(
 </head>
 <body>
   <p>Redirecting to <a href="./${firstSlug}.html">${escapeHtml(metadata.title)}</a>...</p>
+</body>
+</html>`;
+}
+
+/**
+ * Build the site-root `dist/web/index.html` language picker page.
+ *
+ * The picker renders a static list of language choices so users without
+ * JavaScript can still navigate. With JavaScript enabled, an inline
+ * (≤ 1 KB) script consults — in order — `localStorage.lang` (sticky user
+ * choice from a previous visit), `navigator.language[s]` (browser
+ * preference), and finally the explicit `fallback` language. The chosen
+ * language's landing page is loaded via `location.replace` so the picker
+ * does not enter the back-button history.
+ *
+ * Loop-safety: the redirect ONLY fires from this exact page (`pathname`
+ * ends with `/` or `/index.html`). Per-language pages never redirect, and
+ * `localStorage.lang` is set only on an explicit user click — so the
+ * picker can never be reached and immediately bounced away again in a
+ * cycle. Falls back to `fallback` (typically `"en"`) when no signal is
+ * available.
+ */
+export interface LanguagePickerPageOptions {
+  title: string;
+  productName: string;
+  languages: Array<{ lang: string; label: string }>;
+  fallback: string;
+}
+
+/**
+ * Serialize a value to JSON safe for embedding inside an inline `<script>`.
+ *
+ * `JSON.stringify` alone is unsafe in HTML script context: a string containing
+ * `</script>` would terminate the surrounding tag and let attacker-controlled
+ * content execute as HTML. Even though the picker's input is operator-supplied
+ * (`book.config.yaml` `languages`), defense-in-depth requires escaping the
+ * known script-breakout sequences (`<`, `-->`, `--!>`, U+2028, U+2029) before
+ * interpolating into a `<script>` block. Per the HTML5 spec, comments may end
+ * with either `-->` or `--!>`, so both forms are escaped. The two comment-
+ * closer forms use distinct literal replacements so each `>` is escaped via
+ * a global string replace (CodeQL js/incomplete-sanitization).
+ */
+function safeJsonForScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/--!>/g, "--!\\u003e")
+    .replace(/-->/g, "--\\u003e")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+export function buildLanguagePickerPage(
+  opts: LanguagePickerPageOptions,
+): string {
+  const { title, productName, languages, fallback } = opts;
+  const safeTitle = escapeHtml(title);
+  const safeProduct = escapeHtml(productName);
+  const langCodes = languages.map((l) => l.lang);
+  const langCodesJson = safeJsonForScript(langCodes);
+  const fallbackJson = safeJsonForScript(fallback);
+
+  const items = languages
+    .map(
+      (l) =>
+        `      <li><a class="lang-pick" data-lang="${escapeHtml(l.lang)}" hreflang="${escapeHtml(l.lang)}" lang="${escapeHtml(l.lang)}" href="./${escapeHtml(l.lang)}/index.html">${escapeHtml(l.label)}</a></li>`,
+    )
+    .join("\n");
+
+  // The script is intentionally tiny and CSP-friendly. No fetch, no CDN,
+  // no eval. It runs once on first load of `/` (or `/index.html`).
+  const script = `(function(){
+  var SUPPORTED=${langCodesJson};
+  var FALLBACK=${fallbackJson};
+  function pick(){
+    try{
+      var ls=window.localStorage&&window.localStorage.getItem("lang");
+      if(ls&&SUPPORTED.indexOf(ls)>=0)return ls;
+    }catch(e){}
+    var navs=[];
+    if(navigator.languages&&navigator.languages.length){
+      for(var i=0;i<navigator.languages.length;i++)navs.push(navigator.languages[i]);
+    }
+    if(navigator.language)navs.push(navigator.language);
+    for(var j=0;j<navs.length;j++){
+      var tag=String(navs[j]||"").toLowerCase();
+      // Try full tag, then primary subtag (e.g. "ko-kr" -> "ko").
+      if(SUPPORTED.indexOf(tag)>=0)return tag;
+      var primary=tag.split("-")[0];
+      if(SUPPORTED.indexOf(primary)>=0)return primary;
+    }
+    return FALLBACK;
+  }
+  // Loop-safety guard: only redirect from the picker page itself, never
+  // from inside a language subtree. The picker script is only included in
+  // the root index.html, but this check makes the safety property visible
+  // and survives accidental re-inclusion (e.g. via templating mistakes).
+  var p=(window.location.pathname||"").toLowerCase();
+  var atRoot=/(?:^|\\/)(?:index\\.html)?$/.test(p);
+  var inLangDir=false;
+  for(var k=0;k<SUPPORTED.length;k++){
+    if(p.indexOf("/"+SUPPORTED[k]+"/")>=0){inLangDir=true;break;}
+  }
+  if(!atRoot||inLangDir)return;
+  var target=pick();
+  if(SUPPORTED.indexOf(target)<0)target=FALLBACK;
+  window.location.replace("./"+target+"/index.html");
+})();
+// Persist explicit user choice from the visible picker.
+document.addEventListener("click",function(e){
+  var t=e.target;
+  while(t&&t!==document){
+    if(t.tagName==="A"&&t.classList&&t.classList.contains("lang-pick")){
+      try{window.localStorage.setItem("lang",t.getAttribute("data-lang"));}catch(err){}
+      return;
+    }
+    t=t.parentNode;
+  }
+});`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${safeTitle}</title>
+  <meta name="robots" content="noindex" />
+  <style>
+    body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;margin:0;background:#fff;color:#1c1e21;display:flex;min-height:100vh;align-items:center;justify-content:center;padding:2rem;}
+    .lp-card{max-width:30rem;width:100%;border:1px solid #ebedf0;border-radius:.5rem;padding:2rem;box-shadow:0 1px 3px rgba(0,0,0,.05);}
+    .lp-title{margin:0 0 .25rem 0;font-size:1.5rem;}
+    .lp-product{margin:0 0 1.5rem 0;color:#606770;font-size:.875rem;}
+    .lp-list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:.5rem;}
+    .lp-list a{display:block;padding:.75rem 1rem;border:1px solid #ebedf0;border-radius:.4rem;color:#3578e5;text-decoration:none;font-weight:500;}
+    .lp-list a:hover,.lp-list a:focus{background:#f5f6f7;border-color:#dadde1;}
+  </style>
+</head>
+<body>
+  <main class="lp-card">
+    <h1 class="lp-title">${safeTitle}</h1>
+    <p class="lp-product">${safeProduct}</p>
+    <ul class="lp-list">
+${items}
+    </ul>
+  </main>
+  <script>${script}</script>
 </body>
 </html>`;
 }

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -8,17 +8,18 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { execFileSync } from "child_process";
-import { parse as parseYaml } from "yaml";
 import { processMarkdownFilesForWeb } from "./markdown-processor-web.js";
 import type { LinkDiagnostic } from "./markdown-processor-web.js";
 import { slugify } from "./markdown-processor.js";
 import {
   buildWebPage,
   buildIndexPage,
+  buildLanguagePickerPage,
   applyImageAttributes,
 } from "./website-builder.js";
 import { buildSearchIndex } from "./search-index-builder.js";
 import type {
+  LanguagePeer,
   PageAssets,
   PageSeoContext,
   PageVersionContext,
@@ -34,6 +35,7 @@ import {
 import { canonicalPathFor } from "./versions.js";
 import { generateWebsiteStyles } from "./styles-web.js";
 import { getDocVersion } from "./version.js";
+import { loadBookConfig, type NormalizedBookConfig } from "./book-config.js";
 import type { ResolvedDocConfig } from "./config.js";
 import { writeHashedAsset, type AssetManifest } from "./asset-hasher.js";
 import { readImageDimensions } from "./image-meta.js";
@@ -45,13 +47,6 @@ import {
   type Version,
   type PageEnumerationRow,
 } from "./versions.js";
-
-interface BookConfig {
-  title: string;
-  description: string;
-  languages: string[];
-  navigation: Record<string, Array<{ title: string; path: string }>>;
-}
 
 export interface GenerateWebsiteOptions {
   lang: string;
@@ -206,10 +201,10 @@ export async function generateWebsite(
   config: ResolvedDocConfig,
   options?: Partial<GenerateWebsiteOptions>,
 ): Promise<GenerateWebsiteResult> {
-  const configPath = path.join(config.srcDir, "book.config.yaml");
-  const bookConfig: BookConfig = parseYaml(
-    fs.readFileSync(configPath, "utf-8"),
-  );
+  // Single-line `title` is used for `<title>`, sidebar headers, and console
+  // output. `book.config.yaml`'s `title: |` block scalar is collapsed at
+  // load time so embedded newlines never reach the rendered HTML.
+  const bookConfig = loadBookConfig(config.srcDir);
 
   const { display: version } = getDocVersion(
     config.versionSource,
@@ -398,13 +393,7 @@ export async function generateWebsite(
               projectRoot: versionRoot,
               srcDir: path.join(versionRoot, "src"),
             };
-      const versionBookConfigPath = path.join(
-        versionConfig.srcDir,
-        "book.config.yaml",
-      );
-      const versionBookConfig: BookConfig = parseYaml(
-        fs.readFileSync(versionBookConfigPath, "utf-8"),
-      );
+      const versionBookConfig = loadBookConfig(versionConfig.srcDir);
 
       console.log(`=== Version ${v.label}${v.isLatest ? " (latest)" : ""} ===`);
       const versionDir = path.join(distBase, v.outDir);
@@ -530,6 +519,23 @@ export async function generateWebsite(
     process.exit(1);
   }
 
+  // Site-root language picker (F1). Lives at dist/web/index.html and is
+  // the only page outside any language subtree. Always uses `en` as the
+  // hard fallback so the picker never enters an infinite redirect loop
+  // even on user agents that report no language signal at all.
+  const peerLangsForPicker = availableLanguages.map((peerLang) => ({
+    lang: peerLang,
+    label: config.languageLabels[peerLang] ?? peerLang,
+  }));
+  const pickerHtml = buildLanguagePickerPage({
+    title,
+    productName,
+    languages: peerLangsForPicker,
+    fallback: availableLanguages.includes("en") ? "en" : availableLanguages[0],
+  });
+  fs.writeFileSync(path.join(distBase, "index.html"), pickerHtml, "utf-8");
+  console.log(`Written: index.html (language picker)`);
+
   console.log(`Website generated at: ${distBase}`);
 
   return {
@@ -567,7 +573,7 @@ async function buildLanguage(args: {
   version: string;
   title: string;
   config: ResolvedDocConfig;
-  bookConfig: BookConfig;
+  bookConfig: NormalizedBookConfig;
   outRoot: string;
   rootDepth: 2 | 3;
   versionLabel: string | null;
@@ -625,7 +631,23 @@ async function buildLanguage(args: {
   );
   for (const d of langDiagnostics) allDiagnostics.push(d);
 
-  const metadata: WebsiteMetadata = { title, version, lang };
+  const availableLanguages = bookConfig.languages;
+  const metadata: WebsiteMetadata = { title, version, lang, availableLanguages };
+
+  // Per-language nav-path -> slug index. The language switcher (F1) maps
+  // `quickstart.md` (path) in the current language to the same path in
+  // every peer language, then resolves the peer's localized slug for the
+  // cross-language link target. Paths are stable across languages — slugs
+  // are not — so the join key is the path.
+  const slugByPathPerLang: Record<string, Map<string, string>> = {};
+  for (const peerLang of availableLanguages) {
+    const peerNav = bookConfig.navigation[peerLang] ?? [];
+    const map = new Map<string, string>();
+    for (const entry of peerNav) {
+      map.set(entry.path, slugify(entry.title));
+    }
+    slugByPathPerLang[peerLang] = map;
+  }
 
   // Collect last-modified dates for all navigation files
   const navFilePaths = navigation.map((nav) => path.join(lang, nav.path));
@@ -717,6 +739,31 @@ async function buildLanguage(args: {
       lastModSink.set(pagePath, lastDate);
     }
 
+    // Resolve the same chapter in every peer language. Missing peers
+    // (e.g. a page only translated into a subset of languages) are still
+    // listed in the switcher but link to that language's index page so
+    // users always have an escape hatch.
+    const peers: LanguagePeer[] = availableLanguages.map((peerLang) => {
+      const peerSlug = navEntry
+        ? slugByPathPerLang[peerLang]?.get(navEntry.path)
+        : undefined;
+      const langLabelPeer = config.languageLabels[peerLang] ?? peerLang;
+      if (peerSlug) {
+        return {
+          lang: peerLang,
+          label: langLabelPeer,
+          href: `../${peerLang}/${peerSlug}.html`,
+          available: true,
+        };
+      }
+      return {
+        lang: peerLang,
+        label: langLabelPeer,
+        href: `../${peerLang}/index.html`,
+        available: false,
+      };
+    });
+
     let pageHtml = buildWebPage({
       chapter: chapters[i],
       allChapters: chapters,
@@ -726,6 +773,7 @@ async function buildLanguage(args: {
       navPath: navEntry?.path,
       lastUpdated: lastDate ? formatDate(lastDate, lang) : undefined,
       assets: pageAssets,
+      peers,
       versionContext,
       seo,
     });


### PR DESCRIPTION
Resolves #6998 (FR-2713)

## Summary
F1 of FR-2710: site entry and multilingual routing for the docs site.
- Root `dist/web/index.html` with language picker (`localStorage.lang` + `navigator.languages` with primary-subtag fallback; air-gapped, inline JS, no CDN)
- Per-page language switcher in a new `<header class="page-header-bar">` (semantic `<nav>` so F4/F6 can drop in siblings without reflowing)
- `<link rel="alternate" hreflang>` per page covering all 4 languages plus `x-default` (points at English)
- Multi-line `<title>` bug fixed: new `book-config.ts` loader exposes both `title` (single-line, whitespace-collapsed) for `<title>` / sidebar / filenames and `titleMultiline` (raw) for the PDF cover
- ARCHITECTURE.md updated with the title-normalization rule, picker design, switcher layout, and cross-language link resolution

## Stack
- Spec: #6988 (merged)
- Dev plan: #7004
- F5 (build robustness + static assets): #7006
- This PR (F1): stacked on F5

## Cross-cutting verification
- [x] `pnpm run build:web` (all 4 langs) exits 0; emits `dist/web/index.html` + per-lang trees
- [x] `pnpm run pdf:en` exits 0 (73.3 s, 25.7 MB, 73 pages — matches baseline)
- [x] PDF cover renderer reads `titleMultiline`, so the line-break-formatted cover is preserved
- [x] Pre-existing CJK PDF failure on parent commit (`pdf:ko/ja/th` fails with `WinAnsi cannot encode "目"` in `pdf-renderer.ts:289`) is **NOT** caused by this PR — it is documented in the FR-2710 wave-1 findings and tracked separately. F1 does not touch `pdf-renderer.ts`.
- [x] `bash scripts/verify.sh` → `=== ALL PASS ===`
- [x] No literal `\n` appears in any rendered `<title>` or sidebar header in any of the 4 languages (verified by post-build grep across all 116 generated HTML pages)
- [x] Strict mode (`build:web --strict`) passes — no broken-link diagnostics introduced

## Test plan
- [ ] Open `packages/backend.ai-webui-docs/dist/web/index.html` locally → language picker visible, no 404
- [ ] In a browser with Korean preference, visit `/` → redirects to `/ko/index.html`
- [ ] Click a different language on the picker → `localStorage.lang` is set; subsequent root visits honor it
- [ ] Navigate `/en/quickstart.html` → header switcher → arrives at `/ko/빠른-시작.html` (cross-language link uses path-based join)
- [ ] View page source: `<link rel="alternate" hreflang="…">` present for all 4 languages + `x-default` pointing to the English page
- [ ] `grep -F $'\n' dist/web/en/quickstart.html | grep "<title>"` → empty
- [ ] `pnpm run pdf:en` → exits 0, cover page shows multi-line "Backend.AI WebUI / User Guide"

## Files changed
- New: `packages/backend.ai-docs-toolkit/src/book-config.ts` — single read site for `book.config.yaml`; exposes `title` (normalized) + `titleMultiline` (raw)
- `packages/backend.ai-docs-toolkit/src/website-builder.ts` — adds `LanguagePeer`, `buildLanguagePickerPage`, `buildPageHeader`; emits `hreflang` link tags; updates `WebsiteMetadata`/`WebPageContext`
- `packages/backend.ai-docs-toolkit/src/website-generator.ts` — builds per-language nav-path → slug map; writes `dist/web/index.html`; passes `peers` per page
- `packages/backend.ai-docs-toolkit/src/styles-web.ts` — new `.page-header-bar` / `.lang-switcher` block
- `packages/backend.ai-docs-toolkit/src/html-builder.ts` — `DocMetadata.titleMultiline` (optional); cover renderer prefers it
- `packages/backend.ai-docs-toolkit/src/generate-pdf.ts` — uses `loadBookConfig`; passes both `title` and `titleMultiline` into builder
- `packages/backend.ai-docs-toolkit/src/preview-server*.ts` — three preview servers switched to `loadBookConfig` for parity
- `packages/backend.ai-docs-toolkit/src/index.ts` — re-exports new public types/functions
- `packages/backend.ai-docs-toolkit/ARCHITECTURE.md` — F1 section added

## Coordination notes for F3 (which stacks on F1)
- F3 should add the right-rail TOC + breadcrumbs + grouped sidebar, **without** moving the language switcher out of `<header class="page-header-bar">`. The switcher is positioned above the chapter content; F3 can add a parallel `.breadcrumbs` block in the same header bar if desired.
- F4 (Copy button) and F6 (version selector) reserve sibling slots inside `<nav class="page-header-nav">`; CSS uses `flex-wrap: wrap` so additional controls don't overflow.
- The `book-config.ts` loader is the only path to read `book.config.yaml`. F3 should extend the schema there (grouped `navigation`) rather than re-introducing `parseYaml` calls in feature code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
