### PR TITLE
fix: drop stale pnpm@10 pin in amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -112,15 +112,15 @@ applications:
             # lives at the repo root; nvm walks up to find it.
             - nvm install
             - nvm use
-            # Pin pnpm to the major declared by `package.json#engines.pnpm`
-            # (currently ^10.16.0). `pnpm@latest` would be non-reproducible —
-            # a future major could change install behavior without warning.
-            # When the repo root adds a `packageManager` field to
-            # `package.json`, corepack will auto-use it and the explicit
-            # `prepare` line below can be dropped (just `corepack enable`
-            # would suffice).
+            # Pin pnpm to the version declared by `package.json#packageManager`
+            # (currently `pnpm@11.0.8`). With that field present, `corepack
+            # enable` is sufficient — corepack auto-resolves the pinned
+            # version on the first pnpm invocation. Do NOT add a
+            # `corepack prepare pnpm@<major> --activate` line here: a stale
+            # major (e.g. `@10` left behind after `package.json` bumped to v11)
+            # silently overrides `packageManager` and produces broken
+            # workspace bin links (FR-2840 follow-up).
             - corepack enable
-            - corepack prepare pnpm@10 --activate
             # Reproducible installs only — never `--no-frozen-lockfile`.
             # `pnpm install` from anywhere in the workspace installs the
             # entire monorepo by default (it locates the workspace root
@@ -242,8 +242,9 @@ applications:
           commands:
             - nvm install
             - nvm use
+            # `corepack enable` is sufficient when `package.json#packageManager`
+            # is set (see the docs entry above for the rationale).
             - corepack enable
-            - corepack prepare pnpm@10 --activate
             - pnpm install --frozen-lockfile
         build:
           commands:
@@ -282,8 +283,9 @@ applications:
           commands:
             - nvm install
             - nvm use
+            # `corepack enable` is sufficient when `package.json#packageManager`
+            # is set (see the docs entry above for the rationale).
             - corepack enable
-            - corepack prepare pnpm@10 --activate
             - pnpm install --frozen-lockfile
             # Relay codegen for both projects, invoked at the
             # workspace root via pnpm's `-w` flag so the current


### PR DESCRIPTION
Fixes the AWS Amplify docs deployment failure introduced after FR-2840 (#7307) bumped pnpm to v11.

## Symptom

```
# Executing command: pnpm --filter backend.ai-webui-docs exec docs-toolkit build:web --lang all --no-strict
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "docs-toolkit" not found
!!! Build failed
```

## Root cause

\`amplify.yml\` activated pnpm via:

\`\`\`yaml
- corepack enable
- corepack prepare pnpm@10 --activate
\`\`\`

After #7307, \`package.json\` declares \`packageManager: pnpm@11.0.8\` and \`engines.pnpm: ^11.0.0\`, but the \`prepare pnpm@10\` line silently overrode \`packageManager\` in the build environment. pnpm v10 then ran against the v11-shaped lockfile and failed to wire the workspace bin link for \`backend.ai-docs-toolkit\`, so \`pnpm exec docs-toolkit ...\` resolved nothing.

## Fix

Drop the \`corepack prepare pnpm@<major>\` line in all three \`applications[]\` entries (docs, react, storybook). \`corepack enable\` alone is sufficient — modern corepack reads \`package.json#packageManager\` automatically. The new comment also warns against re-adding a major pin, so future pnpm bumps no longer require an \`amplify.yml\` edit.

## Verification

- Local: \`pnpm install --frozen-lockfile && pnpm --filter backend.ai-docs-toolkit run build && pnpm install --frozen-lockfile && pnpm --filter backend.ai-webui-docs exec docs-toolkit --help\` resolves the CLI under pnpm 11.0.8.
- Amplify: next deploy of the docs app should proceed past the \`docs-toolkit build:web\` step.