### PR TITLE
feat(backend.ai-ui): add AppShell layout components and branding schema

### DIFF
--- a/packages/backend.ai-ui/eslint.config.js
+++ b/packages/backend.ai-ui/eslint.config.js
@@ -63,6 +63,21 @@ export default [
     },
   },
 
+  // Branding-schema JSON assets (the JSON Schema itself + the example
+  // theme files). They are not source code, but lint-staged passes them
+  // through eslint anyway when they live under `src/`. Use the JSONC
+  // parser so eslint accepts them; no rules are applied — the contents
+  // are verified at runtime by the schema instead.
+  {
+    files: [
+      "src/branding-schema/schema.json",
+      "src/branding-schema/examples/*.json",
+    ],
+    languageOptions: {
+      parser: jsoncParser,
+    },
+  },
+
   {
     ignores: ["**/*.graphql.*", "dist/**"],
   },

--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -28,11 +28,23 @@
     "./dist/locale/*": {
       "import": "./dist/locale/*.js",
       "types": "./dist/locale/*.d.ts"
+    },
+    "./branding-schema": {
+      "import": "./dist/branding-schema/index.js",
+      "types": "./dist/branding-schema/index.d.ts"
+    },
+    "./branding-schema/schema.json": "./dist/branding-schema/schema.json",
+    "./branding-schema/examples/*": "./dist/branding-schema/examples/*",
+    "./app-shell": {
+      "import": "./dist/app-shell/index.js",
+      "types": "./dist/app-shell/index.d.ts"
     }
   },
   "files": [
     "dist",
-    "dist/locale"
+    "dist/locale",
+    "dist/branding-schema",
+    "dist/app-shell"
   ],
   "scripts": {
     "dev": "vite build --watch --mode development",

--- a/packages/backend.ai-ui/src/app-shell/AppShell.tsx
+++ b/packages/backend.ai-ui/src/app-shell/AppShell.tsx
@@ -1,0 +1,76 @@
+import { AppShellHeader } from './AppShellHeader';
+import { AppShellSider } from './AppShellSider';
+import { AppShellStateContext } from './hooks/useAppShellState';
+import { useKeyboardShortcut } from './hooks/useKeyboardShortcut';
+import { useSiderCollapsed } from './hooks/useSiderCollapsed';
+import { useAppShellStyles } from './styles';
+import type { AppShellProps } from './types';
+import { Layout } from 'antd';
+import { useCallback, useMemo } from 'react';
+
+export function AppShell({
+  siderHeader,
+  siderContent,
+  siderFooter,
+  headerLeft,
+  headerRight,
+  showHeaderCollapseToggle = false,
+  showSiderCollapseToggle = true,
+  contentBanner,
+  children,
+  defaultCollapsed = false,
+  collapseStorageKey = 'appShell.sideCollapsed',
+  collapseShortcut = '[',
+}: AppShellProps) {
+  const { styles } = useAppShellStyles();
+  const { collapsed, setCollapsed, setCollapsedTransient, restorePersisted } =
+    useSiderCollapsed(collapseStorageKey, defaultCollapsed);
+  const toggleCollapsed = useCallback(
+    () => setCollapsed((c) => !c),
+    [setCollapsed],
+  );
+  const handleBreakpoint = useCallback(
+    (broken: boolean) => {
+      if (broken) setCollapsedTransient(true);
+      else restorePersisted();
+    },
+    [setCollapsedTransient, restorePersisted],
+  );
+
+  useKeyboardShortcut(collapseShortcut, toggleCollapsed);
+
+  const stateValue = useMemo(
+    () => ({ collapsed, toggleCollapsed }),
+    [collapsed, toggleCollapsed],
+  );
+
+  return (
+    <AppShellStateContext.Provider value={stateValue}>
+      <Layout hasSider style={{ flex: 1, minHeight: 'inherit' }}>
+        <AppShellSider
+          collapsed={collapsed}
+          onToggleCollapse={toggleCollapsed}
+          onBreakpointCollapse={handleBreakpoint}
+          showEdgeToggle={showSiderCollapseToggle}
+          header={siderHeader}
+          footer={siderFooter}
+        >
+          {siderContent}
+        </AppShellSider>
+        <Layout>
+          <AppShellHeader
+            collapsed={collapsed}
+            onToggleCollapse={toggleCollapsed}
+            showCollapseToggle={showHeaderCollapseToggle}
+            left={headerLeft}
+            right={headerRight}
+          />
+          {contentBanner && (
+            <div className={styles.banner}>{contentBanner}</div>
+          )}
+          <Layout.Content className={styles.content}>{children}</Layout.Content>
+        </Layout>
+      </Layout>
+    </AppShellStateContext.Provider>
+  );
+}

--- a/packages/backend.ai-ui/src/app-shell/AppShellHeader.tsx
+++ b/packages/backend.ai-ui/src/app-shell/AppShellHeader.tsx
@@ -1,0 +1,32 @@
+import { useAppShellStyles } from './styles';
+import type { AppShellHeaderProps } from './types';
+import { Button, Layout } from 'antd';
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+
+export function AppShellHeader({
+  collapsed,
+  onToggleCollapse,
+  showCollapseToggle = true,
+  left,
+  right,
+}: AppShellHeaderProps) {
+  const { styles } = useAppShellStyles();
+  const ToggleIcon = collapsed ? PanelLeftOpen : PanelLeftClose;
+  return (
+    <Layout.Header className={styles.header}>
+      {showCollapseToggle && (
+        <Button
+          type="text"
+          size="middle"
+          icon={<ToggleIcon size={18} aria-hidden="true" />}
+          onClick={onToggleCollapse}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-expanded={!collapsed}
+          className={styles.collapseToggle}
+        />
+      )}
+      <div className={styles.headerLeft}>{left}</div>
+      <div className={styles.headerRight}>{right}</div>
+    </Layout.Header>
+  );
+}

--- a/packages/backend.ai-ui/src/app-shell/AppShellProvider.tsx
+++ b/packages/backend.ai-ui/src/app-shell/AppShellProvider.tsx
@@ -1,0 +1,48 @@
+import { defaultBranding } from '../branding-schema';
+import { BrandingContext } from './hooks/useBranding';
+import { ThemeModeContext, useThemeModeState } from './hooks/useThemeMode';
+import { useAppShellStyles } from './styles';
+import type { AppShellProviderProps } from './types';
+import { buildAntdTheme } from './utils/antdTheme';
+import { buildShellCssVars } from './utils/cssVars';
+import { App as AntdApp, ConfigProvider } from 'antd';
+import { useMemo } from 'react';
+
+export function AppShellProvider({
+  branding,
+  defaultThemeMode = 'system',
+  themeStorageKey = 'appShell.themeMode',
+  children,
+}: AppShellProviderProps) {
+  const { styles, cx } = useAppShellStyles();
+  const themeMode = useThemeModeState(defaultThemeMode, themeStorageKey);
+  const resolvedBranding = branding ?? defaultBranding;
+
+  const cssVars = useMemo(
+    () => buildShellCssVars(resolvedBranding, themeMode.isDarkMode),
+    [resolvedBranding, themeMode.isDarkMode],
+  );
+
+  const antdThemeConfig = useMemo(
+    () => buildAntdTheme(resolvedBranding, themeMode.isDarkMode),
+    [resolvedBranding, themeMode.isDarkMode],
+  );
+
+  const className = cx(
+    styles.root,
+    'bai-app-shell-root',
+    themeMode.isDarkMode && 'bai-dark',
+  );
+
+  return (
+    <BrandingContext.Provider value={resolvedBranding}>
+      <ThemeModeContext.Provider value={themeMode}>
+        <ConfigProvider theme={antdThemeConfig}>
+          <AntdApp className={className} style={cssVars} component="div">
+            {children}
+          </AntdApp>
+        </ConfigProvider>
+      </ThemeModeContext.Provider>
+    </BrandingContext.Provider>
+  );
+}

--- a/packages/backend.ai-ui/src/app-shell/AppShellSider.tsx
+++ b/packages/backend.ai-ui/src/app-shell/AppShellSider.tsx
@@ -1,0 +1,169 @@
+import type { LogoConfig } from '../branding-schema';
+import { useBranding } from './hooks/useBranding';
+import { useThemeMode } from './hooks/useThemeMode';
+import { useAppShellStyles } from './styles';
+import type { AppShellSiderProps } from './types';
+import { Layout, Tooltip, theme as antdTheme } from 'antd';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+
+interface LogoImageProps {
+  src: string;
+  size: LogoConfig['size'];
+  alt: string;
+  className?: string;
+}
+
+function LogoImage({ src, size, alt, className }: LogoImageProps) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={size?.width}
+      height={size?.height}
+      className={className}
+      draggable={false}
+      style={{ maxWidth: '100%', height: 'auto', userSelect: 'none' }}
+    />
+  );
+}
+
+function DefaultSiderHeader({ collapsed }: { collapsed: boolean }) {
+  const { logo, branding } = useBranding();
+  const { isDarkMode } = useThemeMode();
+  const { token } = antdTheme.useToken();
+  const { styles } = useAppShellStyles();
+
+  if (!logo?.src) {
+    return (
+      <span
+        className={styles.brandText}
+        style={{ fontSize: token.fontSizeLG, fontWeight: 600 }}
+      >
+        {branding?.brandName ?? 'Backend.AI'}
+      </span>
+    );
+  }
+
+  const alt = logo.alt ?? branding?.brandName ?? 'Logo';
+
+  // Pick the active logo variant based on collapsed + theme. Falls back to
+  // simpler variants when more specific ones aren't supplied.
+  let activeSrc = logo.src;
+  let activeSize = logo.size;
+  if (collapsed) {
+    activeSrc = isDarkMode
+      ? (logo.srcCollapsedDark ?? logo.srcCollapsed ?? logo.srcDark ?? logo.src)
+      : (logo.srcCollapsed ?? logo.src);
+    activeSize = logo.sizeCollapsed ?? logo.size;
+  } else if (isDarkMode) {
+    activeSrc = logo.srcDark ?? logo.src;
+  }
+
+  const image = <LogoImage src={activeSrc} size={activeSize} alt={alt} />;
+
+  if (logo.href) {
+    return (
+      <a href={logo.href} className={styles.logoLink} aria-label={alt}>
+        {image}
+      </a>
+    );
+  }
+  return image;
+}
+
+/** Inline kbd-style hint shown inside the edge-toggle tooltip. */
+function KbdHint({ children }: { children: string }) {
+  return (
+    <kbd
+      style={{
+        marginLeft: 6,
+        padding: '0 5px',
+        fontFamily:
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+        fontSize: 11,
+        lineHeight: '16px',
+        border: '1px solid rgba(255, 255, 255, 0.4)',
+        borderRadius: 3,
+        background: 'rgba(255, 255, 255, 0.08)',
+      }}
+    >
+      {children}
+    </kbd>
+  );
+}
+
+export function AppShellSider({
+  collapsed,
+  onToggleCollapse,
+  onBreakpointCollapse,
+  showEdgeToggle = true,
+  header,
+  children,
+  footer,
+}: AppShellSiderProps) {
+  const { sider } = useBranding();
+  const { styles, cx } = useAppShellStyles();
+  const [hovered, setHovered] = useState(false);
+  const ToggleIcon = collapsed ? ChevronRight : ChevronLeft;
+  const tooltipLabel = collapsed ? 'Expand sidebar' : 'Collapse sidebar';
+
+  return (
+    <Layout.Sider
+      width={sider?.widthExpanded ?? 240}
+      collapsedWidth={sider?.widthCollapsed ?? 74}
+      collapsed={collapsed}
+      collapsible
+      trigger={null}
+      breakpoint="lg"
+      onBreakpoint={(broken) => onBreakpointCollapse?.(broken)}
+      className={cx(styles.sider, collapsed && styles.siderCollapsed)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div
+        className={cx(
+          styles.siderHeader,
+          collapsed && styles.siderHeaderCollapsed,
+        )}
+      >
+        {header ?? <DefaultSiderHeader collapsed={collapsed} />}
+      </div>
+      {showEdgeToggle && onToggleCollapse && (
+        <Tooltip
+          placement="right"
+          title={
+            <>
+              {tooltipLabel}
+              <KbdHint>[</KbdHint>
+            </>
+          }
+        >
+          <button
+            type="button"
+            className={cx(
+              styles.edgeToggle,
+              hovered && styles.edgeToggleVisible,
+            )}
+            onClick={onToggleCollapse}
+            aria-label={tooltipLabel}
+            tabIndex={0}
+          >
+            <ToggleIcon size={14} aria-hidden="true" />
+          </button>
+        </Tooltip>
+      )}
+      <div
+        className={cx(
+          styles.siderContent,
+          hovered && styles.siderContentHovering,
+        )}
+      >
+        {children}
+      </div>
+      {footer && !collapsed && (
+        <div className={styles.siderFooter}>{footer}</div>
+      )}
+    </Layout.Sider>
+  );
+}

--- a/packages/backend.ai-ui/src/app-shell/RootAppShell.test.tsx
+++ b/packages/backend.ai-ui/src/app-shell/RootAppShell.test.tsx
@@ -1,0 +1,83 @@
+import { RootAppShell, type RootAppShellMenuItem } from './RootAppShell';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const menus: RootAppShellMenuItem[] = [
+  { key: 'dashboard', label: 'Dashboard', group: 'Main' },
+  { key: 'workflows', label: 'Workflows', group: 'Main' },
+  { key: 'experiments', label: 'Experiments', group: 'MLOps' },
+];
+
+describe('<RootAppShell />', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders all menu items', () => {
+    render(
+      <RootAppShell menus={menus}>
+        <div>page content</div>
+      </RootAppShell>,
+    );
+    expect(
+      screen.getByRole('menuitem', { name: 'Dashboard' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Workflows' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Experiments' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the children in the content slot', () => {
+    render(
+      <RootAppShell menus={menus}>
+        <div data-testid="page">page content</div>
+      </RootAppShell>,
+    );
+    expect(screen.getByTestId('page')).toHaveTextContent('page content');
+  });
+
+  it('selects the first menu item by default (uncontrolled)', () => {
+    render(
+      <RootAppShell menus={menus}>
+        <div />
+      </RootAppShell>,
+    );
+    const selected = screen.getByRole('menuitem', { name: 'Dashboard' });
+    expect(selected.className).toMatch(/selected/);
+  });
+
+  it('honors defaultSelectedKey when uncontrolled', () => {
+    render(
+      <RootAppShell menus={menus} defaultSelectedKey="workflows">
+        <div />
+      </RootAppShell>,
+    );
+    const selected = screen.getByRole('menuitem', { name: 'Workflows' });
+    expect(selected.className).toMatch(/selected/);
+  });
+
+  it('calls onSelect when a menu item is clicked', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RootAppShell menus={menus} onSelect={onSelect}>
+        <div />
+      </RootAppShell>,
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Workflows' }));
+    expect(onSelect).toHaveBeenCalledWith('workflows');
+  });
+
+  it('respects controlled selectedKey (parent owns the state)', () => {
+    render(
+      <RootAppShell menus={menus} selectedKey="experiments">
+        <div />
+      </RootAppShell>,
+    );
+    const selected = screen.getByRole('menuitem', { name: 'Experiments' });
+    expect(selected.className).toMatch(/selected/);
+  });
+});

--- a/packages/backend.ai-ui/src/app-shell/RootAppShell.tsx
+++ b/packages/backend.ai-ui/src/app-shell/RootAppShell.tsx
@@ -1,0 +1,176 @@
+import { AppShell } from './AppShell';
+import { AppShellProvider } from './AppShellProvider';
+import {
+  DefaultHeaderActions,
+  type DefaultHeaderActionsProps,
+} from './internal/DefaultHeaderActions';
+import { DefaultHeaderLeft } from './internal/DefaultHeaderLeft';
+import { DefaultSiderMenu } from './internal/DefaultSiderMenu';
+import type { RootAppShellMenuItem } from './internal/buildAntdMenuItems';
+import {
+  type RootAppShellBrandingProps,
+  buildBrandingFromProps,
+} from './internal/buildBrandingFromProps';
+import type { ThemeMode } from './types';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
+
+export type { RootAppShellMenuItem } from './internal/buildAntdMenuItems';
+export type {
+  RootAppShellTokens,
+  RootAppShellBrandingProps,
+} from './internal/buildBrandingFromProps';
+
+export interface RootAppShellProps
+  extends RootAppShellBrandingProps, DefaultHeaderActionsProps {
+  /** Sider navigation items. Group items by setting the same `group` field on consecutive entries. */
+  menus: RootAppShellMenuItem[];
+
+  /** Currently selected menu key. Pass to control the selection from outside. */
+  selectedKey?: string;
+  /** Initial selected menu key when uncontrolled. Defaults to the first menu item. */
+  defaultSelectedKey?: string;
+  /** Called when the user picks a menu item. Use this to navigate. */
+  onSelect?: (key: string) => void;
+
+  /** Override the header's left slot. Default: brand name + chevron + selected page title. */
+  headerLeft?: ReactNode;
+  /** Override the header's right slot. Default: theme toggle + help + user buttons. */
+  headerRight?: ReactNode;
+  /** Sider footer. Default: copyright with company name. */
+  siderFooter?: ReactNode;
+  /** Optional banner rendered between header and content (e.g. connectivity warning). */
+  contentBanner?: ReactNode;
+
+  /** Initial theme mode. Defaults to `'system'`. */
+  defaultThemeMode?: ThemeMode;
+  /** Initial collapsed state when no value is persisted. Defaults to false. */
+  defaultCollapsed?: boolean;
+  /** Single-character key that toggles collapse. Defaults to `'['`. Set to null to disable. */
+  collapseShortcut?: string | null;
+
+  /** Page content rendered in the main column. */
+  children: ReactNode;
+}
+
+/**
+ * High-level convenience component that wires up Provider + Shell + default
+ * sider menu + default header actions in a single tag.
+ *
+ * For full control, use the lower-level `<AppShellProvider>` + `<AppShell>`
+ * with custom slot content.
+ */
+export function RootAppShell({
+  // Branding props (extracted for buildBrandingFromProps)
+  branding,
+  logo,
+  brandName,
+  companyName,
+  productName,
+  colors,
+  tokens,
+
+  // Menu
+  menus,
+  selectedKey: controlledSelectedKey,
+  defaultSelectedKey,
+  onSelect,
+
+  // Slot overrides
+  headerLeft,
+  headerRight,
+  siderFooter,
+  contentBanner,
+
+  // Header action toggles (forwarded to DefaultHeaderActions)
+  showThemeToggle,
+  showHelpButton,
+  showUserButton,
+  onHelpClick,
+  onUserClick,
+
+  // Behavior
+  defaultThemeMode = 'system',
+  defaultCollapsed = false,
+  collapseShortcut = '[',
+
+  children,
+}: RootAppShellProps) {
+  const resolvedBranding = useMemo(
+    () =>
+      buildBrandingFromProps({
+        branding,
+        logo,
+        brandName,
+        companyName,
+        productName,
+        colors,
+        tokens,
+      }),
+    [branding, logo, brandName, companyName, productName, colors, tokens],
+  );
+
+  // Controlled / uncontrolled selectedKey
+  const initialKey = defaultSelectedKey ?? menus[0]?.key ?? '';
+  const [internalSelectedKey, setInternalSelectedKey] =
+    useState<string>(initialKey);
+  const selectedKey = controlledSelectedKey ?? internalSelectedKey;
+
+  const handleSelect = useCallback(
+    (key: string) => {
+      if (controlledSelectedKey === undefined) setInternalSelectedKey(key);
+      onSelect?.(key);
+    },
+    [controlledSelectedKey, onSelect],
+  );
+
+  const selectedMenu = useMemo(
+    () => menus.find((m) => m.key === selectedKey),
+    [menus, selectedKey],
+  );
+
+  const resolvedHeaderLeft = headerLeft ?? (
+    <DefaultHeaderLeft pageTitle={selectedMenu?.label} />
+  );
+  const resolvedHeaderRight = headerRight ?? (
+    <DefaultHeaderActions
+      showThemeToggle={showThemeToggle}
+      showHelpButton={showHelpButton}
+      showUserButton={showUserButton}
+      onHelpClick={onHelpClick}
+      onUserClick={onUserClick}
+    />
+  );
+  const resolvedSiderFooter =
+    siderFooter ??
+    (companyName || resolvedBranding?.branding?.companyName ? (
+      <>
+        © {new Date().getFullYear()}{' '}
+        {companyName ?? resolvedBranding?.branding?.companyName}
+      </>
+    ) : undefined);
+
+  return (
+    <AppShellProvider
+      branding={resolvedBranding}
+      defaultThemeMode={defaultThemeMode}
+    >
+      <AppShell
+        defaultCollapsed={defaultCollapsed}
+        collapseShortcut={collapseShortcut}
+        siderContent={
+          <DefaultSiderMenu
+            menus={menus}
+            selectedKey={selectedKey}
+            onSelect={handleSelect}
+          />
+        }
+        siderFooter={resolvedSiderFooter}
+        headerLeft={resolvedHeaderLeft}
+        headerRight={resolvedHeaderRight}
+        contentBanner={contentBanner}
+      >
+        {children}
+      </AppShell>
+    </AppShellProvider>
+  );
+}

--- a/packages/backend.ai-ui/src/app-shell/hooks/useAppShellState.ts
+++ b/packages/backend.ai-ui/src/app-shell/hooks/useAppShellState.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+
+export interface AppShellStateValue {
+  collapsed: boolean;
+  toggleCollapsed: () => void;
+}
+
+export const AppShellStateContext = createContext<AppShellStateValue | null>(
+  null,
+);
+
+export function useAppShellState(): AppShellStateValue {
+  const ctx = useContext(AppShellStateContext);
+  if (!ctx) {
+    throw new Error('useAppShellState must be used inside <AppShell>');
+  }
+  return ctx;
+}

--- a/packages/backend.ai-ui/src/app-shell/hooks/useBranding.ts
+++ b/packages/backend.ai-ui/src/app-shell/hooks/useBranding.ts
@@ -1,0 +1,9 @@
+import type { BrandingConfig } from '../../branding-schema';
+import { defaultBranding } from '../../branding-schema';
+import { createContext, useContext } from 'react';
+
+export const BrandingContext = createContext<BrandingConfig>(defaultBranding);
+
+export function useBranding(): BrandingConfig {
+  return useContext(BrandingContext);
+}

--- a/packages/backend.ai-ui/src/app-shell/hooks/useKeyboardShortcut.ts
+++ b/packages/backend.ai-ui/src/app-shell/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+export function useKeyboardShortcut(
+  key: string | null | undefined,
+  handler: () => void,
+): void {
+  useEffect(() => {
+    if (!key || typeof window === 'undefined') return;
+    const listener = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.key !== key) return;
+      if (isEditableTarget(event.target)) return;
+      event.preventDefault();
+      handler();
+    };
+    window.addEventListener('keydown', listener);
+    return () => window.removeEventListener('keydown', listener);
+  }, [key, handler]);
+}

