### PR TITLE
feat(FR-2749): add web-only home page, language-stable URLs, and icon-only language switcher to docs site

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -397,6 +397,21 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     // page. Rendered ONLY when `versions[].pdfTag` is set; absent versions
     // (e.g., `next`) emit no card markup at all.
     downloadPdfThisVersion: "Download PDF (this version)",
+    homeWelcome: "Welcome to the Backend.AI WebUI User Guide",
+    homeIntro:
+      "Backend.AI WebUI is the official browser-based control plane for Backend.AI — Lablup's distributed compute platform for AI and ML workloads. This guide walks you through every screen and every workflow, from your first compute session to administering a multi-tenant deployment.",
+    homeAboutWebUI: "About Backend.AI WebUI",
+    homeAboutWebUIBody:
+      "Connect to your Backend.AI cluster, launch interactive or batch sessions on CPUs and GPUs, share storage folders with your team, and serve trained models as inference endpoints — all without leaving the browser.",
+    homeAboutDocs: "About this manual",
+    homeAboutDocsBody:
+      "Each chapter is grouped by topic in the left sidebar. Use the search bar at the top to jump directly to a feature, or pick a different release from the version selector. The full manual is also available as a downloadable PDF.",
+    homeBrowse: "Browse the manual",
+    homeQuickstartCta: "Get started",
+    homeQuickstartHint:
+      "First time here? Start with the Quickstart chapter to set up your first session.",
+    homeViewOnGitHub: "View source on GitHub",
+    homePagesSuffix: "pages",
   },
   ko: {
     previous: "이전",
@@ -422,6 +437,21 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     previousVersions: "이전 버전",
     versionLabel: "버전",
     downloadPdfThisVersion: "PDF 다운로드 (이 버전)",
+    homeWelcome: "Backend.AI WebUI 사용자 매뉴얼에 오신 것을 환영합니다",
+    homeIntro:
+      "Backend.AI WebUI는 Lablup의 분산 AI/ML 컴퓨팅 플랫폼인 Backend.AI를 위한 공식 브라우저 기반 관리 콘솔입니다. 이 매뉴얼은 첫 연산 세션 생성부터 멀티 테넌트 운영까지, 모든 화면과 워크플로우를 단계별로 안내합니다.",
+    homeAboutWebUI: "Backend.AI WebUI 소개",
+    homeAboutWebUIBody:
+      "Backend.AI 클러스터에 접속해 CPU·GPU 위에서 대화형 또는 배치 세션을 실행하고, 팀과 스토리지 폴더를 공유하며, 학습된 모델을 추론 엔드포인트로 서빙하세요. 모든 작업을 브라우저에서 수행할 수 있습니다.",
+    homeAboutDocs: "이 매뉴얼에 대해",
+    homeAboutDocsBody:
+      "왼쪽 사이드바에서 주제별로 정리된 챕터를 확인할 수 있습니다. 상단 검색창으로 원하는 기능에 바로 이동하거나, 버전 선택기에서 다른 릴리스 문서를 볼 수 있습니다. 전체 매뉴얼은 PDF로도 내려받을 수 있습니다.",
+    homeBrowse: "매뉴얼 둘러보기",
+    homeQuickstartCta: "시작하기",
+    homeQuickstartHint:
+      "처음 방문하셨다면 빠른 시작 챕터에서 첫 세션을 만들어 보세요.",
+    homeViewOnGitHub: "GitHub에서 소스 보기",
+    homePagesSuffix: "개 페이지",
   },
   ja: {
     previous: "前へ",
@@ -448,6 +478,21 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     previousVersions: "以前のバージョン",
     versionLabel: "バージョン",
     downloadPdfThisVersion: "PDFダウンロード（このバージョン）",
+    homeWelcome: "Backend.AI WebUI ユーザーガイドへようこそ",
+    homeIntro:
+      "Backend.AI WebUI は、Lablup の分散 AI／ML コンピューティング基盤 Backend.AI 向けの公式ブラウザインターフェイスです。本マニュアルは、初回のコンピュートセッション作成からマルチテナント運用に至るまで、すべての画面とワークフローを順を追って解説します。",
+    homeAboutWebUI: "Backend.AI WebUI について",
+    homeAboutWebUIBody:
+      "Backend.AI クラスターに接続し、CPU や GPU 上でインタラクティブ／バッチセッションを起動し、ストレージフォルダをチームと共有し、学習済みモデルを推論エンドポイントとして提供できます。すべての操作をブラウザだけで完結できます。",
+    homeAboutDocs: "このマニュアルについて",
+    homeAboutDocsBody:
+      "左サイドバーには各章がトピックごとにまとめられています。上部の検索バーから機能に直接ジャンプしたり、バージョンセレクタから別リリースの文書を参照したりできます。マニュアル全文は PDF でもダウンロード可能です。",
+    homeBrowse: "マニュアルを見る",
+    homeQuickstartCta: "はじめる",
+    homeQuickstartHint:
+      "はじめてご利用の方は、クイックスタートから読み始めてください。",
+    homeViewOnGitHub: "ソースを GitHub で表示",
+    homePagesSuffix: "ページ",
   },
   th: {
     previous: "ก่อนหน้า",
@@ -474,6 +519,21 @@ export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
     previousVersions: "เวอร์ชันก่อนหน้า",
     versionLabel: "เวอร์ชัน",
     downloadPdfThisVersion: "ดาวน์โหลด PDF (เวอร์ชันนี้)",
+    homeWelcome: "ยินดีต้อนรับสู่คู่มือผู้ใช้ Backend.AI WebUI",
+    homeIntro:
+      "Backend.AI WebUI คืออินเทอร์เฟซเว็บอย่างเป็นทางการสำหรับ Backend.AI — แพลตฟอร์มการประมวลผลแบบกระจายของ Lablup สำหรับงาน AI และ ML คู่มือนี้จะพาคุณรู้จักทุกหน้าจอและทุกขั้นตอนการทำงาน ตั้งแต่การสร้างเซสชันการคำนวณครั้งแรก จนถึงการดูแลระบบแบบหลายผู้เช่า",
+    homeAboutWebUI: "เกี่ยวกับ Backend.AI WebUI",
+    homeAboutWebUIBody:
+      "เชื่อมต่อกับคลัสเตอร์ Backend.AI ของคุณ เริ่มเซสชันแบบ interactive หรือ batch บน CPU และ GPU แชร์โฟลเดอร์จัดเก็บกับทีม และให้บริการโมเดลที่ฝึกแล้วเป็น inference endpoint — ทั้งหมดทำได้บนเบราว์เซอร์",
+    homeAboutDocs: "เกี่ยวกับคู่มือนี้",
+    homeAboutDocsBody:
+      "แต่ละบทถูกจัดกลุ่มตามหัวข้อในแถบด้านซ้าย ใช้ช่องค้นหาด้านบนเพื่อข้ามไปยังคุณสมบัติที่ต้องการ หรือเลือกรุ่นอื่นจากตัวเลือกเวอร์ชัน คู่มือฉบับเต็มยังสามารถดาวน์โหลดเป็น PDF ได้",
+    homeBrowse: "ดูคู่มือ",
+    homeQuickstartCta: "เริ่มต้นใช้งาน",
+    homeQuickstartHint:
+      "หากเข้ามาครั้งแรก ขอแนะนำให้เริ่มจากบท เริ่มต้นอย่างรวดเร็ว เพื่อสร้างเซสชันแรกของคุณ",
+    homeViewOnGitHub: "ดูซอร์สโค้ดบน GitHub",
+    homePagesSuffix: "หน้า",
   },
 };
 

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -57,7 +57,9 @@ export type { Chapter, Heading } from "./markdown-processor.js";
 export {
   processMarkdownFiles,
   processCatalogMarkdownForPdf,
+  RESERVED_HOME_SLUG,
   slugify,
+  slugFromNavPath,
   resolveMarkdownPath,
 } from "./markdown-processor.js";
 export type {
@@ -101,8 +103,10 @@ export type {
   WebPageContext,
   WebsiteMetadata,
 } from "./website-builder.js";
+export type { HomePageContext } from "./website-builder.js";
 export {
   applyImageAttributes,
+  buildHomePage,
   buildIndexPage,
   buildLanguagePickerPage,
   buildWebPage,

--- a/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
@@ -8,6 +8,7 @@ import path from "path";
 import { Marked } from "marked";
 import {
   slugify,
+  slugFromNavPath,
   deduplicateH1,
   substituteTemplateVars,
   normalizeRstTables,
@@ -544,7 +545,7 @@ export async function processMarkdownFilesForWeb(
 
     chapterIndex++;
     let markdown = fs.readFileSync(mdPath, "utf-8");
-    const chapterSlug = slugify(nav.title);
+    const chapterSlug = slugFromNavPath(nav.path);
 
     // Pre-processing pipeline (reused from PDF processor)
     markdown = deduplicateH1(markdown);

--- a/packages/backend.ai-docs-toolkit/src/markdown-processor.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor.ts
@@ -97,6 +97,112 @@ export function slugify(text: string): string {
     .replace(/^-|-$/g, '');
 }
 
+/**
+ * Reserved chapter slug for the per-language home page (web build).
+ * The website generator writes the home page to `<lang>/index.html`,
+ * so a real chapter whose path slugifies to `index` (e.g. `index.md`)
+ * would silently overwrite the home. `slugFromNavPath` enforces this
+ * boundary by throwing when a navigation path resolves to the
+ * reserved slug — operators are required to rename the offending
+ * chapter (or use a sub-folder) before the build can proceed.
+ */
+export const RESERVED_HOME_SLUG = 'index';
+
+/**
+ * Derive a chapter slug from the navigation `path` rather than the
+ * (localized) navigation title.
+ *
+ * The navigation path is identical across every language (only the
+ * title is translated), so this guarantees that the same chapter
+ * resolves to the same slug — and therefore the same `<slug>.html`
+ * filename — in every language. This in turn lets readers swap the
+ * language segment in a URL (e.g. `/ko/quickstart.html` ↔
+ * `/en/quickstart.html`) and land on the same chapter without
+ * juggling localized filenames.
+ *
+ * Sanitization is intentionally *less* aggressive than `slugify`:
+ *
+ *   - `slugify` strips underscores (they fall outside its
+ *     `[\p{L}\p{N}\s-]` allowlist), but every existing `book.config`
+ *     in the wild stores paths like `admin_menu/admin_menu.md`. We
+ *     keep `_` so the resulting URL — `admin_menu.html` — matches
+ *     the on-disk filename and the corresponding section anchor in
+ *     the PDF, instead of collapsing to `adminmenu.html`.
+ *   - All other non-`[a-z0-9_-]` characters are dropped to avoid
+ *     surprising URL-encoded paths if someone introduces a path
+ *     with spaces or punctuation.
+ *
+ * The leading basename + extension strip is the structural part: it
+ * pins the slug to the file's leaf identity, which is the property
+ * the language-stable URL contract relies on.
+ *
+ * Implementation note: an earlier version used a chain of `.replace()`
+ * calls with quantified character classes (`/[^a-z0-9_-]+/g`,
+ * `/-+/g`, `/^[-_]+|[-_]+$/g`). CodeQL flagged each of those as a
+ * potential polynomial-regex hot spot on uncontrolled input, even
+ * though the input here is bounded by `book.config.yaml`. The
+ * single-pass character loop below has the same semantics with
+ * unambiguously linear runtime — no regex backtracking, no
+ * compounding quantifiers — so it satisfies the lint *and* removes
+ * the need for a manual `// codeql ignore` annotation.
+ */
+export function slugFromNavPath(navPath: string): string {
+  const base = path.basename(navPath, path.extname(navPath)).toLowerCase();
+  // Single linear pass: keep `[a-z0-9_-]` characters, collapse any
+  // run of disallowed characters into a single `-`. Underscores are
+  // explicitly preserved so `admin_menu.md` stays `admin_menu`
+  // instead of collapsing to `adminmenu`.
+  let cleaned = '';
+  let lastWasDash = false;
+  for (let i = 0; i < base.length; i++) {
+    const ch = base[i];
+    const code = base.charCodeAt(i);
+    const isAllowed =
+      (code >= 0x30 && code <= 0x39) || // 0-9
+      (code >= 0x61 && code <= 0x7a) || // a-z
+      ch === '_' ||
+      ch === '-';
+    if (isAllowed) {
+      // Collapse runs of `-` so `foo--bar` becomes `foo-bar`.
+      if (ch === '-') {
+        if (!lastWasDash && cleaned.length > 0) cleaned += '-';
+        lastWasDash = true;
+      } else {
+        cleaned += ch;
+        lastWasDash = false;
+      }
+    } else {
+      // Treat any disallowed character (or run of them) as a single
+      // dash separator, so `foo bar` becomes `foo-bar`.
+      if (!lastWasDash && cleaned.length > 0) cleaned += '-';
+      lastWasDash = true;
+    }
+  }
+  // Trim trailing `-` / `_` boundary chars one at a time. The leading
+  // boundary is naturally handled by the `cleaned.length > 0` guard
+  // above (we never start with `-`).
+  while (
+    cleaned.length > 0 &&
+    (cleaned[cleaned.length - 1] === '-' ||
+      cleaned[cleaned.length - 1] === '_')
+  ) {
+    cleaned = cleaned.slice(0, -1);
+  }
+  if (!cleaned) {
+    // Refusing the input is preferable to returning `base` (the
+    // earlier `cleaned || base` fallback could leak filtered
+    // characters back into the URL — e.g. spaces or non-ASCII —
+    // producing an unsafe or URL-encoded slug). A `book.config.yaml`
+    // path that sanitizes to nothing is a config error.
+    throw new Error(
+      `Cannot derive a slug from navigation path "${navPath}": ` +
+        `no [a-z0-9_-] characters in basename. Rename the file or ` +
+        `set an explicit ASCII-friendly path.`,
+    );
+  }
+  return cleaned;
+}
+
 export function resolveMarkdownPath(
   lang: string,
   configPath: string,
@@ -306,7 +412,7 @@ export async function processMarkdownFiles(
 
     chapterIndex++;
     let markdown = fs.readFileSync(mdPath, 'utf-8');
-    const chapterSlug = slugify(nav.title);
+    const chapterSlug = slugFromNavPath(nav.path);
 
     // Pre-processing pipeline
     markdown = deduplicateH1(markdown);

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1994,55 +1994,75 @@ details > :last-child {
   flex-wrap: wrap;
 }
 
-/* Lang switcher (FR-2728): native <select> styled as a BAI button.
-   The wrapping <label> serves as the visual frame so we can paint a
-   chevron via background-image without disturbing the native popup. */
+/* Lang switcher (FR-2737 — icon-only variant).
+   Renders as a single Lucide languages icon button. The native <select>
+   is sized to cover the icon and made fully transparent, so clicking
+   the icon opens the OS-native option list — keyboard support, screen
+   reader support, and per-platform dropdown chrome all come "for free"
+   from the underlying <select>. The icon is the only thing the user
+   sees; selected language is communicated via the <select>'s
+   aria-label, the option list, and the chosen-option attribute. */
 .lang-switcher {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  position: relative;
-  /* gap is a no-op when the switcher contains a single SELECT
-     (the native variant FR-2728 ships) but matters for legacy HTML
-     that still renders multiple .lang-switcher__item children inline.
-     Keep it so older bundles don't collapse the spacing. */
-  gap: 2px;
-  border-radius: 6px;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
   background: transparent;
+  color: var(--bai-text-2);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.lang-switcher:hover,
+.lang-switcher:focus-within {
+  background: var(--bai-primary-soft);
+  color: var(--bai-primary);
+}
+
+.lang-switcher__icon {
+  width: 18px;
+  height: 18px;
+  color: inherit;
+  pointer-events: none;
 }
 
 .lang-switcher__select {
+  /* Cover the entire button surface so any click on the icon (or the
+     surrounding hit-area) opens the native dropdown. Opacity 0 hides
+     the native chrome — including the platform chevron — without
+     hiding the control from the accessibility tree. */
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: transparent;
+  font: inherit;
+  opacity: 0;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  display: inline-flex;
-  align-items: center;
-  height: 30px;
-  padding: 0 28px 0 10px;
-  border: 1px solid var(--bai-border);
-  border-radius: 6px;
-  background: var(--bai-bg);
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238C8C8C' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
-  background-repeat: no-repeat;
-  background-position: right 8px center;
-  background-size: 12px 12px;
-  color: var(--bai-text-2);
-  font: inherit;
-  font-size: 12.5px;
-  line-height: 1;
   cursor: pointer;
-  transition: border-color 120ms ease, color 120ms ease, background-color 120ms ease;
+  /* Native popup positioning honors direction. font-size 16px
+     prevents iOS Safari from auto-zooming when the user opens the
+     option list. */
+  font-size: 16px;
 }
 
-.lang-switcher__select:hover {
-  border-color: var(--bai-primary);
-  color: var(--bai-text);
+.lang-switcher__select:focus-visible + .lang-switcher__icon,
+.lang-switcher:focus-within .lang-switcher__icon {
+  color: var(--bai-primary);
 }
 
-.lang-switcher__select:focus,
-.lang-switcher__select:focus-visible {
+.lang-switcher:focus-within {
   outline: 2px solid var(--bai-primary);
-  outline-offset: 1px;
-  color: var(--bai-text);
+  outline-offset: 2px;
 }
 
 [data-theme="dark"] .lang-switcher__select {
@@ -2069,6 +2089,212 @@ details > :last-child {
 .lang-switcher__item--current {
   background: var(--bai-primary);
   color: #fff;
+}
+
+/* ==========================================================================
+   Home page (FR-2737)
+   ==========================================================================
+   The home page reuses the doc layout chrome (topbar, sidebar, footer,
+   search palette) but its <main> body is structured differently — a
+   hero block, a two-column intro, and a category-card grid that
+   doubles as a topical index. The .doc-main--home opt-in widens the
+   content column slightly and removes the chapter top padding so the
+   hero can breathe.
+   ========================================================================== */
+.doc-main--home {
+  padding-top: 56px;
+  max-width: 960px;
+}
+
+.home-article {
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+.home-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--bai-border);
+}
+
+.home-hero__eyebrow {
+  margin: 0;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--bai-primary);
+}
+
+.home-hero__title {
+  margin: 0;
+  font-size: 34px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  font-weight: 700;
+  color: var(--bai-text);
+}
+
+.home-hero__lede {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--bai-text-2);
+}
+
+.home-hero__cta-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.home-hero__hint {
+  margin: 0;
+  font-size: 13px;
+  color: var(--bai-text-3);
+}
+
+.home-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease, transform 120ms ease;
+}
+
+.home-cta__arrow {
+  transition: transform 120ms ease;
+}
+
+.home-cta--primary {
+  background: var(--bai-primary);
+  color: #fff;
+}
+
+.home-cta--primary:hover {
+  background: var(--bai-primary-hover);
+  color: #fff;
+}
+
+.home-cta--primary:hover .home-cta__arrow {
+  transform: translateX(2px);
+}
+
+.home-cta--secondary {
+  background: transparent;
+  color: var(--bai-text);
+  border-color: var(--bai-border);
+}
+
+.home-cta--secondary:hover {
+  border-color: var(--bai-primary);
+  color: var(--bai-primary);
+}
+
+.home-section {
+  display: grid;
+  gap: 12px;
+}
+
+.home-section__title {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.3;
+  font-weight: 700;
+  color: var(--bai-text);
+}
+
+.home-section__body {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--bai-text-2);
+}
+
+.home-section--intro {
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+}
+
+@media (max-width: 720px) {
+  .home-section--intro {
+    grid-template-columns: 1fr;
+  }
+}
+
+.home-section__col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.home-browse__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.home-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px 18px 16px;
+  border: 1px solid var(--bai-border);
+  border-radius: 10px;
+  background: var(--bai-bg);
+  color: var(--bai-text);
+  text-decoration: none;
+  transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
+}
+
+.home-card:hover {
+  border-color: var(--bai-primary);
+  background: var(--bai-primary-soft);
+  transform: translateY(-1px);
+}
+
+.home-card--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.home-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bai-primary-soft);
+  color: var(--bai-primary);
+}
+
+.home-card__icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.home-card__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--bai-text);
+}
+
+.home-card__count {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--bai-text-3);
 }
 
 /* Pagination Navigation (FR-2726 Phase 3 — BAI pager card style) */

