### PR TITLE
feat(FR-2715): F3 information architecture (sidebar grouping, right-rail TOC, breadcrumbs)

### DIFF
--- a/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
+++ b/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
@@ -534,3 +534,128 @@ The same lookup also drives `<link rel="alternate" hreflang="…">` in the `<hea
 - **Air-gapped** — the language picker script is inline; no CDN, no fetch, no eval.
 - **JS budget** — the picker script is a few hundred bytes; the per-page switcher adds zero JS (links are plain `<a>`).
 - **PDF non-regression** — the cover page still receives the multi-line title via `titleMultiline`; the `<title>` element remains single-line via the existing `.trim().replace(/\n/g, " ")` safety net.
+
+## F3 — Information architecture (sidebar grouping + right-rail TOC + breadcrumbs)
+
+### Navigation schema (backward compatible)
+
+`book.config.yaml`'s `navigation.<lang>` accepts two forms:
+
+```yaml
+# Legacy (F1 and earlier; still accepted)
+navigation:
+  en:
+    - { title: Quickstart, path: quickstart.md }
+    - { title: Overview,   path: overview/overview.md }
+
+# Grouped (F3)
+navigation:
+  en:
+    - category: Getting Started
+      items:
+        - { title: Quickstart, path: quickstart.md }
+    - category: Workloads
+      items:
+        - { title: Sessions, path: sessions/sessions.md }
+```
+
+`loadBookConfig` normalizes both forms into:
+
+| Field                  | Shape                              | Used by                                                                         |
+|------------------------|------------------------------------|---------------------------------------------------------------------------------|
+| `navigation`           | `Record<lang, NavItem[]>` (flat)   | PDF pipeline; web cross-language slug map; backward-compat consumers            |
+| `navigationGroups`     | `Record<lang, NavGroup[]>`         | F3 web sidebar groups, breadcrumb category resolution                            |
+
+When the input is the legacy flat form, `navigationGroups[lang]` contains a single group with `category: ""` (anonymous). The web sidebar renders an anonymous group as a flat list (no `<details>` drawer) so a config that hasn't migrated to grouped form looks identical to F1's sidebar — no breadcrumb middle segment, no group headers.
+
+The two forms cannot be **mixed within a single language** (e.g. `en: [grouped, grouped, flat]`). The loader inspects only the first entry to decide the form; mismatched siblings are dropped with a warning. Each language can independently choose its form, however — `en: grouped, th: flat` is fine while a translator works through categorization.
+
+Soft-fail policy on grouped-form structural problems:
+
+- Group with empty `category:` → dropped with warning, items skipped.
+- Group with no valid `items` → dropped with warning.
+- Item missing `title` or `path` → dropped with warning, group keeps remaining items.
+
+The build never crashes on these — matches F5's diagnostics-sink philosophy.
+
+### Sidebar render (CSS-only collapsible groups)
+
+The web sidebar renders one `<details class="doc-sidebar-group">` per category, each containing a `<ul class="doc-sidebar-nav doc-sidebar-nav--grouped">` of nav items. No JavaScript is involved — `<details>` natively handles the open/close state. The active page's group is `<details open>` on first load (computed at build time by checking which group contains the current item's path); other groups are collapsed by default.
+
+The pre-F3 inline H2 sub-list under the active sidebar item is gone; that data lives in the right-rail TOC now.
+
+### Right-rail "On this page" TOC
+
+Every chapter page renders an `<aside class="doc-toc">` in the third grid column on desktop. The list shows H2 + H3 headings only (H4+ are excluded so the rail stays short on long chapters). The aside is sticky-positioned with `position: sticky; top: 0; height: 100vh; overflow-y: auto`.
+
+**Scroll-spy**: `templates/assets/toc-scrollspy.js` (~1 KB) uses a single `IntersectionObserver` with `rootMargin: "-25% 0px -75% 0px"` (a 25%–75% spy band of the viewport). The link whose target heading is currently in the band gets `.is-active`. When no heading is intersecting (between two sections), the script falls back to picking the last heading whose top is above the spy line. On TOC link click, the active state syncs immediately so it doesn't lag behind the smooth-scroll animation.
+
+The script ships only when `templates/assets/toc-scrollspy.js` exists — `website-generator.ts`'s asset pipeline registers it the same way as F4's optional `code-copy.js`. Pages with no H2 headings render an empty `<aside data-empty="true">`; CSS hides the heading and the script is a cheap no-op (no targets to observe).
+
+### Breadcrumbs
+
+A `<nav class="breadcrumb">` block appears between the page-header-bar (language switcher) and the chapter content. Format:
+
+```
+Home › Category › Chapter Title
+```
+
+- "Home" links to the per-language `index.html` landing page.
+- "Category" is the F3 group containing the page (rendered as plain text — no per-category landing exists).
+- "Chapter Title" is the current page (plain text, marked `aria-current="page"`).
+
+When the page belongs to the synthetic anonymous group (legacy flat config), the middle segment is dropped — `Home › Chapter Title`. Separators (`›`, U+203A) are CSS pseudo-elements, so the structural HTML stays semantic (`<ol>` of `<li>` segments).
+
+The breadcrumb is intentionally **not** placed inside the `<header class="page-header-bar">` flex container. The header is reserved for site-level controls (lang switcher, F6's incoming version selector). Keeping the breadcrumb as a separate block above the chapter avoids tight coupling with F6's layout.
+
+### Layout grid
+
+`.doc-page` is a 3-column CSS grid:
+
+| Column         | Width                                            |
+|----------------|--------------------------------------------------|
+| `.doc-sidebar` | `var(--doc-sidebar-width)` (260px)               |
+| `.doc-main`    | `minmax(0, 1fr)` — fills remaining width, max 960px content |
+| `.doc-toc`     | `var(--doc-toc-width)` (220px)                   |
+
+Responsive breakpoints:
+
+- **≤1100px**: drop the third column. `.doc-toc` is hidden via `display: none`. Headings remain anchor-reachable from inline `#` links — the TOC content is recoverable, just not always visible. (Moving the rail inline would require runtime JS to relocate the `<aside>`; out of scope for F3.)
+- **≤768px**: collapse to a single column. Sidebar becomes a top strip (`max-height: 40vh`), main content flows below.
+
+### Localization
+
+WEBSITE_LABELS (`config.ts`) gains three keys:
+
+| Key           | en              | ja               | ko                | th                |
+|---------------|-----------------|------------------|-------------------|-------------------|
+| `home`        | "Home"          | "ホーム"           | "홈"              | "หน้าแรก"          |
+| `onThisPage`  | "On this page"  | "このページの目次"   | "이 페이지의 목차"  | "หัวข้อในหน้านี้"   |
+| `tocToggle`   | (same)          | (same)           | (same)            | (same)            |
+
+Category labels themselves are localized **inline in `book.config.yaml`** — each language declares its own `category:` strings. There's no per-category lookup table; the localized label for the breadcrumb is whatever the matching nav-group's `category:` field says.
+
+### PDF pipeline non-regression
+
+The PDF pipeline reads `bookConfig.navigation[lang]` (the flat list). Since the flat list is constructed by walking `navigationGroups` in order and concatenating items, the PDF chapter ordering follows the grouped sequence. For the WebUI docs this means the legacy `Vfolder/Sessions All/.../Cluster Session` interleave is replaced by a clean `Getting Started → Workloads → Storage & Data → Administration → Reference` order — a small, deliberate ordering change documented in the F3 PR. The PDF pipeline itself never sees the categories, so the cover page, TOC entries, and chapter outline structure are unaffected.
+
+### Files touched
+
+| File                                           | Role                                                                                        |
+|------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `src/book-config.ts`                           | `RawNavigation` type union (flat \| grouped); `NavGroup`/`NavItem` exports; normalization    |
+| `src/website-builder.ts`                       | `buildBreadcrumb`, `buildRightRailToc`, grouped sidebar, `tocScrollspy` asset slot          |
+| `src/website-generator.ts`                     | Resolve `categoryByPath` per language; write `toc-scrollspy.js`; pass `navGroups`+`category` |
+| `src/styles-web.ts`                            | 3-column grid; sidebar `<details>` styles; breadcrumb; right-rail TOC; responsive breakpoints |
+| `src/config.ts`                                | New WEBSITE_LABELS keys: `home`, `onThisPage`, `tocToggle`                                  |
+| `src/index.ts`                                 | Re-export `NavGroup`, `NavItem`, `RawNavigation`                                            |
+| `templates/assets/toc-scrollspy.js` (new)      | IntersectionObserver scroll-spy (~1 KB)                                                     |
+| `packages/backend.ai-webui-docs/src/book.config.yaml` | Author the default 5-category mapping for all 29 chapters in 4 languages              |
+
+### Constraints honoured (F3)
+
+- **Air-gapped** — scroll-spy is a small bundled script using native IntersectionObserver; no CDN, no fetch.
+- **JS budget** — `toc-scrollspy.js` source is ~3 KB unminified, well under the per-page 25 KB budget.
+- **CSS-only collapse** — sidebar groups use native `<details>`/`<summary>`; no runtime JS for collapse.
+- **PDF non-regression** — flat `navigation` shape preserved for the PDF pipeline; only the chapter ordering changes (intentionally).
+- **Backward compat** — flat `navigation` form still loads and renders identically to F1's sidebar.