--- a/packages/backend.ai-ui/src/app-shell/hooks/useSiderCollapsed.test.ts
+++ b/packages/backend.ai-ui/src/app-shell/hooks/useSiderCollapsed.test.ts
@@ -1,0 +1,47 @@
+import { useSiderCollapsed } from './useSiderCollapsed';
+import { act, renderHook } from '@testing-library/react';
+
+const KEY = 'test.sideCollapsed';
+
+describe('useSiderCollapsed', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('initializes from defaultValue when nothing is persisted', () => {
+    const { result } = renderHook(() => useSiderCollapsed(KEY, false));
+    expect(result.current.collapsed).toBe(false);
+  });
+
+  it('reads persisted value from localStorage', () => {
+    window.localStorage.setItem(KEY, 'true');
+    const { result } = renderHook(() => useSiderCollapsed(KEY, false));
+    expect(result.current.collapsed).toBe(true);
+  });
+
+  it('setCollapsed persists to localStorage', () => {
+    const { result } = renderHook(() => useSiderCollapsed(KEY, false));
+    act(() => result.current.setCollapsed(true));
+    expect(result.current.collapsed).toBe(true);
+    expect(window.localStorage.getItem(KEY)).toBe('true');
+  });
+
+  it('setCollapsedTransient updates state but does NOT persist', () => {
+    // Regression test for B3: breakpoint-driven collapse must not overwrite
+    // the user's manual choice.
+    window.localStorage.setItem(KEY, 'false');
+    const { result } = renderHook(() => useSiderCollapsed(KEY, false));
+    act(() => result.current.setCollapsedTransient(true));
+    expect(result.current.collapsed).toBe(true);
+    expect(window.localStorage.getItem(KEY)).toBe('false');
+  });
+
+  it('restorePersisted snaps state back to whatever is in localStorage', () => {
+    window.localStorage.setItem(KEY, 'false');
+    const { result } = renderHook(() => useSiderCollapsed(KEY, false));
+    act(() => result.current.setCollapsedTransient(true));
+    expect(result.current.collapsed).toBe(true);
+    act(() => result.current.restorePersisted());
+    expect(result.current.collapsed).toBe(false);
+  });
+});

