### PR TITLE
fix(FR-2837): set shmem under config.resource_opts and display SHM in endpoint detail

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -801,11 +801,13 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
               : undefined),
           },
           ...(values.resource.shmem && {
-            shmem:
-              compareNumberWithUnits(values.resource.mem, '4g') > 0 &&
-              compareNumberWithUnits(values.resource.shmem, '1g') < 0
-                ? '1g'
-                : values.resource.shmem,
+            resource_opts: {
+              shmem:
+                compareNumberWithUnits(values.resource.mem, '4g') > 0 &&
+                compareNumberWithUnits(values.resource.shmem, '1g') < 0
+                  ? '1g'
+                  : values.resource.shmem,
+            },
           }),
         },
       };

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -86,6 +86,7 @@ import {
   useSemanticColorMap,
   BAITable,
   BAIFetchKeyButton,
+  convertToBinaryUnit,
 } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import * as _ from 'lodash-es';
@@ -530,7 +531,12 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     _.map(endpoint_auto_scaling_rules?.edges, (edge) => edge?.node),
   );
 
-  const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
+  const parsedResourceOpts = JSON.parse(endpoint?.resource_opts || '{}');
+  const resource_opts = {
+    shmem: parsedResourceOpts.shmem
+      ? convertToBinaryUnit(parsedResourceOpts.shmem, '')?.number
+      : undefined,
+  };
 
   const items: DescriptionsItemType[] = [
     {


### PR DESCRIPTION
Resolves #7292 ([FR-2837](https://lablup.atlassian.net/browse/FR-2837))

> Test server: \<webui>/serving/dc384809-56d5-4a17-9d2e-73fde29af978 in `10.82.1.246`

## Summary

- Move `shmem` from being set directly under `config` to under `config.resource_opts.shmem` when creating model services in `ServiceLauncherPageContent`, matching the pattern used by `useStartSession` for compute sessions.
- Display SHM next to the memory resource on the endpoint detail page by parsing `endpoint.resource_opts.shmem` and converting it to bytes via `convertToBinaryUnit`, so users can verify the configured shared memory size of a deployed model service.

## Test plan

- [ ] Create a new model service with custom shared memory (e.g. 2 GiB) and verify the deployment is created with the requested SHM (not 0.06 GiB).
- [ ] Open the endpoint detail page for the created service and confirm `(SHM: …GiB)` appears next to the memory value.
- [ ] Verify that when `shmem` is not set, the memory display does not show an empty/zero SHM hint.

[FR-2837]: https://lablup.atlassian.net/browse/FR-2837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