### PR TITLE
chore(FR-2789): fix backend.ai-client package.json for publishable distribution

### DIFF
--- a/packages/backend.ai-client/package.json
+++ b/packages/backend.ai-client/package.json
@@ -4,8 +4,10 @@
   "description": "Backend.AI API client library for JavaScript/TypeScript",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lablup/backend.ai-webui/tree/main/packages/backend.ai-client"
+    "url": "git+https://github.com/lablup/backend.ai-webui.git",
+    "directory": "packages/backend.ai-client"
   },
+  "homepage": "https://github.com/lablup/backend.ai-webui/tree/main/packages/backend.ai-client#readme",
   "bugs": {
     "url": "https://github.com/lablup/backend.ai-webui/issues"
   },
@@ -23,13 +25,21 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",


### PR DESCRIPTION
Resolves #7196(FR-2789)

Epic: FR-2792 (backend.ai-client production readiness)

## Summary

Tightens `packages/backend.ai-client/package.json` so the package is safe to publish and predictable to consume. The package is built ESM-only by `tsup` (`format: ['esm']` + `"type": "module"`), so the metadata is shaped to match an ESM-only tarball.

## Changes

- **`exports`** — moved `types` before `import` per Node ESM resolution rules, no `require` branch (ESM-only).
- **`main`** — kept as `./dist/index.js` for parity with sibling publishable packages (`backend.ai-ui`, `backend.ai-docs-toolkit`) that all retain `main` alongside `module` + `exports` for legacy bundlers.
- **`engines`** — added `"node": ">=22"` — drops EOL versions (Node 18 EOL Apr 2025, Node 20 EOL Apr 2026), aligns with Vitest 4 (`^20 || ^22 || >=24`), and matches the repo `.nvmrc` (Node 24) we actually CI against.
- **`publishConfig.access: public`** — explicit so a first publish doesn't depend on local registry defaults.
- **`repository`** — switched from a tree URL to a proper `git+https://` URL with `directory: "packages/backend.ai-client"` so npm's "View Source" link works correctly.
- **`homepage`** — added a tree-anchored URL pointing at the package README.
- **`files`** — added `README.md` and `LICENSE` (sibling PR #7202 / FR-2788 lands them; pack tolerates missing entries until that lands).

## Out of scope

- LICENSE and README content (FR-2788 / #7202).
- ESLint config (FR-2790 / #7204).
- CI workflow (FR-2791 / #7203).

## Verification

- `pnpm install` from repo root — workspace link unchanged.
- `pnpm --filter backend.ai-client run build` — ESM 174.99 KB + DTS 65.36 KB.
- `pnpm pack --dry-run` (combined with #7202) — tarball lists `dist/`, `LICENSE`, `package.json`, `README.md`.
- ESM smoke import (`import { Client, ClientConfig } from 'backend.ai-client'`) — both resolve.
- `bash scripts/verify.sh` — Relay/Lint/Format pass; TypeScript pre-existing errors in `client.ts` exist on `origin/main` and are unrelated to this PR.