### PR TITLE
ci(FR-2861): drop pnpm/action-setup version: 11 (use packageManager field)

### DIFF
--- a/.github/actions/daily-test-improver/coverage-steps/action.yml
+++ b/.github/actions/daily-test-improver/coverage-steps/action.yml
@@ -8,7 +8,6 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v5
       with:
-        version: 11
         run_install: false
 
     - name: Setup Node.js

--- a/.github/workflows/e2e-healer.lock.yml
+++ b/.github/workflows/e2e-healer.lock.yml
@@ -110,8 +110,6 @@ jobs:
         with:
           node-version: "20"
       - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
-        with:
-          version: 11
       - name: Print E2E endpoints
         run: "echo \"=== E2E Test Configuration ===\"\necho \"E2E_WEBUI_ENDPOINT: $E2E_WEBUI_ENDPOINT\"\necho \"E2E_WEBSERVER_ENDPOINT: $E2E_WEBSERVER_ENDPOINT\"\n"
       - run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/e2e-watchdog.lock.yml
+++ b/.github/workflows/e2e-watchdog.lock.yml
@@ -103,8 +103,6 @@ jobs:
         with:
           node-version: "20"
       - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
-        with:
-          version: 11
       - name: Print E2E endpoints
         run: "echo \"=== E2E Test Configuration ===\"\necho \"E2E_WEBUI_ENDPOINT: $E2E_WEBUI_ENDPOINT\"\necho \"E2E_WEBSERVER_ENDPOINT: $E2E_WEBSERVER_ENDPOINT\"\n"
       - run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,7 +45,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
 
       - name: Install Node.js
@@ -100,7 +99,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
 
       - name: Install Node.js
@@ -168,7 +166,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
 
       - name: Install Node.js
@@ -234,7 +231,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/publish-backend.ai-docs-toolkit.yml
+++ b/.github/workflows/publish-backend.ai-docs-toolkit.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/publish-backend.ai-ui.yml
+++ b/.github/workflows/publish-backend.ai-ui.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -59,7 +59,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
       - uses: actions/setup-node@v5
         with:
@@ -104,7 +103,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
       - uses: actions/setup-node@v5
         with:
@@ -146,7 +144,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/weekly-merge-branch-lockfiles.yml
+++ b/.github/workflows/weekly-merge-branch-lockfiles.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: pnpm/action-setup@v5
         name: Install pnpm
         with:
-          version: 11
           run_install: false
 
       - uses: actions/setup-node@v5

--- a/amplify.yml
+++ b/amplify.yml
@@ -113,7 +113,7 @@ applications:
             - nvm install
             - nvm use
             # Pin pnpm to the version declared by `package.json#packageManager`
-            # (currently `pnpm@11.0.8`). With that field present, `corepack
+            # (currently `pnpm@11.1.0`). With that field present, `corepack
             # enable` is sufficient — corepack auto-resolves the pinned
             # version on the first pnpm invocation. Do NOT add a
             # `corepack prepare pnpm@<major> --activate` line here: a stale

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "pnpm": "^11.0.0"
   },
-  "packageManager": "pnpm@11.0.8",
+  "packageManager": "pnpm@11.1.0",
   "scripts": {
     "lint": "eslint src --quiet; exit 0",
     "lint-fix": "eslint src --quiet --fix; exit 0",


### PR DESCRIPTION
Resolves #7344(FR-2861)

## Summary

Since the pnpm v11 migration ([FR-2840 / #7307](https://github.com/lablup/backend.ai-webui/pull/7307)), the root `package.json` declares `"packageManager": "pnpm@11.1.0"`. Several GitHub Actions workflows still pass `version: 11` to `pnpm/action-setup@v5`, which fails on every PR with:

```
Error: Multiple versions of pnpm specified:
  - version 11 in the GitHub Action config with the key "version"
  - version pnpm@11.1.0 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

Example failure: https://github.com/lablup/backend.ai-webui/actions/runs/25669252851/job/75349895261

This blocks `react-vitest` (and the publish / package / weekly-merge / e2e-watchdog / e2e-healer jobs) for every open PR.

## Fix

Drop the `version: 11` input from all `pnpm/action-setup@v5` calls. With `packageManager` set, pnpm/action-setup uses it as the single source of truth.

For two `.lock.yml` steps where `version: 11` was the only `with:` input, also drop the now-empty `with:` mapping (which GitHub Actions rejects).

Also bump the pinned pnpm version from `11.0.8` to `11.1.0` (current npm `latest`) so the field reflects the latest patch. Verified via `corepack prepare pnpm@11.1.0 --activate` + `pnpm install --frozen-lockfile` (lockfile compatible — no migration).

## Changes

- `.github/workflows/vitest.yml` (3 occurrences — the active PR blocker)
- `.github/workflows/publish-backend.ai-ui.yml`
- `.github/workflows/publish-backend.ai-docs-toolkit.yml`
- `.github/workflows/package.yml` (4)
- `.github/workflows/weekly-merge-branch-lockfiles.yml`
- `.github/workflows/e2e-healer.lock.yml` (also drop empty `with:`)
- `.github/workflows/e2e-watchdog.lock.yml` (also drop empty `with:`)
- `.github/actions/daily-test-improver/coverage-steps/action.yml` (composite action, surfaced by Copilot)
- `package.json` — bump `packageManager` to `pnpm@11.1.0`
- `amplify.yml` — sync the pinned-version comment

`e2e-watchdog.md` / `e2e-healer.md` are documentation, not active workflows — left untouched.

## Verification

- The pnpm/action-setup error will not reproduce against this PR's CI.
- Existing tests run as before (no change to install command, just the action input).
- `pnpm install --frozen-lockfile` with `pnpm@11.1.0` reports `Already up to date` — lockfile remains valid.