### PR TITLE
feat(FR-2744): restore Vitest coverage reporting in CI

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -15,6 +15,9 @@ on:
 
 permissions:
   contents: read
+  # `davelosert/vitest-coverage-report-action` writes a PR comment with the
+  # coverage diff; needs write access on pull-requests for that.
+  pull-requests: write
 
 jobs:
   check-changes:
@@ -80,8 +83,14 @@ jobs:
         run: pnpm run lint
       - name: Run relay-compiler
         run: pnpm run relay
-      - name: Run Vitest
-        run: pnpm run vitest
+      - name: Run Vitest with coverage
+        run: pnpm exec vitest run --coverage
+      - name: Report coverage on PR
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./react
+          name: react-coverage
 
   backend-ai-ui-vitest:
     needs: check-changes
@@ -119,8 +128,14 @@ jobs:
         run: pnpm run lint
       - name: Run relay-compiler
         run: cd ../.. && pnpm run relay
-      - name: Run Vitest
-        run: pnpm run vitest
+      - name: Run Vitest with coverage
+        run: pnpm exec vitest run --coverage
+      - name: Report coverage on PR
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./packages/backend.ai-ui
+          name: backend-ai-ui-coverage
 
   root-vitest:
     needs: check-changes
@@ -150,5 +165,10 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
-      - name: Run Vitest
-        run: pnpm run vitest
+      - name: Run Vitest with coverage
+        run: pnpm exec vitest run --coverage
+      - name: Report coverage on PR
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          name: root-coverage

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "tslib": "^2.8.1",
     "typescript": "~5.5.4",
     "vitest": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.4",
     "webpack": "catalog:",
     "webpack-cli": "^6.0.1",
     "workbox-expiration": "^7.4.0",

--- a/packages/backend.ai-ui/.gitignore
+++ b/packages/backend.ai-ui/.gitignore
@@ -31,3 +31,6 @@ storybook-static
 !.vscode/settings.json.sample
 
 dist
+
+# vitest coverage output
+/coverage

--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -118,7 +118,8 @@
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-relay-lite": "^0.11.0",
     "vite-plugin-svgr": "^4.5.0",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.4"
   },
   "type": "module"
 }

--- a/packages/backend.ai-ui/vitest.config.ts
+++ b/packages/backend.ai-ui/vitest.config.ts
@@ -59,5 +59,24 @@ export default defineConfig({
     ],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/__generated__/**'],
+
+    // Coverage settings — see comment in `react/vitest.config.ts`. The
+    // `davelosert/vitest-coverage-report-action` GitHub Action consumes the
+    // `json-summary` reporter to post a PR comment with line/branch/function/
+    // statement coverage diffs.
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/**/*.stories.{ts,tsx}',
+        'src/__generated__/**',
+        'src/**/__generated__/**',
+        'src/index.ts',
+        'src/locale/**',
+      ],
+    },
   },
 });

--- a/react/package.json
+++ b/react/package.json
@@ -163,6 +163,7 @@
     "vite-plugin-node-polyfills": "^0.24.0",
     "vite-plugin-pwa": "^1.2.0",
     "vite-plugin-svgr": "^4.5.0",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.4"
   }
 }

--- a/react/vitest.config.ts
+++ b/react/vitest.config.ts
@@ -97,5 +97,25 @@ export default defineConfig({
     ],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['**/node_modules/**', '**/build/**', '**/__generated__/**'],
+
+    // Coverage settings: V8 provider is the fastest (Node's built-in V8
+    // inspector with no Babel transform). `json-summary` is what
+    // `davelosert/vitest-coverage-report-action` consumes for the PR comment;
+    // `text` keeps a console summary; `html` lets developers open
+    // `coverage/index.html` locally for inline drill-down.
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/**/*.stories.{ts,tsx}',
+        'src/__generated__/**',
+        'src/**/__generated__/**',
+        'src/index.tsx',
+        'src/reportWebVitals.ts',
+      ],
+    },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,5 +31,20 @@ export default defineConfig({
       "react/**",
       "packages/**",
     ],
+
+    // Coverage settings — see comment in `react/vitest.config.ts`. Same
+    // reporters and provider so the `davelosert/vitest-coverage-report-action`
+    // PR comment shape is consistent across the three workspaces.
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "json-summary", "html"],
+      reportsDirectory: "coverage",
+      include: ["{src,scripts}/**/*.{ts,js,cjs}"],
+      exclude: [
+        "{src,scripts}/**/*.{test,spec}.ts",
+        "src/wsproxy/**",
+        "src/lib/backend.ai-client-node.*",
+      ],
+    },
   },
 });


### PR DESCRIPTION
Resolves #7064(FR-2744)

## Summary

FR-2611 dropped `ArtiomTr/jest-coverage-report-action` (Jest-only) when CI moved to Vitest, so PRs lost the coverage diff comment and inline test-failure annotations. This restores the equivalent surface using `davelosert/vitest-coverage-report-action@v2`.

### Local setup
- Add `@vitest/coverage-v8@^4.1.4` as devDependency in `react/`, `packages/backend.ai-ui/`, root.
- Coverage block in each `vitest.config.ts`:
  - `provider: 'v8'` — uses Node's V8 inspector, no Babel transform needed (fastest provider).
  - `reporter: ['text', 'json', 'json-summary', 'html']` — `json-summary` is what the GitHub Action consumes; `text` keeps a console summary; `html` lets devs open `coverage/index.html` locally.
  - `exclude` patterns trim test files, stories, generated Relay artifacts, and zero-logic entries (`src/index.tsx`, `reportWebVitals`, BUI locale catalog, `wsproxy`, bundled `backend.ai-client-node.*`).
- `/coverage` added to `packages/backend.ai-ui/.gitignore` (root and react/ already had it).

### CI setup
- `.github/workflows/vitest.yml` gains `pull-requests: write` permission so the action can post / update its PR comment.
- Each of the three jobs (`react-vitest`, `backend-ai-ui-vitest`, `root-vitest`) runs `pnpm exec vitest run --coverage` and follows it with a `davelosert/vitest-coverage-report-action@v2` step keyed by a unique `name:` so the three PR comments don't collide.
- The action runs with `if: always()` so a coverage comment posts even when tests fail (matches the prior Jest behaviour, which surfaced failed-test annotations).

## Verification

```
=== react/   ===  Lines 7.23%  (1645/22722)
=== BUI      ===  Lines 7.91%  (317/4006)
=== root     ===  Lines 3.66%  (282/7703)
```

- [x] All three workspaces produce `coverage/coverage-summary.json` in the shape the action expects
- [x] Test pass counts unchanged (react 856/856, BUI 315 + 5 skip, root 90 + 1 skip)
- [x] No regression in lint / format

## Out of scope

- **No coverage threshold gates** — baseline %s above are intentionally low (mostly UI code without unit tests). Gating now would block normal PRs. A separate decision on thresholds belongs to a follow-up after the team agrees on a target.
- README coverage badge.
- Backfilling the 6 `TODO(FR-2609)` skipped tests.

## Stack

Top of the Vite migration stack (now 12 PRs). Builds on PR #6879 (`fix(FR-2606)` webpackIgnore → @vite-ignore).