### PR TITLE
fix(FR-2689): allow longer accelerator names in session launcher selector

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -1180,15 +1180,18 @@ const ResourceAllocationFormItems: React.FC<
                               (supportedAcceleratorTypesInRGByImage?.length ??
                                 0) > 0 ? (
                                 <Form.Item
-                                  noStyle
                                   name={['resource', 'acceleratorType']}
                                   initialValue={_.first(
                                     _.keys(acceleratorSlotsInRG),
                                   )}
+                                  style={{
+                                    marginBottom: 0,
+                                    maxWidth: 100,
+                                  }}
                                 >
                                   <BAISelect
                                     style={{
-                                      width: 75,
+                                      width: '100%',
                                     }}
                                     autoSelectOption
                                     tabIndex={-1}


### PR DESCRIPTION
Resolves #6935 (FR-2689)

## Summary

In the session launcher's accelerator-type selector, names longer than `fgpu` (e.g., longer device identifiers like `cuda.shares`) were visually truncated because the inner `BAISelect` was pinned to a fixed `width: 75`.

Moved the width constraint up to the wrapping `Form.Item` and let the `BAISelect` fill it:

- Removed `noStyle` from the `Form.Item` (so it can carry its own `style`) and added `style={{ marginBottom: 0, maxWidth: 100 }}`. `marginBottom: 0` preserves the previous inline alignment that `noStyle` used to give for free.
- Changed the inner `BAISelect` from `width: 75` to `width: '100%'`, so it grows to fit longer labels up to the 100px cap on the wrapper.

`popupMatchSelectWidth={false}` is unchanged, so the dropdown continues to size to its content regardless of the trigger width.

![CleanShot 2026-05-23 at 23.27.36@2x.png](https://app.graphite.com/user-attachments/assets/ba4ddb4b-b65a-4b0b-bea5-a2303a1746cd.png)

![CleanShot 2026-05-23 at 23.27.27@2x.png](https://app.graphite.com/user-attachments/assets/a2fc27be-6645-4c33-941d-88d79a459fff.png)

![CleanShot 2026-05-23 at 23.27.15@2x.png](https://app.graphite.com/user-attachments/assets/cd88ec76-4330-4bc8-8847-dda7a4026602.png)

## Test plan

- [ ] Open the session launcher with a resource group that exposes a short accelerator unit (e.g., `GPU`, `fGPU`) and confirm the selector renders compactly without extra empty space.
- [ ] Switch to a resource group whose accelerator unit label is longer than `fgpu` and confirm the label is fully visible (no truncation) up to the 100px cap.
- [ ] Open the dropdown and confirm options are still readable (`popupMatchSelectWidth={false}` continues to size the popup to its content).
- [ ] Confirm the accelerator-type selector stays vertically aligned with the adjacent resource controls (no extra bottom margin introduced by removing `noStyle`).