### PR TITLE
fix(FR-2728): figure caption centering, lede removal, table compact width

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1154,17 +1154,11 @@ h4 { font-size: var(--ifm-h4-font-size); margin-top: 1.25rem; }
 h5 { font-size: var(--ifm-h5-font-size); }
 h6 { font-size: var(--ifm-h6-font-size); }
 
-/* Lede — the first paragraph immediately after the chapter H1 reads as
-   the page summary. Slightly larger and softer color than body text;
-   capped to 68ch so long paragraphs wrap before reaching the rail. */
-.chapter > h1 + p {
-  font-size: calc(17px * var(--bai-type-scale));
-  line-height: 1.55;
-  color: var(--bai-text-2);
-  margin: 0 0 22px;
-  text-wrap: pretty;
-  max-width: 68ch;
-}
+/* The BAI prototype rendered the first paragraph after H1 as a
+   "lede" summary (larger, muted, capped to 68ch). Our docs don't
+   consistently structure the first paragraph as a summary, so the
+   distinct style + right-side gap read as a defect. The first
+   paragraph now matches the rest of the body. */
 
 /* Heading anchors */
 h1 > a.hash-link,
@@ -1463,16 +1457,26 @@ pre code {
 /* ==========================================================================
    Tables (FR-2726 Phase 3 — BAI bordered card style)
    --------------------------------------------------------------------------
-   Wide tables on narrow viewports must remain horizontally scrollable so
-   the column structure stays readable. We use display: block + overflow-x:
-   auto for the scroll container; min-width keeps the table edge-to-edge
-   on viewports wider than the content. The 1px border + radius wrap the
-   block so the BAI card framing is preserved.
+   Tables size to their content (width: max-content) and are capped at
+   the article column (max-width: 100%). Narrow tables stay compact
+   instead of padding empty space on the right; wide tables hit
+   max-width: 100% and become horizontally scrollable via
+   overflow-x: auto so the column structure stays readable. The 1px
+   border + radius wrap the block so the BAI card framing is preserved.
    ========================================================================== */
 table {
+  /* Sizing: tables are width-of-content (max-content) but capped to
+     the article column (max-width: 100%). This way:
+       - Narrow tables (e.g. 3 short cols) stay compact instead of
+         padding empty space on the right.
+       - Wide tables overflow the column and become horizontally
+         scrollable thanks to overflow-x: auto.
+     We intentionally drop the previously-set min-width: 100% rule
+     (which forced narrow tables to span the column) because it
+     produced 400+ px of dead space inside narrow tables. */
   display: block;
   width: max-content;
-  min-width: 100%;
+  max-width: 100%;
   border-collapse: collapse;
   margin-bottom: var(--ifm-spacing-vertical);
   font-size: 13.5px;
@@ -1563,11 +1567,21 @@ li > ul, li > ol {
 }
 
 figure {
+  /* Figure owns the outer vertical rhythm only. The image is
+     centered horizontally by the figure .doc-image rule below
+     (margin: 0 auto), and the caption is centered by figcaption's
+     own text-align rule — so this block intentionally avoids
+     setting text-align (which would only catch stray inline
+     content and could surprise authors). */
   margin: 1.25rem 0;
 }
 
 figure .doc-image {
-  margin: 0;
+  /* Override .doc-image's default block centering only on the
+     vertical axis (figure owns the outer top/bottom margin); keep
+     auto on the horizontal axis so narrow images stay centered
+     instead of left-aligning to the figure's edge. */
+  margin: 0 auto;
 }
 
 figcaption {


### PR DESCRIPTION
Resolves FR-2728. Stacks on PR γ (#7041).

## Summary

Three small style adjustments surfaced during user verification of the FR-2726 redesign + FR-2728 follow-ups. Each was diagnosed by Playwright (computed style + bounding-box geometry) before the fix was applied, and verified by re-measuring after.

### #1 Figure caption / narrow image off-center

`figure .doc-image { margin: 0 }` overrode `.doc-image`'s default `margin: ... auto`, so narrow images inside `<figure>` were left-aligned while the figcaption (text-align: center) centered text against the *figure's* full width — leaving the caption visually offset from the image (e.g. KO 그림 5.2 has a 400 px image inside a 756 px figure → caption ~178 px right of image center).

Fix: `figure { text-align: center }` + `figure .doc-image { margin: 0 auto }`. After: image.center === figure.center === caption-text.center.

### #2 Remove the first-paragraph lede style

The BAI prototype's "lede" pattern (`.chapter > h1 + p` rendered at 17 px / muted color / `max-width: 68ch`) didn't generalize to our docs, where the first paragraph is often plain body text. The narrower 680 px max-width also produced ~140 px of dead space on the right.

Fix: drop the lede rule entirely. First paragraph now matches the rest of the body (16 px / `--bai-text` / no max-width).

### #3 Table: drop `min-width: 100%`, keep `max-width: 100%`

PR β set `min-width: 100%` (a Copilot-review fix, intended to make narrow tables fill the column for visual consistency). Side effect: a 3-column role-menu table whose columns only need 292 px was forced to 756 px, leaving **464 px of dead space inside the table** on the right.

Fix: `width: max-content; max-width: 100%` — narrow tables stay compact (294 px) while wide tables still hit `max-width: 100%` and scroll horizontally via `overflow-x: auto`.

## Verification (Playwright)

| | Before | After |
|---|---|---|
| KO Login figure 5.2 — image center vs figure center | image at left (left=362, center=562); figure center=740; caption text centered at figure-width | image.center = figure.center = caption.center = 740 ✅ |
| KO Login first p — `max-width / font-size / color` | 680px / 17px / rgb(89,89,89) | none / 16px / rgb(20,20,20) ✅ |
| KO Overview 사용자 역할별 표 — table.width / dead-space-inside | 756 px / 464 px dead | 294 px / 2 px (border-only) ✅ |