### PR TITLE
feat(FR-2826): surface missing AddRevisionInput fields and fix UX issues in Add Revision modal

### DIFF
--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -4,12 +4,12 @@
  */
 import { DeploymentAddRevisionModalAddMutation } from '../__generated__/DeploymentAddRevisionModalAddMutation.graphql';
 import { DeploymentAddRevisionModalQuery } from '../__generated__/DeploymentAddRevisionModalQuery.graphql';
+import { convertToBinaryUnit } from '../helper';
 import { tokenizeShellCommand } from '../helper/parseCliCommand';
 import {
   mergeExtraArgs,
   reverseMapExtraArgs,
 } from '../helper/runtimeExtraArgsParser';
-import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import {
   buildArgsSchemaKeySet,
   buildDefaultsMap,
@@ -18,17 +18,25 @@ import {
   getExtraArgsEnvVarName,
   type RuntimeParameterGroup,
 } from '../hooks/useRuntimeParameterSchema';
+import EnvVarFormList, { type EnvVarFormListValue } from './EnvVarFormList';
 import ImageEnvironmentSelectFormItems, {
   type ImageEnvironmentFormInput,
 } from './ImageEnvironmentSelectFormItems';
 import RuntimeParameterFormSection, {
   type RuntimeParameterValues,
 } from './RuntimeParameterFormSection';
+import ResourceAllocationFormItems, {
+  AUTOMATIC_DEFAULT_SHMEM,
+  RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
+  type ResourceAllocationFormValue,
+} from './SessionFormItems/ResourceAllocationFormItems';
 import VFolderSelect from './VFolderSelect';
-import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import VFolderTableFormItem, {
+  type VFolderTableFormValues,
+} from './VFolderTableFormItem';
 import {
   App,
-  Button,
+  Collapse,
   Divider,
   Form,
   type FormInstance,
@@ -41,17 +49,30 @@ import {
   theme,
 } from 'antd';
 import {
-  BAIButton,
   BAIFlex,
   BAIModal,
-  BAIProjectResourceGroupSelect,
+  BAIModalProps,
+  convertToUUID,
   filterOutNullAndUndefined,
   isValidUUID,
   toLocalId,
 } from 'backend.ai-ui';
-import React, { Suspense, useEffect, useRef, useState } from 'react';
+import * as _ from 'lodash-es';
+import React, {
+  Suspense,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  commitLocalUpdate,
+  graphql,
+  useLazyLoadQuery,
+  useMutation,
+  useRelayEnvironment,
+} from 'react-relay';
 
 /**
  * Resolve a UUID from either a raw UUID or a Strawberry global id like
@@ -70,6 +91,14 @@ const safeDecodeUuid = (idOrGlobalId: string): string | undefined => {
   }
 };
 
+/**
+ * Inverse of `tokenizeShellCommand` for prefill. Joins token list back to a
+ * shell-command-like string, quoting any token that contains whitespace or
+ * shell-significant characters so a subsequent re-tokenize round-trips.
+ */
+const formatShellCommand = (tokens: readonly string[]): string =>
+  tokens.map((t) => (/[\s'"\\$`]/.test(t) ? JSON.stringify(t) : t)).join(' ');
+
 const SectionHeader: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -83,49 +112,43 @@ const SectionHeader: React.FC<{ children: React.ReactNode }> = ({
   );
 };
 
-interface DeploymentAddRevisionModalProps {
-  open: boolean;
-  onClose: () => void;
+interface DeploymentAddRevisionModalProps extends BAIModalProps {
   onSuccess: () => void;
   deploymentId: string;
 }
 
-type FormValues = ImageEnvironmentFormInput & {
-  name?: string;
-  clusterMode: 'SINGLE_NODE' | 'MULTI_NODE';
-  clusterSize: number;
-  resourceGroup: string;
-  runtimeVariantId: string;
-  modelFolderId: string;
-  mountDestination: string;
-  definitionPath: string;
-  customDefinitionMode?: 'command' | 'file';
-  startCommand?: string;
-  commandPort?: number;
-  commandHealthCheck?: string;
-  commandModelMount?: string;
-  commandInitialDelay?: number;
-  commandMaxRetries?: number;
-  environ: { name: string; value: string }[];
-};
+type FormValues = ImageEnvironmentFormInput &
+  ResourceAllocationFormValue &
+  VFolderTableFormValues & {
+    name?: string;
+    runtimeVariantId: string;
+    modelFolderId: string;
+    mountDestination: string;
+    definitionPath: string;
+    customDefinitionMode?: 'command' | 'file';
+    startCommand?: string;
+    commandPort?: number;
+    commandHealthCheck?: string;
+    commandModelMount?: string;
+    commandInitialDelay?: number;
+    commandMaxRetries?: number;
+    environ: EnvVarFormListValue[];
+  };
 
 interface DeploymentAddRevisionModalFormBodyProps {
   deploymentId: string;
   form: FormInstance<FormValues>;
-  open: boolean;
-  onClose: () => void;
   onSuccess: () => void;
   onIsAddingChange: (v: boolean) => void;
 }
 
 const DeploymentAddRevisionModalFormBody: React.FC<
   DeploymentAddRevisionModalFormBodyProps
-> = ({ deploymentId, form, open, onClose, onSuccess, onIsAddingChange }) => {
+> = ({ deploymentId, form, onSuccess, onIsAddingChange }) => {
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
-  const currentProject = useCurrentProjectValue();
 
   // Runtime parameter refs — kept outside form state so slider/input changes
   // don't re-render the modal. Read at submit time via serializeRuntimeParamsToEnviron.
@@ -133,7 +156,30 @@ const DeploymentAddRevisionModalFormBody: React.FC<
   const runtimeParamTouchedKeysRef = useRef<Set<string>>(new Set());
   const runtimeParamGroupsRef = useRef<RuntimeParameterGroup[] | null>(null);
 
-  const { deployment, runtimeVariants, resource_presets } =
+  // Initial values fed into `RuntimeParameterFormSection` for non-custom
+  // variants — split out of `currentRevision.modelRuntimeConfig.environ`
+  // once at mount time so the runtime-parameter UI can reverse-map ARGS-
+  // and ENV-typed presets back into their controls. State (not ref) so the
+  // child re-renders with the right initial data after the body resolves.
+  const [initialRuntimeExtraArgs, setInitialRuntimeExtraArgs] = useState('');
+  const [initialRuntimeEnvVars, setInitialRuntimeEnvVars] = useState<
+    Record<string, string> | undefined
+  >(undefined);
+
+  // Snapshot of prefilled `extraMounts.mountDestination`, keyed by the
+  // dash-stripped vfolder id. Read at submit time as a fallback when
+  // `values.mount_id_map` does not have the entry — VFolderTable's
+  // `onChangeAliasMap` *replaces* (not merges) the alias map and only
+  // surfaces aliases for rows that are visible in the current filtered
+  // table view, so any extra mount that lives outside that view (e.g. a
+  // vfolder owned by another user that the deployment was created with)
+  // would lose its alias as soon as the user edits *any* visible row's
+  // alias. The backend requires `mount_destination`, so without this
+  // fallback the next submit fails with `ExtraVFolderMountInput.__init__()
+  // missing 1 required keyword-only argument: 'mount_destination'`.
+  const prefilledMountAliasesRef = useRef<Record<string, string>>({});
+
+  const { deployment, runtimeVariants } =
     useLazyLoadQuery<DeploymentAddRevisionModalQuery>(
       graphql`
         query DeploymentAddRevisionModalQuery($deploymentId: ID!) {
@@ -148,6 +194,20 @@ const DeploymentAddRevisionModalFormBody: React.FC<
               }
               resourceConfig {
                 resourceGroupName
+                resourceOpts {
+                  entries {
+                    name
+                    value
+                  }
+                }
+              }
+              resourceSlots {
+                slotName
+                quantity
+              }
+              extraMounts {
+                vfolderId
+                mountDestination
               }
               modelRuntimeConfig {
                 runtimeVariantId
@@ -163,6 +223,27 @@ const DeploymentAddRevisionModalFormBody: React.FC<
                 mountDestination
                 definitionPath
               }
+              modelDefinition {
+                models {
+                  name
+                  modelPath
+                  service {
+                    startCommand
+                    port
+                    healthCheck {
+                      path
+                      maxRetries
+                      initialDelay
+                    }
+                  }
+                }
+              }
+              imageV2 {
+                id
+                identity {
+                  canonicalName
+                }
+              }
             }
           }
           runtimeVariants {
@@ -173,15 +254,40 @@ const DeploymentAddRevisionModalFormBody: React.FC<
               }
             }
           }
-          resource_presets {
-            name
-            resource_slots
-          }
         }
       `,
       { deploymentId },
-      { fetchPolicy: 'network-only' },
+      // `network-only` so that every fresh mount of the body refetches
+      // the deployment's current revision instead of returning the
+      // Relay store's previous snapshot — `addModelRevision` mutates
+      // `deployment.currentRevisionId` server-side without writing the
+      // new `currentRevision` sub-tree back into our local store, so
+      // a `store-or-network` read on re-open would prefill from the
+      // *previous* revision indefinitely.
+      //
+      // The historical concern that `network-only` could trigger an
+      // unmount/remount loop (suspending nested children → body
+      // tear-down → refetch → suspend again) does not apply here:
+      //   1. Modern React Suspense (we're on 19.2) keeps suspended
+      //      children mounted-but-paused rather than unmounting them,
+      //      so a child suspending does not reset this hook.
+      //   2. The closest Suspense boundary is the parent modal, not
+      //      the body itself, so children's throws don't bubble back
+      //      into the body.
+      //   3. The parent passes `destroyOnHidden` to BAIModal so the
+      //      body unmounts cleanly on close — re-open is a fresh mount,
+      //      one fetch per open.
+      { fetchPolicy: 'store-and-network' },
     );
+
+  // Captured for the mutation `updater` below: after a successful add,
+  // we need to mark the *parent deployment record* as invalid in the
+  // Relay store so that the next reopen of the modal sees the freshly-
+  // activated revision instead of the previously-cached one. The
+  // `addModelRevision` mutation only returns the new revision; it
+  // doesn't carry the deployment's updated `currentRevisionId`, so
+  // Relay has no way to know the deployment is stale on its own.
+  const relayEnvironment = useRelayEnvironment();
 
   const [commitAdd] = useMutation<DeploymentAddRevisionModalAddMutation>(
     graphql`
@@ -192,69 +298,263 @@ const DeploymentAddRevisionModalFormBody: React.FC<
           revision {
             id
             name
+            clusterConfig {
+              mode
+              size
+            }
+            resourceConfig {
+              resourceGroupName
+              resourceOpts {
+                entries {
+                  name
+                  value
+                }
+              }
+            }
+            resourceSlots {
+              slotName
+              quantity
+            }
+            modelRuntimeConfig {
+              runtimeVariantId
+              environ {
+                entries {
+                  name
+                  value
+                }
+              }
+            }
+            modelMountConfig {
+              vfolderId
+              mountDestination
+              definitionPath
+            }
+            extraMounts {
+              vfolderId
+              mountDestination
+            }
+            modelDefinition {
+              models {
+                name
+                modelPath
+                service {
+                  preStartActions {
+                    action
+                    args
+                  }
+                  startCommand
+                  shell
+                  port
+                  healthCheck {
+                    interval
+                    path
+                    maxRetries
+                    maxWaitTime
+                    expectedStatusCode
+                    initialDelay
+                  }
+                }
+              }
+            }
+            imageV2 {
+              id
+              identity {
+                canonicalName
+              }
+            }
           }
         }
       }
     `,
   );
 
-  const currentRevision = (
-    deployment as unknown as {
-      currentRevision?: {
-        clusterConfig?: { mode?: string; size?: number } | null;
-        resourceConfig?: { resourceGroupName?: string | null } | null;
-        modelRuntimeConfig?: {
-          runtimeVariantId?: string | null;
-          environ?: {
-            entries?: ReadonlyArray<{ name: string; value: string }> | null;
-          } | null;
-        } | null;
-        modelMountConfig?: {
-          vfolderId?: string | null;
-          mountDestination?: string | null;
-          definitionPath?: string | null;
-        } | null;
-      } | null;
-    }
-  )?.currentRevision;
+  const currentRevision = deployment?.currentRevision;
 
   const runtimeVariantOptions = filterOutNullAndUndefined(
     (runtimeVariants?.edges ?? []).map((e) => e?.node),
   ).map((node) => ({ value: toLocalId(node.id) ?? node.id, label: node.name }));
 
   // Pre-populate from current revision once when the modal opens.
-  useEffect(() => {
-    if (!open || !currentRevision) return;
+  // Synchronization key is `open` only — the `currentRevision` object's
+  // identity can shift across renders (type-asserted view of a Relay
+  // result), and including it in deps causes the effect to fire every
+  // render and feed back through `setFieldsValue` → re-render, which
+  // surfaces as an infinite Suspense loop in the form body's nested
+  // queries (`ResourceAllocationFormItems`, etc.). Read the latest value
+  // through a `useEffectEvent` helper instead.
+  const prefillFromCurrentRevision = useEffectEvent(() => {
+    if (!currentRevision) return;
     const rev = currentRevision;
+
+    const slots = rev.resourceSlots ?? [];
+    const cpuSlot = slots.find((s) => s.slotName === 'cpu');
+    const memSlot = slots.find((s) => s.slotName === 'mem');
+    const acceleratorSlot = slots.find(
+      (s) => s.slotName !== 'cpu' && s.slotName !== 'mem',
+    );
+
+    const shmemEntry = (rev.resourceConfig?.resourceOpts?.entries ?? []).find(
+      (e) => e.name === 'shmem',
+    );
+
+    const variantName =
+      runtimeVariantOptions.find(
+        (o) => o.value === rev.modelRuntimeConfig?.runtimeVariantId,
+      )?.label ?? '';
+    const isCustom = variantName === 'custom';
+    const service = rev.modelDefinition?.models?.[0]?.service;
+    const customModelPath = rev.modelDefinition?.models?.[0]?.modelPath;
+    // For custom + command mode: the saved revision carries a populated
+    // `modelDefinition` with a `startCommand` token list. For custom +
+    // file mode the form serializes to a null `modelDefinition`, so the
+    // absence of `service.startCommand` indicates file mode.
+    const hasCustomCommand =
+      isCustom && !!service && (service.startCommand?.length ?? 0) > 0;
+
+    prefilledMountAliasesRef.current = _.fromPairs(
+      (rev.extraMounts ?? [])
+        .filter((m) => !!m.mountDestination)
+        .map((m) => [
+          m.vfolderId.replace(/-/g, ''),
+          m.mountDestination as string,
+        ]),
+    );
+
+    // Split `environ` for non-custom variants: the runtime-parameter
+    // section uses one designated env var (e.g. `BACKEND_VLLM_EXTRA_ARGS`)
+    // to encode CLI-style ARGS presets, and individual env vars for ENV
+    // presets. Build both sides and stash them so the child can reverse-map.
+    const environRecord: Record<string, string> = Object.fromEntries(
+      (rev.modelRuntimeConfig?.environ?.entries ?? []).map((e) => [
+        e.name,
+        e.value,
+      ]),
+    );
+    if (!isCustom && variantName) {
+      const extraArgsKey = getExtraArgsEnvVarName(variantName);
+      const { [extraArgsKey]: extraArgsValue, ...envVarsWithoutArgs } =
+        environRecord;
+      setInitialRuntimeExtraArgs(extraArgsValue ?? '');
+      setInitialRuntimeEnvVars(
+        Object.keys(envVarsWithoutArgs).length > 0
+          ? envVarsWithoutArgs
+          : undefined,
+      );
+    }
+
     form.setFieldsValue({
-      clusterMode:
-        (rev?.clusterConfig?.mode as 'SINGLE_NODE' | 'MULTI_NODE') ??
-        'MULTI_NODE',
-      clusterSize: rev?.clusterConfig?.size ?? 1,
-      resourceGroup: rev?.resourceConfig?.resourceGroupName ?? '',
-      runtimeVariantId: rev?.modelRuntimeConfig?.runtimeVariantId ?? undefined,
-      modelFolderId: rev?.modelMountConfig?.vfolderId ?? undefined,
-      mountDestination: rev?.modelMountConfig?.mountDestination ?? '/models',
+      cluster_mode:
+        rev.clusterConfig?.mode === 'SINGLE_NODE'
+          ? 'single-node'
+          : 'multi-node',
+      cluster_size: rev.clusterConfig?.size ?? 1,
+      resourceGroup: rev.resourceConfig?.resourceGroupName ?? '',
+      // Keep `ResourceAllocationFormItems`' auto-preset effect from
+      // clobbering the prefilled resource values. That effect runs when
+      // `allocationPreset === 'auto-select'` (the default) and rewrites
+      // cpu/mem to the first allocatable preset's values, which would
+      // erase the cpu/mem we set just below.
+      allocationPreset: 'custom',
+      resource: {
+        cpu: cpuSlot ? Number(cpuSlot.quantity) : 0,
+        mem:
+          convertToBinaryUnit(String(memSlot?.quantity ?? '0'), 'g', 3, true)
+            ?.value ?? '0g',
+        shmem:
+          convertToBinaryUnit(
+            shmemEntry?.value ?? AUTOMATIC_DEFAULT_SHMEM,
+            'g',
+            3,
+            true,
+          )?.value ?? AUTOMATIC_DEFAULT_SHMEM,
+        ...(acceleratorSlot
+          ? {
+              acceleratorType: acceleratorSlot.slotName,
+              accelerator:
+                acceleratorSlot.slotName === 'cuda.shares'
+                  ? parseFloat(String(acceleratorSlot.quantity))
+                  : parseInt(String(acceleratorSlot.quantity), 10),
+            }
+          : {}),
+      },
+      enabledAutomaticShmem: !shmemEntry,
+      // Same dash-stripping rationale as `modelFolderId` above: the
+      // VFolderTable's `rowKey="id"` uses the 32-char-hex form, so
+      // selectedRowKeys must match that shape for prefilled rows to
+      // appear checked.
+      mount_ids: (rev.extraMounts ?? []).map((m) =>
+        m.vfolderId.replace(/-/g, ''),
+      ),
+      mount_id_map: _.fromPairs(
+        (rev.extraMounts ?? [])
+          .filter((m) => !!m.mountDestination)
+          .map((m) => [
+            m.vfolderId.replace(/-/g, ''),
+            m.mountDestination as string,
+          ]),
+      ),
+      runtimeVariantId: rev.modelRuntimeConfig?.runtimeVariantId ?? undefined,
+      // VFolderSelect / VFolderTable's row data come from REST `/folders`
+      // which exposes `id` as 32-char hex without dashes, while the
+      // GraphQL `modelMountConfig.vfolderId` and `extraMounts.vfolderId`
+      // come back as canonical UUIDs. Strip dashes here so the form
+      // value matches existing options (and selectedRowKeys for the
+      // additional-mounts table) directly — without it, VFolderTable
+      // never highlights the prefilled rows and the alias map keys
+      // can't be looked up. `convertToUUID` in the submit re-adds
+      // dashes for the GraphQL input.
+      modelFolderId: rev.modelMountConfig?.vfolderId
+        ? rev.modelMountConfig.vfolderId.replace(/-/g, '')
+        : undefined,
+      mountDestination: rev.modelMountConfig?.mountDestination ?? '/models',
       definitionPath:
-        rev?.modelMountConfig?.definitionPath ?? 'model-definition.yaml',
-      environ: (rev?.modelRuntimeConfig?.environ?.entries ?? []).map((e) => ({
-        name: e.name,
+        rev.modelMountConfig?.definitionPath ?? 'model-definition.yaml',
+      // `ImageEnvironmentSelectFormItems` matches the form's
+      // `environments.version` against its image catalog by canonical
+      // name; setting this is enough to drive the rest of the
+      // environment selector (registry/namespace/tag) and ultimately
+      // populate `environments.image.id`. Falling back to
+      // `autoSelectDefault` (the previous behavior) only happened to
+      // pick the right image when the test environment had a single
+      // installed image.
+      environments: rev.imageV2?.identity?.canonicalName
+        ? { version: rev.imageV2.identity.canonicalName }
+        : undefined,
+      // EnvVarFormList stores entries as { variable, value } — translate
+      // from the GraphQL `{ name, value }` shape on prefill. Only used
+      // by the custom-variant branch; non-custom variants reverse-map
+      // the same environ into `RuntimeParameterFormSection` via
+      // `initialRuntimeExtraArgs` / `initialRuntimeEnvVars` above.
+      environ: (rev.modelRuntimeConfig?.environ?.entries ?? []).map((e) => ({
+        variable: e.name,
         value: e.value,
       })),
+      // Custom variant + command mode: the saved revision's
+      // `modelDefinition` carries the start command, port, health-check
+      // path, retries and initial delay, and the per-model `modelPath`.
+      // Reverse-map them into the modal's command-mode form fields so a
+      // round-trip preserves user input. File-mode revisions have a
+      // null `modelDefinition`, so we fall through to the default
+      // command-mode initialValues.
+      ...(hasCustomCommand && service
+        ? {
+            customDefinitionMode: 'command' as const,
+            startCommand: formatShellCommand(service.startCommand ?? []),
+            commandPort: service.port,
+            commandHealthCheck: service.healthCheck?.path ?? undefined,
+            commandModelMount: customModelPath ?? '/models',
+            commandInitialDelay: service.healthCheck?.initialDelay ?? undefined,
+            commandMaxRetries: service.healthCheck?.maxRetries ?? undefined,
+          }
+        : isCustom
+          ? { customDefinitionMode: 'file' as const }
+          : {}),
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, currentRevision]);
+  });
 
-  const parseResourceSlotEntries = (resourceSlotsJson: string | null) => {
-    const slots = JSON.parse(resourceSlotsJson ?? '{}') as Record<
-      string,
-      string
-    >;
-    return Object.entries(slots).map(([resourceType, quantity]) => ({
-      resourceType,
-      quantity: String(quantity),
-    }));
-  };
+  useEffect(() => {
+    prefillFromCurrentRevision();
+  }, []);
 
   // Serialize runtime parameter UI values (from RuntimeParameterFormSection)
   // into an environ map — mirrors ServiceLauncherPageContent logic.
@@ -320,14 +620,25 @@ const DeploymentAddRevisionModalFormBody: React.FC<
   };
 
   const handleFinish = (values: FormValues) => {
-    const imageId = values.environments?.image?.id;
-    if (!imageId) {
+    // `setFields` raises an error programmatically — antd's
+    // `scrollToFirstError` only fires from `onFinishFailed`, so we have
+    // to nudge the scroll explicitly here.
+    const flagImageRequired = () => {
       form.setFields([
         {
           name: ['environments', 'version'],
           errors: [t('modelService.ImageRequired')],
         },
       ]);
+      form.scrollToField(['environments', 'version'], {
+        behavior: 'smooth',
+        block: 'center',
+      });
+    };
+
+    const imageId = values.environments?.image?.id;
+    if (!imageId) {
+      flagImageRequired();
       return;
     }
     // `ImageInput.id` is declared as `ID!` but parsed as `UUID!`
@@ -335,19 +646,75 @@ const DeploymentAddRevisionModalFormBody: React.FC<
     // (`ImageV2:<uuid>` base64-encoded), so decode before submitting.
     const decodedImageId = safeDecodeUuid(imageId);
     if (!decodedImageId) {
-      form.setFields([
-        {
-          name: ['environments', 'version'],
-          errors: [t('modelService.ImageRequired')],
-        },
-      ]);
+      flagImageRequired();
       return;
     }
 
-    const preset = resource_presets?.find(
-      (p) => p?.name === values.resourceGroup,
-    );
-    const entries = parseResourceSlotEntries(preset?.resource_slots ?? null);
+    // Build resource slots entries from form values directly. Mirrors the
+    // ServiceLauncherPageContent pattern: cpu/mem are always present, plus an
+    // optional accelerator slot keyed by `acceleratorType`.
+    const slotEntries: { resourceType: string; quantity: string }[] = [
+      { resourceType: 'cpu', quantity: String(values.resource.cpu) },
+      { resourceType: 'mem', quantity: values.resource.mem },
+    ];
+    if (
+      values.resource.acceleratorType &&
+      values.resource.accelerator &&
+      values.resource.accelerator > 0
+    ) {
+      slotEntries.push({
+        resourceType: values.resource.acceleratorType,
+        quantity: String(values.resource.accelerator),
+      });
+    }
+
+    // Build resource opts entries — currently only shared memory.
+    const optsEntries: { name: string; value: string }[] = [];
+    if (values.resource.shmem) {
+      optsEntries.push({ name: 'shmem', value: values.resource.shmem });
+    }
+
+    // Normalize cluster mode to schema enum. Match the FR-2381 convention
+    // used by ServiceLauncherPageContent: multi-node + size==1 collapses to
+    // SINGLE_NODE so the orchestrator skips inter-node setup.
+    const clusterMode =
+      values.cluster_mode === 'single-node' ||
+      (values.cluster_mode === 'multi-node' && values.cluster_size === 1)
+        ? 'SINGLE_NODE'
+        : 'MULTI_NODE';
+
+    // Build extraMounts — preserve per-folder mount destination from the
+    // VFolderTable alias map. Same shape as ServiceLauncherPageContent.
+    // VFolderTable returns vfolder ids as 32-char hex without dashes,
+    // but ExtraVFolderMountInput.vfolderId is parsed as a UUID server-side.
+    // Normalize to the canonical dashed form before submitting.
+    //
+    // `mount_destination` is required by the backend. The form's
+    // `mount_id_map` is authoritative when present, but VFolderTable's
+    // alias-map updates only carry entries for currently-visible rows —
+    // editing any visible alias drops aliases for invisible mounts (e.g.
+    // a vfolder owned by a different user that this deployment was
+    // originally created with). Fall back through, in order:
+    //   1. `values.mount_id_map[vfolderId]` — fresh user input.
+    //   2. `prefilledMountAliasesRef.current[vfolderId]` — the original
+    //      mount destination from the current revision.
+    //   3. `vfoldersNameMap` →`/home/work/<name>` — same default the
+    //      `mount_id_map` validator uses for un-aliased rows.
+    //   4. `/home/work/<vfolderId>` — last-resort, never empty.
+    const vfoldersNameMap: Record<string, string> =
+      values.vfoldersNameMap ?? {};
+    const extraMounts = (values.mount_ids ?? []).map((vfolderId) => {
+      const mountDestination =
+        values.mount_id_map?.[vfolderId] ||
+        prefilledMountAliasesRef.current[vfolderId] ||
+        (vfoldersNameMap[vfolderId]
+          ? `/home/work/${vfoldersNameMap[vfolderId]}`
+          : `/home/work/${vfolderId}`);
+      return {
+        vfolderId: convertToUUID(vfolderId),
+        mountDestination,
+      };
+    });
 
     const variantName =
       runtimeVariantOptions.find((o) => o.value === values.runtimeVariantId)
@@ -355,14 +722,21 @@ const DeploymentAddRevisionModalFormBody: React.FC<
     const isCustom = variantName === 'custom';
     const isCommandMode = values.customDefinitionMode === 'command';
 
-    // Build environ: runtime param section for non-custom, manual list for custom.
+    // Build environ. The `EnvVarFormList` (`values.environ`) is the
+    // user-controlled, free-form env-var input that the modal exposes
+    // for *every* variant — so its entries always seed the record.
+    // For non-custom variants `serializeRuntimeParamsToEnviron` then
+    // layers the runtime-parameter section's *touched* presets on top
+    // (it deletes the preset keys it owns before re-writing them, so
+    // duplicates collapse predictably). Without this seed, a user who
+    // typed a custom env var via "Add environment variables" on a
+    // non-custom variant lost it on submit.
     const environRecord: Record<string, string> = {};
+    for (const { variable, value } of values.environ ?? []) {
+      if (variable) environRecord[variable] = value;
+    }
     if (!isCustom) {
       serializeRuntimeParamsToEnviron(environRecord, variantName);
-    } else {
-      for (const { name, value } of values.environ ?? []) {
-        if (name) environRecord[name] = value;
-      }
     }
     const environEntries = Object.entries(environRecord).map(
       ([name, value]) => ({ name, value }),
@@ -414,12 +788,14 @@ const DeploymentAddRevisionModalFormBody: React.FC<
           deploymentId: toLocalId(deploymentId) ?? deploymentId,
           name: values.name || undefined,
           clusterConfig: {
-            mode: values.clusterMode,
-            size: values.clusterSize,
+            mode: clusterMode,
+            size: values.cluster_size,
           },
           resourceConfig: {
             resourceGroup: { name: values.resourceGroup },
-            resourceSlots: { entries },
+            resourceSlots: { entries: slotEntries },
+            resourceOpts:
+              optsEntries.length > 0 ? { entries: optsEntries } : null,
           },
           image: { id: decodedImageId },
           modelRuntimeConfig: {
@@ -429,11 +805,15 @@ const DeploymentAddRevisionModalFormBody: React.FC<
               environEntries.length > 0 ? { entries: environEntries } : null,
           },
           modelMountConfig: {
-            vfolderId: values.modelFolderId,
+            // VFolderSelect returns the vfolder id as 32-char hex
+            // without dashes; the server parses this as a UUID, so
+            // normalize before submitting (same as `extraMounts`).
+            vfolderId: convertToUUID(values.modelFolderId),
             mountDestination,
             definitionPath,
           },
           modelDefinition,
+          extraMounts: extraMounts.length > 0 ? extraMounts : null,
           options: { autoActivate: true },
         },
       },
@@ -451,9 +831,23 @@ const DeploymentAddRevisionModalFormBody: React.FC<
           );
           return;
         }
+        // Invalidate the deployment record so the next `useLazyLoadQuery`
+        // (i.e. the next time the user opens Add Revision) treats it as
+        // stale and refetches from the network even though we're on
+        // `store-and-network`. Without this, Relay would hand back the
+        // pre-mutation `currentRevision` sub-tree on the immediate
+        // reopen and the modal would prefill from the *previous*
+        // revision. We invalidate the deployment field at the root —
+        // its arguments mirror what the body query asks for above —
+        // so that the linked `currentRevision` is invalidated too.
+        commitLocalUpdate(relayEnvironment, (store) => {
+          const deploymentRecord = store
+            .getRoot()
+            .getLinkedRecord('deployment', { id: deploymentId });
+          deploymentRecord?.invalidateRecord();
+        });
         form.resetFields();
         onSuccess();
-        onClose();
       },
       onError: (err) => {
         onIsAddingChange(false);
@@ -469,15 +863,36 @@ const DeploymentAddRevisionModalFormBody: React.FC<
     });
   };
 
+  // antd's built-in `scrollToFirstError` walks `errorFields` in field
+  // *registration* order, not DOM order. Because
+  // `ResourceAllocationFormItems` lives inside a Suspense boundary, its
+  // fields register *after* the top-level Form.Items rendered below it
+  // in source — so the "first" errored field by registration ends up
+  // being something like `runtimeVariantId`, even when `resourceGroup`
+  // is visually higher and also errored. Walk the DOM instead and
+  // scroll to whichever errored Form.Item is highest on screen.
+  const handleFinishFailed = () => {
+    requestAnimationFrame(() => {
+      const firstErrorEl = document.querySelector<HTMLElement>(
+        '.ant-modal-body .ant-form-item-has-error',
+      );
+      if (firstErrorEl) {
+        firstErrorEl.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }
+    });
+  };
+
   return (
     <Form<FormValues>
       form={form}
       layout="vertical"
       style={{ marginTop: token.marginXS }}
       onFinish={handleFinish}
-      initialValues={{
-        clusterMode: 'MULTI_NODE',
-        clusterSize: 1,
+      onFinishFailed={handleFinishFailed}
+      initialValues={_.merge({}, RESOURCE_ALLOCATION_INITIAL_FORM_VALUES, {
         mountDestination: '/models',
         definitionPath: 'model-definition.yaml',
         customDefinitionMode: 'command',
@@ -487,46 +902,10 @@ const DeploymentAddRevisionModalFormBody: React.FC<
         commandInitialDelay: 60,
         commandMaxRetries: 10,
         environ: [],
-      }}
+      })}
     >
       <Form.Item name="name" label={t('deployment.RevisionName')}>
         <Input placeholder={t('deployment.RevisionNamePlaceholder')} />
-      </Form.Item>
-
-      <SectionHeader>{t('deployment.step.ClusterAndResources')}</SectionHeader>
-      <BAIFlex gap="sm">
-        <Form.Item
-          name="clusterMode"
-          label={t('deployment.ClusterMode')}
-          rules={[{ required: true }]}
-          style={{ flex: 1 }}
-        >
-          <Select
-            options={[
-              { value: 'SINGLE_NODE', label: 'SINGLE_NODE' },
-              { value: 'MULTI_NODE', label: 'MULTI_NODE' },
-            ]}
-          />
-        </Form.Item>
-        <Form.Item
-          name="clusterSize"
-          label={t('deployment.ClusterSize')}
-          rules={[{ required: true }]}
-          style={{ flex: 1 }}
-        >
-          <InputNumber min={1} style={{ width: '100%' }} />
-        </Form.Item>
-      </BAIFlex>
-      <Form.Item
-        name="resourceGroup"
-        label={t('deployment.ResourceGroup')}
-        rules={[{ required: true }]}
-      >
-        <BAIProjectResourceGroupSelect
-          projectName={currentProject?.name ?? ''}
-          showSearch
-          autoSelectDefault
-        />
       </Form.Item>
 
       <SectionHeader>{t('deployment.step.ModelAndRuntime')}</SectionHeader>
@@ -536,7 +915,13 @@ const DeploymentAddRevisionModalFormBody: React.FC<
         rules={[{ required: true }]}
       >
         <VFolderSelect
-          autoSelectDefault
+          // `autoSelectDefault` runs a mount-time effect inside
+          // VFolderSelect that writes the *first available* folder into
+          // the form, which races with `prefillFromCurrentRevision` and
+          // can clobber the deployment's actual model folder when more
+          // than one is available. We always have the model folder from
+          // the current revision here, so leave the field empty when
+          // the revision somehow lacks one rather than auto-picking.
           valuePropName="id"
           filter={(vf) => vf.usage_mode === 'model' && vf.status === 'ready'}
           showOpenButton
@@ -593,8 +978,8 @@ const DeploymentAddRevisionModalFormBody: React.FC<
                   onGroupsLoaded={(groups) => {
                     runtimeParamGroupsRef.current = groups;
                   }}
-                  initialExtraArgs=""
-                  initialEnvVars={undefined}
+                  initialExtraArgs={initialRuntimeExtraArgs}
+                  initialEnvVars={initialRuntimeEnvVars}
                 />
               </Suspense>
             </div>
@@ -717,107 +1102,120 @@ const DeploymentAddRevisionModalFormBody: React.FC<
         }}
       </Form.Item>
 
-      <ImageEnvironmentSelectFormItems />
+      <SectionHeader>{t('session.launcher.Environments')}</SectionHeader>
 
-      {/* Environment variables — only shown for custom variant */}
-      <Form.Item dependencies={['runtimeVariantId']} noStyle>
-        {({ getFieldValue }) => {
-          const variantId = getFieldValue('runtimeVariantId');
-          const variantName = runtimeVariantOptions.find(
-            (o) => o.value === variantId,
-          )?.label;
-          if (variantName !== 'custom') return null;
-          return (
-            <>
-              <SectionHeader>{t('deployment.Environ')}</SectionHeader>
-              <Form.List name="environ">
-                {(fields, { add, remove }) => (
-                  <BAIFlex direction="column" gap="xs">
-                    {fields.map(({ key, name }) => (
-                      <BAIFlex key={key} gap="xs" align="center">
-                        <Form.Item
-                          name={[name, 'name']}
-                          style={{ flex: 1, marginBottom: 0 }}
-                        >
-                          <Input placeholder="KEY" />
-                        </Form.Item>
-                        <Form.Item
-                          name={[name, 'value']}
-                          style={{ flex: 2, marginBottom: 0 }}
-                        >
-                          <Input placeholder="VALUE" />
-                        </Form.Item>
-                        <MinusCircleOutlined
-                          onClick={() => remove(name)}
-                          style={{ color: token.colorTextSecondary }}
-                        />
-                      </BAIFlex>
-                    ))}
-                    <Button
-                      type="dashed"
-                      onClick={() => add({ name: '', value: '' })}
-                      icon={<PlusOutlined />}
-                    >
-                      {t('button.Add')}
-                    </Button>
-                  </BAIFlex>
-                )}
-              </Form.List>
-            </>
-          );
+      <ImageEnvironmentSelectFormItems />
+      <EnvVarFormList
+        name="environ"
+        formItemProps={{
+          validateTrigger: ['onChange', 'onBlur'],
         }}
-      </Form.Item>
+      />
+
+      <SectionHeader>{t('deployment.step.ClusterAndResources')}</SectionHeader>
+      {/*
+        `ResourceAllocationFormItems` internally uses several
+        `useLazyLoadQuery` calls that suspend whenever the watched
+        form values (resource group, image, allocation preset) change.
+        Those throws are caught by the modal-level Suspense fallback
+        above the form body — combined with the deployment query's
+        default `store-or-network` policy, the body remounts re-read
+        the cached deployment instead of re-fetching it, so the
+        previously observed infinite-fetch loop does not recur.
+      */}
+      <ResourceAllocationFormItems enableResourcePresets />
+
+      <Collapse
+        items={[
+          {
+            key: 'advanced',
+            label: t('session.launcher.AdvancedSettings'),
+            children: (
+              <>
+                <Suspense fallback={<Skeleton active />}>
+                  {/*
+                    `mount_id_map` and `mount_ids` are explicit
+                    dependencies in addition to `modelFolderId` because
+                    `VFolderTableFormItem` passes
+                    `aliasMap={form.getFieldValue('mount_id_map')}` —
+                    an unsubscribed snapshot read — to `VFolderTable`.
+                    Without these deps the wrapping render-prop would
+                    not re-execute when `prefillFromCurrentRevision`
+                    writes new aliases via `form.setFieldsValue`, so
+                    `VFolderTable` would keep showing the previously
+                    captured aliasMap (the user-visible symptom: extra
+                    mount aliases appear stale on reopen even though
+                    the underlying form value is correct).
+                  */}
+                  <Form.Item
+                    noStyle
+                    dependencies={[
+                      'modelFolderId',
+                      'mount_id_map',
+                      'mount_ids',
+                    ]}
+                  >
+                    {({ getFieldValue }) => {
+                      const modelFolderId = getFieldValue('modelFolderId');
+                      return (
+                        <VFolderTableFormItem
+                          label={t('modelService.AdditionalMounts')}
+                          rowKey="id"
+                          tableProps={{
+                            scroll: { x: 'max-content', y: 300 },
+                          }}
+                          rowFilter={(vfolder) =>
+                            vfolder.usage_mode !== 'model' &&
+                            vfolder.status === 'ready' &&
+                            !vfolder.name?.startsWith('.') &&
+                            vfolder.id !== modelFolderId
+                          }
+                        />
+                      );
+                    }}
+                  </Form.Item>
+                </Suspense>
+              </>
+            ),
+          },
+        ]}
+      />
     </Form>
   );
 };
 
 const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
   open,
-  onClose,
   onSuccess,
   deploymentId,
+  ...restModalProps
 }) => {
   'use memo';
   const { t } = useTranslation();
   const [form] = Form.useForm<FormValues>();
   const [isAdding, setIsAdding] = useState(false);
 
-  const handleCancel = () => {
-    form.resetFields();
-    onClose();
-  };
-
   return (
     <BAIModal
       open={open}
       title={t('deployment.AddRevision')}
-      onCancel={handleCancel}
       width={720}
-      footer={
-        <BAIFlex justify="end" gap="xs">
-          <Button onClick={handleCancel}>{t('button.Cancel')}</Button>
-          <BAIButton
-            type="primary"
-            loading={isAdding}
-            onClick={() => form.submit()}
-          >
-            {t('deployment.AddRevision')}
-          </BAIButton>
-        </BAIFlex>
-      }
+      okText={t('deployment.AddRevision')}
+      okButtonProps={{
+        type: 'primary',
+      }}
+      onOk={() => form.submit()}
+      confirmLoading={isAdding}
+      {...restModalProps}
     >
-      {open && (
-        <Suspense fallback={<Skeleton active />}>
-          <DeploymentAddRevisionModalFormBody
-            deploymentId={deploymentId}
-            form={form}
-            open={open}
-            onClose={onClose}
-            onSuccess={onSuccess}
-            onIsAddingChange={setIsAdding}
-          />
-        </Suspense>
-      )}
+      <Suspense fallback={<Skeleton active />}>
+        <DeploymentAddRevisionModalFormBody
+          deploymentId={deploymentId}
+          form={form}
+          onSuccess={onSuccess}
+          onIsAddingChange={setIsAdding}
+        />
+      </Suspense>
     </BAIModal>
   );
 };

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -665,7 +665,7 @@ const ResourceAllocationFormItems: React.FC<
                       sliderProps={{
                         marks: {
                           // remaining mark code should be located before max mark code to prevent overlapping when it is same value
-                          ...(remaining.cpu
+                          ...(remaining.cpu && showRemainingWarning
                             ? {
                                 [remaining.cpu]: {
                                   label: <RemainingMark />,
@@ -841,7 +841,7 @@ const ResourceAllocationFormItems: React.FC<
                               max={resourceLimits.mem?.max}
                               min={resourceLimits.mem?.min}
                               extraMarks={{
-                                ...(remaining.mem
+                                ...(remaining.mem && showRemainingWarning
                                   ? {
                                       //@ts-ignore
                                       [convertToBinaryUnit(
@@ -1102,7 +1102,8 @@ const ResourceAllocationFormItems: React.FC<
                             marks: {
                               0: 0,
                               // remaining mark code should be located before max mark code to prevent overlapping when it is same value
-                              ...(adjustedRemainingMarkValue
+                              ...(adjustedRemainingMarkValue &&
+                              showRemainingWarning
                                 ? {
                                     [adjustedRemainingMarkValue]: {
                                       label: <RemainingMark />,
@@ -1473,7 +1474,7 @@ const ResourceAllocationFormItems: React.FC<
                                 marks: {
                                   1: '1',
                                   // remaining mark code should be located before max mark code to prevent overlapping when it is same value
-                                  ...(remainingMarkValue
+                                  ...(remainingMarkValue && showRemainingWarning
                                     ? {
                                         [remainingMarkValue]: {
                                           label: <RemainingMark />,

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -361,10 +361,16 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   );
 
   const handleAliasUpdate = useEventNotStable(() => {
+    // Only carry aliases for currently-selected rows. The internal form
+    // intentionally preserves values for deselected rows (so re-selecting
+    // restores the user's previous alias), but `aliasMap` is the
+    // authoritative payload for the parent form's mount list and must
+    // mirror the selection.
+    const allValues = internalForm.getFieldsValue({ strict: false });
     setAliasMap(
       _.mapValues(
-        _.pickBy(internalForm.getFieldsValue({ strict: false }), (v) => !!v), //remove empty
-        (v, k) => inputToAliasPath(k, v), // add alias base path
+        _.pickBy(_.pick(allValues, selectedRowKeys), (v) => !!v),
+        (v, k) => inputToAliasPath(k, v),
       ),
     );
     internalForm.validateFields().catch(() => {});
@@ -659,7 +665,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
           </Tooltip>
         </Space.Compact>
       </BAIFlex>
-      <Form form={internalForm} component={false} preserve={false}>
+      <Form form={internalForm} component={false}>
         <BAITable
           // size="small"
           scroll={{ x: 'max-content' }}


### PR DESCRIPTION
Resolves #7270 ([FR-2826](https://lablup.atlassian.net/browse/FR-2826))

## Summary

The Add Revision modal previously hid most of `AddRevisionInput`'s schema and shipped revisions with empty / incorrect resource allocations. This rework wires up every field operators actually need and removes the bugs surfaced along the way.

### What changed

- **Surface the missing fields.** `clusterConfig`, `resourceConfig.resourceSlots`, `resourceConfig.resourceOpts`, and `extraMounts` are all populated from the form now (replacing the broken `resource_presets`-by-name match that mostly produced empty `entries`). `resourceSlots`/`resourceOpts`/`extraMounts` are also pulled from the current revision so the modal pre-fills correctly.
- **Reuse the standard launcher form items.** Cluster + resource section is now `<ResourceAllocationFormItems enableResourcePresets />`, additional mounts use `<VFolderTableFormItem />`, and environment variables use `<EnvVarFormList />` — the same components `SessionLauncherPage` / `ServiceLauncherPageContent` use.
- **Stop the infinite Suspense loop.** The deployment query no longer uses `network-only`; nested form items would suspend into the modal-level boundary and tear the body down on every prefill, saturating `func/admin/gql`. The body now relies on the store cache.
- **Better submit-error UX.** `onFinishFailed` walks `.ant-form-item-has-error` in DOM order and `scrollIntoView`s the visually first error (antd's built-in `scrollToFirstError` walks field *registration* order, which is wrong once `ResourceAllocationFormItems` is inside a Suspense boundary).
- **Reset on reopen.** `<DeploymentAddRevisionModal>` is wrapped in `<BAIUnmountAfterClose>` from its caller so the `.ant-modal-body` element is recreated, dropping the previous `scrollTop`.
- **Normalize vfolder ids.** `VFolderSelect` and `VFolderTable` emit ids as 32-char hex without dashes; the server parses them as UUIDs. Both `modelMountConfig.vfolderId` and every `extraMounts[].vfolderId` go through `convertToUUID` before submitting.
- **`showRemainingWarning` actually opt-out** in `ResourceAllocationFormItems` — remaining marks (CPU / Memory / Accelerator / replicas) are gated on the prop, matching the existing prop name's intent.

### Out of scope (follow-ups)

- `revisionPresetId`, `modelRuntimeConfig.inferenceRuntimeConfig` — left for a separate ticket.
- `BAICard` section grouping and tinted modal body — also follow-up.

## Test plan

- [ ] Open Add Revision on a deployment with an existing revision: form prefills cluster mode/size, resource group + slots + shmem, model folder, runtime variant, image, and extra mounts.
- [ ] Submit unchanged → new revision matches the previous one (verify in revision history).
- [ ] Tweak CPU + add an extra mount → submit → mutation payload contains correct `resourceSlots.entries` / `extraMounts[].vfolderId` (canonical UUID) in the network tab.
- [ ] Submit with empty Resource Group / Runtime Variant → modal scrolls to the first visible error.
- [ ] Open modal, scroll down, cancel, reopen → `scrollTop` is 0.
- [ ] No infinite `func/admin/gql` requests on modal open (confirm with network tab).

[FR-2826]: https://lablup.atlassian.net/browse/FR-2826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