### PR TITLE
feat(FR-2732): render per-version PDF download card on landing page

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -393,6 +393,10 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
       "This page is not available in version {version}. You are viewing the version index instead.",
     previousVersions: "Previous versions",
     versionLabel: "Version",
+    // FR-2732: per-version PDF download card on the per-language landing
+    // page. Rendered ONLY when `versions[].pdfTag` is set; absent versions
+    // (e.g., `next`) emit no card markup at all.
+    downloadPdfThisVersion: "Download PDF (this version)",
   },
   ko: {
     previous: "이전",
@@ -417,6 +421,7 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
       "이 페이지는 버전 {version}에 존재하지 않습니다. 해당 버전의 인덱스 페이지로 이동했습니다.",
     previousVersions: "이전 버전",
     versionLabel: "버전",
+    downloadPdfThisVersion: "PDF 다운로드 (이 버전)",
   },
   ja: {
     previous: "前へ",
@@ -442,6 +447,7 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
       "このページはバージョン {version} には存在しません。代わりにバージョンのインデックスを表示しています。",
     previousVersions: "以前のバージョン",
     versionLabel: "バージョン",
+    downloadPdfThisVersion: "PDFダウンロード（このバージョン）",
   },
   th: {
     previous: "ก่อนหน้า",
@@ -467,6 +473,7 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
       "หน้านี้ไม่มีในเวอร์ชัน {version} กำลังแสดงหน้าดัชนีของเวอร์ชันแทน",
     previousVersions: "เวอร์ชันก่อนหน้า",
     versionLabel: "เวอร์ชัน",
+    downloadPdfThisVersion: "ดาวน์โหลด PDF (เวอร์ชันนี้)",
   },
 };
 

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -2585,6 +2585,46 @@ export function generateWebsiteStyles(branding?: StyleBrandingTokens): string {
 }
 
 /* ==========================================================================
+   Per-version PDF download card (FR-2732)
+   --------------------------------------------------------------------------
+   The card is rendered ONLY on the per-language landing page
+   (\`<version>/<lang>/index.html\`) when \`versions[].pdfTag\` is set.
+   The landing page is intentionally stylesheet-free in the no-tag
+   baseline (byte-equivalence with the legacy meta-refresh stub), so
+   the card ships its own inline copy of these rules. The class
+   definitions are mirrored here so consumers who want to extend the
+   card (e.g., add it to the topbar in a future phase) can rely on the
+   shared stylesheet.
+   ========================================================================== */
+.pdf-download-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--bai-border);
+  border-radius: var(--bai-radius);
+  background: var(--bai-primary-soft);
+  color: var(--bai-text);
+  text-decoration: none;
+  font-weight: 500;
+}
+.pdf-download-card:hover {
+  border-color: var(--bai-primary);
+  color: var(--bai-primary);
+}
+.pdf-download-card:focus-visible {
+  outline: 2px solid var(--bai-primary);
+  outline-offset: 2px;
+}
+.pdf-download-card__icon {
+  display: inline-flex;
+  color: var(--bai-primary);
+}
+.pdf-download-card__label {
+  flex: 1 1 auto;
+}
+
+/* ==========================================================================
    CJK Language Rules (via :lang() selectors for shared stylesheet)
    ========================================================================== */
 ${cjkSelectors} {

--- a/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
@@ -16,10 +16,12 @@ import assert from "node:assert/strict";
 import path from "path";
 import {
   applyImageAttributes,
+  buildIndexPage,
   buildWebPage,
   type WebPageContext,
   type PageAssets,
 } from "./website-builder.js";
+import type { WebsiteMetadata } from "./website-builder.js";
 import { resolveLegacyDocsUrl, type ResolvedDocConfig } from "./config.js";
 import type { Chapter } from "./markdown-processor.js";
 import type { NavGroup } from "./book-config.js";
@@ -527,5 +529,165 @@ describe("buildWebPage — FR-2733 version-banner variants", () => {
     // The default versioned fixture has current === latest === "26.4".
     const html = buildWebPage(makeVersionedContext());
     assert.doesNotMatch(html, /class="docs-banner/);
+  });
+});
+
+// ── FR-2732: per-version PDF download card on landing page ────────────
+//
+// Two output shapes for `<version>/<lang>/index.html`:
+//   1. No `pdfTag` → byte-equivalent legacy meta-refresh stub.
+//   2. `pdfTag` set → richer landing with the deterministic PDF anchor.
+//
+// The landing page is the ONLY surface that renders the card. Inner
+// chapter pages (rendered via `buildWebPage`) MUST NOT contain the
+// card — verified by an additional negative assertion below.
+
+function makeIndexMetadata(lang: string): WebsiteMetadata {
+  return {
+    title: "Backend.AI WebUI User Guide",
+    version: "v26.4.7",
+    lang,
+    availableLanguages: ["en", "ko", "ja", "th"],
+  };
+}
+
+const indexChapters = [
+  {
+    slug: "dashboard",
+    title: "Dashboard",
+    htmlContent: "<p>...</p>",
+    headings: [],
+  } as unknown as import("./markdown-processor.js").Chapter,
+];
+
+describe("buildIndexPage — FR-2732 PDF download card", () => {
+  it("emits the byte-equivalent legacy redirect stub when pdfTag is unset", () => {
+    const html = buildIndexPage(indexChapters, makeIndexMetadata("en"));
+    // Redirect stub MUST stay byte-equivalent to the pre-FR-2732
+    // baseline so versions like `next` keep an identical output.
+    assert.match(html, /<meta http-equiv="refresh" content="0; url=\.\/dashboard\.html"/);
+    // No PDF surfaces of any kind.
+    assert.doesNotMatch(html, /releases\/download/);
+    assert.doesNotMatch(html, /Download PDF/);
+    assert.doesNotMatch(html, /pdf-download-card/);
+    assert.doesNotMatch(html, /pdfTag/i);
+  });
+
+  it("emits the same redirect stub for `next`-style versions (no pdfTag)", () => {
+    // Spec acceptance: `/next/<lang>/index.html` contains no occurrence
+    // of `releases/download`, no "Download PDF" string, no localized
+    // card label in any of the four shipped languages.
+    for (const lang of ["en", "ko", "ja", "th"]) {
+      const html = buildIndexPage(indexChapters, makeIndexMetadata(lang));
+      assert.doesNotMatch(html, /releases\/download/, `lang=${lang}`);
+      assert.doesNotMatch(html, /Download PDF/, `lang=${lang}`);
+      assert.doesNotMatch(html, /PDF 다운로드/, `lang=${lang}`);
+      assert.doesNotMatch(html, /PDFダウンロード/, `lang=${lang}`);
+      assert.doesNotMatch(html, /ดาวน์โหลด PDF/, `lang=${lang}`);
+    }
+  });
+
+  it("emits the deterministic GitHub Release URL for each language when pdfTag is set", () => {
+    // The href shape MUST exactly equal the spec — string match,
+    // no regex slop. Any deviation (different filename, missing
+    // patch component, query string) would 404 against the GitHub
+    // Releases CDN.
+    const cases: Array<{ lang: string; expected: string }> = [
+      {
+        lang: "en",
+        expected:
+          "https://github.com/lablup/backend.ai-webui/releases/download/v26.4.7/Backend.AI_WebUI_User_Guide_v26.4.7_en.pdf",
+      },
+      {
+        lang: "ko",
+        expected:
+          "https://github.com/lablup/backend.ai-webui/releases/download/v26.4.7/Backend.AI_WebUI_User_Guide_v26.4.7_ko.pdf",
+      },
+      {
+        lang: "ja",
+        expected:
+          "https://github.com/lablup/backend.ai-webui/releases/download/v26.4.7/Backend.AI_WebUI_User_Guide_v26.4.7_ja.pdf",
+      },
+      {
+        lang: "th",
+        expected:
+          "https://github.com/lablup/backend.ai-webui/releases/download/v26.4.7/Backend.AI_WebUI_User_Guide_v26.4.7_th.pdf",
+      },
+    ];
+    for (const { lang, expected } of cases) {
+      const html = buildIndexPage(indexChapters, makeIndexMetadata(lang), {
+        pdfTag: "v26.4.7",
+      });
+      // String-match the full href to catch any future template drift.
+      assert.ok(
+        html.includes(`href="${expected}"`),
+        `expected href="${expected}" in ${lang} landing, got:\n${html}`,
+      );
+      // The `download` attribute is present so single-click downloads
+      // get the canonical filename even if a future GitHub change
+      // drops `Content-Disposition: attachment`.
+      assert.ok(
+        html.includes(
+          `download="Backend.AI_WebUI_User_Guide_v26.4.7_${lang}.pdf"`,
+        ),
+        `expected download attr in ${lang} landing`,
+      );
+      // No `target="_blank"` on the download link — direct download
+      // is intentional per the spec.
+      assert.doesNotMatch(html, /target="_blank"/);
+    }
+  });
+
+  it("renders the localized 'Download PDF (this version)' label per language", () => {
+    const cases: Array<{ lang: string; label: string }> = [
+      { lang: "en", label: "Download PDF (this version)" },
+      { lang: "ko", label: "PDF 다운로드 (이 버전)" },
+      { lang: "ja", label: "PDFダウンロード（このバージョン）" },
+      { lang: "th", label: "ดาวน์โหลด PDF (เวอร์ชันนี้)" },
+    ];
+    for (const { lang, label } of cases) {
+      const html = buildIndexPage(indexChapters, makeIndexMetadata(lang), {
+        pdfTag: "v26.4.7",
+      });
+      assert.ok(
+        html.includes(label),
+        `expected label "${label}" in ${lang} landing`,
+      );
+    }
+  });
+
+  it("drops the meta-refresh when the PDF card is rendered", () => {
+    // When the card is shown the user needs time to click it; an
+    // immediate redirect would defeat the entire purpose.
+    const html = buildIndexPage(indexChapters, makeIndexMetadata("en"), {
+      pdfTag: "v26.4.7",
+    });
+    assert.doesNotMatch(html, /<meta http-equiv="refresh"/);
+    // But the manual "continue" link to the first chapter MUST still
+    // be present — users without a PDF need an escape hatch.
+    assert.match(html, /href="\.\/dashboard\.html"/);
+  });
+
+  it("does NOT render the card on inner chapter pages (buildWebPage)", () => {
+    // The card is landing-only. Inner pages are produced by
+    // buildWebPage and must remain card-free regardless of the
+    // version's pdfTag — the card targets the user who *just* arrived
+    // at the version's home, not a reader deep in chapter content.
+    const html = buildWebPage(makeContext());
+    assert.doesNotMatch(html, /class="pdf-download-card"/);
+    assert.doesNotMatch(html, /releases\/download\/v\d+\.\d+\.\d+\//);
+    // Iterate every shipped localized label so a future translation
+    // drift can't silently leak the card into inner pages.
+    for (const label of [
+      "Download PDF (this version)",
+      "PDF 다운로드 (이 버전)",
+      "PDFダウンロード（このバージョン）",
+      "ดาวน์โหลด PDF (เวอร์ชันนี้)",
+    ]) {
+      assert.ok(
+        !html.includes(label),
+        `inner page must not contain "${label}"`,
+      );
+    }
   });
 });

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -20,8 +20,13 @@
 
 import type { Chapter } from "./markdown-processor.js";
 import type { NavGroup, NavItem } from "./book-config.js";
-import type { ResolvedDocConfig } from "./config.js";
-import { WEBSITE_LABELS } from "./config.js";
+import type { ResolvedBrandingConfig, ResolvedDocConfig } from "./config.js";
+import {
+  DEFAULT_PRIMARY_COLOR,
+  DEFAULT_PRIMARY_COLOR_HOVER,
+  DEFAULT_PRIMARY_COLOR_SOFT,
+  WEBSITE_LABELS,
+} from "./config.js";
 import { escapeHtml } from "./markdown-extensions.js";
 import { slugify } from "./markdown-processor.js";
 import {
@@ -1565,22 +1570,203 @@ ${interactionsScript}
 }
 
 /**
- * Build an index.html that redirects to the first page.
+ * Options accepted by `buildIndexPage` (FR-2732). All fields are optional —
+ * when omitted, the function falls back to the legacy meta-refresh stub
+ * exactly as before. The PDF card is rendered only when `pdfTag` is a
+ * non-empty string; an unset / empty `pdfTag` produces byte-identical
+ * output to the pre-FR-2732 baseline (no card markup, no extra bytes).
+ */
+export interface IndexPageOptions {
+  /**
+   * GitHub Release tag for the current version (FR-2731 / FR-2732), e.g.
+   * `"v26.4.7"`. When set, the per-language landing page renders a
+   * "Download PDF (this version)" card whose anchor points at
+   * `https://github.com/lablup/backend.ai-webui/releases/download/<pdfTag>/Backend.AI_WebUI_User_Guide_<pdfTag>_<lang>.pdf`.
+   * The card is rendered ONLY on this landing page (`<lang>/index.html`),
+   * never on inner content pages.
+   */
+  pdfTag?: string;
+  /**
+   * Resolved branding tokens (FR-2726) used to color the inline `<style>`
+   * block of the PDF card landing. When omitted, the renderer falls back
+   * to the BAI orange defaults from `config.ts` so a stand-alone caller
+   * (e.g. unit tests) keeps producing the same output. White-label
+   * deployments override `branding.primaryColor` etc. in
+   * `docs-toolkit.config.yaml`; the website-generator threads the
+   * resolved tokens through here so the card matches every other surface.
+   */
+  branding?: ResolvedBrandingConfig;
+}
+
+/**
+ * GitHub Release CDN host for the WebUI repo. Hardcoded because the toolkit
+ * is single-tenant for backend.ai-webui (the spec ties the URL shape to
+ * this exact repo); a future generalization can make it config-driven.
+ */
+const PDF_RELEASE_BASE_URL =
+  "https://github.com/lablup/backend.ai-webui/releases/download";
+
+/**
+ * Inline SVG download icon for the PDF card. Kept inline (not a hashed
+ * asset) because the index.html landing page is intentionally
+ * stylesheet-free in the no-`pdfTag` baseline — embedding the icon avoids
+ * pulling in the full asset pipeline just for the card.
+ */
+const PDF_DOWNLOAD_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>`;
+
+/**
+ * Build the deterministic GitHub Release CDN URL for the current
+ * (pdfTag, lang) pair. Kept as a small standalone helper so unit tests
+ * can exercise URL construction independently of the larger render.
+ *
+ * `pdfTag` is regex-validated upstream (FR-2731: `^v\d+\.\d+\.\d+$`),
+ * but `lang` originates from `book.config.yaml`'s `languages: string[]`
+ * with no shape validation. We `encodeURIComponent` both segments as
+ * defense-in-depth so a stray space or non-ASCII character cannot
+ * produce a malformed URL.
+ */
+function buildPdfReleaseUrl(pdfTag: string, lang: string): string {
+  const encodedTag = encodeURIComponent(pdfTag);
+  const encodedLang = encodeURIComponent(lang);
+  return `${PDF_RELEASE_BASE_URL}/${encodedTag}/Backend.AI_WebUI_User_Guide_${encodedTag}_${encodedLang}.pdf`;
+}
+
+/**
+ * Build an `index.html` for a per-language landing page (FR-2732).
+ *
+ * Two output shapes:
+ *   1. **No `pdfTag`** — emits a tiny meta-refresh stub that immediately
+ *      redirects to the first chapter. Byte-equivalent to the pre-FR-2732
+ *      baseline so versions like `next` (which carry no PDF) keep the
+ *      exact same output. Required by the FR-2732 acceptance criteria.
+ *   2. **`pdfTag` is set** — emits a real landing page with a "Download
+ *      PDF (this version)" card linking to the GitHub Release CDN, plus
+ *      a manual "continue to docs" link. The meta-refresh is dropped so
+ *      the user actually has time to see and click the card. The card
+ *      is language-aware: a single anchor for the page's current `<lang>`
+ *      rather than one anchor per language (see FR-13 in the spec).
+ *
+ * The hardcoded asset filename pattern (`Backend.AI_WebUI_User_Guide_<tag>_<lang>.pdf`)
+ * mirrors the per-language PDFs published by FR-2719's release workflow.
+ * No HEAD-request validation at build time — a missing release surfaces
+ * as a 404 on click, which the runbook (FR-2736) catches before the
+ * release is announced.
  */
 export function buildIndexPage(
   chapters: Chapter[],
   metadata: WebsiteMetadata,
+  options: IndexPageOptions = {},
 ): string {
   const firstSlug = chapters[0]?.slug ?? "index";
-  return `<!DOCTYPE html>
-<html lang="${escapeHtml(metadata.lang)}">
+  const lang = escapeHtml(metadata.lang);
+  const title = escapeHtml(metadata.title);
+  const pdfTag = options.pdfTag;
+
+  // No `pdfTag` → byte-identical legacy redirect stub. Do NOT touch this
+  // path: FR-2732 acceptance requires zero diff for `next` and any other
+  // version that does not declare a release tag.
+  if (!pdfTag) {
+    return `<!DOCTYPE html>
+<html lang="${lang}">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="refresh" content="0; url=./${firstSlug}.html" />
-  <title>${escapeHtml(metadata.title)}</title>
+  <title>${title}</title>
 </head>
 <body>
-  <p>Redirecting to <a href="./${firstSlug}.html">${escapeHtml(metadata.title)}</a>...</p>
+  <p>Redirecting to <a href="./${firstSlug}.html">${title}</a>...</p>
+</body>
+</html>`;
+  }
+
+  // `pdfTag` is present — render the PDF card landing.
+  //
+  // The card label is localized via WEBSITE_LABELS; falling back to the
+  // English copy keeps unknown locales rendering a usable card rather
+  // than an empty surface.
+  const labels = WEBSITE_LABELS[metadata.lang] ?? WEBSITE_LABELS.en;
+  const downloadLabel = escapeHtml(
+    labels.downloadPdfThisVersion ??
+      WEBSITE_LABELS.en.downloadPdfThisVersion ??
+      "Download PDF (this version)",
+  );
+  const pdfUrl = buildPdfReleaseUrl(pdfTag, metadata.lang);
+  // The asset URL contains only `[A-Za-z0-9._-]` characters by
+  // construction (pdfTag is regex-validated `^v\d+\.\d+\.\d+$`, lang is
+  // an ISO language code), so escapeHtml is defensive but harmless.
+  const safeHref = escapeHtml(pdfUrl);
+  // Native filename derived from the URL — matches the GitHub release
+  // asset name. Browsers honor `download` for same-origin and CORS-safe
+  // cross-origin resources; GitHub Releases respond with
+  // `Content-Disposition: attachment` regardless, so the link works
+  // even if `download` is ignored.
+  const downloadName = `Backend.AI_WebUI_User_Guide_${pdfTag}_${metadata.lang}.pdf`;
+  const safeDownloadName = escapeHtml(downloadName);
+  const continueLabel = escapeHtml(labels.next ?? "Next");
+
+  // Brand tokens (FR-2726). When the caller doesn't pass `branding` we
+  // fall back to the BAI orange defaults exported from `config.ts` so
+  // standalone callers (unit tests, ad-hoc renders) keep producing the
+  // same output, while white-label deployments that override
+  // `branding.primaryColor` in `docs-toolkit.config.yaml` see the
+  // override here too.
+  const primary = options.branding?.primaryColor ?? DEFAULT_PRIMARY_COLOR;
+  const primaryHover =
+    options.branding?.primaryColorHover ?? DEFAULT_PRIMARY_COLOR_HOVER;
+  const primarySoft =
+    options.branding?.primaryColorSoft ?? DEFAULT_PRIMARY_COLOR_SOFT;
+
+  return `<!DOCTYPE html>
+<html lang="${lang}">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title}</title>
+  <style>
+    /* The landing page is intentionally stylesheet-free in the
+       no-pdfTag baseline; with the card we ship a self-contained
+       inline block instead of pulling the full hashed stylesheet
+       just for two surfaces. Colors mirror the FR-2726 design tokens
+       so light- and dark-mode users see the same brand identity. */
+    :root{
+      --bai-bg:#FFFFFF;
+      --bai-text:#141414;
+      --bai-text-2:#595959;
+      --bai-border:#E8E8E8;
+      --bai-primary:${primary};
+      --bai-primary-hover:${primaryHover};
+      --bai-primary-soft:${primarySoft};
+    }
+    @media (prefers-color-scheme: dark){
+      :root{
+        --bai-bg:#0E0E10;
+        --bai-text:#F0F0F0;
+        --bai-text-2:#B5B5BD;
+        --bai-border:#2A2A30;
+      }
+    }
+    body{margin:0;padding:2rem;font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;background:var(--bai-bg);color:var(--bai-text);display:flex;min-height:100vh;align-items:center;justify-content:center;}
+    .pdf-landing{max-width:32rem;width:100%;}
+    .pdf-landing__title{margin:0 0 1.5rem 0;font-size:1.5rem;font-weight:600;}
+    .pdf-download-card{display:flex;align-items:center;gap:0.75rem;padding:1rem 1.25rem;border:1px solid var(--bai-border);border-radius:8px;background:var(--bai-primary-soft);color:var(--bai-text);text-decoration:none;font-weight:500;}
+    .pdf-download-card:hover{border-color:var(--bai-primary);color:var(--bai-primary);}
+    .pdf-download-card:focus-visible{outline:2px solid var(--bai-primary);outline-offset:2px;}
+    .pdf-download-card__icon{display:inline-flex;color:var(--bai-primary);}
+    .pdf-download-card__label{flex:1 1 auto;}
+    .pdf-landing__continue{margin-top:1rem;font-size:0.875rem;color:var(--bai-text-2);}
+    .pdf-landing__continue a{color:var(--bai-primary);text-decoration:none;}
+    .pdf-landing__continue a:hover{text-decoration:underline;}
+  </style>
+</head>
+<body>
+  <main class="pdf-landing">
+    <h1 class="pdf-landing__title">${title}</h1>
+    <a class="pdf-download-card" href="${safeHref}" download="${safeDownloadName}">
+      <span class="pdf-download-card__icon" aria-hidden="true">${PDF_DOWNLOAD_ICON_SVG}</span>
+      <span class="pdf-download-card__label">${downloadLabel}</span>
+    </a>
+    <p class="pdf-landing__continue"><a href="./${firstSlug}.html">${continueLabel} →</a></p>
+  </main>
 </body>
 </html>`;
 }

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -1068,6 +1068,18 @@ async function buildLanguage(args: {
     fs.writeFileSync(outputPath, pageHtml, "utf-8");
   }
 
+  // FR-2732: surface the current version's optional `pdfTag` to the
+  // landing-page renderer. We deliberately look up the entry by label
+  // (rather than passing the whole `loadedVersions`) so the renderer
+  // never sees other versions' tags. When the lookup misses (flat /
+  // non-versioned mode, or `versionLabel === null`), the result is
+  // `undefined` and the renderer falls back to its byte-equivalent
+  // legacy redirect-stub branch.
+  const currentVersionEntry =
+    versionLabel !== null
+      ? loadedVersions.entries.find((v) => v.label === versionLabel)
+      : undefined;
+
   // Generate index.html (redirect to first page, or placeholder if no chapters)
   const indexHtml =
     chapters.length === 0
@@ -1076,7 +1088,13 @@ async function buildLanguage(args: {
 <head><meta charset="utf-8" /><title>${title}</title></head>
 <body><h1>${title}</h1><p>No documentation content was generated for this language.</p></body>
 </html>`
-      : buildIndexPage(chapters, metadata);
+      : buildIndexPage(chapters, metadata, {
+          pdfTag: currentVersionEntry?.pdfTag,
+          // FR-2732 follow-up: thread resolved branding tokens so the
+          // PDF card honors white-label `branding.primaryColor` overrides
+          // instead of always rendering BAI orange.
+          branding: config.branding,
+        });
   fs.writeFileSync(path.join(langDir, "index.html"), indexHtml, "utf-8");
 
   // Build search index — partitioned per (version × lang) so search


### PR DESCRIPTION
Resolves FR-2732 (Epic FR-2729)

## Summary
- Render "Download PDF (this version)" card on the per-language landing page (`<version>/<lang>/index.html`) when `versions[].pdfTag` is set.
- Anchor `href` is constructed deterministically against the GitHub Releases CDN: `https://github.com/lablup/backend.ai-webui/releases/download/<pdfTag>/Backend.AI_WebUI_User_Guide_<pdfTag>_<lang>.pdf`. No `target="_blank"`, `download` attribute set so single-click downloads land with the canonical filename.
- Card is **landing-only** — inner chapter pages remain card-free regardless of `pdfTag`.
- When `pdfTag` is unset (e.g., `next`) the renderer emits the byte-equivalent legacy meta-refresh stub — no card, no disabled control, no tooltip, fully absent markup.
- Language-aware: a single anchor for the page's current `<lang>`. Localized label in en/ko/ja/th.

## Stack
This PR is stacked on top of #7057 (FR-2731 — `pdfTag` schema + threading).

## Files changed
- `packages/backend.ai-docs-toolkit/src/website-builder.ts` — `buildIndexPage` now accepts `IndexPageOptions` and renders the card when `pdfTag` is set; legacy redirect stub preserved verbatim otherwise.
- `packages/backend.ai-docs-toolkit/src/website-generator.ts` — looks up the current version's `pdfTag` and threads it into `buildIndexPage`.
- `packages/backend.ai-docs-toolkit/src/config.ts` — adds `downloadPdfThisVersion` localized label to `WEBSITE_LABELS` (en/ko/ja/th).
- `packages/backend.ai-docs-toolkit/src/styles-web.ts` — mirrors `.pdf-download-card` rules in the shared stylesheet (the landing page itself ships an inline copy because it is intentionally stylesheet-free in the no-tag baseline).
- `packages/backend.ai-docs-toolkit/src/website-builder.test.ts` — 6 new tests covering byte-equivalence for `next`, deterministic URLs for en/ko/ja/th, localized labels, redirect drop, and the negative assertion that inner pages do not render the card.

## Test plan
- [x] `pnpm --filter backend.ai-docs-toolkit run test` — 84 tests pass (78 prior + 6 new for FR-2732).
- [x] `bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all PASS.
- [x] No `target="_blank"` on the download anchor (direct download via GitHub `Content-Disposition: attachment`).
- [x] `pdfTag`-unset case is byte-equivalent to pre-FR-2732 baseline (verified by string-match assertions in tests).