--- a/packages/backend.ai-ui/src/app-shell/hooks/useSiderCollapsed.ts
+++ b/packages/backend.ai-ui/src/app-shell/hooks/useSiderCollapsed.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from 'react';
+
+function readStored(key: string, fallback: boolean): boolean {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+  } catch {
+    // ignore
+  }
+  return fallback;
+}
+
+type SetCollapsed = (next: boolean | ((prev: boolean) => boolean)) => void;
+
+export interface UseSiderCollapsedReturn {
+  collapsed: boolean;
+  /** Set collapsed and persist to localStorage. Use for explicit user action (toggle button, keyboard shortcut). */
+  setCollapsed: SetCollapsed;
+  /** Set collapsed without persisting. Use for transient effects like responsive breakpoint auto-collapse,
+   *  so a brief narrow resize doesn't permanently overwrite the user's last manual choice. */
+  setCollapsedTransient: SetCollapsed;
+  /** Reset in-memory state to whatever's persisted in localStorage. Used to restore the user's last
+   *  saved choice after a transient override (e.g. widening past the breakpoint). */
+  restorePersisted: () => void;
+}
+
+export function useSiderCollapsed(
+  storageKey: string,
+  defaultValue: boolean = false,
+): UseSiderCollapsedReturn {
+  const [collapsed, setCollapsedState] = useState<boolean>(() =>
+    readStored(storageKey, defaultValue),
+  );
+
+  const setCollapsed = useCallback<SetCollapsed>(
+    (next) => {
+      setCollapsedState((prev) => {
+        const value = typeof next === 'function' ? next(prev) : next;
+        try {
+          window.localStorage.setItem(storageKey, String(value));
+        } catch {
+          // ignore
+        }
+        return value;
+      });
+    },
+    [storageKey],
+  );
+
+  const setCollapsedTransient = useCallback<SetCollapsed>((next) => {
+    setCollapsedState((prev) =>
+      typeof next === 'function' ? next(prev) : next,
+    );
+  }, []);
+
+  const restorePersisted = useCallback(() => {
+    setCollapsedState(readStored(storageKey, defaultValue));
+  }, [storageKey, defaultValue]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = (e: StorageEvent) => {
+      if (e.key !== storageKey || e.newValue === null) return;
+      setCollapsedState(e.newValue === 'true');
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [storageKey]);
+
+  return { collapsed, setCollapsed, setCollapsedTransient, restorePersisted };
+}

--- a/packages/backend.ai-ui/src/app-shell/hooks/useThemeMode.test.ts
+++ b/packages/backend.ai-ui/src/app-shell/hooks/useThemeMode.test.ts
@@ -1,0 +1,40 @@
+import { useThemeModeState } from './useThemeMode';
+import { act, renderHook } from '@testing-library/react';
+
+const KEY = 'test.themeMode';
+
+describe('useThemeModeState', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('initializes from defaultMode when nothing is persisted', () => {
+    const { result } = renderHook(() => useThemeModeState('light', KEY));
+    expect(result.current.themeMode).toBe('light');
+  });
+
+  it('reads persisted mode from localStorage', () => {
+    window.localStorage.setItem(KEY, 'dark');
+    const { result } = renderHook(() => useThemeModeState('light', KEY));
+    expect(result.current.themeMode).toBe('dark');
+    expect(result.current.isDarkMode).toBe(true);
+  });
+
+  it('isDarkMode is false when explicit mode is light, regardless of system preference', () => {
+    const { result } = renderHook(() => useThemeModeState('light', KEY));
+    expect(result.current.isDarkMode).toBe(false);
+  });
+
+  it('setThemeMode persists', () => {
+    const { result } = renderHook(() => useThemeModeState('light', KEY));
+    act(() => result.current.setThemeMode('dark'));
+    expect(window.localStorage.getItem(KEY)).toBe('dark');
+    expect(result.current.themeMode).toBe('dark');
+  });
+
+  it('rejects unknown stored values and falls back to defaultMode', () => {
+    window.localStorage.setItem(KEY, 'banana' as never);
+    const { result } = renderHook(() => useThemeModeState('light', KEY));
+    expect(result.current.themeMode).toBe('light');
+  });
+});

