### PR TITLE
fix(FR-2823): migrate Environment > Images table to server-side ordering

### DIFF
--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -7,7 +7,7 @@ import {
   ImageListQuery$data,
   ImageListQuery$variables,
 } from '../__generated__/ImageListQuery.graphql';
-import { getImageFullName, localeCompare } from '../helper';
+import { getImageFullName } from '../helper';
 import { useBackendAIImageMetaData } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
@@ -38,6 +38,7 @@ import {
   INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { Key, useDeferredValue, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
@@ -45,6 +46,19 @@ import { graphql, useLazyLoadQuery } from 'react-relay';
 export type EnvironmentImage = NonNullableNodeOnEdges<
   ImageListQuery$data['image_nodes']
 >;
+
+const availableImageSorterKeys = [
+  'registry',
+  'architecture',
+  'namespace',
+  'base_image_name',
+] as const;
+const availableImageSorterValues = [
+  ...availableImageSorterKeys,
+  ...availableImageSorterKeys.map((key) => `-${key}` as const),
+] as const;
+const isEnableSorter = (key: string) =>
+  _.includes(availableImageSorterKeys, key);
 
 const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
   'use memo';
@@ -65,7 +79,6 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
   const [visibleColumnSettingModal, { toggle: toggleColumnSettingModal }] =
     useToggle();
   const [isPendingRefreshTransition, startRefreshTransition] = useTransition();
-  const [isPendingFilterTransition, startFilterTransition] = useTransition();
   const currentProject = useCurrentProjectValue();
 
   const {
@@ -77,12 +90,19 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
     pageSize: 20,
   });
 
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      order: parseAsStringLiteral(availableImageSorterValues),
+    },
+    { history: 'replace' },
+  );
+
   const queryVariables: ImageListQuery$variables = {
     scopeId: `project:${currentProject.id}`,
     offset: baiPaginationOption.offset,
     first: baiPaginationOption.first,
     filter: imageFilter || undefined,
-    order: undefined,
+    order: queryParams.order || undefined,
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);
@@ -157,10 +177,6 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
       title: t('environment.Status'),
       dataIndex: 'installed',
       key: 'installed',
-      defaultSortOrder: 'descend',
-      sorter: (a, b) => {
-        return _.toNumber(a?.installed || 0) - _.toNumber(b?.installed || 0);
-      },
       render: (_text, row) =>
         row?.id && installingImages.includes(row.id) ? (
           <Tag color="gold">{t('environment.Installing')}</Tag>
@@ -180,39 +196,38 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
           {getImageFullName(row) || ''}
         </Typography.Text>
       ),
-      sorter: (a, b) => localeCompare(getImageFullName(a), getImageFullName(b)),
+      // Computed (`getImageFullName`) — not orderable on the server.
       width: token.screenXS,
     },
     {
       title: t('environment.Registry'),
       dataIndex: 'registry',
       key: 'registry',
-      sorter: (a, b) => localeCompare(a?.registry, b?.registry),
+      sorter: isEnableSorter('registry'),
     },
     {
       title: t('environment.Architecture'),
       dataIndex: 'architecture',
       key: 'architecture',
-      sorter: (a, b) => localeCompare(a?.architecture, b?.architecture),
+      sorter: isEnableSorter('architecture'),
     },
     {
       title: t('environment.Namespace'),
       key: 'namespace',
       dataIndex: 'namespace',
-      sorter: (a, b) => localeCompare(a?.namespace, b?.namespace),
+      sorter: isEnableSorter('namespace'),
     },
     {
       title: t('environment.BaseImageName'),
       key: 'base_image_name',
       dataIndex: 'base_image_name',
-      sorter: (a, b) => localeCompare(a?.base_image_name, b?.base_image_name),
+      sorter: isEnableSorter('base_image_name'),
       render: (text) => tagAlias(text),
     },
     {
       title: t('environment.Version'),
       key: 'version',
       dataIndex: 'version',
-      sorter: (a, b) => localeCompare(a?.version, b?.version),
     },
     {
       title: t('environment.Tags'),
@@ -226,7 +241,6 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
       title: t('environment.Digest'),
       dataIndex: 'digest',
       key: 'digest',
-      sorter: (a, b) => localeCompare(a?.digest || '', b?.digest || ''),
       render: (_text, row) => (
         <Typography.Text ellipsis={{ tooltip: true }} style={{ maxWidth: 200 }}>
           {row.digest}
@@ -390,10 +404,8 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             ])}
             value={imageFilter || undefined}
             onChange={(value) => {
-              startFilterTransition(() => {
-                setImageFilter(value || '');
-                setTablePaginationOption({ current: 1 });
-              });
+              setImageFilter(value || '');
+              setTablePaginationOption({ current: 1 });
             }}
           />
           <BAIFlex gap={'xs'}>
