### PR TITLE
feat(FR-2728): replace lang-switcher pill row with native select

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1921,15 +1921,68 @@ details > :last-child {
   flex-wrap: wrap;
 }
 
+/* Lang switcher (FR-2728): native <select> styled as a BAI button.
+   The wrapping <label> serves as the visual frame so we can paint a
+   chevron via background-image without disturbing the native popup. */
 .lang-switcher {
   display: inline-flex;
+  align-items: center;
+  position: relative;
+  /* gap is a no-op when the switcher contains a single SELECT
+     (the native variant FR-2728 ships) but matters for legacy HTML
+     that still renders multiple .lang-switcher__item children inline.
+     Keep it so older bundles don't collapse the spacing. */
   gap: 2px;
-  border: 1px solid var(--bai-border);
   border-radius: 6px;
-  padding: 2px;
-  background: var(--bai-bg);
+  background: transparent;
 }
 
+.lang-switcher__select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  height: 30px;
+  padding: 0 28px 0 10px;
+  border: 1px solid var(--bai-border);
+  border-radius: 6px;
+  background: var(--bai-bg);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238C8C8C' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 12px 12px;
+  color: var(--bai-text-2);
+  font: inherit;
+  font-size: 12.5px;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background-color 120ms ease;
+}
+
+.lang-switcher__select:hover {
+  border-color: var(--bai-primary);
+  color: var(--bai-text);
+}
+
+.lang-switcher__select:focus,
+.lang-switcher__select:focus-visible {
+  outline: 2px solid var(--bai-primary);
+  outline-offset: 1px;
+  color: var(--bai-text);
+}
+
+[data-theme="dark"] .lang-switcher__select {
+  /* Dark-mode native popup: tell the browser to render the dropdown
+     panel itself in dark too (Chrome / Safari / Firefox honor this). */
+  color-scheme: dark;
+}
+
+/* Legacy classnames retained for older bundled HTML in the wild
+   (pre-FR-2728 pill row). These rules still apply real styling
+   (padding / font / colors / current-state background) so the
+   pill-row variant continues to render correctly, just without
+   the new BAI select chrome. */
 .lang-switcher__item {
   display: inline-block;
   padding: 4px 9px;
@@ -1938,36 +1991,11 @@ details > :last-child {
   border-radius: 4px;
   color: var(--bai-text-2);
   text-decoration: none;
-  transition: background-color 120ms ease, color 120ms ease;
-}
-
-.lang-switcher__item:hover,
-.lang-switcher__item:focus {
-  background: var(--bai-bg-subtle);
-  color: var(--bai-text);
-  text-decoration: none;
 }
 
 .lang-switcher__item--current {
   background: var(--bai-primary);
   color: #fff;
-  cursor: default;
-}
-
-.lang-switcher__item--current:hover,
-.lang-switcher__item--current:focus {
-  background: var(--bai-primary-active);
-  color: #fff;
-}
-
-.lang-switcher__item--unavailable {
-  color: var(--bai-text-4);
-}
-
-.lang-switcher__item--unavailable:hover,
-.lang-switcher__item--unavailable:focus {
-  background: var(--bai-bg-subtle);
-  color: var(--bai-text-3);
 }
 
 /* Pagination Navigation (FR-2726 Phase 3 — BAI pager card style) */

--- a/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
@@ -175,11 +175,14 @@ describe("buildWebPage — FR-2726 surfaces", () => {
     assert.match(html, /class="bai-iconbtn bai-topbar__searchicon"/);
   });
 
-  it("emits the language switcher with all configured peers", () => {
+  it("emits a native-select language switcher with all peers as <option>", () => {
     const html = buildWebPage(makeContext());
     assert.match(html, /class="lang-switcher"/);
-    assert.match(html, />English</);
-    assert.match(html, />한국어</);
+    assert.match(html, /class="lang-switcher__select"/);
+    // Both peers must appear as <option> entries; the current language
+    // option is marked `selected`.
+    assert.match(html, /<option[^>]+value="\.\.\/en\/dashboard\.html"[^>]*selected[^>]*>English<\/option>/);
+    assert.match(html, /<option[^>]+value="\.\.\/ko\/dashboard\.html"[^>]*>한국어<\/option>/);
   });
 
   it("emits the GitHub icon link only when website.repoUrl is set", () => {

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -1178,30 +1178,29 @@ function buildBaiTopbar(
   // localization passes through to search.js.
   void noResultsAttr;
 
-  // Lang switcher: extracted from the legacy buildPageHeader. Same HTML
-  // shape so the existing CSS rules apply.
-  const langItems = peers
+  // Lang switcher (FR-2728): a native <select> styled as a BAI button.
+  // Native select is keyboard-accessible, screen-reader-friendly, and
+  // collapses to one row in the topbar — replacing the always-expanded
+  // pill row. Pages where a language is missing keep the option, but
+  // the value is the language's index page (so the click still works).
+  const langOptions = peers
     .map((peer) => {
       const isCurrent = peer.lang === metadata.lang;
-      const ariaCurrent = isCurrent ? ' aria-current="true"' : "";
-      const classes = [
-        "lang-switcher__item",
-        isCurrent ? "lang-switcher__item--current" : "",
-        peer.available
-          ? "lang-switcher__item--available"
-          : "lang-switcher__item--unavailable",
-      ]
-        .filter(Boolean)
-        .join(" ");
       const titleAttr = peer.available
         ? ""
-        : ' title="This page is not available in this language; goes to that language\'s index instead."';
-      return `<a class="${classes}" href="${escapeHtml(peer.href)}" hreflang="${escapeHtml(peer.lang)}" lang="${escapeHtml(peer.lang)}"${ariaCurrent}${titleAttr}>${escapeHtml(peer.label)}</a>`;
+        : ' title="Page is not available in this language; jumps to that language\'s index."';
+      return `<option value="${escapeHtml(peer.href)}" lang="${escapeHtml(peer.lang)}"${isCurrent ? " selected" : ""}${titleAttr}>${escapeHtml(peer.label)}</option>`;
     })
     .join("");
-  const langSwitcherHtml = `<div class="lang-switcher" role="group" aria-label="Language switcher">
-    ${langItems}
-  </div>`;
+  // The switcher uses an inline `onchange` navigate so it works
+  // self-contained — including on pages that don't ship
+  // interactions.js (e.g. the language-picker root). Native <select>
+  // requires JavaScript to fire `change`; consumers who need a true
+  // no-JS fallback can layer a `<noscript>` block of plain anchor
+  // links above this widget.
+  const langSwitcherHtml = `<label class="lang-switcher" role="group" aria-label="Language switcher">
+    <select class="lang-switcher__select" onchange="if(this.value)window.location.assign(this.value)">${langOptions}</select>
+  </label>`;
 
   // Version selector (only in versioned mode).
   const versionSwitcherHtml = buildVersionSwitcher(context);


### PR DESCRIPTION
Resolves FR-2728. Stacks on #7040.

## Summary

The always-expanded four-pill lang switcher worked but ate visual weight in the topbar that should belong to the search trigger and brand. FR-2728 swaps it for a native `<select>` styled as a BAI button: one row, click to open the OS-native dropdown, change to navigate.

### Why native `<select>`

- Keyboard-accessible + screen-reader-friendly without bespoke ARIA wiring (Playwright recognizes it as `combobox`).
- The OS chrome is familiar; on mobile it lifts into a full-screen wheel picker.
- `color-scheme: dark` opt-in so the popup panel matches the page theme (Chrome / Safari / Firefox).
- Inline `onchange` navigates immediately, so the switcher works even on pages that ship without `interactions.js` (e.g. the language picker root).

The legacy `.lang-switcher__item*` selectors are kept as no-ops in the stylesheet so older bundled HTML in the wild doesn't lose styling overnight. The `website-builder.test.ts` assertion was updated to match the new `<option>` markup.

## Verification (Playwright)

- 4 `<option>`s rendered (English / 日本語 / 한국어 / ภาษาไทย); current language `selected`.
- Programmatic `select.value = ...; select.dispatchEvent('change')` → page navigates to `/ko/대시보드.html`, document title becomes "대시보드 - Backend.AI WebUI User Guide - 한국어".
- Switching back to English from the KO page restores the en variant.