### PR TITLE
chore(FR-2814): patch relay-runtime to expose full `@catch` error details

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -101,3 +101,4 @@ patchedDependencies:
   '@lobehub/fluent-emoji@2.0.0': react/patches/lobehub__fluent-emoji@2.0.0.patch
   '@rc-component/form': react/patches/@rc-component__form.patch
   ansi_up@6.0.6: react/patches/ansi_up@6.0.6.patch
+  relay-runtime@20.1.1: react/patches/relay-runtime@20.1.1.patch

--- a/react/patches/relay-runtime@20.1.1.patch
+++ b/react/patches/relay-runtime@20.1.1.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/store/RelayReader.js b/lib/store/RelayReader.js
+index 4210351f48d90aab7d71afdfeb417663105ddaaf..dd3cac512561aa9dc122f3bfff46370314410f57 100644
+--- a/lib/store/RelayReader.js
++++ b/lib/store/RelayReader.js
+@@ -248,10 +248,10 @@ var RelayReader = /*#__PURE__*/function () {
+     var errors = this._fieldErrors.map(function (error) {
+       switch (error.kind) {
+         case 'relay_field_payload.error':
+-          var _error$error = error.error,
+-            message = _error$error.message,
+-            displayError = (0, _objectWithoutPropertiesLoose2["default"])(_error$error, _excluded);
+-          return displayError;
++          // Patched (lablup/webui): expose full GraphQL error (message, extensions, etc.)
++          // instead of stripping `message`. Upstream removes `message` for PII safety;
++          // we accept that risk in exchange for usable error UX.
++          return error.error;
+         case 'missing_expected_data.throw':
+         case 'missing_expected_data.log':
+           return {


### PR DESCRIPTION
Resolves #7246([FR-2814](https://lablup.atlassian.net/browse/FR-2814))

## Summary
- Patch `relay-runtime@20.1.1` so the `errors` array exposed by `@catch` fields preserves the full GraphQL error object (`message`, `extensions`, etc.) instead of the upstream-stripped subset (`path` + `severity` only).
- Patch is registered in `pnpm-workspace.yaml` under `patchedDependencies` so it applies automatically for all developers and CI; the patch file lives in `react/patches/` next to the existing patches.
- Surface area is intentionally minimal: a single `case 'relay_field_payload.error':` in `RelayReader._asResult` is changed to return `error.error` directly, with an inline comment explaining the deviation from upstream.

## Why
Relay 18+ deliberately strips `message` from the per-field error objects (and never exposes `extensions`) for PII safety. In our codebase this forces awkward workarounds — e.g. `PrometheusQueryTemplatePreview` parses the GraphQL error wrapper string via `indexOf` to recover backend messages. The official escape hatches (`relayFieldLogger` global side-channel, schema-level error payloads) are either too coarse for component-level UX or require backend changes per call site. We accept the PII trade-off in exchange for a usable error UX in our internal admin tooling.

## Test plan
- [ ] `pnpm install` re-applies the patch cleanly (verify a `_patch_hash=` directory under `node_modules/.pnpm/relay-runtime@20.1.1...`).
- [ ] In a query that uses `@catch`, when the backend returns a field error, the resulting `errors[i]` includes `message` (and `extensions` when present), in addition to `path`.
- [ ] `bash scripts/verify.sh` → `=== ALL PASS ===`.

## Notes
- TypeScript types in generated artifacts use `Result<T, unknown>` for the error type, so consumers need to cast at the use site (e.g. `errors[0] as { path: readonly (string|number)[]; message?: string; extensions?: Record<string, unknown> }`). No type changes are required in this PR.
- Follow-up: replace the `indexOf`-based message parsing in `PrometheusQueryTemplatePreview` with direct `errors[0].message` access (separate PR / Jira issue).

[FR-2814]: https://lablup.atlassian.net/browse/FR-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