### PR TITLE
feat(FR-2664): apply meeting feedback — split config card, add endpoint URL, imageV2, reorder tabs

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2883,8 +2883,10 @@ input CreateAccessTokenInput
   """The ID of the model deployment for which the access token is created."""
   modelDeploymentId: ID!
 
-  """The expiration timestamp of the access token."""
-  expiresAt: DateTime
+  """
+  The expiration timestamp of the access token. Required — callers must decide the token lifetime themselves.
+  """
+  expiresAt: DateTime!
 }
 
 """Added in 25.16.0. Payload for creating an access token."""
@@ -3068,7 +3070,7 @@ input CreateDeploymentInput
   metadata: ModelDeploymentMetadataInput!
   networkAccess: ModelDeploymentNetworkAccessInput!
   defaultDeploymentStrategy: DeploymentStrategyInput!
-  desiredReplicaCount: Int!
+  replicaCount: Int!
   initialRevision: CreateRevisionInput = null
 }
 
@@ -3103,6 +3105,57 @@ input CreateDeploymentRevisionPresetInput
 
   """Default deployment strategy for deployments created from this preset."""
   deploymentStrategy: PresetDeploymentStrategyInput = null
+
+  """Added in UNRELEASED. Container image to run the inference server."""
+  imageId: UUID!
+
+  """
+  Added in UNRELEASED. Detailed explanation of when and why to use this preset configuration.
+  """
+  description: String = null
+
+  """
+  Added in UNRELEASED. Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint.
+  """
+  modelDefinition: ModelDefinitionInput = null
+
+  """
+  Added in UNRELEASED. Resource slot allocations (e.g. cpu, mem, cuda.device).
+  """
+  resourceSlots: [ResourceSlotEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Additional resource options such as shared memory (shmem) size.
+  """
+  resourceOpts: [ResourceOptsEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Deployment topology mode (single-node or multi-node).
+  """
+  clusterMode: ClusterMode = null
+
+  """Added in UNRELEASED. Number of worker nodes in the cluster."""
+  clusterSize: Int = null
+
+  """
+  Added in UNRELEASED. Command to start the inference server process inside the container.
+  """
+  startupCommand: String = null
+
+  """
+  Added in UNRELEASED. Script executed before the main process starts (e.g. to download model weights).
+  """
+  bootstrapScript: String = null
+
+  """
+  Added in UNRELEASED. Environment variables injected into the inference container.
+  """
+  environ: [EnvironEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Runtime variant preset values applied when using this deployment preset.
+  """
+  presetValues: [DeploymentRevisionPresetValueEntryInput!] = null
 }
 
 """Added in 26.4.2. Create deployment revision preset payload."""
@@ -4328,6 +4381,22 @@ type DelegateScanArtifactsPayload
   artifacts: [Artifact!]!
 }
 
+"""Added in UNRELEASED. Input for deleting an access token."""
+input DeleteAccessTokenInput
+  @join__type(graph: STRAWBERRY)
+{
+  """The ID of the access token to delete."""
+  id: ID!
+}
+
+"""Added in UNRELEASED. Payload for deleting an access token."""
+type DeleteAccessTokenPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """ID of the deleted access token"""
+  id: UUID!
+}
+
 """
 Added in 24.09.0. Input for soft-deleting artifacts from the system.
 
@@ -5121,6 +5190,19 @@ type DeploymentRevisionPresetEdge
   node: DeploymentRevisionPreset!
 }
 
+"""
+Added in 26.4.2. A single environment variable key-value pair injected into the inference container when a deployment revision preset is applied.
+"""
+type DeploymentRevisionPresetEnvironEntry
+  @join__type(graph: STRAWBERRY)
+{
+  """Environment variable key."""
+  key: String!
+
+  """Environment variable value."""
+  value: String!
+}
+
 """Added in 26.4.2. Filter for deployment revision presets."""
 input DeploymentRevisionPresetFilter
   @join__type(graph: STRAWBERRY)
@@ -5162,6 +5244,19 @@ type DeploymentRevisionPresetValueEntry
   presetId: UUID!
 
   """Value for this preset."""
+  value: String!
+}
+
+"""
+Added in UNRELEASED. A mapping of a runtime variant preset to a concrete value, used to auto-configure runtime parameters when this deployment preset is applied.
+"""
+input DeploymentRevisionPresetValueEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """The runtime variant preset that this value applies to."""
+  presetId: UUID!
+
+  """The concrete value to set for the referenced preset parameter."""
   value: String!
 }
 
@@ -6437,6 +6532,19 @@ type EntityTimestamps
 
   """Timestamp when this entity was last modified."""
   modifiedAt: DateTime
+}
+
+"""
+Added in UNRELEASED. A single environment variable entry with key and value.
+"""
+input EnvironEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Environment variable key (e.g., 'CUDA_VISIBLE_DEVICES')."""
+  key: String!
+
+  """Environment variable value."""
+  value: String!
 }
 
 """
@@ -9283,7 +9391,7 @@ type ModelReplica implements Node
 {
   """The Globally Unique ID of this object"""
   id: ID!
-  sessionId: ID!
+  sessionId: ID
   revisionId: ID!
 
   """Whether the replica has been checked and its health state."""
@@ -9299,9 +9407,9 @@ type ModelReplica implements Node
   createdAt: DateTime!
 
   """
-  The session ID associated with the replica. This can be null right after replica creation.
+  The session associated with the replica. Can be null if the replica is still provisioning.
   """
-  session: ComputeSessionNode! @deprecated(reason: "Use session_v2 instead.")
+  session: ComputeSessionNode @deprecated(reason: "Use session_v2 instead.")
 
   """
   Added in 26.4.3. The compute session running this replica, resolved via DataLoader.
@@ -10677,6 +10785,9 @@ type Mutation
   """Added in 25.16.0. Create access token."""
   createAccessToken(input: CreateAccessTokenInput!): CreateAccessTokenPayload! @join__field(graph: STRAWBERRY)
 
+  """Added in UNRELEASED. Delete access token."""
+  deleteAccessToken(input: DeleteAccessTokenInput!): DeleteAccessTokenPayload! @join__field(graph: STRAWBERRY)
+
   """
   Added in 25.19.0. Activate a specific revision to be the current revision
   """
@@ -11835,7 +11946,7 @@ type PresetExecutionSpec
   bootstrapScript: String
 
   """Environment variables."""
-  environ: [EnvironmentVariableEntry!]!
+  environ: [DeploymentRevisionPresetEnvironEntry!]!
 }
 
 """
@@ -17659,7 +17770,7 @@ input UpdateDeploymentInput
   tags: [String!]
   defaultDeploymentStrategy: DeploymentStrategyInput
   activeRevisionId: ID
-  desiredReplicaCount: Int
+  replicaCount: Int
   name: String
   preferredDomainName: String
 }
