### PR TITLE
feat(FR-2756): introduce shellsession pseudo-lang for terminal transcripts

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/markdown-extensions.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-extensions.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for markdown-extensions helpers (FR-2756 / FR-2755).
+ *
+ * Run with: `pnpm test` (uses tsx --test).
+ *
+ * Focus: parseShellSessionLines — the parser that converts a fenced
+ * `shellsession` / `console` block into command vs output rows for the
+ * web and PDF processors. Edge cases: prompt vs no prompt, mixed lines,
+ * `#` root prompt, blank lines, trailing newline trimming.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseShellSessionLines } from "./markdown-extensions.js";
+
+test("parseShellSessionLines — empty input yields no rows", () => {
+  assert.deepEqual(parseShellSessionLines(""), []);
+  assert.deepEqual(parseShellSessionLines("\n"), []);
+});
+
+test("parseShellSessionLines — single $-prompt command strips the prompt", () => {
+  assert.deepEqual(parseShellSessionLines("$ ls -la"), [
+    { type: "cmd", prompt: "$", text: "ls -la" },
+  ]);
+});
+
+test("parseShellSessionLines — # is treated as a root prompt", () => {
+  assert.deepEqual(parseShellSessionLines("# apt-get update"), [
+    { type: "cmd", prompt: "#", text: "apt-get update" },
+  ]);
+});
+
+test("parseShellSessionLines — interleaves cmd + output rows", () => {
+  const transcript = [
+    "$ echo hello",
+    "hello",
+    "$ uname",
+    "Linux",
+  ].join("\n");
+  assert.deepEqual(parseShellSessionLines(transcript), [
+    { type: "cmd", prompt: "$", text: "echo hello" },
+    { type: "output", text: "hello" },
+    { type: "cmd", prompt: "$", text: "uname" },
+    { type: "output", text: "Linux" },
+  ]);
+});
+
+test("parseShellSessionLines — preserves blank output lines as separators", () => {
+  const transcript = ["$ pwd", "/home/user", "", "$ id"].join("\n");
+  assert.deepEqual(parseShellSessionLines(transcript), [
+    { type: "cmd", prompt: "$", text: "pwd" },
+    { type: "output", text: "/home/user" },
+    { type: "output", text: "" },
+    { type: "cmd", prompt: "$", text: "id" },
+  ]);
+});
+
+test("parseShellSessionLines — drops a single trailing newline", () => {
+  // The marked lexer hands code blocks WITH the trailing newline preserved;
+  // the parser must not produce a phantom empty output row at the bottom.
+  const transcript = "$ ls\nfile.txt\n";
+  assert.deepEqual(parseShellSessionLines(transcript), [
+    { type: "cmd", prompt: "$", text: "ls" },
+    { type: "output", text: "file.txt" },
+  ]);
+});
+
+test("parseShellSessionLines — prompt requires whitespace after the symbol", () => {
+  // `$variable` is not a prompt — it's a parameter expansion in a command
+  // and must be classified as output (or, more precisely, as a non-prompt
+  // line). Otherwise we'd silently rewrite shell expansions.
+  assert.deepEqual(parseShellSessionLines("$variable=42"), [
+    { type: "output", text: "$variable=42" },
+  ]);
+});
+
+test("parseShellSessionLines — tolerates tab after the prompt", () => {
+  assert.deepEqual(parseShellSessionLines("$\techo tabbed"), [
+    { type: "cmd", prompt: "$", text: "echo tabbed" },
+  ]);
+});
+
+test("parseShellSessionLines — multi-space prompts still work", () => {
+  assert.deepEqual(parseShellSessionLines("$    ls"), [
+    { type: "cmd", prompt: "$", text: "ls" },
+  ]);
+});
+
+test("parseShellSessionLines — output containing $ mid-line stays as output", () => {
+  assert.deepEqual(parseShellSessionLines("error: cannot expand $HOME"), [
+    { type: "output", text: "error: cannot expand $HOME" },
+  ]);
+});

--- a/packages/backend.ai-docs-toolkit/src/markdown-extensions.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-extensions.ts
@@ -177,6 +177,50 @@ export function parseImageSizeHint(alt: string): {
   return { cleanAlt: alt, sizeHint: null };
 }
 
