### PR TITLE
fix(FR-2853): restore copymonaco script lost during 26.4 main-merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "wsproxy": "node ./src/wsproxy/local_proxy.js",
-    "build": "rm -rf build/web dist && mkdir -p build/web && pnpm run copyindex && pnpm run copyresource && pnpm run copyconfig && tsc && pnpm run -r --stream build",
+    "build": "rm -rf build/web dist && mkdir -p build/web && pnpm run copyindex && pnpm run copyresource && pnpm run copyconfig && pnpm run copymonaco && tsc && pnpm run -r --stream build",
     "build:react-only": "pnpm run --prefix ./react build:only",
     "server:p": "serve build/web",
     "dev": "node scripts/dev.mjs",
@@ -29,6 +29,7 @@
     "copyresource": "cp -Rp resources build/web && cp -Rp manifest build/web",
     "copyconfig": "./scripts/copy-config.js && cp version.json build/web && cp manifest.json build/web",
     "copyindex": "cp index.html build/web",
+    "copymonaco": "mkdir -p build/web/resources/monaco/vs && cp -R react/node_modules/monaco-editor/min/vs/. build/web/resources/monaco/vs/",
     "prepare": "husky",
     "theme-schema:update": "node scripts/gen-theme-schema.cjs"
   },


### PR DESCRIPTION
Resolves [FR-2853](https://lablup.atlassian.net/browse/FR-2853)

## Problem

Releases **v26.4.6** and **v26.4.7** ship a release zip that is missing the Monaco editor bundle. After unpacking, `resources/monaco/vs/loader.js` and the rest of `resources/monaco/vs/` are absent, so any UI that uses Monaco (VFolder file editor, Theme JSON config modal) fails to load with a 404 on `/resources/monaco/vs/loader.js` in deployed environments.

## Root cause

PR #6959 (FR-2697, commit `547b702f1`, 2026-04-24) added a root `copymonaco` npm script and wired it into the root `build` chain so the Monaco AMD tree is copied from `react/node_modules/monaco-editor/min/vs` into `build/web/resources/monaco/vs/` during the production build. CI bundles `build/web/` directly into the release zip via `Makefile:201 bundle` (called from `.github/workflows/package.yml` `build_web` job), so the `copymonaco` step is what makes Monaco end up in the release artifact.

The merge commit `e5ea9500f` ("Merge branch 'main' into 26.4", 2026-04-24) brought `547b702f1` into the `26.4` release branch but, while resolving conflicts in `package.json` / `electron-app/package.json` / `index.html`, both the `copymonaco` script definition and its invocation in `build` were silently dropped from root `package.json`.

Verification:

- `git show v26.4.7:package.json | grep monaco` → empty.
- `git show v26.4.6:package.json | grep monaco` → empty.
- `git show origin/main:package.json | grep monaco` → both lines present (correct).
- `git merge-base v26.4.5 547b702f1` resolves to `64b9edbcb`; at the merge base the `build` line did not contain `copymonaco`. Only `547b702f1` (one parent of the merge) added it, and `26.4` never modified it — a clean 3-way merge would have brought it through. The deletion was a manual resolution mistake in the merge commit.

`main` is unaffected, which is why local builds done from `main` reproduce Monaco correctly and the regression was not caught before two releases.

## Fix

Restore the two lines in root `package.json` (effectively cherry-picking only the `package.json` hunk of `547b702f1`):

1. In `scripts.build`, re-insert `&& pnpm run copymonaco` between `copyconfig` and `tsc`.
2. Re-add `"copymonaco": "mkdir -p build/web/resources/monaco/vs && cp -R react/node_modules/monaco-editor/min/vs/. build/web/resources/monaco/vs/"` under `scripts`.

## Test plan

- [ ] `pnpm run build` produces `build/web/resources/monaco/vs/loader.js` (and the rest of the Monaco tree).
- [ ] `make bundle` produced zip contains `resources/monaco/vs/loader.js` and the language sub-trees.
- [ ] Open VFolder file editor and Theme JSON config modal against a build served from `build/web/` — both load with no 404 on `/resources/monaco/vs/*`.
- [ ] Cut **v26.4.8** patch release including this fix.

## Follow-up (separate issue, not in this PR)

Add a CI guard in the `build_web` job that fails the build if `build/web/resources/monaco/vs/loader.js` is absent — the failure mode here was silent (build succeeded, only the runtime broke), and a one-line existence check would have caught it.

[FR-2853]: https://lablup.atlassian.net/browse/FR-2853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