### PR TITLE
refactor(FR-2848): use DeleteFilled for permanent delete, DeleteOutlined for trash

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIConfirmModalWithInput.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIConfirmModalWithInput.stories.tsx
@@ -3,7 +3,7 @@
 import BAIButton from './BAIButton';
 import BAIConfirmModalWithInput from './BAIConfirmModalWithInput';
 import BAIText from './BAIText';
-import { DeleteOutlined } from '@ant-design/icons';
+import { DeleteFilled } from '@ant-design/icons';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { theme } from 'antd';
 import { useState } from 'react';
@@ -117,9 +117,7 @@ export const CustomIcon: Story = {
           {...args}
           open={open}
           icon={
-            <DeleteOutlined
-              style={{ color: token.colorError, marginRight: 5 }}
-            />
+            <DeleteFilled style={{ color: token.colorError, marginRight: 5 }} />
           }
           content={
             <BAIText>

--- a/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.stories.tsx
@@ -3,7 +3,7 @@
 import BAIButton from './BAIButton';
 import BAIDeleteConfirmModal from './BAIDeleteConfirmModal';
 import BAIFlex from './BAIFlex';
-import { DeleteOutlined, FolderOutlined } from '@ant-design/icons';
+import { DeleteFilled, FolderOutlined } from '@ant-design/icons';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Checkbox, Space, Tag } from 'antd';
 import { useState } from 'react';
@@ -51,11 +51,7 @@ export const SingleItem: Story = {
     const [open, setOpen] = useState(false);
     return (
       <>
-        <BAIButton
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => setOpen(true)}
-        >
+        <BAIButton danger icon={<DeleteFilled />} onClick={() => setOpen(true)}>
           Delete Item
         </BAIButton>
         <BAIDeleteConfirmModal
@@ -82,11 +78,7 @@ export const SingleItemWithInput: Story = {
     const [open, setOpen] = useState(false);
     return (
       <>
-        <BAIButton
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => setOpen(true)}
-        >
+        <BAIButton danger icon={<DeleteFilled />} onClick={() => setOpen(true)}>
           Delete (Confirm Required)
         </BAIButton>
         <BAIDeleteConfirmModal
@@ -121,11 +113,7 @@ export const MultipleItems: Story = {
     ];
     return (
       <>
-        <BAIButton
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => setOpen(true)}
-        >
+        <BAIButton danger icon={<DeleteFilled />} onClick={() => setOpen(true)}>
           Delete 5 Items
         </BAIButton>
         <BAIDeleteConfirmModal
@@ -156,11 +144,7 @@ export const ManyItems: Story = {
     }));
     return (
       <>
-        <BAIButton
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => setOpen(true)}
-        >
+        <BAIButton danger icon={<DeleteFilled />} onClick={() => setOpen(true)}>
           Delete 50 Items
         </BAIButton>
         <BAIDeleteConfirmModal
@@ -219,11 +203,7 @@ export const CustomRenderedItems: Story = {
     ];
     return (
       <>
-        <BAIButton
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => setOpen(true)}
-        >
+        <BAIButton danger icon={<DeleteFilled />} onClick={() => setOpen(true)}>
           Delete Folders
         </BAIButton>
         <BAIDeleteConfirmModal
@@ -254,11 +234,7 @@ export const WithExtraContent: Story = {
     ];
     return (
       <>
-        <BAIButton
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => setOpen(true)}
-        >
+        <BAIButton danger icon={<DeleteFilled />} onClick={() => setOpen(true)}>
           Purge Users
         </BAIButton>
         <BAIDeleteConfirmModal
@@ -290,11 +266,7 @@ export const EmptyItems: Story = {
     const [open, setOpen] = useState(false);
     return (
       <>
-        <BAIButton
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => setOpen(true)}
-        >
+        <BAIButton danger icon={<DeleteFilled />} onClick={() => setOpen(true)}>
           Delete (No Selection)
         </BAIButton>
         <BAIDeleteConfirmModal

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -1,6 +1,5 @@
 import { initiateDownload } from '../../../helper';
 import { useTanMutation } from '../../../helper/reactQueryAlias';
-import { BAITrashBinIcon } from '../../../icons';
 import BAIButton from '../../BAIButton';
 import BAIFlex from '../../BAIFlex';
 import BAISelectionLabel from '../../BAISelectionLabel';
@@ -14,6 +13,7 @@ import DeleteSelectedItemsModal, {
 } from './DeleteSelectedItemsModal';
 import { useUploadVFolderFiles } from './hooks';
 import {
+  DeleteFilled,
   FileAddOutlined,
   FolderAddOutlined,
   UploadOutlined,
@@ -128,7 +128,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
             <Tooltip title={t('general.button.Delete')} placement="topLeft">
               <Button
                 disabled={!enableDelete}
-                icon={<BAITrashBinIcon style={{ color: token.colorError }} />}
+                icon={<DeleteFilled style={{ color: token.colorError }} />}
                 onClick={() => {
                   toggleDeleteModal();
                 }}

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
@@ -1,12 +1,11 @@
 import { convertToBinaryUnit, initiateDownload } from '../../../helper';
 import { useTanMutation } from '../../../helper/reactQueryAlias';
-import { BAITrashBinIcon } from '../../../icons';
 import BAIButton, { BAIButtonProps } from '../../BAIButton';
 import BAIFlex from '../../BAIFlex';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
 import { VFolderFile } from '../../provider/BAIClientProvider/types';
 import { FolderInfoContext } from './BAIFileExplorer';
-import { MoreOutlined } from '@ant-design/icons';
+import { DeleteFilled, MoreOutlined } from '@ant-design/icons';
 import { App, theme, Dropdown, Tooltip } from 'antd';
 import { DownloadIcon, EditIcon } from 'lucide-react';
 import { use, useState } from 'react';
@@ -110,7 +109,7 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
       <BAIButton
         type="text"
         size="small"
-        icon={<BAITrashBinIcon style={{ color: token.colorError }} />}
+        icon={<DeleteFilled style={{ color: token.colorError }} />}
         disabled={!enableDelete}
         onClick={(e) => {
           e.stopPropagation();

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionDeleteButton.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionDeleteButton.tsx
@@ -1,6 +1,6 @@
 import { BAIArtifactRevisionDeleteButtonFragment$key } from '../../__generated__/BAIArtifactRevisionDeleteButtonFragment.graphql';
-import { BAITrashBinIcon } from '../../icons';
 import BAIButton, { BAIButtonProps } from '../BAIButton';
+import { DeleteFilled } from '@ant-design/icons';
 import { theme } from 'antd';
 import * as _ from 'lodash-es';
 import { graphql, useFragment } from 'react-relay';
@@ -39,7 +39,7 @@ const BAIArtifactRevisionDeleteButton = ({
 
   return (
     <BAIButton
-      icon={<BAITrashBinIcon />}
+      icon={<DeleteFilled />}
       disabled={isDisabled}
       type="text"
       style={{

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx
@@ -13,7 +13,7 @@ import BAITag from '../BAITag';
 import BAIText from '../BAIText';
 import { BAIColumnsType, BAITable, BAITableProps } from '../Table';
 import AllowedVfolderHostsWithPermission from './BAIAllowedVfolderHostsWithPermission';
-import { DeleteOutlined, SettingOutlined } from '@ant-design/icons';
+import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
 import { App, Popconfirm, Tag, theme } from 'antd';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
@@ -209,7 +209,7 @@ const BAIProjectTable = ({
             <BAIButton
               type="text"
               icon={
-                <DeleteOutlined
+                <DeleteFilled
                   style={{
                     color:
                       _.get(record, 'type') === 'MODEL_STORE'

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.tsx
@@ -1,6 +1,6 @@
 import { BAIVFolderDeleteButtonFragment$key } from '../../__generated__/BAIVFolderDeleteButtonFragment.graphql';
-import { BAITrashBinIcon } from '../../icons';
 import BAIButton from '../BAIButton';
+import { DeleteOutlined } from '@ant-design/icons';
 import { theme, type ButtonProps } from 'antd';
 import * as _ from 'lodash-es';
 import { graphql, useFragment } from 'react-relay';
@@ -30,7 +30,7 @@ const BAIVFolderDeleteButton = ({
 
   return (
     <BAIButton
-      icon={<BAITrashBinIcon />}
+      icon={<DeleteOutlined />}
       disabled={buttonProps.disabled || !isDeletable}
       style={{
         color:

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButtonV2.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButtonV2.tsx
@@ -1,6 +1,6 @@
 import { BAIVFolderDeleteButtonV2Fragment$key } from '../../__generated__/BAIVFolderDeleteButtonV2Fragment.graphql';
-import { BAITrashBinIcon } from '../../icons';
 import BAIButton from '../BAIButton';
+import { DeleteOutlined } from '@ant-design/icons';
 import { theme, type ButtonProps } from 'antd';
 import * as _ from 'lodash-es';
 import { graphql, useFragment } from 'react-relay';
@@ -35,7 +35,7 @@ const BAIVFolderDeleteButtonV2 = ({
 
   return (
     <BAIButton
-      icon={<BAITrashBinIcon />}
+      icon={<DeleteOutlined />}
       disabled={buttonProps.disabled}
       style={{
         color: isEnabled ? token.colorError : token.colorTextDisabled,

--- a/react/src/components/AdminDeploymentPresetNodes.tsx
+++ b/react/src/components/AdminDeploymentPresetNodes.tsx
@@ -7,13 +7,12 @@ import type {
   AdminDeploymentPresetNodesFragment$key,
 } from '../__generated__/AdminDeploymentPresetNodesFragment.graphql';
 import type { AdminDeploymentPresetNodesImagesQuery } from '../__generated__/AdminDeploymentPresetNodesImagesQuery.graphql';
-import { SettingOutlined } from '@ant-design/icons';
+import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
 import {
   BAIColumnType,
   BAINameActionCell,
   BAITable,
   BAITableProps,
-  BAITrashBinIcon,
   filterOutEmpty,
   filterOutNullAndUndefined,
   toLocalId,
@@ -159,7 +158,7 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
               {
                 key: 'delete',
                 title: t('button.Delete'),
-                icon: <BAITrashBinIcon />,
+                icon: <DeleteFilled />,
                 type: 'danger' as const,
                 onClick: () => onDelete?.(preset),
               },

--- a/react/src/components/AutoScalingRuleList.tsx
+++ b/react/src/components/AutoScalingRuleList.tsx
@@ -12,11 +12,7 @@ import { AutoScalingRuleListQuery } from '../__generated__/AutoScalingRuleListQu
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import AutoScalingRuleEditorModal from './AutoScalingRuleEditorModal';
-import {
-  DeleteOutlined,
-  PlusOutlined,
-  SettingOutlined,
-} from '@ant-design/icons';
+import { DeleteFilled, PlusOutlined, SettingOutlined } from '@ant-design/icons';
 import { App, Button, Tag, Tooltip, Typography } from 'antd';
 import {
   BAIFetchKeyButton,
@@ -218,7 +214,7 @@ const AutoScalingRuleListNodes: React.FC<AutoScalingRuleListNodesProps> = ({
                   {
                     key: 'delete',
                     title: t('button.Delete'),
-                    icon: <DeleteOutlined />,
+                    icon: <DeleteFilled />,
                     type: 'danger',
                     disabled: isEndpointDestroying || !isOwnedByCurrentUser,
                     onClick: () => onDeleteRule(row.id, row.metricName ?? ''),

--- a/react/src/components/AutoScalingRuleListLegacy.tsx
+++ b/react/src/components/AutoScalingRuleListLegacy.tsx
@@ -7,11 +7,7 @@ import { AutoScalingRuleListLegacyDeleteMutation } from '../__generated__/AutoSc
 import AutoScalingRuleEditorModalLegacy, {
   COMPARATOR_LABELS,
 } from './AutoScalingRuleEditorModalLegacy';
-import {
-  DeleteOutlined,
-  PlusOutlined,
-  SettingOutlined,
-} from '@ant-design/icons';
+import { DeleteFilled, PlusOutlined, SettingOutlined } from '@ant-design/icons';
 import {
   App,
   Button,
@@ -239,7 +235,7 @@ const AutoScalingRuleListLegacy: React.FC<AutoScalingRuleListLegacyProps> = ({
                     <Button
                       type="text"
                       icon={
-                        <DeleteOutlined
+                        <DeleteFilled
                           style={
                             isEndpointDestroying
                               ? undefined

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -16,7 +16,7 @@ import { usePainKiller } from '../hooks/usePainKiller';
 import ContainerRegistryEditorModal from './ContainerRegistryEditorModal';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   ExclamationCircleOutlined,
   PlusOutlined,
   ReloadOutlined,
@@ -295,7 +295,7 @@ const ContainerRegistryList: React.FC<{
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <DeleteOutlined />,
+              icon: <DeleteFilled />,
               type: 'danger',
               onClick: () => {
                 setDeletingRegistry(record);

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -19,7 +19,7 @@ import AliasedImageDoubleTags from './AliasedImageDoubleTags';
 import { ImageTags } from './ImageTags';
 import TextHighlighter from './TextHighlighter';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   ReloadOutlined,
   SearchOutlined,
   SettingOutlined,
@@ -245,7 +245,7 @@ const CustomizedImageList: React.FC = () => {
         <BAIFlex direction="row" align="stretch" justify="center" gap="xxs">
           <Button
             type="text"
-            icon={<DeleteOutlined />}
+            icon={<DeleteFilled />}
             onClick={() => {
               setImageToDelete(row || null);
             }}

--- a/react/src/components/DeploymentAccessTokensTab.tsx
+++ b/react/src/components/DeploymentAccessTokensTab.tsx
@@ -7,7 +7,7 @@ import { DeploymentAccessTokensTabDeleteMutation } from '../__generated__/Deploy
 import { DeploymentAccessTokensTabListQuery } from '../__generated__/DeploymentAccessTokensTabListQuery.graphql';
 import { DeploymentAccessTokensTab_deployment$key } from '../__generated__/DeploymentAccessTokensTab_deployment.graphql';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   PlusOutlined,
   QuestionCircleOutlined,
 } from '@ant-design/icons';
@@ -339,7 +339,7 @@ const DeploymentAccessTokensTable: React.FC<
                     {
                       key: 'delete',
                       title: t('deployment.accessToken.Delete'),
-                      icon: <DeleteOutlined />,
+                      icon: <DeleteFilled />,
                       type: 'danger',
                       disabled: isDeleteDisabled,
                       onClick: () =>

--- a/react/src/components/DeploymentList.tsx
+++ b/react/src/components/DeploymentList.tsx
@@ -13,7 +13,7 @@ import BAIRadioGroup from './BAIRadioGroup';
 import DeploymentOwnerInfo from './DeploymentOwnerInfo';
 import DeploymentStatusTag, { DeploymentStatus } from './DeploymentStatusTag';
 import DeploymentTagChips from './DeploymentTagChips';
-import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import { DeleteFilled, EditOutlined } from '@ant-design/icons';
 import { Alert, App, Typography, theme } from 'antd';
 import {
   BAIConfirmModalWithInput,
@@ -275,7 +275,7 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
         actions.push({
           key: 'delete',
           title: t('deployment.DeleteDeployment'),
-          icon: <DeleteOutlined />,
+          icon: <DeleteFilled />,
           type: 'danger',
           disabled: isDestroying,
           onClick: () => setDeletingDeployment({ id: row.id, name }),

--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -15,7 +15,7 @@ import EndpointStatusTag from './EndpointStatusTag';
 import {
   CheckOutlined,
   CloseOutlined,
-  DeleteOutlined,
+  DeleteFilled,
   SettingOutlined,
 } from '@ant-design/icons';
 import { Typography, theme, App, TablePaginationConfig, Alert } from 'antd';
@@ -155,7 +155,7 @@ const EndpointList: React.FC<EndpointListProps> = ({
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <DeleteOutlined />,
+              icon: <DeleteFilled />,
               type: 'danger',
               disabled: isEndpointInDestroyingCategory(row),
               onClick: () => {

--- a/react/src/components/ErrorLogList.tsx
+++ b/react/src/components/ErrorLogList.tsx
@@ -7,7 +7,7 @@ import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting'
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import TextHighlighter from './TextHighlighter';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   SearchOutlined,
   SettingOutlined,
   LoadingOutlined,
@@ -249,7 +249,7 @@ const ErrorLogList: React.FC<{
             </Button>
             <Button
               danger
-              icon={<DeleteOutlined />}
+              icon={<DeleteFilled />}
               onClick={() => {
                 setIsOpenClearLogsModal(true);
               }}

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -17,7 +17,7 @@ import KeypairResourcePolicyInfoModal from './KeypairResourcePolicyInfoModal';
 import KeypairResourcePolicySettingModal from './KeypairResourcePolicySettingModal';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   InfoCircleOutlined,
   PlusOutlined,
   ReloadOutlined,
@@ -143,7 +143,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <DeleteOutlined />,
+              icon: <DeleteFilled />,
               type: 'danger',
               onClick: () => {
                 setDeletingPolicyName(row?.name ?? null);

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -19,7 +19,7 @@ import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting'
 import ProjectResourcePolicySettingModal from './ProjectResourcePolicySettingModal';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
@@ -131,7 +131,7 @@ const ProjectResourcePolicyList: React.FC<
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <DeleteOutlined />,
+              icon: <DeleteFilled />,
               type: 'danger',
               onClick: () => {
                 setDeletingPolicyName(row?.name ?? null);

--- a/react/src/components/PrometheusQueryPresetNodes.tsx
+++ b/react/src/components/PrometheusQueryPresetNodes.tsx
@@ -7,7 +7,7 @@ import {
   PrometheusQueryPresetNodesFragment$data,
   PrometheusQueryPresetNodesFragment$key,
 } from '../__generated__/PrometheusQueryPresetNodesFragment.graphql';
-import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import { DeleteFilled, EditOutlined } from '@ant-design/icons';
 import { Tag } from 'antd';
 import {
   BAIColumnsType,
@@ -120,7 +120,7 @@ const PrometheusQueryPresetNodes: React.FC<PrometheusQueryPresetNodesProps> = ({
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <DeleteOutlined />,
+              icon: <DeleteFilled />,
               type: 'danger',
               onClick: () => onDeletePreset?.(row),
             },

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -14,7 +14,7 @@ import ResourceGroupSettingModal from './ResourceGroupSettingModal';
 import {
   CheckOutlined,
   CloseOutlined,
-  DeleteOutlined,
+  DeleteFilled,
   InfoCircleOutlined,
   PlusOutlined,
   SettingOutlined,
@@ -213,7 +213,7 @@ const ResourceGroupList: React.FC = () => {
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <DeleteOutlined />,
+              icon: <DeleteFilled />,
               type: 'danger',
               onClick: () => {
                 setSelectedResourceGroupName(record?.name || '');

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -15,7 +15,7 @@ import {
   ReloadOutlined,
   PlusOutlined,
   SettingOutlined,
-  DeleteOutlined,
+  DeleteFilled,
 } from '@ant-design/icons';
 import {
   Tooltip,
@@ -118,7 +118,7 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <DeleteOutlined />,
+              icon: <DeleteFilled />,
               type: 'danger',
               onClick: () => {
                 setDeletingPresetName(record?.name ?? null);

--- a/react/src/components/RoleAssignmentTab.tsx
+++ b/react/src/components/RoleAssignmentTab.tsx
@@ -10,6 +10,7 @@ import { RoleAssignmentTab_roleScopeFragment$key } from '../__generated__/RoleAs
 import { convertToOrderBy } from '../helper';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import AssignRoleModal from './AssignRoleModal';
+import { DeleteFilled } from '@ant-design/icons';
 import { App, Tooltip, theme } from 'antd';
 import {
   BAIButton,
@@ -19,7 +20,6 @@ import {
   BAINameActionCell,
   BAISelectionLabel,
   BAITable,
-  BAITrashBinIcon,
   type GraphQLFilter,
   useBAILogger,
   useMutationWithPromise,
@@ -357,7 +357,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
               <Tooltip title={t('rbac.RevokeUser')}>
                 <BAIButton
                   danger
-                  icon={<BAITrashBinIcon />}
+                  icon={<DeleteFilled />}
                   style={{
                     borderColor: token.colorBorder,
                     background: token.colorErrorBg,
@@ -428,7 +428,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
                   {
                     key: 'delete',
                     title: t('rbac.RevokeUser'),
-                    icon: <BAITrashBinIcon />,
+                    icon: <DeleteFilled />,
                     type: 'danger',
                     onClick: () => handleBulkRevoke([record?.userId]),
                   },

--- a/react/src/components/RolePermissionTab.tsx
+++ b/react/src/components/RolePermissionTab.tsx
@@ -8,6 +8,7 @@ import { RolePermissionTabFragment$key } from '../__generated__/RolePermissionTa
 import { PermissionOrderBy } from '../__generated__/RolePermissionTabRefetchQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import CreatePermissionModal from './CreatePermissionModal';
+import { DeleteFilled } from '@ant-design/icons';
 import { App, Tag } from 'antd';
 import {
   BAIButton,
@@ -16,7 +17,6 @@ import {
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
   BAITable,
-  BAITrashBinIcon,
   type GraphQLFilter,
   toLocalId,
   useBAILogger,
@@ -408,7 +408,7 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
                     {
                       key: 'delete',
                       title: t('rbac.RemovePermission'),
-                      icon: <BAITrashBinIcon />,
+                      icon: <DeleteFilled />,
                       type: 'danger',
                       onClick: () => handleDelete(record),
                     },

--- a/react/src/components/ShellScriptEditModal.tsx
+++ b/react/src/components/ShellScriptEditModal.tsx
@@ -6,7 +6,7 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { ShellScriptType } from '../pages/UserSettingsPage';
 import BAICodeEditor from './BAICodeEditor';
-import { DeleteOutlined, DownOutlined } from '@ant-design/icons';
+import { DeleteFilled, DownOutlined } from '@ant-design/icons';
 import {
   App,
   Alert,
@@ -213,7 +213,7 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
                   setIsDeleteConfirmOpen(true);
                 }}
               >
-                <DeleteOutlined />
+                <DeleteFilled />
               </Button>
               <Popconfirm
                 open={isResetConfirmOpen}

--- a/react/src/components/UserCredentialList.tsx
+++ b/react/src/components/UserCredentialList.tsx
@@ -15,7 +15,7 @@ import BAIRadioGroup from './BAIRadioGroup';
 import KeypairInfoModal from './KeypairInfoModal';
 import KeypairSettingModal from './KeypairSettingModal';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   InfoCircleOutlined,
   ReloadOutlined,
   SettingOutlined,
@@ -407,7 +407,7 @@ const UserCredentialList: React.FC = () => {
                       {
                         key: 'delete',
                         title: t('button.Delete'),
-                        icon: <DeleteOutlined />,
+                        icon: <DeleteFilled />,
                         type: 'danger' as const,
                         onClick: () => {
                           modal.confirm({

--- a/react/src/components/UserManagement.tsx
+++ b/react/src/components/UserManagement.tsx
@@ -17,6 +17,7 @@ import UpdateUsersModal from './UpdateUsersModal';
 import UserInfoModal from './UserInfoModal';
 import UserSettingModal from './UserSettingModal';
 import {
+  DeleteFilled,
   EllipsisOutlined,
   InfoCircleOutlined,
   SettingOutlined,
@@ -36,7 +37,6 @@ import {
   BAIUserNodes,
   BAIButton,
   BAISelectionLabel,
-  BAITrashBinIcon,
   BAINameActionCell,
   BAIUnmountAfterClose,
   INITIAL_FETCH_KEY,
@@ -249,7 +249,7 @@ const UserManagement: React.FC<UserManagementProps> = () => {
           !isActive && {
             key: 'purge',
             title: t('credential.PermanentlyDelete'),
-            icon: <BAITrashBinIcon />,
+            icon: <DeleteFilled />,
             type: 'danger' as const,
             onClick: () => {
               if (record?.id) {
@@ -389,7 +389,7 @@ const UserManagement: React.FC<UserManagementProps> = () => {
               />
               {queryParams.status === 'inactive' && (
                 <BAIButton
-                  icon={<BAITrashBinIcon />}
+                  icon={<DeleteFilled />}
                   style={{
                     color: token.colorError,
                     background: token.colorErrorBg,

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -18,7 +18,7 @@ import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting'
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import UserResourcePolicySettingModal from './UserResourcePolicySettingModal';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
@@ -126,7 +126,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <DeleteOutlined />,
+              icon: <DeleteFilled />,
               type: 'danger',
               onClick: () => {
                 setDeletingPolicyName(row?.name ?? null);

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -18,14 +18,13 @@ import SharedFolderPermissionInfoModal from './SharedFolderPermissionInfoModal';
 import VFolderDeployModal from './VFolderDeployModal';
 import VFolderNodeIdenticon from './VFolderNodeIdenticon';
 import VFolderPermissionCell from './VFolderPermissionCell';
-import { UserOutlined } from '@ant-design/icons';
+import { DeleteFilled, DeleteOutlined, UserOutlined } from '@ant-design/icons';
 import { Alert, App, theme, Typography } from 'antd';
 import {
   filterOutNullAndUndefined,
   BAIEndpointsIcon,
   BAIRestoreIcon,
   BAIShareAltIcon,
-  BAITrashBinIcon,
   BAIUserUnionIcon,
   BAITable,
   BAITableProps,
@@ -166,7 +165,7 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
       ? {
           key: 'delete',
           title: t('data.folders.MoveToTrash'),
-          icon: <BAITrashBinIcon />,
+          icon: <DeleteOutlined />,
           type: 'danger' as const,
           disabled:
             !hasDeletePermission ||
@@ -202,7 +201,7 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
       ? {
           key: 'delete-forever',
           title: t('data.folders.Delete'),
-          icon: <BAITrashBinIcon />,
+          icon: <DeleteFilled />,
           type: 'danger' as const,
           disabled:
             vfolder?.status !== 'delete-pending' ||

--- a/react/src/components/VFolderNodesV2.tsx
+++ b/react/src/components/VFolderNodesV2.tsx
@@ -23,7 +23,12 @@ import SharedFolderPermissionInfoModalV2 from './SharedFolderPermissionInfoModal
 import VFolderDeployModal from './VFolderDeployModal';
 import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
 import VFolderPermissionCellV2 from './VFolderPermissionCellV2';
-import { QuestionCircleOutlined, UserOutlined } from '@ant-design/icons';
+import {
+  DeleteFilled,
+  DeleteOutlined,
+  QuestionCircleOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
 import { App, Modal, Skeleton, theme, Tooltip, Typography } from 'antd';
 import {
   filterOutNullAndUndefined,
@@ -32,7 +37,6 @@ import {
   BAILink,
   BAIRestoreIcon,
   BAIShareAltIcon,
-  BAITrashBinIcon,
   BAIUserUnionIcon,
   BAITable,
   BAITableProps,
@@ -160,7 +164,7 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
       ? {
           key: 'delete',
           title: t('data.folders.MoveToTrash'),
-          icon: <BAITrashBinIcon />,
+          icon: <DeleteOutlined />,
           type: 'danger' as const,
           // TODO(needs-backend): V2 `VFolder` does not expose a per-user
           // action permission (legacy `VirtualFolderNode.permissions` had
@@ -201,7 +205,7 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
       ? {
           key: 'delete-forever',
           title: t('data.folders.Delete'),
-          icon: <BAITrashBinIcon />,
+          icon: <DeleteFilled />,
           type: 'danger' as const,
           disabled: vfolder?.vfolderStatus !== 'DELETE_PENDING',
           onClick: onDeleteForever,

--- a/react/src/pages/AIAgentPage.tsx
+++ b/react/src/pages/AIAgentPage.tsx
@@ -7,7 +7,7 @@ import { FluentEmojiIcon } from '../components/FluentEmojiIcon';
 import { useWebUINavigate } from '../hooks';
 import { AIAgent, useAIAgent } from '../hooks/useAIAgent';
 import {
-  DeleteOutlined,
+  DeleteFilled,
   EditOutlined,
   MoreOutlined,
   PlusOutlined,
@@ -111,7 +111,7 @@ const AIAgentCard: React.FC<AIAgentCardProps> = ({
         key: 'delete',
         danger: true,
         label: t('aiAgent.DeleteAgent'),
-        icon: <DeleteOutlined />,
+        icon: <DeleteFilled />,
         onClick: (e: { domEvent: React.MouseEvent | React.KeyboardEvent }) => {
           e.domEvent.stopPropagation();
           onDelete(agent);

--- a/react/src/pages/AdminModelCardListPage.tsx
+++ b/react/src/pages/AdminModelCardListPage.tsx
@@ -18,7 +18,7 @@ import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginati
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { SettingOutlined } from '@ant-design/icons';
+import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
 import { App, Checkbox, Tooltip, Typography, theme } from 'antd';
 import {
   BAIButton,
@@ -33,7 +33,6 @@ import {
   BAITable,
   BAIText,
   BAITag,
-  BAITrashBinIcon,
   BAIUnmountAfterClose,
   filterOutEmpty,
   filterOutNullAndUndefined,
@@ -255,7 +254,7 @@ const AdminModelCardListPage: React.FC = () => {
             {
               key: 'delete',
               title: t('button.Delete'),
-              icon: <BAITrashBinIcon />,
+              icon: <DeleteFilled />,
               type: 'danger' as const,
               onClick: () => handleDeleteModelCard(modelCard),
             },
@@ -375,7 +374,7 @@ const AdminModelCardListPage: React.FC = () => {
               />
               <BAIButton
                 danger
-                icon={<BAITrashBinIcon />}
+                icon={<DeleteFilled />}
                 onClick={handleBulkDelete}
                 loading={isBulkDeleteInFlight}
               />

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -45,7 +45,7 @@ import {
   CheckCircleOutlined,
   CheckOutlined,
   CloseOutlined,
-  DeleteOutlined,
+  DeleteFilled,
   ExclamationCircleOutlined,
   LoadingOutlined,
   PlusOutlined,
@@ -1172,7 +1172,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                         <Button
                           type="text"
                           icon={
-                            <DeleteOutlined
+                            <DeleteFilled
                               style={
                                 isEndpointInDestroyingCategory(endpoint)
                                   ? undefined

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -12,7 +12,7 @@ import BAIRadioGroup from '../components/BAIRadioGroup';
 import { convertToOrderBy } from '../helper';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { DeleteOutlined } from '@ant-design/icons';
+import { DeleteFilled } from '@ant-design/icons';
 import { App, Skeleton } from 'antd';
 import {
   availableDeploymentSorterValues,
@@ -236,7 +236,7 @@ const ProjectAdminDeploymentsContent: React.FC<
               {
                 key: 'delete',
                 title: t('button.Delete'),
-                icon: <DeleteOutlined />,
+                icon: <DeleteFilled />,
                 type: 'danger',
                 disabled: isDeleteDisabled,
                 onClick: () => {

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -18,6 +18,7 @@ import RoleNodes, {
 } from '../components/RoleNodes';
 import { convertToOrderBy } from '../helper';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { DeleteFilled } from '@ant-design/icons';
 import { App } from 'antd';
 import {
   BAIButton,
@@ -27,7 +28,6 @@ import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
-  BAITrashBinIcon,
   filterOutEmpty,
   type GraphQLFilter,
   INITIAL_FETCH_KEY,
@@ -327,7 +327,7 @@ const RBACManagementPage: React.FC = () => {
                                 {
                                   key: 'purge',
                                   title: t('rbac.PurgeRole'),
-                                  icon: <BAITrashBinIcon />,
+                                  icon: <DeleteFilled />,
                                   type: 'danger' as const,
                                   onClick: () => handlePurgeRole(role),
                                 },


### PR DESCRIPTION
Resolves #7311(FR-2848)

## Summary

Standardize trash-bin icon semantics across the entire WebUI:

- **`DeleteFilled`** = permanent / irreversible delete
- **`DeleteOutlined`** = move to trash / soft delete / reversible form-row removal

This is an icon-only refactor. No behavior, mutation, confirmation modal, or i18n string is changed.

## Changes

### `BAITrashBinIcon` retirement

The custom `BAITrashBinIcon` (a filled silhouette SVG) was previously used for both reversible "Move to Trash" actions (e.g. `data.folders.MoveToTrash`) and irreversible "Delete forever" actions, which made the two visually indistinguishable. It is now replaced everywhere by the standard antd `DeleteOutlined` / `DeleteFilled` pair so the semantic is unambiguous at a glance.

The `BAITrashBinIcon` component file itself is **kept** in `backend.ai-ui` for potential future use as a "Trash location" indicator (page header, tab label, sidebar destination), but no longer has any active usage.

### Switched `DeleteOutlined` → `DeleteFilled` (permanent delete)

| File | Justification |
|---|---|
| `react/src/components/AutoScalingRuleList.tsx` | `DeleteAutoScalingRuleInput` mutation |
| `react/src/components/AutoScalingRuleListLegacy.tsx` | `delete_endpoint_auto_scaling_rule_node` |
| `react/src/components/ContainerRegistryList.tsx` | `BAIConfirmModalWithInput` typed-confirmation flow |
| `react/src/components/CustomizedImageList.tsx` | `untag_image_from_registry` |
| `react/src/components/DeploymentAccessTokensTab.tsx` | `DeploymentAccessTokensTabDeleteMutation` |
| `react/src/components/DeploymentList.tsx` | `DeleteDeploymentInput` |
| `react/src/components/EndpointList.tsx` | terminate endpoint |
| `react/src/components/ErrorLogList.tsx` | clear all error logs (irrecoverable from UI) |
| `react/src/components/KeypairResourcePolicyList.tsx` | policy delete |
| `react/src/components/ProjectResourcePolicyList.tsx` | policy delete |
| `react/src/components/PrometheusQueryPresetNodes.tsx` | preset delete |
| `react/src/components/ResourceGroupList.tsx` | resource group delete |
| `react/src/components/ResourcePresetList.tsx` | preset delete |
| `react/src/components/ShellScriptEditModal.tsx` | typed-confirmation delete |
| `react/src/components/UserCredentialList.tsx` | credential delete |
| `react/src/components/UserResourcePolicyList.tsx` | policy delete |
| `react/src/pages/AIAgentPage.tsx` | agent delete |
| `react/src/pages/EndpointDetailPage.tsx` | auto-scaling rule delete |
| `react/src/pages/ProjectAdminDeploymentsPage.tsx` | deployment delete |

### Switched `BAITrashBinIcon` → `DeleteFilled` (permanent delete)

| File | Justification |
|---|---|
| `packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionDeleteButton.tsx` | revision permanent delete (`reservoirPage.RemoveThisVersion`) |
| `packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx` | single-file delete in VFolder file explorer (no trash for files) |
| `packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx` | bulk file delete in file explorer |
| `react/src/components/UserManagement.tsx` | `credential.PermanentlyDelete` + bulk delete |
| `react/src/components/AdminDeploymentPresetNodes.tsx` | preset delete (`button.Delete`) |
| `react/src/components/RoleAssignmentTab.tsx` | `rbac.RevokeUser` + danger button |
| `react/src/components/RolePermissionTab.tsx` | `rbac.RemovePermission` |
| `react/src/pages/AdminModelCardListPage.tsx` | model card delete + bulk delete |
| `react/src/pages/RBACManagementPage.tsx` | `rbac.PurgeRole` |
| `react/src/components/VFolderNodes.tsx` (line 205) | `data.folders.Delete` (delete-from-trash, permanent) |
| `react/src/components/VFolderNodesV2.tsx` (line 204) | `data.folders.Delete` (delete-from-trash, permanent) |

### Switched `BAITrashBinIcon` → `DeleteOutlined` (move to trash)

| File | Justification |
|---|---|
| `packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.tsx` | always rendered under `Tooltip title="data.folders.MoveToTrash"` |
| `packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButtonV2.tsx` | always rendered under `Tooltip title="data.folders.MoveToTrash"` |
| `react/src/components/VFolderNodes.tsx` (line 169) | `data.folders.MoveToTrash` row action |
| `react/src/components/VFolderNodesV2.tsx` (line 163) | `data.folders.MoveToTrash` row action |

### Files left unchanged (kept `DeleteOutlined`)

| File | Justification |
|---|---|
| `react/src/components/RoleFormModal.tsx` | `Form.List` row removal — reversible while form is unsubmitted |
| `react/src/components/ManageAppsModal.tsx` | `Form.List` row removal — reversible while form is unsubmitted |
| `packages/backend.ai-ui/src/components/Table/BAINameActionCell.stories.tsx` | abstract demo story; intentionally generic |

### Storybook

- `BAIConfirmModalWithInput.stories.tsx` and `BAIDeleteConfirmModal.stories.tsx` updated to use `DeleteFilled` so the trigger reflects the new convention (these modals exclusively front permanent-delete flows).

### Other

- `packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx` already uses `DeleteFilled` for the project Purge action (paired with a `BanIcon` for the reversible Inactivate). No icon change here, included for consistency reference.

## Out-of-scope follow-ups

The following call sites still use `Popconfirm` or `modal.confirm` for permanent deletion instead of `BAIConfirmModalWithInput`. They are flagged here for a follow-up; the icon swap is correct, but the modal type should also migrate per `.claude/rules/destructive-confirmation.md`:

- `AutoScalingRuleListLegacy.tsx` (Popconfirm L183-255)
- `UserCredentialList.tsx` (modal.confirm L413)
- `EndpointDetailPage.tsx` (Popconfirm L1115-1192)
- `AutoScalingRuleList.tsx` (modal.confirm L513)
- `ResourceGroupList.tsx` (modal.confirm L157)
- `BAIProjectTable.tsx` purge (uses `modal.confirm`)

## Test Plan

- [x] `bash scripts/verify.sh`: Relay PASS, Lint PASS, Format PASS. TypeScript fails only on pre-existing errors in `packages/backend.ai-client/src/client.ts` and `react/src/components/DeleteForeverVFolderModalV2.tsx` — both reproduce on a clean `main` checkout and are unrelated to this PR.
- [ ] Visual spot-check on dev server: filled trash for permanent delete, outlined trash for move-to-trash.