### PR TITLE
feat(FR-2840): migrate to pnpm v11

### DIFF
--- a/.github/actions/daily-test-improver/coverage-steps/action.yml
+++ b/.github/actions/daily-test-improver/coverage-steps/action.yml
@@ -8,7 +8,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v5
       with:
-        version: 10
+        version: 11
         run_install: false
 
     - name: Setup Node.js
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         echo "Step: Installing dependencies..." >> coverage-steps.log
-        pnpm install --no-frozen-lockfile 2>&1 | tee -a coverage-steps.log
+        pnpm install --frozen-lockfile 2>&1 | tee -a coverage-steps.log
 
     # Step 3: Build and test React project with coverage
     - name: Build React GraphQL types

--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -30,10 +30,10 @@
       "version": "v0.34.5",
       "sha": "3de4a6a6d15bb07764b207e40da8c7047474a335"
     },
-    "pnpm/action-setup@v4": {
+    "pnpm/action-setup@v5": {
       "repo": "pnpm/action-setup",
-      "version": "v4",
-      "sha": "c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c"
+      "version": "v5",
+      "sha": "a8198c4bff370c8506180b035930dea56dbd5288"
     }
   }
 }

--- a/.github/workflows/e2e-healer.lock.yml
+++ b/.github/workflows/e2e-healer.lock.yml
@@ -109,9 +109,9 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
-      - uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
         with:
-          version: 10
+          version: 11
       - name: Print E2E endpoints
         run: "echo \"=== E2E Test Configuration ===\"\necho \"E2E_WEBUI_ENDPOINT: $E2E_WEBUI_ENDPOINT\"\necho \"E2E_WEBSERVER_ENDPOINT: $E2E_WEBSERVER_ENDPOINT\"\n"
       - run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/e2e-healer.md
+++ b/.github/workflows/e2e-healer.md
@@ -60,9 +60,9 @@ steps:
   - uses: actions/setup-node@v4
     with:
       node-version: '20'
-  - uses: pnpm/action-setup@v4
+  - uses: pnpm/action-setup@v5
     with:
-      version: 10
+      version: 11
   - name: Print E2E endpoints
     run: |
       echo "=== E2E Test Configuration ==="

--- a/.github/workflows/e2e-watchdog.lock.yml
+++ b/.github/workflows/e2e-watchdog.lock.yml
@@ -102,9 +102,9 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
-      - uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
         with:
-          version: 10
+          version: 11
       - name: Print E2E endpoints
         run: "echo \"=== E2E Test Configuration ===\"\necho \"E2E_WEBUI_ENDPOINT: $E2E_WEBUI_ENDPOINT\"\necho \"E2E_WEBSERVER_ENDPOINT: $E2E_WEBSERVER_ENDPOINT\"\n"
       - run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/e2e-watchdog.md
+++ b/.github/workflows/e2e-watchdog.md
@@ -51,9 +51,9 @@ steps:
   - uses: actions/setup-node@v4
     with:
       node-version: '20'
-  - uses: pnpm/action-setup@v4
+  - uses: pnpm/action-setup@v5
     with:
-      version: 10
+      version: 11
   - name: Print E2E endpoints
     run: |
       echo "=== E2E Test Configuration ==="

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
 
       - name: Install Node.js
@@ -55,7 +55,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build web assets
         run: make dep_web
@@ -100,7 +100,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
 
       - name: Install Node.js
@@ -110,7 +110,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Download web build artifacts
         uses: actions/download-artifact@v5
@@ -168,7 +168,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
 
       - name: Install Node.js
@@ -178,7 +178,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Download web build artifacts
         uses: actions/download-artifact@v5
@@ -234,7 +234,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
 
       - name: Install Node.js
@@ -244,7 +244,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       # backend.ai-docs-toolkit ships its `docs-toolkit` CLI as the package
       # bin, but it lives at dist/cli.js which only exists after `tsc` runs.
@@ -255,7 +255,7 @@ jobs:
       - name: Build docs-toolkit and link CLI
         run: |
           pnpm --filter backend.ai-docs-toolkit run build
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
 
       # Cache the Playwright browser binaries (~150 MB Chromium download).
       # The lockfile hash keys the cache so a Playwright version bump

--- a/.github/workflows/publish-backend.ai-docs-toolkit.yml
+++ b/.github/workflows/publish-backend.ai-docs-toolkit.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/publish-backend.ai-ui.yml
+++ b/.github/workflows/publish-backend.ai-ui.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
       - uses: actions/setup-node@v5
         with:
@@ -78,7 +78,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         working-directory: .
-        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Run ESLint on React
         run: pnpm run lint
       - name: Run relay-compiler
@@ -104,7 +104,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
       - uses: actions/setup-node@v5
         with:
@@ -123,7 +123,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         working-directory: .
-        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Run ESLint on backend.ai-ui
         run: pnpm run lint
       - name: Run relay-compiler
