### PR TITLE
feat(FR-2719): build per-language User Guide PDFs in CI release workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,16 +1,20 @@
 # Build and release workflow for Backend.AI Desktop and WebUI bundle.
 #
-# Architecture: 3 parallel jobs after a shared web build step.
+# Architecture: 4 parallel jobs (build_docs is fully independent, the others
+# share a web build step).
 #
 #   build_web (ubuntu) ──┬──> build_mac (macos)    → DMG x64/arm64 + local proxy
 #                        ├──> build_desktop (ubuntu) → Win/Linux ZIP x64/arm64 + local proxy
 #                        └──> upload web bundle
+#   build_docs (ubuntu, independent)               → User Guide PDFs (en/ko/ja/th)
 #
 # Key optimizations over the previous single-job approach:
-#   1. Parallel jobs: macOS + win/linux builds run concurrently (~10 min saved)
+#   1. Parallel jobs: macOS + win/linux + docs builds run concurrently (~10 min saved)
 #   2. No double React build: publicPath patching replaces full rebuild (~5 min saved)
 #   3. Parallel local proxy compilation within each job (~3 min saved)
 #   4. Optimized ZIP compression level (-6 vs -9, marginal size diff, ~1 min saved)
+#   5. PDF generation reuses one Chromium instance and renders languages in
+#      parallel; Playwright browsers are cached across runs.
 
 name: Build and Release Packages
 on:
@@ -204,3 +208,123 @@ jobs:
         run: node upload-release.js app
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 4: Build per-language User Guide PDFs (ubuntu, target ~5 min)
+  #
+  # Independent of the web/desktop jobs — only needs the docs sources under
+  # `packages/backend.ai-webui-docs/src/`. Runs in parallel with build_mac
+  # and build_desktop, so a healthy run does not extend the overall wall
+  # clock (mac is the current critical path at ~10 min).
+  #
+  # Failure handling is scoped to the PDF build step itself (not the whole
+  # job), so partial per-language failures degrade gracefully but a full
+  # generator failure (all languages failed → generate-pdf.ts exits non-
+  # zero) still fails the job. This prevents shipping a release with zero
+  # PDF assets going unnoticed.
+  # ──────────────────────────────────────────────────────────────────────
+  build_docs:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
+        with:
+          version: latest
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      # backend.ai-docs-toolkit ships its `docs-toolkit` CLI as the package
+      # bin, but it lives at dist/cli.js which only exists after `tsc` runs.
+      # On a fresh `pnpm install` the dist directory is empty, so pnpm
+      # cannot create the .bin/docs-toolkit symlink and later `pdf:all`
+      # fails with `spawn ENOENT`. Building the toolkit and re-running
+      # install populates dist/ and lets pnpm wire the bin link.
+      - name: Build docs-toolkit and link CLI
+        run: |
+          pnpm --filter backend.ai-docs-toolkit run build
+          pnpm install --no-frozen-lockfile
+
+      # Cache the Playwright browser binaries (~150 MB Chromium download).
+      # The lockfile hash keys the cache so a Playwright version bump
+      # naturally invalidates the cache without manual intervention.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter backend.ai-webui-docs exec playwright install --with-deps chromium
+
+      # PDF rendering uses two distinct font paths that need different fonts:
+      #
+      # 1. Body text — rendered by Chromium from HTML. Resolves the CSS
+      #    font-family (see styles.ts) via fontconfig, so it understands
+      #    .ttc collections. `fonts-noto-cjk` provides "Noto Sans CJK KR/JP/TC"
+      #    which the CSS lists as the canonical CJK body font.
+      #
+      # 2. Header/footer — stamped post-render by pdf-lib, which cannot embed
+      #    .ttc collections. So we additionally install language-specific
+      #    single-face packages whose paths are listed in
+      #    DEFAULT_CJK_FONT_CANDIDATES (pdf-renderer.ts):
+      #      - fonts-nanum         → /usr/share/fonts/truetype/nanum/NanumBarunGothic.ttf  (ko)
+      #      - fonts-takao-gothic  → /usr/share/fonts/truetype/takao-gothic/TakaoGothic.ttf (ja)
+      #      - fonts-thai-tlwg     → /usr/share/fonts/opentype/tlwg/Loma.otf | Garuda.ttf  (th)
+      #
+      # Languages whose pdf-lib font is missing will be reported as a failure by
+      # generate-pdf.ts but will not abort the other language renders.
+      - name: Install CJK + Thai fonts (best effort)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            fonts-noto-cjk \
+            fonts-nanum fonts-takao-gothic fonts-thai-tlwg || true
+          fc-cache -f || true
+
+      # generate-pdf.ts continues past per-language failures and exits
+      # non-zero only if *every* requested language failed. Combined with
+      # `continue-on-error: true` on the job, a partial PDF run still
+      # uploads the languages that succeeded.
+      - name: Build PDFs (en/ko/ja/th)
+        run: pnpm --filter backend.ai-webui-docs run pdf:all
+
+      - name: Stage PDFs for upload
+        run: |
+          mkdir -p ./app
+          if compgen -G "packages/backend.ai-webui-docs/dist/*.pdf" > /dev/null; then
+            cp packages/backend.ai-webui-docs/dist/*.pdf ./app/
+            ls -lh ./app/*.pdf
+          else
+            echo "::warning::No PDFs were produced; nothing to upload."
+          fi
+
+      - name: Upload PDF release assets
+        if: inputs.dry_run != true
+        run: node upload-release.js app
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Always retain the built PDFs as a workflow artifact for inspection
+      # (handy during dry runs and when debugging the release path).
+      - name: Upload PDFs as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: webui-docs-pdfs
+          path: packages/backend.ai-webui-docs/dist/*.pdf
+          if-no-files-found: warn
+          retention-days: 14

--- a/packages/backend.ai-docs-toolkit/src/generate-pdf.ts
+++ b/packages/backend.ai-docs-toolkit/src/generate-pdf.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { parse as parseYaml } from 'yaml';
+import { chromium } from 'playwright';
 import { processMarkdownFiles } from './markdown-processor.js';
 import { buildFullDocument } from './html-builder.js';
 import { renderPdf } from './pdf-renderer.js';
@@ -20,6 +21,12 @@ export interface GeneratePdfOptions {
   theme: string;
   chapters?: string[];
   note?: string;
+  /**
+   * Maximum number of languages to render concurrently.
+   * Defaults to 2 (safe for GitHub-hosted ubuntu runners with 2 vCPU).
+   * Override via the `BAI_DOCS_PDF_CONCURRENCY` env var.
+   */
+  concurrency?: number;
 }
 
 function parseArgs(argv: string[]): GeneratePdfOptions {
@@ -85,22 +92,40 @@ export async function generatePdf(
     }
   }
 
