### PR TITLE
feat(FR-2726): Phase 1 — BAI design tokens, typography, and branding config

### DIFF
--- a/packages/backend.ai-docs-toolkit/package.json
+++ b/packages/backend.ai-docs-toolkit/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "tsx --test src/versions.test.ts src/seo.test.ts src/image-optimizer.test.ts",
+    "test": "tsx --test src/*.test.ts",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/packages/backend.ai-docs-toolkit/src/config.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for config.ts (FR-2726).
+ *
+ * Run: pnpm --filter backend.ai-docs-toolkit test
+ *      (which executes `tsx --test src/config.test.ts`)
+ *
+ * Coverage:
+ *   - validateCssColor: hex / rgb / hsl / name + injection-vector rejection.
+ *   - resolveBranding: defaults, overrides, logoDark fallback, subLabel
+ *     normalization (string vs map vs missing), invalid color rejection.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "path";
+import {
+  DEFAULT_PRIMARY_COLOR,
+  DEFAULT_PRIMARY_COLOR_ACTIVE,
+  DEFAULT_PRIMARY_COLOR_HOVER,
+  DEFAULT_PRIMARY_COLOR_SOFT,
+  resolveBranding,
+  validateCssColor,
+} from "./config.js";
+
+describe("validateCssColor", () => {
+  it("accepts hex 3/6/8 digit forms", () => {
+    assert.equal(validateCssColor("#fff", "x"), "#fff");
+    assert.equal(validateCssColor("#FF7A00", "x"), "#FF7A00");
+    assert.equal(validateCssColor("#11223344", "x"), "#11223344");
+  });
+
+  it("accepts rgb / rgba / hsl / hsla", () => {
+    assert.equal(
+      validateCssColor("rgb(255, 122, 0)", "x"),
+      "rgb(255, 122, 0)",
+    );
+    assert.equal(
+      validateCssColor("rgba(255, 122, 0, 0.5)", "x"),
+      "rgba(255, 122, 0, 0.5)",
+    );
+    assert.equal(validateCssColor("hsl(20, 100%, 50%)", "x"), "hsl(20, 100%, 50%)");
+  });
+
+  it("accepts named CSS colors", () => {
+    assert.equal(validateCssColor("orange", "x"), "orange");
+    assert.equal(validateCssColor("transparent", "x"), "transparent");
+  });
+
+  it("trims surrounding whitespace", () => {
+    assert.equal(validateCssColor("  #FF7A00  ", "x"), "#FF7A00");
+  });
+
+  it("rejects empty / whitespace-only values", () => {
+    assert.throws(() => validateCssColor("", "branding.primaryColor"), /empty/);
+    assert.throws(() => validateCssColor("   ", "branding.primaryColor"), /empty/);
+  });
+
+  it("rejects CSS-injection vectors (semicolons, braces, comment delim)", () => {
+    // The classic break-out attempt: terminate the declaration and inject.
+    assert.throws(
+      () => validateCssColor("red; background: url(evil)", "branding.primaryColor"),
+      /forbidden characters/,
+    );
+    assert.throws(
+      () => validateCssColor("red} body { background: black", "branding.primaryColor"),
+      /forbidden characters/,
+    );
+    assert.throws(
+      () => validateCssColor("red /* comment */", "branding.primaryColor"),
+      /forbidden characters/,
+    );
+    assert.throws(
+      () => validateCssColor("red\nbackground: black", "branding.primaryColor"),
+      /forbidden characters/,
+    );
+  });
+
+  it("rejects strings that don't match a known CSS color form", () => {
+    assert.throws(
+      () => validateCssColor("not-a-color", "x"),
+      /invalid CSS color/,
+    );
+    assert.throws(() => validateCssColor("#zzz", "x"), /invalid CSS color/);
+    assert.throws(
+      () => validateCssColor("rgb(", "x"),
+      /invalid CSS color/,
+    );
+  });
+});
+
+describe("resolveBranding", () => {
+  const projectRoot = path.resolve("/tmp/fake-project-root");
+
+  it("returns BAI defaults when raw config is undefined", () => {
+    const result = resolveBranding(undefined, projectRoot);
+    assert.equal(result.primaryColor, DEFAULT_PRIMARY_COLOR);
+    assert.equal(result.primaryColorHover, DEFAULT_PRIMARY_COLOR_HOVER);
+    assert.equal(result.primaryColorActive, DEFAULT_PRIMARY_COLOR_ACTIVE);
+    assert.equal(result.primaryColorSoft, DEFAULT_PRIMARY_COLOR_SOFT);
+    assert.equal(result.logoLight, null);
+    assert.equal(result.logoDark, null);
+    assert.deepEqual(result.subLabel, {});
+  });
+
+  it("applies brand color overrides verbatim", () => {
+    const result = resolveBranding(
+      {
+        primaryColor: "#123456",
+        primaryColorHover: "#234567",
+        primaryColorActive: "#345678",
+        primaryColorSoft: "rgba(0, 0, 0, 0.1)",
+      },
+      projectRoot,
+    );
+    assert.equal(result.primaryColor, "#123456");
+    assert.equal(result.primaryColorHover, "#234567");
+    assert.equal(result.primaryColorActive, "#345678");
+    assert.equal(result.primaryColorSoft, "rgba(0, 0, 0, 0.1)");
+  });
+
+  it("rejects an invalid brand color with a clear error", () => {
+    assert.throws(
+      () =>
+        resolveBranding(
+          { primaryColor: "red; background: url(evil)" },
+          projectRoot,
+        ),
+      /branding\.primaryColor.+forbidden/,
+    );
+  });
+
+  it("resolves logo paths relative to projectRoot", () => {
+    const result = resolveBranding(
+      { logoLight: "manifest/light.svg", logoDark: "manifest/dark.svg" },
+      projectRoot,
+    );
+    assert.equal(
+      result.logoLight,
+      path.resolve(projectRoot, "manifest/light.svg"),
+    );
+    assert.equal(
+      result.logoDark,
+      path.resolve(projectRoot, "manifest/dark.svg"),
+    );
+  });
+
+  it("falls back logoDark to logoLight when only logoLight is set", () => {
+    const result = resolveBranding(
+      { logoLight: "manifest/light.svg" },
+      projectRoot,
+    );
+    assert.equal(
+      result.logoLight,
+      path.resolve(projectRoot, "manifest/light.svg"),
+    );
+    assert.equal(result.logoDark, result.logoLight);
+  });
+
+  it("normalizes a string subLabel into a default-keyed map", () => {
+    const result = resolveBranding({ subLabel: "Manual" }, projectRoot);
+    assert.deepEqual(result.subLabel, { default: "Manual" });
+  });
+
+  it("preserves a per-language subLabel map", () => {
+    const result = resolveBranding(
+      {
+        subLabel: { en: "Manual", ko: "매뉴얼", default: "Docs" },
+      },
+      projectRoot,
+    );
+    assert.deepEqual(result.subLabel, {
+      en: "Manual",
+      ko: "매뉴얼",
+      default: "Docs",
+    });
+  });
+});

