### PR TITLE
feat(FR-2451): add Prometheus Query Preset edit modal with live preview

### DIFF
--- a/.specs/draft-auto-scaling-rule-management/spec.md
+++ b/.specs/draft-auto-scaling-rule-management/spec.md
@@ -1,0 +1,160 @@
+# Auto Scaling Rule 관리 기능 Spec
+
+## 개요
+
+슈퍼어드민이 Admin Serving 페이지에서 Prometheus Query Preset을 관리할 수 있도록 한다. 현재 Admin Serving 페이지는 엔드포인트 목록만 표시하는 단일 뷰이며, 새로운 "Auto Scaling Rule" 탭을 추가하여 Prometheus Query Preset CRUD 기능을 제공한다.
+
+## 문제 정의
+
+현재 Auto Scaling Rule 추가 시 메트릭 소스(KERNEL, INFERENCE_FRAMEWORK)와 메트릭 이름을 사용자가 직접 입력해야 한다. Prometheus 쿼리의 복잡성을 사용자에게 노출하지 않으면서도 어드민이 조직에 맞는 커스텀 메트릭 기준을 사전 정의할 수 있는 메커니즘이 필요하다. Prometheus Query Preset을 통해 어드민이 PromQL 템플릿을 미리 등록해두면, 일반 사용자는 해당 Preset의 메트릭 이름만 선택하여 Auto Scaling Rule을 쉽게 설정할 수 있게 된다.
+
+## 요구사항
+
+### 필수 (Must Have)
+
+#### Admin Serving 페이지 탭 구조
+
+- [ ] Admin Serving 페이지(`AdminServingPage.tsx`)에 탭 UI를 추가하여 "Serving" 탭과 "Auto Scaling Rule" 탭으로 분리
+- [ ] 기존 엔드포인트 목록은 "Serving" 탭에 그대로 유지
+- [ ] "Auto Scaling Rule" 탭에서 Prometheus Query Preset 관리 기능 제공
+- [ ] 탭 전환 시 URL query parameter로 현재 탭 상태를 유지 (브라우저 뒤로가기/앞으로가기 대응)
+
+#### Prometheus Query Preset 목록 (Read)
+
+- [ ] "Auto Scaling Rule" 탭에서 등록된 Prometheus Query Preset 목록을 테이블로 표시
+- [ ] 테이블 컬럼: Preset 이름(`name`), 메트릭 이름(`metricName`), 쿼리 템플릿(`queryTemplate`), 타임 윈도우(`timeWindow`), 생성일(`createdAt`), 수정일(`updatedAt`)
+- [ ] `prometheusQueryPresets` 쿼리를 사용하여 데이터 조회 (모든 인증된 사용자 접근 가능)
+- [ ] 페이지네이션 지원 (커서 기반 또는 오프셋 기반)
+- [ ] `QueryDefinitionFilter`에서 제공하는 모든 필터 필드를 활용한 검색 기능 (현재 스키마 기준: `name`). 백엔드에 필터 필드가 추가되면 UI에서도 함께 지원
+
+#### Prometheus Query Preset 생성 (Create)
+
+- [ ] "Preset 추가" 버튼 클릭 시 모달을 통해 새 Preset 생성
+- [ ] 모달 입력 필드:
+  - **이름** (`name`): 고유 식별자, 유니크 (필수, 텍스트 입력)
+  - **설명** (`description`): 사용자에게 표시되는 Preset 설명 (선택 사항)
+  - **카테고리** (`categoryId`): Preset을 묶는 그룹 (선택 사항, 드롭다운)
+  - **정렬 순서** (`rank`): 드롭다운에서 표시 순서. 낮을수록 위에 표시 (선택 사항, 숫자 입력, 기본값 0)
+  - **메트릭 이름** (`metricName`): Prometheus 메트릭 이름 (필수, 텍스트 입력)
+  - **쿼리 템플릿** (`queryTemplate`): PromQL 템플릿 문자열 (필수, 텍스트 입력). `{labels}`, `{window}`, `{group_by}` 플레이스홀더 사용 가능
+  - **타임 윈도우** (`timeWindow`): 기본 시간 윈도우 (선택 사항, 문자열 입력. 예: `5m`)
+  - **필터 레이블** (`options.filterLabels`): PromQL 템플릿의 `{labels}` 플레이스홀더에 대입될 레이블 키 목록 (필수, 빈 배열 허용. 다중 입력)
+  - **그룹 레이블** (`options.groupLabels`): PromQL 템플릿의 `{group_by}` 플레이스홀더에 대입될 레이블 키 목록 (필수, 빈 배열 허용. 다중 입력)
+- [ ] `adminCreatePrometheusQueryPreset` 뮤테이션 호출
+- [ ] 생성 성공 시 목록 자동 갱신
+
+#### Prometheus Query Preset 수정 (Update)
+
+- [ ] 테이블 행의 편집 액션을 통해 기존 Preset 수정 모달 표시
+- [ ] 생성과 동일한 입력 필드를 제공하되, 기존 값을 초기값으로 채움
+- [ ] 수정 모달에서 쿼리 결과값 미리보기 제공 (아래 "미리보기" 섹션 참조)
+- [ ] `adminModifyPrometheusQueryPreset` 뮤테이션 호출 (변경된 필드만 전송)
+
+#### Prometheus Query Preset 미리보기 (Edit 모달 전용)
+
+`prometheusQueryPresetResult` API는 저장된 Preset의 ID를 필요로 하므로 미리보기는 **수정(Edit) 모달에서만** 제공한다. 생성 모달에서는 ID가 없어 미리보기 불가.
+
+- [ ] 수정 모달 상단(또는 쿼리 템플릿 필드 하단)에 "현재 값(Current value):" 레이블 + 결과값 텍스트 + 새로고침 버튼을 표시
+- [ ] `prometheusQueryPresetResult(id, options: { filterLabels: [], groupLabels: [] })` instant query로 현재 값 조회
+- [ ] 결과값이 단일 시리즈인 경우 최신 값(소수점 둘째자리 반올림)을 표시
+- [ ] 결과값이 다중 시리즈인 경우 시리즈 수 및 첫 번째 최신 값을 표시
+- [ ] 데이터 없을 경우 "No data available" 표시
+- [ ] 새로고침 버튼 클릭 시 최신 결과를 재조회. 초기 로딩 및 재조회 중에는 버튼에 로딩 인디케이터 표시
+- [ ] 구현 참조: `AutoScalingRuleEditorModal.tsx`의 `PreviewValue` / `PrometheusPresetPreview` 컴포넌트 패턴을 따름
+
+#### Prometheus Query Preset 삭제 (Delete)
+
+- [ ] 테이블 행의 삭제 액션 제공
+- [ ] 삭제 전 확인 다이얼로그 표시
+- [ ] `adminDeletePrometheusQueryPreset` 뮤테이션 호출
+- [ ] 삭제 성공 시 목록 자동 갱신
+
+### 선택 (Nice to Have)
+
+- [ ] Prometheus Query Preset 목록 테이블에서 정렬 기능 (`QueryDefinitionOrderBy` 활용)
+- [ ] 쿼리 템플릿 입력 시 플레이스홀더(`{labels}`, `{window}`, `{group_by}`) 안내 툴팁 또는 가이드 텍스트 제공
+
+## 사용자 스토리
+
+- 슈퍼어드민으로서, Admin Serving 페이지에서 Prometheus Query Preset을 추가하여 조직에서 사용할 Auto Scaling 메트릭 기준을 사전 정의할 수 있다
+- 슈퍼어드민으로서, 등록된 Prometheus Query Preset을 수정하거나 삭제하여 메트릭 기준을 관리할 수 있다
+
+## 인수 조건 (Acceptance Criteria)
+
+### Admin Serving 페이지
+
+- [ ] Admin Serving 페이지에 "Serving" 탭과 "Auto Scaling Rule" 탭이 표시된다
+- [ ] 기본 탭은 "Serving"이다
+- [ ] "Auto Scaling Rule" 탭 클릭 시 Prometheus Query Preset 목록이 표시된다
+- [ ] Preset 목록에서 이름, 메트릭 이름, 쿼리 템플릿, 타임 윈도우, 생성일, 수정일이 확인 가능하다
+- [ ] "Preset 추가" 버튼으로 새 Preset을 생성할 수 있다
+- [ ] Preset 행의 편집 액션으로 기존 Preset을 수정할 수 있다
+- [ ] Preset 행의 삭제 액션으로 Preset을 삭제할 수 있으며, 삭제 전 확인을 요청한다
+- [ ] 슈퍼어드민만 "Auto Scaling Rule" 탭에 접근할 수 있다
+
+### Prometheus Query Preset 모달
+
+- [ ] 필수 필드(`name`, `metricName`, `queryTemplate`)가 비어있으면 생성/수정이 불가하다
+- [ ] `options.filterLabels`와 `options.groupLabels`는 빈 배열로도 제출 가능하다
+- [ ] `description`, `categoryId`, `rank`, `timeWindow`는 선택 사항이다
+- [ ] 생성/수정 성공 시 성공 메시지가 표시되고 목록이 갱신된다
+- [ ] 오류 발생 시 에러 메시지가 표시된다
+
+### 수정 모달 미리보기
+
+- [ ] 수정 모달에 "현재 값:" 레이블 + 결과값 + 새로고침 버튼이 표시된다
+- [ ] 새로고침 버튼 클릭 시 최신 쿼리 결과를 재조회한다
+- [ ] 조회 중 버튼에 로딩 인디케이터가 표시된다
+- [ ] 결과가 없으면 "No data available"이 표시된다
+
+## GraphQL API 참조
+
+### 쿼리 (모든 인증된 사용자 접근 가능)
+
+| 쿼리 | 설명 |
+|---|---|
+| `prometheusQueryPresets(filter, orderBy, limit, offset)` | Preset 목록 조회 (오프셋 기반 페이지네이션) |
+| `prometheusQueryPreset(id)` | 단일 Preset 조회 |
+| `prometheusQueryPresetResult(id, options)` | Preset 기반 instant query 실행 (수정 모달 미리보기용) |
+
+### 뮤테이션 (어드민 전용)
+
+| 뮤테이션 | 설명 |
+|---|---|
+| `adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!)` | Preset 생성 |
+| `adminModifyPrometheusQueryPreset(id: ID!, input: ModifyQueryDefinitionInput!)` | Preset 수정 |
+| `adminDeletePrometheusQueryPreset(id: ID!)` | Preset 삭제 |
+| `adminCreatePrometheusQueryPresetCategory(input: CreateCategoryInput!)` | 카테고리 생성 (Category CRUD는 이번 범위에서 미구현, 참고용) |
+| `adminDeletePrometheusQueryPresetCategory(id: ID!)` | 카테고리 삭제 (동일) |
+
+### 주요 타입
+
+**QueryDefinition** (Preset 엔티티):
+- `id`, `name`, `description`, `rank`, `categoryId`, `category` (>=26.4.3), `metricName`, `queryTemplate`, `timeWindow`, `options` (filterLabels, groupLabels), `createdAt`, `updatedAt`
+
+**CreateQueryDefinitionInput**:
+- 필수: `name`, `metricName`, `queryTemplate`, `options` (filterLabels `[String!]!`, groupLabels `[String!]!`)
+- 선택: `description`, `rank` (기본값 0), `categoryId`, `timeWindow`
+
+**Seed Presets** (백엔드에서 기본 제공):
+
+| Preset 이름 | 쿼리 템플릿 | 타임 윈도우 |
+|---|---|---|
+| container_gauge | `sum by ({group_by})(backendai_container_utilization{{{labels}}})` | 없음 (instant) |
+| container_rate | `sum by ({group_by})(rate(backendai_container_utilization{{{labels}}}[{window}])) / 5.0` | 5m |
+| container_diff | `sum by ({group_by})(rate(backendai_container_utilization{{{labels}}}[{window}]))` | 5m |
+
+**`options.filterLabels`에 사용할 Prometheus 레이블 키 예시**: 메트릭 범위를 필터링하는 레이블 키이며, PromQL 템플릿의 `{labels}` 플레이스홀더에 대입된다.
+- `container_metric_name`: 컨테이너 메트릭 종류 (예: cpu_util, mem)
+- `kernel_id`, `session_id`, `agent_id`, `user_id`, `project_id`: 각각 커널/세션/에이전트/사용자/프로젝트 단위 필터
+- `value_type`: 메트릭 값 유형
+
+**`options.groupLabels`에 사용할 Prometheus 레이블 키 예시**: 결과를 그룹화하는 레이블 키이며, PromQL 템플릿의 `{group_by}` 플레이스홀더에 대입된다.
+- `kernel_id`, `session_id`, `agent_id`, `user_id`, `project_id`, `value_type`
+
+## 범위 외 (Out of Scope)
+
+- Auto Scaling Rule 자체의 CRUD 및 에디터 UX (서비스 디테일 페이지) → `draft-auto-scaling-rule-ux` 스펙에서 다룸
+- Prometheus 서버 연결 설정 또는 Prometheus 인프라 관리
+- Auto Scaling Rule 실행 이력 조회 및 모니터링 대시보드
+- Prometheus Query Preset의 권한별 세분화 (현재는 슈퍼어드민만 CRUD 관리, 조회는 모든 인증된 사용자 가능)

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -238,8 +238,8 @@ export interface BAITableProps<
  * />
  * ```
  */
-const BAITable = <RecordType extends object = any>({
-  resizable = false,
+const BAITable = <RecordType extends AnyObject = AnyObject>({
+  resizable = true,
   columns,
   components,
   loading,

--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -7,13 +7,12 @@ import {
   AutoScalingRuleEditorModalFragment$data,
   AutoScalingRuleEditorModalFragment$key,
 } from '../__generated__/AutoScalingRuleEditorModalFragment.graphql';
-import { AutoScalingRuleEditorModalPresetResultQuery } from '../__generated__/AutoScalingRuleEditorModalPresetResultQuery.graphql';
 import { AutoScalingRuleEditorModalPresetsQuery } from '../__generated__/AutoScalingRuleEditorModalPresetsQuery.graphql';
 import { AutoScalingRuleEditorModalUpdateMutation } from '../__generated__/AutoScalingRuleEditorModalUpdateMutation.graphql';
 import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
 import { useSuspendedBackendaiClient } from '../hooks';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
-import { ReloadOutlined } from '@ant-design/icons';
+import { PrometheusPresetPreview } from './PrometheusPresetPreview';
 import {
   App,
   AutoComplete,
@@ -28,24 +27,14 @@ import {
 } from 'antd';
 import type { DefaultOptionType } from 'antd/es/select';
 import {
-  BAIButton,
   BAIFlex,
   BAIModal,
   BAIModalProps,
-  INITIAL_FETCH_KEY,
   toLocalId,
   useBAILogger,
-  useUpdatableState,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React, {
-  RefObject,
-  useEffect,
-  useEffectEvent,
-  useRef,
-  useState,
-  useTransition,
-} from 'react';
+import React, { RefObject, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   graphql,
@@ -85,136 +74,6 @@ const METRIC_NAMES_MAP: Partial<
 > = {
   KERNEL: ['cpu_util', 'mem', 'net_rx', 'net_tx'],
   INFERENCE_FRAMEWORK: [],
-};
-
-/**
- * Inner component: fetches and renders only the metric value text.
- * Isolated so that React.Suspense covers just this text node during refresh,
- * leaving the "Current value:" label and refresh button always visible.
- */
-const PreviewValue: React.FC<{
-  presetRawId: string;
-  fetchKey: string;
-  onLoaded?: () => void;
-}> = ({ presetRawId, fetchKey, onLoaded }) => {
-  'use memo';
-  const { t } = useTranslation();
-
-  const data = useLazyLoadQuery<AutoScalingRuleEditorModalPresetResultQuery>(
-    graphql`
-      query AutoScalingRuleEditorModalPresetResultQuery(
-        $id: ID!
-        $options: ExecuteQueryDefinitionOptionsInput
-      ) {
-        prometheusQueryPresetResult(id: $id, options: $options) {
-          status
-          resultType
-          result {
-            metric {
-              key
-              value
-            }
-            values {
-              timestamp
-              value
-            }
-          }
-        }
-      }
-    `,
-    {
-      id: presetRawId,
-      options: {
-        filterLabels: [],
-        groupLabels: [],
-      },
-    },
-    { fetchPolicy: 'network-only', fetchKey: `preview-${fetchKey}` },
-  );
-
-  const results = data.prometheusQueryPresetResult.result;
-
-  const onLoadedEvent = useEffectEvent(() => {
-    onLoaded?.();
-  });
-  useEffect(() => {
-    onLoadedEvent();
-  }, []);
-
-  const formatValue = (raw: string) => {
-    const num = parseFloat(raw);
-    return isNaN(num) ? raw : (Math.round(num * 100) / 100).toString();
-  };
-
-  let displayValue: string | null = null;
-  if (results.length === 1) {
-    const values = results[0].values;
-    const raw = values.length > 0 ? values[values.length - 1].value : null;
-    displayValue = raw != null ? formatValue(raw) : null;
-  } else if (results.length > 1) {
-    const firstValues = results[0].values;
-    const latestValue =
-      firstValues.length > 0 ? firstValues[firstValues.length - 1].value : null;
-    displayValue =
-      latestValue != null
-        ? t('autoScalingRule.MultipleSeriesResult', {
-            count: results.length,
-            value: formatValue(latestValue),
-          })
-        : null;
-  }
-
-  return displayValue != null ? (
-    <Typography.Text type="secondary">{displayValue}</Typography.Text>
-  ) : (
-    <Typography.Text type="secondary">
-      {t('autoScalingRule.NoDataAvailable')}
-    </Typography.Text>
-  );
-};
-
-/**
- * Inline preview component for a selected Prometheus preset.
- * The label and refresh button are always visible; only the value area
- * shows a loading spinner during fetch/refresh.
- */
-const PrometheusPresetPreview: React.FC<{
-  presetGlobalId: string;
-}> = ({ presetGlobalId }) => {
-  'use memo';
-  const { t } = useTranslation();
-  const { token } = theme.useToken();
-  const [fetchKey, updateFetchKey] = useUpdatableState(INITIAL_FETCH_KEY);
-  const [isPending, startTransition] = useTransition();
-  const [isInitialLoading, setIsInitialLoading] = useState(true);
-  const presetRawId = toLocalId(presetGlobalId);
-
-  return (
-    <span>
-      <Typography.Text
-        type="secondary"
-        style={{ marginRight: token.marginXXS }}
-      >
-        {t('autoScalingRule.CurrentValue')}:{' '}
-      </Typography.Text>
-      <React.Suspense fallback={null}>
-        <PreviewValue
-          presetRawId={presetRawId}
-          fetchKey={fetchKey}
-          onLoaded={() => setIsInitialLoading(false)}
-        />
-      </React.Suspense>
-      <BAIButton
-        type="link"
-        size="small"
-        icon={<ReloadOutlined />}
-        loading={isPending || isInitialLoading}
-        onClick={() => startTransition(() => updateFetchKey())}
-        title={t('autoScalingRule.RefreshPreview')}
-        aria-label={t('autoScalingRule.RefreshPreview')}
-      />
-    </span>
-  );
 };
 
 /**

--- a/react/src/components/AutoScalingRulePresetTab.tsx
+++ b/react/src/components/AutoScalingRulePresetTab.tsx
@@ -8,6 +8,7 @@ import {
   AutoScalingRulePresetTabQuery$variables,
   QueryDefinitionFilter,
 } from '../__generated__/AutoScalingRulePresetTabQuery.graphql';
+import { PrometheusQueryPresetEditorModalFragment$key } from '../__generated__/PrometheusQueryPresetEditorModalFragment.graphql';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import PrometheusQueryPresetEditorModal from './PrometheusQueryPresetEditorModal';
 import PrometheusQueryPresetNodes from './PrometheusQueryPresetNodes';
@@ -25,12 +26,7 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { parseAsJson, useQueryStates } from 'nuqs';
-import React, {
-  Suspense,
-  useDeferredValue,
-  useState,
-  useTransition,
-} from 'react';
+import React, { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
@@ -59,8 +55,9 @@ const AutoScalingRulePresetTab: React.FC = () => {
   });
 
   const [fetchKey, updateFetchKey] = useFetchKey();
-  const [, startRefetchTransition] = useTransition();
   const [isCreatingPreset, setIsCreatingPreset] = useState(false);
+  const [editingPreset, setEditingPreset] =
+    useState<PrometheusQueryPresetEditorModalFragment$key | null>(null);
   const [deletingPreset, setDeletingPreset] =
     useState<DeletingPresetTarget | null>(null);
 
@@ -187,6 +184,9 @@ const AutoScalingRulePresetTab: React.FC = () => {
               }
             },
           }}
+          onEditPreset={(preset) => {
+            setEditingPreset(preset);
+          }}
           onDeletePreset={(preset) => {
             setDeletingPreset({ id: preset.id, name: preset.name });
           }}
@@ -197,9 +197,17 @@ const AutoScalingRulePresetTab: React.FC = () => {
         onRequestClose={(success) => {
           setIsCreatingPreset(false);
           if (success) {
-            startRefetchTransition(() => {
-              updateFetchKey();
-            });
+            updateFetchKey();
+          }
+        }}
+      />
+      <PrometheusQueryPresetEditorModal
+        open={!!editingPreset}
+        presetFrgmt={editingPreset}
+        onRequestClose={(success) => {
+          setEditingPreset(null);
+          if (success) {
+            updateFetchKey();
           }
         }}
       />
@@ -240,9 +248,7 @@ const AutoScalingRulePresetTab: React.FC = () => {
               }
               message.success(t('prometheusQueryPreset.SuccessfullyDeleted'));
               setDeletingPreset(null);
-              startRefetchTransition(() => {
-                updateFetchKey();
-              });
+              updateFetchKey();
             },
             onError: (error) => {
               message.error(error.message);

--- a/react/src/components/PrometheusPresetPreview.tsx
+++ b/react/src/components/PrometheusPresetPreview.tsx
@@ -1,0 +1,111 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { PrometheusPresetPreviewResultQuery } from '../__generated__/PrometheusPresetPreviewResultQuery.graphql';
+import { ReloadOutlined } from '@ant-design/icons';
+import { Typography, theme } from 'antd';
+import { BAIButton, toLocalId, useFetchKey } from 'backend.ai-ui';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * Inline preview component for a selected Prometheus preset.
+ * The label and refresh button are always visible; only the value area
+ * shows a loading spinner during fetch/refresh.
+ */
+export const PrometheusPresetPreview: React.FC<{
+  presetGlobalId: string;
+}> = ({ presetGlobalId }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const presetRawId = toLocalId(presetGlobalId);
+
+  const data = useLazyLoadQuery<PrometheusPresetPreviewResultQuery>(
+    graphql`
+      query PrometheusPresetPreviewResultQuery(
+        $id: ID!
+        $options: ExecuteQueryDefinitionOptionsInput
+      ) {
+        prometheusQueryPresetResult(id: $id, options: $options) {
+          status
+          resultType
+          result {
+            metric {
+              key
+              value
+            }
+            values {
+              timestamp
+              value
+            }
+          }
+        }
+      }
+    `,
+    {
+      id: presetRawId,
+      options: {
+        filterLabels: [],
+        groupLabels: [],
+      },
+    },
+    { fetchPolicy: 'network-only', fetchKey: `preview-${fetchKey}` },
+  );
+
+  const results = data.prometheusQueryPresetResult.result;
+
+  const formatValue = (raw: string) => {
+    const num = parseFloat(raw);
+    return isNaN(num) ? raw : (Math.round(num * 100) / 100).toString();
+  };
+
+  let displayValue: string | null = null;
+  if (results.length === 1) {
+    const values = results[0].values;
+    const raw = values.length > 0 ? values[values.length - 1].value : null;
+    displayValue = raw != null ? formatValue(raw) : null;
+  } else if (results.length > 1) {
+    const firstValues = results[0].values;
+    const latestValue =
+      firstValues.length > 0 ? firstValues[firstValues.length - 1].value : null;
+    displayValue =
+      latestValue != null
+        ? t('autoScalingRule.MultipleSeriesResult', {
+            count: results.length,
+            value: formatValue(latestValue),
+          })
+        : null;
+  }
+
+  return (
+    <span>
+      <Typography.Text
+        type="secondary"
+        style={{ marginRight: token.marginXXS }}
+      >
+        {t('autoScalingRule.CurrentValue')}:{' '}
+      </Typography.Text>
+      {displayValue != null ? (
+        <Typography.Text type="secondary">{displayValue}</Typography.Text>
+      ) : (
+        <Typography.Text type="secondary">
+          {t('autoScalingRule.NoDataAvailable')}
+        </Typography.Text>
+      )}
+      <BAIButton
+        type="link"
+        size="small"
+        icon={<ReloadOutlined />}
+        action={async () => updateFetchKey()}
+        title={t('autoScalingRule.RefreshPreview')}
+        aria-label={t('autoScalingRule.RefreshPreview')}
+      />
+    </span>
+  );
+};
+
+export default PrometheusPresetPreview;

--- a/react/src/components/PrometheusQueryPresetEditorModal.tsx
+++ b/react/src/components/PrometheusQueryPresetEditorModal.tsx
@@ -8,11 +8,18 @@ import {
   PrometheusQueryPresetEditorModalFragment$data,
   PrometheusQueryPresetEditorModalFragment$key,
 } from '../__generated__/PrometheusQueryPresetEditorModalFragment.graphql';
+import { PrometheusQueryPresetEditorModalUpdateMutation } from '../__generated__/PrometheusQueryPresetEditorModalUpdateMutation.graphql';
 import BAIErrorBoundary from './BAIErrorBoundary';
+import PrometheusPresetPreview from './PrometheusPresetPreview';
 import { App, Form, FormInstance, Input, InputNumber, Select } from 'antd';
-import { BAIModal, BAIModalProps, useBAILogger } from 'backend.ai-ui';
+import {
+  BAIModal,
+  BAIModalProps,
+  toLocalId,
+  useBAILogger,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React, { useDeferredValue, useRef } from 'react';
+import React, { Suspense, useDeferredValue, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   graphql,
@@ -47,7 +54,7 @@ interface PrometheusQueryPresetEditorModalProps extends Omit<
  * Build the form's initial values.
  * - Create mode: minimal defaults; required fields stay empty so the user is
  *   prompted to fill them.
- * - Edit mode (Sub-task 4): hydrated from the row fragment.
+ * - Edit mode: hydrated from the row fragment.
  */
 const getInitialValues = (
   preset: PrometheusQueryPresetEditorModalFragment$data | null,
@@ -163,14 +170,105 @@ const PrometheusQueryPresetEditorModal: React.FC<
       }
     `);
 
