### PR TITLE
feat(FR-2806): auto-fill login API endpoint from VITE_DEFAULT_API_ENDPOINT in dev

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -9,14 +9,17 @@ description: >
   server's header reflects this Claude session's color. When `/rename <name>`
   is visible, slugify the name and pass it as PORTLESS_APP_NAME so the dev
   URL reflects the session name (falls back to FR-XXXX from the branch, then
-  to the current PR number).
+  to the current PR number). When the current branch's PR description names
+  a backend test server (bare IP, `host:port`, or full URL), set
+  VITE_DEFAULT_API_ENDPOINT so the login screen pre-fills that endpoint and
+  any stale session targeting a different backend is logged out.
   Trigger on: "start dev server", "run dev", "pnpm dev 띄워", "개발 서버 띄워",
   "dev 서버 시작", "boot the dev environment", "실행해줘 dev".
 ---
 
 # Dev Server
 
-Starts the dev server with optional `VITE_THEME_HEADER_COLOR` and `PORTLESS_APP_NAME` derived from this Claude Code session's `/color` and `/rename` history.
+Starts the dev server with optional `VITE_THEME_HEADER_COLOR`, `PORTLESS_APP_NAME`, and `VITE_DEFAULT_API_ENDPOINT` derived from this Claude Code session's `/color` / `/rename` history and the current branch's PR description.
 
 ## 1. Decide the command
 
