### PR TITLE
refactor(FR-2727): clean up dead Lit-bridge events inside useWebUINavigate

### DIFF
--- a/react/eslint.config.js
+++ b/react/eslint.config.js
@@ -47,6 +47,12 @@ export default [
               importNames: ["useThemeMode"],
               message: "Use 'src/hooks/useThemeMode' instead.",
             },
+            {
+              name: "react-router-dom",
+              importNames: ["useNavigate", "Navigate"],
+              message:
+                "Use 'useWebUINavigate' from 'src/hooks' or '<WebUINavigate>' from 'src/components/WebUINavigate' instead.",
+            },
           ],
         },
       ],

--- a/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
+++ b/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
@@ -24,10 +24,9 @@ import {
   useRelayEnvironment,
   useSubscription,
 } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
 import { BAIComputeSessionNodeNotificationItemFragment$key } from 'src/__generated__/BAIComputeSessionNodeNotificationItemFragment.graphql';
 import { BAIComputeSessionNodeNotificationItemRefreshQuery } from 'src/__generated__/BAIComputeSessionNodeNotificationItemRefreshQuery.graphql';
-import { useSuspendedBackendaiClient } from 'src/hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from 'src/hooks';
 import {
   NotificationState,
   useSetBAINotification,
@@ -45,7 +44,7 @@ const BAIComputeSessionNodeNotificationItem: React.FC<
 > = ({ sessionFrgmt, showDate, notification, primaryAppOption }) => {
   const { closeNotification } = useSetBAINotification();
   const { t } = useTranslation();
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const node = useFragment(
     graphql`

--- a/react/src/components/BAIVirtualFolderNodeNotificationItem.tsx
+++ b/react/src/components/BAIVirtualFolderNodeNotificationItem.tsx
@@ -10,8 +10,8 @@ import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
 import { BAIVirtualFolderNodeNotificationItemFragment$key } from 'src/__generated__/BAIVirtualFolderNodeNotificationItemFragment.graphql';
+import { useWebUINavigate } from 'src/hooks';
 import {
   NotificationState,
   useSetBAINotification,
@@ -28,7 +28,7 @@ const BAIVirtualFolderNodeNotificationItem: React.FC<
 > = ({ notification, virtualFolderNodeFrgmt, showDate }) => {
   'use memo';
 
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { closeNotification } = useSetBAINotification();

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -8,6 +8,7 @@ import { buiLanguages } from '../helper/bui-language';
 import {
   backendaiClientPromise,
   createAnonymousBackendaiClient,
+  useWebUINavigate,
 } from '../hooks';
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { useThemeMode } from '../hooks/useThemeMode';
@@ -58,7 +59,7 @@ import React, {
 } from 'react';
 import { useTranslation, initReactI18next } from 'react-i18next';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useDeviceMetaData } from 'src/hooks/backendai';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
@@ -185,7 +186,7 @@ const BAIMetaDataWrapper = ({ children }: { children: ReactNode }) => {
 };
 
 export const RoutingEventHandler = () => {
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const location = useLocation();
   useLayoutEffect(() => {
     const handleNavigate = (e: any) => {

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useWebUINavigate } from '../../hooks';
 import { useBAISettingUserState } from '../../hooks/useBAISetting';
 import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
@@ -35,7 +36,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useNavigate, Outlet, useMatches, useLocation } from 'react-router-dom';
+import { Outlet, useMatches, useLocation } from 'react-router-dom';
 import usePrimaryColors from 'src/hooks/usePrimaryColors';
 import { useWebUIMenuItems } from 'src/hooks/useWebUIMenuItems';
 import { useSetupWebUIPluginEffect } from 'src/hooks/useWebUIPluginState';
@@ -64,7 +65,7 @@ const useStyle = createStyles(({ css, token }) => ({
 
 function MainLayout() {
   'use memo';
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const [compactSidebarActive] = useBAISettingUserState('compact_sidebar');
   const [sideCollapsed, setSideCollapsed] =
     useState<boolean>(!!compactSidebarActive);

--- a/react/src/components/ModelCardDeployModal.tsx
+++ b/react/src/components/ModelCardDeployModal.tsx
@@ -5,6 +5,7 @@
 import { ModelCardDeployModalEndpointPollQuery } from '../__generated__/ModelCardDeployModalEndpointPollQuery.graphql';
 import { ModelCardDeployModalMutation } from '../__generated__/ModelCardDeployModalMutation.graphql';
 import { ModelCardDeployModalQuery } from '../__generated__/ModelCardDeployModalQuery.graphql';
+import { useWebUINavigate } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { App, Form, Typography, theme } from 'antd';
 import type { DefaultOptionType } from 'antd/es/select';
@@ -34,7 +35,6 @@ import {
   useMutation,
   useRelayEnvironment,
 } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * Poll-before-navigate configuration for the post-deploy handoff to the
@@ -75,7 +75,7 @@ const ModelCardDeployModalContent: React.FC<
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const { id: projectId, name: projectName } = useCurrentProjectValue();
   const relayEnvironment = useRelayEnvironment();
 

--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -171,14 +171,7 @@ const UserDropdownMenu: React.FC<{
       key: 'preferences',
       icon: <SettingOutlined />,
       onClick: () => {
-        webuiNavigate('/usersettings', {
-          params: {
-            tab: 'general',
-          },
-        });
-        // dispatch event to update tab of backend-ai-usersettings
-        const event = new CustomEvent('backend-ai-usersettings', {});
-        document.dispatchEvent(event);
+        webuiNavigate('/usersettings?tab=general');
       },
     },
     {
@@ -188,9 +181,6 @@ const UserDropdownMenu: React.FC<{
       icon: <FileTextOutlined />,
       onClick: () => {
         webuiNavigate('/usersettings?tab=logs');
-        // dispatch event to update tab of backend-ai-usersettings
-        const event = new CustomEvent('backend-ai-usersettings', {});
-        document.dispatchEvent(event);
       },
     },
     baiClient._config.allowAppDownloadPanel && {

--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -5,6 +5,7 @@
 import { VFolderDeployModalEndpointPollQuery } from '../__generated__/VFolderDeployModalEndpointPollQuery.graphql';
 import { VFolderDeployModalMutation } from '../__generated__/VFolderDeployModalMutation.graphql';
 import { VFolderDeployModalQuery } from '../__generated__/VFolderDeployModalQuery.graphql';
+import { useWebUINavigate } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { App, Form, Typography, theme } from 'antd';
 import type { DefaultOptionType } from 'antd/es/select';
@@ -35,7 +36,6 @@ import {
   useMutation,
   useRelayEnvironment,
 } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * Poll-before-navigate configuration for the post-deploy handoff to the
@@ -85,7 +85,7 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const { id: projectId, name: projectName } = useCurrentProjectValue();
   const relayEnvironment = useRelayEnvironment();
   const { logger } = useBAILogger();

--- a/react/src/components/WebUILink.tsx
+++ b/react/src/components/WebUILink.tsx
@@ -7,11 +7,7 @@ import * as _ from 'lodash-es';
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 
-interface WebUILinkProps extends LinkProps {
-  options?: {
-    params?: any;
-  };
-}
+interface WebUILinkProps extends LinkProps {}
 
 /**
  * Resolve a react-router `to` prop into a plain string href usable on a
@@ -24,7 +20,7 @@ const resolveHref = (to: LinkProps['to']): string => {
   return (to.pathname ?? '') + (to.search ?? '') + (to.hash ?? '');
 };
 
-const WebUILink: React.FC<WebUILinkProps> = ({ options, ...props }) => {
+const WebUILink: React.FC<WebUILinkProps> = ({ ...props }) => {
   const hasActiveErrorBoundary = useHasActiveErrorBoundary();
 
   // After any error boundary has been triggered, the React tree may still
@@ -51,27 +47,7 @@ const WebUILink: React.FC<WebUILinkProps> = ({ options, ...props }) => {
     );
   }
 
-  return (
-    <Link
-      {...props}
-      onClick={(e) => {
-        props.onClick?.(e);
-        const pathName = _.isString(props.to)
-          ? props.to
-          : props.to.pathname || '';
-        if (!e.metaKey && !e.ctrlKey) {
-          document.dispatchEvent(
-            new CustomEvent('move-to-from-react', {
-              detail: {
-                path: pathName,
-                params: options?.params,
-              },
-            }),
-          );
-        }
-      }}
-    />
-  );
+  return <Link {...props} />;
 };
 
 export default WebUILink;

--- a/react/src/components/WebUINavigate.tsx
+++ b/react/src/components/WebUINavigate.tsx
@@ -3,30 +3,13 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '../hooks';
-import * as _ from 'lodash-es';
-import React, { useEffect } from 'react';
+import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { Navigate, NavigateProps } from 'react-router-dom';
 
 interface WebUINavigateProps extends NavigateProps {}
 const WebUINavigate: React.FC<WebUINavigateProps> = ({ ...props }) => {
   useSuspendedBackendaiClient();
-  const pathName = _.isString(props.to) ? props.to : props.to.pathname || '';
-  const [path, query] = pathName.split('?');
-  const params = {
-    params: Object.fromEntries(new URLSearchParams(query)),
-  };
-  useEffect(() => {
-    document.dispatchEvent(
-      new CustomEvent('move-to-from-react', {
-        detail: {
-          path: path,
-          params,
-        },
-      }),
-    );
-    // Don't need to consider options.params
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathName]);
   return <Navigate {...props} />;
 };
 

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -7,33 +7,22 @@ import { useSuspenseTanQuery } from './reactQueryAlias';
 import { MenuKeys } from './useWebUIMenuItems';
 import * as _ from 'lodash-es';
 import { useEffect, useMemo, useState } from 'react';
-import { NavigateOptions, To, useNavigate } from 'react-router-dom';
+// eslint-disable-next-line no-restricted-imports
+import { useNavigate } from 'react-router-dom';
 
-interface WebUINavigateOptions extends NavigateOptions {
-  params?: any;
-}
-export const useWebUINavigate = () => {
-  const _reactNavigate = useNavigate();
-  // @ts-ignore
-  return (to: To, options?: WebUINavigateOptions) => {
-    _reactNavigate(to, _.omit(options, ['params']));
-    const pathName = _.isString(to) ? to : to.pathname || '';
-    document.dispatchEvent(
-      new CustomEvent('move-to-from-react', {
-        detail: {
-          path: pathName,
-          params: options?.params,
-        },
-      }),
-    );
-
-    // dispatch event to update tab of backend-ai-usersettings
-    if (pathName === '/usersettings') {
-      const event = new CustomEvent('backend-ai-usersettings', {});
-      document.dispatchEvent(event);
-    }
-  };
-};
+/**
+ * Thin wrapper around `useNavigate` from react-router-dom.
+ *
+ * Originally this hook also dispatched `move-to-from-react` and
+ * `backend-ai-usersettings` custom events to bridge navigation to the legacy
+ * Lit shell (with a `params` extension on `NavigateOptions` carrying the
+ * Lit-side Redux action payload). The Lit shell was removed
+ * (`backend-ai-webui.ts` in 428205a79, `backend-ai-usersettings-general-list.ts`
+ * in #2465), so the events and the `params` option no longer have any
+ * consumer. The wrapper is kept as a project-level abstraction point for
+ * future cross-cutting navigation concerns.
+ */
+export const useWebUINavigate = () => useNavigate();
 
 export const useBackendAIConnectedState = () => {
   const [time, setTime] = useState<string>();

--- a/react/src/hooks/useLogout.ts
+++ b/react/src/hooks/useLogout.ts
@@ -2,10 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useWebUINavigate } from '.';
 import { backendaiOptions, backendaiUtils } from '../global-stores';
 import React, { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * Clears all Backend.AI login-related localStorage keys and sessionStorage.
@@ -126,12 +126,12 @@ async function performAppCloseCleanup(notificationMessage: string) {
  * - Provides a `logout` function that cleans up session data and redirects
  * - Provides a `closeAppWindow` function for Electron app-close cleanup
  *
- * Must be used within a React Router context (needs `useNavigate`).
+ * Must be used within a React Router context (needs `useWebUINavigate`).
  */
 export function useLogout() {
   'use memo';
 
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const { t } = useTranslation();
 
   /**

--- a/react/src/pages/AdminServingPage.tsx
+++ b/react/src/pages/AdminServingPage.tsx
@@ -220,19 +220,12 @@ const AdminServingPage: React.FC = () => {
     <BAICard
       activeTabKey={queryParam.tab}
       onTabChange={(key) => {
-        webUINavigate(
-          {
-            pathname: '/admin-serving',
-            search: new URLSearchParams({
-              tab: key,
-            }).toString(),
-          },
-          {
-            params: {
-              tab: key,
-            },
-          },
-        );
+        webUINavigate({
+          pathname: '/admin-serving',
+          search: new URLSearchParams({
+            tab: key,
+          }).toString(),
+        });
         setQueryParam({ tab: key });
       }}
       tabList={filterOutEmpty([

--- a/react/src/pages/AdminSessionPage.tsx
+++ b/react/src/pages/AdminSessionPage.tsx
@@ -33,19 +33,12 @@ const AdminSessionPage: React.FC = () => {
       <BAICard
         activeTabKey={queryParam.tab}
         onTabChange={(key) => {
-          webUINavigate(
-            {
-              pathname: '/admin-session',
-              search: new URLSearchParams({
-                tab: key,
-              }).toString(),
-            },
-            {
-              params: {
-                tab: key,
-              },
-            },
-          );
+          webUINavigate({
+            pathname: '/admin-session',
+            search: new URLSearchParams({
+              tab: key,
+            }).toString(),
+          });
           setQueryParam({ tab: key });
         }}
         tabList={filterOutEmpty([

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -11,6 +11,7 @@ import {
   useHistory,
 } from '../components/Chat/ChatHistory';
 import { type ChatProviderData } from '../components/Chat/ChatModel';
+import WebUINavigate from '../components/WebUINavigate';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { Badge, Button, Card, Drawer, theme, Tooltip, Typography } from 'antd';
 import { createStyles } from 'antd-style';
@@ -328,10 +329,8 @@ function isClonable(chatLength: number) {
 const ChatPage: React.FC = () => {
   const { id } = useParams();
 
-  const webuiNavigate = useWebUINavigate();
-
   if (id && !getChatById(id)) {
-    webuiNavigate(`/chat`, { replace: true });
+    return <WebUINavigate to="/chat" replace />;
   }
 
   return <PureChatPage id={id || generateChatId()} />;

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import { useToggle } from 'ahooks';
 import { theme, Col, Row, Statistic, Card, Button, Tooltip } from 'antd';
@@ -31,7 +32,6 @@ import { BanIcon, Brain, UndoIcon } from 'lucide-react';
 import React, { useMemo, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
 import {
   ReservoirPageQuery,
   ReservoirPageQuery$data,
@@ -63,7 +63,7 @@ const ReservoirPage: React.FC = () => {
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const { upsertNotification } = useSetBAINotification();
 
   const [selectedArtifactIdList, setSelectedArtifactIdList] = useState<

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -25,19 +25,12 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
     <BAICard
       activeTabKey={curTabKey}
       onTabChange={(key) => {
-        webUINavigate(
-          {
-            pathname: '/resource-policy',
-            search: new URLSearchParams({
-              tab: key,
-            }).toString(),
-          },
-          {
-            params: {
-              tab: key,
-            },
-          },
-        );
+        webUINavigate({
+          pathname: '/resource-policy',
+          search: new URLSearchParams({
+            tab: key,
+          }).toString(),
+        });
       }}
       tabList={filterOutEmpty([
         {

--- a/react/src/pages/SchedulerPage.tsx
+++ b/react/src/pages/SchedulerPage.tsx
@@ -29,19 +29,12 @@ const SchedulerPage: React.FC<SchedulerPageProps> = () => {
     <BAICard
       activeTabKey={curTabKey}
       onTabChange={(key) => {
-        webUINavigate(
-          {
-            pathname: '/fair-share',
-            search: new URLSearchParams({
-              tab: key,
-            }).toString(),
-          },
-          {
-            params: {
-              tab: key,
-            },
-          },
-        );
+        webUINavigate({
+          pathname: '/fair-share',
+          search: new URLSearchParams({
+            tab: key,
+          }).toString(),
+        });
       }}
       tabList={[
         {

--- a/react/src/pages/UserCredentialsPage.tsx
+++ b/react/src/pages/UserCredentialsPage.tsx
@@ -9,14 +9,15 @@ import { CardTabListType } from 'antd/es/card';
 import { BAIFlex, BAICard } from 'backend.ai-ui';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
+import { useWebUINavigate } from 'src/hooks';
 
 const UserCredentialsPage: React.FC = () => {
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const currentTab = searchParams.get('tab') || 'users';
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const tabItems: CardTabListType[] = [
     {
       key: 'users',


### PR DESCRIPTION
Resolves FR-2727.

## Summary

`useWebUINavigate` is kept as a **thin wrapper around `useNavigate`** (project-level abstraction point) with all dead Lit-bridge behaviors removed from inside it: two custom event dispatches and the `params` option on the call signature. A new ESLint rule enforces that the abstraction is used everywhere instead of pulling `useNavigate` / `Navigate` directly from `react-router-dom`.

## Why this is safe to slim down

### 1. Both custom events the hook dispatched have zero listeners.

- `move-to-from-react`: the Lit-side listener in `src/components/backend-ai-webui.ts` was removed in `428205a79` (`refactor(FR-5380): slim down backend-ai-webui Lit shell`, 2026-02-19). That file no longer exists.
- `backend-ai-usersettings`: the listener in `src/components/backend-ai-usersettings-general-list.ts` was removed when the user-settings page migrated to React (#2465). That file no longer exists either.
- A full grep across `*.ts`, `*.tsx`, `*.js`, and `*.html` (excluding gitignored build artifacts under `react/build/` and `dist/`) confirms only dispatch sites — no `addEventListener` calls.

### 2. The `params` option was a Lit-side Redux side channel, not a react-router option.

This is non-obvious so worth recording. The original hook (introduced in `70bb20613`) shaped its options as:

\`\`\`ts
interface WebUINavigateOptions extends NavigateOptions {
  params?: any;
}
export const useWebUINavigate = () => {
  const _reactNavigate = useNavigate();
  return (to: To, options?: WebUINavigateOptions) => {
    _reactNavigate(to, _.omit(options, ['params']));            // ← params removed before react-router
    document.dispatchEvent(new CustomEvent('move-to-from-react', {
      detail: { path: pathName, params: options?.params },      // ← params delivered to Lit
    }));
    // ...
  };
};
\`\`\`

The Lit shell received the event and forwarded \`params\` into its **own Redux store** (`store.dispatch(navigate(decodeURIComponent(url), params ?? {}))`). In other words, \`params\` was a cross-framework side channel for keeping the Lit-side Redux routing state in sync with the React-side navigation, NOT a thing react-router consumed. \`react-router\`'s \`NavigateOptions\` is fixed-shape (`replace`, `state`, `relative`, `preventScrollReset`), so the project layered \`params\` on top and stripped it before the call.

With the Lit shell deleted, both the receiver of the event and the Redux store it fed are gone. The \`params\` field has no consumer at runtime — keeping the option type would just preserve a misleading \"this does something\" signal at call sites. Removed.

## Changes

### Hook + abstraction shells

- **`react/src/hooks/index.tsx`** — `useWebUINavigate` reduced to `() => useNavigate()`. The `WebUINavigateOptions` interface, the `_.omit(options, ['params'])` plumbing, and both event dispatches are gone. JSDoc captures the Lit-Redux history so future readers know why the wrapper exists.
- **`react/src/components/WebUINavigate.tsx`** — removed the `move-to-from-react` `useEffect` dispatch. The `useSuspendedBackendaiClient()` Suspense gate is kept (still meaningful before redirects render).
- **`react/src/components/WebUILink.tsx`** — removed the `move-to-from-react` onClick dispatch and the unused `options` prop. The active-error-boundary anchor fallback (consumed by `BAIErrorBoundary.tsx`) is kept.

### Call site cleanups (dead `params` consumers)

- **`react/src/components/UserDropdownMenu.tsx`** — removed two orphan `backend-ai-usersettings` dispatches. The \"Preferences\" entry now uses `?tab=general` query string explicitly (matches the existing `?tab=logs` pattern next to it). Previously the `{ params: { tab: 'general' } }` object was silently dropped by `_.omit` before reaching react-router — meaning the page actually fell back to its default tab; the new explicit query string fixes that latent silent fallback.
- **`react/src/pages/AdminSessionPage.tsx`, `AdminServingPage.tsx`, `SchedulerPage.tsx`, `ResourcePolicyPage.tsx`** — removed the dead `{ params: { tab: key } }` second argument on `webUINavigate({...})` tab-change calls. The pathname + search already fully describe the intended navigation; the `params` payload had nothing to consume it.
- **`react/src/pages/ChatPage.tsx`** — replaced render-time imperative `webuiNavigate('/chat', { replace: true })` with declarative `<WebUINavigate to=\"/chat\" replace />` (Copilot review feedback). Avoids side effects during render under StrictMode.

### Lint rule + migration of stragglers

- **`react/eslint.config.js`** — new `no-restricted-imports` rule erroring on `useNavigate` / `Navigate` from `react-router-dom`, with a message pointing to `useWebUINavigate` / `<WebUINavigate>`. The two wrapper definition files (`react/src/hooks/index.tsx`, `react/src/components/WebUINavigate.tsx`) carry an inline `// eslint-disable-next-line no-restricted-imports` since they are the legitimate import points.

  Rule output on a violating file:
  \`\`\`
  error  'useNavigate' import from 'react-router-dom' is restricted. Use 'useWebUINavigate' from 'src/hooks' or '<WebUINavigate>' from 'src/components/WebUINavigate' instead  no-restricted-imports
  \`\`\`

- **9 files migrated** to the abstraction so the new rule passes:
  - `react/src/components/BAIVirtualFolderNodeNotificationItem.tsx`
  - `react/src/components/BAIComputeSessionNodeNotificationItem.tsx`
  - `react/src/components/DefaultProviders.tsx`
  - `react/src/components/MainLayout/MainLayout.tsx`
  - `react/src/components/ModelCardDeployModal.tsx`
  - `react/src/components/VFolderDeployModal.tsx`
  - `react/src/hooks/useLogout.ts`
  - `react/src/pages/ReservoirPage.tsx`
  - `react/src/pages/UserCredentialsPage.tsx`

All other ~25 `useWebUINavigate()` call sites continue to work unchanged — variable names (`webuiNavigate`, `webUINavigate`) and the calling style \`webuiNavigate(to, navigateOptions)\` are preserved. Only call sites that were actually passing the dead `params` option, or pulling `useNavigate` / `Navigate` directly from `react-router-dom`, needed touching.

## Verification

- `scripts/verify.sh` → Relay / Lint / Format / TypeScript all PASS.

## Test plan

- [x] `scripts/verify.sh` PASS
- [ ] Manual: \"Preferences\" and \"Logs & Errors\" entries in the user dropdown navigate to the correct tab on `/usersettings`.
- [ ] Manual: Tab switching on `/admin-session`, `/admin-serving`, `/fair-share`, `/resource-policy` still updates the URL and active tab.
- [ ] Manual: in-app navigation via sidebar, breadcrumb, and page CTA buttons still works.
- [ ] Manual: Logout / app-close cleanup paths (Electron + web) still navigate correctly.
- [ ] Manual: Post-deploy redirects in `ModelCardDeployModal` and `VFolderDeployModal` still hand off to the serving detail page after the endpoint poll.