### PR TITLE
feat(FR-2734): declare versions: and fix pdfFilenameTemplate in webui-docs config

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/versions.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/versions.test.ts
@@ -350,6 +350,54 @@ describe("loadVersions — pdfTag validation (FR-2731)", () => {
   });
 });
 
+describe("loadVersions — 'next' label sentinel (FR-2710 F6)", () => {
+  it("accepts label='next' when paired with source.kind='workspace'", () => {
+    const result = loadVersions(
+      makeConfig([
+        { label: "26.4", source: { kind: "workspace" }, latest: true },
+        { label: "next", source: { kind: "workspace" } },
+      ]),
+    );
+    assert.equal(result.enabled, true);
+    assert.equal(result.entries.length, 2);
+    assert.equal(result.entries[1].label, "next");
+    assert.equal(result.entries[1].outDir, "next");
+    assert.equal(result.entries[1].isLatest, false);
+  });
+
+  it("rejects label='next' paired with source.kind='archive-branch'", () => {
+    assert.throws(
+      () =>
+        loadVersions(
+          makeConfig([
+            { label: "26.4", source: { kind: "workspace" }, latest: true },
+            {
+              label: "next",
+              source: { kind: "archive-branch", ref: "docs-archive/next" },
+            },
+          ]),
+        ),
+      /label "next" must use source\.kind = "workspace"/,
+    );
+  });
+
+  it("still rejects other non-numeric labels (e.g., 'stable', 'preview', 'latest')", () => {
+    for (const bad of ["stable", "preview", "latest", "main", "dev"]) {
+      assert.throws(
+        () =>
+          loadVersions(
+            makeConfig([
+              { label: "26.4", source: { kind: "workspace" }, latest: true },
+              { label: bad, source: { kind: "workspace" } },
+            ]),
+          ),
+        /must match \^\[0-9\]\+\\\.\[0-9\]\+\$.*or be the literal "next"/,
+        `expected label ${JSON.stringify(bad)} to be rejected`,
+      );
+    }
+  });
+});
+
 describe("canonicalPathFor", () => {
   it("returns flat layout when versions are not enabled", () => {
     const loaded = loadVersions(makeConfig(undefined));

--- a/packages/backend.ai-docs-toolkit/src/versions.ts
+++ b/packages/backend.ai-docs-toolkit/src/versions.ts
@@ -34,8 +34,21 @@ import type {
  * catches any deviation (patch suffix, pre-release tag, slash, etc.)
  * at load time rather than letting it leak into URL paths and filesystem
  * segments downstream.
+ *
+ * One literal exception: the sentinel label `"next"` (see `NEXT_LABEL`)
+ * is accepted IFF its `source.kind === "workspace"`. The `next` channel
+ * always tracks the current checkout and never an archived branch, so
+ * the pairing is enforced as a separate validation rule below.
  */
 const MINOR_LABEL = /^[0-9]+\.[0-9]+$/;
+
+/**
+ * Sentinel label for the workspace-tracking channel (FR-2710 F6). Allowed
+ * as a `versions[].label` only when `source.kind === "workspace"` — the
+ * pairing is intentional: `next` is rebuilt on every commit to the trunk
+ * checkout, never to a frozen `docs-archive/<X.Y>` branch.
+ */
+const NEXT_LABEL = "next";
 
 /**
  * Strict `vMAJOR.MINOR.PATCH` shape for `versions[].pdfTag` (FR-2731).
@@ -169,11 +182,19 @@ function validateEntryShape(entry: VersionEntry, index: number): void {
   // deviation — patch suffix, pre-release tag, slash, etc. — fails fast at
   // config load time instead of leaking into URL paths or filesystem
   // segments downstream.
-  if (!MINOR_LABEL.test(entry.label)) {
+  //
+  // Single exception: the literal label `"next"` (NEXT_LABEL) is allowed
+  // for the workspace-tracking channel. The kind-pairing check below
+  // enforces that `"next"` may only be paired with `source.kind:
+  // "workspace"` — an archive-branch `"next"` is rejected with a clear
+  // error rather than silently producing a directory name that collides
+  // with future minors.
+  if (entry.label !== NEXT_LABEL && !MINOR_LABEL.test(entry.label)) {
     throw new Error(
       `docs-toolkit.config.yaml: "versions[${index}].label" must match ${MINOR_LABEL.source} ` +
-        `(minor only, e.g., "25.16"). Got: ${JSON.stringify(entry.label)}. The selector never ` +
-        `lists patches; the highest patch within a minor is built and published as that minor.`,
+        `(minor only, e.g., "25.16") or be the literal "${NEXT_LABEL}" (workspace-tracking ` +
+        `channel). Got: ${JSON.stringify(entry.label)}. The selector never lists patches; ` +
+        `the highest patch within a minor is built and published as that minor.`,
     );
   }
   if (!entry.source || typeof entry.source !== "object") {
@@ -186,6 +207,17 @@ function validateEntryShape(entry: VersionEntry, index: number): void {
     throw new Error(
       `docs-toolkit.config.yaml: "versions[${index}].source.kind" must be ` +
         `"workspace" or "archive-branch". Got: ${JSON.stringify(kind)}.`,
+    );
+  }
+  // `next` is the workspace-tracking channel by definition — it must never
+  // be paired with an archived branch. Catch the misconfiguration here
+  // instead of letting the build pull frozen content under a label that
+  // implies "tip of trunk".
+  if (entry.label === NEXT_LABEL && kind !== "workspace") {
+    throw new Error(
+      `docs-toolkit.config.yaml: "versions[${index}]" with label "${NEXT_LABEL}" must use ` +
+        `source.kind = "workspace" (got ${JSON.stringify(kind)}). The "${NEXT_LABEL}" channel ` +
+        `always tracks the current checkout, never an archived branch.`,
     );
   }
   if (kind === "archive-branch") {

--- a/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
+++ b/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
@@ -28,6 +28,35 @@ pdfMetadata:
   subject: "Backend.AI WebUI User Guide"
   creator: "Backend.AI Docs PDF Generator"
 
+# Versions (FR-2729 multi-version deployment).
+# - 26.4: archived release (FR-2738 creates the docs-archive/26.4 branch)
+# - next: workspace tip; rebuilt on every commit
+# Exactly one entry must carry `latest: true`.
+# Per FR-2710 F6, version labels are minor-only (no patch); the literal
+# label `next` is the only non-numeric value allowed and must pair with
+# `source.kind: workspace`.
+# `pdfTag` (optional, FR-2731) pins to a GitHub Release tag whose
+# assets are linked from the per-language landing page (FR-2732).
+#
+# Release procedure (when cutting a new minor X.Y):
+#   1. Insert a new entry ABOVE the `next` entry with
+#        label: "X.Y"
+#        source: { kind: archive-branch, ref: docs-archive/X.Y }
+#        pdfTag: "vX.Y.Z"   # highest patch in the minor
+#   2. Move `latest: true` onto the new entry; remove it from the prior one.
+#   3. Leave the `next` entry last; it never carries `latest: true`.
+#   See the docs release runbook for the full procedure.
+versions:
+  - label: "26.4"
+    source:
+      kind: archive-branch
+      ref: docs-archive/26.4
+    latest: true
+    pdfTag: "v26.4.7"
+  - label: "next"
+    source:
+      kind: workspace
+
 # Product name for log messages
 productName: "Backend.AI WebUI Docs"
 


### PR DESCRIPTION
Resolves FR-2734 (Epic FR-2729)

## Summary
- Declare `versions:` for `26.4` (latest, archive-branch source `docs-archive/26.4`, `pdfTag: "v26.4.7"`) and `next` (workspace, no `pdfTag`)
- ~~Update `pdfFilenameTemplate`~~ — **reverted** in commit `f7871a96a`. In-house review caught that `getDocVersion()` already prefixes the version with `v`, so the original template was correct; adding a literal `v` would have produced double-`v` filenames at the next release.

## Stack
This PR is stacked on:
- #7057 (FR-2731 — pdfTag schema)
- #7060 (FR-2732 — PDF card render)

## Test plan
- [x] `build:web` parses the YAML (warn on missing `docs-archive/26.4` is expected; FR-2738 creates it)
- [x] `verify.sh` passes
- [x] `pdfFilenameTemplate` reverted to original `..._{version}_{lang}.pdf` so the next release CI produces filenames matching the v26.4.7 release convention
- [ ] (deferred to FR-2738) `dist/web/26.4/<lang>/` renders PDF card
- [ ] (deferred to FR-2738) `dist/web/next/<lang>/` renders no card