### PR TITLE
chore(FR-2790): add ESLint flat config to backend.ai-client

### DIFF
--- a/packages/backend.ai-client/eslint.config.js
+++ b/packages/backend.ai-client/eslint.config.js
@@ -1,0 +1,45 @@
+import { base } from 'eslint-config-bai';
+
+export default [
+  ...base,
+
+  {
+    ignores: ['dist/**'],
+  },
+
+  {
+    rules: {
+      // Enforce `import type` for type-only imports.
+      '@typescript-eslint/consistent-type-imports': 'error',
+      // Surface real bugs from un-awaited promises.
+      '@typescript-eslint/no-floating-promises': 'error',
+      // Existing code has many `any`s; a strict-typing pass is tracked
+      // separately under the FR-2792 epic. Keep as warn (overrides the
+      // shared base which currently turns this rule off entirely) so
+      // the noise is visible without being a publish-blocker.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_' },
+      ],
+    },
+    languageOptions: {
+      parserOptions: {
+        // `no-floating-promises` requires type information.
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+
+  // Tests: relax the strictest rules so test scaffolding (e.g. mock
+  // objects typed as `any`, intentionally fire-and-forget assertions)
+  // does not block `prepublishOnly`.
+  {
+    files: ['**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+];

--- a/packages/backend.ai-client/package.json
+++ b/packages/backend.ai-client/package.json
@@ -36,15 +36,18 @@
     "test": "vitest run",
     "vitest": "vitest run",
     "vitest:watch": "vitest",
-    "lint": "eslint ./src --max-warnings=0",
+    "lint": "eslint ./src",
     "prepublishOnly": "pnpm lint && pnpm test && pnpm build"
   },
   "dependencies": {
     "crypto-es": "^2.1.0"
   },
   "devDependencies": {
+    "@eslint/js": "catalog:",
+    "eslint-config-bai": "workspace:*",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
+    "typescript-eslint": "catalog:",
     "vitest": "^4.1.4"
   },
   "type": "module"

--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -1379,7 +1379,7 @@ export class Client {
     runId: string,
     mode: string,
     code: string,
-    opts: Object,
+    opts: object = {},
     timeout = 0,
   ): Promise<any> {
     let params = {
@@ -1872,7 +1872,7 @@ export class Client {
       .replace(/\s+/g, '-') // Replace spaces with -
       .replace(p, (c) => b.charAt(a.indexOf(c))) // Replace special chars
       .replace(/&/g, '-and-') // Replace & with 'and'
-      .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+      .replace(/[^\w-]+/g, '') // Remove all non-word chars
       .replace(/--+/g, '-') // Replace multiple - with single -
       .replace(/^-+/, '') // Trim - from start of text
       .replace(/-+$/, ''); // Trim - from end of text

--- a/packages/backend.ai-client/src/resources/pipeline.ts
+++ b/packages/backend.ai-client/src/resources/pipeline.ts
@@ -41,7 +41,7 @@ export class Pipeline {
         }),
       });
       // if there's no token, then user account is invalid
-      if (!result.hasOwnProperty('token')) {
+      if (!Object.prototype.hasOwnProperty.call(result, 'token')) {
         return Promise.resolve(false);
       } else {
         const token = result.token;


### PR DESCRIPTION
Resolves #7197(FR-2790)

Epic: FR-2792 (backend.ai-client production readiness)

## Summary

Adds an ESLint 9 flat config to `packages/backend.ai-client/` so the existing `pnpm lint` script (and therefore `prepublishOnly`) actually validates the source. Without this, lint either no-ops or picks up an unrelated config and `prepublishOnly` is a misleading green light.

## Changes

- **`packages/backend.ai-client/eslint.config.js`** — flat config (`type: module`) extending `eslint-config-bai` `base`, with package-specific overrides:
  - `@typescript-eslint/consistent-type-imports`: `error`
  - `@typescript-eslint/no-floating-promises`: `error` (with `parserOptions.projectService` for type info)
  - `@typescript-eslint/no-explicit-any`: `warn` (overrides the shared `base`'s `off`; the strict-typing pass is intentionally a separate ticket so existing `any` use is visible but not blocking)
  - `**/*.test.ts` files relax `no-floating-promises` and `no-explicit-any`.
- **`package.json`** — drops `--max-warnings=0` from the `lint` script (warnings are expected during the strict-typing migration), adds `@eslint/js` (catalog), `eslint-config-bai` (workspace), and `typescript-eslint` (catalog) as devDependencies.
- **Lint-driven source fixes** (mechanical, surfaced by the new rules):
  - `src/client.ts` — `Object` → `object` parameter type; `[^\w\-]` → `[^\w-]` (unnecessary escape).
  - `src/client.ts` — `opts: object = {}` default to match the JSDoc-declared optionality.
  - `src/resources/pipeline.ts` — `result.hasOwnProperty('token')` → `Object.prototype.hasOwnProperty.call(...)` (avoids `no-prototype-builtins`).

## Lint status

`pnpm --filter backend.ai-client lint` — 0 errors, 242 warnings (exit 0). All 242 warnings are `no-explicit-any` from pre-existing `: any` annotations and are explicitly out of scope.

## Out of scope

- Removing all `any` (separate epic — there are 242 of them).
- Tightening `tsconfig.strict` (separate ticket).
- Pre-existing bug in `Pipeline.login` (always returns `false` even on success) — filed as **FR-2793** under the same Epic, since it's pre-existing in `origin/main` and not introduced by this PR.

## Verification

- `pnpm --filter backend.ai-client lint` — 0 errors / 242 warnings.
- `pnpm --filter backend.ai-client test` — 4/4 pass.
- `pnpm --filter backend.ai-client build` — ESM 174.99 KB + DTS 65.36 KB.
- Sanity: introduced a deliberate floating-promise / explicit-any in a temp file, confirmed lint flagged them, reverted.
- `bash scripts/verify.sh` — Relay/Lint/Format pass; TypeScript pre-existing errors are unrelated.