### PR TITLE
fix(FR-2762): improve preset detail UI and remove service launcher wiring

### DIFF
--- a/react/src/components/DeploymentPresetDetailContent.tsx
+++ b/react/src/components/DeploymentPresetDetailContent.tsx
@@ -3,8 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import type { DeploymentPresetDetailContentFragment$key } from '../__generated__/DeploymentPresetDetailContentFragment.graphql';
-import { Descriptions, Divider, Typography } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { Descriptions, Typography } from 'antd';
+import { BAICard, BAIFlex } from 'backend.ai-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -77,131 +77,105 @@ const DeploymentPresetDetailContent: React.FC<
       {preset.description && (
         <Typography.Text type="secondary">{preset.description}</Typography.Text>
       )}
-      <Descriptions
+      <BAICard
         size="small"
-        column={2}
-        items={[
-          {
-            label: t('adminDeploymentPreset.Rank'),
-            children: preset.rank,
-          },
-          {
-            label: t('adminDeploymentPreset.Runtime'),
-            children: preset.runtimeVariant?.name ?? preset.runtimeVariantId,
-          },
-        ]}
-      />
-
-      <Divider
-        style={{ margin: '4px 0' }}
-        titlePlacement="left"
-        orientationMargin={0}
+        title={t('adminDeploymentPreset.SectionImage')}
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          {t('adminDeploymentPreset.SectionImage')}
-        </Typography.Text>
-      </Divider>
-      <Descriptions
+        <Descriptions
+          size="small"
+          column={1}
+          items={[
+            {
+              label: t('adminDeploymentPreset.Image'),
+              children: preset.execution?.image || '-',
+            },
+            {
+              label: t('adminDeploymentPreset.Runtime'),
+              children: preset.runtimeVariant?.name ?? preset.runtimeVariantId,
+            },
+          ]}
+        />
+      </BAICard>
+      <BAICard
         size="small"
-        column={1}
-        items={[
-          {
-            label: t('adminDeploymentPreset.Image'),
-            children: preset.execution?.image || '-',
-          },
-        ]}
-      />
-
-      <Divider
-        style={{ margin: '4px 0' }}
-        titlePlacement="left"
-        orientationMargin={0}
+        title={t('adminDeploymentPreset.SectionCluster')}
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          {t('adminDeploymentPreset.SectionCluster')}
-        </Typography.Text>
-      </Divider>
-      <Descriptions
+        <Descriptions
+          size="small"
+          column={2}
+          items={[
+            {
+              label: t('adminDeploymentPreset.ClusterMode'),
+              children: preset.cluster?.clusterMode || '-',
+            },
+            {
+              label: t('adminDeploymentPreset.ClusterSize'),
+              children: preset.cluster?.clusterSize ?? '-',
+            },
+          ]}
+        />
+      </BAICard>
+      <BAICard
         size="small"
-        column={2}
-        items={[
-          {
-            label: t('adminDeploymentPreset.ClusterMode'),
-            children: preset.cluster?.clusterMode || '-',
-          },
-          {
-            label: t('adminDeploymentPreset.ClusterSize'),
-            children: preset.cluster?.clusterSize ?? '-',
-          },
-        ]}
-      />
-
-      <Divider
-        style={{ margin: '4px 0' }}
-        titlePlacement="left"
-        orientationMargin={0}
+        title={t('adminDeploymentPreset.SectionResources')}
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          {t('adminDeploymentPreset.SectionResources')}
-        </Typography.Text>
-      </Divider>
-      <Descriptions
+        <Descriptions
+          size="small"
+          column={2}
+          items={[
+            ...(shmem
+              ? [
+                  {
+                    label: t('adminDeploymentPreset.Shmem'),
+                    children: `${shmem} GiB`,
+                  },
+                ]
+              : []),
+            ...(preset.resource?.resourceOpts
+              ?.filter((opt) => opt.name !== 'shmem')
+              .map((opt) => ({
+                label: opt.name,
+                children: opt.value,
+              })) ?? []),
+          ]}
+        />
+      </BAICard>
+      <BAICard
         size="small"
