### PR TITLE
feat(FR-2723): version-mismatch UX notice and view-latest banner

### DIFF
--- a/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
+++ b/packages/backend.ai-docs-toolkit/ARCHITECTURE.md
@@ -287,6 +287,54 @@ Each `PageEnumerationRow` has `{ version, lang, slug, path, isLatest }`.
 F2 iterates `pages` to emit `sitemap.xml`. `canonicalPathFor(loaded, lang, slug)`
 returns the per-page canonical URL relative to the website output root.
 
+### Version mismatch UX (FR-2723)
+
+In versioned mode the build emits two pieces of UX that warn readers
+when they're not on the latest version, or when the version they
+selected doesn't carry the slug they were reading. Both pieces are
+air-gap safe (no fetches, no CDN, no runtime API), localized for
+en/ko/ja/th from `WEBSITE_LABELS`, and dismissible per-session via
+`sessionStorage`.
+
+**Source files:**
+
+| File | Role |
+|---|---|
+| `src/website-builder.ts` → `buildVersionBanner` | Render the "view latest" banner on every non-latest page |
+| `src/website-builder.ts` → `buildVersionNotice` | Render the (initially hidden) "not in selected version" notice |
+| `src/website-builder.ts` → `buildVersionSwitcher` inline script | Set `sessionStorage["docs.notice.notInVersion"]` before navigating to a fallback index |
+| `templates/assets/version-banner.js` | Hashed asset that handles dismissal + notice reveal at runtime |
+| `src/styles-web.ts` → `.docs-banner`, `.docs-notice` | Visual styles |
+| `src/config.ts` → `WEBSITE_LABELS.{bannerViewLatest, bannerViewLatestLink, bannerDismiss, noticeNotInVersion}` | Localized strings |
+
+**"View latest version" banner.** Injected at build time on every
+non-latest version page, BETWEEN `<header class="page-header-bar">`
+and the `.doc-page` flex row, so it spans the full width above the
+sidebar. Renders unconditionally as visible markup (so SSR / no-JS
+readers still see it); on `DOMContentLoaded`, `version-banner.js`
+checks `sessionStorage["docs.banner.viewLatestDismissed:<current>:<latest>"]`
+and hides the banner when set. The dismissal key is scoped per
+(currentVersion, latestVersion) pair so dismissing it on `25.16` does
+not suppress it on `25.10`. The link target follows the same fallback
+rule as the version switcher: same slug in latest if available, else
+the latest version's index.
+
+**"Not in selected version" notice.** Injected hidden inside `<main>`
+above the chapter content. The version-switcher inline script (in
+`buildVersionSwitcher`) sets
+`sessionStorage["docs.notice.notInVersion"] = "<targetVersion>::<originSlug>"`
+right before navigating to a fallback `index.html`. On the destination
+page, `version-banner.js` reads the flag, verifies
+`<targetVersion> === <currentVersion>` (defends against stale flags
+after browser back/forward), substitutes `{version}` into the
+localized `data-message-template` attribute, reveals the notice, and
+clears the flag. A subsequent reload of the same page does not
+re-show the notice (the flag is consumed once).
+
+Both surfaces are skipped entirely in flat mode (no `versionContext`,
+no asset emitted, no CSS used). Total runtime JS overhead: ~5 KB
+unminified hashed asset, well under the 25 KB per-page budget.
+
 ### Single-version compatibility mode
 
 When `versions` is not declared, the build behaves exactly as before

--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -247,7 +247,25 @@ const DEFAULT_FIGURE_LABELS: Record<string, string> = {
   th: "รูปที่",
 };
 
