### PR TITLE
fix(FR-2738): pass --no-strict in Amplify build (overlay tolerates v26.4.7 link drift)

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -184,7 +184,19 @@ applications:
                 }
                 git worktree add --detach "${worktree}" "${ref}"
               done
-            - pnpm --filter backend.ai-webui-docs run build:web
+            # Bypass the `build:web` script's wrapper (which re-runs
+            # `build:toolkit` redundantly — toolkit is already built in
+            # preBuild) and invoke the toolkit CLI directly so we can
+            # pass `--no-strict`.
+            #
+            # Strict mode is OFF for archive overlays: v26.4.7 src/
+            # contains 8 link diagnostics that the toolkit-of-its-day
+            # tolerated but main's stricter toolkit fails on. Tracked in
+            # FR-2752; once those are fixed, drop `--no-strict` and let
+            # strict mode catch future regressions. CI / release builds
+            # still run with strict default-on; only the Amplify overlay
+            # path relaxes it.
+            - pnpm --filter backend.ai-webui-docs exec docs-toolkit build:web --lang all --no-strict
       artifacts:
         # Path is relative to appRoot (this package). The toolkit
         # emits `dist/web/` under this package directory.


### PR DESCRIPTION
resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
