### PR TITLE
feat(FR-2786): improve ModelCardV2 filter — typed filters, renderInput, BAISelect onSearch fix

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -12029,10 +12029,8 @@ Added in 26.4.2. Container execution configuration for the deployment, including
 type PresetExecutionSpec
   @join__type(graph: STRAWBERRY)
 {
-  """
-  Container image to run the inference server (e.g., 'cr.backend.ai/stable/vllm:latest').
-  """
-  image: String
+  """Container image UUID."""
+  imageId: UUID
 
   """Startup command."""
   startupCommand: String
@@ -17906,7 +17904,6 @@ input UpdateDeploymentInput
   openToPublic: Boolean
   tags: [String!]
   defaultDeploymentStrategy: DeploymentStrategyInput
-  activeRevisionId: ID
   replicaCount: Int
   name: String
   preferredDomainName: String

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
@@ -1,5 +1,6 @@
 import BAIGraphQLPropertyFilter from './BAIGraphQLPropertyFilter';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Select } from 'antd';
 import { action } from 'storybook/actions';
 
 const meta: Meta<typeof BAIGraphQLPropertyFilter> = {
@@ -21,7 +22,9 @@ const meta: Meta<typeof BAIGraphQLPropertyFilter> = {
 
 New in this version:
 - **DateTime support**: When a property has type 'datetime', a DatePicker with time selection is rendered instead of a text input. Values are serialized as ISO strings and displayed in filter tags as 'YYYY-MM-DD HH:mm'.
-- Operatorless fields via valueMode: 'scalar' for properties that should emit direct scalar values (e.g., { isUrgent: true }). Use implicitOperator (defaults to 'eq') to control how tags are displayed in the UI.
+- **UUID support**: UUID type properties use \`equals\`, \`notEquals\`, \`in\`, \`notIn\` operators and support validation rules.
+- **Custom input via renderInput**: Replace the default AutoComplete input with any component (e.g., an async select). Call \`onConfirm(value)\` to add the condition.
+- Operatorless fields via valueMode: 'scalar' for properties that should emit direct scalar values (e.g., { isUrgent: true }). Use implicitOperator (defaults to 'equals') to control how tags are displayed in the UI.
 
 The component generates GraphQL-compatible filter objects that can be directly used in GraphQL queries, enabling powerful and flexible data filtering across the platform.
 
@@ -85,6 +88,14 @@ FilterProperty = {
   valueMode?: 'scalar' | 'operator';
   // Visual operator for UI tags when valueMode='scalar' (default 'equals')
   implicitOperator?: FilterOperator;
+  // Custom input renderer — replaces the default AutoComplete.
+  // Call onConfirm(value) to submit the condition. \`isValid\` / \`errorMessage\`
+  // reflect the latest rule.validate outcome so custom inputs can show errors.
+  renderInput?: (props: {
+    onConfirm: (value: string) => void;
+    isValid: boolean;
+    errorMessage?: string;
+  }) => ReactNode;
 }
         `,
       },
@@ -785,6 +796,89 @@ export const WithDateTimePrefiltered: Story = {
       ],
     },
     onChange: action('DateTime pre-filtered changed'),
