### PR TITLE
fix(FR-2766): add webui + storybook entries to amplify.yml monorepo manifest

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -213,3 +213,95 @@ applications:
         paths:
           - $HOME/.pnpm-store/**/*
           - $HOME/.cache/pnpm/**/*
+
+  # ─────────────────────────────────────────────────────────────────
+  # WebUI (React app) — FR-2766
+  #
+  # Until FR-2766 added this entry, the webui Amplify app fell back
+  # to the docs entry above (single-application monorepo manifest)
+  # and served the docs site at the webui domain. The Amplify app's
+  # console "App root" must be set to `react` to match this entry.
+  #
+  # The repo's root `package.json#scripts.build` orchestrates the
+  # full webui build (clean, copy static assets, tsc, workspace
+  # builds). It must be invoked from the workspace root, NOT from
+  # `react/` (running `pnpm run build` inside `react/` would execute
+  # `react/package.json#build` which assumes `../build/web/` already
+  # exists). We therefore `cd ..` into the workspace root for the
+  # build step, and point `artifacts.baseDirectory` at the
+  # workspace-root `build/web/` directory via a `..` segment from
+  # the appRoot.
+  #
+  # `pnpm install` from any workspace directory installs the entire
+  # monorepo via `pnpm-workspace.yaml`, so it's safe to run from
+  # `react/` cwd in preBuild.
+  - appRoot: react
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - nvm install
+            - nvm use
+            - corepack enable
+            - corepack prepare pnpm@10 --activate
+            - pnpm install --frozen-lockfile
+        build:
+          commands:
+            # Run the orchestrating root build script from the
+            # workspace root. It produces the final artifact at
+            # `<workspace-root>/build/web/`.
+            - cd ..
+            - pnpm run build
+      artifacts:
+        # `..` resolves out of appRoot (`react/`) to the workspace
+        # root, then into `build/web/`. Amplify accepts paths that
+        # escape appRoot via `..` segments.
+        baseDirectory: ../build/web
+        files:
+          - "**/*"
+      cache:
+        paths:
+          - $HOME/.pnpm-store/**/*
+          - $HOME/.cache/pnpm/**/*
+
+  # ─────────────────────────────────────────────────────────────────
+  # Storybook (backend.ai-ui component library) — FR-2766
+  #
+  # Storybook lives entirely inside `packages/backend.ai-ui/` and
+  # produces a self-contained static bundle at `storybook-static/`.
+  # The Amplify app's console "App root" must be set to
+  # `packages/backend.ai-ui` to match this entry.
+  #
+  # Relay codegen is required before `storybook build` so any
+  # `__generated__` artifacts referenced by stories are present;
+  # `pnpm relay` at the workspace root walks both projects.
+  - appRoot: packages/backend.ai-ui
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - nvm install
+            - nvm use
+            - corepack enable
+            - corepack prepare pnpm@10 --activate
+            - pnpm install --frozen-lockfile
+            # Relay codegen for both projects, invoked at the
+            # workspace root via pnpm's `-w` flag so the current
+            # working directory stays inside this entry's appRoot
+            # (`packages/backend.ai-ui/`). Using `cd ..; cd ..` here
+            # would assume Amplify resets cwd to appRoot between
+            # phases, which is not contractually guaranteed across
+            # build-runner versions.
+            - pnpm -w run relay
+        build:
+          commands:
+            - pnpm run build-storybook
+      artifacts:
+        # Default Storybook output dir, relative to this entry's appRoot.
+        baseDirectory: storybook-static
+        files:
+          - "**/*"
+      cache:
+        paths:
+          - $HOME/.pnpm-store/**/*
+          - $HOME/.cache/pnpm/**/*


### PR DESCRIPTION
Resolves #7131 ([FR-2766](https://lablup.atlassian.net/browse/FR-2766))

## Why

**Production issue.** All three Amplify apps watching this repo — **webui**, **storybook**, **webui-docs** — currently deploy the **docs site**. After FR-2735 introduced `amplify.yml` at the repo root with a single `applications[]` entry (the docs package), the other two Amplify apps fall back to that single entry and build the docs spec instead of their own targets.

## What

Adds two new `applications[]` entries to the monorepo manifest so each app matches its own spec:

- **`appRoot: react`** for the React webui. The root `package.json#scripts.build` orchestrates the full webui build (clean, copy static assets, tsc, workspace builds), so the build step `cd ..`'s into the workspace root and invokes `pnpm run build`. Artifact at `<workspace-root>/build/web/`, reached via `baseDirectory: ../build/web`.
- **`appRoot: packages/backend.ai-ui`** for the Storybook. preBuild runs the workspace-aware `pnpm relay` so any `__generated__` artifacts referenced by stories are present, then `storybook build` produces the bundle at the default `storybook-static/` (relative to appRoot).

The existing docs entry is unchanged byte-for-byte.

## Console-side actions (DevOps, simultaneous with merge)

This PR alone does NOT fix prod — it must land together with these console changes. AWS Amplify's console inline build spec overrides `amplify.yml`, and `applications[].appRoot` only matches an app whose console "App root" field is set identically.

1. **App root verification** for each Amplify app (App settings → General → Repository details → App root):
   - webui app → `react`
   - storybook app → `packages/backend.ai-ui`
   - webui-docs app → `packages/backend.ai-webui-docs` (already correct)

2. **Clear console inline build spec** for the webui and storybook apps (Build settings → Build spec → "Use repository amplify.yml" or empty out the YAML). **Back up the current inline spec text first** for rollback.

3. **Watched paths** (App settings → Build settings → Build image settings → Watched paths) — set per app to avoid spurious cross-app rebuilds:
   - **webui**: `react/**`, `src/**`, `resources/**`, `packages/backend.ai-ui/**`, `package.json`, `pnpm-lock.yaml`, `tsconfig*.json`
   - **storybook**: `packages/backend.ai-ui/**`, `pnpm-lock.yaml`
   - **webui-docs**: `packages/backend.ai-webui-docs/**`, `packages/backend.ai-docs-toolkit/**`

## Acceptance

- [ ] webui domain serves the React app (not docs).
- [ ] storybook domain serves the Storybook (not docs).
- [ ] webui-docs domain still serves the docs site (unchanged).
- [ ] A docs-only push does not trigger a webui or storybook rebuild.

## Verification (local)

- `python3 -c "import yaml; ..."` parses 3 applications: docs, react, storybook with the expected appRoots and baseDirectories.
- The docs entry is byte-identical to pre-PR.

## Rollback

If a webui or storybook build breaks after this lands, restore the backed-up console inline spec (step 2 above). The repo's amplify.yml change is forward-only — leaving it in place while the inline spec is restored is safe; AWS Amplify gives precedence to the inline spec.

## Predecessors

- FR-2735 — added the initial single-app `amplify.yml`.
- FR-2738 / #7089 / #7093 / #7097 — subsequent fixes to the docs entry; all preserved.

## Checklist

- [x] Documentation — N/A (build infra change; no doc page affected)
- [ ] Console actions completed by DevOps (see above)
- [x] Test case(s) to demonstrate the difference of before/after — local YAML parse + manifest diff inspection; runtime acceptance requires console rollout


[FR-2766]: https://lablup.atlassian.net/browse/FR-2766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