### PR TITLE
fix(FR-2831): disable Deploy as service action when no compatible presets exist

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -103,6 +103,23 @@ interface VFolderNameCellProps {
    * additionally redirects admins (project/domain/super) to that page.
    */
   disableProjectFolderActions?: boolean;
+  /**
+   * When true, the row-level "Deploy as service" action for model folders
+   * is rendered disabled with a tooltip explaining that no deployment
+   * presets are available. Computed once at the page level (via the page's
+   * `useLazyLoadQuery` selecting `deploymentRevisionPresets(first: 0) { count }`)
+   * and forwarded down through `VFolderNodes` so we don't fire one query
+   * per row. The `VFolderDeployModal` retains a `null`-return fallback for
+   * the same condition as defense in depth.
+   *
+   * TODO(needs-backend): the schema exposes
+   * `modelCardAvailablePresets(scope: { modelCardId })`, but we have a
+   * vfolder, not a model card, in this row. Either add a vfolder scope
+   * (`VFolderAvailablePresetsScope`) or expose a vfolder→modelCard link
+   * so we can narrow this check per row. Today this boolean reflects
+   * "any preset exists in this project."
+   */
+  hasNoCompatiblePresets?: boolean;
 }
 
 const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
@@ -113,6 +130,7 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
   onDeleteForever,
   onStartServiceFallback,
   disableProjectFolderActions = false,
+  hasNoCompatiblePresets = false,
 }) => {
   'use memo';
   const { t } = useTranslation();
@@ -148,6 +166,10 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
           key: 'start-service',
           title: t('modelService.DeployAsService'),
           icon: <BAIEndpointsIcon />,
+          disabled: hasNoCompatiblePresets,
+          disabledReason: hasNoCompatiblePresets
+            ? t('data.folders.NoCompatibleDeploymentPresets')
+            : undefined,
           onClick: () => onStartServiceFallback(vfolderId),
         }
       : null,
@@ -248,12 +270,29 @@ interface VFolderNodesProps extends Omit<
    * component. This prop is the V1-friendly stopgap.
    */
   disableProjectFolderActions?: boolean;