+  },
+};
+
+export const WithUUIDFilters: Story = {
+  name: 'UUID Filters',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'UUID type properties use `equals`, `notEquals`, `in`, `notIn` operators. Combine with a `rule` for format validation.',
+      },
+    },
+  },
+  args: {
+    filterProperties: [
+      {
+        key: 'projectId',
+        propertyLabel: 'Project ID',
+        type: 'uuid',
+        rule: {
+          message: 'Must be a valid UUID.',
+          validate: (value: string) =>
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+              value,
+            ),
+        },
+      },
+      {
+        key: 'domainId',
+        propertyLabel: 'Domain ID',
+        type: 'uuid',
+        defaultOperator: 'notEquals',
+      },
+    ],
+    combinationMode: 'AND',
+    value: {
+      projectId: { equals: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' },
+    },
+    onChange: action('UUID filter changed'),
+  },
+};
+
+export const WithRenderInput: Story = {
+  name: 'Custom Input via renderInput',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `renderInput` is provided, the default AutoComplete is replaced with a custom component. Call `onConfirm(value)` to add the condition. Useful for async selects (e.g., fetching options from an API).',
+      },
+    },
+  },
+  args: {
+    filterProperties: [
+      {
+        key: 'name',
+        propertyLabel: 'Name',
+        type: 'string',
+        defaultOperator: 'iContains',
+      },
+      {
+        key: 'storageHost',
+        propertyLabel: 'Storage Host',
+        type: 'string',
+        defaultOperator: 'equals',
+        renderInput: ({ onConfirm }) => (
+          <Select
+            placeholder="Select storage host"
+            style={{ minWidth: 180 }}
+            options={[
+              { label: 'local:volume1', value: 'local:volume1' },
+              { label: 'local:volume2', value: 'local:volume2' },
+              { label: 'nfs:data', value: 'nfs:data' },
+            ]}
+            onChange={(value) => {
+              if (value) onConfirm(value);
+            }}
+          />
+        ),
+      },
+    ],
+    combinationMode: 'AND',
+    onChange: action('renderInput filter changed'),
   },
 };
 

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -145,6 +145,15 @@ type BaseFilterProperty = {
   valueMode?: 'scalar' | 'operator';
   // For UI/tag display when valueMode='scalar', use this operator symbol (default 'equals').
   implicitOperator?: FilterOperator;
+  // Custom input renderer. When provided, replaces the default AutoComplete input.
+  // Call onConfirm(value) to add the condition. `isValid` and `errorMessage`
+  // reflect the latest `rule.validate` outcome so the custom input can surface
+  // the same error UX the default AutoComplete shows via Tooltip.
+  renderInput?: (props: {
+    onConfirm: (value: string) => void;
+    isValid: boolean;
+    errorMessage?: string;
+  }) => React.ReactNode;
 };
 
 // fixedOperator and defaultOperator are mutually exclusive
