### PR TITLE
feat(FR-2735): add amplify.yml for multi-version docs deployment

### DIFF
--- a/packages/backend.ai-webui-docs/amplify-redirects.json
+++ b/packages/backend.ai-webui-docs/amplify-redirects.json
@@ -1,0 +1,34 @@
+{
+  "_comment": [
+    "AWS Amplify 'Rewrites and redirects' rules for webui.docs.backend.ai.",
+    "Spec: .specs/FR-2729-webui-docs-multi-version-deployment/spec.md (FR-4, FR-5).",
+    "",
+    "Amplify Hosting does NOT read this file directly — see amplify.yml header note.",
+    "DevOps applies these rules in the Amplify console under 'App settings →",
+    "Rewrites and redirects' (or via the AWS CLI: `aws amplify update-app",
+    "--custom-rules file://amplify-redirects.json`). Versioning the file",
+    "here keeps the intent reviewable in the repo.",
+    "",
+    "Anti-pattern guard:",
+    "  - The root MUST redirect to /26.4/<...>, NOT to /next/<...>.",
+    "    `next` is opt-in only (FR-5).",
+    "  - The /26.4/ target is hardcoded for v1. When the `latest: true`",
+    "    flip moves to a new minor (e.g., 26.5), update both this file",
+    "    AND re-apply the rules in the console. A future toolkit helper",
+    "    may emit this list from `versions[latest=true]` automatically.",
+    "  - Deep-link redirects (/<lang>/<*> -> /<latest>/<lang>/<*>) are",
+    "    intentionally out of scope for v1. Tracked in FR-2742.",
+    "",
+    "Status codes:",
+    "  301 — Permanent redirect. Used for the root because /26.4/ is",
+    "        the deliberate canonical landing page until the next",
+    "        latest-stable shift."
+  ],
+  "customRules": [
+    {
+      "source": "/",
+      "target": "/26.4/",
+      "status": "301"
+    }
+  ]
+}