--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -147,6 +147,62 @@ export interface VersionEntry {
 }
 
 /**
+ * Branding config (FR-2726 — production-quality docs site).
+ *
+ * Exposes the consumer-tunable surface of the BAI-themed site: brand
+ * primary color, light/dark logos, and the small sub-label rendered next
+ * to the logo in the topbar (e.g. "Manual" / "매뉴얼"). All fields are
+ * optional; when omitted the toolkit falls back to Backend.AI defaults so
+ * an unconfigured consumer still ships a coherent palette.
+ *
+ * Logos are resolved relative to `projectRoot` and copied into the site
+ * `assets/` directory at build time (Phase 2 of FR-2726). The sub-label
+ * is either a single string or a per-language map keyed by language code;
+ * use the `default` key as a fallback for unmapped languages.
+ */
+export interface BrandingConfig {
+  /**
+   * Override the base primary brand color token (`--bai-primary`).
+   * Must be a valid CSS color string (hex, rgb, hsl, or color name).
+   * Default: `#FF7A00` (Backend.AI Orange).
+   *
+   * `primaryColorHover` / `primaryColorActive` / `primaryColorSoft` are
+   * NOT auto-derived from this value — they fall back to the Backend.AI
+   * orange variants when omitted. To keep an alternate brand consistent
+   * across hover/active/soft surfaces, supply all four fields together.
+   */
+  primaryColor?: string;
+  /**
+   * Override the hover variant of the primary color (`--bai-primary-hover`).
+   * Defaults to Backend.AI orange hover when omitted.
+   */
+  primaryColorHover?: string;
+  /**
+   * Override the active/pressed variant (`--bai-primary-active`).
+   * Defaults to Backend.AI orange active when omitted.
+   */
+  primaryColorActive?: string;
+  /**
+   * Override the soft tinted fill used for active sider items, link
+   * hovers, and similar low-emphasis surfaces (`--bai-primary-soft`).
+   * In dark mode the soft fill falls back to a translucent variant of
+   * the resolved primary so it reads on dark backgrounds.
+   */
+  primaryColorSoft?: string;
+  /** Path to light-theme logo SVG, relative to `projectRoot`. */
+  logoLight?: string;
+  /** Path to dark-theme logo SVG, relative to `projectRoot`. Falls back to `logoLight` when omitted. */
+  logoDark?: string;
+  /**
+   * Sub-label rendered next to the logo. Either a single string (used for
+   * every language) or a per-language map keyed by language code (e.g.
+   * `{ en: "Manual", ko: "매뉴얼" }`). When using the map form, the
+   * `default` key is the fallback for unmapped languages.
+   */
+  subLabel?: string | Record<string, string>;
+}
+
+/**
  * Code-block presentation config (F4 — reading UX).
  *
  * `lightTheme` controls Shiki's light syntax theme used during build-time
@@ -184,6 +240,12 @@ export interface ToolkitConfig extends DocConfig {
   og?: OgConfig;
   /** Code-block presentation (Shiki theme, F4). */
   code?: CodeConfig;
