### PR TITLE
feat(FR-2726): Phase 4 — dark-mode toggle, mobile drawer, search palette

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -358,6 +358,14 @@ body {
   display: block;
 }
 
+/* Brand logo swap (FR-2726 Phase 4). Both light and dark variants are
+   in the DOM; CSS hides whichever doesn't match the active data-theme.
+   :root:not([data-theme="dark"]) covers both the unset case (light is
+   default) and the explicit data-theme="light" case. */
+:root:not([data-theme="dark"]) .bai-brand-logo--dark { display: none; }
+[data-theme="dark"] .bai-brand-logo--light { display: none; }
+[data-theme="dark"] .bai-brand-logo--dark { display: block; }
+
 .bai-brand-fallback {
   font-family: var(--bai-font-heading);
   font-weight: 600;
@@ -493,6 +501,226 @@ body {
   background: var(--bai-bg-subtle);
   color: var(--bai-text);
   text-decoration: none;
+}
+
+/* Topbar search trigger label (Phase 4) — replaces the inline input.
+   Visually mimics the input field so the bar still reads as a search
+   surface, but the click opens the palette overlay. */
+.bai-topbar__search-label {
+  flex: 1;
+  text-align: left;
+  color: var(--bai-text-3);
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Theme toggle (Phase 4). Shows the destination icon — the moon when
+   light mode is active, the sun when dark mode is active. */
+.bai-theme-icon {
+  display: none;
+}
+:root:not([data-theme="dark"]) .bai-theme-icon--dark {
+  display: inline;
+}
+[data-theme="dark"] .bai-theme-icon--light {
+  display: inline;
+}
+
+/* Search palette (Phase 4 — FR-2726). The palette is a body-class-
+   controlled modal: when body has bai-palette-open, the .bai-palette
+   element is shown; otherwise it stays hidden. The scrim covers the
+   full viewport; the panel is centered horizontally with a fixed top
+   offset (~14vh) so the field lands near the user's gaze. Inside the
+   panel, #search-input is restyled to match the palette look-and-feel;
+   #search-results renders the existing search.js dropdown, repositioned
+   to flow inside the panel instead of floating absolutely. */
+.bai-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 14vh;
+  pointer-events: none;
+}
+
+.bai-palette[hidden] {
+  display: none;
+}
+
+body.bai-palette-open .bai-palette {
+  pointer-events: auto;
+}
+
+.bai-palette__scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(20, 20, 20, 0.45);
+  backdrop-filter: blur(4px);
+}
+[data-theme="dark"] .bai-palette__scrim {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.bai-palette__panel {
+  position: relative;
+  width: 600px;
+  max-width: 92vw;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bai-bg);
+  border: 1px solid var(--bai-border);
+  border-radius: var(--bai-radius-lg);
+  box-shadow: var(--bai-shadow-lg);
+  overflow: hidden;
+  animation: bai-palette-in 180ms ease-out;
+}
+
+@keyframes bai-palette-in {
+  from {
+    transform: translateY(-12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.bai-palette__searchrow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--bai-border);
+}
+
+.bai-palette__searchrow > svg {
+  color: var(--bai-text-3);
+  flex-shrink: 0;
+}
+
+.bai-palette__panel #search-input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-family: var(--bai-font-sans);
+  font-size: 15.5px;
+  color: var(--bai-text);
+  outline: 0;
+  padding: 0;
+}
+
+.bai-palette__panel #search-input::placeholder {
+  color: var(--bai-text-3);
+}
+
+.bai-palette__close-hint {
+  font-family: var(--bai-font-mono);
+  font-size: 10.5px;
+  background: var(--bai-bg-muted);
+  border: 1px solid var(--bai-border);
+  border-bottom-width: 2px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: var(--bai-text-3);
+  flex-shrink: 0;
+}
+
+/* When the search-results dropdown lives inside the palette panel,
+   override its absolute positioning so it scrolls inline with the
+   panel body instead of floating relative to the viewport. */
+.bai-palette__panel #search-results {
+  position: static;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  background: transparent;
+  max-height: none;
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+
+.bai-palette__panel #search-results .search-result-item {
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--bai-border-soft);
+}
+
+.bai-palette__panel #search-results .search-result-item:last-child {
+  border-bottom: 0;
+}
+
+.bai-palette__panel #search-results .search-result-item:hover,
+.bai-palette__panel #search-results .search-result-item:focus {
+  background: var(--bai-bg-muted);
+  outline: 0;
+}
+
+.bai-palette__panel #search-results .search-result-title {
+  color: var(--bai-text);
+  font-size: 14px;
+}
+
+.bai-palette__panel #search-results .search-result-snippet {
+  color: var(--bai-text-3);
+  font-size: 12px;
+}
+
+/* Mobile drawer scrim (Phase 4). Created lazily by interactions.js
+   and added to the body when the user opens the drawer. Re-uses the
+   palette scrim look so the visual language stays consistent. */
+.bai-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(20, 20, 20, 0.45);
+  backdrop-filter: blur(4px);
+  display: none;
+}
+
+[data-theme="dark"] .bai-scrim {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+body.bai-drawer-open .bai-scrim {
+  display: block;
+}
+
+/* When the drawer is open at narrow viewports, slide the sider in
+   from the left as a fixed-position overlay. Desktop layout is
+   unaffected — the @media query below scopes the override to
+   ≤ 880px so the sider's regular sticky behavior is preserved. */
+@media (max-width: 880px) {
+  body.bai-drawer-open .doc-sidebar {
+    display: block;
+    position: fixed;
+    top: var(--bai-topbar-h);
+    left: 0;
+    width: 280px;
+    max-width: 86vw;
+    height: calc(100vh - var(--bai-topbar-h));
+    z-index: 101;
+    background: var(--bai-bg-sider);
+    border-right: 1px solid var(--bai-border);
+    box-shadow: var(--bai-shadow-lg);
+    overflow-y: auto;
+    animation: bai-drawer-in 200ms ease-out;
+  }
+}
+
+@keyframes bai-drawer-in {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
 }
 
 /* Search results dropdown anchored to the topbar search container. */

--- a/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
@@ -101,6 +101,10 @@ function makeContext(): WebPageContext {
     favicon: "favicon.ico",
     brandLogoLight: "brand-logo-light.abcd.svg",
     brandLogoDark: "brand-logo-dark.abcd.svg",
+    // Phase 4 (FR-2726): buildWebPage requires interactions.js for the
+    // Cmd-K palette + theme toggle + drawer. Including it here keeps
+    // the test fixture aligned with what real builds produce.
+    interactions: "interactions.abcd.js",
   };
   return {
     chapter,

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -208,6 +208,13 @@ export interface PageAssets {
    * by the version-switcher script).
    */
   versionBanner?: string;
+  /**
+   * Hashed `interactions.js` filename (FR-2726 Phase 4). Optional —
+   * only present when the toolkit ships the template asset. Bundles
+   * the theme toggle, mobile drawer, and search palette interactions
+   * in a single script for per-page JS budget tightness.
+   */
+  interactions?: string;
   /** Site-root favicon filename, e.g. `favicon.ico`. */
   favicon?: string;
   /** Site-root apple-touch-icon filename, e.g. `apple-touch-icon.png`. */
@@ -665,6 +672,9 @@ function buildHeadAssetTags(
     `<meta charset="utf-8" />`,
     `<meta name="viewport" content="width=device-width, initial-scale=1" />`,
     `<title>${pageTitle} - ${escapeHtml(langLabel)}</title>`,
+    // FR-2726 Phase 4 anti-FOUC: set data-theme BEFORE the stylesheet
+    // is evaluated so dark-mode users don't see a light flash.
+    buildThemeBootstrapScript(),
     `<link rel="stylesheet" href="${prefix}assets/${escapeHtml(assets.styles)}" />`,
   ];
 
@@ -1014,6 +1024,37 @@ function buildTocScrollspyScriptTag(assets: PageAssets): string {
 }
 
 /**
+ * Build the interactions.js script tag (FR-2726 Phase 4). Receives
+ * `prefix` so the script URL stays correct under versioned-mode page
+ * paths (e.g. `<version>/<lang>/page.html` needs `../../assets/...`).
+ * The Phase 4 topbar is search-trigger-only and the palette starts
+ * hidden, so an absent interactions asset would leave the search UI
+ * inaccessible — the caller MUST verify the asset is present (see
+ * `buildWebPage`).
+ */
+function buildInteractionsScriptTag(
+  assets: PageAssets,
+  prefix: string,
+): string {
+  if (!assets.interactions) return "";
+  return `<script defer src="${prefix}assets/${escapeHtml(assets.interactions)}"></script>`;
+}
+
+/**
+ * Inline `<head>` bootstrap that sets `data-theme` on <html> before
+ * the page paints (FR-2726 Phase 4 — anti-FOUC). Reads `docs-theme`
+ * from localStorage; falls back to `prefers-color-scheme: dark` for
+ * users who never explicitly toggled. Total payload < 300 bytes.
+ *
+ * Returns a `<script>` tag — emitted from `buildHeadAssetTags` so it
+ * runs before any render-blocking stylesheet evaluation.
+ */
+function buildThemeBootstrapScript(): string {
+  const body = `(function(){try{var t=localStorage.getItem('docs-theme');if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches){t='dark';}if(t){document.documentElement.setAttribute('data-theme',t);}}catch(_){ }})();`;
+  return `<script>${body}</script>`;
+}
+
+/**
  * Augment every `<img …>` tag with `loading="lazy"`, `decoding="async"`, and
  * (when supplied) `width`/`height` attributes from `dimensions`. Any pre-
  * existing attributes on the tag are preserved. Tags that already declare
@@ -1078,8 +1119,12 @@ function buildBaiTopbar(
   const { metadata, config, assets } = context;
   const labels = WEBSITE_LABELS[metadata.lang] ?? WEBSITE_LABELS.en;
 
-  // Brand block: <picture> + <img> when logos are configured, otherwise
-  // a text fallback so the topbar still has a recognizable anchor.
+  // Brand block (FR-2726 Phase 4): emit BOTH light and dark logos as
+  // `<img>` elements and let CSS hide the one that doesn't match the
+  // active `data-theme`. The earlier `<picture>` + `prefers-color-scheme`
+  // approach only honored the OS preference and ignored the manual
+  // theme toggle, so users who flipped to dark mode kept seeing the
+  // light logo.
   const lightSrc = assets.brandLogoLight
     ? `${prefix}assets/${escapeHtml(assets.brandLogoLight)}`
     : "";
@@ -1091,10 +1136,8 @@ function buildBaiTopbar(
   if (lightSrc) {
     const altText = escapeHtml(metadata.title);
     if (darkSrc && darkSrc !== lightSrc) {
-      brandLogoHtml = `<picture>
-        <source srcset="${darkSrc}" media="(prefers-color-scheme: dark)" />
-        <img class="bai-brand-logo" src="${lightSrc}" alt="${altText}" />
-      </picture>`;
+      brandLogoHtml = `<img class="bai-brand-logo bai-brand-logo--light" src="${lightSrc}" alt="${altText}" />` +
+        `<img class="bai-brand-logo bai-brand-logo--dark" src="${darkSrc}" alt="${altText}" />`;
     } else {
       brandLogoHtml = `<img class="bai-brand-logo" src="${lightSrc}" alt="${altText}" />`;
     }
@@ -1120,13 +1163,20 @@ function buildBaiTopbar(
   const searchIconSvg = `<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="m21 21-5.5-5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>`;
   const searchIconLargeSvg = `<svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="m21 21-5.5-5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>`;
 
-  const searchHtml = `<div class="bai-topbar__search" role="search">
+  // Phase 4 (FR-2726): the topbar exposes a button trigger that opens
+  // a Cmd-K-style palette. The actual <input id="search-input"> + the
+  // results list live inside the palette overlay (rendered in the
+  // body further down) so search.js continues to work unchanged.
+  const searchHtml = `<button class="bai-topbar__search" type="button" data-search-trigger aria-label="${placeholderAttr}">
     ${searchIconSvg}
-    <input type="text" id="search-input" placeholder="${placeholderAttr}" data-no-results="${noResultsAttr}" autocomplete="off" />
+    <span class="bai-topbar__search-label">${placeholderAttr}</span>
     <span class="bai-kbd-group" aria-hidden="true"><kbd>⌘</kbd><kbd>K</kbd></span>
-    <div id="search-results" class="search-results" hidden></div>
-  </div>
-  <button class="bai-iconbtn bai-topbar__searchicon" type="button" aria-label="${placeholderAttr}" onclick="document.getElementById('search-input').focus()">${searchIconLargeSvg}</button>`;
+  </button>
+  <button class="bai-iconbtn bai-topbar__searchicon" type="button" data-search-trigger aria-label="${placeholderAttr}">${searchIconLargeSvg}</button>`;
+  // The placeholder + no-results attributes are forwarded to the
+  // input via its data-* set inside the palette markup below, so the
+  // localization passes through to search.js.
+  void noResultsAttr;
 
   // Lang switcher: extracted from the legacy buildPageHeader. Same HTML
   // shape so the existing CSS rules apply.
@@ -1164,6 +1214,13 @@ function buildBaiTopbar(
     ? `<a class="bai-iconbtn" href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener noreferrer" aria-label="GitHub">${githubIconSvg}</a>`
     : "";
 
+  // Theme toggle (Phase 4 — FR-2726). Sun/moon icon both rendered;
+  // CSS hides the inactive one based on data-theme. The aria-pressed
+  // state is updated by interactions.js when the user clicks.
+  const themeIconLight = `<svg class="bai-theme-icon bai-theme-icon--light" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.8"/><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M12 3v2M12 19v2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M3 12h2M19 12h2M5.6 18.4 7 17M17 7l1.4-1.4"/></svg>`;
+  const themeIconDark = `<svg class="bai-theme-icon bai-theme-icon--dark" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"/></svg>`;
+  const themeToggleHtml = `<button class="bai-iconbtn" type="button" data-theme-toggle aria-label="Toggle dark mode">${themeIconLight}${themeIconDark}</button>`;
+
   // Mobile menu icon (Phase 2 emits the surface; Phase 4 wires the
   // drawer toggle).
   const menuIconSvg = `<svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>`;
@@ -1179,9 +1236,39 @@ function buildBaiTopbar(
   <div class="bai-topbar__actions">
     ${versionSwitcherHtml}
     ${langSwitcherHtml}
+    ${themeToggleHtml}
     ${githubLinkHtml}
   </div>
 </header>`;
+}
+
+/**
+ * Build the search palette overlay (FR-2726 Phase 4). Hidden until
+ * `interactions.js` toggles `bai-palette-open` on the body. Hosts the
+ * actual `<input id="search-input">` and `<div id="search-results">`
+ * elements so search.js (which binds by id) keeps working unchanged.
+ */
+function buildSearchPalette(metadata: WebsiteMetadata): string {
+  const labels = WEBSITE_LABELS[metadata.lang] ?? WEBSITE_LABELS.en;
+  const placeholderAttr = escapeHtml(labels.searchPlaceholder);
+  const noResultsAttr = escapeHtml(labels.noResults);
+  const searchIconSvg = `<svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="m21 21-5.5-5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>`;
+  // The `doc-search` class is intentional: search.js attaches a
+  // document-level click handler that hides #search-results on any
+  // click outside an ancestor with class `doc-search`. Without it,
+  // clicks inside the palette panel (e.g. focusing the input) would
+  // immediately collapse the result list.
+  return `<div class="bai-palette" data-search-palette role="dialog" aria-modal="true" aria-label="${placeholderAttr}" hidden aria-hidden="true">
+  <div class="bai-palette__scrim"></div>
+  <div class="bai-palette__panel doc-search" role="search">
+    <div class="bai-palette__searchrow">
+      ${searchIconSvg}
+      <input type="text" id="search-input" placeholder="${placeholderAttr}" data-no-results="${noResultsAttr}" autocomplete="off" />
+      <kbd class="bai-palette__close-hint">esc</kbd>
+    </div>
+    <div id="search-results" class="search-results" hidden></div>
+  </div>
+</div>`;
 }
 
 /**
@@ -1297,6 +1384,19 @@ export function buildWebPage(context: WebPageContext): string {
   void buildPageHeaderBar;
   const versionBanner = buildVersionBanner(context);
   const versionNotice = buildVersionNotice(context);
+  // Phase 4 (FR-2726): search palette + interactions script tag.
+  const searchPalette = buildSearchPalette(metadata);
+  // Phase 4 (FR-2726): the topbar exposes only a trigger button while
+  // the palette starts hidden — without interactions.js there is no
+  // way to open it, so the search UI would be inaccessible. Refuse
+  // to emit a page with broken search rather than silently degrade.
+  if (!assets.interactions) {
+    throw new Error(
+      "FR-2726 Phase 4: missing required interactions asset. " +
+        "Search UI requires interactions.js to open the search palette.",
+    );
+  }
+  const interactionsScript = buildInteractionsScriptTag(assets, prefix);
   const searchScript = buildSearchScriptTag(assets, prefix);
   const codeCopyScript = buildCodeCopyScriptTag(assets, prefix);
   const tocScrollspyScript = buildTocScrollspyScriptTag(assets);
@@ -1334,10 +1434,12 @@ ${versionBanner}
   </main>
   ${rightRailToc}
 </div>
+${searchPalette}
 ${searchScript}
 ${codeCopyScript}
 ${tocScrollspyScript}
 ${versionBannerScript}
+${interactionsScript}
 </body>
 </html>`;
 }

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -349,6 +349,28 @@ export async function generateWebsite(
     console.log(`Written: assets/${codeCopyName}`);
   }
 
+  // FR-2726 Phase 4: BAI interactions (theme toggle, mobile drawer,
+  // search palette). Single file so the page only ships one extra
+  // script tag. Skipped when the template doesn't exist so older
+  // toolkit installs build cleanly.
+  const interactionsPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "templates",
+    "assets",
+    "interactions.js",
+  );
+  if (fs.existsSync(interactionsPath)) {
+    const bytes = fs.readFileSync(interactionsPath);
+    const interactionsName = writeHashedAsset(
+      assetsDir,
+      "interactions.js",
+      bytes,
+      assetManifest,
+    );
+    console.log(`Written: assets/${interactionsName}`);
+  }
+
   // Right-rail TOC scroll-spy (F3). Tiny IntersectionObserver script —
   // shipped only when the file exists in templates so a toolkit install
   // without F3 still builds. Page builder also no-ops when the asset is
@@ -482,6 +504,7 @@ export async function generateWebsite(
     codeCopy: assetManifest["code-copy.js"],
     tocScrollspy: assetManifest["toc-scrollspy.js"],
     versionBanner: assetManifest["version-banner.js"],
+    interactions: assetManifest["interactions.js"],
     favicon: rootAssets.favicon,
     appleTouchIcon: rootAssets.appleTouchIcon,
     webmanifest: rootAssets.webmanifest,

--- a/packages/backend.ai-docs-toolkit/templates/assets/interactions.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/interactions.js
@@ -1,0 +1,208 @@
+/* docs-toolkit interactions (FR-2726 Phase 4).
+ *
+ * Three small UX behaviors live here so the page only ships one extra
+ * script tag. All vanilla DOM, no framework, no network access.
+ *
+ *   1. Theme toggle    — flips data-theme between "light" and "dark",
+ *                        persisted in localStorage. The pre-paint
+ *                        bootstrap that prevents FOUC lives inline in
+ *                        <head>; this script wires the visible toggle
+ *                        button and reflects state changes.
+ *   2. Mobile drawer   — slides the sider in from the left when the
+ *                        topbar's hamburger button is clicked. Esc /
+ *                        scrim click closes.
+ *   3. Search palette  — overlays the search input + results in a
+ *                        modal-style palette. Cmd-K / Ctrl-K / `/`
+ *                        opens it; Esc / scrim click / result click
+ *                        closes. Search.js still owns the actual
+ *                        indexing & rendering — the palette just
+ *                        wraps the existing #search-input element.
+ *
+ * Per-page JS budget (≤ 25 KB minified) — this script is < 4 KB
+ * unminified.
+ */
+(function () {
+  if (typeof document === "undefined") return;
+
+  // The BAI topbar may be absent on legacy F3 pages; topbar-dependent
+  // wiring below is conditional so it no-ops cleanly. The global
+  // keyboard shortcuts at the bottom of this file always register so
+  // Cmd-K still works on pages that ship just the palette overlay.
+  var topbar = document.querySelector(".bai-topbar");
+
+  // ── Theme toggle ────────────────────────────────────────────────
+  // The pre-paint bootstrap in <head> already set data-theme; here we
+  // wire the visible button so the user can flip it. The button mounts
+  // late (after the page renders) so the icon swap happens after the
+  // initial paint without any visible flicker.
+  var themeBtn = topbar ? topbar.querySelector("[data-theme-toggle]") : null;
+  if (themeBtn) {
+    var setTheme = function (theme) {
+      var html = document.documentElement;
+      if (theme === "dark") {
+        html.setAttribute("data-theme", "dark");
+      } else {
+        html.setAttribute("data-theme", "light");
+      }
+      try {
+        localStorage.setItem("docs-theme", theme);
+      } catch (_) {}
+      themeBtn.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
+    };
+
+    themeBtn.addEventListener("click", function () {
+      var current = document.documentElement.getAttribute("data-theme");
+      setTheme(current === "dark" ? "light" : "dark");
+    });
+
+    // Initial aria-pressed state reflects what the bootstrap chose.
+    var initial = document.documentElement.getAttribute("data-theme");
+    themeBtn.setAttribute(
+      "aria-pressed",
+      initial === "dark" ? "true" : "false",
+    );
+  }
+
+  // ── Mobile drawer ───────────────────────────────────────────────
+  // The topbar's menu button toggles a body class that the CSS hooks
+  // into. Phase 4 ships the body-class wiring; per-viewport visual
+  // behavior (the slide animation) lives in styles-web.ts.
+  var menuBtn = topbar ? topbar.querySelector(".bai-topbar__menu") : null;
+  var sider = document.querySelector(".doc-sidebar");
+  var scrim = null;
+
+  function ensureScrim() {
+    if (scrim) return scrim;
+    scrim = document.createElement("div");
+    scrim.className = "bai-scrim";
+    scrim.setAttribute("aria-hidden", "true");
+    scrim.addEventListener("click", closeDrawer);
+    document.body.appendChild(scrim);
+    return scrim;
+  }
+
+  function openDrawer() {
+    if (!sider) return;
+    document.body.classList.add("bai-drawer-open");
+    ensureScrim();
+    if (menuBtn) menuBtn.setAttribute("aria-expanded", "true");
+  }
+
+  function closeDrawer() {
+    document.body.classList.remove("bai-drawer-open");
+    if (menuBtn) menuBtn.setAttribute("aria-expanded", "false");
+  }
+
+  if (menuBtn && sider) {
+    menuBtn.setAttribute("aria-expanded", "false");
+    menuBtn.addEventListener("click", function () {
+      if (document.body.classList.contains("bai-drawer-open")) {
+        closeDrawer();
+      } else {
+        openDrawer();
+      }
+    });
+  }
+
+  // ── Search palette ──────────────────────────────────────────────
+  // The palette wraps #search-input + #search-results in a body-class-
+  // controlled overlay. Search.js continues to handle indexing and
+  // result rendering; we just toggle visibility.
+  var palette = document.querySelector("[data-search-palette]");
+  var paletteScrim = palette ? palette.querySelector(".bai-palette__scrim") : null;
+  var paletteInput = document.getElementById("search-input");
+  var triggers = document.querySelectorAll("[data-search-trigger]");
+
+  function openPalette() {
+    if (!palette) return;
+    document.body.classList.add("bai-palette-open");
+    palette.removeAttribute("hidden");
+    palette.setAttribute("aria-hidden", "false");
+    if (paletteInput) {
+      // Defer focus until after the panel is visible so iOS Safari
+      // honors the keyboard-show request.
+      window.setTimeout(function () {
+        paletteInput.focus();
+        paletteInput.select && paletteInput.select();
+      }, 16);
+    }
+  }
+
+  function closePalette() {
+    if (!palette) return;
+    document.body.classList.remove("bai-palette-open");
+    palette.setAttribute("aria-hidden", "true");
+    palette.setAttribute("hidden", "");
+    if (paletteInput) paletteInput.blur();
+  }
+
+  if (palette && paletteInput) {
+    if (triggers.length) {
+      Array.prototype.forEach.call(triggers, function (btn) {
+        btn.addEventListener("click", function (e) {
+          e.preventDefault();
+          openPalette();
+        });
+      });
+    }
+    if (paletteScrim) {
+      paletteScrim.addEventListener("click", openClickOnScrim);
+    }
+
+    // Click on a result inside the palette body should close the
+    // palette (the link still navigates afterward).
+    palette.addEventListener("click", function (e) {
+      var t = e.target;
+      while (t && t !== palette) {
+        if (
+          t.tagName === "A" &&
+          (t.classList.contains("search-result-item") ||
+            (t.parentNode &&
+              t.parentNode.classList &&
+              t.parentNode.classList.contains("search-results")))
+        ) {
+          closePalette();
+          return;
+        }
+        t = t.parentNode;
+      }
+    });
+  }
+
+  function openClickOnScrim(e) {
+    if (e.target === paletteScrim) closePalette();
+  }
+
+  // ── Global keyboard shortcuts ───────────────────────────────────
+  // Cmd-K / Ctrl-K / `/` opens the palette (when not typing in another
+  // input). Esc closes the palette and the drawer. We intentionally
+  // run this even when neither overlay is mounted so the script is
+  // resilient to partially-built pages.
+  document.addEventListener("keydown", function (e) {
+    var key = e.key;
+    var isCmdK =
+      (e.metaKey || e.ctrlKey) && (key === "k" || key === "K");
+    var isSlash = key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey;
+    var inField =
+      document.activeElement &&
+      (document.activeElement.tagName === "INPUT" ||
+        document.activeElement.tagName === "TEXTAREA" ||
+        document.activeElement.isContentEditable);
+
+    if (isCmdK || (isSlash && !inField)) {
+      e.preventDefault();
+      openPalette();
+      return;
+    }
+    if (key === "Escape") {
+      if (document.body.classList.contains("bai-palette-open")) {
+        closePalette();
+        return;
+      }
+      if (document.body.classList.contains("bai-drawer-open")) {
+        closeDrawer();
+        return;
+      }
+    }
+  });
+})();


### PR DESCRIPTION
Resolves #7030 (FR-2726)

Stacks on #7034.

## Summary

Final phase of the production-quality redesign of the `build:web` docs site (FR-2726). Adds three small UX behaviors bundled into a single `interactions.js` asset.

- **Theme toggle**: `data-theme=dark / light` persisted in `localStorage` (`docs-theme` key). An inline anti-FOUC bootstrap in `<head>` reads the stored value (or `prefers-color-scheme: dark`) before the stylesheet evaluates so dark-mode users never see a light flash. Topbar button shows a moon icon in light mode and a sun icon in dark mode (CSS-only swap via `[data-theme]` selectors). The brand logo also swaps via twin `<img>` elements + CSS so the manual toggle flips it (not just the OS preference).

- **Mobile drawer**: at ≤880px the sider slides in as a fixed-position overlay when the topbar's hamburger button is clicked. Esc / scrim click closes. Desktop layout is unaffected — the @media query scopes the override.

- **Search palette**: the topbar's center search field is now a button trigger that opens a modal palette overlay. The actual `<input id="search-input">` + `<div id="search-results">` live inside the palette, so `search.js` continues to bind by id and run unchanged. ⌘K / Ctrl-K / `/` open the palette; Esc / scrim click / result click close it. The palette panel includes the `doc-search` class so `search.js`'s click-outside handler treats clicks inside the palette as in-bounds.

The interactions script tag is now a hard requirement when emitting topbar markup — building without it would render an inaccessible search UI, so the page builder throws if `assets.interactions` is missing.

## Verification

- `pnpm --filter backend.ai-docs-toolkit build` — clean
- Playwright spot-check:
  - Theme toggle: click → `data-theme=dark` set on `<html>`, body bg `#0E0E10`, body text `#F0F0F0`, `localStorage.docs-theme=dark`, brand logo swaps to dark variant.
  - Cmd-K opens palette → input focused → typing "session" yields 10 search results → Esc closes palette → body class cleared.
  - Mobile drawer: resize to 800px → click hamburger → sider slides in as 280px fixed overlay with scrim → click scrim → drawer closes.