-/** Localized labels for website navigation and metadata */
+/** Localized labels for website navigation and metadata.
+ *
+ * Version-mismatch UX (FR-2723) keys:
+ *   - `bannerViewLatest`     — body text of the "view latest" banner shown
+ *                              on every non-latest version page. Includes
+ *                              `{version}` and `{latestVersion}` placeholders
+ *                              (substituted client-side in version-banner.js).
+ *   - `bannerViewLatestLink` — anchor text for the "view latest" link.
+ *   - `bannerDismiss`        — aria-label / tooltip for the dismiss "×" button
+ *                              on both the banner and the notice.
+ *   - `noticeNotInVersion`   — body text shown when the version switcher
+ *                              fell back to the version index because the
+ *                              same slug doesn't exist there. Includes a
+ *                              `{version}` placeholder for the target minor.
+ *
+ * The placeholder syntax is plain `{name}` (NOT i18next `{{name}}`) because
+ * the substitution happens in our own ~1 KB inline JS, not via an i18n
+ * library. See `templates/assets/version-banner.js`.
+ */
 export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
   en: {
     previous: "Previous",
@@ -262,6 +280,12 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     copy: "Copy",
     copied: "Copied!",
     copyFailed: "Copy failed",
+    bannerViewLatest:
+      "You are viewing version {version}. View the latest version ({latestVersion}).",
+    bannerViewLatestLink: "View the latest version ({latestVersion})",
+    bannerDismiss: "Dismiss",
+    noticeNotInVersion:
+      "This page is not available in version {version}. You are viewing the version index instead.",
   },
   ko: {
     previous: "이전",
@@ -276,6 +300,12 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     copy: "복사",
     copied: "복사됨!",
     copyFailed: "복사 실패",
+    bannerViewLatest:
+      "버전 {version} 문서를 보고 있습니다. 최신 버전({latestVersion}) 보기.",
+    bannerViewLatestLink: "최신 버전({latestVersion}) 보기",
+    bannerDismiss: "닫기",
+    noticeNotInVersion:
+      "이 페이지는 버전 {version}에 존재하지 않습니다. 해당 버전의 인덱스 페이지로 이동했습니다.",
   },
   ja: {
     previous: "前へ",
@@ -290,6 +320,12 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     copy: "コピー",
     copied: "コピーしました!",
     copyFailed: "コピーに失敗しました",
+    bannerViewLatest:
+      "バージョン {version} のドキュメントを表示しています。最新バージョン({latestVersion})を表示。",
+    bannerViewLatestLink: "最新バージョン({latestVersion})を表示",
+    bannerDismiss: "閉じる",
+    noticeNotInVersion:
+      "このページはバージョン {version} には存在しません。代わりにバージョンのインデックスを表示しています。",
   },
   th: {
     previous: "ก่อนหน้า",
@@ -304,6 +340,12 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     copy: "คัดลอก",
     copied: "คัดลอกแล้ว!",
     copyFailed: "คัดลอกไม่สำเร็จ",
+    bannerViewLatest:
+      "คุณกำลังดูเวอร์ชัน {version} ดูเวอร์ชันล่าสุด ({latestVersion})",
+    bannerViewLatestLink: "ดูเวอร์ชันล่าสุด ({latestVersion})",
+    bannerDismiss: "ปิด",
+    noticeNotInVersion:
+      "หน้านี้ไม่มีในเวอร์ชัน {version} กำลังแสดงหน้าดัชนีของเวอร์ชันแทน",
   },
 };
 

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1193,6 +1193,88 @@ export function generateWebsiteStyles(): string {
 }
 
 /* ==========================================================================
+   Version-mismatch UX (FR-2723)
+   - .docs-banner.docs-banner--view-latest: shown on every non-latest
+     version page, dismissible per-session.
+   - .docs-notice.docs-notice--not-in-version: shown after the version
+     switcher falls back to the index because the slug doesn't exist
+     in the target version.
+   ========================================================================== */
+.docs-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--ifm-color-warning-dark);
+  background: var(--ifm-color-warning-light);
+  color: var(--ifm-color-emphasis-1000);
+  font-size: 0.875rem;
+}
+.docs-banner[hidden] { display: none; }
+.docs-banner__body {
+  flex: 1 1 auto;
+}
+.docs-banner__link {
+  color: var(--ifm-color-primary-darker);
+  font-weight: 600;
+  text-decoration: underline;
+}
+.docs-banner__link:hover {
+  color: var(--ifm-color-primary-darkest);
+}
+.docs-banner__dismiss {
+  flex: 0 0 auto;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--ifm-color-emphasis-800);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.docs-banner__dismiss:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--ifm-color-emphasis-1000);
+}
+.docs-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 1.5rem 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--ifm-color-info-dark);
+  border-left: 4px solid var(--ifm-color-info-dark);
+  border-radius: var(--ifm-pre-border-radius);
+  background: rgba(84, 199, 236, 0.12);
+  color: var(--ifm-color-emphasis-1000);
+  font-size: 0.875rem;
+}
+.docs-notice[hidden] { display: none; }
+.docs-notice__body {
+  flex: 1 1 auto;
+}
+.docs-notice__dismiss {
+  flex: 0 0 auto;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--ifm-color-emphasis-800);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.docs-notice__dismiss:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--ifm-color-emphasis-1000);
+}
+
+/* ==========================================================================
    CJK Language Rules (via :lang() selectors for shared stylesheet)
    ========================================================================== */
 ${cjkSelectors} {

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -200,6 +200,14 @@ export interface PageAssets {
   codeCopy?: string;
   /** Hashed `toc-scrollspy.js` filename. Optional — added by F3. */
   tocScrollspy?: string;
+  /**
+   * Hashed `version-banner.js` filename (FR-2723). Optional — only
+   * present when the build runs in versioned mode. Powers both the
+   * "view latest version" banner (per-session dismissal) and the
+   * "not in selected version" inline notice (sessionStorage flag set
+   * by the version-switcher script).
+   */
+  versionBanner?: string;
   /** Site-root favicon filename, e.g. `favicon.ico`. */
   favicon?: string;
   /** Site-root apple-touch-icon filename, e.g. `apple-touch-icon.png`. */
@@ -642,6 +650,95 @@ function buildCodeCopyScriptTag(assets: PageAssets, prefix: string): string {
 }
 
 /**
+ * Build optional version-banner script tag (FR-2723). Only emitted when
+ * the build is in versioned mode — the script handles BOTH the
+ * "view latest version" banner dismissal AND the "not in selected
+ * version" notice that fires after a fallback navigation.
+ */
+function buildVersionBannerScriptTag(
+  assets: PageAssets,
+  prefix: string,
+): string {
+  if (!assets.versionBanner) return "";
+  return `<script defer src="${prefix}assets/${escapeHtml(assets.versionBanner)}"></script>`;
+}
+
+/**
+ * Build the "View latest version" banner (FR-2723) — shown on every
+ * NON-latest version page. Renders an unconditional dismissible banner;
+ * the dismissal state is enforced client-side by `version-banner.js`
+ * via per-(currentVersion, latestVersion) sessionStorage keys.
+ *
+ * The banner is rendered visible by default; the script flips it to
+ * `hidden` synchronously on DOMContentLoaded if a sessionStorage flag
+ * exists. We accept a brief flash on slow first paint over the
+ * alternative of starting hidden + showing on missing flag, because
+ * the latter would suppress the banner entirely if JS is disabled.
+ *
+ * Returns an empty string when no version context is present (flat
+ * mode) or when the current page IS the latest version.
+ */
+function buildVersionBanner(context: WebPageContext): string {
+  const ver = context.versionContext;
+  if (!ver) return "";
+  if (ver.current === ver.latest) return "";
+
+  const labels = WEBSITE_LABELS[context.metadata.lang] ?? WEBSITE_LABELS.en;
+  // Build the link target: same slug in latest if available, else the
+  // latest version's index page. We mirror the version-switcher's
+  // fallback rule so the banner never points at a 404.
+  const hops = Math.max(0, ver.rootDepth - 1);
+  const prefix = "../".repeat(hops);
+  const targetExists = ver.slugAvailability[ver.latest] === true;
+  const href = targetExists
+    ? `${prefix}${ver.latest}/${context.metadata.lang}/${ver.slug}.html`
+    : `${prefix}${ver.latest}/${context.metadata.lang}/index.html`;
+
+  // Substitute placeholders directly in the rendered text (keeps the
+  // markup search-engine-friendly without requiring JS to read the
+  // banner). The link uses its own localized label.
+  const message = labels.bannerViewLatest
+    .replace(/\{version\}/g, ver.current)
+    .replace(/\{latestVersion\}/g, ver.latest);
+  const linkLabel = labels.bannerViewLatestLink.replace(
+    /\{latestVersion\}/g,
+    ver.latest,
+  );
+  const dismissLabel = labels.bannerDismiss;
+
+  return `<div class="docs-banner docs-banner--view-latest" role="status" data-current-version="${escapeHtml(ver.current)}" data-latest-version="${escapeHtml(ver.latest)}">
+  <span class="docs-banner__body">${escapeHtml(message)}</span>
+  <a class="docs-banner__link" href="${escapeHtml(href)}">${escapeHtml(linkLabel)}</a>
+  <button type="button" class="docs-banner__dismiss" aria-label="${escapeHtml(dismissLabel)}" title="${escapeHtml(dismissLabel)}">&times;</button>
+</div>`;
+}
+
+/**
+ * Build the "Not in selected version" notice (FR-2723) — injected
+ * hidden on every page and revealed by `version-banner.js` only when
+ * the user arrived here via a version-switcher fallback (sessionStorage
+ * flag set by the inline switcher script).
+ *
+ * The notice's body text is filled in client-side by reading
+ * `data-message-template` and substituting `{version}` with the value
+ * from the sessionStorage flag — so the same hidden markup works for
+ * any (target version, slug) the user came from.
+ *
+ * Returns empty string in flat mode (no version context).
+ */
+function buildVersionNotice(context: WebPageContext): string {
+  const ver = context.versionContext;
+  if (!ver) return "";
+  const labels = WEBSITE_LABELS[context.metadata.lang] ?? WEBSITE_LABELS.en;
+  const messageTemplate = labels.noticeNotInVersion;
+  const dismissLabel = labels.bannerDismiss;
+  return `<div class="docs-notice docs-notice--not-in-version" role="status" hidden data-current-version="${escapeHtml(ver.current)}" data-message-template="${escapeHtml(messageTemplate)}">
+  <span class="docs-notice__body"></span>
+  <button type="button" class="docs-notice__dismiss" aria-label="${escapeHtml(dismissLabel)}" title="${escapeHtml(dismissLabel)}">&times;</button>
+</div>`;
+}
+
+/**
  * Build the page-header bar. F1 (sibling stack arm) introduces the
  * language switcher in this same `<header class="page-header-bar">`
  * structure; F6 contributes the version selector. When F1 lands the
@@ -699,7 +796,14 @@ function buildVersionSwitcher(context: WebPageContext): string {
     .join("");
   // The handler is inlined to avoid a separate hashed asset for ~30 LoC.
   // It is idempotent and language-agnostic: the only state it touches is
-  // `window.location.assign(...)` after a probe of the availability map.
+  // `window.location.assign(...)` after a probe of the availability map,
+  // plus a single `sessionStorage.setItem` when the slug is missing in the
+  // target version (FR-2723: "Not in selected version" notice).
+  //
+  // The sessionStorage flag uses the same key as `templates/assets/
+  // version-banner.js` (`docs.notice.notInVersion`); payload format is
+  // `<targetVersion>::<originSlug>` so the notice script can verify it
+  // landed on the right destination before showing the message.
   const inlineScript = `(function(){
   var sel = document.currentScript && document.currentScript.previousElementSibling;
   if (!sel || sel.tagName !== 'SELECT') return;
@@ -716,7 +820,13 @@ function buildVersionSwitcher(context: WebPageContext): string {
     var hops = Math.max(0, rootDepth - 1);
     var prefix = '';
     for (var i = 0; i < hops; i++) { prefix += '../'; }
-    var dest = availability[target]
+    var hasSlug = availability[target] === true;
+    if (!hasSlug) {
+      try {
+        sessionStorage.setItem('docs.notice.notInVersion', target + '::' + slug);
+      } catch (_) {}
+    }
+    var dest = hasSlug
       ? prefix + target + '/' + lang + '/' + slug + '.html'
       : prefix + target + '/' + lang + '/index.html';
     window.location.assign(dest);
@@ -878,9 +988,12 @@ export function buildWebPage(context: WebPageContext): string {
     context.peers,
   );
   const headerBar = buildPageHeaderBar(context);
+  const versionBanner = buildVersionBanner(context);
+  const versionNotice = buildVersionNotice(context);
   const searchScript = buildSearchScriptTag(assets, prefix);
   const codeCopyScript = buildCodeCopyScriptTag(assets, prefix);
   const tocScrollspyScript = buildTocScrollspyScriptTag(assets);
+  const versionBannerScript = buildVersionBannerScriptTag(assets, prefix);
 
   // F4: data-* attributes on <body> carry the localized labels for the
   // code-copy script (which is content-hashed once across every language,
@@ -899,9 +1012,11 @@ export function buildWebPage(context: WebPageContext): string {
 </head>
 <body ${copyDataAttrs}>
 ${headerBar}
+${versionBanner}
 <div class="doc-page">
   ${sidebar}
   <main class="doc-main">
+    ${versionNotice}
     ${pageHeader}
     ${breadcrumb}
     ${innerContent}
@@ -915,6 +1030,7 @@ ${headerBar}
 ${searchScript}
 ${codeCopyScript}
 ${tocScrollspyScript}
+${versionBannerScript}
 </body>
 </html>`;
 }

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -363,6 +363,36 @@ export async function generateWebsite(
     console.log(`Written: assets/${tocScrollspyName}`);
   }
 
+  // FR-2723: version-banner.js powers the "view latest" banner +
+  // "not in selected version" notice. Only emitted in versioned mode
+  // — in flat mode there is no versioning UX to drive, so we skip the
+  // asset entirely (zero bytes shipped, zero behavior change).
+  if (loadedVersions.enabled) {
+    const versionBannerPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "templates",
+      "assets",
+      "version-banner.js",
+    );
+    if (fs.existsSync(versionBannerPath)) {
+      const bytes = fs.readFileSync(versionBannerPath);
+      const versionBannerName = writeHashedAsset(
+        assetsDir,
+        "version-banner.js",
+        bytes,
+        assetManifest,
+      );
+      console.log(`Written: assets/${versionBannerName}`);
+    } else {
+      console.warn(
+        "[version-banner] templates/assets/version-banner.js not found — " +
+          "version-mismatch UX will not render. Reinstall backend.ai-docs-toolkit " +
+          "or restore the template file.",
+      );
+    }
+  }
+
   // Site-root brand assets (favicon, apple-touch-icon, site.webmanifest).
   // These live at `dist/web/` (not under `assets/`) so absolute references
   // like `/favicon.ico` work for any deployment layout.
@@ -383,11 +413,15 @@ export async function generateWebsite(
   const versionsBuilt: Version[] = [];
 
   // Per-page asset manifest is identical for every page in every layout.
+  // `versionBanner` is only present in versioned mode (asset is only
+  // written when `loadedVersions.enabled`); flat-mode pages get
+  // `undefined`, which the page builder treats as "no script tag".
   const pageAssets: PageAssets = {
     styles: assetManifest["styles.css"],
     search: assetManifest["search.js"],
     codeCopy: assetManifest["code-copy.js"],
     tocScrollspy: assetManifest["toc-scrollspy.js"],
+    versionBanner: assetManifest["version-banner.js"],
     favicon: rootAssets.favicon,
     appleTouchIcon: rootAssets.appleTouchIcon,
     webmanifest: rootAssets.webmanifest,

--- a/packages/backend.ai-docs-toolkit/templates/assets/version-banner.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/version-banner.js
@@ -1,0 +1,136 @@
+/* docs-toolkit version-mismatch UX (FR-2723).
+ *
+ * Two pieces of UI live here:
+ *
+ *   1. "View latest version" banner — injected by website-builder.ts on
+ *      every NON-latest version page. Hides itself when the user clicks
+ *      the dismiss button (per-session via `sessionStorage`). Has no
+ *      runtime API call: the destination URL and label substitutions
+ *      come from `data-` attributes on the banner element.
+ *
+ *   2. "Not in selected version" notice — injected hidden on EVERY
+ *      versioned page (so the destination index pages all carry it).
+ *      The version-switcher inline script in website-builder.ts sets a
+ *      sessionStorage flag right before navigating to a fallback index;
+ *      this script reads that flag on load, fills in `{version}`, and
+ *      reveals the notice. Dismissal also clears the flag so refresh
+ *      doesn't re-show it.
+ *
+ * Both pieces are language-agnostic at runtime: localized strings come
+ * from `data-message-template` attributes (set at build time from
+ * WEBSITE_LABELS) so this script can be content-hashed once and reused
+ * across every language × every version.
+ *
+ * Air-gap safe: no fetches, no CDN, no external dependencies. Total
+ * code budget ~1-2 KB minified. State lives only in sessionStorage so
+ * it never persists across browser sessions (per FR-2723 spec).
+ */
+(function () {
+  var BANNER_DISMISS_KEY = "docs.banner.viewLatestDismissed";
+  var NOTICE_FLAG_KEY = "docs.notice.notInVersion";
+
+  // ── "View latest version" banner ──────────────────────────────────
+  function setupBanner() {
+    var banner = document.querySelector(".docs-banner--view-latest");
+    if (!banner) return;
+
+    // Per-session dismissal: keyed by version pair so a dismissal on
+    // 25.16 doesn't suppress the banner when navigating to 25.10.
+    var current = banner.getAttribute("data-current-version") || "";
+    var latest = banner.getAttribute("data-latest-version") || "";
+    var dismissKey = BANNER_DISMISS_KEY + ":" + current + ":" + latest;
+
+    var dismissed = false;
+    try {
+      dismissed = sessionStorage.getItem(dismissKey) === "1";
+    } catch (_) {
+      // sessionStorage unavailable (private mode, etc.) — show the banner anyway.
+    }
+    if (dismissed) {
+      banner.hidden = true;
+      return;
+    }
+    banner.hidden = false;
+
+    var dismissBtn = banner.querySelector(".docs-banner__dismiss");
+    if (dismissBtn) {
+      dismissBtn.addEventListener("click", function () {
+        banner.hidden = true;
+        try {
+          sessionStorage.setItem(dismissKey, "1");
+        } catch (_) {
+          // Best effort.
+        }
+      });
+    }
+  }
+
+  // ── "Not in selected version" inline notice ───────────────────────
+  function setupNotice() {
+    var notice = document.querySelector(".docs-notice--not-in-version");
+    if (!notice) return;
+
+    var raw = null;
+    try {
+      raw = sessionStorage.getItem(NOTICE_FLAG_KEY);
+    } catch (_) {
+      // Best effort.
+    }
+    if (!raw) {
+      notice.hidden = true;
+      return;
+    }
+
+    // Flag payload is `<targetVersion>::<originSlug>`. Only the version
+    // is shown to the user; the slug is kept for diagnostics.
+    var parts = raw.split("::");
+    var targetVersion = parts[0] || "";
+    var currentVersion = notice.getAttribute("data-current-version") || "";
+
+    // Only show the notice if we're actually viewing the target version.
+    // Defends against stale flags after the user navigates away from the
+    // index page (e.g. clicks into a real chapter, then back via the
+    // browser).
+    if (!targetVersion || targetVersion !== currentVersion) {
+      notice.hidden = true;
+      try {
+        sessionStorage.removeItem(NOTICE_FLAG_KEY);
+      } catch (_) {
+        // Best effort.
+      }
+      return;
+    }
+
+    var template = notice.getAttribute("data-message-template") || "";
+    var body = notice.querySelector(".docs-notice__body");
+    if (body && template) {
+      body.textContent = template.replace(/\{version\}/g, targetVersion);
+    }
+    notice.hidden = false;
+
+    // Clear the flag once we've consumed it so a manual reload doesn't
+    // re-show the notice on a page where the user has already seen it.
+    try {
+      sessionStorage.removeItem(NOTICE_FLAG_KEY);
+    } catch (_) {
+      // Best effort.
+    }
+
+    var dismissBtn = notice.querySelector(".docs-notice__dismiss");
+    if (dismissBtn) {
+      dismissBtn.addEventListener("click", function () {
+        notice.hidden = true;
+      });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function () {
+      setupBanner();
+      setupNotice();
+    });
+  } else {
+    setupBanner();
+    setupNotice();
+  }
+})();


### PR DESCRIPTION
Resolves FR-2723 (gh #7019)

## Summary

F6 stretch goals: version-mismatch UX banner + notice.

- "View latest version" banner shown on every non-latest version page (build-time inject)
- "Not in selected version" inline notice when version switcher falls back to index (client-side detect via sessionStorage flag set by the inline switcher script)
- Both dismissible per-session via `sessionStorage`
- i18n: en/ko/ja/th localized via `WEBSITE_LABELS`
- Air-gap safe; ~5 KB additional JS (well under 25 KB per-page budget)
- New asset only emitted in versioned mode — flat-mode builds are byte-identical to before

## Implementation

- `templates/assets/version-banner.js` (new) — handles dismissal + notice reveal at runtime; reads from `data-` attributes so the script is content-hashed once and shared across every language × every version
- `src/website-builder.ts` — adds `buildVersionBanner` + `buildVersionNotice`; extends version-switcher inline script to set `sessionStorage["docs.notice.notInVersion"]` before fallback navigation
- `src/website-generator.ts` — writes the hashed `version-banner.js` asset only when `loadedVersions.enabled`
- `src/config.ts` — extends `WEBSITE_LABELS` with 4 keys (`bannerViewLatest`, `bannerViewLatestLink`, `bannerDismiss`, `noticeNotInVersion`) × 4 languages
- `src/styles-web.ts` — `.docs-banner` (warning yellow) + `.docs-notice` (info blue) styles, ~80 LoC
- `ARCHITECTURE.md` — new "Version mismatch UX (FR-2723)" subsection under F6

## Verification

- [x] `bash scripts/verify.sh` → ALL PASS (relay, lint, format, tsc)
- [x] `pnpm --filter backend.ai-docs-toolkit run test` → 48/48 pass
- [x] Flat mode (no `versions:`) — verified `dist/web/en/quickstart.html` has zero `docs-banner` / `docs-notice` / `version-banner.js` references; assets dir contains only styles + search + og-default (no version-banner.js)
- [x] Versioned mode (temporary `versions:` block with 26.03 latest + 25.16) — `assets/version-banner.5fa82353.js` written; `25.16/en/admin-menu.html` has banner with link to `../../26.03/en/admin-menu.html`; `26.03/en/admin-menu.html` has NO banner; both have hidden notice with localized template attribute
- [x] All 4 languages (en/ko/ja/th) — banner body and notice template render correct localized strings
- [x] Version-switcher inline script writes `sessionStorage.setItem('docs.notice.notInVersion', target + '::' + slug)` before fallback navigation
- [x] `pnpm run pdf:en` → exit 0 (PDF code path untouched)
- [x] `pnpm run pdf:ko` → exit 0 (FR-2721 CJK PDF fix non-regression)
- [x] Temp `versions:` block reverted from `webui-docs/docs-toolkit.config.yaml` before commit

## Wall-clock impact

Versioned-mode build with 1 language took ~2.0s for 2 versions × 29 chapters (vs ~1.0s for flat-mode 1 version × 29 chapters); banner/notice injection is constant-time per page so the impact is negligible.

## Stack

- F5 in main → F6 #7011 → F2 #7012 → FR-2721 #7027 → FR-2722 #7028 → This PR

## Things NOT shipped

- No CDN URLs / runtime API calls
- No PDF code touched
- No `versions:` enabled in `webui-docs/docs-toolkit.config.yaml` (used as temp test only, reverted)
- `localStorage` not used — only `sessionStorage` per spec