### PR TITLE
chore(FR-2828): adopt new filter input types for RBAC permission/entity queries

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -6543,7 +6543,7 @@ type EntityConnection
 input EntityFilter
   @join__type(graph: STRAWBERRY)
 {
-  entityType: RBACElementType = null
+  entityType: RBACElementTypeFilter = null
   entityId: StringFilter = null
   AND: [EntityFilter!] = null
   OR: [EntityFilter!] = null
@@ -11808,6 +11808,25 @@ enum OperationType
   GRANT_HARD_DELETE @join__enumValue(graph: STRAWBERRY)
 }
 
+"""
+Added in UNRELEASED. Filter for permission operation columns. Supports equals / in / not_equals / not_in.
+"""
+input OperationTypeFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Matches rows with this exact operation."""
+  equals: OperationType = null
+
+  """Matches rows whose operation is in this list."""
+  in: [OperationType!] = null
+
+  """Excludes rows with this exact operation."""
+  notEquals: OperationType = null
+
+  """Excludes rows whose operation is in this list."""
+  notIn: [OperationType!] = null
+}
+
 """Added in 24.09.0. Sort direction for ordering"""
 enum OrderDirection
   @join__type(graph: STRAWBERRY)
@@ -11891,9 +11910,10 @@ type PermissionEdge
 input PermissionFilter
   @join__type(graph: STRAWBERRY)
 {
-  roleId: UUID = null
-  scopeType: RBACElementType = null
-  entityType: RBACElementType = null
+  roleId: UUIDFilter = null
+  scopeType: RBACElementTypeFilter = null
+  scopeId: StringFilter = null
+  entityType: RBACElementTypeFilter = null
   createdAt: DateTimeFilter = null
   AND: [PermissionFilter!] = null
   OR: [PermissionFilter!] = null
@@ -11906,10 +11926,10 @@ Added in 26.4.0. Nested filter for permissions within a role assignment. Filters
 input PermissionNestedFilter
   @join__type(graph: STRAWBERRY)
 {
-  scopeId: String = null
-  scopeType: RBACElementType = null
-  entityType: RBACElementType = null
-  operation: OperationType = null
+  scopeId: StringFilter = null
+  scopeType: RBACElementTypeFilter = null
+  entityType: RBACElementTypeFilter = null
+  operation: OperationTypeFilter = null
   AND: [PermissionNestedFilter!] = null
   OR: [PermissionNestedFilter!] = null
   NOT: [PermissionNestedFilter!] = null
@@ -14451,6 +14471,25 @@ enum RBACElementType
   IMAGE_ALIAS @join__enumValue(graph: STRAWBERRY)
   ROLE_ASSIGNMENT @join__enumValue(graph: STRAWBERRY)
   ARTIFACT_REVISION @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in UNRELEASED. Filter for RBAC element type fields (scope_type / entity_type). Supports equals / in / not_equals / not_in.
+"""
+input RBACElementTypeFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Matches rows with this exact element type."""
+  equals: RBACElementType = null
+
+  """Matches rows whose element type is in this list."""
+  in: [RBACElementType!] = null
+
+  """Excludes rows with this exact element type."""
+  notEquals: RBACElementType = null
+
+  """Excludes rows whose element type is in this list."""
+  notIn: [RBACElementType!] = null
 }
 
 """

