### PR TITLE
fix(FR-2815): break BAITable resizable column infinite update loop

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -339,7 +339,7 @@ const BAITable = <RecordType extends AnyObject = AnyObject>({
             ({
               ...column,
               width:
-                resizedColumnWidths[columnKeyOrIndexKey(column, index)] ||
+                resizedColumnWidths[columnKeyOrIndexKey(column, index)] ??
                 column.width,
               onHeaderCell: (column: ColumnType<RecordType>) => {
                 return {
@@ -624,17 +624,24 @@ const ResizableTitle = (
   const [isResizing, setIsResizing] = useState(false);
   const debouncedIsResizing = useDebounce(isResizing, { wait: 100 });
 
-  // This is a workaround for the initial width of resizable columns if the width is not specified
+  // This is a workaround for the initial width of resizable columns if the width is not specified.
+  // Skip when the measured width is 0 — that happens inside hidden ancestors
+  // (display:none, detached subtrees, etc.) and would otherwise loop because
+  // the parent stores the measured 0 and the next render falls back to
+  // `width = undefined`, re-firing this effect every render (FR-2815).
   useEffect(() => {
     if (wrapRef.current && _.isUndefined(width)) {
-      onResize?.(undefined, {
-        size: {
-          width: wrapRef.current.offsetWidth,
-          height: wrapRef.current.offsetHeight,
-        },
-        node: wrapRef.current,
-        handle: 'e',
-      });
+      const measuredWidth = wrapRef.current.offsetWidth;
+      if (measuredWidth > 0) {
+        onResize?.(undefined, {
+          size: {
+            width: measuredWidth,
+            height: wrapRef.current.offsetHeight,
+          },
+          node: wrapRef.current,
+          handle: 'e',
+        });
+      }
     }
   });
 


### PR DESCRIPTION
Resolves #7248(FR-2815)

## Summary

`/session/start` crashed with **"Maximum update depth exceeded"** on the 26.4.x release backend. The trigger surface was `VFolderTable` inside the Storage step Card while that Card was hidden (`display: none`).

## Root cause

BAITable's `ResizableTitle` workaround for un-specified column widths self-loops when its measurement target has width 0:

1. The `useEffect` that measures the header cell has **no dependency array**, so it fires on every render.
2. When `width` prop is `undefined`, the effect calls `onResize(offsetWidth)`, which `setResizedColumnWidths` records.
3. The parent reads that value back via `resizedColumnWidths[key] || column.width`. Inside a hidden ancestor the measured value is `0`, and **`0 || undefined`** falls through to `undefined`. So the next render again has `width: undefined`.
4. `ResizableTitle` re-runs the effect, again measures `0`, again writes it. React hits its 50-update render limit and throws.

Stack traces pointed at antd `EllipsisMeasure` because `BAIText` (in a sibling cell) was the last commit-target when the limit was hit; the actual setState cascade originates in BAITable's `ResizableTitle` path.

## Why it didn't manifest before

- `resizable` default was `false` until recently; `ResizableTitle` was not used at all so the loop didn't exist.
- After the default flipped to `true`, the loop is latent in any BAITable rendered inside a hidden ancestor with un-widthed columns. `/session/start` is the first surface to hit it because its step Cards stay mounted and toggle visibility with `display: none` (so the Storage VFolderTable mounts at width 0 on initial render).
- Other endpoints don't crash because their VFolder responses have fewer rows / different column widths so the loop never accumulates beyond React's 50-update limit.

## Fix

- Use `??` instead of `||` for the `resizedColumnWidths` fallback so a measured `0` is preserved and not coalesced back to `undefined`.
- Skip the `onResize` self-call when `offsetWidth === 0`. A 0-width measurement is meaningless inside a hidden ancestor, and skipping it breaks the loop without affecting the visible-column code path.

The default `resizable: true` is preserved; only the loop-prone branch is guarded. Other consumers of BAITable inherit the fix automatically.

## Verification

- Relay: PASS
- Lint: PASS
- Format: PASS
- TypeScript: pre-existing failures only on `main` (unrelated; tracked separately under FR-2816).

## Manual smoke test

- Open `/session/start` against the 26.4.x release backend → page loads without the React update-depth crash.
- Navigate through all 5 steps (`SessionType` → `Environment` → `Storage` → `Network` → `Review`) → form values persist; transitions work; Storage step's VFolderTable shows rows correctly.
- Confirm column resize on visible BAITable instances (e.g., `/data` page) still works as before.