+  const envConcurrency = Number.parseInt(
+    process.env.BAI_DOCS_PDF_CONCURRENCY ?? '',
+    10,
+  );
+  const optionConcurrency = Number.isFinite(args.concurrency)
+    ? args.concurrency
+    : undefined;
+  const concurrency = Math.max(
+    1,
+    optionConcurrency ?? (Number.isFinite(envConcurrency) ? envConcurrency : 2),
+  );
+
   const productName = config.productName;
   console.log(`${productName} PDF Generator`);
   console.log(`Title: ${title}`);
   console.log(`Version: ${version}`);
   console.log(`Theme: ${theme.name}`);
   console.log(`Languages: ${languages.join(', ')}`);
+  console.log(`Concurrency: ${concurrency}`);
   console.log('');
 
-  for (const lang of languages) {
+  // Launch a single Chromium instance shared across all language renders.
+  // Each renderPdf call opens its own page on this browser, which avoids
+  // paying the launch cost (~1–2s) per language.
+  const sharedBrowser = await chromium.launch();
+
+  const renderOne = async (lang: string): Promise<void> => {
     const startTime = Date.now();
     console.log(`[${lang}] Generating PDF...`);
 
     let navigation = bookConfig.navigation[lang];
     if (!navigation) {
       console.warn(`[${lang}] No navigation found, skipping`);
-      continue;
+      return;
     }
 
     // Filter chapters if --chapters option is specified
@@ -129,7 +154,7 @@ export async function generatePdf(
           `[${lang}] Chapter identifiers can be a full path (e.g. overview/overview.md), directory name, or filename.`,
         );
         console.error(`[${lang}] Available chapters: ${available}`);
-        process.exit(1);
+        throw new Error(`No chapters matched filter for "${lang}"`);
       }
       navigation = filtered;
       console.log(
@@ -173,6 +198,7 @@ export async function generatePdf(
       lang,
       theme,
       config,
+      browser: sharedBrowser,
     });
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
@@ -181,7 +207,55 @@ export async function generatePdf(
       `[${lang}] Done: ${outputPath} (${fileSize} MB, ${elapsed}s)`,
     );
     console.log('');
+  };
+
+  // Track per-language outcome so a single language failure (e.g. missing
+  // CJK font on a runner) does not kill renders that have already started
+  // or are still queued. The script exits non-zero only if *every*
+  // requested language failed.
+  const failures: Array<{ lang: string; error: Error }> = [];
+
+  try {
+    // Concurrency-limited fan-out: process up to `concurrency` languages at
+    // a time. Each worker pulls the next language from a shared cursor.
+    const queue = [...languages];
+    const workers: Promise<void>[] = [];
+    const workerCount = Math.min(concurrency, queue.length);
+    for (let i = 0; i < workerCount; i++) {
+      workers.push(
+        (async () => {
+          while (queue.length > 0) {
+            const lang = queue.shift();
+            if (!lang) break;
+            try {
+              await renderOne(lang);
+            } catch (err) {
+              const error = err instanceof Error ? err : new Error(String(err));
+              console.error(`[${lang}] FAILED: ${error.message}`);
+              failures.push({ lang, error });
+            }
+          }
+        })(),
+      );
+    }
+    await Promise.all(workers);
+  } finally {
+    await sharedBrowser.close();
   }
 