--- a/packages/backend.ai-docs-toolkit/src/book-config.ts
+++ b/packages/backend.ai-docs-toolkit/src/book-config.ts
@@ -18,14 +18,88 @@
  *                         only for the PDF cover page where line breaks are
  *                         load-bearing for visual layout.
  *
- * Callers that need the layout-friendly multi-line form (currently only the
- * PDF cover renderer) should opt into `titleMultiline`. Everything else
- * should use `title`.
+ * F3 extends the `navigation` schema to accept either the legacy flat list
+ * form or a list of `{ category, items }` groups — see the doc-comment on
+ * `RawNavigation` below. The loader normalizes whichever form it sees into
+ * BOTH:
+ *
+ *   - `navigation`        — flat `Record<lang, NavItem[]>`. Backward-
+ *                           compatible shape; what the PDF pipeline reads
+ *                           and what the web cross-language slug map joins
+ *                           on. Group ordering is preserved when flattening.
+ *   - `navigationGroups`  — categorized `Record<lang, NavGroup[]>`. The web
+ *                           sidebar reads this to render collapsible groups
+ *                           and to compute the per-page breadcrumb category.
+ *                           Flat input is wrapped in a single anonymous
+ *                           group with `category: ""` (rendered as an
+ *                           uncategorized flat list — visually identical to
+ *                           the legacy sidebar).
+ *
+ * Soft-failure on grouped-form structural problems (empty category strings,
+ * empty `items`) — a warning is printed and the offending group is dropped,
+ * but the build does not crash. The PDF pipeline never sees the categories
+ * (it consumes the flat `navigation`), so structural issues in the grouped
+ * form never affect PDF builds.
  */
 
 import fs from "fs";
 import path from "path";
 import { parse as parseYaml } from "yaml";
