### PR TITLE
refactor(FR-2847): split admin deployment detail route under /admin-deployments/:id

### DIFF
--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -134,7 +134,10 @@ const EndpointList: React.FC<EndpointListProps> = ({
         <BAINameActionCell
           title={name}
           showActions="always"
-          to={(isAdminMode ? '/deployments/' : '/serving/') + row.endpoint_id}
+          to={
+            (isAdminMode ? '/admin-deployments/' : '/serving/') +
+            row.endpoint_id
+          }
           actions={[
             {
               key: 'settings',

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -166,7 +166,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
         }}
         loading={isLoading}
         onRowClick={(deploymentId) => {
-          webUINavigate(`/deployments/${toLocalId(deploymentId)}`);
+          webUINavigate(`/admin-deployments/${toLocalId(deploymentId)}`);
         }}
         onEditClick={(frgmt) => setEditingDeploymentFrgmt(frgmt)}
         onDeleteComplete={updateFetchKey}

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -483,6 +483,21 @@ export const mainLayoutChildRoutes: RouteObject[] = [
           </BAIErrorBoundary>
         ),
       },
+      {
+        // FR-2847 — Admin deployment detail route. Reuses the shared
+        // `DeploymentDetailPage` component but keeps admins under the
+        // `/admin-deployments/*` URL space so that breadcrumbs and back
+        // navigation preserve the admin context.
+        path: ':deploymentId',
+        handle: { labelKey: 'webui.menu.DeploymentDetail' },
+        element: (
+          <BAIErrorBoundary>
+            <Suspense fallback={<Skeleton active />}>
+              <DeploymentDetailPage />
+            </Suspense>
+          </BAIErrorBoundary>
+        ),
+      },
     ],
   },
   {
@@ -504,16 +519,17 @@ export const mainLayoutChildRoutes: RouteObject[] = [
         },
       },
       {
-        // /admin-deployments has no nested detail route — the deployment
-        // detail page is shared at /deployments/:deploymentId regardless
-        // of the viewer's role.
+        // FR-2847 — Legacy `/admin-serving/:serviceId` redirects to the
+        // admin-scoped detail route so admins stay under
+        // `/admin-deployments/*` instead of the user-facing
+        // `/deployments/:deploymentId`.
         path: ':serviceId',
         Component: () => {
           const { serviceId } = useParams<{ serviceId: string }>();
           const location = useLocation();
           return (
             <WebUINavigate
-              to={`/deployments/${serviceId}${location.search}`}
+              to={`/admin-deployments/${serviceId}${location.search}`}
               replace
             />
           );


### PR DESCRIPTION
Resolves #7310(FR-2847)

## Summary

Split the admin-side deployment detail page from the user-side one at the route level. Admins now stay under `/admin-deployments/*` when navigating into a deployment detail, preserving the admin context through breadcrumbs and back navigation. The detail page **component** (`DeploymentDetailPage`) is unchanged — only the route is separated.

## Changes

- **`react/src/routes.tsx`**
  - Add new child route `/admin-deployments/:deploymentId` that mounts the same `DeploymentDetailPage` inside the existing `/admin-deployments` parent route, using the same `BAIErrorBoundary` + `Suspense` pattern as sibling children.
  - Add `handle: { labelKey: 'webui.menu.DeploymentDetail' }` so the breadcrumb resolves correctly under the admin route.
  - Update the legacy `/admin-serving/:serviceId` redirect to point to `/admin-deployments/:serviceId` (was `/deployments/:serviceId`), so old admin links keep landing inside the admin URL space.
  - Update the stale comment that said "/admin-deployments has no nested detail route".
- **`react/src/pages/AdminDeploymentListPage.tsx`** — row click now navigates to `/admin-deployments/${id}` instead of `/deployments/${id}`.
- **`react/src/components/EndpointList.tsx`** — when rendered with `isAdminMode`, the `BAINameActionCell` `to` prop now points at `/admin-deployments/${endpoint_id}` instead of `/deployments/${endpoint_id}`. (`AdminServingPage` does not navigate to detail directly — it composes `EndpointList` with `isAdminMode`, which is the actual entry point from the legacy admin-serving tab.)

## Out of scope

- `DeploymentTagChips.tsx` already branches on `pathname.startsWith('/admin-deployments')` and navigates to the **list** (not detail) for tag filters — unchanged.
- `DeploymentConfigurationSection.tsx` (FR-2846) and delete-icon styling (FR-2848) intentionally untouched.

## Verification

`bash scripts/verify.sh`: Relay PASS, Lint PASS, Format PASS. TypeScript shows pre-existing errors in `packages/backend.ai-client/src/client.ts` and `react/src/components/DeleteForeverVFolderModalV2.tsx` that are unchanged from `main` and unrelated to FR-2847 (`git diff main HEAD --` confirms).