### PR TITLE
docs(FR-2764): update authoring guides for shellsession/bash conventions and inline-comment localization

### DIFF
--- a/packages/backend.ai-webui-docs/CLAUDE.md
+++ b/packages/backend.ai-webui-docs/CLAUDE.md
@@ -84,3 +84,11 @@ Read these before writing or editing documentation:
 - Check `resources/i18n/{lang}.json` in the main project for actual UI label translations
 - Images are shared naming across languages: `![](images/filename.png)`
 - Keep all 4 language versions structurally identical
+
+### Code blocks (cheat sheet)
+
+- ` ```bash ` for runnable commands. **No** decorative `$ ` prefix; the snippet must be ready to copy-and-paste.
+- ` ```shellsession ` for terminal *transcripts* (commands + program output / nested prompts). The toolkit hides the `$` / `#` from the clipboard automatically.
+- Avoid unquoted `<placeholder>` in a bash block — bash parses `<` as input redirection unless it is quoted, even in the middle of a token. Use `${VARIABLE}` (with an `export VAR="<placeholder>"` companion) or quote the placeholder.
+- **Translate inline `# …` comments inside code blocks** to the locale's language. The shell command itself stays unchanged.
+- See `DOCUMENTATION-STYLE-GUIDE.md` → "Code Blocks" for the full convention, examples, and authoring checklist.

--- a/packages/backend.ai-webui-docs/DOCUMENTATION-STYLE-GUIDE.md
+++ b/packages/backend.ai-webui-docs/DOCUMENTATION-STYLE-GUIDE.md
@@ -341,6 +341,76 @@ exit
 
 > **PDF note:** the printed PDF shows the `$` prompts visually too, but text-extraction behavior on PDF copy depends on the viewer. Most viewers include the prompt characters that the page renders, including content injected via CSS `::before`. The web copy button is the guaranteed path for prompt-free clipboard text.
 
