### PR TITLE
fix(FR-2721): use CJK-capable font for PDF header/footer stamp

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/pdf-renderer.ts
+++ b/packages/backend.ai-docs-toolkit/src/pdf-renderer.ts
@@ -10,18 +10,33 @@ import { defaultTheme } from './theme.js';
 import type { ResolvedDocConfig } from './config.js';
 
 /**
- * Default CJK font path candidates (in priority order).
- * Uses the first TTF/OTF found on the system.
- * TTC (collection) files are excluded as pdf-lib/fontkit does not support them directly.
+ * Default font path candidates for the header/footer stamp, grouped by
+ * the script kind they cover.
+ *
+ * The header/footer is rendered with pdf-lib (not Chromium), so it needs an
+ * embedded font that covers every codepoint that may appear in the document
+ * title and section labels — which, for ko/ja/th builds, includes CJK and
+ * Thai glyphs that pdf-lib's default WinAnsi-encoded Helvetica cannot encode.
+ *
+ * TTC (TrueType Collection) files are supported via in-process sub-font
+ * extraction (see `extractFontFromTtc`), so `NotoSansCJK-Regular.ttc` works
+ * on Linux without requiring a separate per-language TTF.
+ *
+ * We load only the candidates needed for the current language. Loading
+ * unused fonts wastes memory and (more importantly) can trigger latent
+ * fontkit subsetting bugs in fonts whose glyphs are never actually drawn.
  */
