### PR TITLE
feat(FR-2755): align web docs code-block UI with design

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
@@ -423,8 +423,21 @@ function buildWebRenderer(
         : ` class="shiki-host"`;
       const preBlock = `<pre${langClass}><code>${codeHtml}</code></pre>`;
 
-      if (title) {
-        return `<div class="code-block-wrapper"><div class="code-block-title">${escapeHtml(title)}</div>${preBlock}</div>\n`;
+      // Emit the BAI dark frame whenever we have either a language hint
+      // or a title — the header renders a language pill (left), filename
+      // text slot (middle, flex-grows so the copy button lands flush
+      // right), and an empty slot the runtime copy script populates with
+      // its SVG button. Plain fenced blocks with no lang/title fall
+      // through to bare <pre>; code-copy.js still wraps them with the
+      // doc-code-block-wrapper at runtime so they get the dark frame.
+      if (lang || title) {
+        const langPill = lang
+          ? `<span class="code-block-lang">${escapeHtml(lang)}</span>`
+          : "";
+        const titleText = title
+          ? `<span class="code-block-title-text">${escapeHtml(title)}</span>`
+          : `<span class="code-block-title-text" aria-hidden="true"></span>`;
+        return `<div class="code-block-wrapper"><div class="code-block-title">${langPill}${titleText}</div>${preBlock}</div>\n`;
       }
 
       return preBlock + "\n";

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1338,8 +1338,59 @@ pre code {
   background: #0E0E10 !important;
   color: #E0E0E5;
   padding: 16px 18px;
-  line-height: 1.7;
+  /* Collapse the anonymous text-node strut Shiki emits between
+     <span class="line"> rows: each '\\n' between line spans would
+     otherwise render as a blank line of pre's line-height tall, doubling
+     the apparent vertical gap. line-height: 0 here zeroes that strut,
+     and .shiki-host > code .line below sets line-height back for the
+     visible line spans (display: block). */
+  line-height: 0;
+  /* overflow-x: auto (not scroll) so non-overflowing blocks don't
+     reserve a bottom track gutter. Chromium's overlay scrollbar mode
+     (which would also hide overlay scrollbars on overflow) is opted
+     out via the ::-webkit-scrollbar { -webkit-appearance: none }
+     rule below — the bar then renders classic-style, visible whenever
+     overflow is real. Firefox uses scrollbar-width / scrollbar-color. */
   overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+}
+
+/* -webkit-appearance: none is what actually opts <pre> out of
+   Chromium's overlay scrollbar (which fades out on idle and never
+   reads as "scrollable" at a glance). Without this, the rules below
+   still get applied but the overlay engine hides them between
+   interactions. */
+/* When the runtime detects real horizontal overflow on a <pre> (set by
+   code-copy.js as .has-x-overflow), upgrade overflow-x to scroll so the
+   scrollbar is pinned visible. Without this, Safari respects the macOS
+   "Show scroll bars: When scrolling" system setting and fades the bar
+   out on idle even with -webkit-appearance: none — users on Macs report
+   the bar shows only intermittently. */
+.code-block-wrapper pre.has-x-overflow,
+.doc-code-block-wrapper > pre.has-x-overflow {
+  overflow-x: scroll;
+}
+
+.code-block-wrapper pre::-webkit-scrollbar,
+.doc-code-block-wrapper > pre::-webkit-scrollbar {
+  -webkit-appearance: none;
+  height: 8px;
+  width: 8px;
+}
+.code-block-wrapper pre::-webkit-scrollbar-track,
+.doc-code-block-wrapper > pre::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+}
+.code-block-wrapper pre::-webkit-scrollbar-thumb,
+.doc-code-block-wrapper > pre::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.28);
+  border-radius: 4px;
+}
+.code-block-wrapper pre::-webkit-scrollbar-thumb:hover,
+.doc-code-block-wrapper > pre::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.5);
 }
 
 /* Shiki emits inline-styled <span> tokens inside <pre>. We let those
@@ -1381,8 +1432,11 @@ pre code {
 .shiki-host > code .line {
   /* Each token row Shiki emits. display:block makes line wrapping behave
      consistently — long lines wrap inside the line span instead of pushing
-     the parent <pre> wider. */
+     the parent <pre> wider. line-height restores the visible rhythm
+     after .code-block-wrapper pre / .doc-code-block-wrapper > pre zero
+     out line-height to collapse the inter-line '\\n' strut. */
   display: block;
