### PR TITLE
fix(FR-2776): adapt addModelRevision call sites to new schema

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -171,6 +171,11 @@ input AddRevisionInput
 
   """Extra vfolder mounts"""
   extraMounts: [ExtraVFolderMountInput!] = null
+
+  """
+  Added in UNRELEASED. Additional options for the add revision operation.
+  """
+  options: AddRevisionOptions = null
 }
 
 """Added in 26.4.2. Options for the add_model_revision mutation."""
@@ -1852,6 +1857,51 @@ input BlueGreenConfigInput
 }
 
 """
+Added in UNRELEASED. Failure detail for a single permission entry in bulk add
+"""
+type BulkAddRolePermissionFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """Role ID of the failed entry"""
+  roleId: UUID!
+
+  """Scope element type of the failed entry"""
+  scopeType: String!
+
+  """Scope element ID of the failed entry"""
+  scopeId: String!
+
+  """Entity element type of the failed entry"""
+  entityType: String!
+
+  """Operation type of the failed entry"""
+  operation: String!
+
+  """Error message describing the failure"""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Input for bulk-inserting scoped permissions across one or more roles
+"""
+input BulkAddRolePermissionsInput
+  @join__type(graph: STRAWBERRY)
+{
+  permissions: [CreatePermissionInput!]!
+}
+
+"""Added in UNRELEASED. Payload for bulk role-permission insertion"""
+type BulkAddRolePermissionsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Successfully inserted permission rows"""
+  items: [Permission!]!
+
+  """Permission entries that failed to insert"""
+  failed: [BulkAddRolePermissionFailureInfo!]!
+}
+
+"""
 Added in 26.3.0. Error information for a failed user in bulk role assignment.
 """
 type BulkAssignRoleError
@@ -2002,6 +2052,39 @@ type BulkPurgeVFoldersV2Payload
 {
   """Number of virtual folders successfully purged."""
   purgedCount: Int!
+}
+
+"""
+Added in UNRELEASED. Failure detail for a single permission ID in bulk remove
+"""
+type BulkRemoveRolePermissionFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission row ID that failed to delete"""
+  permissionId: UUID!
+
+  """Error message describing the failure"""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Input for bulk-deleting permission rows by primary key
+"""
+input BulkRemoveRolePermissionsInput
+  @join__type(graph: STRAWBERRY)
+{
+  permissionIds: [UUID!]!
+}
+
+"""Added in UNRELEASED. Payload for bulk role-permission deletion"""
+type BulkRemoveRolePermissionsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Successfully deleted permission rows"""
+  items: [Permission!]!
+
+  """Permission IDs that failed to delete"""
+  failed: [BulkRemoveRolePermissionFailureInfo!]!
 }
 
 """
