### PR TITLE
feat(FR-2801): pre-populate image and preset fields in deployment launcher

### DIFF
--- a/react/src/components/ModelCardDrawer.tsx
+++ b/react/src/components/ModelCardDrawer.tsx
@@ -106,6 +106,7 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
                 name
               }
               execution {
+                imageId
                 startupCommand
               }
               cluster {
@@ -203,6 +204,8 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
                         openLauncher({
                           modelFolderId,
                           launcherFormValues: {
+                            imageId:
+                              presets[0]?.execution?.imageId ?? undefined,
                             startCommand:
                               presets[0]?.execution?.startupCommand ??
                               undefined,

--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -138,6 +138,7 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
                   name
                 }
                 execution {
+                  imageId
                   startupCommand
                 }
                 cluster {
@@ -490,6 +491,8 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
                         resourceGroup: effectiveResourceGroup,
                         revisionPresetId: effectivePresetId,
                         launcherFormValues: {
+                          imageId:
+                            selectedPreset?.execution?.imageId ?? undefined,
                           startCommand:
                             selectedPreset?.execution?.startupCommand ??
                             undefined,

--- a/react/src/hooks/useDeploymentLauncher.ts
+++ b/react/src/hooks/useDeploymentLauncher.ts
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useDeploymentLauncherDeployVFolderMutation } from '../__generated__/useDeploymentLauncherDeployVFolderMutation.graphql';
+import { useDeploymentLauncherImageCanonicalNameQuery } from '../__generated__/useDeploymentLauncherImageCanonicalNameQuery.graphql';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import {
@@ -12,7 +13,12 @@ import {
 import { useBAILogger } from 'backend.ai-ui';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useMutation } from 'react-relay';
+import {
+  fetchQuery,
+  graphql,
+  useMutation,
+  useRelayEnvironment,
+} from 'react-relay';
 
 export interface QuickDeployInput {
   /** Virtual folder (model folder) id that backs the deployment. */
@@ -34,6 +40,12 @@ export interface QuickDeployInput {
     clusterSize?: number;
     desiredReplicaCount?: number;
     openToPublic?: boolean;
+    /**
+     * Image UUID from the preset's execution spec. Resolved to the canonical
+     * name string (registry/ns:tag@arch) before being serialized into
+     * `environments.version` in the URL — the launcher's form field name.
+     */
+    imageId?: string;
   };
 }
 
@@ -52,9 +64,19 @@ export interface DeployInstantlyResult {
  * - `openLauncher`: navigates to `/deployments/start?model=<folderId>` so the
  *   user can configure a deployment in the full launcher UI.
  */
+const imageCanonicalNameQuery = graphql`
+  query useDeploymentLauncherImageCanonicalNameQuery($id: ID!) {
+    imageV2(id: $id) {
+      identity {
+        canonicalName
+      }
+    }
+  }
+`;
+
 export const useDeploymentLauncher = (): {
   deployInstantly: (input: QuickDeployInput) => Promise<DeployInstantlyResult>;
-  openLauncher: (input: QuickDeployInput) => void;
+  openLauncher: (input: QuickDeployInput) => Promise<void>;
   isDeploying: boolean;
   supportsQuickDeploy: boolean;
 } => {
@@ -67,6 +89,8 @@ export const useDeploymentLauncher = (): {
   const currentResourceGroup = useCurrentResourceGroupValue();
   const { upsertNotification } = useSetBAINotification();
   const { logger } = useBAILogger();
+
+  const relayEnvironment = useRelayEnvironment();
 
   const [isDeploying, setIsDeploying] = useState<boolean>(false);
 
@@ -195,16 +219,44 @@ export const useDeploymentLauncher = (): {
     });
   };
 
-  const openLauncher = (input: QuickDeployInput): void => {
+  const openLauncher = async (input: QuickDeployInput): Promise<void> => {
     const params = new URLSearchParams({ model: input.modelFolderId });
     if (input.resourceGroup) params.set('resourceGroup', input.resourceGroup);
     if (input.revisionPresetId)
       params.set('revisionPresetId', input.revisionPresetId);
+
     if (
       input.launcherFormValues &&
       Object.keys(input.launcherFormValues).length > 0
-    )
-      params.set('formValues', JSON.stringify(input.launcherFormValues));
+    ) {
+      const { imageId, ...restFormValues } = input.launcherFormValues;
+      const urlFormValues: Record<string, unknown> = { ...restFormValues };
+
+      if (imageId) {
+        try {
+          const result =
+            await fetchQuery<useDeploymentLauncherImageCanonicalNameQuery>(
+              relayEnvironment,
+              imageCanonicalNameQuery,
+              { id: imageId },
+              { fetchPolicy: 'store-or-network' },
+            ).toPromise();
+          const canonicalName = result?.imageV2?.identity?.canonicalName;
+          if (canonicalName) {
+            urlFormValues.environments = { version: canonicalName };
+          }
+        } catch (e) {
+          logger.warn(
+            '[useDeploymentLauncher] Failed to resolve imageId to canonical name',
+            e,
+          );
+        }
+      }
+
+      if (Object.keys(urlFormValues).length > 0)
+        params.set('formValues', JSON.stringify(urlFormValues));
+    }
+
     navigate(`/deployments/start?${params.toString()}`);
   };
 


### PR DESCRIPTION
Resolves #7223 ([FR-2801](https://lablup.atlassian.net/browse/FR-2801))

## Summary

- Make `openLauncher` async to allow resolving image UUID to canonical name before URL navigation
- Add `imageId` field to `launcherFormValues` in `useDeploymentLauncher`; when present, it is resolved to `environments.version` (canonical name string) via a `fetchQuery` against `imageV2.identity.canonicalName`, then serialized into the launcher's `formValues` URL param
- Add `execution.imageId` to the `ModelCardDrawerFragment` and `VFolderDeployModalQuery` so the image UUID is available from both entry points
- Pass `imageId` alongside the other preset fields (`startCommand`, `runtimeVariant`, `clusterMode`, `clusterSize`, `replicaCount`, `openToPublic`) in both `ModelCardDrawer` and `VFolderDeployModal`

## Test plan

- [ ] Open a model card with a deployment preset that has an image configured
- [ ] Click "Configure and deploy" (QuickDeployDetailed) — verify the launcher opens with the image pre-selected
- [ ] Open a VFolder deploy modal, choose a preset with an image, click the configure dropdown — verify the same image pre-selection behavior
- [ ] Verify presets without an image still navigate correctly (no error, image field left blank)

[FR-2801]: https://lablup.atlassian.net/browse/FR-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