--- a/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
@@ -16,6 +16,7 @@ import assert from "node:assert/strict";
 import path from "path";
 import {
   applyImageAttributes,
+  buildHomePage,
   buildIndexPage,
   buildWebPage,
   type WebPageContext,
@@ -23,7 +24,7 @@ import {
 } from "./website-builder.js";
 import type { WebsiteMetadata } from "./website-builder.js";
 import { resolveLegacyDocsUrl, type ResolvedDocConfig } from "./config.js";
-import type { Chapter } from "./markdown-processor.js";
+import { slugFromNavPath, type Chapter } from "./markdown-processor.js";
 import type { NavGroup } from "./book-config.js";
 
 function makeConfig(): ResolvedDocConfig {
@@ -255,6 +256,241 @@ describe("buildWebPage — FR-2726 surfaces", () => {
     const html = buildWebPage(makeContext());
     assert.match(html, /class="doc-sidebar-group__count"/);
     assert.match(html, /aria-label="1 pages">1</);
+  });
+});
+
+describe("buildWebPage — FR-2737 sidebar category icons are language-stable", () => {
+  // Same Backend.AI WebUI category structure as the real
+  // book.config.yaml (5 groups, identical paths across languages).
+  // Only the labels differ. The chosen Lucide-style icon is decided
+  // from the group's first-item path (`quickstart.md` →
+  // `session_page/...` → `vfolder/...` → `user_settings/...` →
+  // `trouble_shooting/...`), so every language MUST emit the SAME
+  // sequence of <svg> path payloads in the sidebar headers.
+  const navGroupsByLang: Record<string, NavGroup[]> = {
+    en: [
+      {
+        category: "Getting Started",
+        items: [{ title: "Quickstart", path: "quickstart.md" }],
+      },
+      {
+        category: "Workloads",
+        items: [
+          {
+            title: "Session Page",
+            path: "session_page/session_page.md",
+          },
+        ],
+      },
+      {
+        category: "Storage & Data",
+        items: [{ title: "Vfolder", path: "vfolder/vfolder.md" }],
+      },
+      {
+        category: "Administration",
+        items: [
+          {
+            title: "User Settings",
+            path: "user_settings/user_settings.md",
+          },
+        ],
+      },
+      {
+        category: "Reference",
+        items: [
+          {
+            title: "Trouble Shooting",
+            path: "trouble_shooting/trouble_shooting.md",
+          },
+        ],
+      },
+    ],
+    ko: [
+      {
+        category: "시작하기",
+        items: [{ title: "빠른 시작", path: "quickstart.md" }],
+      },
+      {
+        category: "워크로드",
+        items: [
+          {
+            title: "세션 페이지",
+            path: "session_page/session_page.md",
+          },
+        ],
+      },
+      {
+        category: "스토리지 및 데이터",
+        items: [
+          { title: "스토리지 폴더", path: "vfolder/vfolder.md" },
+        ],
+      },
+      {
+        category: "관리",
+        items: [
+          {
+            title: "사용자 설정",
+            path: "user_settings/user_settings.md",
+          },
+        ],
+      },
+      {
+        category: "참고 자료",
+        items: [
+          {
+            title: "FAQ 및 문제 해결",
+            path: "trouble_shooting/trouble_shooting.md",
+          },
+        ],
+      },
+    ],
+    ja: [
+      {
+        category: "はじめに",
+        items: [{ title: "クイックスタート", path: "quickstart.md" }],
+      },
+      {
+        category: "ワークロード",
+        items: [
+          {
+            title: "セッションページ",
+            path: "session_page/session_page.md",
+          },
+        ],
+      },
+      {
+        category: "ストレージとデータ",
+        items: [
+          {
+            title: "ストレージフォルダ",
+            path: "vfolder/vfolder.md",
+          },
+        ],
+      },
+      {
+        category: "管理",
+        items: [
+          {
+            title: "ユーザー設定",
+            path: "user_settings/user_settings.md",
+          },
+        ],
+      },
+      {
+        category: "リファレンス",
+        items: [
+          {
+            title: "FAQ＆トラブルシューティング",
+            path: "trouble_shooting/trouble_shooting.md",
+          },
+        ],
+      },
+    ],
+    th: [
+      {
+        category: "เริ่มต้นใช้งาน",
+        items: [
+          {
+            title: "เริ่มต้นอย่างรวดเร็ว",
+            path: "quickstart.md",
+          },
+        ],
+      },
+      {
+        category: "เวิร์กโหลด",
+        items: [
+          {
+            title: "หน้าเซสชัน",
+            path: "session_page/session_page.md",
+          },
+        ],
+      },
+      {
+        category: "พื้นที่จัดเก็บและข้อมูล",
+        items: [
+          {
+            title: "โฟลเดอร์จัดเก็บ",
+            path: "vfolder/vfolder.md",
+          },
+        ],
+      },
+      {
+        category: "การดูแลระบบ",
+        items: [
+          {
+            title: "ตั้งค่าผู้ใช้",
+            path: "user_settings/user_settings.md",
+          },
+        ],
+      },
+      {
+        category: "เอกสารอ้างอิง",
+        items: [
+          {
+            title: "FAQ และการแก้ไขปัญหา",
+            path: "trouble_shooting/trouble_shooting.md",
+          },
+        ],
+      },
+    ],
+  };
+
+  /**
+   * Capture the sequence of `<svg>` icon HTML emitted inside each
+   * `.doc-sidebar-group__icon` span, in document order.
+   */
+  function extractIconSequence(html: string): string[] {
+    const re =
+      /class="doc-sidebar-group__icon"[^>]*>(<svg[^]*?<\/svg>)/g;
+    return [...html.matchAll(re)].map((m) => m[1]);
+  }
+
+  function makeCtxForLang(
+    lang: string,
+    navGroups: NavGroup[],
+  ): WebPageContext {
+    // Reuse the standard fixture but swap the lang and navGroups so
+    // the sidebar renders the localized labels with the same paths.
+    // The active page (`dashboard`) doesn't appear in any of these
+    // groups, so no group auto-expands — that's fine for the icon
+    // assertion.
+    const ctx = makeContext();
+    ctx.metadata = { ...ctx.metadata, lang };
+    ctx.navGroups = navGroups;
+    return ctx;
+  }
+
+  it("emits the same icon sequence in every language", () => {
+    const sequences = Object.entries(navGroupsByLang).map(
+      ([lang, groups]) => extractIconSequence(buildWebPage(makeCtxForLang(lang, groups))),
+    );
+    // Sanity: 5 categories ⇒ 5 icons per language.
+    for (const seq of sequences) assert.equal(seq.length, 5);
+    // The English sequence is the reference. Every other language
+    // must emit the byte-identical sequence of <svg> bodies.
+    const [reference, ...others] = sequences;
+    for (const other of others) {
+      assert.deepStrictEqual(other, reference);
+    }
+  });
+
+  it("does NOT fall back to the generic stack icon for any localized language", () => {
+    // The stack icon's distinctive d= signature (used by the legacy
+    // fallback). With FR-2737 in place none of the localized
+    // category headers should resort to it.
+    const stackSig = "m12 3 9 5-9 5-9-5 9-5";
+    for (const [lang, groups] of Object.entries(navGroupsByLang)) {
+      if (lang === "en") continue; // the English path also won't hit fallback; skip for symmetry
+      const html = buildWebPage(makeCtxForLang(lang, groups));
+      const icons = extractIconSequence(html);
+      for (const svg of icons) {
+        assert.equal(
+          svg.includes(stackSig),
+          false,
+          `lang=${lang}: localized category icon fell back to ICON_STACK`,
+        );
+      }
+    }
   });
 });
 
