### PR TITLE
refactor(FR-2772): unify deployment card UX with BAICard conventions

### DIFF
--- a/.claude/rules/use-bai-card.md
+++ b/.claude/rules/use-bai-card.md
@@ -1,0 +1,172 @@
+# Use BAICard Over antd Card
+
+Always use `BAICard` from `backend.ai-ui` instead of antd's `<Card>` component for card containers in this project. Apply `styles={{ body: { paddingTop: 0 } }}` at every call site **that does not use `tabList`** so the body sits flush against the header. Cards with `tabList` keep their default body paddingTop — see "Tabbed cards keep their paddingTop" below.
+
+## Why
+
+`BAICard` wraps antd's `Card` with the Backend.AI design-system defaults:
+
+- **Hidden header divider** when `tabList` / `showDivider` is not used. The default antd `Card` renders a horizontal line under the title; `BAICard` removes it for a flatter, cleaner look.
+- **Status-based border colors** via the `status` prop (`'success' | 'error' | 'warning' | 'default'`).
+- **Standardized title + extra layout** using `BAIFlex` (`justify="between"`, `align="center"`, `wrap="wrap"`, `gap="sm"`) so headers across the app are visually aligned.
+
+The Backend.AI card design intends the body to sit **flush against the header** — antd's default `body.paddingTop` (≈24px) leaves a visible gap that is not part of our design language. `BAICard` does not bake `body.paddingTop: 0` into the component itself (it would change every existing call site silently and surprise other apps that consume `backend.ai-ui`), so each call site applies it explicitly via `styles={{ body: { paddingTop: 0 } }}`. This is the project convention.
+
+Mixing `Card` and `BAICard`, or omitting the `paddingTop: 0` style, produces visibly inconsistent header dividers and spacing — every card on a page should look the same.
+
+## Rules
+
+1. **Always import and use `BAICard`** from `backend.ai-ui` for new card containers. Do not introduce new `import { Card } from 'antd'` for card UI.
+2. **When editing a file that uses `<Card>` from `antd`, migrate it to `<BAICard>` in the same change.** The migration is typically a pure rename: `BAICardProps extends Omit<CardProps, 'extra'>`, so every standard Card prop (`title`, `tabList`, `activeTabKey`, `onTabChange`, `size`, `style`, `styles`, `bordered`, `variant`, etc.) passes through unchanged. Drop the `Card` import after the rename.
+3. **Always pass `styles={{ body: { paddingTop: 0 } }}`** when using `BAICard` **without `tabList`**. This is non-negotiable for visual consistency. If the call site already declares other `styles.body` keys (e.g. `padding`, `backgroundColor`), merge `paddingTop: 0` into that same object — do not drop the existing keys.
+
+   **Exception — tabbed cards.** When the card uses `tabList`, **do not** pass `paddingTop: 0`. The tabs render *as the bottom edge of the header*, and a flush body would put the first row of content immediately under the tab underline, which reads as broken. `BAICard` already sets `body.paddingTop` to `token.padding` (or `token.paddingSM` for `size="small"`) automatically when `tabList` is present — accept that default. If you genuinely need to override `body` styling on a tabbed card, do so without touching `paddingTop`.
+4. **Do not add `marginTop` to the first child to "create breathing room"**. The flush-to-header look is intentional. If a layout genuinely needs vertical separation between the header and content, place that spacing **outside** the card (typically via the parent `BAIFlex` `gap`).
+5. **Prefer BAICard's status / extra APIs over custom styling.** Use `status="error" | "warning" | "success"` instead of hand-rolling `style={{ borderColor }}`. Use the `extra` (any `ReactNode`) or `extraButtonTitle` + `onClickExtraButton` props for header actions instead of building a parallel header row above the card.
+6. **Card-scoped actions go in `extra`, not in the body.** Any action that operates on the card as a whole — the orange primary "create / add" button, the refresh button (`BAIFetchKeyButton`), an "edit configuration" button, a section-level export — belongs in the card's header `extra` slot. Use a `BAIFlex gap="xs" align="center"` to group multiple actions, with the primary button rightmost.
+
+   Only **content-scoped** controls stay in the body — i.e., things that filter, sort, or page through what is displayed (`BAIGraphQLPropertyFilter`, search inputs, view-mode toggles when they reshape the body content, sort selectors). If you find yourself duplicating a refresh button in the body when the card already has one in `extra`, remove the body one.
+
+## Pattern
+
+### ❌ Wrong — antd Card
+
+```tsx
+import { Card } from 'antd';
+
+<Card title={t('section.Title')}>
+  <Content />
+</Card>
+```
+
+### ❌ Wrong — BAICard without `paddingTop: 0`
+
+```tsx
+import { BAICard } from 'backend.ai-ui';
+
+<BAICard title={t('section.Title')}>
+  <Content />
+</BAICard>
+```
+
+### ✅ Correct — BAICard with `paddingTop: 0`
+
+```tsx
+import { BAICard } from 'backend.ai-ui';
+
+<BAICard title={t('section.Title')} styles={{ body: { paddingTop: 0 } }}>
+  <Content />
+</BAICard>
+```
+
+### ✅ Correct — card-scoped actions (refresh + add) in `extra`, content-scoped filter in body
+
+```tsx
+<BAICard
+  title={t('section.Rules')}
+  extra={
+    <BAIFlex gap="xs" align="center">
+      <BAIFetchKeyButton loading={isPending} value="" onChange={refetch} />
+      <Button
+        type="primary"
+        icon={<PlusOutlined />}
+        onClick={() => setIsCreateOpen(true)}
+      >
+        {t('section.AddRule')}
+      </Button>
+    </BAIFlex>
+  }
+  styles={{ body: { paddingTop: 0 } }}
+>
+  <BAIFlex direction="column" align="stretch" gap="sm">
+    <BAIGraphQLPropertyFilter style={{ flex: 1 }} {...filterProps} />
+    <BAITable {...tableProps} />
+  </BAIFlex>
+</BAICard>
+```
+
+### ✅ Correct — tabbed BAICard (no `paddingTop: 0`; default kept)
+
+```tsx
+<BAICard
+  activeTabKey={activeTab}
+  onTabChange={setActiveTab}
+  tabList={[
+    { key: 'a', label: 'Tab A' },
+    { key: 'b', label: 'Tab B' },
+  ]}
+>
+  <Content />
+</BAICard>
+```
+
+### ❌ Wrong — `paddingTop: 0` on a tabbed card
+
+```tsx
+// Don't do this — content collides with the tab underline.
+<BAICard
+  activeTabKey={activeTab}
+  tabList={[...]}
+  styles={{ body: { paddingTop: 0 } }}
+>
+  <Content />
+</BAICard>
+```
+
+### ✅ Correct — BAICard with status
+
+```tsx
+<BAICard
+  title={t('section.Errors')}
+  status="error"
+  styles={{ body: { paddingTop: 0 } }}
+>
+  <ErrorList />
+</BAICard>
+```
+
+### ✅ Correct — merging into existing body styles
+
+```tsx
+<BAICard
+  title={t('section.Title')}
+  styles={{ body: { paddingTop: 0, padding: token.paddingLG } }}
+>
+  <Content />
+</BAICard>
+```
+
+## Suspense pairing
+
+When a card's content is data-driven and uses Suspense, place the Suspense boundary **inside** the BAICard so the title stays visible while the content loads:
+
+```tsx
+<BAICard
+  title={t('section.Title')}
+  styles={{ body: { paddingTop: 0 } }}
+>
+  <Suspense fallback={<Skeleton active />}>
+    <DataDrivenContent />
+  </Suspense>
+</BAICard>
+```
+
+This is the project convention for all loading cards: header always visible, body shows `Skeleton` during fetch. Do not wrap the entire `<BAICard>` in a `<Suspense>` — that hides the header during loading and produces inconsistent UX across the page.
+
+## Verification
+
+After editing a file that touches card containers, confirm:
+
+- `import { Card } from 'antd'` is removed from the modified files (unless `Card` is genuinely needed for a non-container use case, which is rare).
+- All `<Card>` JSX usages in the touched files are `<BAICard>`.
+- Every `<BAICard>` call site **without `tabList`** has `styles={{ body: { paddingTop: 0 } }}` (merged into existing `body` styles when present).
+- Tabbed `<BAICard>` call sites do **not** declare `paddingTop` on `body` — they keep BAICard's automatic tab-aware paddingTop.
+- Card-scoped actions (refresh, primary create/add, edit, export) live in the card's `extra` slot — not duplicated in the body.
+- Only content-scoped controls (filter, search, sort) remain inside the body.
+- `bash scripts/verify.sh` passes — TypeScript should accept the prop forwarding because `BAICardProps` extends `Omit<CardProps, 'extra'>`.
+
+## Related
+
+- `component-props-extension.md` — `BAICardProps` follows the wrapper-component prop-extension pattern documented there.
+- `antd-v6-props.md` — when migrating, also apply v6 prop renames to any antd primitives nested inside the card.
+- `BAICard` source: `packages/backend.ai-ui/src/components/BAICard.tsx`