+  /**
+   * When true, the row-level "Deploy as service" action for model folders
+   * is rendered disabled with a tooltip explaining that no deployment
+   * presets are available. Derived at the page-level `useLazyLoadQuery`
+   * from `deploymentRevisionPresets(first: 0) { count }` so we don't fire
+   * one query per row. Defaults to `false` so existing call sites are
+   * additive — page hosts opt in by passing the derived value.
+   *
+   * TODO(needs-backend): the schema exposes
+   * `modelCardAvailablePresets(scope: { modelCardId })`, but we have a
+   * vfolder, not a model card, in this row. Either add a vfolder scope
+   * (`VFolderAvailablePresetsScope`) or expose a vfolder→modelCard link
+   * so we can narrow this check per row. Today this boolean reflects
+   * "any preset exists in this project."
+   */
+  hasNoCompatiblePresets?: boolean;
 }
 
 const VFolderNodes: React.FC<VFolderNodesProps> = ({
   vfoldersFrgmt,
   onRemoveRow,
   disableProjectFolderActions,
+  hasNoCompatiblePresets = false,
   ...tableProps
 }) => {
   const { t } = useTranslation();
@@ -346,6 +385,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                 <VFolderNameCell
                   vfolder={vfolder}
                   disableProjectFolderActions={disableProjectFolderActions}
+                  hasNoCompatiblePresets={hasNoCompatiblePresets}
                   onShare={() => {
                     vfolder?.user === currentUser?.uuid
                       ? setInviteFolderId(toLocalId(vfolder?.id ?? null))

--- a/react/src/components/VFolderNodesV2.tsx
+++ b/react/src/components/VFolderNodesV2.tsx
@@ -119,6 +119,23 @@ interface VFolderNameCellProps {
    * (FR-2599) for the given vfolder instead of navigating away.
    */
   onStartServiceFallback: (vfolderId: string) => void;
+  /**
+   * When true, the row-level "Deploy as service" action for model folders
+   * is rendered disabled with a tooltip explaining that no deployment
+   * presets are available. Computed once at the page level (via the page's
+   * `useLazyLoadQuery` selecting `deploymentRevisionPresets(first: 0) { count }`)
+   * and forwarded down through `VFolderNodesV2` so we don't fire one query
+   * per row. The `VFolderDeployModal` retains a `null`-return fallback for
+   * the same condition as defense in depth.
+   *
+   * TODO(needs-backend): the schema exposes
+   * `modelCardAvailablePresets(scope: { modelCardId })`, but we have a
+   * vfolder, not a model card, in this row. Either add a vfolder scope
+   * (`VFolderAvailablePresetsScope`) or expose a vfolder→modelCard link
+   * so we can narrow this check per row. Today this boolean reflects
+   * "any preset exists in this project."
+   */
+  hasNoCompatiblePresets?: boolean;
 }
 
 const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
@@ -128,6 +145,7 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
   onRestore,
   onDeleteForever,
   onStartServiceFallback,
+  hasNoCompatiblePresets = false,
 }) => {
   'use memo';
   const { t } = useTranslation();
@@ -147,6 +165,10 @@ const VFolderNameCell: React.FC<VFolderNameCellProps> = ({
           key: 'start-service',
           title: t('modelService.DeployAsService'),
           icon: <BAIEndpointsIcon />,
+          disabled: hasNoCompatiblePresets,
+          disabledReason: hasNoCompatiblePresets
+            ? t('data.folders.NoCompatibleDeploymentPresets')
+            : undefined,
           onClick: () => onStartServiceFallback(vfolderId),
         }
       : null,
@@ -409,11 +431,28 @@ interface VFolderNodesV2Props extends Omit<
   vfoldersFrgmt: VFolderNodesV2Fragment$key;
   // Callback when a row is removed from current list
   onRemoveRow?: (updatedFolderId?: string) => void;
+  /**
+   * When true, the row-level "Deploy as service" action for model folders
+   * is rendered disabled with a tooltip explaining that no deployment
+   * presets are available. Derived at the page-level `useLazyLoadQuery`
+   * from `deploymentRevisionPresets(first: 0) { count }` so we don't fire
+   * one query per row. Defaults to `false` so existing call sites are
+   * additive — page hosts opt in by passing the derived value.
+   *
+   * TODO(needs-backend): the schema exposes
+   * `modelCardAvailablePresets(scope: { modelCardId })`, but we have a
+   * vfolder, not a model card, in this row. Either add a vfolder scope
+   * (`VFolderAvailablePresetsScope`) or expose a vfolder→modelCard link
+   * so we can narrow this check per row. Today this boolean reflects
+   * "any preset exists in this project."
+   */
+  hasNoCompatiblePresets?: boolean;
 }
 
 const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
   vfoldersFrgmt,
   onRemoveRow,
+  hasNoCompatiblePresets = false,
   ...tableProps
 }) => {
   'use memo';
@@ -570,6 +609,7 @@ const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
               return (
                 <VFolderNameCell
                   vfolder={vfolder}
+                  hasNoCompatiblePresets={hasNoCompatiblePresets}
                   onShare={() => {
                     vfolder?.ownership?.userId === currentUser?.uuid
                       ? setInviteFolderId(toLocalId(vfolder?.id ?? null))

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -147,7 +147,7 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);
 
-  const { vfolder_nodes, ...folderCounts } =
+  const { vfolder_nodes, deploymentRevisionPresets, ...folderCounts } =
     useLazyLoadQuery<AdminVFolderNodeListPageQuery>(
       graphql`
         query AdminVFolderNodeListPageQuery(
@@ -196,6 +196,17 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
             filter: $filterForDeletedCount
             permission: $permission
           ) {
+            count
+          }
+          # Project-scoped check: gates the row-level Deploy as service
+          # action so model folders show a disabled tooltip instead of a
+          # fully interactive button that opens a modal which then returns
+          # null (FR-2831). Hoisted to the page-level query so we do not
+          # fire one query per row or per table.
+          # first: 1 rather than 0 because the backend's
+          # SearchDeploymentRevisionPresetsInput validates first >= 1.
+          # We only read count, so the single returned edge is unused.
+          deploymentRevisionPresets(first: 1) {
             count
           }
         }
@@ -459,6 +470,10 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
           <VFolderNodes
             order={queryParams.order}
             loading={deferredQueryVariables !== queryVariables}
+            // True only when we have a definitive zero — `null`/`undefined`
+            // (loading or query error) keeps the action enabled so we don't
+            // surface a misleading "no presets" tooltip in those cases.
+            hasNoCompatiblePresets={deploymentRevisionPresets?.count === 0}
             vfoldersFrgmt={filterOutNullAndUndefined(
               _.map(vfolder_nodes?.edges, 'node'),
             )}

--- a/react/src/pages/ProjectAdminDataPage.tsx
+++ b/react/src/pages/ProjectAdminDataPage.tsx
@@ -185,7 +185,7 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);
 
-  const { projectVfolders, ...folderCounts } =
+  const { projectVfolders, deploymentRevisionPresets, ...folderCounts } =
     useLazyLoadQuery<ProjectAdminDataPageQuery>(
       graphql`
         query ProjectAdminDataPageQuery(
@@ -227,6 +227,17 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
             projectId: $projectId
             filter: $filterForDeletedCount
           ) {
+            count
+          }
+          # Project-scoped check: gates the row-level Deploy as service
+          # action so model folders show a disabled tooltip instead of a
+          # fully interactive button that opens a modal which then returns
+          # null (FR-2831). Hoisted to the page-level query so we do not
+          # fire one query per row or per table.
+          # first: 1 rather than 0 because the backend's
+          # SearchDeploymentRevisionPresetsInput validates first >= 1.
+          # We only read count, so the single returned edge is unused.
+          deploymentRevisionPresets(first: 1) {
             count
           }
         }
@@ -433,6 +444,10 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
         <VFolderNodesV2
           order={queryParams.order}
           loading={deferredQueryVariables !== queryVariables}
+          // True only when we have a definitive zero — `null`/`undefined`
+          // (loading or query error) keeps the action enabled so we don't
+          // surface a misleading "no presets" tooltip in those cases.
+          hasNoCompatiblePresets={deploymentRevisionPresets?.count === 0}
           vfoldersFrgmt={filterOutNullAndUndefined(
             _.map(projectVfolders?.edges, 'node'),
           )}

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -181,7 +181,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [invitations.length]);
 
-  const { vfolder_nodes, ...folderCounts } =
+  const { vfolder_nodes, deploymentRevisionPresets, ...folderCounts } =
     useLazyLoadQuery<VFolderNodeListPageQuery>(
       graphql`
         query VFolderNodeListPageQuery(
@@ -234,6 +234,17 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             filter: $filterForDeletedCount
             permission: $permission
           ) {
+            count
+          }
+          # Project-scoped check: gates the row-level Deploy as service
+          # action so model folders show a disabled tooltip instead of a
+          # fully interactive button that opens a modal which then returns
+          # null (FR-2831). Hoisted to the page-level query so we do not
+          # fire one query per row or per table.
+          # first: 1 rather than 0 because the backend's
+          # SearchDeploymentRevisionPresetsInput validates first >= 1.
+          # We only read count, so the single returned edge is unused.
+          deploymentRevisionPresets(first: 1) {
             count
           }
         }
@@ -509,6 +520,10 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             order={queryParams.order}
             loading={deferredQueryVariables !== queryVariables}
             disableProjectFolderActions
+            // True only when we have a definitive zero — `null`/`undefined`
+            // (loading or query error) keeps the action enabled so we don't
+            // surface a misleading "no presets" tooltip in those cases.
+            hasNoCompatiblePresets={deploymentRevisionPresets?.count === 0}
             vfoldersFrgmt={filterOutNullAndUndefined(
               _.map(vfolder_nodes?.edges, 'node'),
             )}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "{{count}} von {{total}} Ordnern wurden dauerhaft gelöscht.",
       "MultipleFolderRestored": "Ausgewählte {{ folderLength }} Ordner wurden wiederhergestellt.",
       "Name": "Name",
+      "NoCompatibleDeploymentPresets": "Keine Deployment-Presets verfügbar.",
       "NoDeletePermission": "Keine Löschberechtigung",
       "NoFolderToDisplay": "Keine Ordner anzeigen",
       "NoRestorePermission": "Keine Wiederherstellungsberechtigung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Διαγράφηκαν οριστικά {{count}} από τους {{total}} φακέλους.",
       "MultipleFolderRestored": "Επιλεγμένα {{ folderLength }} Φάκελοι έχει αποκατασταθεί.",
       "Name": "Ονομα",
+      "NoCompatibleDeploymentPresets": "Δεν υπάρχουν διαθέσιμα προεπιλογές ανάπτυξης.",
       "NoDeletePermission": "Δεν υπάρχει δικαίωμα διαγραφής",
       "NoFolderToDisplay": "Δεν εμφανίζονται φάκελοι",
       "NoRestorePermission": "Δεν υπάρχει δικαίωμα επαναφοράς",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -791,6 +791,7 @@
       "MultipleFolderDeletedForever": "Permanently deleted {{count}} folders out of {{total}}.",
       "MultipleFolderRestored": "Selected {{ folderLength }} folders has been restored.",
       "Name": "Name",
+      "NoCompatibleDeploymentPresets": "No deployment presets available.",
       "NoDeletePermission": "No delete permission",
       "NoFolderToDisplay": "No Folders to display",
       "NoRestorePermission": "No restore permission",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Se eliminaron permanentemente {{count}} carpetas de {{total}}.",
       "MultipleFolderRestored": "Se han restaurado las carpetas seleccionadas {{ folderLength }}.",
       "Name": "Nombre",
+      "NoCompatibleDeploymentPresets": "No hay preajustes de implementación disponibles.",
       "NoDeletePermission": "Sin permiso de eliminación",
       "NoFolderToDisplay": "No hay carpetas que mostrar",
       "NoRestorePermission": "Sin permiso de restauración",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Poistettiin pysyvästi {{count}}/{{total}} kansiota.",
       "MultipleFolderRestored": "Valitut {{ folderLength }} kansiot on palautettu.",
       "Name": "Nimi",
+      "NoCompatibleDeploymentPresets": "Ei käytettävissä olevia käyttöönottoesiasetuksia.",
       "NoDeletePermission": "Ei poistolupaa",
       "NoFolderToDisplay": "Ei näytettäviä kansioita",
       "NoRestorePermission": "Ei palautuslupaa",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "{{count}} dossiers sur {{total}} ont été supprimés définitivement.",
       "MultipleFolderRestored": "Les dossiers sélectionnés {{ folderLength }} ont été restaurés.",
       "Name": "Nom",
+      "NoCompatibleDeploymentPresets": "Aucun préréglage de déploiement disponible.",
       "NoDeletePermission": "Pas d'autorisation de suppression",
       "NoFolderToDisplay": "Aucun dossier à afficher",
       "NoRestorePermission": "Pas d'autorisation de restauration",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Berhasil menghapus permanen {{count}} dari {{total}} folder.",
       "MultipleFolderRestored": "Folder {{ folderLength }} yang dipilih telah dipulihkan.",
       "Name": "Nama",
+      "NoCompatibleDeploymentPresets": "Tidak ada preset deployment yang tersedia.",
       "NoDeletePermission": "Tidak ada izin hapus",
       "NoFolderToDisplay": "Tidak ada Folder untuk ditampilkan",
       "NoRestorePermission": "Tidak ada izin pemulihan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Eliminate definitivamente {{count}} cartelle su {{total}}.",
       "MultipleFolderRestored": "Le cartelle selezionate {{ folderLength }} sono state ripristinate.",
       "Name": "Nome",
+      "NoCompatibleDeploymentPresets": "Nessun preset di distribuzione disponibile.",
       "NoDeletePermission": "Nessun permesso di cancellazione",
       "NoFolderToDisplay": "Nessuna cartella da visualizzare",
       "NoRestorePermission": "Nessun permesso di ripristino",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "{{total}}個中{{count}}個のフォルダを完全に削除しました。",
       "MultipleFolderRestored": "選択された{{ folderLength }}フォルダーが復元されました。",
       "Name": "名前",
+      "NoCompatibleDeploymentPresets": "利用可能なデプロイメントプリセットがありません。",
       "NoDeletePermission": "削除許可なし",
       "NoFolderToDisplay": "フォルダ情報がありません。",
       "NoRestorePermission": "復元許可なし",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -791,6 +791,7 @@
       "MultipleFolderDeletedForever": "총 {{total}}개 중 {{count}}개의 폴더를 영구 삭제했습니다.",
       "MultipleFolderRestored": "선택한 {{ folderLength }} 폴더가 복원되었습니다.",
       "Name": "이름",
+      "NoCompatibleDeploymentPresets": "사용 가능한 배포 프리셋이 없습니다.",
       "NoDeletePermission": "삭제 권한이 없습니다",
       "NoFolderToDisplay": "폴더 정보가 없습니다.",
       "NoRestorePermission": "복원 권한이 없습니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Нийт {{total}} хавтаснаас {{count}} хавтасыг бүрмөсөн устгасан.",
       "MultipleFolderRestored": "Сонгосон {{ folderLength }} хавтасыг сэргээв.",
       "Name": "Нэр",
+      "NoCompatibleDeploymentPresets": "Байршуулах урьдчилан тохиргоо байхгүй байна.",
       "NoDeletePermission": "Устгах зөвшөөрөл байхгүй байна",
       "NoFolderToDisplay": "Харуулах хавтас байхгүй",
       "NoRestorePermission": "Сэргээх зөвшөөрөл байхгүй байна",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "{{count}} daripada {{total}} folder telah dipadam secara kekal.",
       "MultipleFolderRestored": "Dipilih {{ folderLength }} Folder telah dipulihkan.",
       "Name": "Nama",
+      "NoCompatibleDeploymentPresets": "Tiada pratetap penggunaan yang tersedia.",
       "NoDeletePermission": "Tiada kebenaran memadam",
       "NoFolderToDisplay": "Tiada Folder untuk dipaparkan",
       "NoRestorePermission": "Tiada kebenaran memulihkan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Trwale usunięto {{count}} z {{total}} folderów.",
       "MultipleFolderRestored": "Wybrane foldery {{ folderLength }} zostały przywrócone.",
       "Name": "Nazwa",
+      "NoCompatibleDeploymentPresets": "Brak dostępnych ustawień wstępnych wdrożenia.",
       "NoDeletePermission": "Brak uprawnień do usuwania",
       "NoFolderToDisplay": "Brak wyświetlanych folderów",
       "NoRestorePermission": "Brak uprawnień do przywracania",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "{{count}} de {{total}} pastas foram excluídas permanentemente.",
       "MultipleFolderRestored": "As pastas selecionadas {{ folderLength }} foram restauradas.",
       "Name": "Nome",
+      "NoCompatibleDeploymentPresets": "Não há predefinições de implantação disponíveis.",
       "NoDeletePermission": "Sem permissão de eliminação",
       "NoFolderToDisplay": "Não há pastas a apresentar",
       "NoRestorePermission": "Sem permissão de restauração",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Excluídas permanentemente {{count}} de {{total}} pastas.",
       "MultipleFolderRestored": "As pastas selecionadas {{ folderLength }} foram restauradas.",
       "Name": "Nome",
+      "NoCompatibleDeploymentPresets": "Não há predefinições de implementação disponíveis.",
       "NoDeletePermission": "Sem permissão de eliminação",
       "NoFolderToDisplay": "Não há pastas a apresentar",
       "NoRestorePermission": "Sem permissão de restauração",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Навсегда удалено {{count}} из {{total}} папок.",
       "MultipleFolderRestored": "Выбранные папки {{ folderLength }} были восстановлены.",
       "Name": "Имя",
+      "NoCompatibleDeploymentPresets": "Нет доступных предустановок развёртывания.",
       "NoDeletePermission": "Нет разрешения на удаление",
       "NoFolderToDisplay": "Нет папок для отображения",
       "NoRestorePermission": "Нет разрешения на восстановление",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "ลบถาวรแล้ว {{count}} จาก {{total}} โฟลเดอร์",
       "MultipleFolderRestored": "โฟลเดอร์ที่เลือก {{ folderLength }} ได้รับการกู้คืนแล้ว",
       "Name": "ชื่อ",
+      "NoCompatibleDeploymentPresets": "ไม่มีการตั้งค่าล่วงหน้าสำหรับการปรับใช้.",
       "NoDeletePermission": "ไม่มีการลบการอนุญาต",
       "NoFolderToDisplay": "ไม่มีโฟลเดอร์ที่จะแสดง",
       "NoRestorePermission": "ไม่มีการกู้คืนการอนุญาต",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "{{total}} klasörden {{count}} tanesi kalıcı olarak silindi.",
       "MultipleFolderRestored": "Seçilen {{ folderLength }} klasörleri geri yüklendi.",
       "Name": "isim",
+      "NoCompatibleDeploymentPresets": "Kullanılabilir dağıtım ön ayarı yok.",
       "NoDeletePermission": "Silme izni yok",
       "NoFolderToDisplay": "Görüntülenecek Klasör Yok",
       "NoRestorePermission": "Geri yükleme izni yok",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "Đã xóa vĩnh viễn {{count}} thư mục trong tổng số {{total}}.",
       "MultipleFolderRestored": "Đã chọn {{ folderLength }} Các thư mục đã được khôi phục.",
       "Name": "Tên",
+      "NoCompatibleDeploymentPresets": "Không có cài đặt triển khai sẵn có.",
       "NoDeletePermission": "Không xóa quyền",
       "NoFolderToDisplay": "Không có thư mục nào để hiển thị",
       "NoRestorePermission": "Không có quyền khôi phục",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "已从 {{total}} 个文件夹中永久删除 {{count}} 个。",
       "MultipleFolderRestored": "所选{{ folderLength }}文件夹已还原。",
       "Name": "名称",
+      "NoCompatibleDeploymentPresets": "没有可用的部署预设。",
       "NoDeletePermission": "无删除权限",
       "NoFolderToDisplay": "无文件夹显示",
       "NoRestorePermission": "无恢复权限",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -790,6 +790,7 @@
       "MultipleFolderDeletedForever": "已從 {{total}} 個資料夾中永久刪除 {{count}} 個。",
       "MultipleFolderRestored": "所選{{ folderLength }}文件夾已還原。",
       "Name": "名稱",
+      "NoCompatibleDeploymentPresets": "沒有可用的部署預設。",
       "NoDeletePermission": "无删除权限",
       "NoFolderToDisplay": "无文件夹显示",
       "NoRestorePermission": "無還原權限",


### PR DESCRIPTION
Resolves #7282 (FR-2831)

## Summary

On the `/data` page, the row-level "Deploy as service" icon button on a model folder looked fully clickable but did nothing — the modal it opened (`VFolderDeployModal`) early-returns `null` when `deploymentRevisionPresets` is empty, so the user got no chrome, no message, no feedback. Combined with the separate mutation failure tracked by #7249, this presented as a completely silent broken control.

This PR gates the row-level action so it visibly communicates its state instead of pretending to be clickable.

## Approach

Took **approach (a)** from the issue brief: hoisted a count-only `deploymentRevisionPresets(first: 1) { count }` field into the **page-level** `useLazyLoadQuery` of each consumer page (`VFolderNodeListPage`, `AdminVFolderNodeListPage`, `ProjectAdminDataPage`), derive `hasNoCompatiblePresets` from the count, and pass it down as an additive prop to `VFolderNodes` / `VFolderNodesV2`. The shared table components stay fragment consumers — no `useLazyLoadQuery` lives inside them.

The "Deploy as service" action now sets `disabled` + `disabledReason` so it renders greyed out with a tooltip ("No deployment presets available.") instead of opening an empty modal.

> **Note on `first: 1`** — the backend's `SearchDeploymentRevisionPresetsInput` runs a pydantic validator that requires `first >= 1`, so we cannot use `first: 0`. We only read `count` (which is independent of the edges returned), so the single returned edge is unused.

Why hoist to the page level (not the table component):

- Matches the direction the project just moved in (`dfc0d7819` / FR-2842, two days ago: "hoist DeploymentConfigurationSection query to page level"). Shared `*Nodes*` table components are fragment consumers; query roots belong on pages.
- One query per page render, shared by every row.
- Adding the field to existing page queries is a one-line selection-set addition; the alternative (a second query per table) would have fired duplicate requests on pages that already query the project scope.

The `if (hasNoPresets) return null;` early-return inside `VFolderDeployModal` is intentionally left in place as a defense-in-depth safety net — if anything else opens the modal in this state (e.g. a future entry point), it still won't render fragmentary chrome.

`hasNoCompatiblePresets` is derived as `deploymentRevisionPresets?.count === 0` (true only on a definitive zero) so a `null`/`undefined` count (loading or query error) does **not** misleadingly disable the button.

`TODO(needs-backend)` markers note that once the schema exposes a per-vfolder compatibility filter (today only `modelCardAvailablePresets(scope: { modelCardId })` exists, and we have a vfolder rather than a model card here), the check should be narrowed to the actual matching presets per row.

## Files changed

- `react/src/components/VFolderNodes.tsx` — accept `hasNoCompatiblePresets` prop; gate the action via `disabled` + `disabledReason`. No more `useLazyLoadQuery` inside the table.
- `react/src/components/VFolderNodesV2.tsx` — same.
- `react/src/pages/VFolderNodeListPage.tsx` — extend page-level query to select `deploymentRevisionPresets(first: 1) { count }`; pass derived boolean to `<VFolderNodes>`.
- `react/src/pages/AdminVFolderNodeListPage.tsx` — same.
- `react/src/pages/ProjectAdminDataPage.tsx` — same, for `<VFolderNodesV2>`.
- `resources/i18n/en.json` — `data.folders.NoCompatibleDeploymentPresets`: `"No deployment presets available."` (deployment presets are not project-scoped, so we don't qualify them).
- `resources/i18n/{20 other locales}.json` — proper translations of the same string in every supported language (ko, ja, zh-CN, zh-TW, de, es, fr, it, pl, pt, pt-BR, ru, tr, vi, th, id, ms, mn, fi, el).

## Review feedback applied

- Hoisted preset-count query from the shared table components to each consumer page's existing `useLazyLoadQuery` (matches the FR-2842 direction).
- Fixed `(deploymentRevisionPresets?.count ?? 0) === 0` to `deploymentRevisionPresets?.count === 0` so we only disable on a definitive zero, not while loading or on error.
- Removed "in this project" qualifier from the tooltip — deployment presets are not project-scoped, so the qualifier was misleading.
- Replaced the English placeholder in the 20 non-English locale files with proper localized translations (the previous amendment had copied the English string into every locale as a placeholder; the `/fw:i18n` flow now provides real translations).
- Switched `deploymentRevisionPresets(first: 0)` to `first: 1` because the backend's pydantic validator on `SearchDeploymentRevisionPresetsInput.first` requires `>= 1`. The connection's `count` field is independent of the requested edges, so `count` is still authoritative.

## Related

- #7249 — separate failure mode (the deploy mutation itself fails on a GraphQL schema mismatch). This PR does not touch the mutation; it only fixes "the button doesn't communicate its state."

## Verification

`bash scripts/verify.sh`:

- Relay: PASS
- Lint: PASS
- Format: PASS
- TypeScript: pre-existing failures in unrelated files (`packages/backend.ai-client/src/client.ts` implicit-any params and `react/src/components/DeleteForeverVFolderModalV2.tsx` `BulkPurgeVFoldersV2Input` shape) — none introduced by this PR. Files touched in this PR have zero TypeScript errors.

## Test plan

- [ ] On `/data`, with a project/scope that has zero deployment presets, model folders show "Deploy as service" greyed out with the tooltip "No deployment presets available."
- [ ] On `/data`, with at least one preset available, the action is enabled and opens the existing preset-selection modal.
- [ ] Non-model folders are unaffected (no "Deploy as service" action shown).
- [ ] Soft-deleted (trash bin) folders are unaffected.
- [ ] Switch UI language to ko/ja/zh-CN — tooltip displays the localized translation, not the raw key or the English string.