-const DEFAULT_CJK_FONT_CANDIDATES = [
+const CJK_FONT_CANDIDATES = [
   // macOS – user-installed fonts
   path.join(os.homedir(), 'Library/Fonts/NanumBarunGothic.ttf'),
   path.join(os.homedir(), 'Library/Fonts/NanumSquareRegular.ttf'),
   '/System/Library/Fonts/Supplemental/Arial Unicode.ttf',
-  // Linux common paths — Korean
+  // Linux – Noto CJK collection (covers ko/ja/zh-CN/zh-TW/zh-HK)
   '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',
+  // Linux – per-language Noto CJK if installed separately
   '/usr/share/fonts/truetype/noto/NotoSansKR-Regular.ttf',
+  '/usr/share/fonts/truetype/noto/NotoSansJP-Regular.ttf',
+  // Linux – Korean fallback
   '/usr/share/fonts/truetype/nanum/NanumBarunGothic.ttf',
   // Linux common paths — Japanese (fonts-takao-gothic on Debian/Ubuntu)
   '/usr/share/fonts/truetype/takao-gothic/TakaoGothic.ttf',
@@ -32,32 +47,234 @@ const DEFAULT_CJK_FONT_CANDIDATES = [
   '/usr/share/fonts/truetype/tlwg/Garuda.ttf',
 ];
 
+const THAI_FONT_CANDIDATES = [
+  // Linux – TLWG family ships with Debian/Ubuntu by default
+  '/usr/share/fonts/opentype/tlwg/Loma.otf',
+  '/usr/share/fonts/truetype/tlwg/Garuda.ttf',
+  '/usr/share/fonts/truetype/tlwg/Norasi.ttf',
+];
+
+/**
+ * Languages whose header/footer stamp text is expected to contain CJK
+ * Han / Hangul / Kana glyphs.
+ */
+const CJK_LANGS = new Set(['ko', 'ja', 'zh', 'zh-CN', 'zh-TW', 'zh-HK']);
+const THAI_LANGS = new Set(['th']);
+
 type EmbeddedFont = Awaited<ReturnType<PDFDocument['embedFont']>>;
 
-async function loadCjkFont(
+/**
+ * Extract a single sub-font from a TrueType Collection (.ttc) into a
+ * standalone TTF/OTF byte buffer that pdf-lib can embed.
+ *
+ * TTC files concatenate multiple sfnt fonts behind a single header. Each
+ * sub-font's table directory contains absolute offsets into the collection
+ * file. To produce a valid standalone font, we copy the sub-font's tables
+ * into a fresh buffer and rewrite the table directory with new (relative)
+ * offsets. Table data is 4-byte aligned per the OpenType spec.
+ */
+function extractFontFromTtc(buf: Buffer, subIndex: number): Buffer {
+  if (buf.length < 12 || buf.toString('ascii', 0, 4) !== 'ttcf') {
+    throw new Error('Not a TrueType Collection (missing ttcf tag)');
+  }
+  const numFonts = buf.readUInt32BE(8);
+  if (subIndex < 0 || subIndex >= numFonts) {
+    throw new Error(
+      `TTC sub-font index ${subIndex} out of range (0..${numFonts - 1})`,
+    );
+  }
+  if (buf.length < 12 + 4 * numFonts) {
+    throw new Error('Truncated TTC: offset table overruns file');
+  }
+  const subOffset = buf.readUInt32BE(12 + 4 * subIndex);
+  if (subOffset + 12 > buf.length) {
+    throw new Error('Truncated TTC: sub-font offset overruns file');
+  }
+
+  const sfntVersion = buf.readUInt32BE(subOffset);
+  const numTables = buf.readUInt16BE(subOffset + 4);
+  const searchRange = buf.readUInt16BE(subOffset + 6);
+  const entrySelector = buf.readUInt16BE(subOffset + 8);
+  const rangeShift = buf.readUInt16BE(subOffset + 10);
+  if (subOffset + 12 + numTables * 16 > buf.length) {
+    throw new Error('Truncated TTC: table directory overruns file');
+  }
+
+  type TableEntry = {
+    tag: string;
+    checksum: number;
+    offset: number;
+    length: number;
+    newOffset: number;
+  };
+  const tables: TableEntry[] = [];
+  for (let i = 0; i < numTables; i++) {
+    const entryOff = subOffset + 12 + i * 16;
+    const tOffset = buf.readUInt32BE(entryOff + 8);
+    const tLength = buf.readUInt32BE(entryOff + 12);
+    if (tOffset + tLength > buf.length) {
+      throw new Error('Truncated TTC: table data overruns file');
+    }
+    tables.push({
+      tag: buf.toString('ascii', entryOff, entryOff + 4),
+      checksum: buf.readUInt32BE(entryOff + 4),
+      offset: tOffset,
+      length: tLength,
+      newOffset: 0,
+    });
+  }
+
+  const align4 = (n: number) => (n + 3) & ~3;
+  let cursor = 12 + numTables * 16;
+  for (const t of tables) {
+    t.newOffset = cursor;
+    cursor += align4(t.length);
+  }
+
+  const out = Buffer.alloc(cursor, 0);
+  out.writeUInt32BE(sfntVersion, 0);
+  out.writeUInt16BE(numTables, 4);
+  out.writeUInt16BE(searchRange, 6);
+  out.writeUInt16BE(entrySelector, 8);
+  out.writeUInt16BE(rangeShift, 10);
+  for (let i = 0; i < numTables; i++) {
+    const t = tables[i];
+    const dirOff = 12 + i * 16;
+    out.write(t.tag, dirOff, 4, 'ascii');
+    out.writeUInt32BE(t.checksum, dirOff + 4);
+    out.writeUInt32BE(t.newOffset, dirOff + 8);
+    out.writeUInt32BE(t.length, dirOff + 12);
+    buf.copy(out, t.newOffset, t.offset, t.offset + t.length);
+  }
+
+  return out;
+}
+
+/**
+ * Per-language preferred postscript names within a NotoSansCJK TTC.
+ * Used to pick the right sub-font when the candidate is a TTC.
+ * For unlisted languages, falls back to the JP variant which has the
+ * widest Han coverage among the four.
+ */
+const CJK_TTC_LANG_TO_PSNAME: Record<string, string> = {
+  ko: 'NotoSansCJKkr-Regular',
+  ja: 'NotoSansCJKjp-Regular',
+  zh: 'NotoSansCJKsc-Regular',
+  'zh-CN': 'NotoSansCJKsc-Regular',
+  'zh-TW': 'NotoSansCJKtc-Regular',
+  'zh-HK': 'NotoSansCJKhk-Regular',
+};
+
+/**
+ * Load a candidate font path into pdf-lib. Handles plain TTF/OTF and
+ * TrueType Collections (.ttc) by extracting the appropriate sub-font.
+ *
+ * Path syntax: `path/to/font.ttc#PostscriptName` or `path/to/font.ttc#3`
+ * lets the caller pin a specific sub-font; otherwise the language hint is
+ * used to look up the preferred sub-font from `CJK_TTC_LANG_TO_PSNAME`.
+ */
+async function embedFontFromPath(
   pdfDoc: PDFDocument,
-  extraPaths?: string[],
+  candidatePath: string,
+  lang: string,
 ): Promise<EmbeddedFont | null> {
+  const [filePath, selector] = candidatePath.split('#');
+  if (!fs.existsSync(filePath)) return null;
+
+  let fontBytes = fs.readFileSync(filePath);
+
+  // TTC: extract the right sub-font into a standalone OTF/TTF buffer
+  if (fontBytes.length >= 4 && fontBytes.toString('ascii', 0, 4) === 'ttcf') {
+    // fontkit's TypeScript types don't expose the TrueTypeCollection variant,
+    // but at runtime `fontkit.create(ttcBytes)` returns an object with a
+    // `fonts: TTFFont[]` property listing every sub-font in postscript-name order.
+    const collection = fontkit.create(fontBytes) as unknown as {
+      fonts: Array<{ postscriptName: string; fullName: string }>;
+    };
+    const subFonts = collection.fonts;
+
+    let subIndex = -1;
+    if (selector) {
+      const numericSelector = Number(selector);
+      if (Number.isInteger(numericSelector)) {
+        subIndex = numericSelector;
+      } else {
+        subIndex = subFonts.findIndex((f) => f.postscriptName === selector);
+      }
+    }
+    if (subIndex < 0) {
+      const langPsName = CJK_TTC_LANG_TO_PSNAME[lang]
+        ?? CJK_TTC_LANG_TO_PSNAME[lang.split('-')[0]]
+        ?? CJK_TTC_LANG_TO_PSNAME.ja;
+      subIndex = subFonts.findIndex((f) => f.postscriptName === langPsName);
+    }
+    if (subIndex < 0) subIndex = 0;
+
+    fontBytes = extractFontFromTtc(fontBytes, subIndex);
+  }
+
+  const font = await pdfDoc.embedFont(fontBytes, { subset: true });
+  return font;
+}
+
+/**
+ * Load fallback fonts for the header/footer stamp. Returns the first
+ * successfully-embedded font from the language-appropriate candidate list,
+ * wrapped in an array so the caller can extend it with the Latin fallback.
+ *
+ * Loading is language-scoped: only CJK candidates are tried for ko/ja/zh,
+ * only Thai candidates for th, and English builds skip non-Latin fonts
+ * entirely. Loading every candidate up-front would waste memory and (more
+ * importantly) can trigger latent fontkit subsetting bugs in fonts whose
+ * glyphs are never actually drawn on the final PDF.
+ *
+ * When no candidate is available, returns an empty array and the caller
+ * falls back to Latin-only Helvetica with a warning logged.
+ */
+async function loadStampFallbackFonts(
+  pdfDoc: PDFDocument,
+  lang: string,
+  extraPaths?: string[],
+): Promise<EmbeddedFont[]> {
   pdfDoc.registerFontkit(fontkit);
 
-  const candidates = [
-    ...(extraPaths ?? []),
-    ...DEFAULT_CJK_FONT_CANDIDATES,
-  ];
+  const langKey = lang.split('-')[0];
+  let defaultCandidates: string[] = [];
+  if (CJK_LANGS.has(lang) || CJK_LANGS.has(langKey)) {
+    defaultCandidates = CJK_FONT_CANDIDATES;
+  } else if (THAI_LANGS.has(lang) || THAI_LANGS.has(langKey)) {
+    defaultCandidates = THAI_FONT_CANDIDATES;
+  }
 
+  // User-supplied paths take priority and are tried first regardless of
+  // language — the consumer knows their content best.
+  const candidates = [...(extraPaths ?? []), ...defaultCandidates];
+
+  const loaded: EmbeddedFont[] = [];
+  const seen = new Set<string>();
   for (const candidate of candidates) {
-    if (!fs.existsSync(candidate)) continue;
-    if (candidate.endsWith('.ttc')) continue;
+    const filePath = candidate.split('#')[0];
+    if (seen.has(filePath)) continue;
+    seen.add(filePath);
     try {
-      const fontBytes = fs.readFileSync(candidate);
-      const font = await pdfDoc.embedFont(fontBytes, { subset: true });
-      console.log(`  CJK font: ${path.basename(candidate)}`);
-      return font;
+      const font = await embedFontFromPath(pdfDoc, candidate, lang);
+      if (font) {
+        console.log(`  Stamp font loaded: ${path.basename(filePath)}`);
+        loaded.push(font);
+        // Stop after the first successfully-loaded font for this language —
+        // the glyph-coverage check at draw time only needs one good
+        // candidate, and avoiding extra subsetters dodges the CFF-subset
+        // bug in @pdf-lib/fontkit (RangeError in CFFSubset.encode) when a
+        // font is registered but its glyphs are never actually drawn.
+        break;
+      }
     } catch (e) {
-      console.warn(`  Warning: Could not embed font ${candidate}: ${(e as Error).message}`);
+      console.warn(
+        `  Warning: Could not embed font ${candidate}: ${(e as Error).message}`,
+      );
     }
   }
-  return null;
+  return loaded;
 }
 
 export interface RenderOptions {
@@ -261,6 +478,46 @@ async function getAllSections(
 }
 
 /**
+ * Pick the best font for a given text by checking glyph coverage.
+ *
+ * Walks the candidate list in order and returns the first font whose
+ * fontkit instance reports a glyph for every codepoint in the string.
+ * If none cover the text fully, returns the last (Latin) font — drawing
+ * with it may produce tofu boxes for unsupported codepoints, but pdf-lib
+ * will not throw `WinAnsi cannot encode "目"`-style errors because all
+ * fonts we load here are Unicode-encoded subsets.
+ */
+function pickFontForText(text: string, candidates: EmbeddedFont[]): EmbeddedFont {
+  if (candidates.length === 1) return candidates[0];
+  for (const font of candidates) {
+    // pdf-lib does not expose hasGlyphForCodePoint publicly, but the
+    // underlying fontkit instance is reachable via the embedder.
+    const fkFont = (font as unknown as {
+      embedder?: { font?: { hasGlyphForCodePoint?: (cp: number) => boolean } };
+    }).embedder?.font;
+    if (!fkFont?.hasGlyphForCodePoint) {
+      // Standard14 fonts (Helvetica) lack this introspection; only safe
+      // to use when the text is ASCII.
+      let asciiOnly = true;
+      for (const ch of text) {
+        if (ch.codePointAt(0)! > 0x7e) { asciiOnly = false; break; }
+      }
+      if (asciiOnly) return font;
+      continue;
+    }
+    let covers = true;
+    for (const ch of text) {
+      if (!fkFont.hasGlyphForCodePoint(ch.codePointAt(0)!)) {
+        covers = false;
+        break;
+      }
+    }
+    if (covers) return font;
+  }
+  return candidates[candidates.length - 1];
+}
+
+/**
  * Draws header/footer directly with pdf-lib.
  * Does not use Playwright's displayHeaderFooter — gives full control over CJK rendering,
  * positioning, and margins.
@@ -271,21 +528,31 @@ async function getAllSections(
  * Section label logic:
  *   For each page, shows the last section that starts on or before (<=) that page.
  *   Prefers H2 if available; falls back to the current chapter (H1) otherwise.
+ *
+ * Font selection:
+ *   Each text string is drawn with the first font in `fontFallbacks` whose
+ *   underlying fontkit instance reports glyph coverage for every codepoint.
+ *   The Latin font is the last candidate, used for ASCII-only strings (e.g.
+ *   page numbers) and as the final fallback.
  */
 function stampHeaderFooter(
   pdfDoc: PDFDocument,
   opts: {
     title: string;
     font: EmbeddedFont;
-    cjkFont: EmbeddedFont | null;
+    fontFallbacks: EmbeddedFont[];
     sections: SectionInfo[];
     firstChapterPage: number;
   },
 ): void {
-  const { title, font, cjkFont, sections, firstChapterPage } = opts;
+  const { title, font, fontFallbacks, sections, firstChapterPage } = opts;
   const totalPages = pdfDoc.getPageCount();
 
-  const hfFont = cjkFont ?? font;
+  // Order: non-Latin fonts first (so CJK/Thai win when the text needs them),
+  // Latin font last (handles ASCII page numbers and serves as final fallback).
+  const candidates: EmbeddedFont[] = [...fontFallbacks, font];
+
+  const titleFont = pickFontForText(title, candidates);
 
   // Style constants — book-style layout
   const fontSize = 8.5;
@@ -337,7 +604,7 @@ function stampHeaderFooter(
       x: xLeft,
       y: headerTextY,
       size: fontSize,
-      font: hfFont,
+      font: titleFont,
       color: textColor,
     });
     pdfPage.drawLine({
@@ -355,27 +622,32 @@ function stampHeaderFooter(
       color: lineColor,
     });
 
-    // Page number (right-aligned)
+    // Page number (right-aligned, ASCII-only)
     const pageNumStr = String(pageNum);
-    const pageNumWidth = hfFont.widthOfTextAtSize(pageNumStr, fontSize);
+    const pageNumFont = pickFontForText(pageNumStr, candidates);
+    const pageNumWidth = pageNumFont.widthOfTextAtSize(pageNumStr, fontSize);
     pdfPage.drawText(pageNumStr, {
       x: xRight - pageNumWidth,
       y: footerTextY,
       size: fontSize,
-      font: hfFont,
+      font: pageNumFont,
       color: textColor,
     });
 
-    // Section label (left-aligned, from chapter pages onward)
+    // Section label (left-aligned, from chapter pages onward).
+    // Picked per-page because chapter labels in different languages may
+    // need different fonts (e.g. CJK for ko/ja chapter titles, Thai font
+    // for th chapter titles, Latin for English appendix headings).
     const sectionLabel = pageSectionLabel[pageNum];
     if (sectionLabel && pageNum >= firstChapterPage) {
+      const labelFont = pickFontForText(sectionLabel, candidates);
       const maxLabelWidth = contentWidth - pageNumWidth - 20;
       let displayLabel = sectionLabel;
-      let labelWidth = hfFont.widthOfTextAtSize(displayLabel, fontSize);
+      let labelWidth = labelFont.widthOfTextAtSize(displayLabel, fontSize);
       if (labelWidth > maxLabelWidth) {
         while (displayLabel.length > 0 && labelWidth > maxLabelWidth) {
           displayLabel = displayLabel.slice(0, -1);
-          labelWidth = hfFont.widthOfTextAtSize(displayLabel + '\u2026', fontSize);
+          labelWidth = labelFont.widthOfTextAtSize(displayLabel + '\u2026', fontSize);
         }
         displayLabel += '\u2026';
       }
@@ -383,7 +655,7 @@ function stampHeaderFooter(
         x: xLeft,
         y: footerTextY,
         size: fontSize,
-        font: hfFont,
+        font: labelFont,
         color: textColor,
       });
     }
@@ -526,7 +798,19 @@ export async function renderPdf(options: RenderOptions): Promise<void> {
   pdfDoc.setCreationDate(new Date());
 
   const latinFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
-  const cjkFont = await loadCjkFont(pdfDoc, config?.cjkFontPaths);
+  const fontFallbacks = await loadStampFallbackFonts(
+    pdfDoc,
+    options.lang,
+    config?.cjkFontPaths,
+  );
+  if (fontFallbacks.length === 0 && options.lang !== 'en') {
+    console.warn(
+      `  Warning: No CJK/Thai fonts found for lang="${options.lang}". ` +
+        `Header/footer stamp will fall back to Latin (Helvetica) — non-Latin ` +
+        `glyphs may render as missing/tofu. Install Noto Sans CJK and TLWG ` +
+        `(Loma/Garuda) fonts, or set "cjkFontPaths" in docs-toolkit.config.yaml.`,
+    );
+  }
 
   // First chapter start page (skip chapter labels on preceding pages like TOC).
   // Computed from sectionList (H1/H2 heading id attributes) — works around the issue
@@ -543,7 +827,7 @@ export async function renderPdf(options: RenderOptions): Promise<void> {
   stampHeaderFooter(pdfDoc, {
     title: flatTitle,
     font: latinFont,
-    cjkFont,
+    fontFallbacks,
     sections: sectionList,
     firstChapterPage,
   });


### PR DESCRIPTION
Resolves #7017 (FR-2721)

## Summary

Fix CJK PDF rendering — `WinAnsi cannot encode "目"` in `pdf-renderer.ts` header/footer stamp.

The header/footer stamp code path embeds its own font separately from the body text rendered by Chromium. Two combined gaps caused ko/ja/th builds to fail:

1. The Linux-default Noto Sans CJK font ships as a `.ttc` (TrueType Collection), and `loadCjkFont` explicitly skipped TTC files because pdf-lib + `@pdf-lib/fontkit` cannot embed a collection directly. With no usable CJK font on Linux CI, the stamp fell back to Helvetica (WinAnsi), which throws on the first non-Latin glyph.
2. Thai content (`th` build) needs a Thai-script font that the CJK candidate list never covered.

## Approach

**Option (a) — extend the existing single-font stamp path** rather than adding a separate font system.

Changes:

- New `extractFontFromTtc(buf, subIndex)` utility: copies a single sub-font's table data out of a TTC into a standalone TTF/OTF buffer with a rewritten table directory, so pdf-lib can embed it. Bounds-checked against truncated input.
- New `embedFontFromPath` accepts `path/font.ttc#PostscriptName` or `path/font.ttc#index` syntax for pinning a sub-font; otherwise uses a per-language postscript-name lookup table (`NotoSansCJKkr-Regular` for ko, `NotoSansCJKjp-Regular` for ja, etc., falling back to JP for widest Han coverage).
- Split candidate list into `CJK_FONT_CANDIDATES` (NotoSansCJK TTC + Nanum + macOS fallbacks) and `THAI_FONT_CANDIDATES` (TLWG Loma/Garuda/Norasi). Loading is **language-scoped** — only the relevant set is tried.
- `pickFontForText` selects the right embedded font per draw call by checking glyph coverage on each codepoint via fontkit's `hasGlyphForCodePoint`. The Latin font (Helvetica) is always the final fallback for ASCII-only strings (page numbers).
- Graceful fallback: if no non-Latin font is found for a non-en build, log a warning and continue with Helvetica (no hard crash). Header/footer non-Latin glyphs would tofu, but the PDF still builds.

Why language-scoped loading: loading every candidate up front (even those whose glyphs are never drawn) triggers a latent `RangeError` in `@pdf-lib/fontkit`'s CFF subsetter (`CFFSubset.encode`) at PDF save time, even on en-only builds.

## Verification

All four language PDFs build successfully on Ubuntu (with `fonts-noto-cjk` and `fonts-thai-tlwg` installed):

- [x] `pnpm run pdf:en` exits 0 (no fonts loaded — pure Latin path)
- [x] `pnpm run pdf:ko` exits 0 (was failing with `WinAnsi cannot encode "목"`)
- [x] `pnpm run pdf:ja` exits 0 (covers the `目` glyph from the original error)
- [x] `pnpm run pdf:th` exits 0
- [x] Visual spot-check: ko PDF footer renders `3.2 Backend.AI 기능 상세` correctly; th PDF footer renders `3.1 แนวคิดหลัก` correctly
- [x] `bash scripts/verify.sh` → ALL PASS (Relay/Lint/Format/TypeScript)

## Test plan

- [ ] CI builds all 4 language PDFs without errors
- [ ] Sample headers/footers visually correct in each language
- [ ] On environments without CJK/Thai fonts installed, build emits a warning and falls back to Helvetica without crashing

## Stack

- FR-2710 epic stack: #6988 (merged) → #7004 (merged) → #7006 → #7011 → #7012 (F2)
- This PR (FR-2721 follow-up): stacked on F2 (#7012)

## Follow-up issues being stacked next

- FR-2722 / #7018 — `--optimize-images` (will stack on this PR)
- FR-2723 / #7019 — version-mismatch UX banners (will stack on FR-2722)
- FR-2724 / #7020, FR-2725 / #7021 — deferred until FR-2710 stack lands in main (cross-arm dependencies)