### PR TITLE
feat(FR-2834): use Visibility row label with Public/Private tag for deployment OpenToPublic

### DIFF
--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -101,13 +101,13 @@ const DeploymentOverviewContent: React.FC<{
       ),
     },
     {
-      key: 'open-to-public',
-      label: t('deployment.OpenToPublic'),
+      key: 'visibility',
+      label: t('deployment.Visibility'),
       children: (
         <BooleanTag
           value={deployment?.networkAccess.openToPublic}
-          trueLabel={t('button.Yes')}
-          falseLabel={t('button.No')}
+          trueLabel={t('deployment.Public')}
+          falseLabel={t('deployment.Private')}
           fallback={renderFallback()}
         />
       ),

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Öffentlich",
     "Overview": "Übersicht",
     "Owner": "Eigentümer",
+    "Private": "Privat",
     "Project": "Projekt",
     "Public": "Öffentlich",
     "QuickDeploy": "Bereitstellen",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Bereitstellung aktualisieren",
     "UpdatedAt": "Aktualisiert am",
     "ViewRevision": "Revision anzeigen",
+    "Visibility": "Sichtbarkeit",
     "accessToken": {
       "Create": "Zugriffstoken erstellen",
       "Created": "Zugriffstoken wurde erstellt.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Δημόσιο",
     "Overview": "Επισκόπηση",
     "Owner": "Ιδιοκτήτης",
+    "Private": "Ιδιωτικό",
     "Project": "Έργο",
     "Public": "Δημόσιο",
     "QuickDeploy": "Ανάπτυξη",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Ενημέρωση ανάπτυξης",
     "UpdatedAt": "Ενημερώθηκε",
     "ViewRevision": "Προβολή Revision",
+    "Visibility": "Ορατότητα",
     "accessToken": {
       "Create": "Δημιουργία διακριτικού πρόσβασης",
       "Created": "Το διακριτικό πρόσβασης δημιουργήθηκε.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -966,6 +966,7 @@
     "OpenToPublic": "Open To Public",
     "Overview": "Overview",
     "Owner": "Owner",
+    "Private": "Private",
     "Project": "Project",
     "Public": "Public",
     "QuickDeploy": "Deploy",
@@ -999,6 +1000,7 @@
     "UpdateDeployment": "Update Deployment",
     "UpdatedAt": "Updated At",
     "ViewRevision": "View Revision",
+    "Visibility": "Visibility",
     "accessToken": {
       "Create": "Create Access Token",
       "Created": "Access token has been created.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Público",
     "Overview": "Resumen",
     "Owner": "Propietario",
+    "Private": "Privado",
     "Project": "Proyecto",
     "Public": "Público",
     "QuickDeploy": "Desplegar",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Actualizar despliegue",
     "UpdatedAt": "Actualizado el",
     "ViewRevision": "Ver Revision",
+    "Visibility": "Visibilidad",
     "accessToken": {
       "Create": "Crear token de acceso",
       "Created": "El token de acceso ha sido creado.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Julkinen",
     "Overview": "Yleiskatsaus",
     "Owner": "Omistaja",
+    "Private": "Yksityinen",
     "Project": "Projekti",
     "Public": "Julkinen",
     "QuickDeploy": "Ota käyttöön",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Päivitä käyttöönotto",
     "UpdatedAt": "Päivitetty",
     "ViewRevision": "Näytä Revision",
+    "Visibility": "Näkyvyys",
     "accessToken": {
       "Create": "Luo pääsytunnus",
       "Created": "Pääsytunnus on luotu.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Public",
     "Overview": "Aperçu",
     "Owner": "Propriétaire",
+    "Private": "Privé",
     "Project": "Projet",
     "Public": "Public",
     "QuickDeploy": "Déployer",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Mettre à jour le déploiement",
     "UpdatedAt": "Mis à jour le",
     "ViewRevision": "Voir la Revision",
+    "Visibility": "Visibilité",
     "accessToken": {
       "Create": "Créer un jeton d'accès",
       "Created": "Le jeton d'accès a été créé.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Terbuka untuk Publik",
     "Overview": "Ikhtisar",
     "Owner": "Pemilik",
+    "Private": "Privat",
     "Project": "Proyek",
     "Public": "Publik",
     "QuickDeploy": "Terapkan",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Perbarui Penerapan",
     "UpdatedAt": "Diperbarui Pada",
     "ViewRevision": "Lihat Revision",
+    "Visibility": "Visibilitas",
     "accessToken": {
       "Create": "Buat Token Akses",
       "Created": "Token akses telah dibuat.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Pubblico",
     "Overview": "Panoramica",
     "Owner": "Proprietario",
+    "Private": "Privato",
     "Project": "Progetto",
     "Public": "Pubblico",
     "QuickDeploy": "Distribuisci",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Aggiorna distribuzione",
     "UpdatedAt": "Aggiornato il",
     "ViewRevision": "Visualizza Revision",
+    "Visibility": "Visibilità",
     "accessToken": {
       "Create": "Crea token di accesso",
       "Created": "Il token di accesso è stato creato.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "公開",
     "Overview": "概要",
     "Owner": "オーナー",
+    "Private": "非公開",
     "Project": "プロジェクト",
     "Public": "公開",
     "QuickDeploy": "デプロイ",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "デプロイを更新",
     "UpdatedAt": "更新日時",
     "ViewRevision": "Revision を表示",
+    "Visibility": "公開範囲",
     "accessToken": {
       "Create": "アクセストークンを作成",
       "Created": "アクセストークンが作成されました。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -965,6 +965,7 @@
     "OpenToPublic": "외부에 공개",
     "Overview": "개요",
     "Owner": "소유자",
+    "Private": "비공개",
     "Project": "프로젝트",
     "Public": "공개",
     "QuickDeploy": "배포",
@@ -998,6 +999,7 @@
     "UpdateDeployment": "배포 업데이트",
     "UpdatedAt": "수정일",
     "ViewRevision": "리비전 보기",
+    "Visibility": "공개 범위",
     "accessToken": {
       "Create": "액세스 토큰 생성",
       "Created": "액세스 토큰이 생성되었습니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Нийтэд нээлттэй",
     "Overview": "Ерөнхий мэдэгдэл",
     "Owner": "Эзэмшигч",
+    "Private": "Хувийн",
     "Project": "Төсөл",
     "Public": "Нийтийн",
     "QuickDeploy": "Байршуулах",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Байршуулалт шинэчлэх",
     "UpdatedAt": "Шинэчилсэн огноо",
     "ViewRevision": "Revision харах",
+    "Visibility": "Харагдац",
     "accessToken": {
       "Create": "Хандалтын токен үүсгэх",
       "Created": "Хандалтын токен үүсгэгдлээ.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Terbuka kepada Awam",
     "Overview": "Gambaran Keseluruhan",
     "Owner": "Pemilik",
+    "Private": "Peribadi",
     "Project": "Projek",
     "Public": "Awam",
     "QuickDeploy": "Gunakan",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Kemas Kini Penggunaan",
     "UpdatedAt": "Dikemas Kini Pada",
     "ViewRevision": "Lihat Revision",
+    "Visibility": "Keterlihatan",
     "accessToken": {
       "Create": "Cipta Token Akses",
       "Created": "Token akses telah dicipta.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Publiczne",
     "Overview": "Przegląd",
     "Owner": "Właściciel",
+    "Private": "Prywatne",
     "Project": "Projekt",
     "Public": "Publiczny",
     "QuickDeploy": "Wdróż",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Aktualizuj wdrożenie",
     "UpdatedAt": "Zaktualizowano",
     "ViewRevision": "Wyświetl Revision",
+    "Visibility": "Widoczność",
     "accessToken": {
       "Create": "Utwórz token dostępu",
       "Created": "Token dostępu został utworzony.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Público",
     "Overview": "Visão geral",
     "Owner": "Proprietário",
+    "Private": "Privado",
     "Project": "Projeto",
     "Public": "Público",
     "QuickDeploy": "Implantar",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Atualizar implantação",
     "UpdatedAt": "Atualizado em",
     "ViewRevision": "Ver Revision",
+    "Visibility": "Visibilidade",
     "accessToken": {
       "Create": "Criar token de acesso",
       "Created": "O token de acesso foi criado.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Público",
     "Overview": "Visão geral",
     "Owner": "Proprietário",
+    "Private": "Privado",
     "Project": "Projeto",
     "Public": "Público",
     "QuickDeploy": "Implementar",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Atualizar implementação",
     "UpdatedAt": "Atualizado em",
     "ViewRevision": "Ver Revision",
+    "Visibility": "Visibilidade",
     "accessToken": {
       "Create": "Criar token de acesso",
       "Created": "O token de acesso foi criado.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Публичное",
     "Overview": "Обзор",
     "Owner": "Владелец",
+    "Private": "Приватный",
     "Project": "Проект",
     "Public": "Публичный",
     "QuickDeploy": "Развернуть",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Обновить развёртывание",
     "UpdatedAt": "Обновлено",
     "ViewRevision": "Просмотреть Revision",
+    "Visibility": "Видимость",
     "accessToken": {
       "Create": "Создать токен доступа",
       "Created": "Токен доступа создан.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "เปิดสาธารณะ",
     "Overview": "ภาพรวม",
     "Owner": "เจ้าของ",
+    "Private": "ส่วนตัว",
     "Project": "โปรเจกต์",
     "Public": "สาธารณะ",
     "QuickDeploy": "ปรับใช้",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "อัปเดตการปรับใช้",
     "UpdatedAt": "อัปเดตเมื่อ",
     "ViewRevision": "ดู Revision",
+    "Visibility": "การมองเห็น",
     "accessToken": {
       "Create": "สร้างโทเค็นการเข้าถึง",
       "Created": "สร้างโทเค็นการเข้าถึงเรียบร้อยแล้ว",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Herkese Açık",
     "Overview": "Genel Bakış",
     "Owner": "Sahibi",
+    "Private": "Özel",
     "Project": "Proje",
     "Public": "Genel",
     "QuickDeploy": "Dağıt",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Dağıtımı Güncelle",
     "UpdatedAt": "Güncellenme Tarihi",
     "ViewRevision": "Revision'ı Görüntüle",
+    "Visibility": "Görünürlük",
     "accessToken": {
       "Create": "Erişim Jetonu Oluştur",
       "Created": "Erişim jetonu oluşturuldu.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "Công khai",
     "Overview": "Tổng quan",
     "Owner": "Chủ sở hữu",
+    "Private": "Riêng tư",
     "Project": "Dự án",
     "Public": "Công khai",
     "QuickDeploy": "Triển khai",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "Cập nhật triển khai",
     "UpdatedAt": "Ngày cập nhật",
     "ViewRevision": "Xem Revision",
+    "Visibility": "Khả năng hiển thị",
     "accessToken": {
       "Create": "Tạo mã thông báo truy cập",
       "Created": "Mã thông báo truy cập đã được tạo.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -964,6 +964,7 @@
     "OpenToPublic": "公开",
     "Overview": "概览",
     "Owner": "所有者",
+    "Private": "私有",
     "Project": "项目",
     "Public": "公开",
     "QuickDeploy": "部署",
@@ -997,6 +998,7 @@
     "UpdateDeployment": "更新部署",
     "UpdatedAt": "更新时间",
     "ViewRevision": "查看 Revision",
+    "Visibility": "可见性",
     "accessToken": {
       "Create": "创建访问令牌",
       "Created": "访问令牌已创建。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -965,6 +965,7 @@
     "OpenToPublic": "公開",
     "Overview": "概覽",
     "Owner": "擁有者",
+    "Private": "私有",
     "Project": "專案",
     "Public": "公開",
     "QuickDeploy": "部署",
@@ -998,6 +999,7 @@
     "UpdateDeployment": "更新部署",
     "UpdatedAt": "更新時間",
     "ViewRevision": "查看 Revision",
+    "Visibility": "可見性",
     "accessToken": {
       "Create": "建立存取令牌",
       "Created": "存取令牌已建立。",


### PR DESCRIPTION
Resolves #7286 ([FR-2834](https://lablup.atlassian.net/browse/FR-2834))

## Summary
- Change the deployment overview row for endpoint accessibility from `OpenToPublic` (label "Public") to `Visibility` so the tag value reads naturally alongside the label.
- `BooleanTag` now uses `t('deployment.Public')` / `t('deployment.Private')` for its true/false labels (cloud-provider standard convention) instead of the previous Yes/No, which read awkwardly inside a Tag.
- Add `deployment.Visibility` and `deployment.Private` i18n keys across all 22 supported languages.

## Test plan
- [ ] Open a deployment detail page; verify the row label shows "Visibility" (or its localized equivalent) instead of "Public".
- [ ] Verify the BooleanTag value reads "Public" (green) when `openToPublic` is true and "Private" (subdued) when false.
- [ ] Verify `-` fallback renders while the deployment is loading.
- [ ] Spot-check at least Korean, Japanese, and one Latin-script locale to confirm both new keys are translated.

[FR-2834]: https://lablup.atlassian.net/browse/FR-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