### PR TITLE
fix(FR-2606): restore Monaco self-hosting in Vite dev server

### DIFF
--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -231,6 +231,53 @@ function projectRootStaticPlugin(): Plugin {
   };
 }
 
+/**
+ * Serve the Monaco AMD runtime at `/resources/monaco/vs/*` from
+ * `react/node_modules/monaco-editor/min/vs/*` during dev. Mirrors the
+ * `static` directory entry that lived in the deleted `react/craco.config.cjs`.
+ *
+ * `@monaco-editor/react` resolves the URL prefix via
+ *   loader.config({ paths: { vs: '/resources/monaco/vs' } })
+ * (see `react/src/helper/monacoEditor.ts`). Self-hosting keeps Monaco
+ * working in offline / air-gapped deployments where jsDelivr is unreachable.
+ *
+ * Production is unchanged: the root `copymonaco` script (`package.json:32`)
+ * copies the same tree into `build/web/resources/monaco/vs/`.
+ *
+ * `min/vs` is Monaco's prebuilt AMD bundle — used here rather than the ESM
+ * tree because `@monaco-editor/react` consumes the AMD form to keep the
+ * Monaco worker chunks intact for runtime lazy-loading.
+ */
+function monacoStaticPlugin(): Plugin {
+  const monacoRoot = resolve(__dirname, 'node_modules/monaco-editor/min/vs');
+  const URL_PREFIX = '/resources/monaco/vs/';
+
+  return {
+    name: 'bai-monaco-static',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url) return next();
+        const url = req.url.split('?')[0];
+        if (!url.startsWith(URL_PREFIX)) return next();
+
+        const rel = url.slice(URL_PREFIX.length);
+        const filePath = join(monacoRoot, rel);
+        // Path-traversal guard: `join` normalizes `..`, so prefix comparison
+        // catches any URL that escapes `monacoRoot`.
+        if (!filePath.startsWith(monacoRoot)) return next();
+        if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+          return next();
+        }
+        const mime =
+          MIME[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+        res.setHeader('Content-Type', mime);
+        createReadStream(filePath).pipe(res);
+      });
+    },
+  };
+}
+
 export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, projectRoot, '');
   Object.assign(process.env, env);
@@ -405,7 +452,10 @@ export default defineConfig(({ command, mode }) => {
 
     plugins: [
       // Must run before @vitejs/plugin-react so we own the HTML transform
-      // and the index.html resolution.
+      // and the index.html resolution. Monaco's narrower prefix is matched
+      // first so the more general projectRoot middleware never has to
+      // reach into the filesystem for a `/resources/monaco/vs/*` request.
+      monacoStaticPlugin(),
       projectRootStaticPlugin(),
       devAssetsReloadPlugin(),
 


### PR DESCRIPTION
Resolves #6809(FR-2606)

## Summary

Dev-server regression noticed after the Vite cutover: pages that mount a Monaco editor break at mount time because the `/resources/monaco/vs/*` URL prefix no longer resolves on the dev server.

`@monaco-editor/react` loads the Monaco AMD runtime at runtime via:

```ts
loader.config({ paths: { vs: '/resources/monaco/vs' } });
```

(see `react/src/helper/monacoEditor.ts`). The self-hosted prefix exists so the editor works in offline / air-gapped deployments where jsDelivr is unreachable.

Pre-Vite, the dev-server side of this contract was the `static` directory list in `react/craco.config.cjs` (lines 44–60 of the now-deleted file): it served `react/node_modules/monaco-editor/min/vs/*` at the `/resources/monaco/vs` URL prefix. Production builds copy the same tree to `build/web/resources/monaco/vs/` via the root `copymonaco` script (`package.json:32`).

After #6876 (FR-2611) dropped `craco.config.cjs`, the production `copymonaco` step was preserved but the dev-server-side mapping was not ported to `vite.config.ts`. As a result, in `pnpm run dev`, requests to `/resources/monaco/vs/loader.js` 404 and any page that mounts a Monaco editor breaks.

**Fix**: add `monacoStaticPlugin()` to `react/vite.config.ts` mirroring the deleted craco `static` entry.

- Serves `/resources/monaco/vs/*` from `react/node_modules/monaco-editor/min/vs/*`.
- `apply: 'serve'` — dev-only; production is unchanged because `copymonaco` already populates `build/web/resources/monaco/vs/`.
- Path-traversal guard via `filePath.startsWith(monacoRoot)` after `join` normalization.
- Registered in the `plugins` array before `projectRootStaticPlugin()` so the narrower Monaco prefix is matched first.

## Verification

- [x] `bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all PASS
- [ ] `pnpm run dev`, navigate to a Monaco-mounting page (manifest editor on Environments page) — editor renders without console errors, no `cdn.jsdelivr.net` fetches
- [ ] DevTools → Network: `/resources/monaco/vs/loader.js`, `/resources/monaco/vs/editor/editor.main.js` return 200 from the dev server

## Stack

Top of the Vite migration follow-up stack. Sits on top of #7083 (FR-2748).