@@ -5108,9 +5191,6 @@ type DeploymentRevisionPreset implements Node
 {
   """The Globally Unique ID of this object"""
   id: ID!
-
-  """The unique database identifier of this deployment preset."""
-  rowId: UUID!
 
   """The runtime variant this preset is designed for (e.g., vLLM, SGLang)."""
   runtimeVariantId: UUID!
@@ -10635,7 +10715,7 @@ type Mutation
   syncReplicas(input: SyncReplicaInput!): SyncReplicaPayload! @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Add model revision."""
-  addModelRevision(input: AddRevisionInput!, options: AddRevisionOptions = null): AddRevisionPayload! @join__field(graph: STRAWBERRY)
+  addModelRevision(input: AddRevisionInput!): AddRevisionPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.3. Rebuild and activate a fresh revision for every active deployment (superadmin). Used to repair deployments whose current revision has stale or missing model_definition after backing store migrations.
@@ -11101,6 +11181,21 @@ type Mutation
 
   """Added in 26.3.0. Bulk revoke a role from multiple users (admin only)."""
   adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Bulk-insert scoped permission rows across one or more roles (admin only).
+  """
+  adminBulkAddRolePermissions(input: BulkAddRolePermissionsInput!): BulkAddRolePermissionsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Bulk-delete permission rows by primary key (admin only).
+  """
+  adminBulkRemoveRolePermissions(input: BulkRemoveRolePermissionsInput!): BulkRemoveRolePermissionsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Replace one role's entire scoped-permission set (admin only).
+  """
+  adminReplaceRolePermissions(input: ReplaceRolePermissionsInput!): ReplaceRolePermissionsPayload! @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Create role invitations by email."""
   createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload! @join__field(graph: STRAWBERRY)
@@ -14377,6 +14472,54 @@ type ReplaceResourceGroupDefaultSessionOptionsPayload
   defaultSessionOptions: DefaultSessionOptionsInfo!
 }
 
+"""
+Added in UNRELEASED. Failure detail for a single permission entry in replace
+"""
+type ReplaceRolePermissionFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """Role ID of the failed entry"""
+  roleId: UUID!
+
+  """Scope element type of the failed entry"""
+  scopeType: String!
+
+  """Scope element ID of the failed entry"""
+  scopeId: String!
+
+  """Entity element type of the failed entry"""
+  entityType: String!
+
+  """Operation type of the failed entry"""
+  operation: String!
+
+  """Error message describing the failure"""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Input for replacing one role's entire scoped-permission set
+"""
+input ReplaceRolePermissionsInput
+  @join__type(graph: STRAWBERRY)
+{
+  roleId: UUID!
+  permissions: [CreatePermissionInput!]!
+}
+
+"""
+Added in UNRELEASED. Payload for replacing a role's entire scoped-permission set
+"""
+type ReplaceRolePermissionsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission rows that make up the new set"""
+  items: [Permission!]!
+
+  """Permission entries that failed to insert"""
+  failed: [ReplaceRolePermissionFailureInfo!]!
+}
+
 """Added in 25.19.0. """
 input ReplicaFilter
   @join__type(graph: STRAWBERRY)
@@ -15950,9 +16093,6 @@ type RuntimeVariant implements Node
   """The Globally Unique ID of this object"""
   id: ID!
 
-  """The unique database identifier of this runtime variant."""
-  rowId: UUID!
-
   """
   Unique short identifier for the runtime engine (e.g., 'vllm', 'sglang', 'nim', 'tgi').
   """
@@ -16037,9 +16177,6 @@ type RuntimeVariantPreset implements Node
 {
   """The Globally Unique ID of this object"""
   id: ID!
-
-  """The unique database identifier of this preset."""
-  rowId: UUID!
 
   """The runtime variant this preset belongs to."""
   runtimeVariantId: UUID!

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -169,7 +169,7 @@ const DeploymentAddRevisionModalFormBody: React.FC<
       mutation DeploymentAddRevisionModalAddMutation(
         $input: AddRevisionInput!
       ) {
-        addModelRevision(input: $input, options: { autoActivate: true }) {
+        addModelRevision(input: $input) {
           revision {
             id
             name
@@ -398,6 +398,7 @@ const DeploymentAddRevisionModalFormBody: React.FC<
             definitionPath,
           },
           modelDefinition,
+          options: { autoActivate: true },
         },
       },
       onCompleted: (_, errors) => {

--- a/react/src/pages/DeploymentLauncherPage.tsx
+++ b/react/src/pages/DeploymentLauncherPage.tsx
@@ -252,11 +252,8 @@ const DeploymentLauncherPageLayout: React.FC<
 
   const [commitEdit, isEditing] =
     useMutation<DeploymentLauncherPageEditMutation>(graphql`
-      mutation DeploymentLauncherPageEditMutation(
-        $input: AddRevisionInput!
-        $options: AddRevisionOptions
-      ) {
-        addModelRevision(input: $input, options: $options) {
+      mutation DeploymentLauncherPageEditMutation($input: AddRevisionInput!) {
+        addModelRevision(input: $input) {
           revision {
             id
           }
@@ -426,8 +423,8 @@ const DeploymentLauncherPageLayout: React.FC<
               definitionPath,
             },
             modelDefinition,
+            options: { autoActivate: true },
           },
-          options: { autoActivate: true },
         },
         onCompleted: (_, errors) => {
           if (errors && errors.length > 0) {


### PR DESCRIPTION
Resolves #7157 ([FR-2776](https://lablup.atlassian.net/browse/FR-2776))

> Stacks on top of #7153 (FR-2773) → #7152 (FR-2774).

## Symptom

Relay compile errors after a schema sync:

```
✖︎ Unknown argument 'options'.
  react/src/components/DeploymentAddRevisionModal.tsx:172:41
  react/src/pages/DeploymentLauncherPage.tsx:259:41
```

## Schema change

`addModelRevision` no longer takes `options` as a top-level mutation argument. The `AddRevisionOptions` payload is now a field on `AddRevisionInput`:

```graphql
# Before
addModelRevision(input: AddRevisionInput!, options: AddRevisionOptions): AddRevisionPayload!

# After
addModelRevision(input: AddRevisionInput!): AddRevisionPayload!

# AddRevisionInput now has:
options: AddRevisionOptions = null
```

## Changes

### `react/src/pages/DeploymentLauncherPage.tsx`

- `DeploymentLauncherPageEditMutation`: drop the `$options: AddRevisionOptions` variable and the `, options: $options` argument from the `addModelRevision` selection.
- `handleAddRevision`: move `options: { autoActivate: true }` from `variables` (top level) into `variables.input`.

### `react/src/components/DeploymentAddRevisionModal.tsx`

- `DeploymentAddRevisionModalAddMutation`: drop the inline `options: { autoActivate: true }` argument from the `addModelRevision` selection.
- `commitAdd`: pass `options: { autoActivate: true }` inside the `input` payload.

### `data/schema.graphql`

- Sync to the new server schema (drives Relay compiler against the latest definition).

## Test plan

- [x] `pnpm run relay` compiles without errors.
- [x] `bash scripts/verify.sh` passes (Relay / Lint / Format / TypeScript).
- [ ] `/deployments/create`: create-then-add-revision flow still produces an active revision (auto-activated).
- [ ] Standalone Add Revision modal: clicking "Add Revision" creates a new revision and auto-activates it.

[FR-2776]: https://lablup.atlassian.net/browse/FR-2776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