@@ -17733,6 +17844,50 @@ input UpdateDeploymentRevisionPresetInput
   Default deployment strategy for deployments created from this preset. Set to null to clear.
   """
   deploymentStrategy: PresetDeploymentStrategyInput
+
+  """
+  Added in UNRELEASED. Container image for the inference server. Set to null to clear.
+  """
+  imageId: UUID
+
+  """Added in UNRELEASED. Parsed model definition. Set to null to clear."""
+  modelDefinition: ModelDefinitionInput
+
+  """Added in UNRELEASED. Container startup command. Set to null to clear."""
+  startupCommand: String
+
+  """
+  Added in UNRELEASED. Bootstrap script run before the main process. Set to null to clear.
+  """
+  bootstrapScript: String
+
+  """
+  Added in UNRELEASED. Replace resource slot allocations. Omit to leave unchanged.
+  """
+  resourceSlots: [ResourceSlotEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Replace additional resource options. Omit to leave unchanged.
+  """
+  resourceOpts: [ResourceOptsEntryInput!] = null
+
+  """
+  Added in UNRELEASED. New cluster topology mode. Omit to leave unchanged.
+  """
+  clusterMode: ClusterMode = null
+
+  """Added in UNRELEASED. New cluster size. Omit to leave unchanged."""
+  clusterSize: Int = null
+
+  """
+  Added in UNRELEASED. Replace environment variables. Omit to leave unchanged.
+  """
+  environ: [EnvironEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Replace runtime variant preset values. Omit to leave unchanged.
+  """
+  presetValues: [DeploymentRevisionPresetValueEntryInput!] = null
 }
 
 """Added in 26.4.2. Update deployment revision preset payload."""

--- a/react/src/components/DeploymentAccessTokensTab.tsx
+++ b/react/src/components/DeploymentAccessTokensTab.tsx
@@ -5,14 +5,15 @@
 import { DeploymentAccessTokensTabCreateMutation } from '../__generated__/DeploymentAccessTokensTabCreateMutation.graphql';
 import { DeploymentAccessTokensTabListQuery } from '../__generated__/DeploymentAccessTokensTabListQuery.graphql';
 import { DeploymentAccessTokensTab_deployment$key } from '../__generated__/DeploymentAccessTokensTab_deployment.graphql';
-import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
-import { Alert, App, Button, DatePicker, Form, Typography, theme } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import { App, Button, DatePicker, Form, Typography } from 'antd';
 import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIModal,
   BAINameActionCell,
   BAITable,
+  BAIText,
   BAIUnmountAfterClose,
   filterOutNullAndUndefined,
   toLocalId,
@@ -39,8 +40,7 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const { logger } = useBAILogger();
   const [isPendingRefetch, startRefetchTransition] = useTransition();
   const [fetchKey, setFetchKey] = useState(0);
@@ -94,10 +94,6 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
     listData?.accessTokens?.edges?.map((edge) => edge?.node),
   );
 
-  // TODO(needs-backend): BA-5853 — createAccessToken mutation fails with a
-  // Pydantic validation error ("deployment_id Field required"). The frontend
-  // sends `modelDeploymentId` per the supergraph schema but the backend
-  // resolver expects `deployment_id`. Token creation is disabled until fixed.
   const commitCreateMutation =
     useMutationWithPromise<DeploymentAccessTokensTabCreateMutation>(graphql`
       mutation DeploymentAccessTokensTabCreateMutation(
@@ -118,31 +114,6 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
     startRefetchTransition(() => {
       setFetchKey((k) => k + 1);
     });
-  };
-
-  const handleDeleteToken = (tokenId: string) => {
-    modal.confirm({
-      title: t('dialog.warning.CannotBeUndone'),
-      content: t('deployment.accessToken.Delete'),
-      okText: t('button.Delete'),
-      okButtonProps: { danger: true },
-      onOk: () => {
-        // TODO(needs-backend): FR-2679 — ModelDeployment access token
-        // delete mutation is not yet exposed in the GraphQL schema.
-        // When the backend adds e.g. `deleteAccessToken(input: { id })`,
-        // wire it up here and call handleRefetch() on success.
-        void tokenId;
-        message.warning({
-          key: 'access-token-delete-not-implemented',
-          content: t('deployment.accessToken.Delete'),
-        });
-      },
-    });
-  };
-
-  const truncateToken = (rawToken: string) => {
-    if (rawToken.length <= 16) return rawToken;
-    return `${rawToken.slice(0, 8)}…${rawToken.slice(-4)}`;
   };
 
   return (
@@ -179,22 +150,20 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
                 return (
                   <BAINameActionCell
                     title={
-                      <Typography.Text code style={{ fontSize: 12 }}>
-                        {truncateToken(row.token)}
-                      </Typography.Text>
+                      <BAIText
+                        copyable={{ text: row.token }}
+                        ellipsis
+                        code
+                        style={{ maxWidth: 120 }}
+                      >
+                        {row.token}
+                      </BAIText>
                     }
                     showActions="always"
-                    actions={[
-                      {
-                        key: 'delete',
-                        title: t('button.Delete'),
-                        icon: <DeleteOutlined />,
-                        type: 'danger',
-                        disabled:
-                          isDeploymentDestroying || !isOwnedByCurrentUser,
-                        onClick: () => handleDeleteToken(row.id),
-                      },
-                    ]}
+                    // TODO(needs-backend): deleteAccessToken mutation is
+                    // defined in the schema but not yet deployed to the
+                    // running supergraph. Restore once the server is updated.
+                    actions={[]}
                   />
                 );
               },
@@ -231,7 +200,9 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
               commitCreateMutation({
                 input: {
                   modelDeploymentId: toLocalId(deployment.id),
-                  expiresAt: result.expiresAt,
+                  // Schema requires DateTime! (non-null); map "no expiration" to a far-future date.
+                  expiresAt:
+                    result.expiresAt ?? new Date('2099-12-31').toISOString(),
                 },
               })
                 .then((response) => {
@@ -265,33 +236,18 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
           open={createdToken !== null}
           destroyOnHidden
           title={t('deployment.accessToken.Token')}
-          onOk={() => setCreatedToken(null)}
           onCancel={() => setCreatedToken(null)}
-          cancelButtonProps={{ style: { display: 'none' } }}
-          okText={t('button.OK')}
+          footer={null}
           width={520}
         >
           <BAIFlex direction="column" align="stretch" gap="sm">
-            <Alert
-              type="warning"
-              showIcon
-              title={t('deployment.accessToken.Created')}
-              description={t('dialog.warning.CannotBeUndone')}
-            />
+            <Typography.Text>
+              {t('deployment.accessToken.Created')}
+            </Typography.Text>
             {createdToken ? (
-              <div
-                style={{
-                  padding: token.paddingSM,
-                  backgroundColor: token.colorFillQuaternary,
-                  border: `1px solid ${token.colorBorderSecondary}`,
-                  borderRadius: token.borderRadiusSM,
-                  wordBreak: 'break-all',
-                }}
-              >
-                <Typography.Text copyable={{ text: createdToken.token }} code>
-                  {createdToken.token}
-                </Typography.Text>
-              </div>
+              <BAIText copyable={{ text: createdToken.token }} ellipsis code>
+                {createdToken.token}
+              </BAIText>
             ) : null}
             {createdToken?.expiresAt ? (
               <Typography.Text type="secondary">

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -1,0 +1,763 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { DeploymentAddRevisionModalAddMutation } from '../__generated__/DeploymentAddRevisionModalAddMutation.graphql';
+import { DeploymentAddRevisionModalQuery } from '../__generated__/DeploymentAddRevisionModalQuery.graphql';
+import {
+  mergeExtraArgs,
+  reverseMapExtraArgs,
+} from '../helper/runtimeExtraArgsParser';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import {
+  buildArgsSchemaKeySet,
+  buildDefaultsMap,
+  flattenPresets,
+  getAllExtraArgsEnvVarNames,
+  getExtraArgsEnvVarName,
+  type RuntimeParameterGroup,
+} from '../hooks/useRuntimeParameterSchema';
+import ImageEnvironmentSelectFormItems, {
+  type ImageEnvironmentFormInput,
+} from './ImageEnvironmentSelectFormItems';
+import RuntimeParameterFormSection, {
+  type RuntimeParameterValues,
+} from './RuntimeParameterFormSection';
+import VFolderSelect from './VFolderSelect';
+import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import {
+  App,
+  Button,
+  Divider,
+  Form,
+  type FormInstance,
+  Input,
+  InputNumber,
+  Segmented,
+  Select,
+  Spin,
+  Typography,
+  theme,
+} from 'antd';
+import {
+  BAIButton,
+  BAIFlex,
+  BAIModal,
+  BAIProjectResourceGroupSelect,
+  filterOutNullAndUndefined,
+  toLocalId,
+} from 'backend.ai-ui';
+import React, { Suspense, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+
+const SectionHeader: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { token } = theme.useToken();
+  return (
+    <Divider titlePlacement="left">
+      <Typography.Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+        {children}
+      </Typography.Text>
+    </Divider>
+  );
+};
+
+interface DeploymentAddRevisionModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  deploymentId: string;
+}
+
+type FormValues = ImageEnvironmentFormInput & {
+  name?: string;
+  clusterMode: 'SINGLE_NODE' | 'MULTI_NODE';
+  clusterSize: number;
+  resourceGroup: string;
+  runtimeVariantId: string;
+  modelFolderId: string;
+  mountDestination: string;
+  definitionPath: string;
+  customDefinitionMode?: 'command' | 'file';
+  startCommand?: string;
+  commandPort?: number;
+  commandHealthCheck?: string;
+  commandModelMount?: string;
+  commandInitialDelay?: number;
+  commandMaxRetries?: number;
+  environ: { name: string; value: string }[];
+};
+
+interface DeploymentAddRevisionModalFormBodyProps {
+  deploymentId: string;
+  form: FormInstance<FormValues>;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  onIsAddingChange: (v: boolean) => void;
+}
+
+const DeploymentAddRevisionModalFormBody: React.FC<
+  DeploymentAddRevisionModalFormBodyProps
+> = ({ deploymentId, form, open, onClose, onSuccess, onIsAddingChange }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+  const currentProject = useCurrentProjectValue();
+
+  // Runtime parameter refs — kept outside form state so slider/input changes
+  // don't re-render the modal. Read at submit time via serializeRuntimeParamsToEnviron.
+  const runtimeParamValuesRef = useRef<RuntimeParameterValues>({});
+  const runtimeParamTouchedKeysRef = useRef<Set<string>>(new Set());
+  const runtimeParamGroupsRef = useRef<RuntimeParameterGroup[] | null>(null);
+
+  const { deployment, runtimeVariants, resource_presets } =
+    useLazyLoadQuery<DeploymentAddRevisionModalQuery>(
+      graphql`
+        query DeploymentAddRevisionModalQuery($deploymentId: ID!) {
+          deployment(id: $deploymentId) {
+            metadata {
+              projectId
+            }
+            currentRevision {
+              clusterConfig {
+                mode
+                size
+              }
+              resourceConfig {
+                resourceGroupName
+              }
+              modelRuntimeConfig {
+                runtimeVariantId
+                environ {
+                  entries {
+                    name
+                    value
+                  }
+                }
+              }
+              modelMountConfig {
+                vfolderId
+                mountDestination
+                definitionPath
+              }
+            }
+          }
+          runtimeVariants {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+          resource_presets {
+            name
+            resource_slots
+          }
+        }
+      `,
+      { deploymentId },
+      { fetchPolicy: 'network-only' },
+    );
+
+  const [commitAdd] = useMutation<DeploymentAddRevisionModalAddMutation>(
+    graphql`
+      mutation DeploymentAddRevisionModalAddMutation(
+        $input: AddRevisionInput!
+      ) {
+        addModelRevision(input: $input, options: { autoActivate: true }) {
+          revision {
+            id
+            name
+          }
+        }
+      }
+    `,
+  );
+
+  const currentRevision = (
+    deployment as unknown as {
+      currentRevision?: {
+        clusterConfig?: { mode?: string; size?: number } | null;
+        resourceConfig?: { resourceGroupName?: string | null } | null;
+        modelRuntimeConfig?: {
+          runtimeVariantId?: string | null;
+          environ?: {
+            entries?: ReadonlyArray<{ name: string; value: string }> | null;
+          } | null;
+        } | null;
+        modelMountConfig?: {
+          vfolderId?: string | null;
+          mountDestination?: string | null;
+          definitionPath?: string | null;
+        } | null;
+      } | null;
+    }
+  )?.currentRevision;
+
+  const runtimeVariantOptions = filterOutNullAndUndefined(
+    (runtimeVariants?.edges ?? []).map((e) => e?.node),
+  ).map((node) => ({ value: toLocalId(node.id) ?? node.id, label: node.name }));
+
+  // Pre-populate from current revision once when the modal opens.
+  useEffect(() => {
+    if (!open || !currentRevision) return;
+    const rev = currentRevision;
+    form.setFieldsValue({
+      clusterMode:
+        (rev?.clusterConfig?.mode as 'SINGLE_NODE' | 'MULTI_NODE') ??
+        'MULTI_NODE',
+      clusterSize: rev?.clusterConfig?.size ?? 1,
+      resourceGroup: rev?.resourceConfig?.resourceGroupName ?? '',
+      runtimeVariantId: rev?.modelRuntimeConfig?.runtimeVariantId ?? undefined,
+      modelFolderId: rev?.modelMountConfig?.vfolderId ?? undefined,
+      mountDestination: rev?.modelMountConfig?.mountDestination ?? '/models',
+      definitionPath:
+        rev?.modelMountConfig?.definitionPath ?? 'model-definition.yaml',
+      environ: (rev?.modelRuntimeConfig?.environ?.entries ?? []).map((e) => ({
+        name: e.name,
+        value: e.value,
+      })),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, currentRevision]);
+
+  const parseResourceSlotEntries = (resourceSlotsJson: string | null) => {
+    const slots = JSON.parse(resourceSlotsJson ?? '{}') as Record<
+      string,
+      string
+    >;
+    return Object.entries(slots).map(([resourceType, quantity]) => ({
+      resourceType,
+      quantity: String(quantity),
+    }));
+  };
+
+  // Serialize runtime parameter UI values (from RuntimeParameterFormSection)
+  // into an environ map — mirrors ServiceLauncherPageContent logic.
+  const serializeRuntimeParamsToEnviron = (
+    environ: Record<string, string>,
+    runtimeVariant: string,
+  ) => {
+    const groups = runtimeParamGroupsRef.current;
+    if (!groups || Object.keys(runtimeParamValuesRef.current).length === 0)
+      return;
+
+    const extraArgsEnvVar = getExtraArgsEnvVarName(runtimeVariant);
+    for (const envName of getAllExtraArgsEnvVarNames()) {
+      if (envName !== extraArgsEnvVar) delete environ[envName];
+    }
+
+    const touchedValues: Record<string, string> = {};
+    for (const [key, val] of Object.entries(runtimeParamValuesRef.current)) {
+      if (runtimeParamTouchedKeysRef.current.has(key)) touchedValues[key] = val;
+    }
+
+    const presets = flattenPresets(groups);
+    const presetMap = new Map(presets.map((p) => [p.key, p]));
+    const defaults = buildDefaultsMap(groups);
+    const argsValues: Record<string, string> = {};
+    const envValues: Record<string, string> = {};
+
+    for (const [key, val] of Object.entries(touchedValues)) {
+      if (val === '' || val === undefined) continue;
+      const preset = presetMap.get(key);
+      if (!preset) continue;
+      if (preset.presetTarget === 'ENV') envValues[key] = val;
+      else argsValues[key] = val;
+    }
+
+    const argsSchemaKeys = buildArgsSchemaKeySet(groups);
+    if (environ[extraArgsEnvVar] && argsSchemaKeys.size > 0) {
+      const { unmappedText } = reverseMapExtraArgs(
+        environ[extraArgsEnvVar],
+        argsSchemaKeys,
+      );
+      if (unmappedText) environ[extraArgsEnvVar] = unmappedText;
+      else delete environ[extraArgsEnvVar];
+    }
+
+    for (const preset of presets) {
+      if (preset.presetTarget === 'ENV') delete environ[preset.key];
+    }
+
+    if (Object.keys(argsValues).length > 0) {
+      const manualArgs = environ[extraArgsEnvVar] ?? '';
+      const merged = mergeExtraArgs(argsValues, manualArgs, defaults);
+      if (merged) environ[extraArgsEnvVar] = merged;
+      else delete environ[extraArgsEnvVar];
+    }
+
+    for (const [key, val] of Object.entries(envValues)) {
+      const preset = presetMap.get(key);
+      if (preset?.defaultValue !== null && preset?.defaultValue === val)
+        continue;
+      environ[key] = val;
+    }
+  };
+
+  const handleFinish = (values: FormValues) => {
+    const imageId = values.environments?.image?.id;
+    if (!imageId) {
+      form.setFields([
+        {
+          name: ['environments', 'version'],
+          errors: [t('modelService.ImageRequired')],
+        },
+      ]);
+      return;
+    }
+
+    const preset = resource_presets?.find(
+      (p) => p?.name === values.resourceGroup,
+    );
+    const entries = parseResourceSlotEntries(preset?.resource_slots ?? null);
+
+    const variantName =
+      runtimeVariantOptions.find((o) => o.value === values.runtimeVariantId)
+        ?.label ?? '';
+    const isCustom = variantName === 'custom';
+    const isCommandMode = values.customDefinitionMode === 'command';
+
+    // Build environ: runtime param section for non-custom, manual list for custom.
+    const environRecord: Record<string, string> = {};
+    if (!isCustom) {
+      serializeRuntimeParamsToEnviron(environRecord, variantName);
+    } else {
+      for (const { name, value } of values.environ ?? []) {
+        if (name) environRecord[name] = value;
+      }
+    }
+    const environEntries = Object.entries(environRecord).map(
+      ([name, value]) => ({ name, value }),
+    );
+
+    // Build modelDefinition for custom + command mode.
+    const modelDefinition =
+      isCustom && isCommandMode && values.startCommand
+        ? {
+            models: [
+              {
+                name: 'model',
+                modelPath: values.commandModelMount ?? '/models',
+                service: {
+                  preStartActions: [],
+                  startCommand: values.startCommand,
+                  port: values.commandPort ?? 8000,
+                  healthCheck: values.commandHealthCheck
+                    ? {
+                        path: values.commandHealthCheck,
+                        interval: 10,
+                        maxRetries: values.commandMaxRetries ?? 10,
+                        maxWaitTime: 15,
+                      }
+                    : null,
+                },
+              },
+            ],
+          }
+        : null;
+
+    const mountDestination =
+      isCustom && isCommandMode
+        ? (values.commandModelMount ?? '/models')
+        : values.mountDestination || '/models';
+    const definitionPath =
+      isCustom && isCommandMode
+        ? 'model-definition.yaml'
+        : values.definitionPath || 'model-definition.yaml';
+
+    onIsAddingChange(true);
+    commitAdd({
+      variables: {
+        input: {
+          deploymentId: toLocalId(deploymentId) ?? deploymentId,
+          name: values.name || undefined,
+          clusterConfig: {
+            mode: values.clusterMode,
+            size: values.clusterSize,
+          },
+          resourceConfig: {
+            resourceGroup: { name: values.resourceGroup },
+            resourceSlots: { entries },
+          },
+          image: { id: imageId },
+          modelRuntimeConfig: {
+            runtimeVariantId: values.runtimeVariantId,
+            inferenceRuntimeConfig: null,
+            environ:
+              environEntries.length > 0 ? { entries: environEntries } : null,
+          },
+          modelMountConfig: {
+            vfolderId: values.modelFolderId,
+            mountDestination,
+            definitionPath,
+          },
+          modelDefinition,
+        },
+      },
+      onCompleted: (_, errors) => {
+        onIsAddingChange(false);
+        if (errors && errors.length > 0) {
+          message.error(errors[0]?.message ?? t('general.ErrorOccurred'));
+          return;
+        }
+        form.resetFields();
+        onSuccess();
+        onClose();
+      },
+      onError: (err) => {
+        onIsAddingChange(false);
+        message.error(err.message ?? t('general.ErrorOccurred'));
+      },
+    });
+  };
+
+  return (
+    <Form<FormValues>
+      form={form}
+      layout="vertical"
+      style={{ marginTop: token.marginXS }}
+      onFinish={handleFinish}
+      initialValues={{
+        clusterMode: 'MULTI_NODE',
+        clusterSize: 1,
+        mountDestination: '/models',
+        definitionPath: 'model-definition.yaml',
+        customDefinitionMode: 'command',
+        commandPort: 8000,
+        commandHealthCheck: '/health',
+        commandModelMount: '/models',
+        commandInitialDelay: 60,
+        commandMaxRetries: 10,
+        environ: [],
+      }}
+    >
+      <Form.Item name="name" label={t('deployment.RevisionName')}>
+        <Input placeholder={t('deployment.RevisionNamePlaceholder')} />
+      </Form.Item>
+
+      <SectionHeader>{t('deployment.step.ClusterAndResources')}</SectionHeader>
+      <BAIFlex gap="sm">
+        <Form.Item
+          name="clusterMode"
+          label={t('deployment.ClusterMode')}
+          rules={[{ required: true }]}
+          style={{ flex: 1 }}
+        >
+          <Select
+            options={[
+              { value: 'SINGLE_NODE', label: 'SINGLE_NODE' },
+              { value: 'MULTI_NODE', label: 'MULTI_NODE' },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item
+          name="clusterSize"
+          label={t('deployment.ClusterSize')}
+          rules={[{ required: true }]}
+          style={{ flex: 1 }}
+        >
+          <InputNumber min={1} style={{ width: '100%' }} />
+        </Form.Item>
+      </BAIFlex>
+      <Form.Item
+        name="resourceGroup"
+        label={t('deployment.ResourceGroup')}
+        rules={[{ required: true }]}
+      >
+        <BAIProjectResourceGroupSelect
+          projectName={currentProject?.name ?? ''}
+          showSearch
+          autoSelectDefault
+        />
+      </Form.Item>
+
+      <SectionHeader>{t('deployment.step.ModelAndRuntime')}</SectionHeader>
+      <Form.Item
+        name="modelFolderId"
+        label={t('deployment.ModelFolder')}
+        rules={[{ required: true }]}
+      >
+        <VFolderSelect
+          autoSelectDefault
+          valuePropName="id"
+          filter={(vf) => vf.usage_mode === 'model' && vf.status === 'ready'}
+          showOpenButton
+          showCreateButton
+          showRefreshButton
+        />
+      </Form.Item>
+      <Form.Item
+        name="runtimeVariantId"
+        label={t('deployment.RuntimeVariant')}
+        rules={[{ required: true }]}
+      >
+        <Select options={runtimeVariantOptions} showSearch />
+      </Form.Item>
+
+      {/* Runtime parameter section — shown for non-custom variants */}
+      <Form.Item dependencies={['runtimeVariantId']} noStyle>
+        {({ getFieldValue }) => {
+          const variantId = getFieldValue('runtimeVariantId');
+          const variantName = runtimeVariantOptions.find(
+            (o) => o.value === variantId,
+          )?.label;
+          if (!variantName || variantName === 'custom') return null;
+          return (
+            <div style={{ marginBottom: token.marginMD }}>
+              <Suspense fallback={null}>
+                <RuntimeParameterFormSection
+                  runtimeVariant={variantName}
+                  onChange={(values) => {
+                    runtimeParamValuesRef.current = {
+                      ...runtimeParamValuesRef.current,
+                      ...values,
+                    };
+                  }}
+                  onTouchedKeysChange={(keys) => {
+                    runtimeParamTouchedKeysRef.current = keys;
+                  }}
+                  onGroupsLoaded={(groups) => {
+                    runtimeParamGroupsRef.current = groups;
+                  }}
+                  initialExtraArgs=""
+                  initialEnvVars={undefined}
+                />
+              </Suspense>
+            </div>
+          );
+        }}
+      </Form.Item>
+
+      {/* Model definition — command vs file mode for custom variant */}
+      <Form.Item dependencies={['runtimeVariantId']} noStyle>
+        {({ getFieldValue }) => {
+          const variantId = getFieldValue('runtimeVariantId');
+          const variantName = runtimeVariantOptions.find(
+            (o) => o.value === variantId,
+          )?.label;
+          if (variantName !== 'custom') {
+            return null;
+          }
+          // Custom variant: Segmented command vs file mode
+          return (
+            <>
+              <Form.Item name="customDefinitionMode" noStyle>
+                <Segmented
+                  options={[
+                    {
+                      label: t('modelService.EnterCommand'),
+                      value: 'command',
+                    },
+                    { label: t('modelService.UseConfigFile'), value: 'file' },
+                  ]}
+                  style={{ marginBottom: token.marginMD }}
+                />
+              </Form.Item>
+              <Form.Item dependencies={['customDefinitionMode']} noStyle>
+                {({ getFieldValue: getField }) =>
+                  getField('customDefinitionMode') === 'command' ? (
+                    <>
+                      <Form.Item
+                        name="startCommand"
+                        label={t('modelService.StartCommand')}
+                        rules={[{ required: true, whitespace: true }]}
+                      >
+                        <Input.TextArea
+                          placeholder={t(
+                            'modelService.StartCommandPlaceholder',
+                          )}
+                          autoSize={{ minRows: 2 }}
+                        />
+                      </Form.Item>
+                      <Form.Item
+                        name="commandModelMount"
+                        label={t('modelService.ModelMountDestination')}
+                      >
+                        <Input placeholder="/models" allowClear />
+                      </Form.Item>
+                      <BAIFlex gap="sm">
+                        <Form.Item
+                          name="commandPort"
+                          label={t('modelService.Port')}
+                          style={{ flex: 1 }}
+                        >
+                          <InputNumber
+                            min={1}
+                            max={65535}
+                            style={{ width: '100%' }}
+                          />
+                        </Form.Item>
+                        <Form.Item
+                          name="commandHealthCheck"
+                          label={t('modelService.HealthCheck')}
+                          style={{ flex: 1 }}
+                        >
+                          <Input placeholder="/health" allowClear />
+                        </Form.Item>
+                      </BAIFlex>
+                      <BAIFlex gap="sm">
+                        <Form.Item
+                          name="commandInitialDelay"
+                          label={t('modelService.InitialDelay')}
+                          style={{ flex: 1 }}
+                        >
+                          <InputNumber
+                            min={0}
+                            step={0.5}
+                            style={{ width: '100%' }}
+                          />
+                        </Form.Item>
+                        <Form.Item
+                          name="commandMaxRetries"
+                          label={t('modelService.MaxRetries')}
+                          style={{ flex: 1 }}
+                        >
+                          <InputNumber min={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                      </BAIFlex>
+                    </>
+                  ) : (
+                    <BAIFlex gap="sm">
+                      <Form.Item
+                        name="mountDestination"
+                        label={t('deployment.ModelMountDestination')}
+                        rules={[{ required: true }]}
+                        style={{ flex: 1 }}
+                      >
+                        <Input allowClear placeholder="/models" />
+                      </Form.Item>
+                      <Form.Item
+                        name="definitionPath"
+                        label={t('deployment.ModelDefinitionPath')}
+                        rules={[{ required: true }]}
+                        style={{ flex: 1 }}
+                      >
+                        <Input allowClear placeholder="model-definition.yaml" />
+                      </Form.Item>
+                    </BAIFlex>
+                  )
+                }
+              </Form.Item>
+            </>
+          );
+        }}
+      </Form.Item>
+
+      <ImageEnvironmentSelectFormItems />
+
+      {/* Environment variables — only shown for custom variant */}
+      <Form.Item dependencies={['runtimeVariantId']} noStyle>
+        {({ getFieldValue }) => {
+          const variantId = getFieldValue('runtimeVariantId');
+          const variantName = runtimeVariantOptions.find(
+            (o) => o.value === variantId,
+          )?.label;
+          if (variantName !== 'custom') return null;
+          return (
+            <>
+              <SectionHeader>{t('deployment.Environ')}</SectionHeader>
+              <Form.List name="environ">
+                {(fields, { add, remove }) => (
+                  <BAIFlex direction="column" gap="xs">
+                    {fields.map(({ key, name }) => (
+                      <BAIFlex key={key} gap="xs" align="center">
+                        <Form.Item
+                          name={[name, 'name']}
+                          style={{ flex: 1, marginBottom: 0 }}
+                        >
+                          <Input placeholder="KEY" />
+                        </Form.Item>
+                        <Form.Item
+                          name={[name, 'value']}
+                          style={{ flex: 2, marginBottom: 0 }}
+                        >
+                          <Input placeholder="VALUE" />
+                        </Form.Item>
+                        <MinusCircleOutlined
+                          onClick={() => remove(name)}
+                          style={{ color: token.colorTextSecondary }}
+                        />
+                      </BAIFlex>
+                    ))}
+                    <Button
+                      type="dashed"
+                      onClick={() => add({ name: '', value: '' })}
+                      icon={<PlusOutlined />}
+                    >
+                      {t('button.Add')}
+                    </Button>
+                  </BAIFlex>
+                )}
+              </Form.List>
+            </>
+          );
+        }}
+      </Form.Item>
+    </Form>
+  );
+};
+
+const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
+  open,
+  onClose,
+  onSuccess,
+  deploymentId,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const [form] = Form.useForm<FormValues>();
+  const [isAdding, setIsAdding] = useState(false);
+
+  const handleCancel = () => {
+    form.resetFields();
+    onClose();
+  };
+
+  return (
+    <BAIModal
+      open={open}
+      title={t('deployment.AddRevision')}
+      onCancel={handleCancel}
+      width={720}
+      footer={
+        <BAIFlex justify="end" gap="xs">
+          <Button onClick={handleCancel}>{t('button.Cancel')}</Button>
+          <BAIButton
+            type="primary"
+            loading={isAdding}
+            onClick={() => form.submit()}
+          >
+            {t('deployment.AddRevision')}
+          </BAIButton>
+        </BAIFlex>
+      }
+    >
+      {open && (
+        <Suspense
+          fallback={
+            <BAIFlex justify="center" align="center" style={{ minHeight: 200 }}>
+              <Spin />
+            </BAIFlex>
+          }
+        >
+          <DeploymentAddRevisionModalFormBody
+            deploymentId={deploymentId}
+            form={form}
+            open={open}
+            onClose={onClose}
+            onSuccess={onSuccess}
+            onIsAddingChange={setIsAdding}
+          />
+        </Suspense>
+      )}
+    </BAIModal>
+  );
+};
+
+export default DeploymentAddRevisionModal;

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -5,16 +5,32 @@
 import { DeploymentConfigurationSectionQuery } from '../__generated__/DeploymentConfigurationSectionQuery.graphql';
 import { DeploymentConfigurationSection_deployment$key } from '../__generated__/DeploymentConfigurationSection_deployment.graphql';
 import { useWebUINavigate } from '../hooks';
-import ImageNodeSimpleTag from './ImageNodeSimpleTag';
-import { CheckOutlined, CloseOutlined, EditOutlined } from '@ant-design/icons';
-import { Descriptions, Tag, Typography, theme } from 'antd';
+import SourceCodeView from './SourceCodeView';
+import {
+  CheckCircleOutlined,
+  CheckOutlined,
+  CloseOutlined,
+  EditOutlined,
+  LoadingOutlined,
+} from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Card,
+  Descriptions,
+  Tag,
+  Typography,
+  theme,
+} from 'antd';
 import { DescriptionsItemType } from 'antd/es/descriptions';
 import {
   filterOutEmpty,
+  filterOutNullAndUndefined,
   BAIButton,
   BAICard,
   BAIFetchKeyButton,
   BAIFlex,
+  BAIModal,
   toLocalId,
 } from 'backend.ai-ui';
 import React, { useState, useTransition } from 'react';
@@ -37,6 +53,8 @@ const DeploymentConfigurationSection: React.FC<
   const webuiNavigate = useWebUINavigate();
   const [isPendingRefetch, startRefetchTransition] = useTransition();
   const [fetchKey, setFetchKey] = useState(0);
+  const [isCurrentRevisionModalOpen, setIsCurrentRevisionModalOpen] =
+    useState(false);
 
   useFragment(
     graphql`
@@ -64,6 +82,7 @@ const DeploymentConfigurationSection: React.FC<
           }
           networkAccess {
             openToPublic
+            endpointUrl
           }
           defaultDeploymentStrategy {
             type
@@ -107,8 +126,46 @@ const DeploymentConfigurationSection: React.FC<
                 canonicalName
               }
             }
-            image {
-              ...ImageNodeSimpleTagFragment
+            modelDefinition {
+              models {
+                name
+                modelPath
+                service {
+                  startCommand
+                  port
+                  healthCheck {
+                    path
+                    initialDelay
+                    maxRetries
+                  }
+                }
+              }
+            }
+          }
+          revisionHistory(
+            limit: 1
+            orderBy: [{ field: CREATED_AT, direction: DESC }]
+          ) {
+            edges {
+              node {
+                id
+                name
+                modelDefinition {
+                  models {
+                    name
+                    modelPath
+                    service {
+                      startCommand
+                      port
+                      healthCheck {
+                        path
+                        initialDelay
+                        maxRetries
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -135,7 +192,14 @@ const DeploymentConfigurationSection: React.FC<
   const environEntries = runtimeConfig?.environ?.entries ?? [];
   const tags = deployment?.metadata.tags ?? [];
 
-  const items: DescriptionsItemType[] = filterOutEmpty([
+  const descriptionsProps = {
+    bordered: true,
+    column: { xxl: 3, xl: 2, lg: 2, md: 1, sm: 1, xs: 1 },
+    style: { backgroundColor: token.colorBgBase },
+  } as const;
+
+  // ─── Deployment-level items ───────────────────────────────────────────────
+  const deploymentItems: DescriptionsItemType[] = filterOutEmpty([
     {
       key: 'name',
       label: t('deployment.Name'),
@@ -155,6 +219,50 @@ const DeploymentConfigurationSection: React.FC<
       label: t('deployment.Domain'),
       children: deployment?.metadata.domainName || renderFallback(),
     },
+    {
+      key: 'endpoint-url',
+      label: t('deployment.EndpointUrl'),
+      children: deployment?.networkAccess.endpointUrl ? (
+        <Typography.Text copyable>
+          {deployment.networkAccess.endpointUrl}
+        </Typography.Text>
+      ) : (
+        renderFallback()
+      ),
+    },
+    {
+      key: 'open-to-public',
+      label: t('deployment.OpenToPublic'),
+      children: deployment?.networkAccess.openToPublic ? (
+        <CheckOutlined />
+      ) : (
+        <CloseOutlined />
+      ),
+    },
+    {
+      key: 'tags',
+      label: t('deployment.Tags'),
+      children:
+        tags.length > 0 ? (
+          <BAIFlex direction="row" wrap="wrap" gap="xxs">
+            {tags.map((tag) => (
+              <Tag key={tag}>{tag}</Tag>
+            ))}
+          </BAIFlex>
+        ) : (
+          renderFallback()
+        ),
+    },
+    {
+      key: 'desired-replicas',
+      label: t('deployment.DesiredReplicas'),
+      children:
+        deployment?.replicaState?.desiredReplicaCount ?? renderFallback(),
+    },
+  ]);
+
+  // ─── Current-revision config items ───────────────────────────────────────
+  const revisionItems: DescriptionsItemType[] = filterOutEmpty([
     {
       key: 'resource-group',
       label: t('deployment.ResourceGroup'),
@@ -194,11 +302,7 @@ const DeploymentConfigurationSection: React.FC<
     {
       key: 'image',
       label: t('deployment.Image'),
-      // TODO(needs-backend): ModelRevision.image fields return DOWNSTREAM_SERVICE_ERROR
-      // for deployments; fall back to imageV2.identity.canonicalName until fixed.
-      children: currentRevision?.image?.name ? (
-        <ImageNodeSimpleTag imageFrgmt={currentRevision.image} />
-      ) : currentRevision?.imageV2?.identity?.canonicalName ? (
+      children: currentRevision?.imageV2?.identity?.canonicalName ? (
         <Typography.Text copyable>
           {currentRevision.imageV2.identity.canonicalName}
         </Typography.Text>
@@ -216,35 +320,6 @@ const DeploymentConfigurationSection: React.FC<
       ) : (
         renderFallback()
       ),
-    },
-    {
-      key: 'desired-replicas',
-      label: t('deployment.DesiredReplicas'),
-      children:
-        deployment?.replicaState?.desiredReplicaCount ?? renderFallback(),
-    },
-    {
-      key: 'open-to-public',
-      label: t('deployment.OpenToPublic'),
-      children: deployment?.networkAccess.openToPublic ? (
-        <CheckOutlined />
-      ) : (
-        <CloseOutlined />
-      ),
-    },
-    {
-      key: 'tags',
-      label: t('deployment.Tags'),
-      children:
-        tags.length > 0 ? (
-          <BAIFlex direction="row" wrap="wrap" gap="xxs">
-            {tags.map((tag) => (
-              <Tag key={tag}>{tag}</Tag>
-            ))}
-          </BAIFlex>
-        ) : (
-          renderFallback()
-        ),
     },
     {
       key: 'environ',
@@ -265,6 +340,117 @@ const DeploymentConfigurationSection: React.FC<
     },
   ]);
 
+  // ─── Model definition items (ported from EndpointDetailPage) ─────────────
+  const buildModelDefinitionItems = (
+    rawModels:
+      | ReadonlyArray<{
+          readonly name: string | null | undefined;
+          readonly modelPath: string | null | undefined;
+          readonly service?: {
+            readonly startCommand: unknown;
+            readonly port: number | null | undefined;
+            readonly healthCheck?: {
+              readonly path: string | null | undefined;
+              readonly initialDelay: number | null | undefined;
+              readonly maxRetries: number | null | undefined;
+            } | null;
+          } | null;
+        } | null>
+      | null
+      | undefined,
+  ): DescriptionsItemType[] => {
+    const models = filterOutNullAndUndefined(rawModels);
+    if (!models || models.length === 0) return [];
+    return models.flatMap((model, idx) => {
+      const prefix = models.length > 1 ? `[${idx}] ` : '';
+      const modelItems: DescriptionsItemType[] = [
+        {
+          key: `model-name-${idx}`,
+          label: `${prefix}${t('modelStore.ModelName')}`,
+          children: model.name || renderFallback(),
+        },
+        {
+          key: `model-path-${idx}`,
+          label: `${prefix}${t('modelStore.ModelPath')}`,
+          children: model.modelPath || renderFallback(),
+        },
+        ...(model.service
+          ? ([
+              {
+                key: `model-start-command-${idx}`,
+                label: `${prefix}${t('modelService.StartCommand')}`,
+                children: model.service.startCommand ? (
+                  <SourceCodeView language="shell">
+                    {typeof model.service.startCommand === 'string'
+                      ? model.service.startCommand
+                      : JSON.stringify(model.service.startCommand, null, 2)}
+                  </SourceCodeView>
+                ) : (
+                  renderFallback()
+                ),
+                span: { xl: 2 },
+              },
+              {
+                key: `model-port-${idx}`,
+                label: `${prefix}${t('modelService.Port')}`,
+                children: model.service.port ?? renderFallback(),
+              },
+              ...(model.service.healthCheck
+                ? ([
+                    {
+                      key: `model-healthcheck-path-${idx}`,
+                      label: `${prefix}${t('modelService.HealthCheck')}`,
+                      children:
+                        model.service.healthCheck.path || renderFallback(),
+                    },
+                    {
+                      key: `model-initial-delay-${idx}`,
+                      label: `${prefix}${t('modelService.InitialDelay')}`,
+                      children:
+                        model.service.healthCheck.initialDelay ??
+                        renderFallback(),
+                    },
+                    {
+                      key: `model-max-retries-${idx}`,
+                      label: `${prefix}${t('modelService.MaxRetries')}`,
+                      children:
+                        model.service.healthCheck.maxRetries ??
+                        renderFallback(),
+                    },
+                  ] as DescriptionsItemType[])
+                : []),
+            ] as DescriptionsItemType[])
+          : []),
+      ];
+      return modelItems;
+    });
+  };
+
+  const currentModelDefItems = buildModelDefinitionItems(
+    currentRevision?.modelDefinition?.models,
+  );
+  const latestModelDefItems = buildModelDefinitionItems(
+    deployment?.revisionHistory?.edges?.[0]?.node?.modelDefinition?.models,
+  );
+  const currentRevisionName = currentRevision?.name;
+  const latestRevisionName =
+    deployment?.revisionHistory?.edges?.[0]?.node?.name;
+  const isRevisionMismatch =
+    currentRevision?.id != null &&
+    deployment?.revisionHistory?.edges?.[0]?.node?.id != null &&
+    currentRevision.id !== deployment.revisionHistory.edges[0].node.id;
+
+  // Latest revision: prefer latest model def items; current revision config always comes from currentRevision
+  const displayRevisionName =
+    latestModelDefItems.length > 0 ? latestRevisionName : currentRevisionName;
+  const displayRevisionItems = [
+    ...revisionItems,
+    ...(latestModelDefItems.length > 0
+      ? latestModelDefItems
+      : currentModelDefItems),
+  ];
+  const currentRevisionAllItems = [...revisionItems, ...currentModelDefItems];
+
   const handleRefetch = () => {
     startRefetchTransition(() => {
       setFetchKey((k) => k + 1);
@@ -272,37 +458,87 @@ const DeploymentConfigurationSection: React.FC<
   };
 
   return (
-    <BAICard
-      title={t('deployment.Configuration')}
-      extra={
-        <BAIFlex gap="xs" align="center">
-          <BAIFetchKeyButton
-            loading={isPendingRefetch}
-            value=""
-            onChange={handleRefetch}
+    <>
+      <BAICard
+        title={t('deployment.Overview')}
+        extra={
+          <BAIFlex gap="xs" align="center">
+            <BAIFetchKeyButton
+              loading={isPendingRefetch}
+              value=""
+              onChange={handleRefetch}
+            />
+            <BAIButton
+              type="primary"
+              icon={<EditOutlined />}
+              disabled={isDeploymentDestroying}
+              onClick={() => {
+                webuiNavigate(`/deployments/${deploymentLocalId}/edit`);
+              }}
+            >
+              {t('deployment.EditConfiguration')}
+            </BAIButton>
+          </BAIFlex>
+        }
+      >
+        <Descriptions {...descriptionsProps} items={deploymentItems} />
+      </BAICard>
+      {currentRevision && (
+        <Card title={t('modelService.RevisionInfo')}>
+          {isRevisionMismatch && (
+            <Alert
+              type="info"
+              icon={<LoadingOutlined spin />}
+              showIcon
+              title={t('modelService.NextRevisionApplying')}
+              action={
+                <Button onClick={() => setIsCurrentRevisionModalOpen(true)}>
+                  {t('modelService.ViewCurrentRevision')}
+                </Button>
+              }
+              style={{ marginBottom: token.marginMD }}
+            />
+          )}
+          <Descriptions
+            {...descriptionsProps}
+            items={[
+              {
+                key: 'revision-id',
+                label: t('modelService.RevisionID'),
+                children: displayRevisionName || renderFallback(),
+              },
+              ...displayRevisionItems,
+            ]}
           />
-          <BAIButton
-            type="primary"
-            icon={<EditOutlined />}
-            disabled={isDeploymentDestroying}
-            onClick={() => {
-              webuiNavigate(`/deployments/${deploymentLocalId}/edit`);
-            }}
-          >
-            {t('deployment.EditConfiguration')}
-          </BAIButton>
-        </BAIFlex>
-      }
-    >
-      <Descriptions
-        bordered
-        column={{ xxl: 3, xl: 2, lg: 2, md: 1, sm: 1, xs: 1 }}
-        style={{
-          backgroundColor: token.colorBgBase,
-        }}
-        items={items}
-      />
-    </BAICard>
+        </Card>
+      )}
+      <BAIModal
+        open={isCurrentRevisionModalOpen}
+        onCancel={() => setIsCurrentRevisionModalOpen(false)}
+        title={t('modelService.CurrentRevisionTitle')}
+        footer={null}
+        width={800}
+      >
+        <Alert
+          type="info"
+          icon={<CheckCircleOutlined />}
+          showIcon
+          title={t('modelService.CurrentlyApplied')}
+          style={{ marginBottom: token.marginMD }}
+        />
+        <Descriptions
+          {...descriptionsProps}
+          items={[
+            {
+              key: 'current-revision-id',
+              label: t('modelService.RevisionID'),
+              children: currentRevisionName || renderFallback(),
+            },
+            ...currentRevisionAllItems,
+          ]}
+        />
+      </BAIModal>
+    </>
   );
 };
 

--- a/react/src/components/DeploymentLauncherPageContent.tsx
+++ b/react/src/components/DeploymentLauncherPageContent.tsx
@@ -9,7 +9,6 @@ import {
   mergeExtraArgs,
   reverseMapExtraArgs,
 } from '../helper/runtimeExtraArgsParser';
-import { useSuspendedBackendaiClient } from '../hooks';
 import { ResourceSlotName, useResourceSlots } from '../hooks/backendai';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
@@ -135,7 +134,6 @@ export type DeploymentLauncherFormValue = ImageEnvironmentFormInput & {
   resourceGroup: string;
   resourcePresetId?: string;
   desiredReplicaCount: number;
-  autoScalingEnabled: boolean;
 };
 
 export interface DeploymentLauncherPageContentProps {
@@ -202,7 +200,6 @@ const DEFAULT_FORM_VALUES: DeploymentLauncherFormValue = {
   resourceGroup: '',
   resourcePresetId: undefined,
   desiredReplicaCount: 1,
-  autoScalingEnabled: false,
   environments: {
     environment: '',
     version: '',
@@ -875,9 +872,6 @@ const DeploymentLauncherPageContent: React.FC<
             >
               <InputNumber min={0} style={{ width: '100%' }} />
             </Form.Item>
-            <Form.Item name="autoScalingEnabled" valuePropName="checked">
-              <Checkbox>{t('deployment.AutoScaling')}</Checkbox>
-            </Form.Item>
           </Card>
 
           {/* --- Step 4: Review & Create --- */}
@@ -1302,9 +1296,6 @@ const DeploymentReviewSummary: React.FC<{
           </Descriptions.Item>
           <Descriptions.Item label={t('deployment.DesiredReplicas')}>
             {String(values.desiredReplicaCount ?? '-')}
-          </Descriptions.Item>
-          <Descriptions.Item label={t('deployment.AutoScaling')}>
-            {values.autoScalingEnabled ? t('button.Yes') : t('button.No')}
           </Descriptions.Item>
         </Descriptions>
       </BAICard>

--- a/react/src/components/DeploymentRevisionDetailDrawer.tsx
+++ b/react/src/components/DeploymentRevisionDetailDrawer.tsx
@@ -1,0 +1,305 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { DeploymentRevisionDetailDrawerQuery } from '../__generated__/DeploymentRevisionDetailDrawerQuery.graphql';
+import SourceCodeView from './SourceCodeView';
+import { Descriptions, Drawer, Skeleton, Tag, Typography, theme } from 'antd';
+import { DescriptionsItemType } from 'antd/es/descriptions';
+import { DrawerProps } from 'antd/lib';
+import {
+  BAIFlex,
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+} from 'backend.ai-ui';
+import dayjs from 'dayjs';
+import React, { Suspense } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+interface DeploymentRevisionDetailDrawerProps extends DrawerProps {
+  revisionId?: string | null;
+  currentRevisionId?: string | null;
+}
+
+const DeploymentRevisionDetailDrawerContent: React.FC<{
+  revisionId: string;
+  currentRevisionId?: string | null;
+}> = ({ revisionId, currentRevisionId }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  const { revision } = useLazyLoadQuery<DeploymentRevisionDetailDrawerQuery>(
+    graphql`
+      query DeploymentRevisionDetailDrawerQuery($revisionId: ID!) {
+        revision(id: $revisionId) {
+          id
+          name
+          createdAt
+          clusterConfig {
+            mode
+            size
+          }
+          resourceConfig {
+            resourceGroupName
+          }
+          modelRuntimeConfig {
+            runtimeVariant {
+              name
+            }
+            environ {
+              entries {
+                name
+                value
+              }
+            }
+          }
+          modelMountConfig {
+            vfolderId
+            mountDestination
+            definitionPath
+            vfolder {
+              id
+              name
+            }
+          }
+          imageV2 @since(version: "26.4.3") {
+            id
+            identity {
+              canonicalName
+            }
+          }
+          modelDefinition {
+            models {
+              name
+              modelPath
+              service {
+                startCommand
+                port
+                healthCheck {
+                  path
+                  initialDelay
+                  maxRetries
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    { revisionId },
+    { fetchPolicy: 'network-only' },
+  );
+
+  const renderFallback = () => (
+    <Typography.Text type="secondary">-</Typography.Text>
+  );
+
+  const isCurrent = revision?.id === currentRevisionId;
+  const clusterConfig = revision?.clusterConfig;
+  const resourceConfig = revision?.resourceConfig;
+  const runtimeConfig = revision?.modelRuntimeConfig;
+  const mountConfig = revision?.modelMountConfig;
+  const environEntries = runtimeConfig?.environ?.entries ?? [];
+
+  const descriptionsProps = {
+    bordered: true,
+    column: { xxl: 2, xl: 2, lg: 2, md: 1, sm: 1, xs: 1 },
+    style: { backgroundColor: token.colorBgBase },
+  } as const;
+
+  const baseItems: DescriptionsItemType[] = filterOutEmpty([
+    {
+      key: 'revision-name',
+      label: t('modelService.RevisionID'),
+      children: revision?.name ? (
+        <BAIFlex gap="xs" align="center">
+          <Typography.Text>{revision.name}</Typography.Text>
+          {isCurrent && (
+            <Tag color={token.colorPrimary}>{t('deployment.Current')}</Tag>
+          )}
+        </BAIFlex>
+      ) : (
+        renderFallback()
+      ),
+    },
+    {
+      key: 'created-at',
+      label: t('general.CreatedAt'),
+      children: revision?.createdAt
+        ? dayjs(revision.createdAt).format('lll')
+        : renderFallback(),
+    },
+    {
+      key: 'resource-group',
+      label: t('deployment.ResourceGroup'),
+      children: resourceConfig?.resourceGroupName || renderFallback(),
+    },
+    {
+      key: 'model-folder',
+      label: t('deployment.ModelFolder'),
+      children: mountConfig?.vfolder?.name ? (
+        <BAIFlex direction="column" align="start">
+          <Typography.Text>{mountConfig.vfolder.name}</Typography.Text>
+          {mountConfig.mountDestination && (
+            <Typography.Text type="secondary">
+              {mountConfig.mountDestination}
+            </Typography.Text>
+          )}
+        </BAIFlex>
+      ) : (
+        renderFallback()
+      ),
+    },
+    {
+      key: 'model-definition-path',
+      label: t('deployment.ModelDefinitionPath'),
+      children: mountConfig?.definitionPath || renderFallback(),
+    },
+    {
+      key: 'runtime-variant',
+      label: t('deployment.RuntimeVariant'),
+      children: runtimeConfig?.runtimeVariant?.name || renderFallback(),
+    },
+    {
+      key: 'image',
+      label: t('deployment.Image'),
+      children: revision?.imageV2?.identity?.canonicalName ? (
+        <Typography.Text copyable>
+          {revision.imageV2.identity.canonicalName}
+        </Typography.Text>
+      ) : (
+        renderFallback()
+      ),
+    },
+    {
+      key: 'cluster-mode',
+      label: t('deployment.ClusterMode'),
+      children: clusterConfig ? (
+        <Typography.Text>
+          {clusterConfig.mode} / {clusterConfig.size}
+        </Typography.Text>
+      ) : (
+        renderFallback()
+      ),
+    },
+    {
+      key: 'environ',
+      label: t('deployment.Environ'),
+      children:
+        environEntries.length > 0 ? (
+          <BAIFlex direction="column" align="start">
+            {environEntries.map((entry) => (
+              <Typography.Text key={entry.name} code>
+                {entry.name}={entry.value}
+              </Typography.Text>
+            ))}
+          </BAIFlex>
+        ) : (
+          renderFallback()
+        ),
+      span: 2,
+    },
+  ]);
+
+  const rawModels = revision?.modelDefinition?.models;
+  const models = filterOutNullAndUndefined(rawModels);
+  const modelItems: DescriptionsItemType[] = models.flatMap((model, idx) => {
+    const prefix = models.length > 1 ? `[${idx}] ` : '';
+    const items: DescriptionsItemType[] = filterOutEmpty([
+      {
+        key: `model-name-${idx}`,
+        label: `${prefix}${t('modelStore.ModelName')}`,
+        children: model.name || renderFallback(),
+      },
+      {
+        key: `model-path-${idx}`,
+        label: `${prefix}${t('modelStore.ModelPath')}`,
+        children: model.modelPath || renderFallback(),
+      },
+      ...(model.service
+        ? ([
+            {
+              key: `model-start-command-${idx}`,
+              label: `${prefix}${t('modelService.StartCommand')}`,
+              children: model.service.startCommand ? (
+                <SourceCodeView language="shell">
+                  {typeof model.service.startCommand === 'string'
+                    ? model.service.startCommand
+                    : JSON.stringify(model.service.startCommand, null, 2)}
+                </SourceCodeView>
+              ) : (
+                renderFallback()
+              ),
+              span: 2,
+            },
+            {
+              key: `model-port-${idx}`,
+              label: `${prefix}${t('modelService.Port')}`,
+              children: model.service.port ?? renderFallback(),
+            },
+            ...(model.service.healthCheck
+              ? ([
+                  {
+                    key: `model-healthcheck-path-${idx}`,
+                    label: `${prefix}${t('modelService.HealthCheck')}`,
+                    children:
+                      model.service.healthCheck.path || renderFallback(),
+                  },
+                  {
+                    key: `model-initial-delay-${idx}`,
+                    label: `${prefix}${t('modelService.InitialDelay')}`,
+                    children:
+                      model.service.healthCheck.initialDelay ??
+                      renderFallback(),
+                  },
+                  {
+                    key: `model-max-retries-${idx}`,
+                    label: `${prefix}${t('modelService.MaxRetries')}`,
+                    children:
+                      model.service.healthCheck.maxRetries ?? renderFallback(),
+                  },
+                ] as DescriptionsItemType[])
+              : []),
+          ] as DescriptionsItemType[])
+        : []),
+    ]);
+    return items;
+  });
+
+  return (
+    <Descriptions
+      {...descriptionsProps}
+      items={[...baseItems, ...modelItems]}
+    />
+  );
+};
+
+const DeploymentRevisionDetailDrawer: React.FC<
+  DeploymentRevisionDetailDrawerProps
+> = ({ revisionId, currentRevisionId, ...drawerProps }) => {
+  'use memo';
+  const { t } = useTranslation();
+
+  return (
+    <Drawer
+      title={t('deployment.RevisionDetail')}
+      size="large"
+      {...drawerProps}
+    >
+      {revisionId ? (
+        <Suspense fallback={<Skeleton active />}>
+          <DeploymentRevisionDetailDrawerContent
+            revisionId={revisionId}
+            currentRevisionId={currentRevisionId}
+          />
+        </Suspense>
+      ) : (
+        <Skeleton active />
+      )}
+    </Drawer>
+  );
+};
+
+export default DeploymentRevisionDetailDrawer;

--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -10,10 +10,13 @@ import { DeploymentRevisionHistoryTabRollbackMutation } from '../__generated__/D
 import type { DeploymentRevisionHistoryTab_deployment$key } from '../__generated__/DeploymentRevisionHistoryTab_deployment.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
-import { UndoOutlined } from '@ant-design/icons';
+import DeploymentAddRevisionModal from './DeploymentAddRevisionModal';
+import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
+import { PlusOutlined, UndoOutlined } from '@ant-design/icons';
 import { App, Tag, Typography, theme } from 'antd';
 import {
   type BAIColumnType,
+  BAIButton,
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
@@ -70,13 +73,15 @@ const DeploymentRevisionHistoryTab: React.FC<
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const { modal, message } = App.useApp();
+  const { modal } = App.useApp();
   const { logger } = useBAILogger();
   const { upsertNotification } = useSetBAINotification();
   const [isPending, startTransition] = useTransition();
   const [rollingBackRevisionId, setRollingBackRevisionId] = useState<
     string | null
   >(null);
+  const [drawerRevisionId, setDrawerRevisionId] = useState<string | null>(null);
+  const [isAddRevisionModalOpen, setIsAddRevisionModalOpen] = useState(false);
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.DeploymentRevisionHistoryTab',
@@ -156,6 +161,16 @@ const DeploymentRevisionHistoryTab: React.FC<
         ) {
           deployment(id: $deploymentId) {
             currentRevisionId
+            latestRevision: revisionHistory(
+              limit: 1
+              orderBy: [{ field: CREATED_AT, direction: DESC }]
+            ) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
             revisionHistory(
               filter: $filter
               orderBy: $orderBy
@@ -220,6 +235,7 @@ const DeploymentRevisionHistoryTab: React.FC<
     `);
 
   const currentRevisionId = listData?.currentRevisionId;
+  const latestRevisionId = listData?.latestRevision?.edges?.[0]?.node?.id;
   const revisionHistory = listData?.revisionHistory;
 
   type RevisionNode = NonNullable<
@@ -273,14 +289,19 @@ const DeploymentRevisionHistoryTab: React.FC<
               setRollingBackRevisionId(null);
               if (errors && errors.length > 0) {
                 logger.error(errors[0]);
-                message.error(errors[0]?.message ?? t('general.ErrorOccurred'));
+                upsertNotification({
+                  open: true,
+                  duration: 4.5,
+                  message: errors[0]?.message || t('general.ErrorOccurred'),
+                  type: 'error',
+                });
                 resolve();
                 return;
               }
               upsertNotification({
                 open: true,
                 duration: 4.5,
-                title: t('deployment.RollbackSuccess', {
+                message: t('deployment.RollbackSuccess', {
                   revisionNumber: revisionLabel,
                 }),
               });
@@ -290,7 +311,12 @@ const DeploymentRevisionHistoryTab: React.FC<
             onError: (error) => {
               setRollingBackRevisionId(null);
               logger.error(error);
-              message.error(error?.message ?? t('general.ErrorOccurred'));
+              upsertNotification({
+                open: true,
+                duration: 4.5,
+                message: error?.message || t('general.ErrorOccurred'),
+                type: 'error',
+              });
               resolve();
             },
           });
@@ -307,13 +333,24 @@ const DeploymentRevisionHistoryTab: React.FC<
       fixed: 'left',
       render: (_value, record) => {
         const isCurrent = record.id === currentRevisionId;
+        const isLatest = record.id === latestRevisionId;
+        const rollbackDisabledReason =
+          isCurrent || isLatest ? t('deployment.RollbackDisabled') : undefined;
+        const isRollbackDisabled =
+          isCurrent ||
+          isLatest ||
+          isDeploymentDestroying ||
+          rollingBackRevisionId === record.id;
         return (
           <BAINameActionCell
             title={
               <BAIFlex gap="xs" align="center">
-                <Typography.Text strong={isCurrent}>
+                <Typography.Link
+                  strong={isCurrent}
+                  onClick={() => setDrawerRevisionId(record.id)}
+                >
                   {record.name ?? '-'}
-                </Typography.Text>
+                </Typography.Link>
                 {isCurrent ? (
                   <Tag color={token.colorPrimary}>
                     {t('deployment.Current')}
@@ -327,10 +364,8 @@ const DeploymentRevisionHistoryTab: React.FC<
                 key: 'rollback',
                 title: t('deployment.Rollback'),
                 icon: <UndoOutlined />,
-                disabled:
-                  isCurrent ||
-                  isDeploymentDestroying ||
-                  rollingBackRevisionId === record.id,
+                disabled: isRollbackDisabled,
+                disabledReason: rollbackDisabledReason,
                 onClick: () => handleRollback(record),
               },
             ]}
@@ -422,11 +457,24 @@ const DeploymentRevisionHistoryTab: React.FC<
 
   return (
     <>
+      <DeploymentRevisionDetailDrawer
+        revisionId={drawerRevisionId}
+        currentRevisionId={currentRevisionId}
+        open={!!drawerRevisionId}
+        onClose={() => setDrawerRevisionId(null)}
+      />
+      <DeploymentAddRevisionModal
+        open={isAddRevisionModalOpen}
+        onClose={() => setIsAddRevisionModalOpen(false)}
+        onSuccess={handleRefresh}
+        deploymentId={deploymentId}
+      />
       <BAIFlex
         justify="between"
         align="center"
         gap="xs"
         style={{ marginBottom: 12 }}
+        wrap="wrap"
       >
         <BAIGraphQLPropertyFilter
           filterProperties={filterProperties}
@@ -438,11 +486,21 @@ const DeploymentRevisionHistoryTab: React.FC<
             doRefetch({ filter: parsed, offset: 0 });
           }}
         />
-        <BAIFetchKeyButton
-          loading={isPending}
-          value=""
-          onChange={() => handleRefresh()}
-        />
+        <BAIFlex gap="xs" align="center">
+          <BAIFetchKeyButton
+            loading={isPending}
+            value=""
+            onChange={() => handleRefresh()}
+          />
+          <BAIButton
+            type="primary"
+            icon={<PlusOutlined />}
+            disabled={isDeploymentDestroying}
+            onClick={() => setIsAddRevisionModalOpen(true)}
+          >
+            {t('deployment.AddRevision')}
+          </BAIButton>
+        </BAIFlex>
       </BAIFlex>
       <BAITable
         rowKey="id"

--- a/react/src/hooks/useDeploymentLauncher.ts
+++ b/react/src/hooks/useDeploymentLauncher.ts
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useDeploymentLauncherDeployVFolderMutation } from '../__generated__/useDeploymentLauncherDeployVFolderMutation.graphql';
-import { useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import {
   useCurrentProjectValue,
@@ -13,7 +13,6 @@ import { useBAILogger } from 'backend.ai-ui';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
 
 export interface QuickDeployInput {
   /** Virtual folder (model folder) id that backs the deployment. */
@@ -52,7 +51,7 @@ export const useDeploymentLauncher = (): {
   'use memo';
 
   const { t } = useTranslation();
-  const navigate = useNavigate();
+  const navigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const { id: projectId } = useCurrentProjectValue();
   const currentResourceGroup = useCurrentResourceGroupValue();

--- a/react/src/hooks/useModelStoreProject.ts
+++ b/react/src/hooks/useModelStoreProject.ts
@@ -39,7 +39,7 @@ export const useModelStoreProject = () => {
     `,
     { domainName },
     {
-      fetchPolicy: 'store-and-network',
+      fetchPolicy: 'store-or-network',
     },
   );
 

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -18,7 +18,9 @@ import DeploymentList, {
 import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import AdminModelCardListPage from './AdminModelCardListPage';
 import { Skeleton } from 'antd';
+import type { CardTabListType } from 'antd/es/card';
 import {
   BAICard,
   BAIFetchKeyButton,
@@ -30,6 +32,7 @@ import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { Suspense, useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import { useSearchParams } from 'react-router-dom';
 
 const parseFilterVariable = (
   filter: string | null | undefined,
@@ -185,14 +188,36 @@ const AdminDeploymentListPageContent: React.FC = () => {
 const AdminDeploymentListPage: React.FC = () => {
   'use memo';
   const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const currentTab = searchParams.get('tab') || 'deployments';
+  const navigate = useWebUINavigate();
+
+  const tabItems: CardTabListType[] = [
+    {
+      key: 'deployments',
+      label: t('webui.menu.Deployments'),
+    },
+    {
+      key: 'model-store-management',
+      label: t('adminModelCard.ModelStoreManagement'),
+    },
+  ];
+
   return (
     <BAICard
       variant="borderless"
-      title={t('webui.menu.Deployments')}
-      styles={{ body: { paddingTop: 0 } }}
+      activeTabKey={currentTab}
+      onTabChange={(key) =>
+        navigate({
+          pathname: '/admin-deployments',
+          search: `?tab=${key}`,
+        })
+      }
+      tabList={tabItems}
     >
       <Suspense fallback={<Skeleton active />}>
-        <AdminDeploymentListPageContent />
+        {currentTab === 'deployments' && <AdminDeploymentListPageContent />}
+        {currentTab === 'model-store-management' && <AdminModelCardListPage />}
       </Suspense>
     </BAICard>
   );

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -122,42 +122,8 @@ const DeploymentDetailPage: React.FC = () => {
             key: 'revisions',
             label: (
               <>
-                {t('deployment.tab.RevisionHistory')}
-                <Tooltip
-                  title={t('deployment.tab.description.RevisionHistory')}
-                >
-                  <QuestionCircleOutlined
-                    style={{
-                      marginLeft: token.marginXXS,
-                      color: token.colorTextDescription,
-                    }}
-                  />
-                </Tooltip>
-              </>
-            ),
-          },
-          {
-            key: 'tokens',
-            label: (
-              <>
-                {t('deployment.tab.AccessTokens')}
-                <Tooltip title={t('deployment.tab.description.AccessTokens')}>
-                  <QuestionCircleOutlined
-                    style={{
-                      marginLeft: token.marginXXS,
-                      color: token.colorTextDescription,
-                    }}
-                  />
-                </Tooltip>
-              </>
-            ),
-          },
-          {
-            key: 'autoscaling',
-            label: (
-              <>
-                {t('deployment.tab.AutoScaling')}
-                <Tooltip title={t('deployment.tab.description.AutoScaling')}>
+                {t('deployment.tab.Revision')}
+                <Tooltip title={t('deployment.tab.description.Revision')}>
                   <QuestionCircleOutlined
                     style={{
                       marginLeft: token.marginXXS,
@@ -187,19 +153,41 @@ const DeploymentDetailPage: React.FC = () => {
             />
           </Suspense>
         </div>
-        <div hidden={activeTab !== 'tokens'}>
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentAccessTokensTab
-              deploymentFrgmt={deployment}
-              deploymentId={toGlobalId('ModelDeployment', deploymentId)}
-              isOwnedByCurrentUser={isOwnedByCurrentUser}
-              isDeploymentDestroying={isDeploymentDestroying}
-            />
-          </Suspense>
-        </div>
-        <div hidden={activeTab !== 'autoscaling'}>
-          <DeploymentAutoScalingTab deploymentFrgmt={deployment} />
-        </div>
+      </Card>
+      <Card
+        title={
+          <BAIFlex gap="xs" align="center">
+            {t('deployment.tab.AutoScaling')}
+            <Tooltip title={t('deployment.tab.description.AutoScaling')}>
+              <QuestionCircleOutlined
+                style={{ color: token.colorTextDescription }}
+              />
+            </Tooltip>
+          </BAIFlex>
+        }
+      >
+        <DeploymentAutoScalingTab deploymentFrgmt={deployment} />
+      </Card>
+      <Card
+        title={
+          <BAIFlex gap="xs" align="center">
+            {t('deployment.tab.AccessTokens')}
+            <Tooltip title={t('deployment.tab.description.AccessTokens')}>
+              <QuestionCircleOutlined
+                style={{ color: token.colorTextDescription }}
+              />
+            </Tooltip>
+          </BAIFlex>
+        }
+      >
+        <Suspense fallback={<Skeleton active />}>
+          <DeploymentAccessTokensTab
+            deploymentFrgmt={deployment}
+            deploymentId={toGlobalId('ModelDeployment', deploymentId)}
+            isOwnedByCurrentUser={isOwnedByCurrentUser}
+            isDeploymentDestroying={isDeploymentDestroying}
+          />
+        </Suspense>
       </Card>
     </BAIFlex>
   );

--- a/react/src/pages/DeploymentLauncherPage.tsx
+++ b/react/src/pages/DeploymentLauncherPage.tsx
@@ -25,7 +25,7 @@ import { BAIFlex, toGlobalId, toLocalId, useBAILogger } from 'backend.ai-ui';
 import React, { Suspense, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 /**
  * DeploymentLauncherPage — page-level orchestrator for the deployment launcher.
@@ -144,8 +144,8 @@ const DeploymentLauncherPageLayout: React.FC<
 
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const navigate = useNavigate();
-  const webuiNavigate = useWebUINavigate();
+  const navigate = useWebUINavigate();
+  const webuiNavigate = navigate; // alias for readability at call sites
   const app = App.useApp();
   const { logger } = useBAILogger();
 
@@ -419,7 +419,7 @@ const DeploymentLauncherPageLayout: React.FC<
               openToPublic: values.openToPublic,
             },
             defaultDeploymentStrategy: { type: 'ROLLING' },
-            desiredReplicaCount: values.desiredReplicaCount,
+            replicaCount: values.desiredReplicaCount,
             initialRevision: null,
           },
         },

--- a/react/src/pages/ModelStoreListPageV2.tsx
+++ b/react/src/pages/ModelStoreListPageV2.tsx
@@ -242,7 +242,7 @@ const ModelCardV2Grid: React.FC<{
       offset,
     },
     {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'store-and-network',
       fetchKey,
     },
   );

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -521,12 +521,9 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     path: '/admin-deployments',
     handle: { labelKey: 'webui.menu.Serving' },
     Component: () => {
-      const { t } = useTranslation();
       return (
         <BAIErrorBoundary>
-          <Suspense
-            fallback={<BAICard title={t('webui.menu.Serving')} loading />}
-          >
+          <Suspense fallback={<BAICard loading />}>
             <AdminDeploymentListPage />
           </Suspense>
         </BAIErrorBoundary>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Replikate, die derzeit über AppProxy Datenverkehr empfangen.",
     "ActivenessStatus": "Aktivitätsstatus",
+    "AddRevision": "Revision hinzufügen",
     "AutoScaling": "Automatische Skalierung",
     "AutoScalingRules": "Regeln für automatische Skalierung",
     "ClusterMode": "Cluster-Modus",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Bereitstellung erstellen",
     "CreatedAt": "Erstellt am",
     "CreatedBy": "Erstellt von",
+    "Current": "Aktuell",
+    "CurrentRevision": "Aktuelle Revision",
     "DeleteDeployment": "Bereitstellung löschen",
     "Deployment": "Bereitstellung",
     "DeploymentCreated": "Bereitstellung wurde erstellt.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Keine Bereitstellungen gefunden.",
     "NumberOfReplicas": "Anzahl der Replikate",
     "OpenToPublic": "Öffentlich",
+    "Overview": "Übersicht",
     "Owner": "Eigentümer",
     "Project": "Projekt",
     "QuickDeploy": "Bereitstellen",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Ressourcen-Voreinstellung",
     "Resources": "Ressourcen",
     "Revision": "Revision",
+    "RevisionDetail": "Revisionsdetails",
     "RevisionHistory": "Revisionsverlauf",
     "RevisionId": "Revisions-ID",
+    "RevisionIdPlaceholder": "Revisions-ID eingeben (optional)",
+    "RevisionName": "Revisionsname",
+    "RevisionNamePlaceholder": "Leer lassen für automatische Generierung",
     "RevisionNumber": "Revisionsnummer",
     "Revisions": "Revisionen",
     "Rollback": "Rollback",
     "RollbackConfirm": "Möchten Sie wirklich auf Revision #{{revisionNumber}} zurücksetzen? Die aktuelle Revision wird ersetzt.",
+    "RollbackDisabled": "Rollback ist für die aktuelle oder neueste Revision nicht verfügbar.",
     "RollbackSuccess": "Rollback zu Revision #{{revisionNumber}} wurde angefordert.",
     "Running": "Läuft",
     "RuntimeVariant": "Laufzeitvariante",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Grunddaten",
+      "ClusterAndResources": "Cluster & Ressourcen",
       "ModelAndRuntime": "Modell & Laufzeit",
       "ResourcesAndReplicas": "Ressourcen & Replikate",
       "ReviewAndCreate": "Überprüfen & Erstellen"
@@ -900,12 +910,14 @@
       "AutoScaling": "Automatische Skalierung",
       "Overview": "Übersicht",
       "Replicas": "Replikate",
+      "Revision": "Revision",
       "RevisionHistory": "Revisionsverlauf",
       "description": {
         "AccessTokens": "Verwalten Sie Zugriffstoken zur Authentifizierung von API-Anfragen an den Endpunkt dieses Deployments.",
         "AutoScaling": "Konfigurieren Sie Regeln zur automatischen Skalierung, um die Anzahl der Replikate basierend auf Verkehrsmetriken automatisch anzupassen.",
         "Replicas": "Zeigen Sie alle laufenden Replikat-Instanzen dieses Deployments mit ihrem Gesundheitszustand und Ressourcenstatus an.",
-        "RevisionHistory": "Durchsuchen Sie vergangene Deployment-Revisionen und führen Sie ein Rollback auf eine beliebige frühere Version durch. Um eine neue Revision zu erstellen, klicken Sie oben auf „Konfiguration bearbeiten“."
+        "Revision": "Sehen Sie sich vergangene Deployment-Revisionen an und führen Sie einen Rollback auf eine beliebige frühere Version durch.",
+        "RevisionHistory": "Durchsuchen Sie vergangene Deployment-Revisionen und führen Sie ein Rollback auf eine beliebige frühere Version durch."
       }
     }
   },

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Αντίγραφα που λαμβάνουν τρέχουσα κίνηση μέσω AppProxy.",
     "ActivenessStatus": "Κατάσταση ενεργότητας",
+    "AddRevision": "Προσθήκη Revision",
     "AutoScaling": "Αυτόματη κλιμάκωση",
     "AutoScalingRules": "Κανόνες αυτόματης κλιμάκωσης",
     "ClusterMode": "Λειτουργία cluster",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Δημιουργία ανάπτυξης",
     "CreatedAt": "Δημιουργήθηκε",
     "CreatedBy": "Δημιουργήθηκε από",
+    "Current": "Τρέχουσα",
+    "CurrentRevision": "Τρέχουσα Revision",
     "DeleteDeployment": "Διαγραφή ανάπτυξης",
     "Deployment": "Ανάπτυξη",
     "DeploymentCreated": "Η ανάπτυξη δημιουργήθηκε.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Δεν βρέθηκαν αναπτύξεις.",
     "NumberOfReplicas": "Αριθμός αντιγράφων",
     "OpenToPublic": "Δημόσιο",
+    "Overview": "Επισκόπηση",
     "Owner": "Ιδιοκτήτης",
     "Project": "Έργο",
     "QuickDeploy": "Ανάπτυξη",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Προεπιλογή πόρων",
     "Resources": "Πόροι",
     "Revision": "Revision",
+    "RevisionDetail": "Λεπτομέρειες Revision",
     "RevisionHistory": "Ιστορικό Revision",
     "RevisionId": "ID Revision",
+    "RevisionIdPlaceholder": "Εισάγετε ID Revision (προαιρετικό)",
+    "RevisionName": "Όνομα Revision",
+    "RevisionNamePlaceholder": "Αφήστε κενό για αυτόματη δημιουργία",
     "RevisionNumber": "Αριθμός Αναθεώρησης",
     "Revisions": "Revision",
     "Rollback": "Επαναφορά",
     "RollbackConfirm": "Είστε σίγουροι ότι θέλετε να επαναφέρετε στη Revision #{{revisionNumber}}; Η τρέχουσα Revision θα αντικατασταθεί.",
+    "RollbackDisabled": "Η επαναφορά δεν είναι διαθέσιμη για την τρέχουσα ή την πιο πρόσφατη Revision.",
     "RollbackSuccess": "Η επαναφορά στη Revision #{{revisionNumber}} ζητήθηκε.",
     "Running": "Σε εκτέλεση",
     "RuntimeVariant": "Παραλλαγή χρόνου εκτέλεσης",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Βασικές πληροφορίες",
+      "ClusterAndResources": "Σύμπλεγμα & Πόροι",
       "ModelAndRuntime": "Μοντέλο & Χρόνος εκτέλεσης",
       "ResourcesAndReplicas": "Πόροι & Αντίγραφα",
       "ReviewAndCreate": "Αναθεώρηση & Δημιουργία"
@@ -900,12 +910,14 @@
       "AutoScaling": "Αυτόματη κλιμάκωση",
       "Overview": "Επισκόπηση",
       "Replicas": "Αντίγραφα",
+      "Revision": "Revision",
       "RevisionHistory": "Ιστορικό Revision",
       "description": {
         "AccessTokens": "Διαχειριστείτε τα διακριτικά πρόσβασης για την επαλήθευση ταυτότητας αιτημάτων API στο τελικό σημείο αυτής της ανάπτυξης.",
         "AutoScaling": "Ρυθμίστε κανόνες αυτόματης κλιμάκωσης για αυτόματη προσαρμογή του αριθμού των αντιγράφων βάσει μετρικών κυκλοφορίας.",
         "Replicas": "Δείτε όλες τις εκτελούμενες παρουσίες αντιγράφων για αυτήν την ανάπτυξη με την κατάστασή τους και τους πόρους τους.",
-        "RevisionHistory": "Περιηγηθείτε σε προηγούμενες αναθεωρήσεις ανάπτυξης και επαναφέρετε οποιαδήποτε προηγούμενη έκδοση. Για να δημιουργήσετε νέα αναθεώρηση, κάντε κλικ στην επιλογή «Επεξεργασία Διαμόρφωσης» παραπάνω."
+        "Revision": "Περιηγηθείτε σε προηγούμενες αναθεωρήσεις ανάπτυξης και επαναφέρετε οποιαδήποτε προηγούμενη.",
+        "RevisionHistory": "Περιηγηθείτε σε προηγούμενες αναθεωρήσεις ανάπτυξης και επαναφέρετε οποιαδήποτε προηγούμενη έκδοση."
       }
     }
   },

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -770,6 +770,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Replicas currently receiving traffic through AppProxy.",
     "ActivenessStatus": "Activeness Status",
+    "AddRevision": "Add Revision",
     "AutoScaling": "Auto-scaling",
     "AutoScalingRules": "Auto-scaling Rules",
     "ClusterMode": "Cluster Mode",
@@ -782,6 +783,8 @@
     "CreateDeployment": "Create Deployment",
     "CreatedAt": "Created At",
     "CreatedBy": "Created By",
+    "Current": "Current",
+    "CurrentRevision": "Current Revision",
     "DeleteDeployment": "Delete Deployment",
     "Deployment": "Deployment",
     "DeploymentCreated": "Deployment has been created.",
@@ -822,6 +825,7 @@
     "NoDeployments": "No deployments found.",
     "NumberOfReplicas": "Number of Replicas",
     "OpenToPublic": "Open To Public",
+    "Overview": "Overview",
     "Owner": "Owner",
     "Project": "Project",
     "QuickDeploy": "Deploy",
@@ -836,12 +840,17 @@
     "ResourcePreset": "Resource Preset",
     "Resources": "Resources",
     "Revision": "Revision",
+    "RevisionDetail": "Revision Detail",
     "RevisionHistory": "Revision History",
     "RevisionId": "Revision ID",
+    "RevisionIdPlaceholder": "Leave blank to auto-generate",
+    "RevisionName": "Revision Name",
+    "RevisionNamePlaceholder": "Leave blank to auto-generate",
     "RevisionNumber": "Revision Number",
     "Revisions": "Revisions",
     "Rollback": "Rollback",
     "RollbackConfirm": "Are you sure you want to rollback to Revision #{{revisionNumber}}? The current revision will be replaced.",
+    "RollbackDisabled": "Rollback is not available for the current or latest revision.",
     "RollbackSuccess": "Rollback to Revision #{{revisionNumber}} has been requested.",
     "Running": "Running",
     "RuntimeVariant": "Runtime Variant",
@@ -892,6 +901,7 @@
     },
     "step": {
       "BasicInfo": "Basic Info",
+      "ClusterAndResources": "Cluster & Resources",
       "ModelAndRuntime": "Model & Runtime",
       "ResourcesAndReplicas": "Resources & Replicas",
       "ReviewAndCreate": "Review & Create"
@@ -901,12 +911,14 @@
       "AutoScaling": "Auto-scaling",
       "Overview": "Overview",
       "Replicas": "Replicas",
+      "Revision": "Revision",
       "RevisionHistory": "Revision History",
       "description": {
         "AccessTokens": "Manage access tokens for authenticating API requests to this deployment's endpoint.",
         "AutoScaling": "Configure auto-scaling rules to automatically adjust replica count based on traffic metrics.",
         "Replicas": "View all running replica instances for this deployment with their health and resource status.",
-        "RevisionHistory": "Browse past deployment revisions and roll back to any previous one. To create a new revision, click Edit Configuration above."
+        "Revision": "Browse past deployment revisions and roll back to any previous one.",
+        "RevisionHistory": "Browse past deployment revisions and roll back to any previous one."
       }
     }
   },

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Réplicas que actualmente reciben tráfico a través de AppProxy.",
     "ActivenessStatus": "Estado de actividad",
+    "AddRevision": "Agregar Revisión",
     "AutoScaling": "Escalado automático",
     "AutoScalingRules": "Reglas de escalado automático",
     "ClusterMode": "Modo clúster",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Crear despliegue",
     "CreatedAt": "Creado el",
     "CreatedBy": "Creado por",
+    "Current": "Actual",
+    "CurrentRevision": "Revision Actual",
     "DeleteDeployment": "Eliminar despliegue",
     "Deployment": "Despliegue",
     "DeploymentCreated": "El despliegue ha sido creado.",
@@ -821,6 +824,7 @@
     "NoDeployments": "No se encontraron despliegues.",
     "NumberOfReplicas": "Número de réplicas",
     "OpenToPublic": "Público",
+    "Overview": "Resumen",
     "Owner": "Propietario",
     "Project": "Proyecto",
     "QuickDeploy": "Desplegar",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Preset de recursos",
     "Resources": "Recursos",
     "Revision": "Revision",
+    "RevisionDetail": "Detalle de Revision",
     "RevisionHistory": "Historial de Revision",
     "RevisionId": "ID de Revision",
+    "RevisionIdPlaceholder": "Ingrese un ID de Revision (opcional)",
+    "RevisionName": "Nombre de Revision",
+    "RevisionNamePlaceholder": "Dejar en blanco para generar automáticamente",
     "RevisionNumber": "Número de Revisión",
     "Revisions": "Revision",
     "Rollback": "Revertir",
     "RollbackConfirm": "¿Está seguro de que desea revertir a la Revision #{{revisionNumber}}? La Revision actual será reemplazada.",
+    "RollbackDisabled": "El retroceso no está disponible para la Revision actual o más reciente.",
     "RollbackSuccess": "Se ha solicitado la reversión a la Revision #{{revisionNumber}}.",
     "Running": "En ejecución",
     "RuntimeVariant": "Variante de tiempo de ejecución",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Información básica",
+      "ClusterAndResources": "Clúster y recursos",
       "ModelAndRuntime": "Modelo y entorno",
       "ResourcesAndReplicas": "Recursos y réplicas",
       "ReviewAndCreate": "Revisar y crear"
@@ -900,12 +910,14 @@
       "AutoScaling": "Escalado automático",
       "Overview": "Resumen",
       "Replicas": "Réplicas",
+      "Revision": "Revision",
       "RevisionHistory": "Historial de Revision",
       "description": {
         "AccessTokens": "Gestione los tokens de acceso para autenticar las solicitudes de API al endpoint de este despliegue.",
         "AutoScaling": "Configure reglas de escalado automático para ajustar automáticamente el número de réplicas según las métricas de tráfico.",
         "Replicas": "Vea todas las instancias de réplica en ejecución de este despliegue con su estado de salud y recursos.",
-        "RevisionHistory": "Explore las revisiones anteriores del despliegue y revierta a cualquier versión anterior. Para crear una nueva revisión, haga clic en «Editar Configuración» arriba."
+        "Revision": "Explore las revisiones anteriores del despliegue y revierta a cualquier versión anterior.",
+        "RevisionHistory": "Explore las revisiones anteriores del despliegue y revierta a cualquier versión anterior."
       }
     }
   },

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Replikat, jotka vastaanottavat liikennettä AppProxyn kautta.",
     "ActivenessStatus": "Aktiivisuustila",
+    "AddRevision": "Lisää Revision",
     "AutoScaling": "Automaattinen skaalaus",
     "AutoScalingRules": "Automaattisen skaalauksen säännöt",
     "ClusterMode": "Klusteritila",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Luo käyttöönotto",
     "CreatedAt": "Luotu",
     "CreatedBy": "Luonut",
+    "Current": "Nykyinen",
+    "CurrentRevision": "Nykyinen Revision",
     "DeleteDeployment": "Poista käyttöönotto",
     "Deployment": "Käyttöönotto",
     "DeploymentCreated": "Käyttöönotto on luotu.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Käyttöönottoja ei löydy.",
     "NumberOfReplicas": "Replikoiden määrä",
     "OpenToPublic": "Julkinen",
+    "Overview": "Yleiskatsaus",
     "Owner": "Omistaja",
     "Project": "Projekti",
     "QuickDeploy": "Ota käyttöön",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Resurssiesiasetukset",
     "Resources": "Resurssit",
     "Revision": "Revision",
+    "RevisionDetail": "Revision-tiedot",
     "RevisionHistory": "Revision-historia",
     "RevisionId": "Revision ID",
+    "RevisionIdPlaceholder": "Anna Revision ID (valinnainen)",
+    "RevisionName": "Revision nimi",
+    "RevisionNamePlaceholder": "Jätä tyhjäksi automaattista luontia varten",
     "RevisionNumber": "Revisionumero",
     "Revisions": "Revision",
     "Rollback": "Palautus",
     "RollbackConfirm": "Haluatko varmasti palauttaa Revision #{{revisionNumber}}? Nykyinen Revision korvataan.",
+    "RollbackDisabled": "Palautus ei ole käytettävissä nykyiselle tai uusimmalle Revision-versiolle.",
     "RollbackSuccess": "Palautus Revision #{{revisionNumber}} on pyydetty.",
     "Running": "Käynnissä",
     "RuntimeVariant": "Suoritusaikavariantti",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Perustiedot",
+      "ClusterAndResources": "Klusteri ja resurssit",
       "ModelAndRuntime": "Malli ja suoritusaika",
       "ResourcesAndReplicas": "Resurssit ja replikat",
       "ReviewAndCreate": "Tarkista ja luo"
@@ -900,12 +910,14 @@
       "AutoScaling": "Automaattinen skaalaus",
       "Overview": "Yleiskatsaus",
       "Replicas": "Replikat",
+      "Revision": "Revision",
       "RevisionHistory": "Revision-historia",
       "description": {
         "AccessTokens": "Hallitse käyttöoikeustunnuksia, joilla todennetaan API-pyynnöt tämän käyttöönoton päätepisteeseen.",
         "AutoScaling": "Määritä automaattisen skaalauksen säännöt, joiden avulla replikoiden määrää säädetään automaattisesti liikennemittareiden perusteella.",
         "Replicas": "Tarkastele kaikkia tämän käyttöönoton käynnissä olevia replikaesiintymiä niiden terveys- ja resurssitiloineen.",
-        "RevisionHistory": "Selaa aiempia käyttöönottorevisioita ja palauta mikä tahansa niistä. Luo uusi revisio napsauttamalla yllä olevaa Muokkaa kokoonpanoa -painiketta."
+        "Revision": "Selaa aiempia käyttöönottorevisioita ja palauta mikä tahansa aiempi versio.",
+        "RevisionHistory": "Selaa aiempia käyttöönottorevisioita ja palauta mikä tahansa niistä."
       }
     }
   },

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Répliques recevant actuellement du trafic via AppProxy.",
     "ActivenessStatus": "État d'activité",
+    "AddRevision": "Ajouter une Revision",
     "AutoScaling": "Mise à l'échelle automatique",
     "AutoScalingRules": "Règles de mise à l'échelle automatique",
     "ClusterMode": "Mode cluster",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Créer un déploiement",
     "CreatedAt": "Créé le",
     "CreatedBy": "Créé par",
+    "Current": "Actuelle",
+    "CurrentRevision": "Revision Actuelle",
     "DeleteDeployment": "Supprimer le déploiement",
     "Deployment": "Déploiement",
     "DeploymentCreated": "Le déploiement a été créé.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Aucun déploiement trouvé.",
     "NumberOfReplicas": "Nombre de répliques",
     "OpenToPublic": "Public",
+    "Overview": "Aperçu",
     "Owner": "Propriétaire",
     "Project": "Projet",
     "QuickDeploy": "Déployer",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Préréglage de ressources",
     "Resources": "Ressources",
     "Revision": "Revision",
+    "RevisionDetail": "Détail de Revision",
     "RevisionHistory": "Historique de Revision",
     "RevisionId": "ID de Revision",
+    "RevisionIdPlaceholder": "Saisir un ID de Revision (facultatif)",
+    "RevisionName": "Nom de Revision",
+    "RevisionNamePlaceholder": "Laisser vide pour génération automatique",
     "RevisionNumber": "Numéro de Revision",
     "Revisions": "Revision",
     "Rollback": "Retour arrière",
     "RollbackConfirm": "Êtes-vous sûr de vouloir revenir à la Revision #{{revisionNumber}} ? La Revision actuelle sera remplacée.",
+    "RollbackDisabled": "Le retour arrière n'est pas disponible pour la Revision actuelle ou la plus récente.",
     "RollbackSuccess": "Le retour à la Revision #{{revisionNumber}} a été demandé.",
     "Running": "En cours d'exécution",
     "RuntimeVariant": "Variante d'exécution",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Informations de base",
+      "ClusterAndResources": "Cluster et ressources",
       "ModelAndRuntime": "Modèle et environnement",
       "ResourcesAndReplicas": "Ressources et répliques",
       "ReviewAndCreate": "Réviser et créer"
@@ -900,12 +910,14 @@
       "AutoScaling": "Mise à l'échelle automatique",
       "Overview": "Aperçu",
       "Replicas": "Répliques",
+      "Revision": "Revision",
       "RevisionHistory": "Historique de Revision",
       "description": {
         "AccessTokens": "Gérez les jetons d'accès pour authentifier les requêtes API vers le point de terminaison de ce déploiement.",
         "AutoScaling": "Configurez des règles de mise à l'échelle automatique pour ajuster automatiquement le nombre de répliques en fonction des métriques de trafic.",
         "Replicas": "Affichez toutes les instances de réplique en cours d'exécution pour ce déploiement avec leur état de santé et leurs ressources.",
-        "RevisionHistory": "Parcourez les révisions de déploiement passées et revenez à n'importe laquelle. Pour créer une nouvelle révision, cliquez sur « Modifier la configuration » ci-dessus."
+        "Revision": "Parcourez les révisions de déploiement passées et revenez à n'importe laquelle.",
+        "RevisionHistory": "Parcourez les révisions de déploiement passées et revenez à n'importe laquelle."
       }
     }
   },

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Replika yang saat ini menerima lalu lintas melalui AppProxy.",
     "ActivenessStatus": "Status Keaktifan",
+    "AddRevision": "Tambah Revision",
     "AutoScaling": "Skala Otomatis",
     "AutoScalingRules": "Aturan Skala Otomatis",
     "ClusterMode": "Mode Klaster",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Buat Penerapan",
     "CreatedAt": "Dibuat Pada",
     "CreatedBy": "Dibuat Oleh",
+    "Current": "Saat Ini",
+    "CurrentRevision": "Revision Saat Ini",
     "DeleteDeployment": "Hapus Penerapan",
     "Deployment": "Penerapan",
     "DeploymentCreated": "Penerapan telah dibuat.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Tidak ada penerapan ditemukan.",
     "NumberOfReplicas": "Jumlah Replika",
     "OpenToPublic": "Terbuka untuk Publik",
+    "Overview": "Ikhtisar",
     "Owner": "Pemilik",
     "Project": "Proyek",
     "QuickDeploy": "Terapkan",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Preset Sumber Daya",
     "Resources": "Sumber Daya",
     "Revision": "Revision",
+    "RevisionDetail": "Detail Revision",
     "RevisionHistory": "Riwayat Revision",
     "RevisionId": "ID Revision",
+    "RevisionIdPlaceholder": "Masukkan ID Revision (opsional)",
+    "RevisionName": "Nama Revision",
+    "RevisionNamePlaceholder": "Biarkan kosong untuk dibuat otomatis",
     "RevisionNumber": "Nomor Revisi",
     "Revisions": "Revision",
     "Rollback": "Rollback",
     "RollbackConfirm": "Apakah Anda yakin ingin rollback ke Revision #{{revisionNumber}}? Revision saat ini akan diganti.",
+    "RollbackDisabled": "Rollback tidak tersedia untuk Revision saat ini atau terbaru.",
     "RollbackSuccess": "Rollback ke Revision #{{revisionNumber}} telah diminta.",
     "Running": "Berjalan",
     "RuntimeVariant": "Varian Runtime",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Info Dasar",
+      "ClusterAndResources": "Kluster & Sumber Daya",
       "ModelAndRuntime": "Model & Runtime",
       "ResourcesAndReplicas": "Sumber Daya & Replika",
       "ReviewAndCreate": "Tinjau & Buat"
@@ -900,12 +910,14 @@
       "AutoScaling": "Skala Otomatis",
       "Overview": "Ikhtisar",
       "Replicas": "Replika",
+      "Revision": "Revision",
       "RevisionHistory": "Riwayat Revision",
       "description": {
         "AccessTokens": "Kelola token akses untuk mengautentikasi permintaan API ke endpoint deployment ini.",
         "AutoScaling": "Konfigurasikan aturan penskalaan otomatis untuk menyesuaikan jumlah replika secara otomatis berdasarkan metrik lalu lintas.",
         "Replicas": "Lihat semua instans replika yang berjalan untuk deployment ini beserta status kesehatan dan sumber dayanya.",
-        "RevisionHistory": "Jelajahi revisi deployment sebelumnya dan kembalikan ke revisi mana pun. Untuk membuat revisi baru, klik Sunting Konfigurasi di atas."
+        "Revision": "Jelajahi revisi deployment sebelumnya dan kembalikan ke revisi sebelumnya.",
+        "RevisionHistory": "Jelajahi revisi deployment sebelumnya dan kembalikan ke revisi mana pun."
       }
     }
   },

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Repliche che ricevono attualmente traffico tramite AppProxy.",
     "ActivenessStatus": "Stato di attività",
+    "AddRevision": "Aggiungi Revision",
     "AutoScaling": "Scalabilità automatica",
     "AutoScalingRules": "Regole di scalabilità automatica",
     "ClusterMode": "Modalità cluster",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Crea distribuzione",
     "CreatedAt": "Creato il",
     "CreatedBy": "Creato da",
+    "Current": "Corrente",
+    "CurrentRevision": "Revision Corrente",
     "DeleteDeployment": "Elimina distribuzione",
     "Deployment": "Distribuzione",
     "DeploymentCreated": "La distribuzione è stata creata.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Nessuna distribuzione trovata.",
     "NumberOfReplicas": "Numero di repliche",
     "OpenToPublic": "Pubblico",
+    "Overview": "Panoramica",
     "Owner": "Proprietario",
     "Project": "Progetto",
     "QuickDeploy": "Distribuisci",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Preset risorse",
     "Resources": "Risorse",
     "Revision": "Revision",
+    "RevisionDetail": "Dettaglio Revision",
     "RevisionHistory": "Cronologia Revision",
     "RevisionId": "ID Revision",
+    "RevisionIdPlaceholder": "Inserisci un ID Revision (opzionale)",
+    "RevisionName": "Nome Revision",
+    "RevisionNamePlaceholder": "Lascia vuoto per la generazione automatica",
     "RevisionNumber": "Numero di Revisione",
     "Revisions": "Revision",
     "Rollback": "Rollback",
     "RollbackConfirm": "Sei sicuro di voler tornare alla Revision #{{revisionNumber}}? La Revision attuale verrà sostituita.",
+    "RollbackDisabled": "Il rollback non è disponibile per la Revision corrente o più recente.",
     "RollbackSuccess": "Il ripristino alla Revision #{{revisionNumber}} è stato richiesto.",
     "Running": "In esecuzione",
     "RuntimeVariant": "Variante runtime",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Informazioni di base",
+      "ClusterAndResources": "Cluster e risorse",
       "ModelAndRuntime": "Modello e runtime",
       "ResourcesAndReplicas": "Risorse e repliche",
       "ReviewAndCreate": "Revisiona e crea"
@@ -900,12 +910,14 @@
       "AutoScaling": "Scalabilità automatica",
       "Overview": "Panoramica",
       "Replicas": "Repliche",
+      "Revision": "Revision",
       "RevisionHistory": "Cronologia Revision",
       "description": {
         "AccessTokens": "Gestisci i token di accesso per autenticare le richieste API all'endpoint di questo deployment.",
         "AutoScaling": "Configura le regole di scalabilità automatica per regolare automaticamente il numero di repliche in base alle metriche del traffico.",
         "Replicas": "Visualizza tutte le istanze di replica in esecuzione per questo deployment con il loro stato di salute e le risorse.",
-        "RevisionHistory": "Sfoglia le revisioni passate del deployment e ripristina qualsiasi versione precedente. Per creare una nuova revisione, fai clic su «Modifica Configurazione» in alto."
+        "Revision": "Sfoglia le revisioni passate del deployment e ripristina qualsiasi versione precedente.",
+        "RevisionHistory": "Sfoglia le revisioni passate del deployment e ripristina qualsiasi versione precedente."
       }
     }
   },

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "AppProxy を通じてトラフィックを受信中のレプリカです。",
     "ActivenessStatus": "アクティブ状態",
+    "AddRevision": "Revision を追加",
     "AutoScaling": "自動スケーリング",
     "AutoScalingRules": "自動スケーリングルール",
     "ClusterMode": "クラスターモード",
@@ -781,6 +782,8 @@
     "CreateDeployment": "デプロイを作成",
     "CreatedAt": "作成日時",
     "CreatedBy": "作成者",
+    "Current": "現在",
+    "CurrentRevision": "現在の Revision",
     "DeleteDeployment": "デプロイを削除",
     "Deployment": "デプロイ",
     "DeploymentCreated": "デプロイが作成されました。",
@@ -821,6 +824,7 @@
     "NoDeployments": "デプロイが見つかりません。",
     "NumberOfReplicas": "レプリカ数",
     "OpenToPublic": "公開",
+    "Overview": "概要",
     "Owner": "オーナー",
     "Project": "プロジェクト",
     "QuickDeploy": "デプロイ",
@@ -835,12 +839,17 @@
     "ResourcePreset": "リソースプリセット",
     "Resources": "リソース",
     "Revision": "Revision",
+    "RevisionDetail": "Revision 詳細",
     "RevisionHistory": "Revision 履歴",
     "RevisionId": "Revision ID",
+    "RevisionIdPlaceholder": "Revision ID を入力（任意）",
+    "RevisionName": "Revision 名",
+    "RevisionNamePlaceholder": "空白のままにすると自動生成されます",
     "RevisionNumber": "Revision 番号",
     "Revisions": "Revision",
     "Rollback": "ロールバック",
     "RollbackConfirm": "Revision #{{revisionNumber}} にロールバックしてもよろしいですか？現在の Revision は置き換えられます。",
+    "RollbackDisabled": "現在または最新の Revision へのロールバックは利用できません。",
     "RollbackSuccess": "Revision #{{revisionNumber}} へのロールバックが要求されました。",
     "Running": "実行中",
     "RuntimeVariant": "ランタイムバリアント",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "基本情報",
+      "ClusterAndResources": "クラスターとリソース",
       "ModelAndRuntime": "モデルとランタイム",
       "ResourcesAndReplicas": "リソースとレプリカ",
       "ReviewAndCreate": "確認して作成"
@@ -900,12 +910,14 @@
       "AutoScaling": "自動スケーリング",
       "Overview": "概要",
       "Replicas": "レプリカ",
+      "Revision": "Revision",
       "RevisionHistory": "Revision 履歴",
       "description": {
         "AccessTokens": "このデプロイメントのエンドポイントへの API リクエストを認証するためのアクセストークンを管理します。",
         "AutoScaling": "トラフィックメトリクスに基づいてレプリカ数を自動的に調整する自動スケーリングルールを設定します。",
         "Replicas": "このデプロイメントで実行中のすべてのレプリカインスタンスをヘルス状態とリソース状況とともに表示します。",
-        "RevisionHistory": "過去のデプロイメントリビジョンを参照し、任意の以前のバージョンにロールバックできます。新しいリビジョンを作成するには、上部の「構成を編集」をクリックしてください。"
+        "Revision": "過去のデプロイメントリビジョンを参照し、任意の以前のバージョンにロールバックできます。",
+        "RevisionHistory": "過去のデプロイメントリビジョンを参照し、任意の以前のバージョンにロールバックできます。"
       }
     }
   },

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -770,6 +770,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "AppProxy를 통해 현재 트래픽을 수신 중인 레플리카입니다.",
     "ActivenessStatus": "활성 상태",
+    "AddRevision": "리비전 추가",
     "AutoScaling": "자동 스케일링",
     "AutoScalingRules": "자동 스케일링 규칙",
     "ClusterMode": "클러스터 모드",
@@ -782,6 +783,8 @@
     "CreateDeployment": "배포 생성",
     "CreatedAt": "생성일",
     "CreatedBy": "생성자",
+    "Current": "현재",
+    "CurrentRevision": "현재 리비전",
     "DeleteDeployment": "배포 삭제",
     "Deployment": "배포",
     "DeploymentCreated": "배포가 생성되었습니다.",
@@ -822,6 +825,7 @@
     "NoDeployments": "배포가 없습니다.",
     "NumberOfReplicas": "레플리카 수",
     "OpenToPublic": "외부에 공개",
+    "Overview": "개요",
     "Owner": "소유자",
     "Project": "프로젝트",
     "QuickDeploy": "배포",
@@ -836,12 +840,17 @@
     "ResourcePreset": "리소스 프리셋",
     "Resources": "리소스",
     "Revision": "리비전",
+    "RevisionDetail": "리비전 상세",
     "RevisionHistory": "리비전 히스토리",
     "RevisionId": "리비전 ID",
+    "RevisionIdPlaceholder": "리비전 ID를 입력하세요 (선택 사항)",
+    "RevisionName": "리비전 이름",
+    "RevisionNamePlaceholder": "비워두면 자동 생성",
     "RevisionNumber": "리비전 번호",
     "Revisions": "리비전",
     "Rollback": "롤백",
     "RollbackConfirm": "리비전 #{{revisionNumber}}으로 롤백하시겠습니까? 현재 리비전이 교체됩니다.",
+    "RollbackDisabled": "현재 또는 최신 리비전은 롤백할 수 없습니다.",
     "RollbackSuccess": "리비전 #{{revisionNumber}}으로의 롤백이 요청되었습니다.",
     "Running": "실행 중",
     "RuntimeVariant": "런타임 변형",
@@ -892,6 +901,7 @@
     },
     "step": {
       "BasicInfo": "기본 정보",
+      "ClusterAndResources": "클러스터 및 리소스",
       "ModelAndRuntime": "모델 및 런타임",
       "ResourcesAndReplicas": "리소스 및 레플리카",
       "ReviewAndCreate": "검토 및 생성"
@@ -901,12 +911,14 @@
       "AutoScaling": "자동 스케일링",
       "Overview": "개요",
       "Replicas": "레플리카",
+      "Revision": "리비전",
       "RevisionHistory": "리비전 히스토리",
       "description": {
         "AccessTokens": "이 배포의 엔드포인트에 API 요청을 인증하기 위한 액세스 토큰을 관리합니다.",
         "AutoScaling": "트래픽 지표에 따라 레플리카 수를 자동으로 조정하는 자동 스케일링 규칙을 설정합니다.",
         "Replicas": "현재 실행 중인 레플리카 인스턴스의 상태 및 리소스 현황을 확인합니다.",
-        "RevisionHistory": "이전 배포 리비전을 확인하고 롤백할 수 있습니다. 새 리비전을 생성하려면 상단의 설정 편집 버튼을 클릭하세요."
+        "Revision": "이전 배포 리비전을 확인하고 롤백할 수 있습니다.",
+        "RevisionHistory": "이전 배포 리비전을 확인하고 롤백할 수 있습니다."
       }
     }
   },

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "AppProxy-р дамжуулан одоогоор трафик хүлээн авч буй репликүүд.",
     "ActivenessStatus": "Идэвхжилтийн төлөв",
+    "AddRevision": "Revision нэмэх",
     "AutoScaling": "Автомат масштабжуулалт",
     "AutoScalingRules": "Автомат масштабжуулалтын дүрмүүд",
     "ClusterMode": "Кластерийн горим",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Байршуулалт үүсгэх",
     "CreatedAt": "Үүсгэсэн огноо",
     "CreatedBy": "Үүсгэсэн хүн",
+    "Current": "Одоогийн",
+    "CurrentRevision": "Одоогийн Revision",
     "DeleteDeployment": "Байршуулалт устгах",
     "Deployment": "Байршуулалт",
     "DeploymentCreated": "Байршуулалт үүсгэгдлээ.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Байршуулалт олдсонгүй.",
     "NumberOfReplicas": "Репликийн тоо",
     "OpenToPublic": "Нийтэд нээлттэй",
+    "Overview": "Ерөнхий мэдэгдэл",
     "Owner": "Эзэмшигч",
     "Project": "Төсөл",
     "QuickDeploy": "Байршуулах",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Нөөцийн урьдчилсан тохиргоо",
     "Resources": "Нөөцүүд",
     "Revision": "Revision",
+    "RevisionDetail": "Revision-ы дэлгэрэнгүй",
     "RevisionHistory": "Revision-ы түүх",
     "RevisionId": "Revision ID",
+    "RevisionIdPlaceholder": "Revision ID оруулна уу (заавал биш)",
+    "RevisionName": "Revision нэр",
+    "RevisionNamePlaceholder": "Автоматаар үүсгэхийн тулд хоосон үлдээнэ үү",
     "RevisionNumber": "Revision дугаар",
     "Revisions": "Revision-ууд",
     "Rollback": "Буцаах",
     "RollbackConfirm": "Revision #{{revisionNumber}} руу буцаахдаа итгэлтэй байна уу? Одоогийн Revision солигдох болно.",
+    "RollbackDisabled": "Одоогийн эсвэл хамгийн сүүлийн Revision руу буцаах боломжгүй.",
     "RollbackSuccess": "Revision #{{revisionNumber}} руу буцаах хүсэлт гаргагдлаа.",
     "Running": "Ажиллаж байна",
     "RuntimeVariant": "Runtime хувилбар",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Үндсэн мэдээлэл",
+      "ClusterAndResources": "Кластер ба нөөц",
       "ModelAndRuntime": "Загвар ба Runtime",
       "ResourcesAndReplicas": "Нөөц ба Репликүүд",
       "ReviewAndCreate": "Шалгаад үүсгэх"
@@ -900,12 +910,14 @@
       "AutoScaling": "Автомат масштабжуулалт",
       "Overview": "Ерөнхий мэдэгдэл",
       "Replicas": "Репликүүд",
+      "Revision": "Revision",
       "RevisionHistory": "Revision-ы түүх",
       "description": {
         "AccessTokens": "Энэ байршуулалтын төгсгөлийн цэг рүү API хүсэлт дамжуулахад ашиглах хандалтын токенуудыг удирдана уу.",
         "AutoScaling": "Трафикийн хэмжигдэхүүнд үндэслэн репликийн тоог автоматаар тохируулах автомат масштабжуулалтын дүрмүүдийг тохируулна уу.",
         "Replicas": "Энэ байршуулалтын бүх ажиллаж буй репликийн жишээнүүдийг тэдгээрийн эрүүл мэнд болон нөөцийн статустай хамт харна уу.",
-        "RevisionHistory": "Өмнөх байршуулалтын хяналтуудыг үзэж, дурын өмнөх хувилбар руу буцаж орно уу. Шинэ хяналт үүсгэхийн тулд дээрх «Тохиргоог засах» товчийг дарна уу."
+        "Revision": "Өмнөх байршуулалтын хяналтуудыг үзэж, дурын өмнөх хувилбар руу буцаах боломжтой.",
+        "RevisionHistory": "Өмнөх байршуулалтын хяналтуудыг үзэж, дурын өмнөх хувилбар руу буцаж орно уу."
       }
     }
   },

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Replika yang sedang menerima trafik melalui AppProxy.",
     "ActivenessStatus": "Status Keaktifan",
+    "AddRevision": "Tambah Revision",
     "AutoScaling": "Penskalaan Automatik",
     "AutoScalingRules": "Peraturan Penskalaan Automatik",
     "ClusterMode": "Mod Kelompok",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Cipta Penggunaan",
     "CreatedAt": "Dicipta Pada",
     "CreatedBy": "Dicipta Oleh",
+    "Current": "Semasa",
+    "CurrentRevision": "Revision Semasa",
     "DeleteDeployment": "Padam Penggunaan",
     "Deployment": "Penggunaan",
     "DeploymentCreated": "Penggunaan telah dicipta.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Tiada penggunaan ditemui.",
     "NumberOfReplicas": "Bilangan Replika",
     "OpenToPublic": "Terbuka kepada Awam",
+    "Overview": "Gambaran Keseluruhan",
     "Owner": "Pemilik",
     "Project": "Projek",
     "QuickDeploy": "Gunakan",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Pratetap Sumber",
     "Resources": "Sumber",
     "Revision": "Revision",
+    "RevisionDetail": "Butiran Revision",
     "RevisionHistory": "Sejarah Revision",
     "RevisionId": "ID Revision",
+    "RevisionIdPlaceholder": "Masukkan ID Revision (pilihan)",
+    "RevisionName": "Nama Revision",
+    "RevisionNamePlaceholder": "Biarkan kosong untuk jana secara automatik",
     "RevisionNumber": "Nombor Revisi",
     "Revisions": "Revision",
     "Rollback": "Rollback",
     "RollbackConfirm": "Adakah anda pasti mahu rollback ke Revision #{{revisionNumber}}? Revision semasa akan digantikan.",
+    "RollbackDisabled": "Rollback tidak tersedia untuk Revision semasa atau terkini.",
     "RollbackSuccess": "Rollback ke Revision #{{revisionNumber}} telah diminta.",
     "Running": "Sedang berjalan",
     "RuntimeVariant": "Varian Runtime",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Maklumat Asas",
+      "ClusterAndResources": "Kluster & Sumber",
       "ModelAndRuntime": "Model & Runtime",
       "ResourcesAndReplicas": "Sumber & Replika",
       "ReviewAndCreate": "Semak & Cipta"
@@ -900,12 +910,14 @@
       "AutoScaling": "Penskalaan Automatik",
       "Overview": "Gambaran Keseluruhan",
       "Replicas": "Replika",
+      "Revision": "Revision",
       "RevisionHistory": "Sejarah Revision",
       "description": {
         "AccessTokens": "Urus token akses untuk mengesahkan permintaan API ke titik akhir deployment ini.",
         "AutoScaling": "Konfigurasikan peraturan penskalaan automatik untuk melaraskan bilangan replika secara automatik berdasarkan metrik trafik.",
         "Replicas": "Lihat semua instans replika yang sedang berjalan untuk deployment ini beserta status kesihatan dan sumber dayanya.",
-        "RevisionHistory": "Semak semula revisi deployment yang lalu dan gulung balik ke mana-mana versi sebelumnya. Untuk mencipta revisi baharu, klik Edit Konfigurasi di atas."
+        "Revision": "Semak semula revisi deployment yang lalu dan gulung balik ke mana-mana versi sebelumnya.",
+        "RevisionHistory": "Semak semula revisi deployment yang lalu dan gulung balik ke mana-mana versi sebelumnya."
       }
     }
   },

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Repliki aktualnie odbierające ruch przez AppProxy.",
     "ActivenessStatus": "Status aktywności",
+    "AddRevision": "Dodaj Revision",
     "AutoScaling": "Automatyczne skalowanie",
     "AutoScalingRules": "Reguły automatycznego skalowania",
     "ClusterMode": "Tryb klastra",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Utwórz wdrożenie",
     "CreatedAt": "Utworzono",
     "CreatedBy": "Utworzone przez",
+    "Current": "Bieżąca",
+    "CurrentRevision": "Bieżąca Revision",
     "DeleteDeployment": "Usuń wdrożenie",
     "Deployment": "Wdrożenie",
     "DeploymentCreated": "Wdrożenie zostało utworzone.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Nie znaleziono wdrożeń.",
     "NumberOfReplicas": "Liczba replik",
     "OpenToPublic": "Publiczne",
+    "Overview": "Przegląd",
     "Owner": "Właściciel",
     "Project": "Projekt",
     "QuickDeploy": "Wdróż",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Preset zasobów",
     "Resources": "Zasoby",
     "Revision": "Revision",
+    "RevisionDetail": "Szczegóły Revision",
     "RevisionHistory": "Historia Revision",
     "RevisionId": "ID Revision",
+    "RevisionIdPlaceholder": "Wprowadź ID Revision (opcjonalne)",
+    "RevisionName": "Nazwa Revision",
+    "RevisionNamePlaceholder": "Pozostaw puste, aby wygenerować automatycznie",
     "RevisionNumber": "Numer Rewizji",
     "Revisions": "Revision",
     "Rollback": "Cofnij",
     "RollbackConfirm": "Czy na pewno chcesz cofnąć do Revision #{{revisionNumber}}? Bieżąca Revision zostanie zastąpiona.",
+    "RollbackDisabled": "Cofnięcie nie jest dostępne dla bieżącej lub najnowszej Revision.",
     "RollbackSuccess": "Żądanie cofnięcia do Revision #{{revisionNumber}} zostało wysłane.",
     "Running": "Uruchomiony",
     "RuntimeVariant": "Wariant środowiska uruchomieniowego",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Podstawowe informacje",
+      "ClusterAndResources": "Klaster i zasoby",
       "ModelAndRuntime": "Model i środowisko",
       "ResourcesAndReplicas": "Zasoby i repliki",
       "ReviewAndCreate": "Przejrzyj i utwórz"
@@ -900,12 +910,14 @@
       "AutoScaling": "Automatyczne skalowanie",
       "Overview": "Przegląd",
       "Replicas": "Repliki",
+      "Revision": "Revision",
       "RevisionHistory": "Historia Revision",
       "description": {
         "AccessTokens": "Zarządzaj tokenami dostępu do uwierzytelniania żądań API do punktu końcowego tego wdrożenia.",
         "AutoScaling": "Skonfiguruj reguły automatycznego skalowania, aby automatycznie dostosowywać liczbę replik na podstawie metryk ruchu.",
         "Replicas": "Wyświetl wszystkie uruchomione instancje replik tego wdrożenia wraz z ich stanem zdrowia i statusem zasobów.",
-        "RevisionHistory": "Przeglądaj poprzednie wersje wdrożenia i wróć do dowolnej z nich. Aby utworzyć nową wersję, kliknij «Edytuj Konfigurację» powyżej."
+        "Revision": "Przeglądaj poprzednie wersje wdrożenia i wróć do dowolnej z nich.",
+        "RevisionHistory": "Przeglądaj poprzednie wersje wdrożenia i wróć do dowolnej z nich."
       }
     }
   },

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Réplicas atualmente recebendo tráfego pelo AppProxy.",
     "ActivenessStatus": "Status de atividade",
+    "AddRevision": "Adicionar Revision",
     "AutoScaling": "Dimensionamento automático",
     "AutoScalingRules": "Regras de dimensionamento automático",
     "ClusterMode": "Modo de cluster",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Criar implantação",
     "CreatedAt": "Criado em",
     "CreatedBy": "Criado por",
+    "Current": "Atual",
+    "CurrentRevision": "Revision Atual",
     "DeleteDeployment": "Excluir implantação",
     "Deployment": "Implantação",
     "DeploymentCreated": "A implantação foi criada.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Nenhuma implantação encontrada.",
     "NumberOfReplicas": "Número de réplicas",
     "OpenToPublic": "Público",
+    "Overview": "Visão geral",
     "Owner": "Proprietário",
     "Project": "Projeto",
     "QuickDeploy": "Implantar",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Predefinição de recursos",
     "Resources": "Recursos",
     "Revision": "Revision",
+    "RevisionDetail": "Detalhes da Revision",
     "RevisionHistory": "Histórico de Revision",
     "RevisionId": "ID de Revision",
+    "RevisionIdPlaceholder": "Insira um ID de Revision (opcional)",
+    "RevisionName": "Nome da Revision",
+    "RevisionNamePlaceholder": "Deixe em branco para gerar automaticamente",
     "RevisionNumber": "Número de Revisão",
     "Revisions": "Revision",
     "Rollback": "Reverter",
     "RollbackConfirm": "Tem certeza de que deseja reverter para a Revision #{{revisionNumber}}? A Revision atual será substituída.",
+    "RollbackDisabled": "A reversão não está disponível para a Revision atual ou mais recente.",
     "RollbackSuccess": "A reversão para a Revision #{{revisionNumber}} foi solicitada.",
     "Running": "Em execução",
     "RuntimeVariant": "Variante de tempo de execução",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Informações básicas",
+      "ClusterAndResources": "Cluster e recursos",
       "ModelAndRuntime": "Modelo e ambiente",
       "ResourcesAndReplicas": "Recursos e réplicas",
       "ReviewAndCreate": "Revisar e criar"
@@ -900,12 +910,14 @@
       "AutoScaling": "Dimensionamento automático",
       "Overview": "Visão geral",
       "Replicas": "Réplicas",
+      "Revision": "Revision",
       "RevisionHistory": "Histórico de Revision",
       "description": {
         "AccessTokens": "Gerencie tokens de acesso para autenticar requisições de API no endpoint deste deployment.",
         "AutoScaling": "Configure regras de dimensionamento automático para ajustar automaticamente o número de réplicas com base nas métricas de tráfego.",
         "Replicas": "Visualize todas as instâncias de réplica em execução deste deployment com seu status de saúde e recursos.",
-        "RevisionHistory": "Navegue pelas revisões anteriores do deployment e reverta para qualquer uma delas. Para criar uma nova revisão, clique em «Editar Configuração» acima."
+        "Revision": "Navegue pelas revisões anteriores do deployment e reverta para qualquer versão anterior.",
+        "RevisionHistory": "Navegue pelas revisões anteriores do deployment e reverta para qualquer uma delas."
       }
     }
   },

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Réplicas a receber tráfego atualmente através do AppProxy.",
     "ActivenessStatus": "Estado de atividade",
+    "AddRevision": "Adicionar Revision",
     "AutoScaling": "Dimensionamento automático",
     "AutoScalingRules": "Regras de dimensionamento automático",
     "ClusterMode": "Modo de cluster",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Criar implementação",
     "CreatedAt": "Criado em",
     "CreatedBy": "Criado por",
+    "Current": "Atual",
+    "CurrentRevision": "Revision Atual",
     "DeleteDeployment": "Eliminar implementação",
     "Deployment": "Implementação",
     "DeploymentCreated": "A implementação foi criada.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Nenhuma implementação encontrada.",
     "NumberOfReplicas": "Número de réplicas",
     "OpenToPublic": "Público",
+    "Overview": "Visão geral",
     "Owner": "Proprietário",
     "Project": "Projeto",
     "QuickDeploy": "Implementar",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Predefinição de recursos",
     "Resources": "Recursos",
     "Revision": "Revision",
+    "RevisionDetail": "Detalhe da Revision",
     "RevisionHistory": "Histórico de Revision",
     "RevisionId": "ID de Revision",
+    "RevisionIdPlaceholder": "Introduza um ID de Revision (opcional)",
+    "RevisionName": "Nome da Revision",
+    "RevisionNamePlaceholder": "Deixe em branco para geração automática",
     "RevisionNumber": "Número de Revisão",
     "Revisions": "Revision",
     "Rollback": "Reverter",
     "RollbackConfirm": "Tem a certeza de que pretende reverter para a Revision #{{revisionNumber}}? A Revision atual será substituída.",
+    "RollbackDisabled": "A reversão não está disponível para a Revision atual ou mais recente.",
     "RollbackSuccess": "A reversão para a Revision #{{revisionNumber}} foi solicitada.",
     "Running": "Em execução",
     "RuntimeVariant": "Variante de tempo de execução",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Informações básicas",
+      "ClusterAndResources": "Cluster e recursos",
       "ModelAndRuntime": "Modelo e ambiente",
       "ResourcesAndReplicas": "Recursos e réplicas",
       "ReviewAndCreate": "Rever e criar"
@@ -900,12 +910,14 @@
       "AutoScaling": "Dimensionamento automático",
       "Overview": "Visão geral",
       "Replicas": "Réplicas",
+      "Revision": "Revision",
       "RevisionHistory": "Histórico de Revision",
       "description": {
         "AccessTokens": "Gira tokens de acesso para autenticar pedidos de API no endpoint deste deployment.",
         "AutoScaling": "Configure regras de dimensionamento automático para ajustar automaticamente o número de réplicas com base nas métricas de tráfego.",
         "Replicas": "Veja todas as instâncias de réplica em execução deste deployment com o seu estado de saúde e recursos.",
-        "RevisionHistory": "Navegue pelas revisões anteriores do deployment e reverta para qualquer uma delas. Para criar uma nova revisão, clique em «Editar Configuração» acima."
+        "Revision": "Navegue pelas revisões anteriores do deployment e reverta para qualquer versão anterior.",
+        "RevisionHistory": "Navegue pelas revisões anteriores do deployment e reverta para qualquer uma delas."
       }
     }
   },

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Реплики, в настоящее время получающие трафик через AppProxy.",
     "ActivenessStatus": "Статус активности",
+    "AddRevision": "Добавить Revision",
     "AutoScaling": "Автоматическое масштабирование",
     "AutoScalingRules": "Правила автоматического масштабирования",
     "ClusterMode": "Режим кластера",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Создать развёртывание",
     "CreatedAt": "Создано",
     "CreatedBy": "Создано пользователем",
+    "Current": "Текущая",
+    "CurrentRevision": "Текущая Revision",
     "DeleteDeployment": "Удалить развёртывание",
     "Deployment": "Развёртывание",
     "DeploymentCreated": "Развёртывание создано.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Развёртывания не найдены.",
     "NumberOfReplicas": "Количество реплик",
     "OpenToPublic": "Публичное",
+    "Overview": "Обзор",
     "Owner": "Владелец",
     "Project": "Проект",
     "QuickDeploy": "Развернуть",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Предустановка ресурсов",
     "Resources": "Ресурсы",
     "Revision": "Revision",
+    "RevisionDetail": "Детали Revision",
     "RevisionHistory": "История Revision",
     "RevisionId": "ID Revision",
+    "RevisionIdPlaceholder": "Введите ID Revision (необязательно)",
+    "RevisionName": "Название Revision",
+    "RevisionNamePlaceholder": "Оставьте пустым для автоматической генерации",
     "RevisionNumber": "Номер ревизии",
     "Revisions": "Revision",
     "Rollback": "Откат",
     "RollbackConfirm": "Вы уверены, что хотите выполнить откат до Revision #{{revisionNumber}}? Текущая Revision будет заменена.",
+    "RollbackDisabled": "Откат недоступен для текущей или последней Revision.",
     "RollbackSuccess": "Запрошен откат до Revision #{{revisionNumber}}.",
     "Running": "Выполняется",
     "RuntimeVariant": "Вариант среды выполнения",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Основная информация",
+      "ClusterAndResources": "Кластер и ресурсы",
       "ModelAndRuntime": "Модель и среда выполнения",
       "ResourcesAndReplicas": "Ресурсы и реплики",
       "ReviewAndCreate": "Проверить и создать"
@@ -900,12 +910,14 @@
       "AutoScaling": "Автоматическое масштабирование",
       "Overview": "Обзор",
       "Replicas": "Реплики",
+      "Revision": "Revision",
       "RevisionHistory": "История Revision",
       "description": {
         "AccessTokens": "Управляйте токенами доступа для аутентификации API-запросов к конечной точке этого развёртывания.",
         "AutoScaling": "Настройте правила автоматического масштабирования для автоматической корректировки количества реплик на основе метрик трафика.",
         "Replicas": "Просмотрите все запущенные экземпляры реплик этого развёртывания с их состоянием и статусом ресурсов.",
-        "RevisionHistory": "Просматривайте прошлые ревизии развёртывания и откатывайтесь к любой из них. Чтобы создать новую ревизию, нажмите «Изменить конфигурацию» выше."
+        "Revision": "Просматривайте прошлые ревизии развёртывания и откатывайтесь до любой из них.",
+        "RevisionHistory": "Просматривайте прошлые ревизии развёртывания и откатывайтесь к любой из них."
       }
     }
   },

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "เรพลิกาที่กำลังรับทราฟฟิกผ่าน AppProxy ในขณะนี้",
     "ActivenessStatus": "สถานะความเคลื่อนไหว",
+    "AddRevision": "เพิ่ม Revision",
     "AutoScaling": "การปรับขนาดอัตโนมัติ",
     "AutoScalingRules": "กฎการปรับขนาดอัตโนมัติ",
     "ClusterMode": "โหมดคลัสเตอร์",
@@ -781,6 +782,8 @@
     "CreateDeployment": "สร้างการปรับใช้",
     "CreatedAt": "สร้างเมื่อ",
     "CreatedBy": "สร้างโดย",
+    "Current": "ปัจจุบัน",
+    "CurrentRevision": "Revision ปัจจุบัน",
     "DeleteDeployment": "ลบการปรับใช้",
     "Deployment": "การปรับใช้",
     "DeploymentCreated": "สร้างการปรับใช้เรียบร้อยแล้ว",
@@ -821,6 +824,7 @@
     "NoDeployments": "ไม่พบการปรับใช้",
     "NumberOfReplicas": "จำนวนเรพลิกา",
     "OpenToPublic": "เปิดสาธารณะ",
+    "Overview": "ภาพรวม",
     "Owner": "เจ้าของ",
     "Project": "โปรเจกต์",
     "QuickDeploy": "ปรับใช้",
@@ -835,12 +839,17 @@
     "ResourcePreset": "ค่าตั้งต้นทรัพยากร",
     "Resources": "ทรัพยากร",
     "Revision": "Revision",
+    "RevisionDetail": "รายละเอียด Revision",
     "RevisionHistory": "ประวัติ Revision",
     "RevisionId": "ID Revision",
+    "RevisionIdPlaceholder": "กรอก ID Revision (ไม่บังคับ)",
+    "RevisionName": "ชื่อ Revision",
+    "RevisionNamePlaceholder": "ปล่อยว่างเพื่อสร้างอัตโนมัติ",
     "RevisionNumber": "หมายเลข Revision",
     "Revisions": "Revision",
     "Rollback": "ย้อนกลับ",
     "RollbackConfirm": "คุณแน่ใจหรือไม่ว่าต้องการย้อนกลับไปยัง Revision #{{revisionNumber}}? Revision ปัจจุบันจะถูกแทนที่",
+    "RollbackDisabled": "การย้อนกลับไม่สามารถใช้งานได้สำหรับ Revision ปัจจุบันหรือล่าสุด",
     "RollbackSuccess": "ส่งคำขอย้อนกลับไปยัง Revision #{{revisionNumber}} แล้ว",
     "Running": "กำลังทำงาน",
     "RuntimeVariant": "ตัวแปร Runtime",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "ข้อมูลพื้นฐาน",
+      "ClusterAndResources": "คลัสเตอร์และทรัพยากร",
       "ModelAndRuntime": "โมเดลและ Runtime",
       "ResourcesAndReplicas": "ทรัพยากรและเรพลิกา",
       "ReviewAndCreate": "ตรวจสอบและสร้าง"
@@ -900,12 +910,14 @@
       "AutoScaling": "การปรับขนาดอัตโนมัติ",
       "Overview": "ภาพรวม",
       "Replicas": "เรพลิกา",
+      "Revision": "Revision",
       "RevisionHistory": "ประวัติ Revision",
       "description": {
         "AccessTokens": "จัดการโทเค็นการเข้าถึงสำหรับการยืนยันตัวตนคำขอ API ไปยังเอนด์พอยต์ของการปรับใช้นี้",
         "AutoScaling": "กำหนดกฎการปรับขนาดอัตโนมัติเพื่อปรับจำนวนเรพลิกาโดยอัตโนมัติตามตัวชี้วัดปริมาณการใช้งาน",
         "Replicas": "ดูอินสแตนซ์เรพลิกาทั้งหมดที่กำลังทำงานสำหรับการปรับใช้นี้พร้อมสถานะความสมบูรณ์และทรัพยากร",
-        "RevisionHistory": "เรียกดูการแก้ไขการปรับใช้ที่ผ่านมาและย้อนกลับไปยังเวอร์ชันใดก็ได้ หากต้องการสร้างการแก้ไขใหม่ ให้คลิก «แก้ไขการกำหนดค่า» ด้านบน"
+        "Revision": "เรียกดูการแก้ไขการปรับใช้ที่ผ่านมาและย้อนกลับไปยังเวอร์ชันใดก็ได้",
+        "RevisionHistory": "เรียกดูการแก้ไขการปรับใช้ที่ผ่านมาและย้อนกลับไปยังเวอร์ชันใดก็ได้"
       }
     }
   },

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "AppProxy aracılığıyla şu anda trafik alan replikalar.",
     "ActivenessStatus": "Etkinlik Durumu",
+    "AddRevision": "Revision Ekle",
     "AutoScaling": "Otomatik Ölçeklendirme",
     "AutoScalingRules": "Otomatik Ölçeklendirme Kuralları",
     "ClusterMode": "Küme Modu",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Dağıtım Oluştur",
     "CreatedAt": "Oluşturulma Tarihi",
     "CreatedBy": "Oluşturan",
+    "Current": "Mevcut",
+    "CurrentRevision": "Mevcut Revision",
     "DeleteDeployment": "Dağıtımı Sil",
     "Deployment": "Dağıtım",
     "DeploymentCreated": "Dağıtım oluşturuldu.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Dağıtım bulunamadı.",
     "NumberOfReplicas": "Replika Sayısı",
     "OpenToPublic": "Herkese Açık",
+    "Overview": "Genel Bakış",
     "Owner": "Sahibi",
     "Project": "Proje",
     "QuickDeploy": "Dağıt",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Kaynak Ön Ayarı",
     "Resources": "Kaynaklar",
     "Revision": "Revision",
+    "RevisionDetail": "Revision Detayı",
     "RevisionHistory": "Revision Geçmişi",
     "RevisionId": "Revision Kimliği",
+    "RevisionIdPlaceholder": "Bir Revision Kimliği girin (isteğe bağlı)",
+    "RevisionName": "Revision Adı",
+    "RevisionNamePlaceholder": "Otomatik oluşturmak için boş bırakın",
     "RevisionNumber": "Revizyon Numarası",
     "Revisions": "Revision",
     "Rollback": "Geri Al",
     "RollbackConfirm": "Revision #{{revisionNumber}}'a geri almak istediğinizden emin misiniz? Mevcut Revision değiştirilecek.",
+    "RollbackDisabled": "Mevcut veya en son Revision için geri alma kullanılamaz.",
     "RollbackSuccess": "Revision #{{revisionNumber}}'a geri alma işlemi talep edildi.",
     "Running": "Çalışıyor",
     "RuntimeVariant": "Çalışma Zamanı Değişkeni",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Temel Bilgiler",
+      "ClusterAndResources": "Küme ve Kaynaklar",
       "ModelAndRuntime": "Model ve Çalışma Zamanı",
       "ResourcesAndReplicas": "Kaynaklar ve Replikalar",
       "ReviewAndCreate": "İncele ve Oluştur"
@@ -900,12 +910,14 @@
       "AutoScaling": "Otomatik Ölçeklendirme",
       "Overview": "Genel Bakış",
       "Replicas": "Replikalar",
+      "Revision": "Revision",
       "RevisionHistory": "Revision Geçmişi",
       "description": {
         "AccessTokens": "Bu dağıtımın uç noktasına yapılan API isteklerini doğrulamak için erişim jetonlarını yönetin.",
         "AutoScaling": "Trafik ölçütlerine göre replika sayısını otomatik olarak ayarlamak için otomatik ölçeklendirme kurallarını yapılandırın.",
         "Replicas": "Bu dağıtım için çalışan tüm replika örneklerini sağlık durumları ve kaynak statüleriyle birlikte görüntüleyin.",
-        "RevisionHistory": "Geçmiş dağıtım revizyonlarını inceleyin ve istediğiniz bir önceki sürüme geri dönün. Yeni bir revizyon oluşturmak için yukarıdaki «Yapılandırmayı Düzenle» seçeneğine tıklayın."
+        "Revision": "Geçmiş dağıtım revizyonlarını inceleyin ve istediğiniz bir önceki sürüme geri alın.",
+        "RevisionHistory": "Geçmiş dağıtım revizyonlarını inceleyin ve istediğiniz bir önceki sürüme geri dönün."
       }
     }
   },

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Các bản sao đang nhận lưu lượng truy cập qua AppProxy.",
     "ActivenessStatus": "Trạng thái hoạt động",
+    "AddRevision": "Thêm Revision",
     "AutoScaling": "Tự động mở rộng",
     "AutoScalingRules": "Quy tắc tự động mở rộng",
     "ClusterMode": "Chế độ cụm",
@@ -781,6 +782,8 @@
     "CreateDeployment": "Tạo triển khai",
     "CreatedAt": "Ngày tạo",
     "CreatedBy": "Tạo bởi",
+    "Current": "Hiện tại",
+    "CurrentRevision": "Revision Hiện Tại",
     "DeleteDeployment": "Xóa triển khai",
     "Deployment": "Triển khai",
     "DeploymentCreated": "Triển khai đã được tạo.",
@@ -821,6 +824,7 @@
     "NoDeployments": "Không tìm thấy triển khai.",
     "NumberOfReplicas": "Số lượng bản sao",
     "OpenToPublic": "Công khai",
+    "Overview": "Tổng quan",
     "Owner": "Chủ sở hữu",
     "Project": "Dự án",
     "QuickDeploy": "Triển khai",
@@ -835,12 +839,17 @@
     "ResourcePreset": "Cài đặt sẵn tài nguyên",
     "Resources": "Tài nguyên",
     "Revision": "Revision",
+    "RevisionDetail": "Chi tiết Revision",
     "RevisionHistory": "Lịch sử Revision",
     "RevisionId": "ID Revision",
+    "RevisionIdPlaceholder": "Nhập ID Revision (tùy chọn)",
+    "RevisionName": "Tên Revision",
+    "RevisionNamePlaceholder": "Để trống để tự động tạo",
     "RevisionNumber": "Số Revision",
     "Revisions": "Revision",
     "Rollback": "Khôi phục",
     "RollbackConfirm": "Bạn có chắc chắn muốn khôi phục về Revision #{{revisionNumber}} không? Revision hiện tại sẽ được thay thế.",
+    "RollbackDisabled": "Không thể khôi phục về Revision hiện tại hoặc mới nhất.",
     "RollbackSuccess": "Đã yêu cầu khôi phục về Revision #{{revisionNumber}}.",
     "Running": "Đang chạy",
     "RuntimeVariant": "Biến thể thời gian chạy",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "Thông tin cơ bản",
+      "ClusterAndResources": "Cụm và tài nguyên",
       "ModelAndRuntime": "Mô hình và thời gian chạy",
       "ResourcesAndReplicas": "Tài nguyên và bản sao",
       "ReviewAndCreate": "Xem lại và tạo"
@@ -900,12 +910,14 @@
       "AutoScaling": "Tự động mở rộng",
       "Overview": "Tổng quan",
       "Replicas": "Bản sao",
+      "Revision": "Revision",
       "RevisionHistory": "Lịch sử Revision",
       "description": {
         "AccessTokens": "Quản lý mã thông báo truy cập để xác thực các yêu cầu API đến điểm cuối của deployment này.",
         "AutoScaling": "Cấu hình các quy tắc tự động mở rộng để tự động điều chỉnh số lượng bản sao dựa trên số liệu lưu lượng truy cập.",
         "Replicas": "Xem tất cả các phiên bản bản sao đang chạy cho deployment này cùng với trạng thái sức khỏe và tài nguyên của chúng.",
-        "RevisionHistory": "Duyệt qua các lần sửa đổi deployment trước đây và khôi phục về bất kỳ phiên bản nào. Để tạo bản sửa đổi mới, hãy nhấp vào «Chỉnh sửa Cấu hình» ở trên."
+        "Revision": "Duyệt qua các lần sửa đổi deployment trước đây và khôi phục về bất kỳ phiên bản nào.",
+        "RevisionHistory": "Duyệt qua các lần sửa đổi deployment trước đây và khôi phục về bất kỳ phiên bản nào."
       }
     }
   },

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -769,6 +769,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "当前通过 AppProxy 接收流量的副本。",
     "ActivenessStatus": "活跃状态",
+    "AddRevision": "添加 Revision",
     "AutoScaling": "自动扩缩容",
     "AutoScalingRules": "自动扩缩容规则",
     "ClusterMode": "集群模式",
@@ -781,6 +782,8 @@
     "CreateDeployment": "创建部署",
     "CreatedAt": "创建时间",
     "CreatedBy": "创建者",
+    "Current": "当前",
+    "CurrentRevision": "当前 Revision",
     "DeleteDeployment": "删除部署",
     "Deployment": "部署",
     "DeploymentCreated": "部署已创建。",
@@ -821,6 +824,7 @@
     "NoDeployments": "未找到部署。",
     "NumberOfReplicas": "副本数量",
     "OpenToPublic": "公开",
+    "Overview": "概览",
     "Owner": "所有者",
     "Project": "项目",
     "QuickDeploy": "部署",
@@ -835,12 +839,17 @@
     "ResourcePreset": "资源预设",
     "Resources": "资源",
     "Revision": "Revision",
+    "RevisionDetail": "Revision 详情",
     "RevisionHistory": "Revision 历史",
     "RevisionId": "Revision ID",
+    "RevisionIdPlaceholder": "输入 Revision ID（可选）",
+    "RevisionName": "Revision 名称",
+    "RevisionNamePlaceholder": "留空以自动生成",
     "RevisionNumber": "Revision 编号",
     "Revisions": "Revision",
     "Rollback": "回滚",
     "RollbackConfirm": "确定要回滚到 Revision #{{revisionNumber}} 吗？当前 Revision 将被替换。",
+    "RollbackDisabled": "当前或最新 Revision 不可回滚。",
     "RollbackSuccess": "已请求回滚到 Revision #{{revisionNumber}}。",
     "Running": "运行中",
     "RuntimeVariant": "运行时变体",
@@ -891,6 +900,7 @@
     },
     "step": {
       "BasicInfo": "基本信息",
+      "ClusterAndResources": "集群与资源",
       "ModelAndRuntime": "模型与运行时",
       "ResourcesAndReplicas": "资源与副本",
       "ReviewAndCreate": "审查并创建"
@@ -900,12 +910,14 @@
       "AutoScaling": "自动扩缩容",
       "Overview": "概览",
       "Replicas": "副本",
+      "Revision": "Revision",
       "RevisionHistory": "Revision 历史",
       "description": {
         "AccessTokens": "管理用于向此部署端点验证 API 请求的访问令牌。",
         "AutoScaling": "配置自动扩缩容规则，根据流量指标自动调整副本数量。",
         "Replicas": "查看此部署所有正在运行的副本实例及其健康状态和资源状况。",
-        "RevisionHistory": "浏览过去的部署版本历史，并回滚到任意之前的版本。若要创建新版本，请点击上方的「编辑配置」。"
+        "Revision": "浏览过去的部署版本历史，并回滚到任意之前的版本。",
+        "RevisionHistory": "浏览过去的部署版本历史，并回滚到任意之前的版本。"
       }
     }
   },

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -770,6 +770,7 @@
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "目前透過 AppProxy 接收流量的副本。",
     "ActivenessStatus": "活躍狀態",
+    "AddRevision": "新增 Revision",
     "AutoScaling": "自動擴縮容",
     "AutoScalingRules": "自動擴縮容規則",
     "ClusterMode": "叢集模式",
@@ -782,6 +783,8 @@
     "CreateDeployment": "建立部署",
     "CreatedAt": "建立時間",
     "CreatedBy": "建立者",
+    "Current": "目前",
+    "CurrentRevision": "目前 Revision",
     "DeleteDeployment": "刪除部署",
     "Deployment": "部署",
     "DeploymentCreated": "部署已建立。",
@@ -822,6 +825,7 @@
     "NoDeployments": "未找到部署。",
     "NumberOfReplicas": "副本數量",
     "OpenToPublic": "公開",
+    "Overview": "概覽",
     "Owner": "擁有者",
     "Project": "專案",
     "QuickDeploy": "部署",
@@ -836,12 +840,17 @@
     "ResourcePreset": "資源預設",
     "Resources": "資源",
     "Revision": "Revision",
+    "RevisionDetail": "Revision 詳情",
     "RevisionHistory": "Revision 歷史",
     "RevisionId": "Revision ID",
+    "RevisionIdPlaceholder": "輸入 Revision ID（選填）",
+    "RevisionName": "Revision 名稱",
+    "RevisionNamePlaceholder": "留空以自動生成",
     "RevisionNumber": "Revision 編號",
     "Revisions": "Revision",
     "Rollback": "回滾",
     "RollbackConfirm": "確定要回滾到 Revision #{{revisionNumber}} 嗎？當前 Revision 將被替換。",
+    "RollbackDisabled": "目前或最新 Revision 無法回滾。",
     "RollbackSuccess": "已請求回滾到 Revision #{{revisionNumber}}。",
     "Running": "執行中",
     "RuntimeVariant": "執行時變體",
@@ -892,6 +901,7 @@
     },
     "step": {
       "BasicInfo": "基本資訊",
+      "ClusterAndResources": "叢集與資源",
       "ModelAndRuntime": "模型與執行時",
       "ResourcesAndReplicas": "資源與副本",
       "ReviewAndCreate": "審查並建立"
@@ -901,12 +911,14 @@
       "AutoScaling": "自動擴縮容",
       "Overview": "概覽",
       "Replicas": "副本",
+      "Revision": "Revision",
       "RevisionHistory": "Revision 歷史",
       "description": {
         "AccessTokens": "管理用於向此部署端點驗證 API 請求的存取令牌。",
         "AutoScaling": "設定自動擴縮容規則，根據流量指標自動調整副本數量。",
         "Replicas": "檢視此部署所有正在執行的副本實例及其健康狀態和資源狀況。",
-        "RevisionHistory": "瀏覽過去的部署版本歷史，並回滾至任意之前的版本。若要建立新版本，請點擊上方的「編輯設定」。"
+        "Revision": "瀏覽過去的部署版本歷史，並回滾至任意之前的版本。",
+        "RevisionHistory": "瀏覽過去的部署版本歷史，並回滾至任意之前的版本。"
       }
     }
   },


### PR DESCRIPTION
Resolves [FR-2664](https://lablup.atlassian.net/browse/FR-2664)

## Summary

Applies the design-review feedback for the new Deployment detail page. Splits the
monolithic configuration card, surfaces the endpoint URL, switches to imageV2,
reorders detail tabs, and adds a dedicated revision creation/inspection flow.

### Detail page (`DeploymentDetailPage.tsx`)
- Reordered tabs to match the meeting decision: Overview → Replicas → Revisions
  → Auto Scaling → Access Tokens.

### Configuration section (`DeploymentConfigurationSection.tsx`)
- Split the single config card into focused subsections.
- Added the endpoint URL row with copy affordance.
- Migrated image rendering to imageV2.

### Revision flow (new files)
- `DeploymentAddRevisionModal.tsx` (770 LOC): full create-new-revision form
  reusing the launcher fields.
- `DeploymentRevisionDetailDrawer.tsx` (305 LOC): read-only drawer for inspecting
  a past revision; opened from the Revisions tab list.
- `DeploymentRevisionHistoryTab.tsx`: row click now opens the detail drawer;
  the "Add revision" entry-point invokes the new modal.

### Access Tokens tab (`DeploymentAccessTokensTab.tsx`)
- Removed the BA-5853 `TODO(needs-backend)` comment now that backend
  PR lablup/backend.ai#11325 (rename `deployment_id` → `model_deployment_id`)
  has been merged. The mutation already sends `modelDeploymentId`, so this
  unblocks token creation without further FE changes.

### i18n (21 languages)
- Added strings for the new revision modal/drawer and the split config card.
- Removed the obsolete "새 리비전을 생성하려면 상단의 설정 편집 버튼을 클릭하세요." /
  "or create a new revision." sentence from
  `deployment.tab.description.Revision` and `RevisionHistory`.
- Fixed Unicode smart quotes that had crept into `de.json` lines 907–908 and
  caused an ESLint JSON parse error.

### Schema
- Regenerated `data/schema.graphql` (24-line delta) to pick up the renamed
  `CreateAccessTokenInput.modelDeploymentId` field.

## Test plan
- [ ] Detail page: verify tab order Overview / Replicas / Revisions / Auto
      Scaling / Access Tokens.
- [ ] Overview: confirm the split cards render and the endpoint URL is copyable.
- [ ] Revisions tab: click a row → detail drawer; click "Add revision" → modal
      submits a new revision.
- [ ] Access Tokens tab: create a token end-to-end (backend BA-5853 fix
      required).
- [ ] Run `bash scripts/verify.sh` — Relay / Lint / Format / TS all green.
- [ ] Spot-check 2-3 non-English locales for the cleaned Revision tooltip.

[FR-2664]: https://lablup.atlassian.net/browse/FR-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