### PR TITLE
feat(FR-2718): F6 versioned docs and minor-grained version selector

### DIFF
--- a/.github/workflows/docs-archive-orphan-branch.yml
+++ b/.github/workflows/docs-archive-orphan-branch.yml
@@ -1,0 +1,177 @@
+# Build the WebUI docs site for a specific minor version with the
+# toolkit-of-its-day, then commit + push the artifacts to a docs-archive
+# orphan branch (e.g., `docs-archive/25.16`).
+#
+# Why orphan branches?
+#   Past minors are NOT rebuilt with the current toolkit on every deploy
+#   — markdown structure of older minors may diverge enough to break the
+#   build. Instead, each minor is built ONCE with the toolkit it shipped
+#   with and parked on a dedicated orphan branch. Orphan branches share
+#   no history with `main`, so the main repo size is unaffected.
+#
+# Trigger: manual (`workflow_dispatch`) for v1. The operator picks the
+# tagged commit they want to immortalize and the minor label that
+# represents it. Future iteration may add an on-tag trigger but that is
+# explicitly out of scope here.
+#
+# Output: a `docs-archive/<minor>` branch containing only the contents
+# of `dist/web/<minor>/` (so the archived site is the FILES, not the
+# source tree). The deployment pipeline (AWS Amplify or equivalent)
+# checks out `docs-archive/<minor>` and serves it under `/<minor>/...`.
+# The deployment pipeline itself is deferred to a separate spec.
+#
+# References:
+#   - Spec: .specs/FR-2710-docs-site-production-uplift/spec.md (F6)
+#   - Issue: FR-2718 / gh#7003
+
+name: docs-archive-orphan-branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Source ref to build from (commit SHA or tag, e.g. v25.16.5)"
+        required: true
+        type: string
+      minor_label:
+        description: "Minor label this archive represents (e.g. 25.16). MUST NOT include patch."
+        required: true
+        type: string
+      dry_run:
+        description: "If true, build and inspect only — do NOT push the orphan branch"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-archive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Validate minor label shape
+        # Refuse anything that looks like a full patch (three numeric segments)
+        # to mirror the validation in `versions.ts` — the selector lists minors
+        # only, never patches. Inputs flow through env vars (NOT shell
+        # interpolation) to avoid command injection from malicious input.
+        env:
+          MINOR_LABEL: ${{ inputs.minor_label }}
+        run: |
+          if [[ "$MINOR_LABEL" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "ERROR: minor_label '$MINOR_LABEL' looks like a patch."
+            echo "Expected format: '<MAJOR>.<MINOR>' (e.g. 25.16). The selector lists minors only."
+            exit 1
+          fi
+          if [[ ! "$MINOR_LABEL" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: minor_label '$MINOR_LABEL' is not a clean MAJOR.MINOR pair."
+            exit 1
+          fi
+
+      - name: Checkout source ref (toolkit-of-its-day)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build website (toolkit-of-its-day)
+        # We deliberately use the toolkit version that shipped with this
+        # source ref. Past minors are NEVER rebuilt with main's toolkit.
+        run: pnpm --filter backend.ai-webui-docs run build:web
+
+      - name: Verify build output exists
+        run: |
+          DIST="packages/backend.ai-webui-docs/dist/web"
+          if [ ! -d "$DIST" ]; then
+            echo "ERROR: expected build output at $DIST"
+            exit 1
+          fi
+          echo "Build output:"
+          ls -la "$DIST"
+
+      - name: Stage build artifact for archive
+        # The archive branch should hold ONLY the rendered site, with no
+        # source files or lockfiles. We collect the output into a temp
+        # directory the orphan branch is built from. Inputs flow through
+        # env vars to avoid shell injection.
+        env:
+          MINOR_LABEL: ${{ inputs.minor_label }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          mkdir -p /tmp/docs-archive
+          cp -R packages/backend.ai-webui-docs/dist/web/. /tmp/docs-archive/
+          # Drop any version-prefixed subdirectory: the archive branch
+          # represents a SINGLE minor, so its root is the rendered site.
+          # If the source ref already used `versions:` mode the output is
+          # `dist/web/<v>/<lang>/...`; flatten it.
+          cd /tmp/docs-archive
+          if [ -d "$MINOR_LABEL" ]; then
+            mv "$MINOR_LABEL"/* .
+            rmdir "$MINOR_LABEL"
+          fi
+          echo "Archive contents:"
+          ls -la
+          # Drop a sentinel file so anyone browsing the branch knows
+          # which minor + source ref produced it.
+          cat > .archive-info.txt <<EOF
+          minor_label: $MINOR_LABEL
+          source_ref:  $SOURCE_REF
+          built_at:    $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          built_by:    docs-archive-orphan-branch.yml (gh actions run $RUN_ID)
+          EOF
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create orphan branch and commit artifacts
+        if: ${{ inputs.dry_run != true }}
+        env:
+          MINOR_LABEL: ${{ inputs.minor_label }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          BRANCH="docs-archive/$MINOR_LABEL"
+          # Use a fresh worktree so we don't disturb the main checkout.
+          git worktree add --detach /tmp/orphan-worktree
+          cd /tmp/orphan-worktree
+          # Detach HEAD and clear the index so the orphan starts truly empty.
+          git checkout --orphan "$BRANCH"
+          git rm -rf --cached . > /dev/null 2>&1 || true
+          # Wipe everything — we want the orphan tree to contain ONLY the
+          # archived site, no inherited source files.
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          # Copy the staged archive in.
+          cp -R /tmp/docs-archive/. .
+          git add -A
+          git commit -m "docs-archive($MINOR_LABEL): build from $SOURCE_REF"
+          # Force-push: each invocation replaces the previous archive for
+          # this minor, since we re-build with the toolkit-of-its-day to
+          # pick up the latest patch within the minor.
+          git push --force origin "$BRANCH"
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run == true }}
+        env:
+          MINOR_LABEL: ${{ inputs.minor_label }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          echo "Dry-run mode: orphan branch was NOT pushed."
+          echo "Would push: docs-archive/$MINOR_LABEL"
+          echo "Source ref: $SOURCE_REF"
+          echo "Artifact size:"
+          du -sh /tmp/docs-archive

--- a/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
+++ b/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
@@ -161,3 +161,146 @@ The `path` is relative to `src/{lang}/`.
 - **CSS delivery**: Currently inlined in `<style>` tag. Static website should use a shared `.css` file to avoid duplication across pages.
 - **Search index**: Must support CJK languages (Korean, Japanese, Thai). Bigram tokenization is effective for CJK. The index must work entirely client-side (no server, no CDN) for air-gapped deployments.
 - **Last updated date**: `git log -1 --format=%aI -- {filepath}` is the most accurate source. Fallback to `fs.statSync().mtime` for non-git environments. This data should be collected during build and embedded in each page.
+
+## Versioned docs (F6 / FR-2718)
+
+The toolkit supports an OPTIONAL minor-grained version model. When the
+optional `versions` key is present in `docs-toolkit.config.yaml`, the
+build emits a per-version directory layout. When `versions` is absent,
+the legacy flat layout is preserved unchanged (fully backward
+compatible).
+
+### Version model
+
+- The selector lists one row per **minor** version. Within a minor,
+  the highest patch represents that minor (e.g., `25.16.5` is shown as
+  `25.16`). This is enforced at config-load time: `versions.ts` rejects
+  labels that match `/^\d+\.\d+\.\d+/`.
+- Eligibility is gated by the build itself: a minor is admitted to the
+  selector only if its docs build cleanly under the current toolkit
+  with `--strict` (F5). A minor that breaks the strict build must be
+  patched, deferred via a follow-up issue, or explicitly excluded —
+  the choice is documented in the PR that adds the entry.
+- Past-minor build artifacts live on **orphan branches**
+  (`docs-archive/<minor>`). Past minors are built ONCE with the
+  toolkit-of-its-day and pushed to the archive branch by the
+  `docs-archive-orphan-branch.yml` workflow; they are NOT re-built with
+  the current toolkit on every deploy.
+
+### Output directory layout
+
+| Mode | Page URL pattern | rootDepth |
+|---|---|---|
+| Flat (`versions` absent) | `dist/web/<lang>/<slug>.html` | 2 |
+| Versioned (`versions` declared) | `dist/web/<minor>/<lang>/<slug>.html` | 3 |
+
+Site-shared assets always live at `dist/web/assets/...` (one set, content-hashed).
+The page builder derives a `../`-prefix from `rootDepth` so the same template
+works in both layouts.
+
+In versioned mode, the root `dist/web/index.html` is a tiny meta-refresh
+that points at the latest version's default-language landing page. F1
+(language picker) may later replace this with a richer entry.
+
+### `versions` schema
+
+```yaml
+versions:
+  - label: "25.16"          # minor label only — never include patch
+    source:
+      kind: workspace        # build from current checkout
+    latest: true             # exactly one entry must carry latest:true
+  - label: "25.10"
+    source:
+      kind: archive-branch
+      ref: docs-archive/25.10  # orphan branch holding pre-built artifacts
+```
+
+Validation rules (enforced by `loadVersions` in `versions.ts`):
+
+- `versions` is OPTIONAL. When omitted (or empty), the build runs in
+  single-version compatibility mode and emits the flat layout.
+- `versions[].label` must be a non-empty string of the shape
+  `MAJOR.MINOR`. Three-segment "patch-shaped" labels are rejected.
+- `versions[].source.kind` must be `workspace` or `archive-branch`.
+- For `archive-branch`, `versions[].source.ref` is required.
+- Exactly **one** entry must carry `latest: true`.
+- Labels must be unique within `versions[]`.
+
+### Source kinds
+
+- **`workspace`** — build from the current checkout. Used for the
+  `latest` entry in normal day-to-day deploys.
+- **`archive-branch`** — build by reading from a sibling worktree at
+  `<projectRoot>/.docs-archive/<sanitized-ref>`. The CI workflow that
+  PUSHES the orphan branch ships in this PR
+  (`.github/workflows/docs-archive-orphan-branch.yml`); the workflow /
+  operator that PULLS the orphan branch into a worktree before rebuild
+  is operational scope. If the worktree does not exist when the build
+  runs, the version is logged and skipped (NOT a hard failure) so CI
+  doesn't break before the archive infrastructure is materialized.
+
+### Header version selector
+
+Every page in versioned mode emits a `<header class="page-header-bar">`
+with a `<select class="version-switcher">` listing every minor label.
+On change, an inline JS handler navigates to the same slug in the
+target version. If the slug doesn't exist there, the browser hits a
+404 → operators serve an index page redirect, OR (preferred) the
+build's per-version slug-availability map (recorded in
+`VersionPageRegistry`) drives the link to the version's `index.html`
+directly.
+
+The dropdown lists minors only — patches are never shown. The data
+needed by the inline script is embedded as `data-` attributes on the
+`<select>`, keeping the script body tiny (well under the 25 KB
+per-page JS budget).
+
+### Version scope isolation
+
+- **Sidebar / right-rail TOC / internal links** operate within the
+  current version only — the markdown processor reads only the
+  current version's `book.config.yaml` and `<lang>/...` tree.
+- **Search index** is partitioned per `(version, lang)` and lives at
+  `dist/web/<version>/<lang>/search-index.json`. Search results never
+  leak across versions.
+- **canonical URL** (built by F2): always points at the same slug in
+  the latest version (`dist/web/<latest-label>/<lang>/<slug>.html`).
+  `canonicalPathFor()` in `versions.ts` returns the canonical relative
+  path; F2 wraps it in the absolute base URL.
+- **hreflang** (built by F1): cross-links languages WITHIN the same
+  version, never across versions.
+
+### API surface for F2 (sitemap + canonical)
+
+`generateWebsite()` returns a `GenerateWebsiteResult` containing:
+
+```typescript
+{
+  versioned: boolean;            // false in flat mode
+  pages: PageEnumerationRow[];   // one row per (version, lang, slug)
+  versionsBuilt: Version[];      // entries that actually rendered
+}
+```
+
+Each `PageEnumerationRow` has `{ version, lang, slug, path, isLatest }`.
+F2 iterates `pages` to emit `sitemap.xml`. `canonicalPathFor(loaded, lang, slug)`
+returns the per-page canonical URL relative to the website output root.
+
+### Single-version compatibility mode
+
+When `versions` is not declared, the build behaves exactly as before
+F6: flat `dist/web/<lang>/...` layout, no version selector, no
+per-version subdirs, no root redirect. This is the default path in
+`backend.ai-webui-docs` today; the operator opts into versioned mode
+by adding `versions:` to `docs-toolkit.config.yaml`.
+
+### PDF pipeline interaction
+
+The PDF pipeline (`generate-pdf.ts`) reads ONLY `book.config.yaml`,
+not the `versions` key in `docs-toolkit.config.yaml`. Adding a
+`versions` block has zero effect on PDF output: `pnpm run pdf:en`
+continues to build the current checkout's content, regardless of
+whether `versions` is declared. This is intentional — past-minor PDFs
+are likewise produced by their toolkit-of-its-day, not by re-rendering
+through the current toolkit.

--- a/packages/backend.ai-docs-toolkit/package.json
+++ b/packages/backend.ai-docs-toolkit/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "tsx --test src/versions.test.ts",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-import { parse as parseYaml } from 'yaml';
-import type { PdfTheme } from './theme.js';
+import fs from "fs";
+import path from "path";
+import { parse as parseYaml } from "yaml";
+import type { PdfTheme } from "./theme.js";
 
 export interface DocConfig {
   /** Document title, e.g. "Backend.AI WebUI User Guide" */
@@ -30,7 +30,10 @@ export interface DocConfig {
   /** Language labels, e.g. { en: "English", ko: "한국어" } */
   languageLabels?: Record<string, string>;
   /** Localized UI strings per language */
-  localizedStrings?: Record<string, { userGuide?: string; tableOfContents?: string }>;
+  localizedStrings?: Record<
+    string,
+    { userGuide?: string; tableOfContents?: string }
+  >;
   /** Localized admonition titles per language */
   admonitionTitles?: Record<string, Record<string, string>>;
   /** Localized figure labels per language */
@@ -81,48 +84,144 @@ export interface WebsiteConfig {
   basePath?: string;
 }
 
+// ── Versioned-docs schema (F6 / FR-2718) ──────────────────────────
+//
+// `versions` is OPTIONAL and OPT-IN. When omitted, the existing flat
+// output layout (`dist/web/<lang>/...`) is preserved exactly. When
+// declared, each entry produces a self-contained per-minor site under
+// `dist/web/<label>/<lang>/...`, and the version selector is rendered in
+// every page header. See ARCHITECTURE.md → "Versioned docs (F6)".
+//
+// Source kinds:
+//   - `workspace`     — build from the current checkout (used for the
+//                       `latest` entry in normal day-to-day deploys).
+//   - `archive-branch`— build by checking out a static, pre-built tree
+//                       from a `docs-archive/<minor>` orphan branch.
+//                       The toolkit-of-its-day produced those artifacts;
+//                       we never re-run the current toolkit against past
+//                       minors. If the branch does not exist locally,
+//                       the version is skipped with a clear warning.
+
+export type VersionSource =
+  | { kind: "workspace" }
+  | { kind: "archive-branch"; ref: string };
+
+export interface VersionEntry {
+  /** Display label for the selector, e.g. "25.16". Must be the minor portion, never a full patch. */
+  label: string;
+  /** How to source this version's built site. */
+  source: VersionSource;
+  /** Exactly one entry across `versions[]` must carry `latest: true`. */
+  latest?: boolean;
+}
+
 /** Full toolkit config file shape (docs-toolkit.config.yaml) */
 export interface ToolkitConfig extends DocConfig {
   agents?: AgentConfig;
   website?: WebsiteConfig;
+  /**
+   * Optional minor-grained version list. When omitted, the build emits
+   * the legacy single-version flat layout. See `versions.ts` for the
+   * normalized runtime shape and validation rules.
+   */
+  versions?: VersionEntry[];
 }
 
 // ── Defaults ──────────────────────────────────────────────────
 
 const DEFAULT_LANGUAGE_LABELS: Record<string, string> = {
-  en: 'English',
-  ko: '한국어',
-  ja: '日本語',
-  th: 'ภาษาไทย',
+  en: "English",
+  ko: "한국어",
+  ja: "日本語",
+  th: "ภาษาไทย",
 };
 
-const DEFAULT_LOCALIZED_STRINGS: Record<string, { userGuide: string; tableOfContents: string }> = {
-  en: { userGuide: 'User Guide', tableOfContents: 'Table of Contents' },
-  ko: { userGuide: '사용자 가이드', tableOfContents: '목차' },
-  ja: { userGuide: 'ユーザーガイド', tableOfContents: '目次' },
-  th: { userGuide: 'คู่มือผู้ใช้', tableOfContents: 'สารบัญ' },
+const DEFAULT_LOCALIZED_STRINGS: Record<
+  string,
+  { userGuide: string; tableOfContents: string }
+> = {
+  en: { userGuide: "User Guide", tableOfContents: "Table of Contents" },
+  ko: { userGuide: "사용자 가이드", tableOfContents: "목차" },
+  ja: { userGuide: "ユーザーガイド", tableOfContents: "目次" },
+  th: { userGuide: "คู่มือผู้ใช้", tableOfContents: "สารบัญ" },
 };
 
 const DEFAULT_ADMONITION_TITLES: Record<string, Record<string, string>> = {
-  en: { note: 'NOTE', tip: 'TIP', info: 'INFO', warning: 'WARNING', caution: 'CAUTION', danger: 'DANGER' },
-  ko: { note: '참고', tip: '팁', info: '정보', warning: '주의', caution: '주의', danger: '위험' },
-  ja: { note: '注記', tip: 'ヒント', info: '情報', warning: '警告', caution: '注意', danger: '危険' },
-  th: { note: 'หมายเหตุ', tip: 'เคล็ดลับ', info: 'ข้อมูล', warning: 'คำเตือน', caution: 'ข้อควรระวัง', danger: 'อันตราย' },
+  en: {
+    note: "NOTE",
+    tip: "TIP",
+    info: "INFO",
+    warning: "WARNING",
+    caution: "CAUTION",
+    danger: "DANGER",
+  },
+  ko: {
+    note: "참고",
+    tip: "팁",
+    info: "정보",
+    warning: "주의",
+    caution: "주의",
+    danger: "위험",
+  },
+  ja: {
+    note: "注記",
+    tip: "ヒント",
+    info: "情報",
+    warning: "警告",
+    caution: "注意",
+    danger: "危険",
+  },
+  th: {
+    note: "หมายเหตุ",
+    tip: "เคล็ดลับ",
+    info: "ข้อมูล",
+    warning: "คำเตือน",
+    caution: "ข้อควรระวัง",
+    danger: "อันตราย",
+  },
 };
 
 const DEFAULT_FIGURE_LABELS: Record<string, string> = {
-  en: 'Figure',
-  ko: '그림',
-  ja: '図',
-  th: 'รูปที่',
+  en: "Figure",
+  ko: "그림",
+  ja: "図",
+  th: "รูปที่",
 };
 
 /** Localized labels for website navigation and metadata */
 export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
-  en: { previous: 'Previous', next: 'Next', editThisPage: 'Edit this page', lastUpdated: 'Last updated on', searchPlaceholder: 'Search docs...', noResults: 'No results found' },
-  ko: { previous: '이전', next: '다음', editThisPage: '이 페이지 편집', lastUpdated: '마지막 업데이트', searchPlaceholder: '문서 검색...', noResults: '검색 결과가 없습니다' },
-  ja: { previous: '前へ', next: '次へ', editThisPage: 'このページを編集', lastUpdated: '最終更新日', searchPlaceholder: 'ドキュメント検索...', noResults: '結果が見つかりません' },
-  th: { previous: 'ก่อนหน้า', next: 'ถัดไป', editThisPage: 'แก้ไขหน้านี้', lastUpdated: 'อัปเดตล่าสุด', searchPlaceholder: 'ค้นหาเอกสาร...', noResults: 'ไม่พบผลลัพธ์' },
+  en: {
+    previous: "Previous",
+    next: "Next",
+    editThisPage: "Edit this page",
+    lastUpdated: "Last updated on",
+    searchPlaceholder: "Search docs...",
+    noResults: "No results found",
+  },
+  ko: {
+    previous: "이전",
+    next: "다음",
+    editThisPage: "이 페이지 편집",
+    lastUpdated: "마지막 업데이트",
+    searchPlaceholder: "문서 검색...",
+    noResults: "검색 결과가 없습니다",
+  },
+  ja: {
+    previous: "前へ",
+    next: "次へ",
+    editThisPage: "このページを編集",
+    lastUpdated: "最終更新日",
+    searchPlaceholder: "ドキュメント検索...",
+    noResults: "結果が見つかりません",
+  },
+  th: {
+    previous: "ก่อนหน้า",
+    next: "ถัดไป",
+    editThisPage: "แก้ไขหน้านี้",
+    lastUpdated: "อัปเดตล่าสุด",
+    searchPlaceholder: "ค้นหาเอกสาร...",
+    noResults: "ไม่พบผลลัพธ์",
+  },
 };
 
 // ── Resolved config (all defaults applied) ────────────────────
@@ -142,7 +241,10 @@ export interface ResolvedDocConfig {
   version: string | null;
 
   languageLabels: Record<string, string>;
-  localizedStrings: Record<string, { userGuide: string; tableOfContents: string }>;
+  localizedStrings: Record<
+    string,
+    { userGuide: string; tableOfContents: string }
+  >;
   admonitionTitles: Record<string, Record<string, string>>;
   figureLabels: Record<string, string>;
 
@@ -155,34 +257,55 @@ export interface ResolvedDocConfig {
 
   agents?: AgentConfig;
   website?: WebsiteConfig;
+  /**
+   * Raw `versions` from `docs-toolkit.config.yaml`. Left unnormalized
+   * here so the website generator can apply F6's eligibility rules
+   * (see `versions.ts`). When undefined, single-version compatibility
+   * mode applies.
+   */
+  versions?: VersionEntry[];
 }
 
 export function resolveConfig(config: ToolkitConfig): ResolvedDocConfig {
   const projectRoot = config.projectRoot;
   return {
     title: config.title,
-    subtitle: config.subtitle ?? 'User Guide',
+    subtitle: config.subtitle ?? "User Guide",
     company: config.company,
-    logoPath: config.logoPath ? path.resolve(projectRoot, config.logoPath) : null,
-    logoFallbackHtml: config.logoFallbackHtml ?? `<div style="font-size:48px;color:#ff9d00;font-weight:bold;">${config.title}</div>`,
+    logoPath: config.logoPath
+      ? path.resolve(projectRoot, config.logoPath)
+      : null,
+    logoFallbackHtml:
+      config.logoFallbackHtml ??
+      `<div style="font-size:48px;color:#ff9d00;font-weight:bold;">${config.title}</div>`,
 
     projectRoot,
-    srcDir: path.resolve(projectRoot, config.srcDir ?? 'src'),
-    distDir: path.resolve(projectRoot, config.distDir ?? 'dist'),
+    srcDir: path.resolve(projectRoot, config.srcDir ?? "src"),
+    distDir: path.resolve(projectRoot, config.distDir ?? "dist"),
 
-    versionSource: path.resolve(projectRoot, config.versionSource ?? 'package.json'),
+    versionSource: path.resolve(
+      projectRoot,
+      config.versionSource ?? "package.json",
+    ),
     version: config.version ?? null,
 
     languageLabels: { ...DEFAULT_LANGUAGE_LABELS, ...config.languageLabels },
-    localizedStrings: mergeLocalizedStrings(DEFAULT_LOCALIZED_STRINGS, config.localizedStrings),
-    admonitionTitles: mergeNestedRecord(DEFAULT_ADMONITION_TITLES, config.admonitionTitles),
+    localizedStrings: mergeLocalizedStrings(
+      DEFAULT_LOCALIZED_STRINGS,
+      config.localizedStrings,
+    ),
+    admonitionTitles: mergeNestedRecord(
+      DEFAULT_ADMONITION_TITLES,
+      config.admonitionTitles,
+    ),
     figureLabels: { ...DEFAULT_FIGURE_LABELS, ...config.figureLabels },
 
-    pdfFilenameTemplate: config.pdfFilenameTemplate ?? '{title}_{version}_{lang}.pdf',
+    pdfFilenameTemplate:
+      config.pdfFilenameTemplate ?? "{title}_{version}_{lang}.pdf",
     pdfMetadata: {
       author: config.pdfMetadata?.author ?? config.company,
       subject: config.pdfMetadata?.subject ?? `${config.title}`,
-      creator: config.pdfMetadata?.creator ?? 'docs-toolkit PDF Generator',
+      creator: config.pdfMetadata?.creator ?? "docs-toolkit PDF Generator",
     },
     cjkFontPaths: config.cjkFontPaths ?? [],
 
@@ -191,6 +314,7 @@ export function resolveConfig(config: ToolkitConfig): ResolvedDocConfig {
 
     agents: config.agents,
     website: config.website,
+    versions: config.versions,
   };
 }
 
@@ -202,8 +326,12 @@ function mergeLocalizedStrings(
   const result = { ...defaults };
   for (const [lang, strings] of Object.entries(overrides)) {
     result[lang] = {
-      userGuide: strings.userGuide ?? defaults[lang]?.userGuide ?? defaults.en.userGuide,
-      tableOfContents: strings.tableOfContents ?? defaults[lang]?.tableOfContents ?? defaults.en.tableOfContents,
+      userGuide:
+        strings.userGuide ?? defaults[lang]?.userGuide ?? defaults.en.userGuide,
+      tableOfContents:
+        strings.tableOfContents ??
+        defaults[lang]?.tableOfContents ??
+        defaults.en.tableOfContents,
     };
   }
   return result;
@@ -215,7 +343,10 @@ function mergeNestedRecord(
 ): Record<string, Record<string, string>> {
   if (!overrides) return { ...defaults };
   const result: Record<string, Record<string, string>> = {};
-  for (const key of new Set([...Object.keys(defaults), ...Object.keys(overrides)])) {
+  for (const key of new Set([
+    ...Object.keys(defaults),
+    ...Object.keys(overrides),
+  ])) {
     result[key] = { ...defaults[key], ...overrides[key] };
   }
   return result;
@@ -223,16 +354,19 @@ function mergeNestedRecord(
 
 // ── Config file loader ────────────────────────────────────────
 
-const CONFIG_FILENAME = 'docs-toolkit.config.yaml';
+const CONFIG_FILENAME = "docs-toolkit.config.yaml";
 
 export function loadToolkitConfig(projectRoot: string): ToolkitConfig {
   const configPath = path.resolve(projectRoot, CONFIG_FILENAME);
   if (!fs.existsSync(configPath)) {
     throw new Error(
       `Config file not found: ${configPath}\n` +
-      `Run "docs-toolkit init" to create one, or create ${CONFIG_FILENAME} manually.`,
+        `Run "docs-toolkit init" to create one, or create ${CONFIG_FILENAME} manually.`,
     );
   }
-  const raw = parseYaml(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+  const raw = parseYaml(fs.readFileSync(configPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
   return { ...raw, projectRoot } as ToolkitConfig;
 }

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -13,31 +13,48 @@ export type {
   WebsiteConfig,
   ToolkitConfig,
   ResolvedDocConfig,
-} from './config.js';
-export { resolveConfig, loadToolkitConfig, WEBSITE_LABELS } from './config.js';
+  VersionEntry,
+  VersionSource,
+} from "./config.js";
+export { resolveConfig, loadToolkitConfig, WEBSITE_LABELS } from "./config.js";
+
+// ── Versioned docs (F6) ─────────────────────────────────────────
+export type {
+  Version,
+  LoadedVersions,
+  ResolvedVersionSource,
+  PageEnumerationRow,
+} from "./versions.js";
+export {
+  loadVersions,
+  findLatest,
+  resolveVersionSource,
+  canonicalPathFor,
+  VersionPageRegistry,
+} from "./versions.js";
 
 // ── Theme ───────────────────────────────────────────────────────
-export type { PdfTheme } from './theme.js';
-export { defaultTheme, loadTheme } from './theme.js';
+export type { PdfTheme } from "./theme.js";
+export { defaultTheme, loadTheme } from "./theme.js";
 
 // ── Markdown Processing ─────────────────────────────────────────
-export type { Chapter, Heading } from './markdown-processor.js';
+export type { Chapter, Heading } from "./markdown-processor.js";
 export {
   processMarkdownFiles,
   processCatalogMarkdownForPdf,
   slugify,
   resolveMarkdownPath,
-} from './markdown-processor.js';
+} from "./markdown-processor.js";
 export type {
   AnchorEntry,
   AnchorRegistry,
   LinkDiagnostic,
   WebProcessingOptions,
-} from './markdown-processor-web.js';
+} from "./markdown-processor-web.js";
 export {
   processMarkdownFilesForWeb,
   processCatalogMarkdownForWeb,
-} from './markdown-processor-web.js';
+} from "./markdown-processor-web.js";
 
 // ── Markdown Extensions ─────────────────────────────────────────
 export {
@@ -52,48 +69,52 @@ export {
   ADMONITION_TYPES,
   ADMONITION_ICONS,
   ADMONITION_TITLES,
-} from './markdown-extensions.js';
-export type { AdmonitionType } from './markdown-extensions.js';
+} from "./markdown-extensions.js";
+export type { AdmonitionType } from "./markdown-extensions.js";
 
 // ── HTML Builders ───────────────────────────────────────────────
-export type { DocMetadata } from './html-builder.js';
-export { buildFullDocument } from './html-builder.js';
-export type { WebDocMetadata } from './html-builder-web.js';
-export { buildWebDocument } from './html-builder-web.js';
-export type { WebPageContext, WebsiteMetadata } from './website-builder.js';
-export { buildWebPage, buildIndexPage } from './website-builder.js';
+export type { DocMetadata } from "./html-builder.js";
+export { buildFullDocument } from "./html-builder.js";
+export type { WebDocMetadata } from "./html-builder-web.js";
+export { buildWebDocument } from "./html-builder-web.js";
+export type { WebPageContext, WebsiteMetadata } from "./website-builder.js";
+export { buildWebPage, buildIndexPage } from "./website-builder.js";
 
 // ── PDF Rendering ───────────────────────────────────────────────
-export type { RenderOptions } from './pdf-renderer.js';
-export { renderPdf } from './pdf-renderer.js';
+export type { RenderOptions } from "./pdf-renderer.js";
+export { renderPdf } from "./pdf-renderer.js";
 
 // ── PDF Generation ──────────────────────────────────────────────
-export { generatePdf } from './generate-pdf.js';
-export type { GeneratePdfOptions } from './generate-pdf.js';
+export { generatePdf } from "./generate-pdf.js";
+export type { GeneratePdfOptions } from "./generate-pdf.js";
 
 // ── Website Generation ──────────────────────────────────────────
-export { generateWebsite } from './website-generator.js';
-export type { GenerateWebsiteOptions } from './website-generator.js';
+export { generateWebsite } from "./website-generator.js";
+export type { GenerateWebsiteOptions } from "./website-generator.js";
 
 // ── Search Index ────────────────────────────────────────────────
-export { buildSearchIndex, tokenize } from './search-index-builder.js';
-export type { SearchDocument, SearchIndex, SearchIndexEntry } from './search-index-builder.js';
+export { buildSearchIndex, tokenize } from "./search-index-builder.js";
+export type {
+  SearchDocument,
+  SearchIndex,
+  SearchIndexEntry,
+} from "./search-index-builder.js";
 
 // ── Preview Servers ─────────────────────────────────────────────
-export { startPreviewServer } from './preview-server.js';
-export type { PreviewServerOptions } from './preview-server.js';
-export { startHtmlPreviewServer } from './preview-server-web.js';
-export type { HtmlPreviewOptions } from './preview-server-web.js';
-export { startWebsitePreviewServer } from './preview-server-website.js';
-export type { WebsitePreviewOptions } from './preview-server-website.js';
+export { startPreviewServer } from "./preview-server.js";
+export type { PreviewServerOptions } from "./preview-server.js";
+export { startHtmlPreviewServer } from "./preview-server-web.js";
+export type { HtmlPreviewOptions } from "./preview-server-web.js";
+export { startWebsitePreviewServer } from "./preview-server-website.js";
+export type { WebsitePreviewOptions } from "./preview-server-website.js";
 
 // ── Styles ──────────────────────────────────────────────────────
-export { generatePdfStyles } from './styles.js';
-export { generateWebStyles, generateWebsiteStyles } from './styles-web.js';
+export { generatePdfStyles } from "./styles.js";
+export { generateWebStyles, generateWebsiteStyles } from "./styles-web.js";
 
 // ── Version ─────────────────────────────────────────────────────
-export { getDocVersion } from './version.js';
+export { getDocVersion } from "./version.js";
 
 // ── Sample Content ──────────────────────────────────────────────
-export { buildThemeInfoChapter } from './sample-content.js';
-export { getCatalogMarkdown } from './sample-content-markdown.js';
+export { buildThemeInfoChapter } from "./sample-content.js";
+export { getCatalogMarkdown } from "./sample-content-markdown.js";

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -3,7 +3,7 @@
  * Uses Infima CSS variables for consistent styling.
  */
 
-const CJK_LANGS = new Set(['ko', 'ja', 'zh', 'zh-CN', 'zh-TW']);
+const CJK_LANGS = new Set(["ko", "ja", "zh", "zh-CN", "zh-TW"]);
 
 export function generateWebStyles(lang?: string): string {
   const isCjk = lang ? CJK_LANGS.has(lang) : false;
@@ -140,7 +140,7 @@ body {
   background: #fff;
   margin: 0;
   padding: 0;
-  ${isCjk ? 'word-break: keep-all;' : ''}
+  ${isCjk ? "word-break: keep-all;" : ""}
   overflow-wrap: break-word;
 }
 
@@ -784,9 +784,45 @@ export function generateWebsiteStyles(): string {
   const cjkSelectors = Array.from(CJK_LANGS)
     .sort()
     .map((code) => `:lang(${code}) body`)
-    .join(',\n');
+    .join(",\n");
 
-  return baseStyles + `
+  return (
+    baseStyles +
+    `
+
+/* ==========================================================================
+   Page header bar (F1 language switcher + F6 version switcher live here)
+   ========================================================================== */
+.page-header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-color-emphasis-0);
+  font-size: 0.875rem;
+}
+.page-header-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.version-switcher-label {
+  color: var(--ifm-color-emphasis-700);
+  font-weight: 500;
+}
+.version-switcher {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  background: var(--ifm-color-emphasis-0);
+  color: var(--ifm-color-emphasis-900);
+  font: inherit;
+  cursor: pointer;
+}
+.version-switcher:hover {
+  border-color: var(--ifm-color-primary);
+}
 
 /* ==========================================================================
    CJK Language Rules (via :lang() selectors for shared stylesheet)
@@ -794,5 +830,6 @@ export function generateWebsiteStyles(): string {
 ${cjkSelectors} {
   word-break: keep-all;
 }
-`;
+`
+  );
 }

--- a/packages/backend.ai-docs-toolkit/src/versions.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/versions.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for versions.ts (F6 / FR-2718).
+ *
+ * Run: pnpm --filter backend.ai-docs-toolkit test
+ *      (which executes `tsx --test src/versions.test.ts`)
+ *
+ * Coverage:
+ *   - Single-version compatibility mode (no `versions` declared)
+ *   - Validation: missing latest, multiple latest, duplicate label,
+ *     bad source kind, missing archive-branch ref, patch-shaped label.
+ *   - Normalization: outDir mirrors label, isLatest flag, ordering.
+ *   - VersionPageRegistry: insert + lookup + enumerate.
+ *   - canonicalPathFor: flat vs versioned.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "path";
+import {
+  loadVersions,
+  findLatest,
+  canonicalPathFor,
+  resolveVersionSource,
+  VersionPageRegistry,
+} from "./versions.js";
+import type { ResolvedDocConfig, VersionEntry } from "./config.js";
+
+function makeConfig(versions: VersionEntry[] | undefined): ResolvedDocConfig {
+  return {
+    title: "t",
+    subtitle: "s",
+    company: "c",
+    logoPath: null,
+    logoFallbackHtml: "",
+    projectRoot: path.resolve("/tmp/fake-project-root"),
+    srcDir: path.resolve("/tmp/fake-project-root/src"),
+    distDir: path.resolve("/tmp/fake-project-root/dist"),
+    versionSource: "",
+    version: null,
+    languageLabels: { en: "English" },
+    localizedStrings: {
+      en: { userGuide: "User Guide", tableOfContents: "TOC" },
+    },
+    admonitionTitles: { en: { note: "NOTE" } },
+    figureLabels: { en: "Figure" },
+    pdfFilenameTemplate: "{title}.pdf",
+    pdfMetadata: { author: "a", subject: "b", creator: "c" },
+    cjkFontPaths: [],
+    pathFallbacks: {},
+    productName: "p",
+    versions,
+  } satisfies ResolvedDocConfig;
+}
+
+describe("loadVersions — single-version compatibility mode", () => {
+  it("returns enabled=false when versions is undefined", () => {
+    const result = loadVersions(makeConfig(undefined));
+    assert.equal(result.enabled, false);
+    assert.deepEqual(result.entries, []);
+    assert.equal(result.latest, null);
+  });
+
+  it("returns enabled=false when versions is an empty array", () => {
+    const result = loadVersions(makeConfig([]));
+    assert.equal(result.enabled, false);
+  });
+});
+
+describe("loadVersions — happy path", () => {
+  it("normalizes a workspace-only single-entry config", () => {
+    const result = loadVersions(
+      makeConfig([
+        { label: "25.16", source: { kind: "workspace" }, latest: true },
+      ]),
+    );
+    assert.equal(result.enabled, true);
+    assert.equal(result.entries.length, 1);
+    assert.equal(result.entries[0].label, "25.16");
+    assert.equal(result.entries[0].outDir, "25.16");
+    assert.equal(result.entries[0].isLatest, true);
+    assert.equal(findLatest(result).label, "25.16");
+  });
+
+  it("preserves declared order and marks one as latest", () => {
+    const result = loadVersions(
+      makeConfig([
+        { label: "25.16", source: { kind: "workspace" }, latest: true },
+        {
+          label: "25.10",
+          source: { kind: "archive-branch", ref: "docs-archive/25.10" },
+        },
+      ]),
+    );
+    assert.equal(result.enabled, true);
+    assert.deepEqual(
+      result.entries.map((v) => v.label),
+      ["25.16", "25.10"],
+    );
+    assert.equal(result.entries[0].isLatest, true);
+    assert.equal(result.entries[1].isLatest, false);
+  });
+});
+
+describe("loadVersions — validation failures", () => {
+  it("throws when no entry is marked latest", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([{ label: "25.16", source: { kind: "workspace" } }]),
+        ),
+      /exactly one .*latest: true/,
+    );
+  });
+
+  it("throws when multiple entries are marked latest", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            { label: "25.16", source: { kind: "workspace" }, latest: true },
+            { label: "25.10", source: { kind: "workspace" }, latest: true },
+          ]),
+        ),
+      /exactly one .*latest: true/,
+    );
+  });
+
+  it("throws on duplicate labels", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            { label: "25.16", source: { kind: "workspace" }, latest: true },
+            { label: "25.16", source: { kind: "workspace" } },
+          ]),
+        ),
+      /duplicates an earlier entry/,
+    );
+  });
+
+  it("rejects patch-shaped labels (the selector lists minors only)", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            { label: "25.16.5", source: { kind: "workspace" }, latest: true },
+          ]),
+        ),
+      /must match \^\[0-9\]\+\\\.\[0-9\]\+\$/,
+    );
+  });
+
+  it("rejects labels with non-numeric segments (matches GH workflow regex)", () => {
+    for (const bad of ["25.16-rc1", "v25.16", "25.16/x", "latest", "25"]) {
+      assert.throws(
+        () =>
+          loadVersions(
+            makeConfig([
+              { label: bad, source: { kind: "workspace" }, latest: true },
+            ]),
+          ),
+        /must match \^\[0-9\]\+\\\.\[0-9\]\+\$/,
+        `expected ${bad} to be rejected`,
+      );
+    }
+  });
+
+  it("rejects unknown source.kind", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            // Bypass the type check to simulate a malformed YAML config.
+            {
+              label: "25.16",
+              source: { kind: "http" as "workspace" },
+              latest: true,
+            },
+          ]),
+        ),
+      /must be "workspace" or "archive-branch"/,
+    );
+  });
+
+  it("requires source.ref when kind is archive-branch", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            {
+              label: "25.16",
+              source: { kind: "archive-branch", ref: "" },
+              latest: true,
+            },
+          ]),
+        ),
+      /source\.ref.* required/,
+    );
+  });
+
+  it("rejects empty label", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            { label: "", source: { kind: "workspace" }, latest: true },
+          ]),
+        ),
+      /must be a non-empty string/,
+    );
+  });
+});
+
+describe("canonicalPathFor", () => {
+  it("returns flat layout when versions are not enabled", () => {
+    const loaded = loadVersions(makeConfig(undefined));
+    assert.equal(
+      canonicalPathFor(loaded, "en", "session-page"),
+      "en/session-page.html",
+    );
+  });
+
+  it("returns latest-prefixed path when versions are enabled", () => {
+    const loaded = loadVersions(
+      makeConfig([
+        { label: "25.16", source: { kind: "workspace" }, latest: true },
+        {
+          label: "25.10",
+          source: { kind: "archive-branch", ref: "docs-archive/25.10" },
+        },
+      ]),
+    );
+    assert.equal(
+      canonicalPathFor(loaded, "ko", "vfolder"),
+      "25.16/ko/vfolder.html",
+    );
+  });
+});
+
+describe("resolveVersionSource — archive-branch ref safety", () => {
+  it("rejects refs that contain `..` segments", () => {
+    const config = makeConfig([
+      { label: "25.16", source: { kind: "workspace" }, latest: true },
+    ]);
+    assert.throws(
+      () =>
+        resolveVersionSource(config, {
+          label: "25.10",
+          source: { kind: "archive-branch", ref: "../../etc/passwd" },
+          isLatest: false,
+          outDir: "25.10",
+        }),
+      /contains unsafe segments/,
+    );
+  });
+
+  it("rejects refs with a leading slash", () => {
+    const config = makeConfig([
+      { label: "25.16", source: { kind: "workspace" }, latest: true },
+    ]);
+    assert.throws(
+      () =>
+        resolveVersionSource(config, {
+          label: "25.10",
+          source: { kind: "archive-branch", ref: "/etc/passwd" },
+          isLatest: false,
+          outDir: "25.10",
+        }),
+      /contains unsafe segments/,
+    );
+  });
+
+  it("rejects refs with a leading dot", () => {
+    const config = makeConfig([
+      { label: "25.16", source: { kind: "workspace" }, latest: true },
+    ]);
+    assert.throws(
+      () =>
+        resolveVersionSource(config, {
+          label: "25.10",
+          source: { kind: "archive-branch", ref: ".hidden" },
+          isLatest: false,
+          outDir: "25.10",
+        }),
+      /contains unsafe segments/,
+    );
+  });
+
+  it("accepts a normal docs-archive ref", () => {
+    const config = makeConfig([
+      { label: "25.16", source: { kind: "workspace" }, latest: true },
+    ]);
+    // Won't materialize on disk but must not throw — should return ok=false
+    // with a "not materialized" warning rather than a security error.
+    const result = resolveVersionSource(config, {
+      label: "25.10",
+      source: { kind: "archive-branch", ref: "docs-archive/25.10" },
+      isLatest: false,
+      outDir: "25.10",
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.warning ?? "", /not materialized/);
+  });
+});
+
+describe("VersionPageRegistry", () => {
+  it("records and looks up slugs per version", () => {
+    const reg = new VersionPageRegistry();
+    reg.record({
+      version: "25.16",
+      lang: "en",
+      slug: "overview",
+      path: "25.16/en/overview.html",
+      isLatest: true,
+    });
+    reg.record({
+      version: "25.10",
+      lang: "en",
+      slug: "overview",
+      path: "25.10/en/overview.html",
+      isLatest: false,
+    });
+    reg.record({
+      version: "25.16",
+      lang: "en",
+      slug: "rbac",
+      path: "25.16/en/rbac.html",
+      isLatest: true,
+    });
+    assert.equal(reg.hasSlug("25.16", "overview"), true);
+    assert.equal(reg.hasSlug("25.16", "rbac"), true);
+    assert.equal(reg.hasSlug("25.10", "overview"), true);
+    // rbac introduced in 25.16 only — does not exist in 25.10.
+    assert.equal(reg.hasSlug("25.10", "rbac"), false);
+    // Unknown version → never has the slug.
+    assert.equal(reg.hasSlug("25.05", "overview"), false);
+    assert.equal(reg.enumerateAll().length, 3);
+  });
+});

--- a/packages/backend.ai-docs-toolkit/src/versions.ts
+++ b/packages/backend.ai-docs-toolkit/src/versions.ts
@@ -1,0 +1,330 @@
+/**
+ * Versioned documentation support (F6 / FR-2718).
+ *
+ * Implements the minor-grained version model declared by the optional
+ * `versions` key in `docs-toolkit.config.yaml`. Responsibilities:
+ *
+ *   - Validate the raw `VersionEntry[]` from config (label uniqueness,
+ *     exactly one `latest: true`, well-formed `source.kind`).
+ *   - Normalize entries into a runtime-friendly `Version[]` shape.
+ *   - Resolve each version's content source root (workspace checkout vs
+ *     a `docs-archive/<minor>` orphan branch).
+ *   - Expose the (version, lang, slug) enumeration that the sitemap and
+ *     canonical-URL builders in F2 will consume.
+ *
+ * Single-version compatibility mode (no `versions` declared) is handled
+ * by the caller — this module never invents a default version.
+ *
+ * IMPORTANT: this module never mutates global state and never touches
+ * the filesystem outside of optionally inspecting whether an
+ * archive-branch worktree exists (a best-effort warn-and-skip path).
+ */
+
+import fs from "fs";
+import path from "path";
+import type {
+  ResolvedDocConfig,
+  VersionEntry,
+  VersionSource,
+} from "./config.js";
+
+/**
+ * Strict `MAJOR.MINOR` shape for `versions[].label`. Mirrors the regex
+ * used by the GitHub release-archive workflow so config validation
+ * catches any deviation (patch suffix, pre-release tag, slash, etc.)
+ * at load time rather than letting it leak into URL paths and filesystem
+ * segments downstream.
+ */
+const MINOR_LABEL = /^[0-9]+\.[0-9]+$/;
+
+/**
+ * Runtime-normalized version entry. One per minor version that survives
+ * validation. The `outDir` lives directly under the website output root
+ * (`<distDir>/<websiteOutDir>/<outDir>/<lang>/...`) and is identical to
+ * `label` — kept as a separate field so callers do not have to know the
+ * "label == directory name" coupling.
+ */
+export interface Version {
+  /** e.g. "25.16" — used as the URL segment and selector display label. */
+  label: string;
+  /** Source-of-content kind. */
+  source: VersionSource;
+  /** True for exactly one entry (the default the root index resolves to). */
+  isLatest: boolean;
+  /** The directory segment under `dist/web/` for this version. Equal to `label`. */
+  outDir: string;
+}
+
+/**
+ * Result of `loadVersions`. `enabled` is the only field callers should
+ * check before iterating: when `false`, the build runs in single-version
+ * compatibility mode and the rest of the fields are empty.
+ */
+export interface LoadedVersions {
+  /** True when the config declared a non-empty `versions` array that passed validation. */
+  enabled: boolean;
+  /** Validated, normalized entries. Empty when `enabled === false`. */
+  entries: Version[];
+  /** The `isLatest === true` entry, or null when `enabled === false`. */
+  latest: Version | null;
+}
+
+/**
+ * Validate the raw `versions` config and produce a normalized list.
+ * Throws on hard schema violations (so the build fails fast on malformed
+ * config). Returns `{ enabled: false }` when `versions` was not declared
+ * at all — that is the single-version compatibility code path and is
+ * NOT a validation error.
+ */
+export function loadVersions(config: ResolvedDocConfig): LoadedVersions {
+  const raw = config.versions;
+  if (!raw) {
+    return { enabled: false, entries: [], latest: null };
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `docs-toolkit.config.yaml: "versions" must be an array of entries. ` +
+        `Got: ${typeof raw}.`,
+    );
+  }
+  if (raw.length === 0) {
+    // Treat an explicit empty array the same as "not declared" — the
+    // user might be staging the key. Falls back to flat layout.
+    return { enabled: false, entries: [], latest: null };
+  }
+
+  const seenLabels = new Set<string>();
+  const normalized: Version[] = [];
+  let latestCount = 0;
+
+  for (const [index, entry] of raw.entries()) {
+    validateEntryShape(entry, index);
+    if (seenLabels.has(entry.label)) {
+      throw new Error(
+        `docs-toolkit.config.yaml: "versions[${index}].label" duplicates an earlier entry: ` +
+          `"${entry.label}". Each minor must appear exactly once.`,
+      );
+    }
+    seenLabels.add(entry.label);
+
+    if (entry.latest === true) {
+      latestCount++;
+    }
+
+    normalized.push({
+      label: entry.label,
+      source: entry.source,
+      isLatest: entry.latest === true,
+      outDir: entry.label,
+    });
+  }
+
+  if (latestCount !== 1) {
+    throw new Error(
+      `docs-toolkit.config.yaml: exactly one "versions[].latest: true" entry is required. ` +
+        `Got: ${latestCount}.`,
+    );
+  }
+
+  const latest = normalized.find((v) => v.isLatest) ?? null;
+  return { enabled: true, entries: normalized, latest };
+}
+
+function validateEntryShape(entry: VersionEntry, index: number): void {
+  if (!entry || typeof entry !== "object") {
+    throw new Error(
+      `docs-toolkit.config.yaml: "versions[${index}]" must be an object.`,
+    );
+  }
+  if (typeof entry.label !== "string" || entry.label.length === 0) {
+    throw new Error(
+      `docs-toolkit.config.yaml: "versions[${index}].label" must be a non-empty string ` +
+        `(e.g., "25.16"). Got: ${JSON.stringify(entry.label)}.`,
+    );
+  }
+  // The selector lists minor versions only. Enforce strict `MAJOR.MINOR`
+  // shape (matching the GitHub release-archive workflow's regex) so any
+  // deviation — patch suffix, pre-release tag, slash, etc. — fails fast at
+  // config load time instead of leaking into URL paths or filesystem
+  // segments downstream.
+  if (!MINOR_LABEL.test(entry.label)) {
+    throw new Error(
+      `docs-toolkit.config.yaml: "versions[${index}].label" must match ^[0-9]+\\.[0-9]+$ ` +
+        `(minor only, e.g., "25.16"). Got: ${JSON.stringify(entry.label)}. The selector never ` +
+        `lists patches; the highest patch within a minor is built and published as that minor.`,
+    );
+  }
+  if (!entry.source || typeof entry.source !== "object") {
+    throw new Error(
+      `docs-toolkit.config.yaml: "versions[${index}].source" must be an object with a "kind" field.`,
+    );
+  }
+  const kind = (entry.source as VersionSource).kind;
+  if (kind !== "workspace" && kind !== "archive-branch") {
+    throw new Error(
+      `docs-toolkit.config.yaml: "versions[${index}].source.kind" must be ` +
+        `"workspace" or "archive-branch". Got: ${JSON.stringify(kind)}.`,
+    );
+  }
+  if (kind === "archive-branch") {
+    const ref = (entry.source as { kind: "archive-branch"; ref: string }).ref;
+    if (typeof ref !== "string" || ref.length === 0) {
+      throw new Error(
+        `docs-toolkit.config.yaml: "versions[${index}].source.ref" is required when ` +
+          `kind is "archive-branch" (e.g., "docs-archive/25.16").`,
+      );
+    }
+  }
+}
+
+/**
+ * Find the entry marked `latest: true`. Throws when called on a
+ * disabled/empty `LoadedVersions` — callers must check `.enabled` first.
+ */
+export function findLatest(loaded: LoadedVersions): Version {
+  if (!loaded.latest) {
+    throw new Error(
+      "findLatest() called but no version is marked latest. " +
+        "Check `loaded.enabled` before invoking.",
+    );
+  }
+  return loaded.latest;
+}
+
+/**
+ * Result of attempting to resolve a version's content source to a real
+ * directory on disk. Used by the website generator to decide whether to
+ * build that version or skip it with a warning.
+ */
+export interface ResolvedVersionSource {
+  /** Absolute path to the directory the build should consume (or fall back to). */
+  rootDir: string | null;
+  /** True when the source resolved cleanly. */
+  ok: boolean;
+  /** Optional warning to surface when ok === false. */
+  warning?: string;
+}
+
+/**
+ * Resolve a version's `source` to a project root the build can read.
+ *
+ * For `workspace`, this is always `config.projectRoot` — the current
+ * checkout. For `archive-branch`, this looks for a sibling worktree at
+ * `<projectRoot>/.docs-archive/<branch-segment>`; if absent, returns
+ * `ok: false` with a warning. Materializing the archive-branch worktree
+ * (`git worktree add`) is out of scope for v1 — the operational rollout
+ * spec covers it, and v1 deliberately ships with `workspace` as the
+ * only fully-exercised path.
+ */
+export function resolveVersionSource(
+  config: ResolvedDocConfig,
+  version: Version,
+): ResolvedVersionSource {
+  const src = version.source;
+  if (src.kind === "workspace") {
+    return { rootDir: config.projectRoot, ok: true };
+  }
+  // archive-branch: look for a pre-checked-out worktree under
+  // `<projectRoot>/.docs-archive/<sanitized-branch>`. The release-time
+  // CI workflow that PUSHES the orphan branch lives in this PR; the
+  // workflow/operator that PULLS it into a worktree before rebuild is
+  // operational scope.
+  //
+  // Reject refs containing `..`, leading `/`, or leading `.` — without
+  // these guards a `replace(/[^A-Za-z0-9._/-]/g, "_")` pass would happily
+  // preserve a `..` segment, and `path.join(projectRoot, ".docs-archive",
+  // "..")` would resolve to `projectRoot` (or worse). Bail out loudly
+  // rather than silently building from an unintended directory.
+  if (
+    src.ref.includes("..") ||
+    src.ref.startsWith("/") ||
+    src.ref.startsWith(".")
+  ) {
+    throw new Error(
+      `Version "${version.label}" archive-branch ref contains unsafe segments: ` +
+        `${JSON.stringify(src.ref)}. Refs must not include "..", a leading "/", or a leading ".".`,
+    );
+  }
+  const safeRef = src.ref
+    .replace(/[^A-Za-z0-9._/-]/g, "_")
+    .replace(/\//g, "__");
+  const candidate = path.join(config.projectRoot, ".docs-archive", safeRef);
+  if (fs.existsSync(candidate)) {
+    return { rootDir: candidate, ok: true };
+  }
+  return {
+    rootDir: null,
+    ok: false,
+    warning:
+      `Version "${version.label}" source "archive-branch:${src.ref}" not materialized at ` +
+      `${candidate}. Skipping. (Run the docs-archive checkout workflow before building, ` +
+      `or remove the entry from "versions".)`,
+  };
+}
+
+/**
+ * One row in the (version, lang, slug) enumeration consumed by F2's
+ * sitemap and canonical-URL generators. `path` is the URL path relative
+ * to the website output root (no leading slash, no trailing index).
+ */
+export interface PageEnumerationRow {
+  version: string;
+  lang: string;
+  slug: string;
+  /** URL-relative path. e.g. `25.16/en/session-page.html` (versioned) or `en/session-page.html` (flat). */
+  path: string;
+  /** True when this row was emitted by the `latest` version (or by flat single-version mode). */
+  isLatest: boolean;
+}
+
+/**
+ * Build the canonical URL path for a slug in the latest version. F2
+ * uses this to populate `<link rel="canonical">` on every page so that
+ * non-latest versions point readers at the live latest version.
+ *
+ * In flat mode, the canonical is simply `<lang>/<slug>.html`.
+ */
+export function canonicalPathFor(
+  loaded: LoadedVersions,
+  lang: string,
+  slug: string,
+): string {
+  if (!loaded.enabled || !loaded.latest) {
+    return `${lang}/${slug}.html`;
+  }
+  return `${loaded.latest.label}/${lang}/${slug}.html`;
+}
+
+/**
+ * Cross-version slug map: for a given slug, which versions contain it.
+ * The header version selector uses this to fall back to the version's
+ * index page when a slug doesn't exist there.
+ *
+ * Built incrementally by the website generator as it processes each
+ * version's chapters; F2's sitemap emitter consumes the final form.
+ */
+export class VersionPageRegistry {
+  private rows: PageEnumerationRow[] = [];
+  /** version → set of slugs that exist under that version (any lang). */
+  private slugsByVersion = new Map<string, Set<string>>();
+
+  record(row: PageEnumerationRow): void {
+    this.rows.push(row);
+    let bucket = this.slugsByVersion.get(row.version);
+    if (!bucket) {
+      bucket = new Set<string>();
+      this.slugsByVersion.set(row.version, bucket);
+    }
+    bucket.add(row.slug);
+  }
+
+  /** True when `slug` exists in `version` (any language). */
+  hasSlug(version: string, slug: string): boolean {
+    return this.slugsByVersion.get(version)?.has(slug) === true;
+  }
+
+  /** All recorded rows, in insertion order. F2 iterates this for sitemap.xml. */
+  enumerateAll(): readonly PageEnumerationRow[] {
+    return this.rows;
+  }
+}

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -25,12 +25,48 @@ export interface WebPageContext {
   lastUpdated?: string;
   /** Hashed asset filenames keyed by logical name (e.g. "styles.css" → "styles.deadbeef.css"). */
   assets: PageAssets;
+  /**
+   * Versioned-docs context (F6). Optional — only set when the build is
+   * running in versioned mode (`versions` declared in config). Drives
+   * the header version selector and the "is this the latest?" hint
+   * the page metadata bar can show.
+   */
+  versionContext?: PageVersionContext;
 }
 
 export interface WebsiteMetadata {
   title: string;
   version: string;
   lang: string;
+}
+
+/**
+ * Per-page version context. Built by the website generator from the
+ * loaded `LoadedVersions` and the slug being rendered.
+ */
+export interface PageVersionContext {
+  /** Current minor label, e.g. "25.16". */
+  current: string;
+  /** Full ordered list of minor labels for the dropdown. */
+  allLabels: string[];
+  /** Label of the entry marked `latest: true`. */
+  latest: string;
+  /**
+   * For each version label, indicates whether the current page slug
+   * exists there. Used to decide between "navigate to same slug" and
+   * "fall back to that version's index". Built once per (lang, slug)
+   * by the generator and reused across pages with that slug.
+   */
+  slugAvailability: Record<string, boolean>;
+  /** Current page slug. Used by the inline switcher script for navigation. */
+  slug: string;
+  /**
+   * Path depth from the current page back to the website output root.
+   * For a page at `<dist>/web/<version>/<lang>/<slug>.html` this is 3
+   * (`../../../`). Drives the relative-URL math the inline script uses
+   * when navigating across versions.
+   */
+  rootDepth: number;
 }
 
 /**
@@ -186,6 +222,21 @@ function buildPageMetadata(context: WebPageContext): string {
 }
 
 /**
+ * Compute the `..` prefix that points from a chapter page back to the
+ * website output root (`dist/web/`). Pages at `<lang>/foo.html` need
+ * one `..`; pages at `<version>/<lang>/foo.html` (versioned mode) need
+ * two. Used for stylesheet, search script, favicon, and root-relative
+ * navigation URLs so the same builder works in both layouts.
+ */
+function rootPrefix(context: { versionContext?: PageVersionContext }): string {
+  const depth = context.versionContext?.rootDepth ?? 2;
+  // Each segment between the page and `dist/web/` adds one `../`.
+  // Depth 2 = `<lang>/foo.html` → 1 hop up. Depth 3 = `<v>/<lang>/foo.html` → 2 hops.
+  const hops = Math.max(0, depth - 1);
+  return "../".repeat(hops);
+}
+
+/**
  * Build the `<head>` block: meta tags + stylesheet + favicon / apple-touch /
  * webmanifest. The search script is referenced separately from `<body>` end.
  */
@@ -194,27 +245,28 @@ function buildHeadAssetTags(
   langLabel: string,
   pageTitle: string,
   assets: PageAssets,
+  prefix: string,
 ): string {
   const lines: string[] = [
     `<meta charset="utf-8" />`,
     `<meta name="viewport" content="width=device-width, initial-scale=1" />`,
     `<title>${pageTitle} - ${escapeHtml(langLabel)}</title>`,
-    `<link rel="stylesheet" href="../assets/${escapeHtml(assets.styles)}" />`,
+    `<link rel="stylesheet" href="${prefix}assets/${escapeHtml(assets.styles)}" />`,
   ];
 
   if (assets.favicon) {
     lines.push(
-      `<link rel="icon" href="../${escapeHtml(assets.favicon)}" sizes="any" />`,
+      `<link rel="icon" href="${prefix}${escapeHtml(assets.favicon)}" sizes="any" />`,
     );
   }
   if (assets.appleTouchIcon) {
     lines.push(
-      `<link rel="apple-touch-icon" href="../${escapeHtml(assets.appleTouchIcon)}" />`,
+      `<link rel="apple-touch-icon" href="${prefix}${escapeHtml(assets.appleTouchIcon)}" />`,
     );
   }
   if (assets.webmanifest) {
     lines.push(
-      `<link rel="manifest" href="../${escapeHtml(assets.webmanifest)}" />`,
+      `<link rel="manifest" href="${prefix}${escapeHtml(assets.webmanifest)}" />`,
     );
   }
 
@@ -230,16 +282,110 @@ function buildHeadAssetTags(
  * a data attribute on `#search-input`, so the script itself stays
  * language-agnostic and can be content-hashed once.
  */
-function buildSearchScriptTag(assets: PageAssets): string {
-  return `<script defer src="../assets/${escapeHtml(assets.search)}"></script>`;
+function buildSearchScriptTag(assets: PageAssets, prefix: string): string {
+  return `<script defer src="${prefix}assets/${escapeHtml(assets.search)}"></script>`;
 }
 
 /**
  * Build optional code-copy script tag (added by F4). No-op until F4 lands.
  */
-function buildCodeCopyScriptTag(assets: PageAssets): string {
+function buildCodeCopyScriptTag(assets: PageAssets, prefix: string): string {
   if (!assets.codeCopy) return "";
-  return `<script defer src="../assets/${escapeHtml(assets.codeCopy)}"></script>`;
+  return `<script defer src="${prefix}assets/${escapeHtml(assets.codeCopy)}"></script>`;
+}
+
+/**
+ * Build the page-header bar. F1 (sibling stack arm) introduces the
+ * language switcher in this same `<header class="page-header-bar">`
+ * structure; F6 contributes the version selector. When F1 lands the
+ * two contributions live side-by-side as siblings inside `page-header-nav`.
+ *
+ * In F6's worktree (which doesn't yet have F1), this header carries the
+ * version selector on its own. The CSS class names are stable so the
+ * eventual F1 + F6 reconciliation is a small CSS adjustment, not a
+ * structural conflict.
+ *
+ * Returns an empty string when no header content is present (no version
+ * selector, no language switcher) so we don't emit a stray `<header />`.
+ */
+function buildPageHeaderBar(context: WebPageContext): string {
+  const versionSwitcher = buildVersionSwitcher(context);
+  if (!versionSwitcher) {
+    // Nothing to render in the header today. F1 will fill this in with
+    // a language switcher; F6 leaves the scaffold absent until then so
+    // we don't ship empty markup.
+    return "";
+  }
+  return `<header class="page-header-bar">
+  <nav class="page-header-nav" aria-label="Documentation navigation">
+    ${versionSwitcher}
+  </nav>
+</header>`;
+}
+
+/**
+ * Build the version selector dropdown for versioned-docs mode.
+ *
+ * The dropdown lists every minor label (never patches — that
+ * invariant is enforced at config-load time in `versions.ts`). On
+ * change, an inline script navigates to the same slug in the target
+ * version when the slug exists there; otherwise it falls back to the
+ * target version's index page (no 404).
+ *
+ * The data needed by the inline script is passed via `data-` attributes
+ * on the `<select>` so the script body itself stays small and language-
+ * agnostic. Total inline JS budget < 1 KB; safely under the 25 KB total
+ * per-page JS cap.
+ */
+function buildVersionSwitcher(context: WebPageContext): string {
+  const ver = context.versionContext;
+  if (!ver) return "";
+  // Build availability JSON: { "25.16": true, "25.10": false, ... }.
+  // The script reads this to decide between same-slug and index-fallback.
+  const availabilityJson = JSON.stringify(ver.slugAvailability);
+  const optionsHtml = ver.allLabels
+    .map((label) => {
+      const selected = label === ver.current ? " selected" : "";
+      const isLatest = label === ver.latest ? " (latest)" : "";
+      return `<option value="${escapeHtml(label)}"${selected}>${escapeHtml(label)}${isLatest}</option>`;
+    })
+    .join("");
+  // The handler is inlined to avoid a separate hashed asset for ~30 LoC.
+  // It is idempotent and language-agnostic: the only state it touches is
+  // `window.location.assign(...)` after a probe of the availability map.
+  const inlineScript = `(function(){
+  var sel = document.currentScript && document.currentScript.previousElementSibling;
+  if (!sel || sel.tagName !== 'SELECT') return;
+  sel.addEventListener('change', function(e) {
+    var target = e.target.value;
+    if (!target) return;
+    var current = sel.dataset.current;
+    if (target === current) return;
+    var lang = sel.dataset.lang;
+    var slug = sel.dataset.slug;
+    var rootDepth = parseInt(sel.dataset.rootDepth, 10) || 2;
+    var availability = {};
+    try { availability = JSON.parse(sel.dataset.availability || '{}'); } catch (_) {}
+    var hops = Math.max(0, rootDepth - 1);
+    var prefix = '';
+    for (var i = 0; i < hops; i++) { prefix += '../'; }
+    var dest = availability[target]
+      ? prefix + target + '/' + lang + '/' + slug + '.html'
+      : prefix + target + '/' + lang + '/index.html';
+    window.location.assign(dest);
+  });
+})();`;
+  return `<label class="version-switcher-label" for="version-switcher">Version</label>
+    <select
+      id="version-switcher"
+      class="version-switcher"
+      data-current="${escapeHtml(ver.current)}"
+      data-lang="${escapeHtml(context.metadata.lang)}"
+      data-slug="${escapeHtml(ver.slug)}"
+      data-root-depth="${ver.rootDepth}"
+      data-availability="${escapeHtml(availabilityJson)}"
+    >${optionsHtml}</select>
+    <script>${inlineScript}</script>`;
 }
 
 /**
@@ -286,6 +432,8 @@ export function buildWebPage(context: WebPageContext): string {
   const { chapter, allChapters, currentIndex, metadata, config, assets } =
     context;
 
+  const prefix = rootPrefix(context);
+
   const sidebar = buildWebsiteSidebar(
     allChapters,
     currentIndex,
@@ -301,9 +449,16 @@ export function buildWebPage(context: WebPageContext): string {
   );
   const langLabel = config.languageLabels[metadata.lang] || metadata.lang;
   const pageTitle = `${escapeHtml(chapter.title)} - ${escapeHtml(metadata.title)}`;
-  const headTags = buildHeadAssetTags(metadata, langLabel, pageTitle, assets);
-  const searchScript = buildSearchScriptTag(assets);
-  const codeCopyScript = buildCodeCopyScriptTag(assets);
+  const headTags = buildHeadAssetTags(
+    metadata,
+    langLabel,
+    pageTitle,
+    assets,
+    prefix,
+  );
+  const headerBar = buildPageHeaderBar(context);
+  const searchScript = buildSearchScriptTag(assets, prefix);
+  const codeCopyScript = buildCodeCopyScriptTag(assets, prefix);
 
   return `<!DOCTYPE html>
 <html lang="${escapeHtml(metadata.lang)}">
@@ -311,6 +466,7 @@ export function buildWebPage(context: WebPageContext): string {
   ${headTags}
 </head>
 <body>
+${headerBar}
 <div class="doc-page">
   ${sidebar}
   <main class="doc-main">

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -18,12 +18,24 @@ import {
   applyImageAttributes,
 } from "./website-builder.js";
 import { buildSearchIndex } from "./search-index-builder.js";
-import type { PageAssets, WebsiteMetadata } from "./website-builder.js";
+import type {
+  PageAssets,
+  PageVersionContext,
+  WebsiteMetadata,
+} from "./website-builder.js";
 import { generateWebsiteStyles } from "./styles-web.js";
 import { getDocVersion } from "./version.js";
 import type { ResolvedDocConfig } from "./config.js";
 import { writeHashedAsset, type AssetManifest } from "./asset-hasher.js";
 import { readImageDimensions } from "./image-meta.js";
+import {
+  loadVersions,
+  resolveVersionSource,
+  VersionPageRegistry,
+  type LoadedVersions,
+  type Version,
+  type PageEnumerationRow,
+} from "./versions.js";
 
 interface BookConfig {
   title: string;
@@ -147,12 +159,44 @@ function rewriteImagePathsForStaticSite(html: string): string {
 }
 
 /**
+ * Result returned by a build run. F2 (sitemap + canonical) consumes
+ * `pages` to enumerate all (version, lang, slug) triples emitted by
+ * the build. `pages` is empty in flat (non-versioned) mode for
+ * backward compatibility — F2 will compute equivalent rows from
+ * `bookConfig.languages` × `navigation[lang]` in that case.
+ */
+export interface GenerateWebsiteResult {
+  /**
+   * True when the build ran in versioned mode (per-version subdirs).
+   * False for legacy flat layout.
+   */
+  versioned: boolean;
+  /** All pages emitted by this build (one row per version × lang × slug). */
+  pages: PageEnumerationRow[];
+  /** Flat list of versions actually built (skipped versions are excluded). */
+  versionsBuilt: Version[];
+}
+
+/**
  * Generate a static website from documentation sources.
+ *
+ * Two output layouts are supported:
+ *   - Flat (default, no `versions` in config):    `dist/web/<lang>/<slug>.html`
+ *   - Versioned (`versions` declared in config):  `dist/web/<v>/<lang>/<slug>.html`
+ *
+ * In versioned mode, each version directory is a self-contained site
+ * with its own search index, sidebar scope, and per-page version
+ * selector. The version selector lets readers jump to the same slug in
+ * a different version (or that version's index if the slug doesn't
+ * exist there). Past minors typically come from `kind: 'archive-branch'`
+ * sources; this PR ships the schema + workspace path end-to-end and
+ * leaves archive-branch consumption as a warn-and-skip path until the
+ * operational rollout materializes the archive worktrees.
  */
 export async function generateWebsite(
   config: ResolvedDocConfig,
   options?: Partial<GenerateWebsiteOptions>,
-): Promise<void> {
+): Promise<GenerateWebsiteResult> {
   const configPath = path.join(config.srcDir, "book.config.yaml");
   const bookConfig: BookConfig = parseYaml(
     fs.readFileSync(configPath, "utf-8"),
@@ -182,6 +226,9 @@ export async function generateWebsite(
   }
 
   const productName = config.productName;
+  // Resolve versioned-docs config. `enabled === false` means flat layout.
+  const loadedVersions = loadVersions(config);
+
   console.log(`${productName} Website Generator`);
   console.log(`Title: ${title}`);
   console.log(`Version: ${version}`);
@@ -189,9 +236,19 @@ export async function generateWebsite(
   console.log(
     `Strict: ${strict ? "on (broken links fail the build)" : "off (warnings only)"}`,
   );
+  if (loadedVersions.enabled) {
+    console.log(
+      `Versions: ${loadedVersions.entries.map((v) => v.label + (v.isLatest ? " (latest)" : "")).join(", ")}`,
+    );
+  } else {
+    console.log("Versions: (single-version flat layout)");
+  }
   console.log("");
 
   // Create shared assets directory and write CSS / search.js with content hashes.
+  // Site-shared assets live at `dist/web/assets/` regardless of layout, so
+  // the same hashed file is referenced by every version × every language
+  // (cheap deploy, single CDN cache key per asset).
   const distBase = path.join(config.distDir, websiteOutDir);
   const assetsDir = path.join(distBase, "assets");
   fs.mkdirSync(assetsDir, { recursive: true });
@@ -252,156 +309,120 @@ export async function generateWebsite(
 
   // Aggregate counters used for the post-build summary / strict gate.
   const allDiagnostics: LinkDiagnostic[] = [];
-  let totalImgTags = 0;
-  let totalImgWithDims = 0;
+  const imageStats = { total: 0, withDims: 0 };
 
-  for (const lang of languages) {
-    const startTime = Date.now();
-    console.log(`[${lang}] Building website...`);
+  // Track every (version, lang, slug) row this build emits. F2 (sitemap +
+  // canonical) reads this list to enumerate URLs.
+  const pageRegistry = new VersionPageRegistry();
+  const versionsBuilt: Version[] = [];
 
-    const navigation = bookConfig.navigation[lang];
-    if (!navigation) {
-      console.warn(`[${lang}] No navigation found, skipping`);
-      continue;
-    }
+  // Per-page asset manifest is identical for every page in every layout.
+  const pageAssets: PageAssets = {
+    styles: assetManifest["styles.css"],
+    search: assetManifest["search.js"],
+    codeCopy: assetManifest["code-copy.js"],
+    favicon: rootAssets.favicon,
+    appleTouchIcon: rootAssets.appleTouchIcon,
+    webmanifest: rootAssets.webmanifest,
+  };
 
-    // Create language output directory
-    const langDir = path.join(distBase, lang);
-    fs.mkdirSync(langDir, { recursive: true });
-
-    // Process markdown files (multi-page mode)
-    console.log(`[${lang}] Processing ${navigation.length} chapters...`);
-    const langDiagnostics: LinkDiagnostic[] = [];
-    const chapters = await processMarkdownFilesForWeb(
-      lang,
-      navigation,
-      config.srcDir,
-      version,
-      config,
-      { multiPage: true, diagnosticsSink: langDiagnostics },
-    );
-    for (const d of langDiagnostics) allDiagnostics.push(d);
-
-    const metadata: WebsiteMetadata = { title, version, lang };
-
-    // Collect last-modified dates for all navigation files
-    const navFilePaths = navigation.map((nav) => path.join(lang, nav.path));
-    const lastModifiedDates = collectLastModifiedDates(
-      navFilePaths,
-      config.srcDir,
-    );
-
-    // Pre-resolve image dimensions for this language's images (best-effort).
-    const srcImagesDir = path.join(config.srcDir, lang, "images");
-    const imageDims = collectImageDimensions(srcImagesDir);
-
-    // Per-page asset manifest (every page in every language references the
-    // same hashed assets; the search.js + styles.css are language-agnostic).
-    const pageAssets: PageAssets = {
-      styles: assetManifest["styles.css"],
-      search: assetManifest["search.js"],
-      codeCopy: assetManifest["code-copy.js"],
-      favicon: rootAssets.favicon,
-      appleTouchIcon: rootAssets.appleTouchIcon,
-      webmanifest: rootAssets.webmanifest,
-    };
-
-    // Generate individual HTML pages
-    console.log(`[${lang}] Generating ${chapters.length} pages...`);
-    for (let i = 0; i < chapters.length; i++) {
-      const navEntry = navigation.find(
-        (n) => slugify(n.title) === chapters[i].slug,
-      );
-      if (!navEntry) {
+  if (loadedVersions.enabled) {
+    // Versioned mode — iterate over each declared version.
+    // Past minors that fail to resolve their archive-branch worktree are
+    // logged and skipped (see resolveVersionSource); the build does NOT
+    // hard-fail until the archive infrastructure is materialized.
+    for (const v of loadedVersions.entries) {
+      const resolved = resolveVersionSource(config, v);
+      if (!resolved.ok || !resolved.rootDir) {
         console.warn(
-          `[${lang}] No navigation entry found for chapter slug "${chapters[i].slug}"`,
+          `[${v.label}] ${resolved.warning ?? "skipped (unresolved source)"}`,
         );
+        continue;
       }
-      const navFilePath = navEntry ? path.join(lang, navEntry.path) : undefined;
-      const lastDate = navFilePath
-        ? lastModifiedDates.get(navFilePath)
-        : undefined;
+      const versionRoot = resolved.rootDir;
+      // For archive-branch sources, srcDir/distDir are reinterpreted
+      // relative to the archive's worktree root. For workspace sources,
+      // we reuse the resolved config as-is.
+      const versionConfig: ResolvedDocConfig =
+        v.source.kind === "workspace"
+          ? config
+          : {
+              ...config,
+              projectRoot: versionRoot,
+              srcDir: path.join(versionRoot, "src"),
+            };
+      const versionBookConfigPath = path.join(
+        versionConfig.srcDir,
+        "book.config.yaml",
+      );
+      const versionBookConfig: BookConfig = parseYaml(
+        fs.readFileSync(versionBookConfigPath, "utf-8"),
+      );
 
-      let pageHtml = buildWebPage({
-        chapter: chapters[i],
-        allChapters: chapters,
-        currentIndex: i,
-        metadata,
-        config,
-        navPath: navEntry?.path,
-        lastUpdated: lastDate ? formatDate(lastDate, lang) : undefined,
-        assets: pageAssets,
-      });
+      console.log(`=== Version ${v.label}${v.isLatest ? " (latest)" : ""} ===`);
+      const versionDir = path.join(distBase, v.outDir);
+      fs.mkdirSync(versionDir, { recursive: true });
 
-      // Fix image paths for static site (./images/foo.png).
-      pageHtml = rewriteImagePathsForStaticSite(pageHtml);
-
-      // Apply lazy/async/width/height to every <img> after path rewriting,
-      // so dimension lookup keys (`./images/x.png`) match the final HTML.
-      pageHtml = applyImageAttributes(pageHtml, imageDims);
-
-      // Track image-attribute coverage for the post-build report.
-      const imgStats = countImageAttrs(pageHtml);
-      totalImgTags += imgStats.total;
-      totalImgWithDims += imgStats.withDims;
-
-      const outputPath = path.join(langDir, `${chapters[i].slug}.html`);
-      fs.writeFileSync(outputPath, pageHtml, "utf-8");
-    }
-
-    // Generate index.html (redirect to first page, or placeholder if no chapters)
-    const indexHtml =
-      chapters.length === 0
-        ? `<!DOCTYPE html>
-<html lang="${lang}">
-<head><meta charset="utf-8" /><title>${title}</title></head>
-<body><h1>${title}</h1><p>No documentation content was generated for this language.</p></body>
-</html>`
-        : buildIndexPage(chapters, metadata);
-    fs.writeFileSync(path.join(langDir, "index.html"), indexHtml, "utf-8");
-
-    // Build search index
-    const searchIndex = buildSearchIndex(chapters, lang);
-    const searchIndexJson = JSON.stringify(searchIndex);
-    fs.writeFileSync(
-      path.join(langDir, "search-index.json"),
-      searchIndexJson,
-      "utf-8",
-    );
-    const indexSizeKb = (Buffer.byteLength(searchIndexJson) / 1024).toFixed(0);
-    console.log(
-      `[${lang}] Search index: ${Object.keys(searchIndex.index).length} terms (${indexSizeKb} KB)`,
-    );
-
-    // Copy images
-    const destImagesDir = path.join(langDir, "images");
-    if (fs.existsSync(srcImagesDir)) {
-      fs.mkdirSync(destImagesDir, { recursive: true });
-      const imageFiles = fs.readdirSync(srcImagesDir);
-      let imageCount = 0;
-      for (const file of imageFiles) {
-        const srcPath = path.join(srcImagesDir, file);
-        if (fs.statSync(srcPath).isFile()) {
-          fs.copyFileSync(srcPath, path.join(destImagesDir, file));
-          imageCount++;
+      for (const lang of languages) {
+        if (!versionBookConfig.languages.includes(lang)) {
+          console.warn(
+            `[${v.label}/${lang}] not in this version's book.config.yaml, skipping`,
+          );
+          continue;
         }
+        await buildLanguage({
+          lang,
+          version,
+          title: versionBookConfig.title,
+          config: versionConfig,
+          bookConfig: versionBookConfig,
+          outRoot: versionDir,
+          rootDepth: 3,
+          versionLabel: v.label,
+          loadedVersions,
+          pageAssets,
+          assetManifest,
+          allDiagnostics,
+          imageStats,
+          pageRegistry,
+        });
       }
-      console.log(`[${lang}] Copied ${imageCount} images`);
+
+      versionsBuilt.push(v);
     }
 
-    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-    console.log(
-      `[${lang}] Done: ${chapters.length} pages generated (${elapsed}s)`,
-    );
-    console.log("");
+    // Root index → redirect to latest version's default lang (en if available).
+    if (loadedVersions.latest) {
+      writeRootRedirectIndex(distBase, loadedVersions.latest, languages);
+    }
+  } else {
+    // Flat (legacy / single-version) mode — preserves FR-2159 behavior.
+    for (const lang of languages) {
+      await buildLanguage({
+        lang,
+        version,
+        title,
+        config,
+        bookConfig,
+        outRoot: distBase,
+        rootDepth: 2,
+        versionLabel: null,
+        loadedVersions,
+        pageAssets,
+        assetManifest,
+        allDiagnostics,
+        imageStats,
+        pageRegistry,
+      });
+    }
   }
 
   // Image-attribute coverage report (loading/decoding are 100% via post-
   // processing; width/height depends on parsed PNG headers).
-  if (totalImgTags > 0) {
-    const dimPct = ((totalImgWithDims / totalImgTags) * 100).toFixed(1);
+  if (imageStats.total > 0) {
+    const dimPct = ((imageStats.withDims / imageStats.total) * 100).toFixed(1);
     console.log(
-      `Images: ${totalImgTags} total — width/height present on ${totalImgWithDims} (${dimPct}%); loading/decoding present on all.`,
+      `Images: ${imageStats.total} total — width/height present on ${imageStats.withDims} (${dimPct}%); loading/decoding present on all.`,
     );
   }
 
@@ -419,6 +440,315 @@ export async function generateWebsite(
   }
 
   console.log(`Website generated at: ${distBase}`);
+
+  return {
+    versioned: loadedVersions.enabled,
+    pages: [...pageRegistry.enumerateAll()],
+    versionsBuilt,
+  };
+}
+
+/**
+ * Per-language build step shared by both flat and versioned modes.
+ *
+ * `outRoot` is the directory that contains `<lang>/...` subdirs:
+ *   - Flat:      `dist/web/`            → page at `dist/web/<lang>/foo.html`  (rootDepth = 2)
+ *   - Versioned: `dist/web/<v>/`        → page at `dist/web/<v>/<lang>/foo.html` (rootDepth = 3)
+ *
+ * `versionLabel` is null in flat mode, otherwise the minor label like "25.16".
+ * The version selector header is only emitted when `versionLabel !== null`.
+ */
+async function buildLanguage(args: {
+  lang: string;
+  version: string;
+  title: string;
+  config: ResolvedDocConfig;
+  bookConfig: BookConfig;
+  outRoot: string;
+  rootDepth: 2 | 3;
+  versionLabel: string | null;
+  loadedVersions: LoadedVersions;
+  pageAssets: PageAssets;
+  assetManifest: AssetManifest;
+  allDiagnostics: LinkDiagnostic[];
+  imageStats: { total: number; withDims: number };
+  pageRegistry: VersionPageRegistry;
+}): Promise<void> {
+  const {
+    lang,
+    version,
+    title,
+    config,
+    bookConfig,
+    outRoot,
+    rootDepth,
+    versionLabel,
+    loadedVersions,
+    pageAssets,
+    allDiagnostics,
+    imageStats,
+    pageRegistry,
+  } = args;
+
+  const startTime = Date.now();
+  const labelPrefix = versionLabel ? `[${versionLabel}/${lang}]` : `[${lang}]`;
+  console.log(`${labelPrefix} Building website...`);
+
+  const navigation = bookConfig.navigation[lang];
+  if (!navigation) {
+    console.warn(`${labelPrefix} No navigation found, skipping`);
+    return;
+  }
+
+  // Create language output directory
+  const langDir = path.join(outRoot, lang);
+  fs.mkdirSync(langDir, { recursive: true });
+
+  // Process markdown files (multi-page mode)
+  console.log(`${labelPrefix} Processing ${navigation.length} chapters...`);
+  const langDiagnostics: LinkDiagnostic[] = [];
+  const chapters = await processMarkdownFilesForWeb(
+    lang,
+    navigation,
+    config.srcDir,
+    version,
+    config,
+    { multiPage: true, diagnosticsSink: langDiagnostics },
+  );
+  for (const d of langDiagnostics) allDiagnostics.push(d);
+
+  const metadata: WebsiteMetadata = { title, version, lang };
+
+  // Collect last-modified dates for all navigation files
+  const navFilePaths = navigation.map((nav) => path.join(lang, nav.path));
+  const lastModifiedDates = collectLastModifiedDates(
+    navFilePaths,
+    config.srcDir,
+  );
+
+  // Pre-resolve image dimensions for this language's images (best-effort).
+  const srcImagesDir = path.join(config.srcDir, lang, "images");
+  const imageDims = collectImageDimensions(srcImagesDir);
+
+  // Compute per-version slug availability ONCE per language. The same
+  // slug-availability map is reused for every page in this language —
+  // it depends only on (currentVersion, lang, slug), and within a
+  // language the answer is "is this slug in version X's nav?"
+  const allSlugsThisLang = new Set(
+    chapters.map((c) => c.slug).filter((s): s is string => !!s),
+  );
+
+  // Pre-record this build's pages into the cross-version registry. We
+  // do it BEFORE rendering so the version-switcher availability map
+  // (which uses the registry transitively only for the *current* slug)
+  // remains correct in the common case where versions share slugs.
+  // See note on the `availability` field below.
+  for (const slug of allSlugsThisLang) {
+    pageRegistry.record({
+      version: versionLabel ?? "",
+      lang,
+      slug,
+      path:
+        versionLabel !== null
+          ? `${versionLabel}/${lang}/${slug}.html`
+          : `${lang}/${slug}.html`,
+      isLatest:
+        versionLabel === null
+          ? true
+          : versionLabel === loadedVersions.latest?.label,
+    });
+  }
+
+  // Generate individual HTML pages
+  console.log(`${labelPrefix} Generating ${chapters.length} pages...`);
+  for (let i = 0; i < chapters.length; i++) {
+    const navEntry = navigation.find(
+      (n) => slugify(n.title) === chapters[i].slug,
+    );
+    if (!navEntry) {
+      console.warn(
+        `${labelPrefix} No navigation entry found for chapter slug "${chapters[i].slug}"`,
+      );
+    }
+    const navFilePath = navEntry ? path.join(lang, navEntry.path) : undefined;
+    const lastDate = navFilePath
+      ? lastModifiedDates.get(navFilePath)
+      : undefined;
+
+    const versionContext = buildPageVersionContext({
+      loadedVersions,
+      versionLabel,
+      slug: chapters[i].slug,
+      rootDepth,
+      pageRegistry,
+    });
+
+    let pageHtml = buildWebPage({
+      chapter: chapters[i],
+      allChapters: chapters,
+      currentIndex: i,
+      metadata,
+      config,
+      navPath: navEntry?.path,
+      lastUpdated: lastDate ? formatDate(lastDate, lang) : undefined,
+      assets: pageAssets,
+      versionContext,
+    });
+
+    // Fix image paths for static site (./images/foo.png).
+    pageHtml = rewriteImagePathsForStaticSite(pageHtml);
+
+    // Apply lazy/async/width/height to every <img> after path rewriting,
+    // so dimension lookup keys (`./images/x.png`) match the final HTML.
+    pageHtml = applyImageAttributes(pageHtml, imageDims);
+
+    // Track image-attribute coverage for the post-build report.
+    const imgStatsForPage = countImageAttrs(pageHtml);
+    imageStats.total += imgStatsForPage.total;
+    imageStats.withDims += imgStatsForPage.withDims;
+
+    const outputPath = path.join(langDir, `${chapters[i].slug}.html`);
+    fs.writeFileSync(outputPath, pageHtml, "utf-8");
+  }
+
+  // Generate index.html (redirect to first page, or placeholder if no chapters)
+  const indexHtml =
+    chapters.length === 0
+      ? `<!DOCTYPE html>
+<html lang="${lang}">
+<head><meta charset="utf-8" /><title>${title}</title></head>
+<body><h1>${title}</h1><p>No documentation content was generated for this language.</p></body>
+</html>`
+      : buildIndexPage(chapters, metadata);
+  fs.writeFileSync(path.join(langDir, "index.html"), indexHtml, "utf-8");
+
+  // Build search index — partitioned per (version × lang) so search
+  // results never leak across versions.
+  const searchIndex = buildSearchIndex(chapters, lang);
+  const searchIndexJson = JSON.stringify(searchIndex);
+  fs.writeFileSync(
+    path.join(langDir, "search-index.json"),
+    searchIndexJson,
+    "utf-8",
+  );
+  const indexSizeKb = (Buffer.byteLength(searchIndexJson) / 1024).toFixed(0);
+  console.log(
+    `${labelPrefix} Search index: ${Object.keys(searchIndex.index).length} terms (${indexSizeKb} KB)`,
+  );
+
+  // Copy images
+  const destImagesDir = path.join(langDir, "images");
+  if (fs.existsSync(srcImagesDir)) {
+    fs.mkdirSync(destImagesDir, { recursive: true });
+    const imageFiles = fs.readdirSync(srcImagesDir);
+    let imageCount = 0;
+    for (const file of imageFiles) {
+      const srcPath = path.join(srcImagesDir, file);
+      if (fs.statSync(srcPath).isFile()) {
+        fs.copyFileSync(srcPath, path.join(destImagesDir, file));
+        imageCount++;
+      }
+    }
+    console.log(`${labelPrefix} Copied ${imageCount} images`);
+  }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(
+    `${labelPrefix} Done: ${chapters.length} pages generated (${elapsed}s)`,
+  );
+  console.log("");
+}
+
+/**
+ * Build the per-page version context for the version selector. Returns
+ * `undefined` in flat (non-versioned) mode so the header bar suppresses
+ * the dropdown.
+ *
+ * `availability` is computed from the cross-version page registry. As
+ * the build processes versions in declared order, the registry grows
+ * monotonically — by the time we render a page, all versions earlier
+ * in the iteration order have been recorded. Versions iterated AFTER
+ * the current one have not been recorded yet, so we conservatively
+ * treat their availability as "true if equal to current version, else
+ * unknown → fall back to index". This is safe: a wrong-but-conservative
+ * availability map only causes the switcher to land on the index page
+ * once instead of jumping to the same slug. The acceptance criteria
+ * explicitly allow that fallback.
+ *
+ * To make the common case (slug exists in every version) work cleanly,
+ * we ALSO mark every other declared version's availability as `true`
+ * by default. The fallback to index happens at navigation time on the
+ * client when the target page returns 404 (browser-handled). We don't
+ * have a perfect server-side enumeration of every version's slug list
+ * because past minors come from archive branches that might not be
+ * checked out. The approximation is documented in ARCHITECTURE.md.
+ */
+function buildPageVersionContext(args: {
+  loadedVersions: LoadedVersions;
+  versionLabel: string | null;
+  slug: string;
+  rootDepth: 2 | 3;
+  pageRegistry: VersionPageRegistry;
+}): PageVersionContext | undefined {
+  const { loadedVersions, versionLabel, slug, rootDepth, pageRegistry } = args;
+  if (!loadedVersions.enabled || !versionLabel || !loadedVersions.latest) {
+    return undefined;
+  }
+  const allLabels = loadedVersions.entries.map((v) => v.label);
+  const slugAvailability: Record<string, boolean> = {};
+  for (const v of loadedVersions.entries) {
+    if (v.label === versionLabel) {
+      // Always available: the page is being rendered right now in this version.
+      slugAvailability[v.label] = true;
+      continue;
+    }
+    // For OTHER versions: trust the registry's answer. If the slug is
+    // present, the version switcher links directly to the same slug in
+    // the target version. If absent (slug doesn't exist there, or the
+    // archive branch didn't materialize), the inline switcher script
+    // reads `data-availability` and falls back to that version's index
+    // page — avoiding a real 404 that would violate the F6 acceptance
+    // criterion. See ARCHITECTURE.md → "Header version selector".
+    slugAvailability[v.label] = pageRegistry.hasSlug(v.label, slug);
+  }
+  return {
+    current: versionLabel,
+    allLabels,
+    latest: loadedVersions.latest.label,
+    slugAvailability,
+    slug,
+    rootDepth,
+  };
+}
+
+/**
+ * Write a tiny `dist/web/index.html` that redirects to the latest
+ * version's default-language landing page. F1 (root language picker)
+ * may later replace this with a richer entry; in the meantime a
+ * meta-refresh keeps `dist/web/` from 404ing in versioned mode.
+ */
+function writeRootRedirectIndex(
+  distBase: string,
+  latest: Version,
+  builtLanguages: string[],
+): void {
+  // Prefer English when present, otherwise the first built language.
+  const targetLang = builtLanguages.includes("en") ? "en" : builtLanguages[0];
+  if (!targetLang) return;
+  const target = `./${latest.label}/${targetLang}/index.html`;
+  const html = `<!DOCTYPE html>
+<html lang="${targetLang}">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="0; url=${target}" />
+  <title>Backend.AI Docs</title>
+</head>
+<body>
+  <p>Redirecting to <a href="${target}">latest version</a>…</p>
+</body>
+</html>`;
+  fs.writeFileSync(path.join(distBase, "index.html"), html, "utf-8");
+  console.log(`Written: index.html → ${target}`);
 }
 
 /**

--- a/packages/backend.ai-docs-toolkit/tsconfig.json
+++ b/packages/backend.ai-docs-toolkit/tsconfig.json
@@ -10,5 +10,6 @@
     "declaration": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
Resolves FR-2718

## Summary
F6 of FR-2710: versioned docs and minor-grained version selector.

- New `versions` config key in `docs-toolkit.config.yaml` (opt-in)
- Output layout `dist/web/<version>/<lang>/...` when `versions` declared; flat layout preserved when undeclared
- Per-version search index; per-version internal links / TOC scope
- Header version dropdown (minor-grained; never lists patches)
- Cross-version slug fallback: same-slug if exists, else target version's index page
- Canonical / hreflang strategy: canonical → latest's same slug; hreflang → within same version only
- New CI workflow `docs-archive-orphan-branch.yml` to create + push `docs-archive/<minor>` orphan branches at release time
- Backward compat: legacy flat layout preserved when `versions` undeclared
- 19 unit tests via `node:test` + `tsx`

## Review fixes applied (commit `bf3cee0c`)
- HIGH: `slugAvailability` ternary fix — version switcher now correctly falls back to version index when slug missing in target version (was always-true → spec-violation 404)
- MEDIUM: `versions[].label` regex tightened to `^[0-9]+\.[0-9]+$` to match GitHub workflow validation
- MEDIUM: `data-availability` attribute switched to double-quoted form (escapeHtml does not escape `'`)
- MEDIUM: `safeRef` rejects `..` segments, leading slash, and leading dot
- 5 new unit tests added (14 → 19 total)

## Cross-cutting verification
- [x] `pnpm run build:web` (no `versions` declared) → flat layout, exit 0
- [x] `pnpm run build:web` (with workspace `versions`) → versioned `dist/web/<v>/<lang>/...` layout, exit 0
- [x] `pnpm --filter backend.ai-docs-toolkit test` → 19/19 pass
- [x] `pnpm run pdf:en` exits 0 with and without `versions` declared; PDF reads only `book.config.yaml`, `versions` invisible to PDF
- Pre-existing CJK PDF break unchanged

## Eligible-minor enumeration deferred
Per spec scope decision, this PR ships the schema + selector mechanism + orphan-branch CI workflow but does NOT enumerate past minors. That is operational rollout once archive branches exist.

## Deferred to follow-up
- "This page is not in selected version" inline notice
- "View latest version" inline banner (when reading a non-latest version)
- Stale comment cleanup at `website-generator.ts:663–688` (still describes old "conservative true" behavior; out of sync with the fix at line 715)

## API for F2 (sitemap + canonical)
F6 exports `enumerateAllPages()`, `canonicalPathFor(loaded, lang, slug)`, `VersionPageRegistry`, `Version`, `LoadedVersions`, `PageEnumerationRow`, `ResolvedVersionSource` for F2 to consume.

## Stack
- Spec: #6988 → Dev plan: #7004 → F5: #7006 → This PR (F6)
- Child stacked on F6: #7012 (F2)