+  line-height: 1.6;
 }
 
 /* Wrapper injected at runtime by code-copy.js around every <pre> on the
@@ -1422,8 +1476,10 @@ pre code {
   background: #0E0E10 !important;
   color: #E0E0E5;
   padding: 16px 18px;
-  line-height: 1.7;
+  line-height: 0; /* See .code-block-wrapper pre comment above. */
   overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
 }
 
 /* Tokens are inline-styled by Shiki for the configured lightTheme.
@@ -1445,13 +1501,16 @@ pre code {
   position: absolute;
   top: 6px;
   right: 8px;
-  padding: 3px 9px;
-  font-size: 11px;
-  line-height: 1.2;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-family: var(--bai-font-sans);
   color: #B5B5BD;
   background: transparent;
-  border: 1px solid #2A2A30;
+  border: 1px solid transparent;
   border-radius: 4px;
   cursor: pointer;
   opacity: 1;
@@ -1459,13 +1518,21 @@ pre code {
     background-color 120ms ease;
 }
 
-/* When inside a title bar, anchor to the bar's right edge instead of
-   floating absolute. The copy script puts the button at the top-right
-   of the wrapper; the title bar already renders at the top, so the
-   absolute position lands on the bar visually. */
-.code-block-wrapper .doc-code-copy-btn {
-  top: 6px;
-  right: 8px;
+.doc-code-copy-btn svg {
+  width: 14px;
+  height: 14px;
+  display: block;
+}
+
+/* When inside a title bar, drop absolute positioning and sit inline
+   at the right edge of the bar (the title bar uses flex with an empty
+   text slot that flex-grows so the button always lands on the right). */
+.code-block-title .doc-code-copy-btn {
+  position: static;
+  top: auto;
+  right: auto;
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .doc-code-copy-btn:hover {
@@ -1492,16 +1559,17 @@ pre code {
    pipeline does not auto-emit this today, but the styles are in place
    so a future enhancement can flip it on. */
 .code-block-lang {
+  /* Subtle inline language label — readable but not loud. No background,
+     no uppercasing, regular weight. The header bar is the visual frame;
+     the language string is just metadata. */
   display: inline-flex;
   align-items: center;
-  background: var(--bai-primary);
-  color: #fff;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  color: #8E8E96;
+  padding: 0;
+  font-size: 11.5px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: lowercase;
   flex-shrink: 0;
 }
 

--- a/packages/backend.ai-docs-toolkit/templates/assets/code-copy.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/code-copy.js
@@ -89,23 +89,53 @@
     return fallbackCopy(text);
   }
 
+  /* SVG icons. Inline so no extra HTTP request and no font dependency.
+   * The 16-unit viewBox keeps stroke weight crisp on high-DPI without
+   * scaling artifacts; CSS sizes the rendered icon to 14×14 CSS px via
+   * `.doc-code-copy-btn svg`. */
+  var ICONS = {
+    idle:
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" ' +
+      'stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" ' +
+      'aria-hidden="true">' +
+      '<rect x="5" y="5" width="9" height="9" rx="1.5"/>' +
+      '<path d="M3 11V3.5A1.5 1.5 0 0 1 4.5 2H11"/>' +
+      "</svg>",
+    copied:
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" ' +
+      'stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" ' +
+      'aria-hidden="true">' +
+      '<path d="M3 8.5l3.2 3.2L13 5"/>' +
+      "</svg>",
+    failed:
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" ' +
+      'stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" ' +
+      'aria-hidden="true">' +
+      '<path d="M4 4l8 8M12 4l-8 8"/>' +
+      "</svg>",
+  };
+
+  function setIcon(btn, state) {
+    btn.innerHTML = ICONS[state] || ICONS.idle;
+  }
+
   function makeButton(labels) {
     var btn = document.createElement("button");
     btn.type = "button";
     btn.className = "doc-code-copy-btn";
     btn.setAttribute("aria-label", labels.copy);
     btn.setAttribute("data-state", "idle");
-    btn.textContent = labels.copy;
+    setIcon(btn, "idle");
     return btn;
   }
 
-  function flash(btn, label, state, restore, labels) {
-    btn.textContent = label;
+  function flash(btn, label, state, labels) {
+    setIcon(btn, state);
     btn.setAttribute("data-state", state);
     btn.setAttribute("aria-label", label);
     if (btn.__resetTimer) clearTimeout(btn.__resetTimer);
     btn.__resetTimer = setTimeout(function () {
-      btn.textContent = restore;
+      setIcon(btn, "idle");
       btn.setAttribute("data-state", "idle");
       btn.setAttribute("aria-label", labels.copy);
     }, 1500);
@@ -115,38 +145,92 @@
     if (pre.__copyAttached) return;
     pre.__copyAttached = true;
 
-    /* Wrap the <pre> so the absolutely-positioned button sits in the same
-     * stacking context. Skip if a wrapper already exists (idempotent). */
-    var wrapper;
-    if (
+    /* Decide where the copy button lives:
+     *   1. Server-rendered titled wrapper (.code-block-wrapper with a
+     *      .code-block-title bar) — append the button into the title bar
+     *      so it sits inline at the bar's right edge (CSS drops the
+     *      absolute positioning for this case).
+     *   2. Bare <pre> — wrap with a fresh .doc-code-block-wrapper so the
+     *      absolutely-positioned button has a stacking context, then
+     *      append the button inside that wrapper.
+     * Idempotent: a second pass over the same <pre> bails out via the
+     *   pre.__copyAttached guard at the top of attach(). */
+    var titledWrapper =
       pre.parentNode &&
       pre.parentNode.classList &&
-      pre.parentNode.classList.contains("doc-code-block-wrapper")
-    ) {
-      wrapper = pre.parentNode;
-    } else {
-      wrapper = document.createElement("div");
-      wrapper.className = "doc-code-block-wrapper";
-      var parent = pre.parentNode;
-      if (!parent) return;
-      parent.insertBefore(wrapper, pre);
-      wrapper.appendChild(pre);
-    }
+      pre.parentNode.classList.contains("code-block-wrapper")
+        ? pre.parentNode
+        : null;
 
     var btn = makeButton(labels);
-    wrapper.appendChild(btn);
+
+    if (titledWrapper) {
+      var titleBar = titledWrapper.querySelector(".code-block-title");
+      if (titleBar) {
+        titleBar.appendChild(btn);
+      } else {
+        titledWrapper.appendChild(btn);
+      }
+    } else {
+      var wrapper;
+      if (
+        pre.parentNode &&
+        pre.parentNode.classList &&
+        pre.parentNode.classList.contains("doc-code-block-wrapper")
+      ) {
+        wrapper = pre.parentNode;
+      } else {
+        wrapper = document.createElement("div");
+        wrapper.className = "doc-code-block-wrapper";
+        var parent = pre.parentNode;
+        if (!parent) return;
+        parent.insertBefore(wrapper, pre);
+        wrapper.appendChild(pre);
+      }
+      wrapper.appendChild(btn);
+    }
 
     btn.addEventListener("click", function () {
       var text = extractCode(pre);
       copyText(text).then(
         function () {
-          flash(btn, labels.copied, "copied", labels.copy, labels);
+          flash(btn, labels.copied, "copied", labels);
         },
         function () {
-          flash(btn, labels.failed, "failed", labels.copy, labels);
+          flash(btn, labels.failed, "failed", labels);
         },
       );
     });
+
+    /* Force a permanent slim horizontal scrollbar on overflowing blocks.
+     * Pure CSS can't do this in Safari: even with -webkit-appearance: none
+     * on ::-webkit-scrollbar, Safari respects the macOS "Show scroll bars"
+     * system setting and fades the bar out when idle, so users miss the
+     * scroll affordance on long lines. The only spec-guaranteed way to
+     * pin the bar is overflow: scroll — but applying it unconditionally
+     * leaves a 8px gutter on every short non-overflowing block.
+     *
+     * Solution: detect real overflow per <pre> and toggle a class. CSS
+     * upgrades the matching <pre> from overflow-x: auto to scroll, which
+     * forces Safari (and any other overlay-default browser) to keep the
+     * bar visible. ResizeObserver re-checks on container resize / sidebar
+     * collapse / window resize / late font load. */
+    function syncOverflow() {
+      var overflows = pre.scrollWidth > pre.clientWidth + 1;
+      pre.classList.toggle("has-x-overflow", overflows);
+    }
+    syncOverflow();
+    if (typeof ResizeObserver !== "undefined") {
+      try {
+        new ResizeObserver(syncOverflow).observe(pre);
+      } catch (_) {
+        /* Defensive: a few embedded WebViews stub ResizeObserver. */
+      }
+    }
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(syncOverflow).catch(function () {});
+    }
+    window.addEventListener("resize", syncOverflow, { passive: true });
   }
 
   function init() {


### PR DESCRIPTION
Resolves #7105(FR-2755)

## Summary

Visual fixes to align web-build code blocks with the BAI Figma design (Backend.AI Web UI Manual):

1. **Header bar always visible when `lang` or `title` is set** — `markdown-processor-web.ts` now emits the `.code-block-wrapper` + `.code-block-title` shell whenever a fenced block has *either* a language hint or a `title=` attribute.

2. **Subtle inline language label** (replaces the loud orange pill) — `.code-block-lang` is now soft gray (`#8E8E96`), 11.5px, regular weight, lowercase, no background. The header bar is the visual frame; the language string is just metadata.

3. **Filename slot** — `<span class="code-block-title-text">{filename}</span>` flex-grows so the copy button lands flush right; rendered as an empty `aria-hidden` span when there is no title.

4. **SVG copy button inside the header bar** — `templates/assets/code-copy.js` replaces the text "Copy" label with three inline 16-unit-viewBox SVGs (clipboard idle / check copied / x failed) toggled via `data-state`, rendered at 14×14 CSS px via `.doc-code-copy-btn svg`. When the wrapper has a `.code-block-title`, the button is appended *into* the bar (CSS drops `position: absolute` for that case via `.code-block-title .doc-code-copy-btn`). Bare `<pre>` blocks still get the absolute-floating button on top-right of the runtime-injected `.doc-code-block-wrapper`. `aria-label` keeps the localized text labels for a11y.

5. **Vertical rhythm — fix the doubled gap** — Shiki emits `<span class="line">…</span>\n<span class="line">…</span>` for each row, and the `\n` text nodes between line spans were rendering as blank lines under `<pre>`'s `white-space: pre`, doubling the visible vertical gap (baseline-to-baseline = `line-height × 2`). Fix: zero `line-height` on `.code-block-wrapper pre` / `.doc-code-block-wrapper > pre` to collapse the inter-line strut, then put `line-height: 1.6` on `.shiki-host > code .line` (display: block) so the visible rows render at a comfortable rhythm. Verified via Playwright: baselineDelta drops from 35px → 20px on multi-line blocks; `pre` height shrinks accordingly.

6. **Always-visible slim horizontal scrollbar (cross-browser)** — pure CSS can't pin scrollbars in Safari (it follows the macOS "Show scroll bars: When scrolling" system setting and fades the overlay bar even with `-webkit-appearance: none`). Solution: `code-copy.js` measures `pre.scrollWidth > pre.clientWidth` per block on load, after font-load, and via ResizeObserver, and toggles a `.has-x-overflow` class. CSS upgrades the matching `<pre>` from `overflow-x: auto` to `scroll`, which forces Safari and any other overlay-default browser to keep the bar visible. Non-overflowing blocks stay on `auto` so they don't reserve a bottom track gutter (no white scrollbar shadow).

## Out of scope (follow-up PRs)

- `console` pseudo-lang to author terminal transcripts where `$` prompts are visual-only (excluded from drag-select / copy button)
- PDF code-block restyling
- Shiki theme changes (light/dark token palette pairing)

## Test plan

- [x] `bash scripts/verify.sh` → `=== ALL PASS ===`
- [x] `pnpm --filter backend.ai-docs-toolkit test` → 126/126 pass
- [x] `pnpm --filter backend.ai-webui-docs run build:web:en` succeeds; generated HTML emits `<span class="code-block-lang">{lang}</span>` for every fenced block with a language; generated CSS contains the `line-height: 0` + `.line { line-height: 1.6 }` pairing and the `-webkit-appearance: none` scrollbar styling.
- [x] Playwright headless verification on `next/en/sftp_to_container.html`:
      - line-height fix: 4-line block goes from `baselineDelta: 35px / preH: 154.5px` (before) to `baselineDelta: 20px / preH: ~115px` (after) — verified by injecting/removing the override and re-measuring.
      - overflow class toggling: 16/16 blocks correctly classified as overflowing vs non-overflowing; 0 mismatches after viewport resize from 1280px → 800px (ResizeObserver works).
      - scrollbar gutter: non-overflowing blocks no longer reserve an 8px bottom track.
- [x] Confirmed visually in author's actual browser (Chrome and Safari) — scrollbar visible only when needed; line spacing comfortable; subtle language label.