### PR TITLE
fix(FR-2795): restore dev-time theme header color override broken after Vite migration

### DIFF
--- a/.env.development.local.sample
+++ b/.env.development.local.sample
@@ -2,33 +2,35 @@
 # Copy this to .env.development.local and modify as needed
 
 # Theme header color override (optional)
-# Bridged into REACT_APP_THEME_COLOR by scripts/dev.mjs so CRA can pick it up.
-THEME_HEADER_COLOR=#7C3AED
+# Vite auto-loads any VITE_* var from this file and exposes it on
+# import.meta.env. The webui reads VITE_THEME_HEADER_COLOR to tint the
+# header in dev so multiple parallel instances are visually distinguishable.
+VITE_THEME_HEADER_COLOR=#7C3AED
 
 # AI/Tech Purple Options:
-# THEME_HEADER_COLOR=#6B46C1  # Deep Purple (recommended)
-# THEME_HEADER_COLOR=#8B5CF6  # Electric Purple
-# THEME_HEADER_COLOR=#7C3AED  # AI Violet (current)
-# THEME_HEADER_COLOR=#5B21B6  # Neural Purple
-# THEME_HEADER_COLOR=#9333EA  # Bright Purple
+# VITE_THEME_HEADER_COLOR=#6B46C1  # Deep Purple (recommended)
+# VITE_THEME_HEADER_COLOR=#8B5CF6  # Electric Purple
+# VITE_THEME_HEADER_COLOR=#7C3AED  # AI Violet (current)
+# VITE_THEME_HEADER_COLOR=#5B21B6  # Neural Purple
+# VITE_THEME_HEADER_COLOR=#9333EA  # Bright Purple
 #
 # Professional Blue Options:
-# THEME_HEADER_COLOR=#2563EB  # Professional Blue
-# THEME_HEADER_COLOR=#1D4ED8  # Deep Blue
-# THEME_HEADER_COLOR=#3B82F6  # Sky Blue
-# THEME_HEADER_COLOR=#1E40AF  # Navy Blue
+# VITE_THEME_HEADER_COLOR=#2563EB  # Professional Blue
+# VITE_THEME_HEADER_COLOR=#1D4ED8  # Deep Blue
+# VITE_THEME_HEADER_COLOR=#3B82F6  # Sky Blue
+# VITE_THEME_HEADER_COLOR=#1E40AF  # Navy Blue
 #
 # Modern Green Options:
-# THEME_HEADER_COLOR=#059669  # Emerald Green
-# THEME_HEADER_COLOR=#047857  # Forest Green
-# THEME_HEADER_COLOR=#10B981  # Mint Green
+# VITE_THEME_HEADER_COLOR=#059669  # Emerald Green
+# VITE_THEME_HEADER_COLOR=#047857  # Forest Green
+# VITE_THEME_HEADER_COLOR=#10B981  # Mint Green
 #
 # Elegant Dark Options:
-# THEME_HEADER_COLOR=#374151  # Dark Gray
-# THEME_HEADER_COLOR=#1F2937  # Charcoal
-# THEME_HEADER_COLOR=#111827  # Almost Black
+# VITE_THEME_HEADER_COLOR=#374151  # Dark Gray
+# VITE_THEME_HEADER_COLOR=#1F2937  # Charcoal
+# VITE_THEME_HEADER_COLOR=#111827  # Almost Black
 #
 # Warm Options:
-# THEME_HEADER_COLOR=#DC2626  # Red
-# THEME_HEADER_COLOR=#EA580C  # Orange
-# THEME_HEADER_COLOR=#D97706  # Amber
+# VITE_THEME_HEADER_COLOR=#DC2626  # Red
+# VITE_THEME_HEADER_COLOR=#EA580C  # Orange
+# VITE_THEME_HEADER_COLOR=#D97706  # Amber

--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -74,10 +74,10 @@ Each worktree picks up its own branch's FR number, so two worktrees on different
 Create `.env.development.local` (copy from `.env.development.local.sample`) and set:
 
 ```bash
-THEME_HEADER_COLOR=#7C3AED
+VITE_THEME_HEADER_COLOR=#7C3AED
 ```
 
-`scripts/dev.mjs` forwards this value as `REACT_APP_THEME_COLOR` to the CRA process, tinting the header so you can tell multiple instances apart at a glance.
+Vite auto-loads `VITE_*` vars from this file and exposes them on `import.meta.env` for the React app, tinting the header so you can tell multiple instances apart at a glance. You can also export `VITE_THEME_HEADER_COLOR` in the shell — same effect, no file edit needed.
 
 ## Storybook
 