--- a/packages/backend.ai-ui/src/app-shell/hooks/useThemeMode.ts
+++ b/packages/backend.ai-ui/src/app-shell/hooks/useThemeMode.ts
@@ -1,0 +1,77 @@
+import type { ThemeMode } from '../types';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+interface ThemeModeContextValue {
+  themeMode: ThemeMode;
+  isDarkMode: boolean;
+  setThemeMode: (mode: ThemeMode) => void;
+}
+
+export const ThemeModeContext = createContext<ThemeModeContextValue | null>(
+  null,
+);
+
+export function useThemeMode(): ThemeModeContextValue {
+  const ctx = useContext(ThemeModeContext);
+  if (!ctx) {
+    throw new Error('useThemeMode must be used inside <AppShellProvider>');
+  }
+  return ctx;
+}
+
+function readStoredMode(key: string, fallback: ThemeMode): ThemeMode {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === 'light' || raw === 'dark' || raw === 'system') return raw;
+  } catch {
+    // localStorage unavailable
+  }
+  return fallback;
+}
+
+function systemPrefersDark(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+export function useThemeModeState(
+  defaultMode: ThemeMode,
+  storageKey: string,
+): ThemeModeContextValue {
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(() =>
+    readStoredMode(storageKey, defaultMode),
+  );
+  const [systemDark, setSystemDark] = useState<boolean>(systemPrefersDark);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  const setThemeMode = useCallback(
+    (mode: ThemeMode) => {
+      setThemeModeState(mode);
+      try {
+        window.localStorage.setItem(storageKey, mode);
+      } catch {
+        // ignore
+      }
+    },
+    [storageKey],
+  );
+
+  const isDarkMode =
+    themeMode === 'dark' || (themeMode === 'system' && systemDark);
+
+  return { themeMode, isDarkMode, setThemeMode };
+}

--- a/packages/backend.ai-ui/src/app-shell/index.ts
+++ b/packages/backend.ai-ui/src/app-shell/index.ts
@@ -1,0 +1,24 @@
+export { AppShell } from './AppShell';
+export { AppShellProvider } from './AppShellProvider';
+export { AppShellHeader } from './AppShellHeader';
+export { AppShellSider } from './AppShellSider';
+export { RootAppShell } from './RootAppShell';
+export type {
+  RootAppShellProps,
+  RootAppShellMenuItem,
+  RootAppShellTokens,
+  RootAppShellBrandingProps,
+} from './RootAppShell';
+
+export { useBranding } from './hooks/useBranding';
+export { useThemeMode } from './hooks/useThemeMode';
+export { useSiderCollapsed } from './hooks/useSiderCollapsed';
+export { useAppShellState } from './hooks/useAppShellState';
+
+export type {
+  AppShellProps,
+  AppShellHeaderProps,
+  AppShellSiderProps,
+  AppShellProviderProps,
+  ThemeMode,
+} from './types';

--- a/packages/backend.ai-ui/src/app-shell/internal/DefaultHeaderActions.tsx
+++ b/packages/backend.ai-ui/src/app-shell/internal/DefaultHeaderActions.tsx
@@ -1,0 +1,69 @@
+import { useThemeMode } from '../hooks/useThemeMode';
+import { Button, Space, Tooltip } from 'antd';
+import { CircleHelp, CircleUser, Moon, Sun } from 'lucide-react';
+
+export interface DefaultHeaderActionsProps {
+  /** Show the theme toggle button. Defaults to true. */
+  showThemeToggle?: boolean;
+  /** Show a help button. Defaults to true. Override `onHelpClick` to wire it up. */
+  showHelpButton?: boolean;
+  /** Show a user-menu button. Defaults to true. Override `onUserClick` to wire it up. */
+  showUserButton?: boolean;
+  /** Click handler for the help button. */
+  onHelpClick?: () => void;
+  /** Click handler for the user-menu button. */
+  onUserClick?: () => void;
+}
+
+export function DefaultHeaderActions({
+  showThemeToggle = true,
+  showHelpButton = true,
+  showUserButton = true,
+  onHelpClick,
+  onUserClick,
+}: DefaultHeaderActionsProps) {
+  const { isDarkMode, setThemeMode } = useThemeMode();
+  const NextIcon = isDarkMode ? Sun : Moon;
+  const next = isDarkMode ? 'light' : 'dark';
+  const tooltipLabel = isDarkMode
+    ? 'Switch to light mode'
+    : 'Switch to dark mode';
+
+  return (
+    <Space size={4}>
+      {showThemeToggle && (
+        <Tooltip title={tooltipLabel} placement="bottom">
+          <Button
+            type="text"
+            shape="circle"
+            icon={<NextIcon size={18} aria-hidden="true" />}
+            onClick={() => setThemeMode(next)}
+            aria-label={tooltipLabel}
+          />
+        </Tooltip>
+      )}
+      {showHelpButton && (
+        <Tooltip title="Help" placement="bottom">
+          <Button
+            type="text"
+            shape="circle"
+            icon={<CircleHelp size={18} aria-hidden="true" />}
+            onClick={onHelpClick}
+            aria-label="Help"
+          />
+        </Tooltip>
+      )}
+      {showUserButton && (
+        <Tooltip title="User menu" placement="bottom">
+          <Button
+            type="text"
+            shape="circle"
+            icon={<CircleUser size={18} aria-hidden="true" />}
+            onClick={onUserClick}
+            aria-label="User menu"
+          />
+        </Tooltip>
+      )}
+    </Space>
+  );
+}

--- a/packages/backend.ai-ui/src/app-shell/internal/DefaultHeaderLeft.tsx
+++ b/packages/backend.ai-ui/src/app-shell/internal/DefaultHeaderLeft.tsx
@@ -1,0 +1,35 @@
+import { useBranding } from '../hooks/useBranding';
+import { ChevronRight } from 'lucide-react';
+
+interface DefaultHeaderLeftProps {
+  pageTitle?: string;
+}
+
+export function DefaultHeaderLeft({ pageTitle }: DefaultHeaderLeftProps) {
+  const { branding } = useBranding();
+  const productName = branding?.productName;
+  const brandName = branding?.brandName;
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+      {brandName && (
+        <strong style={{ fontSize: 15 }}>
+          {brandName}
+          {productName ? ` ${productName}` : ''}
+        </strong>
+      )}
+      {pageTitle && (
+        <>
+          {brandName && (
+            <ChevronRight
+              size={14}
+              aria-hidden="true"
+              style={{ opacity: 0.5 }}
+            />
+          )}
+          <span style={{ fontSize: 14, opacity: 0.85 }}>{pageTitle}</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/backend.ai-ui/src/app-shell/internal/DefaultSiderMenu.tsx
+++ b/packages/backend.ai-ui/src/app-shell/internal/DefaultSiderMenu.tsx
@@ -1,0 +1,44 @@
+import { useAppShellState } from '../hooks/useAppShellState';
+import {
+  type RootAppShellMenuItem,
+  buildAntdMenuItems,
+} from './buildAntdMenuItems';
+import { Menu } from 'antd';
+import { memo, useMemo } from 'react';
+
+interface DefaultSiderMenuProps {
+  menus: RootAppShellMenuItem[];
+  selectedKey: string;
+  onSelect: (key: string) => void;
+}
+
+export const DefaultSiderMenu = memo(function DefaultSiderMenu({
+  menus,
+  selectedKey,
+  onSelect,
+}: DefaultSiderMenuProps) {
+  const { collapsed } = useAppShellState();
+  const items = useMemo(
+    () => buildAntdMenuItems(menus, collapsed),
+    [menus, collapsed],
+  );
+
+  // Note: no `theme={...}` prop. ConfigProvider's algorithm (set by
+  // AppShellProvider) drives dark/light coloring; setting Menu's `theme` here
+  // would override our `Layout.siderBg` and `colorPrimary` token customizations
+  // with antd's hardcoded preset palette.
+  return (
+    <Menu
+      mode="inline"
+      inlineCollapsed={collapsed}
+      items={items}
+      selectedKeys={[selectedKey]}
+      onClick={({ key }) => onSelect(key)}
+      style={{
+        borderInlineEnd: 'none',
+        background: 'transparent',
+        userSelect: 'none',
+      }}
+    />
+  );
+});

--- a/packages/backend.ai-ui/src/app-shell/internal/buildAntdMenuItems.test.tsx
+++ b/packages/backend.ai-ui/src/app-shell/internal/buildAntdMenuItems.test.tsx
@@ -1,0 +1,71 @@
+import { buildAntdMenuItems } from './buildAntdMenuItems';
+
+describe('buildAntdMenuItems', () => {
+  it('groups consecutive items with the same group field', () => {
+    const items = buildAntdMenuItems(
+      [
+        { key: 'a', label: 'A', group: 'X' },
+        { key: 'b', label: 'B', group: 'X' },
+        { key: 'c', label: 'C', group: 'Y' },
+      ],
+      false,
+    );
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      type: 'group',
+      children: [{ key: 'a' }, { key: 'b' }],
+    });
+    expect(items[1]).toMatchObject({
+      type: 'group',
+      children: [{ key: 'c' }],
+    });
+  });
+
+  it('renders ungrouped items directly without a group wrapper', () => {
+    const items = buildAntdMenuItems([{ key: 'flat', label: 'Flat' }], false);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ key: 'flat', label: 'Flat' });
+    expect(items[0]).not.toHaveProperty('type', 'group');
+  });
+
+  it('emits monotonically unique keys when the same group name reappears', () => {
+    // Regression test for B4: duplicate "__group:Main" keys would crash antd's reconciler.
+    const items = buildAntdMenuItems(
+      [
+        { key: 'a', label: 'A', group: 'Main' },
+        { key: 'b', label: 'B', group: 'Other' },
+        { key: 'c', label: 'C', group: 'Main' },
+      ],
+      false,
+    );
+    const keys = items.map((i) => i?.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('still groups correctly when collapsed (the label changes but structure stays)', () => {
+    const expanded = buildAntdMenuItems(
+      [{ key: 'a', label: 'A', group: 'X' }],
+      false,
+    );
+    const collapsed = buildAntdMenuItems(
+      [{ key: 'a', label: 'A', group: 'X' }],
+      true,
+    );
+    expect(collapsed).toHaveLength(expanded.length);
+    expect((collapsed[0] as { children: unknown[] }).children).toHaveLength(1);
+  });
+
+  it('handles an empty menu list', () => {
+    expect(buildAntdMenuItems([], false)).toEqual([]);
+  });
+
+  it('does not lose icons during the grouping pass', () => {
+    const icon = '★' as unknown as React.ReactNode;
+    const items = buildAntdMenuItems(
+      [{ key: 'a', label: 'A', icon, group: 'X' }],
+      false,
+    );
+    const first = items[0] as { children: Array<{ icon: unknown }> };
+    expect(first.children[0]?.icon).toBe(icon);
+  });
+});

--- a/packages/backend.ai-ui/src/app-shell/internal/buildAntdMenuItems.tsx
+++ b/packages/backend.ai-ui/src/app-shell/internal/buildAntdMenuItems.tsx
@@ -1,0 +1,86 @@
+import { Typography } from 'antd';
+import type { MenuProps } from 'antd';
+import type { ReactNode } from 'react';
+
+export interface RootAppShellMenuItem {
+  key: string;
+  label: string;
+  /** Optional icon node. Recommend a 16px lucide-react icon. */
+  icon?: ReactNode;
+  /** Optional group name. Consecutive items with the same group are grouped together. */
+  group?: string;
+}
+
+type AntdMenuItem = NonNullable<MenuProps['items']>[number];
+
+function groupTitle(text: string, collapsed: boolean) {
+  if (collapsed) {
+    return (
+      <div
+        style={{
+          height: 0,
+          borderBottom: '1px solid var(--bai-sider-border)',
+        }}
+      />
+    );
+  }
+  return (
+    <Typography.Text
+      type="secondary"
+      ellipsis
+      style={{ fontSize: 14, fontWeight: 500 }}
+    >
+      {text}
+    </Typography.Text>
+  );
+}
+
+/**
+ * Convert RootAppShell's flat menu list into antd Menu's nested
+ * `MenuProps['items']` structure. Items are bucketed by their `group` field —
+ * consecutive items with the same group share one antd `type: 'group'` parent.
+ *
+ * Items without a group are rendered directly without a group wrapper.
+ */
+export function buildAntdMenuItems(
+  menus: RootAppShellMenuItem[],
+  collapsed: boolean,
+): NonNullable<MenuProps['items']> {
+  const result: AntdMenuItem[] = [];
+  let currentGroup: string | undefined;
+  let bucket: AntdMenuItem[] = [];
+  let groupIndex = 0;
+
+  const flush = () => {
+    if (bucket.length === 0) return;
+    if (currentGroup === undefined) {
+      result.push(...bucket);
+    } else {
+      // Monotonic prefix in the key so the same group name appearing twice
+      // (e.g. Main → MLOps → Main) doesn't collide on antd's reconciler.
+      result.push({
+        type: 'group',
+        key: `__group:${groupIndex}:${currentGroup}`,
+        label: groupTitle(currentGroup, collapsed),
+        children: bucket,
+      });
+      groupIndex += 1;
+    }
+    bucket = [];
+  };
+
+  for (const menu of menus) {
+    if (menu.group !== currentGroup) {
+      flush();
+      currentGroup = menu.group;
+    }
+    bucket.push({
+      key: menu.key,
+      label: menu.label,
+      icon: menu.icon,
+    });
+  }
+  flush();
+
+  return result;
+}

--- a/packages/backend.ai-ui/src/app-shell/internal/buildBrandingFromProps.test.ts
+++ b/packages/backend.ai-ui/src/app-shell/internal/buildBrandingFromProps.test.ts
@@ -1,0 +1,50 @@
+import { buildBrandingFromProps } from './buildBrandingFromProps';
+
+describe('buildBrandingFromProps', () => {
+  it('returns undefined when nothing is supplied (lets defaults take over)', () => {
+    expect(buildBrandingFromProps({})).toBeUndefined();
+  });
+
+  it('individual props override the corresponding fields on a passed branding object', () => {
+    const result = buildBrandingFromProps({
+      branding: {
+        branding: { brandName: 'Old', companyName: 'OldCo' },
+      },
+      brandName: 'New',
+    });
+    expect(result?.branding?.brandName).toBe('New');
+    expect(result?.branding?.companyName).toBe('OldCo');
+  });
+
+  it('shallow-merges colors per mode (light + dark)', () => {
+    const result = buildBrandingFromProps({
+      branding: {
+        colors: {
+          light: { primary: '#111', headerBg: '#222' },
+          dark: { primary: '#AAA' },
+        },
+      },
+      colors: {
+        light: { headerBg: '#333' }, // overrides light.headerBg only
+      },
+    });
+    expect(result?.colors?.light?.primary).toBe('#111');
+    expect(result?.colors?.light?.headerBg).toBe('#333');
+    expect(result?.colors?.dark?.primary).toBe('#AAA');
+  });
+
+  it('translates the flat tokens shape into nested sider/header config', () => {
+    const result = buildBrandingFromProps({
+      tokens: {
+        siderWidth: 250,
+        siderCollapsedWidth: 80,
+        headerHeight: 64,
+        fontFamily: "'Inter', sans-serif",
+      },
+    });
+    expect(result?.sider?.widthExpanded).toBe(250);
+    expect(result?.sider?.widthCollapsed).toBe(80);
+    expect(result?.header?.height).toBe(64);
+    expect(result?.fontFamily).toBe("'Inter', sans-serif");
+  });
+});

--- a/packages/backend.ai-ui/src/app-shell/internal/buildBrandingFromProps.ts
+++ b/packages/backend.ai-ui/src/app-shell/internal/buildBrandingFromProps.ts
@@ -1,0 +1,101 @@
+import type {
+  BrandingConfig,
+  ColorTokens,
+  LogoConfig,
+} from '../../branding-schema';
+
+export interface RootAppShellTokens {
+  /** Sider expanded width in px. Default 240. */
+  siderWidth?: number;
+  /** Sider collapsed width in px. Default 74. */
+  siderCollapsedWidth?: number;
+  /** Header height in px. Default 60. */
+  headerHeight?: number;
+  /** CSS font-family value. Default `'Ubuntu', system-ui, ...`. */
+  fontFamily?: string;
+}
+
+export interface RootAppShellBrandingProps {
+  /** Optional full BrandingConfig — individual props (logo/colors/etc.) override its fields. */
+  branding?: BrandingConfig;
+  /** Logo config (variants for light/dark, expanded/collapsed). */
+  logo?: LogoConfig;
+  /** Brand display name (e.g. "Backend.AI"). */
+  brandName?: string;
+  /** Company name shown in default sider footer copyright. */
+  companyName?: string;
+  /** Product display name (e.g. "FastTrack") shown next to brand name in header. */
+  productName?: string;
+  /** Color tokens for light + dark modes. */
+  colors?: { light?: ColorTokens; dark?: ColorTokens };
+  /** Dimension tokens (sider/header sizes, font family). */
+  tokens?: RootAppShellTokens;
+}
+
+/**
+ * Build a BrandingConfig from the flat props on RootAppShell. Individual props
+ * override the corresponding fields of `branding` if both are provided.
+ */
+export function buildBrandingFromProps(
+  props: RootAppShellBrandingProps,
+): BrandingConfig | undefined {
+  const {
+    branding,
+    logo,
+    brandName,
+    companyName,
+    productName,
+    colors,
+    tokens,
+  } = props;
+
+  // If no individual props are given and no branding object, return undefined
+  // so AppShellProvider falls back to defaultBranding.
+  const hasAny =
+    branding ||
+    logo ||
+    brandName ||
+    companyName ||
+    productName ||
+    colors ||
+    tokens;
+  if (!hasAny) return undefined;
+
+  const merged: BrandingConfig = {
+    ...(branding ?? {}),
+    logo: logo ?? branding?.logo,
+    branding: {
+      ...(branding?.branding ?? {}),
+      ...(brandName !== undefined ? { brandName } : {}),
+      ...(companyName !== undefined ? { companyName } : {}),
+      ...(productName !== undefined ? { productName } : {}),
+    },
+    colors: colors
+      ? {
+          light: {
+            ...(branding?.colors?.light ?? {}),
+            ...(colors.light ?? {}),
+          },
+          dark: { ...(branding?.colors?.dark ?? {}), ...(colors.dark ?? {}) },
+        }
+      : branding?.colors,
+    fontFamily: tokens?.fontFamily ?? branding?.fontFamily,
+    sider: {
+      ...(branding?.sider ?? {}),
+      ...(tokens?.siderWidth !== undefined
+        ? { widthExpanded: tokens.siderWidth }
+        : {}),
+      ...(tokens?.siderCollapsedWidth !== undefined
+        ? { widthCollapsed: tokens.siderCollapsedWidth }
+        : {}),
+    },
+    header: {
+      ...(branding?.header ?? {}),
+      ...(tokens?.headerHeight !== undefined
+        ? { height: tokens.headerHeight }
+        : {}),
+    },
+  };
+
+  return merged;
+}

--- a/packages/backend.ai-ui/src/app-shell/styles.ts
+++ b/packages/backend.ai-ui/src/app-shell/styles.ts
@@ -1,0 +1,267 @@
+import { createStyles } from 'antd-style';
+
+/**
+ * Styles for the AppShell layout primitives. Mirrors the staging-repo
+ * `styles.css` (see `lablup/backend.ai-appshell` source), but adapted to
+ * `antd-style` `createStyles` so it composes into BUI's library bundle and
+ * scopes class names through the css-in-js pipeline.
+ *
+ * The component-level antd theming (colors, fonts, sizes) lives in
+ * `utils/antdTheme.ts` and is applied by `AppShellProvider` via
+ * `<ConfigProvider>`. The `--bai-*` CSS custom properties below are still
+ * set by `AppShellProvider` on the root div as inline style — keeping them
+ * available for non-antd custom styling consumers might want.
+ */
+export const useAppShellStyles = createStyles(({ css }) => ({
+  /** Root wrapper applied to the AntdApp <div>. Holds default `--bai-*` vars
+   *  and base flex layout. */
+  root: css`
+    --bai-color-primary: #1677ff;
+    --bai-color-primary-hover: #4096ff;
+    --bai-header-bg: #ffffff;
+    --bai-header-text: #141414;
+    --bai-sider-bg: #ffffff;
+    --bai-sider-text: #141414;
+    --bai-sider-active-bg: #e6f4ff;
+    --bai-sider-active-text: #1677ff;
+    --bai-sider-border: #dee1e7;
+    --bai-content-bg: #f5f7fa;
+    --bai-content-text: #141414;
+    --bai-border-color: #dee1e7;
+
+    --bai-sider-width-expanded: 240px;
+    --bai-sider-width-collapsed: 74px;
+    --bai-header-height: 60px;
+    --bai-font-family: 'Ubuntu', system-ui, -apple-system, sans-serif;
+
+    --bai-logo-bg: var(--bai-color-primary);
+    --bai-logo-text: var(--bai-header-text);
+
+    font-family: var(--bai-font-family);
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    /* Inherit min-height from parent so consumers mounting this inside a sized
+       container (e.g. WebUI's existing chrome) get the right scroll boundary
+       instead of forcing 100vh. Falls back to 100vh on bare html/body. */
+    min-height: inherit;
+
+    /* When the root is the document's direct child, fall back to viewport
+       height so demo templates and standalone consumers fill the screen. */
+    body > & {
+      min-height: 100vh;
+    }
+  `,
+
+  /** Sider wrapper — sticky positioning + box-shadow on top of antd Sider. */
+  sider: css`
+    &.ant-layout-sider {
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+    }
+
+    /* Sider must be a flex column to stack header + content + footer correctly */
+    .ant-layout-sider-children {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      overflow: visible; /* allow edge toggle to escape */
+    }
+
+    /* Align antd Menu group title with the icon column of items below.
+     *   Menu items: itemMarginInline=16 + itemPaddingInline=16 → icons start at 32px.
+     *   Group title default padding-inline: 16px — bump to 32px (paddingXL convention)
+     *   so the title text and icon column line up. Tighter vertical rhythm too. */
+    .ant-menu-item-group-title {
+      padding-inline-start: 32px;
+      padding-inline-end: 16px;
+      padding-block: 12px 4px;
+    }
+  `,
+
+  /** Modifier on the sider when collapsed. */
+  siderCollapsed: css`
+    /* Collapsed: no inline padding so the divider line spans the full sider width. */
+    .ant-menu-item-group-title {
+      padding-inline: 0;
+      padding-block: 8px;
+    }
+  `,
+
+  /** Logo bar — custom; antd has no equivalent. */
+  siderHeader: css`
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    height: var(--bai-header-height);
+    padding: 0 30px;
+    background: var(--bai-logo-bg);
+    color: var(--bai-logo-text);
+    flex-shrink: 0;
+    transition:
+      padding 200ms ease,
+      background-color 200ms ease;
+  `,
+
+  /** Modifier on the sider header when collapsed (centers the logo). */
+  siderHeaderCollapsed: css`
+    justify-content: center;
+    padding: 0 8px;
+  `,
+
+  /** Logo image — pre-rendered for every variant; CSS shows the active one. */
+  logo: css`
+    max-width: 100%;
+    height: auto;
+    display: none;
+    user-select: none;
+  `,
+
+  logoLink: css`
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+    outline: none;
+  `,
+
+  brandText: css`
+    color: inherit;
+    white-space: nowrap;
+    overflow: hidden;
+  `,
+
+  /** Sider scrollable content with hover-reveal scrollbar.
+   *  Visibility is driven by the parent sider's :hover / :focus-within state
+   *  (handled by `siderHovering` modifier rules in the React component). */
+  siderContent: css`
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 16px 0 8px;
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    &::-webkit-scrollbar-thumb {
+      background-color: transparent;
+      border-radius: 3px;
+      transition: background-color 200ms ease;
+    }
+  `,
+
+  /** Modifier toggled when the sider is hovered/focused — reveals the
+   *  scrollbar thumb. Apply alongside `siderContent`. */
+  siderContentHovering: css`
+    scrollbar-color: var(--bai-sider-border) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--bai-sider-border);
+    }
+  `,
+
+  /** Sider footer (small, muted; only shown when expanded). */
+  siderFooter: css`
+    padding: 12px 16px;
+    border-top: 1px solid var(--bai-sider-border);
+    font-size: 12px;
+    opacity: 0.65;
+    text-align: center;
+    flex-shrink: 0;
+  `,
+
+  /** Hover-reveal collapse toggle on sider's right edge.
+   *  `translateX(12px)` matches WebUI's SiderToggleButton — the button
+   *  protrudes 12px outside the sider's right edge so it's clearly tappable. */
+  edgeToggle: css`
+    position: absolute;
+    right: 0;
+    top: calc(var(--bai-header-height) + 16px);
+    transform: translateX(12px);
+    z-index: 11;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 1px solid var(--bai-sider-border);
+    background: var(--bai-sider-bg);
+    color: var(--bai-sider-text);
+    cursor: pointer;
+    padding: 0;
+    visibility: hidden;
+    opacity: 0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    transition:
+      opacity 200ms ease,
+      visibility 200ms ease,
+      background-color 120ms ease;
+
+    &:hover {
+      background: var(--bai-sider-active-bg);
+      color: var(--bai-sider-active-text);
+    }
+
+    &:focus-visible {
+      visibility: visible;
+      opacity: 1;
+      outline: 2px solid var(--bai-color-primary);
+      outline-offset: 2px;
+    }
+  `,
+
+  /** Modifier that forces the edge toggle visible (e.g. on hover). */
+  edgeToggleVisible: css`
+    visibility: visible;
+    opacity: 1;
+  `,
+
+  /** Header — antd Layout.Header, with our slot layout on top. */
+  header: css`
+    display: flex;
+    align-items: center;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    gap: 12px;
+  `,
+
+  collapseToggle: css`
+    flex-shrink: 0;
+  `,
+
+  headerLeft: css`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
+    min-width: 0;
+  `,
+
+  headerRight: css`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  `,
+
+  banner: css`
+    flex-shrink: 0;
+  `,
+
+  content: css`
+    padding: 16px;
+    overflow: auto;
+  `,
+}));

--- a/packages/backend.ai-ui/src/app-shell/types.ts
+++ b/packages/backend.ai-ui/src/app-shell/types.ts
@@ -1,0 +1,67 @@
+import type { BrandingConfig } from '../branding-schema';
+import type { ReactNode } from 'react';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+export interface AppShellProviderProps {
+  branding?: BrandingConfig;
+  defaultThemeMode?: ThemeMode;
+  themeStorageKey?: string;
+  children: ReactNode;
+}
+
+export interface AppShellProps {
+  /** Slot rendered at the top of the sider (the logo bar). Defaults to the branding logo. */
+  siderHeader?: ReactNode;
+  /** Sider body — typically a navigation menu. Consumer brings their own (antd Menu, custom, etc.). */
+  siderContent?: ReactNode;
+  /** Optional sider footer (copyright, version). Hidden when collapsed. */
+  siderFooter?: ReactNode;
+
+  /** Header left slot — typically a project selector, breadcrumb, or page title. */
+  headerLeft?: ReactNode;
+  /** Header right slot — typically theme toggle + user menu cluster. */
+  headerRight?: ReactNode;
+  /** Show the collapse toggle button in the header. Defaults to false — the sider edge
+   *  hover-reveal toggle is the canonical collapse control. Set true to add a second
+   *  always-visible toggle in the header (helpful for touch devices). */
+  showHeaderCollapseToggle?: boolean;
+
+  /** Show the hover-reveal collapse toggle on the sider's right edge. Defaults to true. */
+  showSiderCollapseToggle?: boolean;
+
+  /** Optional banner rendered between header and content (e.g. connectivity warning). */
+  contentBanner?: ReactNode;
+
+  /** Main content. */
+  children?: ReactNode;
+
+  /** Initial collapsed state when no value is persisted. Defaults to false. */
+  defaultCollapsed?: boolean;
+  /** localStorage key for persisting collapse. Defaults to 'appShell.sideCollapsed'. */
+  collapseStorageKey?: string;
+  /** Single-character key that toggles collapse. Defaults to '['. Set to null to disable. */
+  collapseShortcut?: string | null;
+}
+
+export interface AppShellHeaderProps {
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+  showCollapseToggle?: boolean;
+  left?: ReactNode;
+  right?: ReactNode;
+}
+
+export interface AppShellSiderProps {
+  collapsed: boolean;
+  onToggleCollapse?: () => void;
+  /** Called whenever the antd Sider crosses the responsive breakpoint, with
+   *  `broken=true` when entering narrow mode and `broken=false` when entering
+   *  wide mode. AppShell wires this to (a) force-collapse on narrow without
+   *  persisting and (b) restore the user's persisted choice on wide. */
+  onBreakpointCollapse?: (broken: boolean) => void;
+  showEdgeToggle?: boolean;
+  header?: ReactNode;
+  children?: ReactNode;
+  footer?: ReactNode;
+}

--- a/packages/backend.ai-ui/src/app-shell/utils/antdTheme.test.ts
+++ b/packages/backend.ai-ui/src/app-shell/utils/antdTheme.test.ts
@@ -1,0 +1,63 @@
+import { buildAntdTheme } from './antdTheme';
+
+describe('hexToRgba (via itemSelectedBg)', () => {
+  it('produces rgba 15% from a #RRGGBB primary in light mode', () => {
+    const theme = buildAntdTheme(
+      { colors: { light: { primary: '#FF7A00' } } },
+      false,
+    );
+    expect(theme.components?.Menu?.itemSelectedBg).toBe(
+      'rgba(255, 122, 0, 0.15)',
+    );
+  });
+
+  it('uses dark primary when isDarkMode=true', () => {
+    const theme = buildAntdTheme(
+      {
+        colors: { light: { primary: '#1677FF' }, dark: { primary: '#4096FF' } },
+      },
+      true,
+    );
+    expect(theme.components?.Menu?.itemSelectedBg).toBe(
+      'rgba(64, 150, 255, 0.15)',
+    );
+  });
+
+  it('falls back to undefined for invalid hex (no #fff shorthand support)', () => {
+    const theme = buildAntdTheme(
+      { colors: { light: { primary: '#fff' } } },
+      false,
+    );
+    // Invalid → undefined. Documented limitation; #RRGGBB only.
+    expect(theme.components?.Menu?.itemSelectedBg).toBeUndefined();
+  });
+});
+
+describe('buildAntdTheme', () => {
+  it('selects dark or light algorithm based on isDarkMode', () => {
+    const dark = buildAntdTheme(undefined, true);
+    const light = buildAntdTheme(undefined, false);
+    expect(dark.algorithm).not.toBe(light.algorithm);
+  });
+
+  it('forwards Layout.headerBg from branding.colors[mode]', () => {
+    const theme = buildAntdTheme(
+      {
+        colors: {
+          light: { headerBg: '#ABCDEF' },
+          dark: { headerBg: '#123456' },
+        },
+      },
+      false,
+    );
+    expect(theme.components?.Layout?.headerBg).toBe('#ABCDEF');
+  });
+
+  it('keeps Menu component tokens locked to WebUI/FastTrack convention', () => {
+    const theme = buildAntdTheme(undefined, false);
+    expect(theme.components?.Menu?.itemHeight).toBe(40);
+    expect(theme.components?.Menu?.itemBorderRadius).toBe(20);
+    expect(theme.components?.Menu?.itemMarginInline).toBe(16);
+    expect(theme.components?.Menu?.fontSize).toBe(16);
+  });
+});

--- a/packages/backend.ai-ui/src/app-shell/utils/antdTheme.ts
+++ b/packages/backend.ai-ui/src/app-shell/utils/antdTheme.ts
@@ -1,0 +1,94 @@
+import type { BrandingConfig, ColorTokens } from '../../branding-schema';
+import { defaultBranding } from '../../branding-schema';
+import { theme as antdTheme } from 'antd';
+import type { ThemeConfig } from 'antd';
+
+function mergeColors(
+  base: ColorTokens | undefined,
+  override: ColorTokens | undefined,
+): ColorTokens {
+  return { ...(base ?? {}), ...(override ?? {}) };
+}
+
+/**
+ * Convert a `#RRGGBB` hex color to an `rgba(r, g, b, alpha)` string.
+ * Mirrors WebUI's `colorPrimaryWithAlpha` computation in BAIMenu.
+ */
+function hexToRgba(hex: string | undefined, alpha: number): string | undefined {
+  if (!hex || hex[0] !== '#' || hex.length !== 7) return undefined;
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
+ * Map BrandingConfig + dark-mode flag to antd's ThemeConfig.
+ *
+ * The component-token settings here come from the WebUI/FastTrack BAIMenu
+ * inventory: 40px item height, pill-shape (20px radius), 16px horizontal
+ * margin, 16px font (fontSizeLG), selected bg = primary @ 15% alpha
+ * (handled by antd via colorPrimaryBg / itemSelectedBg).
+ */
+export function buildAntdTheme(
+  branding: BrandingConfig | undefined,
+  isDarkMode: boolean,
+): ThemeConfig {
+  const merged: BrandingConfig = {
+    ...defaultBranding,
+    ...(branding ?? {}),
+    colors: {
+      light: mergeColors(
+        defaultBranding.colors?.light,
+        branding?.colors?.light,
+      ),
+      dark: mergeColors(defaultBranding.colors?.dark, branding?.colors?.dark),
+    },
+    sider: { ...defaultBranding.sider, ...(branding?.sider ?? {}) },
+    header: { ...defaultBranding.header, ...(branding?.header ?? {}) },
+  };
+  const c = isDarkMode ? merged.colors?.dark : merged.colors?.light;
+
+  return {
+    algorithm: isDarkMode
+      ? antdTheme.darkAlgorithm
+      : antdTheme.defaultAlgorithm,
+    token: {
+      colorPrimary: c?.primary,
+      colorLink: c?.primary,
+      colorBgLayout: c?.contentBg,
+      colorText: c?.contentText,
+      colorBorder: c?.borderColor,
+      colorBorderSecondary: c?.siderBorder,
+      fontFamily: merged.fontFamily,
+    },
+    components: {
+      Layout: {
+        headerBg: c?.headerBg,
+        headerColor: c?.headerText,
+        headerHeight: merged.header?.height,
+        headerPadding: '0 16px',
+        siderBg: c?.siderBg,
+        bodyBg: c?.contentBg,
+      },
+      Menu: {
+        itemHeight: 40,
+        itemBorderRadius: 20,
+        itemMarginInline: 16,
+        itemMarginBlock: 4,
+        itemPaddingInline: 16,
+        // Match WebUI's BAIMenu: items use fontSizeLG (16). Group titles stay
+        // at 14 via inline style on Typography.Text — produces the visual
+        // hierarchy where labels read as headings and items as body text.
+        fontSize: 16,
+        iconSize: 16,
+        collapsedWidth: merged.sider?.widthCollapsed,
+        // Selected-item background: primary @ 15% alpha (matches WebUI's BAIMenu)
+        itemSelectedBg: hexToRgba(c?.primary, 0.15),
+      },
+      Button: {
+        controlHeight: 36,
+      },
+    },
+  };
+}

--- a/packages/backend.ai-ui/src/app-shell/utils/cssVars.ts
+++ b/packages/backend.ai-ui/src/app-shell/utils/cssVars.ts
@@ -1,0 +1,70 @@
+import type { BrandingConfig, ColorTokens } from '../../branding-schema';
+import { defaultBranding } from '../../branding-schema';
+import type { CSSProperties } from 'react';
+
+const COLOR_VAR_MAP: Record<keyof ColorTokens, string> = {
+  primary: '--bai-color-primary',
+  primaryHover: '--bai-color-primary-hover',
+  headerBg: '--bai-header-bg',
+  headerText: '--bai-header-text',
+  siderBg: '--bai-sider-bg',
+  siderText: '--bai-sider-text',
+  siderActiveBg: '--bai-sider-active-bg',
+  siderActiveText: '--bai-sider-active-text',
+  siderBorder: '--bai-sider-border',
+  contentBg: '--bai-content-bg',
+  contentText: '--bai-content-text',
+  borderColor: '--bai-border-color',
+};
+
+function mergeColors(
+  base: ColorTokens | undefined,
+  override: ColorTokens | undefined,
+): ColorTokens {
+  return { ...(base ?? {}), ...(override ?? {}) };
+}
+
+export function buildShellCssVars(
+  branding: BrandingConfig | undefined,
+  isDarkMode: boolean,
+): CSSProperties {
+  const merged: BrandingConfig = {
+    ...defaultBranding,
+    ...(branding ?? {}),
+    colors: {
+      light: mergeColors(
+        defaultBranding.colors?.light,
+        branding?.colors?.light,
+      ),
+      dark: mergeColors(defaultBranding.colors?.dark, branding?.colors?.dark),
+    },
+    sider: { ...defaultBranding.sider, ...(branding?.sider ?? {}) },
+    header: { ...defaultBranding.header, ...(branding?.header ?? {}) },
+  };
+
+  const activeColors = isDarkMode ? merged.colors?.dark : merged.colors?.light;
+  const vars: Record<string, string | number> = {};
+
+  if (activeColors) {
+    for (const [key, value] of Object.entries(activeColors)) {
+      if (value === undefined) continue;
+      const varName = COLOR_VAR_MAP[key as keyof ColorTokens];
+      if (varName) vars[varName] = value;
+    }
+  }
+
+  if (merged.sider?.widthExpanded !== undefined) {
+    vars['--bai-sider-width-expanded'] = `${merged.sider.widthExpanded}px`;
+  }
+  if (merged.sider?.widthCollapsed !== undefined) {
+    vars['--bai-sider-width-collapsed'] = `${merged.sider.widthCollapsed}px`;
+  }
+  if (merged.header?.height !== undefined) {
+    vars['--bai-header-height'] = `${merged.header.height}px`;
+  }
+  if (merged.fontFamily) {
+    vars['--bai-font-family'] = merged.fontFamily;
+  }
+
+  return vars as CSSProperties;
+}

--- a/packages/backend.ai-ui/src/branding-schema/defaults.ts
+++ b/packages/backend.ai-ui/src/branding-schema/defaults.ts
@@ -1,0 +1,66 @@
+import type { BrandingConfig, ColorTokens } from './types';
+
+const lightColors: Required<
+  Pick<
+    ColorTokens,
+    | 'primary'
+    | 'primaryHover'
+    | 'headerBg'
+    | 'headerText'
+    | 'siderBg'
+    | 'siderText'
+    | 'siderActiveBg'
+    | 'siderActiveText'
+    | 'siderBorder'
+    | 'contentBg'
+    | 'contentText'
+    | 'borderColor'
+  >
+> = {
+  primary: '#1677FF',
+  primaryHover: '#4096FF',
+  headerBg: '#FFFFFF',
+  headerText: '#141414',
+  siderBg: '#FFFFFF',
+  siderText: '#141414',
+  siderActiveBg: '#E6F4FF',
+  siderActiveText: '#1677FF',
+  siderBorder: '#DEE1E7',
+  contentBg: '#F5F7FA',
+  contentText: '#141414',
+  borderColor: '#DEE1E7',
+};
+
+const darkColors: typeof lightColors = {
+  primary: '#4096FF',
+  primaryHover: '#69B1FF',
+  headerBg: '#141414',
+  headerText: '#FFFFFF',
+  siderBg: '#1F1F1F',
+  siderText: '#FFFFFF',
+  siderActiveBg: '#111B26',
+  siderActiveText: '#4096FF',
+  siderBorder: '#303030',
+  contentBg: '#000000',
+  contentText: '#FFFFFF',
+  borderColor: '#303030',
+};
+
+export const defaultBranding: BrandingConfig = {
+  branding: {
+    companyName: 'Lablup Inc.',
+    brandName: 'Backend.AI',
+  },
+  colors: {
+    light: lightColors,
+    dark: darkColors,
+  },
+  fontFamily: "'Ubuntu', system-ui, -apple-system, sans-serif",
+  sider: {
+    widthExpanded: 240,
+    widthCollapsed: 74,
+  },
+  header: {
+    height: 60,
+  },
+};

--- a/packages/backend.ai-ui/src/branding-schema/examples/fasttrack.theme.json
+++ b/packages/backend.ai-ui/src/branding-schema/examples/fasttrack.theme.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "../schema.json",
+  "logo": {
+    "src": "/static/manifest/backend.ai-fasttrack-white.svg",
+    "srcDark": "/static/manifest/backend.ai-fasttrack-black.svg",
+    "srcCollapsed": "/static/manifest/backend.ai-brand-simple-white.svg",
+    "srcCollapsedDark": "/static/manifest/backend.ai-brand-simple-dark.svg",
+    "size": { "width": 159, "height": 30 },
+    "sizeCollapsed": { "width": 32, "height": 32 },
+    "href": "/",
+    "alt": "Backend.AI FastTrack"
+  },
+  "branding": {
+    "companyName": "Lablup Inc.",
+    "brandName": "Backend.AI",
+    "productName": "FastTrack"
+  },
+  "colors": {
+    "light": {
+      "primary": "#1677FF",
+      "headerBg": "#1677FF",
+      "headerText": "#FFFFFF",
+      "siderActiveBg": "#E6F4FF",
+      "siderActiveText": "#1677FF",
+      "siderBorder": "#DEE1E7"
+    },
+    "dark": {
+      "primary": "#4096FF",
+      "headerBg": "#141414",
+      "headerText": "#FFFFFF",
+      "siderActiveBg": "#111B26",
+      "siderActiveText": "#4096FF"
+    }
+  },
+  "fontFamily": "'Ubuntu', system-ui, -apple-system, sans-serif"
+}

--- a/packages/backend.ai-ui/src/branding-schema/examples/lablup-default.theme.json
+++ b/packages/backend.ai-ui/src/branding-schema/examples/lablup-default.theme.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "../schema.json",
+  "logo": {
+    "src": "/manifest/backend.ai-webui-white.svg",
+    "srcDark": "/manifest/backend.ai-webui-black.svg",
+    "srcCollapsed": "/manifest/backend.ai-brand-simple-white.svg",
+    "srcCollapsedDark": "/manifest/backend.ai-brand-simple-black.svg",
+    "size": { "width": 159, "height": 24 },
+    "sizeCollapsed": { "width": 32, "height": 32 },
+    "href": "/",
+    "alt": "Backend.AI"
+  },
+  "branding": {
+    "companyName": "Lablup Inc.",
+    "brandName": "Backend.AI"
+  },
+  "colors": {
+    "light": {
+      "primary": "#FF7A00",
+      "primaryHover": "#FF9729",
+      "headerBg": "#FF9729",
+      "headerText": "#FFFFFF",
+      "siderBg": "#FFFFFF",
+      "siderText": "#141414",
+      "siderActiveBg": "#FFF1E0",
+      "siderActiveText": "#FF7A00",
+      "siderBorder": "#DEE1E7",
+      "contentBg": "#F5F7FA",
+      "contentText": "#141414",
+      "borderColor": "#DEE1E7"
+    },
+    "dark": {
+      "primary": "#DC6B03",
+      "primaryHover": "#FF7A00",
+      "headerBg": "#1F1F1F",
+      "headerText": "#FFFFFF",
+      "siderBg": "#1F1F1F",
+      "siderText": "#FFFFFF",
+      "siderActiveBg": "#2A1A0A",
+      "siderActiveText": "#FF9729",
+      "siderBorder": "#303030",
+      "contentBg": "#141414",
+      "contentText": "#FFFFFF",
+      "borderColor": "#303030"
+    }
+  },
+  "fontFamily": "'Ubuntu', system-ui, -apple-system, sans-serif",
+  "sider": { "widthExpanded": 240, "widthCollapsed": 74 },
+  "header": { "height": 60 }
+}

--- a/packages/backend.ai-ui/src/branding-schema/examples/webui.theme.json
+++ b/packages/backend.ai-ui/src/branding-schema/examples/webui.theme.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../schema.json",
+  "logo": {
+    "src": "/manifest/backend.ai-webui-white.svg",
+    "srcDark": "/manifest/backend.ai-webui-black.svg",
+    "srcCollapsed": "/manifest/backend.ai-brand-simple-white.svg",
+    "srcCollapsedDark": "/manifest/backend.ai-brand-simple-black.svg",
+    "size": { "width": 159, "height": 24 },
+    "sizeCollapsed": { "width": 34, "height": 34 },
+    "href": "/start",
+    "alt": "Backend.AI"
+  },
+  "branding": {
+    "companyName": "Lablup Inc.",
+    "brandName": "Backend.AI"
+  },
+  "colors": {
+    "light": {
+      "primary": "#FF7A00",
+      "headerBg": "#FF9729",
+      "headerText": "#FFFFFF",
+      "siderActiveBg": "#FFF1E0",
+      "siderActiveText": "#FF7A00"
+    },
+    "dark": {
+      "primary": "#DC6B03",
+      "headerBg": "#1F1F1F",
+      "headerText": "#FFFFFF"
+    }
+  },
+  "fontFamily": "'Ubuntu', Roboto, sans-serif"
+}

--- a/packages/backend.ai-ui/src/branding-schema/index.ts
+++ b/packages/backend.ai-ui/src/branding-schema/index.ts
@@ -1,0 +1,10 @@
+export type {
+  BrandingConfig,
+  LogoConfig,
+  LogoSize,
+  ColorTokens,
+  SiderDimensions,
+  HeaderDimensions,
+} from './types';
+
+export { defaultBranding } from './defaults';

--- a/packages/backend.ai-ui/src/branding-schema/schema.json
+++ b/packages/backend.ai-ui/src/branding-schema/schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lablup.com/schemas/backend-ai-branding.json",
+  "title": "Backend.AI Branding Config",
+  "description": "Configuration consumed by @lablup/backend-ai-app-shell. All fields optional; unspecified values fall back to defaults.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "logo": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "src": {
+          "type": "string",
+          "description": "Logo URL for expanded sider on light background."
+        },
+        "srcDark": {
+          "type": "string",
+          "description": "Logo URL for expanded sider on dark background."
+        },
+        "srcCollapsed": {
+          "type": "string",
+          "description": "Logo URL for collapsed sider on light background."
+        },
+        "srcCollapsedDark": {
+          "type": "string",
+          "description": "Logo URL for collapsed sider on dark background."
+        },
+        "size": { "$ref": "#/definitions/logoSize" },
+        "sizeCollapsed": { "$ref": "#/definitions/logoSize" },
+        "href": {
+          "type": "string",
+          "description": "Click target for the logo."
+        },
+        "alt": { "type": "string" }
+      },
+      "required": ["src"]
+    },
+    "branding": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "companyName": { "type": "string" },
+        "brandName": { "type": "string" },
+        "productName": { "type": "string" }
+      }
+    },
+    "colors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "light": { "$ref": "#/definitions/colorTokens" },
+        "dark": { "$ref": "#/definitions/colorTokens" }
+      }
+    },
+    "fontFamily": { "type": "string" },
+    "sider": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "widthExpanded": { "type": "number", "minimum": 0 },
+        "widthCollapsed": { "type": "number", "minimum": 0 }
+      }
+    },
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "height": { "type": "number", "minimum": 0 }
+      }
+    }
+  },
+  "definitions": {
+    "logoSize": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "width": { "type": "number", "minimum": 0 },
+        "height": { "type": "number", "minimum": 0 }
+      },
+      "required": ["width", "height"]
+    },
+    "colorTokens": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "primary": { "type": "string" },
+        "primaryHover": { "type": "string" },
+        "headerBg": { "type": "string" },
+        "headerText": { "type": "string" },
+        "siderBg": { "type": "string" },
+        "siderText": { "type": "string" },
+        "siderActiveBg": { "type": "string" },
+        "siderActiveText": { "type": "string" },
+        "siderBorder": { "type": "string" },
+        "contentBg": { "type": "string" },
+        "contentText": { "type": "string" },
+        "borderColor": { "type": "string" }
+      }
+    }
+  }
+}

