### PR TITLE
feat(FR-2731): add pdfTag field to docs-toolkit versions schema

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -144,6 +144,19 @@ export interface VersionEntry {
   source: VersionSource;
   /** Exactly one entry across `versions[]` must carry `latest: true`. */
   latest?: boolean;
+  /**
+   * Optional release tag used to build the per-version PDF download URL
+   * (FR-2731). Must match `^v\d+\.\d+\.\d+$` (e.g., `"v26.4.7"`) — the
+   * format the GitHub Releases CDN expects under
+   * `https://github.com/<org>/<repo>/releases/download/<pdfTag>/<asset>`.
+   *
+   * The toolkit owns this schema; consumers only pass a value through.
+   * When omitted, downstream renderers must treat the version as "no PDF
+   * card" (no defaults, no synthesized URL). Rendering is implemented in
+   * a follow-up sub-task — this field is wired through the pipeline but
+   * does not yet drive any UI.
+   */
+  pdfTag?: string;
 }
 
 /**

--- a/packages/backend.ai-docs-toolkit/src/versions.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/versions.test.ts
@@ -223,6 +223,133 @@ describe("loadVersions — validation failures", () => {
   });
 });
 
+describe("loadVersions — pdfTag validation (FR-2731)", () => {
+  it("accepts a well-formed pdfTag and exposes it on the runtime entry", () => {
+    const result = loadVersions(
+      makeConfig([
+        {
+          label: "26.4",
+          source: { kind: "workspace" },
+          latest: true,
+          pdfTag: "v26.4.7",
+        },
+      ]),
+    );
+    assert.equal(result.enabled, true);
+    assert.equal(result.entries[0].pdfTag, "v26.4.7");
+  });
+
+  it("treats absent pdfTag as no value at runtime (no defaults)", () => {
+    const result = loadVersions(
+      makeConfig([
+        { label: "26.4", source: { kind: "workspace" }, latest: true },
+      ]),
+    );
+    // Must be missing entirely — not coerced to null or empty string.
+    assert.equal(result.entries[0].pdfTag, undefined);
+    assert.equal("pdfTag" in result.entries[0], false);
+  });
+
+  it("rejects a tag missing the leading 'v'", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            {
+              label: "26.4",
+              source: { kind: "workspace" },
+              latest: true,
+              pdfTag: "26.4.7",
+            },
+          ]),
+        ),
+      /pdfTag.*must match \^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/,
+    );
+  });
+
+  it("rejects a tag missing the patch component", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            {
+              label: "26.4",
+              source: { kind: "workspace" },
+              latest: true,
+              pdfTag: "v26.4",
+            },
+          ]),
+        ),
+      /pdfTag.*must match \^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/,
+    );
+  });
+
+  it("rejects assorted malformed pdfTag shapes", () => {
+    for (const bad of [
+      "v26",
+      "v26.4.7-rc1",
+      "26.4.7v",
+      "vv26.4.7",
+      "v26.4.7.0",
+      "release-26.4.7",
+      "",
+    ]) {
+      assert.throws(
+        () =>
+          loadVersions(
+            makeConfig([
+              {
+                label: "26.4",
+                source: { kind: "workspace" },
+                latest: true,
+                pdfTag: bad,
+              },
+            ]),
+          ),
+        /pdfTag/,
+        `expected pdfTag ${JSON.stringify(bad)} to be rejected`,
+      );
+    }
+  });
+
+  it("error messages name the offending entry index", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            { label: "26.4", source: { kind: "workspace" }, latest: true },
+            {
+              label: "25.16",
+              source: { kind: "archive-branch", ref: "docs-archive/25.16" },
+              pdfTag: "25.16.5",
+            },
+          ]),
+        ),
+      /versions\[1\]\.pdfTag/,
+    );
+  });
+
+  it("preserves pdfTag presence per entry in a mixed multi-entry config", () => {
+    const result = loadVersions(
+      makeConfig([
+        {
+          label: "26.4",
+          source: { kind: "workspace" },
+          latest: true,
+          pdfTag: "v26.4.7",
+        },
+        { label: "26.3", source: { kind: "workspace" } },
+      ]),
+    );
+    // Entry with pdfTag carries the value
+    assert.equal(result.entries[0].pdfTag, "v26.4.7");
+    assert.equal("pdfTag" in result.entries[0], true);
+    // Entry without pdfTag has the key omitted entirely
+    assert.equal(result.entries[1].pdfTag, undefined);
+    assert.equal("pdfTag" in result.entries[1], false);
+  });
+});
+
 describe("canonicalPathFor", () => {
   it("returns flat layout when versions are not enabled", () => {
     const loaded = loadVersions(makeConfig(undefined));

--- a/packages/backend.ai-docs-toolkit/src/versions.ts
+++ b/packages/backend.ai-docs-toolkit/src/versions.ts
@@ -38,6 +38,15 @@ import type {
 const MINOR_LABEL = /^[0-9]+\.[0-9]+$/;
 
 /**
+ * Strict `vMAJOR.MINOR.PATCH` shape for `versions[].pdfTag` (FR-2731).
+ * The value is interpolated into a GitHub Releases CDN URL like
+ * `https://github.com/<org>/<repo>/releases/download/<pdfTag>/<asset>`,
+ * so any deviation (missing `v`, missing patch, trailing suffix) would
+ * yield a 404 at request time. Validate at config load instead.
+ */
+const PDF_TAG_REGEX = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
+
+/**
  * Runtime-normalized version entry. One per minor version that survives
  * validation. The `outDir` lives directly under the website output root
  * (`<distDir>/<websiteOutDir>/<outDir>/<lang>/...`) and is identical to
@@ -53,6 +62,14 @@ export interface Version {
   isLatest: boolean;
   /** The directory segment under `dist/web/` for this version. Equal to `label`. */
   outDir: string;
