### PR TITLE
fix(FR-2807): prevent BAILink ellipsis crash and isolate DeploymentDetailPage tab errors

### DIFF
--- a/packages/backend.ai-ui/src/components/BAILink.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.stories.tsx
@@ -1,5 +1,6 @@
 import BAIFlex from './BAIFlex';
 import BAILink from './BAILink';
+import BAIText from './BAIText';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -18,7 +19,15 @@ const meta: Meta<typeof BAILink> = {
 - Uses React Router \`Link\` when \`to\` prop is provided
 - Falls back to Ant Design \`Typography.Link\` when \`to\` is not provided
 - Custom hover and disabled states
-- Ellipsis with tooltip support
+- Ellipsis with tooltip support via \`BAIText\` (CSS-based, no layout-loop risk)
+
+## Ellipsis Behavior
+When \`ellipsis\` is provided, the content is wrapped by \`BAIText\` internally:
+- \`ellipsis={true}\` — CSS truncation + tooltip showing full text on overflow
+- \`ellipsis={{ tooltip: 'custom' }}\` — CSS truncation + custom tooltip text
+
+This avoids antd's JS-based \`EllipsisMeasure\` component, which can cause infinite
+render loops when nested inside flex containers with \`ResizeObserver\`.
 
 ## BAI-Specific Props
 | Prop | Type | Default | Description |
@@ -50,7 +59,8 @@ For other props, refer to [React Router Link](https://reactrouter.com/en/main/co
     },
     ellipsis: {
       control: false,
-      description: 'Enable text ellipsis with optional tooltip',
+      description:
+        'Enable text ellipsis with optional tooltip. Internally uses BAIText for CSS-based truncation.',
       table: {
         type: { summary: 'boolean | { tooltip?: string }' },
       },
@@ -118,30 +128,130 @@ export const WithEllipsis: Story = {
   parameters: {
     docs: {
       description: {
-        story:
-          'Long text can be truncated with ellipsis. Add `tooltip` property to show full text on hover.',
+        story: `Long text is truncated via CSS ellipsis (no layout-loop risk).
+\`ellipsis={true}\` shows the full text as a tooltip on overflow.
+Hover over the truncated links below to see the tooltip.`,
       },
     },
   },
   render: () => (
     <BAIFlex direction="column" gap="md">
-      <BAIFlex direction="column" gap="xs" style={{ width: '200px' }}>
-        <strong>Ellipsis without tooltip</strong>
+      <BAIFlex direction="column" gap="xs">
+        <strong>ellipsis (boolean) — tooltip on overflow</strong>
+        <div style={{ width: 200 }}>
+          <BAILink ellipsis>
+            This is a very long link text that will be truncated with ellipsis
+          </BAILink>
+        </div>
+      </BAIFlex>
+      <BAIFlex direction="column" gap="xs">
+        <strong>ellipsis with custom tooltip</strong>
+        <div style={{ width: 200 }}>
+          <BAILink ellipsis={{ tooltip: 'Full text shown here as tooltip' }}>
+            This is a very long link text that will be truncated with ellipsis
+          </BAILink>
+        </div>
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+export const EllipsisInsideBAIText: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `\`BAILink ellipsis\` nested inside \`BAIText ellipsis\` — as used in \`BAINameActionCell\`.
+
+Both components are CSS-based and do not conflict. The outer \`BAIText\`'s overflow check
+(\`scrollWidth > clientWidth\` on its span) returns false because the inner \`BAIText\`
+constrains itself to \`maxWidth: 100%\` of the outer span — so the outer span sees no overflow.
+Only the inner \`BAIText\`'s \`ResizeObserver\` detects overflow and shows the tooltip.
+
+Result: a single tooltip with the plain text content (not a React element). Hover to confirm.`,
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md">
+      <BAIFlex direction="column" gap="xs" style={{ width: 240 }}>
+        <strong>Overflow (truncated) — single tooltip</strong>
+        <BAIText ellipsis={{ tooltip: true }}>
+          <BAILink type="hover" ellipsis>
+            very-long-revision-name-abc123def456ghi789
+          </BAILink>
+        </BAIText>
+      </BAIFlex>
+      <BAIFlex direction="column" gap="xs" style={{ width: 240 }}>
+        <strong>No overflow (short text)</strong>
+        <BAIText ellipsis={{ tooltip: true }}>
+          <BAILink type="hover" ellipsis>
+            rev-001
+          </BAILink>
+        </BAIText>
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+export const EllipsisInsideBAITextTooltipDiff: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `Tooltip content difference: \`BAILink\` with vs. without \`ellipsis\` inside \`BAIText ellipsis\`.
+
+- **With \`ellipsis\` on \`BAILink\`**: inner \`BAIText\` handles overflow; tooltip title = plain text string (clean).
+- **Without \`ellipsis\` on \`BAILink\`**: outer \`BAIText\` handles overflow; tooltip title = \`BAILink\` ReactNode (renders with link styling inside the tooltip popup).
+
+Both show a single tooltip — the difference is only in what the tooltip renders as its title.`,
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md">
+      <BAIFlex direction="column" gap="xs" style={{ width: 240 }}>
+        <strong>BAILink with ellipsis — tooltip is plain text</strong>
+        <BAIText ellipsis={{ tooltip: true }}>
+          <BAILink type="hover" ellipsis>
+            very-long-revision-name-abc123def456ghi789
+          </BAILink>
+        </BAIText>
+      </BAIFlex>
+      <BAIFlex direction="column" gap="xs" style={{ width: 240 }}>
+        <strong>BAILink without ellipsis — tooltip is ReactNode (link)</strong>
+        <BAIText ellipsis={{ tooltip: true }}>
+          <BAILink type="hover">
+            very-long-revision-name-abc123def456ghi789
+          </BAILink>
+        </BAIText>
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+export const EllipsisTrueBehavior: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `\`ellipsis={true}\` now normalizes to \`{ tooltip: true }\` internally.
+
+Previously (before this fix), \`ellipsis={true}\` delegated to antd's \`Typography.Link\`
+which used JS-based \`EllipsisMeasure\` — no tooltip, and caused infinite render loops
+when nested inside a \`ResizeObserver\`-powered container.
+
+Now it uses CSS-based truncation via \`BAIText\` and shows a tooltip on overflow.
+Hover over the truncated link below to confirm.`,
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="xs">
+      <strong>ellipsis={'{true}'} — tooltip appears on overflow</strong>
+      <div style={{ width: 240 }}>
         <BAILink ellipsis>
-          This is a very long link text that will be truncated with ellipsis
+          This is a very long link text that will be truncated with ellipsis and
+          show a tooltip
         </BAILink>
-      </BAIFlex>
-      <BAIFlex direction="column" gap="xs" style={{ width: '200px' }}>
-        <strong>Ellipsis with tooltip</strong>
-        <BAILink
-          ellipsis={{
-            tooltip:
-              'This is a very long link text that will be truncated with ellipsis',
-          }}
-        >
-          This is a very long link text that will be truncated with ellipsis
-        </BAILink>
-      </BAIFlex>
+      </div>
     </BAIFlex>
   ),
 };