--- a/react/src/components/AutoScalingRuleList.tsx
+++ b/react/src/components/AutoScalingRuleList.tsx
@@ -34,7 +34,12 @@ import type { BAITableProps, GraphQLFilter } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import * as _ from 'lodash-es';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
-import React, { useDeferredValue, useState, useTransition } from 'react';
+import React, {
+  useDeferredValue,
+  useImperativeHandle,
+  useState,
+  useTransition,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 
@@ -321,11 +326,29 @@ const AutoScalingRuleListNodes: React.FC<AutoScalingRuleListNodesProps> = ({
 
 // --- List orchestrator component ---
 
+export interface AutoScalingRuleListRef {
+  openAddModal: () => void;
+}
+
 interface AutoScalingRuleListProps {
   deploymentId: string; // Relay global ID (e.g., toGlobalId('ModelDeployment', uuid))
   isEndpointDestroying: boolean;
   isOwnedByCurrentUser: boolean;
   fetchKey?: string;
+  /**
+   * When true, the inline "Add rules" primary button is hidden so the parent
+   * can render its own trigger (typically in a `BAICard.extra` slot). The
+   * editor modal is still managed internally; callers should use
+   * `ref.current.openAddModal()` to open it.
+   */
+  hideInlineAddButton?: boolean;
+  /**
+   * When true, the inline refresh button (`BAIFetchKeyButton`) is hidden so
+   * the parent can render refresh in a `BAICard.extra` slot. Drive the
+   * refetch externally by bumping `fetchKey`.
+   */
+  hideInlineRefreshButton?: boolean;
+  ref?: React.Ref<AutoScalingRuleListRef>;
 }
 
 const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
@@ -333,6 +356,9 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
   isEndpointDestroying,
   isOwnedByCurrentUser,
   fetchKey: parentFetchKey,
+  hideInlineAddButton = false,
+  hideInlineRefreshButton = false,
+  ref,
 }) => {
   'use memo';
   const { t } = useTranslation();
@@ -342,6 +368,17 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
 
   const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
   const [isOpenEditorModal, setIsOpenEditorModal] = useState(false);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      openAddModal: () => {
+        setEditingRuleId(null);
+        setIsOpenEditorModal(true);
+      },
+    }),
+    [],
+  );
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.AutoScalingRuleList',
@@ -532,24 +569,28 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
               });
             }}
           />
-          <BAIFetchKeyButton
-            loading={isPendingRefetch}
-            value=""
-            onChange={() => {
-              startRefetchTransition(() => updateFetchKey());
-            }}
-          />
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            disabled={isEndpointDestroying || !isOwnedByCurrentUser}
-            onClick={() => {
-              setEditingRuleId(null);
-              setIsOpenEditorModal(true);
-            }}
-          >
-            {t('modelService.AddRules')}
-          </Button>
+          {!hideInlineRefreshButton && (
+            <BAIFetchKeyButton
+              loading={isPendingRefetch}
+              value=""
+              onChange={() => {
+                startRefetchTransition(() => updateFetchKey());
+              }}
+            />
+          )}
+          {!hideInlineAddButton && (
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              disabled={isEndpointDestroying || !isOwnedByCurrentUser}
+              onClick={() => {
+                setEditingRuleId(null);
+                setIsOpenEditorModal(true);
+              }}
+            >
+              {t('modelService.AddRules')}
+            </Button>
+          )}
         </BAIFlex>
         <AutoScalingRuleListNodes
           autoScalingRulesFrgmt={autoScalingRuleNodes}

--- a/react/src/components/DeploymentAccessTokensTab.tsx
+++ b/react/src/components/DeploymentAccessTokensTab.tsx
@@ -6,9 +6,24 @@ import { DeploymentAccessTokensTabCreateMutation } from '../__generated__/Deploy
 import { DeploymentAccessTokensTabDeleteMutation } from '../__generated__/DeploymentAccessTokensTabDeleteMutation.graphql';
 import { DeploymentAccessTokensTabListQuery } from '../__generated__/DeploymentAccessTokensTabListQuery.graphql';
 import { DeploymentAccessTokensTab_deployment$key } from '../__generated__/DeploymentAccessTokensTab_deployment.graphql';