--- a/packages/backend.ai-ui/src/branding-schema/types.ts
+++ b/packages/backend.ai-ui/src/branding-schema/types.ts
@@ -1,0 +1,56 @@
+export interface LogoSize {
+  width: number;
+  height: number;
+}
+
+export interface LogoConfig {
+  src: string;
+  srcDark?: string;
+  srcCollapsed?: string;
+  srcCollapsedDark?: string;
+  size?: LogoSize;
+  sizeCollapsed?: LogoSize;
+  href?: string;
+  alt?: string;
+}
+
+export interface ColorTokens {
+  primary?: string;
+  primaryHover?: string;
+  headerBg?: string;
+  headerText?: string;
+  siderBg?: string;
+  siderText?: string;
+  siderActiveBg?: string;
+  siderActiveText?: string;
+  siderBorder?: string;
+  contentBg?: string;
+  contentText?: string;
+  borderColor?: string;
+}
+
+export interface SiderDimensions {
+  widthExpanded?: number;
+  widthCollapsed?: number;
+}
+
+export interface HeaderDimensions {
+  height?: number;
+}
+
+export interface BrandingConfig {
+  logo?: LogoConfig;
+  branding?: {
+    companyName?: string;
+    brandName?: string;
+    productName?: string;
+  };
+  colors?: {
+    light?: ColorTokens;
+    dark?: ColorTokens;
+  };
+  fontFamily?: string;
+  sider?: SiderDimensions;
+  header?: HeaderDimensions;
+  [extension: string]: unknown;
+}

