### PR TITLE
chore(FR-2808): fix duplicate prometheusQueryPresetResult queries by aligning fetch policy

### DIFF
--- a/react/src/components/PrometheusPresetPreview.tsx
+++ b/react/src/components/PrometheusPresetPreview.tsx
@@ -5,7 +5,12 @@
 import { PrometheusPresetPreviewResultQuery } from '../__generated__/PrometheusPresetPreviewResultQuery.graphql';
 import { ReloadOutlined } from '@ant-design/icons';
 import { Typography, theme } from 'antd';
-import { BAIButton, toLocalId, useFetchKey } from 'backend.ai-ui';
+import {
+  BAIButton,
+  INITIAL_FETCH_KEY,
+  toLocalId,
+  useFetchKey,
+} from 'backend.ai-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
@@ -53,7 +58,11 @@ export const PrometheusPresetPreview: React.FC<{
         groupLabels: [],
       },
     },
-    { fetchPolicy: 'network-only', fetchKey: `preview-${fetchKey}` },
+    {
+      fetchPolicy:
+        fetchKey === INITIAL_FETCH_KEY ? 'store-and-network' : 'network-only',
+      fetchKey,
+    },
   );
 
   const results = data.prometheusQueryPresetResult.result;

--- a/react/src/components/PrometheusQueryPresetEditorModal.tsx
+++ b/react/src/components/PrometheusQueryPresetEditorModal.tsx
@@ -125,7 +125,9 @@ const PrometheusQueryPresetEditorModal: React.FC<
       {},
       {
         fetchPolicy:
-          deferredOpen && baiModalProps.open ? 'network-only' : 'store-only',
+          deferredOpen && baiModalProps.open
+            ? 'store-and-network'
+            : 'store-only',
       },
     );
 


### PR DESCRIPTION
Resolves #7238 ([FR-2808](https://lablup.atlassian.net/browse/FR-2808))

## Summary

- Change `PrometheusPresetPreview` fetch policy from `network-only` to the standard `INITIAL_FETCH_KEY` pattern: `store-and-network` on initial mount, `network-only` on explicit refresh via the reload button
- Remove the redundant `preview-` prefix from `fetchKey` (Relay fetchKey is per-component instance, no namespacing needed)
- Change the categories query in `PrometheusQueryPresetEditorModal` from `network-only` to `store-and-network` so previously loaded categories display immediately on re-open

## Test plan

- [ ] Open the preset editor modal — `prometheusQueryPresetResult` is called once (not twice)
- [ ] Click the reload button in the preview — query is called again with `network-only`
- [ ] Re-open the modal — categories populate instantly from cache

[FR-2808]: https://lablup.atlassian.net/browse/FR-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