+  const [commitUpdateMutation, isInflightUpdate] =
+    useMutation<PrometheusQueryPresetEditorModalUpdateMutation>(graphql`
+      mutation PrometheusQueryPresetEditorModalUpdateMutation(
+        $id: ID!
+        $input: ModifyQueryDefinitionInput!
+      ) {
+        adminModifyPrometheusQueryPreset(id: $id, input: $input) {
+          preset {
+            id
+            name
+            description
+            rank
+            categoryId
+            metricName
+            queryTemplate
+            timeWindow
+            options {
+              filterLabels
+              groupLabels
+            }
+          }
+        }
+      }
+    `);
+
   const handleOk = () => {
     return formRef.current
       ?.validateFields()
       .then((values) => {
         if (preset) {
-          // Edit mode is implemented in Sub-task 4. Guard here so the modal
-          // does not silently drop a save in the meantime.
-          // TODO(needs-frontend): wire up edit mutation in FR-2451 sub-task 4
+          // Edit mode: compute diff and send only changed fields.
+          const initial = getInitialValues(preset);
+
+          // Build partial input containing only fields that differ from initial.
+          const input: Record<string, unknown> = {};
+
+          if (values.name !== initial.name) {
+            input.name = values.name;
+          }
+          if (values.description !== initial.description) {
+            input.description = values.description ?? null;
+          }
+          if (values.categoryId !== initial.categoryId) {
+            input.categoryId = values.categoryId ?? null;
+          }
+          if (values.rank !== initial.rank) {
+            input.rank = values.rank ?? 0;
+          }
+          if (values.metricName !== initial.metricName) {
+            input.metricName = values.metricName;
+          }
+          if (values.queryTemplate !== initial.queryTemplate) {
+            input.queryTemplate = values.queryTemplate;
+          }
+          if (values.timeWindow !== initial.timeWindow) {
+            input.timeWindow = values.timeWindow ?? null;
+          }
+
+          // For label arrays, compare element-by-element. If the user explicitly
+          // clears to [], we must send [] (not omit). If unchanged, omit.
+          const currentFilterLabels = values.filterLabels ?? [];
+          const initialFilterLabels = initial.filterLabels ?? [];
+          if (!_.isEqual(currentFilterLabels, initialFilterLabels)) {
+            input.options = {
+              ...(input.options as object | undefined),
+              filterLabels: currentFilterLabels,
+            };
+          }
+          const currentGroupLabels = values.groupLabels ?? [];
+          const initialGroupLabels = initial.groupLabels ?? [];
+          if (!_.isEqual(currentGroupLabels, initialGroupLabels)) {
+            input.options = {
+              ...(input.options as object | undefined),
+              groupLabels: currentGroupLabels,
+            };
+          }
+
+          commitUpdateMutation({
+            variables: {
+              id: toLocalId(preset.id),
+              input,
+            },
+            onCompleted: (_res, errors) => {
+              if (errors && errors.length > 0) {
+                const errorMsgList = _.map(errors, (error) => error.message);
+                for (const error of errorMsgList) {
+                  message.error(error);
+                }
+                // Keep modal open so the user can correct the input and retry
+                return;
+              }
+              message.success(t('prometheusQueryPreset.SuccessfullyUpdated'));
+              onRequestClose(true);
+            },
+            onError: (error) => {
+              message.error(error.message);
+              // Keep modal open so the user can correct the input and retry
+            },
+          });
           return;
         }
 
@@ -234,7 +332,7 @@ const PrometheusQueryPresetEditorModal: React.FC<
           : t('prometheusQueryPreset.CreatePreset')
       }
       okText={preset ? t('button.Save') : t('button.Create')}
-      confirmLoading={isInflightCreate}
+      confirmLoading={isInflightCreate || isInflightUpdate}
     >
       <BAIErrorBoundary>
         <Form
@@ -302,6 +400,13 @@ const PrometheusQueryPresetEditorModal: React.FC<
                 message: t('prometheusQueryPreset.QueryTemplateRequired'),
               },
             ]}
