### PR TITLE
fix(FR-2762): move DeploymentPresetDetailModal outside Form.Item to prevent double query

### DIFF
--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -413,11 +413,6 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
               </Tooltip>
             </Space.Compact>
           </BAIFlex>
-          <DeploymentPresetDetailModal
-            open={!!presetDetailId}
-            presetId={presetDetailId}
-            onRequestClose={() => setPresetDetailId(undefined)}
-          />
         </Form.Item>
         <Form.Item
           label={t('modelStore.ResourceGroup')}
@@ -432,6 +427,11 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
           />
         </Form.Item>
       </Form>
+      <DeploymentPresetDetailModal
+        open={!!presetDetailId}
+        presetId={presetDetailId}
+        onRequestClose={() => setPresetDetailId(undefined)}
+      />
       <BAIFlex justify="end" gap="sm">
         <BAIButton onClick={onClose}>{t('button.Cancel')}</BAIButton>
         {supportsQuickDeploy && vfolderId ? (


### PR DESCRIPTION
Resolves #7122 (FR-2762)

## Summary

- Move `DeploymentPresetDetailModal` from inside `Form.Item` to a sibling of the `Form` element
- Ant Design's `Form.Item` clones its children on every render; having the modal inside `Form.Item` caused `DeploymentPresetDetailModalContent` to unmount and remount on each render, triggering two network requests instead of one