### PR TITLE
feat(FR-2714): F2 SEO and sharing metadata

### DIFF
--- a/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
+++ b/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
@@ -304,3 +304,128 @@ continues to build the current checkout's content, regardless of
 whether `versions` is declared. This is intentional — past-minor PDFs
 are likewise produced by their toolkit-of-its-day, not by re-rendering
 through the current toolkit.
+
+## SEO & sharing metadata (F2 / FR-2714)
+
+The web build emits per-page SEO/sharing tags plus site-root
+`sitemap.xml` and `robots.txt`. Everything is generated at build time;
+no runtime JS is added (the F2 head tags live entirely in `<head>`).
+Pure helpers in `seo.ts`, `sitemap.ts`, and `robots-txt.ts` are
+side-effect free and unit-testable; the website generator wires the
+inputs.
+
+### Per-page head tags
+
+Each rendered page now carries the following tags in `<head>` (in
+addition to the base set from F5 and the language switcher / version
+selector from F1 / F6):
+
+| Tag | Source | Notes |
+|---|---|---|
+| `<meta name="description">` | first non-heading paragraph in chapter HTML | capped at 155 chars; sentence-boundary preferred, then word boundary, then ellipsis |
+| `<meta property="og:type">` | constant `"article"` | site index uses `"website"` (F1) |
+| `<meta property="og:title">` | chapter title | |
+| `<meta property="og:description">` | same as description | omitted when description is empty |
+| `<meta property="og:url">` | `og.baseUrl` + page path | omitted when `og.baseUrl` unset |
+| `<meta property="og:image">` | absolute path to `assets/og-default.png` (or override) | omitted when no image was rendered |
+| `<meta property="og:site_name">` | `og.siteName` (default: doc title) | |
+| `<meta property="og:locale">` | page language code | |
+| `<meta name="twitter:card">` | constant `"summary_large_image"` | |
+| `<meta name="twitter:title">` | chapter title | |
+| `<meta name="twitter:description">` | same as description | omitted when description is empty |
+| `<meta name="twitter:image">` | same as `og:image` | omitted when no image was rendered |
+| `<link rel="canonical">` | `og.baseUrl` + canonicalPath (absolute) OR relative `prefix + canonicalPath` (when baseUrl unset) | canonicalPath comes from F6's `canonicalPathFor()` so non-latest versions point at the latest version |
+| `<script type="application/ld+json">` | Schema.org `TechArticle` | includes `headline`, `inLanguage`, `dateModified`, `author`, `publisher`, `description`, `url`, `image` |
+
+Description extraction is implemented in `seo.ts::extractDescription()`
+and runs against the already-rendered chapter HTML — it deliberately
+does NOT touch the markdown processor (preserves PDF non-regression).
+The first `<p>` block (Marked emits `<p>` only for plain paragraphs;
+admonitions/figures/tables are wrapped in `<div>` / `<figure>` / `<aside>`)
+becomes the seed text.
+
+### `og.baseUrl` behavior
+
+`og.baseUrl` is the public deploy URL (e.g. `https://docs.backend.ai`).
+It is OPTIONAL but strongly recommended. Behavior matrix:
+
+| Tag / artifact | `og.baseUrl` set | `og.baseUrl` unset |
+|---|---|---|
+| `<link rel="canonical">` | Absolute URL | Relative path (`prefix + canonicalPath`) — still emits the tag |
+| `<meta property="og:url">` | Absolute URL | Tag omitted |
+| `<meta property="og:image">` | Absolute URL | Relative path (`prefix + assets/og-default.png`) — still emits the tag |
+| `<meta name="twitter:image">` | Absolute URL | Relative path |
+| JSON-LD `url` / `image` | Absolute URLs | Omitted |
+| `dist/web/sitemap.xml` | Emitted with absolute `<loc>` values | NOT emitted (sitemap with relative `<loc>` is non-conformant) |
+| `dist/web/robots.txt` | Emitted with `Sitemap:` reference | Emitted without `Sitemap:` reference |
+
+Air-gapped builds (no public URL) thus get a usable site without
+crashing — the SEO tags degrade gracefully. A single warning is
+printed at build start when `og.baseUrl` is unset.
+
+### `dist/web/sitemap.xml`
+
+A standards-compliant sitemap (`http://www.sitemaps.org/schemas/sitemap/0.9`).
+
+- One `<url>` per page emitted by the build. F6's `generateWebsite()`
+  returns `pages: PageEnumerationRow[]`, which the sitemap builder
+  consumes verbatim. In versioned mode that means `versions × langs ×
+  pages`; in flat mode `langs × pages`.
+- `<lastmod>` is the chapter file's git `--format=%aI` timestamp,
+  falling back to `fs.statSync().mtime`. Resolution happens once per
+  language during the per-page render and is keyed by URL-relative
+  page path (the same key the registry uses).
+- `<changefreq>` and `<priority>` are intentionally omitted — Google
+  ignores them and they add noise.
+
+### `dist/web/robots.txt`
+
+```
+User-agent: *
+Disallow:
+
+Sitemap: <og.baseUrl>/sitemap.xml
+```
+
+- The empty `Disallow:` allows everything per the de-facto standard.
+- The `Sitemap:` line is omitted when `og.baseUrl` is unset.
+
+### Default OG image strategy
+
+Two sources, in priority order:
+
+1. **`og.imagePath`** — operator-supplied image, copied verbatim to
+   `dist/web/assets/og-default.<ext>`. Useful when the team wants a
+   designed share card, or when rendering via Playwright is not
+   available in the target environment.
+2. **Default rendering** — `manifest/backend.ai-brand-simple.svg` is
+   centered on a white 1200×630 canvas and rasterized to PNG via
+   Playwright (`og-image-renderer.ts`). Output: `dist/web/assets/og-default.png`.
+
+If Playwright is not available (the consumer skipped the optional peer
+dep) and `og.imagePath` is unset, the image step is skipped with a
+warning and every page's `og:image` / `twitter:image` tag is dropped.
+The build never fails because of a missing OG image.
+
+The 1200×630 dimensions match Facebook's recommended OG aspect ratio
+and exceed Twitter's `summary_large_image` minimum (300×157), so the
+same asset works across networks.
+
+### `og` config schema
+
+```yaml
+og:
+  baseUrl: "https://docs.backend.ai"   # optional; enables absolute URLs + sitemap.xml
+  siteName: "Backend.AI Docs"          # optional; defaults to doc title
+  imagePath: "assets/share-card.png"   # optional override; relative to projectRoot
+```
+
+All three fields are optional. When the entire `og` block is omitted,
+the build proceeds with sensible defaults: site name = doc title,
+image = rendered brand SVG (or none), no absolute URLs, no sitemap.
+
+### PDF pipeline interaction (F2)
+
+The PDF pipeline reads ONLY `book.config.yaml`, not the `og` key in
+`docs-toolkit.config.yaml`. Adding an `og` block has zero effect on
+PDF output. `pnpm run pdf:en` is unchanged by F2.

--- a/packages/backend.ai-docs-toolkit/package.json
+++ b/packages/backend.ai-docs-toolkit/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "tsx --test src/versions.test.ts",
+    "test": "tsx --test src/versions.test.ts src/seo.test.ts",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -84,6 +84,37 @@ export interface WebsiteConfig {
   basePath?: string;
 }
 
+// ── SEO / Open Graph schema (F2 / FR-2714) ────────────────────────
+//
+// `og` is OPTIONAL. When omitted, every per-page SEO tag that does NOT
+// require an absolute base URL is still emitted (description, twitter
+// card, JSON-LD without canonical URL). Tags that REQUIRE an absolute
+// URL (canonical, og:url, sitemap entries with `<loc>`) are silently
+// skipped/relativized so that air-gapped builds without a public URL
+// do not crash. A warning is printed once per build when `baseUrl` is
+// missing. See ARCHITECTURE.md → "SEO & sharing metadata (F2)".
+export interface OgConfig {
+  /**
+   * Override path to the default Open Graph image, relative to the
+   * project root (NOT the docs source dir). When set, the file is
+   * copied verbatim to `dist/web/assets/og-default.<ext>` and used as
+   * the `og:image`. When unset, the toolkit attempts to render
+   * `manifest/backend.ai-brand-simple.svg` to a 1200×630 PNG via
+   * Playwright at build time.
+   */
+  imagePath?: string;
+  /** `og:site_name` value. Defaults to `config.title`. */
+  siteName?: string;
+  /**
+   * Public deploy URL (e.g. `https://docs.backend.ai`). Used to build
+   * absolute URLs in `<link rel="canonical">`, `og:url`, and the
+   * `<loc>` entries of `sitemap.xml`. When unset, those tags are
+   * omitted (canonical points to the page itself as a relative URL,
+   * `og:url` is dropped, `sitemap.xml` uses relative paths).
+   */
+  baseUrl?: string;
+}
+
 // ── Versioned-docs schema (F6 / FR-2718) ──────────────────────────
 //
 // `versions` is OPTIONAL and OPT-IN. When omitted, the existing flat