-        column={2}
-        items={[
-          ...(shmem
-            ? [
-                {
-                  label: t('adminDeploymentPreset.Shmem'),
-                  children: `${shmem} GiB`,
-                },
-              ]
-            : []),
-          ...(preset.resource?.resourceOpts
-            ?.filter((opt) => opt.name !== 'shmem')
-            .map((opt) => ({
-              label: opt.name,
-              children: opt.value,
-            })) ?? []),
-        ]}
-      />
-
-      <Divider
-        style={{ margin: '4px 0' }}
-        titlePlacement="left"
-        orientationMargin={0}
+        title={t('adminDeploymentPreset.SectionDeploymentDefaults')}
+        styles={{ body: { paddingTop: 0 } }}
       >
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          {t('adminDeploymentPreset.SectionDeploymentDefaults')}
-        </Typography.Text>
-      </Divider>
-      <Descriptions
-        size="small"
-        column={2}
-        items={[
-          {
-            label: t('adminDeploymentPreset.Replicas'),
-            children: preset.deploymentDefaults?.replicaCount ?? '-',
-          },
-          {
-            label: t('adminDeploymentPreset.RevisionHistoryLimit'),
-            children: preset.deploymentDefaults?.revisionHistoryLimit ?? '-',
-          },
-          {
-            label: t('adminDeploymentPreset.Strategy'),
-            children: preset.deploymentDefaults?.deploymentStrategy ?? '-',
-          },
-          {
-            label: t('adminDeploymentPreset.OpenToPublic'),
-            children:
-              preset.deploymentDefaults?.openToPublic != null
-                ? preset.deploymentDefaults.openToPublic
-                  ? t('button.Yes')
-                  : t('button.No')
-                : '-',
-          },
-        ]}
-      />
+        <Descriptions
+          size="small"
+          column={2}
+          items={[
+            {
+              label: t('adminDeploymentPreset.Replicas'),
+              children: preset.deploymentDefaults?.replicaCount ?? '-',
+            },
+            {
+              label: t('adminDeploymentPreset.RevisionHistoryLimit'),
+              children: preset.deploymentDefaults?.revisionHistoryLimit ?? '-',
+            },
+            {
+              label: t('adminDeploymentPreset.Strategy'),
+              children: preset.deploymentDefaults?.deploymentStrategy ?? '-',
+            },
+            {
+              label: t('adminDeploymentPreset.OpenToPublic'),
+              children:
+                preset.deploymentDefaults?.openToPublic != null
+                  ? preset.deploymentDefaults.openToPublic
+                    ? t('button.Yes')
+                    : t('button.No')
+                  : '-',
+            },
+          ]}
+        />
+      </BAICard>
     </BAIFlex>
   );
 };

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -43,7 +43,6 @@ import {
 } from '../hooks/useRuntimeParameterSchema';
 import { useValidateServiceName } from '../hooks/useValidateServiceName';
 import { useRuntimeEnvVarConfigs } from '../hooks/useVariantConfigs';
