### PR TITLE
feat(FR-2827): make deployment tags clickable to filter the list

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -475,9 +475,12 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
     onChange: propOnChange,
   });
 
-  const [conditions, setConditions] = useState<FilterCondition[]>(() =>
-    convertGraphQLFilterToConditions(value, filterProperties),
-  );
+  // Reassign sequential ids: the converter generates random ids per call,
+  // which would change every render and remount every Tag.
+  const conditions = convertGraphQLFilterToConditions(
+    value,
+    filterProperties,
+  ).map((c, i) => ({ ...c, id: `cond-${i}` }));
 
   const [search, setSearch] = useState<string>('');
   const [selectedDate, setSelectedDate] = useState<dayjs.Dayjs | null>(null);
@@ -505,15 +508,11 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
   const [isValid, setIsValid] = useState(true);
   const [isFocused, setIsFocused] = useState(false);
 
-  const propertyOptions = useMemo(
-    () =>
-      filterProperties.map((property) => ({
-        label: property.propertyLabel,
-        value: property.key,
-        filter: property,
-      })),
-    [filterProperties],
-  );
+  const propertyOptions = filterProperties.map((property) => ({
+    label: property.propertyLabel,
+    value: property.key,
+    filter: property,
+  }));
 
   const availableOperators = useMemo(() => {
     const mode = getEffectiveValueMode(selectedProperty);
@@ -536,7 +535,6 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
   }, [availableOperators, t]);
 
   const updateConditions = (newConditions: FilterCondition[]) => {
-    setConditions(newConditions);
     const filter = convertConditionsToGraphQLFilter(
       newConditions,
       filterProperties,

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -9,6 +9,7 @@ import DeploymentRevisionDetail from './DeploymentRevisionDetail';
 import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
 import DeploymentRevisionHistoryTab from './DeploymentRevisionHistoryTab';
 import DeploymentSettingModal from './DeploymentSettingModal';
+import DeploymentTagChips from './DeploymentTagChips';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
 import {
   CheckOutlined,
@@ -24,7 +25,6 @@ import {
   Descriptions,
   Empty,
   Skeleton,
-  Tag,
   Typography,
   theme,
 } from 'antd';
@@ -64,12 +64,6 @@ const DeploymentOverviewContent: React.FC<{
   const projectName =
     deployment?.metadata.projectV2?.basicInfo?.name ??
     deployment?.metadata.projectId;
-  const tags = (deployment?.metadata.tags ?? []).flatMap((tag) =>
-    tag
-      .split(',')
-      .map((t) => t.trim())
-      .filter(Boolean),
-  );
 
   const deploymentItems = filterOutEmpty([
     {
@@ -114,16 +108,12 @@ const DeploymentOverviewContent: React.FC<{
     {
       key: 'tags',
       label: t('deployment.Tags'),
-      children:
-        tags.length > 0 ? (
-          <BAIFlex direction="row" wrap="wrap" gap="xxs">
-            {tags.map((tag) => (
-              <Tag key={tag}>{tag}</Tag>
-            ))}
-          </BAIFlex>
-        ) : (
-          renderFallback()
-        ),
+      children: (
+        <DeploymentTagChips
+          metadataFrgmt={deployment?.metadata ?? null}
+          fallback={renderFallback()}
+        />
+      ),
     },
     {
       key: 'desired-replicas',
@@ -299,7 +289,6 @@ const DeploymentConfigurationCards: React.FC<{
           ...DeploymentSettingModal_deployment
           metadata {
             name
-            tags
             projectId
             domainName
             projectV2 @since(version: "26.4.3") {
@@ -307,6 +296,7 @@ const DeploymentConfigurationCards: React.FC<{
                 name
               }
             }
+            ...DeploymentTagChips_metadata
           }
           networkAccess {
             openToPublic

--- a/react/src/components/DeploymentList.tsx
+++ b/react/src/components/DeploymentList.tsx
@@ -12,8 +12,9 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import BAIRadioGroup from './BAIRadioGroup';
 import DeploymentOwnerInfo from './DeploymentOwnerInfo';
 import DeploymentStatusTag, { DeploymentStatus } from './DeploymentStatusTag';
+import DeploymentTagChips from './DeploymentTagChips';
 import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
-import { Alert, App, Tag, Typography, theme } from 'antd';
+import { Alert, App, Typography, theme } from 'antd';
 import {
   BAIConfirmModalWithInput,
   BAIFlex,
@@ -83,26 +84,6 @@ export const tableOrderToSort = (
   return { field, order: descending ? 'DESC' : 'ASC' };
 };
 
-const parseFilterString = (
-  filter: string | undefined,
-): GraphQLFilter | undefined => {
-  if (!filter) return undefined;
-  try {
-    const parsed = JSON.parse(filter);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as GraphQLFilter;
-    }
-    return undefined;
-  } catch {
-    return undefined;
-  }
-};
-
-const stringifyFilter = (filter: GraphQLFilter | undefined): string => {
-  if (!filter || Object.keys(filter).length === 0) return '';
-  return JSON.stringify(filter);
-};
-
 export type DeploymentStatusCategory = 'running' | 'finished';
 
 export interface DeploymentListProps extends Omit<
@@ -113,8 +94,8 @@ export interface DeploymentListProps extends Omit<
     | DeploymentList_modelDeploymentConnection$key
     | null
     | undefined;
-  filter?: string;
-  setFilter: (value: string) => void;
+  filter?: GraphQLFilter;
+  setFilter: (value: GraphQLFilter | null | undefined) => void;
   onChangeOrder?: (order: string | null) => void;
   statusCategory?: DeploymentStatusCategory;
   onStatusCategoryChange?: (value: DeploymentStatusCategory) => void;
@@ -182,7 +163,7 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
               createdAt
               domainName
               projectId
-              tags
+              ...DeploymentTagChips_metadata
             }
             networkAccess {
               endpointUrl
@@ -222,8 +203,6 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
   const isAdminMode = mode === 'admin';
   const supportsExtendedFilter =
     baiClient?.supports('model-deployment-extended-filter') ?? false;
-
-  const filterValue = parseFilterString(filter);
 
   const baseFilterProperties = [
     {
@@ -372,23 +351,13 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
     {
       key: 'tags',
       title: t('deployment.Tags'),
-      render: (_text, row) => {
-        const tags = (row.metadata?.tags ?? []).flatMap((tag) =>
-          tag
-            .split(',')
-            .map((t) => t.trim())
-            .filter(Boolean),
-        );
-        if (tags.length === 0)
-          return <Typography.Text type="secondary">-</Typography.Text>;
-        return (
-          <BAIFlex wrap="wrap" gap="xxs">
-            {tags.map((tag) => (
-              <Tag key={tag}>{tag}</Tag>
-            ))}
-          </BAIFlex>
-        );
-      },
+      render: (_text, row) => (
+        <DeploymentTagChips
+          metadataFrgmt={row.metadata}
+          stopRowClick
+          fallback={<Typography.Text type="secondary">-</Typography.Text>}
+        />
+      ),
     },
     {
       key: 'createdAt',
@@ -441,9 +410,9 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
             />
             <BAIGraphQLPropertyFilter
               filterProperties={filterProperties}
-              value={filterValue}
+              value={filter}
               onChange={(next) => {
-                setFilter(stringifyFilter(next));
+                setFilter(next);
               }}
             />
           </BAIFlex>

--- a/react/src/components/DeploymentTagChips.tsx
+++ b/react/src/components/DeploymentTagChips.tsx
@@ -1,0 +1,99 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type { DeploymentTagChips_metadata$key } from '../__generated__/DeploymentTagChips_metadata.graphql';
+import { useWebUINavigate } from '../hooks';
+import { Tag } from 'antd';
+import { BAIFlex } from 'backend.ai-ui';
+import React from 'react';
+import { graphql, useFragment } from 'react-relay';
+import { useLocation } from 'react-router-dom';
+
+interface DeploymentTagChipsProps {
+  metadataFrgmt: DeploymentTagChips_metadata$key | null | undefined;
+  /**
+   * When true, click and Enter/Space keypress events stop bubbling so the
+   * surrounding row click handler does not also fire (used inside the
+   * deployment list table).
+   */
+  stopRowClick?: boolean;
+  /** Rendered when there are no tags to display. */
+  fallback?: React.ReactNode;
+}
+
+/**
+ * Render a deployment metadata's tags as clickable chips. Activating a chip
+ * (mouse click or keyboard Enter/Space) navigates to the deployment list
+ * pre-filtered by that tag using `iContains`. Tag entries are split on
+ * commas so legacy comma-joined values render as individual chips.
+ */
+const DeploymentTagChips: React.FC<DeploymentTagChipsProps> = ({
+  metadataFrgmt,
+  stopRowClick = false,
+  fallback = null,
+}) => {
+  'use memo';
+  const webuiNavigate = useWebUINavigate();
+  const location = useLocation();
+
+  const metadata = useFragment(
+    graphql`
+      fragment DeploymentTagChips_metadata on ModelDeploymentMetadata {
+        tags
+      }
+    `,
+    metadataFrgmt ?? null,
+  );
+
+  const tags = (metadata?.tags ?? []).flatMap((tag) =>
+    tag
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean),
+  );
+
+  if (tags.length === 0) return <>{fallback}</>;
+
+  const navigateToFiltered = (tag: string) => {
+    const filter = JSON.stringify({ tags: { iContains: tag } });
+    // Stay within the admin deployments list when activated from there;
+    // otherwise navigate to the user-facing deployment list.
+    const targetPathname = location.pathname.startsWith('/admin-deployments')
+      ? '/admin-deployments'
+      : '/deployments';
+
+    webuiNavigate({
+      pathname: targetPathname,
+      search: new URLSearchParams({ filter }).toString(),
+    });
+  };
+
+  return (
+    <BAIFlex wrap="wrap" gap="xxs">
+      {tags.map((tag) => (
+        <Tag
+          key={tag}
+          role="button"
+          tabIndex={0}
+          style={{ cursor: 'pointer' }}
+          onClick={(e) => {
+            if (stopRowClick) e.stopPropagation();
+            navigateToFiltered(tag);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              if (stopRowClick) e.stopPropagation();
+              navigateToFiltered(tag);
+            }
+          }}
+        >
+          {tag}
+        </Tag>
+      ))}
+    </BAIFlex>
+  );
+};
+
+export default DeploymentTagChips;

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -30,30 +30,16 @@ import {
   BAICard,
   BAIFetchKeyButton,
   filterOutEmpty,
+  GraphQLFilter,
   INITIAL_FETCH_KEY,
   toLocalId,
   useFetchKey,
 } from 'backend.ai-ui';
-import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
+import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useSearchParams } from 'react-router-dom';
-
-const parseFilterVariable = (
-  filter: string | null | undefined,
-): DeploymentFilter | undefined => {
-  if (!filter) return undefined;
-  try {
-    const parsed = JSON.parse(filter);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as DeploymentFilter;
-    }
-    return undefined;
-  } catch {
-    return undefined;
-  }
-};
 
 const AdminDeploymentListPageContent: React.FC = () => {
   'use memo';
@@ -72,7 +58,11 @@ const AdminDeploymentListPageContent: React.FC = () => {
 
   const [queryParams, setQueryParams] = useQueryStates(
     {
-      filter: parseAsString.withDefault(''),
+      filter: parseAsJson<GraphQLFilter>((value) =>
+        typeof value === 'object' && value !== null && !Array.isArray(value)
+          ? (value as GraphQLFilter)
+          : ({} as GraphQLFilter),
+      ),
       order: parseAsStringLiteral(availableDeploymentOrderValues),
       statusCategory: parseAsStringLiteral<DeploymentStatusCategory>([
         'running',
@@ -96,7 +86,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
       : { status: { notIn: finishedStatuses } };
   const queryVariables = {
     filter: {
-      ...parseFilterVariable(queryParams.filter),
+      ...((queryParams.filter ?? {}) as DeploymentFilter),
       ...statusCategoryFilter,
     },
     orderBy: sort
@@ -150,9 +140,9 @@ const AdminDeploymentListPageContent: React.FC = () => {
       <DeploymentList
         mode="admin"
         deploymentsFrgmt={adminDeployments}
-        filter={queryParams.filter}
+        filter={queryParams.filter ?? undefined}
         setFilter={(value) => {
-          setQueryParams({ filter: value || null });
+          setQueryParams({ filter: value ?? null });
           setTablePaginationOption({ current: 1 });
         }}
         order={queryParams.order ?? undefined}

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -25,29 +25,15 @@ import {
   BAICard,
   BAIFetchKeyButton,
   BAIFlex,
+  GraphQLFilter,
   INITIAL_FETCH_KEY,
   toLocalId,
   useFetchKey,
 } from 'backend.ai-ui';
-import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
+import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-
-const parseFilterForQuery = (
-  filter: string | null,
-): DeploymentFilter | undefined => {
-  if (!filter) return undefined;
-  try {
-    const parsed = JSON.parse(filter);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as DeploymentFilter;
-    }
-    return undefined;
-  } catch {
-    return undefined;
-  }
-};
 
 const DeploymentListPageContent: React.FC = () => {
   'use memo';
@@ -66,7 +52,11 @@ const DeploymentListPageContent: React.FC = () => {
 
   const [queryParams, setQueryParams] = useQueryStates(
     {
-      filter: parseAsString,
+      filter: parseAsJson<GraphQLFilter>((value) =>
+        typeof value === 'object' && value !== null && !Array.isArray(value)
+          ? (value as GraphQLFilter)
+          : ({} as GraphQLFilter),
+      ),
       order: parseAsStringLiteral(availableDeploymentOrderValues),
       statusCategory: parseAsStringLiteral<DeploymentStatusCategory>([
         'running',
@@ -98,7 +88,7 @@ const DeploymentListPageContent: React.FC = () => {
       : { status: { notIn: finishedStatuses } };
   const queryVariables = {
     filter: {
-      ...parseFilterForQuery(queryParams.filter),
+      ...((queryParams.filter ?? {}) as DeploymentFilter),
       ...statusCategoryFilter,
     },
     orderBy,
@@ -146,7 +136,7 @@ const DeploymentListPageContent: React.FC = () => {
         deploymentsFrgmt={myDeployments}
         filter={queryParams.filter ?? undefined}
         setFilter={(value) => {
-          setQueryParams({ filter: value || null });
+          setQueryParams({ filter: value ?? null });
           setTablePaginationOption({ current: 1 });
         }}
         order={queryParams.order ?? undefined}


### PR DESCRIPTION
Resolves #7273(FR-2827)

Stacked on #7272.

## Summary

Deployment tags shown in the deployment list table and the detail Overview card are now interactive. Activating a tag (mouse click or keyboard Enter/Space) navigates to the deployment list with that tag pre-applied as a filter, so a tag becomes a one-click pivot to "find all deployments tagged X."

The URL shape uses the existing `iContains` filter that the list page already understands:

```
/deployments?filter={"tags":{"iContains":"<tag>"}}
```

(URI-encoded in the actual link.) Activating a chip from the admin context routes to `/admin-deployments` instead so users stay within the admin list.

## Changes

- `react/src/components/DeploymentTagChips.tsx` *(new)* — fragment-based component (`DeploymentTagChips_metadata` on `ModelDeploymentMetadata`) that renders all tag chips for a deployment. Wraps antd `<Tag>` with `role="button"`, `tabIndex={0}`, and Enter/Space `onKeyDown`. Owns the filter-URL contract inline (`buildDeploymentTagFilterUrl`) and uses `useLocation()` to keep admin-context activations on `/admin-deployments`. `stopRowClick` prop opts into `e.stopPropagation()` for use inside the table row; `fallback` prop renders when there are no tags.
- `react/src/components/DeploymentList.tsx` — replaces the inline tag rendering with `<DeploymentTagChips metadataFrgmt={row.metadata} stopRowClick fallback={…} />`. Filter prop changed from `string` to `GraphQLFilter` object so callers no longer JSON-stringify.
- `react/src/components/DeploymentConfigurationSection.tsx` — replaces the inline tag rendering in the Overview "Tags" descriptions item with `<DeploymentTagChips metadataFrgmt={deployment?.metadata ?? null} fallback={renderFallback()} />`. Spreads `DeploymentTagChips_metadata` in the page query.
- `react/src/pages/DeploymentListPage.tsx` and `react/src/pages/AdminDeploymentListPage.tsx` — read `filter` as a `GraphQLFilter` object via `nuqs` `parseAsJson`, with a guard that falls back to `{}` for non-object payloads (null/array/primitive). Removes the page-local `parseFilter*` helpers.
- `packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx` — derive `conditions` from `value` instead of holding it in `useState`. Reassigns sequential ids (`cond-${i}`) on derive so React keys stay stable; the previous random-id-per-call approach would have unmounted every Tag on every render once `conditions` was no longer a state. This is the bug surfaced when an external prop change (URL-driven query state) updated `value` but the rendered tags stayed on the stale state.

## Verification

- `bash scripts/verify.sh`: Relay PASS, Lint PASS, Format PASS. Two pre-existing TypeScript failures (`packages/backend.ai-client/src/client.ts` implicit-any errors and `react/src/components/DeleteForeverVFolderModalV2.tsx` missing-`options` error) reproduce on the parent branch (PR #7272) without these changes — they are unrelated.
- Manual: clicking and Enter/Space-activating a tag in both the list and the detail page navigate to the filtered list URL, the table reloads with only matching deployments, and the rendered filter tags reflect the URL value across re-renders. Activating a tag from `/admin-deployments` stays within the admin list.

## Notes

- No backend changes — the `{ tags: { iContains: ... } }` filter shape is already handled by the list pages.
- Detail-side splits comma-joined tag strings before render (preserved behavior); each individual tag becomes its own clickable chip.
- The chip currently replaces the entire `filter` query param when activated. This matches the issue's "filter applied" requirement; merging with an already-applied filter is left as a future polish.