@@ -125,6 +156,12 @@ export interface ToolkitConfig extends DocConfig {
    * normalized runtime shape and validation rules.
    */
   versions?: VersionEntry[];
+  /**
+   * Optional Open Graph / SEO config. Controls per-page `<meta>`
+   * tags (description, og:*, twitter card, canonical, JSON-LD) plus
+   * `sitemap.xml` and `robots.txt` generation. See `OgConfig`.
+   */
+  og?: OgConfig;
 }
 
 // ── Defaults ──────────────────────────────────────────────────
@@ -264,6 +301,11 @@ export interface ResolvedDocConfig {
    * mode applies.
    */
   versions?: VersionEntry[];
+  /**
+   * Raw `og` block from `docs-toolkit.config.yaml`. Consumed by F2's
+   * SEO tag emitter, sitemap, and OG image renderer.
+   */
+  og?: OgConfig;
 }
 
 export function resolveConfig(config: ToolkitConfig): ResolvedDocConfig {
@@ -315,6 +357,7 @@ export function resolveConfig(config: ToolkitConfig): ResolvedDocConfig {
     agents: config.agents,
     website: config.website,
     versions: config.versions,
+    og: config.og,
   };
 }
 

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -15,6 +15,7 @@ export type {
   ResolvedDocConfig,
   VersionEntry,
   VersionSource,
+  OgConfig,
 } from "./config.js";
 export { resolveConfig, loadToolkitConfig, WEBSITE_LABELS } from "./config.js";
 
@@ -77,8 +78,32 @@ export type { DocMetadata } from "./html-builder.js";
 export { buildFullDocument } from "./html-builder.js";
 export type { WebDocMetadata } from "./html-builder-web.js";
 export { buildWebDocument } from "./html-builder-web.js";
-export type { WebPageContext, WebsiteMetadata } from "./website-builder.js";
+export type {
+  WebPageContext,
+  WebsiteMetadata,
+  PageAssets,
+  PageVersionContext,
+  PageSeoContext,
+} from "./website-builder.js";
 export { buildWebPage, buildIndexPage } from "./website-builder.js";
+
+// ── SEO (F2) ────────────────────────────────────────────────────
+export type { OgTagOptions, TwitterCardOptions, JsonLdOptions } from "./seo.js";
+export {
+  extractDescription,
+  truncateForDescription,
+  buildOgTags,
+  buildTwitterCard,
+  buildJsonLd,
+  joinBaseUrl,
+  DEFAULT_DESCRIPTION_CHAR_LIMIT,
+} from "./seo.js";
+export type { BuildSitemapOptions } from "./sitemap.js";
+export { buildSitemapXml } from "./sitemap.js";
+export type { BuildRobotsTxtOptions } from "./robots-txt.js";
+export { buildRobotsTxt } from "./robots-txt.js";
+export type { RenderedOgImage } from "./og-image-renderer.js";
+export { renderDefaultOgImage, copyUserOgImage } from "./og-image-renderer.js";
 
 // ── PDF Rendering ───────────────────────────────────────────────
 export type { RenderOptions } from "./pdf-renderer.js";

