### PR TITLE
refactor(FR-2841): rename WSProxy i18n keys/values to App Proxy

### DIFF
--- a/react/src/components/ResourceGroupInfoModal.tsx
+++ b/react/src/components/ResourceGroupInfoModal.tsx
@@ -90,7 +90,7 @@ const ResourceGroupInfoModal: React.FC<ResourceGroupInfoModalProps> = ({
         <Descriptions.Item label={t('resourceGroup.Scheduler')}>
           {_.toUpper(resourceGroup?.scheduler ?? '')}
         </Descriptions.Item>
-        <Descriptions.Item label={t('resourceGroup.WsproxyAddress')}>
+        <Descriptions.Item label={t('resourceGroup.AppProxyAddress')}>
           {resourceGroup?.wsproxy_addr || '-'}
         </Descriptions.Item>
       </Descriptions>

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -254,7 +254,7 @@ const ResourceGroupList: React.FC = () => {
     },
     {
       key: 'wsproxy_addr',
-      title: t('resourceGroup.WsproxyAddress'),
+      title: t('resourceGroup.AppProxyAddress'),
       dataIndex: 'wsproxy_addr',
       render: (value) => value || '-',
     },

--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -345,14 +345,14 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
             />
           </Form.Item>
           <Form.Item
-            label={t('resourceGroup.WsproxyAddress')}
+            label={t('resourceGroup.AppProxyAddress')}
             name="wsProxyAddress"
             rules={[{ type: 'url', message: t('error.InvalidUrl') }]}
           >
             <Input placeholder="http://localhost:10200" />
           </Form.Item>
           <Form.Item
-            label={t('resourceGroup.WsproxyAPIToken')}
+            label={t('resourceGroup.AppProxyAPIToken')}
             name="wsProxyAPIToken"
           >
             <Input.Password placeholder={t('resourceGroup.EnterAPIToken')} />

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2311,6 +2311,8 @@
     "Active": "Aktiv",
     "ActiveStatus": "Aktiver Status",
     "AllowedSessionTypes": "Erlaubte Sitzungstypen",
+    "AppProxyAPIToken": "App-Proxy-API-Token",
+    "AppProxyAddress": "App-Proxy-Serveradresse",
     "CreateResourceGroup": "Ressourcengruppe erstellen",
     "Deactivate": "Deaktivieren",
     "DeactivateResourceGroup": "Deaktivierung der Ressourcengruppe",
@@ -2347,9 +2349,7 @@
     "SelectDomain": "Domain auswählen",
     "SelectScheduler": "Wählen Sie Planer",
     "TimeoutSeconds": "Sekunden",
-    "TypeResourceGroupNameToDelete": "Geben Sie den Namen der zu löschenden Ressourcengruppe ein",
-    "WsproxyAPIToken": "WSProxy-API-Token",
-    "WsproxyAddress": "WSProxy-Server-Adresse"
+    "TypeResourceGroupNameToDelete": "Geben Sie den Namen der zu löschenden Ressourcengruppe ein"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Sie sind im Begriff, diese Ressourcenrichtlinie zu löschen:",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2309,6 +2309,8 @@
     "Active": "Ενεργός",
     "ActiveStatus": "Ενεργή κατάσταση",
     "AllowedSessionTypes": "Επιτρεπόμενοι τύποι συνόδου",
+    "AppProxyAPIToken": "Διακριτικό API App Proxy",
+    "AppProxyAddress": "Διεύθυνση διακομιστή App Proxy",
     "CreateResourceGroup": "Δημιουργία ομάδας πόρων",
     "Deactivate": "Απενεργοποιούμαι",
     "DeactivateResourceGroup": "Απενεργοποίηση ομάδας πόρων",
@@ -2345,9 +2347,7 @@
     "SelectDomain": "Επιλέξτε τομέα",
     "SelectScheduler": "Επιλέξτε Προγραμματιστής",
     "TimeoutSeconds": "δευτερόλεπτα",
-    "TypeResourceGroupNameToDelete": "Πληκτρολογήστε όνομα ομάδας πόρων για διαγραφή",
-    "WsproxyAPIToken": "Διακριτικό API WSProxy",
-    "WsproxyAddress": "Διεύθυνση διακομιστή WSProxy"
+    "TypeResourceGroupNameToDelete": "Πληκτρολογήστε όνομα ομάδας πόρων για διαγραφή"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Πρόκειται να διαγράψετε αυτήν την πολιτική πόρων:",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2318,6 +2318,8 @@
     "Active": "Active",
     "ActiveStatus": "Active Status",
     "AllowedSessionTypes": "Allowed session types",
+    "AppProxyAPIToken": "App Proxy API Token",
+    "AppProxyAddress": "App Proxy Server Address",
     "CreateResourceGroup": "Create Resource Group",
     "Deactivate": "Deactivate",
     "DeactivateResourceGroup": "Deactivate resource group",
@@ -2354,9 +2356,7 @@
     "SelectDomain": "Select Domain",
     "SelectScheduler": "Select Scheduler",
     "TimeoutSeconds": "Seconds",
-    "TypeResourceGroupNameToDelete": "Type resource group name to delete",
-    "WsproxyAPIToken": "WSProxy API Token",
-    "WsproxyAddress": "WSProxy Server Address"
+    "TypeResourceGroupNameToDelete": "Type resource group name to delete"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "You are about to delete this resource policy: ",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2309,6 +2309,8 @@
     "Active": "Activo",
     "ActiveStatus": "Estado activo",
     "AllowedSessionTypes": "Tipos de sesión permitidos",
+    "AppProxyAPIToken": "Token API de App Proxy",
+    "AppProxyAddress": "Dirección del servidor App Proxy",
     "CreateResourceGroup": "Crear grupo de recursos",
     "Deactivate": "Desactivar",
     "DeactivateResourceGroup": "Desactivar el grupo de recursos",
@@ -2345,9 +2347,7 @@
     "SelectDomain": "Seleccionar dominio",
     "SelectScheduler": "Seleccione Programador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Escriba el nombre del grupo de recursos que desea eliminar",
-    "WsproxyAPIToken": "Token API de WSProxy",
-    "WsproxyAddress": "Dirección del servidor WSProxy"
+    "TypeResourceGroupNameToDelete": "Escriba el nombre del grupo de recursos que desea eliminar"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Está a punto de eliminar esta política de recursos:",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2309,6 +2309,8 @@
     "Active": "Aktiivinen",
     "ActiveStatus": "Aktiivinen tila",
     "AllowedSessionTypes": "Sallitut istuntotyypit",
+    "AppProxyAPIToken": "App Proxy API -avain",
+    "AppProxyAddress": "App Proxy-palvelimen osoite",
     "CreateResourceGroup": "Luo resurssiryhmä",
     "Deactivate": "Deaktivoida",
     "DeactivateResourceGroup": "Deaktivoi resurssiryhmä",
@@ -2345,9 +2347,7 @@
     "SelectDomain": "Valitse verkkotunnus",
     "SelectScheduler": "Valitse Ajastin",
     "TimeoutSeconds": "Sekuntia",
-    "TypeResourceGroupNameToDelete": "Kirjoita poistettavan resurssiryhmän nimi",
-    "WsproxyAPIToken": "WSProxy API -avain",
-    "WsproxyAddress": "WSProxy-palvelimen osoite"
+    "TypeResourceGroupNameToDelete": "Kirjoita poistettavan resurssiryhmän nimi"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Olet poistamassa tätä resurssikäytäntöä:",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2311,6 +2311,8 @@
     "Active": "actif",
     "ActiveStatus": "Statut Actif",
     "AllowedSessionTypes": "Types de session autorisés",
+    "AppProxyAPIToken": "Jeton d'API App Proxy",
+    "AppProxyAddress": "Adresse du serveur App Proxy",
     "CreateResourceGroup": "Créer un groupe de ressources",
     "Deactivate": "Désactiver",
     "DeactivateResourceGroup": "Désactiver le groupe de ressources",
@@ -2347,9 +2349,7 @@
     "SelectDomain": "Sélectionnez le domaine",
     "SelectScheduler": "Sélectionnez le planificateur",
     "TimeoutSeconds": "Seconds",
-    "TypeResourceGroupNameToDelete": "Tapez le nom du groupe de ressources à supprimer",
-    "WsproxyAPIToken": "Jeton d'API WSProxy",
-    "WsproxyAddress": "Adresse du serveur WSProxy"
+    "TypeResourceGroupNameToDelete": "Tapez le nom du groupe de ressources à supprimer"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Vous êtes sur le point de supprimer cette stratégie de ressources :",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2312,6 +2312,8 @@
     "Active": "Aktif",
     "ActiveStatus": "Status Aktif",
     "AllowedSessionTypes": "Jenis sesi yang diizinkan",
+    "AppProxyAPIToken": "Token API App Proxy",
+    "AppProxyAddress": "Alamat Server App Proxy",
     "CreateResourceGroup": "Buat Grup Sumber Daya",
     "Deactivate": "Menonaktifkan",
     "DeactivateResourceGroup": "Nonaktifkan Grup Sumber Daya",
@@ -2348,9 +2350,7 @@
     "SelectDomain": "Pilih Domain",
     "SelectScheduler": "Pilih Penjadwal",
     "TimeoutSeconds": "Detik",
-    "TypeResourceGroupNameToDelete": "Ketik nama grup sumber daya yang akan dihapus",
-    "WsproxyAPIToken": "Token API WSProxy",
-    "WsproxyAddress": "Alamat Server WSProxy"
+    "TypeResourceGroupNameToDelete": "Ketik nama grup sumber daya yang akan dihapus"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Anda akan menghapus kebijakan sumber daya ini:",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2309,6 +2309,8 @@
     "Active": "Attivo",
     "ActiveStatus": "Stato attivo",
     "AllowedSessionTypes": "Tipi di sessione consentiti",
+    "AppProxyAPIToken": "Token API di App Proxy",
+    "AppProxyAddress": "Indirizzo del server App Proxy",
     "CreateResourceGroup": "Crea gruppo di risorse",
     "Deactivate": "Disattivare",
     "DeactivateResourceGroup": "Disattiva il gruppo di risorse",
@@ -2345,9 +2347,7 @@
     "SelectDomain": "Seleziona dominio",
     "SelectScheduler": "Seleziona l'agenda",
     "TimeoutSeconds": "Secondi",
-    "TypeResourceGroupNameToDelete": "Digita il nome del gruppo di risorse da eliminare",
-    "WsproxyAPIToken": "Token API di WSProxy",
-    "WsproxyAddress": "Indirizzo del server WSProxy"
+    "TypeResourceGroupNameToDelete": "Digita il nome del gruppo di risorse da eliminare"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Stai per eliminare questa policy sulle risorse:",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2311,6 +2311,8 @@
     "Active": "アクティブ",
     "ActiveStatus": "アクティブステータス",
     "AllowedSessionTypes": "許可されたセッションタイプ",
+    "AppProxyAPIToken": "App Proxy APIトークン",
+    "AppProxyAddress": "App Proxy サーバアドレス",
     "CreateResourceGroup": "リソースグループの作成",
     "Deactivate": "無効にします",
     "DeactivateResourceGroup": "リソースグループを無効にします",
@@ -2347,9 +2349,7 @@
     "SelectDomain": "ドメインを選択",
     "SelectScheduler": "スケジューラを選択",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "削除するリソースグループ名を入力します",
-    "WsproxyAPIToken": "WSProxy APIトークン",
-    "WsproxyAddress": "WSProxy サーバアドレス"
+    "TypeResourceGroupNameToDelete": "削除するリソースグループ名を入力します"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "このリソースポリシーを削除しようとしています。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2319,6 +2319,8 @@
     "Active": "활성",
     "ActiveStatus": "활성 상태",
     "AllowedSessionTypes": "허용된 세션 타입",
+    "AppProxyAPIToken": "App Proxy API 토큰",
+    "AppProxyAddress": "App Proxy 서버 주소",
     "CreateResourceGroup": "자원 그룹 추가",
     "Deactivate": "비활성화",
     "DeactivateResourceGroup": "자원 그룹 비활성화",
@@ -2355,9 +2357,7 @@
     "SelectDomain": "도메인 선택",
     "SelectScheduler": "스케줄러 선택",
     "TimeoutSeconds": "초",
-    "TypeResourceGroupNameToDelete": "삭제하려는 자원 그룹 이름을 다시 한번 입력하세요.",
-    "WsproxyAPIToken": "WSProxy API 토큰",
-    "WsproxyAddress": "WSProxy 서버 주소"
+    "TypeResourceGroupNameToDelete": "삭제하려는 자원 그룹 이름을 다시 한번 입력하세요."
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "아래의 자원 정책을 삭제하려고 합니다: ",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2310,6 +2310,8 @@
     "Active": "Идэвхтэй",
     "ActiveStatus": "Идэвхтэй байдал",
     "AllowedSessionTypes": "Зөвшөөрөгдсөн сессийн төрлүүд",
+    "AppProxyAPIToken": "App Proxy API токен",
+    "AppProxyAddress": "App Proxy серверийн хаяг",
     "CreateResourceGroup": "Нөөцийн бүлэг үүсгэх",
     "Deactivate": "Идэвхгүй болгох",
     "DeactivateResourceGroup": "Нөөцийн бүлгийг идэвхгүй болгох",
@@ -2346,9 +2348,7 @@
     "SelectDomain": "Домэйн сонгоно уу",
     "SelectScheduler": "Цагийн хуваарийг сонгоно уу",
     "TimeoutSeconds": "Секунд",
-    "TypeResourceGroupNameToDelete": "Устгахын тулд нөөцийн бүлгийн нэрийг бичнэ үү",
-    "WsproxyAPIToken": "WSProxy API токен",
-    "WsproxyAddress": "WSProxy серверийн хаяг"
+    "TypeResourceGroupNameToDelete": "Устгахын тулд нөөцийн бүлгийн нэрийг бичнэ үү"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Та энэ нөөцийн бодлогыг устгах гэж байна:",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2309,6 +2309,8 @@
     "Active": "Aktif",
     "ActiveStatus": "Status Aktif",
     "AllowedSessionTypes": "Jenis sesi yang dibenarkan",
+    "AppProxyAPIToken": "Token API App Proxy",
+    "AppProxyAddress": "Alamat Pelayan App Proxy",
     "CreateResourceGroup": "Buat Kumpulan Sumber",
     "Deactivate": "Menyahaktifkan",
     "DeactivateResourceGroup": "Kumpulan sumber menyahaktifkan",
@@ -2345,9 +2347,7 @@
     "SelectDomain": "Pilih Domain",
     "SelectScheduler": "Pilih Penjadual",
     "TimeoutSeconds": "Detik",
-    "TypeResourceGroupNameToDelete": "Taipkan nama kumpulan sumber untuk dipadamkan",
-    "WsproxyAPIToken": "Token API WSProxy",
-    "WsproxyAddress": "Alamat Pelayan WSProxy"
+    "TypeResourceGroupNameToDelete": "Taipkan nama kumpulan sumber untuk dipadamkan"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Anda akan memadamkan dasar sumber ini:",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2311,6 +2311,8 @@
     "Active": "Aktywny",
     "ActiveStatus": "Stan aktywny",
     "AllowedSessionTypes": "Dozwolone typy sesji",
+    "AppProxyAPIToken": "Token API App Proxy",
+    "AppProxyAddress": "Adres serwera App Proxy",
     "CreateResourceGroup": "Utwórz grupę zasobów",
     "Deactivate": "Dezaktywować",
     "DeactivateResourceGroup": "Dezaktywna grupa zasobów",
@@ -2347,9 +2349,7 @@
     "SelectDomain": "Wybierz domenę",
     "SelectScheduler": "Wybierz harmonogram",
     "TimeoutSeconds": "sekundy",
-    "TypeResourceGroupNameToDelete": "Wpisz nazwę grupy zasobów do usunięcia",
-    "WsproxyAPIToken": "Token API WSProxy",
-    "WsproxyAddress": "Adres serwera WSProxy"
+    "TypeResourceGroupNameToDelete": "Wpisz nazwę grupy zasobów do usunięcia"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Zamierzasz usunąć tę zasadę dotyczącą zasobów:",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2309,6 +2309,8 @@
     "Active": "Ativo",
     "ActiveStatus": "Status Ativo",
     "AllowedSessionTypes": "Tipos de sessão permitidos",
+    "AppProxyAPIToken": "Token da API do App Proxy",
+    "AppProxyAddress": "Endereço do servidor App Proxy",
     "CreateResourceGroup": "Criar Grupo de Recursos",
     "Deactivate": "Desativar",
     "DeactivateResourceGroup": "Grupo de Recursos Desativados",
@@ -2345,9 +2347,7 @@
     "SelectDomain": "Selecione o domínio",
     "SelectScheduler": "Selecione o Agendador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir",
-    "WsproxyAPIToken": "Token da API do WSProxy",
-    "WsproxyAddress": "Endereço do servidor WSProxy"
+    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Você está prestes a excluir esta política de recursos:",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2311,6 +2311,8 @@
     "Active": "Ativo",
     "ActiveStatus": "Status Ativo",
     "AllowedSessionTypes": "Tipos de sessão permitidos",
+    "AppProxyAPIToken": "Token de API do App Proxy",
+    "AppProxyAddress": "Endereço do servidor App Proxy",
     "CreateResourceGroup": "Criar Grupo de Recursos",
     "Deactivate": "Desativar",
     "DeactivateResourceGroup": "Grupo de Recursos Desativados",
@@ -2347,9 +2349,7 @@
     "SelectDomain": "Selecione o domínio",
     "SelectScheduler": "Selecione o Agendador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir",
-    "WsproxyAPIToken": "Token de API do WSProxy",
-    "WsproxyAddress": "Endereço do servidor WSProxy"
+    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Você está prestes a excluir esta política de recursos:",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2309,6 +2309,8 @@
     "Active": "Активный",
     "ActiveStatus": "Активный статус",
     "AllowedSessionTypes": "Разрешенные типы сессий",
+    "AppProxyAPIToken": "API-токен App Proxy",
+    "AppProxyAddress": "Адрес сервера App Proxy",
     "CreateResourceGroup": "Создать группу ресурсов",
     "Deactivate": "Деактивировать",
     "DeactivateResourceGroup": "Деактивировать ресурсную группу",
@@ -2345,9 +2347,7 @@
     "SelectDomain": "Выбрать домен",
     "SelectScheduler": "Выберите планировщик",
     "TimeoutSeconds": "Секунды",
-    "TypeResourceGroupNameToDelete": "Введите имя группы ресурсов для удаления",
-    "WsproxyAPIToken": "API-токен WSProxy",
-    "WsproxyAddress": "Адрес WSProxy-сервера"
+    "TypeResourceGroupNameToDelete": "Введите имя группы ресурсов для удаления"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Вы собираетесь удалить эту политику ресурсов:",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2311,6 +2311,8 @@
     "Active": "ใช้งาน",
     "ActiveStatus": "สถานะใช้งาน",
     "AllowedSessionTypes": "ประเภทเซสชันที่อนุญาต",
+    "AppProxyAPIToken": "โทเค็น API ของ App Proxy",
+    "AppProxyAddress": "ที่อยู่เซิร์ฟเวอร์ App Proxy",
     "CreateResourceGroup": "สร้างกลุ่มทรัพยากร",
     "Deactivate": "ปิดใช้งาน",
     "DeactivateResourceGroup": "ปิดการใช้งานกลุ่มทรัพยากร",
@@ -2347,9 +2349,7 @@
     "SelectDomain": "เลือกโดเมน",
     "SelectScheduler": "เลือกตัวจัดกำหนดการ",
     "TimeoutSeconds": "วินาที",
-    "TypeResourceGroupNameToDelete": "พิมพ์ชื่อกลุ่มทรัพยากรเพื่อลบ",
-    "WsproxyAPIToken": "โทเค็น API ของ WSProxy",
-    "WsproxyAddress": "ที่อยู่เซิร์ฟเวอร์ WSProxy"
+    "TypeResourceGroupNameToDelete": "พิมพ์ชื่อกลุ่มทรัพยากรเพื่อลบ"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "คุณกำลังจะลบนโยบายทรัพยากรนี้: ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2309,6 +2309,8 @@
     "Active": "Aktif",
     "ActiveStatus": "Aktif Durum",
     "AllowedSessionTypes": "İzin verilen oturum türleri",
+    "AppProxyAPIToken": "App Proxy API Jetonu",
+    "AppProxyAddress": "App Proxy Sunucu Adresi",
     "CreateResourceGroup": "Kaynak Grubu Oluştur",
     "Deactivate": "Devre dışı bırakmak",
     "DeactivateResourceGroup": "Kaynak grubunu devre dışı bırak",
@@ -2345,9 +2347,7 @@
     "SelectDomain": "Etki Alanı Seç",
     "SelectScheduler": "Zamanlayıcı Seç",
     "TimeoutSeconds": "saniye",
-    "TypeResourceGroupNameToDelete": "Silmek için kaynak grubu adını yazın",
-    "WsproxyAPIToken": "WSProxy API Jetonu",
-    "WsproxyAddress": "WSProxy Sunucu Adresi"
+    "TypeResourceGroupNameToDelete": "Silmek için kaynak grubu adını yazın"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Bu kaynak politikasını silmek üzeresiniz:",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2311,6 +2311,8 @@
     "Active": "Hoạt động",
     "ActiveStatus": "Trạng thái hoạt động",
     "AllowedSessionTypes": "Các loại phiên được phép",
+    "AppProxyAPIToken": "Token API App Proxy",
+    "AppProxyAddress": "Địa chỉ máy chủ App Proxy",
     "CreateResourceGroup": "Tạo nhóm tài nguyên",
     "Deactivate": "Vô hiệu hóa",
     "DeactivateResourceGroup": "Vô hiệu hóa nhóm tài nguyên",
@@ -2347,9 +2349,7 @@
     "SelectDomain": "Chọn miền",
     "SelectScheduler": "Chọn bộ lập lịch",
     "TimeoutSeconds": "Giây",
-    "TypeResourceGroupNameToDelete": "Nhập tên nhóm tài nguyên để xóa",
-    "WsproxyAPIToken": "Token API WSProxy",
-    "WsproxyAddress": "Địa chỉ máy chủ WSProxy"
+    "TypeResourceGroupNameToDelete": "Nhập tên nhóm tài nguyên để xóa"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Bạn sắp xóa chính sách tài nguyên này:",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2311,6 +2311,8 @@
     "Active": "积极的",
     "ActiveStatus": "活动状态",
     "AllowedSessionTypes": "允许的会话类型",
+    "AppProxyAPIToken": "App Proxy API令牌",
+    "AppProxyAddress": "App Proxy 服务器地址",
     "CreateResourceGroup": "创建资源组",
     "Deactivate": "停用",
     "DeactivateResourceGroup": "停用资源组",
@@ -2347,9 +2349,7 @@
     "SelectDomain": "选择域",
     "SelectScheduler": "选择调度程序",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "输入要删除的资源组名称",
-    "WsproxyAPIToken": "WSProxy API令牌",
-    "WsproxyAddress": "WSProxy 服务器地址"
+    "TypeResourceGroupNameToDelete": "输入要删除的资源组名称"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "您即将删除此资源策略：",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2313,6 +2313,8 @@
     "Active": "積極的",
     "ActiveStatus": "活動狀態",
     "AllowedSessionTypes": "允许的会话类型",
+    "AppProxyAPIToken": "App Proxy API 令牌",
+    "AppProxyAddress": "App Proxy 伺服器位址",
     "CreateResourceGroup": "創建資源組",
     "Deactivate": "停用",
     "DeactivateResourceGroup": "停用資源組",
@@ -2349,9 +2351,7 @@
     "SelectDomain": "選擇域",
     "SelectScheduler": "選擇調度程序",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "輸入要刪除的資源組名稱",
-    "WsproxyAPIToken": "WSProxy API 令牌",
-    "WsproxyAddress": "WSProxy 服务器地址"
+    "TypeResourceGroupNameToDelete": "輸入要刪除的資源組名稱"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "您即將刪除此資源策略：",


### PR DESCRIPTION
Resolves #7298(FR-2841)

## Summary

Rename the i18n keys `resourceGroup.WsproxyAPIToken` and `resourceGroup.WsproxyAddress` to `resourceGroup.AppProxyAPIToken` and `resourceGroup.AppProxyAddress`, and replace the user-facing string `WSProxy` with `App Proxy` across all 21 locale files.

This is a rename of the **i18n surface only** — internal API and method names (`closeWsproxy`, `getWsproxyVersion`, `wsproxy_addr`, `wsProxyAddress`, `wsProxyAPIToken`) are intentionally untouched.

## Changes

- 21 locale files under `resources/i18n/` — keys renamed, values updated, alphabetically re-sorted within `resourceGroup`
- 3 React components updated to call the new keys:
  - `react/src/components/ResourceGroupInfoModal.tsx`
  - `react/src/components/ResourceGroupList.tsx`
  - `react/src/components/ResourceGroupSettingModal.tsx`

## Verification

- `bash scripts/verify.sh` — Lint PASS, Format PASS. TypeScript failures exist but are pre-existing on `main` (in `packages/backend.ai-client/src/client.ts` and `src/components/DeleteForeverVFolderModalV2.tsx`) and are unrelated to this change.
- Confirmed no leftover `Wsproxy(APIToken|Address)` references in `*.ts`, `*.tsx`, or `*.json` files.

## Source

Discussion: [Teams thread in *UX Ideas, References, and Questions*](https://teams.microsoft.com/l/message/19:2806b848642744138244b7358cd282d9@thread.skype/1778140833745?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=ea5c466a-2dcf-4ea7-88f8-a9a797f66903&parentMessageId=1778137938349&teamName=Lablup&channelName=UX%20Ideas%2C%20References%2C%20and%20Questions&createdTime=1778140833745)