### PR TITLE
ci(FR-2791): add backend.ai-client lint/typecheck/test/build workflow

### DIFF
--- a/.github/workflows/backend-ai-client-ci.yml
+++ b/.github/workflows/backend-ai-client-ci.yml
@@ -1,0 +1,65 @@
+name: backend.ai-client CI
+
+on:
+  pull_request:
+    paths:
+      - 'packages/backend.ai-client/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/backend-ai-client-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/backend.ai-client/**'
+      - 'pnpm-lock.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-ai-client-ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v5
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
+
+      - name: Lint
+        run: pnpm --filter backend.ai-client run lint
+
+      - name: Typecheck
+        run: pnpm --filter backend.ai-client exec tsc --noEmit
+
+      - name: Test
+        run: pnpm --filter backend.ai-client run test
+
+      - name: Build
+        run: pnpm --filter backend.ai-client run build


### PR DESCRIPTION
Resolves #7198(FR-2791)

Epic: FR-2792 (backend.ai-client production readiness)

## Summary

Adds a dedicated GitHub Actions workflow that validates `packages/backend.ai-client` on PRs and on `main` pushes. The repo's existing `scripts/verify.sh` only covers the React app, so library-only regressions (lint, typecheck, test, build) currently slip through.

## Workflow

`.github/workflows/backend-ai-client-ci.yml` runs on PRs and pushes that touch the package or the lockfile, and executes:

1. `pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile` (matches the `vitest.yml` pattern; the repo uses `gitBranchLockfile: true`)
2. `pnpm --filter backend.ai-client run lint`
3. `pnpm --filter backend.ai-client exec tsc --noEmit`
4. `pnpm --filter backend.ai-client run test`
5. `pnpm --filter backend.ai-client run build`

Path filter covers `packages/backend.ai-client/**`, `pnpm-lock.yaml`, and the workflow file itself; concurrency is set to cancel in-flight runs of the same head ref.

## Soft dependency

The lint step depends on FR-2790 / #7204 landing first (that PR adds `eslint.config.js`). Both PRs are in the same Epic FR-2792 and intended to merge together; CI will be green on `main` after both land.

## Out of scope

- `npm publish` workflow — separate ticket once a publishing strategy is decided.
- Coverage thresholds — separate ticket once additional unit tests land.
- Branch protection / required-check enforcement — left to the maintainer.

## Verification

- YAML parses (`python3 -c "yaml.safe_load(...)"`).
- All step commands run green locally on the merged-Epic state (lint 0 errors / 242 warnings, typecheck pass, tests 4/4 pass, build success).
- Action and pnpm versions (`actions/checkout@v5`, `pnpm/action-setup@v5`, `actions/setup-node@v5`, `actions/cache@v5`) match what's already used by `vitest.yml` and `publish-backend.ai-ui.yml`.