### PR TITLE
fix(FR-2836): remove unused revision name field from Add Revision modal

### DIFF
--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -116,7 +116,6 @@ interface DeploymentAddRevisionModalProps extends BAIModalProps {
 type FormValues = ImageEnvironmentFormInput &
   ResourceAllocationFormValue &
   VFolderTableFormValues & {
-    name?: string;
     runtimeVariantId: string;
     modelFolderId: string;
     mountDestination: string;
@@ -294,7 +293,6 @@ const DeploymentAddRevisionModalFormBody: React.FC<
         addModelRevision(input: $input) {
           revision {
             id
-            name
             clusterConfig {
               mode
               size
@@ -783,7 +781,6 @@ const DeploymentAddRevisionModalFormBody: React.FC<
       variables: {
         input: {
           deploymentId: toLocalId(deploymentId) ?? deploymentId,
-          name: values.name || undefined,
           clusterConfig: {
             mode: clusterMode,
             size: values.cluster_size,
@@ -902,9 +899,6 @@ const DeploymentAddRevisionModalFormBody: React.FC<
         autoActivate: true,
       })}
     >
-      <Form.Item name="name" label={t('deployment.RevisionName')}>
-        <Input placeholder={t('deployment.RevisionNamePlaceholder')} />
-      </Form.Item>
       <Form.Item name="autoActivate" valuePropName="checked">
         <Checkbox>{t('deployment.AutoActivate')}</Checkbox>
       </Form.Item>

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -202,12 +202,10 @@ const DeploymentConfigurationSection: React.FC<
         }
         currentRevision @since(version: "26.4.3") {
           id
-          name
           ...DeploymentRevisionDetail_revision
         }
         deployingRevision @since(version: "26.4.3") {
           id
-          name
           ...DeploymentRevisionDetail_revision
         }
         ...DeploymentRevisionHistoryTab_deployment
@@ -378,7 +376,7 @@ const DeploymentConfigurationSection: React.FC<
                 icon={<LoadingOutlined spin />}
                 showIcon
                 title={t('deployment.DeployingRevisionApplying', {
-                  name: deployingRevision.name ?? '',
+                  name: toLocalId(deployingRevision.id) ?? '',
                 })}
                 action={
                   <Button

--- a/react/src/components/DeploymentReplicasTab.tsx
+++ b/react/src/components/DeploymentReplicasTab.tsx
@@ -23,6 +23,7 @@ import {
   BAIUnmountAfterClose,
   type GraphQLFilter,
   filterOutEmpty,
+  toLocalId,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
@@ -175,7 +176,6 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
                   createdAt
                   revision {
                     id
-                    name
                   }
                 }
               }
@@ -288,7 +288,9 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
       key: 'revision',
       title: t('deployment.Revision'),
       render: (_: unknown, record: ReplicaNode) =>
-        record.revision?.name ?? (
+        record.revision?.id ? (
+          toLocalId(record.revision.id)
+        ) : (
           <Typography.Text type="secondary">—</Typography.Text>
         ),
     },

--- a/react/src/components/DeploymentRevisionDetail.tsx
+++ b/react/src/components/DeploymentRevisionDetail.tsx
@@ -40,7 +40,6 @@ const DeploymentRevisionDetail: React.FC<{
     graphql`
       fragment DeploymentRevisionDetail_revision on ModelRevision {
         id
-        name
         createdAt
         clusterConfig {
           mode
@@ -132,9 +131,9 @@ const DeploymentRevisionDetail: React.FC<{
     {
       key: 'revision-name',
       label: t('modelService.RevisionID'),
-      children: revision.name ? (
+      children: revision.id ? (
         <BAIFlex gap="xs" align="center">
-          <Typography.Text>{revision.name}</Typography.Text>
+          <Typography.Text>{toLocalId(revision.id)}</Typography.Text>
           {status === 'current' && (
             <BAITag color="success">{t('deployment.Current')}</BAITag>
           )}

--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -195,8 +195,8 @@ const DeploymentRevisionHistoryTab: React.FC<
               edges {
                 node {
                   id
-                  name
                   createdAt
+
                   clusterConfig {
                     mode
                     size
@@ -245,7 +245,6 @@ const DeploymentRevisionHistoryTab: React.FC<
             currentRevisionId
             currentRevision {
               id
-              name
             }
           }
           previousRevisionId
@@ -278,10 +277,7 @@ const DeploymentRevisionHistoryTab: React.FC<
   };
 
   const handleRollback = (revision: RevisionNode): Promise<boolean> => {
-    // The `name` field is the human-readable revision number label
-    // ("#3"). Fall back to the trimmed UUID if absent so the confirm
-    // text is never blank.
-    const revisionLabel = revision.name ?? toLocalId(revision.id);
+    const revisionLabel = toLocalId(revision.id);
     return new Promise<boolean>((resolveOuter) => {
       modal.confirm({
         title: t('deployment.Deploy'),
@@ -382,7 +378,7 @@ const DeploymentRevisionHistoryTab: React.FC<
                     })
                   }
                 >
-                  {record.name ?? '-'}
+                  {recordLocalId ?? '-'}
                 </Typography.Link>
                 {isCurrent ? (
                   <BAITag color="success">{t('deployment.Current')}</BAITag>

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1405,7 +1405,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
             ) {
               edges {
                 node {
-                  name
                   modelDefinition {
                     models {
                       service {

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -81,6 +81,7 @@ import {
   GraphQLFilter,
   SemanticColor,
   toGlobalId,
+  toLocalId,
   useFetchKey,
   useSemanticColorMap,
   BAITable,
@@ -365,7 +366,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           }
           currentRevision {
             id
-            name
             modelDefinition {
               models {
                 name
@@ -389,7 +389,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             edges {
               node {
                 id
-                name
                 modelDefinition {
                   models {
                     name
@@ -807,9 +806,13 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
   const latestRevisionItems = buildModelDefinitionItems(
     modelDeployment?.revisionHistory?.edges?.[0]?.node?.modelDefinition?.models,
   );
-  const currentRevisionName = modelDeployment?.currentRevision?.name;
-  const latestRevisionName =
-    modelDeployment?.revisionHistory?.edges?.[0]?.node?.name;
+  const currentRevisionName = modelDeployment?.currentRevision?.id
+    ? toLocalId(modelDeployment.currentRevision.id)
+    : undefined;
+  const latestRevisionName = modelDeployment?.revisionHistory?.edges?.[0]?.node
+    ?.id
+    ? toLocalId(modelDeployment.revisionHistory.edges[0].node.id)
+    : undefined;
   const isRevisionMismatch =
     modelDeployment?.currentRevision?.id != null &&
     modelDeployment?.revisionHistory?.edges?.[0]?.node?.id != null &&

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Revisionsverlauf",
     "RevisionId": "Revisions-ID",
     "RevisionIdPlaceholder": "Revisions-ID eingeben (optional)",
-    "RevisionName": "Revisionsname",
-    "RevisionNamePlaceholder": "Leer lassen für automatische Generierung",
     "RevisionNumber": "Revisionsnummer",
     "Revisions": "Revisionen",
     "Running": "Läuft",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Ιστορικό Revision",
     "RevisionId": "ID Revision",
     "RevisionIdPlaceholder": "Εισάγετε ID Revision (προαιρετικό)",
-    "RevisionName": "Όνομα Revision",
-    "RevisionNamePlaceholder": "Αφήστε κενό για αυτόματη δημιουργία",
     "RevisionNumber": "Αριθμός Αναθεώρησης",
     "Revisions": "Revision",
     "Running": "Σε εκτέλεση",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -988,8 +988,6 @@
     "RevisionHistory": "Revision History",
     "RevisionId": "Revision ID",
     "RevisionIdPlaceholder": "Leave blank to auto-generate",
-    "RevisionName": "Revision Name",
-    "RevisionNamePlaceholder": "Leave blank to auto-generate",
     "RevisionNumber": "Revision Number",
     "Revisions": "Revisions",
     "Running": "Running",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Historial de Revision",
     "RevisionId": "ID de Revision",
     "RevisionIdPlaceholder": "Ingrese un ID de Revision (opcional)",
-    "RevisionName": "Nombre de Revision",
-    "RevisionNamePlaceholder": "Dejar en blanco para generar automáticamente",
     "RevisionNumber": "Número de Revisión",
     "Revisions": "Revision",
     "Running": "En ejecución",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Revision-historia",
     "RevisionId": "Revision ID",
     "RevisionIdPlaceholder": "Anna Revision ID (valinnainen)",
-    "RevisionName": "Revision nimi",
-    "RevisionNamePlaceholder": "Jätä tyhjäksi automaattista luontia varten",
     "RevisionNumber": "Revisionumero",
     "Revisions": "Revision",
     "Running": "Käynnissä",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Historique de Revision",
     "RevisionId": "ID de Revision",
     "RevisionIdPlaceholder": "Saisir un ID de Revision (facultatif)",
-    "RevisionName": "Nom de Revision",
-    "RevisionNamePlaceholder": "Laisser vide pour génération automatique",
     "RevisionNumber": "Numéro de Revision",
     "Revisions": "Revision",
     "Running": "En cours d'exécution",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Riwayat Revision",
     "RevisionId": "ID Revision",
     "RevisionIdPlaceholder": "Masukkan ID Revision (opsional)",
-    "RevisionName": "Nama Revision",
-    "RevisionNamePlaceholder": "Biarkan kosong untuk dibuat otomatis",
     "RevisionNumber": "Nomor Revisi",
     "Revisions": "Revision",
     "Running": "Berjalan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Cronologia Revision",
     "RevisionId": "ID Revision",
     "RevisionIdPlaceholder": "Inserisci un ID Revision (opzionale)",
-    "RevisionName": "Nome Revision",
-    "RevisionNamePlaceholder": "Lascia vuoto per la generazione automatica",
     "RevisionNumber": "Numero di Revisione",
     "Revisions": "Revision",
     "Running": "In esecuzione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Revision 履歴",
     "RevisionId": "Revision ID",
     "RevisionIdPlaceholder": "Revision ID を入力（任意）",
-    "RevisionName": "Revision 名",
-    "RevisionNamePlaceholder": "空白のままにすると自動生成されます",
     "RevisionNumber": "Revision 番号",
     "Revisions": "Revision",
     "Running": "実行中",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -987,8 +987,6 @@
     "RevisionHistory": "리비전 히스토리",
     "RevisionId": "리비전 ID",
     "RevisionIdPlaceholder": "리비전 ID를 입력하세요 (선택 사항)",
-    "RevisionName": "리비전 이름",
-    "RevisionNamePlaceholder": "비워두면 자동 생성",
     "RevisionNumber": "리비전 번호",
     "Revisions": "리비전",
     "Running": "실행 중",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Revision-ы түүх",
     "RevisionId": "Revision ID",
     "RevisionIdPlaceholder": "Revision ID оруулна уу (заавал биш)",
-    "RevisionName": "Revision нэр",
-    "RevisionNamePlaceholder": "Автоматаар үүсгэхийн тулд хоосон үлдээнэ үү",
     "RevisionNumber": "Revision дугаар",
     "Revisions": "Revision-ууд",
     "Running": "Ажиллаж байна",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Sejarah Revision",
     "RevisionId": "ID Revision",
     "RevisionIdPlaceholder": "Masukkan ID Revision (pilihan)",
-    "RevisionName": "Nama Revision",
-    "RevisionNamePlaceholder": "Biarkan kosong untuk jana secara automatik",
     "RevisionNumber": "Nombor Revisi",
     "Revisions": "Revision",
     "Running": "Sedang berjalan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Historia Revision",
     "RevisionId": "ID Revision",
     "RevisionIdPlaceholder": "Wprowadź ID Revision (opcjonalne)",
-    "RevisionName": "Nazwa Revision",
-    "RevisionNamePlaceholder": "Pozostaw puste, aby wygenerować automatycznie",
     "RevisionNumber": "Numer Rewizji",
     "Revisions": "Revision",
     "Running": "Uruchomiony",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Histórico de Revision",
     "RevisionId": "ID de Revision",
     "RevisionIdPlaceholder": "Insira um ID de Revision (opcional)",
-    "RevisionName": "Nome da Revision",
-    "RevisionNamePlaceholder": "Deixe em branco para gerar automaticamente",
     "RevisionNumber": "Número de Revisão",
     "Revisions": "Revision",
     "Running": "Em execução",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Histórico de Revision",
     "RevisionId": "ID de Revision",
     "RevisionIdPlaceholder": "Introduza um ID de Revision (opcional)",
-    "RevisionName": "Nome da Revision",
-    "RevisionNamePlaceholder": "Deixe em branco para geração automática",
     "RevisionNumber": "Número de Revisão",
     "Revisions": "Revision",
     "Running": "Em execução",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "История Revision",
     "RevisionId": "ID Revision",
     "RevisionIdPlaceholder": "Введите ID Revision (необязательно)",
-    "RevisionName": "Название Revision",
-    "RevisionNamePlaceholder": "Оставьте пустым для автоматической генерации",
     "RevisionNumber": "Номер ревизии",
     "Revisions": "Revision",
     "Running": "Выполняется",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "ประวัติ Revision",
     "RevisionId": "ID Revision",
     "RevisionIdPlaceholder": "กรอก ID Revision (ไม่บังคับ)",
-    "RevisionName": "ชื่อ Revision",
-    "RevisionNamePlaceholder": "ปล่อยว่างเพื่อสร้างอัตโนมัติ",
     "RevisionNumber": "หมายเลข Revision",
     "Revisions": "Revision",
     "Running": "กำลังทำงาน",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Revision Geçmişi",
     "RevisionId": "Revision Kimliği",
     "RevisionIdPlaceholder": "Bir Revision Kimliği girin (isteğe bağlı)",
-    "RevisionName": "Revision Adı",
-    "RevisionNamePlaceholder": "Otomatik oluşturmak için boş bırakın",
     "RevisionNumber": "Revizyon Numarası",
     "Revisions": "Revision",
     "Running": "Çalışıyor",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Lịch sử Revision",
     "RevisionId": "ID Revision",
     "RevisionIdPlaceholder": "Nhập ID Revision (tùy chọn)",
-    "RevisionName": "Tên Revision",
-    "RevisionNamePlaceholder": "Để trống để tự động tạo",
     "RevisionNumber": "Số Revision",
     "Revisions": "Revision",
     "Running": "Đang chạy",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -986,8 +986,6 @@
     "RevisionHistory": "Revision 历史",
     "RevisionId": "Revision ID",
     "RevisionIdPlaceholder": "输入 Revision ID（可选）",
-    "RevisionName": "Revision 名称",
-    "RevisionNamePlaceholder": "留空以自动生成",
     "RevisionNumber": "Revision 编号",
     "Revisions": "Revision",
     "Running": "运行中",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -987,8 +987,6 @@
     "RevisionHistory": "Revision 歷史",
     "RevisionId": "Revision ID",
     "RevisionIdPlaceholder": "輸入 Revision ID（選填）",
-    "RevisionName": "Revision 名稱",
-    "RevisionNamePlaceholder": "留空以自動生成",
     "RevisionNumber": "Revision 編號",
     "Revisions": "Revision",
     "Running": "執行中",


### PR DESCRIPTION
Resolves #7290 ([FR-2836](https://lablup.atlassian.net/browse/FR-2836))

> Stacked on top of #7289

## Summary
- Remove the unused `Revision Name` text input from the `Add Revision` modal.
- Drop `name` from the `FormValues` type and from the `addModelRevision` mutation payload.
- Delete the now-unused i18n keys `deployment.RevisionName` and `deployment.RevisionNamePlaceholder` across all 21 supported locales.

## Test plan
- [ ] Open the deployment page and click `Add Revision`.
- [ ] Verify the `Revision Name` input is no longer present.
- [ ] Submit the modal — the new revision is created without sending a `name` to the backend.
- [ ] Confirm no missing-i18n-key warnings appear in the dev console.

[FR-2836]: https://lablup.atlassian.net/browse/FR-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