--- a/packages/backend.ai-webui-docs/amplify.yml
+++ b/packages/backend.ai-webui-docs/amplify.yml
@@ -1,0 +1,182 @@
+# AWS Amplify build specification for `webui.docs.backend.ai`.
+#
+# Spec: .specs/FR-2729-webui-docs-multi-version-deployment/spec.md
+# Sub-task: FR-2735 (add `amplify.yml` for multi-version docs deployment)
+#
+# ─────────────────────────────────────────────────────────────────────
+# LOCATION (monorepo)
+#
+# This file lives at `packages/backend.ai-webui-docs/amplify.yml`, NOT
+# at the repo root. The repository is a pnpm monorepo and a root-level
+# `amplify.yml` would falsely advertise the entire repo as one Amplify
+# deployment. Co-locating with the package being deployed makes
+# ownership obvious and leaves the root free for any future Amplify
+# apps owned by sibling packages.
+#
+# The Amplify app for this site MUST be configured with:
+#   App settings → General → App root: packages/backend.ai-webui-docs
+#
+# Without that setting, Amplify looks for `amplify.yml` at the repo
+# root and the build fails. Provisioning the app root is part of the
+# operational sub-task FR-2737. See AWS Amplify Hosting "Set up
+# monorepos" docs:
+# https://docs.aws.amazon.com/amplify/latest/userguide/monorepo-configuration.html
+#
+# All paths in this file are RELATIVE TO THE APP ROOT (i.e., relative
+# to `packages/backend.ai-webui-docs/`). For commands that need to act
+# on the whole workspace (`pnpm install`, `git fetch` for archive
+# branches), pnpm walks up the directory tree to find
+# `pnpm-workspace.yaml` automatically, and git operates on the
+# enclosing repo regardless of cwd.
+#
+# ─────────────────────────────────────────────────────────────────────
+# Mechanism notes (do NOT remove without re-checking AWS docs).
+#
+# 1. Build phases / artifacts / cache: file-based (this file). Amplify
+#    Hosting reads `frontend.phases`, `frontend.artifacts`, and
+#    `frontend.cache` from `amplify.yml` at the App root.
+#
+# 2. Redirects / rewrites (FR-4 / FR-5): CONSOLE-BASED. Amplify Hosting
+#    does NOT natively read a `_redirects` file from the artifacts.
+#    The "Rewrites and redirects" rules live in the Amplify app config
+#    and must be applied in the Amplify console (or via the AWS Amplify
+#    CLI / CloudFormation, which DevOps owns).
+#
+#    For v1 we keep the desired rules versioned in this repo at
+#    `packages/backend.ai-webui-docs/amplify-redirects.json` so
+#    reviewers can audit the intent. DevOps copies them into the
+#    Amplify console as part of FR-2737. FR-2729 spec
+#    "Dependencies / Open Items" tracks the limitation; a follow-up
+#    (FR-2740) may emit `amplify-redirects.json` from the toolkit so
+#    the `latest: true` flip propagates without manual edits.
+#
+#    Deep-link coverage (e.g., `/<lang>/<*>` → `/<latest>/<lang>/<*>`)
+#    is intentionally deferred from v1 and tracked separately in
+#    FR-2742. The v1 rule set covers only the root redirect.
+#
+#    Reference: AWS Amplify Hosting "Rewrites and redirects" docs
+#    https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html
+#
+# 3. Paths-filter rebuild trigger (FR-8): CONSOLE-BASED. Amplify's
+#    GitHub-app integration reads "Build settings → Build image
+#    settings → Custom build images / Monorepo settings → Watched
+#    paths" from the Amplify console — NOT from `amplify.yml`. The
+#    desired filter is documented below for DevOps to apply during
+#    FR-2737. As with redirects, the intent is versioned (this comment
+#    block) so the PR review trail captures it.
+#
+#    Desired watched paths (rebuild only when these change):
+#      packages/backend.ai-webui-docs/**
+#      packages/backend.ai-docs-toolkit/**
+#
+# 4. HTTPS / TLS: managed by Amplify (ACM cert + CloudFront). No config
+#    needed here.
+#
+# ─────────────────────────────────────────────────────────────────────
+# Local sanity check (run from anywhere in the workspace — pnpm walks
+# up to find `pnpm-workspace.yaml`):
+#
+#   pnpm install --frozen-lockfile
+#   pnpm --filter backend.ai-webui-docs run build:web
+#
+# Produces `packages/backend.ai-webui-docs/dist/web/`. Once FR-2734
+# declares `versions:` in `docs-toolkit.config.yaml` and the
+# `docs-archive/26.4` orphan branch exists (FR-2738), the layout is
+# `dist/web/26.4/<lang>/...` and `dist/web/next/<lang>/...`. Until
+# then, the toolkit warns and skips unresolved archive sources, so
+# the local build produces only the `next` subtree.
+#
+# Manual archive-branch fetch (when reproducing a full Amplify build
+# locally — Amplify performs the equivalent automatically via the
+# `git fetch` step in the runner):
+#
+#   git fetch origin docs-archive/26.4:docs-archive/26.4
+#   git worktree add packages/backend.ai-webui-docs/.docs-archive/docs-archive__26.4 docs-archive/26.4
+#
+# ─────────────────────────────────────────────────────────────────────
+
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        # Use the Node version pinned by `.nvmrc` (currently 24).
+        # Amplify's Linux build images ship with `nvm`. `.nvmrc` lives
+        # at the repo root; nvm walks up to find it.
+        - nvm install
+        - nvm use
+        # Pin pnpm to the major matching `pnpm-lock.yaml` (lockfileVersion
+        # 9.0 ⇒ pnpm 9). `pnpm@latest` is non-reproducible — a future
+        # major could change install behavior without warning. When the
+        # repo root adds a `packageManager` field to `package.json`,
+        # corepack will auto-use it and the explicit `prepare` line below
+        # can be dropped (just `corepack enable` would suffice).
+        - corepack enable
+        - corepack prepare pnpm@9 --activate
+        # Reproducible installs only — never `--no-frozen-lockfile`.
+        # `pnpm install` from anywhere in the workspace installs the
+        # entire monorepo by default (it locates the workspace root
+        # via `pnpm-workspace.yaml`).
+        - pnpm install --frozen-lockfile
+    build:
+      commands:
+        # The toolkit's website-generator (FR-2710 F6) iterates over
+        # `versions:` from `docs-toolkit.config.yaml`. For each entry
+        # whose `source.kind` is `archive-branch`, it expects a
+        # pre-checked-out worktree at
+        # `<projectRoot>/.docs-archive/<sanitized-ref>`. With the App
+        # root set to this package, `<projectRoot>` IS the cwd, so the
+        # worktree path is simply `.docs-archive/<sanitized-ref>`.
+        # The list is hardcoded to `26.4` for v1; future archived
+        # minors must be added here in lockstep with the `versions:`
+        # config until a toolkit helper does it dynamically.
+        - |
+          set -euo pipefail
+          ARCHIVE_REFS=(docs-archive/26.4)
+          for ref in "${ARCHIVE_REFS[@]}"; do
+            sanitized="${ref//\//__}"
+            worktree=".docs-archive/${sanitized}"
+            # Idempotency check: a plain `[ -d "${worktree}" ]` is too
+            # shallow — a stray empty directory or a stale path from a
+            # previous archive ref would pass it, but `git worktree add`
+            # would then fail or behave incorrectly. Ask git directly
+            # whether the path is a registered worktree.
+            worktree_abs="$(realpath -m "${worktree}")"
+            if git worktree list --porcelain | grep -q "^worktree ${worktree_abs}$"; then
+              echo "Archive worktree already registered: ${worktree}"
+              continue
+            fi
+            # If a stray non-worktree directory exists at the path,
+            # remove it before `git worktree add` (which would refuse to
+            # write into a non-empty existing directory).
+            if [ -d "${worktree}" ]; then
+              echo "Removing stray directory at ${worktree} (not a registered worktree)"
+              rm -rf "${worktree}"
+            fi
+            echo "Fetching ${ref} ..."
+            # `git` operates on the enclosing repo regardless of cwd —
+            # this works even though cwd is a subdirectory of the
+            # workspace root.
+            git fetch --depth=1 origin "${ref}:${ref}" || {
+              echo "WARNING: ${ref} not found on origin — skipping (toolkit will warn)"
+              continue
+            }
+            git worktree add --detach "${worktree}" "${ref}"
+          done
+        - pnpm --filter backend.ai-webui-docs run build:web
+  artifacts:
+    # Path is relative to App root (this package). The toolkit emits
+    # `dist/web/` under this package directory.
+    baseDirectory: dist/web
+    files:
+      - "**/*"
+  cache:
+    # pnpm's content-addressable store lives in the user's home dir
+    # and is unaffected by the App root setting. Caching the
+    # workspace-root `node_modules/` from a subdirectory App root is
+    # awkward and mostly contains symlinks for pnpm — we rely on the
+    # store cache plus a clean `pnpm install --frozen-lockfile` (fast
+    # when the store is warm).
+    paths:
+      - $HOME/.pnpm-store/**/*
+      - $HOME/.cache/pnpm/**/*


