### PR TITLE
fix(FR-2802): allow custom resource allocation when creating a new deployment

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -12114,6 +12114,16 @@ input PreStartActionInput
 }
 
 """
+Added in UNRELEASED. Input for previewing a prometheus query template (admin only).
+"""
+input PreviewQueryDefinitionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """PromQL template to validate."""
+  queryTemplate: String!
+}
+
+"""
 Added in 26.2.0. Basic project information. Contains identity and descriptive fields for the project.
 """
 type ProjectBasicInfo
@@ -13688,6 +13698,11 @@ type Query
   Added in 26.4.2. Execute a prometheus query preset by ID and return the result. Available to any authenticated user; the underlying preset query is the same regardless of who runs it.
   """
   prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
+  """
+  adminPreviewPrometheusQueryPreset(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.

--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -48,6 +48,7 @@ const BAIText: React.FC<BAITextProps> = ({
   keyboardWithLightBorder,
   ...restProps
 }) => {
+  'use memo';
   const { token } = theme.useToken();
   const { t } = useTranslation();
   const textRef = useRef<HTMLSpanElement>(null);
@@ -57,13 +58,15 @@ const BAIText: React.FC<BAITextProps> = ({
   const expandable = typeof ellipsis === 'object' ? ellipsis.expandable : false;
   const onExpand = typeof ellipsis === 'object' ? ellipsis.onExpand : undefined;
 
+  const ellipsisEnabled = !!ellipsis;
+  const ellipsisRows = typeof ellipsis === 'object' ? (ellipsis.rows ?? 1) : 1;
+
   useEffect(() => {
-    if (!ellipsis || !textRef.current || isExpanded) return;
+    if (!ellipsisEnabled || !textRef.current || isExpanded) return;
     const element = textRef.current;
-    const rows = typeof ellipsis === 'object' ? ellipsis.rows || 1 : 1;
     const check = () => {
       if (!element) return;
-      if (rows === 1) {
+      if (ellipsisRows === 1) {
         setIsOverflowing(element.scrollWidth > element.clientWidth);
       } else {
         setIsOverflowing(element.scrollHeight > element.clientHeight);
@@ -73,7 +76,7 @@ const BAIText: React.FC<BAITextProps> = ({
     const ro = new ResizeObserver(check);
     ro.observe(element);
     return () => ro.disconnect();
-  }, [ellipsis, children, isExpanded]);
+  }, [ellipsisEnabled, ellipsisRows, isExpanded, children]);
 
   const handleExpand = (e: React.MouseEvent<HTMLElement>) => {
     const newExpandedState = !isExpanded;

--- a/react/src/components/DeploymentLauncherPageContent.tsx
+++ b/react/src/components/DeploymentLauncherPageContent.tsx
@@ -4,6 +4,7 @@
  */
 import { DeploymentLauncherPageContentPresetSummaryQuery } from '../__generated__/DeploymentLauncherPageContentPresetSummaryQuery.graphql';
 import { DeploymentLauncherPageContent_deployment$key } from '../__generated__/DeploymentLauncherPageContent_deployment.graphql';
+import { compareNumberWithUnits, convertToBinaryUnit } from '../helper';
 import { parseCliCommand } from '../helper/parseCliCommand';
 import {
   mergeExtraArgs,
@@ -20,14 +21,17 @@ import {
   getExtraArgsEnvVarName,
   type RuntimeParameterGroup,
 } from '../hooks/useRuntimeParameterSchema';
+import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
 import ImageEnvironmentSelectFormItems, {
   ImageEnvironmentFormInput,
 } from './ImageEnvironmentSelectFormItems';
-import ResourcePresetSelect from './ResourcePresetSelect';
 import RuntimeParameterFormSection, {
   RuntimeParameterValues,
 } from './RuntimeParameterFormSection';
+import ResourceAllocationFormItems, {
+  type ResourceAllocationFormValue,
+} from './SessionFormItems/ResourceAllocationFormItems';
 import SourceCodeView from './SourceCodeView';
 import VFolderLazyView from './VFolderLazyView';
 import VFolderSelect from './VFolderSelect';
@@ -132,7 +136,9 @@ export type DeploymentLauncherFormValue = ImageEnvironmentFormInput & {
 
   // Step 3 — Resources & Replicas
   resourceGroup: string;
-  resourcePresetId?: string;
+  allocationPreset?: string;
+  resource?: ResourceAllocationFormValue['resource'];
+  enabledAutomaticShmem?: boolean;
   desiredReplicaCount: number;
 };
 
@@ -146,6 +152,15 @@ export interface DeploymentLauncherPageContentProps {
   deploymentFrgmt?: DeploymentLauncherPageContent_deployment$key | null;
   /** Available runtime variants fetched by the parent page layout. */
   runtimeVariants?: ReadonlyArray<{ name: string; id: string }>;
+  /** Available resource presets — used in edit mode to detect custom allocation. */
+  resourcePresets?: ReadonlyArray<
+    | {
+        name?: string | null;
+        resource_slots?: string | null;
+      }
+    | null
+    | undefined
+  >;
   /**
    * Optional change observer forwarded to the underlying antd `<Form>`.
    * Useful for parent pages that want to persist the draft state
@@ -174,6 +189,102 @@ export interface DeploymentLauncherPageContentProps {
 }
 
 /**
+ * Compare revision resourceSlots against available presets to detect custom
+ * allocation, and return the matching form fields. Returns `allocationPreset:
+ * 'custom'` with populated `resource.*` values when no preset matches.
+ *
+ * TODO(needs-backend): Remove this function once `ModelRevision.revisionPresetId`
+ * is exposed by the API. At that point, the fragment can query the field directly
+ * and the allocationPreset can be set with a single line:
+ *   allocationPreset: revision.revisionPresetId ?? 'custom'
+ */
+const resolveEditModeResourcePreset = (
+  revisionSlots: ReadonlyArray<{
+    slotName: string;
+    quantity: string;
+  } | null> | null,
+  resourceOptsEntries: ReadonlyArray<{
+    name: string;
+    value: string;
+  } | null> | null,
+  presets: ReadonlyArray<
+    | {
+        name?: string | null;
+        resource_slots?: string | null;
+      }
+    | null
+    | undefined
+  > | null,
+): Partial<DeploymentLauncherFormValue> => {
+  // When slots are unavailable, return 'custom' to prevent ResourceAllocationFormItems
+  // from triggering auto-select (which only skips when allocationPreset === 'custom').
+  if (!revisionSlots || revisionSlots.length === 0) {
+    return { allocationPreset: 'custom' };
+  }
+
+  const slots = revisionSlots.filter(
+    (s): s is { slotName: string; quantity: string } => s !== null,
+  );
+
+  const matchingPreset = presets?.find((p) => {
+    if (!p?.name || !p?.resource_slots) return false;
+    let presetSlots: Record<string, string>;
+    try {
+      presetSlots = JSON.parse(p.resource_slots);
+    } catch {
+      return false;
+    }
+    const presetKeys = Object.keys(presetSlots);
+    if (presetKeys.length !== slots.length) return false;
+    return presetKeys.every((key) => {
+      const revSlot = slots.find((s) => s.slotName === key);
+      if (!revSlot) return false;
+      return key === 'mem'
+        ? compareNumberWithUnits(revSlot.quantity, presetSlots[key]) === 0
+        : revSlot.quantity === String(presetSlots[key]);
+    });
+  });
+
+  // Reconstruct resource.* fields from revision slots (used for both custom
+  // and named-preset cases so sliders are pre-populated on edit).
+  const cpu = Number(slots.find((s) => s.slotName === 'cpu')?.quantity ?? 0);
+  const rawMem = slots.find((s) => s.slotName === 'mem')?.quantity ?? '0g';
+  // Server returns mem in bytes; convert to "Xg" format for the slider.
+  const mem = convertToBinaryUnit(rawMem, 'g', 4)?.value ?? rawMem;
+  const shmemEntry = resourceOptsEntries
+    ?.filter((e): e is { name: string; value: string } => e !== null)
+    .find((e) => e.name === 'shmem');
+  const acceleratorSlot = slots.find(
+    (s) => s.slotName !== 'cpu' && s.slotName !== 'mem',
+  );
+  const resourceFields = {
+    resource: {
+      cpu,
+      mem,
+      shmem: shmemEntry?.value ?? '0g',
+      accelerator: acceleratorSlot ? Number(acceleratorSlot.quantity) : 0,
+      acceleratorType: acceleratorSlot?.slotName,
+    },
+    enabledAutomaticShmem: !shmemEntry,
+  };
+
+  // A revision with custom shmem (explicit resourceOpts entry) cannot be
+  // represented by any preset, even if the slot counts happen to match.
+  // Treating it as custom ensures the shmem value is preserved on save.
+  if (matchingPreset?.name && !shmemEntry) {
+    return {
+      allocationPreset: matchingPreset.name,
+      ...resourceFields,
+    };
+  }
+
+  return {
+    allocationPreset: 'custom',
+    ...resourceFields,
+  };
+};
+
+/**
  * Default values applied when neither `deploymentFrgmt` nor
  * `preFilledModel` is provided. Also used as the merge base for
  * edit-mode pre-fill so that un-populated fields get safe defaults.
@@ -196,7 +307,9 @@ const DEFAULT_FORM_VALUES: DeploymentLauncherFormValue = {
   clusterMode: 'SINGLE_NODE',
   clusterSize: 1,
   resourceGroup: '',
-  resourcePresetId: undefined,
+  allocationPreset: 'auto-select',
+  resource: { cpu: 0, mem: '0g', shmem: '0g', accelerator: 0 },
+  enabledAutomaticShmem: true,
   desiredReplicaCount: 1,
   environments: {
     environment: '',
@@ -227,6 +340,7 @@ const DeploymentLauncherPageContent: React.FC<
   form,
   deploymentFrgmt,
   runtimeVariants = [],
+  resourcePresets,
   onValuesChange,
   onSubmit,
   isSubmitting,
@@ -388,6 +502,16 @@ const DeploymentLauncherPageContent: React.FC<
           }
           resourceConfig {
             resourceGroupName
+            resourceOpts {
+              entries {
+                name
+                value
+              }
+            }
+          }
+          resourceSlots @since(version: "26.4.2") {
+            slotName
+            quantity
           }
           modelRuntimeConfig {
             runtimeVariantId
@@ -468,18 +592,26 @@ const DeploymentLauncherPageContent: React.FC<
           revision?.clusterConfig?.size ?? DEFAULT_FORM_VALUES.clusterSize,
         resourceGroup: revision?.resourceConfig?.resourceGroupName ?? '',
         desiredReplicaCount: deployment.replicaState.desiredReplicaCount,
-        // TODO(needs-backend): FR-2787 — resourcePresetId is not exposed in the
-        // ModelRevision schema, so the preset selector cannot be pre-populated in
-        // edit mode. Once the backend exposes resourcePresetName/id on the
-        // revision, add it here.
+        ...resolveEditModeResourcePreset(
+          revision?.resourceSlots ?? null,
+          revision?.resourceConfig?.resourceOpts?.entries ?? null,
+          resourcePresets ?? null,
+        ),
       } satisfies Partial<DeploymentLauncherFormValue>);
     }
     return _.merge({}, DEFAULT_FORM_VALUES, {
       ...(urlModel && { modelFolderId: urlModel }),
       ...(urlResourceGroup && { resourceGroup: urlResourceGroup }),
-      ...(urlResourcePresetId && { resourcePresetId: urlResourcePresetId }),
+      ...(urlResourcePresetId && { allocationPreset: urlResourcePresetId }),
     });
-  }, [mode, deployment, urlModel, urlResourceGroup, urlResourcePresetId]);
+  }, [
+    mode,
+    deployment,
+    urlModel,
+    urlResourceGroup,
+    urlResourcePresetId,
+    resourcePresets,
+  ]);
 
   // Apply initial values to the parent-owned form instance exactly once
   // per mount / deployment change. Using `useEffectEvent` keeps the
@@ -506,11 +638,10 @@ const DeploymentLauncherPageContent: React.FC<
     //
     // Membership rule: add a field here only if its step-2/3 Select passes
     // `autoSelectDefault`. Currently: BAIProjectResourceGroupSelect (step 3)
-    // and ResourcePresetSelect (step 3). VFolderSelect (step 2) does not pass
+    // and BAIProjectResourceGroupSelect (step 3). VFolderSelect (step 2) does not pass
     // autoSelectDefault; if that ever changes, add 'modelFolderId' here.
     const autoSelectKeys: Array<keyof DeploymentLauncherFormValue> = [
       'resourceGroup',
-      'resourcePresetId',
     ];
     const omitKeys =
       mode === 'create' ? autoSelectKeys.filter((k) => !merged[k]) : [];
@@ -867,37 +998,31 @@ const DeploymentLauncherPageContent: React.FC<
             }}
           >
             <Form.Item
-              name="resourceGroup"
-              label={t('session.ResourceGroup')}
-              rules={[{ required: true }]}
-            >
-              <BAIProjectResourceGroupSelect
-                projectName={currentProject.name ?? ''}
-                autoSelectDefault
-                showSearch
-              />
-            </Form.Item>
-            <Form.Item dependencies={['resourceGroup']} noStyle>
-              {({ getFieldValue }) => (
-                <Form.Item
-                  name="resourcePresetId"
-                  label={t('resourcePreset.ResourcePresets')}
-                >
-                  <ResourcePresetSelect
-                    resourceGroup={getFieldValue('resourceGroup')}
-                    autoSelectDefault
-                    showSearch
-                  />
-                </Form.Item>
-              )}
-            </Form.Item>
-            <Form.Item
               name="desiredReplicaCount"
               label={t('deployment.DesiredReplicas')}
               rules={[{ required: true, type: 'number', min: 1 }]}
             >
               <InputNumber min={1} style={{ width: '100%' }} />
             </Form.Item>
+            <Form.Item
+              name="resourceGroup"
+              label={t('session.ResourceGroup')}
+              rules={[{ required: true }]}
+            >
+              <BAIProjectResourceGroupSelect
+                projectName={currentProject.name ?? ''}
+                autoSelectDefault={mode === 'create'}
+                showSearch
+              />
+            </Form.Item>
+            <Suspense>
+              <ResourceAllocationFormItems
+                enableResourcePresets
+                hideClusterFormItems
+                hideResourceGroup
+                autoSelectPreset={mode === 'create'}
+              />
+            </Suspense>
           </Card>
 
           {/* --- Step 4: Review & Create --- */}
@@ -1301,11 +1426,27 @@ const DeploymentReviewSummary: React.FC<{
             {values.resourceGroup || '-'}
           </Descriptions.Item>
           <Descriptions.Item label={t('resourcePreset.ResourcePresets')}>
-            {values.resourcePresetId ? (
-              <Suspense fallback={<>{values.resourcePresetId}</>}>
+            {values.allocationPreset === 'custom' ||
+            values.allocationPreset === 'minimum-required' ? (
+              <BAIFlex direction="column" gap="xs" align="start">
+                <Typography.Text>
+                  {t('session.launcher.CustomAllocation')}
+                </Typography.Text>
+                {values.resource && (
+                  <BAIFlex
+                    direction="row"
+                    gap="xxs"
+                    style={{ flexWrap: 'wrap' }}
+                  >
+                    <ResourceNumbersOfSession resource={values.resource} />
+                  </BAIFlex>
+                )}
+              </BAIFlex>
+            ) : values.allocationPreset ? (
+              <Suspense fallback={<>{values.allocationPreset}</>}>
                 <ErrorBoundaryWithNullFallback>
                   <ResourcePresetReviewDisplay
-                    presetName={values.resourcePresetId}
+                    presetName={values.allocationPreset}
                   />
                 </ErrorBoundaryWithNullFallback>
               </Suspense>

--- a/react/src/components/DeploymentOwnerInfo.tsx
+++ b/react/src/components/DeploymentOwnerInfo.tsx
@@ -4,6 +4,7 @@
  */
 import { DeploymentOwnerInfo_deployment$key } from '../__generated__/DeploymentOwnerInfo_deployment.graphql';
 import { Tooltip, Typography } from 'antd';
+import { BAIText } from 'backend.ai-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -55,9 +56,9 @@ const DeploymentOwnerInfo: React.FC<DeploymentOwnerInfoProps> = ({
     <Tooltip
       title={<span style={{ whiteSpace: 'pre-line' }}>{tooltipLines}</span>}
     >
-      <Typography.Text ellipsis={{ tooltip: false }} style={{ maxWidth: 200 }}>
+      <BAIText ellipsis style={{ maxWidth: 200 }}>
         {email}
-      </Typography.Text>
+      </BAIText>
     </Tooltip>
   );
 };

--- a/react/src/components/DeploymentRevisionDetailDrawer.tsx
+++ b/react/src/components/DeploymentRevisionDetailDrawer.tsx
@@ -3,6 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { DeploymentRevisionDetailDrawerQuery } from '../__generated__/DeploymentRevisionDetailDrawerQuery.graphql';
+import { convertToBinaryUnit } from '../helper';
+import { useResourceSlots } from '../hooks/backendai';
 import FolderLink from './FolderLink';
 import SourceCodeView from './SourceCodeView';
 import {
@@ -18,11 +20,13 @@ import { DescriptionsItemType } from 'antd/es/descriptions';
 import { DrawerProps } from 'antd/lib';
 import {
   BAIFlex,
+  BAIResourceNumberWithIcon,
   filterOutEmpty,
   filterOutNullAndUndefined,
   toLocalId,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
+import * as _ from 'lodash-es';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
@@ -52,6 +56,16 @@ const DeploymentRevisionDetailDrawerContent: React.FC<{
           }
           resourceConfig {
             resourceGroupName
+            resourceOpts {
+              entries {
+                name
+                value
+              }
+            }
+          }
+          resourceSlots @since(version: "26.4.2") {
+            slotName
+            quantity
           }
           modelRuntimeConfig {
             runtimeVariant {
@@ -126,9 +140,18 @@ const DeploymentRevisionDetailDrawerContent: React.FC<{
     !!revision?.id &&
     !!currentRevisionId &&
     safeToLocalId(revision.id) === safeToLocalId(currentRevisionId);
+  const [resourceSlotsMeta] = useResourceSlots();
   const clusterConfig = revision?.clusterConfig;
   const resourceConfig = revision?.resourceConfig;
   const runtimeConfig = revision?.modelRuntimeConfig;
+
+  const shmem = resourceConfig?.resourceOpts?.entries?.find(
+    (e) => e.name === 'shmem',
+  )?.value;
+  const allocatedSlots = _.keyBy(
+    filterOutNullAndUndefined(revision?.resourceSlots ?? []),
+    'slotName',
+  );
   const mountConfig = revision?.modelMountConfig;
   const environEntries = runtimeConfig?.environ?.entries ?? [];
 
@@ -165,6 +188,39 @@ const DeploymentRevisionDetailDrawerContent: React.FC<{
       label: t('deployment.ResourceGroup'),
       children: resourceConfig?.resourceGroupName || renderFallback(),
     },
+    Object.keys(allocatedSlots).length > 0
+      ? {
+          key: 'resource-slots',
+          label: t('session.launcher.ResourceAllocation'),
+          children: (
+            <BAIFlex direction="row" gap="xxs" style={{ flexWrap: 'wrap' }}>
+              {_.map(allocatedSlots, ({ slotName, quantity }) => {
+                if (
+                  !resourceSlotsMeta[slotName as keyof typeof resourceSlotsMeta]
+                )
+                  return null;
+                return (
+                  <BAIResourceNumberWithIcon
+                    key={slotName}
+                    // @ts-ignore
+                    type={slotName}
+                    value={parseFloat(String(quantity)).toString()}
+                    opts={
+                      slotName === 'mem' && shmem
+                        ? {
+                            shmem:
+                              convertToBinaryUnit(shmem, '')?.number ??
+                              undefined,
+                          }
+                        : undefined
+                    }
+                  />
+                );
+              })}
+            </BAIFlex>
+          ),
+        }
+      : null,
     {
       key: 'model-folder',
       label: t('deployment.ModelFolder'),
@@ -236,7 +292,7 @@ const DeploymentRevisionDetailDrawerContent: React.FC<{
         ) : (
           renderFallback()
         ),
-      span: 2,
+      span: screens.md ? 2 : 1,
     },
   ]);
 
@@ -269,7 +325,7 @@ const DeploymentRevisionDetailDrawerContent: React.FC<{
               ) : (
                 renderFallback()
               ),
-              span: 2,
+              span: screens.md ? 2 : 1,
             },
             {
               key: `model-port-${idx}`,

--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -27,6 +27,7 @@ import {
   BAINameActionCell,
   BAITable,
   BAITag,
+  BAIText,
   BAIUnmountAfterClose,
   type GraphQLFilter,
   filterOutNullAndUndefined,
@@ -422,13 +423,13 @@ const DeploymentRevisionHistoryTab: React.FC<
         const canonicalName = record.imageV2?.identity?.canonicalName;
         if (!canonicalName) return '-';
         return (
-          <Typography.Text
+          <BAIText
             copyable={{ text: canonicalName }}
-            ellipsis={{ tooltip: canonicalName }}
+            ellipsis={{ tooltip: true }}
             style={{ maxWidth: 240 }}
           >
             {canonicalName}
-          </Typography.Text>
+          </BAIText>
         );
       },
     },

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -88,6 +88,10 @@ interface ResourceAllocationFormItemsProps {
   showRemainingWarning?: boolean;
   forceImageMinValues?: boolean;
   hideClusterFormItems?: boolean;
+  hideResourceGroup?: boolean;
+  /** When false, suppresses the auto-select-preset behaviour on mount.
+   *  Pass false in edit mode so a pre-filled allocationPreset is not overwritten. */
+  autoSelectPreset?: boolean;
   extraAcceleratorRules?: Array<{
     warningOnly?: boolean;
     validator: (rule: unknown, value: number) => Promise<void>;
@@ -102,6 +106,8 @@ const ResourceAllocationFormItems: React.FC<
   forceImageMinValues = false,
   showRemainingWarning = false,
   hideClusterFormItems = false,
+  hideResourceGroup = false,
+  autoSelectPreset = true,
   extraAcceleratorRules,
 }) => {
   const form = Form.useFormInstance<MergedResourceAllocationFormValue>();
@@ -224,6 +230,7 @@ const ResourceAllocationFormItems: React.FC<
 
   useEffect(() => {
     if (
+      autoSelectPreset &&
       !currentResourceValue &&
       form.getFieldValue('allocationPreset') !== 'custom'
     ) {
@@ -238,7 +245,12 @@ const ResourceAllocationFormItems: React.FC<
         },
       });
     }
-  }, [supportedAcceleratorTypesInRGByImage, form, currentResourceValue]);
+  }, [
+    supportedAcceleratorTypesInRGByImage,
+    form,
+    currentResourceValue,
+    autoSelectPreset,
+  ]);
 
   const allocatablePresetNames = useMemo(() => {
     return getAllocatablePresetNames(
@@ -523,20 +535,22 @@ const ResourceAllocationFormItems: React.FC<
 
   return (
     <>
-      <Form.Item
-        name="resourceGroup"
-        label={t('session.ResourceGroup')}
-        rules={[
-          {
-            required: true,
-          },
-        ]}
-      >
-        <BAIProjectResourceGroupSelect
-          projectName={currentProject.name}
-          showSearch
-        />
-      </Form.Item>
+      {!hideResourceGroup && (
+        <Form.Item
+          name="resourceGroup"
+          label={t('session.ResourceGroup')}
+          rules={[
+            {
+              required: true,
+            },
+          ]}
+        >
+          <BAIProjectResourceGroupSelect
+            projectName={currentProject.name}
+            showSearch
+          />
+        </Form.Item>
+      )}
 
       {enableResourcePresets ? (
         <Form.Item

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -20,6 +20,7 @@ import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
+import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 
 const DeploymentDetailPage: React.FC = () => {
   'use memo';
@@ -132,23 +133,27 @@ const DeploymentDetailPage: React.FC = () => {
           },
         ]}
       >
-        <div hidden={activeTab !== 'replicas'}>
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentReplicasTab
-              deploymentFrgmt={deployment}
-              deploymentId={toGlobalId('ModelDeployment', deploymentId)}
-            />
-          </Suspense>
-        </div>
-        <div hidden={activeTab !== 'revisions'}>
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentRevisionHistoryTab
-              deploymentFrgmt={deployment}
-              deploymentId={toGlobalId('ModelDeployment', deploymentId)}
-              isDeploymentDestroying={isDeploymentDestroying}
-            />
-          </Suspense>
-        </div>
+        {activeTab === 'replicas' && (
+          <BAIErrorBoundary>
+            <Suspense fallback={<Skeleton active />}>
+              <DeploymentReplicasTab
+                deploymentFrgmt={deployment}
+                deploymentId={toGlobalId('ModelDeployment', deploymentId)}
+              />
+            </Suspense>
+          </BAIErrorBoundary>
+        )}
+        {activeTab === 'revisions' && (
+          <BAIErrorBoundary>
+            <Suspense fallback={<Skeleton active />}>
+              <DeploymentRevisionHistoryTab
+                deploymentFrgmt={deployment}
+                deploymentId={toGlobalId('ModelDeployment', deploymentId)}
+                isDeploymentDestroying={isDeploymentDestroying}
+              />
+            </Suspense>
+          </BAIErrorBoundary>
+        )}
       </BAICard>
       <DeploymentAutoScalingTab deploymentFrgmt={deployment} />
       <DeploymentAccessTokensTab

--- a/react/src/pages/DeploymentLauncherPage.tsx
+++ b/react/src/pages/DeploymentLauncherPage.tsx
@@ -298,10 +298,32 @@ const DeploymentLauncherPageLayout: React.FC<
     targetDeploymentId: string,
     imageId: string,
   ): Promise<void> => {
-    const preset = resource_presets?.find(
-      (p) => p?.name === values.resourcePresetId,
-    );
-    const entries = parseResourceSlotEntries(preset?.resource_slots ?? null);
+    const isCustomAllocation =
+      values.allocationPreset === 'custom' ||
+      values.allocationPreset === 'minimum-required';
+    const entries = isCustomAllocation
+      ? (() => {
+          const r = values.resource;
+          const slots: Array<{ resourceType: string; quantity: string }> = [];
+          if (r?.cpu !== undefined)
+            slots.push({ resourceType: 'cpu', quantity: String(r.cpu) });
+          if (r?.mem !== undefined)
+            slots.push({ resourceType: 'mem', quantity: String(r.mem) });
+          if (
+            r?.accelerator !== undefined &&
+            r.accelerator > 0 &&
+            r.acceleratorType
+          )
+            slots.push({
+              resourceType: r.acceleratorType,
+              quantity: String(r.accelerator),
+            });
+          return slots;
+        })()
+      : parseResourceSlotEntries(
+          resource_presets?.find((p) => p?.name === values.allocationPreset)
+            ?.resource_slots ?? null,
+        );
 
     // Resolve runtimeVariantId: prefer value stored in form (edit pre-fill),
     // fall back to decoding the Strawberry global id from the runtimeVariants
@@ -403,6 +425,16 @@ const DeploymentLauncherPageLayout: React.FC<
             resourceConfig: {
               resourceGroup: { name: values.resourceGroup },
               resourceSlots: { entries },
+              resourceOpts:
+                isCustomAllocation &&
+                values.resource?.shmem &&
+                !values.enabledAutomaticShmem
+                  ? {
+                      entries: [
+                        { name: 'shmem', value: values.resource.shmem },
+                      ],
+                    }
+                  : null,
             },
             image: { id: decodedImageId },
             modelRuntimeConfig: {
@@ -641,6 +673,7 @@ const DeploymentLauncherPageLayout: React.FC<
         form={form}
         deploymentFrgmt={deploymentFrgmt}
         runtimeVariants={runtimeVariantList}
+        resourcePresets={resource_presets ?? undefined}
         onSubmit={handleSubmit}
         isSubmitting={isSubmitting}
         serializerRef={serializerRef}

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -25,7 +25,6 @@ import {
   populateRouterPaths,
 } from './hooks/useWebUIMenuItems';
 import { pluginApiEndpointState } from './hooks/useWebUIPluginState';
-// High priority to import the component
 import ComputeSessionListPage from './pages/ComputeSessionListPage';
 import Page404 from './pages/Page404';
 import VFolderNodeListPage from './pages/VFolderNodeListPage';
@@ -316,9 +315,11 @@ export const mainLayoutChildRoutes: RouteObject[] = [
         path: ':deploymentId',
         handle: { labelKey: 'modelService.RoutingInfo' },
         element: (
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentDetailPage />
-          </Suspense>
+          <BAIErrorBoundary>
+            <Suspense fallback={<Skeleton active />}>
+              <DeploymentDetailPage />
+            </Suspense>
+          </BAIErrorBoundary>
         ),
       },
       {


### PR DESCRIPTION
Resolves #7226 ([FR-2802](https://lablup.atlassian.net/browse/FR-2802))

## Summary

**Core fix — custom resource allocation in deployment launcher (**FR-2802**):**

- Pass `showCustom` and `showMinimumRequired` props (gated by `baiClient._config.allowCustomResourceAllocation`) to `ResourcePresetSelect` in `DeploymentLauncherPageContent`.
- When the user picks `'custom'`, render `ResourceAllocationFormItems` (with new `hideResourceGroup` prop to avoid the duplicate resource-group field) so CPU / memory / shmem / accelerator can be set directly.
- On submit, `DeploymentLauncherPage` builds `resourceSlots.entries` from the form values when allocation is custom, and forwards `resourceOpts.shmem` when the user opted out of automatic shmem.
- Reorder launcher fields so `DesiredReplicas` appears before resource group, matching the session launcher.

**Edit-mode preset detection:**

- New `resolveEditModeResourcePreset` helper compares a revision's `resourceSlots` (and `resourceOpts.shmem`) against the available presets and either selects the matching preset or marks the form as `'custom'` and reconstructs `resource.{cpu, mem, shmem, accelerator, acceleratorType}`.
- Query `revision.resourceSlots` and `resourceOpts.entries` to support the comparison.
- When the revision has no `resourceSlots` data (e.g. `currentRevision` is null), fall back to `allocationPreset: 'custom'` so the launcher does not silently overwrite the field with `'auto-select'`.
- Replaces the previous `TODO(needs-backend): FR-2787` placeholder.

**Edit-mode auto-select gating:**

- New `autoSelectPreset?: boolean` prop on `ResourceAllocationFormItems`. The mount-time effect that flips `allocationPreset` to `'auto-select'` only runs when `autoSelectPreset === true`. The launcher passes `autoSelectPreset={mode === 'create'}` so a pre-filled preset is not clobbered on first render (where `Form.useWatch(['resource'])` returns `undefined`).
- `BAIProjectResourceGroupSelect` is now invoked with `autoSelectDefault={mode === 'create'}` from the deployment launcher, so edit mode keeps the resource group already attached to the deployment instead of snapping to `'default'`.

**Revision detail display:**

- `DeploymentRevisionDetailDrawer` now renders allocated slots with `BAIResourceNumberWithIcon` and surfaces shmem from `resourceOpts`. Descriptions span adapts to viewport (`screens.md ? 2 : 1`).

**Robustness:**

- Wrap `DeploymentDetailPage` and each tab (`replicas`, `revisions`) in `BAIErrorBoundary`; switch from `hidden` div to conditional mounting so a failing tab does not blank out the whole page.

**Drive-by cleanup:**

- Migrate `DeploymentOwnerInfo` and `DeploymentRevisionHistoryTab` from `Typography.Text` to `BAIText`.
- `BAIText`: add `'use memo'` and narrow the `useEffect` deps to avoid re-running the overflow check on every children change.

## Test plan

- [ ] Create deployment with `allowCustomResourceAllocation = true` → custom option appears, allocation form renders, deployment succeeds with custom slots.
- [ ] Create deployment with `allowCustomResourceAllocation = false` → only preset list shown, no custom option.
- [ ] Edit deployment whose revision matches a known preset → preset is auto-selected; resource group stays as the deployment's actual group (no flicker to `default`).
- [ ] Edit deployment whose revision does not match any preset → form shows `custom` with the original CPU/mem/shmem/accelerator values.
- [ ] Edit deployment whose `currentRevision` is null → form shows `custom` with empty allocation; no false `auto-select` flip.
- [ ] Force a tab error (e.g. malformed revision data) → `BAIErrorBoundary` catches it, other tab still works.
- [ ] Open revision detail drawer → resource slots and shmem render correctly.

[FR-2802]: https://lablup.atlassian.net/browse/FR-2802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