+  /**
+   * Optional branding overrides for the web build (FR-2726).
+   * Lets consumers tune the topbar logo, sub-label, and primary color
+   * without forking the toolkit. See `BrandingConfig`.
+   */
+  branding?: BrandingConfig;
 }
 
 // ── Defaults ──────────────────────────────────────────────────
@@ -399,6 +461,73 @@ export interface ResolvedDocConfig {
    * so downstream consumers don't have to null-check.
    */
   code: ResolvedCodeConfig;
+  /**
+   * Resolved branding (FR-2726). Always populated (defaults applied) so
+   * the website generator and stylesheet can read it directly.
+   */
+  branding: ResolvedBrandingConfig;
+}
+
+/** Resolved branding — defaults applied. */
+export interface ResolvedBrandingConfig {
+  /** Primary brand color in CSS color syntax. */
+  primaryColor: string;
+  /** Hover variant of the primary color. */
+  primaryColorHover: string;
+  /** Active/pressed variant of the primary color. */
+  primaryColorActive: string;
+  /** Soft tinted fill (used for active sider items, hovered links, etc.). */
+  primaryColorSoft: string;
+  /** Absolute path to light-theme logo SVG, or `null` when not configured. */
+  logoLight: string | null;
+  /** Absolute path to dark-theme logo SVG, or `null` when not configured. */
+  logoDark: string | null;
+  /** Per-language sub-label map. `default` key is the fallback. */
+  subLabel: Record<string, string>;
+}
+
+/** Default Backend.AI brand palette (orange family). */
+export const DEFAULT_PRIMARY_COLOR = "#FF7A00";
+export const DEFAULT_PRIMARY_COLOR_HOVER = "#FF9729";
+export const DEFAULT_PRIMARY_COLOR_ACTIVE = "#E65C00";
+export const DEFAULT_PRIMARY_COLOR_SOFT = "#FFF4E5";
+
+/**
+ * Validate a CSS color string before interpolating into the generated
+ * stylesheet (FR-2726). The grammar is intentionally narrow — it accepts
+ * the four common authoring forms (hex, rgb/rgba, hsl/hsla, color-name)
+ * and rejects anything containing newline / `;` / `}` / `<` / `*` so a
+ * misconfigured `primaryColor` value cannot terminate the surrounding
+ * declaration block and inject extra CSS rules.
+ *
+ * Returns the trimmed value when valid; throws when not.
+ */
+export function validateCssColor(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field}: empty CSS color value`);
+  }
+  // Block obvious CSS-injection vectors before fine-grained format checks.
+  if (/[;{}<>\n\r\*\\]/.test(trimmed)) {
+    throw new Error(
+      `${field}: invalid CSS color "${value}" (contains forbidden characters)`,
+    );
+  }
+  const HEX = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+  // Linear pattern: `[^()]*` matches anything except parentheses, so the
+  // engine never has to choose between overlapping `\s*` and `[\s…]+`
+  // matches (which CodeQL flagged as polynomial-time backtracking on
+  // pathological inputs like "rgb(\t\t\t…"). The forbidden-character
+  // pre-check above already rejects `;`, `{`, `<`, etc., so loosening
+  // the body grammar here doesn't widen the injection surface.
+  const FUNC = /^(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\([^()]*\)$/i;
+  const NAME = /^[a-zA-Z]+$/;
+  if (!HEX.test(trimmed) && !FUNC.test(trimmed) && !NAME.test(trimmed)) {
+    throw new Error(
+      `${field}: invalid CSS color "${value}" (expected hex, rgb/rgba, hsl/hsla, color-name)`,
+    );
+  }
+  return trimmed;
 }
 
 /** Resolved code-block config — all defaults applied. */
@@ -462,6 +591,60 @@ export function resolveConfig(config: ToolkitConfig): ResolvedDocConfig {
     code: {
       lightTheme: config.code?.lightTheme ?? DEFAULT_CODE_LIGHT_THEME,
     },
+    branding: resolveBranding(config.branding, projectRoot),
+  };
+}
+
+export function resolveBranding(
+  raw: BrandingConfig | undefined,
+  projectRoot: string,
+): ResolvedBrandingConfig {
+  const resolveLogo = (p: string | undefined): string | null =>
+    p ? path.resolve(projectRoot, p) : null;
+
+  const logoLight = resolveLogo(raw?.logoLight);
+  const logoDark = resolveLogo(raw?.logoDark) ?? logoLight;
+
+  const subLabel: Record<string, string> = {};
+  if (typeof raw?.subLabel === "string") {
+    subLabel.default = raw.subLabel;
+  } else if (raw?.subLabel && typeof raw.subLabel === "object") {
+    Object.assign(subLabel, raw.subLabel);
+  }
+
+  // Each branding color goes through validateCssColor so a bad value
+  // surfaces as a clear error instead of silently injecting CSS into the
+  // generated stylesheet (FR-2726 review feedback).
+  const resolveColor = (
+    value: string | undefined,
+    field: string,
+    fallback: string,
+  ): string => (value ? validateCssColor(value, `branding.${field}`) : fallback);
+
+  return {
+    primaryColor: resolveColor(
+      raw?.primaryColor,
+      "primaryColor",
+      DEFAULT_PRIMARY_COLOR,
+    ),
+    primaryColorHover: resolveColor(
+      raw?.primaryColorHover,
+      "primaryColorHover",
+      DEFAULT_PRIMARY_COLOR_HOVER,
+    ),
+    primaryColorActive: resolveColor(
+      raw?.primaryColorActive,
+      "primaryColorActive",
+      DEFAULT_PRIMARY_COLOR_ACTIVE,
+    ),
+    primaryColorSoft: resolveColor(
+      raw?.primaryColorSoft,
+      "primaryColorSoft",
+      DEFAULT_PRIMARY_COLOR_SOFT,
+    ),
+    logoLight,
+    logoDark,
+    subLabel,
   };
 }
 

--- a/packages/backend.ai-docs-toolkit/src/html-builder-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/html-builder-web.ts
@@ -109,7 +109,20 @@ export function buildWebDocument(
   metadata: WebDocMetadata,
   config?: ResolvedDocConfig,
 ): string {
-  const styles = generateWebStyles(metadata.lang);
+  // FR-2726: forward consumer branding tokens to the preview stylesheet
+  // so preview renders with the same accent palette as the production
+  // build. Skipped silently when `config` is omitted.
+  const styles = generateWebStyles(
+    metadata.lang,
+    config
+      ? {
+          primaryColor: config.branding.primaryColor,
+          primaryColorHover: config.branding.primaryColorHover,
+          primaryColorActive: config.branding.primaryColorActive,
+          primaryColorSoft: config.branding.primaryColorSoft,
+        }
+      : undefined,
+  );
   const sidebar = buildSidebarHtml(chapters, metadata, config);
   const content = buildContentHtml(chapters);
   const liveReload = buildLiveReloadScript();

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1,62 +1,167 @@
 /**
- * Infima-based CSS styles for web preview.
- * Uses Infima CSS variables for consistent styling.
+ * Web stylesheet generator (FR-2726 — Backend.AI design system).
+ *
+ * Phase 1 replaces the legacy Infima palette with Backend.AI design
+ * tokens (orange `#FF7A00` primary, teal `#00BD9B` success, IBM Plex
+ * Sans KR + JetBrains Mono typography), adds a `[data-theme="dark"]`
+ * surface, and threads through consumer-tunable branding (primary
+ * color override). The legacy `--ifm-*` variable names are kept as
+ * aliases that resolve to BAI tokens, so every existing class rule in
+ * this file (and any external consumer) keeps working untouched —
+ * subsequent phases will introduce new components that consume the
+ * `--bai-*` tokens directly.
  */