+#### How to choose: bash or shellsession?
+
+Ask: **does the block include any program output, error messages, or a follow-up shell prompt?**
+
+- **No** → ` ```bash `. Strip any decorative `$ ` from each line. The reader's copy button gives them runnable commands directly.
+- **Yes** → ` ```shellsession `. Author the transcript as the user would actually see it (prompts, commands, output). The toolkit hides the `$` / `#` from the clipboard automatically.
+
+A multi-line command joined by `\` line continuations is still a single command — keep it in ` ```bash `:
+
+````markdown
+```bash
+curl -H "Content-Type: application/json" -X GET \
+  -H "Authorization: Bearer $TOKEN" \
+  https://api.example.com/v1/resource
+```
+````
+
+#### Placeholders in bash blocks
+
+In shells like `bash`, an unquoted `<word>` in a command can be parsed as **input redirection**, even when it appears mid-token. A naive copy-paste of `docker pull image:<version>` will fail because the shell tries to read from a file named `version`. Two safe patterns:
+
+| Pattern | Use when |
+|---|---|
+| `${VARIABLE}` (with an `export VAR="<placeholder>"` companion) | The placeholder appears multiple times, or the block is meant to be edited then run end-to-end. |
+| Quoted string `"<placeholder>"` | A single-occurrence placeholder where the reader will replace the whole quoted token. |
+
+````markdown
+```bash
+# ✅ safe — VERSION is a real shell variable
+export VERSION="<the version you want, e.g. 24.09>"
+docker pull lablup/backend.ai-client:${VERSION}
+```
+````
+
+````markdown
+```bash
+# ✅ safe — quoted; reader replaces the literal token
+docker pull "lablup/backend.ai-client:<version>"
+```
+````
+
+````markdown
+```bash
+# ❌ broken — bash parses <version> as input redirection
+docker pull lablup/backend.ai-client:<version>
+```
+````
+
+The same rule applies to `<token>`, `<endpoint>`, `<path>`, etc. — and not just inside ` ```bash ` blocks. ` ```shellsession ` blocks also have a copy button, and readers paste the resulting command text into a real shell; an unquoted `<placeholder>` in a shellsession command line will fail in their terminal too. Apply the placeholder-safety rule whenever you expect readers to copy and run the command, regardless of fence type.
+
+#### Code-block authoring checklist
+
+Before merging a doc page that contains code blocks, verify:
+
+1. The fence language matches the **content type** (single command vs transcript).
+2. There is no decorative `$ ` prefix in ` ```bash ` blocks. Use ` ```shellsession ` if you need to show the prompt.
+3. No unquoted `<placeholder>` at the start of a token in a bash block.
+4. **Inline comments inside the code block are localized**: if the source `.md` is in `ko/`, `ja/`, or `th/`, any `# comment` lines must be translated to that locale (the comment is part of the user-facing rendered code, not a build-time directive). See [TRANSLATION-GUIDE.md](TRANSLATION-GUIDE.md#inline-code-comments).
+5. Pasting the rendered (web copy-button) output into a real shell would actually run.
+
+#### Common mistakes
+
+| Mistake | Why it's wrong | Fix |
+|---|---|---|
+| Decorative `$ ` in ` ```bash ` | The reader's copy includes `$ ` which is not a command — paste fails. | Drop the `$ `, or move to ` ```shellsession ` if showing transcript intent. |
+| Unquoted `<placeholder>` | Bash parses `<…>` as redirection. | Use `${VARIABLE}` or quoted form (see above). |
+| English `# comment` in a translated locale | Reader sees an untranslated string in the middle of otherwise-localized prose. | Translate the comment to the locale's language. |
+| ` ```shellsession ` for a single command with no output | Adds prompt visual noise without transcript value. | Use ` ```bash ` without prompt. |
+| ` ```shell ` (legacy alias) | Deprecated in this manual; avoid using it in new or updated pages. | Use ` ```bash ` (or ` ```sh ` for explicit POSIX-only intent). |
+
 #### Code Block with Title
 
 Add `title="filename"` after the language to display a filename label above the code block:

--- a/packages/backend.ai-webui-docs/TRANSLATION-GUIDE.md
+++ b/packages/backend.ai-webui-docs/TRANSLATION-GUIDE.md
@@ -146,7 +146,8 @@ Keep these in their original form across all languages:
 - Product name: **Backend.AI**
 - Technical identifiers: fGPU, API, SSH, SFTP, HTTP, GPU, CPU, RAM
 - File paths: `/home/work/`, `config.toml`
-- Code examples and shell commands
+- **Shell commands themselves** — the runnable code (e.g. `docker pull lablup/backend.ai-client`) is identical across languages
+- **Code and configuration examples** in fenced blocks (for example, `toml`, `yaml`, `json`, and similar formats) — keep the code itself identical across languages; only comment lines should be translated, as described below
 - Image filenames
 - Cross-reference anchor names
 - Version numbers
@@ -159,6 +160,46 @@ Keep these in their original form across all languages:
 - Dialog field descriptions
 - Notes and warnings
 - Navigation titles in `book.config.yaml`
+- **Inline `# …` comments inside code blocks** (see below)
+
+<a id="inline-code-comments"></a>
+
+### Inline code comments
+
+Comment lines inside a code block (e.g. `# If you want to use the specific version, …`) are **user-facing prose** that happens to live inside a fenced block. They render as part of the rendered transcript and are seen by the reader exactly as authored.
+
+Treat them like any other narrative text:
+
+- **Translate the comment** to the locale's language.
+- The shell command itself stays unchanged.
+
+````markdown
+<!-- en/ -->
+```bash
+# If you want a specific version, pull the image with:
+docker pull lablup/backend.ai-client:${VERSION}
+```
+
+<!-- ko/ -->
+```bash
+# 특정 버전을 사용하려면 다음 명령으로 이미지를 가져올 수 있습니다:
+docker pull lablup/backend.ai-client:${VERSION}
+```
+
+<!-- ja/ -->
+```bash
+# 特定のバージョンを使用したい場合は、次のコマンドでイメージを取得できます:
+docker pull lablup/backend.ai-client:${VERSION}
+```
+
+<!-- th/ -->
+```bash
+# หากคุณต้องการใช้เวอร์ชันที่ระบุ คุณสามารถดึงอิมเมจได้ด้วยคำสั่งต่อไปนี้:
+docker pull lablup/backend.ai-client:${VERSION}
+```
+````
+
+This rule applies to ` ```bash `, ` ```shellsession `, and any other fenced block that uses `#` / `//` for comments. Leaving English comments inside a translated locale is a translation defect (FR-2763 surfaced this in the Thai locale).
 
 ## Quality Checklist
 
@@ -168,6 +209,7 @@ For each translated document, verify:
 - [ ] Consistent formality level throughout
 - [ ] Terminology matches `TERMINOLOGY.md`
 - [ ] No untranslated English sentences left in the body text
+- [ ] No untranslated English `#` / `//` comments inside code blocks (see [Inline code comments](#inline-code-comments))
 - [ ] Image references are identical to the English version
 - [ ] Cross-reference anchors are preserved
 - [ ] Natural sentence structure (not word-for-word translation)


### PR DESCRIPTION
Linked Jira: [FR-2764](https://lablup.atlassian.net/browse/FR-2764)
(GitHub issue clone pending Jira webhook; will link as `Resolves #N` once it appears.)

## Summary

Lessons learned from FR-2755 → FR-2756 → FR-2757 → FR-2763 are now documented in the authoring guides so future writers (and AI agents) follow the conventions without re-deriving them.

### `DOCUMENTATION-STYLE-GUIDE.md` — three new subsections under **Code Blocks**

1. **How to choose: bash or shellsession?** — a one-line decision: "does the block include any program output?" → no = `bash`, yes = `shellsession`. Multi-line `\` continuations are still single commands.
2. **Placeholders in bash blocks** — explains the `<word>` shell-redirection gotcha, with two safe patterns:
   - `${VARIABLE}` + `export VAR=\"<placeholder>\"` companion line (preferred for multi-occurrence or end-to-end runnable blocks)
   - Quoted `\"<placeholder>\"` for single-shot replacement
   Includes a side-by-side ✅ / ❌ example.
3. **Code-block authoring checklist + Common mistakes table** — five-item pre-merge checklist (fence matches content, no decorative `\$ `, no unquoted `<placeholder>`, comments localized, copied output actually runs) plus a table of the five recurring mistakes I saw across FR-2757 / FR-2763 review feedback with their fixes.

### `TRANSLATION-GUIDE.md` — new \"Inline code comments\" rule

- **What MUST be translated** list now includes \`# …\` comment lines inside code blocks.
- A new \"Inline code comments\" subsection (with anchor `#inline-code-comments`) shows en/ko/ja/th versions of the same comment side-by-side, and emphasizes that the *shell command itself* stays unchanged across locales.
- Quality Checklist gains: \"No untranslated English `#` / `//` comments inside code blocks\".

### `CLAUDE.md` (docs root agent guide) — \"Code blocks (cheat sheet)\"

A 5-bullet quick reference under \"Quick Rules\" so an AI agent doesn't have to scroll through the full style guide to get the rule right on a fresh task. Cross-links to the full convention.

### `TERMINOLOGY.md` — intentionally unchanged

Style guide owns code-block conventions; terminology guide stays focused on Backend.AI domain terms.

## Test plan

- [x] `bash scripts/verify.sh` → ALL PASS
- [x] `pnpm --filter backend.ai-webui-docs run build:web:en` succeeds
- [x] Cross-references between the three updated guides resolve (CLAUDE.md → DOCUMENTATION-STYLE-GUIDE.md → TRANSLATION-GUIDE.md anchor)

## Out of scope

- Updating individual chapter pages (en/ja/ko/th) to demonstrate the new conventions — already done in FR-2757 / FR-2763.
- New Jira / GitHub issue templates referencing these conventions.

[FR-2764]: https://lablup.atlassian.net/browse/FR-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