@@ -689,5 +925,226 @@ describe("buildIndexPage — FR-2732 PDF download card", () => {
         `inner page must not contain "${label}"`,
       );
     }
+  });
+});
+
+describe("slugFromNavPath — FR-2737 language-stable slugs", () => {
+  it("derives the slug from the basename, lowercased", () => {
+    assert.equal(slugFromNavPath("quickstart.md"), "quickstart");
+    assert.equal(slugFromNavPath("Quickstart.md"), "quickstart");
+  });
+
+  it("uses only the leaf segment of nested paths", () => {
+    assert.equal(
+      slugFromNavPath("model_serving/model_serving.md"),
+      "model_serving",
+    );
+    assert.equal(slugFromNavPath("a/b/c/dashboard.md"), "dashboard");
+  });
+
+  it("preserves underscores so on-disk filenames survive into URLs", () => {
+    assert.equal(slugFromNavPath("admin_menu/admin_menu.md"), "admin_menu");
+    assert.equal(
+      slugFromNavPath("trouble_shooting/trouble_shooting.md"),
+      "trouble_shooting",
+    );
+  });
+
+  it("produces a deterministic, language-independent slug from the path", () => {
+    // The path is identical across languages; only the localized title
+    // differs in book.config.yaml. The slug must therefore depend
+    // *only* on the path — that is the whole point of FR-2737. The
+    // earlier `assert.equal(f(p), f(p))` shape was a tautology that
+    // could never fail; assert against a known expected value instead
+    // so a regression to title-derived slugs would be caught.
+    assert.equal(
+      slugFromNavPath("model_serving/model_serving.md"),
+      "model_serving",
+    );
+    // And for completeness, also verify the call is idempotent
+    // (same input → same output every time, no hidden state).
+    const first = slugFromNavPath("session_page/session_page.md");
+    const second = slugFromNavPath("session_page/session_page.md");
+    assert.equal(first, "session_page");
+    assert.equal(second, first);
+  });
+
+  it("collapses runs of disallowed characters into a single dash", () => {
+    // The single-pass sanitizer must collapse `foo  bar.md` into
+    // `foo-bar`, not `foo--bar`. Guards against quantifier drift in
+    // the linear-time replacement loop.
+    assert.equal(slugFromNavPath("foo  bar.md"), "foo-bar");
+    assert.equal(slugFromNavPath("foo!!!bar.md"), "foo-bar");
+  });
+
+  it("trims trailing dash / underscore boundary characters", () => {
+    assert.equal(slugFromNavPath("foo--.md"), "foo");
+    assert.equal(slugFromNavPath("foo__.md"), "foo");
+  });
+
+  it("throws when the path basename has no allowlisted characters", () => {
+    // Earlier code returned the raw basename here, which could leak
+    // unsafe characters (spaces, non-ASCII) into the URL. The
+    // post-feedback contract is to refuse the input and surface a
+    // config-error instead, so the operator fixes book.config.yaml
+    // before the build emits a broken slug.
+    assert.throws(() => slugFromNavPath("   .md"), /Cannot derive a slug/);
+    assert.throws(() => slugFromNavPath("***.md"), /Cannot derive a slug/);
+  });
+});
+
+describe("buildHomePage — FR-2737 home page", () => {
+  function makeHomeContext() {
+    const config = makeConfig();
+    const navGroups: NavGroup[] = [
+      {
+        category: "Getting Started",
+        items: [
+          { title: "Quickstart", path: "quickstart.md" },
+          { title: "Overview", path: "overview/overview.md" },
+        ],
+      },
+      {
+        category: "Workloads",
+        items: [
+          {
+            title: "Session Page",
+            path: "session_page/session_page.md",
+          },
+        ],
+      },
+    ];
+    const allChapters: Chapter[] = [
+      {
+        title: "Quickstart",
+        slug: "quickstart",
+        htmlContent: "<p>start</p>",
+        headings: [],
+      },
+      {
+        title: "Overview",
+        slug: "overview",
+        htmlContent: "<p>overview</p>",
+        headings: [],
+      },
+      {
+        title: "Session Page",
+        slug: "session_page",
+        htmlContent: "<p>session</p>",
+        headings: [],
+      },
+    ];
+    const assets: PageAssets = {
+      styles: "styles.abcd.css",
+      search: "search.abcd.js",
+      favicon: "favicon.ico",
+      brandLogoLight: "brand-logo-light.abcd.svg",
+      brandLogoDark: "brand-logo-dark.abcd.svg",
+      interactions: "interactions.abcd.js",
+    };
+    return {
+      metadata: {
+        title: "Backend.AI WebUI User Guide",
+        version: "v26.5.0",
+        lang: "ko",
+        availableLanguages: ["en", "ko", "ja", "th"],
+      },
+      config,
+      navGroups,
+      allChapters,
+      assets,
+      peers: [
+        {
+          lang: "en",
+          label: "English",
+          href: "../en/index.html",
+          available: true,
+        },
+        {
+          lang: "ko",
+          label: "한국어",
+          href: "../ko/index.html",
+          available: true,
+        },
+        {
+          lang: "ja",
+          label: "日本語",
+          href: "../ja/index.html",
+          available: true,
+        },
+        {
+          lang: "th",
+          label: "ภาษาไทย",
+          href: "../th/index.html",
+          available: true,
+        },
+      ],
+    };
+  }
+
+  it("emits hero, intro sections, and a category-card grid", () => {
+    const html = buildHomePage(makeHomeContext());
+    assert.match(html, /class="home-hero"/);
+    assert.match(html, /class="home-hero__title"/);
+    assert.match(html, /home-section--intro/);
+    assert.match(html, /class="home-browse__grid"/);
+    // Two non-empty categories ⇒ two cards.
+    const cardMatches = html.match(/class="home-card"/g) ?? [];
+    assert.equal(cardMatches.length, 2);
+  });
+
+  it("points each category card at the first chapter inside that group", () => {
+    const html = buildHomePage(makeHomeContext());
+    // Getting Started → quickstart.md → quickstart.html
+    assert.match(html, /<a class="home-card" href="\.\/quickstart\.html">/);
+    // Workloads → session_page/session_page.md → session_page.html
+    assert.match(html, /<a class="home-card" href="\.\/session_page\.html">/);
+  });
+
+  it("uses localized strings for the current language", () => {
+    const html = buildHomePage(makeHomeContext());
+    // Korean fixture above ⇒ Korean welcome line.
+    assert.match(html, /Backend\.AI WebUI 사용자 매뉴얼에 오신 것을 환영합니다/);
+    // The hint copy mentions "빠른 시작" (the Korean Quickstart label).
+    assert.match(html, /빠른 시작/);
+  });
+
+  it("links the primary CTA at the first chapter slug", () => {
+    const html = buildHomePage(makeHomeContext());
+    assert.match(
+      html,
+      /<a class="home-cta home-cta--primary" href="\.\/quickstart\.html">/,
+    );
+  });
+
+  it("reuses the topbar (logo, search, lang switcher) and the sidebar", () => {
+    const html = buildHomePage(makeHomeContext());
+    assert.match(html, /<header class="bai-topbar"/);
+    assert.match(html, /class="bai-topbar__brand"[^>]*href="\.\/index\.html"/);
+    assert.match(html, /class="lang-switcher__icon"/); // FR-2737 icon
+    assert.match(html, /class="doc-sidebar"/);
+  });
+
+  it("does NOT emit a breadcrumb (the home page IS the home destination)", () => {
+    const html = buildHomePage(makeHomeContext());
+    assert.doesNotMatch(html, /class="breadcrumb"/);
+  });
+
+  it("does NOT emit pagination (no prev/next on the home page)", () => {
+    const html = buildHomePage(makeHomeContext());
+    assert.doesNotMatch(html, /class="pagination-nav"/);
+  });
+
+  it("renders a GitHub CTA only when website.repoUrl is set", () => {
+    const html = buildHomePage(makeHomeContext());
+    assert.match(html, /class="home-cta home-cta--secondary"/);
+
+    const ctxNoRepo = makeHomeContext();
+    ctxNoRepo.config = {
+      ...ctxNoRepo.config,
+      website: { editBaseUrl: ctxNoRepo.config.website?.editBaseUrl },
+    };
+    const html2 = buildHomePage(ctxNoRepo);
+    assert.doesNotMatch(html2, /class="home-cta home-cta--secondary"/);
   });
 });

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -28,7 +28,11 @@ import {
   WEBSITE_LABELS,
 } from "./config.js";
 import { escapeHtml } from "./markdown-extensions.js";