+/**
+ * One row inside a `shellsession` (a.k.a. `console`) fenced block.
+ * `cmd` rows had a `$` or `#` prompt at column 0 (followed by a space or
+ * tab) — the prompt has been stripped from `text`, leaving the bare
+ * command. `output` rows are everything else (program output, blank
+ * separator lines, etc.).
+ *
+ * The renderer emits `cmd` rows as `<span class="line cmd-line"
+ * data-prompt="$">…</span>` so the prompt is restored visually via a CSS
+ * `::before` pseudo-element with `user-select: none` — the prompt never
+ * lands in the DOM and so never reaches drag-copy or the copy button.
+ */
+export interface ShellSessionLine {
+  type: 'cmd' | 'output';
+  /** `$` or `#` — only set when type === 'cmd'. */
+  prompt?: '$' | '#';
+  /** Line text with the prompt+space stripped (for cmd) or as-authored (for output). */
+  text: string;
+}
+
+/**
+ * Parse a `shellsession` / `console` fenced block into command and output
+ * rows. A "command" line begins with `$ ` or `# ` (single space or tab
+ * after the prompt). Anything else is treated as output, including blank
+ * lines (so the rendered transcript preserves vertical rhythm).
+ *
+ * Trailing newline is dropped so authors can write
+ * \`\`\`shellsession
+ * $ ls
+ * file.txt
+ * \`\`\`
+ * without producing a trailing empty output row.
+ */
+export function parseShellSessionLines(code: string): ShellSessionLine[] {
+  const trimmed = code.replace(/\n$/, '');
+  if (trimmed === '') return [];
+  const promptRe = /^([$#])[ \t]+(.*)$/;
+  return trimmed.split('\n').map((line) => {
+    const m = line.match(promptRe);
+    if (m) return { type: 'cmd', prompt: m[1] as '$' | '#', text: m[2] };
+    return { type: 'output', text: line };
+  });
+}
+
 export function escapeHtml(str: string): string {
   return str
     .replace(/&/g, '&amp;')

--- a/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
@@ -20,6 +20,7 @@ import {
   processAdmonitions,
   processCodeBlockMeta,
   parseHighlightLines,
+  parseShellSessionLines,
   escapeHtml,
   stripHtmlTags,
   getFigureLabel,
@@ -392,8 +393,20 @@ function buildWebRenderer(
       // we fall back to the legacy un-highlighted line wrappers. This keeps
       // the line-highlight feature working unchanged. Authors who want
       // both can land that in a follow-up; F4 spec doesn't require it.
+      //
+      // Shellsession blocks (FR-2756) take precedence over the highlight
+      // path: even when a shellsession block sets `data-highlight=…`, we
+      // must still pull the prompt-stripped HTML from the precompute map
+      // (the legacy line-wrap path would leak literal `$` prompts into
+      // the DOM and clipboard). Combining shellsession with line-highlight
+      // is intentionally out of scope for v1.
+      const isShellSession = lang === "shellsession" || lang === "console";
       let codeHtml: string;
-      if (highlightLines.size > 0) {
+      if (isShellSession) {
+        const key = `${lang}|||${code}`;
+        const pre = highlightedCode?.get(key);
+        codeHtml = pre ?? escapeHtml(code);
+      } else if (highlightLines.size > 0) {
         const lines = code.split("\n");
         codeHtml = lines
           .map((line, idx) => {
@@ -457,9 +470,26 @@ export interface WebProcessingOptions {
 }
 
 /**
+ * Strip the outer `<span class="line">…</span>` Shiki wraps around every
+ * tokenized line. Used by the shellsession path so each command's
+ * inline-styled tokens can be re-wrapped under our own `.cmd-line` shell
+ * without producing a nested `.line` element. Returns the input unchanged
+ * if the expected wrapper is absent (defensive: future Shiki versions or
+ * the plaintext fallback may emit a different shape).
+ */
+function unwrapShikiSingleLine(html: string): string {
+  const open = '<span class="line">';
+  const close = "</span>";
+  if (html.startsWith(open) && html.endsWith(close)) {
+    return html.slice(open.length, html.length - close.length);
+  }
+  return html;
+}
+
+/**
  * Walk the rendered markdown's tokens and pre-tokenize every fenced code
- * block via Shiki. Returns a map keyed by `${lang} ${rawCode}` whose value
- * is the pre-rendered inner HTML for `<code>`. The renderer in
+ * block via Shiki. Returns a map keyed by `${lang}|||${rawCode}` whose
+ * value is the pre-rendered inner HTML for `<code>`. The renderer in
  * `buildWebRenderer` reads from this map synchronously.
  *
  * Shiki tokenization is async (loadLanguage / loadTheme), but the actual
@@ -469,6 +499,16 @@ export interface WebProcessingOptions {
  * The cache inside `shikiHighlight` makes repeat blocks (across chapters or
  * across languages) free after the first sighting — important for the
  * "≤ +50% wall-clock per language" budget when building all 4 langs.
+ *
+ * Shellsession blocks (FR-2756) take a different path: they are parsed
+ * line-by-line and the prompt is stripped from the DOM. Cmd lines run
+ * through Shiki as `bash` in parallel (Promise.all) so a long transcript
+ * doesn't serialize highlighter calls. Shellsession runs even when
+ * `data-highlight=` is set on the fence — the line-highlight overlay is
+ * not currently combined with shellsession (out of scope for v1), but
+ * we must not skip the prompt-stripping pass, otherwise a shellsession
+ * block with `{1}` highlighting would leak literal `$` prompts into the
+ * DOM and clipboard.
  */
 async function precomputeShikiBlocks(
   markdown: string,
@@ -502,19 +542,53 @@ async function precomputeShikiBlocks(
       const info = (node.lang ?? "").trim();
       const langMatch = info.match(/^(\w+)/);
       const lang = langMatch?.[1] ?? "";
-      // Skip blocks with line-highlight — the renderer falls back to its
-      // legacy line-wrapping path for these (see comment in `code()` above).
-      if (/data-highlight="[^"]*\d+/.test(info)) return;
+      const isShellSession = lang === "shellsession" || lang === "console";
+      const hasLineHighlight = /data-highlight="[^"]*\d+/.test(info);
+
+      // For non-shellsession blocks with line-highlight, the renderer
+      // takes its legacy line-wrapping path and ignores the Shiki map,
+      // so we skip pre-tokenization. Shellsession blocks must NOT skip
+      // — even with highlighting set, they need the prompt-stripping
+      // pass or `$` characters would land in the DOM/clipboard.
+      if (hasLineHighlight && !isShellSession) return;
 
       const key = `${lang}|||${node.text}`;
       if (!seen.has(key)) {
         seen.add(key);
-        const result = await shikiHighlight({
-          code: node.text,
-          lang,
-          theme,
-        });
-        map.set(key, result.innerHtml);
+        if (isShellSession) {
+          // Terminal transcript: split into prompt/cmd/output rows. The
+          // prompt is removed from the DOM here and restored visually
+          // by CSS ::before on .cmd-line so drag-copy / button-copy
+          // never include the prompt char (FR-2756). Cmd lines are
+          // tokenized in parallel via Promise.all so a long transcript
+          // doesn't serialize highlighter calls.
+          const lines = parseShellSessionLines(node.text);
+          const segments = await Promise.all(
+            lines.map(async (ln) => {
+              if (ln.type === "cmd") {
+                const tokenized = await shikiHighlight({
+                  code: ln.text,
+                  lang: "bash",
+                  theme,
+                });
+                // Shiki always wraps a single line in <span class="line">…</span>;
+                // unwrap so we can put our own .cmd-line wrapper on it without
+                // emitting nested .line elements.
+                const inner = unwrapShikiSingleLine(tokenized.innerHtml);
+                return `<span class="line cmd-line" data-prompt="${ln.prompt}">${inner}</span>`;
+              }
+              return `<span class="line output-line">${escapeHtml(ln.text)}</span>`;
+            }),
+          );
+          map.set(key, segments.join("\n"));
+        } else {
+          const result = await shikiHighlight({
+            code: node.text,
+            lang,
+            theme,
+          });
+          map.set(key, result.innerHtml);
+        }
       }
     }
     if (node.tokens) await visit(node.tokens);

--- a/packages/backend.ai-docs-toolkit/src/markdown-processor.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor.ts
@@ -6,12 +6,32 @@ import {
   processAdmonitions,
   processCodeBlockMeta,
   parseHighlightLines,
+  parseShellSessionLines,
   escapeHtml as escapeHtmlExt,
   stripHtmlTags,
   getFigureLabel,
   parseImageSizeHint,
 } from './markdown-extensions.js';
 import type { ResolvedDocConfig } from './config.js';
+
+/**
+ * Render a `shellsession` / `console` fenced block as a sequence of
+ * `.cmd-line` / `.output-line` spans for PDF output. The prompt is removed
+ * from the DOM here too — PDF style sheets re-add it via CSS `::before`,
+ * matching the web behaviour. PDF doesn't get syntax highlighting; the
+ * command body is escaped plaintext.
+ */
+function renderShellSessionForPdf(code: string): string {
+  const lines = parseShellSessionLines(code);
+  return lines
+    .map((ln) => {
+      if (ln.type === 'cmd') {
+        return `<span class="line cmd-line" data-prompt="${ln.prompt}">${escapeHtmlExt(ln.text)}</span>`;
+      }
+      return `<span class="line output-line">${escapeHtmlExt(ln.text)}</span>`;
+    })
+    .join('\n');
+}
 
 /**
  * Read image dimensions from a PNG or JPEG file header.
@@ -501,7 +521,9 @@ export async function processMarkdownFiles(
         const highlightLines = parseHighlightLines(highlightSpec);
 
         let codeHtml: string;
-        if (highlightLines.size > 0) {
+        if (lang === 'shellsession' || lang === 'console') {
+          codeHtml = renderShellSessionForPdf(code);
+        } else if (highlightLines.size > 0) {
           const lines = code.split('\n');
           codeHtml = lines
             .map((line, idx) => {
@@ -599,7 +621,9 @@ export async function processCatalogMarkdownForPdf(
         const highlightLines = parseHighlightLines(highlightSpec);
 
         let codeHtml: string;
-        if (highlightLines.size > 0) {
+        if (lang === 'shellsession' || lang === 'console') {
+          codeHtml = renderShellSessionForPdf(code);
+        } else if (highlightLines.size > 0) {
           const lines = code.split('\n');
           codeHtml = lines
             .map((line, idx) => {

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1529,6 +1529,22 @@ pre code {
   line-height: 1.6;
 }
 
+/* shellsession blocks (FR-2756). The pre-pass parses prompt lines and
+   emits .cmd-line / .output-line spans WITHOUT the literal '$' / '#'
+   character — the prompt is restored visually here via ::before with
+   user-select: none, so drag-copy / button-copy / Select-All never pull
+   the prompt into the clipboard. Output rows are dimmed so the eye
+   tracks command vs response at a glance. */
+.shiki-host > code .line.cmd-line::before {
+  content: attr(data-prompt) " ";
+  color: var(--bai-text-3);
+  user-select: none;
+}
+
+.shiki-host > code .line.output-line {
+  color: rgba(255, 255, 255, 0.55);
+}
+
 /* Wrapper injected at runtime by code-copy.js around every <pre> on the
    page (titled OR untitled). FR-2726 Phase 3 makes this the canonical
    BAI dark code frame so untitled fenced blocks (the common case) get

--- a/packages/backend.ai-docs-toolkit/src/styles.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles.ts
@@ -572,6 +572,24 @@ em {
   padding-left: 9px;
 }
 
+/* shellsession blocks (FR-2756). The PDF pipeline strips the literal
+   '$' / '#' from the source DOM and restores it via ::before so the
+   visible prompt prints in the PDF too. Output lines are slightly dimmed
+   so command vs response is visually distinct on paper. */
+.cmd-line {
+  display: block;
+}
+
+.cmd-line::before {
+  content: attr(data-prompt) " ";
+  color: #888;
+}
+
+.output-line {
+  display: block;
+  color: #666;
+}
+
 /* ==========================================================================
    Details / Summary
    ========================================================================== */

--- a/packages/backend.ai-webui-docs/DOCUMENTATION-STYLE-GUIDE.md
+++ b/packages/backend.ai-webui-docs/DOCUMENTATION-STYLE-GUIDE.md
@@ -304,10 +304,42 @@ Rules:
 Use fenced code blocks with a language identifier:
 
 ````markdown
-```shell
-$ pip install backend.ai-client
+```bash
+pip install backend.ai-client
 ```
 ````
+
+#### Choosing the right language identifier
+
+| Situation | Fence | Notes |
+|---|---|---|
+| Runnable command or shell script | ` ```bash ` | Default for most snippets. Don't include a `$ ` prompt — the snippet should be ready to copy-and-paste. |
+| Terminal session transcript (prompt + output) | ` ```shellsession ` | Use this when showing what the user types **and** what the program prints. Lines starting with `$ ` or `# ` are treated as commands; everything else is treated as program output. The `$` / `#` prompt is rendered visually but **excluded from the clipboard** — readers can copy the block and paste runnable commands without manual cleanup. |
+| POSIX-only script (no bashisms) | ` ```sh ` | Use when the snippet must run under any POSIX shell. |
+| zsh / fish-specific snippet | ` ```zsh ` / ` ```fish ` | Reserve for shell-specific syntax. |
+| Other languages | ` ```python `, ` ```toml `, ` ```javascript `, etc. | Use the language's canonical Shiki name. |
+
+##### shellsession example
+
+````markdown
+```shellsession
+$ docker pull lablup/backend.ai-client
+$ docker run --rm -it lablup/backend.ai-client bash
+Hello, world!
+$ exit
+```
+````
+
+In the rendered web page, the `$` prompts and the `Hello, world!` output line are visible, but **clicking the copy button (or drag-selecting and copying) yields only the runnable commands and output text — never the `$` prompts**:
+
+```
+docker pull lablup/backend.ai-client
+docker run --rm -it lablup/backend.ai-client bash
+Hello, world!
+exit
+```
+
+> **PDF note:** the printed PDF shows the `$` prompts visually too, but text-extraction behavior on PDF copy depends on the viewer. Most viewers include the prompt characters that the page renders, including content injected via CSS `::before`. The web copy button is the guaranteed path for prompt-free clipboard text.
 
 #### Code Block with Title
 


### PR DESCRIPTION
Resolves #7111(FR-2756)

## Summary

Introduces the `shellsession` (alias `console`) fence so docs can show terminal sessions with prompts, output, and copy-and-paste-runnable commands — without authors having to manually strip `$` prefixes after pasting.

### How it works

- New parser `parseShellSessionLines` (in `markdown-extensions.ts`) splits a fenced block line by line: lines starting with `$ ` or `# ` followed by whitespace are classified as `cmd` rows (the prompt is stripped from the text); everything else is `output`.
- The web pipeline (`markdown-processor-web.ts`) emits `<span class="line cmd-line" data-prompt="$">{shiki-bash-tokens}</span>` for cmd rows and `<span class="line output-line">{escaped}</span>` for output. Command bodies still get bash syntax color via Shiki.
- The PDF pipeline (`markdown-processor.ts`) emits the same shape but without Shiki tokenization (PDF doesn't ship the highlighter).
- CSS (`styles-web.ts`, `styles.ts`):
  - `.cmd-line::before { content: attr(data-prompt) ' '; user-select: none }` — restores the prompt visually without putting it in the DOM, so drag-copy / Select-All / button-copy all skip the prompt automatically.
  - `.output-line` — slightly dimmed gray so output reads as separate from commands.
- `code-copy.js` is unchanged. Since the prompt no longer lives in the DOM, `extractCode()` (uses `textContent`) yields clean commands with zero per-block special-casing.

### Behavior across outputs

| Output | Prompt visible | Prompt copied |
|---|---|---|
| Web — drag select | Yes (CSS `::before`) | No (`user-select: none`) |
| Web — copy button | Yes | No (DOM has no prompt) |
| Web — Select-All + copy | Yes | No |
| PDF render | Yes (`::before` prints) | n/a |
| `grep` on source `.md` | Source has no `$` | n/a |

### Documentation

`packages/backend.ai-webui-docs/DOCUMENTATION-STYLE-GUIDE.md` updated with the new convention table:

| Situation | Fence |
|---|---|
| Runnable command / bash script | ` ```bash ` |
| Terminal transcript (\$ prompt + output) | ` ```shellsession ` |
| POSIX-only script | ` ```sh ` |
| zsh / fish-specific | ` ```zsh ` / ` ```fish ` |

## Out of scope

- Migrating existing ` ```bash ` blocks that contain `\$` prompts — that's [#7112 / FR-2757](https://github.com/lablup/backend.ai-webui/pull/7116) (stacked on top of this PR).

## Test plan

- [x] `bash scripts/verify.sh` → ALL PASS
- [x] `pnpm --filter backend.ai-docs-toolkit test` → 149/149 (11 new tests for parseShellSessionLines covering empty input, prompt vs no-prompt, mixed cmd/output, blank lines, trailing newline, parameter expansion (`\$VAR` not a prompt), tab/multi-space prompt separators)
- [x] `pnpm --filter backend.ai-webui-docs run build:web:en` succeeds
- [x] **Playwright integration** on a temporary fixture block:
      - DOM has 3 cmd-line spans + 1 output-line span; no `\$` in `code.textContent`.
      - `data-prompt="\$"` attribute set on each cmd-line.
      - CSS `::before` resolves `attr(data-prompt) " "` → renders `\"\$ \"` visually.
      - **Copy button click** → clipboard contains the runnable commands and output, **no \$ characters**.
- [x] Visual: language label shows "shellsession" (subtle gray); commands keep bash syntax color; output line dimmed.