--- a/packages/backend.ai-docs-toolkit/src/og-image-renderer.ts
+++ b/packages/backend.ai-docs-toolkit/src/og-image-renderer.ts
@@ -1,0 +1,196 @@
+/**
+ * Default Open Graph image renderer (F2 / FR-2714).
+ *
+ * Renders an SVG file (typically `manifest/backend.ai-brand-simple.svg`)
+ * to a 1200×630 PNG using Playwright's headless Chromium. The result is
+ * written to `dist/web/assets/og-default.png`. We use Playwright because
+ * it is already a peer dep of the toolkit (used by the PDF pipeline)
+ * and because rendering an SVG to PNG without a real browser engine
+ * would require pulling in resvg/sharp, both heavyweight native deps.
+ *
+ * If Playwright isn't installed (the consumer skipped the optional peer
+ * dep) the renderer returns `null` after logging a warning. The website
+ * generator gracefully drops the `og:image` tag in that case rather
+ * than crashing the build — the spec explicitly allows this fallback
+ * to keep air-gapped consumers without a browser engine working.
+ */
+
+import fs from "fs";
+import path from "path";
+
+/**
+ * Result of an OG image render attempt. `path` is the absolute
+ * destination path written to disk; `relUrl` is the URL fragment to
+ * embed in `<meta property="og:image">` (relative to the website
+ * output root, e.g. `assets/og-default.png`).
+ */
+export interface RenderedOgImage {
+  absPath: string;
+  relUrl: string;
+}
+
+/**
+ * Render the default OG image. Inputs:
+ *   - `svgSourcePath`: absolute path to the source SVG file.
+ *   - `destDir`: absolute path to the assets directory
+ *      (`<distBase>/assets`). Created if missing.
+ *   - `width` / `height`: PNG dimensions. Defaults to 1200×630, the
+ *      Facebook-recommended OG image size that also satisfies Twitter's
+ *      `summary_large_image` minimum.
+ *
+ * Returns `null` when Playwright is unavailable, the SVG is missing,
+ * or rendering fails for any reason. A warning is printed in each
+ * case; the caller decides whether to fall back to "no og:image".
+ */
+export async function renderDefaultOgImage(args: {
+  svgSourcePath: string;
+  destDir: string;
+  width?: number;
+  height?: number;
+}): Promise<RenderedOgImage | null> {
+  const { svgSourcePath, destDir } = args;
+  const width = args.width ?? 1200;
+  const height = args.height ?? 630;
+
+  if (!fs.existsSync(svgSourcePath)) {
+    console.warn(
+      `[og-image] Source SVG not found at ${svgSourcePath}. Skipping default OG image.`,
+    );
+    return null;
+  }
+
+  // Try to load Playwright. The dynamic import keeps it optional —
+  // consumers without the peer dep just don't get an OG image.
+  let chromium: typeof import("playwright").chromium;
+  try {
+    // Use a dynamic import so the toolkit never hard-imports playwright
+    // at top-level. Bare-string import is required so bundlers don't
+    // try to inline the dep into the toolkit's published artifact.
+    const playwright =
+      (await import("playwright")) as typeof import("playwright");
+    chromium = playwright.chromium;
+  } catch {
+    console.warn(
+      "[og-image] Playwright is not installed. Skipping default OG image. " +
+        "Install playwright as a peer dep, or set `og.imagePath` to ship a pre-rendered image.",
+    );
+    return null;
+  }
+
+  const svgContent = fs.readFileSync(svgSourcePath, "utf-8");
+
+  // Center the SVG on a Backend.AI-orange background. Twitter and OG
+  // both crop center-out; the safe-area is roughly the middle 80% of
+  // the canvas.
+  // We use `<img src="data:image/svg+xml;base64,...">` instead of
+  // inlining the SVG markup directly because the source SVG contains
+  // an XML declaration + DOCTYPE that confuses HTML parsers.
+  const svgBase64 = Buffer.from(svgContent, "utf-8").toString("base64");
+  const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        width: ${width}px;
+        height: ${height}px;
+        background: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      img {
+        width: 60%;
+        height: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <img src="data:image/svg+xml;base64,${svgBase64}" />
+  </body>
+</html>`;
+
+  fs.mkdirSync(destDir, { recursive: true });
+  const outPath = path.join(destDir, "og-default.png");
+
+  let browser: import("playwright").Browser | null = null;
+  try {
+    browser = await chromium.launch();
+    const context = await browser.newContext({
+      viewport: { width, height },
+      deviceScaleFactor: 1,
+    });
+    const page = await context.newPage();
+    // Air-gap enforcement: block ALL non-local network requests before
+    // the page sees any content. The wrapping HTML is inlined via
+    // setContent and the brand SVG is embedded as a base64 data URI,
+    // so legitimate rendering only ever needs `data:` and `about:blank`
+    // (the initial document URL Playwright assigns to setContent pages).
+    // An adversarial SVG that smuggles `<image href="http://…">` or
+    // `xlink:href="https://…"` would otherwise cause the headless
+    // browser to fetch external resources at build time, which the
+    // F2 spec explicitly forbids. Do NOT remove this route handler.
+    await page.route("**/*", (route) => {
+      const url = route.request().url();
+      if (url.startsWith("data:") || url.startsWith("about:")) {
+        return route.continue();
+      }
+      return route.abort();
+    });
+    await page.setContent(html, { waitUntil: "domcontentloaded" });
+    await page.screenshot({ path: outPath, type: "png", fullPage: false });
+    await context.close();
+  } catch (err) {
+    console.warn(
+      `[og-image] Failed to render default OG image: ${
+        err instanceof Error ? err.message : String(err)
+      }. Skipping og:image tag.`,
+    );
+    return null;
+  } finally {
+    if (browser) {
+      try {
+        await browser.close();
+      } catch {
+        // Ignore close errors — the file is already written.
+      }
+    }
+  }
+
+  return {
+    absPath: outPath,
+    relUrl: "assets/og-default.png",
+  };
+}
+
+/**
+ * Copy a user-provided OG image from `og.imagePath` into the assets
+ * directory. The destination filename preserves the source extension
+ * so MIME detection works on naive web servers.
+ *
+ * Returns `null` (and warns) when the source is missing.
+ */
+export function copyUserOgImage(args: {
+  sourcePath: string;
+  destDir: string;
+}): RenderedOgImage | null {
+  const { sourcePath, destDir } = args;
+  if (!fs.existsSync(sourcePath)) {
+    console.warn(
+      `[og-image] og.imagePath points to a non-existent file: ${sourcePath}. ` +
+        `Falling back to default rendering (or skipping og:image entirely).`,
+    );
+    return null;
+  }
+  fs.mkdirSync(destDir, { recursive: true });
+  const ext = path.extname(sourcePath).toLowerCase() || ".png";
+  const destFile = `og-default${ext}`;
+  const dest = path.join(destDir, destFile);
+  fs.copyFileSync(sourcePath, dest);
+  return {
+    absPath: dest,
+    relUrl: `assets/${destFile}`,
+  };
+}

--- a/packages/backend.ai-docs-toolkit/src/robots-txt.ts
+++ b/packages/backend.ai-docs-toolkit/src/robots-txt.ts
@@ -1,0 +1,34 @@
+/**
+ * robots.txt builder (F2 / FR-2714).
+ *
+ * Trivial pure function. Isolated in its own module so it can be
+ * unit-tested without dragging in the website generator.
+ *
+ * F2's policy: documentation should be indexed by all crawlers. We
+ * emit `User-agent: *` + empty `Disallow:` (which means "allow
+ * everything" per the standard) and a `Sitemap:` reference when the
+ * sitemap URL is known.
+ */
+
+export interface BuildRobotsTxtOptions {
+  /**
+   * Absolute URL of the sitemap, e.g. `https://docs.backend.ai/sitemap.xml`.
+   * When omitted, no `Sitemap:` line is emitted (the rest of the file
+   * still renders correctly — `Sitemap:` is optional per the de facto
+   * standard).
+   */
+  sitemapUrl?: string;
+}
+
+/**
+ * Build a robots.txt body. Returns the complete file content as a
+ * UTF-8 string with a trailing newline.
+ */
+export function buildRobotsTxt(opts: BuildRobotsTxtOptions = {}): string {
+  const lines: string[] = ["User-agent: *", "Disallow:"];
+  if (opts.sitemapUrl) {
+    lines.push("");
+    lines.push(`Sitemap: ${opts.sitemapUrl}`);
+  }
+  return lines.join("\n") + "\n";
+}

--- a/packages/backend.ai-docs-toolkit/src/seo.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/seo.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for SEO helpers (F2 / FR-2714).
+ *
+ * Run with: `pnpm test` (uses tsx --test).
+ *
+ * The helpers in `seo.ts` and friends are pure, so the tests don't
+ * touch the filesystem. Sitemap is tested with a fixed mock page
+ * enumeration so we can compare full XML output.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractDescription,
+  truncateForDescription,
+  buildOgTags,
+  buildTwitterCard,
+  buildJsonLd,
+  joinBaseUrl,
+  DEFAULT_DESCRIPTION_CHAR_LIMIT,
+} from "./seo.js";
+import { buildSitemapXml } from "./sitemap.js";
+import { buildRobotsTxt } from "./robots-txt.js";
+
+test("extractDescription — strips HTML, decodes entities, picks first paragraph", () => {
+  const html = `
+    <h1 id="x">Title <a href="#x">#</a></h1>
+    <p>This is the <strong>first</strong> paragraph with &quot;quotes&quot; and <code>code</code>.</p>
+    <p>Second paragraph.</p>
+  `;
+  const desc = extractDescription(html);
+  assert.equal(
+    desc,
+    'This is the first paragraph with "quotes" and code.',
+  );
+});
+
+test("extractDescription — skips empty <p> blocks", () => {
+  const html = `<p>   </p><p>Real content.</p>`;
+  assert.equal(extractDescription(html), "Real content.");
+});
+
+test("extractDescription — returns '' when no <p> exists", () => {
+  const html = `<h1>Only heading</h1><pre><code>x</code></pre>`;
+  assert.equal(extractDescription(html), "");
+});
+
+test("extractDescription — truncates to 155 chars by default", () => {
+  const longText = "Sentence one. " + "word ".repeat(80) + "tail.";
+  const html = `<p>${longText}</p>`;
+  const desc = extractDescription(html);
+  assert.ok(desc.length <= DEFAULT_DESCRIPTION_CHAR_LIMIT);
+});
+
+test("truncateForDescription — prefers sentence boundary", () => {
+  // Two sentences in a 200-char window: the cut at limit=80 falls
+  // mid-second-sentence, so the truncator backs up to the period
+  // after the first sentence (no ellipsis on sentence-boundary cuts).
+  const text =
+    "First sentence here ends with a period. Second sentence runs much longer than the limit allows for sure.";
+  const result = truncateForDescription(text, 80);
+  assert.equal(result, "First sentence here ends with a period.");
+});
+
+test("truncateForDescription — falls back to word boundary", () => {
+  const text = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda";
+  const result = truncateForDescription(text, 50);
+  // Should end at a word boundary, with ellipsis.
+  assert.ok(result.endsWith("…"));
+  assert.ok(!result.endsWith(" …"));
+  assert.ok(result.length <= 50);
+});
+
+test("buildOgTags — emits article type and required fields", () => {
+  const tags = buildOgTags({
+    title: "Quickstart",
+    description: "Welcome to the docs.",
+    pageUrl: "https://example.com/en/quickstart.html",
+    imageUrl: "https://example.com/assets/og.png",
+    siteName: "Backend.AI",
+    locale: "en",
+  });
+  assert.equal(tags.length, 7);
+  assert.ok(tags[0].includes('og:type" content="article"'));
+  assert.ok(tags[1].includes('og:title" content="Quickstart"'));
+  assert.ok(tags.some((t) => t.includes("og:description")));
+  assert.ok(tags.some((t) => t.includes("og:url")));
+  assert.ok(tags.some((t) => t.includes("og:image")));
+  assert.ok(tags.some((t) => t.includes("og:site_name")));
+  assert.ok(tags.some((t) => t.includes("og:locale")));
+});
+
+test("buildOgTags — omits optional fields when undefined", () => {
+  const tags = buildOgTags({ title: "Minimal" });
+  // Only og:type and og:title are required.
+  assert.equal(tags.length, 2);
+});
+
+test("buildTwitterCard — always summary_large_image", () => {
+  const tags = buildTwitterCard({ title: "X" });
+  assert.ok(tags[0].includes('twitter:card" content="summary_large_image"'));
+});
+
+test("buildJsonLd — produces valid JSON in <script>", () => {
+  const tag = buildJsonLd({
+    headline: "X",
+    inLanguage: "en",
+    description: "Y",
+    dateModified: "2026-01-01T00:00:00Z",
+    author: "Lablup",
+    publisher: "Lablup",
+    url: "https://example.com/x.html",
+    imageUrl: "https://example.com/og.png",
+  });
+  assert.ok(tag.startsWith('<script type="application/ld+json">'));
+  assert.ok(tag.endsWith("</script>"));
+  const json = tag.slice(
+    '<script type="application/ld+json">'.length,
+    -"</script>".length,
+  );
+  const parsed = JSON.parse(json);
+  assert.equal(parsed["@type"], "TechArticle");
+  assert.equal(parsed.headline, "X");
+  assert.equal(parsed.author.name, "Lablup");
+});
+
+test("buildJsonLd — escapes </script> sequences", () => {
+  const tag = buildJsonLd({
+    headline: "</script><script>alert(1)</script>",
+    inLanguage: "en",
+  });
+  // The raw `</script>` must NOT appear unescaped between the
+  // wrapper tags (other than the closing wrapper itself).
+  const inner = tag.slice(
+    '<script type="application/ld+json">'.length,
+    -"</script>".length,
+  );
+  assert.ok(!/<\/script/i.test(inner));
+});
+
+test("joinBaseUrl — composes correctly", () => {
+  assert.equal(
+    joinBaseUrl("https://docs.backend.ai", "en/x.html"),
+    "https://docs.backend.ai/en/x.html",
+  );
+  assert.equal(
+    joinBaseUrl("https://docs.backend.ai/", "/en/x.html"),
+    "https://docs.backend.ai/en/x.html",
+  );
+  assert.equal(joinBaseUrl(undefined, "en/x.html"), undefined);
+});
+
+test("buildSitemapXml — emits absolute URLs and lastmod", () => {
+  const xml = buildSitemapXml({
+    pages: [
+      { version: "", lang: "en", slug: "a", path: "en/a.html", isLatest: true },
+      { version: "", lang: "ko", slug: "a", path: "ko/a.html", isLatest: true },
+    ],
+    baseUrl: "https://docs.example.com",
+    lastModFor: () => "2026-01-01T00:00:00Z",
+  });
+  assert.ok(xml.includes("<loc>https://docs.example.com/en/a.html</loc>"));
+  assert.ok(xml.includes("<loc>https://docs.example.com/ko/a.html</loc>"));
+  assert.ok(xml.includes("<lastmod>2026-01-01T00:00:00Z</lastmod>"));
+  assert.ok(xml.startsWith('<?xml version="1.0"'));
+});
+
+test("buildSitemapXml — versioned mode emits per-version <loc>", () => {
+  const xml = buildSitemapXml({
+    pages: [
+      {
+        version: "26.03",
+        lang: "en",
+        slug: "a",
+        path: "26.03/en/a.html",
+        isLatest: true,
+      },
+      {
+        version: "25.16",
+        lang: "en",
+        slug: "a",
+        path: "25.16/en/a.html",
+        isLatest: false,
+      },
+    ],
+    baseUrl: "https://docs.example.com",
+    lastModFor: () => undefined,
+  });
+  assert.ok(xml.includes("<loc>https://docs.example.com/26.03/en/a.html</loc>"));
+  assert.ok(xml.includes("<loc>https://docs.example.com/25.16/en/a.html</loc>"));
+  // No <lastmod> when the resolver returns undefined.
+  assert.ok(!xml.includes("<lastmod>"));
+});
+
+test("buildRobotsTxt — allow-all + sitemap reference", () => {
+  const txt = buildRobotsTxt({ sitemapUrl: "https://x.com/sitemap.xml" });
+  assert.ok(txt.includes("User-agent: *"));
+  assert.ok(txt.includes("Disallow:"));
+  assert.ok(txt.includes("Sitemap: https://x.com/sitemap.xml"));
+});
+
+test("buildRobotsTxt — omits Sitemap line when URL missing", () => {
+  const txt = buildRobotsTxt();
+  assert.ok(txt.includes("User-agent: *"));
+  assert.ok(!txt.includes("Sitemap:"));
+});