+  /**
+   * Optional release tag (FR-2731) for building the per-version PDF
+   * download URL. Validated against `^v\d+\.\d+\.\d+$` at config load.
+   * `undefined` means "no PDF card for this version" — downstream
+   * renderers must distinguish missing vs present rather than coercing
+   * to an empty string.
+   */
+  pdfTag?: string;
 }
 
 /**
@@ -116,6 +133,11 @@ export function loadVersions(config: ResolvedDocConfig): LoadedVersions {
       source: entry.source,
       isLatest: entry.latest === true,
       outDir: entry.label,
+      // `pdfTag` is fully optional. We deliberately omit the property
+      // (rather than store `undefined` explicitly) so downstream
+      // `JSON.stringify` and `'pdfTag' in v` checks behave intuitively
+      // — a version without a tag has no key at all.
+      ...(entry.pdfTag !== undefined ? { pdfTag: entry.pdfTag } : {}),
     });
   }
 
@@ -149,7 +171,7 @@ function validateEntryShape(entry: VersionEntry, index: number): void {
   // segments downstream.
   if (!MINOR_LABEL.test(entry.label)) {
     throw new Error(
-      `docs-toolkit.config.yaml: "versions[${index}].label" must match ^[0-9]+\\.[0-9]+$ ` +
+      `docs-toolkit.config.yaml: "versions[${index}].label" must match ${MINOR_LABEL.source} ` +
         `(minor only, e.g., "25.16"). Got: ${JSON.stringify(entry.label)}. The selector never ` +
         `lists patches; the highest patch within a minor is built and published as that minor.`,
     );
@@ -172,6 +194,24 @@ function validateEntryShape(entry: VersionEntry, index: number): void {
       throw new Error(
         `docs-toolkit.config.yaml: "versions[${index}].source.ref" is required when ` +
           `kind is "archive-branch" (e.g., "docs-archive/25.16").`,
+      );
+    }
+  }
+  // FR-2731: optional `pdfTag` must shape as `vMAJOR.MINOR.PATCH`. We
+  // validate at config-load time rather than letting a malformed value
+  // produce a 404 from the GitHub Releases CDN at request time.
+  if (entry.pdfTag !== undefined) {
+    if (typeof entry.pdfTag !== "string" || entry.pdfTag.length === 0) {
+      throw new Error(
+        `docs-toolkit.config.yaml: "versions[${index}].pdfTag" must be a non-empty string ` +
+          `(e.g., "v26.4.7"). Got: ${JSON.stringify(entry.pdfTag)}.`,
+      );
+    }
+    if (!PDF_TAG_REGEX.test(entry.pdfTag)) {
+      throw new Error(
+        `docs-toolkit.config.yaml: "versions[${index}].pdfTag" must match ${PDF_TAG_REGEX.source} ` +
+          `(e.g., "v26.4.7"). Got: ${JSON.stringify(entry.pdfTag)}. The value is used to build a ` +
+          `GitHub Releases CDN URL — a leading "v" and a full patch component are both required.`,
       );
     }
   }

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -183,6 +183,16 @@ export interface PageVersionContext {
    * when navigating across versions.
    */
   rootDepth: number;
