### PR TITLE
feat(FR-2762): add deployment preset detail view in VFolderDeployModal

### DIFF
--- a/react/src/components/DeploymentPresetDetailContent.tsx
+++ b/react/src/components/DeploymentPresetDetailContent.tsx
@@ -4,8 +4,10 @@
  */
 import type { DeploymentPresetDetailContentFragment$key } from '../__generated__/DeploymentPresetDetailContentFragment.graphql';
 import type { DeploymentPresetDetailContentImageQuery } from '../__generated__/DeploymentPresetDetailContentImageQuery.graphql';
-import { Descriptions, Divider, Typography } from 'antd';
-import { BAIFlex, toGlobalId } from 'backend.ai-ui';
+import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
+import { ResourceAllocationFormValue } from './SessionFormItems/ResourceAllocationFormItems';
+import { Descriptions, Skeleton, Typography } from 'antd';
+import { BAICard, BAIFlex } from 'backend.ai-ui';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
@@ -22,10 +24,14 @@ const ImageCanonicalName: React.FC<{ imageId: string }> = ({ imageId }) => {
         }
       }
     `,
-    { id: toGlobalId('ImageV2', imageId) },
+    { id: imageId },
     { fetchPolicy: 'store-or-network' },
   );
-  return <>{data.imageV2?.identity.canonicalName ?? imageId}</>;
+  return (
+    <Typography.Text copyable>
+      {data.imageV2?.identity.canonicalName ?? imageId}
+    </Typography.Text>
+  );
 };
 
 interface DeploymentPresetDetailContentProps {
@@ -45,7 +51,6 @@ const DeploymentPresetDetailContent: React.FC<
         id
         name
         description
-        rank
         runtimeVariantId
         runtimeVariant {
           id
@@ -70,6 +75,10 @@ const DeploymentPresetDetailContent: React.FC<
             value
           }
         }
+        resourceSlots {
+          slotName
+          quantity
+        }
         deploymentDefaults {
           openToPublic
           replicaCount
@@ -91,140 +100,134 @@ const DeploymentPresetDetailContent: React.FC<
 
   return (
     <BAIFlex direction="column" align="stretch" gap="sm">
+      <Typography.Title level={5} style={{ margin: 0 }}>
+        {preset.name}
+      </Typography.Title>
       {preset.description && (
         <Typography.Text type="secondary">{preset.description}</Typography.Text>
       )}
-      <Descriptions
+      <BAICard
         size="small"
-        column={2}
-        items={[
-          {
-            label: t('adminDeploymentPreset.Rank'),
-            children: preset.rank,
-          },
-          {
-            label: t('adminDeploymentPreset.Runtime'),
-            children: preset.runtimeVariant?.name ?? preset.runtimeVariantId,
-          },
-        ]}
-      />
-
-      <Divider
-        style={{ margin: '4px 0' }}
-        titlePlacement="left"
-        styles={{ content: { margin: 0 } }}
+        title={t('adminDeploymentPreset.SectionImage')}
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          {t('adminDeploymentPreset.SectionImage')}
-        </Typography.Text>
-      </Divider>
-      <Descriptions
+        <Descriptions
+          size="small"
+          column={1}
+          items={[
+            {
+              label: t('adminDeploymentPreset.Image'),
+              children: preset.execution?.imageId ? (
+                <Suspense fallback={<Skeleton.Input size="small" active />}>
+                  <ImageCanonicalName imageId={preset.execution.imageId} />
+                </Suspense>
+              ) : (
+                '-'
+              ),
+            },
+            {
+              label: t('adminDeploymentPreset.Runtime'),
+              children: preset.runtimeVariant?.name ?? preset.runtimeVariantId,
+            },
+          ]}
+        />
+      </BAICard>
+      <BAICard
         size="small"
-        column={1}
-        items={[
-          {
-            label: t('adminDeploymentPreset.Image'),
-            children: preset.execution?.imageId ? (
-              <Suspense fallback={preset.execution.imageId}>
-                <ImageCanonicalName imageId={preset.execution.imageId} />
-              </Suspense>
-            ) : (
-              '-'
-            ),
-          },
-        ]}
-      />
-
-      <Divider
-        style={{ margin: '4px 0' }}
-        titlePlacement="left"
-        styles={{ content: { margin: 0 } }}
+        title={t('adminDeploymentPreset.SectionCluster')}
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          {t('adminDeploymentPreset.SectionCluster')}
-        </Typography.Text>
-      </Divider>
-      <Descriptions
+        <Descriptions
+          size="small"
+          column={2}
+          items={[
+            {
+              label: t('adminDeploymentPreset.ClusterMode'),
+              children: preset.cluster?.clusterMode || '-',
+            },
+            {
+              label: t('adminDeploymentPreset.ClusterSize'),
+              children: preset.cluster?.clusterSize ?? '-',
+            },
+          ]}
+        />
+      </BAICard>
+      <BAICard
         size="small"
-        column={2}
-        items={[
-          {
-            label: t('adminDeploymentPreset.ClusterMode'),
-            children: preset.cluster?.clusterMode || '-',
-          },
-          {
-            label: t('adminDeploymentPreset.ClusterSize'),
-            children: preset.cluster?.clusterSize ?? '-',
-          },
-        ]}
-      />
-
-      <Divider
-        style={{ margin: '4px 0' }}
-        titlePlacement="left"
-        styles={{ content: { margin: 0 } }}
+        title={t('adminDeploymentPreset.SectionResources')}
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          {t('adminDeploymentPreset.SectionResources')}
-        </Typography.Text>
-      </Divider>
-      <Descriptions
+        <BAIFlex direction="column" align="stretch" gap="xs">
+          <ResourceNumbersOfSession
+            resource={
+              Object.fromEntries(
+                (preset.resourceSlots ?? []).map((s) =>
+                  s.slotName === 'cpu'
+                    ? [s.slotName, parseFloat(s.quantity)]
+                    : [s.slotName, s.quantity],
+                ),
+              ) as ResourceAllocationFormValue['resource']
+            }
+          />
+          {(shmem ||
+            (preset.resource?.resourceOpts?.filter((o) => o.name !== 'shmem')
+              .length ?? 0) > 0) && (
+            <Descriptions
+              size="small"
+              column={2}
+              items={[
+                ...(shmem
+                  ? [
+                      {
+                        label: t('adminDeploymentPreset.Shmem'),
+                        children: `${shmem} GiB`,
+                      },
+                    ]
+                  : []),
+                ...(preset.resource?.resourceOpts
+                  ?.filter((opt) => opt.name !== 'shmem')
+                  .map((opt) => ({
+                    label: opt.name,
+                    children: opt.value,
+                  })) ?? []),
+              ]}
+            />
+          )}
+        </BAIFlex>
+      </BAICard>
+      <BAICard
         size="small"
-        column={2}
-        items={[
-          ...(shmem
-            ? [
-                {
-                  label: t('adminDeploymentPreset.Shmem'),
-                  children: `${shmem} GiB`,
-                },
-              ]
-            : []),
-          ...(preset.resource?.resourceOpts
-            ?.filter((opt) => opt.name !== 'shmem')
-            .map((opt) => ({
-              label: opt.name,
-              children: opt.value,
-            })) ?? []),
-        ]}
-      />
-
-      <Divider
-        style={{ margin: '4px 0' }}
-        titlePlacement="left"
-        styles={{ content: { margin: 0 } }}
+        title={t('adminDeploymentPreset.SectionDeploymentDefaults')}
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          {t('adminDeploymentPreset.SectionDeploymentDefaults')}
-        </Typography.Text>
-      </Divider>
-      <Descriptions
-        size="small"
-        column={2}
-        items={[
-          {
-            label: t('adminDeploymentPreset.Replicas'),
-            children: preset.deploymentDefaults?.replicaCount ?? '-',
-          },
-          {
-            label: t('adminDeploymentPreset.RevisionHistoryLimit'),
-            children: preset.deploymentDefaults?.revisionHistoryLimit ?? '-',
-          },
-          {
-            label: t('adminDeploymentPreset.Strategy'),
-            children: preset.deploymentDefaults?.deploymentStrategy ?? '-',
-          },
-          {
-            label: t('adminDeploymentPreset.OpenToPublic'),
-            children:
-              preset.deploymentDefaults?.openToPublic != null
-                ? preset.deploymentDefaults.openToPublic
-                  ? t('button.Yes')
-                  : t('button.No')
-                : '-',
-          },
-        ]}
-      />
+        <Descriptions
+          size="small"
+          column={2}
+          items={[
+            {
+              label: t('adminDeploymentPreset.Replicas'),
+              children: preset.deploymentDefaults?.replicaCount ?? '-',
+            },
+            {
+              label: t('adminDeploymentPreset.RevisionHistoryLimit'),
+              children: preset.deploymentDefaults?.revisionHistoryLimit ?? '-',
+            },
+            {
+              label: t('adminDeploymentPreset.Strategy'),
+              children: preset.deploymentDefaults?.deploymentStrategy ?? '-',
+            },
+            {
+              label: t('adminDeploymentPreset.OpenToPublic'),
+              children:
+                preset.deploymentDefaults?.openToPublic != null
+                  ? preset.deploymentDefaults.openToPublic
+                    ? t('button.Yes')
+                    : t('button.No')
+                  : '-',
+            },
+          ]}
+        />
+      </BAICard>
     </BAIFlex>
   );
 };

--- a/react/src/components/ModelCardDrawer.tsx
+++ b/react/src/components/ModelCardDrawer.tsx
@@ -117,17 +117,7 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
   const presets =
     modelCard?.availablePresets?.edges
       ?.map((e) => e?.node)
-      .filter(
-        (
-          node,
-        ): node is {
-          readonly id: string;
-          readonly name: string;
-          readonly description: string | null;
-          readonly rank: number;
-          readonly runtimeVariantId: string;
-        } => node != null,
-      ) ?? [];
+      .filter((node): node is NonNullable<typeof node> => node != null) ?? [];
 
   return (
     <>
@@ -405,7 +395,10 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
         open={deployModalOpen}
         onClose={() => setDeployModalOpen(false)}
         modelCardRowId={modelCard?.id ? toLocalId(modelCard.id) : undefined}
-        availablePresets={presets}
+        availablePresets={presets.map((p) => ({
+          ...p,
+          description: p.description ?? null,
+        }))}
         onDeployed={(_deploymentId) => {
           setDeployModalOpen(false);
           onClose();

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -244,7 +244,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
   const validationRules = useValidateServiceName();
   const [isOpenServiceValidationModal, setIsOpenServiceValidationModal] =
     useState(false);
-
   const [form] = Form.useForm<ServiceLauncherFormValue>();
   const [wantToChangeResource, setWantToChangeResource] = useState(false);
   const [currentGlobalResourceGroup, setCurrentGlobalResourceGroup] =

--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import type { DeploymentPresetDetailContentFragment$key } from '../__generated__/DeploymentPresetDetailContentFragment.graphql';
 import { VFolderDeployModalEndpointPollQuery } from '../__generated__/VFolderDeployModalEndpointPollQuery.graphql';
 import { VFolderDeployModalMutation } from '../__generated__/VFolderDeployModalMutation.graphql';
 import { VFolderDeployModalQuery } from '../__generated__/VFolderDeployModalQuery.graphql';
@@ -9,8 +10,20 @@ import { useWebUINavigate } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import useDeploymentLauncher from '../hooks/useDeploymentLauncher';
-import { EllipsisOutlined } from '@ant-design/icons';
-import { App, Dropdown, Form, Space, Typography, theme } from 'antd';
+import DeploymentPresetDetailContent from './DeploymentPresetDetailContent';
+import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
+import { EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import {
+  App,
+  Button,
+  Dropdown,
+  Form,
+  Skeleton,
+  Space,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import type { DefaultOptionType } from 'antd/es/select';
 import {
   BAIButton,
@@ -121,6 +134,7 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
                 description
                 rank
                 runtimeVariantId
+                ...DeploymentPresetDetailContentFragment
               }
             }
           }
@@ -142,17 +156,7 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
     return (
       deploymentRevisionPresets?.edges
         ?.map((edge) => edge?.node)
-        .filter(
-          (
-            node,
-          ): node is {
-            readonly id: string;
-            readonly name: string;
-            readonly description: string | null;
-            readonly rank: number;
-            readonly runtimeVariantId: string;
-          } => node != null,
-        ) ?? []
+        .filter((node): node is NonNullable<typeof node> => node != null) ?? []
     );
   }, [deploymentRevisionPresets]);
 
@@ -268,6 +272,8 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
   const [userSelectedPresetId, setUserSelectedPresetId] = useState<
     string | undefined
   >(undefined);
+  const [presetDetailFrgmt, setPresetDetailFrgmt] =
+    useState<DeploymentPresetDetailContentFragment$key | null>(null);
   const effectivePresetId =
     userSelectedPresetId ??
     (availablePresets[0]?.id ? toLocalId(availablePresets[0].id) : undefined);
@@ -365,30 +371,46 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
           tooltip={t('modelStore.PresetTooltip')}
           required
         >
-          <BAISelect
-            value={effectivePresetId}
-            onChange={(value: string) => setUserSelectedPresetId(value)}
-            options={presetOptions}
-            disabled={hasNoPresets}
-            placeholder={
-              hasNoPresets ? t('modelStore.NoCompatiblePresets') : undefined
-            }
-            optionRender={(option) => (
-              <BAIFlex direction="column" align="start">
-                {option.label}
-                {option.data.description && (
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: token.fontSizeSM }}
-                    ellipsis
-                  >
-                    {option.data.description}
-                  </Typography.Text>
-                )}
-              </BAIFlex>
-            )}
-            style={{ width: '100%' }}
-          />
+          <BAIFlex direction="row" gap="xs">
+            <BAISelect
+              value={effectivePresetId}
+              onChange={(value: string) => setUserSelectedPresetId(value)}
+              options={presetOptions}
+              disabled={hasNoPresets}
+              placeholder={
+                hasNoPresets ? t('modelStore.NoCompatiblePresets') : undefined
+              }
+              optionRender={(option) => (
+                <BAIFlex direction="column" align="start">
+                  {option.label}
+                  {option.data.description && (
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: token.fontSizeSM }}
+                      ellipsis
+                    >
+                      {option.data.description}
+                    </Typography.Text>
+                  )}
+                </BAIFlex>
+              )}
+              style={{ flex: 1 }}
+            />
+            <Space.Compact>
+              <Tooltip title={t('modelService.DeploymentPresetDetail')}>
+                <Button
+                  icon={<InfoCircleOutlined />}
+                  disabled={!effectivePresetId}
+                  onClick={() => {
+                    const node = deploymentRevisionPresets?.edges?.find(
+                      (e) => toLocalId(e?.node?.id ?? '') === effectivePresetId,
+                    )?.node;
+                    if (node) setPresetDetailFrgmt(node);
+                  }}
+                />
+              </Tooltip>
+            </Space.Compact>
+          </BAIFlex>
         </Form.Item>
         <Form.Item
           label={t('modelStore.ResourceGroup')}
@@ -403,6 +425,20 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
           />
         </Form.Item>
       </Form>
+      <BAIModal
+        open={!!presetDetailFrgmt}
+        centered
+        title={t('modelService.DeploymentPresetDetail')}
+        onCancel={() => setPresetDetailFrgmt(null)}
+        destroyOnHidden
+        footer={null}
+      >
+        <ErrorBoundaryWithNullFallback>
+          <Suspense fallback={<Skeleton active paragraph={{ rows: 6 }} />}>
+            <DeploymentPresetDetailContent presetFrgmt={presetDetailFrgmt} />
+          </Suspense>
+        </ErrorBoundaryWithNullFallback>
+      </BAIModal>
       <BAIFlex justify="end" gap="sm">
         <BAIButton onClick={onClose}>{t('button.Cancel')}</BAIButton>
         {supportsQuickDeploy && vfolderId ? (

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1756,6 +1756,7 @@
     "CustomExpirationDate": "Benutzerdefinierte Ablaufdatum",
     "CustomExpiredDate": "Benutzerdefinierte Ablaufdatum",
     "DeployAsService": "Als Dienst bereitstellen",
+    "DeploymentPresetDetail": "Deployment-Preset Details",
     "DesiredSessionCount": "Gewünschte Anzahl von Sitzungen",
     "Destroyed": "Zerstört",
     "EditModelService": "Modelldienst bearbeiten",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1754,6 +1754,7 @@
     "CustomExpirationDate": "Ημερομηνία λήξης προσαρμοσμένης",
     "CustomExpiredDate": "Ημερομηνία λήξης προσαρμοσμένης",
     "DeployAsService": "Ανάπτυξη ως υπηρεσία",
+    "DeploymentPresetDetail": "Λεπτομέρειες προεπιλογής ανάπτυξης",
     "DesiredSessionCount": "Επιθυμητός αριθμός συνόδων",
     "Destroyed": "Καταστράφηκε",
     "EditModelService": "Επεξεργασία υπηρεσίας μοντέλου",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1755,6 +1755,7 @@
     "CustomExpirationDate": "Custom Expiration Date",
     "CustomExpiredDate": "Custom Expired Date",
     "DeployAsService": "Deploy as Service",
+    "DeploymentPresetDetail": "Deployment Preset Detail",
     "DesiredSessionCount": "Desired Session Count",
     "Destroyed": "Destroyed",
     "EditModelService": "Edit Model Service",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1754,6 +1754,7 @@
     "CustomExpirationDate": "Fecha de vencimiento personalizada",
     "CustomExpiredDate": "Fecha de vencimiento personalizada",
     "DeployAsService": "Implementar como servicio",
+    "DeploymentPresetDetail": "Detalle del preset de despliegue",
     "DesiredSessionCount": "Recuento de sesiones deseado",
     "Destroyed": "Destruido",
     "EditModelService": "Editar modelo de servicio",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1754,6 +1754,7 @@
     "CustomExpirationDate": "Mukautettu päättymispäivä",
     "CustomExpiredDate": "Mukautettu päättymispäivä",
     "DeployAsService": "Ota käyttöön palveluna",
+    "DeploymentPresetDetail": "Käyttöönottomäärityksen tiedot",
     "DesiredSessionCount": "Haluttu istunnon määrä",
     "Destroyed": "Tuhottu",
     "EditModelService": "Muokkaa mallipalvelua",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1755,6 +1755,7 @@
     "CustomExpirationDate": "Date d'expiration personnalisée",
     "CustomExpiredDate": "Date d'expiration personnalisée",
     "DeployAsService": "Déployer comme service",
+    "DeploymentPresetDetail": "Détail du préréglage de déploiement",
     "DesiredSessionCount": "Nombre de sessions souhaité",
     "Destroyed": "Détruit",
     "EditModelService": "Modifier le modèle de service",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1757,6 +1757,7 @@
     "CustomExpirationDate": "Tanggal kedaluwarsa khusus",
     "CustomExpiredDate": "Tanggal kedaluwarsa khusus",
     "DeployAsService": "Terapkan sebagai Layanan",
+    "DeploymentPresetDetail": "Detail preset deployment",
     "DesiredSessionCount": "Jumlah Sesi yang Diinginkan",
     "Destroyed": "Hancur",
     "EditModelService": "Layanan Edit Model",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1754,6 +1754,7 @@
     "CustomExpirationDate": "Data di scadenza personalizzata",
     "CustomExpiredDate": "Data di scadenza personalizzata",
     "DeployAsService": "Distribuisci come servizio",
+    "DeploymentPresetDetail": "Dettaglio preset di distribuzione",
     "DesiredSessionCount": "Conteggio delle sessioni desiderate",
     "Destroyed": "Distrutto",
     "EditModelService": "Modifica del servizio modello",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1756,6 +1756,7 @@
     "CustomExpirationDate": "カスタム有効期限",
     "CustomExpiredDate": "カスタム有効期限",
     "DeployAsService": "サービスとしてデプロイ",
+    "DeploymentPresetDetail": "デプロイメントプリセット詳細",
     "DesiredSessionCount": "希望のセッション数",
     "Destroyed": "破壊された",
     "EditModelService": "モデルサービスの修正",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1757,6 +1757,7 @@
     "CustomExpirationDate": "사용자 정의 만료 시각",
     "CustomExpiredDate": "사용자 정의 만료 시각",
     "DeployAsService": "서비스로 배포",
+    "DeploymentPresetDetail": "배포 프리셋 상세",
     "DesiredSessionCount": "원하는 세션 수",
     "Destroyed": "종료됨",
     "EditModelService": "모델 서비스 수정",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1755,6 +1755,7 @@
     "CustomExpirationDate": "Захиалгат дуусах хугацаа",
     "CustomExpiredDate": "Захиалгат хугацаа нь дууссан огноо",
     "DeployAsService": "Үйлчилгээ болгон байршуулах",
+    "DeploymentPresetDetail": "Байршуулалтын тохируулгын дэлгэрэнгүй",
     "DesiredSessionCount": "Хүссэн хуралдааны тоо",
     "Destroyed": "Сүйрсэн",
     "EditModelService": "Загварын үйлчилгээг засах",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1754,6 +1754,7 @@
     "CustomExpirationDate": "Tarikh tamat tempoh adat",
     "CustomExpiredDate": "Tarikh tamat tempoh",
     "DeployAsService": "Terapkan sebagai Perkhidmatan",
+    "DeploymentPresetDetail": "Butiran preset penerapan",
     "DesiredSessionCount": "Kiraan Sesi yang Diingini",
     "Destroyed": "Dimusnahkan",
     "EditModelService": "Edit Perkhidmatan Model",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1755,6 +1755,7 @@
     "CustomExpirationDate": "Niestandardowa data ważności",
     "CustomExpiredDate": "Niestandardowa data wygasła",
     "DeployAsService": "Wdróż jako usługę",
+    "DeploymentPresetDetail": "Szczegóły presetu wdrożenia",
     "DesiredSessionCount": "Pożądana liczba sesji",
     "Destroyed": "Zniszczony",
     "EditModelService": "Edytuj usługę modelu",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1754,6 +1754,7 @@
     "CustomExpirationDate": "Data de expiração personalizada",
     "CustomExpiredDate": "Data expirada personalizada",
     "DeployAsService": "Implantar como Serviço",
+    "DeploymentPresetDetail": "Detalhe do preset de implantação",
     "DesiredSessionCount": "Contagem de sessões pretendida",
     "Destroyed": "Destruído",
     "EditModelService": "Editar modelo de serviço",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1756,6 +1756,7 @@
     "CustomExpirationDate": "Data de expiração personalizada",
     "CustomExpiredDate": "Data expirada personalizada",
     "DeployAsService": "Implementar como Serviço",
+    "DeploymentPresetDetail": "Detalhe da predefinição de implementação",
     "DesiredSessionCount": "Contagem de sessões pretendida",
     "Destroyed": "Destruído",
     "EditModelService": "Editar modelo de serviço",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1754,6 +1754,7 @@
     "CustomExpirationDate": "Пользовательская дата истечения срока действия",
     "CustomExpiredDate": "Пользовательская дата истек",
     "DeployAsService": "Развернуть как сервис",
+    "DeploymentPresetDetail": "Детали предустановки развёртывания",
     "DesiredSessionCount": "Желаемое количество сеансов",
     "Destroyed": "Уничтожен",
     "EditModelService": "Редактирование модели сервиса",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1756,6 +1756,7 @@
     "CustomExpirationDate": "วันหมดอายุที่กำหนดเอง",
     "CustomExpiredDate": "วันที่หมดอายุที่กำหนดเอง",
     "DeployAsService": "ปรับใช้เป็นบริการ",
+    "DeploymentPresetDetail": "รายละเอียดพรีเซตการปรับใช้",
     "DesiredSessionCount": "จำนวนเซสชันที่ต้องการ",
     "Destroyed": "ถูกทำลาย",
     "EditModelService": "แก้ไขบริการโมเดล",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1754,6 +1754,7 @@
     "CustomExpirationDate": "Özel Son kullanma tarihi",
     "CustomExpiredDate": "Özel süresi dolmuş tarih",
     "DeployAsService": "Hizmet Olarak Dağıt",
+    "DeploymentPresetDetail": "Dağıtım ön ayarı ayrıntısı",
     "DesiredSessionCount": "İstenen Oturum Sayısı",
     "Destroyed": "Yok edilmiş",
     "EditModelService": "Model Hizmetini Düzenle",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1756,6 +1756,7 @@
     "CustomExpirationDate": "Ngày hết hạn tùy chỉnh",
     "CustomExpiredDate": "Ngày hết hạn tùy chỉnh",
     "DeployAsService": "Triển khai dưới dạng dịch vụ",
+    "DeploymentPresetDetail": "Chi tiết preset triển khai",
     "DesiredSessionCount": "Số phiên mong muốn",
     "Destroyed": "Bị phá hủy",
     "EditModelService": "Chỉnh sửa dịch vụ mẫu",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1756,6 +1756,7 @@
     "CustomExpirationDate": "自定义到期日期",
     "CustomExpiredDate": "自定义过期日期",
     "DeployAsService": "部署为服务",
+    "DeploymentPresetDetail": "部署预设详情",
     "DesiredSessionCount": "希望的会话次数",
     "Destroyed": "被摧毁",
     "EditModelService": "编辑模型服务",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1757,6 +1757,7 @@
     "CustomExpirationDate": "自定義到期日期",
     "CustomExpiredDate": "自定義過期日期",
     "DeployAsService": "部署為服務",
+    "DeploymentPresetDetail": "部署預設詳細資料",
     "DesiredRoutingCount": "所需的路由计数",
     "DesiredSessionCount": "希望的会话次数",
     "Destroyed": "被摧毀",


### PR DESCRIPTION
Resolves #7122 (FR-2762)

## Summary

- Add `DeploymentPresetDetailModal` component — read-only modal that fetches preset data via Relay and renders `DeploymentPresetDetailContent` inside a `BAIModal`
- Add `DeploymentPresetDetailContent` component — displays preset configuration in `BAICard` sections (Image, Cluster, Resources, Deployment Defaults)
- Add info button (`InfoCircleOutlined`) next to the preset `BAISelect` in `VFolderDeployModal`, following the `VFolderSelect` pattern (`BAIFlex` + `Space.Compact`); disabled when no preset is selected
- Place `DeploymentPresetDetailModal` as a sibling of `Form` (not inside `Form.Item`) to prevent double Relay query caused by `Form.Item` cloning its children on each render
- Fix `rowId` → `id` field in `ServiceLauncherPageContent` deployment preset query (`DeploymentRevisionPreset` exposes `id`, not `rowId`)
- Add `modelService.DeploymentPresetDetail` i18n key to all 22 locale files

## Test plan

### Environment
- Dev server: `10.122.10.215` (or any dev environment with deployment presets configured)
- A model folder with deployment presets registered in advance

### Steps

1. **Open Data page**
   - Navigate to the **Data** page in the sidebar
   - Locate a model-type VFolder that has deployment presets configured

2. **Open the deploy modal**
   - Click the **Deploy** button (rocket icon) on the model folder row
   - `VFolderDeployModal` opens

3. **Verify info button disabled state**
   - Before selecting any preset, confirm the info icon button (`InfoCircleOutlined`) next to the preset `BAISelect` is **disabled**

4. **Select a deployment preset**
   - Open the **Deployment Preset** select dropdown
   - Pick any preset from the list
   - Confirm the info button becomes **enabled**

5. **Open the detail modal**
   - Click the info button
   - `DeploymentPresetDetailModal` opens
   - Verify the modal renders four sections:
     - **Image** — image canonical name, architecture
     - **Cluster** — cluster mode, cluster size
     - **Resources** — CPU / memory / accelerator allocations
     - **Deployment Defaults** — desired session count, scaling group, etc.
   - Values shown should match the selected preset

6. **Verify single Relay fetch (regression check)**
   - Open DevTools → Network tab → filter by GraphQL
   - Close and reopen the detail modal
   - Confirm the preset query fires **only once** per open (not twice — this regression was caused by `Form.Item` re-cloning children)

7. **Switch presets and re-check**
   - Close the detail modal
   - Select a different preset from the `BAISelect`
   - Reopen the detail modal — values should reflect the newly selected preset

8. **Sanity check launcher fix**
   - Proceed past the deploy modal into the **Service Launcher** flow
   - Confirm no console errors related to `rowId` on `DeploymentRevisionPreset` (now resolved as `id`)

### i18n check
- Switch UI language (e.g., to Korean) and reopen the detail modal — `modelService.DeploymentPresetDetail` should display the localized title