+
+/** Single navigation item — same in both flat and grouped forms. */
+export interface NavItem {
+  title: string;
+  path: string;
+}
+
+/** A category group (F3 grouped form). */
+export interface NavGroup {
+  /**
+   * Localized category label shown in the sidebar and breadcrumb. Empty
+   * string is reserved for the synthetic "uncategorized" group produced
+   * when the input was the legacy flat form. Authors should never write
+   * an empty `category:` themselves — the loader drops such groups with a
+   * warning to avoid silently rendering an unlabeled drawer.
+   */
+  category: string;
+  items: NavItem[];
+}
+
+/**
+ * Per-language `navigation` value — either the legacy flat list or the F3
+ * grouped form.
+ *
+ * Legacy (F1 and earlier; still accepted):
+ *
+ *   navigation:
+ *     en:
+ *       - { title: Quickstart, path: quickstart.md }
+ *       - { title: Overview,   path: overview/overview.md }
+ *
+ * Grouped (F3):
+ *
+ *   navigation:
+ *     en:
+ *       - category: Getting Started
+ *         items:
+ *           - { title: Quickstart, path: quickstart.md }
+ *       - category: Workloads
+ *         items:
+ *           - { title: Sessions, path: sessions/sessions.md }
+ *
+ * The two forms cannot be mixed within the same language — a non-grouped
+ * entry inside an otherwise grouped list is dropped with a warning. Each
+ * language can independently choose its form (e.g., `en` grouped, `th`
+ * flat) so a translator who hasn't categorized yet doesn't block the rest
+ * of the site.
+ */
+export type RawNavigation = NavItem[] | RawNavGroup[];
+
+/** Grouped form before validation/normalization. */
+interface RawNavGroup {
+  category: string;
+  items: NavItem[];
+}
 
 /**
  * Raw shape of `book.config.yaml`. Kept intentionally minimal — pipelines
@@ -36,7 +110,7 @@ export interface RawBookConfig {
   title: string;
   description?: string;
   languages: string[];
-  navigation: Record<string, Array<{ title: string; path: string }>>;
+  navigation: Record<string, RawNavigation>;
 }
 
 /**
@@ -45,6 +119,11 @@ export interface RawBookConfig {
  * `titleMultiline` always equals the raw value (post-`trim`, with newlines
  * preserved) so pipelines that need the visual line breaks have a stable
  * field to read. `title` is always single-line.
+ *
+ * `navigation` is always the flat per-language list (group ordering is
+ * preserved when flattening). `navigationGroups` is the same data partitioned
+ * into the F3 group form — pipelines that don't care about grouping (PDF,
+ * cross-language slug map) keep using `navigation` unchanged.
  */
 export interface NormalizedBookConfig {
   /** Single-line, whitespace-collapsed. Safe for `<title>` and headers. */
@@ -53,7 +132,14 @@ export interface NormalizedBookConfig {
   titleMultiline: string;
   description: string;
   languages: string[];
-  navigation: Record<string, Array<{ title: string; path: string }>>;
+  /** Flat per-language nav list (backward-compatible, used by PDF pipeline). */
+  navigation: Record<string, NavItem[]>;
+  /**
+   * Per-language nav grouped into categories (F3). Always present — flat
+   * input becomes a single group with `category: ""`. Web pipeline reads
+   * this; PDF ignores it.
+   */
+  navigationGroups: Record<string, NavGroup[]>;
 }
 
 /**
@@ -62,6 +148,105 @@ export interface NormalizedBookConfig {
  */
 export function normalizeTitle(raw: string): string {
   return raw.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Type guard — does this look like a grouped entry (has `category` and
+ * `items`)? Soft check: if either field is missing the entry is treated as
+ * a flat NavItem, which the validator below will reject if it lacks `path`.
+ */
+function isGroupedEntry(entry: unknown): entry is RawNavGroup {
+  if (typeof entry !== "object" || entry === null) return false;
+  const obj = entry as Record<string, unknown>;
+  return "category" in obj && "items" in obj;
+}
+
+/**
+ * Normalize a per-language navigation value into both the flat list (for
+ * PDF / slug-map consumers) and the grouped list (for the F3 web sidebar).
+ *
+ * Soft-fails on per-entry problems: structurally invalid entries are
+ * dropped with a console warning but never crash the build. This matches
+ * F5's diagnostics-sink philosophy — the build keeps going so authors see
+ * the maximum amount of feedback per run.
+ */
+function normalizePerLangNavigation(
+  lang: string,
+  raw: RawNavigation | undefined,
+): { flat: NavItem[]; groups: NavGroup[] } {
+  if (!raw || !Array.isArray(raw) || raw.length === 0) {
+    return { flat: [], groups: [] };
+  }
+
+  // Decide form by inspecting the first entry. The two forms cannot be
+  // mixed — entries that don't match the chosen form are dropped.
+  const grouped = isGroupedEntry(raw[0]);
+
+  if (grouped) {
+    const groups: NavGroup[] = [];
+    const flat: NavItem[] = [];
+    for (const entry of raw) {
+      if (!isGroupedEntry(entry)) {
+        console.warn(
+          `[book.config.yaml] navigation.${lang}: ignoring entry with no "category" inside a grouped list (mixed forms are not allowed): ${JSON.stringify(entry)}`,
+        );
+        continue;
+      }
+      const category = (entry.category ?? "").toString().trim();
+      const items = Array.isArray(entry.items) ? entry.items : [];
+      if (!category) {
+        console.warn(
+          `[book.config.yaml] navigation.${lang}: dropping group with empty category (${items.length} item(s) skipped)`,
+        );
+        continue;
+      }
+      const validItems = items.filter((it): it is NavItem => {
+        if (
+          typeof it !== "object" ||
+          it === null ||
+          typeof (it as NavItem).title !== "string" ||
+          typeof (it as NavItem).path !== "string"
+        ) {
+          console.warn(
+            `[book.config.yaml] navigation.${lang}/${category}: dropping item missing title/path: ${JSON.stringify(it)}`,
+          );
+          return false;
+        }
+        return true;
+      });
+      if (validItems.length === 0) {
+        console.warn(
+          `[book.config.yaml] navigation.${lang}: dropping group "${category}" with no valid items`,
+        );
+        continue;
+      }
+      groups.push({ category, items: validItems });
+      for (const it of validItems) flat.push(it);
+    }
+    return { flat, groups };
+  }
+
+  // Legacy flat form. Wrap in a single anonymous group ("") so the F3 web
+  // sidebar has a uniform shape to render — empty-string category gets a
+  // visually-flat fallback path in `buildWebsiteSidebar`.
+  const flat: NavItem[] = [];
+  for (const entry of raw) {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as NavItem).title !== "string" ||
+      typeof (entry as NavItem).path !== "string"
+    ) {
+      console.warn(
+        `[book.config.yaml] navigation.${lang}: dropping flat entry missing title/path: ${JSON.stringify(entry)}`,
+      );
+      continue;
+    }
+    flat.push(entry as NavItem);
+  }
+  const groups: NavGroup[] =
+    flat.length > 0 ? [{ category: "", items: flat }] : [];
+  return { flat, groups };
 }
 
 /**
@@ -76,11 +261,21 @@ export function loadBookConfig(srcDir: string): NormalizedBookConfig {
   const titleMultiline = (raw.title ?? "").trimEnd();
   const title = normalizeTitle(titleMultiline);
 
+  const navigation: Record<string, NavItem[]> = {};
+  const navigationGroups: Record<string, NavGroup[]> = {};
+  const rawNav = raw.navigation ?? {};
+  for (const [lang, value] of Object.entries(rawNav)) {
+    const { flat, groups } = normalizePerLangNavigation(lang, value);
+    navigation[lang] = flat;
+    navigationGroups[lang] = groups;
+  }
+
   return {
     title,
     titleMultiline,
     description: raw.description ?? "",
     languages: raw.languages ?? [],
-    navigation: raw.navigation ?? {},
+    navigation,
+    navigationGroups,
   };
 }

--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -234,6 +234,9 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     lastUpdated: "Last updated on",
     searchPlaceholder: "Search docs...",
     noResults: "No results found",
+    home: "Home",
+    onThisPage: "On this page",
+    tocToggle: "On this page",
   },
   ko: {
     previous: "이전",
@@ -242,6 +245,9 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     lastUpdated: "마지막 업데이트",
     searchPlaceholder: "문서 검색...",
     noResults: "검색 결과가 없습니다",
+    home: "홈",
+    onThisPage: "이 페이지의 목차",
+    tocToggle: "이 페이지의 목차",
   },
   ja: {
     previous: "前へ",
@@ -250,6 +256,9 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     lastUpdated: "最終更新日",
     searchPlaceholder: "ドキュメント検索...",
     noResults: "結果が見つかりません",
+    home: "ホーム",
+    onThisPage: "このページの目次",
+    tocToggle: "このページの目次",
   },
   th: {
     previous: "ก่อนหน้า",
@@ -258,6 +267,9 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     lastUpdated: "อัปเดตล่าสุด",
     searchPlaceholder: "ค้นหาเอกสาร...",
     noResults: "ไม่พบผลลัพธ์",
+    home: "หน้าแรก",
+    onThisPage: "หัวข้อในหน้านี้",
+    tocToggle: "หัวข้อในหน้านี้",
   },
 };
 

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -95,7 +95,13 @@ export {
 } from "./website-builder.js";
 
 // ── Book Config (shared loader for book.config.yaml) ────────────
-export type { NormalizedBookConfig, RawBookConfig } from "./book-config.js";
+export type {
+  NavGroup,
+  NavItem,
+  NormalizedBookConfig,
+  RawBookConfig,
+  RawNavigation,
+} from "./book-config.js";
 export { loadBookConfig, normalizeTitle } from "./book-config.js";
 
 // ── SEO (F2) ────────────────────────────────────────────────────

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -116,6 +116,9 @@ export function generateWebStyles(lang?: string): string {
   --ifm-alert-padding-horizontal: 1.2rem;
 
   --doc-sidebar-width: 260px;
+  /* F3: right-rail "On this page" TOC width. Coexists with sidebar (260px)
+     and main column (~720-960px) on a desktop CSS grid. */
+  --doc-toc-width: 220px;
 }
 
 /* ==========================================================================
@@ -145,20 +148,24 @@ body {
 }
 
 /* ==========================================================================
-   Page Layout
+   Page Layout — F3 three-column grid
+   --------------------------------------------------------------------------
+   Desktop: [sidebar] [main, max ~960px] [right-rail TOC, fixed width].
+   The grid lets the right-rail size predictably and lets the main column
+   fill any spare width. Below 1100px the right-rail collapses (see the
+   responsive section near the end of this file).
    ========================================================================== */
 .doc-page {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--doc-sidebar-width) minmax(0, 1fr) var(--doc-toc-width);
   min-height: 100vh;
 }
 
 .doc-sidebar {
   position: sticky;
   top: 0;
-  width: var(--doc-sidebar-width);
   height: 100vh;
   overflow-y: auto;
-  flex-shrink: 0;
   border-right: 1px solid var(--ifm-color-emphasis-200);
   background: var(--ifm-color-emphasis-0);
   padding: 1rem 0;
@@ -258,10 +265,82 @@ body {
   text-align: center;
 }
 
+/* F3: sidebar nav. Two render modes share the same .doc-sidebar-nav
+   ruleset:
+     1. Grouped (default for F3) — wrapped in details.doc-sidebar-group
+        with a summary header per category.
+     2. Ungrouped (legacy flat config) — a single .doc-sidebar-nav directly
+        under .doc-sidebar-groups, no details wrapper.
+   The H2 sub-list inside the active sidebar entry is gone — that data lives
+   in the right-rail TOC now. */
+.doc-sidebar-groups {
+  padding: 0;
+  margin: 0;
+}
+
+.doc-sidebar-group {
+  /* Override the global <details> rule so groups don't render the rounded
+     bordered card style — they're navigation, not callouts. */
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+}
+
+.doc-sidebar-group > summary,
+.doc-sidebar-group__summary {
+  cursor: pointer;
+  display: block;
+  padding: 0.55rem 1rem 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-700);
+  user-select: none;
+  list-style: none;
+  position: relative;
+}
+
+/* Hide the default disclosure triangle — we draw our own caret below. */
+.doc-sidebar-group > summary::-webkit-details-marker {
+  display: none;
+}
+.doc-sidebar-group > summary::marker {
+  display: none;
+  content: "";
+}
+
+.doc-sidebar-group > summary::after {
+  content: "";
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: translateY(-65%) rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.doc-sidebar-group[open] > summary::after {
+  transform: translateY(-30%) rotate(45deg);
+}
+
+.doc-sidebar-group > summary:hover {
+  color: var(--ifm-color-primary);
+}
+
+.doc-sidebar-group[open] > summary {
+  margin-bottom: 0.25rem;
+}
+
 .doc-sidebar-nav {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 0 0 0.5rem 0;
 }
 
 .doc-sidebar-nav > li {
@@ -279,6 +358,11 @@ body {
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
+.doc-sidebar-nav--grouped > li > a {
+  /* Slightly indented so items visually nest under the category header. */
+  padding-left: 1.5rem;
+}
+
 .doc-sidebar-nav > li > a:hover {
   background: var(--ifm-color-emphasis-100);
   color: var(--ifm-color-primary);
@@ -290,29 +374,10 @@ body {
   background: rgba(53, 120, 229, 0.06);
 }
 
-.doc-sidebar-nav .toc-subsections {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 0.25rem 0;
-}
-
-.doc-sidebar-nav .toc-subsections a {
-  display: block;
-  padding: 0.25rem 1rem 0.25rem 1.75rem;
-  font-size: 0.8rem;
-  color: var(--ifm-color-emphasis-600);
-  text-decoration: none;
-  transition: color 0.15s;
-}
-
-.doc-sidebar-nav .toc-subsections a:hover {
-  color: var(--ifm-color-primary);
-}
-
 .doc-main {
-  flex: 1;
   min-width: 0;
-  max-width: 800px;
+  max-width: 960px;
+  width: 100%;
   margin: 0 auto;
   padding: 2rem 2.5rem;
 }
@@ -809,11 +874,160 @@ details > :last-child {
 }
 
 /* ==========================================================================
-   Responsive
+   Breadcrumb (F3)
+   --------------------------------------------------------------------------
+   Sits above the chapter content, below the page-header-bar. The "›"
+   separators are CSS pseudo-elements so the structural HTML stays
+   semantic (an ol of li segments) and translates cleanly.
    ========================================================================== */
+.breadcrumb {
+  margin: 0 0 1rem 0;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.breadcrumb__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.5rem;
+  align-items: center;
+}
+
+.breadcrumb__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.breadcrumb__item + .breadcrumb__item::before {
+  /* Note: NOT a > glyph (which would conflict with HTML escaping in some
+     reading-mode tools). U+203A SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+     reads naturally in all four supported languages. */
+  content: "›";
+  color: var(--ifm-color-emphasis-500);
+}
+
+.breadcrumb__link {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.breadcrumb__link:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb__item--current {
+  color: var(--ifm-color-emphasis-900);
+  font-weight: 600;
+}
+
+.breadcrumb__item--category {
+  /* Category is non-navigable (no per-category landing page), so render as
+     plain text rather than implying it's a link. */
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* ==========================================================================
+   Right-rail "On this page" TOC (F3)
+   --------------------------------------------------------------------------
+   Sticky aside in the third grid column on desktop. IntersectionObserver
+   scroll-spy adds .is-active to the link whose section is in view.
+   ========================================================================== */
+.doc-toc {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 2rem 1rem 2rem 1.5rem;
+  font-size: 0.85rem;
+  border-left: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.doc-toc[data-empty="true"] .doc-toc__heading,
+.doc-toc[data-empty="true"] .doc-toc__list {
+  /* Hide the heading when there is nothing to list. We still render the
+     aside element (preserves grid column width) so layout does not shift
+     between pages with and without TOC entries. */
+  display: none;
+}
+
+.doc-toc__heading {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 0.75rem;
+}
+
+.doc-toc__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-left: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.doc-toc__item {
+  margin: 0;
+}
+
+.doc-toc__item--h3 {
+  /* Sub-items rendered with extra left padding so the visual hierarchy
+     mirrors the heading levels they reference. */
+  padding-left: 0.75rem;
+}
+
+.doc-toc__link {
+  display: block;
+  padding: 0.25rem 0.75rem;
+  margin-left: -1px;
+  border-left: 2px solid transparent;
+  color: var(--ifm-color-emphasis-700);
+  text-decoration: none;
+  line-height: 1.35;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.doc-toc__link:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.doc-toc__link.is-active {
+  color: var(--ifm-color-primary);
+  border-left-color: var(--ifm-color-primary);
+  background: rgba(53, 120, 229, 0.06);
+}
+
+/* ==========================================================================
+   Responsive
+   --------------------------------------------------------------------------
+   Two breakpoints:
+     - 1100px: drop the right-rail TOC. Its content is still anchor-
+       reachable from inline headings; on a narrow viewport the prose
+       column needs the room more than the rail does. The rail HTML stays
+       in place (we don't move it inline; that would require JS) — it just
+       isn't displayed.
+     - 768px: collapse the sidebar to a top strip and let the page flow
+       in a single column.
+   ========================================================================== */
+@media (max-width: 1100px) {
+  .doc-page {
+    grid-template-columns: var(--doc-sidebar-width) minmax(0, 1fr);
+  }
+  .doc-toc {
+    display: none;
+  }
+}
+
 @media (max-width: 768px) {
   .doc-page {
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
   .doc-sidebar {
     position: static;
@@ -836,6 +1050,9 @@ details > :last-child {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
+  }
+  .breadcrumb {
+    font-size: 0.8rem;
   }
 }
 `;

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -1,12 +1,29 @@
 /**
  * Multi-page HTML builder for static website generation.
  * Generates individual HTML pages from processed chapters with sidebar navigation.
+ *
+ * F3 layout (this file owns the page template):
+ *
+ *   <body>
+ *     <div class="doc-page">                    ← CSS grid: sidebar | main | rail
+ *       <aside class="doc-sidebar">             ← collapsible category groups
+ *       <main class="doc-main">
+ *         <header class="page-header-bar">      ← language switcher (F1) + future
+ *         <nav class="breadcrumb">              ← Home › Category › Title (F3)
+ *         <section class="chapter">             ← markdown body
+ *         <div class="page-footer">             ← edit-this-page + prev/next
+ *       <aside class="doc-toc">                 ← right-rail "On this page" (F3)
+ *
+ * The right-rail TOC and breadcrumb together replace the legacy
+ * sidebar-embedded H2 list.
  */
 
 import type { Chapter } from "./markdown-processor.js";
+import type { NavGroup, NavItem } from "./book-config.js";
 import type { ResolvedDocConfig } from "./config.js";
 import { WEBSITE_LABELS } from "./config.js";
 import { escapeHtml } from "./markdown-extensions.js";
+import { slugify } from "./markdown-processor.js";
 import {
   buildJsonLd,
   buildOgTags,
@@ -39,6 +56,20 @@ export interface WebPageContext {
    * marked `available: false`.
    */
   peers: LanguagePeer[];
+  /**
+   * F3 grouped navigation for the current language. Always present — even
+   * legacy flat configs are wrapped in a single anonymous-category group
+   * by the loader. Sidebar render walks this directly so groups stay in
+   * authored order.
+   */
+  navGroups: NavGroup[];
+  /**
+   * F3 category for the current chapter (the group that contains it).
+   * Empty string when the page falls into the synthetic uncategorized
+   * group (legacy flat configs) — breadcrumb omits the middle segment in
+   * that case.
+   */
+  category: string;
   /**
    * Versioned-docs context (F6). Optional — only set when the build is
    * running in versioned mode (`versions` declared in config). Drives
@@ -167,6 +198,8 @@ export interface PageAssets {
   search: string;
   /** Hashed `code-copy.js` filename. Optional — added by F4. */
   codeCopy?: string;
+  /** Hashed `toc-scrollspy.js` filename. Optional — added by F3. */
+  tocScrollspy?: string;
   /** Site-root favicon filename, e.g. `favicon.ico`. */
   favicon?: string;
   /** Site-root apple-touch-icon filename, e.g. `apple-touch-icon.png`. */
@@ -177,39 +210,81 @@ export interface PageAssets {
 
 /**
  * Build sidebar HTML for a multi-page website.
- * Current page is highlighted, subsections shown only for active page.
+ *
+ * F3 — categories render as `<details>` drawers (CSS-only, no runtime JS).
+ * The active page's category is `<details open>` so it shows on first load;
+ * other categories are collapsed by default. The synthetic anonymous group
+ * (legacy flat input) renders as a flat list with no drawer wrapper, so a
+ * config that hasn't migrated to grouped form looks identical to F1.
  */
 function buildWebsiteSidebar(
   chapters: Chapter[],
   currentIndex: number,
   metadata: WebsiteMetadata,
   config: ResolvedDocConfig,
+  navGroups: NavGroup[],
 ): string {
   const langLabel = config.languageLabels[metadata.lang] || metadata.lang;
 
-  const navItems = chapters
-    .map((chapter, index) => {
-      const num = index + 1;
-      const isActive = index === currentIndex;
-      const href = `./${chapter.slug}.html`;
-      const activeClass = isActive ? ' class="active"' : "";
+  // Build a map of nav.path -> index in `chapters` so we can render the
+  // group's items in `book.config.yaml` order while still highlighting the
+  // active one (which is identified by index, not by path/title).
+  const indexByPath = new Map<string, number>();
+  // The chapter index sequence matches the flattened nav order produced by
+  // `loadBookConfig`, but path may not be on the Chapter (it's derived
+  // from nav). Walk navGroups + a mirror counter so we know each item's
+  // global index.
+  let counter = 0;
+  for (const group of navGroups) {
+    for (const item of group.items) {
+      indexByPath.set(item.path, counter);
+      counter++;
+    }
+  }
 
-      let subsectionHtml = "";
-      if (isActive) {
-        const subsections = chapter.headings.filter((h) => h.level === 2);
-        if (subsections.length > 0) {
-          const subItems = subsections
-            .map(
-              (h) =>
-                `<li><a href="#${encodeURIComponent(h.id)}">${escapeHtml(h.text)}</a></li>`,
-            )
-            .join("\n");
-          subsectionHtml = `<ul class="toc-subsections">${subItems}</ul>`;
-        }
-      }
+  const renderItem = (item: NavItem, globalIndex: number): string => {
+    const num = globalIndex + 1;
+    const chapter = chapters[globalIndex];
+    if (!chapter) {
+      // Defensive fallback: chapter array length and nav length should
+      // always match because both are derived from the same flattened
+      // navigation. If they don't, render a plain text entry rather than
+      // throwing — keeps the build alive while the mismatch is debugged.
+      return `<li><span>${num}. ${escapeHtml(item.title)}</span></li>`;
+    }
+    const isActive = globalIndex === currentIndex;
+    const href = `./${chapter.slug}.html`;
+    const activeClass = isActive ? ' class="active" aria-current="page"' : "";
+    return `<li><a href="${href}"${activeClass}>${num}. ${escapeHtml(chapter.title)}</a></li>`;
+  };
 
-      return `<li><a href="${href}"${activeClass}>${num}. ${escapeHtml(chapter.title)}</a>${subsectionHtml}</li>`;
-    })
+  const renderGroup = (group: NavGroup, isAnonymous: boolean): string => {
+    const itemsHtml = group.items
+      .map((item) => renderItem(item, indexByPath.get(item.path) ?? -1))
+      .join("\n");
+
+    if (isAnonymous) {
+      // Legacy flat config — no `<details>` drawer, just a flat list.
+      return `<ul class="doc-sidebar-nav">${itemsHtml}</ul>`;
+    }
+
+    const containsActive = group.items.some(
+      (item) => indexByPath.get(item.path) === currentIndex,
+    );
+    const openAttr = containsActive ? " open" : "";
+    const groupSlug = slugify(group.category) || "group";
+    return `<details class="doc-sidebar-group"${openAttr}>
+  <summary class="doc-sidebar-group__summary">${escapeHtml(group.category)}</summary>
+  <ul class="doc-sidebar-nav doc-sidebar-nav--grouped" data-group="${escapeHtml(groupSlug)}">
+    ${itemsHtml}
+  </ul>
+</details>`;
+  };
+
+  const isLegacyFlat =
+    navGroups.length === 1 && navGroups[0].category === "";
+  const groupsHtml = navGroups
+    .map((g) => renderGroup(g, isLegacyFlat))
     .join("\n");
 
   const searchLabels = WEBSITE_LABELS[metadata.lang] ?? WEBSITE_LABELS.en;
@@ -226,8 +301,79 @@ function buildWebsiteSidebar(
     <input type="text" id="search-input" placeholder="${placeholderAttr}" data-no-results="${noResultsAttr}" autocomplete="off" />
     <div id="search-results" class="search-results" hidden></div>
   </div>
-  <ul class="doc-sidebar-nav">
-    ${navItems}
+  <nav class="doc-sidebar-groups" aria-label="Documentation navigation">
+    ${groupsHtml}
+  </nav>
+</aside>`;
+}
+
+/**
+ * Build the breadcrumb trail (F3): `Home › Category › Page Title`. When the
+ * page belongs to the synthetic uncategorized group, the middle segment is
+ * dropped — `Home › Page Title`. Each segment except the last is a link.
+ *
+ * "Home" links to the language's `index.html` (the per-language landing
+ * page). It is intentionally not a cross-language site root link — the
+ * language picker at `dist/web/index.html` is reachable via the language
+ * switcher in the page header.
+ */
+function buildBreadcrumb(chapter: Chapter, category: string, lang: string): string {
+  const labels = WEBSITE_LABELS[lang] ?? WEBSITE_LABELS.en;
+  const homeLabel = labels.home ?? "Home";
+  const segments: string[] = [
+    `<li class="breadcrumb__item"><a class="breadcrumb__link" href="./index.html">${escapeHtml(homeLabel)}</a></li>`,
+  ];
+  if (category) {
+    // Category is not a navigable destination on its own (no per-category
+    // landing page), so render it as plain text rather than a stub link.
+    segments.push(
+      `<li class="breadcrumb__item breadcrumb__item--category">${escapeHtml(category)}</li>`,
+    );
+  }
+  segments.push(
+    `<li class="breadcrumb__item breadcrumb__item--current" aria-current="page">${escapeHtml(chapter.title)}</li>`,
+  );
+  return `<nav class="breadcrumb" aria-label="Breadcrumb">
+  <ol class="breadcrumb__list">
+    ${segments.join("\n    ")}
+  </ol>
+</nav>`;
+}
+
+/**
+ * Build the right-rail "On this page" TOC (F3). Lists H2 + H3 only — H4+
+ * are excluded to keep the rail short on long chapters. Anchors are the
+ * heading IDs already produced by the markdown pipeline.
+ *
+ * The list is plain `<a>` links; the scroll-spy script (toc-scrollspy.js)
+ * adds a `.is-active` class to the link whose section is currently in
+ * view. When there are no H2 headings, the rail renders empty so the
+ * layout grid column doesn't shift between pages.
+ */
+function buildRightRailToc(chapter: Chapter, lang: string): string {
+  const labels = WEBSITE_LABELS[lang] ?? WEBSITE_LABELS.en;
+  const heading = labels.onThisPage ?? "On this page";
+  const items = chapter.headings.filter(
+    (h) => h.level === 2 || h.level === 3,
+  );
+  if (items.length === 0) {
+    // Render the aside container even when empty so the grid column has a
+    // stable layout; CSS hides the heading when the list is empty.
+    return `<aside class="doc-toc" aria-labelledby="doc-toc-heading" data-empty="true">
+  <div class="doc-toc__heading" id="doc-toc-heading">${escapeHtml(heading)}</div>
+  <ul class="doc-toc__list"></ul>
+</aside>`;
+  }
+  const listItems = items
+    .map(
+      (h) =>
+        `<li class="doc-toc__item doc-toc__item--h${h.level}"><a class="doc-toc__link" href="#${encodeURIComponent(h.id)}" data-toc-target="${escapeHtml(h.id)}">${escapeHtml(h.text)}</a></li>`,
+    )
+    .join("\n      ");
+  return `<aside class="doc-toc" aria-labelledby="doc-toc-heading">
+  <div class="doc-toc__heading" id="doc-toc-heading">${escapeHtml(heading)}</div>
+  <ul class="doc-toc__list">
+      ${listItems}
   </ul>
 </aside>`;
 }
@@ -589,6 +735,18 @@ function buildVersionSwitcher(context: WebPageContext): string {
 }
 
 /**
+ * Build the right-rail TOC scroll-spy script tag (F3). The script uses
+ * IntersectionObserver to track which heading section is currently in
+ * view, then toggles the matching `.doc-toc__link` to `.is-active`.
+ * Skipped when there is no TOC (chapter has no H2 headings) — in that
+ * case the rail is rendered empty and the script is a no-op anyway.
+ */
+function buildTocScrollspyScriptTag(assets: PageAssets): string {
+  if (!assets.tocScrollspy) return "";
+  return `<script defer src="../assets/${escapeHtml(assets.tocScrollspy)}"></script>`;
+}
+
+/**
  * Augment every `<img …>` tag with `loading="lazy"`, `decoding="async"`, and
  * (when supplied) `width`/`height` attributes from `dimensions`. Any pre-
  * existing attributes on the tag are preserved. Tags that already declare
@@ -631,6 +789,11 @@ export function applyImageAttributes(
  * controls into the same `<header class="page-header-bar">`; the
  * `<nav class="page-header-nav">` slots them as siblings of the language
  * switcher so they can extend without reflowing the layout.
+ *
+ * F3 deliberately does NOT put the breadcrumb in this header bar — the
+ * spec calls for a breadcrumb "above the chapter content", and keeping
+ * the header reserved for site-level controls (lang switcher, future
+ * version selector) avoids a tight coupling with F6's incoming UI.
  */
 function buildPageHeader(
   metadata: WebsiteMetadata,
@@ -677,6 +840,8 @@ export function buildWebPage(context: WebPageContext): string {
     config,
     assets,
     peers,
+    navGroups,
+    category,
   } = context;
 
   const prefix = rootPrefix(context);
@@ -686,9 +851,12 @@ export function buildWebPage(context: WebPageContext): string {
     currentIndex,
     metadata,
     config,
+    navGroups,
   );
   const pageHeader = buildPageHeader(metadata, peers);
+  const breadcrumb = buildBreadcrumb(chapter, category, metadata.lang);
   const innerContent = buildPageContent(chapter);
+  const rightRailToc = buildRightRailToc(chapter, metadata.lang);
   const metadataBar = buildPageMetadata(context);
   const pagination = buildPaginationNav(
     allChapters,
@@ -711,6 +879,7 @@ export function buildWebPage(context: WebPageContext): string {
   const headerBar = buildPageHeaderBar(context);
   const searchScript = buildSearchScriptTag(assets, prefix);
   const codeCopyScript = buildCodeCopyScriptTag(assets, prefix);
+  const tocScrollspyScript = buildTocScrollspyScriptTag(assets);
 
   return `<!DOCTYPE html>
 <html lang="${escapeHtml(metadata.lang)}">
@@ -723,15 +892,18 @@ ${headerBar}
   ${sidebar}
   <main class="doc-main">
     ${pageHeader}
+    ${breadcrumb}
     ${innerContent}
     <div class="page-footer">
       ${metadataBar}
       ${pagination}
     </div>
   </main>
+  ${rightRailToc}
 </div>
 ${searchScript}
 ${codeCopyScript}
+${tocScrollspyScript}
 </body>
 </html>`;
 }

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -35,7 +35,11 @@ import {
 import { canonicalPathFor } from "./versions.js";
 import { generateWebsiteStyles } from "./styles-web.js";
 import { getDocVersion } from "./version.js";
-import { loadBookConfig, type NormalizedBookConfig } from "./book-config.js";
+import {
+  loadBookConfig,
+  type NavGroup,
+  type NormalizedBookConfig,
+} from "./book-config.js";
 import type { ResolvedDocConfig } from "./config.js";
 import { writeHashedAsset, type AssetManifest } from "./asset-hasher.js";
 import { readImageDimensions } from "./image-meta.js";
@@ -306,6 +310,28 @@ export async function generateWebsite(
     console.log(`Written: assets/${codeCopyName}`);
   }
 
+  // Right-rail TOC scroll-spy (F3). Tiny IntersectionObserver script —
+  // shipped only when the file exists in templates so a toolkit install
+  // without F3 still builds. Page builder also no-ops when the asset is
+  // absent, so this is safe regardless.
+  const tocScrollspyPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "templates",
+    "assets",
+    "toc-scrollspy.js",
+  );
+  if (fs.existsSync(tocScrollspyPath)) {
+    const bytes = fs.readFileSync(tocScrollspyPath);
+    const tocScrollspyName = writeHashedAsset(
+      assetsDir,
+      "toc-scrollspy.js",
+      bytes,
+      assetManifest,
+    );
+    console.log(`Written: assets/${tocScrollspyName}`);
+  }
+
   // Site-root brand assets (favicon, apple-touch-icon, site.webmanifest).
   // These live at `dist/web/` (not under `assets/`) so absolute references
   // like `/favicon.ico` work for any deployment layout.
@@ -325,6 +351,7 @@ export async function generateWebsite(
     styles: assetManifest["styles.css"],
     search: assetManifest["search.js"],
     codeCopy: assetManifest["code-copy.js"],
+    tocScrollspy: assetManifest["toc-scrollspy.js"],
     favicon: rootAssets.favicon,
     appleTouchIcon: rootAssets.appleTouchIcon,
     webmanifest: rootAssets.webmanifest,
@@ -634,6 +661,19 @@ async function buildLanguage(args: {
   const availableLanguages = bookConfig.languages;
   const metadata: WebsiteMetadata = { title, version, lang, availableLanguages };
 
+  // F3: nav groups for the current language. Always present — even legacy
+  // flat configs are wrapped in a single anonymous-category group by the
+  // loader. Build a path → category map once so per-page breadcrumb
+  // resolution is O(1). Empty-string category (anonymous group) means
+  // the breadcrumb omits the middle segment for that page.
+  const navGroups: NavGroup[] = bookConfig.navigationGroups[lang] ?? [];
+  const categoryByPath = new Map<string, string>();
+  for (const group of navGroups) {
+    for (const item of group.items) {
+      categoryByPath.set(item.path, group.category);
+    }
+  }
+
   // Per-language nav-path -> slug index. The language switcher (F1) maps
   // `quickstart.md` (path) in the current language to the same path in
   // every peer language, then resolves the peer's localized slug for the
@@ -764,6 +804,13 @@ async function buildLanguage(args: {
       };
     });
 
+    // F3: resolve the page's category from the path (set when navGroups
+    // were normalized). Empty string for legacy flat configs — the
+    // breadcrumb renders without a middle segment in that case.
+    const category = navEntry
+      ? categoryByPath.get(navEntry.path) ?? ""
+      : "";
+
     let pageHtml = buildWebPage({
       chapter: chapters[i],
       allChapters: chapters,
@@ -774,6 +821,8 @@ async function buildLanguage(args: {
       lastUpdated: lastDate ? formatDate(lastDate, lang) : undefined,
       assets: pageAssets,
       peers,
+      navGroups,
+      category,
       versionContext,
       seo,
     });

--- a/packages/backend.ai-docs-toolkit/templates/assets/toc-scrollspy.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/toc-scrollspy.js
@@ -1,0 +1,120 @@
+/**
+ * Right-rail "On this page" TOC scroll-spy (F3).
+ *
+ * Tracks which heading section is currently in view and toggles
+ * `.is-active` on the matching `.doc-toc__link`. Pure DOM + native
+ * IntersectionObserver — no library, no fetch, no eval. Air-gapped safe.
+ *
+ * The script is content-hashed by the generator's asset pipeline; it ships
+ * once per build and is referenced from every page that has a TOC. Pages
+ * without TOC entries render `data-empty="true"` on the rail; the script
+ * still runs (cheaply) but finds no targets and exits.
+ *
+ * Strategy:
+ *   1. Resolve every `.doc-toc__link` and look up its target heading by
+ *      `data-toc-target` (the heading's `id`).
+ *   2. Single IntersectionObserver tracks all of them at once. The active
+ *      heading is the LAST observed entry whose top has crossed the
+ *      "spy line" 25% from the viewport top — this matches the user's
+ *      reading position better than picking the topmost intersecting
+ *      heading.
+ *   3. On hash navigation (clicking a TOC link) we bypass the observer
+ *      briefly so the active state matches the click immediately, even
+ *      before the scroll settles.
+ *
+ * Size budget: target ≤ 1 KB minified.
+ */
+(function () {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  if (!("IntersectionObserver" in window)) return;
+
+  function init() {
+    var toc = document.querySelector(".doc-toc");
+    if (!toc) return;
+    var links = toc.querySelectorAll(".doc-toc__link");
+    if (!links.length) return;
+
+    var linkByTarget = Object.create(null);
+    var headings = [];
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i];
+      var targetId = link.getAttribute("data-toc-target");
+      if (!targetId) continue;
+      var heading = document.getElementById(targetId);
+      if (!heading) continue;
+      linkByTarget[targetId] = link;
+      headings.push(heading);
+    }
+    if (!headings.length) return;
+
+    var activeLink = null;
+    function setActive(link) {
+      if (link === activeLink) return;
+      if (activeLink) activeLink.classList.remove("is-active");
+      activeLink = link;
+      if (link) link.classList.add("is-active");
+    }
+
+    // visible[id] = true while the heading is intersecting the spy band.
+    // We pick the topmost visible heading on each callback firing.
+    var visible = Object.create(null);
+
+    var observer = new IntersectionObserver(
+      function (entries) {
+        for (var i = 0; i < entries.length; i++) {
+          var entry = entries[i];
+          var id = entry.target.id;
+          if (!id) continue;
+          if (entry.isIntersecting) visible[id] = true;
+          else delete visible[id];
+        }
+        // Walk headings in document order, pick the last intersecting one
+        // before the first non-intersecting heading below the spy band.
+        // This makes the active state track the section the user is most
+        // likely reading, not the section that just scrolled out at the top.
+        var current = null;
+        for (var j = 0; j < headings.length; j++) {
+          if (visible[headings[j].id]) current = headings[j].id;
+        }
+        // Fallback: when nothing is in the spy band (e.g. between two
+        // sections), pick the last heading whose top is above the spy line.
+        if (!current) {
+          var spyLine = window.innerHeight * 0.25;
+          for (var k = 0; k < headings.length; k++) {
+            var rect = headings[k].getBoundingClientRect();
+            if (rect.top <= spyLine) current = headings[k].id;
+          }
+        }
+        if (current) setActive(linkByTarget[current]);
+      },
+      {
+        // Spy band: top 25% to 75% of the viewport. Headings entering this
+        // band are considered "currently being read".
+        rootMargin: "-25% 0px -75% 0px",
+        threshold: 0,
+      },
+    );
+
+    for (var n = 0; n < headings.length; n++) observer.observe(headings[n]);
+
+    // Sync immediately on link click — the observer can lag behind on
+    // hash navigation because the smooth-scroll animation hasn't started
+    // crossing thresholds yet. This keeps the active state responsive.
+    toc.addEventListener("click", function (e) {
+      var t = e.target;
+      while (t && t !== toc) {
+        if (t.classList && t.classList.contains("doc-toc__link")) {
+          setActive(t);
+          return;
+        }
+        t = t.parentNode;
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/packages/backend.ai-webui-docs/src/book.config.yaml
+++ b/packages/backend.ai-webui-docs/src/book.config.yaml
@@ -9,240 +9,303 @@ languages:
   - ja
   - ko
   - th
+# F3 — Information architecture
+# ----------------------------------------------------------------------------
+# `navigation` per language uses the F3 grouped form:
+#
+#   - category: <localized category label>
+#     items:
+#       - { title: <chapter title>, path: <markdown path> }
+#
+# The legacy flat form (a list of `{title, path}` directly under each
+# language) is still accepted by `loadBookConfig`. Pages within a group
+# render in the listed order; group ordering is preserved when flattened
+# for the PDF pipeline. The 5 categories below were chosen to balance
+# bucket sizes (4-9 chapters each) and follow a typical reader's journey:
+# learn the product (Getting Started) → use it (Workloads → Storage & Data) →
+# administer it (Administration) → look up reference material (Reference).
+#
+# Reordering note: The flat order produced by flattening these groups
+# differs slightly from the legacy book.config.yaml ordering — chapters
+# now group with their thematic siblings (e.g. Cluster Session moves
+# next to other Workloads chapters; SFTP-to-container moves into Storage &
+# Data). The PDF pipeline reads the flattened list, so the PDF chapter
+# order will match the new grouped sequence.
+# ----------------------------------------------------------------------------
 navigation:
   en:
-    - title: Quickstart
-      path: quickstart.md
-    - title: Disclaimer
-      path: disclaimer.md
-    - title: Overview
-      path: overview/overview.md
-    - title: Installation
-      path: installation/installation.md
-    - title: Login
-      path: login/login.md
-    - title: Header
-      path: header/header.md
-    - title: Start
-      path: start/start.md
-    - title: Dashboard
-      path: dashboard/dashboard.md
-    - title: Summary
-      path: summary/summary.md
-    - title: Vfolder
-      path: vfolder/vfolder.md
-    - title: Session Page
-      path: session_page/session_page.md
-    - title: Sessions All
-      path: sessions_all/sessions_all.md
-    - title: Mount Vfolder
-      path: mount_vfolder/mount_vfolder.md
-    - title: Share Vfolder
-      path: share_vfolder/share_vfolder.md
-    - title: Model Serving
-      path: model_serving/model_serving.md
-    - title: Chat
-      path: chat/chat.md
-    - title: Import Run
-      path: import_run/import_run.md
-    - title: My Environments
-      path: my_environments/my_environments.md
-    - title: Agent Summary
-      path: agent_summary/agent_summary.md
-    - title: Statistics
-      path: statistics/statistics.md
-    - title: Sftp To Container
-      path: sftp_to_container/sftp_to_container.md
-    - title: User Settings
-      path: user_settings/user_settings.md
-    - title: Cluster Session
-      path: cluster_session/cluster_session.md
-    - title: RBAC Management
-      path: rbac_management/rbac_management.md
-    - title: Admin Menu
-      path: admin_menu/admin_menu.md
-    - title: Trouble Shooting
-      path: trouble_shooting/trouble_shooting.md
-    - title: Appendix
-      path: appendix/appendix.md
-    - title: License Agreement
-      path: license_agreement/license_agreement.md
-    - title: References
-      path: references/references.md
+    - category: Getting Started
+      items:
+        - title: Quickstart
+          path: quickstart.md
+        - title: Disclaimer
+          path: disclaimer.md
+        - title: Overview
+          path: overview/overview.md
+        - title: Installation
+          path: installation/installation.md
+        - title: Login
+          path: login/login.md
+        - title: Header
+          path: header/header.md
+        - title: Start
+          path: start/start.md
+        - title: Dashboard
+          path: dashboard/dashboard.md
+        - title: Summary
+          path: summary/summary.md
+    - category: Workloads
+      items:
+        - title: Session Page
+          path: session_page/session_page.md
+        - title: Sessions All
+          path: sessions_all/sessions_all.md
+        - title: Cluster Session
+          path: cluster_session/cluster_session.md
+        - title: Model Serving
+          path: model_serving/model_serving.md
+        - title: Chat
+          path: chat/chat.md
+        - title: Import Run
+          path: import_run/import_run.md
+        - title: My Environments
+          path: my_environments/my_environments.md
+    - category: Storage & Data
+      items:
+        - title: Vfolder
+          path: vfolder/vfolder.md
+        - title: Mount Vfolder
+          path: mount_vfolder/mount_vfolder.md
+        - title: Share Vfolder
+          path: share_vfolder/share_vfolder.md
+        - title: Sftp To Container
+          path: sftp_to_container/sftp_to_container.md
+    - category: Administration
+      items:
+        - title: User Settings
+          path: user_settings/user_settings.md
+        - title: RBAC Management
+          path: rbac_management/rbac_management.md
+        - title: Admin Menu
+          path: admin_menu/admin_menu.md
+        - title: Agent Summary
+          path: agent_summary/agent_summary.md
+        - title: Statistics
+          path: statistics/statistics.md
+    - category: Reference
+      items:
+        - title: Trouble Shooting
+          path: trouble_shooting/trouble_shooting.md
+        - title: Appendix
+          path: appendix/appendix.md
+        - title: License Agreement
+          path: license_agreement/license_agreement.md
+        - title: References
+          path: references/references.md
   ja:
-    - title: クイックスタート
-      path: quickstart.md
-    - title: 免責事項
-      path: disclaimer.md
-    - title: 概要
-      path: overview/overview.md
-    - title: インストール
-      path: installation/installation.md
-    - title: ログイン
-      path: login/login.md
-    - title: ヘッダー
-      path: header/header.md
-    - title: スタート
-      path: start/start.md
-    - title: ダッシュボード
-      path: dashboard/dashboard.md
-    - title: サマリー
-      path: summary/summary.md
-    - title: ストレージフォルダ
-      path: vfolder/vfolder.md
-    - title: セッションページ
-      path: session_page/session_page.md
-    - title: 全セッション
-      path: sessions_all/sessions_all.md
-    - title: ストレージフォルダのマウント
-      path: mount_vfolder/mount_vfolder.md
-    - title: ストレージフォルダの共有
-      path: share_vfolder/share_vfolder.md
-    - title: モデルサービング
-      path: model_serving/model_serving.md
-    - title: チャット
-      path: chat/chat.md
-    - title: インポート＆実行
-      path: import_run/import_run.md
-    - title: マイ環境
-      path: my_environments/my_environments.md
-    - title: エージェントサマリー
-      path: agent_summary/agent_summary.md
-    - title: 統計
-      path: statistics/statistics.md
-    - title: コンピュートセッションへのSFTP接続
-      path: sftp_to_container/sftp_to_container.md
-    - title: ユーザー設定
-      path: user_settings/user_settings.md
-    - title: クラスターセッション
-      path: cluster_session/cluster_session.md
-    - title: RBAC管理
-      path: rbac_management/rbac_management.md
-    - title: 管理者メニュー
-      path: admin_menu/admin_menu.md
-    - title: FAQ＆トラブルシューティング
-      path: trouble_shooting/trouble_shooting.md
-    - title: 付録
-      path: appendix/appendix.md
-    - title: ライセンス契約
-      path: license_agreement/license_agreement.md
-    - title: 参考資料
-      path: references/references.md
+    - category: はじめに
+      items:
+        - title: クイックスタート
+          path: quickstart.md
+        - title: 免責事項
+          path: disclaimer.md
+        - title: 概要
+          path: overview/overview.md
+        - title: インストール
+          path: installation/installation.md
+        - title: ログイン
+          path: login/login.md
+        - title: ヘッダー
+          path: header/header.md
+        - title: スタート
+          path: start/start.md
+        - title: ダッシュボード
+          path: dashboard/dashboard.md
+        - title: サマリー
+          path: summary/summary.md
+    - category: ワークロード
+      items:
+        - title: セッションページ
+          path: session_page/session_page.md
+        - title: 全セッション
+          path: sessions_all/sessions_all.md
+        - title: クラスターセッション
+          path: cluster_session/cluster_session.md
+        - title: モデルサービング
+          path: model_serving/model_serving.md
+        - title: チャット
+          path: chat/chat.md
+        - title: インポート＆実行
+          path: import_run/import_run.md
+        - title: マイ環境
+          path: my_environments/my_environments.md
+    - category: ストレージとデータ
+      items:
+        - title: ストレージフォルダ
+          path: vfolder/vfolder.md
+        - title: ストレージフォルダのマウント
+          path: mount_vfolder/mount_vfolder.md
+        - title: ストレージフォルダの共有
+          path: share_vfolder/share_vfolder.md
+        - title: コンピュートセッションへのSFTP接続
+          path: sftp_to_container/sftp_to_container.md
+    - category: 管理
+      items:
+        - title: ユーザー設定
+          path: user_settings/user_settings.md
+        - title: RBAC管理
+          path: rbac_management/rbac_management.md
+        - title: 管理者メニュー
+          path: admin_menu/admin_menu.md
+        - title: エージェントサマリー
+          path: agent_summary/agent_summary.md
+        - title: 統計
+          path: statistics/statistics.md
+    - category: リファレンス
+      items:
+        - title: FAQ＆トラブルシューティング
+          path: trouble_shooting/trouble_shooting.md
+        - title: 付録
+          path: appendix/appendix.md
+        - title: ライセンス契約
+          path: license_agreement/license_agreement.md
+        - title: 参考資料
+          path: references/references.md
   ko:
-    - title: 빠른 시작
-      path: quickstart.md
-    - title: 면책 조항
-      path: disclaimer.md
-    - title: 개요
-      path: overview/overview.md
-    - title: 설치
-      path: installation/installation.md
-    - title: 로그인
-      path: login/login.md
-    - title: 헤더
-      path: header/header.md
-    - title: 시작 페이지
-      path: start/start.md
-    - title: 대시보드
-      path: dashboard/dashboard.md
-    - title: 요약
-      path: summary/summary.md
-    - title: 스토리지 폴더
-      path: vfolder/vfolder.md
-    - title: 세션 페이지
-      path: session_page/session_page.md
-    - title: 전체 세션
-      path: sessions_all/sessions_all.md
-    - title: 스토리지 폴더 마운트
-      path: mount_vfolder/mount_vfolder.md
-    - title: 스토리지 폴더 공유
-      path: share_vfolder/share_vfolder.md
-    - title: 모델 서빙
-      path: model_serving/model_serving.md
-    - title: 채팅
-      path: chat/chat.md
-    - title: 가져오기 및 실행
-      path: import_run/import_run.md
-    - title: 내 환경
-      path: my_environments/my_environments.md
-    - title: 에이전트 요약
-      path: agent_summary/agent_summary.md
-    - title: 통계
-      path: statistics/statistics.md
-    - title: 연산 세션에 대한 SFTP 연결
-      path: sftp_to_container/sftp_to_container.md
-    - title: 사용자 설정
-      path: user_settings/user_settings.md
-    - title: 클러스터 세션
-      path: cluster_session/cluster_session.md
-    - title: RBAC 관리
-      path: rbac_management/rbac_management.md
-    - title: 관리자 메뉴
-      path: admin_menu/admin_menu.md
-    - title: FAQ 및 문제 해결
-      path: trouble_shooting/trouble_shooting.md
-    - title: 부록
-      path: appendix/appendix.md
-    - title: 사용권 계약 조건
-      path: license_agreement/license_agreement.md
-    - title: 참고 자료
-      path: references/references.md
+    - category: 시작하기
+      items:
+        - title: 빠른 시작
+          path: quickstart.md
+        - title: 면책 조항
+          path: disclaimer.md
+        - title: 개요
+          path: overview/overview.md
+        - title: 설치
+          path: installation/installation.md
+        - title: 로그인
+          path: login/login.md
+        - title: 헤더
+          path: header/header.md
+        - title: 시작 페이지
+          path: start/start.md
+        - title: 대시보드
+          path: dashboard/dashboard.md
+        - title: 요약
+          path: summary/summary.md
+    - category: 워크로드
+      items:
+        - title: 세션 페이지
+          path: session_page/session_page.md
+        - title: 전체 세션
+          path: sessions_all/sessions_all.md
+        - title: 클러스터 세션
+          path: cluster_session/cluster_session.md
+        - title: 모델 서빙
+          path: model_serving/model_serving.md
+        - title: 채팅
+          path: chat/chat.md
+        - title: 가져오기 및 실행
+          path: import_run/import_run.md
+        - title: 내 환경
+          path: my_environments/my_environments.md
+    - category: 스토리지 및 데이터
+      items:
+        - title: 스토리지 폴더
+          path: vfolder/vfolder.md
+        - title: 스토리지 폴더 마운트
+          path: mount_vfolder/mount_vfolder.md
+        - title: 스토리지 폴더 공유
+          path: share_vfolder/share_vfolder.md
+        - title: 연산 세션에 대한 SFTP 연결
+          path: sftp_to_container/sftp_to_container.md
+    - category: 관리
+      items:
+        - title: 사용자 설정
+          path: user_settings/user_settings.md
+        - title: RBAC 관리
+          path: rbac_management/rbac_management.md
+        - title: 관리자 메뉴
+          path: admin_menu/admin_menu.md
+        - title: 에이전트 요약
+          path: agent_summary/agent_summary.md
+        - title: 통계
+          path: statistics/statistics.md
+    - category: 참고 자료
+      items:
+        - title: FAQ 및 문제 해결
+          path: trouble_shooting/trouble_shooting.md
+        - title: 부록
+          path: appendix/appendix.md
+        - title: 사용권 계약 조건
+          path: license_agreement/license_agreement.md
+        - title: 참고 자료
+          path: references/references.md
   th:
-    - title: เริ่มต้นอย่างรวดเร็ว
-      path: quickstart.md
-    - title: ข้อจำกัดความรับผิดชอบ
-      path: disclaimer.md
-    - title: ภาพรวม
-      path: overview/overview.md
-    - title: การติดตั้ง
-      path: installation/installation.md
-    - title: การเข้าสู่ระบบ
-      path: login/login.md
-    - title: ส่วนหัว
-      path: header/header.md
-    - title: เริ่มต้น
-      path: start/start.md
-    - title: แดชบอร์ด
-      path: dashboard/dashboard.md
-    - title: สรุป
-      path: summary/summary.md
-    - title: โฟลเดอร์จัดเก็บ
-      path: vfolder/vfolder.md
-    - title: หน้าเซสชัน
-      path: session_page/session_page.md
-    - title: เซสชันทั้งหมด
-      path: sessions_all/sessions_all.md
-    - title: การเมาท์โฟลเดอร์จัดเก็บ
-      path: mount_vfolder/mount_vfolder.md
-    - title: การแชร์โฟลเดอร์จัดเก็บ
-      path: share_vfolder/share_vfolder.md
-    - title: การให้บริการโมเดล
-      path: model_serving/model_serving.md
-    - title: แชท
-      path: chat/chat.md
-    - title: นำเข้าและรัน
-      path: import_run/import_run.md
-    - title: สภาพแวดล้อมของฉัน
-      path: my_environments/my_environments.md
-    - title: สรุปเอเจนต์
-      path: agent_summary/agent_summary.md
-    - title: สถิติ
-      path: statistics/statistics.md
-    - title: การเชื่อมต่อ SFTP ไปยังเซสชันการคำนวณ
-      path: sftp_to_container/sftp_to_container.md
-    - title: ตั้งค่าผู้ใช้
-      path: user_settings/user_settings.md
-    - title: เซสชันคลัสเตอร์
-      path: cluster_session/cluster_session.md
-    - title: การจัดการ RBAC
-      path: rbac_management/rbac_management.md
-    - title: เมนูผู้ดูแลระบบ
-      path: admin_menu/admin_menu.md
-    - title: FAQ และการแก้ไขปัญหา
-      path: trouble_shooting/trouble_shooting.md
-    - title: ภาคผนวก
-      path: appendix/appendix.md
-    - title: ข้อตกลงการอนุญาตใช้งาน
-      path: license_agreement/license_agreement.md
-    - title: อ้างอิง
-      path: references/references.md
+    - category: เริ่มต้นใช้งาน
+      items:
+        - title: เริ่มต้นอย่างรวดเร็ว
+          path: quickstart.md
+        - title: ข้อจำกัดความรับผิดชอบ
+          path: disclaimer.md
+        - title: ภาพรวม
+          path: overview/overview.md
+        - title: การติดตั้ง
+          path: installation/installation.md
+        - title: การเข้าสู่ระบบ
+          path: login/login.md
+        - title: ส่วนหัว
+          path: header/header.md
+        - title: เริ่มต้น
+          path: start/start.md
+        - title: แดชบอร์ด
+          path: dashboard/dashboard.md
+        - title: สรุป
+          path: summary/summary.md
+    - category: เวิร์กโหลด
+      items:
+        - title: หน้าเซสชัน
+          path: session_page/session_page.md
+        - title: เซสชันทั้งหมด
+          path: sessions_all/sessions_all.md
+        - title: เซสชันคลัสเตอร์
+          path: cluster_session/cluster_session.md
+        - title: การให้บริการโมเดล
+          path: model_serving/model_serving.md
+        - title: แชท
+          path: chat/chat.md
+        - title: นำเข้าและรัน
+          path: import_run/import_run.md
+        - title: สภาพแวดล้อมของฉัน
+          path: my_environments/my_environments.md
+    - category: พื้นที่จัดเก็บและข้อมูล
+      items:
+        - title: โฟลเดอร์จัดเก็บ
+          path: vfolder/vfolder.md
+        - title: การเมาท์โฟลเดอร์จัดเก็บ
+          path: mount_vfolder/mount_vfolder.md
+        - title: การแชร์โฟลเดอร์จัดเก็บ
+          path: share_vfolder/share_vfolder.md
+        - title: การเชื่อมต่อ SFTP ไปยังเซสชันการคำนวณ
+          path: sftp_to_container/sftp_to_container.md
+    - category: การดูแลระบบ
+      items:
+        - title: ตั้งค่าผู้ใช้
+          path: user_settings/user_settings.md
+        - title: การจัดการ RBAC
+          path: rbac_management/rbac_management.md
+        - title: เมนูผู้ดูแลระบบ
+          path: admin_menu/admin_menu.md
+        - title: สรุปเอเจนต์
+          path: agent_summary/agent_summary.md
+        - title: สถิติ
+          path: statistics/statistics.md
+    - category: เอกสารอ้างอิง
+      items:
+        - title: FAQ และการแก้ไขปัญหา
+          path: trouble_shooting/trouble_shooting.md
+        - title: ภาคผนวก
+          path: appendix/appendix.md
+        - title: ข้อตกลงการอนุญาตใช้งาน
+          path: license_agreement/license_agreement.md
+        - title: อ้างอิง
+          path: references/references.md


### PR DESCRIPTION
Resolves #7000 (FR-2715)

## Summary
F3 of FR-2710: information architecture overhaul.

- `book.config.yaml` `navigation` extended to accept `{ category, items }[]` groups (flat form still works)
- Sidebar renders collapsible category groups (CSS `<details>`); active group auto-expands on first load
- Right-rail "On this page" TOC (H2 + H3) with sticky positioning and IntersectionObserver scroll-spy
- Breadcrumb (`Home › Category › Page`) above each chapter
- H2 list moved out of sidebar into right rail
- Default 5-category mapping authored for all 29 chapters across 4 languages
- 3-column CSS grid layout; right-rail collapses below 1100px viewport, sidebar collapses below 768px

## Categories chosen (5)

1. **Getting Started** — Quickstart, Disclaimer, Overview, Installation, Login, Header, Start, Dashboard, Summary
2. **Workloads** — Session Page, Sessions All, Cluster Session, Model Serving, Chat, Import Run, My Environments
3. **Storage & Data** — Vfolder, Mount Vfolder, Share Vfolder, Sftp To Container
4. **Administration** — User Settings, RBAC Management, Admin Menu, Agent Summary, Statistics
5. **Reference** — Trouble Shooting, Appendix, License Agreement, References

5 categories chosen instead of the spec's proposed 4 because Reference material doesn't fit cleanly into Administration. Refine in code review if reviewers prefer different boundaries.

**Reordering note**: The flattened sequence (web sidebar order + PDF chapter order) differs slightly from the legacy book.config.yaml ordering — chapters now group with their thematic siblings (e.g. Cluster Session moves next to other Workloads chapters; SFTP-to-container moves into Storage & Data). The PDF pipeline reads the flattened list, so the PDF chapter order matches the new grouped sequence.

## Backward compatibility

The legacy flat `navigation: [NavItem, ...]` form is still accepted. `loadBookConfig` normalizes it into a single anonymous-category group so the sidebar renders as a flat list (no `<details>` drawer) and the breadcrumb renders without a middle category segment. Verified by temporarily reverting the docs config to F1's flat form and rebuilding `--lang en` cleanly.

## Cross-cutting verification

- [x] `pnpm run build:web` (all 4 langs) exits 0 with the new grouped schema
- [x] `pnpm run build:web --lang en` exits 0 with the legacy flat schema (backward compat smoke test)
- [x] `pnpm run pdf:en` exits 0 — 25.7 MB PDF renders cleanly with the grouped book config (chapter ordering reflects new grouped sequence; outline 142/142 sections resolved)
- [x] CJK PDF (ko/ja/th) — pre-existing break on parent commit (`WinAnsi cannot encode "目"` and similar). NOT regressed by this PR; not addressed here.
- [x] `bash scripts/verify.sh` → ALL PASS (Relay / Lint / Format / TypeScript)

## Implementation notes for F4 (which stacks on this PR)

The page template now has these new structural elements F4 should be aware of:

- `<header class="page-header-bar">` — F4's "Copy" toggle (if added) goes inside `<nav class="page-header-nav">` as a sibling of `.lang-switcher`.
- `<nav class="breadcrumb">` — sits between page header and chapter content. Don't repurpose this region.
- `<aside class="doc-toc">` — third grid column. Hidden below 1100px viewport. Inside it are `<a class="doc-toc__link" data-toc-target="...">` entries that the scroll-spy controls; F4 should not touch these.
- The page is now a 3-column CSS grid (`.doc-page { display: grid; grid-template-columns: var(--doc-sidebar-width) minmax(0, 1fr) var(--doc-toc-width); }`). If F4's Shiki output adds horizontal overflow, the `.doc-main` `min-width: 0` already lets the main column shrink — code blocks that overflow get a horizontal scroll inside the column, not push the layout.
- `PageAssets.tocScrollspy?` is a new optional asset slot in `WebPageContext.assets`. F4's `code-copy.js` slot (`assets.codeCopy`) is unchanged.
- New WEBSITE_LABELS keys: `home`, `onThisPage`, `tocToggle` — for any F4 string additions, follow the same per-language inline pattern in `config.ts`.

## Stack

- Spec PR: #6988 (merged)
- Dev plan: #7004
- F5: #7006
- F1: #7008
- This PR (F3): stacked on F1

## Test plan

- [x] Open any chapter page in any language → 5 collapsible groups in sidebar, active group expanded
- [x] Right-rail TOC renders with H2 + H3 entries; localized "On this page" heading per language
- [x] Breadcrumb renders `Home › Category › Title` with localized labels
- [x] Resize to 1100px → right-rail collapses; below 768px → sidebar becomes top strip
- [x] Backward compat: legacy flat `navigation` form still builds without code changes
- [x] PDF pipeline non-regression: `pnpm run pdf:en` exits 0; chapter outline reflects new grouped order

🤖 Generated with [Claude Code](https://claude.com/claude-code)