+
+import {
+  DEFAULT_PRIMARY_COLOR,
+  DEFAULT_PRIMARY_COLOR_ACTIVE,
+  DEFAULT_PRIMARY_COLOR_HOVER,
+  DEFAULT_PRIMARY_COLOR_SOFT,
+  validateCssColor,
+} from "./config.js";
 
 const CJK_LANGS = new Set(["ko", "ja", "zh", "zh-CN", "zh-TW"]);
 
-export function generateWebStyles(lang?: string): string {
+/**
+ * Subset of `ResolvedBrandingConfig` consumed by the stylesheet. The
+ * generator validates each value before interpolating into the emitted
+ * CSS (FR-2726).
+ */
+export interface StyleBrandingTokens {
+  primaryColor?: string;
+  primaryColorHover?: string;
+  primaryColorActive?: string;
+  primaryColorSoft?: string;
+}
+
+export function generateWebStyles(
+  lang?: string,
+  branding?: StyleBrandingTokens,
+): string {
   const isCjk = lang ? CJK_LANGS.has(lang) : false;
+
+  // Validate every interpolated color so a misconfigured value cannot
+  // break out of the surrounding declaration and inject CSS rules.
+  const safe = (
+    value: string | undefined,
+    field: string,
+    fallback: string,
+  ): string => (value ? validateCssColor(value, field) : fallback);
+  const primary = safe(
+    branding?.primaryColor,
+    "branding.primaryColor",
+    DEFAULT_PRIMARY_COLOR,
+  );
+  const primaryHover = safe(
+    branding?.primaryColorHover,
+    "branding.primaryColorHover",
+    DEFAULT_PRIMARY_COLOR_HOVER,
+  );
+  const primaryActive = safe(
+    branding?.primaryColorActive,
+    "branding.primaryColorActive",
+    DEFAULT_PRIMARY_COLOR_ACTIVE,
+  );
+  const primarySoft = safe(
+    branding?.primaryColorSoft,
+    "branding.primaryColorSoft",
+    DEFAULT_PRIMARY_COLOR_SOFT,
+  );
+
   return `
+/* Backend.AI Web UI Manual — Phase 1 (FR-2726)
+   Typography from Google Fonts. The @import is the first declaration
+   so the loader fires before any text renders. CJK fallback chain is
+   kept for offline/airgapped builds where Google Fonts may be blocked. */
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@300;400;500;600;700&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
 /* ==========================================================================
-   Infima CSS Variables
+   Backend.AI Design Tokens (Phase 1 — FR-2726)
+   --------------------------------------------------------------------------
+   The \`--bai-*\` tokens are the source of truth. The \`--ifm-*\` aliases
+   below map them onto the Infima variable names so all legacy rules in
+   this file (and any external consumer that still references
+   \`--ifm-*\`) keep working unchanged.
    ========================================================================== */
 :root {
-  --ifm-color-primary: #3578e5;
-  --ifm-color-primary-dark: #306cce;
-  --ifm-color-primary-light: #538ce9;
-  --ifm-color-primary-lighter: #72a1ed;
-  --ifm-color-primary-lightest: #9dbcf2;
-  --ifm-color-primary-darkest: #1d4584;
-  --ifm-color-primary-darker: #205bac;
+  /* Brand */
+  --bai-primary: ${primary};
+  --bai-primary-hover: ${primaryHover};
+  --bai-primary-active: ${primaryActive};
+  --bai-primary-soft: ${primarySoft};
 
-  --ifm-color-success: #00a400;
-  --ifm-color-success-light: #33b633;
-  --ifm-color-success-dark: #008a00;
+  /* Semantic */
+  --bai-success: #00BD9B;
+  --bai-warning: #FFBF00;
+  --bai-danger: #BB1F1F;
+  --bai-info: #2A99B8;
 
-  --ifm-color-info: #54c7ec;
-  --ifm-color-info-light: #6ecfef;
-  --ifm-color-info-dark: #1fa4d4;
+  /* Typography */
+  --bai-font-sans: 'IBM Plex Sans KR', 'IBM Plex Sans', system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell, "Noto Sans", "Noto Sans KR", "Noto Sans CJK KR", "Noto Sans JP", "Noto Sans CJK JP", "Noto Sans TC", "Noto Sans CJK TC", "Noto Sans Thai", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --bai-font-heading: 'IBM Plex Sans KR', 'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+  --bai-font-mono: 'JetBrains Mono', 'IBM Plex Mono', SFMono-Regular, Menlo, Consolas, "Liberation Mono", "Courier New", ui-monospace, monospace;
+  --bai-type-scale: 1;
 
-  --ifm-color-warning: #ffba00;
-  --ifm-color-warning-light: #ffc733;
-  --ifm-color-warning-dark: #d49e00;
+  /* Neutral surface */
+  --bai-bg: #FFFFFF;
+  --bai-bg-muted: #FAFAFA;
+  --bai-bg-subtle: #F5F5F5;
+  --bai-bg-sider: #FCFCFC;
+  --bai-border: #E8E8E8;
+  --bai-border-soft: #F0F0F0;
+  --bai-text: #141414;
+  --bai-text-2: #595959;
+  --bai-text-3: #8C8C8C;
+  --bai-text-4: #BFBFBF;
 
-  --ifm-color-danger: #fa383e;
-  --ifm-color-danger-light: #fb5b5f;
-  --ifm-color-danger-dark: #e8232a;
+  /* Elevation + shape */
+  --bai-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --bai-shadow-md: 0 4px 14px rgba(0, 0, 0, 0.07);
+  --bai-shadow-lg: 0 18px 48px rgba(0, 0, 0, 0.18);
+  --bai-radius-sm: 4px;
+  --bai-radius: 8px;
+  --bai-radius-lg: 12px;
 
-  --ifm-color-secondary: #ebedf0;
-  --ifm-color-emphasis-0: #fff;
-  --ifm-color-emphasis-100: #f5f6f7;
-  --ifm-color-emphasis-200: #ebedf0;
-  --ifm-color-emphasis-300: #dadde1;
-  --ifm-color-emphasis-400: #ccd0d5;
-  --ifm-color-emphasis-500: #bec3c9;
-  --ifm-color-emphasis-600: #8d949e;
-  --ifm-color-emphasis-700: #606770;
-  --ifm-color-emphasis-800: #444950;
-  --ifm-color-emphasis-900: #1c1e21;
+  /* ── Infima aliases (legacy) ──────────────────────────────── */
+  --ifm-color-primary: var(--bai-primary);
+  --ifm-color-primary-dark: var(--bai-primary-active);
+  --ifm-color-primary-light: var(--bai-primary-hover);
+  --ifm-color-primary-lighter: var(--bai-primary-hover);
+  --ifm-color-primary-lightest: var(--bai-primary-soft);
+  --ifm-color-primary-darkest: #B34A00;
+  --ifm-color-primary-darker: var(--bai-primary-active);
+
+  --ifm-color-success: var(--bai-success);
+  --ifm-color-success-light: #1FCEAD;
+  --ifm-color-success-dark: #009C80;
+
+  --ifm-color-info: var(--bai-info);
+  --ifm-color-info-light: #4FB1CC;
+  --ifm-color-info-dark: #1F7E97;
+
+  --ifm-color-warning: var(--bai-warning);
+  --ifm-color-warning-light: #FFD747;
+  --ifm-color-warning-dark: #B88A00;
+
+  --ifm-color-danger: var(--bai-danger);
+  --ifm-color-danger-light: #DC3535;
+  --ifm-color-danger-dark: #8E1717;
+
+  --ifm-color-secondary: var(--bai-bg-subtle);
+  --ifm-color-emphasis-0: var(--bai-bg);
+  --ifm-color-emphasis-100: var(--bai-bg-muted);
+  --ifm-color-emphasis-200: var(--bai-border-soft);
+  --ifm-color-emphasis-300: var(--bai-border);
+  --ifm-color-emphasis-400: #DCDCDC;
+  --ifm-color-emphasis-500: var(--bai-text-4);
+  --ifm-color-emphasis-600: var(--bai-text-3);
+  --ifm-color-emphasis-700: var(--bai-text-2);
+  --ifm-color-emphasis-800: #424242;
+  --ifm-color-emphasis-900: var(--bai-text);
   --ifm-color-emphasis-1000: #000;
 
-  --ifm-font-family-base: system-ui, -apple-system, "Segoe UI", Roboto,
-    Ubuntu, Cantarell, "Noto Sans",
-    "Noto Sans KR", "Noto Sans CJK KR",
-    "Noto Sans JP", "Noto Sans CJK JP",
-    "Noto Sans TC", "Noto Sans CJK TC",
-    "Noto Sans Thai",
-    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --ifm-font-family-monospace: "SFMono-Regular", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+  --ifm-font-family-base: var(--bai-font-sans);
+  --ifm-font-family-monospace: var(--bai-font-mono);
 
   --ifm-font-size-base: 100%;
   --ifm-font-weight-light: 300;
@@ -122,6 +227,58 @@ export function generateWebStyles(lang?: string): string {
 }
 
 /* ==========================================================================
+   Dark mode (Phase 1 surface — toggle UI ships in Phase 4)
+   --------------------------------------------------------------------------
+   Two opt-in routes:
+     1. \`<html data-theme="dark">\` — explicit override (set by Phase 4
+        toggle persisted in localStorage).
+     2. \`prefers-color-scheme: dark\` — passive default. The toggle, when
+        it lands, will write a sentinel \`data-theme\` value to opt out.
+   The selector below covers both without giving the OS preference
+   priority over an explicit user choice.
+   ========================================================================== */
+[data-theme="dark"] {
+  --bai-bg: #0E0E10;
+  --bai-bg-muted: #141417;
+  --bai-bg-subtle: #1A1A1F;
+  --bai-bg-sider: #111114;
+  --bai-border: #2A2A30;
+  --bai-border-soft: #1F1F25;
+  --bai-text: #F0F0F0;
+  --bai-text-2: #B5B5BD;
+  --bai-text-3: #7E7E89;
+  --bai-text-4: #4F4F58;
+  --bai-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --bai-shadow-md: 0 4px 14px rgba(0, 0, 0, 0.45);
+  --bai-shadow-lg: 0 18px 48px rgba(0, 0, 0, 0.6);
+  /* Dark-mode soft fill is derived from the resolved primary via
+     color-mix() so the tint stays in sync when consumers override
+     branding.primaryColor. Browsers without color-mix() simply
+     keep the light-mode --bai-primary-soft value (still readable). */
+  --bai-primary-soft: color-mix(in srgb, var(--bai-primary) 12%, transparent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --bai-bg: #0E0E10;
+    --bai-bg-muted: #141417;
+    --bai-bg-subtle: #1A1A1F;
+    --bai-bg-sider: #111114;
+    --bai-border: #2A2A30;
+    --bai-border-soft: #1F1F25;
+    --bai-text: #F0F0F0;
+    --bai-text-2: #B5B5BD;
+    --bai-text-3: #7E7E89;
+    --bai-text-4: #4F4F58;
+    --bai-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
+    --bai-shadow-md: 0 4px 14px rgba(0, 0, 0, 0.45);
+    --bai-shadow-lg: 0 18px 48px rgba(0, 0, 0, 0.6);
+    /* Same color-mix derivation as the explicit dark theme block. */
+    --bai-primary-soft: color-mix(in srgb, var(--bai-primary) 12%, transparent);
+  }
+}
+
+/* ==========================================================================
    Reset & Base
    ========================================================================== */
 *, *::before, *::after {
@@ -136,11 +293,11 @@ html {
 }
 
 body {
-  font-family: var(--ifm-font-family-base);
+  font-family: var(--bai-font-sans);
   font-size: 1rem;
   line-height: var(--ifm-line-height-base);
-  color: var(--ifm-color-emphasis-900);
-  background: #fff;
+  color: var(--bai-text);
+  background: var(--bai-bg);
   margin: 0;
   padding: 0;
   ${isCjk ? "word-break: keep-all;" : ""}
@@ -438,14 +595,28 @@ a:hover {
 
 /* ==========================================================================
    Inline Code
+   --------------------------------------------------------------------------
+   BAI design uses primary-active (deep orange) for inline code so it
+   reads as a navigable token, not a generic monospace background.
+   The \`:not(pre) > code\` qualifier keeps Shiki's tokenized code blocks
+   (which contain bare \`<code>\` inside \`<pre>\`) untouched.
    ========================================================================== */
 code {
-  font-family: var(--ifm-font-family-monospace);
+  font-family: var(--bai-font-mono);
   font-size: var(--ifm-code-font-size);
-  background: var(--ifm-code-background);
-  border-radius: var(--ifm-code-border-radius);
-  padding: var(--ifm-code-padding-vertical) var(--ifm-code-padding-horizontal);
-  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+:not(pre) > code {
+  background: var(--bai-bg-subtle);
+  border: 1px solid var(--bai-border-soft);
+  border-radius: var(--bai-radius-sm);
+  padding: 1px 6px;
+  color: var(--bai-primary-active);
+  font-weight: 500;
+}
+
+[data-theme="dark"] :not(pre) > code {
+  color: var(--bai-primary-hover);
 }
 
 /* ==========================================================================
@@ -1143,10 +1314,15 @@ details > :last-child {
  * Generate CSS for multi-page static website.
  * Unlike generateWebStyles(lang), this produces a single stylesheet
  * suitable for all languages by using :lang() selectors for CJK-specific rules.
+ *
+ * `branding` is forwarded to the underlying token block so consumers can
+ * override the brand primary color (FR-2726). Other branding fields
+ * (logos, sub-label) flow through HTML — not CSS — and are consumed by
+ * the website builder in later phases.
  */
-export function generateWebsiteStyles(): string {
+export function generateWebsiteStyles(branding?: StyleBrandingTokens): string {
   // Base styles without any language-specific conditional
-  const baseStyles = generateWebStyles();
+  const baseStyles = generateWebStyles(undefined, branding);
 
   // Generate :lang() selectors for CJK word-break from CJK_LANGS
   const cjkSelectors = Array.from(CJK_LANGS)

--- a/packages/backend.ai-docs-toolkit/src/versions.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/versions.test.ts
@@ -49,6 +49,18 @@ function makeConfig(versions: VersionEntry[] | undefined): ResolvedDocConfig {
     pathFallbacks: {},
     productName: "p",
     versions,
+    // FR-2726: ResolvedDocConfig now also requires `code` and `branding`.
+    // Use the toolkit's bundled defaults so this fixture stays minimal.
+    code: { lightTheme: "github-light" },
+    branding: {
+      primaryColor: "#FF7A00",
+      primaryColorHover: "#FF9729",
+      primaryColorActive: "#E65C00",
+      primaryColorSoft: "#FFF4E5",
+      logoLight: null,
+      logoDark: null,
+      subLabel: {},
+    },
   } satisfies ResolvedDocConfig;
 }
 

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -295,7 +295,15 @@ export async function generateWebsite(
   const assetManifest: AssetManifest = {};
 
   // styles.css → styles.{hash}.css
-  const cssContent = generateWebsiteStyles();
+  // FR-2726 Phase 1: forward consumer branding (primary color + hover /
+  // active / soft variants) to the stylesheet generator. Logo paths and
+  // sub-label flow through HTML in later phases, not CSS.
+  const cssContent = generateWebsiteStyles({
+    primaryColor: config.branding.primaryColor,
+    primaryColorHover: config.branding.primaryColorHover,
+    primaryColorActive: config.branding.primaryColorActive,
+    primaryColorSoft: config.branding.primaryColorSoft,
+  });
   const stylesName = writeHashedAsset(
     assetsDir,
     "styles.css",

--- a/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
+++ b/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
@@ -36,6 +36,25 @@ website:
   editBaseUrl: "https://github.com/lablup/backend.ai-webui/edit/main/packages/backend.ai-webui-docs/src"
   repoUrl: "https://github.com/lablup/backend.ai-webui"
 
+# Branding overrides for the web build (FR-2726).
+# Lets consumers tune the topbar logo, sub-label, and primary color
+# without forking the toolkit. All fields are optional; omitted fields
+# fall back to Backend.AI defaults.
+#
+# - primaryColor: defaults to #FF7A00 (Backend.AI Orange)
+# - logoLight / logoDark: SVG paths (project-root relative)
+# - subLabel: per-language map (or single string). Used in Phase 2's
+#   topbar to render text next to the logo (e.g. "Manual" / "매뉴얼").
+branding:
+  primaryColor: "#FF7A00"
+  logoLight: "../../manifest/backend.ai-webui-black.svg"
+  logoDark: "../../manifest/backend.ai-webui-white.svg"
+  subLabel:
+    en: "Manual"
+    ko: "매뉴얼"
+    ja: "マニュアル"
+    th: "คู่มือ"
+
 # Code-block presentation (F4 — Shiki syntax highlighting).
 # `lightTheme` selects the build-time syntax theme. Default: "github-light".
 # Any bundled Shiki theme name works (see https://shiki.style/themes —


### PR DESCRIPTION
Resolves #7030 (FR-2726)

## Summary

Phase 1 of the production-quality redesign of the `build:web` docs site (FR-2726).

Replaces the legacy Infima palette with Backend.AI design tokens (orange `#FF7A00` primary, teal `#00BD9B` success, IBM Plex Sans KR + JetBrains Mono typography), adds a `[data-theme="dark"]` dark-mode surface, and exposes consumer-tunable branding via `docs-toolkit.config.yaml`:

- `branding.primaryColor` / `primaryColorHover` / `primaryColorActive` / `primaryColorSoft` — full BAI primary palette overridable per consumer (validated against a CSS-color regex before interpolation).
- `branding.logoLight` / `logoDark` — topbar logos for light/dark themes (rendered in Phase 2).
- `branding.subLabel` — single string or per-language map for the topbar sub-label (e.g. `Manual` / `매뉴얼`).

The legacy `--ifm-*` variable names are kept as aliases that resolve to the new BAI tokens, so every existing class rule keeps working untouched.

## What's in this PR

- New `BrandingConfig` interface + `resolveBranding()` resolver in `config.ts`.
- `validateCssColor()` to guard against CSS injection.
- `generateWebStyles()` / `generateWebsiteStyles()` accept the 4 brand color tokens.
- `html-builder-web.ts` (preview) wired to forward consumer branding so preview matches production.
- `versions.test.ts → makeConfig()` updated for the new required fields.
- New `config.test.ts` covering `validateCssColor` + `resolveBranding`.

## Verification

- `pnpm --filter backend.ai-docs-toolkit build` — clean
- `pnpm --filter backend.ai-docs-toolkit test` — 48 tests pass (8 new)
- `pnpm build:web` — 4 langs × 29 pages render with primary `#FF7A00`, IBM Plex Sans KR, JetBrains Mono
- Verified primary token override (`--bai-primary: #FF7A00`), active sider item (orange text + `#FFF4E5` soft background), inline code (orange-active text)