@@ -88,6 +91,65 @@ Do not invent additional names or alternate hex values. If the user's `/color` a
 
 **Detecting `/rename` in history**: scan the current conversation for `<command-name>/rename</command-name>` blocks. Take the **most recent** one whose `<local-command-stdout>` does not look like an error (e.g. doesn't start with `Error` / `Invalid`). Use `<command-args>` as the raw input to the slug rules.
 
+## 2c. Decide the default API endpoint (webui only)
+
+`react/src/components/LoginView.tsx` reads `VITE_DEFAULT_API_ENDPOINT` (only when `import.meta.env.DEV` is true) and:
+
+- pre-fills the login form's API endpoint with that value, **overriding** any value in `localStorage.backendaiwebui.api_endpoint` and any `api_endpoint` baked into `config.toml`;
+- when an existing in-memory session targets a different backend, logs that session out and shows the login panel instead of attempting silent re-login.
+
+This skill auto-derives the value from the current branch's PR description so dev sessions land on the right per-PR backend without the user re-typing the endpoint on every cold start. Pick a value with this priority:
+
+1. **User explicitly named an endpoint in the prompt or in conversation** (e.g. "use 10.0.1.5 as the test server", "use https://api.staging.lablup.ai") — honor that and convert per the rules below.
+2. **Most recent open PR for the current branch** — fetch the PR body and scan it.
+   ```bash
+   gh pr view --json body -q '.body' 2>/dev/null
+   ```
+   Skip silently when the branch has no PR.
+3. **None of the above** — omit the env var. Do **not** invent a default endpoint.
+
+**Conversion rules** (apply to the candidate string before passing as `VITE_DEFAULT_API_ENDPOINT`):
+
+| Input | Output |
+|---|---|
+| `10.0.1.5` (bare IPv4) | `http://10.0.1.5:8090` |
+| `10.0.1.5:9090` (bare `host:port`) | `http://10.0.1.5:9090` |
+| `manager.example.com` (bare hostname) | `http://manager.example.com:8090` |
+| `manager.example.com:9090` | `http://manager.example.com:9090` |
+| `http://...` / `https://...` (full URL) | use as-is, with any trailing `/` stripped |
+
+The bare-IP-defaults-to-`8090` rule reflects the project convention that PR descriptions usually list just an IP and the WebUI talks to the manager on `:8090`.
+
+**Scanning the PR body** — do this in two passes, top-to-bottom, taking the **first** valid candidate:
+
+**Pass 1 (preferred): contextual match.** Scan only lines that look like they're naming a backend, i.e. the line contains one of these markers (case-insensitive): `test server`, `test backend`, `manager`, `api endpoint`, `endpoint`, `target server`, `dev server` (when adjacent to an address), or the line lives under a heading whose text contains `Backend`, `Test`, `Server`, or `Endpoint`. On those lines, run the address regex below.
+
+**Pass 2 (fallback): full-body match.** Only if Pass 1 found nothing, run the same regex against the whole body.
+
+**Address regex** (apply per pass):
+
+```
+(https?:\/\/)?(\b(?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[01]?\d?\d)){3}\b|[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,})(?::(\d{1,5}))?(?:\/[^\s)]*)?
+```
+
+The IPv4 alternative is octet-bounded (rejects `999.999.999.999` and other invalid quads) but still matches version-shaped strings like `1.2.3.4` — Pass 1's contextual filter is what keeps version numbers in changelogs from being adopted. The hostname alternative accepts both 2-label hosts (`example.com`, `manager.com`) and longer ones (`api.staging.example.com`) — TLD is the trailing `[a-z]{2,}` segment.
+
+**Reject the following candidates** even if the regex matches them (apply *after* matching, *before* converting):
+
+- **Documentation / source-control hosts**: any host equal to or ending in `github.com`, `gitlab.com`, `bitbucket.org`, `lablup.atlassian.net`, `readthedocs.io`, or any host starting with `docs.`. These are referenced from PR bodies all the time and are never the dev backend.
+- **Filename-shaped tails**: if the matched candidate's last segment (after the final `.`, before any `:port` or `/path`) is in this denylist, drop it: `ts | tsx | js | jsx | mjs | cjs | md | mdx | py | rs | go | json | yaml | yml | toml | html | htm | css | scss | svg | png | jpg | jpeg | gif | webp | sh | lock | txt | log`. Catches `app.test.ts`, `README.md`, `package-lock.json`, etc.
+- **Loopback / link-local IPs**: `127.0.0.1`, `0.0.0.0`, `169.254.*.*` — these are almost never the dev backend a PR is targeting; treat as a false match.
+
+If the matched candidate is rejected, keep scanning (within the same pass) for the next candidate. If a pass finishes with all candidates rejected, fall through to the next pass; if both passes finish with no usable candidate, omit `VITE_DEFAULT_API_ENDPOINT`.
+
+**Announce what you did.** When you start the dev server, briefly say which source the endpoint came from and — if you considered and rejected one — what you skipped. Example:
+
+> `VITE_DEFAULT_API_ENDPOINT=http://10.0.1.5:8090` from PR #1234 description (skipped `docs.backend.ai` and `package-lock.json` mentions before it).
+
+Silent misconfiguration is the worst failure mode here — it sends the dev session to the wrong backend without anyone noticing.
+
+If the resolved value matches the existing default backend the WebUI would otherwise use (i.e. it has no effect), still pass it — being explicit avoids the auto-logout silently disagreeing with the form on edge cases.
+
 ## 3. Compose the run
 
 **Default: no env vars.** If you cannot resolve a color from step 2a (no `/color` in history, or the most recent was `default`, or anything ambiguous), run the command with **no `VITE_THEME_HEADER_COLOR` prefix at all**. Do not invent a color, do not pick a "neutral" default, do not pass an empty string. Just omit the env var. Same goes for `PORTLESS_APP_NAME` from step 2b.
@@ -103,11 +165,13 @@ Do not invent additional names or alternate hex values. If the user's `/color` a
 
 If step **2b** picked a Portless app name from `/rename` or a PR number, also prefix `PORTLESS_APP_NAME='<slug>'`. If 2b selected the FR-XXXX branch fallback (option 2) or "none" (option 4), **omit** `PORTLESS_APP_NAME` — `dev.mjs` handles those itself.
 
+If step **2c** resolved a default API endpoint, also prefix `VITE_DEFAULT_API_ENDPOINT='<url>'`. If 2c resolved nothing, **omit** the variable entirely — do not pass an empty string.
+
 ```bash
-VITE_THEME_HEADER_COLOR='#2563EB' PORTLESS_APP_NAME='iphoto-disk-cleanup' pnpm dev
+VITE_THEME_HEADER_COLOR='#2563EB' PORTLESS_APP_NAME='iphoto-disk-cleanup' VITE_DEFAULT_API_ENDPOINT='http://10.0.1.5:8090' pnpm dev
 ```
 
-For non-webui projects, substitute the discovered command and package manager. Use whatever color env var the project actually reads (check `vite.config.*`, `next.config.*`, etc., or grep for `*THEME_HEADER_COLOR` / `*_THEME_COLOR`). Apply the prefix only when (a) a color is actually resolved AND (b) the project really consumes that env var. If either is false, skip the prefix. `PORTLESS_APP_NAME` is webui-specific.
+For non-webui projects, substitute the discovered command and package manager. Use whatever color env var the project actually reads (check `vite.config.*`, `next.config.*`, etc., or grep for `*THEME_HEADER_COLOR` / `*_THEME_COLOR`). Apply the prefix only when (a) a color is actually resolved AND (b) the project really consumes that env var. If either is false, skip the prefix. `PORTLESS_APP_NAME` and `VITE_DEFAULT_API_ENDPOINT` are webui-specific.
 
 ## 4. Run it
 
@@ -144,10 +208,11 @@ Many projects don't use Portless. Read the dev server's stdout for whatever URL(
 
 ## 6. Edge cases
 
-- **User overrides via env (webui)**: Vite's `loadEnv()` reads `VITE_THEME_HEADER_COLOR` from `.env.development.local` and from the shell automatically. If the user already has it set, do not override — the user-set value wins. For `PORTLESS_APP_NAME`, the same rule applies: if it's already exported in the inherited env, treat the user-set value as authoritative.
-- **User overrides via prompt**: if the user says "use a green header" or "no color this time" or "name the dev URL <foo>", honor their words over the conversation-history values.
-- **Multiple Claude windows / worktrees**: each Claude Code session has its own conversation, so both color and app name are naturally session-scoped. Don't try to read either from disk — there's no shared state (built-in `/color` and `/rename` are in-memory only).
+- **User overrides via env (webui)**: Vite's `loadEnv()` reads `VITE_THEME_HEADER_COLOR`, `VITE_DEFAULT_API_ENDPOINT` from `.env.development.local` and from the shell automatically. If the user already has any of them set, do not override — the user-set value wins. For `PORTLESS_APP_NAME`, the same rule applies: if it's already exported in the inherited env, treat the user-set value as authoritative.
+- **User overrides via prompt**: if the user says "use a green header" or "no color this time" or "name the dev URL <foo>" or "ignore the PR's IP, use 10.0.0.7 instead", honor their words over the conversation-history and PR-description values.
+- **Multiple Claude windows / worktrees**: each Claude Code session has its own conversation, so both color and app name are naturally session-scoped. Don't try to read either from disk — there's no shared state (built-in `/color` and `/rename` are in-memory only). For `VITE_DEFAULT_API_ENDPOINT`, the *PR* is the shared source of truth; reading it via `gh pr view` works the same from any worktree on that branch.
 - **No `/color` in history but user mentioned a color**: treat the user's mention as the source of truth. If they said "use orange", map `orange` → `#EA580C` and prefix accordingly.
+- **PR description mentions multiple addresses or none**: take the **first** match for the multi-match case; for the no-match case, omit `VITE_DEFAULT_API_ENDPOINT` rather than guessing. The login form will fall back to `localStorage` / `config.toml` like before.
 
 ## 7. Out of scope
 

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -58,6 +58,26 @@ const extractErrorType = (typeUrl?: string): string => {
   return parts[parts.length - 1] || '';
 };
 
+/**
+ * Dev-only override for the API endpoint shown on the login screen.
+ *
+ * Set `VITE_DEFAULT_API_ENDPOINT` to a full URL (e.g. `http://1.2.3.4:8090`)
+ * to pre-fill the login endpoint field and skip silent re-login when a
+ * stale session targets a different backend. The dev-server skill derives
+ * this value from the current branch's PR description automatically; see
+ * `.claude/skills/dev-server/SKILL.md`.
+ *
+ * Production builds (`import.meta.env.DEV === false`) ignore the variable.
+ */
+const devApiEndpointOverride: string | undefined =
+  import.meta.env.DEV &&
+  typeof import.meta.env.VITE_DEFAULT_API_ENDPOINT === 'string' &&
+  import.meta.env.VITE_DEFAULT_API_ENDPOINT.trim() !== ''
+    ? import.meta.env.VITE_DEFAULT_API_ENDPOINT.trim().replace(/\/+$/, '')
+    : undefined;
+
+const STORED_API_ENDPOINT_KEY = 'backendaiwebui.api_endpoint';
+
 const LoginView: React.FC<{
   /**
    * When true, delays closing the login panel until MainLayout signals
@@ -101,9 +121,20 @@ const LoginView: React.FC<{
   const [connectionMode, setConnectionMode] =
     useState<ConnectionMode>('SESSION');
   const [apiEndpoint, setApiEndpoint] = useState(() => {
-    const stored = localStorage.getItem('backendaiwebui.api_endpoint');
+    if (devApiEndpointOverride) return devApiEndpointOverride;
+    const stored = localStorage.getItem(STORED_API_ENDPOINT_KEY);
     return stored ? stored.replace(/^"+|"+$/g, '') : '';
   });
+  // Persist the dev override so other modules that read
+  // backendaiwebui.api_endpoint (e.g., orchestration's Electron fallback)
+  // observe it too. Kept in an effect — not the useState initializer — so
+  // the initializer stays pure and StrictMode's double-invocation can't
+  // surprise future readers.
+  useEffect(() => {
+    if (devApiEndpointOverride) {
+      localStorage.setItem(STORED_API_ENDPOINT_KEY, devApiEndpointOverride);
+    }
+  }, []);
   const [otpRequired, setOtpRequired] = useState(false);
   const [needsOtpRegistration, setNeedsOtpRegistration] = useState(false);
   const [totpRegistrationToken, setTotpRegistrationToken] = useState('');
@@ -168,10 +199,15 @@ const LoginView: React.FC<{
     const newCfg = atomLoginConfig;
     setLoginConfig(newCfg);
     setConnectionMode(newCfg.connection_mode);
-    setApiEndpoint((prev) => newCfg.api_endpoint || prev);
+    // The dev-only env-var override (VITE_DEFAULT_API_ENDPOINT) wins over
+    // both the config.toml api_endpoint and the previously-stored value so
+    // that PR-targeted dev sessions land on the right backend.
+    setApiEndpoint(
+      (prev) => devApiEndpointOverride || newCfg.api_endpoint || prev,
+    );
 
     // Handle endpoint visibility
-    if (newCfg.api_endpoint === '') {
+    if (newCfg.api_endpoint === '' || devApiEndpointOverride) {
       setShowEndpointInput(true);
       setIsEndpointDisabled(false);
     } else {
@@ -933,6 +969,7 @@ const LoginView: React.FC<{
     onLogoutSession: logoutSession,
     apiEndpoint,
     connectionMode,
+    enforcedEndpoint: devApiEndpointOverride,
   });
 
   const handleConnectionModeChange = useCallback(

--- a/react/src/hooks/useLoginOrchestration.test.ts
+++ b/react/src/hooks/useLoginOrchestration.test.ts
@@ -459,6 +459,123 @@ describe('useLoginOrchestration - error handling', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: dev-only enforced endpoint (VITE_DEFAULT_API_ENDPOINT)
+// ---------------------------------------------------------------------------
+
+/**
+ * Set up a fake, already-connected client that reports the given endpoint
+ * via `_config.endpoint`. Mirrors how the real backend.ai-client populates
+ * `_config` after `createBackendAIClient`.
+ */
+function makeConnectedClientAt(endpoint: string) {
+  (globalThis as any).backendaiclient = {
+    ready: true,
+    _config: { endpoint },
+    logout: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('useLoginOrchestration - enforcedEndpoint (dev-only)', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('logs out the stale client and opens the panel when the connected endpoint differs', async () => {
+    makeConnectedClientAt('http://OLD:8090');
+
+    const { options } = await renderOrchestrationHook(true, false, {
+      enforcedEndpoint: 'http://NEW:8090',
+    });
+
+    expect(options.onLogoutSession).toHaveBeenCalledTimes(1);
+    expect(options.onOpen).toHaveBeenCalledTimes(1);
+    expect(options.onLogin).not.toHaveBeenCalled();
+    // Global client ref must be cleared so isClientConnected() returns false
+    // on the next pass.
+    expect(globalThis.backendaiclient).toBeNull();
+  });
+
+  it('treats trailing slashes as equivalent (strips before compare)', async () => {
+    makeConnectedClientAt('http://NEW:8090/');
+
+    const { options } = await renderOrchestrationHook(true, false, {
+      enforcedEndpoint: 'http://NEW:8090',
+    });
+
+    // Endpoint matches once normalized — orchestrator must NOT log out.
+    expect(options.onLogoutSession).not.toHaveBeenCalled();
+    expect(options.onOpen).not.toHaveBeenCalled();
+  });
+
+  it('normalizes the enforced endpoint too (trailing slash and whitespace)', async () => {
+    makeConnectedClientAt('http://NEW:8090');
+
+    const { options } = await renderOrchestrationHook(true, false, {
+      enforcedEndpoint: '  http://NEW:8090/  ',
+    });
+
+    // Both sides normalize to 'http://NEW:8090' — no false mismatch logout.
+    expect(options.onLogoutSession).not.toHaveBeenCalled();
+    expect(options.onOpen).not.toHaveBeenCalled();
+  });
+
+  it('does nothing special when enforcedEndpoint is undefined (production parity)', async () => {
+    makeConnectedClientAt('http://OLD:8090');
+
+    const { options } = await renderOrchestrationHook(true, false, {
+      enforcedEndpoint: undefined,
+    });
+
+    // Falls through to the existing isClientConnected() early-return.
+    expect(options.onLogoutSession).not.toHaveBeenCalled();
+    expect(options.onOpen).not.toHaveBeenCalled();
+    expect(options.onLogin).not.toHaveBeenCalled();
+  });
+
+  it('still opens the login panel even if onLogoutSession throws (best-effort)', async () => {
+    makeConnectedClientAt('http://OLD:8090');
+
+    const { options } = await renderOrchestrationHook(true, false, {
+      enforcedEndpoint: 'http://NEW:8090',
+      onLogoutSession: vi.fn().mockRejectedValue(new Error('unreachable')),
+    });
+
+    expect(options.onLogoutSession).toHaveBeenCalledTimes(1);
+    expect(options.onOpen).toHaveBeenCalledTimes(1);
+    expect(globalThis.backendaiclient).toBeNull();
+  });
+
+  it('consumes INTENTIONAL_LOGOUT_FLAG so the next pass does not double-handle it', async () => {
+    sessionStorage.setItem(INTENTIONAL_LOGOUT_FLAG, '1');
+    makeConnectedClientAt('http://OLD:8090');
+
+    await renderOrchestrationHook(true, false, {
+      enforcedEndpoint: 'http://NEW:8090',
+    });
+
+    expect(sessionStorage.getItem(INTENTIONAL_LOGOUT_FLAG)).toBeNull();
+  });
+
+  it('skips entirely on applauncher routes (no logout side-effect from a deep link)', async () => {
+    setWindowPathname('/edu-applauncher/some-app');
+    makeConnectedClientAt('http://OLD:8090');
+
+    const { options } = await renderOrchestrationHook(true, false, {
+      enforcedEndpoint: 'http://NEW:8090',
+    });
+
+    expect(options.onLogoutSession).not.toHaveBeenCalled();
+    expect(options.onOpen).not.toHaveBeenCalled();
+    // Global client untouched.
+    expect((globalThis as any).backendaiclient).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: idempotency (runs only once)
 // ---------------------------------------------------------------------------
 

--- a/react/src/hooks/useLoginOrchestration.ts
+++ b/react/src/hooks/useLoginOrchestration.ts
@@ -27,6 +27,7 @@ import { loadConfigFromWebServer } from '../helper/loginSessionAuth';
 import TabCount from '../lib/TabCounter';
 import { INTENTIONAL_LOGOUT_FLAG } from './useLogout';
 import { autoLogoutState, configLoadedState } from './useWebUIConfig';
+import { useBAILogger } from 'backend.ai-ui';
 import { useAtomValue } from 'jotai';
 import { useEffect, useEffectEvent, useRef } from 'react';
 
@@ -66,6 +67,19 @@ function isClientConnected(): boolean {
     globalThis.backendaiclient !== null &&
     globalThis.backendaiclient.ready !== false
   );
+}
+
+/**
+ * Read the in-memory client's current endpoint (trailing slashes stripped),
+ * or `''` if no client is bound. `_config` is not part of the published
+ * BackendAIClient surface, so the structural escape hatch is contained here.
+ */
+function getConnectedEndpoint(): string {
+  const client = globalThis.backendaiclient as
+    | (BackendAIClient & { _config?: { endpoint?: string } })
+    | null
+    | undefined;
+  return (client?._config?.endpoint ?? '').replace(/\/+$/, '');
 }
 
 interface UseLoginOrchestrationOptions {
@@ -108,6 +122,17 @@ interface UseLoginOrchestrationOptions {
    * The current connection mode.
    */
   connectionMode: 'SESSION' | 'API';
+
+  /**
+   * Dev-only: when set, the orchestrator forces this endpoint. If a
+   * previously-connected backend client targets a different endpoint,
+   * it is logged out and the login panel is opened so the user lands
+   * on the dev-targeted backend instead of resuming a stale session.
+   *
+   * Sourced from VITE_DEFAULT_API_ENDPOINT in dev mode; ignored in
+   * production builds.
+   */
+  enforcedEndpoint?: string;
 }
 
 /**
@@ -124,22 +149,60 @@ export function useLoginOrchestration({
   onLogoutSession,
   apiEndpoint,
   connectionMode,
+  enforcedEndpoint,
 }: UseLoginOrchestrationOptions): void {
   const isConfigLoaded = useAtomValue(configLoadedState);
   const autoLogout = useAtomValue(autoLogoutState);
+  const { logger } = useBAILogger();
 
   // Guard against running the effect more than once
   const hasRunRef = useRef(false);
 
+  // Normalize the enforced endpoint the same way getConnectedEndpoint()
+  // normalizes the connected client's endpoint so a trailing-slash or
+  // surrounding-whitespace difference doesn't trigger a false mismatch.
+  const normalizedEnforcedEndpoint = enforcedEndpoint
+    ?.trim()
+    .replace(/\/+$/, '');
+
   // useEffectEvent captures the latest callback values without making
   // them dependencies of the useEffect below.
   const doOrchestrate = useEffectEvent(async () => {
-    // If the client is already connected, nothing to do.
-    if (isClientConnected()) return;
-
     // Edu-applauncher and applauncher pages are handled by React Router
     // routes that perform their own login flow.
     if (isAppLauncherPage()) return;
+
+    // Dev-only: when an enforced endpoint is supplied (from
+    // VITE_DEFAULT_API_ENDPOINT) and the in-memory client targets a
+    // different backend, log it out and surface the login panel rather
+    // than letting the orchestrator resume the stale session.
+    if (normalizedEnforcedEndpoint && isClientConnected()) {
+      const connectedEp = getConnectedEndpoint();
+      if (connectedEp !== normalizedEnforcedEndpoint) {
+        // Consume any pending intentional-logout flag so the next
+        // orchestration pass doesn't redundantly short-circuit on it.
+        sessionStorage.removeItem(INTENTIONAL_LOGOUT_FLAG);
+        try {
+          await onLogoutSession();
+        } catch (err) {
+          // Best-effort: the stale client may already be unreachable.
+          // Log so dev-only enforced-endpoint behavior stays debuggable.
+          logger.warn(
+            'enforcedEndpoint: stale-session logout failed; continuing to clear client and open login panel',
+            err,
+          );
+        }
+        // onLogoutSession only logs the client out on the server; it does
+        // not clear the global ref. Null it here so isClientConnected()
+        // returns false on the next orchestration pass.
+        globalThis.backendaiclient = null;
+        onOpen();
+        return;
+      }
+    }
+
+    // If the client is already connected, nothing to do.
+    if (isClientConnected()) return;
 
     // Check for intentional logout flag set by useLogout before the reload.
     // When present, skip silent re-login and show the login panel directly


### PR DESCRIPTION
Resolves #7234(FR-2806)

## Summary

Add a Vite-only env var `VITE_DEFAULT_API_ENDPOINT` that pre-fills the WebUI login screen's API endpoint and force-logs out any in-memory client targeting a different backend, and update the `dev-server` skill to derive the value from the current branch's PR description automatically.

## Why

When developing against per-PR backend test servers, the API endpoint shown on the login screen still points to whatever was last used (from `localStorage` or a previously connected client). Developers manually re-type the target endpoint on every cold start, and a stale session for a different endpoint can silently silent-re-login to the wrong server. This makes "open the dev URL → land on the right backend" the default path instead of a per-session ritual.

## Changes

- `react/src/components/LoginView.tsx`
  - Read `import.meta.env.VITE_DEFAULT_API_ENDPOINT` (only when `import.meta.env.DEV`) into `devApiEndpointOverride`.
  - Initial `apiEndpoint` state uses the override over `localStorage.backendaiwebui.api_endpoint` and persists the override back into `localStorage` so other modules see it.
  - When `config.toml` later loads, the override still wins over `loginConfig.api_endpoint`, and the endpoint field is shown as editable so the developer can swap it on the fly.
- `react/src/hooks/useLoginOrchestration.ts`
  - New `enforcedEndpoint` option. When set and the in-memory client's `_config.endpoint` differs, the orchestrator logs the stale session out, nulls the global client, and opens the login panel instead of silent-re-logging in.
  - Production builds pass `undefined` (no behavior change).
- `.claude/skills/dev-server/SKILL.md`
  - New "2c. Decide the default API endpoint" section: priority order (user mention → PR body via `gh pr view --json body` → omit), the bare-IP-defaults-to-`:8090` rule, hostname / `host:port` / full-URL handling, and the regex used to scan the PR body.
  - Step 3 (compose) and step 6 (edge cases) updated to include `VITE_DEFAULT_API_ENDPOINT`.

## Test plan

- [ ] `VITE_DEFAULT_API_ENDPOINT=http://1.2.3.4:8090 pnpm dev` → cold-start login form is pre-filled with `http://1.2.3.4:8090`; endpoint field is editable.
- [ ] With a stale `localStorage.backendaiwebui.api_endpoint = "http://OLD:8090"`, the env-var value still wins on first render.
- [ ] With an in-memory `globalThis.backendaiclient` connected to a different endpoint (HMR-preserved), the orchestrator logs it out and shows the login panel — no silent re-login.
- [ ] `pnpm build` then serve → env var has no effect (`import.meta.env.DEV === false`).
- [ ] From a branch with an open PR whose body contains a bare IP, invoking the dev-server skill prefixes `pnpm dev` with `VITE_DEFAULT_API_ENDPOINT='http://<ip>:8090'`. From a branch with no PR or no IP in the body, the variable is omitted.
- [ ] `bash scripts/verify.sh` — Relay/Lint/Format pass; the only TypeScript failures are the pre-existing ones on `main` (`packages/backend.ai-client/src/client.ts`, `src/components/VFolderDeployModal.tsx`).