--- a/react/src/components/RoleDetailDrawer.tsx
+++ b/react/src/components/RoleDetailDrawer.tsx
@@ -122,7 +122,7 @@ const RoleDetailDrawerInner: React.FC<RoleDetailDrawerInnerProps> = ({
     {
       id: localRoleId,
       assignmentFilter: { roleId: { equals: localRoleId } },
-      permissionFilter: { roleId: localRoleId },
+      permissionFilter: { roleId: { equals: localRoleId } },
       scopeFilter: null,
       scopeOrderBy: null,
       assignmentLimit: 10,

--- a/react/src/components/RolePermissionTab.tsx
+++ b/react/src/components/RolePermissionTab.tsx
@@ -178,7 +178,7 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
       refetch(
         {
           filter: {
-            roleId,
+            roleId: { equals: roleId },
             ...(overrides?.filter !== undefined
               ? overrides.filter
               : queryParams.filter),
@@ -272,7 +272,6 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
               key: 'scopeType',
               propertyLabel: t('rbac.ScopeType'),
               type: 'enum',
-              valueMode: 'scalar',
               options: [
                 'DOMAIN',
                 'PROJECT',
@@ -292,7 +291,6 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
               key: 'entityType',
               propertyLabel: t('rbac.EntityType'),
               type: 'enum',
-              valueMode: 'scalar',
               options: [
                 'DOMAIN',
                 'PROJECT',

--- a/react/src/components/RoleScopeTab.tsx
+++ b/react/src/components/RoleScopeTab.tsx
@@ -190,7 +190,6 @@ const RoleScopeTab: React.FC<RoleScopeTabProps> = ({ queryRef }) => {
               key: 'entityType',
               propertyLabel: t('rbac.ScopeType'),
               type: 'enum',
-              valueMode: 'scalar',
               options: [
                 'DOMAIN',
                 'PROJECT',

--- a/react/src/hooks/useCurrentUserProjectRoles.ts
+++ b/react/src/hooks/useCurrentUserProjectRoles.ts
@@ -41,7 +41,7 @@ export const useCurrentUserProjectRoles = (): CurrentUserProjectRolesResult => {
       query useCurrentUserProjectRolesQuery {
         myRolesResult: myRoles(
           first: 100
-          filter: { permission: { entityType: PROJECT_ADMIN_PAGE } }
+          filter: { permission: { entityType: { equals: PROJECT_ADMIN_PAGE } } }
         ) @catch(to: RESULT) {
           edges {
             node {


### PR DESCRIPTION
Resolves #7275(FR-2828)

## Summary

The backend wrapped scalar fields on RBAC filter input types into operator objects:

- `PermissionFilter.roleId`: `UUID` → `UUIDFilter`
- `PermissionFilter.scopeType` / `entityType`: `RBACElementType` → `RBACElementTypeFilter`
- `PermissionFilter.scopeId`: new `StringFilter` field
- `PermissionNestedFilter.scopeId`: `String` → `StringFilter`
- `PermissionNestedFilter.scopeType` / `entityType`: `RBACElementType` → `RBACElementTypeFilter`
- `PermissionNestedFilter.operation`: `OperationType` → `OperationTypeFilter`
- `EntityFilter.entityType`: `RBACElementType` → `RBACElementTypeFilter`

This PR updates the frontend call sites to emit the new wrapped shape so existing queries no longer fail with `GRAPHQL_VALIDATION_FAILED`.

## Changes

- `RoleDetailDrawer`: `permissionFilter.roleId` now `{ equals: localRoleId }`.
- `RolePermissionTab`: `roleId` now `{ equals: roleId }`; dropped `valueMode: 'scalar'` on the `scopeType` / `entityType` `BAIGraphQLPropertyFilter` properties so the default operator mode emits `{ equals: VALUE }`, matching `RBACElementTypeFilter`.
- `RoleScopeTab`: dropped `valueMode: 'scalar'` on the `entityType` filter property for the same reason.
- `useCurrentUserProjectRoles`: nested `entityType` under `{ equals: PROJECT_ADMIN_PAGE }` in the `myRoles` permission filter.
- `data/schema.graphql`: pulled the new filter input types (`UUIDFilter`-style wrappers, `OperationTypeFilter`, `RBACElementTypeFilter`, `StringFilter` on permission/entity filters).

## Verification

`bash scripts/verify.sh`:

- Relay: PASS
- Lint: PASS
- Format: PASS
- TypeScript: only pre-existing failures (`packages/backend.ai-client/src/client.ts`, `DeleteForeverVFolderModalV2.tsx`, `VFolderDeployModal.tsx`) remain — no new errors introduced by this change.

## Test plan

- [ ] Open Role detail drawer for any role: scope / permission / assignment tabs load without `GRAPHQL_VALIDATION_FAILED`.
- [ ] In RolePermissionTab, apply scopeType / entityType filters and confirm rows are correctly filtered.
- [ ] In RoleScopeTab, apply scopeType filter and confirm rows are correctly filtered.
- [ ] Log in as a project admin (non-superadmin) and confirm `useCurrentUserProjectRoles` resolves project admin scopes (admin-only menus appear).