### PR DESCRIPTION
Resolves FR-2735 (Epic FR-2729)

## Summary

Adds the AWS Amplify build specification for `webui.docs.backend.ai`:

- `packages/backend.ai-webui-docs/amplify.yml` — co-located with the deployed package (NOT at repo root, since this is a pnpm monorepo and the docs site is just one package's deployment)
- `packages/backend.ai-webui-docs/amplify-redirects.json` — versioned source-of-truth for console-managed redirect rules

The Amplify app for this site MUST be configured with **App root = `packages/backend.ai-webui-docs`** (App settings → General). That setting is what makes Amplify read `amplify.yml` from inside the package instead of the repo root. Provisioning the App root is part of operational sub-task FR-2737.

## Build behaviour

- `nvm install`/`nvm use` per repo-root `.nvmrc` (Node 24)
- `pnpm install --frozen-lockfile` from the package directory (walks up to find `pnpm-workspace.yaml`, installs the whole monorepo)
- Inline bash with `set -euo pipefail` materializes `docs-archive/*` worktrees under `.docs-archive/<sanitized-ref>/` (relative to App root). For v1: hardcoded `ARCHIVE_REFS=(docs-archive/26.4)`; future minors must be added in lockstep with `versions:` in `docs-toolkit.config.yaml` until a toolkit helper does it dynamically (FR-2740 follow-up).
- `pnpm --filter backend.ai-webui-docs run build:web` produces `dist/web/<version>/<lang>/...`
- `artifacts.baseDirectory: dist/web` (relative to App root)
- `cache.paths` only includes the pnpm content-addressable store (`$HOME/.pnpm-store`, `$HOME/.cache/pnpm`); workspace-root `node_modules/` is dropped because pnpm symlinks don't cache cleanly under a subdirectory App root

## Console-managed pieces (NOT in this PR)

Amplify Hosting reads three things from the console, NOT from `amplify.yml`:

1. **Rewrites and redirects** — `amplify-redirects.json` is the versioned intent; DevOps copies into the console as part of FR-2737.
2. **Watched paths** — `packages/backend.ai-webui-docs/**` and `packages/backend.ai-docs-toolkit/**`. Documented in `amplify.yml` header for DevOps.
3. **HTTPS / TLS** — Amplify-managed (ACM cert + CloudFront).

## Test plan

Local (verifiable now):
- [x] `amplify.yml` parses as valid YAML
- [x] `amplify-redirects.json` parses as valid JSON
- [x] Local sanity build: `pnpm install --frozen-lockfile && pnpm --filter backend.ai-webui-docs run build:web` produces `packages/backend.ai-webui-docs/dist/web/`

End-to-end (deferred to after FR-2737 provisions Amplify):
- [ ] `https://webui.docs.backend.ai/` returns 3xx with `Location: /26.4/<lang>/`
- [ ] Push to `main` modifying only files outside the watched paths does NOT trigger rebuild
- [ ] Build failure leaves the previous successful deployment serving

## Follow-ups filed

- **FR-2740** — Toolkit: emit `amplify-redirects.json` from `versions[latest=true]` so the redirect target follows future `latest` flips automatically