+            extra={
+              preset ? (
+                <Suspense fallback={null}>
+                  <PrometheusPresetPreview presetGlobalId={preset.id} />
+                </Suspense>
+              ) : undefined
+            }
           >
             <TextArea autoSize={{ minRows: 4, maxRows: 12 }} />
           </Form.Item>

--- a/react/src/components/PrometheusQueryPresetNodes.tsx
+++ b/react/src/components/PrometheusQueryPresetNodes.tsx
@@ -2,12 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { PrometheusQueryPresetEditorModalFragment$key } from '../__generated__/PrometheusQueryPresetEditorModalFragment.graphql';
 import {
   PrometheusQueryPresetNodesFragment$data,
   PrometheusQueryPresetNodesFragment$key,
 } from '../__generated__/PrometheusQueryPresetNodesFragment.graphql';
 import { localeCompare } from '../helper';
-import { DeleteOutlined } from '@ant-design/icons';
+import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import { Button, Typography } from 'antd';
 import {
   BAIColumnsType,
@@ -31,6 +32,7 @@ interface PrometheusQueryPresetNodesProps extends Omit<
 > {
   presetsFrgmt: PrometheusQueryPresetNodesFragment$key;
   onDeletePreset?: (preset: PrometheusQueryPresetNodeInList) => void;
+  onEditPreset?: (preset: PrometheusQueryPresetEditorModalFragment$key) => void;
   customizeColumns?: (
     baseColumns: BAIColumnsType<PrometheusQueryPresetNodeInList>,
   ) => BAIColumnsType<PrometheusQueryPresetNodeInList>;
@@ -39,6 +41,7 @@ interface PrometheusQueryPresetNodesProps extends Omit<
 const PrometheusQueryPresetNodes: React.FC<PrometheusQueryPresetNodesProps> = ({
   presetsFrgmt,
   onDeletePreset,
+  onEditPreset,
   customizeColumns,
   ...tableProps
 }) => {
@@ -67,6 +70,7 @@ const PrometheusQueryPresetNodes: React.FC<PrometheusQueryPresetNodesProps> = ({
           id
           name
         }
+        ...PrometheusQueryPresetEditorModalFragment
       }
     `,
     presetsFrgmt,
@@ -129,6 +133,11 @@ const PrometheusQueryPresetNodes: React.FC<PrometheusQueryPresetNodesProps> = ({
       fixed: 'right',
       render: (_value, row) => (
         <BAIFlex gap="xxs">
+          <Button
+            type="text"
+            icon={<EditOutlined />}
+            onClick={() => onEditPreset?.(row)}
+          />
           <Button
             type="text"
             danger

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1949,6 +1949,7 @@
     "Rank": "Rank",
     "SuccessfullyCreated": "Prometheus query preset has been successfully created.",
     "SuccessfullyDeleted": "Prometheus query preset has been successfully deleted.",
+    "SuccessfullyUpdated": "Prometheus query preset has been successfully updated.",
     "TimeWindow": "Time Window",
     "UpdatedAt": "Updated At"
   },


### PR DESCRIPTION
Resolves #6357 (FR-2451)

> Stacked on top of #7086

## Summary

- **Extracted `PrometheusPresetPreview`** from `AutoScalingRuleEditorModal.tsx` into a new shared `PrometheusPresetPreview.tsx` module. This is a pure move — zero behavior change in `AutoScalingRuleEditorModal`. The Relay query (`PrometheusPresetPreviewResultQuery`) now lives in the new file.
- **Edit mutation wired** in `PrometheusQueryPresetEditorModal`: calls `adminModifyPrometheusQueryPreset` with a **diff-only** input (only changed fields are sent; label arrays correctly distinguish "user cleared to `[]`" from "unchanged/omitted").
- **Live preview** rendered in edit mode under the QueryTemplate field using `<PrometheusPresetPreview presetGlobalId={preset.id} />`. Preview is edit-only (no ID available in create mode).
- **Edit button** (`EditOutlined`) added to the left of the Delete button in the `PrometheusQueryPresetList` action column.
- **`AutoScalingRulePresetTab`** wires `editingPreset` state and passes the fragment ref into `<PrometheusQueryPresetEditorModal presetFrgmt={editingPreset} />`.
- **i18n**: added `prometheusQueryPreset.SuccessfullyUpdated` to `en.json`.

## Verification

```
=== Relay ===
--- Relay: PASS ---

=== Lint ===
--- Lint: PASS ---

=== Format ===
--- Format: PASS ---

=== TypeScript ===
--- TypeScript: PASS ---

=== ALL PASS ===
```