--- a/packages/backend.ai-ui/vite.config.ts
+++ b/packages/backend.ai-ui/vite.config.ts
@@ -1,19 +1,54 @@
 import react from '@vitejs/plugin-react';
 import glob from 'fast-glob';
-import { dirname, resolve, basename } from 'node:path';
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, relative, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
 import relay from 'vite-plugin-relay-lite';
 import svgr from 'vite-plugin-svgr';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Copies the branding-schema JSON assets (schema.json + examples/*.json) from
+ * `src/branding-schema/` into `dist/branding-schema/`. Vite's library bundler
+ * compiles `.ts` entries but ignores standalone JSON files, so we copy them
+ * after the bundle is written.
+ */
+function copyBrandingSchemaJson(): Plugin {
+  return {
+    name: 'bui-copy-branding-schema-json',
+    apply: 'build',
+    closeBundle() {
+      const srcDir = resolve(__dirname, 'src/branding-schema');
+      const outDir = resolve(__dirname, 'dist/branding-schema');
+      const jsonFiles = glob.sync('**/*.json', { cwd: srcDir });
+      for (const file of jsonFiles) {
+        const from = resolve(srcDir, file);
+        const to = resolve(outDir, file);
+        mkdirSync(dirname(to), { recursive: true });
+        copyFileSync(from, to);
+      }
+      const rels = jsonFiles.map((f) =>
+        relative(__dirname, resolve(outDir, f)),
+      );
+      // eslint-disable-next-line no-console
+      console.log(
+        `[bui-copy-branding-schema-json] copied ${rels.length} file(s):`,
+        rels.join(', '),
+      );
+    },
+  };
+}
+
 export default defineConfig(({ mode }) => {
   const isDevMode = mode === 'development';
   const localeFiles = glob.sync('src/locale/*.ts', { cwd: __dirname });
   const entries: Record<string, string> = {
     'backend.ai-ui': resolve(__dirname, 'src/index.ts'),
+    'branding-schema/index': resolve(__dirname, 'src/branding-schema/index.ts'),
+    'app-shell/index': resolve(__dirname, 'src/app-shell/index.ts'),
   };
   // Add locale entries
   localeFiles.forEach((file) => {
@@ -78,6 +113,7 @@ export default defineConfig(({ mode }) => {
         },
       }),
       svgr(),
+      copyBrandingSchemaJson(),
     ],
     server: {
       watch: {


### PR DESCRIPTION
## Summary
- Add brand-aligned `<RootAppShell>` and lower-level `<AppShell>` composition primitives — top bar, left sider, main content frame — for shared use across Backend.AI products.
- Add a co-located branding schema (TS types, JSON Schema, example themes) exposed as the `backend.ai-ui/branding-schema` subpath export.
- 32 new tests, 351 existing tests still pass, build + lint clean.

## Closes
Closes #7265 (sub-issue of #7264). Sub-issue #7266 will switch WebUI's existing `MainLayout` over to `<RootAppShell>` in a follow-up PR.

## Changes

### New: `packages/backend.ai-ui/src/components/Layout/`
- `AppShell.tsx` — Layout composer (Sider + Header + Content slots)
- `AppShellProvider.tsx` — wraps `<ConfigProvider>` + `<App>` with the computed antd theme and the `--bai-*` CSS custom-property bag
- `AppShellHeader.tsx`, `AppShellSider.tsx` — exposed for advanced use
- `RootAppShell.tsx` — one-tag convenience component
- `internal/{DefaultSiderMenu, DefaultHeaderActions, DefaultHeaderLeft, buildAntdMenuItems, buildBrandingFromProps}` (with `*.test.{ts,tsx}` for the two builders)
- `hooks/{useAppShellState, useBranding, useThemeMode, useSiderCollapsed, useKeyboardShortcut}` (with `*.test.ts` for `useThemeMode` and `useSiderCollapsed`)
- `utils/{antdTheme, cssVars}` (with `antdTheme.test.ts` covering `hexToRgba`, dark/light algorithm switch, Layout token forwarding)
- `styles.ts` — `antd-style createStyles` for the logo bar, sider edge hover-reveal toggle, hover-reveal scrollbar, and group-title alignment
- `types.ts`, `index.ts`
- `RootAppShell.test.tsx` — smoke render, controlled/uncontrolled, `onSelect`, `defaultSelectedKey`

### New: `packages/backend.ai-ui/src/branding-schema/`
- `types.ts`, `defaults.ts`, `index.ts` — TS source
- `schema.json` — JSON Schema (Draft-07)
- `examples/{lablup-default,fasttrack,webui}.theme.json` — three concrete branding configs. Logo `src` paths reference WebUI's existing `/manifest/backend.ai-*.svg` assets directly — no new asset files added.

### Modified
- `package.json` — adds `./branding-schema`, `./branding-schema/schema.json`, `./branding-schema/examples/*` to `exports`; adds `dist/branding-schema` to `files`
- `vite.config.ts` — adds `branding-schema/index` library entry; inline `bui-copy-branding-schema-json` plugin copies `schema.json` and `examples/*.json` into `dist/branding-schema/` after each build (Vite's lib bundler ignores standalone JSON)
- `eslint.config.js` — registers the JSONC parser for `src/branding-schema/{schema.json,examples/*.json}` so lint-staged accepts them
- `src/components/index.ts` — re-exports the new `Layout` subtree

## Notable design choices

- **Vitest** — matches the existing `packages/backend.ai-ui/vitest.config.ts`. Test files use `vi.fn()` and the standard globals; `localStorage`-backed hook tests clear the key in `beforeEach` so they don't bleed.
- **`antd-style createStyles`** — single factory for the Layout subtree, matching the rest of `backend.ai-ui`. `--bai-*` CSS custom properties remain available (set by `<AppShellProvider>` as inline style on the AntdApp root) so consumers can override per-instance.
- **Branding schema as subpath** — lives at `src/branding-schema/`, exposed at `backend.ai-ui/branding-schema` plus the JSON file and example subpaths. Co-located so type changes ship in lockstep with components.
- **No new brand assets** — `LogoConfig` defaults reference WebUI's existing `manifest/` SVGs.

## Acceptance
- [x] New tests pass (`pnpm test src/components/Layout/`: 32 tests, 6 files)
- [x] All existing tests still pass (`pnpm test`: 351 tests, 19 files; 1 pre-existing skip from `BAIDomainSelect.test.tsx` unrelated to this PR)
- [x] `pnpm build` emits the new exports — `dist/branding-schema/{index.js,index.d.ts,schema.json,examples/*.json}`
- [x] `pnpm lint` clean (no warnings)
- [x] `pnpm prettier --check` clean on all new files
- [x] No duplicated brand assets

## Test plan
- [ ] Reviewer pulls branch, runs `pnpm install && pnpm run relay && pnpm --filter backend.ai-ui test build lint`
- [ ] Verify `dist/branding-schema/` contains `index.js`, `index.d.ts`, `schema.json`, and the three example JSON files
- [ ] (Optional) Smoke-test `<RootAppShell>` in a sandbox — full WebUI chrome swap is in #7266, not this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)