### PR TITLE
fix(FR-2773): preserve auto-selected resourcePresetId across applyInitialValues

### DIFF
--- a/react/src/components/DeploymentLauncherPageContent.tsx
+++ b/react/src/components/DeploymentLauncherPageContent.tsx
@@ -496,14 +496,25 @@ const DeploymentLauncherPageContent: React.FC<
         ? _.merge({}, initialValues, formValuesFromURL)
         : initialValues;
 
-    // In create mode, skip setting an empty resourceGroup so that
-    // BAIProjectResourceGroupSelect.autoSelectDefault can pick the first option.
-    // Child effects (auto-select) run before parent effects (this one), so
-    // passing '' here would override the already-selected value.
+    // In create mode, skip setting empty fields whose child component owns an
+    // autoSelectDefault flow. Child effects (auto-select) run before parent
+    // effects (this one), so passing an empty value here would clobber the
+    // value the child has already selected — the child's internal display
+    // state would survive but the form value reads as undefined, so downstream
+    // readers (e.g. the review summary) see '-'.
+    //
+    // Membership rule: add a field here only if its step-2/3 Select passes
+    // `autoSelectDefault`. Currently: BAIProjectResourceGroupSelect (step 3)
+    // and ResourcePresetSelect (step 3). VFolderSelect (step 2) does not pass
+    // autoSelectDefault; if that ever changes, add 'modelFolderId' here.
+    const autoSelectKeys: Array<keyof DeploymentLauncherFormValue> = [
+      'resourceGroup',
+      'resourcePresetId',
+    ];
+    const omitKeys =
+      mode === 'create' ? autoSelectKeys.filter((k) => !merged[k]) : [];
     form.setFieldsValue(
-      mode === 'create' && !merged.resourceGroup
-        ? _.omit(merged, 'resourceGroup')
-        : merged,
+      omitKeys.length > 0 ? _.omit(merged, omitKeys) : merged,
     );
   });
 


### PR DESCRIPTION
Resolves #7150 ([FR-2773](https://lablup.atlassian.net/browse/FR-2773))

> Stacks on top of #7152 (FR-2774).

## Summary

The Resource Preset row showed `-` on the deployment launcher review step even though the user had a preset selected on step 3. Fixed by extending the `applyInitialValues` omit list so any field whose child component owns an `autoSelectDefault` flow is left alone when its merged value is empty.

## Root cause

1. On mount, `ResourcePresetSelect`'s `autoSelectDefault` effect (a child) runs **before** the parent's `applyInitialValues` effect.
2. Auto-select sets `resourcePresetId` to the first available preset name.
3. `applyInitialValues` then runs and called `form.setFieldsValue(merged)` with `merged.resourcePresetId === undefined`, clobbering the auto-selected value.
4. `ResourcePresetSelect` uses `useControllableState_deprecated`, whose `stateRef` retains the auto-selected value when the antd-injected `value` is `undefined`. So the step-3 Select **kept displaying** the preset name (giving the user the impression it was selected), while `form.getFieldsValue()` returned `undefined`.
5. The review summary's `values.resourcePresetId ? <ResourcePresetReviewDisplay … /> : '-'` fell to the dash branch.

The existing code already handled the same race for `resourceGroup` via `_.omit(merged, 'resourceGroup')`. This PR generalizes that omit list to also cover `resourcePresetId`.

## Test plan

- [ ] `bash scripts/verify.sh` passes.
- [ ] `/deployments/create`: select a resource group, allow auto-select to pick a preset on step 3, click Next → review step renders the preset name and resource slot icons (no `-`).
- [ ] Manually change the resource preset on step 3 → review reflects the new preset.
- [ ] Edit mode (`/deployments/:id/edit`): pre-filled preset still renders on review.
- [ ] Edge: open `/deployments/create` directly (no URL pre-fill) and skip to review immediately → preset row shows the auto-selected preset, not `-`.

[FR-2773]: https://lablup.atlassian.net/browse/FR-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