--- a/packages/backend.ai-docs-toolkit/src/seo.ts
+++ b/packages/backend.ai-docs-toolkit/src/seo.ts
@@ -1,0 +1,296 @@
+/**
+ * SEO & sharing-metadata helpers (F2 / FR-2714).
+ *
+ * Pure functions used by `website-builder.ts` to emit per-page `<head>`
+ * tags: description, Open Graph, Twitter Card, canonical, JSON-LD
+ * `TechArticle`. None of these helpers touch the filesystem or the
+ * environment — they take primitives and return strings, so they are
+ * trivially unit-testable and safe to call from any pipeline that has
+ * already resolved the inputs.
+ *
+ * The helpers in this module are intentionally split from the head
+ * builder: the head builder concerns itself with PageAssets / version
+ * context wiring, while this module concerns itself only with SEO
+ * metadata shape. F1 (hreflang), F3 (breadcrumb), F4 (Shiki/copy)
+ * touch other parts of the head builder; keeping SEO isolated here
+ * minimizes merge friction across the F1+F2+F3+F4+F6 stack.
+ */
+
+import { stripHtmlTags, escapeHtml } from "./markdown-extensions.js";
+
+/**
+ * Default character cap for `<meta name="description">`. The spec says
+ * "≤ 160" with first-paragraph extraction "capped at ~155". We use 155
+ * so that we never accidentally cross the 160-char hard limit due to
+ * a trailing word boundary slip.
+ */
+export const DEFAULT_DESCRIPTION_CHAR_LIMIT = 155;
+
+/**
+ * Extract a plain-text description from rendered chapter HTML.
+ *
+ * Strategy:
+ *   1. Look at the chapter HTML linearly and skip every block that is a
+ *      heading, code block, table, list, image/figure, admonition, or
+ *      anything else that would not read as a description.
+ *   2. The first remaining `<p>...</p>` block is the seed description.
+ *   3. Strip HTML tags and normalize whitespace.
+ *   4. Truncate to `charLimit`. Prefer cutting at a sentence boundary
+ *      (`. `, `? `, `! `, `。`, `？`, `！`); otherwise fall back to the
+ *      last whitespace before the limit; otherwise hard-truncate with
+ *      an ellipsis.
+ *
+ * Returns an empty string when no suitable paragraph can be found —
+ * the caller decides whether to fall back to the document title or
+ * skip the description tag.
+ */
+export function extractDescription(
+  html: string,
+  charLimit: number = DEFAULT_DESCRIPTION_CHAR_LIMIT,
+): string {
+  if (!html) return "";
+  // Find the first <p>...</p> block. Marked emits `<p>` for plain
+  // paragraphs; anything else (admonitions, figures, tables) is wrapped
+  // in <div>/<figure>/<aside>/etc. So the first-<p> heuristic naturally
+  // skips non-paragraph blocks.
+  // The regex is non-greedy and case-insensitive; we iterate so we can
+  // skip empty / whitespace-only paragraphs.
+  const paraRegex = /<p\b[^>]*>([\s\S]*?)<\/p>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = paraRegex.exec(html)) !== null) {
+    const inner = match[1];
+    const text = decodeHtmlEntities(stripHtmlTags(inner))
+      .replace(/\s+/g, " ")
+      .trim();
+    if (text.length === 0) continue;
+    return truncateForDescription(text, charLimit);
+  }
+  return "";
+}
+
+/**
+ * Decode the small set of HTML entities that Marked emits in chapter
+ * HTML: `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`, `&#39;`, plus
+ * numeric `&#NN;` / `&#xNN;` escapes. Used in the description
+ * extraction path so that `&quot;AS IS&quot;` rendered into HTML
+ * decodes back to `"AS IS"` before being re-encoded for the meta tag.
+ */
+function decodeHtmlEntities(input: string): string {
+  return input
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_m, hex) =>
+      String.fromCodePoint(parseInt(hex, 16)),
+    )
+    .replace(/&#(\d+);/g, (_m, dec) => String.fromCodePoint(parseInt(dec, 10)));
+}
+
+/**
+ * Truncate a plain-text string to `charLimit` characters, preferring
+ * sentence boundaries, then word boundaries, with a trailing `…` when
+ * the input is longer than the limit.
+ */
+export function truncateForDescription(
+  text: string,
+  charLimit: number,
+): string {
+  if (text.length <= charLimit) return text;
+  // Don't degenerate to single-word descriptions: insist on cutting
+  // at a boundary only if the resulting snippet is at least 40% of
+  // the requested limit. Below that we'd rather keep more text and
+  // just trail with an ellipsis.
+  const minBoundary = Math.max(20, Math.floor(charLimit * 0.4));
+  // Look for the last sentence boundary within the limit window.
+  // Patterns covered: ". ", "? ", "! ", "。", "？", "！", "．" (full-width period).
+  const slice = text.slice(0, charLimit);
+  const sentenceBoundary = Math.max(
+    slice.lastIndexOf(". "),
+    slice.lastIndexOf("? "),
+    slice.lastIndexOf("! "),
+    slice.lastIndexOf("。"),
+    slice.lastIndexOf("？"),
+    slice.lastIndexOf("！"),
+    slice.lastIndexOf("．"),
+  );
+  if (sentenceBoundary >= minBoundary) {
+    // ASCII boundaries match ". " etc.; CJK boundaries match a
+    // single char. Either way keep the punctuation, drop trailing space.
+    return slice.slice(0, sentenceBoundary + 1).trim();
+  }
+  // Fall back to the last whitespace boundary inside the slice.
+  const wordBoundary = slice.lastIndexOf(" ");
+  if (wordBoundary >= minBoundary) {
+    return slice.slice(0, wordBoundary).trim() + "…";
+  }
+  // Hard truncate.
+  return slice.trim() + "…";
+}
+
+/**
+ * Inputs for `buildOgTags`. URLs are passed in already resolved (the
+ * caller decides how to mix relative / absolute, and what to emit when
+ * `baseUrl` is unset). When a field is `undefined`, the corresponding
+ * tag is omitted — never rendered as `<meta content="undefined">`.
+ */
+export interface OgTagOptions {
+  title: string;
+  description?: string;
+  imageUrl?: string;
+  pageUrl?: string;
+  siteName?: string;
+  locale?: string;
+}
+
+/**
+ * Build Open Graph `<meta>` tags. The order is stable so the test
+ * fixtures (and visual diffs) are deterministic. Returns an array of
+ * fully-formed `<meta>` tag strings; the caller joins them with the
+ * indentation appropriate for its surrounding template.
+ */
+export function buildOgTags(opts: OgTagOptions): string[] {
+  const lines: string[] = [];
+  // og:type is always "article" for chapter pages — F2 emits these per
+  // chapter only. The site index page (F1) uses "website" but is
+  // assembled by F1, not F2.
+  lines.push(`<meta property="og:type" content="article" />`);
+  lines.push(
+    `<meta property="og:title" content="${escapeHtml(opts.title)}" />`,
+  );
+  if (opts.description) {
+    lines.push(
+      `<meta property="og:description" content="${escapeHtml(opts.description)}" />`,
+    );
+  }
+  if (opts.pageUrl) {
+    lines.push(
+      `<meta property="og:url" content="${escapeHtml(opts.pageUrl)}" />`,
+    );
+  }
+  if (opts.imageUrl) {
+    lines.push(
+      `<meta property="og:image" content="${escapeHtml(opts.imageUrl)}" />`,
+    );
+  }
+  if (opts.siteName) {
+    lines.push(
+      `<meta property="og:site_name" content="${escapeHtml(opts.siteName)}" />`,
+    );
+  }
+  if (opts.locale) {
+    lines.push(
+      `<meta property="og:locale" content="${escapeHtml(opts.locale)}" />`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * Inputs for `buildTwitterCard`.
+ */
+export interface TwitterCardOptions {
+  title: string;
+  description?: string;
+  imageUrl?: string;
+}
+
+/**
+ * Build Twitter Card `<meta>` tags (always `summary_large_image`).
+ * F2 deliberately does NOT emit `twitter:site` / `twitter:creator`
+ * — Backend.AI does not have a project-wide Twitter handle declared
+ * anywhere in repo config, so guessing a value would be worse than
+ * omitting it. Operators who want those tags can add them post-build
+ * (proxy / CDN edge) without changing the toolkit.
+ */
+export function buildTwitterCard(opts: TwitterCardOptions): string[] {
+  const lines: string[] = [
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${escapeHtml(opts.title)}" />`,
+  ];
+  if (opts.description) {
+    lines.push(
+      `<meta name="twitter:description" content="${escapeHtml(opts.description)}" />`,
+    );
+  }
+  if (opts.imageUrl) {
+    lines.push(
+      `<meta name="twitter:image" content="${escapeHtml(opts.imageUrl)}" />`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * Inputs for `buildJsonLd`. `headline` is the page title; `inLanguage`
+ * is the BCP-47 / Open Graph locale (en, ko, ja, th); `dateModified`
+ * is an ISO-8601 timestamp from the page's last-modified record; the
+ * remaining fields come from `og.siteName` / `pdfMetadata.author`
+ * fallback chains.
+ */
+export interface JsonLdOptions {
+  headline: string;
+  description?: string;
+  inLanguage: string;
+  dateModified?: string;
+  author?: string;
+  publisher?: string;
+  url?: string;
+  imageUrl?: string;
+}
+
+/**
+ * Build a JSON-LD `<script type="application/ld+json">` block carrying
+ * a Schema.org `TechArticle`. Only well-formed fields are included;
+ * `undefined` fields are omitted entirely so the JSON validator stays
+ * happy. The output is a complete `<script>` element ready to inject
+ * into `<head>`.
+ *
+ * Note: schema.org's `Article`/`TechArticle` allow either a string or
+ * an `Organization` for `publisher`. We use the simpler `Organization`
+ * shape because tooling consensus is to prefer it; when no name is
+ * known, we omit `publisher` rather than synthesize a placeholder.
+ */
+export function buildJsonLd(opts: JsonLdOptions): string {
+  const data: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: opts.headline,
+    inLanguage: opts.inLanguage,
+  };
+  if (opts.description) data.description = opts.description;
+  if (opts.dateModified) data.dateModified = opts.dateModified;
+  if (opts.url) data.url = opts.url;
+  if (opts.imageUrl) data.image = opts.imageUrl;
+  if (opts.author) {
+    data.author = { "@type": "Organization", name: opts.author };
+  }
+  if (opts.publisher) {
+    data.publisher = { "@type": "Organization", name: opts.publisher };
+  }
+  // JSON.stringify produces output that is safe for a `<script>` body
+  // EXCEPT for the closing `</script>` sequence. Defensively escape the
+  // forward slash inside `</` so embedding cannot break the host page.
+  const json = JSON.stringify(data).replace(/<\/(?=script)/gi, "<\\/");
+  return `<script type="application/ld+json">${json}</script>`;
+}
+
+/**
+ * Resolve an absolute URL by joining `baseUrl` (no trailing slash
+ * required) with a relative path. Returns `undefined` when `baseUrl`
+ * is missing — callers use this to decide whether to omit absolute-URL
+ * tags entirely.
+ */
+export function joinBaseUrl(
+  baseUrl: string | undefined,
+  relativePath: string,
+): string | undefined {
+  if (!baseUrl) return undefined;
+  const trimmedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  const trimmedRel = relativePath.startsWith("/")
+    ? relativePath.slice(1)
+    : relativePath;
+  return `${trimmedBase}/${trimmedRel}`;
+}

--- a/packages/backend.ai-docs-toolkit/src/sitemap.ts
+++ b/packages/backend.ai-docs-toolkit/src/sitemap.ts
@@ -1,0 +1,84 @@
+/**
+ * sitemap.xml builder (F2 / FR-2714).
+ *
+ * Pure function: takes the page enumeration produced by F6's
+ * `generateWebsite()` and returns an XML string. Side-effect free so
+ * it can be unit-tested without touching the filesystem.
+ *
+ * The output conforms to https://www.sitemaps.org/protocol.html:
+ *   - Wrapped in `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`.
+ *   - One `<url>` element per page.
+ *   - `<loc>` is required; `<lastmod>` is optional (W3C Datetime).
+ *   - We omit `<changefreq>` / `<priority>` — Google ignores them and
+ *     they add noise.
+ *
+ * In versioned mode (per F6), every (version, lang, slug) row gets its
+ * own `<url>`. In flat mode, every (lang, slug) row gets its own
+ * `<url>`. The `isLatest` flag is NOT used to filter — search engines
+ * benefit from indexing all versions; the `<link rel="canonical">` on
+ * each non-latest page already tells them which version to prefer.
+ */
+
+import type { PageEnumerationRow } from "./versions.js";
+
+/** XML-escape `&`, `<`, `>`, `'`, `"` for safe inclusion in element text. */
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export interface BuildSitemapOptions {
+  /** Pages to include (one row per (version, lang, slug)). */
+  pages: readonly PageEnumerationRow[];
+  /**
+   * Public deploy URL, e.g. `https://docs.backend.ai`. Required for a
+   * standards-compliant sitemap (W3C `<loc>` mandates a fully-qualified
+   * URL). When unset, the caller should NOT call `buildSitemapXml` —
+   * we still tolerate it here and emit relative `<loc>` values, but a
+   * sitemap with relative paths is non-conformant and most crawlers
+   * will reject it. F2's generator emits a warning and skips the file
+   * when `baseUrl` is unset; this function is defensive but not lenient.
+   */
+  baseUrl?: string;
+  /**
+   * Resolve a `<lastmod>` ISO date string for a given page row. The
+   * caller picks the strategy (git log, fs.stat mtime, or a constant).
+   * Returning `undefined` omits the `<lastmod>` element.
+   */
+  lastModFor: (row: PageEnumerationRow) => string | undefined;
+}
+
+/**
+ * Build a sitemap.xml document body. Returns the complete XML string
+ * including the XML declaration. Lines are joined with `\n` for human
+ * readability — crawlers ignore whitespace between elements.
+ */
+export function buildSitemapXml(opts: BuildSitemapOptions): string {
+  const { pages, baseUrl, lastModFor } = opts;
+  const trimmedBase = baseUrl
+    ? baseUrl.endsWith("/")
+      ? baseUrl.slice(0, -1)
+      : baseUrl
+    : "";
+
+  const urlBlocks: string[] = [];
+  for (const row of pages) {
+    const fullUrl = trimmedBase ? `${trimmedBase}/${row.path}` : row.path;
+    const lastMod = lastModFor(row);
+    const inner: string[] = [`    <loc>${escapeXml(fullUrl)}</loc>`];
+    if (lastMod) {
+      inner.push(`    <lastmod>${escapeXml(lastMod)}</lastmod>`);
+    }
+    urlBlocks.push(`  <url>\n${inner.join("\n")}\n  </url>`);
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urlBlocks.join("\n")}
+</urlset>
+`;
+}

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -7,6 +7,13 @@ import type { Chapter } from "./markdown-processor.js";
 import type { ResolvedDocConfig } from "./config.js";
 import { WEBSITE_LABELS } from "./config.js";
 import { escapeHtml } from "./markdown-extensions.js";
+import {
+  buildJsonLd,
+  buildOgTags,
+  buildTwitterCard,
+  extractDescription,
+  joinBaseUrl,
+} from "./seo.js";
 
 export interface WebPageContext {
   /** Current chapter to render */
@@ -32,6 +39,57 @@ export interface WebPageContext {
    * the page metadata bar can show.
    */
   versionContext?: PageVersionContext;
+  /**
+   * SEO metadata context (F2). Optional — when omitted, only the base
+   * `<head>` tags (title, viewport, stylesheet, favicons) are emitted.
+   * When supplied, F2's per-page tags (description, OG, Twitter,
+   * canonical, JSON-LD) are added to the head block. The website
+   * generator builds this from `og` config + page-relative paths +
+   * lastModified date.
+   */
+  seo?: PageSeoContext;
+}
+
+/**
+ * Per-page SEO context. Built once per (version, lang, slug) by the
+ * website generator and threaded through to the head builder. All
+ * URL fields are RELATIVE to the website output root (`dist/web/`)
+ * unless explicitly absolute. The head builder converts to absolute
+ * with `og.baseUrl` only when emitting the OG / canonical tags.
+ */
+export interface PageSeoContext {
+  /**
+   * Public deploy URL, e.g. `https://docs.backend.ai`. When `undefined`,
+   * the head builder omits the canonical tag and `og:url`, and the
+   * sitemap-emitter step is skipped at the generator level.
+   */
+  baseUrl?: string;
+  /** `og:site_name` / JSON-LD publisher name. Defaults to doc title. */
+  siteName?: string;
+  /**
+   * Path to this page relative to the website output root, e.g.
+   * `en/quickstart.html` (flat) or `25.16/en/quickstart.html` (versioned).
+   * Used to compute `og:url`.
+   */
+  pagePath: string;
+  /**
+   * Path to the canonical URL relative to the website output root.
+   * In versioned mode, points at the same slug under the latest
+   * version (per F6's `canonicalPathFor`). In flat mode, equals
+   * `pagePath`.
+   */
+  canonicalPath: string;
+  /**
+   * Default OG image path relative to the website output root, e.g.
+   * `assets/og-default.png`. When `undefined` (Playwright unavailable
+   * and no override), the `og:image` and `twitter:image` tags are
+   * dropped.
+   */
+  ogImageRelUrl?: string;
+  /** ISO-8601 last-modified timestamp for JSON-LD `dateModified`. */
+  lastModifiedIso?: string;
+  /** Publisher / author for JSON-LD. Falls back to `pdfMetadata.author`. */
+  publisher?: string;
 }
 
 export interface WebsiteMetadata {
@@ -239,13 +297,30 @@ function rootPrefix(context: { versionContext?: PageVersionContext }): string {
 /**
  * Build the `<head>` block: meta tags + stylesheet + favicon / apple-touch /
  * webmanifest. The search script is referenced separately from `<body>` end.
+ *
+ * F2 (SEO) extends this with description / OG / Twitter / canonical /
+ * JSON-LD when `seo` is supplied. The order is:
+ *   - charset / viewport / title / stylesheet (always)
+ *   - favicon / apple-touch / webmanifest (when bundled)
+ *   - description (always when chapter has any prose)
+ *   - canonical (when seo.baseUrl is set)
+ *   - OG tags (always; omits absolute-URL tags when seo.baseUrl is unset)
+ *   - Twitter card (always)
+ *   - JSON-LD TechArticle (always)
+ *
+ * F1 (NOT in this worktree) injects `<link rel="alternate" hreflang>`
+ * tags. F2's contribution stays additive — the F1 + F2 reconciliation
+ * is mechanical.
  */
 function buildHeadAssetTags(
   metadata: WebsiteMetadata,
   langLabel: string,
   pageTitle: string,
+  chapterHeadline: string,
+  chapterHtml: string,
   assets: PageAssets,
   prefix: string,
+  seo: PageSeoContext | undefined,
 ): string {
   const lines: string[] = [
     `<meta charset="utf-8" />`,
@@ -270,11 +345,90 @@ function buildHeadAssetTags(
     );
   }
 
-  // Suppress unused-variable warning under strict TS — `metadata` is reserved
-  // for future per-language `<head>` extensions (e.g., hreflang) but not used yet.
-  void metadata;
+  // ── F2: SEO / sharing metadata ────────────────────────────────
+  // Description is extracted from the chapter HTML's first paragraph;
+  // when the chapter has no prose (e.g. a stub page), we fall back to
+  // the title so social-share previews still get a useful blurb.
+  const description =
+    extractDescription(chapterHtml) || stripChapterTitle(chapterHeadline);
+
+  if (description) {
+    lines.push(
+      `<meta name="description" content="${escapeHtml(description)}" />`,
+    );
+  }
+
+  if (seo) {
+    // Canonical: when baseUrl is set, point at the absolute URL of the
+    // canonical page (latest version's same slug, per F6). When baseUrl
+    // is unset, fall back to a relative canonical pointing at the page
+    // itself — better than no canonical at all because it still tells
+    // crawlers "this URL is canonical for itself" (vs. ?utm_… etc.).
+    const canonicalAbs = joinBaseUrl(seo.baseUrl, seo.canonicalPath);
+    if (canonicalAbs) {
+      lines.push(`<link rel="canonical" href="${escapeHtml(canonicalAbs)}" />`);
+    } else {
+      // Relative canonical: from this page back to the canonical path.
+      // In flat mode, canonicalPath === pagePath, so the relative ref
+      // is just "./<basename>" — but the simpler form is the bare
+      // basename, which the browser resolves against the document URL.
+      // We use `prefix + canonicalPath` so versioned-mode canonical
+      // works (canonical lives in the latest-version subdir, possibly
+      // a sibling to the current page).
+      lines.push(
+        `<link rel="canonical" href="${prefix}${escapeHtml(seo.canonicalPath)}" />`,
+      );
+    }
+
+    const pageUrlAbs = joinBaseUrl(seo.baseUrl, seo.pagePath);
+    const ogImageAbs = seo.ogImageRelUrl
+      ? (joinBaseUrl(seo.baseUrl, seo.ogImageRelUrl) ??
+        `${prefix}${seo.ogImageRelUrl}`)
+      : undefined;
+
+    const ogTags = buildOgTags({
+      title: chapterHeadline,
+      description: description || undefined,
+      imageUrl: ogImageAbs,
+      pageUrl: pageUrlAbs,
+      siteName: seo.siteName,
+      locale: metadata.lang,
+    });
+    for (const tag of ogTags) lines.push(tag);
+
+    const twitterTags = buildTwitterCard({
+      title: chapterHeadline,
+      description: description || undefined,
+      imageUrl: ogImageAbs,
+    });
+    for (const tag of twitterTags) lines.push(tag);
+
+    lines.push(
+      buildJsonLd({
+        headline: chapterHeadline,
+        description: description || undefined,
+        inLanguage: metadata.lang,
+        dateModified: seo.lastModifiedIso,
+        author: seo.publisher,
+        publisher: seo.publisher,
+        url: pageUrlAbs,
+        imageUrl: ogImageAbs,
+      }),
+    );
+  }
 
   return lines.join("\n  ");
+}
+
+/**
+ * Trim a "Chapter Title - Doc Title" composite back to just the chapter
+ * portion, used as a description fallback when no prose paragraph
+ * exists. The composite shape is built one layer up (`pageTitle =
+ * "<chapter> - <doc title>"`); F2's description fallback prefers the
+ * chapter portion alone since the doc title is already in `<title>`.
+ */
+function stripChapterTitle(headline: string): string {
+  return headline.replace(/\s+-\s+.*$/, "").trim();
 }
 
 /**
@@ -453,8 +607,11 @@ export function buildWebPage(context: WebPageContext): string {
     metadata,
     langLabel,
     pageTitle,
+    chapter.title,
+    chapter.htmlContent,
     assets,
     prefix,
+    context.seo,
   );
   const headerBar = buildPageHeaderBar(context);
   const searchScript = buildSearchScriptTag(assets, prefix);

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -20,9 +20,18 @@ import {
 import { buildSearchIndex } from "./search-index-builder.js";
 import type {
   PageAssets,
+  PageSeoContext,
   PageVersionContext,
   WebsiteMetadata,
 } from "./website-builder.js";
+import { buildSitemapXml } from "./sitemap.js";
+import { buildRobotsTxt } from "./robots-txt.js";
+import {
+  copyUserOgImage,
+  renderDefaultOgImage,
+  type RenderedOgImage,
+} from "./og-image-renderer.js";
+import { canonicalPathFor } from "./versions.js";
 import { generateWebsiteStyles } from "./styles-web.js";
 import { getDocVersion } from "./version.js";
 import type { ResolvedDocConfig } from "./config.js";
@@ -326,6 +335,44 @@ export async function generateWebsite(
     webmanifest: rootAssets.webmanifest,
   };
 
+  // ── F2: Default OG image rendering ────────────────────────────
+  // Two strategies, in priority order:
+  //   1. `og.imagePath` (operator override) — copied verbatim.
+  //   2. Default rendering — `manifest/backend.ai-brand-simple.svg`
+  //      → 1200×630 PNG via Playwright.
+  // Both produce a file under `dist/web/assets/og-default.<ext>`. When
+  // both are unavailable (missing file or no Playwright), the OG image
+  // tag is dropped per page — no crash, just degraded preview cards.
+  const ogImage = await prepareOgImage(config, assetsDir);
+  if (ogImage) {
+    console.log(`Written: ${ogImage.relUrl}`);
+  }
+
+  // ── F2: SEO context skeleton (per-page details filled later) ──
+  const ogConfig = config.og ?? {};
+  const baseUrl = normalizeBaseUrl(ogConfig.baseUrl);
+  if (!baseUrl) {
+    console.warn(
+      "[seo] og.baseUrl not set in docs-toolkit.config.yaml. " +
+        "sitemap.xml will be skipped, canonical URLs will be relative, " +
+        'og:url will be omitted. Set `og.baseUrl: "https://..."` to enable.',
+    );
+  }
+  // F2 normalizes multi-line `book.config.yaml` titles before embedding
+  // them in `og:site_name` / JSON-LD. F1 will fix the `<title>` tag at
+  // its own layer (and may also normalize the value at config-read
+  // time), but until F1 lands, F2 must not ship literal newlines in
+  // SEO tags — they break Open Graph parsers.
+  const siteName = collapseWhitespace(ogConfig.siteName ?? title);
+  const publisher = config.pdfMetadata.author ?? config.productName;
+
+  // ── F2: Last-modified timestamps shared across emissions ──────
+  // The website generator passes a sink Map down to every per-language
+  // step; each step adds its (filePath → Date) pairs. After the build
+  // completes, the sitemap emitter consumes the same Map to attach
+  // `<lastmod>` per (version, lang, slug) row.
+  const lastModSink = new Map<string, Date>();
+
   if (loadedVersions.enabled) {
     // Versioned mode — iterate over each declared version.
     // Past minors that fail to resolve their archive-branch worktree are
@@ -385,6 +432,13 @@ export async function generateWebsite(
           allDiagnostics,
           imageStats,
           pageRegistry,
+          seoBase: {
+            baseUrl,
+            siteName,
+            publisher,
+            ogImageRelUrl: ogImage?.relUrl,
+          },
+          lastModSink,
         });
       }
 
@@ -413,9 +467,46 @@ export async function generateWebsite(
         allDiagnostics,
         imageStats,
         pageRegistry,
+        seoBase: {
+          baseUrl,
+          siteName,
+          publisher,
+          ogImageRelUrl: ogImage?.relUrl,
+        },
+        lastModSink,
       });
     }
   }
+
+  // ── F2: sitemap.xml + robots.txt emission ─────────────────────
+  // We only emit sitemap.xml when `og.baseUrl` is set, because a
+  // sitemap with relative `<loc>` is non-conformant. robots.txt is
+  // always emitted (it's useful even without a sitemap reference).
+  if (baseUrl) {
+    const sitemapXml = buildSitemapXml({
+      pages: pageRegistry.enumerateAll(),
+      baseUrl,
+      lastModFor: (row) => {
+        // F6's path is `<v>/<lang>/<slug>.html` or `<lang>/<slug>.html`.
+        // The sink uses the SAME path key, so we can look up directly.
+        const date = lastModSink.get(row.path);
+        return date ? date.toISOString() : undefined;
+      },
+    });
+    fs.writeFileSync(path.join(distBase, "sitemap.xml"), sitemapXml, "utf-8");
+    console.log(
+      `Written: sitemap.xml (${pageRegistry.enumerateAll().length} URLs)`,
+    );
+  } else {
+    console.log("Skipped: sitemap.xml (og.baseUrl not configured)");
+  }
+
+  const sitemapAbs = baseUrl
+    ? `${baseUrl.replace(/\/$/, "")}/sitemap.xml`
+    : undefined;
+  const robotsTxt = buildRobotsTxt({ sitemapUrl: sitemapAbs });
+  fs.writeFileSync(path.join(distBase, "robots.txt"), robotsTxt, "utf-8");
+  console.log(`Written: robots.txt`);
 
   // Image-attribute coverage report (loading/decoding are 100% via post-
   // processing; width/height depends on parsed PNG headers).
@@ -458,6 +549,19 @@ export async function generateWebsite(
  * `versionLabel` is null in flat mode, otherwise the minor label like "25.16".
  * The version selector header is only emitted when `versionLabel !== null`.
  */
+/**
+ * Per-build SEO base context. Built once in `generateWebsite()` and
+ * forwarded to every `buildLanguage()` invocation; the per-page
+ * `PageSeoContext` is composed on the fly by mixing in pagePath,
+ * canonicalPath, and lastModifiedIso.
+ */
+interface SeoBaseContext {
+  baseUrl: string | undefined;
+  siteName: string;
+  publisher: string;
+  ogImageRelUrl: string | undefined;
+}
+
 async function buildLanguage(args: {
   lang: string;
   version: string;
@@ -473,6 +577,8 @@ async function buildLanguage(args: {
   allDiagnostics: LinkDiagnostic[];
   imageStats: { total: number; withDims: number };
   pageRegistry: VersionPageRegistry;
+  seoBase: SeoBaseContext;
+  lastModSink: Map<string, Date>;
 }): Promise<void> {
   const {
     lang,
@@ -488,6 +594,8 @@ async function buildLanguage(args: {
     allDiagnostics,
     imageStats,
     pageRegistry,
+    seoBase,
+    lastModSink,
   } = args;
 
   const startTime = Date.now();
@@ -583,6 +691,32 @@ async function buildLanguage(args: {
       pageRegistry,
     });
 
+    // ── F2: Per-page SEO context ──────────────────────────────
+    // pagePath is the URL-relative path used in the cross-version
+    // page registry. canonicalPath uses F6's canonicalPathFor() so
+    // non-latest versions point at the latest version's same slug.
+    const pagePath =
+      versionLabel !== null
+        ? `${versionLabel}/${lang}/${chapters[i].slug}.html`
+        : `${lang}/${chapters[i].slug}.html`;
+    const canonicalPath = canonicalPathFor(
+      loadedVersions,
+      lang,
+      chapters[i].slug,
+    );
+    const seo: PageSeoContext = {
+      baseUrl: seoBase.baseUrl,
+      siteName: seoBase.siteName,
+      publisher: seoBase.publisher,
+      pagePath,
+      canonicalPath,
+      ogImageRelUrl: seoBase.ogImageRelUrl,
+      lastModifiedIso: lastDate ? lastDate.toISOString() : undefined,
+    };
+    if (lastDate) {
+      lastModSink.set(pagePath, lastDate);
+    }
+
     let pageHtml = buildWebPage({
       chapter: chapters[i],
       allChapters: chapters,
@@ -593,6 +727,7 @@ async function buildLanguage(args: {
       lastUpdated: lastDate ? formatDate(lastDate, lang) : undefined,
       assets: pageAssets,
       versionContext,
+      seo,
     });
 
     // Fix image paths for static site (./images/foo.png).
@@ -860,4 +995,99 @@ function writeRootBrandAssets(
   console.log(`Written: site.webmanifest`);
 
   return out;
+}
+
+/**
+ * Resolve and prepare the default OG image (F2). Two strategies:
+ *
+ *   1. Operator override via `og.imagePath` — file is copied verbatim
+ *      into `dist/web/assets/og-default.<ext>`. Operators control the
+ *      design; the toolkit just ships it.
+ *   2. Default rendering — the bundled `manifest/backend.ai-brand-simple.svg`
+ *      is rendered to a 1200×630 PNG via Playwright. The brand SVG path
+ *      is resolved relative to the toolkit's project root candidates so
+ *      the renderer works whether the toolkit is checked out as part of
+ *      the monorepo (typical) or installed as a published package.
+ *
+ * Returns `null` (and warns) when neither path produces a file. The
+ * generator passes that null through to every page's `PageSeoContext`,
+ * which then drops the `og:image` tag rather than emitting a broken
+ * reference.
+ */
+async function prepareOgImage(
+  config: ResolvedDocConfig,
+  assetsDir: string,
+): Promise<RenderedOgImage | null> {
+  const og = config.og;
+
+  // Strategy 1: operator override.
+  if (og?.imagePath) {
+    const sourceAbs = path.resolve(config.projectRoot, og.imagePath);
+    const result = copyUserOgImage({
+      sourcePath: sourceAbs,
+      destDir: assetsDir,
+    });
+    if (result) return result;
+    // Fall through to default rendering when the override file is
+    // missing — better than no OG image at all.
+  }
+
+  // Strategy 2: render the bundled brand SVG.
+  const brandSvgCandidates = [
+    // Monorepo layout — toolkit is at packages/backend.ai-docs-toolkit/
+    // and the brand SVG is at <repo-root>/manifest/backend.ai-brand-simple.svg.
+    path.resolve(
+      config.projectRoot,
+      "../../manifest/backend.ai-brand-simple.svg",
+    ),
+    // Workspace layout — docs site is the project root, brand lives at
+    // a relative manifest dir.
+    path.resolve(config.projectRoot, "manifest/backend.ai-brand-simple.svg"),
+    // Direct override via the resolved logoPath — useful when operators
+    // ship a custom brand SVG via `logoPath` but no separate `og.imagePath`.
+    config.logoPath ?? "",
+  ].filter((p): p is string => !!p && fs.existsSync(p));
+
+  if (brandSvgCandidates.length === 0) {
+    console.warn(
+      "[og-image] No brand SVG found at any of the expected paths " +
+        "(repo-root/manifest, projectRoot/manifest, or config.logoPath). " +
+        "Skipping default OG image. Set `og.imagePath` to ship a static one.",
+    );
+    return null;
+  }
+
+  return renderDefaultOgImage({
+    svgSourcePath: brandSvgCandidates[0],
+    destDir: assetsDir,
+  });
+}
+
+/**
+ * Collapse internal whitespace runs (including newlines from YAML
+ * `title: |` block scalars) into single spaces, then trim. Used by F2
+ * to keep multi-line book titles from breaking Open Graph parsers.
+ * F1 may later normalize `book.config.yaml`'s title at read-time,
+ * making this redundant — until then F2 defends its own surface.
+ */
+function collapseWhitespace(input: string): string {
+  return input.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Normalize the `og.baseUrl` config value. Strips a trailing slash so
+ * URL composition doesn't double up. Returns `undefined` when the
+ * input is missing or doesn't look like an http(s) URL — consumers
+ * use the undefined to skip absolute-URL tags entirely.
+ */
+function normalizeBaseUrl(raw: string | undefined): string | undefined {
+  if (!raw || typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (!/^https?:\/\//i.test(trimmed)) {
+    console.warn(
+      `[seo] og.baseUrl "${trimmed}" does not start with http(s):// — ignored.`,
+    );
+    return undefined;
+  }
+  return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
 }


### PR DESCRIPTION
Resolves FR-2714

## Summary
F2 of FR-2710 (final bucket): SEO and sharing metadata.

- Per-page `<meta name="description">` extracted from first non-heading paragraph (≤ 155 chars, with title fallback)
- Open Graph tags per page: `og:title`, `og:description`, `og:image`, `og:url`, `og:type=article`, `og:site_name`, `og:locale`
- Twitter Card per page: `summary_large_image`
- `<link rel="canonical">` per page (absolute when `og.baseUrl` set, relative fallback otherwise)
- `dist/web/sitemap.xml` (all versions × langs × pages — consumes F6's `enumerateAllPages()`)
- `dist/web/robots.txt` (always emitted; `Sitemap:` line conditional on `og.baseUrl`)
- JSON-LD `TechArticle` per page with `headline`, `inLanguage`, `dateModified`, `author`, `publisher`
- Default OG image: `manifest/backend.ai-brand-simple.svg` rendered to `dist/web/assets/og-default.png` at build time via Playwright; `og.imagePath` config override
- New `og` config block: `{ imagePath?, siteName?, baseUrl? }` — graceful behavior when `baseUrl` is unset (sitemap skipped with one warning, no crash)
- 17 SEO unit tests; 35 toolkit tests passing in total (incl. F6's 19)

## Review fix applied (commit `1aa00670`)
- HIGH: Playwright OG renderer now blocks all non-local network via `page.route('**/*', abort)` with `data:`/`about:` allowlist installed BEFORE `page.setContent` — air-gap constraint upheld even for adversarial SVG content with external `<image href>`. (`file:` not needed because the renderer uses `setContent`, not `goto`; the brand SVG is embedded as base64 `data:` URI.)

## Cross-cutting verification
- [x] `pnpm run build:web` (flat) exits 0; `robots.txt` emitted, `sitemap.xml` skipped with one warning (no `og.baseUrl`)
- [x] `pnpm run build:web` (with workspace `versions`) exits 0; sitemap covers all versions × langs × pages
- [x] `pnpm run pdf:en` exits 0; `og` config invisible to PDF (PDF reads only `book.config.yaml`, verified)
- [x] OG image renders to `dist/web/assets/og-default.png` at 19,307 B
- Pre-existing CJK PDF break (ko/ja/th) and pre-existing TS verify failure in `react/src/pages/Reservoir*.tsx` are unchanged — environmental, not introduced by this PR

## Air-gap defense
Playwright `page.route` allowlist (`data:` + `about:` only) installed before `setContent` — adversarial SVG with `<image href="http://...">` will not trigger network fetch.

## Stack
- Spec: #6988 → Dev plan: #7004 → F5: #7006 → F6: #7011 → This PR (F2)
