### PR TITLE
feat(FR-2762): add deployment preset detail button to VFolderDeployModal

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -905,7 +905,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           deploymentRevisionPresets(limit: 100) {
             edges {
               node {
-                rowId
+                id
                 name
               }
             }
@@ -1716,7 +1716,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                 options={
                                   deploymentRevisionPresets?.edges?.map(
                                     (edge) => ({
-                                      value: edge.node.rowId,
+                                      value: edge.node.id,
                                       label: edge.node.name,
                                     }),
                                   ) ?? []

--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -9,8 +9,18 @@ import { useWebUINavigate } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import useDeploymentLauncher from '../hooks/useDeploymentLauncher';
-import { EllipsisOutlined } from '@ant-design/icons';
-import { App, Dropdown, Form, Space, Typography, theme } from 'antd';
+import DeploymentPresetDetailModal from './DeploymentPresetDetailModal';
+import { EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import {
+  App,
+  Button,
+  Dropdown,
+  Form,
+  Space,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import type { DefaultOptionType } from 'antd/es/select';
 import {
   BAIButton,
@@ -268,6 +278,9 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
   const [userSelectedPresetId, setUserSelectedPresetId] = useState<
     string | undefined
   >(undefined);
+  const [presetDetailId, setPresetDetailId] = useState<string | undefined>(
+    undefined,
+  );
   const effectivePresetId =
     userSelectedPresetId ??
     (availablePresets[0]?.id ? toLocalId(availablePresets[0].id) : undefined);
@@ -365,29 +378,43 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
           tooltip={t('modelStore.PresetTooltip')}
           required
         >
-          <BAISelect
-            value={effectivePresetId}
-            onChange={(value: string) => setUserSelectedPresetId(value)}
-            options={presetOptions}
-            disabled={hasNoPresets}
-            placeholder={
-              hasNoPresets ? t('modelStore.NoCompatiblePresets') : undefined
-            }
-            optionRender={(option) => (
-              <BAIFlex direction="column" align="start">
-                {option.label}
-                {option.data.description && (
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: token.fontSizeSM }}
-                    ellipsis
-                  >
-                    {option.data.description}
-                  </Typography.Text>
-                )}
-              </BAIFlex>
-            )}
-            style={{ width: '100%' }}
+          <Space.Compact style={{ width: '100%' }}>
+            <BAISelect
+              value={effectivePresetId}
+              onChange={(value: string) => setUserSelectedPresetId(value)}
+              options={presetOptions}
+              disabled={hasNoPresets}
+              placeholder={
+                hasNoPresets ? t('modelStore.NoCompatiblePresets') : undefined
+              }
+              optionRender={(option) => (
+                <BAIFlex direction="column" align="start">
+                  {option.label}
+                  {option.data.description && (
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: token.fontSizeSM }}
+                      ellipsis
+                    >
+                      {option.data.description}
+                    </Typography.Text>
+                  )}
+                </BAIFlex>
+              )}
+              style={{ flex: 1 }}
+            />
+            <Tooltip title={t('modelService.DeploymentPresetDetail')}>
+              <Button
+                icon={<InfoCircleOutlined />}
+                disabled={!effectivePresetId}
+                onClick={() => setPresetDetailId(effectivePresetId)}
+              />
+            </Tooltip>
+          </Space.Compact>
+          <DeploymentPresetDetailModal
+            open={!!presetDetailId}
+            presetId={presetDetailId}
+            onRequestClose={() => setPresetDetailId(undefined)}
           />
         </Form.Item>
         <Form.Item


### PR DESCRIPTION
Resolves #7122 (FR-2762)

## Summary

- Add info button (`InfoCircleOutlined`) next to the preset `BAISelect` in `VFolderDeployModal`, following the `VFolderSelect` pattern (`BAIFlex` + `Space.Compact`)
- Clicking the button opens `DeploymentPresetDetailModal` for the currently selected preset
- Button is disabled when no preset is selected
- Fix `rowId` → `id` field reference in `ServiceLauncherPageContent` deployment preset query (`DeploymentRevisionPreset` exposes `id`, not `rowId`)