-import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
-import { App, Button, DatePicker, Form, Select, Typography } from 'antd';
 import {
+  DeleteOutlined,
+  PlusOutlined,
+  QuestionCircleOutlined,
+} from '@ant-design/icons';
+import {
+  App,
+  Button,
+  DatePicker,
+  Form,
+  Select,
+  Skeleton,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import {
+  BAICard,
   BAIFetchKeyButton,
   BAIFlex,
   BAIModal,
@@ -22,7 +37,7 @@ import {
   useMutationWithPromise,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
-import React, { useState, useTransition } from 'react';
+import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   graphql,
@@ -46,7 +61,8 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { message, modal } = App.useApp();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
   const { logger } = useBAILogger();
   const [isPendingRefetch, startRefetchTransition] = useTransition();
   const [fetchKey, setFetchKey] = useState(0);
@@ -67,39 +83,6 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
     deploymentFrgmt,
   );
 
-  const { deployment: listData } =
-    useLazyLoadQuery<DeploymentAccessTokensTabListQuery>(
-      graphql`
-        query DeploymentAccessTokensTabListQuery($deploymentId: ID!) {
-          deployment(id: $deploymentId) {
-            accessTokens(orderBy: [{ field: CREATED_AT, direction: DESC }]) {
-              count
-              edges {
-                node {
-                  id
-                  token
-                  createdAt
-                  expiresAt
-                }
-              }
-            }
-          }
-        }
-      `,
-      { deploymentId },
-      { fetchKey, fetchPolicy: 'network-only' },
-    );
-
-  type AccessTokenNode = NonNullable<
-    NonNullable<
-      NonNullable<typeof listData>['accessTokens']
-    >['edges'][number]['node']
-  >;
-
-  const accessTokens = filterOutNullAndUndefined(
-    listData?.accessTokens?.edges?.map((edge) => edge?.node),
-  );
-
   const commitCreateMutation =
     useMutationWithPromise<DeploymentAccessTokensTabCreateMutation>(graphql`
       mutation DeploymentAccessTokensTabCreateMutation(
@@ -116,137 +99,56 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
       }
     `);
 
-  const [commitDelete, isDeletingToken] =
-    useMutation<DeploymentAccessTokensTabDeleteMutation>(graphql`
-      mutation DeploymentAccessTokensTabDeleteMutation(
-        $input: DeleteAccessTokenInput!
-      ) {
-        deleteAccessToken(input: $input) {
-          id
-        }
-      }
-    `);
-
   const handleRefetch = () => {
     startRefetchTransition(() => {
       setFetchKey((k) => k + 1);
     });
   };
 
+  const isMutationDisabled = isDeploymentDestroying || !isOwnedByCurrentUser;
+
   return (
     <>
-      <BAIFlex direction="column" align="stretch" gap="sm">
-        <BAIFlex justify="end" gap="xs">
-          <BAIFetchKeyButton
-            loading={isPendingRefetch}
-            value=""
-            onChange={handleRefetch}
+      <BAICard
+        title={
+          <BAIFlex gap="xs" align="center">
+            {t('deployment.tab.AccessTokens')}
+            <Tooltip title={t('deployment.tab.description.AccessTokens')}>
+              <QuestionCircleOutlined
+                style={{ color: token.colorTextDescription }}
+              />
+            </Tooltip>
+          </BAIFlex>
+        }
+        extra={
+          <BAIFlex gap="xs" align="center">
+            <BAIFetchKeyButton
+              loading={isPendingRefetch}
+              value=""
+              onChange={handleRefetch}
+            />
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              disabled={isMutationDisabled}
+              onClick={() => setIsCreateModalOpen(true)}
+            >
+              {t('deployment.accessToken.Create')}
+            </Button>
+          </BAIFlex>
+        }
+        styles={{ body: { paddingTop: 0 } }}
+      >
+        <Suspense fallback={<Skeleton active />}>
+          <DeploymentAccessTokensTable
+            deploymentId={deploymentId}
+            fetchKey={fetchKey}
+            isPendingRefetch={isPendingRefetch}
+            isDeleteDisabled={isMutationDisabled}
+            onAfterDelete={handleRefetch}
           />
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            disabled={isDeploymentDestroying || !isOwnedByCurrentUser}
-            onClick={() => setIsCreateModalOpen(true)}
-          >
-            {t('deployment.accessToken.Create')}
-          </Button>
-        </BAIFlex>
-        <BAITable<AccessTokenNode>
-          scroll={{ x: 'max-content' }}
-          rowKey="id"
-          loading={isPendingRefetch || isDeletingToken}
-          dataSource={accessTokens}
-          pagination={false}
-          columns={[
-            {
-              key: 'token',
-              title: t('deployment.accessToken.Token'),
-              dataIndex: 'token',
-              render: (_text, row) => {
-                if (!row) return '-';
-                return (
-                  <BAINameActionCell
-                    title={
-                      <BAIText
-                        copyable={{ text: row.token }}
-                        ellipsis
-                        code
-                        style={{ maxWidth: 120 }}
-                      >
-                        {row.token}
-                      </BAIText>
-                    }
-                    showActions="always"
-                    actions={[
-                      {
-                        key: 'delete',
-                        title: t('deployment.accessToken.Delete'),
-                        icon: <DeleteOutlined />,
-                        type: 'danger',
-                        disabled:
-                          isDeploymentDestroying || !isOwnedByCurrentUser,
-                        onClick: () => {
-                          modal.confirm({
-                            title: t('deployment.accessToken.Delete'),
-                            content: t('deployment.accessToken.DeleteConfirm'),
-                            okText: t('button.Delete'),
-                            okButtonProps: { danger: true },
-                            onOk: () => {
-                              commitDelete({
-                                variables: {
-                                  input: {
-                                    id: toLocalId(row.id) ?? row.id,
-                                  },
-                                },
-                                onCompleted: (_res, errors) => {
-                                  if (errors && errors.length > 0) {
-                                    logger.error(errors[0]);
-                                    message.error(
-                                      errors[0]?.message ??
-                                        t('dialog.ErrorOccurred'),
-                                    );
-                                    return;
-                                  }
-                                  message.success(
-                                    t('deployment.accessToken.Deleted'),
-                                  );
-                                  handleRefetch();
-                                },
-                                onError: (err) => {
-                                  logger.error(err);
-                                  message.error(
-                                    err.message ?? t('dialog.ErrorOccurred'),
-                                  );
-                                },
-                              });
-                            },
-                          });
-                        },
-                      },
-                    ]}
-                  />
-                );
-              },
-            },
-            {
-              key: 'createdAt',
-              title: t('deployment.CreatedAt'),
-              dataIndex: 'createdAt',
-              render: (_text, row) =>
-                row?.createdAt ? dayjs(row.createdAt).format('ll LT') : '-',
-            },
-            {
-              key: 'expiresAt',
-              title: t('deployment.accessToken.Expiration'),
-              dataIndex: 'expiresAt',
-              render: (_text, row) =>
-                row?.expiresAt
-                  ? dayjs(row.expiresAt).format('ll LT')
-                  : t('deployment.accessToken.NoExpiration'),
-            },
-          ]}
-        />
-      </BAIFlex>
+        </Suspense>
+      </BAICard>
 
       <BAIUnmountAfterClose>
         <CreateAccessTokenModal
@@ -324,6 +226,175 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
         </BAIModal>
       </BAIUnmountAfterClose>
     </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Inner table component — owns the data fetch and per-row delete mutation so
+// the BAICard header above can remain visible while the list suspends.
+// ---------------------------------------------------------------------------
+
+interface DeploymentAccessTokensTableProps {
+  deploymentId: string;
+  fetchKey: number;
+  isPendingRefetch: boolean;
+  isDeleteDisabled: boolean;
+  onAfterDelete: () => void;
+}
+
+const DeploymentAccessTokensTable: React.FC<
+  DeploymentAccessTokensTableProps
+> = ({
+  deploymentId,
+  fetchKey,
+  isPendingRefetch,
+  isDeleteDisabled,
+  onAfterDelete,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message, modal } = App.useApp();
+  const { logger } = useBAILogger();
+
+  const { deployment: listData } =
+    useLazyLoadQuery<DeploymentAccessTokensTabListQuery>(
+      graphql`
+        query DeploymentAccessTokensTabListQuery($deploymentId: ID!) {
+          deployment(id: $deploymentId) {
+            accessTokens(orderBy: [{ field: CREATED_AT, direction: DESC }]) {
+              count
+              edges {
+                node {
+                  id
+                  token
+                  createdAt
+                  expiresAt
+                }
+              }
+            }
+          }
+        }
+      `,
+      { deploymentId },
+      { fetchKey, fetchPolicy: 'network-only' },
+    );
+
+  type AccessTokenNode = NonNullable<
+    NonNullable<
+      NonNullable<typeof listData>['accessTokens']
+    >['edges'][number]['node']
+  >;
+
+  const accessTokens = filterOutNullAndUndefined(
+    listData?.accessTokens?.edges?.map((edge) => edge?.node),
+  );
+
+  const [commitDelete, isDeletingToken] =
+    useMutation<DeploymentAccessTokensTabDeleteMutation>(graphql`
+      mutation DeploymentAccessTokensTabDeleteMutation(
+        $input: DeleteAccessTokenInput!
+      ) {
+        deleteAccessToken(input: $input) {
+          id
+        }
+      }
+    `);
+
+  return (
+    <BAITable<AccessTokenNode>
+      scroll={{ x: 'max-content' }}
+      rowKey="id"
+      loading={isPendingRefetch || isDeletingToken}
+      dataSource={accessTokens}
+      pagination={false}
+      columns={[
+        {
+          key: 'token',
+          title: t('deployment.accessToken.Token'),
+          dataIndex: 'token',
+          render: (_text, row) => {
+            if (!row) return '-';
+            return (
+              <BAINameActionCell
+                title={
+                  <BAIText
+                    copyable={{ text: row.token }}
+                    ellipsis
+                    code
+                    style={{ maxWidth: 120 }}
+                  >
+                    {row.token}
+                  </BAIText>
+                }
+                showActions="always"
+                actions={[
+                  {
+                    key: 'delete',
+                    title: t('deployment.accessToken.Delete'),
+                    icon: <DeleteOutlined />,
+                    type: 'danger',
+                    disabled: isDeleteDisabled,
+                    onClick: () => {
+                      modal.confirm({
+                        title: t('deployment.accessToken.Delete'),
+                        content: t('deployment.accessToken.DeleteConfirm'),
+                        okText: t('button.Delete'),
+                        okButtonProps: { danger: true },
+                        onOk: () => {
+                          commitDelete({
+                            variables: {
+                              input: {
+                                id: toLocalId(row.id) ?? row.id,
+                              },
+                            },
+                            onCompleted: (_res, errors) => {
+                              if (errors && errors.length > 0) {
+                                logger.error(errors[0]);
+                                message.error(
+                                  errors[0]?.message ??
+                                    t('dialog.ErrorOccurred'),
+                                );
+                                return;
+                              }
+                              message.success(
+                                t('deployment.accessToken.Deleted'),
+                              );
+                              onAfterDelete();
+                            },
+                            onError: (err) => {
+                              logger.error(err);
+                              message.error(
+                                err.message ?? t('dialog.ErrorOccurred'),
+                              );
+                            },
+                          });
+                        },
+                      });
+                    },
+                  },
+                ]}
+              />
+            );
+          },
+        },
+        {
+          key: 'createdAt',
+          title: t('deployment.CreatedAt'),
+          dataIndex: 'createdAt',
+          render: (_text, row) =>
+            row?.createdAt ? dayjs(row.createdAt).format('ll LT') : '-',
+        },
+        {
+          key: 'expiresAt',
+          title: t('deployment.accessToken.Expiration'),
+          dataIndex: 'expiresAt',
+          render: (_text, row) =>
+            row?.expiresAt
+              ? dayjs(row.expiresAt).format('ll LT')
+              : t('deployment.accessToken.NoExpiration'),
+        },
+      ]}
+    />
   );
 };
 

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -35,7 +35,7 @@ import {
   InputNumber,
   Segmented,
   Select,
-  Spin,
+  Skeleton,
   Typography,
   theme,
 } from 'antd';
@@ -754,13 +754,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
       }
     >
       {open && (
-        <Suspense
-          fallback={
-            <BAIFlex justify="center" align="center" style={{ minHeight: 200 }}>
-              <Spin />
-            </BAIFlex>
-          }
-        >
+        <Suspense fallback={<Skeleton active />}>
           <DeploymentAddRevisionModalFormBody
             deploymentId={deploymentId}
             form={form}

--- a/react/src/components/DeploymentAutoScalingTab.tsx
+++ b/react/src/components/DeploymentAutoScalingTab.tsx
@@ -4,33 +4,42 @@
  */
 import { DeploymentAutoScalingTab_deployment$key } from '../__generated__/DeploymentAutoScalingTab_deployment.graphql';
 import { useCurrentUserInfo } from '../hooks/backendai';
-import AutoScalingRuleList from './AutoScalingRuleList';
-import React from 'react';
+import AutoScalingRuleList, {
+  type AutoScalingRuleListRef,
+} from './AutoScalingRuleList';
+import { PlusOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { Button, Skeleton, Tooltip, theme } from 'antd';
+import { BAICard, BAIFetchKeyButton, BAIFlex } from 'backend.ai-ui';
+import React, { Suspense, useRef, useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 interface DeploymentAutoScalingTabProps {
   deploymentFrgmt: DeploymentAutoScalingTab_deployment$key | null | undefined;
-  fetchKey?: string;
 }
 
 /**
- * DeploymentAutoScalingTab — tab shown on the Deployment detail page that
+ * DeploymentAutoScalingTab — section card on the Deployment detail page that
  * hosts the Auto-Scaling Rules management UI.
  *
- * This is a thin wrapper around `<AutoScalingRuleList />`. It extracts the
- * Relay global ID from the deployment fragment and derives the
- * `isEndpointDestroying` / `isOwnedByCurrentUser` flags that the underlying
- * list needs for permission gating. `AutoScalingRuleList` is already
- * Deployment-API based (its GraphQL query is rooted at `deployment(id: $id)`)
- * so no API migration is needed — we only need to surface it inside the new
- * Deployment detail page tabs.
+ * The card owns the section title, the refresh button, and the primary "Add
+ * rules" button — all rendered in the BAICard `extra` slot per project
+ * convention. The actual rule list (`AutoScalingRuleList`) still owns the
+ * editor modal; we drive it via an imperative `ref` so the trigger can live
+ * in the card header while the modal stays co-located with the data it
+ * mutates.
  */
 const DeploymentAutoScalingTab: React.FC<DeploymentAutoScalingTabProps> = ({
   deploymentFrgmt,
-  fetchKey,
 }) => {
   'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
   const [currentUser] = useCurrentUserInfo();
+  const autoScalingRef = useRef<AutoScalingRuleListRef>(null);
+
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, setFetchKey] = useState(0);
 
   const deployment = useFragment(
     graphql`
@@ -66,13 +75,57 @@ const DeploymentAutoScalingTab: React.FC<DeploymentAutoScalingTabProps> = ({
   const isOwnedByCurrentUser =
     !creatorEmail || creatorEmail === currentUser.email;
 
+  const isAddDisabled = isEndpointDestroying || !isOwnedByCurrentUser;
+
+  const handleRefetch = () => {
+    startRefetchTransition(() => {
+      setFetchKey((k) => k + 1);
+    });
+  };
+
   return (
-    <AutoScalingRuleList
-      deploymentId={deployment.id}
-      isEndpointDestroying={isEndpointDestroying}
-      isOwnedByCurrentUser={isOwnedByCurrentUser}
-      fetchKey={fetchKey}
-    />
+    <BAICard
+      title={
+        <BAIFlex gap="xs" align="center">
+          {t('deployment.tab.AutoScaling')}
+          <Tooltip title={t('deployment.tab.description.AutoScaling')}>
+            <QuestionCircleOutlined
+              style={{ color: token.colorTextDescription }}
+            />
+          </Tooltip>
+        </BAIFlex>
+      }
+      extra={
+        <BAIFlex gap="xs" align="center">
+          <BAIFetchKeyButton
+            loading={isPendingRefetch}
+            value=""
+            onChange={handleRefetch}
+          />
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            disabled={isAddDisabled}
+            onClick={() => autoScalingRef.current?.openAddModal()}
+          >
+            {t('modelService.AddRules')}
+          </Button>
+        </BAIFlex>
+      }
+      styles={{ body: { paddingTop: 0 } }}
+    >
+      <Suspense fallback={<Skeleton active />}>
+        <AutoScalingRuleList
+          ref={autoScalingRef}
+          deploymentId={deployment.id}
+          isEndpointDestroying={isEndpointDestroying}
+          isOwnedByCurrentUser={isOwnedByCurrentUser}
+          fetchKey={String(fetchKey)}
+          hideInlineAddButton
+          hideInlineRefreshButton
+        />
+      </Suspense>
+    </BAICard>
   );
 };
 

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -2,7 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { DeploymentConfigurationSectionQuery } from '../__generated__/DeploymentConfigurationSectionQuery.graphql';
+import { DeploymentConfigurationSectionCurrentRevisionModalQuery } from '../__generated__/DeploymentConfigurationSectionCurrentRevisionModalQuery.graphql';
+import { DeploymentConfigurationSectionOverviewQuery } from '../__generated__/DeploymentConfigurationSectionOverviewQuery.graphql';
+import { DeploymentConfigurationSectionRevisionInfoQuery } from '../__generated__/DeploymentConfigurationSectionRevisionInfoQuery.graphql';
 import { DeploymentConfigurationSection_deployment$key } from '../__generated__/DeploymentConfigurationSection_deployment.graphql';
 import { useWebUINavigate } from '../hooks';
 import SourceCodeView from './SourceCodeView';
@@ -16,8 +18,8 @@ import {
 import {
   Alert,
   Button,
-  Card,
   Descriptions,
+  Skeleton,
   Tag,
   Typography,
   theme,
@@ -31,9 +33,10 @@ import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIModal,
+  BAIUnmountAfterClose,
   toLocalId,
 } from 'backend.ai-ui';
-import React, { useState, useTransition } from 'react';
+import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 
@@ -43,162 +46,141 @@ interface DeploymentConfigurationSectionProps {
   isDeploymentDestroying?: boolean;
 }
 
-const DeploymentConfigurationSection: React.FC<
-  DeploymentConfigurationSectionProps
-> = ({ deploymentFrgmt, deploymentId, isDeploymentDestroying = false }) => {
+type ModelDef = {
+  readonly name: string | null | undefined;
+  readonly modelPath: string | null | undefined;
+  readonly service?: {
+    readonly startCommand: unknown;
+    readonly port: number | null | undefined;
+    readonly healthCheck?: {
+      readonly path: string | null | undefined;
+      readonly initialDelay: number | null | undefined;
+      readonly maxRetries: number | null | undefined;
+    } | null;
+  } | null;
+};
+
+const descriptionsProps = {
+  bordered: true,
+  column: { xxl: 3, xl: 2, lg: 2, md: 1, sm: 1, xs: 1 },
+} as const;
+
+const renderFallback = () => (
+  <Typography.Text type="secondary">-</Typography.Text>
+);
+
+const buildModelDefinitionItems = (
+  rawModels: ReadonlyArray<ModelDef | null> | null | undefined,
+  t: (key: string) => string,
+): DescriptionsItemType[] => {
+  const models = filterOutNullAndUndefined(rawModels);
+  if (!models || models.length === 0) return [];
+  return models.flatMap((model, idx) => {
+    const prefix = models.length > 1 ? `[${idx}] ` : '';
+    const modelItems: DescriptionsItemType[] = [
+      {
+        key: `model-name-${idx}`,
+        label: `${prefix}${t('modelStore.ModelName')}`,
+        children: model.name || renderFallback(),
+      },
+      {
+        key: `model-path-${idx}`,
+        label: `${prefix}${t('modelStore.ModelPath')}`,
+        children: model.modelPath || renderFallback(),
+      },
+      ...(model.service
+        ? ([
+            {
+              key: `model-start-command-${idx}`,
+              label: `${prefix}${t('modelService.StartCommand')}`,
+              children: model.service.startCommand ? (
+                <SourceCodeView language="shell">
+                  {typeof model.service.startCommand === 'string'
+                    ? model.service.startCommand
+                    : JSON.stringify(model.service.startCommand, null, 2)}
+                </SourceCodeView>
+              ) : (
+                renderFallback()
+              ),
+              span: { xl: 2 },
+            },
+            {
+              key: `model-port-${idx}`,
+              label: `${prefix}${t('modelService.Port')}`,
+              children: model.service.port ?? renderFallback(),
+            },
+            ...(model.service.healthCheck
+              ? ([
+                  {
+                    key: `model-healthcheck-path-${idx}`,
+                    label: `${prefix}${t('modelService.HealthCheck')}`,
+                    children:
+                      model.service.healthCheck.path || renderFallback(),
+                  },
+                  {
+                    key: `model-initial-delay-${idx}`,
+                    label: `${prefix}${t('modelService.InitialDelay')}`,
+                    children:
+                      model.service.healthCheck.initialDelay ??
+                      renderFallback(),
+                  },
+                  {
+                    key: `model-max-retries-${idx}`,
+                    label: `${prefix}${t('modelService.MaxRetries')}`,
+                    children:
+                      model.service.healthCheck.maxRetries ?? renderFallback(),
+                  },
+                ] as DescriptionsItemType[])
+              : []),
+          ] as DescriptionsItemType[])
+        : []),
+    ];
+    return modelItems;
+  });
+};
+
+const DeploymentOverviewContent: React.FC<{
+  deploymentId: string;
+  fetchKey: number;
+}> = ({ deploymentId, fetchKey }) => {
   'use memo';
-
   const { t } = useTranslation();
-  const { token } = theme.useToken();
-  const webuiNavigate = useWebUINavigate();
-  const [isPendingRefetch, startRefetchTransition] = useTransition();
-  const [fetchKey, setFetchKey] = useState(0);
-  const [isCurrentRevisionModalOpen, setIsCurrentRevisionModalOpen] =
-    useState(false);
 
-  useFragment(
-    graphql`
-      fragment DeploymentConfigurationSection_deployment on ModelDeployment {
-        id
-      }
-    `,
-    deploymentFrgmt,
-  );
-
-  const { deployment } = useLazyLoadQuery<DeploymentConfigurationSectionQuery>(
-    graphql`
-      query DeploymentConfigurationSectionQuery($deploymentId: ID!) {
-        deployment(id: $deploymentId) {
-          metadata {
-            name
-            tags
-            projectId
-            domainName
-            projectV2 @since(version: "26.4.3") {
-              basicInfo {
-                name
-              }
-            }
-          }
-          networkAccess {
-            openToPublic
-            endpointUrl
-          }
-          defaultDeploymentStrategy {
-            type
-          }
-          replicaState {
-            desiredReplicaCount
-          }
-          currentRevision @since(version: "26.4.3") {
-            id
-            name
-            clusterConfig {
-              mode
-              size
-            }
-            resourceConfig {
-              resourceGroupName
-            }
-            modelRuntimeConfig {
-              runtimeVariant {
-                name
-              }
-              environ {
-                entries {
+  const { deployment } =
+    useLazyLoadQuery<DeploymentConfigurationSectionOverviewQuery>(
+      graphql`
+        query DeploymentConfigurationSectionOverviewQuery($deploymentId: ID!) {
+          deployment(id: $deploymentId) {
+            metadata {
+              name
+              tags
+              projectId
+              domainName
+              projectV2 @since(version: "26.4.3") {
+                basicInfo {
                   name
-                  value
                 }
               }
             }
-            modelMountConfig {
-              vfolderId
-              mountDestination
-              definitionPath
-              vfolder {
-                id
-                name
-              }
+            networkAccess {
+              openToPublic
+              endpointUrl
             }
-            imageV2 @since(version: "26.4.3") {
-              id
-              identity {
-                canonicalName
-              }
-            }
-            modelDefinition {
-              models {
-                name
-                modelPath
-                service {
-                  startCommand
-                  port
-                  healthCheck {
-                    path
-                    initialDelay
-                    maxRetries
-                  }
-                }
-              }
-            }
-          }
-          revisionHistory(
-            limit: 1
-            orderBy: [{ field: CREATED_AT, direction: DESC }]
-          ) {
-            edges {
-              node {
-                id
-                name
-                modelDefinition {
-                  models {
-                    name
-                    modelPath
-                    service {
-                      startCommand
-                      port
-                      healthCheck {
-                        path
-                        initialDelay
-                        maxRetries
-                      }
-                    }
-                  }
-                }
-              }
+            replicaState {
+              desiredReplicaCount
             }
           }
         }
-      }
-    `,
-    { deploymentId },
-    { fetchKey, fetchPolicy: 'network-only' },
-  );
+      `,
+      { deploymentId },
+      { fetchKey, fetchPolicy: 'network-only' },
+    );
 
-  const deploymentLocalId = toLocalId(deploymentId);
-  const currentRevision = deployment?.currentRevision;
-  const clusterConfig = currentRevision?.clusterConfig;
-  const resourceConfig = currentRevision?.resourceConfig;
-  const runtimeConfig = currentRevision?.modelRuntimeConfig;
-  const mountConfig = currentRevision?.modelMountConfig;
   const projectName =
     deployment?.metadata.projectV2?.basicInfo?.name ??
     deployment?.metadata.projectId;
-
-  const renderFallback = () => (
-    <Typography.Text type="secondary">-</Typography.Text>
-  );
-
-  const environEntries = runtimeConfig?.environ?.entries ?? [];
   const tags = deployment?.metadata.tags ?? [];
 
-  const descriptionsProps = {
-    bordered: true,
-    column: { xxl: 3, xl: 2, lg: 2, md: 1, sm: 1, xs: 1 },
-    style: { backgroundColor: token.colorBgBase },
-  } as const;
-
-  // ─── Deployment-level items ───────────────────────────────────────────────
   const deploymentItems: DescriptionsItemType[] = filterOutEmpty([
     {
       key: 'name',
@@ -261,7 +243,121 @@ const DeploymentConfigurationSection: React.FC<
     },
   ]);
 
-  // ─── Current-revision config items ───────────────────────────────────────
+  return <Descriptions {...descriptionsProps} items={deploymentItems} />;
+};
+
+const DeploymentRevisionInfoContent: React.FC<{
+  deploymentId: string;
+  fetchKey: number;
+  onShowCurrentRevisionModal: () => void;
+}> = ({ deploymentId, fetchKey, onShowCurrentRevisionModal }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  const { deployment } =
+    useLazyLoadQuery<DeploymentConfigurationSectionRevisionInfoQuery>(
+      graphql`
+        query DeploymentConfigurationSectionRevisionInfoQuery(
+          $deploymentId: ID!
+        ) {
+          deployment(id: $deploymentId) {
+            currentRevision @since(version: "26.4.3") {
+              id
+              name
+              clusterConfig {
+                mode
+                size
+              }
+              resourceConfig {
+                resourceGroupName
+              }
+              modelRuntimeConfig {
+                runtimeVariant {
+                  name
+                }
+                environ {
+                  entries {
+                    name
+                    value
+                  }
+                }
+              }
+              modelMountConfig {
+                vfolderId
+                mountDestination
+                definitionPath
+                vfolder {
+                  id
+                  name
+                }
+              }
+              imageV2 @since(version: "26.4.3") {
+                id
+                identity {
+                  canonicalName
+                }
+              }
+              modelDefinition {
+                models {
+                  name
+                  modelPath
+                  service {
+                    startCommand
+                    port
+                    healthCheck {
+                      path
+                      initialDelay
+                      maxRetries
+                    }
+                  }
+                }
+              }
+            }
+            revisionHistory(
+              limit: 1
+              orderBy: [{ field: CREATED_AT, direction: DESC }]
+            ) {
+              edges {
+                node {
+                  id
+                  name
+                  modelDefinition {
+                    models {
+                      name
+                      modelPath
+                      service {
+                        startCommand
+                        port
+                        healthCheck {
+                          path
+                          initialDelay
+                          maxRetries
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      { deploymentId },
+      { fetchKey, fetchPolicy: 'network-only' },
+    );
+
+  const currentRevision = deployment?.currentRevision;
+  if (!currentRevision) {
+    return null;
+  }
+
+  const clusterConfig = currentRevision.clusterConfig;
+  const resourceConfig = currentRevision.resourceConfig;
+  const runtimeConfig = currentRevision.modelRuntimeConfig;
+  const mountConfig = currentRevision.modelMountConfig;
+  const environEntries = runtimeConfig?.environ?.entries ?? [];
+
   const revisionItems: DescriptionsItemType[] = filterOutEmpty([
     {
       key: 'resource-group',
@@ -287,7 +383,7 @@ const DeploymentConfigurationSection: React.FC<
     {
       key: 'model-version',
       label: t('deployment.ModelVersion'),
-      children: currentRevision?.name || renderFallback(),
+      children: currentRevision.name || renderFallback(),
     },
     {
       key: 'model-definition-path',
@@ -302,7 +398,7 @@ const DeploymentConfigurationSection: React.FC<
     {
       key: 'image',
       label: t('deployment.Image'),
-      children: currentRevision?.imageV2?.identity?.canonicalName ? (
+      children: currentRevision.imageV2?.identity?.canonicalName ? (
         <Typography.Text copyable>
           {currentRevision.imageV2.identity.canonicalName}
         </Typography.Text>
@@ -340,107 +436,22 @@ const DeploymentConfigurationSection: React.FC<
     },
   ]);
 
-  // ─── Model definition items (ported from EndpointDetailPage) ─────────────
-  const buildModelDefinitionItems = (
-    rawModels:
-      | ReadonlyArray<{
-          readonly name: string | null | undefined;
-          readonly modelPath: string | null | undefined;
-          readonly service?: {
-            readonly startCommand: unknown;
-            readonly port: number | null | undefined;
-            readonly healthCheck?: {
-              readonly path: string | null | undefined;
-              readonly initialDelay: number | null | undefined;
-              readonly maxRetries: number | null | undefined;
-            } | null;
-          } | null;
-        } | null>
-      | null
-      | undefined,
-  ): DescriptionsItemType[] => {
-    const models = filterOutNullAndUndefined(rawModels);
-    if (!models || models.length === 0) return [];
-    return models.flatMap((model, idx) => {
-      const prefix = models.length > 1 ? `[${idx}] ` : '';
-      const modelItems: DescriptionsItemType[] = [
-        {
-          key: `model-name-${idx}`,
-          label: `${prefix}${t('modelStore.ModelName')}`,
-          children: model.name || renderFallback(),
-        },
-        {
-          key: `model-path-${idx}`,
-          label: `${prefix}${t('modelStore.ModelPath')}`,
-          children: model.modelPath || renderFallback(),
-        },
-        ...(model.service
-          ? ([
-              {
-                key: `model-start-command-${idx}`,
-                label: `${prefix}${t('modelService.StartCommand')}`,
-                children: model.service.startCommand ? (
-                  <SourceCodeView language="shell">
-                    {typeof model.service.startCommand === 'string'
-                      ? model.service.startCommand
-                      : JSON.stringify(model.service.startCommand, null, 2)}
-                  </SourceCodeView>
-                ) : (
-                  renderFallback()
-                ),
-                span: { xl: 2 },
-              },
-              {
-                key: `model-port-${idx}`,
-                label: `${prefix}${t('modelService.Port')}`,
-                children: model.service.port ?? renderFallback(),
-              },
-              ...(model.service.healthCheck
-                ? ([
-                    {
-                      key: `model-healthcheck-path-${idx}`,
-                      label: `${prefix}${t('modelService.HealthCheck')}`,
-                      children:
-                        model.service.healthCheck.path || renderFallback(),
-                    },
-                    {
-                      key: `model-initial-delay-${idx}`,
-                      label: `${prefix}${t('modelService.InitialDelay')}`,
-                      children:
-                        model.service.healthCheck.initialDelay ??
-                        renderFallback(),
-                    },
-                    {
-                      key: `model-max-retries-${idx}`,
-                      label: `${prefix}${t('modelService.MaxRetries')}`,
-                      children:
-                        model.service.healthCheck.maxRetries ??
-                        renderFallback(),
-                    },
-                  ] as DescriptionsItemType[])
-                : []),
-            ] as DescriptionsItemType[])
-          : []),
-      ];
-      return modelItems;
-    });
-  };
-
   const currentModelDefItems = buildModelDefinitionItems(
-    currentRevision?.modelDefinition?.models,
+    currentRevision.modelDefinition?.models,
+    t,
   );
   const latestModelDefItems = buildModelDefinitionItems(
     deployment?.revisionHistory?.edges?.[0]?.node?.modelDefinition?.models,
+    t,
   );
-  const currentRevisionName = currentRevision?.name;
+  const currentRevisionName = currentRevision.name;
   const latestRevisionName =
     deployment?.revisionHistory?.edges?.[0]?.node?.name;
   const isRevisionMismatch =
-    currentRevision?.id != null &&
+    currentRevision.id != null &&
     deployment?.revisionHistory?.edges?.[0]?.node?.id != null &&
     currentRevision.id !== deployment.revisionHistory.edges[0].node.id;
 
-  // Latest revision: prefer latest model def items; current revision config always comes from currentRevision
   const displayRevisionName =
     latestModelDefItems.length > 0 ? latestRevisionName : currentRevisionName;
   const displayRevisionItems = [
@@ -449,7 +460,257 @@ const DeploymentConfigurationSection: React.FC<
       ? latestModelDefItems
       : currentModelDefItems),
   ];
-  const currentRevisionAllItems = [...revisionItems, ...currentModelDefItems];
+
+  return (
+    <>
+      {isRevisionMismatch && (
+        <Alert
+          type="info"
+          icon={<LoadingOutlined spin />}
+          showIcon
+          title={t('modelService.NextRevisionApplying')}
+          action={
+            <Button onClick={onShowCurrentRevisionModal}>
+              {t('modelService.ViewCurrentRevision')}
+            </Button>
+          }
+          style={{ marginBottom: token.marginMD }}
+        />
+      )}
+      <Descriptions
+        {...descriptionsProps}
+        items={[
+          {
+            key: 'revision-id',
+            label: t('modelService.RevisionID'),
+            children: displayRevisionName || renderFallback(),
+          },
+          ...displayRevisionItems,
+        ]}
+      />
+    </>
+  );
+};
+
+const DeploymentCurrentRevisionModalContent: React.FC<{
+  deploymentId: string;
+  fetchKey: number;
+}> = ({ deploymentId, fetchKey }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  const { deployment } =
+    useLazyLoadQuery<DeploymentConfigurationSectionCurrentRevisionModalQuery>(
+      graphql`
+        query DeploymentConfigurationSectionCurrentRevisionModalQuery(
+          $deploymentId: ID!
+        ) {
+          deployment(id: $deploymentId) {
+            currentRevision @since(version: "26.4.3") {
+              id
+              name
+              clusterConfig {
+                mode
+                size
+              }
+              resourceConfig {
+                resourceGroupName
+              }
+              modelRuntimeConfig {
+                runtimeVariant {
+                  name
+                }
+                environ {
+                  entries {
+                    name
+                    value
+                  }
+                }
+              }
+              modelMountConfig {
+                vfolderId
+                mountDestination
+                definitionPath
+                vfolder {
+                  id
+                  name
+                }
+              }
+              imageV2 @since(version: "26.4.3") {
+                id
+                identity {
+                  canonicalName
+                }
+              }
+              modelDefinition {
+                models {
+                  name
+                  modelPath
+                  service {
+                    startCommand
+                    port
+                    healthCheck {
+                      path
+                      initialDelay
+                      maxRetries
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      { deploymentId },
+      { fetchKey, fetchPolicy: 'store-and-network' },
+    );
+
+  const currentRevision = deployment?.currentRevision;
+  if (!currentRevision) {
+    return null;
+  }
+
+  const clusterConfig = currentRevision.clusterConfig;
+  const resourceConfig = currentRevision.resourceConfig;
+  const runtimeConfig = currentRevision.modelRuntimeConfig;
+  const mountConfig = currentRevision.modelMountConfig;
+  const environEntries = runtimeConfig?.environ?.entries ?? [];
+
+  const revisionItems: DescriptionsItemType[] = filterOutEmpty([
+    {
+      key: 'resource-group',
+      label: t('deployment.ResourceGroup'),
+      children: resourceConfig?.resourceGroupName || renderFallback(),
+    },
+    {
+      key: 'model-folder',
+      label: t('deployment.ModelFolder'),
+      children: mountConfig?.vfolder?.name ? (
+        <BAIFlex direction="column" align="start">
+          <Typography.Text>{mountConfig.vfolder.name}</Typography.Text>
+          {mountConfig.mountDestination && (
+            <Typography.Text type="secondary">
+              {mountConfig.mountDestination}
+            </Typography.Text>
+          )}
+        </BAIFlex>
+      ) : (
+        renderFallback()
+      ),
+    },
+    {
+      key: 'model-version',
+      label: t('deployment.ModelVersion'),
+      children: currentRevision.name || renderFallback(),
+    },
+    {
+      key: 'model-definition-path',
+      label: t('deployment.ModelDefinitionPath'),
+      children: mountConfig?.definitionPath || renderFallback(),
+    },
+    {
+      key: 'runtime-variant',
+      label: t('deployment.RuntimeVariant'),
+      children: runtimeConfig?.runtimeVariant?.name || renderFallback(),
+    },
+    {
+      key: 'image',
+      label: t('deployment.Image'),
+      children: currentRevision.imageV2?.identity?.canonicalName ? (
+        <Typography.Text copyable>
+          {currentRevision.imageV2.identity.canonicalName}
+        </Typography.Text>
+      ) : (
+        renderFallback()
+      ),
+    },
+    {
+      key: 'cluster-mode',
+      label: t('deployment.ClusterMode'),
+      children: clusterConfig ? (
+        <Typography.Text>
+          {clusterConfig.mode} / {clusterConfig.size}
+        </Typography.Text>
+      ) : (
+        renderFallback()
+      ),
+    },
+    {
+      key: 'environ',
+      label: t('deployment.Environ'),
+      children:
+        environEntries.length > 0 ? (
+          <BAIFlex direction="column" align="start">
+            {environEntries.map((entry) => (
+              <Typography.Text key={entry.name} code>
+                {entry.name}={entry.value}
+              </Typography.Text>
+            ))}
+          </BAIFlex>
+        ) : (
+          renderFallback()
+        ),
+      span: { xl: 2 },
+    },
+  ]);
+
+  const currentModelDefItems = buildModelDefinitionItems(
+    currentRevision.modelDefinition?.models,
+    t,
+  );
+
+  return (
+    <>
+      <Alert
+        type="info"
+        icon={<CheckCircleOutlined />}
+        showIcon
+        title={t('modelService.CurrentlyApplied')}
+        style={{ marginBottom: token.marginMD }}
+      />
+      <Descriptions
+        {...descriptionsProps}
+        items={[
+          {
+            key: 'current-revision-id',
+            label: t('modelService.RevisionID'),
+            children: currentRevision.name || renderFallback(),
+          },
+          ...revisionItems,
+          ...currentModelDefItems,
+        ]}
+      />
+    </>
+  );
+};
+
+const DeploymentConfigurationSection: React.FC<
+  DeploymentConfigurationSectionProps
+> = ({ deploymentFrgmt, deploymentId, isDeploymentDestroying = false }) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const webuiNavigate = useWebUINavigate();
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, setFetchKey] = useState(0);
+  const [isCurrentRevisionModalOpen, setIsCurrentRevisionModalOpen] =
+    useState(false);
+
+  const deployment = useFragment(
+    graphql`
+      fragment DeploymentConfigurationSection_deployment on ModelDeployment {
+        id
+        currentRevision @since(version: "26.4.3") {
+          id
+        }
+      }
+    `,
+    deploymentFrgmt,
+  );
+
+  const deploymentLocalId = toLocalId(deploymentId);
+  const hasCurrentRevision = !!deployment?.currentRevision?.id;
 
   const handleRefetch = () => {
     startRefetchTransition(() => {
@@ -480,64 +741,47 @@ const DeploymentConfigurationSection: React.FC<
             </BAIButton>
           </BAIFlex>
         }
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Descriptions {...descriptionsProps} items={deploymentItems} />
-      </BAICard>
-      {currentRevision && (
-        <Card title={t('modelService.RevisionInfo')}>
-          {isRevisionMismatch && (
-            <Alert
-              type="info"
-              icon={<LoadingOutlined spin />}
-              showIcon
-              title={t('modelService.NextRevisionApplying')}
-              action={
-                <Button onClick={() => setIsCurrentRevisionModalOpen(true)}>
-                  {t('modelService.ViewCurrentRevision')}
-                </Button>
-              }
-              style={{ marginBottom: token.marginMD }}
-            />
-          )}
-          <Descriptions
-            {...descriptionsProps}
-            items={[
-              {
-                key: 'revision-id',
-                label: t('modelService.RevisionID'),
-                children: displayRevisionName || renderFallback(),
-              },
-              ...displayRevisionItems,
-            ]}
+        <Suspense fallback={<Skeleton active />}>
+          <DeploymentOverviewContent
+            deploymentId={deploymentId}
+            fetchKey={fetchKey}
           />
-        </Card>
+        </Suspense>
+      </BAICard>
+      {hasCurrentRevision && (
+        <BAICard
+          title={t('modelService.RevisionInfo')}
+          styles={{ body: { paddingTop: 0 } }}
+        >
+          <Suspense fallback={<Skeleton active />}>
+            <DeploymentRevisionInfoContent
+              deploymentId={deploymentId}
+              fetchKey={fetchKey}
+              onShowCurrentRevisionModal={() =>
+                setIsCurrentRevisionModalOpen(true)
+              }
+            />
+          </Suspense>
+        </BAICard>
       )}
-      <BAIModal
-        open={isCurrentRevisionModalOpen}
-        onCancel={() => setIsCurrentRevisionModalOpen(false)}
-        title={t('modelService.CurrentRevisionTitle')}
-        footer={null}
-        width={800}
-      >
-        <Alert
-          type="info"
-          icon={<CheckCircleOutlined />}
-          showIcon
-          title={t('modelService.CurrentlyApplied')}
-          style={{ marginBottom: token.marginMD }}
-        />
-        <Descriptions
-          {...descriptionsProps}
-          items={[
-            {
-              key: 'current-revision-id',
-              label: t('modelService.RevisionID'),
-              children: currentRevisionName || renderFallback(),
-            },
-            ...currentRevisionAllItems,
-          ]}
-        />
-      </BAIModal>
+      <BAIUnmountAfterClose>
+        <BAIModal
+          open={isCurrentRevisionModalOpen}
+          onCancel={() => setIsCurrentRevisionModalOpen(false)}
+          title={t('modelService.CurrentRevisionTitle')}
+          footer={null}
+          width={800}
+        >
+          <Suspense fallback={<Skeleton active />}>
+            <DeploymentCurrentRevisionModalContent
+              deploymentId={deploymentId}
+              fetchKey={fetchKey}
+            />
+          </Suspense>
+        </BAIModal>
+      </BAIUnmountAfterClose>
     </>
   );
 };

--- a/react/src/components/DeploymentList.tsx
+++ b/react/src/components/DeploymentList.tsx
@@ -108,7 +108,10 @@ export interface DeploymentListProps extends Omit<
   BAITableProps<DeploymentNode>,
   'dataSource' | 'columns' | 'onChangeOrder'
 > {
-  deploymentsFrgmt: DeploymentList_modelDeploymentConnection$key;
+  deploymentsFrgmt:
+    | DeploymentList_modelDeploymentConnection$key
+    | null
+    | undefined;
   filter?: string;
   setFilter: (value: string) => void;
   onChangeOrder?: (order: string | null) => void;

--- a/react/src/components/DeploymentStatusTag.tsx
+++ b/react/src/components/DeploymentStatusTag.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import type { TagProps } from 'antd';
-import { BAITag, type SemanticColor } from 'backend.ai-ui';
+import { BAITag } from 'backend.ai-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -20,6 +20,17 @@ export type DeploymentStatus =
   | 'PENDING'
   | 'READY';
 
+// antd Tag preset status colors. `'info'` is NOT a preset — passing it falls
+// through as a raw CSS color and renders as a vivid default tag in dark mode,
+// which is why this map uses `'processing'` (the in-flight preset with a
+// colorInfo-tinted background and pulsing dot).
+type StatusTagColor =
+  | 'success'
+  | 'processing'
+  | 'error'
+  | 'default'
+  | 'warning';
+
 /**
  * Maps each deployment status to a Tag color.
  *
@@ -28,12 +39,12 @@ export type DeploymentStatus =
  * - warning:    DEGRADED, UNHEALTHY, STOPPING — attention needed or transitioning away.
  * - default:    NOT_CHECKED, STOPPED, TERMINATED — neutral / inactive.
  */
-const deploymentStatusColorMap: Record<DeploymentStatus, SemanticColor> = {
+const deploymentStatusColorMap: Record<DeploymentStatus, StatusTagColor> = {
   HEALTHY: 'success',
   READY: 'success',
-  DEPLOYING: 'info',
-  SCALING: 'info',
-  PENDING: 'info',
+  DEPLOYING: 'processing',
+  SCALING: 'processing',
+  PENDING: 'processing',
   DEGRADED: 'warning',
   UNHEALTHY: 'warning',
   STOPPING: 'warning',

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -137,7 +137,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
   const isLoading =
     deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
 
-  return adminDeployments ? (
+  return (
     <DeploymentList
       mode="admin"
       deploymentsFrgmt={adminDeployments}
@@ -182,7 +182,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
         />
       }
     />
-  ) : null;
+  );
 };
 
 const AdminDeploymentListPage: React.FC = () => {

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -13,8 +13,8 @@ import DeploymentStatusTag, {
 } from '../components/DeploymentStatusTag';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Card, Skeleton, Tooltip, Typography, theme } from 'antd';
-import { BAIFlex, toGlobalId } from 'backend.ai-ui';
+import { Skeleton, Tooltip, Typography, theme } from 'antd';
+import { BAICard, BAIFlex, toGlobalId } from 'backend.ai-ui';
 import { parseAsString, useQueryState } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -91,14 +91,12 @@ const DeploymentDetailPage: React.FC = () => {
         </Typography.Title>
         <DeploymentStatusTag status={deploymentStatus} />
       </BAIFlex>
-      <Suspense fallback={<Skeleton active />}>
-        <DeploymentConfigurationSection
-          deploymentFrgmt={deployment}
-          deploymentId={toGlobalId('ModelDeployment', deploymentId)}
-          isDeploymentDestroying={isDeploymentDestroying}
-        />
-      </Suspense>
-      <Card
+      <DeploymentConfigurationSection
+        deploymentFrgmt={deployment}
+        deploymentId={toGlobalId('ModelDeployment', deploymentId)}
+        isDeploymentDestroying={isDeploymentDestroying}
+      />
+      <BAICard
         activeTabKey={activeTab}
         onTabChange={(key) => setActiveTab(key)}
         tabList={[
@@ -153,42 +151,14 @@ const DeploymentDetailPage: React.FC = () => {
             />
           </Suspense>
         </div>
-      </Card>
-      <Card
-        title={
-          <BAIFlex gap="xs" align="center">
-            {t('deployment.tab.AutoScaling')}
-            <Tooltip title={t('deployment.tab.description.AutoScaling')}>
-              <QuestionCircleOutlined
-                style={{ color: token.colorTextDescription }}
-              />
-            </Tooltip>
-          </BAIFlex>
-        }
-      >
-        <DeploymentAutoScalingTab deploymentFrgmt={deployment} />
-      </Card>
-      <Card
-        title={
-          <BAIFlex gap="xs" align="center">
-            {t('deployment.tab.AccessTokens')}
-            <Tooltip title={t('deployment.tab.description.AccessTokens')}>
-              <QuestionCircleOutlined
-                style={{ color: token.colorTextDescription }}
-              />
-            </Tooltip>
-          </BAIFlex>
-        }
-      >
-        <Suspense fallback={<Skeleton active />}>
-          <DeploymentAccessTokensTab
-            deploymentFrgmt={deployment}
-            deploymentId={toGlobalId('ModelDeployment', deploymentId)}
-            isOwnedByCurrentUser={isOwnedByCurrentUser}
-            isDeploymentDestroying={isDeploymentDestroying}
-          />
-        </Suspense>
-      </Card>
+      </BAICard>
+      <DeploymentAutoScalingTab deploymentFrgmt={deployment} />
+      <DeploymentAccessTokensTab
+        deploymentFrgmt={deployment}
+        deploymentId={toGlobalId('ModelDeployment', deploymentId)}
+        isOwnedByCurrentUser={isOwnedByCurrentUser}
+        isDeploymentDestroying={isDeploymentDestroying}
+      />
     </BAIFlex>
   );
 };

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -133,7 +133,7 @@ const DeploymentListPageContent: React.FC = () => {
   const isPending =
     deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
 
-  return myDeployments ? (
+  return (
     <DeploymentList
       deploymentsFrgmt={myDeployments}
       filter={queryParams.filter ?? undefined}
@@ -187,7 +187,7 @@ const DeploymentListPageContent: React.FC = () => {
         </BAIFlex>
       }
     />
-  ) : null;
+  );
 };
 
 const DeploymentListPage: React.FC = () => {


### PR DESCRIPTION
Resolves #7145 ([FR-2772](https://lablup.atlassian.net/browse/FR-2772))

## Summary

- All deployment cards now use `BAICard` with `styles={{ body: { paddingTop: 0 } }}` so the body sits flush against the header. Tabbed `BAICard`s keep BAICard's default tab-aware paddingTop.
- Card-scoped actions (refresh button, primary `+ Add` / `+ Create`, `Edit configuration`) live in `BAICard.extra`. Only content-scoped controls (filter, search) remain inside the body.
- Suspense boundary now lives **inside** each card so the header is always visible while the body shows `Skeleton active`.
- `DeploymentConfigurationSection` is split into `DeploymentOverviewContent`, `DeploymentRevisionInfoContent`, and `DeploymentCurrentRevisionModalContent`. Each owns its own `useLazyLoadQuery` and internal `Suspense` / `Skeleton`. `currentRevision { id }` was added to the parent fragment so the Revision Info card's frame can be rendered conditionally without waiting for the inner fetch.
- `AutoScalingRuleList` gained `hideInlineAddButton` / `hideInlineRefreshButton` props and an imperative `ref` exposing `openAddModal()`, so `DeploymentAutoScalingTab` can render the title, refresh, and `+ Add rule` button in the card `extra` while the list owns the editor modal. EndpointDetailPage usage is unaffected (defaults preserved).
- `DeploymentAccessTokensTab` is wrapped in its own BAICard with refresh + create in `extra`; the list query was extracted into `DeploymentAccessTokensTable` so the card header stays visible during fetch.
- `Descriptions` no longer overrides `backgroundColor` to `colorBgBase` — label / value strips render correctly in dark mode (the `colorFillAlter` label band is restored).
- `DeploymentStatusTag` maps in-flight statuses (`DEPLOYING`, `SCALING`, `PENDING`) to `'processing'` instead of the non-preset `'info'`, fixing the vivid dark-mode tag and matching the doc-comment intent.
- `DeploymentList`'s `deploymentsFrgmt` prop is nullable; both `DeploymentListPage` and `AdminDeploymentListPage` drop the `: null` branch so transient `myDeployments === null` shows the toolbar + empty table instead of an empty card.
- Add Revision modal Suspense fallback unified to `Skeleton active` (was a centered `Spin`).
- New `.claude/rules/use-bai-card.md` documents the BAICard convention: prefer over `Card`, `body.paddingTop: 0` (except tabbed), card-scoped actions go in `extra`, Suspense lives inside the card with `Skeleton` fallback.

## Test plan

- [ ] `bash scripts/verify.sh` passes (Relay / Lint / Format / TypeScript).
- [ ] Deployment list page (light + dark): toolbar (filter, search, refresh, create) renders normally; navigating into a deployment and back does not leave an empty card — table + "no data" / rows render.
- [ ] Deployment detail page (light + dark): Overview, Revision Info, AutoScaling, Access Tokens, Replicas/Revisions tabs all show their card title during loading; bodies show `Skeleton`; refresh + primary action sit in each card header.
- [ ] Descriptions in Overview / Revision Info: in dark mode the label column shows the `colorFillAlter` band and the value column matches card background (no flat black plane).
- [ ] Status tag: an in-flight deployment (e.g. `DEPLOYING` / `PENDING`) shows the antd `processing` preset (transparent body, processing dot) — not the vivid default tag.
- [ ] AutoScaling card: clicking `+ Add rule` in the card header opens the editor modal; refresh button in header refetches; AutoScalingRuleList in `EndpointDetailPage` (legacy) still has its inline buttons (no regression).
- [ ] Access Tokens card: clicking `+ Create access token` in the card header opens the create modal; refresh button in header refetches.
- [ ] Add Revision modal: while loading, body shows `Skeleton`, not a centered spinner.

[FR-2772]: https://lablup.atlassian.net/browse/FR-2772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