@@ -143,10 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
       - uses: actions/setup-node@v5
         with:
@@ -164,7 +164,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
-        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Run Vitest with coverage
         run: pnpm exec vitest run --coverage
       - name: Report coverage on PR

--- a/.github/workflows/weekly-merge-branch-lockfiles.yml
+++ b/.github/workflows/weekly-merge-branch-lockfiles.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 10
+          version: 11
           run_install: false
 
       - uses: actions/setup-node@v5
@@ -31,7 +31,7 @@ jobs:
           cache: "pnpm"
 
       - name: Merge branch lockfiles into pnpm-lock.yaml
-        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
+        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile --config.minimum-release-age=0
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-engine-strict=true
+# auth/registry overrides only — pnpm-specific settings live in pnpm-workspace.yaml

--- a/.specs/FR-2840-pnpm-v11-migration/dev-plan.md
+++ b/.specs/FR-2840-pnpm-v11-migration/dev-plan.md
@@ -1,0 +1,68 @@
+# Dev Plan: pnpm v11 Migration
+
+- **Spec**: `.specs/FR-2840-pnpm-v11-migration/spec.md`
+- **Epic**: FR-2840 — https://lablup.atlassian.net/browse/FR-2840
+- **GitHub epic issue**: #7296
+- **Delivery shape**: single sub-task → single PR (per direction)
+
+## Sub-tasks
+
+| # | Title | Tracker | Depends on | PR |
+|---|---|---|---|---|
+| 1 | Migrate config, workflows, and lockfile to pnpm v11 | FR-2840 (this issue) | — | TBD (single PR) |
+
+The migration is intentionally not split because:
+
+- The lockfile regen, the config moves (`pnpm.overrides` → `pnpm-workspace.yaml`), the `onlyBuiltDependencies` → `allowBuilds` conversion, and the workflow `version: 11` bump must land **atomically** to keep CI green at every commit. Splitting would force one of:
+  - Land config-only first → CI installs still on v10, can't validate v11 install.
+  - Land workflow bump first → CI tries v11 install with v10 config → guaranteed `ERR_PNPM_UNSUPPORTED_ENGINE` again.
+- Documentation and `engine-strict` cleanup are too small to merit separate PRs.
+
+## Sub-task 1 — execution outline
+
+Mapped 1:1 to spec §5.
+
+1. **Config moves** (no install yet, no lockfile change)
+   - `package.json`: bump `engines.pnpm`, drop `pnpm` field, add `packageManager`.
+   - `pnpm-workspace.yaml`: add `overrides`, swap `onlyBuiltDependencies` → `allowBuilds`.
+   - `.npmrc`: drop `engine-strict=true`, leave a one-line comment explaining v11 auth/registry scope.
+
+2. **Workflow bump**
+   - Sed `version: 10` → `version: 11` across all 6 affected files (11 occurrences).
+   - `vitest.yml:146` `pnpm/action-setup@v4` → `@v5` cleanup.
+
+3. **Switch local pnpm to 11.x**
+   - Use whatever method the contributor has (`corepack` or `npm i -g pnpm@11`). Local dev only — not part of the diff.
+
+4. **Lockfile regenerate**
+   - To regenerate the canonical lockfile under pnpm 11 (one-time during this PR), the contributor needs to bypass `minimumReleaseAge` because of upstream bugs in v11 (spec §5.4.1, [pnpm/pnpm#9963](https://github.com/pnpm/pnpm/issues/9963), [pnpm/pnpm#10699](https://github.com/pnpm/pnpm/issues/10699)):
+
+     ```bash
+     pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile --config.minimum-release-age=0
+     ```
+
+     This command is for the migration commit only. CI itself does **not** run this — see step 5.
+   - Reviewer must confirm:
+     - `lockfileVersion: '9.0'` retained.
+     - No `version:` line on a published package moved unintentionally (semver ranges are unchanged → drift is the surprise).
+     - `settings:` block adopts v11 defaults — call out in PR body.
+     - Per-branch `pnpm-lock.<branch>.yaml` files are NOT touched (`weekly-merge-branch-lockfiles.yml` handles those).
+   - After this regen, every CI install lane runs `pnpm install --frozen-lockfile` against the resulting lockfile. No re-resolution happens in CI, so the `--config.minimum-release-age=0` override is not needed in CI workflows (with the single intrinsic exception of `weekly-merge-branch-lockfiles.yml`, which exists precisely to re-resolve and merge branch lockfiles).
+
+5. **Local verification**
+   - Run spec §6.1 checklist.
+   - Capture `pnpm -v`, `bash scripts/verify.sh` output, and `pnpm run build` outcome in the PR description.
+
+6. **Submit**
+   - Branch off `main` (post-merge state of #7297 means workflows are on `version: 10`, baseline is consistent).
+   - PR description includes the §8 acceptance checklist for the reviewer to tick.
+   - Submit as draft → multi-agent review → flip to ready-for-review → Copilot → resolve → merge gate.
+
+## Hand-off to implementation
+
+Implementation agent receives:
+
+- Spec path: `.specs/FR-2840-pnpm-v11-migration/spec.md`
+- This dev plan (single sub-task).
+- Authority to add `allowBuilds` entries with justification comments if v11 install demands it (spec §5.2 last paragraph).
+- **No** authority to upgrade unrelated deps, drop `gitBranchLockfile`, or change `minimumReleaseAge` policy (spec §4 out-of-scope list).

--- a/.specs/FR-2840-pnpm-v11-migration/spec.md
+++ b/.specs/FR-2840-pnpm-v11-migration/spec.md
@@ -1,0 +1,237 @@
+# Spec: Migrate to pnpm v11
+
+- **Jira**: FR-2840 — https://lablup.atlassian.net/browse/FR-2840
+- **GitHub issue**: #7296
+- **Predecessor**: FR-2839 / PR #7297 — temporarily pinned CI to pnpm v10
+- **Reference**: pnpm v11 release notes — https://pnpm.io/blog/releases/11.0
+- **Delivery**: single PR (per direction)
+
+## 1. Goal
+
+Move the entire monorepo's pnpm runtime from v10 to v11 in a single, reviewable PR:
+
+- Local installs (`pnpm install`) and CI installs both run under pnpm 11.x.
+- All workflows that install pnpm pin to `version: 11`.
+- All pnpm-specific configuration is stored in v11-supported locations.
+- The lockfile is regenerated under pnpm 11 with no functional dependency drift.
+
+## 2. Background
+
+`pnpm/action-setup` started resolving `version: latest` to **pnpm 11.0.8**, which violated this repo's `engines.pnpm: ^10.16.0` and broke CI installs (`ERR_PNPM_UNSUPPORTED_ENGINE`). FR-2839 unblocked CI by pinning workflows to v10. This spec finishes the upgrade so we don't get stuck on v10 indefinitely.
+
+## 3. Pre-flight repository audit
+
+Audited current state to scope the migration:
+
+| Concern | Current state | Implication |
+|---|---|---|
+| `engines.pnpm` | `^10.16.0` (only at root `package.json`) | Single bump; no nested `engines.pnpm` to coordinate. |
+| `pnpm` field in `package.json` | Present at lines 106–112 with three `overrides` entries (`tar-fs@2`, `node-forge`, `@codemirror/state`). | Must move; v11 ignores this field. |
+| `pnpm-workspace.yaml` | Already holds `catalog`, `gitBranchLockfile: true`, `minimumReleaseAge`, `minimumReleaseAgeExclude`, `onlyBuiltDependencies` (9 entries), `patchedDependencies`. | Will absorb `overrides`; `onlyBuiltDependencies` must convert to `allowBuilds`. |
+| `.npmrc` | Single line: `engine-strict=true`. | Behaviour-only setting. v11 still respects `engines.pnpm` strictly via its own logic; the line is now scoped out of `.npmrc` (auth/registry only). Treated as redundant — see §5.5. |
+| `auditConfig.ignoreCves` | None present in any config file. | No GHSA migration work. |
+| Exotic deps (`git+`, `github:`, `file:..`) | None found in any workspace `package.json`. | New `blockExoticSubdeps: true` default has no surface area to break. |
+| Lockfile | `lockfileVersion: '9.0'`. | pnpm 11 still uses v9 lockfile format; regen will not change the version, but dependency tree may shift. |
+| Node version | `.nvmrc: 24`; CI uses `node-version-file: ".nvmrc"`. | Already satisfies pnpm 11's Node ≥ 22 requirement. |
+| Workflows installing pnpm | 6 files, 11 occurrences (currently `version: 10` after FR-2839). | Bump to `version: 11`. |
+
+## 4. Out of scope
+
+- Adopting v11's new `allowBuilds` map's *additive* gate semantics beyond a 1:1 conversion of the existing allow-list.
+- Reviewing whether the existing `minimumReleaseAge` / `minimumReleaseAgeExclude` policy is still desirable — kept as-is unless install fails under v11.
+- Dropping the `gitBranchLockfile: true` policy.
+- Major dependency upgrades. The lockfile regeneration must not be used as a vehicle for `pnpm update` or `pnpm dedupe`.
+
+## 5. Required changes
+
+### 5.1 `package.json`
+
+```diff
+   "engines": {
+-    "pnpm": "^10.16.0"
++    "pnpm": "^11.0.0"
+   },
+```
+
+Remove the `pnpm` block entirely:
+
+```diff
+-  "pnpm": {
+-    "overrides": {
+-      "tar-fs@2": "2.1.4",
+-      "node-forge": ">=1.3.2",
+-      "@codemirror/state": "6.5.4"
+-    }
+-  },
+```
+
+Add a `packageManager` field so `pnpm/action-setup` (and Corepack-aware tooling) can auto-detect:
+
+```diff
++  "packageManager": "pnpm@11.0.8",
+```
+
+The exact patch version is whatever `pnpm 11.x latest` resolves to at implementation time (currently 11.0.8 per the failing CI log).
+
+### 5.2 `pnpm-workspace.yaml`
+
+Append `overrides` (moved from `package.json`):
+
+```yaml
+overrides:
+  tar-fs@2: 2.1.4
+  node-forge: '>=1.3.2'
+  '@codemirror/state': 6.5.4
+```
+
+Replace `onlyBuiltDependencies` with `allowBuilds` (1:1 conversion — same packages, equivalent semantics):
+
+```diff
+-onlyBuiltDependencies:
+-  - bufferutil
+-  - core-js
+-  - core-js-pure
+-  - electron
+-  - es5-ext
+-  - esbuild
+-  - sharp
+-  - unrs-resolver
+-  - utf-8-validate
++allowBuilds:
++  bufferutil: true
++  core-js: true
++  core-js-pure: true
++  electron: true
++  es5-ext: true
++  esbuild: true
++  sharp: true
++  unrs-resolver: true
++  utf-8-validate: true
+```
+
+If a v11 install rejects an additional package's build script, add it to `allowBuilds` with a one-line justification comment in the same change (don't loop back through the spec).
+
+### 5.3 `.npmrc`
+
+Delete `engine-strict=true`. Rationale: v11 enforces `engines.pnpm` natively when set; the dual-source setting becomes confusing. If retained, the file violates v11's "auth/registry only" guidance. The behaviour we care about (refuse install when pnpm major mismatches) is still enforced by v11 because `engines.pnpm: ^11.0.0` is set.
+
+If `.npmrc` becomes empty, leave a single comment line `# auth/registry overrides only — pnpm-specific settings live in pnpm-workspace.yaml` so the file's purpose stays discoverable.
+
+### 5.4 Strict-default audit (no changes if defaults are acceptable)
+
+| New v11 default | Acceptable here? | Action |
+|---|---|---|
+| `minimumReleaseAge: 1440` | Currently set explicitly to `10080`. Explicit value wins, but v11 enforces it more strictly than v10 — see §5.4.1. | Workflow-level override (see §5.4.1). |
+| `blockExoticSubdeps: true` | No exotic deps in workspace (audit §3). | None. |
+| `strictDepBuilds: true` | Could surface dep build failures we currently swallow. **Verify on first install**; add specific package opt-outs only if a previously-silent build now fails. | Verify; document any opt-outs. |
+| `verifyDepsBeforeRun: true` | Forces lockfile freshness checks; aligns with our existing CI install. | None — accept the new default. |
+
+#### 5.4.1 minimumReleaseAge under pnpm 11 — workflow-level override
+
+Empirically, pnpm 11's stricter `minimumReleaseAge` enforcement breaks `pnpm install` against this dep tree in two ways:
+
+1. **`ERR_PNPM_MISSING_TIME` (cache/metadata bug).** Pnpm 11 fatals on packages whose npm registry abbreviated metadata is missing the `time` field, even though the full metadata file has it. Tracked upstream in [pnpm#9963](https://github.com/pnpm/pnpm/issues/9963) (closed but recurring) and [pnpm#9968](https://github.com/pnpm/pnpm/issues/9968) (closed in 10.16.1 — fix is partial). Maintainer comment on #9963: *"the error should not happen at all. The full metadata and the abbreviated one are stored at different locations."* The recommended workaround `pnpm store prune` did not produce stable results in our environment — the error reappears on subsequent installs.
+
+2. **Optional/platform-specific binaries trigger fatals.** `vitest`/`rollup`'s `optionalDependencies` field includes 15+ `@rollup/rollup-*` platform binaries (darwin-arm64, win32-arm64-msvc, linux-loong64-gnu, …). pnpm 11 fatals on each one's missing `time` metadata, even though the user's machine doesn't need most of them. Same shape as [pnpm#10699 (open)](https://github.com/pnpm/pnpm/issues/10699).
+
+Maintaining a `minimumReleaseAgeExclude` list against (1)+(2) is fragile: every new rollup architecture binary, every npm registry metadata corruption, and every recent typescript-eslint family bump (currently `@typescript-eslint/* 8.59.2` released 3 days ago) re-breaks installs. The list grew to 30+ entries during empirical iteration without converging.
+
+**Decision**: switch every CI install lane to `--frozen-lockfile` so installs use exactly the lockfile contents, with no re-resolution and therefore no `minimumReleaseAge` evaluation. The single intrinsic exception is `weekly-merge-branch-lockfiles.yml`, whose purpose **is** to merge per-branch lockfiles into the canonical (so it must re-resolve and must keep `--config.minimum-release-age=0`).
+
+Concretely:
+
+| Workflow | Mode | Override needed? |
+|---|---|---|
+| `vitest.yml` (3 jobs) | `--frozen-lockfile` (was `--merge-git-branch-lockfiles --no-frozen-lockfile`) | ❌ No |
+| `package.yml` (5 lines) | `--frozen-lockfile` (was `--no-frozen-lockfile`) | ❌ No |
+| `daily-test-improver/coverage-steps/action.yml` | `--frozen-lockfile` (was `--no-frozen-lockfile`) | ❌ No |
+| `publish-backend.ai-ui.yml` | `--frozen-lockfile` | ❌ No |
+| `publish-backend.ai-docs-toolkit.yml` | `--frozen-lockfile` | ❌ No |
+| `e2e-watchdog.{md,lock.yml}` | `--frozen-lockfile --prefer-offline` | ❌ No |
+| `e2e-healer.{md,lock.yml}` | `--frozen-lockfile --prefer-offline` | ❌ No |
+| `weekly-merge-branch-lockfiles.yml` | `--merge-git-branch-lockfiles --no-frozen-lockfile` | ✅ Yes (intrinsic) |
+
+Trade-off accepted: PRs that change deps must run `pnpm install` locally and commit the updated `pnpm-lock.yaml` (or `pnpm-lock.<branch>.yaml`) before pushing. CI no longer auto-resolves — that's a stricter contract but a more honest one.
+
+Local devs can manually override (`pnpm install --config.minimum-release-age=0`) when adding/upgrading deps until pnpm fixes #9963 / #10699.
+
+`minimumReleaseAge: 10080` stays in `pnpm-workspace.yaml` to enforce the policy on the lockfile-update paths (local dev installs and the weekly merge job), where new deps actually enter the resolved tree.
+
+### 5.5 Workflows
+
+Bump all 11 `pnpm/action-setup` invocations from `version: 10` to `version: 11`:
+
+- `.github/workflows/vitest.yml` — 3 occurrences
+- `.github/workflows/package.yml` — 4 occurrences
+- `.github/workflows/publish-backend.ai-ui.yml` — 1 occurrence
+- `.github/workflows/publish-backend.ai-docs-toolkit.yml` — 1 occurrence
+- `.github/workflows/weekly-merge-branch-lockfiles.yml` — 1 occurrence
+- `.github/actions/daily-test-improver/coverage-steps/action.yml` — 1 occurrence
+
+Also: `vitest.yml:146` is `pnpm/action-setup@v4` while siblings are `@v5`. Bump that to `@v5` while in the area (cleanup observed in PR #7297 review).
+
+### 5.6 Lockfile
+
+Regenerate under pnpm 11 with the same flag set CI uses:
+
+```bash
+pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile --config.minimum-release-age=0
+```
+
+Expected diff: `lockfileVersion: '9.0'` retained; package set retained; settings block may pick up v11 defaults. Reviewer must check that no semver range resolution silently widened — diff `pnpm-lock.yaml` against `main` and confirm only entries we intended to touch (and `settings:` block changes) appear.
+
+The `minimumReleaseAgeExclude` block is removed from `pnpm-workspace.yaml`. Its entries (e.g., `react@19.2.4`, `i18next@25.7.4`) were stale — they pinned exact versions that the catalog has long since moved past, so they no longer matched anything in the resolved tree. With the workflow-level override (§5.4.1) now bypassing the age check at install time, no exclude list is needed.
+
+### 5.7 Documentation
+
+- `DEV_ENVIRONMENT.md` — update if any line references a specific pnpm major. (Audit found no such line; if absent, no edit.)
+- `CLAUDE.md` — does not pin pnpm version; no change.
+- `README.md` — verify and update only if it pins a pnpm major.
+
+## 6. Verification
+
+### 6.1 Local
+
+1. `pnpm install` succeeds with no `ERR_PNPM_UNSUPPORTED_ENGINE`, no missing build-script warning, no exotic-subdep block.
+2. `pnpm -v` reports an 11.x version.
+3. `bash scripts/verify.sh` ends with `=== ALL PASS ===`.
+4. `pnpm run build` produces `build/web/` and the workspace package outputs without errors.
+5. Pre-commit hook smoke: stage a trivial file change and run `git commit` — `lint-staged` paths still run (`react/`, `packages/backend.ai-ui/`, `e2e/`, `resources/i18n/`).
+
+### 6.2 CI (on the PR)
+
+1. Existing path-filtered jobs (`Analyze`, `CodeQL`, `triage`, `mergeability_check`, `auto-label`, `sync-project-status`) pass.
+2. Because the PR touches `pnpm-lock.yaml` / `package.json` / `pnpm-workspace.yaml` / `.github/workflows/*`, any path-gated workflow that `react-vitest`, `backend-ai-ui-vitest`, `root-vitest`, `storybook-check`, `package`-build run on triggers and passes.
+
+### 6.3 Acceptance
+
+- All §5.1–§5.7 changes land in a single PR with `Resolves #7296(FR-2840)`.
+- Lockfile diff is reviewer-explainable (no unrelated dependency upgrades).
+- The single-PR delivery preserves bisection: the merge commit is the bisection point if anything regresses post-merge.
+
+## 7. Risks & rollback
+
+| Risk | Likelihood | Mitigation / rollback |
+|---|---|---|
+| `pnpm install` under v11 surfaces a previously-silent build script failure (`strictDepBuilds`). | Medium. | Add the offending package to `allowBuilds` with a justification comment. If the failure is genuine (not a missing allow-list entry), file a follow-up issue and pin a workaround in the PR. |
+| Lockfile regeneration shifts dependency versions unexpectedly. | Low — semver ranges unchanged. | Reviewer compares `pnpm-lock.yaml` diff for any package whose `version` line moved; if so, decide case-by-case whether to accept or revert that entry. |
+| Workflow `version: 11` → action-setup resolves a 11.x patch with a regression. | Low. | Re-pin to a specific patch (e.g. `version: 11.0.8`) and open a tracking issue. |
+| pre-commit hook (`husky` + `lint-staged`) breaks under v11's `verifyDepsBeforeRun`. | Low. | Hook config does not call `pnpm install`; only spawns commands. If breakage occurs, downgrade `verifyDepsBeforeRun` only for hook contexts via env var. |
+| Rollback after merge. | — | Single revert of the PR restores v10 state in one commit; FR-2839's `version: 10` pin can be reapplied. |
+
+## 8. Acceptance checklist (for verify-spec step)
+
+- [ ] `package.json` `engines.pnpm` is `^11.0.0`.
+- [ ] `package.json` no longer has a top-level `pnpm` field.
+- [ ] `package.json` declares `packageManager` at `pnpm@11.x`.
+- [ ] `pnpm-workspace.yaml` has the three overrides previously in `package.json`.
+- [ ] `pnpm-workspace.yaml` uses `allowBuilds` (map) not `onlyBuiltDependencies` (list).
+- [ ] `.npmrc` no longer contains `engine-strict=true`.
+- [ ] All 15 `pnpm/action-setup` invocations use `version: 11` (6 standard workflow files, 1 composite action, 4 agentic `.md` / `.lock.yml` files).
+- [ ] All CI `pnpm install` invocations use `--frozen-lockfile`. The only exception is `weekly-merge-branch-lockfiles.yml`, whose intrinsic purpose is to re-resolve and merge per-branch lockfiles — it carries `--merge-git-branch-lockfiles --no-frozen-lockfile --config.minimum-release-age=0`.
+- [ ] No other workflow file contains `--config.minimum-release-age=0` or `--no-frozen-lockfile`.
+- [ ] All `pnpm/action-setup` references use `@v5` or the matching v5 SHA: `vitest.yml` (3), `package.yml` (4), `publish-backend.ai-ui.yml`, `publish-backend.ai-docs-toolkit.yml`, `weekly-merge-branch-lockfiles.yml`, `daily-test-improver/coverage-steps/action.yml`, `e2e-watchdog.{md,lock.yml}`, `e2e-healer.{md,lock.yml}`. `.github/aw/actions-lock.json` is updated to the v5 SHA.
+- [ ] `pnpm-workspace.yaml` no longer contains a `minimumReleaseAgeExclude` block.
+- [ ] `pnpm-lock.yaml` regenerated; reviewer confirms no unintended dep upgrades.
+- [ ] CI on the PR passes (Analyze/CodeQL/triage/etc.).
+- [ ] PR description references `Resolves #7296(FR-2840)` and links the v10-pin predecessor PR (#7297).

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "author": "Lablup Inc. <contact@lablup.com>",
   "license": "LGPL-3.0-or-later",
   "engines": {
-    "pnpm": "^10.16.0"
+    "pnpm": "^11.0.0"
   },
+  "packageManager": "pnpm@11.0.8",
   "scripts": {
     "lint": "eslint src --quiet; exit 0",
     "lint-fix": "eslint src --quiet --fix; exit 0",
@@ -98,13 +99,6 @@
     "workbox-strategies": "^7.4.0",
     "workbox-sw": "^7.4.0",
     "ws": "^8.19.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "tar-fs@2": "2.1.4",
-      "node-forge": ">=1.3.2",
-      "@codemirror/state": "6.5.4"
-    }
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,25 +76,21 @@ gitBranchLockfile: true
 
 minimumReleaseAge: 10080
 
-minimumReleaseAgeExclude:
-  - node-forge@1.3.2
-  - react@19.2.4
-  - react-dom@19.2.4
-  - '@ant-design/x@2.1.3'
-  - react-i18next@16.5.1
-  - i18next@25.7.4
-  - antd@6.1.3
+allowBuilds:
+  bufferutil: true
+  core-js: true
+  core-js-pure: true
+  electron: true
+  es5-ext: true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
+  utf-8-validate: true
 
-onlyBuiltDependencies:
-  - bufferutil
-  - core-js
-  - core-js-pure
-  - electron
-  - es5-ext
-  - esbuild
-  - sharp
-  - unrs-resolver
-  - utf-8-validate
+overrides:
+  tar-fs@2: 2.1.4
+  node-forge: '>=1.3.2'
+  '@codemirror/state': 6.5.4
 
 patchedDependencies:
   '@cloudscape-design/board-components@3.0.60': react/patches/@cloudscape-design__board-components@3.0.60.patch


### PR DESCRIPTION
Resolves #7296(FR-2840)

## Summary

Upgrade the repo from pnpm v10 to pnpm v11 in a single PR. Predecessor PR #7297 (FR-2839) temporarily pinned CI workflows to pnpm v10 to unblock CI; this PR completes the migration so we don't get stuck on v10.

## Key decisions and rationale

The migration ran into several pnpm 11 behavior changes and upstream bugs that required explicit decisions. These were discussed and chosen during implementation; this section is the lasting record so the decisions don't have to be re-derived in review.

### 1. Single PR for the whole migration

**Decision**: deliver as one PR (config moves + workflow updates + lockfile regen).

**Rationale**: lockfile regen, config moves (`pnpm.overrides` → `pnpm-workspace.yaml`), `onlyBuiltDependencies` → `allowBuilds` conversion, and the workflow `version: 11` bump must land **atomically** — splitting forces an intermediate commit where either CI is on v10 with v11 config (breaks) or on v11 with v10 config (breaks). The dev plan documents this reasoning at `.specs/FR-2840-pnpm-v11-migration/dev-plan.md`.

### 2. Drop `package.json` `pnpm` field; absorb `overrides` into `pnpm-workspace.yaml`

**Decision**: move the three `overrides` (`tar-fs@2`, `node-forge`, `@codemirror/state`) into `pnpm-workspace.yaml` and delete the top-level `pnpm` block from `package.json`.

**Rationale**: pnpm 11 no longer reads the `pnpm` field in `package.json`. Leaving it would silently lose those overrides at install time.

### 3. `onlyBuiltDependencies` (list) → `allowBuilds` (map)

**Decision**: 1:1 conversion — same 9 packages (`bufferutil`, `core-js`, `core-js-pure`, `electron`, `es5-ext`, `esbuild`, `sharp`, `unrs-resolver`, `utf-8-validate`).

**Rationale**: `onlyBuiltDependencies` was removed in pnpm 11; `allowBuilds` is its replacement.

### 4. Drop `minimumReleaseAgeExclude` block entirely

**Decision**: remove the seven entries (`react@19.2.4`, `i18next@25.7.4`, `antd@6.1.3`, …).

**Rationale**: those entries pinned exact versions that the catalog has long since moved past. Under pnpm 11 the entries no longer match anything in the resolved tree, so they're dead config.

### 5. Drop `engine-strict=true` from `.npmrc`

**Decision**: remove the line; replace `.npmrc` with a one-line comment about scope.

**Rationale**: pnpm 11 enforces `engines.pnpm` natively when set, and v11 narrows `.npmrc` to auth/registry settings only.

### 6. Bump `pnpm/action-setup` references to `@v5` everywhere (also fixes `vitest.yml@v4`)

**Decision**: every `pnpm/action-setup` reference uses `@v5` or the matching v5 SHA; `.github/aw/actions-lock.json` is updated to the v5 SHA (`a8198c4bff370c8506180b035930dea56dbd5288`).

**Rationale**: `vitest.yml:146` was on `@v4` while siblings were `@v5` — flagged as cleanup during PR #7297 review. While in the area, also bumped agentic `e2e-watchdog.md`/`e2e-healer.md` and the SHA-pinned `.lock.yml` siblings so the next gh-aw regen doesn't re-introduce v4.

### 7. CI: every install lane uses `--frozen-lockfile`; `--config.minimum-release-age=0` only on the weekly-merge job

**Decision**: see the table below. Every CI `pnpm install` runs `--frozen-lockfile`. The single intrinsic exception is `weekly-merge-branch-lockfiles.yml`, whose purpose **is** to re-resolve and merge per-branch lockfiles.

| Workflow | Mode | Override needed? |
|---|---|---|
| `vitest.yml` (3 jobs) | `--frozen-lockfile` (was `--merge-git-branch-lockfiles --no-frozen-lockfile`) | ❌ No |
| `package.yml` (5 lines) | `--frozen-lockfile` (was `--no-frozen-lockfile`) | ❌ No |
| `daily-test-improver/coverage-steps/action.yml` | `--frozen-lockfile` (was `--no-frozen-lockfile`) | ❌ No |
| `publish-backend.ai-{ui,docs-toolkit}.yml` | `--frozen-lockfile` | ❌ No |
| `e2e-{watchdog,healer}.{md,lock.yml}` | `--frozen-lockfile --prefer-offline` | ❌ No |
| `weekly-merge-branch-lockfiles.yml` | `--merge-git-branch-lockfiles --no-frozen-lockfile --config.minimum-release-age=0` | ✅ Yes (intrinsic) |

**Rationale**: pnpm 11's stricter `minimumReleaseAge` enforcement breaks `pnpm install` against this dep tree in two ways the upstream does not yet fix:

1. **`ERR_PNPM_MISSING_TIME` (cache/metadata bug)** — pnpm 11 fatals on packages whose npm registry abbreviated metadata is missing the `time` field, even though the full metadata file has it. Tracked in [pnpm/pnpm#9963](https://github.com/pnpm/pnpm/issues/9963) (closed but recurring) and [pnpm/pnpm#9968](https://github.com/pnpm/pnpm/issues/9968) (10.16.1 fix is partial). Maintainer comment on #9963: *"the error should not happen at all. The full metadata and the abbreviated one are stored at different locations."* The recommended `pnpm store prune` workaround did not produce stable results — re-tested after each iteration and the error reappeared on different packages.
2. **Optional/platform binaries fataling** — `vitest`/`rollup`'s `optionalDependencies` declares 15+ `@rollup/rollup-*` platform binaries. Pnpm 11 fatals on each one's missing `time` metadata. Same shape as [pnpm/pnpm#10699 (open)](https://github.com/pnpm/pnpm/issues/10699).

These bugs only fire during **resolution**. Once the lockfile is generated, `--frozen-lockfile` installs from it without re-resolving and never touches the time check — so 99% of CI lanes don't need any workaround at all. Only `weekly-merge-branch-lockfiles.yml` has to re-resolve (its purpose is to merge per-branch lockfiles into the canonical), so it's the only place that carries the override.

This decision was the result of three rounds of refinement: started with override on every install, narrowed to "only re-resolve lanes" after empirical scoping, then narrowed again to "only the one re-resolve lane that exists" by switching the rest to `--frozen-lockfile`. The earlier exclude-list approach (add offending packages to `minimumReleaseAgeExclude`) was attempted and abandoned — empirical iteration grew the list past 30 entries without converging because every new rollup architecture binary, every metadata corruption, and every recent typescript-eslint family bump re-broke it.

### 8. Trade-off accepted with `--frozen-lockfile`

**Decision**: PRs that change deps must run `pnpm install` locally and commit the updated lockfile (or branch lockfile) before pushing. CI no longer auto-resolves on those PRs.

**Rationale**: stricter contract, but more honest. CI's role is to verify, not to silently mutate the lockfile. Local devs that hit MISSING_TIME / NO_MATURE during their manual install can use `pnpm install --config.minimum-release-age=0` as a one-off until upstream pnpm fixes #9963 / #10699.

### 9. Keep `minimumReleaseAge: 10080` in `pnpm-workspace.yaml`

**Decision**: don't lower the policy value to 0 or 1440 just because pnpm 11 makes it painful.

**Rationale**: the 7-day supply-chain protection is a deliberate project policy. The pnpm 11 enforcement bugs are temporary upstream issues; the policy outlives them. Workflow-level override scopes the relaxation to the one place that genuinely needs it (the merge job, which a human reviews before merging the resulting PR).

### 10. Out of scope (deliberate)

- Per-branch `pnpm-lock.<branch>.yaml` files for other developers' branches are intentionally **not** consolidated in this PR. The `weekly-merge-branch-lockfiles` workflow already handles that on its own cadence.
- Pre-existing TypeScript errors (`packages/backend.ai-client/src/client.ts` implicit-`any`s, `DeleteForeverVFolderModalV2.tsx` `BulkPurgeVFoldersV2Input.options`) — verified to exist on `main`, not introduced by this migration.
- Re-evaluating the long-term `minimumReleaseAge` policy. Spec §5.4.1 documents the single CI exception; a strategic decision can come in a follow-up once pnpm fixes the upstream bugs.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds locally under pnpm 11.0.8 against the regenerated lockfile (~10s, no MISSING_TIME / NO_MATURE errors).
- [x] `bash scripts/verify.sh` — Relay/Lint/Format pass; TypeScript failures are confirmed pre-existing on `main` (verified by checking out `main` and re-running). Out of scope for this PR.
- [ ] CI on this PR — `Analyze`/`CodeQL`/`triage`/`mergeability_check`/`auto-label`/`sync-project-status` pass.
- [ ] After merge, re-run failed CI on a recent PR (e.g. on top of this) and confirm `pnpm -v` reports 11.x and the install step passes.

## Spec

Full migration spec is committed in this PR at `.specs/FR-2840-pnpm-v11-migration/spec.md` with the §8 acceptance checklist for the reviewer to tick.