@@ -458,7 +470,19 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             columns,
             (column) => !_.includes(hiddenColumnKeys, _.toString(column?.key)),
           )}
-          loading={isPendingFilterTransition}
+          loading={
+            deferredFetchKey !== fetchKey ||
+            deferredQueryVariables !== queryVariables
+          }
+          order={queryParams.order}
+          onChangeOrder={(order) => {
+            setQueryParams({
+              order: order as
+                | (typeof availableImageSorterValues)[number]
+                | null,
+            });
+            setTablePaginationOption({ current: 1 });
+          }}
           rowSelection={{
             type: 'checkbox',
             onChange: (_, selectedRows) => {


### PR DESCRIPTION
Resolves #7257(FR-2823)

## Summary

The Images tab on `/environment?tab=image` paginates server-side but sorted client-side via per-column `sorter: (a, b) => ...` callbacks, which can only reorder rows on the current page — column header clicks gave a misleading partial sort. The backing `image_nodes` GraphQL query already exposes `$order: String`, but the page hard-coded `order: undefined` and never plumbed the table's sort state through.

## Changes

- **URL-persisted sort state**: add `useQueryStates({ order })` from `nuqs`. No default order is set; the server returns its natural order until the user picks a sortable column.
- **Pass `order` through to GraphQL**: replace `order: undefined` with `order: queryParams.order || undefined` so the server actually receives the sort key.
- **Server-orderable columns only**: the `image_nodes` ordering parser only accepts a fixed set of fields (`id`, `name`, `namespace`, `tag`, `status`, `project`, `image`, `base_image_name`, `created_at`, `registry`, `registry_id`, `architecture`, `is_local`, `type`, `accelerators`). Of the columns currently rendered, only **Registry**, **Architecture**, **Namespace**, and **BaseImageName** map to supported fields and get `sorter: true`. Status (`installed`), Version, Digest, and FullImagePath are not server-orderable, so the sort affordance is dropped on those columns.
- **Wire BAITable**: pass `order={queryParams.order}` and `onChangeOrder={...}`. The handler updates URL state and resets pagination to page 1 (matching `ProjectPage`'s convention).
- **Loading indicator**: switch the table's `loading` prop from `isPendingFilterTransition` (which only tracked filter transitions) to the deferred-value diff pattern used in `ProjectPage` — `deferredFetchKey !== fetchKey || deferredQueryVariables !== queryVariables`. This shows the spinner during filter, order, page, and refresh transitions uniformly.
- Remove now-unused `localeCompare` import.

## Pattern reference

Follows the URL-state-driven server-ordering pattern already used in `react/src/pages/ProjectPage.tsx` (`order: queryParams.order` + `onChangeOrder` + deferred-value loading).

## Verification

- Relay: PASS (no schema change)
- Lint: PASS
- Format: PASS
- TypeScript: pre-existing failures only on `main` (unrelated; tracked separately under FR-2816).

## Manual smoke test

- Open `/environment?tab=image`.
- Click any sortable column header (Registry, Architecture, Namespace, BaseImageName).
- The URL `?order=` reflects the new key (e.g., `registry`, `-namespace`).
- Loading spinner appears on the table during the order/filter/page transition.
- Navigate between pages — rows are now globally sorted across all pages, not partially per page.
- Status, Version, Digest, and FullImagePath column headers are no longer clickable to sort (these are not exposed as orderable fields by the backend).

## Notes

- Out of scope: other paginated `BAITable` consumers in the codebase still use in-memory comparators. The issue description acknowledges this and recommends capturing them as follow-up work.
