### PR TITLE
feat(FR-2716): F4 code-block syntax highlighting and copy button

### DIFF
--- a/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
+++ b/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
@@ -659,3 +659,86 @@ The PDF pipeline reads `bookConfig.navigation[lang]` (the flat list). Since the 
 - **CSS-only collapse** — sidebar groups use native `<details>`/`<summary>`; no runtime JS for collapse.
 - **PDF non-regression** — flat `navigation` shape preserved for the PDF pipeline; only the chapter ordering changes (intentionally).
 - **Backward compat** — flat `navigation` form still loads and renders identically to F1's sidebar.
+
+## F4 — Reading UX (code-block syntax highlighting + Copy button)
+
+F4 upgrades the web pipeline's code-block presentation:
+
+1. **Build-time syntax highlighting** via [Shiki](https://shiki.style) — Shiki tokenizes source with TextMate grammars and returns inline-styled `<span>` rows. Zero runtime highlight JS is shipped (no Prism, no highlight.js).
+2. A **Copy button** per code block, served as a tiny vanilla JS asset `templates/assets/code-copy.js`.
+
+### Shiki integration
+
+`src/shiki-highlighter.ts` is the only place the toolkit talks to Shiki. It exposes a single `highlight({ code, lang, theme })` API used by `markdown-processor-web.ts`.
+
+```text
+markdown-processor-web.ts
+  precomputeShikiBlocks(markdown, theme)         ← walks marked's lexer tokens
+    ↓ for each code token: shikiHighlight(...)
+    ↓ tokens cached in-memory: (theme, lang, sha1(code)) → innerHtml
+  buildWebRenderer({ highlightedCode })          ← sync renderer
+    ↓ code() looks up `${lang}|||${node.text}` → wraps in <pre><code>
+```
+
+**Why the pre-pass walks marked's lexer (not regex):** code blocks inside list items are dedented by marked's lexer before reaching the renderer. A regex over the raw markdown would store keys with the original indent, while the renderer looks up the dedented form — every list-nested code block would miss the cache. Walking the lexer guarantees the same `(lang, code)` tuple is used on both sides.
+
+**Cache scope:** the in-memory map persists for the duration of one Node process (one `build:web` invocation). Building all four languages in sequence reuses the cache, so a snippet that appears in `en/foo.md` and again in `ko/foo.md` tokenizes once. The cache is not persisted to disk — Shiki's tokenization is fast enough on second-run that an in-memory cache covers the spec's "build wall-clock per language ≤ +50%" budget; for the WebUI docs the all-langs build runs in ~4s end-to-end.
+
+**Defensive paths:** unknown languages render as plain `<span class="line">` rows (not highlighted, not error). Unknown themes warn once and fall back to `github-light`. Shiki errors during tokenization are caught and degrade to plain escaped text — never fail the build.
+
+### Theme configuration
+
+Operators control the syntax theme via `docs-toolkit.config.yaml`:
+
+```yaml
+code:
+  lightTheme: "github-light"   # default; any bundled Shiki theme works
+```
+
+Any [bundled Shiki theme](https://shiki.style/themes) is accepted (`github-light`, `vitesse-light`, `light-plus`, etc.). Unknown theme names warn once and fall back to `github-light`.
+
+**Reserved namespace — `code.darkTheme`:** intentionally NOT wired in F4. The spec scopes F4 to light-theme only; a future dark-mode bucket will introduce `code.darkTheme` paired with Shiki's dual-theme rendering (`themes: { light, dark }`). Adding the key now would commit us to a CSS-variables vs inline-style output format before that work has chosen one. The slot is reserved at the type level via a code comment in `src/config.ts` only.
+
+### Copy button (`templates/assets/code-copy.js`)
+
+A vanilla DOM script (no framework, no deps; ~5 KB unminified, well under the per-page 25 KB JS budget). On `DOMContentLoaded`:
+
+1. Wrap each `<pre><code>` in `.doc-code-block-wrapper` (idempotent).
+2. Inject a `.doc-code-copy-btn` button that reads `[data-copy-label]` etc. from `<body>` for localized strings.
+3. Click → `navigator.clipboard.writeText(<pre>.textContent)`. Falls back to a hidden-textarea + `document.execCommand("copy")` for non-secure-context previews.
+4. Flash "Copied!" / "Copy failed" states for 1.5s, then revert.
+
+Localized labels (`copy`, `copied`, `copyFailed`) live in `WEBSITE_LABELS` (`src/config.ts`) and are injected as `data-*` attributes on `<body>`, so the script itself stays language-agnostic and gets content-hashed once across every language.
+
+The script is automatically picked up by `website-generator.ts`'s asset pipeline (the slot was wired in F5) — drop the file at `templates/assets/code-copy.js` and the build hashes it and includes it via `PageAssets.codeCopy`.
+
+### CSS additions (`styles-web.ts`)
+
+- `.shiki-host > code .line { display: block }` — ensures Shiki's `.line` rows wrap correctly inside the `<pre>` frame instead of pushing it wider.
+- `.doc-code-block-wrapper` — positioning context for the absolutely-placed Copy button. The wrapper is invisible (no border / margin override).
+- `.doc-code-copy-btn` — top-right corner pill that fades in on hover/focus of the wrapper. Distinct color states: `idle` (default), `copied` (green tint), `failed` (red tint).
+
+### Files touched (F4)
+
+| File                                              | Role                                                                           |
+|---------------------------------------------------|--------------------------------------------------------------------------------|
+| `src/shiki-highlighter.ts` (new)                  | Lazy Shiki highlighter, in-memory `(theme, lang, sha1(code))` cache             |
+| `src/markdown-processor-web.ts`                   | `precomputeShikiBlocks()` pre-pass; renderer reads pre-rendered HTML            |
+| `src/config.ts`                                   | `CodeConfig` / `ResolvedCodeConfig` types; `code.lightTheme` default; copy labels in WEBSITE_LABELS |
+| `src/styles-web.ts`                               | `.shiki-host`, `.doc-code-block-wrapper`, `.doc-code-copy-btn` styles           |
+| `src/website-builder.ts`                          | `<body data-copy-label=…>` data attrs for the Copy script                       |
+| `src/index.ts`                                    | Re-exports for `highlightCode`, `CodeConfig`, `DEFAULT_CODE_LIGHT_THEME`        |
+| `templates/assets/code-copy.js` (new)             | Vanilla JS Copy button (no deps, no CDN)                                         |
+| `package.json`                                    | `shiki@1.29.2` runtime dependency                                                |
+
+### PDF pipeline non-regression (F4)
+
+F4 only touches `markdown-processor-web.ts`. The PDF pipeline (`markdown-processor.ts`) keeps its existing renderer — PDF code blocks remain unhighlighted (the spec does not require Shiki in PDFs). Verified by running `pnpm run pdf:en` on this commit (PDF generated successfully).
+
+### Constraints honoured (F4)
+
+- **Air-gapped** — Shiki bundles its grammars and themes as JSON inside the `shiki` npm package; no CDN, no network at build time. The Copy button uses `navigator.clipboard` (browser-native, no network).
+- **JS budget** — `code-copy.js` source is ~5 KB unminified, well under the per-page 25 KB budget. No runtime highlight JS is shipped (Shiki runs build-time only).
+- **Build wall-clock** — Shiki tokenization is amortized by the in-memory cache. The all-langs WebUI docs build runs in ~4s end-to-end (well within the "≤ +50% per language" budget).
+- **No dark-mode leakage** — F4 emits inline-styled spans for the configured light theme only. No `data-theme` attributes, no toggle UI, no `code.darkTheme` wiring (namespace reserved by comment only).
+- **Backward compat** — code blocks with `data-highlight="…"` (line-highlight feature) keep using the legacy `code-line.highlighted` renderer; mixing per-token Shiki colors with line-level overlays is left for a follow-up.

--- a/packages/backend.ai-docs-toolkit/package.json
+++ b/packages/backend.ai-docs-toolkit/package.json
@@ -46,6 +46,7 @@
     "handlebars": "^4.7.8",
     "marked": "^12.0.2",
     "pdf-lib": "^1.17.1",
+    "shiki": "1.29.2",
     "yaml": "^2.8.2"
   },
   "peerDependencies": {

--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -146,6 +146,26 @@ export interface VersionEntry {
   latest?: boolean;
 }
 
+/**
+ * Code-block presentation config (F4 — reading UX).
+ *
+ * `lightTheme` controls Shiki's light syntax theme used during build-time
+ * highlighting in the web pipeline. Any theme bundled with `shiki` is
+ * accepted (e.g. `github-light`, `vitesse-light`, `light-plus`). Unknown
+ * themes fall back to `github-light` with a warning.
+ *
+ * Reserved namespace — do not wire yet:
+ *   - `darkTheme`: a future dark-mode bucket will introduce this and pair
+ *     it with Shiki's dual-theme (`themes: { light, dark }`) rendering.
+ *     Adding the key here now would commit us to an output format before
+ *     that work has chosen one. Keep the slot reserved at the type level
+ *     only via this comment.
+ */
+export interface CodeConfig {
+  /** Shiki light theme name. Default: `'github-light'`. */
+  lightTheme?: string;
+}
+
 /** Full toolkit config file shape (docs-toolkit.config.yaml) */
 export interface ToolkitConfig extends DocConfig {
   agents?: AgentConfig;
@@ -162,6 +182,8 @@ export interface ToolkitConfig extends DocConfig {
    * `sitemap.xml` and `robots.txt` generation. See `OgConfig`.
    */
   og?: OgConfig;
+  /** Code-block presentation (Shiki theme, F4). */
+  code?: CodeConfig;
 }
 
 // ── Defaults ──────────────────────────────────────────────────
@@ -237,6 +259,9 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     home: "Home",
     onThisPage: "On this page",
     tocToggle: "On this page",
+    copy: "Copy",
+    copied: "Copied!",
+    copyFailed: "Copy failed",
   },
   ko: {
     previous: "이전",
@@ -248,6 +273,9 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     home: "홈",
     onThisPage: "이 페이지의 목차",
     tocToggle: "이 페이지의 목차",
+    copy: "복사",
+    copied: "복사됨!",
+    copyFailed: "복사 실패",
   },
   ja: {
     previous: "前へ",
@@ -259,6 +287,9 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     home: "ホーム",
     onThisPage: "このページの目次",
     tocToggle: "このページの目次",
+    copy: "コピー",
+    copied: "コピーしました!",
+    copyFailed: "コピーに失敗しました",
   },
   th: {
     previous: "ก่อนหน้า",
@@ -270,6 +301,9 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     home: "หน้าแรก",
     onThisPage: "หัวข้อในหน้านี้",
     tocToggle: "หัวข้อในหน้านี้",
+    copy: "คัดลอก",
+    copied: "คัดลอกแล้ว!",
+    copyFailed: "คัดลอกไม่สำเร็จ",
   },
 };
 
@@ -318,7 +352,20 @@ export interface ResolvedDocConfig {
    * SEO tag emitter, sitemap, and OG image renderer.
    */
   og?: OgConfig;
+  /**
+   * Resolved code-block presentation. Always populated (defaults applied)
+   * so downstream consumers don't have to null-check.
+   */
+  code: ResolvedCodeConfig;
 }
+
+/** Resolved code-block config — all defaults applied. */
+export interface ResolvedCodeConfig {
+  lightTheme: string;
+}
+
+/** Default Shiki light theme — readable, neutral, ships with shiki/themes. */
+export const DEFAULT_CODE_LIGHT_THEME = "github-light";
 
 export function resolveConfig(config: ToolkitConfig): ResolvedDocConfig {
   const projectRoot = config.projectRoot;
@@ -370,6 +417,9 @@ export function resolveConfig(config: ToolkitConfig): ResolvedDocConfig {
     website: config.website,
     versions: config.versions,
     og: config.og,
+    code: {
+      lightTheme: config.code?.lightTheme ?? DEFAULT_CODE_LIGHT_THEME,
+    },
   };
 }
 

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -11,13 +11,27 @@ export type {
   DocConfig,
   AgentConfig,
   WebsiteConfig,
+  CodeConfig,
   ToolkitConfig,
   ResolvedDocConfig,
   VersionEntry,
   VersionSource,
   OgConfig,
+  ResolvedCodeConfig,
 } from "./config.js";
-export { resolveConfig, loadToolkitConfig, WEBSITE_LABELS } from "./config.js";
+export {
+  resolveConfig,
+  loadToolkitConfig,
+  WEBSITE_LABELS,
+  DEFAULT_CODE_LIGHT_THEME,
+} from "./config.js";
+
+// ── Shiki Code Highlighting (F4) ────────────────────────────────
+export { highlight as highlightCode } from "./shiki-highlighter.js";
+export type {
+  ShikiHighlightOptions,
+  ShikiHighlightResult,
+} from "./shiki-highlighter.js";
 
 // ── Versioned docs (F6) ─────────────────────────────────────────
 export type {

--- a/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
@@ -25,6 +25,8 @@ import {
   parseImageSizeHint,
 } from "./markdown-extensions.js";
 import type { ResolvedDocConfig } from "./config.js";
+import { DEFAULT_CODE_LIGHT_THEME } from "./config.js";
+import { highlight as shikiHighlight } from "./shiki-highlighter.js";
 
 export type { Chapter, Heading };
 
@@ -318,6 +320,14 @@ function reportLinkDiagnostics(diagnostics: LinkDiagnostic[]): void {
  * Build a custom Marked renderer for web preview.
  * Handles headings with anchor links, images with doc-image class,
  * and code blocks with title/line-highlighting support.
+ *
+ * Code blocks: F4 swaps the legacy `escapeHtml` body with Shiki-tokenized
+ * inner HTML. Tokenization is async (Shiki loads grammars on demand) so a
+ * pre-pass populates `highlightedCode` (keyed by `lang\0source`) before
+ * `marked.parse()` runs. The renderer is purely sync here — it just looks
+ * up the pre-rendered HTML, falling back to `escapeHtml` if the lookup
+ * misses (defensive: should not happen because the pre-pass walks the
+ * exact same tokens marked will render).
  */
 function buildWebRenderer(
   chapterSlug: string,
@@ -326,11 +336,14 @@ function buildWebRenderer(
     chapterIndex?: number;
     lang?: string;
     figureLabels?: Record<string, string>;
+    /** Pre-rendered Shiki HTML keyed by `${lang}\0${code}`. */
+    highlightedCode?: Map<string, string>;
   },
 ) {
   let imgCounter = 0;
   const chapterIndex = options?.chapterIndex ?? 0;
   const figureLabel = getFigureLabel(options?.lang, options?.figureLabels);
+  const highlightedCode = options?.highlightedCode;
 
   return {
     heading(text: string, level: number, _raw: string): string {
@@ -371,6 +384,13 @@ function buildWebRenderer(
       const highlightSpec = highlightMatch?.[1] || "";
       const highlightLines = parseHighlightLines(highlightSpec);
 
+      // F4: line-highlight feature (data-highlight="1,3-5") wraps each line
+      // in `.code-line.highlighted`. Mixing this with Shiki's per-token
+      // colored spans is messy (we'd have to walk Shiki's output and split
+      // by line preserving colors), so when an author uses data-highlight
+      // we fall back to the legacy un-highlighted line wrappers. This keeps
+      // the line-highlight feature working unchanged. Authors who want
+      // both can land that in a follow-up; F4 spec doesn't require it.
       let codeHtml: string;
       if (highlightLines.size > 0) {
         const lines = code.split("\n");
@@ -384,11 +404,23 @@ function buildWebRenderer(
           })
           .join("\n");
       } else {
-        codeHtml = escapeHtml(code);
+        // Look up Shiki's pre-rendered output. The pre-pass uses the exact
+        // same `(lang, code)` tuple, so a miss means either the pre-pass
+        // wasn't run (catalog mode) or the renderer was invoked with a
+        // token that didn't go through Marked's lexer (no realistic path
+        // today, but defensive). Fall back to escaped plaintext.
+        const key = `${lang}|||${code}`;
+        const pre = highlightedCode?.get(key);
+        codeHtml = pre ?? escapeHtml(code);
       }
 
-      const langClass = lang ? ` class="language-${lang}"` : "";
-      const preBlock = `<pre><code${langClass}>${codeHtml}</code></pre>`;
+      // Add `language-{lang}` for legacy CSS hooks (existing themes target
+      // these classes). Shiki adds its own `.shiki` / `.line` classes inside
+      // the `<code>` body — both shells coexist without conflict.
+      const langClass = lang
+        ? ` class="language-${lang} shiki-host"`
+        : ` class="shiki-host"`;
+      const preBlock = `<pre${langClass}><code>${codeHtml}</code></pre>`;
 
       if (title) {
         return `<div class="code-block-wrapper"><div class="code-block-title">${escapeHtml(title)}</div>${preBlock}</div>\n`;
@@ -410,6 +442,75 @@ export interface WebProcessingOptions {
   diagnosticsSink?: LinkDiagnostic[];
 }
 
+/**
+ * Walk the rendered markdown's tokens and pre-tokenize every fenced code
+ * block via Shiki. Returns a map keyed by `${lang} ${rawCode}` whose value
+ * is the pre-rendered inner HTML for `<code>`. The renderer in
+ * `buildWebRenderer` reads from this map synchronously.
+ *
+ * Shiki tokenization is async (loadLanguage / loadTheme), but the actual
+ * `codeToHtml` call is synchronous once the grammar is loaded. We do the
+ * loading upfront here so the marked render pipeline stays sync.
+ *
+ * The cache inside `shikiHighlight` makes repeat blocks (across chapters or
+ * across languages) free after the first sighting — important for the
+ * "≤ +50% wall-clock per language" budget when building all 4 langs.
+ */
+async function precomputeShikiBlocks(
+  markdown: string,
+  theme: string,
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const seen = new Set<string>();
+
+  // Lex the same markdown the renderer will parse so we see the same `text`
+  // marked passes to `code()`. Walking marked's lexer output (rather than
+  // a regex over the raw markdown) handles list-indented code blocks, CRLF
+  // normalization, and the trailing-newline trimming the lexer applies —
+  // any of which would cause key mismatches if we tokenized by regex.
+  const lexer = new Marked();
+  const tokens = lexer.lexer(markdown);
+
+  type AnyToken = {
+    type: string;
+    lang?: string;
+    text?: string;
+    tokens?: AnyToken[];
+    items?: AnyToken[];
+  };
+
+  const visit = async (node: AnyToken | AnyToken[]): Promise<void> => {
+    if (Array.isArray(node)) {
+      for (const child of node) await visit(child);
+      return;
+    }
+    if (node.type === "code" && typeof node.text === "string") {
+      const info = (node.lang ?? "").trim();
+      const langMatch = info.match(/^(\w+)/);
+      const lang = langMatch?.[1] ?? "";
+      // Skip blocks with line-highlight — the renderer falls back to its
+      // legacy line-wrapping path for these (see comment in `code()` above).
+      if (/data-highlight="[^"]*\d+/.test(info)) return;
+
+      const key = `${lang}|||${node.text}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        const result = await shikiHighlight({
+          code: node.text,
+          lang,
+          theme,
+        });
+        map.set(key, result.innerHtml);
+      }
+    }
+    if (node.tokens) await visit(node.tokens);
+    if (node.items) await visit(node.items);
+  };
+
+  await visit(tokens as unknown as AnyToken[]);
+  return map;
+}
+
 export async function processMarkdownFilesForWeb(
   lang: string,
   navigation: NavEntry[],
@@ -424,6 +525,10 @@ export async function processMarkdownFilesForWeb(
   const pathFallbacks = config?.pathFallbacks ?? {};
   const admonitionTitles = config?.admonitionTitles;
   const figureLabels = config?.figureLabels;
+  // F4: Shiki theme. Resolved config always has a value; in the bare
+  // `processMarkdownFilesForWeb({ config: undefined })` path we fall back
+  // to the same default the resolver would pick.
+  const shikiTheme = config?.code?.lightTheme ?? DEFAULT_CODE_LIGHT_THEME;
 
   // ── Pass 1: Render all chapters to HTML ──────────────────────
   const rendered: RenderedChapter[] = [];
@@ -452,6 +557,12 @@ export async function processMarkdownFilesForWeb(
     markdown = processAdmonitions(markdown, lang, admonitionTitles);
     markdown = processCodeBlockMeta(markdown);
 
+    // F4: pre-tokenize all fenced code blocks via Shiki so the marked
+    // renderer (which is sync) can read pre-rendered HTML by lookup. The
+    // shared in-memory cache makes this a near-noop for repeating snippets
+    // across chapters / languages.
+    const highlightedCode = await precomputeShikiBlocks(markdown, shikiTheme);
+
     const headings: Heading[] = [];
     const marked = new Marked();
     marked.use({
@@ -459,6 +570,7 @@ export async function processMarkdownFilesForWeb(
         chapterIndex,
         lang,
         figureLabels,
+        highlightedCode,
       }),
     });
 
@@ -521,9 +633,19 @@ export async function processCatalogMarkdownForWeb(
     markdown = processAdmonitions(markdown);
     markdown = processCodeBlockMeta(markdown);
 
+    // F4: catalog mode uses default Shiki theme — there's no toolkit config
+    // available here. Operators who want a different theme will see it
+    // applied in the real `build:web` path which threads `config.code` in.
+    const highlightedCode = await precomputeShikiBlocks(
+      markdown,
+      DEFAULT_CODE_LIGHT_THEME,
+    );
+
     const headings: Heading[] = [];
     const marked = new Marked();
-    marked.use({ renderer: buildWebRenderer(chapterSlug, headings) });
+    marked.use({
+      renderer: buildWebRenderer(chapterSlug, headings, { highlightedCode }),
+    });
 
     const htmlContent = await marked.parse(markdown);
 

--- a/packages/backend.ai-docs-toolkit/src/shiki-highlighter.ts
+++ b/packages/backend.ai-docs-toolkit/src/shiki-highlighter.ts
@@ -1,0 +1,255 @@
+/**
+ * Shiki integration (F4 — code-block syntax highlighting).
+ *
+ * Build-time only — no runtime highlighter is shipped. Each unique
+ * `(theme, lang, source)` triple is tokenized once via the bundled Shiki
+ * grammars and cached in-memory across the build, so large doc sets with
+ * repeating snippets don't re-tokenize the same content.
+ *
+ * The highlighter is created lazily and shared across all chapters of all
+ * languages within a single build invocation. Shiki ships its grammars as
+ * JSON in the package — no CDN, no network. Air-gapped friendly.
+ *
+ * Future dark-mode work (out of scope for F4) can extend this to call
+ * `codeToHtml(code, { themes: { light, dark } })` instead of the single
+ * `theme` form. The cache key shape is already a tuple-style string so
+ * adding a `dark` segment is a one-line change.
+ */
+
+import crypto from "crypto";
+import { createHighlighter, bundledLanguages, bundledThemes } from "shiki";
+import type { Highlighter, BundledLanguage, BundledTheme } from "shiki";
+import { escapeHtml } from "./markdown-extensions.js";
+
+export interface ShikiHighlightOptions {
+  /** Source code (already de-indented; trailing newline trimmed by caller). */
+  code: string;
+  /** Language hint from the fenced block (`\`\`\`python`). Empty for unspecified. */
+  lang: string;
+  /** Light theme name (validated against bundledThemes; defaults applied). */
+  theme: string;
+}
+
+export interface ShikiHighlightResult {
+  /**
+   * Inner HTML for `<code>`: a sequence of `<span class="line">` rows whose
+   * spans carry inline `style="color:#…"` from Shiki's tokenizer. The caller
+   * wraps this in `<pre><code class="language-…">…</code></pre>`.
+   *
+   * Shiki's `codeToHtml` returns the full `<pre>` wrapper with theme bg etc;
+   * we strip that down to just the inner content so the docs-toolkit's own
+   * code-block frame (with optional title bar, line-highlight overlay, and
+   * the F4 Copy button wrapper) stays in control of presentation.
+   */
+  innerHtml: string;
+  /** True iff Shiki actually highlighted (resolved language was non-text). */
+  highlighted: boolean;
+  /** Resolved language ("plaintext" if input was unknown). */
+  resolvedLang: string;
+}
+
+/* ── Lazy highlighter + tokenization cache ───────────────────────────── */
+
+interface HighlighterEntry {
+  highlighter: Highlighter;
+  loadedThemes: Set<string>;
+  loadedLangs: Set<string>;
+}
+
+let entryPromise: Promise<HighlighterEntry> | null = null;
+
+/**
+ * Tokenization cache. Keyed by `${theme}\0${lang}\0${sha1(code)}`.
+ *
+ * Cache lifetime is the duration of a single build invocation. The Node
+ * process exits after `build:web` completes, so the cache naturally
+ * resets between runs. We do not persist to disk in v1 — Shiki's
+ * tokenization is fast enough on second-and-later runs of the same
+ * build that an in-memory cache covers the spec's "build wall-clock
+ * per language ≤ +50%" budget.
+ */
+const tokenCache = new Map<string, ShikiHighlightResult>();
+
+/**
+ * Initialize the Shiki highlighter once per process. Subsequent calls return
+ * the same instance. Themes and languages are loaded on demand — we start
+ * with the default light theme and let `highlight()` register more if the
+ * config asks for them.
+ */
+async function getEntry(initialTheme: string): Promise<HighlighterEntry> {
+  if (entryPromise) return entryPromise;
+  entryPromise = (async () => {
+    const themeName = resolveTheme(initialTheme);
+    const highlighter = await createHighlighter({
+      themes: [themeName],
+      langs: [],
+    });
+    return {
+      highlighter,
+      loadedThemes: new Set([themeName]),
+      loadedLangs: new Set<string>(),
+    };
+  })();
+  return entryPromise;
+}
+
+/**
+ * Validate a theme name against Shiki's bundled themes. Unknown theme names
+ * fall back to `github-light` with a one-time console warning so a typo in
+ * config doesn't silently swap to a wildly different palette.
+ */
+const warnedThemes = new Set<string>();
+function resolveTheme(name: string): BundledTheme {
+  if (name in bundledThemes) return name as BundledTheme;
+  if (!warnedThemes.has(name)) {
+    warnedThemes.add(name);
+    console.warn(
+      `[shiki] Unknown theme "${name}". Falling back to "github-light". ` +
+        `See https://shiki.style/themes for available themes.`,
+    );
+  }
+  return "github-light";
+}
+
+/**
+ * Resolve a language alias to a bundled grammar. Returns `null` for unknown
+ * languages (caller renders as plain escaped text). Empty input → null.
+ */
+function resolveLang(lang: string): BundledLanguage | null {
+  if (!lang) return null;
+  const normalized = lang.toLowerCase();
+  if (normalized in bundledLanguages) return normalized as BundledLanguage;
+  return null;
+}
+
+/**
+ * Tokenize `code` with Shiki and return inner HTML for the `<code>` element.
+ * Caches by (theme, lang, sha1(code)) so identical blocks across pages /
+ * languages tokenize once.
+ *
+ * On any Shiki error (corrupt grammar, OOM, etc.), falls back to plain
+ * escaped HTML so the build never fails because of a code block.
+ */
+export async function highlight(
+  options: ShikiHighlightOptions,
+): Promise<ShikiHighlightResult> {
+  const { code, lang, theme } = options;
+  const themeName = resolveTheme(theme);
+  const langName = resolveLang(lang);
+
+  const cacheKey =
+    themeName +
+    "\0" +
+    (langName ?? "plaintext") +
+    "\0" +
+    crypto.createHash("sha1").update(code).digest("hex");
+
+  const cached = tokenCache.get(cacheKey);
+  if (cached) return cached;
+
+  if (!langName) {
+    /* No grammar — fall through to escaped plaintext. We still cache so the
+     * lookup stays O(1) even when the doc set has hundreds of unspecified
+     * fenced blocks (e.g. shell session transcripts without a hint). */
+    const result: ShikiHighlightResult = {
+      innerHtml: escapeAsLines(code),
+      highlighted: false,
+      resolvedLang: "plaintext",
+    };
+    tokenCache.set(cacheKey, result);
+    return result;
+  }
+
+  const entry = await getEntry(themeName);
+
+  if (!entry.loadedThemes.has(themeName)) {
+    await entry.highlighter.loadTheme(themeName);
+    entry.loadedThemes.add(themeName);
+  }
+  if (!entry.loadedLangs.has(langName)) {
+    await entry.highlighter.loadLanguage(langName);
+    entry.loadedLangs.add(langName);
+  }
+
+  let inner: string;
+  try {
+    const fullHtml = entry.highlighter.codeToHtml(code, {
+      lang: langName,
+      theme: themeName,
+    });
+    inner = extractInner(fullHtml);
+  } catch (err) {
+    /* Defensive: never let a single bad code block break the build. */
+    console.warn(
+      `[shiki] Failed to highlight ${langName} block (${err instanceof Error ? err.message : String(err)}). Falling back to plain text.`,
+    );
+    const result: ShikiHighlightResult = {
+      innerHtml: escapeAsLines(code),
+      highlighted: false,
+      resolvedLang: langName,
+    };
+    tokenCache.set(cacheKey, result);
+    return result;
+  }
+
+  const result: ShikiHighlightResult = {
+    innerHtml: inner,
+    highlighted: true,
+    resolvedLang: langName,
+  };
+  tokenCache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Strip Shiki's `<pre>` and `<code>` wrappers, returning only the inner
+ * `<span class="line">…` content. This lets the docs-toolkit own the outer
+ * frame (so existing `.code-block-wrapper` / `.code-block-title` markup and
+ * the F4 Copy button wrapper continue to apply uniformly).
+ */
+function extractInner(shikiHtml: string): string {
+  /* Shiki's output: `<pre class="shiki ..." style="..."><code>…</code></pre>`.
+   * The regex below tolerates attribute order changes between Shiki versions
+   * (no positional assumptions beyond the open/close tags). */
+  const codeOpen = shikiHtml.indexOf("<code");
+  const codeOpenEnd = codeOpen >= 0 ? shikiHtml.indexOf(">", codeOpen) : -1;
+  const codeClose = shikiHtml.lastIndexOf("</code>");
+  if (codeOpen < 0 || codeOpenEnd < 0 || codeClose < 0) return shikiHtml;
+  return shikiHtml.slice(codeOpenEnd + 1, codeClose);
+}
+
+/**
+ * Plain-text fallback (no grammar / Shiki error). Wraps each line in
+ * `<span class="line">` so the line-highlight overlay (F4 keeps the existing
+ * data-highlight feature working on top of Shiki output) can attach by
+ * `nth-child` if a future bucket needs it.
+ *
+ * The legacy renderer wrapped lines in `<span class="code-line">` only when
+ * `data-highlight` was present; here we always emit `<span class="line">`
+ * for shape consistency with Shiki's output.
+ */
+function escapeAsLines(code: string): string {
+  if (code === "") return '<span class="line"></span>';
+  return code
+    .split("\n")
+    .map((line) => `<span class="line">${escapeHtml(line)}</span>`)
+    .join("\n");
+}
+
+/** Cache stats — for build summary / debug. */
+export function getHighlightCacheStats(): { hits: number; size: number } {
+  /* `hits` is not tracked granularly to keep the hot path branch-free; the
+   * size of the map is a useful proxy for "distinct code blocks tokenized". */
+  return { hits: 0, size: tokenCache.size };
+}
+
+/**
+ * Reset the cache and clear the cached highlighter. Test-only; the
+ * production build path doesn't call this — the cache lives for the
+ * duration of the Node process.
+ */
+export function _resetForTests(): void {
+  tokenCache.clear();
+  entryPromise = null;
+  warnedThemes.clear();
+}

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -507,6 +507,87 @@ pre code {
 }
 
 /* ==========================================================================
+   F4 — Shiki tokenized code blocks + Copy button
+   --------------------------------------------------------------------------
+   Build-time syntax highlighting (Shiki) emits inline-styled <span> tokens
+   inside <span class="line"> rows. We only need a few rules:
+     - Keep Shiki's per-token color spans visible (don't over-style).
+     - Wrap each <pre> with a positioning context so the Copy button can
+       sit at the top-right corner.
+     - Provide a hover-revealed Copy button with a transient "Copied!" state.
+   ========================================================================== */
+.shiki-host > code .line {
+  /* Each token row Shiki emits. display:block makes line wrapping behave
+     consistently — long lines wrap inside the line span instead of pushing
+     the parent <pre> wider. */
+  display: block;
+}
+
+/* Wrapper injected at runtime by code-copy.js. Provides the positioning
+   context for the absolutely-positioned button. The wrapper is invisible
+   itself — the <pre> inside keeps its frame styling. */
+.doc-code-block-wrapper {
+  position: relative;
+  margin: 0 0 var(--ifm-spacing-vertical);
+}
+
+/* When inside a titled wrapper (already provides a frame), reset the
+   bottom margin so the doc-code-block-wrapper doesn't double-space. */
+.code-block-wrapper .doc-code-block-wrapper {
+  margin: 0;
+}
+
+.doc-code-block-wrapper > pre {
+  /* Reset margin on pre when wrapped — wrapper owns the bottom margin. */
+  margin: 0;
+}
+
+.doc-code-copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  font-family: var(--ifm-font-family-base);
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-color-emphasis-0);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease, color 120ms ease, border-color 120ms ease,
+    background-color 120ms ease;
+}
+
+.doc-code-block-wrapper:hover .doc-code-copy-btn,
+.doc-code-block-wrapper:focus-within .doc-code-copy-btn,
+.doc-code-copy-btn:focus,
+.doc-code-copy-btn:focus-visible {
+  opacity: 1;
+}
+
+.doc-code-copy-btn:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.doc-code-copy-btn[data-state="copied"] {
+  color: var(--ifm-color-success-dark);
+  border-color: var(--ifm-color-success);
+  background: rgba(0, 164, 0, 0.08);
+  opacity: 1;
+}
+
+.doc-code-copy-btn[data-state="failed"] {
+  color: var(--ifm-color-danger-dark);
+  border-color: var(--ifm-color-danger);
+  background: rgba(250, 56, 62, 0.06);
+  opacity: 1;
+}
+
+/* ==========================================================================
    Tables
    ========================================================================== */
 table {

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -281,8 +281,7 @@ function buildWebsiteSidebar(
 </details>`;
   };
 
-  const isLegacyFlat =
-    navGroups.length === 1 && navGroups[0].category === "";
+  const isLegacyFlat = navGroups.length === 1 && navGroups[0].category === "";
   const groupsHtml = navGroups
     .map((g) => renderGroup(g, isLegacyFlat))
     .join("\n");
@@ -317,7 +316,11 @@ function buildWebsiteSidebar(
  * language picker at `dist/web/index.html` is reachable via the language
  * switcher in the page header.
  */
-function buildBreadcrumb(chapter: Chapter, category: string, lang: string): string {
+function buildBreadcrumb(
+  chapter: Chapter,
+  category: string,
+  lang: string,
+): string {
   const labels = WEBSITE_LABELS[lang] ?? WEBSITE_LABELS.en;
   const homeLabel = labels.home ?? "Home";
   const segments: string[] = [
@@ -353,9 +356,7 @@ function buildBreadcrumb(chapter: Chapter, category: string, lang: string): stri
 function buildRightRailToc(chapter: Chapter, lang: string): string {
   const labels = WEBSITE_LABELS[lang] ?? WEBSITE_LABELS.en;
   const heading = labels.onThisPage ?? "On this page";
-  const items = chapter.headings.filter(
-    (h) => h.level === 2 || h.level === 3,
-  );
+  const items = chapter.headings.filter((h) => h.level === 2 || h.level === 3);
   if (items.length === 0) {
     // Render the aside container even when empty so the grid column has a
     // stable layout; CSS hides the heading when the list is empty.
@@ -881,12 +882,22 @@ export function buildWebPage(context: WebPageContext): string {
   const codeCopyScript = buildCodeCopyScriptTag(assets, prefix);
   const tocScrollspyScript = buildTocScrollspyScriptTag(assets);
 
+  // F4: data-* attributes on <body> carry the localized labels for the
+  // code-copy script (which is content-hashed once across every language,
+  // so the script itself stays language-agnostic).
+  const labels = WEBSITE_LABELS[metadata.lang] ?? WEBSITE_LABELS.en;
+  const copyDataAttrs = [
+    `data-copy-label="${escapeHtml(labels.copy ?? "Copy")}"`,
+    `data-copied-label="${escapeHtml(labels.copied ?? "Copied!")}"`,
+    `data-copy-failed-label="${escapeHtml(labels.copyFailed ?? "Copy failed")}"`,
+  ].join(" ");
+
   return `<!DOCTYPE html>
 <html lang="${escapeHtml(metadata.lang)}">
 <head>
   ${headTags}
 </head>
-<body>
+<body ${copyDataAttrs}>
 ${headerBar}
 <div class="doc-page">
   ${sidebar}

--- a/packages/backend.ai-docs-toolkit/templates/assets/code-copy.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/code-copy.js
@@ -1,0 +1,174 @@
+/* docs-toolkit code-block "Copy" button (F4).
+ *
+ * For every <pre> rendered by Shiki (marked with .doc-code-block, or any
+ * <pre><code>) we inject a small button. Click → copy the raw code text to
+ * the clipboard via navigator.clipboard.writeText, then flash a transient
+ * "Copied!" label so the user gets feedback.
+ *
+ * Constraints:
+ *   - No framework, no external dependencies — vanilla DOM only.
+ *   - Air-gapped: navigator.clipboard is browser-native; no network access.
+ *   - Localized labels are read from data-* attributes on the wrapper so the
+ *     script itself stays language-agnostic and content-hashed once across
+ *     every language.
+ *   - Per-page JS budget (≤ 25 KB minified) — this script is < 2 KB
+ *     unminified.
+ */
+(function () {
+  if (typeof document === "undefined") return;
+
+  function getLabels(root) {
+    var labels = {
+      copy: "Copy",
+      copied: "Copied!",
+      failed: "Copy failed",
+    };
+    if (!root) return labels;
+    if (root.getAttribute("data-copy-label"))
+      labels.copy = root.getAttribute("data-copy-label");
+    if (root.getAttribute("data-copied-label"))
+      labels.copied = root.getAttribute("data-copied-label");
+    if (root.getAttribute("data-copy-failed-label"))
+      labels.failed = root.getAttribute("data-copy-failed-label");
+    return labels;
+  }
+
+  /* Extract the source text from a <pre><code> node. We prefer .textContent
+   * over innerText so newlines are preserved exactly as authored. Shiki wraps
+   * each token in <span style="color:..."> elements; .textContent collapses
+   * those into a clean source string. */
+  function extractCode(pre) {
+    var code = pre.querySelector("code");
+    var text = (code || pre).textContent || "";
+    /* Strip a single trailing newline that some renderers emit so the
+     * clipboard contents don't gain a blank tail line on every paste. */
+    return text.replace(/\n$/, "");
+  }
+
+  function fallbackCopy(text) {
+    /* navigator.clipboard requires a secure context (https / localhost).
+     * The static docs site is normally served over https, but operators may
+     * preview from a plain-http LAN host — fall back to a hidden textarea +
+     * document.execCommand('copy') so the button still works there. */
+    var ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "absolute";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    var prevSelection = document.getSelection();
+    var prevRange =
+      prevSelection && prevSelection.rangeCount > 0
+        ? prevSelection.getRangeAt(0)
+        : null;
+    ta.select();
+    var ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } catch (_e) {
+      ok = false;
+    }
+    document.body.removeChild(ta);
+    if (prevRange && prevSelection) {
+      prevSelection.removeAllRanges();
+      prevSelection.addRange(prevRange);
+    }
+    return ok
+      ? Promise.resolve()
+      : Promise.reject(new Error("execCommand failed"));
+  }
+
+  function copyText(text) {
+    if (
+      navigator &&
+      navigator.clipboard &&
+      typeof navigator.clipboard.writeText === "function"
+    ) {
+      return navigator.clipboard.writeText(text);
+    }
+    return fallbackCopy(text);
+  }
+
+  function makeButton(labels) {
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "doc-code-copy-btn";
+    btn.setAttribute("aria-label", labels.copy);
+    btn.setAttribute("data-state", "idle");
+    btn.textContent = labels.copy;
+    return btn;
+  }
+
+  function flash(btn, label, state, restore, labels) {
+    btn.textContent = label;
+    btn.setAttribute("data-state", state);
+    btn.setAttribute("aria-label", label);
+    if (btn.__resetTimer) clearTimeout(btn.__resetTimer);
+    btn.__resetTimer = setTimeout(function () {
+      btn.textContent = restore;
+      btn.setAttribute("data-state", "idle");
+      btn.setAttribute("aria-label", labels.copy);
+    }, 1500);
+  }
+
+  function attach(pre, labels) {
+    if (pre.__copyAttached) return;
+    pre.__copyAttached = true;
+
+    /* Wrap the <pre> so the absolutely-positioned button sits in the same
+     * stacking context. Skip if a wrapper already exists (idempotent). */
+    var wrapper;
+    if (
+      pre.parentNode &&
+      pre.parentNode.classList &&
+      pre.parentNode.classList.contains("doc-code-block-wrapper")
+    ) {
+      wrapper = pre.parentNode;
+    } else {
+      wrapper = document.createElement("div");
+      wrapper.className = "doc-code-block-wrapper";
+      var parent = pre.parentNode;
+      if (!parent) return;
+      parent.insertBefore(wrapper, pre);
+      wrapper.appendChild(pre);
+    }
+
+    var btn = makeButton(labels);
+    wrapper.appendChild(btn);
+
+    btn.addEventListener("click", function () {
+      var text = extractCode(pre);
+      copyText(text).then(
+        function () {
+          flash(btn, labels.copied, "copied", labels.copy, labels);
+        },
+        function () {
+          flash(btn, labels.failed, "failed", labels.copy, labels);
+        },
+      );
+    });
+  }
+
+  function init() {
+    var root =
+      document.querySelector("[data-copy-label], [data-copied-label]") ||
+      document.body;
+    var labels = getLabels(root);
+    /* Target every <pre> the markdown renderer produced. Shiki output uses
+     * <pre class="shiki ..."><code>…</code></pre>; legacy non-highlighted
+     * code blocks are plain <pre><code>. Both shapes match this query. */
+    var pres = document.querySelectorAll("pre > code");
+    for (var i = 0; i < pres.length; i++) {
+      var pre = pres[i].parentNode;
+      if (pre && pre.tagName && pre.tagName.toLowerCase() === "pre") {
+        attach(pre, labels);
+      }
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
+++ b/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
@@ -36,6 +36,15 @@ website:
   editBaseUrl: "https://github.com/lablup/backend.ai-webui/edit/main/packages/backend.ai-webui-docs/src"
   repoUrl: "https://github.com/lablup/backend.ai-webui"
 
+# Code-block presentation (F4 — Shiki syntax highlighting).
+# `lightTheme` selects the build-time syntax theme. Default: "github-light".
+# Any bundled Shiki theme name works (see https://shiki.style/themes —
+# e.g. "vitesse-light", "light-plus"). Unknown names fall back to
+# "github-light" with a one-time warning.
+# Dark mode is intentionally out of scope; a future bucket may add code.darkTheme.
+# code:
+#   lightTheme: "github-light"
+
 # Agent configuration (for 'docs-toolkit agents' command)
 agents:
   projectTitle: "Backend.AI WebUI"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
+      shiki:
+        specifier: 1.29.2
+        version: 1.29.2
       yaml:
         specifier: ^2.8.2
         version: 2.8.3
@@ -4634,23 +4637,41 @@ packages:
   '@rushstack/ts-command-line@5.3.5':
     resolution: {integrity: sha512-ToJQu3+o6aEdDoApGrwb/RsbwDi/NSC7jIEaAezzWM470TRrsXfSHoYAm1eWkhh34xJ+kZxU1ZzKSHiOMlOFPA==}
 
+  '@shikijs/core@1.29.2':
+    resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
+
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@1.29.2':
+    resolution: {integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==}
 
   '@shikijs/engine-javascript@3.23.0':
     resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
+  '@shikijs/engine-oniguruma@1.29.2':
+    resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
+
   '@shikijs/engine-oniguruma@3.23.0':
     resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
 
+  '@shikijs/langs@1.29.2':
+    resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
+
   '@shikijs/langs@3.23.0':
     resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@1.29.2':
+    resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
 
   '@shikijs/themes@3.23.0':
     resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
 
   '@shikijs/transformers@3.23.0':
     resolution: {integrity: sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==}
+
+  '@shikijs/types@1.29.2':
+    resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
 
   '@shikijs/types@3.23.0':
     resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
@@ -7657,6 +7678,9 @@ packages:
 
   emoji-mart@5.6.0:
     resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -10705,6 +10729,9 @@ packages:
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
+  oniguruma-to-es@2.3.0:
+    resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
+
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
@@ -11980,11 +12007,17 @@ packages:
   regex-parser@2.3.1:
     resolution: {integrity: sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==}
 
+  regex-recursion@5.1.1:
+    resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@5.1.1:
+    resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
@@ -12443,6 +12476,9 @@ packages:
         optional: true
       vue:
         optional: true
+
+  shiki@1.29.2:
+    resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
@@ -18515,6 +18551,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@shikijs/core@1.29.2':
+    dependencies:
+      '@shikijs/engine-javascript': 1.29.2
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/core@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -18522,20 +18567,39 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/engine-javascript@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 2.3.0
+
   '@shikijs/engine-javascript@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.5
 
+  '@shikijs/engine-oniguruma@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/engine-oniguruma@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@shikijs/langs@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+
   '@shikijs/langs@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
 
   '@shikijs/themes@3.23.0':
     dependencies:
@@ -18545,6 +18609,11 @@ snapshots:
     dependencies:
       '@shikijs/core': 3.23.0
       '@shikijs/types': 3.23.0
+
+  '@shikijs/types@1.29.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   '@shikijs/types@3.23.0':
     dependencies:
@@ -22114,6 +22183,8 @@ snapshots:
   emittery@0.8.1: {}
 
   emoji-mart@5.6.0: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   emoji-regex@10.6.0: {}
 
@@ -26608,6 +26679,12 @@ snapshots:
 
   oniguruma-parser@0.12.1: {}
 
+  oniguruma-to-es@2.3.0:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 5.1.1
+      regex-recursion: 5.1.1
+
   oniguruma-to-es@4.3.5:
     dependencies:
       oniguruma-parser: 0.12.1
@@ -28103,11 +28180,20 @@ snapshots:
 
   regex-parser@2.3.1: {}
 
+  regex-recursion@5.1.1:
+    dependencies:
+      regex: 5.1.1
+      regex-utilities: 2.3.0
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
 
   regex-utilities@2.3.0: {}
+
+  regex@5.1.1:
+    dependencies:
+      regex-utilities: 2.3.0
 
   regex@6.1.0:
     dependencies:
@@ -28690,6 +28776,17 @@ snapshots:
     optionalDependencies:
       react: 19.2.5
       solid-js: 1.9.11
+
+  shiki@1.29.2:
+    dependencies:
+      '@shikijs/core': 1.29.2
+      '@shikijs/engine-javascript': 1.29.2
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/langs': 1.29.2
+      '@shikijs/themes': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   shiki@3.23.0:
     dependencies:


### PR DESCRIPTION
Resolves #7001 (FR-2716)

## Summary
F4 of FR-2710: code-block reading UX.

- **Build-time syntax highlighting** via [Shiki](https://shiki.style) — zero runtime highlight JS shipped. Tokenization cached in-memory by `(theme, lang, sha1(code))`, so repeating snippets across chapters/languages tokenize once. All-langs build runs in ~4s end-to-end.
- **Configurable theme** via `code.lightTheme` in `docs-toolkit.config.yaml`. Default `github-light`. Any [bundled Shiki theme](https://shiki.style/themes) is accepted; unknown names fall back to `github-light` with a one-time warning. **Dark mode is intentionally not wired** — the namespace is reserved for a future bucket via comments only.
- **Copy button** per code block, shipped as `templates/assets/code-copy.js` (vanilla JS, ~5 KB unminified, well under the 25 KB JS budget). Localized labels (`Copy` / `Copied!` / `Copy failed`) injected via `data-*` attrs on `<body>` so the script stays language-agnostic and is content-hashed once across every language. Falls back to hidden-textarea + `execCommand("copy")` for non-secure-context previews.

## Cross-cutting verification
- `pnpm run build:web` (all 4 langs) exits 0; Shiki tokens visible in built HTML; per-language localized copy labels present in `<body data-copy-label="…">` attributes
- `pnpm run pdf:en` exits 0; PDF code blocks unchanged (PDF pipeline uses its own core renderer in `markdown-processor.ts` — F4 only touches the web pipeline)
- Pre-existing CJK PDF break (ko/ja/th, `WinAnsi cannot encode "目"`) is unchanged
- `bash scripts/verify.sh`: Lint PASS, Format PASS. TypeScript errors are pre-existing in `react/src/pages/Reservoir*.tsx` and `Service/Serving/StorageHostSetting/VFolderNodeListPage.tsx` (unrelated to F4 — verified by reproducing on the parent commit with my changes stashed)

## Test plan
- [x] Open a chapter with code blocks (e.g. `dist/web/en/sftp-to-container.html`) → tokens have `github-light` colors (verified inline `<span style="color:#…">`)
- [x] Set `code.lightTheme: "vitesse-light"` in `docs-toolkit.config.yaml` → rebuild → colors change (verified)
- [x] Click Copy button on a built page → "Copied!" feedback → paste elsewhere → content matches (manual)
- [x] Per-page JS budget: code-copy ~5.8 KB, search ~4.6 KB, toc-scrollspy ~4.6 KB → total ~15 KB unminified, well under 25 KB
- [x] Cache effectiveness: en build cold-starts at 1.2s; ja/ko/th each take 0.7-0.8s with the cache warm

## Stack
- Spec: #6988
- Dev plan: #7004
- F5: #7006
- F1: #7008
- F3: #7009
- This PR (F4): stacked on F3

## Notes for F2 reviewer
F2 stacks on F6, NOT on F4. F4 introduces:
- A new `shiki@1.29.2` runtime dep (bundles grammars and themes as JSON inside the package — air-gapped friendly, no CDN)
- A new public export `highlightCode` (re-exported from `shiki-highlighter.ts`) and types `CodeConfig` / `ResolvedCodeConfig`
- Pre-tokenization pre-pass that walks marked's lexer tokens (`precomputeShikiBlocks`) so the sync renderer can do O(1) lookups
- New CSS classes `.shiki-host`, `.doc-code-block-wrapper`, `.doc-code-copy-btn`
- New `WEBSITE_LABELS` keys: `copy`, `copied`, `copyFailed`