+  /**
+   * Optional GitHub release tag for the current version (FR-2731). When
+   * present, downstream renderers may use it to build a PDF download
+   * URL like `https://github.com/<org>/<repo>/releases/download/<pdfTag>/<asset>`.
+   * `undefined` means "no PDF card" — renderers MUST suppress the card
+   * entirely rather than coercing to an empty href. This sub-task wires
+   * the value through; the actual UI rendering is implemented in a
+   * follow-up sub-task.
+   */
+  pdfTag?: string;
 }
 
 /**

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -1137,10 +1137,17 @@ function buildPageVersionContext(args: {
   }
   const allLabels = loadedVersions.entries.map((v) => v.label);
   const slugAvailability: Record<string, boolean> = {};
+  // FR-2731: also capture the current version's entry in this same pass
+  // so a follow-up sub-task can render the PDF download card. We
+  // deliberately omit `pdfTag` from the result (rather than store
+  // `undefined` explicitly) so template engines that check for property
+  // presence behave the same for "no entry" and "entry without tag".
+  let currentEntry: Version | undefined;
   for (const v of loadedVersions.entries) {
     if (v.label === versionLabel) {
       // Always available: the page is being rendered right now in this version.
       slugAvailability[v.label] = true;
+      currentEntry = v;
       continue;
     }
     // For OTHER versions: trust the registry's answer. If the slug is
@@ -1159,6 +1166,9 @@ function buildPageVersionContext(args: {
     slugAvailability,
     slug,
     rootDepth,
+    ...(currentEntry?.pdfTag !== undefined
+      ? { pdfTag: currentEntry.pdfTag }
+      : {}),
   };
 }
 


### PR DESCRIPTION
Resolves FR-2731 (Epic FR-2729)

## Summary
- Add optional `pdfTag` field to the toolkit's `versions[]` entry schema for per-version PDF download URLs
- Validate the value against `^v\d+\.\d+\.\d+$` (e.g., `v26.4.7`); reject `26.4.7` (no `v`) and `v26.4` (no patch) with a clear error message
- Thread the validated value into the per-page `PageVersionContext` so a follow-up sub-task (FR-2732) can render the PDF download card
- No UI rendering in this PR — only schema + plumbing

## Anti-patterns avoided
- No parsing in two places — toolkit owns the schema, consumers pass the value through
- No UI / card / link rendered yet — that is FR-2732
- No new `versions[].source.kind` values — reuses FR-2710 F6's `workspace` and `archive-branch`
- No patch-level entries — `versions[]` granularity remains minor-only

## Test plan
- [x] Toolkit unit tests pass — added 6 new pdfTag tests under "loadVersions — pdfTag validation (FR-2731)" suite (78/78 total)
- [x] Existing consumers without `pdfTag` unaffected — absence treated as no value at runtime; the `pdfTag` key is omitted entirely (not coerced to `undefined`) so `'pdfTag' in entry` and `JSON.stringify(entry)` behave intuitively
- [x] `bash scripts/verify.sh` exits with `=== ALL PASS ===` (Relay, Lint, Format, TypeScript)
- [x] `pnpm --filter backend.ai-docs-toolkit run build` compiles cleanly