-  console.log('PDF generation complete!');
+  if (failures.length > 0) {
+    console.log('');
+    console.log(`PDF generation finished with ${failures.length}/${languages.length} failures:`);
+    for (const { lang, error } of failures) {
+      console.log(`  - [${lang}] ${error.message}`);
+    }
+    if (failures.length === languages.length) {
+      throw new Error('All requested languages failed to build');
+    }
+    console.log(
+      `Continuing because ${languages.length - failures.length} language(s) succeeded.`,
+    );
+  } else {
+    console.log('PDF generation complete!');
+  }
 }

--- a/packages/backend.ai-docs-toolkit/src/pdf-renderer.ts
+++ b/packages/backend.ai-docs-toolkit/src/pdf-renderer.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { chromium } from 'playwright';
+import { chromium, type Browser } from 'playwright';
 import { PDFDocument, PDFName, PDFArray, PDFDict, PDFRef, rgb, StandardFonts } from 'pdf-lib';
 import fontkit from '@pdf-lib/fontkit';
 import type { PdfTheme } from './theme.js';
@@ -19,10 +19,17 @@ const DEFAULT_CJK_FONT_CANDIDATES = [
   path.join(os.homedir(), 'Library/Fonts/NanumBarunGothic.ttf'),
   path.join(os.homedir(), 'Library/Fonts/NanumSquareRegular.ttf'),
   '/System/Library/Fonts/Supplemental/Arial Unicode.ttf',
-  // Linux common paths
+  // Linux common paths — Korean
   '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',
   '/usr/share/fonts/truetype/noto/NotoSansKR-Regular.ttf',
   '/usr/share/fonts/truetype/nanum/NanumBarunGothic.ttf',
+  // Linux common paths — Japanese (fonts-takao-gothic on Debian/Ubuntu)
+  '/usr/share/fonts/truetype/takao-gothic/TakaoGothic.ttf',
+  '/usr/share/fonts/truetype/takao-mincho/TakaoMincho.ttf',
+  // Linux common paths — Thai (fonts-thai-tlwg on Debian/Ubuntu)
+  '/usr/share/fonts/truetype/tlwg/Loma.ttf',
+  '/usr/share/fonts/opentype/tlwg/Loma.otf',
+  '/usr/share/fonts/truetype/tlwg/Garuda.ttf',
 ];
 
 type EmbeddedFont = Awaited<ReturnType<PDFDocument['embedFont']>>;
