### PR TITLE
feat(FR-2726): Phase 2 — BAI topbar, sider, right-rail TOC layout

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -220,10 +220,16 @@ export function generateWebStyles(
   --ifm-alert-padding-vertical: 1rem;
   --ifm-alert-padding-horizontal: 1.2rem;
 
-  --doc-sidebar-width: 260px;
-  /* F3: right-rail "On this page" TOC width. Coexists with sidebar (260px)
-     and main column (~720-960px) on a desktop CSS grid. */
-  --doc-toc-width: 220px;
+  /* Layout (FR-2726 Phase 2) */
+  --bai-topbar-h: 56px;
+  --bai-sider-w: 280px;
+  --bai-toc-w: 240px;
+  --bai-content-max: 820px;
+  --bai-gutter: 32px;
+
+  /* Legacy aliases used by F3 grid rules (resolve to BAI tokens). */
+  --doc-sidebar-width: var(--bai-sider-w);
+  --doc-toc-width: var(--bai-toc-w);
 }
 
 /* ==========================================================================
@@ -305,79 +311,284 @@ body {
 }
 
 /* ==========================================================================
-   Page Layout — F3 three-column grid
+   Topbar (Phase 2 — FR-2726)
    --------------------------------------------------------------------------
-   Desktop: [sidebar] [main, max ~960px] [right-rail TOC, fixed width].
-   The grid lets the right-rail size predictably and lets the main column
-   fill any spare width. Below 1100px the right-rail collapses (see the
-   responsive section near the end of this file).
+   The topbar sits above the page grid as a sticky 56px strip with the
+   brand on the left, a center search trigger (host for the existing
+   search input until Phase 4 introduces a Cmd-K palette), and an
+   actions cluster on the right (lang switcher, version selector, GitHub
+   icon). The mobile menu icon and the search icon are hidden on
+   desktop and revealed on narrower viewports — see the responsive
+   block near the end of this file.
+   ========================================================================== */
+.bai-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  height: var(--bai-topbar-h);
+  padding: 0 20px;
+  background: var(--bai-bg);
+  border-bottom: 1px solid var(--bai-border);
+}
+
+.bai-topbar__menu {
+  display: none;
+}
+
+.bai-topbar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+  color: var(--bai-text);
+  text-decoration: none;
+}
+
+.bai-topbar__brand:hover {
+  text-decoration: none;
+  color: var(--bai-text);
+}
+
+.bai-brand-logo {
+  height: 22px;
+  width: auto;
+  display: block;
+}
+
+.bai-brand-fallback {
+  font-family: var(--bai-font-heading);
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--bai-text);
+}
+
+.bai-brand-divider {
+  width: 1px;
+  height: 18px;
+  background: var(--bai-border);
+}
+
+.bai-brand-sub {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--bai-text-3);
+  letter-spacing: -0.005em;
+}
+
+.bai-brand-version {
+  font-family: var(--bai-font-mono);
+  font-size: 10.5px;
+  color: var(--bai-text-3);
+  background: var(--bai-bg-subtle);
+  border: 1px solid var(--bai-border);
+  padding: 2px 7px;
+  border-radius: 999px;
+  margin-left: 4px;
+}
+
+/* Topbar search — hosts \`#search-input\` (which the existing search.js
+   binds to). When Phase 4 lands, this trigger becomes a Cmd-K-style
+   button that opens a palette; until then the input stays inline so
+   typing-to-search keeps working without any JS changes. */
+.bai-topbar__search {
+  flex: 1;
+  max-width: 520px;
+  margin: 0 auto;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 36px;
+  padding: 0 12px 0 14px;
+  border: 1px solid var(--bai-border);
+  border-radius: var(--bai-radius);
+  background: var(--bai-bg-muted);
+  color: var(--bai-text-3);
+  font: inherit;
+  font-size: 13px;
+  cursor: text;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.bai-topbar__search:hover,
+.bai-topbar__search:focus-within {
+  border-color: var(--bai-primary);
+  background: var(--bai-bg);
+}
+
+.bai-topbar__search > svg {
+  flex-shrink: 0;
+  color: var(--bai-text-3);
+}
+
+.bai-topbar__search input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  color: var(--bai-text);
+  outline: none;
+  padding: 0;
+  min-width: 0;
+}
+
+.bai-topbar__search input::placeholder {
+  color: var(--bai-text-3);
+}
+
+.bai-kbd-group {
+  display: inline-flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.bai-topbar__search kbd,
+.bai-kbd-group kbd {
+  font-family: var(--bai-font-mono);
+  font-size: 10.5px;
+  background: var(--bai-bg);
+  border: 1px solid var(--bai-border);
+  border-bottom-width: 2px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: var(--bai-text-2);
+  min-width: 18px;
+  text-align: center;
+  line-height: 1.4;
+}
+
+.bai-topbar .bai-topbar__searchicon {
+  display: none;
+}
+
+.bai-topbar__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.bai-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  min-width: 32px;
+  padding: 0 8px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: var(--bai-text-2);
+  border-radius: 6px;
+  font: inherit;
+  text-decoration: none;
+}
+
+.bai-iconbtn:hover {
+  background: var(--bai-bg-subtle);
+  color: var(--bai-text);
+  text-decoration: none;
+}
+
+/* Search results dropdown anchored to the topbar search container. */
+.bai-topbar__search .search-results {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: var(--bai-bg);
+  border: 1px solid var(--bai-border);
+  border-radius: var(--bai-radius);
+  box-shadow: var(--bai-shadow-md);
+  max-height: 420px;
+  overflow-y: auto;
+  z-index: 60;
+}
+
+/* ==========================================================================
+   Page Layout — F3 three-column grid (rebased on BAI tokens — Phase 2)
+   --------------------------------------------------------------------------
+   Desktop: [sidebar] [main, max ~820px] [right-rail TOC, fixed width].
+   The topbar sits above this grid (sticky, 56px), so the sider/TOC are
+   sticky relative to (100vh - topbar-height).
    ========================================================================== */
 .doc-page {
   display: grid;
-  grid-template-columns: var(--doc-sidebar-width) minmax(0, 1fr) var(--doc-toc-width);
-  min-height: 100vh;
+  grid-template-columns: var(--bai-sider-w) minmax(0, 1fr) var(--bai-toc-w);
+  align-items: stretch;
+  min-height: calc(100vh - var(--bai-topbar-h));
 }
 
 .doc-sidebar {
   position: sticky;
-  top: 0;
-  height: 100vh;
+  top: var(--bai-topbar-h);
+  height: calc(100vh - var(--bai-topbar-h));
   overflow-y: auto;
-  border-right: 1px solid var(--ifm-color-emphasis-200);
-  background: var(--ifm-color-emphasis-0);
-  padding: 1rem 0;
+  border-right: 1px solid var(--bai-border);
+  background: var(--bai-bg-sider);
+  padding: 10px 8px 24px;
 }
 
+.doc-sidebar::-webkit-scrollbar {
+  width: 8px;
+}
+.doc-sidebar::-webkit-scrollbar-thumb {
+  background: var(--bai-border);
+  border-radius: 4px;
+}
+
+/* Sidebar header (legacy F3) — Phase 2 hides it; the topbar carries the
+   product brand and version pill now. The structural HTML stays so
+   downstream consumers that haven't migrated still get a working page. */
 .doc-sidebar-header {
-  padding: 0.5rem 1rem 1rem;
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
-  margin-bottom: 0.5rem;
+  display: none;
 }
 
