### PR TITLE
fix(FR-2606): clear residual build-time warnings (BUI dts + module directive)

### DIFF
--- a/packages/backend.ai-ui/.prettierrc.json
+++ b/packages/backend.ai-ui/.prettierrc.json
@@ -1,13 +1,22 @@
 {
-    "tabWidth": 2,
-    "semi": true,
-    "singleQuote": true,
-    "importOrderSeparation": true,
-    "importOrderParserPlugins": ["typescript", "jsx"],
-    "printWidth": 80,
-    "bracketSpacing": true,
-    "trailingComma": "all",
-    "plugins": ["@trivago/prettier-plugin-sort-imports"],
-    "singleAttributePerLine": false
-  }
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "importOrderSeparation": true,
+  "importOrderParserPlugins": ["typescript", "jsx"],
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "trailingComma": "all",
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "singleAttributePerLine": false,
+  "overrides": [
+    {
+      "files": "src/locale/*.json",
+      "options": {
+        "plugins": ["prettier-plugin-sort-json"],
+        "jsonRecursiveSort": true
+      }
+    }
+  ]
+}
   

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useAnonymousBAIClient.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useAnonymousBAIClient.ts
@@ -1,4 +1,4 @@
-import { useBAILogger } from '../../../../hooks';
+import useBAILogger from '../../../../hooks/useBAILogger';
 import { BAIAnonymousClientContext } from '../context';
 import { BAIClient } from '../types';
 import { useContext } from 'react';

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIDeviceMetaData.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIDeviceMetaData.ts
@@ -1,4 +1,4 @@
-import { useBAILogger } from '../../../../hooks';
+import useBAILogger from '../../../../hooks/useBAILogger';
 import { BAIDeviceMetaDataContext } from '../context';
 import { useContext } from 'react';
 

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/types.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/types.ts
@@ -1,4 +1,4 @@
-import { ResourceSlotDetail } from '../../../hooks';
+import type { ResourceSlotDetail } from '../../../hooks';
 
 export type DeviceMetaData = {
   [name: string]: ResourceSlotDetail | undefined;

--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -1,8 +1,6 @@
-import {
-  ResourceSlotName,
-  useBAIDeviceMetaData,
-  useConnectedBAIClient,
-} from '../components';
+import useConnectedBAIClient from '../components/provider/BAIClientProvider/hooks/useConnectedBAIClient';
+import useBAIDeviceMetaData from '../components/provider/BAIMetaDataProvider/hooks/useBAIDeviceMetaData';
+import type { ResourceSlotName } from '../components/provider/BAIMetaDataProvider/types';
 import { useSuspenseTanQuery, useTanQuery } from '../helper/reactQueryAlias';
 import { useBAISignedRequestWithPromise } from './useBAISignedRequestWithPromise';
 import { useEventNotStable } from './useEventNotStable';

--- a/packages/backend.ai-ui/src/hooks/useBAILogger.tsx
+++ b/packages/backend.ai-ui/src/hooks/useBAILogger.tsx
@@ -44,7 +44,7 @@ export interface LoggerPlugin {
 class Logger {
   private plugins: LoggerPlugin[] = [];
   private metadata: Record<string, any> = {};
-  private enabled: boolean = process.env.NODE_ENV !== 'production';
+  private enabled: boolean = !import.meta.env.PROD;
   private static instance: Logger;
 
   private constructor() {

--- a/packages/backend.ai-ui/src/hooks/useBAISignedRequestWithPromise.ts
+++ b/packages/backend.ai-ui/src/hooks/useBAISignedRequestWithPromise.ts
@@ -1,4 +1,4 @@
-import { useConnectedBAIClient } from '../components';
+import useConnectedBAIClient from '../components/provider/BAIClientProvider/hooks/useConnectedBAIClient';
 
 export const baiSignedRequestWithPromise = ({
   method,

--- a/packages/backend.ai-ui/src/locale/.prettierrc
+++ b/packages/backend.ai-ui/src/locale/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "plugins": ["prettier-plugin-sort-json"],
-  "jsonRecursiveSort": true
-}

--- a/packages/backend.ai-ui/src/locale/index.ts
+++ b/packages/backend.ai-ui/src/locale/index.ts
@@ -20,7 +20,7 @@ import vi from './vi.json';
 import zh_CN from './zh-CN.json';
 import zh_TW from './zh-TW.json';
 import { Locale } from 'antd/es/locale';
-import { createInstance } from 'i18next';
+import { createInstance, type i18n as I18nInstance } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
 const resources = {
@@ -89,7 +89,7 @@ const resources = {
   },
 };
 
-export const i18n = createInstance({
+export const i18n: I18nInstance = createInstance({
   lng: 'en',
   fallbackLng: 'en',
   defaultNS: 'backend.ai-ui',

--- a/packages/backend.ai-ui/tsconfig.json
+++ b/packages/backend.ai-ui/tsconfig.json
@@ -16,6 +16,6 @@
     "resolveJsonModule": true,
     "types": ["vite-plugin-svgr/client"]
   },
-  "include": ["src/**/*", "svg.d.ts", "vite.config.ts", "setupTests.ts"],
+  "include": ["src/**/*", "svg.d.ts", "vite-env.d.ts", "vite.config.ts", "setupTests.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/backend.ai-ui/vite-env.d.ts
+++ b/packages/backend.ai-ui/vite-env.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />

--- a/packages/backend.ai-ui/vite.config.ts
+++ b/packages/backend.ai-ui/vite.config.ts
@@ -69,7 +69,7 @@ export default defineConfig(({ mode }) => {
         codegen: !isDevMode,
       }),
       dts({
-        include: ['src/**/*'],
+        include: ['src/**/*', 'vite-env.d.ts'],
         exclude: ['**/*.{stories,test}.{ts,tsx}', 'src/locale/*.json'],
         rollupTypes: false,
         insertTypesEntry: true,

--- a/react/src/ambient.d.ts
+++ b/react/src/ambient.d.ts
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+/// <reference types="vite/client" />
 /// <reference types="vitest/globals" />
 // Project-wide ambient TypeScript declarations: shared utility types,
 // global variables seeded by the host shell, and `Window` augmentations.

--- a/react/src/components/STokenLoginBoundary.test.tsx
+++ b/react/src/components/STokenLoginBoundary.test.tsx
@@ -36,50 +36,52 @@ import fs from 'fs';
 import { Provider as JotaiProvider, createStore } from 'jotai';
 import path from 'path';
 import React from 'react';
+import { vi, type Mock, type MockedFunction } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
 
-jest.mock('./DefaultProviders', () => ({
+vi.mock('./DefaultProviders', () => ({
   __esModule: true,
   jotaiStore: { get: () => null, set: () => {} },
 }));
 
-jest.mock('../hooks/useWebUIConfig', () => ({
+vi.mock('../hooks/useWebUIConfig', () => ({
   __esModule: true,
   loginConfigState: { toString: () => 'loginConfigState' },
 }));
 
-jest.mock('../hooks/useResolvedApiEndpoint', () => {
+vi.mock('../hooks/useResolvedApiEndpoint', () => {
   const state: { endpoint: string } = { endpoint: 'https://api.example.com' };
   return {
     __esModule: true,
-    useResolvedApiEndpoint: jest.fn(() => state.endpoint),
+    useResolvedApiEndpoint: vi.fn(() => state.endpoint),
     __endpointState: state,
   };
 });
 
-jest.mock('../helper/loginSessionAuth', () => ({
+vi.mock('../helper/loginSessionAuth', () => ({
   __esModule: true,
-  createBackendAIClient: jest.fn(),
-  tokenLogin: jest.fn(),
-  connectViaGQL: jest.fn(),
+  createBackendAIClient: vi.fn(),
+  tokenLogin: vi.fn(),
+  connectViaGQL: vi.fn(),
 }));
 
-jest.mock('backend.ai-ui', () => {
-  const actual = jest.requireActual('backend.ai-ui');
+vi.mock('backend.ai-ui', async () => {
+  const actual =
+    await vi.importActual<typeof import('backend.ai-ui')>('backend.ai-ui');
   return {
     ...actual,
     useBAILogger: () => ({
-      logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+      logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
     }),
   };
 });
 
 // Mock Jotai's useAtomValue to return null (no config in test env).
-jest.mock('jotai', () => {
-  const actual = jest.requireActual('jotai');
+vi.mock('jotai', async () => {
+  const actual = await vi.importActual<typeof import('jotai')>('jotai');
   return {
     ...actual,
     useAtomValue: () => null,
@@ -90,10 +92,11 @@ jest.mock('jotai', () => {
 // Test helpers
 // ---------------------------------------------------------------------------
 
-const mockedCreateBackendAIClient =
-  createBackendAIClient as jest.MockedFunction<typeof createBackendAIClient>;
-const mockedTokenLogin = tokenLogin as jest.MockedFunction<typeof tokenLogin>;
-const mockedConnectViaGQL = connectViaGQL as jest.MockedFunction<
+const mockedCreateBackendAIClient = createBackendAIClient as MockedFunction<
+  typeof createBackendAIClient
+>;
+const mockedTokenLogin = tokenLogin as MockedFunction<typeof tokenLogin>;
+const mockedConnectViaGQL = connectViaGQL as MockedFunction<
   typeof connectViaGQL
 >;
 const endpointState = (
@@ -104,15 +107,15 @@ const setEndpoint = (next: string) => {
 };
 
 type FakeClient = {
-  get_manager_version: jest.Mock;
-  check_login: jest.Mock;
-  token_login: jest.Mock;
+  get_manager_version: Mock;
+  check_login: Mock;
+  token_login: Mock;
 };
 
 const buildFakeClient = (overrides: Partial<FakeClient> = {}): FakeClient => ({
-  get_manager_version: jest.fn().mockResolvedValue('1.0'),
-  check_login: jest.fn().mockResolvedValue(false),
-  token_login: jest.fn().mockResolvedValue(true),
+  get_manager_version: vi.fn().mockResolvedValue('1.0'),
+  check_login: vi.fn().mockResolvedValue(false),
+  token_login: vi.fn().mockResolvedValue(true),
   ...overrides,
 });
 
@@ -166,7 +169,7 @@ beforeEach(() => {
 
 afterEach(() => {
   document.removeEventListener('backend-ai-connected', connectedEventHandler);
-  jest.clearAllMocks();
+  vi.clearAllMocks();
 });
 
 // ---------------------------------------------------------------------------
@@ -175,7 +178,7 @@ afterEach(() => {
 
 describe('STokenLoginBoundary', () => {
   test('renders children after the login sequence succeeds', async () => {
-    const onSuccess = jest.fn();
+    const onSuccess = vi.fn();
     renderBoundary({ onSuccess });
 
     await waitFor(() => {
@@ -195,7 +198,7 @@ describe('STokenLoginBoundary', () => {
   });
 
   test('reports missing-token when sToken prop is empty', async () => {
-    const onError = jest.fn();
+    const onError = vi.fn();
     renderBoundary({ sToken: '', onError });
 
     await waitFor(() => {
@@ -206,7 +209,7 @@ describe('STokenLoginBoundary', () => {
   });
 
   test('reports endpoint-unresolved when the resolver returns empty', async () => {
-    const onError = jest.fn();
+    const onError = vi.fn();
     setEndpoint('');
     renderBoundary({ onError });
 
@@ -221,12 +224,12 @@ describe('STokenLoginBoundary', () => {
     const serverErr = new Error('network down');
     mockedCreateBackendAIClient.mockImplementation(() => ({
       client: {
-        get_manager_version: jest.fn().mockRejectedValue(serverErr),
-        token_login: jest.fn(),
+        get_manager_version: vi.fn().mockRejectedValue(serverErr),
+        token_login: vi.fn(),
       },
       clientConfig: {},
     }));
-    const onError = jest.fn();
+    const onError = vi.fn();
     renderBoundary({ onError });
 
     await waitFor(() => {
@@ -242,7 +245,7 @@ describe('STokenLoginBoundary', () => {
   test('reports token-invalid when tokenLogin throws', async () => {
     const tokenErr = new Error('bad token');
     mockedTokenLogin.mockRejectedValue(tokenErr);
-    const onError = jest.fn();
+    const onError = vi.fn();
     renderBoundary({ onError });
 
     await waitFor(() => {
@@ -257,13 +260,13 @@ describe('STokenLoginBoundary', () => {
   test('skips token_login when the browser already holds a valid session', async () => {
     // Reuse the existing session: check_login resolves truthy.
     const client = buildFakeClient({
-      check_login: jest.fn().mockResolvedValue(true),
+      check_login: vi.fn().mockResolvedValue(true),
     });
     mockedCreateBackendAIClient.mockImplementation(() => ({
       client,
       clientConfig: {},
     }));
-    const onSuccess = jest.fn();
+    const onSuccess = vi.fn();
     renderBoundary({ onSuccess });
 
     await waitFor(() => {
@@ -281,7 +284,7 @@ describe('STokenLoginBoundary', () => {
   test('errorFallback replaces the built-in card for every kind', async () => {
     const tokenErr = new Error('bad token');
     mockedTokenLogin.mockRejectedValue(tokenErr);
-    const errorFallback = jest.fn((error: STokenLoginError) => (
+    const errorFallback = vi.fn((error: STokenLoginError) => (
       <div>custom-{error.kind}</div>
     ));
     renderBoundary({ errorFallback });

--- a/react/src/components/SwitchToProjectButton.tsx
+++ b/react/src/components/SwitchToProjectButton.tsx
@@ -2,8 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-'use memo';
-
 import { SwitchToProjectButtonQuery } from '../__generated__/SwitchToProjectButtonQuery.graphql';
 import { useSetCurrentProject } from '../hooks/useCurrentProject';
 import {
@@ -24,6 +22,7 @@ const SwitchToProjectButtonContent: React.FC<SwitchToProjectButtonProps> = ({
   projectId,
   ...buttonProps
 }) => {
+  'use memo';
   const { t } = useTranslation();
   const setCurrentProject = useSetCurrentProject();
   const [isPending, startTransition] = useTransition();


### PR DESCRIPTION
Resolves #6809(FR-2606)

## Summary

Cleans up residual `pnpm run build` warnings introduced or surfaced by the Vite migration (FR-2611). All non-fatal in the original log (build was already exiting 0); cleared here as a follow-up to the FR-2606 series.

Three classes of warnings are addressed:

1. **BUI dts emit type errors** (TS2742 + TS2591 + a follow-on TS2339)
2. **Module-level `'use memo'` directive** ignored by Rollup
3. **Components ↔ hooks circular dependency** in BUI, surfaced via `ResourceTypeIcon` re-export through the components barrel

## 1. BUI dts emit (`vite-plugin-dts`) — three TS diagnostics

### TS2742 — `i18n` inferred type (`packages/backend.ai-ui/src/locale/index.ts:92`)

> The inferred type of 'i18n' cannot be named without a reference to '../../node_modules/i18next'.

`createInstance(...)`'s inferred return type referenced `i18next` internal types, breaking portable `.d.ts` emit. Added explicit annotation:

```ts
import { createInstance, type i18n as I18nInstance } from 'i18next';
export const i18n: I18nInstance = createInstance({ ... });
```

### TS2591 — `process` not defined (`packages/backend.ai-ui/src/hooks/useBAILogger.tsx:47`)

BUI's `tsconfig.types` is intentionally `["vite-plugin-svgr/client"]` (no `node` types) because BUI is a browser-only library. The single `process.env.NODE_ENV` read violated that policy. Switched to Vite's first-class env API:

```ts
private enabled: boolean = !import.meta.env.PROD;
```

### TS2339 — `import.meta.env` not typed (follow-up to TS2591 fix)

For `import.meta.env.PROD` to be typed in BUI's dts emit, `vite/client` ambient types had to be wired in. Three coordinated changes:

- `packages/backend.ai-ui/vite-env.d.ts` — added `/// <reference types="vite/client" />`. The file already existed at the package root but was orphaned; included it so it actually gets picked up.
- `packages/backend.ai-ui/tsconfig.json` — added `vite-env.d.ts` to `include`.
- `packages/backend.ai-ui/vite.config.ts` — added `vite-env.d.ts` to the `dts` plugin's own `include` array (separate from `tsconfig.include`; this was the missing piece that made `import.meta.env.PROD` typed in dts emit context).
- `react/src/ambient.d.ts` — added the same reference for the `react/` tsc check (verify.sh) which compiles BUI source through the path alias.

## 2. Module-level `'use memo'` (`react/src/components/SwitchToProjectButton.tsx:1`)

> Module level directives cause errors when bundled, "use memo" in "..." was ignored.

Moved the directive from module level to the inner function body (`SwitchToProjectButtonContent`), matching `.claude/rules/react-compiler-memoization.md` convention. The wrapper component (`SwitchToProjectButton`) renders only Suspense + child and does not need its own memo directive.

## 3. BUI components ↔ hooks circular dependency

Rollup chunk-graph warning:

> Export "ResourceTypeIcon" of module ".../BAIResourceNumberWithIcon.tsx" was reexported through module ".../components/index.ts" while both modules are dependencies of each other...

The actual cycle traced:

```
components/index.ts (barrel)
  ↓ re-exports BAIResourceNumberWithIcon
BAIResourceNumberWithIcon.tsx
  ↓ imports './provider' (provider barrel)
provider barrel
  ↓ exports BAIMetaDataProvider, BAIClientProvider hooks
BAIMetaDataProvider/hooks/useBAIDeviceMetaData.ts:1
BAIClientProvider/hooks/useAnonymousBAIClient.ts:1
BAIMetaDataProvider/types.ts:1
  ↓ each imports from '../../../[..]/hooks' (hooks barrel)
hooks/index.ts:1-5
  ↓ imports value names from '../components'         🔴 cycle closes
```

The cycle was reachable through three back-edges from the `components/provider/...` subtree into the hooks barrel, plus the hooks barrel's own value imports back into the components barrel. Six coordinated edits broke it:

- `BUI/src/hooks/index.ts:1-5` — barrel-to-barrel import replaced with three direct module imports + one `import type` (for the type-only `ResourceSlotName`).
- `BUI/src/hooks/useBAISignedRequestWithPromise.ts:1` — same pattern; barrel → direct module path.
- `BUI/src/components/provider/BAIMetaDataProvider/hooks/useBAIDeviceMetaData.ts:1` — barrel → direct module path on the hooks side.
- `BUI/src/components/provider/BAIClientProvider/hooks/useAnonymousBAIClient.ts:1` — same pattern.
- `BUI/src/components/provider/BAIMetaDataProvider/types.ts:1` — value-style import of a type promoted to `import type`.

Net structural change: the BUI hooks barrel no longer imports anything from the components barrel, and the surviving `provider/* → hooks` edges all go through direct module paths whose target files have no further cycle exposure. Components-subtree files are still free to use the hooks barrel; the dependency arrow is now one-way only.

## Locale Prettier config — fixed parent override (in earlier amend)

`packages/backend.ai-ui/src/locale/.prettierrc` was a per-directory override containing only the JSON-sort plugin, with no other options set. Prettier's config resolution picks the nearest config file and does NOT cascade from parents, so `singleQuote` defaulted to `false` for files in `src/locale/` — including `index.ts`, which kept getting double-quoted whenever lint-staged ran.

Fix: deleted `src/locale/.prettierrc` and moved the JSON-sort options into the parent BUI `.prettierrc.json` as an `overrides` entry scoped to `src/locale/*.json`. The directory now inherits the rest of the BUI Prettier config (including `singleQuote: true`) while retaining the JSON-only sort behavior.

## Verification

- [x] `bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all PASS
- [x] `pnpm run build` — exit 0; the following diagnostics are no longer present in the log:
  - TS2742 (`i18n` portable)
  - TS2591 (`process` not defined)
  - TS2339 (`import.meta.env.PROD` not typed)
  - "Module level directives cause errors" (`'use memo'`)
  - "reexported through ... while both modules are dependencies of each other" (`ResourceTypeIcon` cycle)

Remaining build warnings (5 mixed dynamic+static imports, 2 chunks > 2 MB, several runtime-resolved CSS/manifest assets) are out of scope and tracked separately.

## Stack

Sits on top of #7104 (FR-2606 Monaco self-hosting). Top of the Vite migration follow-up stack.