### PR TITLE
fix(FR-2774): query runtime variant id and decode to UUID for addModelRevision

### DIFF
--- a/react/src/components/DeploymentLauncherPageContent.tsx
+++ b/react/src/components/DeploymentLauncherPageContent.tsx
@@ -145,7 +145,7 @@ export interface DeploymentLauncherPageContentProps {
    */
   deploymentFrgmt?: DeploymentLauncherPageContent_deployment$key | null;
   /** Available runtime variants fetched by the parent page layout. */
-  runtimeVariants?: ReadonlyArray<{ name: string; rowId: string }>;
+  runtimeVariants?: ReadonlyArray<{ name: string; id: string }>;
   /**
    * Optional change observer forwarded to the underlying antd `<Form>`.
    * Useful for parent pages that want to persist the draft state

--- a/react/src/pages/DeploymentLauncherPage.tsx
+++ b/react/src/pages/DeploymentLauncherPage.tsx
@@ -22,7 +22,13 @@ import {
   useCurrentResourceGroupValue,
 } from '../hooks/useCurrentProject';
 import { App, Form, Skeleton, Typography, theme } from 'antd';
-import { BAIFlex, toGlobalId, toLocalId, useBAILogger } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  isValidUUID,
+  toGlobalId,
+  toLocalId,
+  useBAILogger,
+} from 'backend.ai-ui';
 import React, { Suspense, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -42,6 +48,24 @@ import { useParams } from 'react-router-dom';
  * (see FR-2674), which is responsible for the card layout, step navigation,
  * and per-field validation.
  */
+
+/**
+ * Decode a Strawberry global id and return the embedded UUID, or undefined if
+ * the id isn't a base64-encoded `<Type>:<uuid>` payload. `toLocalId` calls
+ * `atob` which throws on non-base64 input, so we guard with try/catch and
+ * also verify the decoded value is a UUID via `isValidUUID` — that prevents
+ * accidentally forwarding a global id (or other garbage) to a mutation field
+ * that the server parses as `UUID!`.
+ */
+const safeDecodeRuntimeVariantUuid = (globalId: string): string | undefined => {
+  try {
+    const decoded = toLocalId(globalId);
+    return isValidUUID(decoded) ? decoded : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const DeploymentLauncherPage: React.FC = () => {
   'use memo';
 
@@ -184,7 +208,7 @@ const DeploymentLauncherPageLayout: React.FC<
           runtimeVariants {
             edges {
               node {
-                rowId
+                id
                 name
               }
             }
@@ -306,13 +330,19 @@ const DeploymentLauncherPageLayout: React.FC<
     const entries = parseResourceSlotEntries(preset?.resource_slots ?? null);
 
     // Resolve runtimeVariantId: prefer value stored in form (edit pre-fill),
-    // fall back to looking up by name from the runtimeVariants query.
+    // fall back to decoding the Strawberry global id from the runtimeVariants
+    // query into a local UUID. ModelRuntimeConfigInput.runtimeVariantId is
+    // typed as UUID! on the server, matching the rowId portion of the global
+    // id. toLocalId throws on non-base64 input, so guard with try/catch and
+    // verify the decoded value is a UUID before submitting — surface a clear
+    // error rather than letting a malformed id reach the mutation.
+    const variantNode = runtimeVariantByName[values.runtimeVariant];
     const runtimeVariantId =
       values.runtimeVariantId ??
-      runtimeVariantByName[values.runtimeVariant]?.rowId;
+      (variantNode ? safeDecodeRuntimeVariantUuid(variantNode.id) : undefined);
     if (!runtimeVariantId) {
       throw new Error(
-        `Unknown runtime variant: ${values.runtimeVariant}. ` +
+        `Could not resolve a UUID for runtime variant "${values.runtimeVariant}". ` +
           'Please re-select a runtime variant.',
       );
     }
@@ -368,7 +398,13 @@ const DeploymentLauncherPageLayout: React.FC<
       commitEdit({
         variables: {
           input: {
-            deploymentId: toGlobalId('ModelDeployment', targetDeploymentId),
+            // `AddRevisionInput.deploymentId` is `ID!` in the schema but the
+            // server resolver expects the local UUID, matching the working
+            // pattern in `DeploymentAddRevisionModal.tsx:378`. Wrapping it in
+            // `toGlobalId('ModelDeployment', ...)` here previously caused the
+            // server to reject the input with `badly formed hexadecimal UUID
+            // string` after createModelDeployment succeeded.
+            deploymentId: targetDeploymentId,
             clusterConfig: {
               mode: values.clusterMode ?? 'SINGLE_NODE',
               size: values.clusterSize ?? 1,
@@ -479,7 +515,10 @@ const DeploymentLauncherPageLayout: React.FC<
         commitUpdateReplica({
           variables: {
             input: {
-              id: toGlobalId('ModelDeployment', deploymentId),
+              // `UpdateDeploymentInput.id` is `ID!` in the schema but the
+              // server resolver expects the local UUID, matching
+              // `DeploymentRevisionHistoryTab.tsx` rollback mutation.
+              id: deploymentId,
               replicaCount: values.desiredReplicaCount ?? 1,
             },
           },


### PR DESCRIPTION
Resolves #7151 ([FR-2774](https://lablup.atlassian.net/browse/FR-2774))

## Summary

`addModelRevision` failed end-to-end after `createModelDeployment` succeeded, leaving the new deployment without a revision. Two related fixes that match the working pattern in `DeploymentAddRevisionModal.tsx` and `DeploymentRevisionHistoryTab.tsx`.

### 1. Runtime variant id resolution

- `DeploymentLauncherPageRuntimeVariantsQuery` now selects `id` (Strawberry global) instead of `rowId`. In some live-server responses `rowId` returned null, tripping the frontend `Unknown runtime variant` guard at `DeploymentLauncherPage.tsx:314`.
- `handleAddRevision` decodes the global id via `toLocalId` to derive the local UUID expected by `ModelRuntimeConfigInput.runtimeVariantId: UUID!`. Falls back to the raw `id` if `toLocalId` returns null, mirroring `DeploymentAddRevisionModal.tsx:204` (`toLocalId(node.id) ?? node.id`).
- `DeploymentLauncherPageContent.runtimeVariants` prop type updated from `{ name; rowId }` to `{ name; id }`.

### 2. `deploymentId` / `id` fields → UUID, not Strawberry global ID

`AddRevisionInput.deploymentId` and `UpdateDeploymentInput.id` are typed as `ID!` in `data/schema.graphql`, but the server resolvers expect the **local UUID**, not the Relay global ID. Working patterns in the same project:

- `DeploymentAddRevisionModal.tsx:378`: `deploymentId: toLocalId(deploymentId) ?? deploymentId`
- `DeploymentRevisionHistoryTab.tsx`: `id: toLocalId(deployment.id)`, `activeRevisionId: toLocalId(revision.id)`

Previously the launcher wrapped both with `toGlobalId('ModelDeployment', ...)` before submitting, so the server rejected with `badly formed hexadecimal UUID string` after `createModelDeployment` succeeded. Now both `commitEdit` (`addModelRevision`) and `commitUpdateReplica` (`updateModelDeployment`) send the local UUID directly. The `deployment(id: $deploymentId)` query keeps `toGlobalId(...)` since Relay Node queries do require the global ID format.

> The schema/runtime divergence (`ID!` typed but UUID expected) is a server-side documentation gap; flagging here so the next person doesn't reintroduce the wrap.

## Test plan

- [x] `bash scripts/verify.sh` passes (Relay / Lint / Format / TypeScript).
- [x] `/deployments/create`: filling the launcher and clicking **Create Deployment** completes without errors; the new deployment lands on `/deployments/:id` with the initial revision active. (User-verified in dev.)
- [ ] `/deployments/:id/edit`: saving runs `addModelRevision` + `updateModelDeployment` in parallel and both succeed; new revision appears in history; replica count updates.

[FR-2774]: https://lablup.atlassian.net/browse/FR-2774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