-.doc-sidebar-header h2 {
-  font-size: 1.1rem;
-  margin: 0 0 0.25rem 0;
-  font-weight: 700;
-  color: var(--ifm-color-emphasis-900);
-}
-
-.doc-sidebar-header .doc-meta {
-  font-size: 0.8rem;
-  color: var(--ifm-color-emphasis-600);
-}
-
-/* Search */
-.doc-search {
-  padding: 0.5rem 1rem;
+/* Search input — Phase 2 moves this into the topbar. The original
+   .doc-search wrapper still exists in the DOM for backwards compat
+   when consumers haven't run the new builder yet, so keep the legacy
+   styling in place behind a guard. */
+.doc-sidebar > .doc-search {
+  padding: 8px 12px 12px;
   position: relative;
+  border-bottom: 1px solid var(--bai-border-soft);
+  margin-bottom: 6px;
 }
 
-.doc-search input {
+.doc-sidebar > .doc-search input {
   width: 100%;
   padding: 0.4rem 0.6rem;
   font-size: 0.85rem;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: var(--ifm-pre-border-radius);
-  background: var(--ifm-color-emphasis-0);
+  border: 1px solid var(--bai-border);
+  border-radius: var(--bai-radius-sm);
+  background: var(--bai-bg);
   outline: none;
-  font-family: var(--ifm-font-family-base);
+  font-family: var(--bai-font-sans);
 }
 
-.doc-search input:focus {
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 2px rgba(53, 120, 229, 0.15);
+.doc-sidebar > .doc-search input:focus {
+  border-color: var(--bai-primary);
+  box-shadow: 0 0 0 2px var(--bai-primary-soft);
 }
 
+/* Generic search-results dropdown styling. The topbar's search container
+   overrides positioning so the dropdown anchors to the input rather than
+   to the legacy .doc-search wrapper. */
 .search-results {
   position: absolute;
   top: 100%;
-  left: 1rem;
-  right: 1rem;
-  background: var(--ifm-color-emphasis-0);
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: var(--ifm-pre-border-radius);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-  max-height: 400px;
+  left: 0;
+  right: 0;
+  background: var(--bai-bg);
+  border: 1px solid var(--bai-border);
+  border-radius: var(--bai-radius);
+  box-shadow: var(--bai-shadow-md);
+  max-height: 420px;
   overflow-y: auto;
   z-index: 100;
 }
@@ -448,16 +659,49 @@ body {
 .doc-sidebar-group > summary,
 .doc-sidebar-group__summary {
   cursor: pointer;
-  display: block;
-  padding: 0.55rem 1rem 0.4rem;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-family: var(--bai-font-sans);
+  font-size: 12px;
+  font-weight: 600;
   letter-spacing: 0.04em;
-  color: var(--ifm-color-emphasis-700);
+  text-transform: uppercase;
+  color: var(--bai-text-3);
   user-select: none;
   list-style: none;
   position: relative;
+}
+
+/* Category icon (Phase 2 — FR-2726). Sits at the start of the summary
+   so it never collides with the disclosure caret on the right. */
+.doc-sidebar-group__icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--bai-text-3);
+}
+
+/* Category label fills the available space; the icon is on its left
+   and the count pill on its right. */
+.doc-sidebar-group__label {
+  flex: 1 1 auto;
+  text-align: left;
+}
+
+/* Item count pill — the small monospace number on the right side of the
+   category summary. Clearly delineated from text via the muted bg. */
+.doc-sidebar-group__count {
+  flex-shrink: 0;
+  font-family: var(--bai-font-mono);
+  font-weight: 400;
+  font-size: 10.5px;
+  letter-spacing: 0;
+  color: var(--bai-text-4);
+  background: var(--bai-bg-subtle);
+  padding: 1px 6px;
+  border-radius: 999px;
 }
 
 /* Hide the default disclosure triangle — we draw our own caret below. */
@@ -471,23 +715,25 @@ body {
 
 .doc-sidebar-group > summary::after {
   content: "";
-  position: absolute;
-  right: 1rem;
-  top: 50%;
   width: 0.5rem;
   height: 0.5rem;
-  border-right: 1.5px solid currentColor;
-  border-bottom: 1.5px solid currentColor;
-  transform: translateY(-65%) rotate(-45deg);
+  border-right: 1.5px solid var(--bai-text-3);
+  border-bottom: 1.5px solid var(--bai-text-3);
+  transform: rotate(-45deg);
   transition: transform 120ms ease;
+  flex-shrink: 0;
+  margin-left: 4px;
+  margin-top: -2px;
 }
 
 .doc-sidebar-group[open] > summary::after {
-  transform: translateY(-30%) rotate(45deg);
+  transform: rotate(45deg);
+  margin-top: -4px;
 }
 
 .doc-sidebar-group > summary:hover {
-  color: var(--ifm-color-primary);
+  background: var(--bai-bg-subtle);
+  color: var(--bai-text-2);
 }
 
 .doc-sidebar-group[open] > summary {
@@ -497,7 +743,20 @@ body {
 .doc-sidebar-nav {
   list-style: none;
   padding: 0;
-  margin: 0 0 0.5rem 0;
+  margin: 2px 0 8px;
+  position: relative;
+}
+
+/* Connector line between category and items — same visual idiom as the
+   BAI sider in the main app. */
+.doc-sidebar-nav--grouped::before {
+  content: "";
+  position: absolute;
+  left: 19px;
+  top: 4px;
+  bottom: 4px;
+  width: 1px;
+  background: var(--bai-border-soft);
 }
 
 .doc-sidebar-nav > li {
@@ -505,38 +764,94 @@ body {
 }
 
 .doc-sidebar-nav > li > a {
-  display: block;
-  padding: 0.4rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--ifm-color-emphasis-800);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px 7px 28px;
+  border-radius: 6px;
+  color: var(--bai-text-2);
+  font-size: 13.5px;
+  font-weight: 400;
   text-decoration: none;
-  border-left: 3px solid transparent;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  position: relative;
+  margin: 1px 0;
+  transition: background 0.15s, color 0.15s;
 }
 
 .doc-sidebar-nav--grouped > li > a {
-  /* Slightly indented so items visually nest under the category header. */
-  padding-left: 1.5rem;
+  /* Reset: indentation + bullet are produced by ::before on the link. */
+  padding-left: 28px;
+}
+
+.doc-sidebar-nav > li > a::before {
+  content: "";
+  position: absolute;
+  left: 17px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--bai-border);
+  transition: background 0.15s, width 0.15s, height 0.15s;
 }
 
 .doc-sidebar-nav > li > a:hover {
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-primary);
+  background: var(--bai-bg-subtle);
+  color: var(--bai-text);
+  text-decoration: none;
+}
+
+.doc-sidebar-nav > li > a:hover::before {
+  background: var(--bai-text-3);
 }
 
 .doc-sidebar-nav > li > a.active {
-  border-left-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
-  background: rgba(53, 120, 229, 0.06);
+  background: var(--bai-primary-soft);
+  color: var(--bai-primary);
+  font-weight: 500;
+}
+
+.doc-sidebar-nav > li > a.active::before {
+  background: var(--bai-primary);
+  width: 6px;
+  height: 6px;
+}
+
+/* NEW badge (FR-2726). Rendered on the sidebar nav item to highlight
+   recently added pages. The data attribute trick lets consumers set
+   data-new="true" on a nav LI via book-config without changing HTML —
+   Phase 2 ships the styling; per-page tagging arrives later. */
+.doc-sidebar-nav .bai-badge {
+  margin-left: auto;
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-family: var(--bai-font-sans);
+}
+
+.doc-sidebar-nav .bai-badge--new {
+  background: rgba(0, 189, 155, 0.12);
+  color: var(--bai-success);
 }
 
 .doc-main {
   min-width: 0;
-  max-width: 960px;
+  max-width: var(--bai-content-max);
   width: 100%;
   margin: 0 auto;
-  padding: 2rem 2.5rem;
+  padding: 28px var(--bai-gutter) 80px;
+}
+
+@media (min-width: 1181px) {
+  /* When the right rail isn't shown we still cap the article width so
+     prose doesn't stretch. The grid keeps the column flexible; this
+     just bounds the inner content. */
+  .doc-main {
+    max-width: var(--bai-content-max);
+  }
 }
 
 /* ==========================================================================
@@ -1015,73 +1330,71 @@ details > :last-child {
 }
 
 /* ==========================================================================
-   Page Header Bar (website mode) — F1: language switcher slot.
-   F4 (Copy button toggle) and F6 (version selector) will hang off the same
-   <nav class="page-header-nav"> region.
+   In-page header bar (legacy F1 slot).
+   --------------------------------------------------------------------------
+   Phase 2 (FR-2726) moves the language switcher and version selector
+   into the new sticky topbar. We keep the .page-header-bar / .lang-switcher
+   classnames so older bundled HTML and external consumers still parse,
+   but visually fold the bar away when there's nothing to render.
    ========================================================================== */
 .page-header-bar {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  margin: 0 0 1.5rem 0;
-  padding-bottom: 0.75rem;
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  display: none;
 }
 
 .page-header-nav {
   display: flex;
-  gap: 0.5rem;
+  gap: 8px;
   align-items: center;
   flex-wrap: wrap;
 }
 
 .lang-switcher {
   display: inline-flex;
-  gap: 0.25rem;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 0.4rem;
-  padding: 0.15rem;
-  background: var(--ifm-color-emphasis-0);
+  gap: 2px;
+  border: 1px solid var(--bai-border);
+  border-radius: 6px;
+  padding: 2px;
+  background: var(--bai-bg);
 }
 
 .lang-switcher__item {
   display: inline-block;
-  padding: 0.25rem 0.6rem;
-  font-size: 0.8rem;
+  padding: 4px 9px;
+  font-size: 12px;
   line-height: 1.2;
-  border-radius: 0.25rem;
-  color: var(--ifm-color-emphasis-700);
+  border-radius: 4px;
+  color: var(--bai-text-2);
   text-decoration: none;
   transition: background-color 120ms ease, color 120ms ease;
 }
 
 .lang-switcher__item:hover,
 .lang-switcher__item:focus {
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-900);
+  background: var(--bai-bg-subtle);
+  color: var(--bai-text);
   text-decoration: none;
 }
 
 .lang-switcher__item--current {
-  background: var(--ifm-color-primary);
+  background: var(--bai-primary);
   color: #fff;
   cursor: default;
 }
 
 .lang-switcher__item--current:hover,
 .lang-switcher__item--current:focus {
-  background: var(--ifm-color-primary-dark);
+  background: var(--bai-primary-active);
   color: #fff;
 }
 
 .lang-switcher__item--unavailable {
-  color: var(--ifm-color-emphasis-500);
+  color: var(--bai-text-4);
 }
 
 .lang-switcher__item--unavailable:hover,
 .lang-switcher__item--unavailable:focus {
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-700);
+  background: var(--bai-bg-subtle);
+  color: var(--bai-text-3);
 }
 
 /* Pagination Navigation */
@@ -1133,9 +1446,9 @@ details > :last-child {
    semantic (an ol of li segments) and translates cleanly.
    ========================================================================== */
 .breadcrumb {
-  margin: 0 0 1rem 0;
-  font-size: 0.85rem;
-  color: var(--ifm-color-emphasis-700);
+  margin: 0 0 18px 0;
+  font-size: 12.5px;
+  color: var(--bai-text-3);
 }
 
 .breadcrumb__list {
@@ -1144,84 +1457,84 @@ details > :last-child {
   margin: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem 0.5rem;
+  gap: 6px 8px;
   align-items: center;
 }
 
 .breadcrumb__item {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   margin: 0;
 }
 
 .breadcrumb__item + .breadcrumb__item::before {
-  /* Note: NOT a > glyph (which would conflict with HTML escaping in some
-     reading-mode tools). U+203A SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-     reads naturally in all four supported languages. */
+  /* U+203A SINGLE RIGHT-POINTING ANGLE QUOTATION MARK — reads naturally
+     across all four supported languages. */
   content: "›";
-  color: var(--ifm-color-emphasis-500);
+  color: var(--bai-text-4);
 }
 
 .breadcrumb__link {
-  color: var(--ifm-color-primary);
+  color: var(--bai-text-3);
   text-decoration: none;
+  transition: color 0.12s;
 }
 
 .breadcrumb__link:hover {
-  text-decoration: underline;
+  color: var(--bai-primary);
+  text-decoration: none;
 }
 
 .breadcrumb__item--current {
-  color: var(--ifm-color-emphasis-900);
-  font-weight: 600;
+  color: var(--bai-text);
+  font-weight: 500;
 }
 
 .breadcrumb__item--category {
-  /* Category is non-navigable (no per-category landing page), so render as
-     plain text rather than implying it's a link. */
-  color: var(--ifm-color-emphasis-700);
+  color: var(--bai-text-3);
 }
 
 /* ==========================================================================
-   Right-rail "On this page" TOC (F3)
+   Right-rail "On this page" TOC (F3 + FR-2726 Phase 2)
    --------------------------------------------------------------------------
    Sticky aside in the third grid column on desktop. IntersectionObserver
    scroll-spy adds .is-active to the link whose section is in view.
    ========================================================================== */
 .doc-toc {
   position: sticky;
-  top: 0;
+  top: var(--bai-topbar-h);
   align-self: start;
-  height: 100vh;
+  height: calc(100vh - var(--bai-topbar-h));
   overflow-y: auto;
-  padding: 2rem 1rem 2rem 1.5rem;
-  font-size: 0.85rem;
-  border-left: 1px solid var(--ifm-color-emphasis-200);
+  padding: 28px 22px;
+  font-size: 13px;
+  background: var(--bai-bg);
+  border-left: 1px solid var(--bai-border);
 }
 
 .doc-toc[data-empty="true"] .doc-toc__heading,
 .doc-toc[data-empty="true"] .doc-toc__list {
-  /* Hide the heading when there is nothing to list. We still render the
-     aside element (preserves grid column width) so layout does not shift
-     between pages with and without TOC entries. */
+  /* Hide the heading and list when there is nothing to spy on, but
+     keep the aside in the grid (and the Get-help section visible) so
+     the rail still looks intentional. */
   display: none;
 }
 
 .doc-toc__heading {
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--ifm-color-emphasis-700);
-  margin-bottom: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--bai-text-3);
+  margin-bottom: 10px;
 }
 
 .doc-toc__list {
   list-style: none;
   padding: 0;
-  margin: 0;
-  border-left: 1px solid var(--ifm-color-emphasis-200);
+  margin: 0 0 24px;
+  border-left: 1px solid var(--bai-border-soft);
 }
 
 .doc-toc__item {
@@ -1229,68 +1542,138 @@ details > :last-child {
 }
 
 .doc-toc__item--h3 {
-  /* Sub-items rendered with extra left padding so the visual hierarchy
-     mirrors the heading levels they reference. */
-  padding-left: 0.75rem;
+  padding-left: 12px;
 }
 
 .doc-toc__link {
   display: block;
-  padding: 0.25rem 0.75rem;
+  padding: 4px 12px;
   margin-left: -1px;
   border-left: 2px solid transparent;
-  color: var(--ifm-color-emphasis-700);
+  color: var(--bai-text-3);
   text-decoration: none;
-  line-height: 1.35;
-  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+  line-height: 1.45;
+  transition: color 120ms ease, border-color 120ms ease;
 }
 
 .doc-toc__link:hover {
-  color: var(--ifm-color-primary);
+  color: var(--bai-text);
   text-decoration: none;
 }
 
 .doc-toc__link.is-active {
-  color: var(--ifm-color-primary);
-  border-left-color: var(--ifm-color-primary);
-  background: rgba(53, 120, 229, 0.06);
+  color: var(--bai-primary);
+  border-left-color: var(--bai-primary);
+  font-weight: 500;
+  background: transparent;
+}
+
+/* Get help — small link cluster below the scroll-spy list. Phase 2
+   surface; the list of links is built by the website builder from
+   editBaseUrl + repoUrl. Empty when neither is configured. */
+.doc-toc__divider {
+  height: 1px;
+  background: var(--bai-border-soft);
+  margin: 18px 0;
+}
+
+.doc-toc__contrib {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 22px;
+}
+
+.doc-toc__contrib .doc-toc__heading {
+  margin-bottom: 6px;
+}
+
+.doc-toc__link--external {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+  font-size: 12.5px;
+  color: var(--bai-text-2);
+  border-left: 0;
+  margin-left: 0;
+}
+
+.doc-toc__link--external > svg {
+  flex-shrink: 0;
+  color: var(--bai-text-3);
+  transition: color 0.12s;
+}
+
+.doc-toc__link--external:hover {
+  color: var(--bai-primary);
+}
+
+.doc-toc__link--external:hover > svg {
+  color: var(--bai-primary);
 }
 
 /* ==========================================================================
-   Responsive
+   Responsive — FR-2726 Phase 2 breakpoints
    --------------------------------------------------------------------------
-   Two breakpoints:
-     - 1100px: drop the right-rail TOC. Its content is still anchor-
-       reachable from inline headings; on a narrow viewport the prose
-       column needs the room more than the rail does. The rail HTML stays
-       in place (we don't move it inline; that would require JS) — it just
-       isn't displayed.
-     - 768px: collapse the sidebar to a top strip and let the page flow
-       in a single column.
+   - 1180px: drop the right-rail TOC. Article reclaims its width; TOC
+     headings remain anchor-reachable from the table of contents in the
+     page itself.
+   -  880px: hide the topbar search bar AND the sidebar; replace search
+     with the magnifier icon button. The icon click focuses #search-input
+     in Phase 2 (works because the input is still inside the search
+     container, just visually hidden until Phase 4 adds a real palette).
+
+   Phase 2 intentionally keeps the topbar search bar visible at 1024px
+   widths so users on tablet-class viewports (≤1180px) still have a
+   working inline search. Phase 4 introduces the Cmd-K palette and can
+   re-introduce a tighter breakpoint then.
    ========================================================================== */
-@media (max-width: 1100px) {
+@media (max-width: 1180px) {
   .doc-page {
-    grid-template-columns: var(--doc-sidebar-width) minmax(0, 1fr);
+    grid-template-columns: var(--bai-sider-w) minmax(0, 1fr);
   }
   .doc-toc {
     display: none;
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 880px) {
+  .bai-topbar .bai-topbar__search {
+    display: none;
+  }
+  .bai-topbar .bai-topbar__searchicon {
+    display: inline-flex;
+    margin-left: auto;
+  }
+  .bai-topbar__actions {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 880px) {
+  :root {
+    --bai-sider-w: 0px;
+  }
   .doc-page {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
   .doc-sidebar {
-    position: static;
-    width: 100%;
-    height: auto;
-    max-height: 40vh;
-    border-right: none;
-    border-bottom: 1px solid var(--ifm-color-emphasis-200);
+    display: none;
+  }
+  .bai-topbar__menu {
+    display: inline-flex;
+  }
+  .bai-topbar__brand {
+    gap: 8px;
+  }
+  .bai-brand-divider,
+  .bai-brand-sub,
+  .bai-brand-version {
+    display: none;
   }
   .doc-main {
-    padding: 1.5rem;
+    padding: 24px 16px 60px;
   }
   .pagination-nav {
     flex-direction: column;
@@ -1302,9 +1685,6 @@ details > :last-child {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
-  }
-  .breadcrumb {
-    font-size: 0.8rem;
   }
 }
 `;

--- a/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for website-builder.ts (FR-2726).
+ *
+ * Run: pnpm --filter backend.ai-docs-toolkit test
+ *      (which executes `tsx --test src/website-builder.test.ts`)
+ *
+ * Coverage:
+ *   - applyImageAttributes: lazy/decoding/dimensions injection.
+ *   - buildWebPage: presence of FR-2726 surfaces (topbar, brand, search
+ *     trigger, lang switcher, get-help links, palette, article footer)
+ *     so future phases can't silently drop them.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "path";
+import {
+  applyImageAttributes,
+  buildWebPage,
+  type WebPageContext,
+  type PageAssets,
+} from "./website-builder.js";
+import type { ResolvedDocConfig } from "./config.js";
+import type { Chapter } from "./markdown-processor.js";
+import type { NavGroup } from "./book-config.js";
+
+function makeConfig(): ResolvedDocConfig {
+  const projectRoot = path.resolve("/tmp/fake-project-root");
+  return {
+    title: "Backend.AI WebUI User Guide",
+    subtitle: "User Guide",
+    company: "Lablup Inc.",
+    logoPath: null,
+    logoFallbackHtml: "",
+    projectRoot,
+    srcDir: path.join(projectRoot, "src"),
+    distDir: path.join(projectRoot, "dist"),
+    versionSource: "",
+    version: null,
+    languageLabels: {
+      en: "English",
+      ko: "한국어",
+      ja: "日本語",
+      th: "ภาษาไทย",
+    },
+    localizedStrings: {
+      en: { userGuide: "User Guide", tableOfContents: "TOC" },
+    },
+    admonitionTitles: { en: { note: "NOTE" } },
+    figureLabels: { en: "Figure" },
+    pdfFilenameTemplate: "{title}.pdf",
+    pdfMetadata: { author: "a", subject: "b", creator: "c" },
+    cjkFontPaths: [],
+    pathFallbacks: {},
+    productName: "Backend.AI WebUI Docs",
+    code: { lightTheme: "github-light" },
+    branding: {
+      primaryColor: "#FF7A00",
+      primaryColorHover: "#FF9729",
+      primaryColorActive: "#E65C00",
+      primaryColorSoft: "#FFF4E5",
+      logoLight: null,
+      logoDark: null,
+      subLabel: { en: "Manual", default: "Manual" },
+    },
+    website: {
+      editBaseUrl: "https://github.com/owner/repo/edit/main/docs",
+      repoUrl: "https://github.com/owner/repo",
+    },
+  } satisfies ResolvedDocConfig;
+}
+
+function makeChapter(slug = "dashboard", title = "Dashboard"): Chapter {
+  return {
+    slug,
+    title,
+    htmlContent: `<h1 id="dashboard-${slug}">${title}</h1><p>Lede paragraph.</p>`,
+    headings: [
+      { level: 1, text: title, id: `${slug}-${slug}` },
+      { level: 2, text: "Auto-Refresh", id: `${slug}-auto-refresh` },
+    ],
+  } as unknown as Chapter;
+}
+
+function makeContext(): WebPageContext {
+  const chapter = makeChapter();
+  const navGroups: NavGroup[] = [
+    {
+      category: "Getting Started",
+      items: [
+        {
+          title: "Dashboard",
+          path: "dashboard/dashboard.md",
+        },
+      ],
+    },
+  ];
+  const assets: PageAssets = {
+    styles: "styles.abcd.css",
+    search: "search.abcd.js",
+    favicon: "favicon.ico",
+    brandLogoLight: "brand-logo-light.abcd.svg",
+    brandLogoDark: "brand-logo-dark.abcd.svg",
+  };
+  return {
+    chapter,
+    allChapters: [chapter],
+    currentIndex: 0,
+    metadata: {
+      title: "Backend.AI WebUI User Guide",
+      version: "v26.5.0",
+      lang: "en",
+      availableLanguages: ["en", "ko", "ja", "th"],
+    },
+    config: makeConfig(),
+    navPath: "dashboard/dashboard.md",
+    assets,
+    peers: [
+      { lang: "en", label: "English", href: "../en/dashboard.html", available: true },
+      { lang: "ko", label: "한국어", href: "../ko/dashboard.html", available: true },
+    ],
+    navGroups,
+    category: "Getting Started",
+  };
+}
+
+describe("applyImageAttributes", () => {
+  it("injects loading=lazy and decoding=async on bare <img> tags", () => {
+    const html = `<img src="./images/foo.png" alt="" />`;
+    const out = applyImageAttributes(html, new Map());
+    assert.match(out, /loading="lazy"/);
+    assert.match(out, /decoding="async"/);
+  });
+
+  it("preserves existing loading/decoding attributes", () => {
+    const html = `<img src="./images/foo.png" alt="" loading="eager" decoding="sync" />`;
+    const out = applyImageAttributes(html, new Map());
+    assert.match(out, /loading="eager"/);
+    assert.match(out, /decoding="sync"/);
+    assert.doesNotMatch(out, /loading="lazy"/);
+  });
+
+  it("attaches width/height from the dimensions map when missing", () => {
+    const html = `<img src="./images/foo.png" alt="" />`;
+    const dims = new Map([["./images/foo.png", { width: 800, height: 600 }]]);
+    const out = applyImageAttributes(html, dims);
+    assert.match(out, /width="800"/);
+    assert.match(out, /height="600"/);
+  });
+});
+
+describe("buildWebPage — FR-2726 surfaces", () => {
+  it("emits the BAI topbar with brand, sub-label, version pill", () => {
+    const html = buildWebPage(makeContext());
+    assert.match(html, /<header class="bai-topbar"/);
+    assert.match(html, /class="bai-topbar__brand"/);
+    assert.match(html, />Manual</); // sub-label
+    assert.match(html, />v26\.5\.0</); // version pill
+  });
+
+  it("emits brand logo light/dark sources", () => {
+    const html = buildWebPage(makeContext());
+    assert.match(html, /brand-logo-light\.abcd\.svg/);
+    assert.match(html, /brand-logo-dark\.abcd\.svg/);
+  });
+
+  it("emits the search input + magnifier-icon fallback in the topbar", () => {
+    const html = buildWebPage(makeContext());
+    assert.match(html, /class="bai-topbar__search"/);
+    assert.match(html, /id="search-input"/);
+    assert.match(html, /class="bai-iconbtn bai-topbar__searchicon"/);
+  });
+
+  it("emits the language switcher with all configured peers", () => {
+    const html = buildWebPage(makeContext());
+    assert.match(html, /class="lang-switcher"/);
+    assert.match(html, />English</);
+    assert.match(html, />한국어</);
+  });
+
+  it("emits the GitHub icon link only when website.repoUrl is set", () => {
+    const html = buildWebPage(makeContext());
+    assert.match(html, /aria-label="GitHub"/);
+    assert.match(html, /https:\/\/github\.com\/owner\/repo/);
+
+    // And NOT when repoUrl is unset.
+    const ctx = makeContext();
+    ctx.config = {
+      ...ctx.config,
+      website: { editBaseUrl: ctx.config.website?.editBaseUrl },
+    };
+    const html2 = buildWebPage(ctx);
+    assert.doesNotMatch(html2, /aria-label="GitHub"/);
+  });
+
+  it("emits the right-rail Get help cluster with edit + GitHub links", () => {
+    const html = buildWebPage(makeContext());
+    assert.match(html, /class="doc-toc__contrib"/);
+    assert.match(html, /class="doc-toc__link doc-toc__link--external"[^>]*href="[^"]*\/edit\/main\/docs\/en\/dashboard\/dashboard\.md/);
+    assert.match(html, /class="doc-toc__link doc-toc__link--external"[^>]*href="https:\/\/github\.com\/owner\/repo"/);
+  });
+
+  it("emits sider category groups with item count pills", () => {
+    const html = buildWebPage(makeContext());
+    assert.match(html, /class="doc-sidebar-group__count"/);
+    assert.match(html, /aria-label="1 pages">1</);
+  });
+});

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -214,6 +214,19 @@ export interface PageAssets {
   appleTouchIcon?: string;
   /** Site-root web app manifest filename, e.g. `site.webmanifest`. */
   webmanifest?: string;
+  /**
+   * Hashed light-theme brand logo filename (FR-2726 Phase 2). Optional —
+   * present only when the consumer configured `branding.logoLight` in
+   * `docs-toolkit.config.yaml`. Topbar omits the `<img>` and renders a
+   * text fallback when both light and dark are absent.
+   */
+  brandLogoLight?: string;
+  /**
+   * Hashed dark-theme brand logo filename (FR-2726 Phase 2). Optional —
+   * falls back to `brandLogoLight` when only light is configured. The
+   * topbar uses `<picture>` + `prefers-color-scheme: dark` to swap.
+   */
+  brandLogoDark?: string;
 }
 
 /**
@@ -281,8 +294,16 @@ function buildWebsiteSidebar(
     );
     const openAttr = containsActive ? " open" : "";
     const groupSlug = slugify(group.category) || "group";
+    // Phase 2 (FR-2726): each summary now carries a leading icon + a
+    // trailing count pill matching the BAI sider pattern.
+    const iconSvg = sidebarCategoryIconSvg(group.category);
+    const itemCount = group.items.length;
     return `<details class="doc-sidebar-group"${openAttr}>
-  <summary class="doc-sidebar-group__summary">${escapeHtml(group.category)}</summary>
+  <summary class="doc-sidebar-group__summary">
+    <span class="doc-sidebar-group__icon" aria-hidden="true">${iconSvg}</span>
+    <span class="doc-sidebar-group__label">${escapeHtml(group.category)}</span>
+    <span class="doc-sidebar-group__count" aria-label="${itemCount} pages">${itemCount}</span>
+  </summary>
   <ul class="doc-sidebar-nav doc-sidebar-nav--grouped" data-group="${escapeHtml(groupSlug)}">
     ${itemsHtml}
   </ul>
@@ -294,25 +315,53 @@ function buildWebsiteSidebar(
     .map((g) => renderGroup(g, isLegacyFlat))
     .join("\n");
 
-  const searchLabels = WEBSITE_LABELS[metadata.lang] ?? WEBSITE_LABELS.en;
-  const placeholderAttr = escapeHtml(searchLabels.searchPlaceholder);
-  const noResultsAttr = escapeHtml(searchLabels.noResults);
+  // Phase 2 (FR-2726): the brand block, version pill, and search input now
+  // live in the topbar. The legacy sidebar header / search input are
+  // intentionally omitted from the new output — keeping the language label
+  // unused here is fine; \`langLabel\` is referenced earlier in this file
+  // for the legacy code path.
+  void langLabel;
 
   return `
 <aside class="doc-sidebar">
-  <div class="doc-sidebar-header">
-    <h2>${escapeHtml(metadata.title)}</h2>
-    <div class="doc-meta">${escapeHtml(metadata.version)} &middot; ${escapeHtml(langLabel)}</div>
-  </div>
-  <div class="doc-search">
-    <input type="text" id="search-input" placeholder="${placeholderAttr}" data-no-results="${noResultsAttr}" autocomplete="off" />
-    <div id="search-results" class="search-results" hidden></div>
-  </div>
   <nav class="doc-sidebar-groups" aria-label="Documentation navigation">
     ${groupsHtml}
   </nav>
 </aside>`;
 }
+
+/**
+ * Inline SVG icon for a sidebar category header (FR-2726 Phase 2).
+ *
+ * The mapping matches a small whitelist of canonical English category
+ * labels (case-insensitive). Categories that don't match — including
+ * every non-English label in localized navs — fall through to a generic
+ * "stack of pages" icon so every category still gets a visual anchor.
+ * Phase 3+ may extend this with a config knob in `book.config.yaml`,
+ * letting consumers map any category label to any icon name.
+ */
+function sidebarCategoryIconSvg(category: string): string {
+  const key = category.trim().toLowerCase();
+  // Common Backend.AI WebUI categories. Other consumers fall through to
+  // the default icon, which is intentional — Phase 3 will add per-category
+  // icon configuration to book.config.yaml.
+  const map: Record<string, string> = {
+    "getting started": ICON_ROCKET,
+    workloads: ICON_BOX,
+    "storage & data": ICON_FOLDER,
+    "storage and data": ICON_FOLDER,
+    administration: ICON_SETTINGS,
+    reference: ICON_BOOK,
+  };
+  return map[key] ?? ICON_STACK;
+}
+
+const ICON_ROCKET = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M14.5 4c4 1 5.5 4.5 5.5 5.5 0 0-3.5 1.5-5.5 5.5h-5C7.5 11 4 9.5 4 9.5S5.5 5 9.5 4h5Zm-2.5 5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM7 17l-2 3 3-2m8-1 2 3-3-2"/></svg>`;
+const ICON_BOX = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" d="m12 3 9 5v8l-9 5-9-5V8l9-5Z"/><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" d="m3 8 9 5 9-5M12 13v8"/></svg>`;
+const ICON_FOLDER = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z"/></svg>`;
+const ICON_SETTINGS = `<svg width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.6"/><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg>`;
+const ICON_BOOK = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14ZM4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>`;
+const ICON_STACK = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" d="m12 3 9 5-9 5-9-5 9-5Z"/><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" d="m3 13 9 5 9-5"/></svg>`;
 
 /**
  * Build the breadcrumb trail (F3): `Home › Category › Page Title`. When the
@@ -361,30 +410,106 @@ function buildBreadcrumb(
  * view. When there are no H2 headings, the rail renders empty so the
  * layout grid column doesn't shift between pages.
  */
-function buildRightRailToc(chapter: Chapter, lang: string): string {
+function buildRightRailToc(
+  chapter: Chapter,
+  lang: string,
+  config: ResolvedDocConfig,
+  navPath: string | undefined,
+): string {
   const labels = WEBSITE_LABELS[lang] ?? WEBSITE_LABELS.en;
   const heading = labels.onThisPage ?? "On this page";
   const items = chapter.headings.filter((h) => h.level === 2 || h.level === 3);
-  if (items.length === 0) {
-    // Render the aside container even when empty so the grid column has a
-    // stable layout; CSS hides the heading when the list is empty.
-    return `<aside class="doc-toc" aria-labelledby="doc-toc-heading" data-empty="true">
+
+  // Get-help section (FR-2726 Phase 2): edit-this-page + view-on-github.
+  // Rendered below the scroll-spy list. Only emitted when at least one
+  // link can be built, so the rail doesn't show an empty heading.
+  const contribHtml = buildTocGetHelp(config, navPath, lang);
+
+  const isEmpty = items.length === 0;
+  const tocList = isEmpty
+    ? `<ul class="doc-toc__list"></ul>`
+    : `<ul class="doc-toc__list">
+      ${items
+        .map(
+          (h) =>
+            `<li class="doc-toc__item doc-toc__item--h${h.level}"><a class="doc-toc__link" href="#${encodeURIComponent(h.id)}" data-toc-target="${escapeHtml(h.id)}">${escapeHtml(h.text)}</a></li>`,
+        )
+        .join("\n      ")}
+  </ul>`;
+
+  const dataEmpty = isEmpty ? ' data-empty="true"' : "";
+  // The divider only appears when both sections are present, so the rail
+  // doesn't show a stray separator on TOC-less or help-less pages.
+  const divider = !isEmpty && contribHtml ? `<div class="doc-toc__divider"></div>` : "";
+
+  return `<aside class="doc-toc" aria-labelledby="doc-toc-heading"${dataEmpty}>
   <div class="doc-toc__heading" id="doc-toc-heading">${escapeHtml(heading)}</div>
-  <ul class="doc-toc__list"></ul>
+  ${tocList}
+  ${divider}
+  ${contribHtml}
 </aside>`;
+}
+
+/**
+ * Build the "Get help" link cluster shown below the scroll-spy list in
+ * the right rail (FR-2726 Phase 2). Pulls "Edit this page" from
+ * `editBaseUrl + lang/navPath` and "View on GitHub" from `repoUrl`.
+ * Returns an empty string when neither can be built.
+ */
+function buildTocGetHelp(
+  config: ResolvedDocConfig,
+  navPath: string | undefined,
+  lang: string,
+): string {
+  const labels = WEBSITE_LABELS[lang] ?? WEBSITE_LABELS.en;
+  const links: string[] = [];
+
+  const editBaseUrl = config.website?.editBaseUrl;
+  if (editBaseUrl && navPath) {
+    const editUrl = `${editBaseUrl}/${lang}/${navPath}`;
+    const editIcon = `<svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M12 20h9M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5Z"/></svg>`;
+    links.push(
+      `<a class="doc-toc__link doc-toc__link--external" href="${escapeHtml(editUrl)}" target="_blank" rel="noopener noreferrer">${editIcon}${escapeHtml(labels.editThisPage)}</a>`,
+    );
   }
-  const listItems = items
-    .map(
-      (h) =>
-        `<li class="doc-toc__item doc-toc__item--h${h.level}"><a class="doc-toc__link" href="#${encodeURIComponent(h.id)}" data-toc-target="${escapeHtml(h.id)}">${escapeHtml(h.text)}</a></li>`,
-    )
-    .join("\n      ");
-  return `<aside class="doc-toc" aria-labelledby="doc-toc-heading">
-  <div class="doc-toc__heading" id="doc-toc-heading">${escapeHtml(heading)}</div>
-  <ul class="doc-toc__list">
-      ${listItems}
-  </ul>
-</aside>`;
+
+  const repoUrl = config.website?.repoUrl;
+  if (repoUrl) {
+    const githubIcon = `<svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.27-.01-1.16-.02-2.1-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.7 1.25 3.36.96.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.16 1.18a10.95 10.95 0 0 1 5.76 0c2.2-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.41-5.27 5.69.41.36.78 1.06.78 2.13 0 1.54-.01 2.78-.01 3.16 0 .31.21.67.8.56C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>`;
+    // The link text is intentionally the literal product name "GitHub"
+    // rather than a translatable label — "GitHub" is a proper noun
+    // recognized in every supported language. If a translatable
+    // alternative becomes desired (e.g. "View on GitHub"), introduce a
+    // dedicated WEBSITE_LABELS key for it; do NOT reuse `editThisPage`.
+    links.push(
+      `<a class="doc-toc__link doc-toc__link--external" href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener noreferrer">${githubIcon}GitHub</a>`,
+    );
+  }
+
+  if (links.length === 0) return "";
+
+  // The heading reuses the "On this page" typographic style but with a
+  // dedicated id-less heading element so it doesn't conflict with the
+  // scroll-spy aria-label.
+  return `<div class="doc-toc__contrib">
+    <div class="doc-toc__heading">${escapeHtml(getHelpLabel(lang))}</div>
+    ${links.join("\n    ")}
+  </div>`;
+}
+
+/**
+ * Localized "Get help" heading. Uses a small built-in map; falls back
+ * to English. Phase 2 doesn't add this to WEBSITE_LABELS to keep the
+ * existing label bucket additive — Phase 3 may consolidate.
+ */
+function getHelpLabel(lang: string): string {
+  const map: Record<string, string> = {
+    en: "Get help",
+    ko: "도움 받기",
+    ja: "ヘルプ",
+    th: "ขอความช่วยเหลือ",
+  };
+  return map[lang] ?? map.en;
 }
 
 /**
@@ -895,6 +1020,140 @@ export function applyImageAttributes(
 }
 
 /**
+ * Build the BAI topbar (FR-2726 Phase 2).
+ *
+ * The topbar is a sticky 56px strip above the page grid. It carries the
+ * brand block (logo + sub-label + version pill), an inline search input
+ * (which the existing search.js script binds to via #search-input), and
+ * an actions cluster on the right (lang switcher, version selector,
+ * GitHub icon).
+ *
+ * The lang switcher and version selector were previously rendered inside
+ * the in-page `.page-header-bar`. Phase 2 relocates them into the topbar
+ * so site-level controls live above the page chrome and the article
+ * column starts cleanly with breadcrumbs + content.
+ *
+ * Layout:
+ *   [menu] [brand|sub|version]   [search ............]   [lang][version][github]
+ *
+ * The mobile menu icon and the search-as-icon button are hidden on
+ * desktop and revealed at narrow viewports via the responsive CSS.
+ */
+function buildBaiTopbar(
+  context: WebPageContext,
+  peers: LanguagePeer[],
+  prefix: string,
+): string {
+  const { metadata, config, assets } = context;
+  const labels = WEBSITE_LABELS[metadata.lang] ?? WEBSITE_LABELS.en;
+
+  // Brand block: <picture> + <img> when logos are configured, otherwise
+  // a text fallback so the topbar still has a recognizable anchor.
+  const lightSrc = assets.brandLogoLight
+    ? `${prefix}assets/${escapeHtml(assets.brandLogoLight)}`
+    : "";
+  const darkSrc = assets.brandLogoDark
+    ? `${prefix}assets/${escapeHtml(assets.brandLogoDark)}`
+    : lightSrc;
+
+  let brandLogoHtml: string;
+  if (lightSrc) {
+    const altText = escapeHtml(metadata.title);
+    if (darkSrc && darkSrc !== lightSrc) {
+      brandLogoHtml = `<picture>
+        <source srcset="${darkSrc}" media="(prefers-color-scheme: dark)" />
+        <img class="bai-brand-logo" src="${lightSrc}" alt="${altText}" />
+      </picture>`;
+    } else {
+      brandLogoHtml = `<img class="bai-brand-logo" src="${lightSrc}" alt="${altText}" />`;
+    }
+  } else {
+    brandLogoHtml = `<span class="bai-brand-fallback">${escapeHtml(metadata.title)}</span>`;
+  }
+
+  // Sub-label: per-language map → fallback to `default` → fallback to "".
+  const subLabelMap = config.branding.subLabel;
+  const subLabel =
+    subLabelMap[metadata.lang] ?? subLabelMap.default ?? "";
+
+  const subLabelHtml = subLabel
+    ? `<span class="bai-brand-divider" aria-hidden="true"></span><span class="bai-brand-sub">${escapeHtml(subLabel)}</span>`
+    : "";
+
+  const versionPillHtml = `<span class="bai-brand-version">${escapeHtml(metadata.version)}</span>`;
+
+  // Search input (existing search.js binds via #search-input). Placeholder
+  // and noResults message localized via WEBSITE_LABELS.
+  const placeholderAttr = escapeHtml(labels.searchPlaceholder);
+  const noResultsAttr = escapeHtml(labels.noResults);
+  const searchIconSvg = `<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="m21 21-5.5-5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>`;
+  const searchIconLargeSvg = `<svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="m21 21-5.5-5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>`;
+
+  const searchHtml = `<div class="bai-topbar__search" role="search">
+    ${searchIconSvg}
+    <input type="text" id="search-input" placeholder="${placeholderAttr}" data-no-results="${noResultsAttr}" autocomplete="off" />
+    <span class="bai-kbd-group" aria-hidden="true"><kbd>⌘</kbd><kbd>K</kbd></span>
+    <div id="search-results" class="search-results" hidden></div>
+  </div>
+  <button class="bai-iconbtn bai-topbar__searchicon" type="button" aria-label="${placeholderAttr}" onclick="document.getElementById('search-input').focus()">${searchIconLargeSvg}</button>`;
+
+  // Lang switcher: extracted from the legacy buildPageHeader. Same HTML
+  // shape so the existing CSS rules apply.
+  const langItems = peers
+    .map((peer) => {
+      const isCurrent = peer.lang === metadata.lang;
+      const ariaCurrent = isCurrent ? ' aria-current="true"' : "";
+      const classes = [
+        "lang-switcher__item",
+        isCurrent ? "lang-switcher__item--current" : "",
+        peer.available
+          ? "lang-switcher__item--available"
+          : "lang-switcher__item--unavailable",
+      ]
+        .filter(Boolean)
+        .join(" ");
+      const titleAttr = peer.available
+        ? ""
+        : ' title="This page is not available in this language; goes to that language\'s index instead."';
+      return `<a class="${classes}" href="${escapeHtml(peer.href)}" hreflang="${escapeHtml(peer.lang)}" lang="${escapeHtml(peer.lang)}"${ariaCurrent}${titleAttr}>${escapeHtml(peer.label)}</a>`;
+    })
+    .join("");
+  const langSwitcherHtml = `<div class="lang-switcher" role="group" aria-label="Language switcher">
+    ${langItems}
+  </div>`;
+
+  // Version selector (only in versioned mode).
+  const versionSwitcherHtml = buildVersionSwitcher(context);
+
+  // GitHub link — derived from website.repoUrl. When unset, the icon is
+  // omitted so we don't ship a dead link.
+  const repoUrl = config.website?.repoUrl;
+  const githubIconSvg = `<svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.27-.01-1.16-.02-2.1-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.7 1.25 3.36.96.1-.74.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.16 1.18a10.95 10.95 0 0 1 5.76 0c2.2-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.41-5.27 5.69.41.36.78 1.06.78 2.13 0 1.54-.01 2.78-.01 3.16 0 .31.21.67.8.56C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>`;
+  const githubLinkHtml = repoUrl
+    ? `<a class="bai-iconbtn" href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener noreferrer" aria-label="GitHub">${githubIconSvg}</a>`
+    : "";
+
+  // Mobile menu icon (Phase 2 emits the surface; Phase 4 wires the
+  // drawer toggle).
+  const menuIconSvg = `<svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>`;
+
+  return `<header class="bai-topbar" role="banner">
+  <button class="bai-iconbtn bai-topbar__menu" type="button" aria-label="Toggle navigation">${menuIconSvg}</button>
+  <a class="bai-topbar__brand" href="./index.html">
+    ${brandLogoHtml}
+    ${subLabelHtml}
+    ${versionPillHtml}
+  </a>
+  ${searchHtml}
+  <div class="bai-topbar__actions">
+    ${versionSwitcherHtml}
+    ${langSwitcherHtml}
+    ${githubLinkHtml}
+  </div>
+</header>`;
+}
+
+/**
  * Build the in-page header bar. Currently hosts the language switcher (F1).
  * F4 (code-block copy) and F6 (version selector) will add additional
  * controls into the same `<header class="page-header-bar">`; the
@@ -905,6 +1164,11 @@ export function applyImageAttributes(
  * spec calls for a breadcrumb "above the chapter content", and keeping
  * the header reserved for site-level controls (lang switcher, future
  * version selector) avoids a tight coupling with F6's incoming UI.
+ *
+ * FR-2726 Phase 2 supersedes this for the website build — the language
+ * switcher is now rendered inside the BAI topbar by `buildBaiTopbar`.
+ * `buildPageHeader` is kept for any external consumer still building
+ * pages from individual helpers.
  */
 function buildPageHeader(
   metadata: WebsiteMetadata,
@@ -964,10 +1228,19 @@ export function buildWebPage(context: WebPageContext): string {
     config,
     navGroups,
   );
-  const pageHeader = buildPageHeader(metadata, peers);
+  // Phase 2 (FR-2726): the topbar replaces the legacy in-page header
+  // (lang switcher) and version-selector header. We omit pageHeader /
+  // headerBar from the body output below; they're folded into the topbar.
+  const topbar = buildBaiTopbar(context, peers, prefix);
+  void buildPageHeader;
   const breadcrumb = buildBreadcrumb(chapter, category, metadata.lang);
   const innerContent = buildPageContent(chapter);
-  const rightRailToc = buildRightRailToc(chapter, metadata.lang);
+  const rightRailToc = buildRightRailToc(
+    chapter,
+    metadata.lang,
+    config,
+    context.navPath,
+  );
   const metadataBar = buildPageMetadata(context);
   const pagination = buildPaginationNav(
     allChapters,
@@ -987,7 +1260,9 @@ export function buildWebPage(context: WebPageContext): string {
     context.seo,
     context.peers,
   );
-  const headerBar = buildPageHeaderBar(context);
+  // Phase 2 (FR-2726): the version-switcher header bar is folded into
+  // the BAI topbar — `buildPageHeaderBar` is intentionally not invoked.
+  void buildPageHeaderBar;
   const versionBanner = buildVersionBanner(context);
   const versionNotice = buildVersionNotice(context);
   const searchScript = buildSearchScriptTag(assets, prefix);
@@ -1011,13 +1286,12 @@ export function buildWebPage(context: WebPageContext): string {
   ${headTags}
 </head>
 <body ${copyDataAttrs}>
-${headerBar}
+${topbar}
 ${versionBanner}
 <div class="doc-page">
   ${sidebar}
   <main class="doc-main">
     ${versionNotice}
-    ${pageHeader}
     ${breadcrumb}
     ${innerContent}
     <div class="page-footer">

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -406,6 +406,58 @@ export async function generateWebsite(
   // like `/favicon.ico` work for any deployment layout.
   const rootAssets = writeRootBrandAssets(distBase, title, productName);
 
+  // Topbar brand logos (FR-2726 Phase 2). Copied into `assets/` with a
+  // content hash so the topbar can reference them via relative URLs that
+  // survive deploys to any subpath. Both light and dark are optional;
+  // when unconfigured, the topbar renders a text fallback.
+  let brandLogoLight: string | undefined;
+  let brandLogoDark: string | undefined;
+  if (config.branding.logoLight && fs.existsSync(config.branding.logoLight)) {
+    const ext = path.extname(config.branding.logoLight) || ".svg";
+    const bytes = fs.readFileSync(config.branding.logoLight);
+    brandLogoLight = writeHashedAsset(
+      assetsDir,
+      `brand-logo-light${ext}`,
+      bytes,
+      assetManifest,
+    );
+    console.log(`Written: assets/${brandLogoLight}`);
+  } else if (config.branding.logoLight) {
+    console.warn(
+      `[branding] logoLight not found at ${config.branding.logoLight}; topbar will use text fallback.`,
+    );
+  }
+  if (
+    config.branding.logoDark &&
+    config.branding.logoDark !== config.branding.logoLight &&
+    fs.existsSync(config.branding.logoDark)
+  ) {
+    const ext = path.extname(config.branding.logoDark) || ".svg";
+    const bytes = fs.readFileSync(config.branding.logoDark);
+    brandLogoDark = writeHashedAsset(
+      assetsDir,
+      `brand-logo-dark${ext}`,
+      bytes,
+      assetManifest,
+    );
+    console.log(`Written: assets/${brandLogoDark}`);
+  } else if (
+    config.branding.logoDark &&
+    config.branding.logoDark === config.branding.logoLight
+  ) {
+    // Same file — re-use the light variant's hashed name.
+    brandLogoDark = brandLogoLight;
+  } else if (
+    config.branding.logoDark &&
+    config.branding.logoDark !== config.branding.logoLight
+  ) {
+    // Symmetric warning to the logoLight branch above so a missing
+    // dark-mode logo is just as easy to spot as a missing light one.
+    console.warn(
+      `[branding] logoDark not found at ${config.branding.logoDark}; topbar will fall back to the light logo in dark mode.`,
+    );
+  }
+
   // Aggregate counters used for the post-build summary / strict gate.
   const allDiagnostics: LinkDiagnostic[] = [];
   const imageStats = { total: 0, withDims: 0 };
@@ -433,6 +485,8 @@ export async function generateWebsite(
     favicon: rootAssets.favicon,
     appleTouchIcon: rootAssets.appleTouchIcon,
     webmanifest: rootAssets.webmanifest,
+    brandLogoLight,
+    brandLogoDark,
   };
 
   // ── F2: Default OG image rendering ────────────────────────────


### PR DESCRIPTION
Resolves #7030 (FR-2726)

Stacks on #7032.

## Summary

Phase 2 of the production-quality redesign of the `build:web` docs site (FR-2726).

Introduces the new BAI layout chrome:

- **Topbar** (sticky, 56px): brand logo + sub-label + version pill + inline search input + language switcher + GitHub icon.
- **Sider** (280px, white): 5 category groups with inline SVG icons + count pills + collapsible sections + active-state highlight (orange soft fill).
- **Right-rail TOC** (240px): scroll-spy heading list + new "Get help" cluster (Edit this page / GitHub) below.
- **Responsive breakpoints**: 1180px hides TOC; 880px hides sider AND topbar search bar (search icon takes over). Phase 4 introduces the Cmd-K palette and may tighten further.
- Brand logos copied into `assets/` with content hashes; rendered via `<picture>` with `prefers-color-scheme: dark` so the dark variant kicks in automatically (Phase 4 rewires this to track `data-theme`).

The lang switcher and version selector were previously rendered inside the in-page `.page-header-bar`; they're folded into the topbar so the article column starts cleanly with breadcrumbs + content.

## What's in this PR

- `buildBaiTopbar()` helper + brand asset copy in `website-generator.ts`.
- Sidebar category icons (`Getting Started → rocket`, `Workloads → box`, …) + count pills.
- Right-rail TOC `Get help` section with localized heading per language.
- Symmetric `console.warn` for missing `logoDark` configuration.
- `website-builder.test.ts` asserting the FR-2726 surfaces (topbar, brand, search trigger, lang switcher, get-help, article footer, palette markers, sider count pills).

## Verification

- `pnpm --filter backend.ai-docs-toolkit build` — clean
- `pnpm --filter backend.ai-docs-toolkit test` — passes (incl. new website-builder tests)
- Playwright spot-check: topbar 56px sticky, sider 280px, TOC 240px, 1180/880 breakpoints work, sub-label correct in 4 langs (`Manual` / `매뉴얼` / `マニュアル` / `คู่มือ`).