### PR TITLE
ci(FR-2839): pin pnpm to v10 in GitHub Actions workflows

### DIFF
--- a/.github/actions/daily-test-improver/coverage-steps/action.yml
+++ b/.github/actions/daily-test-improver/coverage-steps/action.yml
@@ -8,7 +8,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v5
       with:
-        version: latest
+        version: 10
         run_install: false
 
     - name: Setup Node.js

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
 
       - name: Install Node.js
@@ -100,7 +100,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
 
       - name: Install Node.js
@@ -168,7 +168,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
 
       - name: Install Node.js
@@ -234,7 +234,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/publish-backend.ai-docs-toolkit.yml
+++ b/.github/workflows/publish-backend.ai-docs-toolkit.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/publish-backend.ai-ui.yml
+++ b/.github/workflows/publish-backend.ai-ui.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
       - uses: actions/setup-node@v5
         with:
@@ -104,7 +104,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
       - uses: actions/setup-node@v5
         with:
@@ -146,7 +146,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/weekly-merge-branch-lockfiles.yml
+++ b/.github/workflows/weekly-merge-branch-lockfiles.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: latest
+          version: 10
           run_install: false
 
       - uses: actions/setup-node@v5


### PR DESCRIPTION
Resolves #7295(FR-2839)

## Summary

`pnpm/action-setup` was using `version: latest`, which now resolves to **pnpm 11.0.8**. This conflicts with this repo's `engines.pnpm: ^10.16.0` (and `engine-strict=true` in `.npmrc`), causing every CI install step to fail with:

```
ERR_PNPM_UNSUPPORTED_ENGINE
Expected version: ^10.16.0
Got: 11.0.8
```

Example failure on PR #7289 (`react-vitest` job): https://github.com/lablup/backend.ai-webui/actions/runs/25532505739/job/74941615237

Pin all 11 `pnpm/action-setup` invocations to `version: 10` so CI tracks the latest 10.x release and stops drifting onto v11. The full pnpm v11 migration (config moves, `onlyBuiltDependencies` → `allowBuilds`, lockfile regen, audit GHSA migration, etc.) is tracked separately under #7296(FR-2840).

## Changes

- `.github/workflows/vitest.yml` — 3 occurrences
- `.github/workflows/package.yml` — 4 occurrences
- `.github/workflows/publish-backend.ai-ui.yml` — 1 occurrence
- `.github/workflows/publish-backend.ai-docs-toolkit.yml` — 1 occurrence
- `.github/workflows/weekly-merge-branch-lockfiles.yml` — 1 occurrence
- `.github/actions/daily-test-improver/coverage-steps/action.yml` — 1 occurrence (composite action used by `daily-test-improver`)

`grep -rn "version: latest" .github/` returns no results after this change.

No application code, lockfile, or `package.json` changes.

## Test plan

- [ ] After merge, re-run failed CI on a recent PR (e.g. #7289) and verify the install step passes.
- [ ] Confirm `pnpm -v` in CI logs reports a 10.x version.
- [ ] No regression on the `Analyze` / `CodeQL` / `triage` checks (they don't use pnpm).