@@ -61,6 +68,13 @@ export interface RenderOptions {
   lang: string;
   theme?: PdfTheme;
   config?: ResolvedDocConfig;
+  /**
+   * Optional shared Chromium instance. When provided, renderPdf reuses it
+   * by opening a new page on the existing browser, and the caller owns its
+   * lifecycle. This avoids paying the per-call launch cost when generating
+   * multiple PDFs in one run (e.g. one PDF per language during release builds).
+   */
+  browser?: Browser;
 }
 
 interface ChapterInfo {
@@ -382,16 +396,23 @@ export async function renderPdf(options: RenderOptions): Promise<void> {
 
   fs.mkdirSync(path.dirname(options.outputPath), { recursive: true });
 
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bai-docs-'));
-  const tmpHtmlPath = path.join(tmpDir, 'document.html');
-  fs.writeFileSync(tmpHtmlPath, options.html, 'utf-8');
+  const ownsBrowser = !options.browser;
+  const browser = options.browser ?? (await chromium.launch());
 
-  const browser = await chromium.launch();
+  // tmpDir is created after the browser is ready so a chromium.launch()
+  // failure cannot leave an orphaned temp directory behind. Use an outer
+  // try/finally so a failure between mkdtempSync and the inner try also
+  // cleans up the browser when we own it.
+  let tmpDir: string | undefined;
   let pdfBuffer: Buffer;
   let chapterInfoList: ChapterInfo[] = [];
   let sectionList: SectionInfo[] = [];
+  let page: Awaited<ReturnType<Browser['newPage']>> | undefined;
   try {
-    const page = await browser.newPage({
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bai-docs-'));
+    const tmpHtmlPath = path.join(tmpDir, 'document.html');
+    fs.writeFileSync(tmpHtmlPath, options.html, 'utf-8');
+    page = await browser.newPage({
       viewport: { width: PRINT_WIDTH_PX, height: 800 },
     });
 
@@ -479,8 +500,15 @@ export async function renderPdf(options: RenderOptions): Promise<void> {
     console.log('  Rendering final PDF...');
     pdfBuffer = await page.pdf(PDF_OPTIONS);
   } finally {
-    await browser.close();
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (page) {
+      await page.close().catch(() => {});
+    }
+    if (ownsBrowser) {
+      await browser.close();
+    }
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   }
 
   // ── Post-processing ──────────────────────────────────────────

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -50,7 +50,11 @@ export function generateWebStyles(lang?: string): string {
   --ifm-color-emphasis-1000: #000;
 
   --ifm-font-family-base: system-ui, -apple-system, "Segoe UI", Roboto,
-    Ubuntu, Cantarell, "Noto Sans", "Noto Sans KR", "Noto Sans JP", "Noto Sans Thai",
+    Ubuntu, Cantarell, "Noto Sans",
+    "Noto Sans KR", "Noto Sans CJK KR",
+    "Noto Sans JP", "Noto Sans CJK JP",
+    "Noto Sans TC", "Noto Sans CJK TC",
+    "Noto Sans Thai",
     sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --ifm-font-family-monospace: "SFMono-Regular", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
 

--- a/packages/backend.ai-docs-toolkit/src/styles.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles.ts
@@ -20,7 +20,26 @@ export function generatePdfStyles(theme: PdfTheme, lang?: string): string {
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
-    "Noto Sans KR", "Noto Sans JP", "Noto Sans Thai",
+    "Noto Sans KR", "Noto Sans CJK KR",
+    "Noto Sans JP", "Noto Sans CJK JP",
+    "Noto Sans TC", "Noto Sans CJK TC",
+    "Noto Sans Thai",
+    Helvetica, Arial, sans-serif;
+}
+
+/* Per-language font priorities so Chromium picks the language-appropriate
+ * Noto CJK face first (KR/JP/TC differ in kanji/hanja glyph style). The
+ * <html lang="..."> attribute is set by html-builder.ts. */
+:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+    "Noto Sans JP", "Noto Sans CJK JP",
+    "Noto Sans KR", "Noto Sans CJK KR",
+    Helvetica, Arial, sans-serif;
+}
+
+:lang(th) {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+    "Noto Sans Thai", "Loma", "Garuda",
     Helvetica, Arial, sans-serif;
   font-size: ${theme.baseFontSize};
   line-height: 1.6;

--- a/upload-release.js
+++ b/upload-release.js
@@ -47,19 +47,19 @@ const getUploadURL = async (releaseId) => {
 
 const main = async () => {
     if (process.argv.length !== 3) {
-        console.error('usage: node upload-release.js <folder containing DMG/ZIP files>')
+        console.error('usage: node upload-release.js <folder containing DMG/ZIP/PDF files>')
         process.exit(1)
     }
     const folder = process.argv[2]
-    let DMGs = []
+    let assets = []
     try {
-        DMGs = (await fs.promises.readdir(folder)).filter((s) => !s.startsWith('.') && (s.endsWith('.dmg') || s.endsWith('.zip')))
+        assets = (await fs.promises.readdir(folder)).filter((s) => !s.startsWith('.') && (s.endsWith('.dmg') || s.endsWith('.zip') || s.endsWith('.pdf')))
     } catch (e) {
         console.error(e.message)
         process.exit(1)
     }
 
-    console.log(`found ${DMGs.length} DMG(s): ${DMGs}`)
+    console.log(`found ${assets.length} asset(s): ${assets}`)
 
     const tag = process.env.RELEASE_TAG || (await getLatestTag())
     const releaseId = await getReleaseIdFromTag(tag)
@@ -94,8 +94,8 @@ const main = async () => {
     }
 
     // Process uploads in batches to avoid overwhelming the API
-    for (let i = 0; i < DMGs.length; i += CONCURRENCY) {
-        const batch = DMGs.slice(i, i + CONCURRENCY)
+    for (let i = 0; i < assets.length; i += CONCURRENCY) {
+        const batch = assets.slice(i, i + CONCURRENCY)
         await Promise.all(batch.map(uploadFile))
     }
 }


### PR DESCRIPTION
Resolves #7013 ([FR-2719](https://lablup.atlassian.net/browse/FR-2719))

## Summary

Bring the existing `backend.ai-docs-toolkit` PDF pipeline into the GitHub Actions release workflow so every published release ships per-language User Guide PDFs (en/ko/ja/th) alongside the existing DMG and ZIP assets — without extending the overall wall-clock time of the release build.

The release critical path is the macOS desktop job (~10 min on `macos-latest`). The new `build_docs` job runs on `ubuntu-latest` **independently** of `build_web`, in parallel with the desktop jobs, so a healthy run does not extend the overall release time. Verified end-to-end via a `workflow_dispatch` dry-run on this branch (run `24946962212`): `build_docs` finished in 3 m 34 s while `build_mac` was still queued — net wall-clock impact: 0.

## Changes

### Workflow (`.github/workflows/package.yml`)
- New `build_docs` job (`runs-on: ubuntu-latest`).
- No `needs:` dependency — runs in parallel with `build_mac` / `build_desktop`.
- Caches Playwright browsers (`~/.cache/ms-playwright`, keyed on `pnpm-lock.yaml`).
- `playwright install --with-deps chromium` only.
- Installs `fonts-noto-cjk` (so Chromium's HTML rendering picks the proper Noto Sans CJK family for body text) plus `fonts-nanum` / `fonts-takao-gothic` / `fonts-thai-tlwg` (single-face fonts pdf-lib uses for header/footer stamping — Ubuntu's `fonts-noto-cjk` ships only TTC bundles which pdf-lib/fontkit cannot embed).
- Re-runs `pnpm install` after building the toolkit so pnpm can create the `.bin/docs-toolkit` symlink (the toolkit's `dist/cli.js` does not exist on a fresh install).
- Runs `pnpm --filter backend.ai-webui-docs run pdf:all`, stages PDFs to `./app/`, uploads via `upload-release.js` (gated on `inputs.dry_run != true`), and always retains them as a `webui-docs-pdfs` artifact (14-day retention).
- Failure handling is at the step level, not the job, so partial per-language failures degrade gracefully but a full generator failure (every language failed → `generate-pdf.ts` exits non-zero) still fails the job. Prevents shipping a release with zero PDF assets going unnoticed.

### Toolkit optimizations (`packages/backend.ai-docs-toolkit/src/`)
- `pdf-renderer.ts` — `RenderOptions` accepts an optional `browser?: Browser`. When provided, `renderPdf` reuses it (`newPage` / `page.close`) and the caller owns the lifecycle, avoiding the per-call launch cost (~1–2 s × N languages). Closes the page in `finally` to keep memory bounded across reuse. tmpDir is created after `chromium.launch()` returns, and an outer try/finally guards both browser cleanup (when we own it) and tmpDir removal so a launch failure cannot leak.
- `pdf-renderer.ts` — `DEFAULT_CJK_FONT_CANDIDATES` extended with single-face paths for Japanese (`TakaoGothic.ttf`) and Thai (`Loma.otf`, `Garuda.ttf`) so the apt-installed fonts in the workflow are actually picked up.
- `generate-pdf.ts` — Launches one shared Chromium and passes it to every `renderPdf` call. Replaces the sequential per-language loop with a concurrency-limited fan-out (default 2 workers, override via `BAI_DOCS_PDF_CONCURRENCY` env var or the `concurrency` option). `args.concurrency` is normalized through `Number.isFinite` so a NaN input does not silently produce zero workers. Per-language errors are collected; the script continues with remaining languages and exits non-zero only if **every** requested language failed.
- `styles.ts` / `styles-web.ts` — Body `font-family` extended with `Noto Sans CJK KR/JP/TC` (Ubuntu's `fonts-noto-cjk` registers only the `CJK`-suffixed family names, not `Noto Sans KR`). `:lang(ja)` and `:lang(th)` overrides ensure Chromium picks the language-appropriate Noto CJK face (`KR`/`JP`/`TC` differ in kanji/hanja glyph style) instead of always falling back to the Korean face.

### Release uploader (`upload-release.js`)
- Asset extension filter accepts `.pdf` alongside `.dmg` and `.zip`. Variable renamed `DMGs` → `assets`. Usage message updated to mention PDFs.

## Local verification

- `pnpm --filter backend.ai-docs-toolkit run build` (tsc) — passes.
- `pnpm --filter backend.ai-webui-docs run pdf:all` — produces all four PDFs in ~2 m 32 s with `concurrency=2`.
- `pdffonts` confirms language-appropriate fonts are embedded:
  - **en** → NotoSansCJKkr (Latin coverage) + Liberation/DejaVu
  - **ko** → NotoSansCJKkr-Regular/Bold (body) + NanumBarunGothic (header/footer)
  - **ja** → NotoSansCJKjp-Regular/Bold (body) — Japanese variant, not the Korean fallback
  - **th** → Loma + Loma-Bold + Loma-Oblique
- `bash scripts/verify.sh` — Lint, Format, Relay all pass. The TypeScript failures present in `react/src/pages/...` (`__generated__` Relay query files missing) are pre-existing on `main` and unrelated to this PR (verified by stashing changes and re-running on the clean base).

## CI verification

`workflow_dispatch` dry-run on this branch (run [24946962212](https://github.com/lablup/backend.ai-webui/actions/runs/24946962212)):
- `build_docs` job: 3 m 34 s, `success`. All four PDFs produced and uploaded as the `webui-docs-pdfs` artifact.
- `build_mac` was still `queued` at `build_docs` completion → net wall-clock impact: 0.
- Artifact PDFs verified via `pdffonts` — fonts match the local build exactly.

The v26.4.7 release assets were also re-built and re-uploaded via `gh release upload --clobber` to validate the end-to-end upload path against a real release tag.

## Out of scope (follow-ups)

- Tighten the per-language failure isolation once the pipeline has soaked over a couple of releases — drop the partial-failure tolerance and consider a per-language matrix if `pdf:all` wall-clock approaches the `build_mac` critical path.
- The CSS still lists `Noto Sans KR/JP/Thai` as well as the `CJK`-suffixed family names. If/when official `fonts-noto-core-cjk` (single-face Noto Sans KR) becomes available on Ubuntu LTS, the CSS can be simplified.

## Test plan

- [x] Manual `workflow_dispatch` dry-run — `build_docs` succeeds and uploads the four PDFs as a workflow artifact.
- [x] CI artifact PDF font verification (`pdffonts`) matches the intended language-specific Noto CJK / Loma faces.
- [x] Wall-clock confirmed not extended (build_docs finished while build_mac was still queued).
- [ ] Real release run on the next published release — confirm the four PDFs appear as release assets.


[FR-2719]: https://lablup.atlassian.net/browse/FR-2719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