### PR TITLE
fix(FR-2779): respect PORTLESS_PORT env var as Portless daemon-port fallback

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -36,6 +36,16 @@ Open that URL in your browser. Portless 0.10+ serves HTTPS/2 by default; the loc
 
 Portless's default daemon port is 443, which requires `sudo`. `dev.mjs` starts the daemon with `-p 1355` so dev never prompts for a password.
 
+To pin a different daemon port on a machine — for example, when another Portless daemon is already running — export `PORTLESS_PORT` in your shell rc:
+
+```bash
+export PORTLESS_PORT=1356
+```
+
+When `PORTLESS_PORT` is set, `dev.mjs` skips its explicit `-p` flag entirely and lets Portless read the env var itself — both for the daemon start and for subsequent `portless` client calls (`portless run`, `portless list`, …) — so daemon and clients stay aligned via a single source of truth.
+
+The remaining `*.localhost:1355` URLs and `portless proxy start -p 1355` examples in this document describe the default. When `PORTLESS_PORT` is set, substitute its value in those URLs and commands.
+
 ### Hostname rules
 
 `scripts/dev.mjs` picks the Portless app name as follows:

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -22,10 +22,19 @@ if (!env.REACT_APP_THEME_COLOR && existsSync(envFile)) {
   }
 }
 
-// Ensure the Portless daemon is running on port 1355. Portless 0.10+ defaults
-// the daemon to port 443 which requires sudo; binding 1355 keeps it
-// unprivileged. The call is idempotent (no-op if already running).
-spawnSync('portless', ['proxy', 'start', '-p', '1355'], { stdio: 'inherit' });
+// Ensure the Portless daemon is running. Portless 0.10+ defaults the daemon
+// to port 443 which requires sudo; we override that to an unprivileged 1355
+// only when the user has not already pinned a port via PORTLESS_PORT. When
+// PORTLESS_PORT is set, Portless reads it directly — both the daemon here
+// and subsequent `portless` client invocations later in this script — so we
+// stay out of its way and avoid the explicit `-p` flag overriding the env.
+// An empty export (`PORTLESS_PORT=`) is treated as unset, matching shell
+// convention. The call is idempotent (no-op if already running).
+const proxyArgs = ['proxy', 'start'];
+if (!process.env.PORTLESS_PORT?.trim()) {
+  proxyArgs.push('-p', '1355');
+}
+spawnSync('portless', proxyArgs, { stdio: 'inherit' });
 
 // Optional fixed port via `PORT=9081 pnpm run dev`. If unset, Portless picks a free port.
 const portFlag = process.env.PORT ? `--app-port ${process.env.PORT} ` : '';


### PR DESCRIPTION
Resolves #7163(FR-2779)

## Summary

`scripts/dev.mjs` always passed `-p 1355` to `portless proxy start`, which overrode Portless's own `PORTLESS_PORT` env var. As a result, a machine with `PORTLESS_PORT=1356` exported in its shell rc could not opt into a fixed daemon port — running `pnpm run dev` would silently spawn a second daemon on `1355` and register the app there, leaving two daemons coexisting until one was killed manually.

## Change

`scripts/dev.mjs` now only passes `-p 1355` when `PORTLESS_PORT` is unset. When the user has set the env var, dev.mjs stays out of the way and Portless reads it directly — both for the daemon here and for the subsequent `portless run` / `portless list` calls — so daemon and clients share a single source of truth.

```js
const proxyArgs = ['proxy', 'start'];
if (!process.env.PORTLESS_PORT?.trim()) {
  proxyArgs.push('-p', '1355');  // override portless's sudo-requiring 443 default
}
spawnSync('portless', proxyArgs, { stdio: 'inherit' });
```

`PORTLESS_PORT` is documented in `portless --help` as "Override the default proxy port (e.g. in .bashrc)", so this opt-in is part of the public Portless contract.

An empty export (`PORTLESS_PORT=`) is treated as unset (shell convention).

`DEV_ENVIRONMENT.md` — added a short note under "Why port 1355?" documenting the opt-in.

## Verification

Locally exercised both branches of the new conditional:

| `PORTLESS_PORT` | `dev.mjs` argv to portless | Daemon binding |
| --- | --- | --- |
| unset | `['proxy', 'start', '-p', '1355']` | `HTTPS/2 proxy started on port 1355`, listener on `:1355` |
| `1356` | `['proxy', 'start']` (no `-p`) | `HTTPS/2 proxy started on port 1356`, listener on `:1356` |

`bash scripts/verify.sh` → `=== ALL PASS ===`.

## Checklist

- [x] Documentation (DEV_ENVIRONMENT.md)
- [ ] Minimum required manager version — N/A (dev-tooling only)
- [ ] Specific setting for review — none
- [x] Minimum requirements to check during review — verify the env var is honored when set, and that the default behavior on machines without it is unchanged
- [x] Test case(s) to demonstrate before/after — covered in the Verification table above
