### PR TITLE
fix(FR-2805): correct tab key and use URLSearchParams in deployment preset navigation

### DIFF
--- a/react/src/pages/AdminDeploymentPresetSettingPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetSettingPage.tsx
@@ -203,8 +203,14 @@ const AdminDeploymentPresetSettingPage: React.FC = () => {
       `,
     );
 
-  const navigateToList = () =>
-    webuiNavigate('/admin-deployments?tab=deployment-preset');
+  const navigateToList = () => {
+    const params = new URLSearchParams();
+    params.set('tab', 'deployment-presets');
+    webuiNavigate({
+      pathname: '/admin-deployments',
+      search: params.toString(),
+    });
+  };
 
   const handleSubmit = async () => {
     // validateFields() triggers field-level validation (shows error messages).


### PR DESCRIPTION
Resolves #7232 ([FR-2805](https://lablup.atlassian.net/browse/FR-2805))

## Summary
- Fix typo in the tab query parameter when navigating back from `AdminDeploymentPresetSettingPage` (`deployment-preset` → `deployment-presets`), which is the key actually registered in `AdminDeploymentListPage`.
- Build the navigation URL with `URLSearchParams` instead of string concatenation for safer query handling.

## Test plan
- [ ] Create a deployment preset → after save, the list page opens on the **Deployment Presets** tab.
- [ ] Edit a deployment preset → after save, the list page opens on the **Deployment Presets** tab.

[FR-2805]: https://lablup.atlassian.net/browse/FR-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