### PR TITLE
fix(FR-2775): localize ROLE_ASSIGNMENT and resolve scope name in permission modal

### DIFF
--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -83,6 +83,43 @@ const CreatePermissionModal: React.FC<CreatePermissionModalProps> = ({
             node {
               scopeType
               scopeId
+              scope {
+                ... on DomainV2 {
+                  basicInfo {
+                    domainName: name
+                  }
+                }
+                ... on ProjectV2 {
+                  basicInfo {
+                    projectName: name
+                  }
+                }
+                ... on UserV2 {
+                  basicInfo {
+                    email
+                  }
+                }
+                ... on VirtualFolderNode {
+                  vfolderName: name
+                }
+                ... on SessionV2 {
+                  metadata {
+                    sessionName: name
+                  }
+                }
+                ... on ModelDeployment {
+                  metadata {
+                    deploymentName: name
+                  }
+                }
+                ... on ResourceGroup {
+                  resourceGroupName: name
+                }
+                ... on ContainerRegistryV2 {
+                  registryName
+                  project
+                }
+              }
             }
           }
         }
@@ -108,10 +145,7 @@ const CreatePermissionModal: React.FC<CreatePermissionModalProps> = ({
 
   const roleScopes = (roleScope?.allScopes?.edges ?? [])
     .map((e) => e?.node)
-    .filter(
-      (n): n is { scopeType: RBACElementType; scopeId: string } =>
-        !!n && !!n.scopeType && !!n.scopeId,
-    );
+    .filter((n): n is NonNullable<typeof n> => !!n);
 
   const hasRoleScopes = roleScopes.length > 0;
   const watchedRoleScopeKey = Form.useWatch('roleScopeKey', form) as
@@ -368,12 +402,47 @@ const CreatePermissionModal: React.FC<CreatePermissionModalProps> = ({
             <BAISelect
               showSearch
               placeholder={t('rbac.ScopeTypeAndId')}
-              options={actionableRoleScopes.map((s) => ({
-                value: makeScopeKey(s.scopeType, s.scopeId),
-                label: `${t(`rbac.types.${s.scopeType}`, {
-                  defaultValue: s.scopeType,
-                })} / ${s.scopeId}`,
-              }))}
+              options={actionableRoleScopes.map((s) => {
+                const scope = s.scope;
+                let resolvedName: string | null | undefined = null;
+                if (scope) {
+                  switch (s.scopeType) {
+                    case 'DOMAIN':
+                      resolvedName = scope.basicInfo?.domainName;
+                      break;
+                    case 'PROJECT':
+                      resolvedName = scope.basicInfo?.projectName;
+                      break;
+                    case 'USER':
+                      resolvedName = scope.basicInfo?.email;
+                      break;
+                    case 'VFOLDER':
+                      resolvedName = scope.vfolderName;
+                      break;
+                    case 'SESSION':
+                      resolvedName = scope.metadata?.sessionName;
+                      break;
+                    case 'MODEL_DEPLOYMENT':
+                      resolvedName = scope.metadata?.deploymentName;
+                      break;
+                    case 'RESOURCE_GROUP':
+                      resolvedName = scope.resourceGroupName;
+                      break;
+                    case 'CONTAINER_REGISTRY':
+                      resolvedName = scope.project
+                        ? `${scope.registryName} - ${scope.project}`
+                        : scope.registryName;
+                      break;
+                  }
+                }
+                const displayName = resolvedName || s.scopeId;
+                return {
+                  value: makeScopeKey(s.scopeType, s.scopeId),
+                  label: `${t(`rbac.types.${s.scopeType}`, {
+                    defaultValue: s.scopeType,
+                  })} / ${displayName}`,
+                };
+              })}
             />
           </Form.Item>
         ) : (

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2064,6 +2064,7 @@
       "RESOURCE_GROUP": "Ressourcengruppe",
       "RESOURCE_PRESET": "Ressourcenvorlage",
       "ROLE": "Rolle",
+      "ROLE_ASSIGNMENT": "Rollenzuweisung",
       "ROUTING": "Routing",
       "SESSION": "Sitzung",
       "SESSION_TEMPLATE": "Sitzungsvorlage",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2062,6 +2062,7 @@
       "RESOURCE_GROUP": "Ομάδα πόρων",
       "RESOURCE_PRESET": "Προεπιλογή πόρων",
       "ROLE": "Ρόλος",
+      "ROLE_ASSIGNMENT": "Ανάθεση ρόλου",
       "ROUTING": "Δρομολόγηση",
       "SESSION": "Συνεδρία",
       "SESSION_TEMPLATE": "Πρότυπο συνεδρίας",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2072,6 +2072,7 @@
       "RESOURCE_GROUP": "Resource Group",
       "RESOURCE_PRESET": "Resource Preset",
       "ROLE": "Role",
+      "ROLE_ASSIGNMENT": "Role Assignment",
       "ROUTING": "Routing",
       "SESSION": "Session",
       "SESSION_TEMPLATE": "Session Template",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2062,6 +2062,7 @@
       "RESOURCE_GROUP": "Grupo de recursos",
       "RESOURCE_PRESET": "Preajuste de recursos",
       "ROLE": "Rol",
+      "ROLE_ASSIGNMENT": "Asignación de rol",
       "ROUTING": "Enrutamiento",
       "SESSION": "Sesión",
       "SESSION_TEMPLATE": "Plantilla de sesión",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2062,6 +2062,7 @@
       "RESOURCE_GROUP": "Resurssiryhmä",
       "RESOURCE_PRESET": "Resurssiasiasetus",
       "ROLE": "Rooli",
+      "ROLE_ASSIGNMENT": "Roolin määritys",
       "ROUTING": "Reititys",
       "SESSION": "Istunto",
       "SESSION_TEMPLATE": "Istuntomalli",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2064,6 +2064,7 @@
       "RESOURCE_GROUP": "Groupe de ressources",
       "RESOURCE_PRESET": "Préréglage de ressources",
       "ROLE": "Rôle",
+      "ROLE_ASSIGNMENT": "Attribution de rôle",
       "ROUTING": "Routage",
       "SESSION": "Session",
       "SESSION_TEMPLATE": "Modèle de session",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2065,6 +2065,7 @@
       "RESOURCE_GROUP": "Grup Sumber Daya",
       "RESOURCE_PRESET": "Preset Sumber Daya",
       "ROLE": "Peran",
+      "ROLE_ASSIGNMENT": "Penugasan peran",
       "ROUTING": "Perutean",
       "SESSION": "Sesi",
       "SESSION_TEMPLATE": "Template Sesi",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2062,6 +2062,7 @@
       "RESOURCE_GROUP": "Gruppo di risorse",
       "RESOURCE_PRESET": "Preset risorse",
       "ROLE": "Ruolo",
+      "ROLE_ASSIGNMENT": "Assegnazione del ruolo",
       "ROUTING": "Instradamento",
       "SESSION": "Sessione",
       "SESSION_TEMPLATE": "Template sessione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2064,6 +2064,7 @@
       "RESOURCE_GROUP": "リソースグループ",
       "RESOURCE_PRESET": "リソースプリセット",
       "ROLE": "ロール",
+      "ROLE_ASSIGNMENT": "ロールの割り当て",
       "ROUTING": "ルーティング",
       "SESSION": "セッション",
       "SESSION_TEMPLATE": "セッションテンプレート",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2074,6 +2074,7 @@
       "RESOURCE_GROUP": "자원 그룹",
       "RESOURCE_PRESET": "자원 프리셋",
       "ROLE": "역할",
+      "ROLE_ASSIGNMENT": "권한 할당",
       "ROUTING": "라우팅",
       "SESSION": "세션",
       "SESSION_TEMPLATE": "세션 템플릿",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2063,6 +2063,7 @@
       "RESOURCE_GROUP": "Нөөцийн бүлэг",
       "RESOURCE_PRESET": "Нөөцийн урьдчилсан тохиргоо",
       "ROLE": "Үүрэг",
+      "ROLE_ASSIGNMENT": "Үүрэг хуваарилалт",
       "ROUTING": "Чиглүүлэлт",
       "SESSION": "Сесс",
       "SESSION_TEMPLATE": "Сессийн загвар",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2062,6 +2062,7 @@
       "RESOURCE_GROUP": "Kumpulan Sumber",
       "RESOURCE_PRESET": "Pratetap Sumber",
       "ROLE": "Peranan",
+      "ROLE_ASSIGNMENT": "Penugasan peranan",
       "ROUTING": "Penghalaan",
       "SESSION": "Sesi",
       "SESSION_TEMPLATE": "Templat Sesi",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2064,6 +2064,7 @@
       "RESOURCE_GROUP": "Grupa zasobów",
       "RESOURCE_PRESET": "Ustawienie wstępne zasobów",
       "ROLE": "Rola",
+      "ROLE_ASSIGNMENT": "Przypisanie roli",
       "ROUTING": "Routing",
       "SESSION": "Sesja",
       "SESSION_TEMPLATE": "Szablon sesji",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2062,6 +2062,7 @@
       "RESOURCE_GROUP": "Grupo de recursos",
       "RESOURCE_PRESET": "Predefinição de recursos",
       "ROLE": "Função",
+      "ROLE_ASSIGNMENT": "Atribuição de função",
       "ROUTING": "Roteamento",
       "SESSION": "Sessão",
       "SESSION_TEMPLATE": "Modelo de sessão",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2064,6 +2064,7 @@
       "RESOURCE_GROUP": "Grupo de recursos",
       "RESOURCE_PRESET": "Predefinição de recursos",
       "ROLE": "Função",
+      "ROLE_ASSIGNMENT": "Atribuição de função",
       "ROUTING": "Roteamento",
       "SESSION": "Sessão",
       "SESSION_TEMPLATE": "Modelo de sessão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2062,6 +2062,7 @@
       "RESOURCE_GROUP": "Группа ресурсов",
       "RESOURCE_PRESET": "Предустановка ресурсов",
       "ROLE": "Роль",
+      "ROLE_ASSIGNMENT": "Назначение роли",
       "ROUTING": "Маршрутизация",
       "SESSION": "Сессия",
       "SESSION_TEMPLATE": "Шаблон сессии",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2064,6 +2064,7 @@
       "RESOURCE_GROUP": "กลุ่มทรัพยากร",
       "RESOURCE_PRESET": "ค่าที่ตั้งล่วงหน้าของทรัพยากร",
       "ROLE": "บทบาท",
+      "ROLE_ASSIGNMENT": "การกำหนดบทบาท",
       "ROUTING": "การกำหนดเส้นทาง",
       "SESSION": "เซสชัน",
       "SESSION_TEMPLATE": "เทมเพลตเซสชัน",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2062,6 +2062,7 @@
       "RESOURCE_GROUP": "Kaynak Grubu",
       "RESOURCE_PRESET": "Kaynak Ön Ayarı",
       "ROLE": "Rol",
+      "ROLE_ASSIGNMENT": "Rol Ataması",
       "ROUTING": "Yönlendirme",
       "SESSION": "Oturum",
       "SESSION_TEMPLATE": "Oturum Şablonu",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2064,6 +2064,7 @@
       "RESOURCE_GROUP": "Nhóm tài nguyên",
       "RESOURCE_PRESET": "Cài đặt sẵn tài nguyên",
       "ROLE": "Vai trò",
+      "ROLE_ASSIGNMENT": "Gán vai trò",
       "ROUTING": "Định tuyến",
       "SESSION": "Phiên",
       "SESSION_TEMPLATE": "Mẫu phiên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2064,6 +2064,7 @@
       "RESOURCE_GROUP": "资源组",
       "RESOURCE_PRESET": "资源预设",
       "ROLE": "角色",
+      "ROLE_ASSIGNMENT": "角色分配",
       "ROUTING": "路由",
       "SESSION": "会话",
       "SESSION_TEMPLATE": "会话模板",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2066,6 +2066,7 @@
       "RESOURCE_GROUP": "資源群組",
       "RESOURCE_PRESET": "資源預設",
       "ROLE": "角色",
+      "ROLE_ASSIGNMENT": "角色指派",
       "ROUTING": "路由",
       "SESSION": "工作階段",
       "SESSION_TEMPLATE": "工作階段範本",


### PR DESCRIPTION
Resolves #7154 ([FR-2775](https://lablup.atlassian.net/browse/FR-2775))

## Summary
- Add `rbac.types.ROLE_ASSIGNMENT` translation key to all 21 supported locales (ko: "권한 할당", en: "Role Assignment", etc.) so the Permission Type select no longer falls back to the raw API value.
- Extend `CreatePermissionModal_roleScopeFragment` to fetch the resolved `scope: EntityNode` with inline fragments for DOMAIN / PROJECT / USER / VFOLDER / SESSION / MODEL_DEPLOYMENT / RESOURCE_GROUP / CONTAINER_REGISTRY, mirroring the pattern already used in `RolePermissionTab.tsx` and `RoleScopeTab.tsx`.
- Render the Scope / Target select label as `"<scopeType> / <resolved name>"`, falling back to the raw `scopeId` only when the scope object is unresolvable (e.g., STORAGE_HOST and KEYPAIR are not part of the `EntityNode` union yet).
- The selected option `value` remains `${scopeType}|${scopeId}` so backend submissions are unchanged.

## Test plan
- [ ] Open RBAC role detail → Add Permission, on a role whose scopes include a project: the Scope / Target select shows the project name, and the Permission Type select includes a translated `ROLE_ASSIGNMENT` entry.
- [ ] Switch UI language to Korean: `ROLE_ASSIGNMENT` displays as "권한 할당".
- [ ] Switch language to other locales (ja, zh-CN, fr, …) and confirm the localized label is shown.
- [ ] Confirm `scripts/verify.sh` reports `=== ALL PASS ===`.

## Notes
- STORAGE_HOST scope IDs are storage host names already, so the fallback path renders correctly. KEYPAIR scope IDs are access keys; without an `EntityNode` resolver they remain as the raw access-key string until backend support lands.

[FR-2775]: https://lablup.atlassian.net/browse/FR-2775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