-import { slugify } from "./markdown-processor.js";
+import {
+  RESERVED_HOME_SLUG,
+  slugFromNavPath,
+  slugify,
+} from "./markdown-processor.js";
 import {
   buildJsonLd,
   buildOgTags,
@@ -318,8 +322,10 @@ function buildWebsiteSidebar(
     const openAttr = containsActive ? " open" : "";
     const groupSlug = slugify(group.category) || "group";
     // Phase 2 (FR-2726): each summary now carries a leading icon + a
-    // trailing count pill matching the BAI sider pattern.
-    const iconSvg = sidebarCategoryIconSvg(group.category);
+    // trailing count pill matching the BAI sider pattern. FR-2737:
+    // pass the whole group so the icon helper can key off the first
+    // item's path (language-stable) instead of the localized label.
+    const iconSvg = sidebarCategoryIconSvg(group);
     const itemCount = group.items.length;
     return `<details class="doc-sidebar-group"${openAttr}>
   <summary class="doc-sidebar-group__summary">
@@ -371,21 +377,48 @@ ${versionBlockHtml}  <nav class="doc-sidebar-groups" aria-label="Documentation n
 }
 
 /**
- * Inline SVG icon for a sidebar category header (FR-2726 Phase 2).
+ * Inline SVG icon for a sidebar category header.
  *
- * The mapping matches a small whitelist of canonical English category
- * labels (case-insensitive). Categories that don't match — including
- * every non-English label in localized navs — fall through to a generic
- * "stack of pages" icon so every category still gets a visual anchor.
- * Phase 3+ may extend this with a config knob in `book.config.yaml`,
- * letting consumers map any category label to any icon name.
+ * Originally (FR-2726 Phase 2) the mapping keyed off the localized
+ * category label and only matched English. That meant the Korean /
+ * Japanese / Thai sidebars all collapsed to the generic "stack" icon
+ * for every category — visually identical drawers with no per-topic
+ * cue.
+ *
+ * FR-2737 fixes that by deriving the icon from the FIRST item's
+ * navigation path instead of the localized label. Paths in
+ * `book.config.yaml` are identical across every language (only titles
+ * are translated), so the same group resolves to the same icon in
+ * every language. The English label match is kept as a soft fallback
+ * for projects that re-order their nav so a non-Backend.AI first
+ * item shows up under a familiar English category name.
  */
-function sidebarCategoryIconSvg(category: string): string {
-  const key = category.trim().toLowerCase();
-  // Common Backend.AI WebUI categories. Other consumers fall through to
-  // the default icon, which is intentional — Phase 3 will add per-category
-  // icon configuration to book.config.yaml.
-  const map: Record<string, string> = {
+function sidebarCategoryIconSvg(group: NavGroup): string {
+  // 1) Language-stable path lookup. The slug of the group's first item
+  //    uniquely identifies the canonical Backend.AI WebUI category
+  //    even after the label is translated. Matches the on-disk
+  //    filename convention (`<topic>.md` or `<topic>/<topic>.md`).
+  //    Defensive guard: a synthetic empty group would make the path
+  //    empty, which `slugFromNavPath` would reject. Fall through to
+  //    the label / stack-icon fallbacks below in that case rather
+  //    than crashing the build.
+  const firstPath = group.items[0]?.path;
+  const firstSlug = firstPath ? slugFromNavPath(firstPath) : "";
+  const slugIcon: Record<string, string> = {
+    quickstart: ICON_ROCKET, // Getting Started
+    session_page: ICON_BOX, // Workloads
+    vfolder: ICON_FOLDER, // Storage & Data
+    user_settings: ICON_SETTINGS, // Administration
+    trouble_shooting: ICON_BOOK, // Reference
+  };
+  if (slugIcon[firstSlug]) return slugIcon[firstSlug];
+
+  // 2) Fallback: English category-label lookup. Useful for downstream
+  //    consumers that build their own nav groups with the canonical
+  //    English headings but a different first item, and for legacy
+  //    book configs that haven't been re-keyed yet.
+  const labelKey = group.category.trim().toLowerCase();
+  const labelIcon: Record<string, string> = {
     "getting started": ICON_ROCKET,
     workloads: ICON_BOX,
     "storage & data": ICON_FOLDER,
@@ -393,10 +426,25 @@ function sidebarCategoryIconSvg(category: string): string {
     administration: ICON_SETTINGS,
     reference: ICON_BOOK,
   };
-  return map[key] ?? ICON_STACK;
+  if (labelIcon[labelKey]) return labelIcon[labelKey];
+
+  // 3) Last resort: generic "stack of pages" so every category still
+  //    gets some visual anchor.
+  return ICON_STACK;
 }
 
-const ICON_ROCKET = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M14.5 4c4 1 5.5 4.5 5.5 5.5 0 0-3.5 1.5-5.5 5.5h-5C7.5 11 4 9.5 4 9.5S5.5 5 9.5 4h5Zm-2.5 5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM7 17l-2 3 3-2m8-1 2 3-3-2"/></svg>`;
+/**
+ * Lucide `languages` icon — used to signal the purpose of the topbar
+ * language switcher (FR-2737). Inline SVG, currentColor stroke so it
+ * inherits the surrounding text color in both light and dark themes.
+ * Source: https://lucide.dev/icons/languages
+ */
+const LUCIDE_LANGUAGES_ICON_SVG = `<svg class="lang-switcher__icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 8 6 6"/><path d="m4 14 6-6 2-3"/><path d="M2 5h12"/><path d="M7 2h1"/><path d="m22 22-5-10-5 10"/><path d="M14 18h6"/></svg>`;
+
+// Canonical Lucide `rocket` icon. Swapped in (FR-2737) for the
+// hand-drawn placeholder, whose silhouette read as a horizontal blob
+// at 14px. Source: https://lucide.dev/icons/rocket
+const ICON_ROCKET = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>`;
 const ICON_BOX = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" d="m12 3 9 5v8l-9 5-9-5V8l9-5Z"/><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" d="m3 8 9 5 9-5M12 13v8"/></svg>`;
 const ICON_FOLDER = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z"/></svg>`;
 const ICON_SETTINGS = `<svg width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.6"/><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg>`;
@@ -1295,11 +1343,19 @@ function buildBaiTopbar(
   // localization passes through to search.js.
   void noResultsAttr;
 
-  // Lang switcher (FR-2728): a native <select> styled as a BAI button.
-  // Native select is keyboard-accessible, screen-reader-friendly, and
-  // collapses to one row in the topbar — replacing the always-expanded
-  // pill row. Pages where a language is missing keep the option, but
-  // the value is the language's index page (so the click still works).
+  // Lang switcher (FR-2737 — icon-only variant).
+  //
+  // The visible affordance is a single Lucide `languages` icon. A
+  // transparent native `<select>` is layered on top of the icon, so
+  // clicking the icon opens the OS-native option list — every browser
+  // and platform (incl. mobile) renders this dropdown using its own
+  // accessible UI. We don't reinvent the menu in JS: keyboard support,
+  // screen-reader announcements, and touch-friendly option pickers all
+  // come "for free" from the native control.
+  //
+  // Pages where the chapter is missing in a peer language still get an
+  // option, but its value is that language's `index.html` so the click
+  // never lands on a 404.
   const langOptions = peers
     .map((peer) => {
       const isCurrent = peer.lang === metadata.lang;
@@ -1315,8 +1371,15 @@ function buildBaiTopbar(
   // requires JavaScript to fire `change`; consumers who need a true
   // no-JS fallback can layer a `<noscript>` block of plain anchor
   // links above this widget.
-  const langSwitcherHtml = `<label class="lang-switcher" role="group" aria-label="Language switcher">
-    <select class="lang-switcher__select" onchange="if(this.value)window.location.assign(this.value)">${langOptions}</select>
+  //
+  // The <select> is rendered BEFORE the icon so the icon paints on
+  // top of it (later DOM order = higher in the natural stacking
+  // context). Both elements share the wrapping <label>, which means
+  // a click on the icon still focuses the select via the implicit
+  // label association.
+  const langSwitcherHtml = `<label class="lang-switcher" aria-label="Language switcher">
+    <select class="lang-switcher__select" aria-label="Language switcher" onchange="if(this.value)window.location.assign(this.value)">${langOptions}</select>
+    ${LUCIDE_LANGUAGES_ICON_SVG}
   </label>`;
 
   // FR-2733: the version selector used to render here in the topbar
@@ -1575,6 +1638,12 @@ ${interactionsScript}
  * exactly as before. The PDF card is rendered only when `pdfTag` is a
  * non-empty string; an unset / empty `pdfTag` produces byte-identical
  * output to the pre-FR-2732 baseline (no card markup, no extra bytes).
+ *
+ * Note: the production website build now uses `buildHomePage` for the
+ * per-language landing — `buildIndexPage` is retained as a thin fallback
+ * for languages with no chapters (an empty navigation is still a valid
+ * `book.config.yaml` shape) and for external callers that have not
+ * migrated to `buildHomePage`. See `website-generator.ts`.
  */
 export interface IndexPageOptions {
   /**
@@ -1657,7 +1726,7 @@ export function buildIndexPage(
   metadata: WebsiteMetadata,
   options: IndexPageOptions = {},
 ): string {
-  const firstSlug = chapters[0]?.slug ?? "index";
+  const firstSlug = chapters[0]?.slug ?? RESERVED_HOME_SLUG;
   const lang = escapeHtml(metadata.lang);
   const title = escapeHtml(metadata.title);
   const pdfTag = options.pdfTag;
@@ -1767,6 +1836,274 @@ export function buildIndexPage(
     </a>
     <p class="pdf-landing__continue"><a href="./${firstSlug}.html">${continueLabel} →</a></p>
   </main>
+</body>
+</html>`;
+}
+
+/**
+ * Per-language Home page (FR-2737).
+ *
+ * The home page is web-only — the PDF pipeline starts directly with
+ * the first chapter and has no concept of a landing page. It serves
+ * three purposes:
+ *
+ *   1. Give first-time visitors a real introduction to Backend.AI
+ *      WebUI and to the manual itself, instead of bouncing them via
+ *      a `<meta refresh>` redirect into a chapter that assumes prior
+ *      context.
+ *   2. Provide a stable destination for the topbar logo and the
+ *      breadcrumb "Home" link in the *current* language. With this
+ *      page in place, both controls now go somewhere meaningful
+ *      rather than dropping the user one chapter into the manual.
+ *   3. Surface the top-level category structure as a grid of cards,
+ *      mirroring the sidebar's grouped nav. Each card jumps to the
+ *      first chapter inside its group, so the home doubles as a
+ *      browse-by-topic index.
+ *
+ * The page reuses every piece of chrome already used by chapter pages
+ * (topbar, sidebar, version banner / notice, footer, search palette,
+ * scripts) to keep visual continuity. Only the article body differs.
+ */
+export interface HomePageContext {
+  metadata: WebsiteMetadata;
+  config: ResolvedDocConfig;
+  /** Sidebar nav groups for the current language. */
+  navGroups: NavGroup[];
+  /** All chapters for the current language (powers the sidebar). */
+  allChapters: Chapter[];
+  /** Resolved per-page asset filenames (already content-hashed). */
+  assets: PageAssets;
+  /** Per-language switcher links (always one entry per declared lang). */
+  peers: LanguagePeer[];
+  /**
+   * Versioned-docs context, when running in versioned mode. Plumbed
+   * through so the topbar / sidebar version selector and the
+   * "you are viewing an older version" banner show on the home page
+   * too — otherwise users can't read the version of the docs they're
+   * looking at without first navigating into a chapter.
+   */
+  versionContext?: PageVersionContext;
+  /** Per-page SEO context. Optional. */
+  seo?: PageSeoContext;
+}
+
+/**
+ * Resolve the slug of the first chapter listed in a category group.
+ * Used to point the "Browse the manual" cards at a concrete first
+ * page rather than an abstract "category landing" that does not
+ * exist. Returns `undefined` for an empty group, in which case the
+ * caller renders the card as plain text rather than a dead link.
+ */
+function firstChapterSlugInGroup(group: NavGroup): string | undefined {
+  const first = group.items[0];
+  if (!first) return undefined;
+  // Reuse the shared `slugFromNavPath` helper (also used by the
+  // markdown processor + website generator) so the sidebar card
+  // targets and the on-disk chapter filenames cannot drift apart
+  // — a duplicate local implementation here would silently diverge
+  // the day someone tweaked the slug rules in markdown-processor.ts.
+  return slugFromNavPath(first.path);
+}
+
+export function buildHomePage(context: HomePageContext): string {
+  const {
+    metadata,
+    config,
+    navGroups,
+    allChapters,
+    assets,
+    peers,
+    versionContext,
+  } = context;
+
+  const labels = WEBSITE_LABELS[metadata.lang] ?? WEBSITE_LABELS.en;
+  const langLabel = config.languageLabels[metadata.lang] || metadata.lang;
+
+  // The topbar + sidebar + banner / notice / version-switcher widgets
+  // expect a `WebPageContext`. Wrap the home context in a minimal
+  // synthetic chapter so we can reuse them verbatim — this keeps
+  // every visual surface (logo, search, lang switcher, version
+  // selector, theme toggle) identical to a chapter page.
+  // The synthetic home chapter borrows the reserved `index` slug
+  // because every downstream surface that consumes a chapter slug
+  // (sidebar, version switcher, peer-link math) ultimately maps
+  // back to `<lang>/<slug>.html`, and the home page is written to
+  // `<lang>/index.html`. Real chapters cannot collide with this
+  // value: `slugFromNavPath` is the only producer of chapter slugs,
+  // and the website generator validates against `RESERVED_HOME_SLUG`
+  // (see website-generator.ts) before any chapter is rendered, so
+  // a `nav.path` like `index.md` aborts the build with a clear
+  // error rather than silently overwriting the home output.
+  const homeChapter: Chapter = {
+    title: labels.home ?? "Home",
+    slug: RESERVED_HOME_SLUG,
+    htmlContent: "",
+    headings: [],
+  };
+  const fakeWebContext: WebPageContext = {
+    chapter: homeChapter,
+    allChapters: [homeChapter, ...allChapters],
+    // currentIndex of -1 marks "no active chapter" so the sidebar
+    // doesn't highlight any item. `buildWebsiteSidebar` matches by
+    // numeric equality, so any out-of-range value works; -1 is the
+    // most explicit sentinel.
+    currentIndex: -1,
+    metadata,
+    config,
+    assets,
+    peers,
+    navGroups,
+    category: "",
+    versionContext,
+    seo: context.seo,
+  };
+
+  const prefix = rootPrefix(fakeWebContext);
+  const versionSwitcherHtml = buildVersionSwitcher(fakeWebContext);
+  // Sidebar uses the real `allChapters` (not the synthetic one) so the
+  // numbered list matches every chapter's standalone page.
+  const sidebar = buildWebsiteSidebar(
+    allChapters,
+    -1,
+    metadata,
+    config,
+    navGroups,
+    versionSwitcherHtml,
+  );
+  const topbar = buildBaiTopbar(fakeWebContext, peers, prefix);
+  const versionBanner = buildVersionBanner(fakeWebContext);
+  const versionNotice = buildVersionNotice(fakeWebContext);
+  const articleFooter = buildArticleFooter(config);
+  const searchPalette = buildSearchPalette(metadata);
+
+  if (!assets.interactions) {
+    throw new Error(
+      "FR-2726 Phase 4: missing required interactions asset. " +
+        "Search UI requires interactions.js to open the search palette.",
+    );
+  }
+  const interactionsScript = buildInteractionsScriptTag(assets, prefix);
+  const searchScript = buildSearchScriptTag(assets, prefix);
+  const versionBannerScript = buildVersionBannerScriptTag(assets, prefix);
+
+  // Hero CTA target: the first chapter overall (typically Quickstart
+  // in Backend.AI's nav). When the manual has no chapters at all
+  // (empty nav), suppress the CTA rather than emit a dead link.
+  const firstChapterSlug = allChapters[0]?.slug;
+  const ctaQuickstart = firstChapterSlug
+    ? `<a class="home-cta home-cta--primary" href="./${escapeHtml(firstChapterSlug)}.html">${escapeHtml(labels.homeQuickstartCta ?? "Get started")}<span class="home-cta__arrow" aria-hidden="true">&rarr;</span></a>`
+    : "";
+
+  const repoUrl = config.website?.repoUrl;
+  const ctaGithub = repoUrl
+    ? `<a class="home-cta home-cta--secondary" href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(labels.homeViewOnGitHub ?? "View source on GitHub")}</a>`
+    : "";
+
+  // Hero
+  const heroHtml = `<section class="home-hero">
+    <p class="home-hero__eyebrow">${escapeHtml(metadata.title)} &middot; ${escapeHtml(metadata.version)}</p>
+    <h1 class="home-hero__title">${escapeHtml(labels.homeWelcome ?? "Welcome")}</h1>
+    <p class="home-hero__lede">${escapeHtml(labels.homeIntro ?? "")}</p>
+    <div class="home-hero__cta-row">
+      ${ctaQuickstart}
+      ${ctaGithub}
+    </div>
+    ${labels.homeQuickstartHint ? `<p class="home-hero__hint">${escapeHtml(labels.homeQuickstartHint)}</p>` : ""}
+  </section>`;
+
+  // Two intro sections — about the product, about the manual.
+  const aboutHtml = `<section class="home-section home-section--intro">
+    <div class="home-section__col">
+      <h2 class="home-section__title">${escapeHtml(labels.homeAboutWebUI ?? "About")}</h2>
+      <p class="home-section__body">${escapeHtml(labels.homeAboutWebUIBody ?? "")}</p>
+    </div>
+    <div class="home-section__col">
+      <h2 class="home-section__title">${escapeHtml(labels.homeAboutDocs ?? "About this manual")}</h2>
+      <p class="home-section__body">${escapeHtml(labels.homeAboutDocsBody ?? "")}</p>
+    </div>
+  </section>`;
+
+  // Browse-by-category cards. Skip the synthetic anonymous group used
+  // for legacy flat configs (`category === ""`) — there is nothing
+  // useful to title that card with.
+  const pagesSuffix = labels.homePagesSuffix ?? "pages";
+  const categoryCardsHtml = navGroups
+    .filter((g) => g.category)
+    .map((group) => {
+      const slug = firstChapterSlugInGroup(group);
+      const iconSvg = sidebarCategoryIconSvg(group);
+      const inner = `<span class="home-card__icon" aria-hidden="true">${iconSvg}</span>
+        <h3 class="home-card__title">${escapeHtml(group.category)}</h3>
+        <p class="home-card__count">${group.items.length} ${escapeHtml(pagesSuffix)}</p>`;
+      if (slug) {
+        return `<a class="home-card" href="./${escapeHtml(slug)}.html">${inner}</a>`;
+      }
+      return `<div class="home-card home-card--disabled">${inner}</div>`;
+    })
+    .join("\n      ");
+
+  const browseHtml = categoryCardsHtml
+    ? `<section class="home-section home-browse">
+    <h2 class="home-section__title">${escapeHtml(labels.homeBrowse ?? "Browse")}</h2>
+    <div class="home-browse__grid">
+      ${categoryCardsHtml}
+    </div>
+  </section>`
+    : "";
+
+  // <head> tags. We pass an empty `chapterHtml` so the description
+  // falls back to the home headline (the welcome line). We also
+  // intentionally pass an empty `peers` for hreflang purposes only
+  // when the metadata.availableLanguages list is empty — otherwise
+  // the head builder emits one `<link rel=alternate>` per peer. The
+  // peer hrefs use `../{lang}/index.html` which is already correct
+  // for the home page.
+  const pageTitle = escapeHtml(metadata.title);
+  const headTags = buildHeadAssetTags(
+    metadata,
+    langLabel,
+    pageTitle,
+    labels.homeWelcome ?? metadata.title,
+    `<p>${escapeHtml(labels.homeIntro ?? "")}</p>`,
+    assets,
+    prefix,
+    context.seo,
+    peers,
+  );
+
+  // Body data-* attrs for the code-copy script (it's content-hashed
+  // language-agnostic so we keep emitting them — even though there
+  // are no code blocks on the home, the script no-ops gracefully).
+  const copyDataAttrs = [
+    `data-copy-label="${escapeHtml(labels.copy ?? "Copy")}"`,
+    `data-copied-label="${escapeHtml(labels.copied ?? "Copied!")}"`,
+    `data-copy-failed-label="${escapeHtml(labels.copyFailed ?? "Copy failed")}"`,
+  ].join(" ");
+
+  return `<!DOCTYPE html>
+<html lang="${escapeHtml(metadata.lang)}">
+<head>
+  ${headTags}
+</head>
+<body ${copyDataAttrs} data-page="home">
+${topbar}
+${versionBanner}
+<div class="doc-page doc-page--home">
+  ${sidebar}
+  <main class="doc-main doc-main--home">
+    ${versionNotice}
+    <article class="home-article">
+      ${heroHtml}
+      ${aboutHtml}
+      ${browseHtml}
+    </article>
+    ${articleFooter}
+  </main>
+</div>
+${searchPalette}
+${searchScript}
+${versionBannerScript}
+${interactionsScript}
 </body>
 </html>`;
 }

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -10,10 +10,13 @@ import { fileURLToPath } from "url";
 import { execFileSync } from "child_process";
 import { processMarkdownFilesForWeb } from "./markdown-processor-web.js";
 import type { LinkDiagnostic } from "./markdown-processor-web.js";
-import { slugify } from "./markdown-processor.js";
+import {
+  RESERVED_HOME_SLUG,
+  slugFromNavPath,
+} from "./markdown-processor.js";
 import {
   buildWebPage,
-  buildIndexPage,
+  buildHomePage,
   buildLanguagePickerPage,
   applyImageAttributes,
 } from "./website-builder.js";
@@ -856,15 +859,19 @@ async function buildLanguage(args: {
 
   // Per-language nav-path -> slug index. The language switcher (F1) maps
   // `quickstart.md` (path) in the current language to the same path in
-  // every peer language, then resolves the peer's localized slug for the
-  // cross-language link target. Paths are stable across languages — slugs
-  // are not — so the join key is the path.
+  // every peer language, then resolves the peer's slug for the
+  // cross-language link target. Paths are stable across languages, and
+  // slugs are now derived from those paths (FR-2737), so the join key
+  // and the resulting slug are both language-stable. The map is kept
+  // (rather than collapsed to a single shared slug map) so future
+  // language-specific slug overrides — e.g. an explicit `slug:` in
+  // `book.config.yaml` — would slot in here without changing callers.
   const slugByPathPerLang: Record<string, Map<string, string>> = {};
   for (const peerLang of availableLanguages) {
     const peerNav = bookConfig.navigation[peerLang] ?? [];
     const map = new Map<string, string>();
     for (const entry of peerNav) {
-      map.set(entry.path, slugify(entry.title));
+      map.set(entry.path, slugFromNavPath(entry.path));
     }
     slugByPathPerLang[peerLang] = map;
   }
@@ -888,12 +895,39 @@ async function buildLanguage(args: {
     chapters.map((c) => c.slug).filter((s): s is string => !!s),
   );
 
+  // FR-2737 reserved-slug guard: `RESERVED_HOME_SLUG` is the slug
+  // the synthetic home chapter writes to (`<lang>/index.html`). If a
+  // real chapter's `nav.path` ever sanitizes to that same value
+  // (e.g. somebody adds `index.md`), the chapter HTML and the home
+  // HTML would target the same file — only the last writer would
+  // win, silently. Fail the build with an actionable error instead
+  // of producing a broken site.
+  const collidingSlug = chapters.find(
+    (c) => c.slug === RESERVED_HOME_SLUG,
+  );
+  if (collidingSlug) {
+    throw new Error(
+      `Chapter slug "${RESERVED_HOME_SLUG}" is reserved for the home page. ` +
+        `The chapter titled "${collidingSlug.title}" sanitizes to that ` +
+        `slug — rename the source file or move it under a sub-folder ` +
+        `(e.g. "overview/index.md") in book.config.yaml.`,
+    );
+  }
+
   // Pre-record this build's pages into the cross-version registry. We
   // do it BEFORE rendering so the version-switcher availability map
   // (which uses the registry transitively only for the *current* slug)
   // remains correct in the common case where versions share slugs.
   // See note on the `availability` field below.
-  for (const slug of allSlugsThisLang) {
+  //
+  // FR-2737: also register the synthetic home slug for the home
+  // page. Every language ships an `index.html`, so listing it lets
+  // the version switcher resolve "same slug in another version" to
+  // that version's home page rather than falling back to Quickstart
+  // when the user changes the version from the landing screen.
+  const recordedSlugs = new Set(allSlugsThisLang);
+  recordedSlugs.add(RESERVED_HOME_SLUG);
+  for (const slug of recordedSlugs) {
     pageRegistry.record({
       version: versionLabel ?? "",
       lang,
@@ -952,7 +986,7 @@ async function buildLanguage(args: {
   console.log(`${labelPrefix} Generating ${chapters.length} pages...`);
   for (let i = 0; i < chapters.length; i++) {
     const navEntry = navigation.find(
-      (n) => slugify(n.title) === chapters[i].slug,
+      (n) => slugFromNavPath(n.path) === chapters[i].slug,
     );
     if (!navEntry) {
       console.warn(
@@ -1068,33 +1102,80 @@ async function buildLanguage(args: {
     fs.writeFileSync(outputPath, pageHtml, "utf-8");
   }
 
-  // FR-2732: surface the current version's optional `pdfTag` to the
-  // landing-page renderer. We deliberately look up the entry by label
-  // (rather than passing the whole `loadedVersions`) so the renderer
-  // never sees other versions' tags. When the lookup misses (flat /
-  // non-versioned mode, or `versionLabel === null`), the result is
-  // `undefined` and the renderer falls back to its byte-equivalent
-  // legacy redirect-stub branch.
-  const currentVersionEntry =
-    versionLabel !== null
-      ? loadedVersions.entries.find((v) => v.label === versionLabel)
-      : undefined;
-
-  // Generate index.html (redirect to first page, or placeholder if no chapters)
-  const indexHtml =
-    chapters.length === 0
-      ? `<!DOCTYPE html>
+  // Generate index.html. FR-2737 replaces the legacy meta-refresh
+  // redirect with a real Home page — production-quality intro to
+  // Backend.AI WebUI and the manual itself, anchored to the current
+  // language. The fallback below is intentionally kept for the
+  // empty-navigation case (a language declared in book.config.yaml
+  // with no chapters yet) so partial translations still produce a
+  // visible page rather than crashing the build.
+  let indexHtml: string;
+  if (chapters.length === 0) {
+    indexHtml = `<!DOCTYPE html>
 <html lang="${lang}">
 <head><meta charset="utf-8" /><title>${title}</title></head>
 <body><h1>${title}</h1><p>No documentation content was generated for this language.</p></body>
-</html>`
-      : buildIndexPage(chapters, metadata, {
-          pdfTag: currentVersionEntry?.pdfTag,
-          // FR-2732 follow-up: thread resolved branding tokens so the
-          // PDF card honors white-label `branding.primaryColor` overrides
-          // instead of always rendering BAI orange.
-          branding: config.branding,
-        });
+</html>`;
+  } else {
+    // Home page peers — every peer language has its own home, so the
+    // switcher always lands on `../<peer>/index.html` and `available`
+    // is always true. (Per-page availability is a chapter-level
+    // concept that does not apply here.)
+    const homePeers: LanguagePeer[] = availableLanguages.map((peerLang) => ({
+      lang: peerLang,
+      label: config.languageLabels[peerLang] ?? peerLang,
+      href: `../${peerLang}/index.html`,
+      available: true,
+    }));
+    // Version context for the home page. Reuses the per-page builder
+    // with the reserved home slug so the version switcher's same-slug
+    // navigation lands on each version's home rather than dropping
+    // the user back into Quickstart on every version change.
+    const homeVersionContext = buildPageVersionContext({
+      loadedVersions,
+      versionLabel,
+      slug: RESERVED_HOME_SLUG,
+      rootDepth,
+      pageRegistry,
+    });
+    // Home page SEO. `pagePath` and `canonicalPath` both point at the
+    // language's `index.html`, with the version segment included in
+    // versioned mode so the OG / canonical URLs are accurate.
+    const homePagePath =
+      versionLabel !== null
+        ? `${versionLabel}/${lang}/index.html`
+        : `${lang}/index.html`;
+    const homeCanonicalPath = loadedVersions.latest
+      ? `${loadedVersions.latest.label}/${lang}/index.html`
+      : homePagePath;
+    const homeSeo: PageSeoContext = {
+      baseUrl: seoBase.baseUrl,
+      siteName: seoBase.siteName,
+      publisher: seoBase.publisher,
+      pagePath: homePagePath,
+      canonicalPath: homeCanonicalPath,
+      ogImageRelUrl: seoBase.ogImageRelUrl,
+    };
+    indexHtml = buildHomePage({
+      metadata,
+      config,
+      navGroups,
+      allChapters: chapters,
+      assets: pageAssets,
+      peers: homePeers,
+      versionContext: homeVersionContext,
+      seo: homeSeo,
+    });
+    // Mirror the chapter-page post-processing pipeline for image tags
+    // (lazy-load attrs + WebP/AVIF rewrite). The home page does not
+    // currently render `<img>` tags, but keeping the pipeline parity
+    // means future content edits — e.g. adding a hero illustration —
+    // pick up the same optimizations without further wiring.
+    indexHtml = applyImageAttributes(indexHtml, imageDims);
+    if (variantAvailability.size > 0) {
+      indexHtml = rewriteImageTagsToPicture(indexHtml, variantAvailability);
+    }
+  }
   fs.writeFileSync(path.join(langDir, "index.html"), indexHtml, "utf-8");
 
   // Build search index — partitioned per (version × lang) so search


### PR DESCRIPTION
Resolves #7087 ([FR-2749](https://lablup.atlassian.net/browse/FR-2749))

## Summary

Follow-up improvements for the multi-version docs deployment (FR-2730 / FR-2733 / FR-2735) on the WebUI documentation site.

- **Web-only Home page**: Replaced the per-language `index.html` meta-refresh redirect with a real Home page (hero + intro sections + category-card grid) so the topbar logo and breadcrumb "Home" link have a meaningful destination. Localized in all four languages (en / ko / ja / th). PDF pipeline is unchanged.
- **Language-stable chapter slugs**: Slugs are now derived from the navigation `path` instead of the localized title. Same chapter resolves to the same `<slug>.html` filename in every language, so readers can swap the language segment in the URL (e.g. `/ko/quickstart.html` ↔ `/en/quickstart.html`) to switch languages.
- **Icon-only language switcher**: The topbar lang switcher now shows a single Lucide `languages` icon. A transparent native `<select>` is layered on top, so a click opens the OS-native dropdown (keyboard / screen-reader / mobile-touch all handled by the native control).
- **Sidebar category icons across all languages**: Icon mapping was keyed off English category labels, so non-English sidebars all rendered the generic stack icon. Now keyed off the group's first-item path (language-stable), so all four languages render the proper rocket / box / folder / settings / book icons. The rocket icon was also swapped for the canonical Lucide path so the silhouette is recognizable at 14px.

## Files changed

- `packages/backend.ai-docs-toolkit/src/markdown-processor.ts` — new `slugFromNavPath()` helper.
- `packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts`, `website-generator.ts` — call `slugFromNavPath()` for chapter slugs and the cross-language slug map.
- `packages/backend.ai-docs-toolkit/src/website-builder.ts` — new `buildHomePage()`, icon-only lang switcher markup, language-stable sidebar icon mapping, canonical Lucide rocket SVG.
- `packages/backend.ai-docs-toolkit/src/styles-web.ts` — home page CSS (hero / sections / cards) + icon-only switcher CSS.
- `packages/backend.ai-docs-toolkit/src/config.ts` — localized labels for the home page (`homeWelcome`, `homeIntro`, etc.).
- `packages/backend.ai-docs-toolkit/src/index.ts` — export `buildHomePage` + `slugFromNavPath`.
- `packages/backend.ai-docs-toolkit/src/website-builder.test.ts` — 13 new tests covering slug stability, the home page surface, and language-stable sidebar icons.

## Test plan

- [x] `pnpm --filter backend.ai-docs-toolkit test` — 115 tests pass (13 new).
- [x] `bash scripts/verify.sh` — Relay / Lint / Format / TypeScript ALL PASS.
- [x] Playwright probe across en / ko / ja / th: 116/116 navigation paths (29 sidebar links per language × 4 languages + CTA + cards + logo + breadcrumb) return 200.
- [x] Visual: home page hero / cards / topbar / sidebar in all 4 languages; sidebar icons (rocket, box, folder, settings, book) render identically across languages.
- [ ] Reviewer to hard-reload the deployed preview and confirm `/ko/admin_menu.html` ↔ `/en/admin_menu.html` ↔ `/ja/admin_menu.html` ↔ `/th/admin_menu.html` all resolve to the same chapter, only with the language differing.

[FR-2749]: https://lablup.atlassian.net/browse/FR-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