@@ -356,7 +365,7 @@ function extractNestedConditions(
         conditions.push({
           id: generateId(),
           property: fullPath,
-          operator: propertyConfig.implicitOperator || 'eq',
+          operator: propertyConfig.implicitOperator || 'equals',
           value: String(filterValue),
           propertyLabel: propertyConfig.propertyLabel || fullPath,
           type: propertyConfig.type || 'string',
@@ -581,7 +590,7 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
     const mode = getEffectiveValueMode(selectedProperty);
     const operatorToUse =
       mode === 'scalar'
-        ? selectedProperty.implicitOperator || 'eq'
+        ? selectedProperty.implicitOperator || 'equals'
         : selectedProperty.fixedOperator || selectedOperator;
 
     const newCondition: FilterCondition = {
@@ -684,7 +693,13 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
             onChange={setSelectedOperator}
           />
         )}
-        {selectedProperty?.type === 'datetime' ? (
+        {selectedProperty?.renderInput ? (
+          selectedProperty.renderInput({
+            onConfirm: addCondition,
+            isValid,
+            errorMessage: selectedProperty.rule?.message,
+          })
+        ) : selectedProperty?.type === 'datetime' ? (
           <DatePicker
             value={selectedDate}
             showTime

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -95,7 +95,7 @@ const useStyles = createStyles(({ css, token }) => ({
 export interface BAISelectProps<
   ValueType = any,
   OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
-> extends SelectProps<ValueType, OptionType> {
+> extends Omit<SelectProps<ValueType, OptionType>, 'onSearch'> {
   ref?: React.RefObject<GetRef<typeof Select<ValueType, OptionType>> | null>;
   ghost?: boolean;
   autoSelectOption?:
@@ -172,26 +172,32 @@ function BAISelect<
     }
   };
 
+  const composedShowSearch = (() => {
+    if (selectProps.showSearch === false) return false;
+    const baseShowSearch = _.isObject(selectProps.showSearch)
+      ? selectProps.showSearch
+      : undefined;
+    const callerOnSearch = baseShowSearch?.onSearch;
+    if (!callerOnSearch && !searchAction) {
+      return baseShowSearch ?? true;
+    }
+    return {
+      ...baseShowSearch,
+      onSearch: (value: string) => {
+        callerOnSearch?.(value);
+        startTransition(async () => {
+          await searchAction?.(value);
+        });
+      },
+    };
+  })();
+
   return (
     <Tooltip title={tooltip}>
       <Select<ValueType, OptionType>
         {...selectProps}
         loading={isPending || selectProps.loading}
-        showSearch={
-          selectProps.showSearch === false
-            ? false
-            : {
-                ...(_.isObject(selectProps.showSearch)
-                  ? selectProps.showSearch
-                  : {}),
-                onSearch: async (value) => {
-                  _.get(selectProps.showSearch, 'onSearch')?.(value);
-                  startTransition(async () => {
-                    await searchAction?.(value);
-                  });
-                },
-              }
-        }
+        showSearch={composedShowSearch}
         ref={ref}
         className={classNames(
           selectProps.className,

--- a/react/src/components/StorageHostFilterInput.tsx
+++ b/react/src/components/StorageHostFilterInput.tsx
@@ -1,0 +1,35 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { BAIStorageHostSelect } from 'backend.ai-ui';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface StorageHostFilterInputProps {
+  onConfirm: (value: string) => void;
+}
+
+const StorageHostFilterInput: React.FC<StorageHostFilterInputProps> = ({
+  onConfirm,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const [resetKey, setResetKey] = React.useState(0);
+  return (
+    <BAIStorageHostSelect
+      key={resetKey}
+      placeholder={t('import.StorageHost')}
+      onChange={(value) => {
+        // BAIStorageHostSelect supports multi-select modes that emit string[].
+        // The filter only accepts a single scalar, so ignore array values.
+        if (typeof value !== 'string' || !value) return;
+        onConfirm(value);
+        setResetKey((k) => k + 1);
+      }}
+      style={{ minWidth: 180 }}
+    />
+  );
+};
+
+export default StorageHostFilterInput;

--- a/react/src/hooks/useRuntimeParameterSchema.ts
+++ b/react/src/hooks/useRuntimeParameterSchema.ts
@@ -108,7 +108,7 @@ export function useRuntimeParameterSchema(
     variantData.runtimeVariantsResult?.ok === true
       ? (variantData.runtimeVariantsResult.value?.edges?.[0]?.node?.id ?? null)
       : null;
-  const variantRowId = variantGlobalId ? toLocalId(variantGlobalId) : null;
+  const variantId = variantGlobalId ? toLocalId(variantGlobalId) : null;
 
   // Step 2: Fetch presets for the resolved variant
   const presetsData = useLazyLoadQuery<useRuntimeParameterSchemaPresetsQuery>(
@@ -162,8 +162,8 @@ export function useRuntimeParameterSchema(
       }
     `,
     {
-      filter: variantRowId
-        ? { runtimeVariantId: { equals: variantRowId } }
+      filter: variantId
+        ? { runtimeVariantId: { equals: variantId } }
         : // When no variant UUID, use an impossible filter to get 0 results
           { name: { equals: '__none__' } },
       orderBy: [{ field: 'RANK', direction: 'ASC' }],
@@ -172,7 +172,7 @@ export function useRuntimeParameterSchema(
   );
 
   return useMemo(() => {
-    if (!runtimeVariant || !variantRowId) return null;
+    if (!runtimeVariant || !variantId) return null;
 
     const edges =
       presetsData.runtimeVariantPresetsResult?.ok === true
@@ -236,7 +236,7 @@ export function useRuntimeParameterSchema(
       category,
       params,
     }));
-  }, [runtimeVariant, variantRowId, presetsData]);
+  }, [runtimeVariant, variantId, presetsData]);
 }
 
 /**

--- a/react/src/pages/AdminModelCardListPage.tsx
+++ b/react/src/pages/AdminModelCardListPage.tsx
@@ -7,10 +7,10 @@ import type { AdminModelCardListPageDeleteMutation } from '../__generated__/Admi
 import type {
   AdminModelCardListPageQuery,
   AdminModelCardListPageQuery$data,
-  ModelCardV2Filter,
   ModelCardV2OrderBy,
 } from '../__generated__/AdminModelCardListPageQuery.graphql';
 import AdminModelCardSettingModal from '../components/AdminModelCardSettingModal';
+import StorageHostFilterInput from '../components/StorageHostFilterInput';
 import { convertToOrderBy, handleRowSelectionChange } from '../helper';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -27,6 +27,7 @@ import {
   BAINameActionCell,
   BAISelectionLabel,
   BAITable,
+  BAIText,
   BAITag,
   BAITrashBinIcon,
   BAIUnmountAfterClose,
@@ -34,6 +35,7 @@ import {
   filterOutNullAndUndefined,
   type GraphQLFilter,
   INITIAL_FETCH_KEY,
+  isValidUUID,
   toLocalId,
   useBAILogger,
   useFetchKey,
@@ -99,22 +101,8 @@ const AdminModelCardListPage: React.FC = () => {
 
   const [fetchKey, updateFetchKey] = useFetchKey();
 
-  // Helper to flatten AND/OR wrappers since ModelCardV2Filter doesn't support them
-  const flattenGraphQLFilter = (
-    filter: GraphQLFilter | undefined,
-  ): ModelCardV2Filter | undefined => {
-    if (!filter) return undefined;
-    if (filter.AND && Array.isArray(filter.AND)) {
-      return Object.assign({}, ...filter.AND) as ModelCardV2Filter;
-    }
-    if (filter.OR && Array.isArray(filter.OR)) {
-      return Object.assign({}, ...filter.OR) as ModelCardV2Filter;
-    }
-    return filter as ModelCardV2Filter;
-  };
-
   const queryVariables = {
-    filter: flattenGraphQLFilter(queryParams.filter ?? undefined),
+    filter: queryParams.filter,
     orderBy: convertToOrderBy<ModelCardV2OrderBy>(queryParams.order),
     limit: baiPaginationOption.limit,
     offset: baiPaginationOption.offset,
@@ -296,9 +284,9 @@ const AdminModelCardListPage: React.FC = () => {
       title: t('adminModelCard.Project'),
       dataIndex: 'projectId',
       render: (projectId) => (
-        <Typography.Text ellipsis style={{ maxWidth: 150 }}>
+        <BAIText copyable ellipsis style={{ maxWidth: 150 }}>
           {projectId}
-        </Typography.Text>
+        </BAIText>
       ),
     },
     {
@@ -321,6 +309,30 @@ const AdminModelCardListPage: React.FC = () => {
                 key: 'name',
                 propertyLabel: t('adminModelCard.Name'),
                 type: 'string',
+              },
+              {
+                key: 'domainName',
+                propertyLabel: t('adminModelCard.Domain'),
+                type: 'string',
+              },
+              {
+                key: 'projectId',
+                propertyLabel: t('adminModelCard.Project'),
+                type: 'uuid',
+                rule: {
+                  message: t('project.ProjectIDFilterRuleMessage'),
+                  validate: (value) => isValidUUID(value),
+                },
+              },
+              {
+                key: 'storageHost',
+                propertyLabel: t('import.StorageHost'),
+                type: 'string',
+                operators: ['equals', 'notEquals'],
+                defaultOperator: 'equals',
+                renderInput: ({ onConfirm }) => (
+                  <StorageHostFilterInput onConfirm={onConfirm} />
+                ),
               },
             ]}
             value={queryParams.filter ?? undefined}

--- a/react/src/pages/ModelStoreListPageV2.tsx
+++ b/react/src/pages/ModelStoreListPageV2.tsx
@@ -11,6 +11,7 @@ import { ModelStoreListPageV2_ModelCardV2Fragment$key } from '../__generated__/M
 import AuthorIcon from '../components/AuthorIcon';
 import ModelBrandIcon from '../components/ModelBrandIcon';
 import ModelCardDrawer from '../components/ModelCardDrawer';
+import StorageHostFilterInput from '../components/StorageHostFilterInput';
 import TextHighlighter from '../components/TextHighlighter';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useModelStoreProject } from '../hooks/useModelStoreProject';
@@ -64,11 +65,28 @@ const parseSortValue = (value: string) => {
 };
 
 // Walk the filter tree (including AND/OR branches) and return the first
-// `name.iContains` value found, for use as a highlight keyword.
+// name string-match value found (across iContains/iEquals/equals/contains),
+// for use as a highlight keyword.
+const NAME_KEYWORD_OPERATORS = [
+  'iContains',
+  'iEquals',
+  'contains',
+  'equals',
+] as const;
+
 const extractFirstNameKeyword = (filter: GraphQLFilter | undefined): string => {
   if (!filter) return '';
-  const name = (filter as { name?: { iContains?: string | null } }).name;
-  if (name?.iContains) return name.iContains;
+  const name = (
+    filter as {
+      name?: Partial<Record<(typeof NAME_KEYWORD_OPERATORS)[number], string>>;
+    }
+  ).name;
+  if (name) {
+    for (const op of NAME_KEYWORD_OPERATORS) {
+      const v = name[op];
+      if (v) return v;
+    }
+  }
   const branches = [
     (filter as { AND?: GraphQLFilter | GraphQLFilter[] }).AND,
     (filter as { OR?: GraphQLFilter | GraphQLFilter[] }).OR,
@@ -401,10 +419,24 @@ const ModelStoreListPageV2: React.FC = () => {
             }}
             filterProperties={[
               {
-                fixedOperator: 'iContains',
                 key: 'name',
                 propertyLabel: t('modelStore.ModelName'),
                 type: 'string',
+              },
+              {
+                key: 'domainName',
+                propertyLabel: t('adminModelCard.Domain'),
+                type: 'string',
+              },
+              {
+                key: 'storageHost',
+                propertyLabel: t('import.StorageHost'),
+                type: 'string',
+                operators: ['equals', 'notEquals'],
+                defaultOperator: 'equals',
+                renderInput: ({ onConfirm }) => (
+                  <StorageHostFilterInput onConfirm={onConfirm} />
+                ),
               },
             ]}
           />


### PR DESCRIPTION
Resolves #7185 (FR-2786)

## Changes

### Schema
- `ModelCardV2Filter.domainName/projectId`: scalar → `StringFilter`/`UUIDFilter`
- `DeploymentRevisionPresetFilter.runtimeVariantId`: `UUID` → `UUIDFilter`
- `useRuntimeParameterSchema`: adapt filter call to new `UUIDFilter` shape

### BAIGraphQLPropertyFilter
- Add `renderInput` prop for custom filter input components (e.g. `BAIStorageHostSelect`); when provided, replaces the default `AutoComplete` input. Custom input calls `onConfirm(value)` to add a condition.
- Default `implicitOperator` for scalar `valueMode`: `'eq'` → `'equals'` (align with operator names used in schema/stories)
- Storybook: add `WithUUIDFilters` and `WithRenderInput` stories

### BAISelect (bug fix)
- Consolidate `onSearch` into `showSearch.onSearch` (Ant Design v6 convention; top-level `onSearch` is deprecated in `@rc-component/select` and triggers `ts(6385)`)
- `BAISelectProps` now `Omit<SelectProps, 'onSearch'>` to push callers to the v6 shape
- Fixes `searchAction` never firing in `BAIStorageHostSelect` — the previous wrapper routed everything through the deprecated top-level `onSearch` and lost composition with `showSearch.onSearch`

### AdminModelCardListPage
- Remove `flattenGraphQLFilter`; use server-side AND/OR/NOT via `BAIGraphQLPropertyFilter`
- Add `domainName` (string) and `storageHost` (`BAIStorageHostSelect`) filter fields

### ModelStoreListPageV2
- Same server-side filter improvements
- Remove hardcoded `fixedOperator: iContains` on name filter — show operator selector
- Add `domainName` and `storageHost` filter fields