### PR TITLE
fix(FR-2818): fall back to legacy model store on managers where PresetExecutionSpec.imageId was renamed

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -762,6 +762,14 @@ export class Client {
     if (this.isManagerVersionCompatibleWith('26.4.3')) {
       this._features['model-deployment-extended-filter'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('26.4.4')) {
+      // PresetExecutionSpec.imageId was renamed to `image` on the server, so
+      // the V2 model-store fragments (which still query `imageId`) hit
+      // GRAPHQL_VALIDATION_FAILED. Disable model-card-v2 here until the
+      // fragments migrate to the new field name; consumers fall back to the
+      // legacy model-store flow.
+      this._features['model-card-v2'] = false;
+    }
   }
 
   /**


### PR DESCRIPTION
Resolves #7252(FR-2818)

## Summary

On managers running 26.4.4rc2+, `PresetExecutionSpec.imageId` was renamed to `image` on the server. The Relay fragment in `ModelCardDrawer.tsx` still queries `imageId`, which fails with `GRAPHQL_VALIDATION_FAILED` and breaks the entire `/model-store` V2 page.

## Fix

Reuse the existing `model-card-v2` feature flag and disable it at 26.4.4 so consumers fall back to the legacy model-store flow until the V2 fragments migrate to the new field name. Routing in `routes.tsx` is unchanged — `supports('model-card-v2')` now returns `false` on 26.4.4+, so `/model-store` automatically renders `LegacyModelStoreListPage`.

## Why this approach

The fragment-level rename is a separate, larger change. Disabling the flag is a minimal, version-gated workaround that restores functionality on 26.4.4+ while preserving V2 behavior on 26.4.0–26.4.3.