### PR TITLE
fix(FR-2844): keep 'Revision' untranslated in zh-CN/zh-TW NoCurrentRevisionDeployed alert

### DIFF
--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -958,7 +958,7 @@
     "NewDeployment": "新建部署",
     "NewRevisionWillBeCreated": "将创建新的 Revision。之前的 Revision 将被保留。",
     "NewRevisionWillBeCreatedConfirm": "保存将创建新的 Revision。是否继续？",
-    "NoCurrentRevisionDeployed": "尚未部署任何修订版 — 添加修订版以激活此服务。",
+    "NoCurrentRevisionDeployed": "尚未部署任何 Revision — 添加 Revision 以激活此服务。",
     "NoDeployments": "未找到部署。",
     "NumberOfReplicas": "副本数量",
     "OpenToPublic": "公开",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -959,7 +959,7 @@
     "NewDeployment": "新建部署",
     "NewRevisionWillBeCreated": "將建立新的 Revision。之前的 Revision 將被保留。",
     "NewRevisionWillBeCreatedConfirm": "儲存將建立新的 Revision。是否繼續？",
-    "NoCurrentRevisionDeployed": "尚未部署任何修訂版 — 新增修訂版以啟動此服務。",
+    "NoCurrentRevisionDeployed": "尚未部署任何 Revision — 新增 Revision 以啟動此服務。",
     "NoDeployments": "未找到部署。",
     "NumberOfReplicas": "副本數量",
     "OpenToPublic": "公開",


### PR DESCRIPTION
Resolves #7305 ([FR-2844](https://lablup.atlassian.net/browse/FR-2844))

## Summary
- Address Copilot review feedback on #7304: in zh-CN and zh-TW, every other deployment-revision string in this feature ('AddRevision', 'CurrentRevision', 'RevisionHistory') keeps the English 'Revision' term, but the new `deployment.NoCurrentRevisionDeployed` alert text was translated to '修订版' / '修訂版'. That made the alert read inconsistently with the buttons and tab labels users see on the same screen.
- Replace the localized term with 'Revision' so the alert text now reads consistently with the surrounding UI.

## Test plan
- [ ] Switch language to zh-CN; on a deployment with no revision, verify the alert reads '尚未部署任何 Revision — 添加 Revision 以激活此服务。'
- [ ] Switch language to zh-TW; verify the alert reads '尚未部署任何 Revision — 新增 Revision 以啟動此服務。'
- [ ] Confirm the wording matches the 'AddRevision' / 'CurrentRevision' / 'RevisionHistory' labels on the same page.

[FR-2844]: https://lablup.atlassian.net/browse/FR-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