### PR TITLE
feat(FR-2800): enforce relative import paths via ESLint

### DIFF
--- a/packages/eslint-config-bai/react.js
+++ b/packages/eslint-config-bai/react.js
@@ -37,6 +37,20 @@ export const react = [
   },
 
   {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector: "ImportDeclaration[source.value=/^src\\u002F.+/]",
+          message:
+            "Use a relative import path instead of 'src/...'. Mixing absolute and relative paths in the same file is inconsistent; prefer relative paths.",
+        },
+      ],
+    },
+  },
+
+  {
     files: ["**/*.tsx", "**/*.jsx"],
     rules: {
       "react/react-in-jsx-scope": "off",

--- a/react/src/components/AgentDetailDrawer.tsx
+++ b/react/src/components/AgentDetailDrawer.tsx
@@ -2,13 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AgentDetailDrawerFragment$key } from '../__generated__/AgentDetailDrawerFragment.graphql';
 import AgentDetailDrawerContent from './AgentDetailDrawerContent';
 import { Drawer, type DrawerProps, Skeleton } from 'antd';
 import { BAIFetchKeyButton, toLocalId, useBAILogger } from 'backend.ai-ui';
 import { Suspense, useEffect, useEffectEvent, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation, useRefetchableFragment } from 'react-relay';
-import { AgentDetailDrawerFragment$key } from 'src/__generated__/AgentDetailDrawerFragment.graphql';
 
 interface AgentDetailDrawerProps extends DrawerProps {
   onRequestClose?: () => void;

--- a/react/src/components/AgentDetailDrawerContent.tsx
+++ b/react/src/components/AgentDetailDrawerContent.tsx
@@ -2,6 +2,8 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AgentDetailDrawerContentFragment$key } from '../__generated__/AgentDetailDrawerContentFragment.graphql';
+import { useSuspendedBackendaiClient } from '../hooks';
 import AgentActionButtons from './AgentNodeItems/AgentActionButtons';
 import AgentComputePlugins from './AgentNodeItems/AgentComputePlugins';
 import AgentResources from './AgentNodeItems/AgentResources';
@@ -19,8 +21,6 @@ import * as _ from 'lodash-es';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { AgentDetailDrawerContentFragment$key } from 'src/__generated__/AgentDetailDrawerContentFragment.graphql';
-import { useSuspendedBackendaiClient } from 'src/hooks';
 
 interface AgentDetailDrawerContentProps {
   agentNodeFrgmt?: AgentDetailDrawerContentFragment$key | null;

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -8,6 +8,7 @@ import {
   AgentListQuery$variables,
 } from '../__generated__/AgentListQuery.graphql';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useThemeMode } from '../hooks/useThemeMode';
 import AgentDetailDrawer from './AgentDetailDrawer';
 import BAIRadioGroup from './BAIRadioGroup';
@@ -32,7 +33,6 @@ import { parseAsString, useQueryStates } from 'nuqs';
 import React, { useState, useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 
 type Agent = NonNullable<
   NonNullable<AgentListQuery$data['agent_nodes']>['edges'][number]

--- a/react/src/components/AgentNodeItems/AgentActionButtons.tsx
+++ b/react/src/components/AgentNodeItems/AgentActionButtons.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AgentActionButtonsFragment$key } from '../../__generated__/AgentActionButtonsFragment.graphql';
 import AgentSettingModal from '../AgentSettingModal';
 import { SettingOutlined } from '@ant-design/icons';
 import { Space, Tooltip } from 'antd';
@@ -9,7 +10,6 @@ import { BAIButton, BAIButtonProps } from 'backend.ai-ui';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { AgentActionButtonsFragment$key } from 'src/__generated__/AgentActionButtonsFragment.graphql';
 
 interface AgentActionButtonsProps {
   size?: BAIButtonProps['size'];

--- a/react/src/components/AgentNodeItems/AgentComputePlugins.tsx
+++ b/react/src/components/AgentNodeItems/AgentComputePlugins.tsx
@@ -2,10 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AgentComputePluginsFragment$key } from '../../__generated__/AgentComputePluginsFragment.graphql';
 import { BAIDoubleTag, BAITag } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { graphql, useFragment } from 'react-relay';
-import { AgentComputePluginsFragment$key } from 'src/__generated__/AgentComputePluginsFragment.graphql';
 
 interface AgentComputePluginsProps {
   agentNodeFrgmt?: AgentComputePluginsFragment$key | null;

--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AgentResourcesFragment$key } from '../../__generated__/AgentResourcesFragment.graphql';
 import AgentDetailModal from '../AgentDetailModal';
 import SimpleProgressWithLabel from '../SimpleProgressWithLabel';
 import { InfoCircleOutlined } from '@ant-design/icons';
@@ -22,7 +23,6 @@ import * as _ from 'lodash-es';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { AgentResourcesFragment$key } from 'src/__generated__/AgentResourcesFragment.graphql';
 
 interface AgentResourcesProps {
   agentNodeFrgmt?: AgentResourcesFragment$key | null;

--- a/react/src/components/AgentNodeItems/AgentStatusTag.tsx
+++ b/react/src/components/AgentNodeItems/AgentStatusTag.tsx
@@ -2,11 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AgentStatusTagFragment$key } from '../../__generated__/AgentStatusTagFragment.graphql';
 import { BAIDoubleTag, BAIDoubleTagProps, BAIFlex } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { AgentStatusTagFragment$key } from 'src/__generated__/AgentStatusTagFragment.graphql';
 
 interface AgentStatusTagProps extends Omit<BAIDoubleTagProps, 'values'> {
   agentNodeFrgmt?: AgentStatusTagFragment$key | null;

--- a/react/src/components/AgentSettingModal.tsx
+++ b/react/src/components/AgentSettingModal.tsx
@@ -7,6 +7,8 @@ import {
   AgentSettingModalFragment$key,
 } from '../__generated__/AgentSettingModalFragment.graphql';
 import { AgentSettingModalMutation } from '../__generated__/AgentSettingModalMutation.graphql';
+import { AgentSettingModalQuery } from '../__generated__/AgentSettingModalQuery.graphql';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { App, Form, type FormInstance, Switch } from 'antd';
 import {
   BAIAdminResourceGroupSelect,
@@ -22,8 +24,6 @@ import {
   useLazyLoadQuery,
   useMutation,
 } from 'react-relay';
-import { AgentSettingModalQuery } from 'src/__generated__/AgentSettingModalQuery.graphql';
-import { useSuspendedBackendaiClient } from 'src/hooks';
 
 interface AgentSettingModalProps extends BAIModalProps {
   agentNodeFrgmt?: AgentSettingModalFragment$key | null;

--- a/react/src/components/AgentStats.tsx
+++ b/react/src/components/AgentStats.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AgentStatsFragment$key } from '../__generated__/AgentStatsFragment.graphql';
 import { useControllableValue } from 'ahooks';
 import { Segmented, Skeleton, theme, Typography } from 'antd';
 import {
@@ -18,7 +19,6 @@ import * as _ from 'lodash-es';
 import { useTransition, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useRefetchableFragment } from 'react-relay';
-import { AgentStatsFragment$key } from 'src/__generated__/AgentStatsFragment.graphql';
 
 interface AgentStatsProps extends BAIFlexProps {
   queryRef: AgentStatsFragment$key;

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -13,6 +13,7 @@ import {
 } from '../helper';
 import { ResourceSlotName } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useResourceGroupsForCurrentProject } from '../hooks/useCurrentProject';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import BAIRadioGroup from './BAIRadioGroup';
@@ -42,7 +43,6 @@ import * as _ from 'lodash-es';
 import React, { useDeferredValue, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 type AgentSummary = NonNullable<

--- a/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
+++ b/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
@@ -2,6 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { BAIComputeSessionNodeNotificationItemFragment$key } from '../__generated__/BAIComputeSessionNodeNotificationItemFragment.graphql';
+import { BAIComputeSessionNodeNotificationItemRefreshQuery } from '../__generated__/BAIComputeSessionNodeNotificationItemRefreshQuery.graphql';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import {
+  NotificationState,
+  useSetBAINotification,
+} from '../hooks/useBAINotification';
 import SessionActionButtons, {
   PrimaryAppOption,
 } from './ComputeSessionNodeItems/SessionActionButtons';
@@ -24,13 +31,6 @@ import {
   useRelayEnvironment,
   useSubscription,
 } from 'react-relay';
-import { BAIComputeSessionNodeNotificationItemFragment$key } from 'src/__generated__/BAIComputeSessionNodeNotificationItemFragment.graphql';
-import { BAIComputeSessionNodeNotificationItemRefreshQuery } from 'src/__generated__/BAIComputeSessionNodeNotificationItemRefreshQuery.graphql';
-import { useSuspendedBackendaiClient, useWebUINavigate } from 'src/hooks';
-import {
-  NotificationState,
-  useSetBAINotification,
-} from 'src/hooks/useBAINotification';
 
 interface BAINodeNotificationItemProps {
   notification: NotificationState;

--- a/react/src/components/BAINodeNotificationItem.tsx
+++ b/react/src/components/BAINodeNotificationItem.tsx
@@ -2,13 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { BAINodeNotificationItemFragment$key } from '../__generated__/BAINodeNotificationItemFragment.graphql';
 import { NotificationState } from '../hooks/useBAINotification';
 import BAIComputeSessionNodeNotificationItem from './BAIComputeSessionNodeNotificationItem';
 import BAIVFolderNotificationItem from './BAIVFolderNotificationItem';
 import BAIVirtualFolderNodeNotificationItem from './BAIVirtualFolderNodeNotificationItem';
 import React from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
-import { BAINodeNotificationItemFragment$key } from 'src/__generated__/BAINodeNotificationItemFragment.graphql';
 
 // `... on VFolder` is the V2 (Strawberry GraphQL, FR-2573) branch and the
 // preferred path for new VFolder list/mutation flows.

--- a/react/src/components/BAINotificationBackgroundProgress.tsx
+++ b/react/src/components/BAINotificationBackgroundProgress.tsx
@@ -2,9 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { NotificationState } from '../hooks/useBAINotification';
 import { Progress, theme } from 'antd';
 import * as _ from 'lodash-es';
-import { NotificationState } from 'src/hooks/useBAINotification';
 
 interface BAINotificationBackgroundProgressProps {
   backgroundTask: NotificationState['backgroundTask'];

--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -6,6 +6,7 @@ import {
   useBAINotificationEffect,
   useBAINotificationState,
 } from '../hooks/useBAINotification';
+import useKeyboardShortcut from '../hooks/useKeyboardShortcut';
 import ReverseThemeProvider from './ReverseThemeProvider';
 import WEBUINotificationDrawer from './WEBUINotificationDrawer';
 import { BellOutlined } from '@ant-design/icons';
@@ -15,7 +16,6 @@ import { t } from 'i18next';
 import { atom, useAtom } from 'jotai';
 import * as _ from 'lodash-es';
 import React, { useEffect } from 'react';
-import useKeyboardShortcut from 'src/hooks/useKeyboardShortcut';
 
 export const isOpenDrawerState = atom(false);
 

--- a/react/src/components/BAIVFolderNotificationItem.tsx
+++ b/react/src/components/BAIVFolderNotificationItem.tsx
@@ -2,6 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { BAIVFolderNotificationItemFragment$key } from '../__generated__/BAIVFolderNotificationItemFragment.graphql';
+import { useWebUINavigate } from '../hooks';
+import {
+  NotificationState,
+  useSetBAINotification,
+} from '../hooks/useBAINotification';
 import BAINotificationBackgroundProgress from './BAINotificationBackgroundProgress';
 import { useToggle } from 'ahooks';
 import { Card, List, theme, Typography } from 'antd';
@@ -16,12 +22,6 @@ import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { BAIVFolderNotificationItemFragment$key } from 'src/__generated__/BAIVFolderNotificationItemFragment.graphql';
-import { useWebUINavigate } from 'src/hooks';
-import {
-  NotificationState,
-  useSetBAINotification,
-} from 'src/hooks/useBAINotification';
 
 interface BAIVFolderNotificationItemProps {
   notification: NotificationState;

--- a/react/src/components/BAIVirtualFolderNodeNotificationItem.tsx
+++ b/react/src/components/BAIVirtualFolderNodeNotificationItem.tsx
@@ -2,6 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { BAIVirtualFolderNodeNotificationItemFragment$key } from '../__generated__/BAIVirtualFolderNodeNotificationItemFragment.graphql';
+import { useWebUINavigate } from '../hooks';
+import {
+  NotificationState,
+  useSetBAINotification,
+} from '../hooks/useBAINotification';
 import BAINotificationBackgroundProgress from './BAINotificationBackgroundProgress';
 import { useToggle } from 'ahooks';
 import { Card, List, theme, Typography } from 'antd';
@@ -10,12 +16,6 @@ import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { BAIVirtualFolderNodeNotificationItemFragment$key } from 'src/__generated__/BAIVirtualFolderNodeNotificationItemFragment.graphql';
-import { useWebUINavigate } from 'src/hooks';
-import {
-  NotificationState,
-  useSetBAINotification,
-} from 'src/hooks/useBAINotification';
 
 interface BAIVirtualFolderNodeNotificationItemProps {
   notification: NotificationState;

--- a/react/src/components/BrandingSettingItems/FontFamilySettingItem.tsx
+++ b/react/src/components/BrandingSettingItems/FontFamilySettingItem.tsx
@@ -2,9 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useUserCustomThemeConfig } from '../../hooks/useUserCustomThemeConfig';
 import { theme } from 'antd';
 import { BAIUncontrolledInput } from 'backend.ai-ui';
-import { useUserCustomThemeConfig } from 'src/hooks/useUserCustomThemeConfig';
 
 const FontFamilySettingItem: React.FC = () => {
   'use memo';

--- a/react/src/components/BrandingSettingItems/LogoPreviewer.tsx
+++ b/react/src/components/BrandingSettingItems/LogoPreviewer.tsx
@@ -2,14 +2,14 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
+import { useUserCustomThemeConfig } from '../../hooks/useUserCustomThemeConfig';
 import { App, Image, Space, Tooltip, Typography, Upload } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIButton, BAIFlex, BAIUncontrolledInput } from 'backend.ai-ui';
 import { t } from 'i18next';
 import * as _ from 'lodash-es';
 import { ImagePlus } from 'lucide-react';
-import { useCustomThemeConfig } from 'src/hooks/useCustomThemeConfig';
-import { useUserCustomThemeConfig } from 'src/hooks/useUserCustomThemeConfig';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 

--- a/react/src/components/BrandingSettingItems/LogoSizeSettingItem.tsx
+++ b/react/src/components/BrandingSettingItems/LogoSizeSettingItem.tsx
@@ -2,11 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
+import { useUserCustomThemeConfig } from '../../hooks/useUserCustomThemeConfig';
 import { Col, Row, theme, Typography } from 'antd';
 import { BAIFlex, BAIUncontrolledInput } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';
-import { useCustomThemeConfig } from 'src/hooks/useCustomThemeConfig';
-import { useUserCustomThemeConfig } from 'src/hooks/useUserCustomThemeConfig';
 
 interface LogoSizeSettingItemProps {
   logoType?: 'wide' | 'collapsed' | 'login' | 'about';

--- a/react/src/components/BrandingSettingItems/ThemeColorPicker.tsx
+++ b/react/src/components/BrandingSettingItems/ThemeColorPicker.tsx
@@ -2,13 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useUserCustomThemeConfig } from '../../hooks/useUserCustomThemeConfig';
 import { Col, ColorPicker, type ColorPickerProps, Row, theme } from 'antd';
 import { ComponentTokenMap } from 'antd/es/theme/interface';
 import { AliasToken } from 'antd/lib/theme/internal';
 import { BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
-import { useUserCustomThemeConfig } from 'src/hooks/useUserCustomThemeConfig';
 
 type TokenPath = `token.${keyof AliasToken & string}`;
 type ComponentPath = `components.${keyof ComponentTokenMap & string}.${string}`;

--- a/react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx
+++ b/react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx
@@ -2,6 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { downloadBlob } from '../../helper/csv-util';
+import { loadMonacoEditor } from '../../helper/monacoEditor';
+import { useThemeMode } from '../../hooks/useThemeMode';
+import { useUserCustomThemeConfig } from '../../hooks/useUserCustomThemeConfig';
 import { ExportOutlined, ImportOutlined } from '@ant-design/icons';
 import type { Monaco } from '@monaco-editor/react';
 import { Alert, App, Skeleton, theme, Upload } from 'antd';
@@ -15,10 +19,6 @@ import {
 import * as _ from 'lodash-es';
 import React, { Suspense, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { downloadBlob } from 'src/helper/csv-util';
-import { loadMonacoEditor } from 'src/helper/monacoEditor';
-import { useThemeMode } from 'src/hooks/useThemeMode';
-import { useUserCustomThemeConfig } from 'src/hooks/useUserCustomThemeConfig';
 
 const MonacoEditor = React.lazy(() =>
   loadMonacoEditor().then((module) => ({

--- a/react/src/components/BrandingSettingList.tsx
+++ b/react/src/components/BrandingSettingList.tsx
@@ -2,6 +2,8 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
+import { useUserCustomThemeConfig } from '../hooks/useUserCustomThemeConfig';
 import FontFamilySettingItem from './BrandingSettingItems/FontFamilySettingItem';
 import LogoPreviewer, {
   getLogoThemeKey,
@@ -24,8 +26,6 @@ import * as _ from 'lodash-es';
 import { Fullscreen } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useCustomThemeConfig } from 'src/hooks/useCustomThemeConfig';
-import { useUserCustomThemeConfig } from 'src/hooks/useUserCustomThemeConfig';
 
 interface BrandingSettingListProps {}
 

--- a/react/src/components/ComputeSessionNodeItems/AppLaunchConfirmationModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLaunchConfirmationModal.tsx
@@ -2,12 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AppLaunchConfirmationModalFragment$key } from '../../__generated__/AppLaunchConfirmationModalFragment.graphql';
+import { useBackendAIAppLauncher } from '../../hooks/useBackendAIAppLauncher';
 import { Typography } from 'antd';
 import { BAIButton, BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { AppLaunchConfirmationModalFragment$key } from 'src/__generated__/AppLaunchConfirmationModalFragment.graphql';
-import { useBackendAIAppLauncher } from 'src/hooks/useBackendAIAppLauncher';
 
 interface AppLaunchConfirmationModalProps extends BAIModalProps {
   sessionFrgmt: AppLaunchConfirmationModalFragment$key;

--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -5,6 +5,10 @@
 import { AppLauncherModalFragment$key } from '../../__generated__/AppLauncherModalFragment.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import {
+  TCP_APPS,
+  useBackendAIAppLauncher,
+} from '../../hooks/useBackendAIAppLauncher';
+import {
   ServicePort,
   TemplateItem,
   useSuspendedFilteredAppTemplate,
@@ -44,10 +48,6 @@ import * as _ from 'lodash-es';
 import { useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import {
-  TCP_APPS,
-  useBackendAIAppLauncher,
-} from 'src/hooks/useBackendAIAppLauncher';
 
 interface AppLauncherModalProps extends ModalProps {
   onRequestClose: () => void;

--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -6,6 +6,7 @@ import { ContainerLogModalFragment$key } from '../../__generated__/ContainerLogM
 import { downloadBlob } from '../../helper/csv-util';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import { useTanQuery } from '../../hooks/reactQueryAlias';
+import { useBAISettingUserState } from '../../hooks/useBAISetting';
 import { useMemoWithPrevious } from '../../hooks/useMemoWithPrevious';
 import AutoRefreshSwitch from '../AutoRefreshSwitch';
 import { ReloadOutlined } from '@ant-design/icons';
@@ -25,7 +26,6 @@ import { DownloadIcon } from 'lucide-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 
 interface ContainerLogModalProps extends BAIModalProps {
   sessionFrgmt: ContainerLogModalFragment$key | null;

--- a/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
@@ -2,6 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { SFTPConnectionInfoModalFragment$key } from '../../__generated__/SFTPConnectionInfoModalFragment.graphql';
+import { useSuspendedBackendaiClient } from '../../hooks';
+import { useTanQuery } from '../../hooks/reactQueryAlias';
 import SourceCodeView from '../SourceCodeView';
 import { Alert, Descriptions } from 'antd';
 import { createStyles } from 'antd-style';
@@ -9,9 +12,6 @@ import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useTranslation, Trans } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { SFTPConnectionInfoModalFragment$key } from 'src/__generated__/SFTPConnectionInfoModalFragment.graphql';
-import { useSuspendedBackendaiClient } from 'src/hooks';
-import { useTanQuery } from 'src/hooks/reactQueryAlias';
 
 const useStyles = createStyles(({ css, token }) => ({
   description: css`

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
@@ -6,6 +6,7 @@ import {
   SessionStatusTagFragment$data,
   SessionStatusTagFragment$key,
 } from '../../__generated__/SessionStatusTagFragment.graphql';
+import { useSuspendedBackendaiClient } from '../../hooks';
 import { statusInfoTagColor } from './SessionStatusDetailModal';
 import { LoadingOutlined } from '@ant-design/icons';
 import { Tag, Tooltip, theme } from 'antd';
@@ -15,7 +16,6 @@ import { CircleAlertIcon } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { useSuspendedBackendaiClient } from 'src/hooks';
 
 interface SessionStatusTagProps {
   sessionFrgmt?: SessionStatusTagFragment$key | null;

--- a/react/src/components/ComputeSessionNodeItems/TensorboardPathModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TensorboardPathModal.tsx
@@ -2,6 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { TensorboardPathModalFragment$key } from '../../__generated__/TensorboardPathModalFragment.graphql';
+import { useSuspendedBackendaiClient } from '../../hooks';
+import { useBackendAIAppLauncher } from '../../hooks/useBackendAIAppLauncher';
 import { App, Form, Input, Typography } from 'antd';
 import {
   BAIButton,
@@ -13,9 +16,6 @@ import {
 } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { TensorboardPathModalFragment$key } from 'src/__generated__/TensorboardPathModalFragment.graphql';
-import { useSuspendedBackendaiClient } from 'src/hooks';
-import { useBackendAIAppLauncher } from 'src/hooks/useBackendAIAppLauncher';
 
 interface TensorboardPathModalProps extends BAIModalProps {
   sessionFrgmt: TensorboardPathModalFragment$key;

--- a/react/src/components/ComputeSessionNodeItems/VSCodeDesktopConnectionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/VSCodeDesktopConnectionModal.tsx
@@ -2,6 +2,8 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useSuspendedBackendaiClient } from '../../hooks';
+import { useTanQuery } from '../../hooks/reactQueryAlias';
 import SourceCodeView from '../SourceCodeView';
 import { ReloadOutlined } from '@ant-design/icons';
 import { Descriptions, Skeleton, Typography } from 'antd';
@@ -14,8 +16,6 @@ import {
   BAIText,
 } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';
-import { useSuspendedBackendaiClient } from 'src/hooks';
-import { useTanQuery } from 'src/hooks/reactQueryAlias';
 
 const PASSWORD_FILE_PATH = '/home/work/.password';
 

--- a/react/src/components/ConfigurableResourceCard.tsx
+++ b/react/src/components/ConfigurableResourceCard.tsx
@@ -2,7 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ConfigurableResourceCardQuery } from '../__generated__/ConfigurableResourceCardQuery.graphql';
+import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
 import MyResource from './MyResource';
 import MyResourceWithinResourceGroup from './MyResourceWithinResourceGroup';
 import TotalResourceWithinResourceGroup, {
@@ -15,9 +18,6 @@ import * as _ from 'lodash-es';
 import React, { Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { ConfigurableResourceCardQuery } from 'src/__generated__/ConfigurableResourceCardQuery.graphql';
-import { useCurrentUserRole } from 'src/hooks/backendai';
-import { useCurrentResourceGroupValue } from 'src/hooks/useCurrentProject';
 
 export type ResourcePanelType =
   | 'MyResource'

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -10,6 +10,7 @@ import {
   createAnonymousBackendaiClient,
   useWebUINavigate,
 } from '../hooks';
+import { useDeviceMetaData } from '../hooks/backendai';
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { useThemeMode } from '../hooks/useThemeMode';
 // @ts-ignore
@@ -60,7 +61,6 @@ import React, {
 import { useTranslation, initReactI18next } from 'react-i18next';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
 import { useLocation } from 'react-router-dom';
-import { useDeviceMetaData } from 'src/hooks/backendai';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 

--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -10,6 +10,7 @@ import {
 } from '../__generated__/DeploymentRevisionHistoryTabListQuery.graphql';
 import type { DeploymentRevisionHistoryTab_deployment$key } from '../__generated__/DeploymentRevisionHistoryTab_deployment.graphql';
 import { convertToOrderBy } from '../helper';
+import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
 import { LoadingOutlined, PlayCircleOutlined } from '@ant-design/icons';
@@ -46,7 +47,6 @@ import {
   useLazyLoadQuery,
   useMutation,
 } from 'react-relay';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
 
 type RevisionNode = NonNullable<
   NonNullable<

--- a/react/src/components/EduAppLauncher.tsx
+++ b/react/src/components/EduAppLauncher.tsx
@@ -8,6 +8,8 @@
  * Handles token-based authentication, session management, and app launching
  * for education-specific use cases.
  */
+import { EduAppLauncherSessionQuery } from '../__generated__/EduAppLauncherSessionQuery.graphql';
+import { useBackendAIAppLauncherFragment$key } from '../__generated__/useBackendAIAppLauncherFragment.graphql';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useBackendAIAppLauncher } from '../hooks/useBackendAIAppLauncher';
 import { fetchAndParseConfig } from '../hooks/useWebUIConfig';
@@ -17,8 +19,6 @@ import React, { useEffect, useEffectEvent, useRef, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { EduAppLauncherSessionQuery } from 'src/__generated__/EduAppLauncherSessionQuery.graphql';
-import { useBackendAIAppLauncherFragment$key } from 'src/__generated__/useBackendAIAppLauncherFragment.graphql';
 
 interface EduAppLauncherProps {
   apiEndpoint: string;

--- a/react/src/components/FairShareItems/DomainFairShareTable.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareTable.tsx
@@ -2,6 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  DomainFairShareTableFragment$data,
+  DomainFairShareTableFragment$key,
+} from '../../__generated__/DomainFairShareTableFragment.graphql';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import DomainResourceGroupWarningIcon from './DomainResourceGroupWarningIcon';
 import { SettingOutlined } from '@ant-design/icons';
@@ -20,10 +24,6 @@ import * as _ from 'lodash-es';
 import { parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import {
-  DomainFairShareTableFragment$data,
-  DomainFairShareTableFragment$key,
-} from 'src/__generated__/DomainFairShareTableFragment.graphql';
 
 export type Domain = NonNullable<
   NonNullable<DomainFairShareTableFragment$data[number]>

--- a/react/src/components/FairShareItems/DomainResourceGroupAlert.tsx
+++ b/react/src/components/FairShareItems/DomainResourceGroupAlert.tsx
@@ -1,9 +1,9 @@
+import type { DomainResourceGroupAlertFragment$key } from '../../__generated__/DomainResourceGroupAlertFragment.graphql';
+import type { DomainResourceGroupAlertQuery } from '../../__generated__/DomainResourceGroupAlertQuery.graphql';
 import { Alert, AlertProps } from 'antd';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
-import type { DomainResourceGroupAlertFragment$key } from 'src/__generated__/DomainResourceGroupAlertFragment.graphql';
-import type { DomainResourceGroupAlertQuery } from 'src/__generated__/DomainResourceGroupAlertQuery.graphql';
 
 interface DomainResourceGroupAlertProps extends AlertProps {
   domainFairShareFrgmt: DomainResourceGroupAlertFragment$key;

--- a/react/src/components/FairShareItems/DomainResourceGroupWarningIcon.tsx
+++ b/react/src/components/FairShareItems/DomainResourceGroupWarningIcon.tsx
@@ -1,10 +1,10 @@
+import type { DomainResourceGroupWarningIconFragment$key } from '../../__generated__/DomainResourceGroupWarningIconFragment.graphql';
+import type { DomainResourceGroupWarningIconQuery } from '../../__generated__/DomainResourceGroupWarningIconQuery.graphql';
 import { Tooltip, theme } from 'antd';
 import * as _ from 'lodash-es';
 import { TriangleAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
-import type { DomainResourceGroupWarningIconFragment$key } from 'src/__generated__/DomainResourceGroupWarningIconFragment.graphql';
-import type { DomainResourceGroupWarningIconQuery } from 'src/__generated__/DomainResourceGroupWarningIconQuery.graphql';
 
 interface DomainResourceGroupWarningIconProps {
   domainFairShareFrgmt: DomainResourceGroupWarningIconFragment$key;

--- a/react/src/components/FairShareItems/FairShareList.tsx
+++ b/react/src/components/FairShareItems/FairShareList.tsx
@@ -2,6 +2,20 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  RGProjectFairShareFilter,
+  DomainFairShareOrderBy,
+  FairShareListQuery,
+  FairShareListQuery$variables,
+  RGDomainFairShareFilter,
+  ProjectFairShareOrderBy,
+  ResourceGroupFilter,
+  ResourceGroupOrderBy,
+  RGUserFairShareFilter,
+  UserFairShareOrderBy,
+} from '../../__generated__/FairShareListQuery.graphql';
+import { convertToOrderBy, handleRowSelectionChange } from '../../helper';
+import { useBAIPaginationOptionStateOnSearchParam } from '../../hooks/reactPaginationQueryOptions';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import DomainFairShareTable, {
   availableDomainFairShareSorterValues,
@@ -55,20 +69,6 @@ import {
 } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import {
-  RGProjectFairShareFilter,
-  DomainFairShareOrderBy,
-  FairShareListQuery,
-  FairShareListQuery$variables,
-  RGDomainFairShareFilter,
-  ProjectFairShareOrderBy,
-  ResourceGroupFilter,
-  ResourceGroupOrderBy,
-  RGUserFairShareFilter,
-  UserFairShareOrderBy,
-} from 'src/__generated__/FairShareListQuery.graphql';
-import { convertToOrderBy, handleRowSelectionChange } from 'src/helper';
-import { useBAIPaginationOptionStateOnSearchParam } from 'src/hooks/reactPaginationQueryOptions';
 
 const useStyles = createStyles(({ css, token }) => ({
   step: css`

--- a/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
+++ b/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
@@ -2,6 +2,16 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { FairShareWeightSettingModal_BulkModifyDomainWeightMutation } from '../../__generated__/FairShareWeightSettingModal_BulkModifyDomainWeightMutation.graphql';
+import { FairShareWeightSettingModal_BulkModifyProjectWeightMutation } from '../../__generated__/FairShareWeightSettingModal_BulkModifyProjectWeightMutation.graphql';
+import { FairShareWeightSettingModal_BulkModifyUserWeightMutation } from '../../__generated__/FairShareWeightSettingModal_BulkModifyUserWeightMutation.graphql';
+import { FairShareWeightSettingModal_DomainFragment$key } from '../../__generated__/FairShareWeightSettingModal_DomainFragment.graphql';
+import { FairShareWeightSettingModal_ModifyDomainWeightMutation } from '../../__generated__/FairShareWeightSettingModal_ModifyDomainWeightMutation.graphql';
+import { FairShareWeightSettingModal_ModifyProjectWeightMutation } from '../../__generated__/FairShareWeightSettingModal_ModifyProjectWeightMutation.graphql';
+import { FairShareWeightSettingModal_ModifyUserWeightMutation } from '../../__generated__/FairShareWeightSettingModal_ModifyUserWeightMutation.graphql';
+import { FairShareWeightSettingModal_ProjectFragment$key } from '../../__generated__/FairShareWeightSettingModal_ProjectFragment.graphql';
+import { FairShareWeightSettingModal_ResourceGroupFragment$key } from '../../__generated__/FairShareWeightSettingModal_ResourceGroupFragment.graphql';
+import { FairShareWeightSettingModal_UserFragment$key } from '../../__generated__/FairShareWeightSettingModal_UserFragment.graphql';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import DomainResourceGroupAlert from './DomainResourceGroupAlert';
 import ProjectResourceGroupAlert from './ProjectResourceGroupAlert';
@@ -20,16 +30,6 @@ import * as _ from 'lodash-es';
 import { Suspense, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
-import { FairShareWeightSettingModal_BulkModifyDomainWeightMutation } from 'src/__generated__/FairShareWeightSettingModal_BulkModifyDomainWeightMutation.graphql';
-import { FairShareWeightSettingModal_BulkModifyProjectWeightMutation } from 'src/__generated__/FairShareWeightSettingModal_BulkModifyProjectWeightMutation.graphql';
-import { FairShareWeightSettingModal_BulkModifyUserWeightMutation } from 'src/__generated__/FairShareWeightSettingModal_BulkModifyUserWeightMutation.graphql';
-import { FairShareWeightSettingModal_DomainFragment$key } from 'src/__generated__/FairShareWeightSettingModal_DomainFragment.graphql';
-import { FairShareWeightSettingModal_ModifyDomainWeightMutation } from 'src/__generated__/FairShareWeightSettingModal_ModifyDomainWeightMutation.graphql';
-import { FairShareWeightSettingModal_ModifyProjectWeightMutation } from 'src/__generated__/FairShareWeightSettingModal_ModifyProjectWeightMutation.graphql';
-import { FairShareWeightSettingModal_ModifyUserWeightMutation } from 'src/__generated__/FairShareWeightSettingModal_ModifyUserWeightMutation.graphql';
-import { FairShareWeightSettingModal_ProjectFragment$key } from 'src/__generated__/FairShareWeightSettingModal_ProjectFragment.graphql';
-import { FairShareWeightSettingModal_ResourceGroupFragment$key } from 'src/__generated__/FairShareWeightSettingModal_ResourceGroupFragment.graphql';
-import { FairShareWeightSettingModal_UserFragment$key } from 'src/__generated__/FairShareWeightSettingModal_UserFragment.graphql';
 
 interface FairShareWeightSettingModalProps extends BAIModalProps {
   resourceGroupFrgmt?: FairShareWeightSettingModal_ResourceGroupFragment$key | null;

--- a/react/src/components/FairShareItems/ProjectFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareTable.tsx
@@ -2,6 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  ProjectFairShareTableFragment$data,
+  ProjectFairShareTableFragment$key,
+} from '../../__generated__/ProjectFairShareTableFragment.graphql';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import ProjectResourceGroupWarningIcon from './ProjectResourceGroupWarningIcon';
 import { SettingOutlined } from '@ant-design/icons';
@@ -20,10 +24,6 @@ import * as _ from 'lodash-es';
 import { parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import {
-  ProjectFairShareTableFragment$data,
-  ProjectFairShareTableFragment$key,
-} from 'src/__generated__/ProjectFairShareTableFragment.graphql';
 
 export type ProjectFairShare = NonNullable<
   ProjectFairShareTableFragment$data[number]

--- a/react/src/components/FairShareItems/ProjectResourceGroupAlert.tsx
+++ b/react/src/components/FairShareItems/ProjectResourceGroupAlert.tsx
@@ -1,9 +1,9 @@
+import type { ProjectResourceGroupAlertFragment$key } from '../../__generated__/ProjectResourceGroupAlertFragment.graphql';
+import type { ProjectResourceGroupAlertQuery } from '../../__generated__/ProjectResourceGroupAlertQuery.graphql';
 import { Alert, AlertProps } from 'antd';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
-import type { ProjectResourceGroupAlertFragment$key } from 'src/__generated__/ProjectResourceGroupAlertFragment.graphql';
-import type { ProjectResourceGroupAlertQuery } from 'src/__generated__/ProjectResourceGroupAlertQuery.graphql';
 
 interface ProjectResourceGroupAlertProps extends AlertProps {
   projectFairShareFrgmt: ProjectResourceGroupAlertFragment$key;

--- a/react/src/components/FairShareItems/ProjectResourceGroupWarningIcon.tsx
+++ b/react/src/components/FairShareItems/ProjectResourceGroupWarningIcon.tsx
@@ -1,10 +1,10 @@
+import type { ProjectResourceGroupWarningIconFragment$key } from '../../__generated__/ProjectResourceGroupWarningIconFragment.graphql';
+import type { ProjectResourceGroupWarningIconQuery } from '../../__generated__/ProjectResourceGroupWarningIconQuery.graphql';
 import { Tooltip, theme } from 'antd';
 import * as _ from 'lodash-es';
 import { TriangleAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
-import type { ProjectResourceGroupWarningIconFragment$key } from 'src/__generated__/ProjectResourceGroupWarningIconFragment.graphql';
-import type { ProjectResourceGroupWarningIconQuery } from 'src/__generated__/ProjectResourceGroupWarningIconQuery.graphql';
 
 interface ProjectResourceGroupWarningIconProps {
   projectFairShareFrgmt: ProjectResourceGroupWarningIconFragment$key;

--- a/react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx
@@ -2,6 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ResourceGroupFairShareSettingModalFragment$key } from '../../__generated__/ResourceGroupFairShareSettingModalFragment.graphql';
+import {
+  ResourceGroupFairShareSettingModalMutation,
+  ResourceGroupFairShareSettingModalMutation$variables,
+} from '../../__generated__/ResourceGroupFairShareSettingModalMutation.graphql';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { App, Col, Form, Input, InputNumber, Row, theme } from 'antd';
 import { FormInstance } from 'antd/lib';
@@ -18,11 +23,6 @@ import * as _ from 'lodash-es';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
-import { ResourceGroupFairShareSettingModalFragment$key } from 'src/__generated__/ResourceGroupFairShareSettingModalFragment.graphql';
-import {
-  ResourceGroupFairShareSettingModalMutation,
-  ResourceGroupFairShareSettingModalMutation$variables,
-} from 'src/__generated__/ResourceGroupFairShareSettingModalMutation.graphql';
 
 interface ResourceGroupFairShareTableProps extends BAIModalProps {
   resourceGroupNodeFrgmt: ResourceGroupFairShareSettingModalFragment$key | null;

--- a/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
@@ -2,6 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  ResourceGroupFairShareTableFragment$data,
+  ResourceGroupFairShareTableFragment$key,
+} from '../../__generated__/ResourceGroupFairShareTableFragment.graphql';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import ResourceGroupFairShareSettingModal from './ResourceGroupFairShareSettingModal';
 import { SettingOutlined } from '@ant-design/icons';
@@ -22,10 +26,6 @@ import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import {
-  ResourceGroupFairShareTableFragment$data,
-  ResourceGroupFairShareTableFragment$key,
-} from 'src/__generated__/ResourceGroupFairShareTableFragment.graphql';
 
 type ResourceGroup = NonNullable<
   ResourceGroupFairShareTableFragment$data[number]

--- a/react/src/components/FairShareItems/UsageBucketChartContent.tsx
+++ b/react/src/components/FairShareItems/UsageBucketChartContent.tsx
@@ -2,6 +2,16 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  DomainV2Filter,
+  ProjectV2Filter,
+  UserV2Filter,
+  UsageBucketChartContentQuery,
+  UsageBucketChartContentQuery$variables,
+} from '../../__generated__/UsageBucketChartContentQuery.graphql';
+import { UsageBucketChartContent_DomainFragment$key } from '../../__generated__/UsageBucketChartContent_DomainFragment.graphql';
+import { UsageBucketChartContent_ProjectFragment$key } from '../../__generated__/UsageBucketChartContent_ProjectFragment.graphql';
+import { UsageBucketChartContent_UserFragment$key } from '../../__generated__/UsageBucketChartContent_UserFragment.graphql';
 import { presetPalettes } from '@ant-design/colors';
 import { Empty, Tabs, Typography, theme } from 'antd';
 import { createStyles } from 'antd-style';
@@ -27,16 +37,6 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import {
-  DomainV2Filter,
-  ProjectV2Filter,
-  UserV2Filter,
-  UsageBucketChartContentQuery,
-  UsageBucketChartContentQuery$variables,
-} from 'src/__generated__/UsageBucketChartContentQuery.graphql';
-import { UsageBucketChartContent_DomainFragment$key } from 'src/__generated__/UsageBucketChartContent_DomainFragment.graphql';
-import { UsageBucketChartContent_ProjectFragment$key } from 'src/__generated__/UsageBucketChartContent_ProjectFragment.graphql';
-import { UsageBucketChartContent_UserFragment$key } from 'src/__generated__/UsageBucketChartContent_UserFragment.graphql';
 
 interface UsageBucketChartContentProps {
   domainFairShareFrgmt?: UsageBucketChartContent_DomainFragment$key | null;

--- a/react/src/components/FairShareItems/UsageBucketModal.tsx
+++ b/react/src/components/FairShareItems/UsageBucketModal.tsx
@@ -2,6 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { UsageBucketModal_DomainFragment$key } from '../../__generated__/UsageBucketModal_DomainFragment.graphql';
+import { UsageBucketModal_ProjectFragment$key } from '../../__generated__/UsageBucketModal_ProjectFragment.graphql';
+import { UsageBucketModal_UserFragment$key } from '../../__generated__/UsageBucketModal_UserFragment.graphql';
 import UsageBucketChartContent from './UsageBucketChartContent';
 import { DatePicker, Descriptions, Skeleton } from 'antd';
 import {
@@ -18,9 +21,6 @@ import * as _ from 'lodash-es';
 import { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { UsageBucketModal_DomainFragment$key } from 'src/__generated__/UsageBucketModal_DomainFragment.graphql';
-import { UsageBucketModal_ProjectFragment$key } from 'src/__generated__/UsageBucketModal_ProjectFragment.graphql';
-import { UsageBucketModal_UserFragment$key } from 'src/__generated__/UsageBucketModal_UserFragment.graphql';
 
 interface UsageBucketModalProps extends BAIModalProps {
   domainFairShareFrgmt?: UsageBucketModal_DomainFragment$key | null;

--- a/react/src/components/FairShareItems/UserFairShareTable.tsx
+++ b/react/src/components/FairShareItems/UserFairShareTable.tsx
@@ -2,6 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  UserFairShareTableFragment$data,
+  UserFairShareTableFragment$key,
+} from '../../__generated__/UserFairShareTableFragment.graphql';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { SettingOutlined } from '@ant-design/icons';
 import { Divider, theme, Typography } from 'antd';
@@ -19,10 +23,6 @@ import * as _ from 'lodash-es';
 import { parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import {
-  UserFairShareTableFragment$data,
-  UserFairShareTableFragment$key,
-} from 'src/__generated__/UserFairShareTableFragment.graphql';
 
 export type UserFairShare = NonNullable<
   UserFairShareTableFragment$data[number]

--- a/react/src/components/FairShareItems/UserResourceGroupAlert.tsx
+++ b/react/src/components/FairShareItems/UserResourceGroupAlert.tsx
@@ -1,9 +1,9 @@
+import type { UserResourceGroupAlertQuery } from '../../__generated__/UserResourceGroupAlertQuery.graphql';
 import { Alert, AlertProps } from 'antd';
 import * as _ from 'lodash-es';
 import { parseAsString, useQueryStates } from 'nuqs';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import type { UserResourceGroupAlertQuery } from 'src/__generated__/UserResourceGroupAlertQuery.graphql';
 
 interface UserResourceGroupAlertProps extends AlertProps {
   isModalOpen?: boolean;

--- a/react/src/components/FileBrowserButton.tsx
+++ b/react/src/components/FileBrowserButton.tsx
@@ -2,7 +2,19 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useWebUINavigate } from '../hooks';
+import { FileBrowserButtonFragment$key } from '../__generated__/FileBrowserButtonFragment.graphql';
+import {
+  useCurrentDomainValue,
+  useSuspendedBackendaiClient,
+  useWebUINavigate,
+} from '../hooks';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useDefaultFileBrowserImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
+import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
+import {
+  StartSessionWithDefaultValue,
+  useStartSession,
+} from '../hooks/useStartSession';
 import { PrimaryAppOption } from './ComputeSessionNodeItems/SessionActionButtons';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { App, Dropdown, Image, Space, Tooltip } from 'antd';
@@ -17,15 +29,6 @@ import * as _ from 'lodash-es';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { FileBrowserButtonFragment$key } from 'src/__generated__/FileBrowserButtonFragment.graphql';
-import { useCurrentDomainValue, useSuspendedBackendaiClient } from 'src/hooks';
-import { useCurrentProjectValue } from 'src/hooks/useCurrentProject';
-import { useDefaultFileBrowserImageWithFallback } from 'src/hooks/useDefaultImagesWithFallback';
-import { useMergedAllowedStorageHostPermission } from 'src/hooks/useMergedAllowedStorageHostPermission';
-import {
-  StartSessionWithDefaultValue,
-  useStartSession,
-} from 'src/hooks/useStartSession';
 
 interface FileBrowserButtonProps extends BAIButtonProps {
   showTitle?: boolean;

--- a/react/src/components/FileBrowserButtonV2.tsx
+++ b/react/src/components/FileBrowserButtonV2.tsx
@@ -2,7 +2,19 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useWebUINavigate } from '../hooks';
+import { FileBrowserButtonV2Fragment$key } from '../__generated__/FileBrowserButtonV2Fragment.graphql';
+import {
+  useCurrentDomainValue,
+  useSuspendedBackendaiClient,
+  useWebUINavigate,
+} from '../hooks';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useDefaultFileBrowserImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
+import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
+import {
+  StartSessionWithDefaultValue,
+  useStartSession,
+} from '../hooks/useStartSession';
 import { PrimaryAppOption } from './ComputeSessionNodeItems/SessionActionButtons';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { App, Dropdown, Image, Space, Tooltip } from 'antd';
@@ -17,15 +29,6 @@ import * as _ from 'lodash-es';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { FileBrowserButtonV2Fragment$key } from 'src/__generated__/FileBrowserButtonV2Fragment.graphql';
-import { useCurrentDomainValue, useSuspendedBackendaiClient } from 'src/hooks';
-import { useCurrentProjectValue } from 'src/hooks/useCurrentProject';
-import { useDefaultFileBrowserImageWithFallback } from 'src/hooks/useDefaultImagesWithFallback';
-import { useMergedAllowedStorageHostPermission } from 'src/hooks/useMergedAllowedStorageHostPermission';
-import {
-  StartSessionWithDefaultValue,
-  useStartSession,
-} from 'src/hooks/useStartSession';
 
 interface FileBrowserButtonV2Props extends BAIButtonProps {
   showTitle?: boolean;

--- a/react/src/components/FileUploadManager.tsx
+++ b/react/src/components/FileUploadManager.tsx
@@ -2,7 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import { theme, Typography } from 'antd';
 import { RcFile } from 'antd/es/upload';
@@ -19,8 +21,6 @@ import * as _ from 'lodash-es';
 import PQueue from 'p-queue';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSuspendedBackendaiClient } from 'src/hooks';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 import * as tus from 'tus-js-client';
 
 type uploadStartFunction = (callbacks?: {

--- a/react/src/components/FolderExplorerModal.tsx
+++ b/react/src/components/FolderExplorerModal.tsx
@@ -2,6 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { FolderExplorerModalQuery } from '../__generated__/FolderExplorerModalQuery.graphql';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
+import { useSetBAINotification } from '../hooks/useBAINotification';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
 import { useFileUploadManager } from './FileUploadManager';
 import FolderExplorerHeader from './FolderExplorerHeader';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
@@ -27,11 +32,6 @@ import * as _ from 'lodash-es';
 import { Suspense, useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { FolderExplorerModalQuery } from 'src/__generated__/FolderExplorerModalQuery.graphql';
-import { useCurrentDomainValue, useSuspendedBackendaiClient } from 'src/hooks';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
-import { useCurrentProjectValue } from 'src/hooks/useCurrentProject';
-import { useMergedAllowedStorageHostPermission } from 'src/hooks/useMergedAllowedStorageHostPermission';
 
 const useStyles = createStyles(({ css }) => ({
   baiModalHeader: css`

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -2,6 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { FolderExplorerModalV2Query } from '../__generated__/FolderExplorerModalV2Query.graphql';
+import { formatToUUID } from '../helper';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
+import { useSetBAINotification } from '../hooks/useBAINotification';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
 import { useFileUploadManager } from './FileUploadManager';
 import FolderExplorerHeaderV2 from './FolderExplorerHeaderV2';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
@@ -26,12 +32,6 @@ import * as _ from 'lodash-es';
 import { Suspense, useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { FolderExplorerModalV2Query } from 'src/__generated__/FolderExplorerModalV2Query.graphql';
-import { formatToUUID } from 'src/helper';
-import { useCurrentDomainValue, useSuspendedBackendaiClient } from 'src/hooks';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
-import { useCurrentProjectValue } from 'src/hooks/useCurrentProject';
-import { useMergedAllowedStorageHostPermission } from 'src/hooks/useMergedAllowedStorageHostPermission';
 
 const useStyles = createStyles(({ css }) => ({
   baiModalHeader: css`

--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useSetBAINotification } from '../hooks/useBAINotification';
 import {
   InvitationItem,
   useVFolderInvitations,
@@ -19,7 +20,6 @@ import {
 } from 'backend.ai-ui';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
 
 interface FolderInvitationResponseModalProps extends BAIModalProps {}
 

--- a/react/src/components/GeneratedKeypairListModal.tsx
+++ b/react/src/components/GeneratedKeypairListModal.tsx
@@ -2,6 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  GeneratedKeypairListModalFragment$data,
+  GeneratedKeypairListModalFragment$key,
+} from '../__generated__/GeneratedKeypairListModalFragment.graphql';
 import { localeCompare } from '../helper';
 import { exportCSVWithFormattingRules } from '../helper/csv-util';
 import { Alert } from 'antd';
@@ -17,10 +21,6 @@ import { DownloadIcon } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import {
-  GeneratedKeypairListModalFragment$data,
-  GeneratedKeypairListModalFragment$key,
-} from 'src/__generated__/GeneratedKeypairListModalFragment.graphql';
 
 type KeypairType = NonNullable<
   NonNullable<GeneratedKeypairListModalFragment$data>[number]

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -9,6 +9,7 @@ import {
 } from '../__generated__/ImageListQuery.graphql';
 import { getImageFullName, localeCompare } from '../helper';
 import { useBackendAIImageMetaData } from '../hooks';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import AliasedImageDoubleTags from './AliasedImageDoubleTags';
@@ -40,7 +41,6 @@ import * as _ from 'lodash-es';
 import { Key, useDeferredValue, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useBAIPaginationOptionStateOnSearchParam } from 'src/hooks/reactPaginationQueryOptions';
 
 export type EnvironmentImage = NonNullableNodeOnEdges<
   ImageListQuery$data['image_nodes']

--- a/react/src/components/ImportArtifactRevisionToFolderModal.tsx
+++ b/react/src/components/ImportArtifactRevisionToFolderModal.tsx
@@ -2,6 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key } from '../__generated__/ImportArtifactRevisionToFolderModalArtifactRevisionFragment.graphql';
+import { ImportArtifactRevisionToFolderModalModelStoreProjectsFragment$key } from '../__generated__/ImportArtifactRevisionToFolderModalModelStoreProjectsFragment.graphql';
+import { ImportArtifactRevisionToFolderModalMutation } from '../__generated__/ImportArtifactRevisionToFolderModalMutation.graphql';
+import {
+  useCurrentProjectValue,
+  useSetCurrentProject,
+} from '../hooks/useCurrentProject';
 import FolderCreateModalV2 from './FolderCreateModalV2';
 import { useToggle } from 'ahooks';
 import {
@@ -30,13 +37,6 @@ import { PlusIcon } from 'lucide-react';
 import { startTransition, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation, useFragment } from 'react-relay';
-import { ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key } from 'src/__generated__/ImportArtifactRevisionToFolderModalArtifactRevisionFragment.graphql';
-import { ImportArtifactRevisionToFolderModalModelStoreProjectsFragment$key } from 'src/__generated__/ImportArtifactRevisionToFolderModalModelStoreProjectsFragment.graphql';
-import { ImportArtifactRevisionToFolderModalMutation } from 'src/__generated__/ImportArtifactRevisionToFolderModalMutation.graphql';
-import {
-  useCurrentProjectValue,
-  useSetCurrentProject,
-} from 'src/hooks/useCurrentProject';
 
 export interface ImportArtifactRevisionToFolderModalProps extends Omit<
   BAIModalProps,

--- a/react/src/components/ImportNotebookForm.tsx
+++ b/react/src/components/ImportNotebookForm.tsx
@@ -3,6 +3,10 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import {
+  StartSessionWithDefaultValue,
+  useStartSession,
+} from '../hooks/useStartSession';
 import CopyButton from './Chat/CopyButton';
 import { PrimaryAppOption } from './ComputeSessionNodeItems/SessionActionButtons';
 import { EllipsisOutlined } from '@ant-design/icons';
@@ -27,10 +31,6 @@ import {
 import { FolderInput } from 'lucide-react';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  StartSessionWithDefaultValue,
-  useStartSession,
-} from 'src/hooks/useStartSession';
 
 const regularizeGithubURL = (url: string) => {
   url = url.replace('/blob/', '/');

--- a/react/src/components/ImportRepoForm.tsx
+++ b/react/src/components/ImportRepoForm.tsx
@@ -3,6 +3,11 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useSetBAINotification } from '../hooks/useBAINotification';
+import {
+  StartSessionWithDefaultValue,
+  useStartSession,
+} from '../hooks/useStartSession';
 import StorageSelect from './StorageSelect';
 import {
   App,
@@ -22,11 +27,6 @@ import {
 import { FolderInput } from 'lucide-react';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
-import {
-  StartSessionWithDefaultValue,
-  useStartSession,
-} from 'src/hooks/useStartSession';
 
 type URLType = 'github' | 'gitlab';
 

--- a/react/src/components/LegacyModelTryContentButton.tsx
+++ b/react/src/components/LegacyModelTryContentButton.tsx
@@ -9,6 +9,7 @@ import {
   useBaiSignedRequestWithPromise,
 } from '../helper';
 import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import {
   useSetBAINotification,
@@ -33,7 +34,6 @@ import * as _ from 'lodash-es';
 import React, { useRef, useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
-import { useCurrentUserInfo, useCurrentUserRole } from 'src/hooks/backendai';
 
 interface LegacyModelTryContentButtonProps {
   vfolderNode: LegacyModelTryContentButtonVFolderFragment$key | null;

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -7,7 +7,10 @@ import { useBAISettingUserState } from '../../hooks/useBAISetting';
 import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import { useLogoutEventListeners } from '../../hooks/useLogout';
+import usePrimaryColors from '../../hooks/usePrimaryColors';
 import { useThemeMode } from '../../hooks/useThemeMode';
+import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
+import { useSetupWebUIPluginEffect } from '../../hooks/useWebUIPluginState';
 import Page401 from '../../pages/Page401';
 import Page404 from '../../pages/Page404';
 import BAIContentWithDrawerArea from '../BAIContentWithDrawerArea';
@@ -37,9 +40,6 @@ import React, {
   useState,
 } from 'react';
 import { Outlet, useMatches, useLocation } from 'react-router-dom';
-import usePrimaryColors from 'src/hooks/usePrimaryColors';
-import { useWebUIMenuItems } from 'src/hooks/useWebUIMenuItems';
-import { useSetupWebUIPluginEffect } from 'src/hooks/useWebUIPluginState';
 
 // Z-index for header in MainLayout. Should be higher than any other elements in the page content.
 // Since fixed column z-index in antd table is dynamically calculated based on the number of columns,

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -5,6 +5,10 @@
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
 import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
 import usePrimaryColors from '../../hooks/usePrimaryColors';
+import {
+  getPathFromMenuKey,
+  useWebUIMenuItems,
+} from '../../hooks/useWebUIMenuItems';
 import AboutBackendAIModal from '../AboutBackendAIModal';
 import BAIMenu from '../BAIMenu';
 import BAISider, { BAISiderProps } from '../BAISider';
@@ -31,10 +35,6 @@ import { ArrowLeftIcon, ShieldUserIcon } from 'lucide-react';
 import React, { useContext, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import {
-  getPathFromMenuKey,
-  useWebUIMenuItems,
-} from 'src/hooks/useWebUIMenuItems';
 
 interface WebUISiderProps extends Pick<
   BAISiderProps,

--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -13,6 +13,7 @@ import { MyKeypairManagementModalRevokeMyKeypairMutation } from '../__generated_
 import { MyKeypairManagementModalSwitchMainKeyMutation } from '../__generated__/MyKeypairManagementModalSwitchMainKeyMutation.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import BAIRadioGroup from './BAIRadioGroup';
 import {
   Alert,
@@ -54,7 +55,6 @@ import {
 import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 
 type ActiveFilter = 'active' | 'inactive';
 

--- a/react/src/components/PendingSessionNodeList.tsx
+++ b/react/src/components/PendingSessionNodeList.tsx
@@ -2,6 +2,14 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  PendingSessionNodeListQuery,
+  PendingSessionNodeListQuery$variables,
+} from '../__generated__/PendingSessionNodeListQuery.graphql';
+import { useWebUINavigate } from '../hooks';
+import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
 import SessionNodes from './SessionNodes';
 import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';
 import { Form } from 'antd';
@@ -18,14 +26,6 @@ import { useDeferredValue, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useLocation } from 'react-router-dom';
-import {
-  PendingSessionNodeListQuery,
-  PendingSessionNodeListQuery$variables,
-} from 'src/__generated__/PendingSessionNodeListQuery.graphql';
-import { useWebUINavigate } from 'src/hooks';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from 'src/hooks/reactPaginationQueryOptions';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
-import { useCurrentResourceGroupValue } from 'src/hooks/useCurrentProject';
 
 const PendingSessionNodeList: React.FC = () => {
   const { t } = useTranslation();

--- a/react/src/components/RoleAssignmentTab.tsx
+++ b/react/src/components/RoleAssignmentTab.tsx
@@ -8,6 +8,7 @@ import { RoleAssignmentTabFragment$key } from '../__generated__/RoleAssignmentTa
 import { RoleAssignmentOrderBy } from '../__generated__/RoleAssignmentTabRefetchQuery.graphql';
 import { RoleAssignmentTab_roleScopeFragment$key } from '../__generated__/RoleAssignmentTab_roleScopeFragment.graphql';
 import { convertToOrderBy } from '../helper';
+import { useSetBAINotification } from '../hooks/useBAINotification';
 import AssignRoleModal from './AssignRoleModal';
 import { App, Tooltip, theme } from 'antd';
 import {
@@ -40,7 +41,6 @@ import {
   useRefetchableFragment,
   useMutation,
 } from 'react-relay';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
 
 const assignmentOrderValues = [
   'EMAIL_ASC',

--- a/react/src/components/SFTPServerButton.tsx
+++ b/react/src/components/SFTPServerButton.tsx
@@ -2,7 +2,22 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useWebUINavigate } from '../hooks';
+import { SFTPServerButtonFragment$key } from '../__generated__/SFTPServerButtonFragment.graphql';
+import {
+  useCurrentDomainValue,
+  useSuspendedBackendaiClient,
+  useWebUINavigate,
+} from '../hooks';
+import {
+  useCurrentProjectValue,
+  useResourceGroupsForCurrentProject,
+} from '../hooks/useCurrentProject';
+import { useDefaultSystemSSHImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
+import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
+import {
+  StartSessionWithDefaultValue,
+  useStartSession,
+} from '../hooks/useStartSession';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { App, Dropdown, Image, Space, Tooltip } from 'antd';
 import {
@@ -15,18 +30,6 @@ import {
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { SFTPServerButtonFragment$key } from 'src/__generated__/SFTPServerButtonFragment.graphql';
-import { useCurrentDomainValue, useSuspendedBackendaiClient } from 'src/hooks';
-import {
-  useCurrentProjectValue,
-  useResourceGroupsForCurrentProject,
-} from 'src/hooks/useCurrentProject';
-import { useDefaultSystemSSHImageWithFallback } from 'src/hooks/useDefaultImagesWithFallback';
-import { useMergedAllowedStorageHostPermission } from 'src/hooks/useMergedAllowedStorageHostPermission';
-import {
-  StartSessionWithDefaultValue,
-  useStartSession,
-} from 'src/hooks/useStartSession';
 
 interface SFTPServerButtonProps extends BAIButtonProps {
   showTitle?: boolean;

--- a/react/src/components/SFTPServerButtonV2.tsx
+++ b/react/src/components/SFTPServerButtonV2.tsx
@@ -2,7 +2,22 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useWebUINavigate } from '../hooks';
+import { SFTPServerButtonV2Fragment$key } from '../__generated__/SFTPServerButtonV2Fragment.graphql';
+import {
+  useCurrentDomainValue,
+  useSuspendedBackendaiClient,
+  useWebUINavigate,
+} from '../hooks';
+import {
+  useCurrentProjectValue,
+  useResourceGroupsForCurrentProject,
+} from '../hooks/useCurrentProject';
+import { useDefaultSystemSSHImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
+import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
+import {
+  StartSessionWithDefaultValue,
+  useStartSession,
+} from '../hooks/useStartSession';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { App, Dropdown, Image, Space, Tooltip } from 'antd';
 import {
@@ -15,18 +30,6 @@ import {
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { SFTPServerButtonV2Fragment$key } from 'src/__generated__/SFTPServerButtonV2Fragment.graphql';
-import { useCurrentDomainValue, useSuspendedBackendaiClient } from 'src/hooks';
-import {
-  useCurrentProjectValue,
-  useResourceGroupsForCurrentProject,
-} from 'src/hooks/useCurrentProject';
-import { useDefaultSystemSSHImageWithFallback } from 'src/hooks/useDefaultImagesWithFallback';
-import { useMergedAllowedStorageHostPermission } from 'src/hooks/useMergedAllowedStorageHostPermission';
-import {
-  StartSessionWithDefaultValue,
-  useStartSession,
-} from 'src/hooks/useStartSession';
 
 interface SFTPServerButtonV2Props extends BAIButtonProps {
   showTitle?: boolean;

--- a/react/src/components/ScanArtifactModelsFromHuggingFaceModal.tsx
+++ b/react/src/components/ScanArtifactModelsFromHuggingFaceModal.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ScanArtifactModelsFromHuggingFaceModalMutation } from '../__generated__/ScanArtifactModelsFromHuggingFaceModalMutation.graphql';
 import { App, Form, type FormInstance, Input, theme } from 'antd';
 import {
   BAIFlex,
@@ -13,7 +14,6 @@ import {
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation } from 'react-relay';
-import { ScanArtifactModelsFromHuggingFaceModalMutation } from 'src/__generated__/ScanArtifactModelsFromHuggingFaceModalMutation.graphql';
 
 export interface ScanArtifactModelsFromHuggingFaceModalProps extends BAIModalProps {
   onRequestClose?: (

--- a/react/src/components/SessionCountDashboardItem.tsx
+++ b/react/src/components/SessionCountDashboardItem.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { SessionCountDashboardItemFragment$key } from '../__generated__/SessionCountDashboardItemFragment.graphql';
 import { theme } from 'antd';
 import {
   BAIBoardItemTitle,
@@ -15,7 +16,6 @@ import * as _ from 'lodash-es';
 import { useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useRefetchableFragment } from 'react-relay';
-import { SessionCountDashboardItemFragment$key } from 'src/__generated__/SessionCountDashboardItemFragment.graphql';
 
 interface SessionCountDashboardItemProps extends BAIFlexProps {
   queryRef: SessionCountDashboardItemFragment$key;

--- a/react/src/components/SessionSchedulingHistoryModal.tsx
+++ b/react/src/components/SessionSchedulingHistoryModal.tsx
@@ -1,4 +1,10 @@
 import {
+  SessionSchedulingHistoryFilter,
+  SessionSchedulingHistoryModalQuery,
+  SessionSchedulingHistoryOrderBy,
+} from '../__generated__/SessionSchedulingHistoryModalQuery.graphql';
+import { convertToOrderBy } from '../helper';
+import {
   BAIButton,
   BAIFetchKeyButton,
   BAIFlex,
@@ -12,12 +18,6 @@ import * as _ from 'lodash-es';
 import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import {
-  SessionSchedulingHistoryFilter,
-  SessionSchedulingHistoryModalQuery,
-  SessionSchedulingHistoryOrderBy,
-} from 'src/__generated__/SessionSchedulingHistoryModalQuery.graphql';
-import { convertToOrderBy } from 'src/helper';
 
 interface SessionSchedulingHistoryModalProps extends Omit<
   BAIModalProps,

--- a/react/src/components/StorageStatusPanelCard.tsx
+++ b/react/src/components/StorageStatusPanelCard.tsx
@@ -6,6 +6,7 @@ import { StorageStatusPanelCardQuery } from '../__generated__/StorageStatusPanel
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
 import BAIPanelItem from './BAIPanelItem';
 import { useUpdateEffect } from 'ahooks';
 import { Badge, theme, Tooltip, Typography } from 'antd';
@@ -20,7 +21,6 @@ import * as _ from 'lodash-es';
 import React, { useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useVFolderInvitations } from 'src/hooks/useVFolderInvitations';
 
 const useStyles = createStyles(({ css, token }) => ({
   invitationTooltip: css`

--- a/react/src/components/TotalResourceWithinResourceGroup.tsx
+++ b/react/src/components/TotalResourceWithinResourceGroup.tsx
@@ -3,7 +3,9 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { TotalResourceWithinResourceGroupFragment$key } from '../__generated__/TotalResourceWithinResourceGroupFragment.graphql';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';
+import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
 import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';
 import { useControllableValue } from 'ahooks';
 import { Segmented, theme, Typography } from 'antd';
@@ -30,8 +32,6 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useRefetchableFragment } from 'react-relay';
-import { useSuspendedBackendaiClient } from 'src/hooks';
-import { useCurrentResourceGroupValue } from 'src/hooks/useCurrentProject';
 
 interface TotalResourceWithinResourceGroupProps extends BAIFlexProps {
   queryRef: TotalResourceWithinResourceGroupFragment$key;

--- a/react/src/components/UpdateUsersModal.tsx
+++ b/react/src/components/UpdateUsersModal.tsx
@@ -2,6 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { UpdateUsersModalFragment$key } from '../__generated__/UpdateUsersModalFragment.graphql';
+import {
+  ModifyUserInput,
+  UpdateUsersModalMutation,
+} from '../__generated__/UpdateUsersModalMutation.graphql';
+import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
 import ProjectSelect from './ProjectSelect';
 import UserResourcePolicySelect from './UserResourcePolicySelect';
 import { App, Form, InputNumber, theme } from 'antd';
@@ -22,12 +28,6 @@ import { Suspense, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 import { PayloadError } from 'relay-runtime';
-import { UpdateUsersModalFragment$key } from 'src/__generated__/UpdateUsersModalFragment.graphql';
-import {
-  ModifyUserInput,
-  UpdateUsersModalMutation,
-} from 'src/__generated__/UpdateUsersModalMutation.graphql';
-import { SIGNED_32BIT_MAX_INT } from 'src/helper/const-vars';
 
 interface UpdateUsersFormValues {
   domain_name?: string;

--- a/react/src/components/UserManagement.tsx
+++ b/react/src/components/UserManagement.tsx
@@ -8,6 +8,9 @@ import {
   UserManagementQuery$data,
 } from '../__generated__/UserManagementQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCSVExport } from '../hooks/useCSVExport';
 import BAIRadioGroup from './BAIRadioGroup';
 import PurgeUsersModal from './PurgeUsersModal';
 import UpdateUsersModal from './UpdateUsersModal';
@@ -45,9 +48,6 @@ import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { useState, useTransition, useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
-import { useBAIPaginationOptionStateOnSearchParam } from 'src/hooks/reactPaginationQueryOptions';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
-import { useCSVExport } from 'src/hooks/useCSVExport';
 
 interface UserManagementProps {}
 

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { GeneratedKeypairListModalFragment$key } from '../__generated__/GeneratedKeypairListModalFragment.graphql';
 import {
   UserSettingModalBulkCreateMutation,
   UserRoleV2,
@@ -53,7 +54,6 @@ import * as _ from 'lodash-es';
 import React, { Suspense, useDeferredValue, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation, useLazyLoadQuery } from 'react-relay';
-import { GeneratedKeypairListModalFragment$key } from 'src/__generated__/GeneratedKeypairListModalFragment.graphql';
 
 type UserRole = {
   [key: string]: string[];

--- a/react/src/components/VFolderLazyView.tsx
+++ b/react/src/components/VFolderLazyView.tsx
@@ -2,13 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { VFolderLazyViewQuery } from '../__generated__/VFolderLazyViewQuery.graphql';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import VFolderNodeIdenticon from './VFolderNodeIdenticon';
 import { Typography } from 'antd';
 import { BAIFlex, toGlobalId, toLocalId } from 'backend.ai-ui';
 import React from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { VFolderLazyViewQuery } from 'src/__generated__/VFolderLazyViewQuery.graphql';
 
 interface VFolderLazyViewProps {
   uuid: string;

--- a/react/src/components/VFolderLazyViewV2.tsx
+++ b/react/src/components/VFolderLazyViewV2.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { VFolderLazyViewV2Query } from '../__generated__/VFolderLazyViewV2Query.graphql';
 import { useWebUINavigate } from '../hooks';
 import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
 import { Typography } from 'antd';
@@ -9,7 +10,6 @@ import { BAIFlex, toLocalId } from 'backend.ai-ui';
 import React from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useLocation } from 'react-router-dom';
-import { VFolderLazyViewV2Query } from 'src/__generated__/VFolderLazyViewV2Query.graphql';
 
 interface VFolderLazyViewV2Props {
   uuid: string;

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { VFolderSelectFallbackProbeQuery } from '../__generated__/VFolderSelectFallbackProbeQuery.graphql';
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import useControllableState_deprecated from '../hooks/useControllableState';
@@ -28,7 +29,6 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { VFolderSelectFallbackProbeQuery } from 'src/__generated__/VFolderSelectFallbackProbeQuery.graphql';
 
 export type VFolder = {
   name: string;

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -3,8 +3,10 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useWebUINavigate } from '.';
+import { BAINodeNotificationItemFragment$key } from '../__generated__/BAINodeNotificationItemFragment.graphql';
 import BAIGeneralNotificationItem from '../components/BAIGeneralNotificationItem';
 import BAIMultiStepNotificationItem from '../components/BAIMultiStepNotificationItem';
+import BAINodeNotificationItem from '../components/BAINodeNotificationItem';
 import { SSEEventHandlerTypes, listenToBackgroundTask } from '../helper';
 import { useBAISettingUserState } from './useBAISetting';
 import { App } from 'antd';
@@ -21,8 +23,6 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { To, createPath } from 'react-router-dom';
-import { BAINodeNotificationItemFragment$key } from 'src/__generated__/BAINodeNotificationItemFragment.graphql';
-import BAINodeNotificationItem from 'src/components/BAINodeNotificationItem';
 import { v4 as uuidv4 } from 'uuid';
 
 const _activeNotificationKeys: Key[] = [];

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -5,12 +5,12 @@
 import { BAIBoardItem } from '../components/BAIBoard';
 import { jotaiStore } from '../components/DefaultProviders';
 import { backendaiOptions } from '../global-stores';
+import { CustomThemeConfig } from '../helper/customThemeConfig';
 import type { AIAgent } from './useAIAgent';
 import { BAITableColumnOverrideRecord } from 'backend.ai-ui';
 import { atom, useAtom } from 'jotai';
 import { atomFamily } from 'jotai-family';
 import { SetStateAction } from 'react';
-import { CustomThemeConfig } from 'src/helper/customThemeConfig';
 
 export interface UserSettings {
   has_opened_tour_neo_session_validation?: boolean;

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -3,12 +3,12 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '.';
+import { useBackendAIAppLauncherFragment$key } from '../__generated__/useBackendAIAppLauncherFragment.graphql';
 import { useSetBAINotification } from './useBAINotification';
 import { BAILink, useBAILogger, useErrorMessageResolver } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { useBackendAIAppLauncherFragment$key } from 'src/__generated__/useBackendAIAppLauncherFragment.graphql';
 
 export const TCP_APPS = ['sshd', 'vscode-desktop', 'xrdp', 'vnc'];
 export const useBackendAIAppLauncher = (

--- a/react/src/hooks/useDefaultImagesWithFallback.ts
+++ b/react/src/hooks/useDefaultImagesWithFallback.ts
@@ -3,16 +3,16 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { backendaiClientPromise } from '.';
+import {
+  useDefaultImagesWithFallbackQuery,
+  useDefaultImagesWithFallbackQuery$data,
+} from '../__generated__/useDefaultImagesWithFallbackQuery.graphql';
+import { getImageFullName } from '../helper';
 import { atom, useAtom } from 'jotai';
 import { atomWithDefault } from 'jotai/utils';
 import * as _ from 'lodash-es';
 import { useEffect, useEffectEvent } from 'react';
 import { fetchQuery, graphql, useRelayEnvironment } from 'react-relay';
-import {
-  useDefaultImagesWithFallbackQuery,
-  useDefaultImagesWithFallbackQuery$data,
-} from 'src/__generated__/useDefaultImagesWithFallbackQuery.graphql';
-import { getImageFullName } from 'src/helper';
 
 const IMAGES_QUERY = graphql`
   query useDefaultImagesWithFallbackQuery($installed: Boolean) {

--- a/react/src/hooks/useMergedAllowedStorageHostPermission.ts
+++ b/react/src/hooks/useMergedAllowedStorageHostPermission.ts
@@ -3,10 +3,10 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '.';
+import { useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery } from '../__generated__/useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery.graphql';
+import { useMergedAllowedStorageHostPermission_KeypairQuery } from '../__generated__/useMergedAllowedStorageHostPermission_KeypairQuery.graphql';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery } from 'src/__generated__/useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery.graphql';
-import { useMergedAllowedStorageHostPermission_KeypairQuery } from 'src/__generated__/useMergedAllowedStorageHostPermission_KeypairQuery.graphql';
 
 export const useMergedAllowedStorageHostPermission = (
   domain: string,

--- a/react/src/hooks/useStartSession.tsx
+++ b/react/src/hooks/useStartSession.tsx
@@ -3,6 +3,13 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '.';
+import { useStartSessionCreationQuery } from '../__generated__/useStartSessionCreationQuery.graphql';
+import { transformPortValuesToNumbers } from '../components/PortSelectFormItem';
+import { RESOURCE_ALLOCATION_INITIAL_FORM_VALUES } from '../components/SessionFormItems/ResourceAllocationFormItems';
+import {
+  SessionLauncherFormValue,
+  SessionResources,
+} from '../pages/SessionLauncherPage';
 import { useSetBAINotification } from './useBAINotification';
 import {
   useCurrentProjectValue,
@@ -12,13 +19,6 @@ import { generateRandomString, toGlobalId } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { fetchQuery, graphql, useRelayEnvironment } from 'react-relay';
-import { useStartSessionCreationQuery } from 'src/__generated__/useStartSessionCreationQuery.graphql';
-import { transformPortValuesToNumbers } from 'src/components/PortSelectFormItem';
-import { RESOURCE_ALLOCATION_INITIAL_FORM_VALUES } from 'src/components/SessionFormItems/ResourceAllocationFormItems';
-import {
-  SessionLauncherFormValue,
-  SessionResources,
-} from 'src/pages/SessionLauncherPage';
 
 // Type for successful session creation result
 type SessionCreationSuccess = {

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '.';
+import WebUILink from '../components/WebUILink';
 import { useCurrentUserRole } from './backendai';
 import { useDiagnosticsBadgeSeverity } from './useAutoDiagnostics';
 import { useBAISettingUserState } from './useBAISetting';
@@ -56,7 +57,6 @@ import {
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import WebUILink from 'src/components/WebUILink';
 
 // Mutable registry populated by routes.tsx at module initialization time.
 // Using mutable objects (Set / Array) means importers share the same reference

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -16,7 +16,10 @@ import SessionNodes, {
 import { handleRowSelectionChange } from '../helper';
 import { ExtractResultValue } from '../helper/resultTypes';
 import { useWebUINavigate } from '../hooks';
+import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCSVExport } from '../hooks/useCSVExport';
 import { Alert, App, Badge, Button, theme, Tooltip } from 'antd';
 import {
   BAIFetchKeyButton,
@@ -37,9 +40,6 @@ import { useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useLocation } from 'react-router-dom';
-import { useCurrentUserRole } from 'src/hooks/backendai';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
-import { useCSVExport } from 'src/hooks/useCSVExport';
 
 const typeFilterValues = [
   'all',

--- a/react/src/pages/AdminDashboardPage.tsx
+++ b/react/src/pages/AdminDashboardPage.tsx
@@ -3,6 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { AdminDashboardPageQuery } from '../__generated__/AdminDashboardPageQuery.graphql';
+import ActiveAgents from '../components/ActiveAgents';
+import AgentStats from '../components/AgentStats';
 import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
 import RecentlyCreatedSession from '../components/RecentlyCreatedSession';
 import SessionCountDashboardItem from '../components/SessionCountDashboardItem';
@@ -10,6 +12,7 @@ import TotalResourceWithinResourceGroup, {
   useIsAvailableTotalResourceWithinResourceGroup,
 } from '../components/TotalResourceWithinResourceGroup';
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   useCurrentProjectValue,
@@ -26,9 +29,6 @@ import * as _ from 'lodash-es';
 import { Suspense, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import ActiveAgents from 'src/components/ActiveAgents';
-import AgentStats from 'src/components/AgentStats';
-import { useCurrentUserRole } from 'src/hooks/backendai';
 
 const AdminDashboardPage: React.FC = () => {
   const { token } = theme.useToken();

--- a/react/src/pages/AdminSessionPage.tsx
+++ b/react/src/pages/AdminSessionPage.tsx
@@ -2,15 +2,15 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
+import PendingSessionNodeList from '../components/PendingSessionNodeList';
+import SessionDetailAndContainerLogOpenerLegacy from '../components/SessionDetailAndContainerLogOpenerLegacy';
+import { useWebUINavigate } from '../hooks';
 import { Skeleton } from 'antd';
 import { BAICard, filterOutEmpty } from 'backend.ai-ui';
 import { parseAsString, useQueryStates } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
-import PendingSessionNodeList from 'src/components/PendingSessionNodeList';
-import SessionDetailAndContainerLogOpenerLegacy from 'src/components/SessionDetailAndContainerLogOpenerLegacy';
-import { useWebUINavigate } from 'src/hooks';
 
 const AdminComputeSessionListPage = React.lazy(
   () => import('./AdminComputeSessionListPage'),

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -15,6 +15,8 @@ import RestoreVFolderModal from '../components/RestoreVFolderModal';
 import VFolderNodes, { VFolderNodeInList } from '../components/VFolderNodes';
 import { handleRowSelectionChange } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { isDeletedCategory } from './VFolderNodeListPage';
 import { useToggle } from 'ahooks';
 import { Badge, theme, Tooltip } from 'antd';
@@ -37,8 +39,6 @@ import { PlusIcon } from 'lucide-react';
 import React, { useDeferredValue, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from 'src/hooks/reactPaginationQueryOptions';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 type VFolderNodesType = NonNullableNodeOnEdges<

--- a/react/src/pages/BrandingPage.tsx
+++ b/react/src/pages/BrandingPage.tsx
@@ -2,12 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
+import BrandingSettingList from '../components/BrandingSettingList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
-import BrandingSettingList from 'src/components/BrandingSettingList';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 const tabParam = withDefault(StringParam, 'branding');

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -18,7 +18,10 @@ import SessionNodes, {
 import { handleRowSelectionChange } from '../helper';
 import { ExtractResultValue } from '../helper/resultTypes';
 import { useWebUINavigate } from '../hooks';
+import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCSVExport } from '../hooks/useCSVExport';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import {
   Alert,
@@ -56,9 +59,6 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useLocation } from 'react-router-dom';
-import { useCurrentUserRole } from 'src/hooks/backendai';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
-import { useCSVExport } from 'src/hooks/useCSVExport';
 
 const typeFilterValues = [
   'all',

--- a/react/src/pages/ConfigurationsPage.tsx
+++ b/react/src/pages/ConfigurationsPage.tsx
@@ -2,12 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ConfigurationsSettingList from '../components/ConfigurationsSettingList';
 import { Card, Skeleton } from 'antd';
 import { filterOutEmpty } from 'backend.ai-ui';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'configurations';

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -3,6 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { DashboardPageQuery } from '../__generated__/DashboardPageQuery.graphql';
+import ActiveAgents from '../components/ActiveAgents';
+import AgentStats from '../components/AgentStats';
 import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
 import MyResource from '../components/MyResource';
 import MyResourceWithinResourceGroup from '../components/MyResourceWithinResourceGroup';
@@ -14,6 +16,7 @@ import TotalResourceWithinResourceGroup, {
   useIsAvailableTotalResourceWithinResourceGroup,
 } from '../components/TotalResourceWithinResourceGroup';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   useCurrentProjectValue,
@@ -31,9 +34,6 @@ import * as _ from 'lodash-es';
 import { Suspense, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import ActiveAgents from 'src/components/ActiveAgents';
-import AgentStats from 'src/components/AgentStats';
-import { useCurrentUserRole } from 'src/hooks/backendai';
 
 const DashboardPage: React.FC = () => {
   const { token } = theme.useToken();

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { DeploymentDetailPageQuery } from '../__generated__/DeploymentDetailPageQuery.graphql';
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import DeploymentAccessTokensTab from '../components/DeploymentAccessTokensTab';
 import DeploymentAutoScalingTab from '../components/DeploymentAutoScalingTab';
 import DeploymentConfigurationSection from '../components/DeploymentConfigurationSection';
@@ -18,7 +19,6 @@ import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 
 const DeploymentDetailPage: React.FC = () => {
   'use memo';

--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -4,6 +4,7 @@
  */
 import CspDiagnosticsSection from '../components/CspDiagnosticsSection';
 import EndpointDiagnosticsSection from '../components/EndpointDiagnosticsSection';
+import ErrorBoundaryWithNullFallback from '../components/ErrorBoundaryWithNullFallback';
 import StorageProxyDiagnosticsSection from '../components/StorageProxyDiagnosticsSection';
 import WebServerConfigDiagnosticsSection from '../components/WebServerConfigDiagnosticsSection';
 import { downloadBlob } from '../helper/csv-util';
@@ -24,7 +25,6 @@ import {
 import { BAIButton, BAICard, BAIFlex, useFetchKey } from 'backend.ai-ui';
 import { Suspense, useCallback, useRef, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import ErrorBoundaryWithNullFallback from 'src/components/ErrorBoundaryWithNullFallback';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'diagnostics';

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -33,6 +33,7 @@ import SessionDetailDrawer from '../components/SessionDetailDrawer';
 import SourceCodeView from '../components/SourceCodeView';
 import SwitchToProjectButton from '../components/SwitchToProjectButton';
 import VFolderLazyViewV2 from '../components/VFolderLazyViewV2';
+import VFolderNodeIdenticon from '../components/VFolderNodeIdenticon';
 import { baiSignedRequestWithPromise, convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
@@ -102,7 +103,6 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 import { useParams } from 'react-router-dom';
 import { PayloadError } from 'relay-runtime';
-import VFolderNodeIdenticon from 'src/components/VFolderNodeIdenticon';
 
 interface RoutingInfo {
   route_id: string;

--- a/react/src/pages/EnvironmentPage.tsx
+++ b/react/src/pages/EnvironmentPage.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ContainerRegistryList from '../components/ContainerRegistryList';
 import ImageList from '../components/ImageList';
 import ResourcePresetList from '../components/ResourcePresetList';
@@ -10,7 +11,6 @@ import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 const tabParam = withDefault(StringParam, 'image');

--- a/react/src/pages/MaintenancePage.tsx
+++ b/react/src/pages/MaintenancePage.tsx
@@ -2,12 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import MaintenanceSettingList from '../components/MaintenanceSettingList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'maintenance';

--- a/react/src/pages/ProjectPage.tsx
+++ b/react/src/pages/ProjectPage.tsx
@@ -2,6 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  ProjectPageQuery,
+  ProjectPageQuery$data,
+  ProjectPageQuery$variables,
+} from '../__generated__/ProjectPageQuery.graphql';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useCSVExport } from '../hooks/useCSVExport';
 import { PlusOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import { App } from 'antd';
@@ -27,13 +34,6 @@ import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import {
-  ProjectPageQuery,
-  ProjectPageQuery$data,
-  ProjectPageQuery$variables,
-} from 'src/__generated__/ProjectPageQuery.graphql';
-import { useBAIPaginationOptionStateOnSearchParam } from 'src/hooks/reactPaginationQueryOptions';
-import { useCSVExport } from 'src/hooks/useCSVExport';
 
 type ProjectNode = NonNullable<
   NonNullable<

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -2,7 +2,17 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key } from '../__generated__/ImportArtifactRevisionToFolderModalArtifactRevisionFragment.graphql';
+import {
+  ArtifactStatus,
+  ReservoirArtifactDetailPageQuery,
+  ReservoirArtifactDetailPageQuery$data,
+  ReservoirArtifactDetailPageQuery$variables,
+} from '../__generated__/ReservoirArtifactDetailPageQuery.graphql';
 import ImportArtifactRevisionToFolderButton from '../components/ImportArtifactRevisionToFolderButton';
+import ImportArtifactRevisionToFolderModal from '../components/ImportArtifactRevisionToFolderModal';
+import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useSetBAINotification } from '../hooks/useBAINotification';
 import { Button, Typography, Descriptions, theme, Tooltip } from 'antd';
 import {
   BAIArtifactRevisionDeleteButton,
@@ -35,16 +45,6 @@ import { useDeferredValue, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
-import { ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key } from 'src/__generated__/ImportArtifactRevisionToFolderModalArtifactRevisionFragment.graphql';
-import {
-  ArtifactStatus,
-  ReservoirArtifactDetailPageQuery,
-  ReservoirArtifactDetailPageQuery$data,
-  ReservoirArtifactDetailPageQuery$variables,
-} from 'src/__generated__/ReservoirArtifactDetailPageQuery.graphql';
-import ImportArtifactRevisionToFolderModal from 'src/components/ImportArtifactRevisionToFolderModal';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from 'src/hooks/reactPaginationQueryOptions';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
 import { JsonParam, useQueryParams, withDefault } from 'use-query-params';
 
 dayjs.extend(relativeTime);

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -2,8 +2,18 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import {
+  ReservoirPageQuery,
+  ReservoirPageQuery$data,
+  ReservoirPageQuery$variables,
+  ArtifactType,
+} from '../__generated__/ReservoirPageQuery.graphql';
+import BAIRadioGroup from '../components/BAIRadioGroup';
+import ScanArtifactModelsFromHuggingFaceModal from '../components/ScanArtifactModelsFromHuggingFaceModal';
 import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useSetBAINotification } from '../hooks/useBAINotification';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useToggle } from 'ahooks';
 import { theme, Col, Row, Statistic, Card, Button, Tooltip } from 'antd';
 import {
@@ -32,16 +42,6 @@ import { BanIcon, Brain, UndoIcon } from 'lucide-react';
 import React, { useMemo, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import {
-  ReservoirPageQuery,
-  ReservoirPageQuery$data,
-  ReservoirPageQuery$variables,
-  ArtifactType,
-} from 'src/__generated__/ReservoirPageQuery.graphql';
-import BAIRadioGroup from 'src/components/BAIRadioGroup';
-import ScanArtifactModelsFromHuggingFaceModal from 'src/components/ScanArtifactModelsFromHuggingFaceModal';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 import {
   withDefault,
   JsonParam,

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import KeypairResourcePolicyList from '../components/KeypairResourcePolicyList';
 import ProjectResourcePolicyList from '../components/ProjectResourcePolicyList';
 import UserResourcePolicyList from '../components/UserResourcePolicyList';
@@ -10,7 +11,6 @@ import { Skeleton } from 'antd';
 import { filterOutEmpty, BAICard } from 'backend.ai-ui';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 import { withDefault, StringParam, useQueryParam } from 'use-query-params';
 
 const tabParam = withDefault(StringParam, 'keypair');

--- a/react/src/pages/ResourcesPage.tsx
+++ b/react/src/pages/ResourcesPage.tsx
@@ -3,13 +3,13 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import AgentList from '../components/AgentList';
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ResourceGroupList from '../components/ResourceGroupList';
 import StorageProxyList from '../components/StorageProxyList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'agents' | 'storages' | 'resourceGroup';

--- a/react/src/pages/SchedulerPage.tsx
+++ b/react/src/pages/SchedulerPage.tsx
@@ -2,6 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { type ErrorWithGraphQL } from '../components/BAIErrorBoundary';
+import FairShareList from '../components/FairShareItems/FairShareList';
+import { useWebUINavigate } from '../hooks';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, Result, Skeleton, theme, Tooltip } from 'antd';
 import { BAICard, BAIFlex } from 'backend.ai-ui';
@@ -10,9 +13,6 @@ import { parseAsString, useQueryStates } from 'nuqs';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
-import { type ErrorWithGraphQL } from 'src/components/BAIErrorBoundary';
-import FairShareList from 'src/components/FairShareItems/FairShareList';
-import { useWebUINavigate } from 'src/hooks';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 const tabParam = withDefault(StringParam, 'fair-share');

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -37,6 +37,7 @@ import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';
 import { useCurrentResourceGroupState } from '../hooks/useCurrentProject';
 import { useRecentSessionHistory } from '../hooks/useRecentSessionHistory';
+import { useStartSession } from '../hooks/useStartSession';
 // @ts-ignore
 import customCSS from './SessionLauncherPage.css?raw';
 import {
@@ -98,7 +99,6 @@ import React, {
 import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { useStartSession } from 'src/hooks/useStartSession';
 import {
   JsonParam,
   NumberParam,

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -11,6 +11,8 @@ import ThemeSecondaryProvider from '../components/ThemeSecondaryProvider';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
+import { MenuKeys } from '../hooks/useWebUIMenuItems';
 import { SessionLauncherFormValue } from './SessionLauncherPage';
 import { AppstoreAddOutlined } from '@ant-design/icons';
 import {
@@ -27,8 +29,6 @@ import * as _ from 'lodash-es';
 import { useEffect, useState, useMemo, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { useVFolderInvitations } from 'src/hooks/useVFolderInvitations';
-import { MenuKeys } from 'src/hooks/useWebUIMenuItems';
 import {
   useQueryParams,
   withDefault,

--- a/react/src/pages/StatisticsPage.tsx
+++ b/react/src/pages/StatisticsPage.tsx
@@ -3,13 +3,13 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import AllocationHistory from '../components/AllocationHistory';
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import UserSessionsMetrics from '../components/UserSessionsMetrics';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { Skeleton, theme } from 'antd';
 import { filterOutEmpty, BAICard } from 'backend.ai-ui';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 interface ResourcesPageProps {}

--- a/react/src/pages/StorageHostSettingPage.tsx
+++ b/react/src/pages/StorageHostSettingPage.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { StorageHostSettingPageQuery } from '../__generated__/StorageHostSettingPageQuery.graphql';
+import ErrorBoundaryWithNullFallback from '../components/ErrorBoundaryWithNullFallback';
 import StorageHostResourcePanel from '../components/StorageHostResourcePanel';
 import StorageHostSettingsPanel from '../components/StorageHostSettingsPanel';
 import { useWebUINavigate } from '../hooks';
@@ -12,7 +13,6 @@ import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
-import ErrorBoundaryWithNullFallback from 'src/components/ErrorBoundaryWithNullFallback';
 
 interface StorageHostSettingPageProps {
   // storageHostId: string;

--- a/react/src/pages/UserCredentialsPage.tsx
+++ b/react/src/pages/UserCredentialsPage.tsx
@@ -2,16 +2,16 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import UserCredentialList from '../components/UserCredentialList';
 import UserManagement from '../components/UserManagement';
+import { useWebUINavigate } from '../hooks';
 import { Skeleton } from 'antd';
 import { CardTabListType } from 'antd/es/card';
 import { BAIFlex, BAICard } from 'backend.ai-ui';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
-import { useWebUINavigate } from 'src/hooks';
 
 const UserCredentialsPage: React.FC = () => {
   const { t } = useTranslation();

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ErrorLogList from '../components/ErrorLogList';
 import MyKeypairInfoModalLegacy from '../components/MyKeypairInfoModalLegacy';
 import MyKeypairManagementModal from '../components/MyKeypairManagementModal';
@@ -22,7 +23,6 @@ import { filterOutEmpty } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { Suspense, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'general' | 'logs';

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -15,7 +15,10 @@ import RestoreVFolderModal from '../components/RestoreVFolderModal';
 import VFolderNodes, { VFolderNodeInList } from '../components/VFolderNodes';
 import { handleRowSelectionChange } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
 import { useToggle } from 'ahooks';
 import { Badge, theme, Tooltip } from 'antd';
 import {
@@ -36,9 +39,6 @@ import * as _ from 'lodash-es';
 import React, { useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from 'src/hooks/reactPaginationQueryOptions';
-import { useBAISettingUserState } from 'src/hooks/useBAISetting';
-import { useVFolderInvitations } from 'src/hooks/useVFolderInvitations';
 import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 export const isDeletedCategory = (status?: string | null) => {


### PR DESCRIPTION
Resolves #7218 (FR-2800)

## Summary

The codebase mixed two import styles for files inside `react/src/` — bare absolute (`from 'src/X'`, enabled by tsconfig `baseUrl: "."`) and relative (`from '../X'`). This PR standardizes on **relative paths** and enforces it via a new ESLint rule.

## Changes

| Layer | Change |
|---|---|
| **ESLint rule** | New `no-restricted-syntax` (warn) in `packages/eslint-config-bai/react.js` — bans every `ImportDeclaration` whose source matches `^src/`. **No carve-out** for `src/__generated__/*`. |
| **Import rewrites** | 235 occurrences across the affected files: 153 regular (`src/components/*`, `src/hooks/*`, `src/helper/*`, `src/pages/*`) + 82 Relay-generated (`src/__generated__/*.graphql`). |
| **Duplicate-import cleanup** | 4 files (`FileBrowserButton`, `FileBrowserButtonV2`, `SFTPServerButton`, `SFTPServerButtonV2`) had latent `import/no-duplicates` violations that surfaced once both sides normalized to `'../hooks'`. Merged into single import statements. |

## Before / After

```ts
// Before
import { useSuspendedBackendaiClient } from 'src/hooks';
import { useBAINotification } from 'src/hooks/useBAINotification';
import { FooFragment$key } from 'src/__generated__/FooFragment.graphql';

// After
import { useSuspendedBackendaiClient } from '../hooks';
import { useBAINotification } from '../hooks/useBAINotification';
import { FooFragment$key } from '../__generated__/FooFragment.graphql';
```

## The rule itself

```js
// packages/eslint-config-bai/react.js
{
  files: ["**/*.ts", "**/*.tsx"],
  rules: {
    "no-restricted-syntax": [
      "warn",
      {
        selector: "ImportDeclaration[source.value=/^src\\u002F.+/]",
        message:
          "Use a relative import path instead of 'src/...'. Mixing absolute and relative paths in the same file is inconsistent; prefer relative paths.",
      },
    ],
  },
},
```

`/` escapes the `/` so the esquery selector parser doesn't terminate the regex early. The selector matches any `import` whose source string starts with `src/` followed by at least one char.

## Why warn (not error)

| Context | Behavior on warning |
|---|---|
| `pnpm run lint` (CI / repo-wide check) | Exits 0 (`eslint src --quiet; exit 0`) — won't break builds. |
| `lint-staged` (pre-commit hook) | Runs `eslint ./src --max-warnings=0` — **fails the commit**, blocking new violations. |

This matches the issue's UX requirement: "warning level, but commit fails."

## Why no exception for `src/__generated__/*`

An earlier draft exempted the Relay-generated artifacts under `src/__generated__/*` (advisor flagged it as defensible). After review feedback, the exception was removed: a single rule with no carve-outs is easier to remember and IDE auto-imports happily produce `'../__generated__/Foo.graphql'` once the codebase commits to it. The 82-import rewrite is a one-time cost.

## Why `no-restricted-syntax` (and not `no-restricted-imports`)

`react/eslint.config.js` already declares `no-restricted-imports` at **error** level (banning `antd-style.useThemeMode`, `react-router-dom.useNavigate`). ESLint flat config replaces — not merges — rule options across blocks for matching files. Adding the new ban under the same rule name in `eslint-config-bai/react.js` would have been silently overridden by `react/eslint.config.js`. `no-restricted-syntax` is a different rule, so the two coexist cleanly.

## Future-package note

Any package later consuming `eslint-config-bai/react` will inherit this rule. `backend.ai-ui` is unaffected today (zero `src/*` imports today). If a new package adopts a different `baseUrl` setup where `src/*` is meaningful, the rule may need scoping back to `react/` only.

## Test plan

- [x] `bash scripts/verify.sh` — Relay / Lint / Format all pass. The TypeScript failures are pre-existing in `packages/backend.ai-client/src/client.ts` on `main` (verified by stashing my changes — same errors).
- [x] `grep -rE "from 'src/" react/src --include="*.ts" --include="*.tsx" | wc -l` → **0**.
- [x] Pre-commit hook (`lint-staged` → `eslint ./src --max-warnings=0`) blocks new `src/*` imports — surfaced 4 latent duplicate-import errors during this PR's first commit attempt; merged and re-tested green.

## Reviewer notes

- Most of the diff is mechanical (the path-string substitutions). The interesting bits are concentrated in:
  - `packages/eslint-config-bai/react.js` (the rule definition).
  - `react/src/components/{FileBrowser,SFTPServer}Button{,V2}.tsx` (the merged-import structural changes).
- The codebase has no internal `@/` or `~/` aliases — `baseUrl: "."` was the only mechanism enabling `src/*`, so this PR doesn't touch tsconfig.