--- a/packages/backend.ai-ui/src/components/BAILink.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.tsx
@@ -1,3 +1,4 @@
+import BAIText from './BAIText';
 import { theme, Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import React from 'react';
@@ -37,40 +38,41 @@ const BAILink: React.FC<BAILinkProps> = ({
 }) => {
   const { styles } = useStyles();
   const { token } = theme.useToken();
-  return type !== 'disabled' && to ? (
-    <Link
-      className={type ? styles?.[type] : undefined}
-      to={to}
-      {...linkProps}
-      style={{ fontFamily: token.fontFamily, ...linkProps.style }}
-    >
-      {children}
-      {icon}
-    </Link>
-  ) : (
+  if (type !== 'disabled' && to) {
+    return (
+      <Link
+        className={type ? styles?.[type] : undefined}
+        to={to}
+        {...linkProps}
+        style={{ fontFamily: token.fontFamily, ...linkProps.style }}
+      >
+        {children}
+        {icon}
+      </Link>
+    );
+  }
+
+  const link = (
     <Typography.Link
       className={type ? styles?.[type] : undefined}
       onClick={linkProps.onClick}
       disabled={type === 'disabled'}
-      ellipsis={!!ellipsis}
       {...linkProps}
     >
-      {typeof ellipsis === 'object' && ellipsis.tooltip ? (
-        <Typography.Text
-          className={type ? styles?.[type] : undefined}
-          ellipsis={ellipsis}
-        >
-          {children}
-          {icon}
-        </Typography.Text>
-      ) : (
-        <>
-          {children}
-          {icon}
-        </>
-      )}
+      {children}
+      {icon}
     </Typography.Link>
   );
+
+  if (ellipsis) {
+    return (
+      <BAIText ellipsis={ellipsis === true ? { tooltip: true } : ellipsis}>
+        {link}
+      </BAIText>
+    );
+  }
+
+  return link;
 };
 
 export default BAILink;

--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -22,14 +22,12 @@ function resolveTooltipProps(
 
   const { tooltip } = ellipsis;
   if (tooltip === true) return { title: children };
-  if (
-    tooltip &&
-    typeof tooltip === 'object' &&
-    !React.isValidElement(tooltip)
-  ) {
+  if (!tooltip) return null;
+  if (typeof tooltip === 'object' && !React.isValidElement(tooltip)) {
     return { title: children, ...(tooltip as TooltipProps) };
   }
-  return null;
+  // string or ReactNode — use directly as tooltip title
+  return { title: tooltip as ReactNode };
 }
 
 const BAIText: React.FC<BAITextProps> = ({

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -20,6 +20,7 @@ import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
+import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 
 const DeploymentDetailPage: React.FC = () => {
   'use memo';
@@ -132,23 +133,27 @@ const DeploymentDetailPage: React.FC = () => {
           },
         ]}
       >
-        <div hidden={activeTab !== 'replicas'}>
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentReplicasTab
-              deploymentFrgmt={deployment}
-              deploymentId={toGlobalId('ModelDeployment', deploymentId)}
-            />
-          </Suspense>
-        </div>
-        <div hidden={activeTab !== 'revisions'}>
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentRevisionHistoryTab
-              deploymentFrgmt={deployment}
-              deploymentId={toGlobalId('ModelDeployment', deploymentId)}
-              isDeploymentDestroying={isDeploymentDestroying}
-            />
-          </Suspense>
-        </div>
+        {activeTab === 'replicas' && (
+          <BAIErrorBoundary>
+            <Suspense fallback={<Skeleton active />}>
+              <DeploymentReplicasTab
+                deploymentFrgmt={deployment}
+                deploymentId={toGlobalId('ModelDeployment', deploymentId)}
+              />
+            </Suspense>
+          </BAIErrorBoundary>
+        )}
+        {activeTab === 'revisions' && (
+          <BAIErrorBoundary>
+            <Suspense fallback={<Skeleton active />}>
+              <DeploymentRevisionHistoryTab
+                deploymentFrgmt={deployment}
+                deploymentId={toGlobalId('ModelDeployment', deploymentId)}
+                isDeploymentDestroying={isDeploymentDestroying}
+              />
+            </Suspense>
+          </BAIErrorBoundary>
+        )}
       </BAICard>
       <DeploymentAutoScalingTab deploymentFrgmt={deployment} />
       <DeploymentAccessTokensTab


### PR DESCRIPTION
Resolves #7235 ([FR-2807](https://lablup.atlassian.net/browse/FR-2807))

## Summary

### BAILink: replace antd `EllipsisMeasure` with CSS-based ellipsis

- `BAILink` previously passed `ellipsis={!!ellipsis}` directly to antd's `Typography.Link`, which activates the internal `EllipsisMeasure` component
- `EllipsisMeasure` performs JS binary-search truncation via `useLayoutEffect` + `setState`; when nested inside `BAIText` (which uses `ResizeObserver`), each binary-search DOM layout change fires the `ResizeObserver` → `setState` → re-render → `EllipsisMeasure` restarts → infinite loop → "Maximum update depth exceeded" crash
- Fix: when `ellipsis` prop is provided, wrap children with `BAIText` instead of delegating to antd's JS ellipsis — `BAIText` uses CSS-based truncation + tooltip that is loop-free
- `ellipsis={true}` is normalized to `{ tooltip: true }` so tooltip-on-overflow behavior is preserved
- No call-site changes required; existing `<BAILink ellipsis>` usage continues to work

### DeploymentDetailPage: isolate tab errors and avoid mounting inactive tabs

- Tab content was rendered with `<div hidden={activeTab !== '…'}>`, which keeps both tabs mounted simultaneously — a crash inside one tab (e.g. the BAILink loop above) would tear down the whole page
- Switched to conditional rendering (`activeTab === '…' && …`) so only the active tab mounts, and wrapped each tab in `BAIErrorBoundary` so a future failure inside one tab no longer affects the rest of the page

[FR-2807]: https://lablup.atlassian.net/browse/FR-2807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