-import DeploymentPresetDetailModal from './DeploymentPresetDetailModal';
 import EnvVarFormList, {
   sanitizeSensitiveEnv,
   EnvVarFormListValue,
@@ -65,7 +64,6 @@ import SwitchToProjectButton from './SwitchToProjectButton';
 import VFolderLazyViewV2 from './VFolderLazyViewV2';
 import VFolderSelect from './VFolderSelect';
 import VFolderTableFormItem from './VFolderTableFormItem';
-import { InfoCircleOutlined } from '@ant-design/icons';
 import { useDebounceFn } from 'ahooks';
 import {
   App,
@@ -79,7 +77,6 @@ import {
   Segmented,
   Skeleton,
   Select,
-  Space,
   theme,
   Tooltip,
   Tag,
@@ -251,8 +248,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
   const [selectedPresetId, setSelectedPresetId] = useState<
     string | null | undefined
   >(null);
-  const [isPresetDetailOpen, setIsPresetDetailOpen] = useState(false);
-
   const [form] = Form.useForm<ServiceLauncherFormValue>();
   const [wantToChangeResource, setWantToChangeResource] = useState(false);
   const [currentGlobalResourceGroup, setCurrentGlobalResourceGroup] =
@@ -1710,41 +1705,24 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                           <Form.Item
                             label={t('modelService.SelectDeploymentPreset')}
                           >
-                            <BAIFlex direction="row" gap="xs">
-                              <Select
-                                allowClear
-                                options={
-                                  deploymentRevisionPresets?.edges?.map(
-                                    (edge) => ({
-                                      value: edge.node.id,
-                                      label: edge.node.name,
-                                    }),
-                                  ) ?? []
-                                }
-                                value={selectedPresetId}
-                                onChange={(value) => {
-                                  setSelectedPresetId(value ?? null);
-                                }}
-                                placeholder={t(
-                                  'modelService.SelectDeploymentPreset',
-                                )}
-                              />
-                              <Space.Compact>
-                                <Tooltip
-                                  title={t(
-                                    'modelService.DeploymentPresetDetail',
-                                  )}
-                                >
-                                  <Button
-                                    icon={<InfoCircleOutlined />}
-                                    disabled={!selectedPresetId}
-                                    onClick={() => {
-                                      setIsPresetDetailOpen(true);
-                                    }}
-                                  />
-                                </Tooltip>
-                              </Space.Compact>
-                            </BAIFlex>
+                            <Select
+                              allowClear
+                              options={
+                                deploymentRevisionPresets?.edges?.map(
+                                  (edge) => ({
+                                    value: edge.node.id,
+                                    label: edge.node.name,
+                                  }),
+                                ) ?? []
+                              }
+                              value={selectedPresetId}
+                              onChange={(value) => {
+                                setSelectedPresetId(value ?? null);
+                              }}
+                              placeholder={t(
+                                'modelService.SelectDeploymentPreset',
+                              )}
+                            />
                           </Form.Item>
                         )}
                         <ImageEnvironmentSelectFormItems
@@ -2279,13 +2257,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
       >
         <ServiceValidationView serviceData={validateServiceData} />
       </BAIModal>
-      <DeploymentPresetDetailModal
-        open={isPresetDetailOpen}
-        presetId={selectedPresetId}
-        onRequestClose={() => {
-          setIsPresetDetailOpen(false);
-        }}
-      />
     </>
   );
 };

--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -378,7 +378,7 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
           tooltip={t('modelStore.PresetTooltip')}
           required
         >
-          <Space.Compact style={{ width: '100%' }}>
+          <BAIFlex direction="row" gap="xs">
             <BAISelect
               value={effectivePresetId}
               onChange={(value: string) => setUserSelectedPresetId(value)}
@@ -403,14 +403,16 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
               )}
               style={{ flex: 1 }}
             />
-            <Tooltip title={t('modelService.DeploymentPresetDetail')}>
-              <Button
-                icon={<InfoCircleOutlined />}
-                disabled={!effectivePresetId}
-                onClick={() => setPresetDetailId(effectivePresetId)}
-              />
-            </Tooltip>
-          </Space.Compact>
+            <Space.Compact>
+              <Tooltip title={t('modelService.DeploymentPresetDetail')}>
+                <Button
+                  icon={<InfoCircleOutlined />}
+                  disabled={!effectivePresetId}
+                  onClick={() => setPresetDetailId(effectivePresetId)}
+                />
+              </Tooltip>
+            </Space.Compact>
+          </BAIFlex>
           <DeploymentPresetDetailModal
             open={!!presetDetailId}
             presetId={presetDetailId}


### PR DESCRIPTION
Resolves #7122 (FR-2762)

## Summary

- Replace divider-separated sections in `DeploymentPresetDetailContent` with `BAICard` sections (Image, Cluster, Resources, Deployment Defaults) for cleaner visual grouping
- Remove `rank` field from the preset detail view
- Remove preset detail modal wiring from `ServiceLauncherPageContent` (info button, `isPresetDetailOpen` state, `DeploymentPresetDetailModal`, unused `InfoCircleOutlined` / `Space` / `DeploymentPresetDetailModal` imports)