@@ -93,7 +93,7 @@ Runs behind Portless on a fixed internal port 6006. Open the printed `*.localhos
 - **Service-worker error like `Script .../sw.js load failed`** — fixed in this branch (`index.html` now skips SW registration on `*.localhost`). If you still see it, unregister the stale SW via DevTools → Application → Service Workers.
 - **`already registered by a running process`** — Portless route from a previously killed dev server still exists. `dev.mjs` passes `--force` so this should self-heal; if not, run `pnpm exec portless proxy stop && pnpm exec portless proxy start -p 1355` once.
 - **HTTPS request hangs / `HTTP 000`** — TLS cert generation can fail for very long hostnames. Either rename the branch to include `FR-XXXX`, or switch the daemon to HTTP with `pnpm exec portless proxy start -p 1355 --no-tls`.
-- **Theme color not applied** — confirm `THEME_HEADER_COLOR` is set in `.env.development.local` (not just exported in the shell) and restart `pnpm run dev`. The bridge only runs on start.
+- **Theme color not applied** — confirm `VITE_THEME_HEADER_COLOR` is set in `.env.development.local` or the shell, and restart `pnpm run dev`. Vite reads env at server start, so existing dev servers won't pick up changes until restarted.
 - **Watchers seem stuck** — all three dev children (tsc, Relay watch, CRA) run under `concurrently` with `--kill-others`; Ctrl+C tears them down together.
 
 ## Commands reference

--- a/react/src/helper/customThemeConfig.test.ts
+++ b/react/src/helper/customThemeConfig.test.ts
@@ -99,9 +99,10 @@ describe('customThemeConfig', () => {
       expect(theme?.logo).toEqual(mockLegacyTheme.logo);
     });
 
-    it('should apply REACT_APP_THEME_COLOR in development environment', async () => {
-      vi.stubEnv('NODE_ENV', 'development');
-      process.env.REACT_APP_THEME_COLOR = '#ff0000';
+    it('should apply VITE_THEME_HEADER_COLOR in development environment', async () => {
+      vi.stubEnv('MODE', 'development');
+      vi.stubEnv('DEV', true);
+      vi.stubEnv('VITE_THEME_HEADER_COLOR', '#ff0000');
 
       const mockTheme: CustomThemeConfig = {
         light: {
@@ -132,9 +133,10 @@ describe('customThemeConfig', () => {
       expect(theme?.dark.components?.Layout?.headerBg).toBe('#ff0000');
     });
 
-    it('should not apply REACT_APP_THEME_COLOR in production environment', async () => {
-      vi.stubEnv('NODE_ENV', 'production');
-      process.env.REACT_APP_THEME_COLOR = '#ff0000';
+    it('should not apply VITE_THEME_HEADER_COLOR in production environment', async () => {
+      vi.stubEnv('MODE', 'production');
+      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_THEME_HEADER_COLOR', '#ff0000');
 
       const mockTheme: CustomThemeConfig = {
         light: {
@@ -371,9 +373,10 @@ describe('customThemeConfig', () => {
       expect(dispatchEventSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('should only apply REACT_APP_THEME_COLOR when both development mode and env var are set', async () => {
-      vi.stubEnv('NODE_ENV', 'development');
-      delete process.env.REACT_APP_THEME_COLOR;
+    it('should only apply VITE_THEME_HEADER_COLOR when both development mode and env var are set', async () => {
+      vi.stubEnv('MODE', 'development');
+      vi.stubEnv('DEV', true);
+      vi.stubEnv('VITE_THEME_HEADER_COLOR', '');
 
       const mockTheme: CustomThemeConfig = {
         light: {
@@ -404,9 +407,10 @@ describe('customThemeConfig', () => {
       expect(theme?.dark.components?.Layout?.headerBg).toBeUndefined();
     });
 
-    it('should preserve existing Layout component settings when applying REACT_APP_THEME_COLOR', async () => {
-      vi.stubEnv('NODE_ENV', 'development');
-      process.env.REACT_APP_THEME_COLOR = '#ff0000';
+    it('should preserve existing Layout component settings when applying VITE_THEME_HEADER_COLOR', async () => {
+      vi.stubEnv('MODE', 'development');
+      vi.stubEnv('DEV', true);
+      vi.stubEnv('VITE_THEME_HEADER_COLOR', '#ff0000');
 
       const mockTheme: CustomThemeConfig = {
         light: {

--- a/react/src/helper/customThemeConfig.ts
+++ b/react/src/helper/customThemeConfig.ts
@@ -113,18 +113,18 @@ export const loadCustomThemeConfig = () => {
       }
       if (
         _customTheme &&
-        process.env.NODE_ENV === 'development' &&
-        process.env.REACT_APP_THEME_COLOR
+        import.meta.env.DEV &&
+        import.meta.env.VITE_THEME_HEADER_COLOR
       ) {
         _.set(
           _customTheme,
           'light.components.Layout.headerBg',
-          process.env.REACT_APP_THEME_COLOR,
+          import.meta.env.VITE_THEME_HEADER_COLOR,
         );
         _.set(
           _customTheme,
           'dark.components.Layout.headerBg',
-          process.env.REACT_APP_THEME_COLOR,
+          import.meta.env.VITE_THEME_HEADER_COLOR,
         );
       }
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,26 +1,11 @@
 #!/usr/bin/env node
-// Bridges THEME_HEADER_COLOR from .env.development.local into REACT_APP_THEME_COLOR,
-// then spawns concurrently with three children (tsc watch, Relay watch, CRA via Portless).
+// Spawns concurrently with three children (tsc watch, Relay watch, Vite via Portless).
+// The dev-time header color override is exposed to the React app via
+// VITE_THEME_HEADER_COLOR — set it in `.env.development.local` or the shell
+// and Vite's loadEnv() picks it up natively (no bridge needed).
 import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 
 const env = { ...process.env };
-const envFile = resolve(process.cwd(), '.env.development.local');
-if (!env.REACT_APP_THEME_COLOR && existsSync(envFile)) {
-  for (const line of readFileSync(envFile, 'utf8').split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eq = trimmed.indexOf('=');
-    if (eq === -1) continue;
-    const key = trimmed.slice(0, eq).trim();
-    const value = trimmed.slice(eq + 1).trim().replace(/^['"]|['"]$/g, '');
-    if (key === 'THEME_HEADER_COLOR' && value) {
-      env.REACT_APP_THEME_COLOR = value;
-      break;
-    }
-  }
-}
 
 // Ensure the Portless daemon is running. Portless 0.10+ defaults the daemon
 // to port 443 which requires sudo; we override that to an unprivileged 1355


### PR DESCRIPTION
Resolves #7207(FR-2795)

## Problem

The CRA→Vite bundler migration (FR-2605) did not account for the env var convention difference between the two bundlers:

- **CRA** exposes user-defined env vars at runtime via `process.env.REACT_APP_*`.
- **Vite** exposes them via `import.meta.env.VITE_*` and ignores anything not prefixed with `VITE_`.

`react/src/helper/customThemeConfig.ts` was still reading `process.env.REACT_APP_THEME_COLOR`, which is always `undefined` under Vite. The dev-time theme header color override silently stopped working — no error, no warning.

## Fix

Unify on the Vite-native env var name. No bridge, no alias.

- `react/src/helper/customThemeConfig.ts` — read `import.meta.env.VITE_THEME_HEADER_COLOR` gated on `import.meta.env.DEV` instead of the CRA-style `process.env` access.
- `react/src/helper/customThemeConfig.test.ts` — update the four affected tests to stub `MODE`, `DEV`, and `VITE_THEME_HEADER_COLOR` via `vi.stubEnv`.
- `scripts/dev.mjs` — no bridge needed. Vite's `loadEnv()` auto-loads `VITE_*` vars from `.env.development.local` and from the shell environment.
- `.env.development.local.sample` and `DEV_ENVIRONMENT.md` — rename the variable and drop the bridge commentary.

## Migration

Existing `.env.development.local` files using `THEME_HEADER_COLOR=#xxx` need a one-line rename to `VITE_THEME_HEADER_COLOR=#xxx`. No bridge is provided — keeping a single name is cleaner than supporting two.

## How to verify

1. Add `VITE_THEME_HEADER_COLOR=#7C3AED` to `.env.development.local` (or export it in your shell).
2. Run `pnpm dev`.
3. The WebUI top header should be tinted purple.

**Checklist:**

- [x] Documentation (`.env.development.local.sample`, `DEV_ENVIRONMENT.md`)
- [ ] Minimum required manager version
- [ ] Specific setting for review
- [x] Minimum requirements to check during review (env var works under Vite)
- [x] Test case(s) (`customThemeConfig.test.ts` updated to cover the Vite path)