### PR TITLE
fix: use pnpm rebuild to wire docs-toolkit bin under pnpm v11

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -130,13 +130,23 @@ applications:
             # the package bin, but it lives at dist/cli.js which only
             # exists after `tsc` runs. On a fresh `pnpm install` the
             # dist directory is empty, so pnpm cannot create the
-            # .bin/docs-toolkit symlink and the later `build:web` step
-            # fails with `spawn ENOENT`. Building the toolkit and
-            # re-running install populates dist/ and lets pnpm wire
-            # the bin link. (Same pattern as FR-2719's build_docs job
-            # in package.yml and the docs-archive workflow.)
+            # `.bin/docs-toolkit` symlink — it emits a warning and skips
+            # the link. After building the toolkit we have to ask pnpm
+            # to (re)wire the bin links.
+            #
+            # Subtle pnpm-v11 behavior: a second `pnpm install
+            # --frozen-lockfile` here is a no-op (`Already up to date`,
+            # ~100ms) because the lockfile is already satisfied — it
+            # does NOT revisit bin links. `pnpm rebuild` is what
+            # actually re-runs link creation against the now-populated
+            # `dist/`. Without this the later `pnpm exec docs-toolkit`
+            # call fails with `[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL]
+            # Command "docs-toolkit" not found`. (Same chicken-and-egg
+            # pattern as FR-2719's build_docs job in package.yml and
+            # the docs-archive workflow; the v10→v11 bump in #7307
+            # silently regressed the old install/build/install dance.)
             - pnpm --filter backend.ai-docs-toolkit run build
-            - pnpm install --frozen-lockfile
+            - pnpm rebuild
         build:
           commands:
             # The toolkit's website-generator (FR-2710 F6) iterates


### PR DESCRIPTION
Follow-up to #7342. The previous fix dropped a stale `pnpm@10` pin in `amplify.yml` but the Amplify docs build kept failing with the same error:

```
# Executing command: pnpm --filter backend.ai-webui-docs exec docs-toolkit build:web --lang all --no-strict
undefined
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "docs-toolkit" not found
```

## Root cause (verified locally)

`backend.ai-docs-toolkit` exposes its CLI via `package.json#bin.docs-toolkit → ./dist/cli.js`, but `dist/cli.js` only exists after `tsc` runs. The existing `amplify.yml` flow tried to work around the chicken-and-egg by running install **twice** around the toolkit build:

```yaml
- pnpm install --frozen-lockfile          # 1st: dist/ empty → bin link skipped with warning
- pnpm --filter backend.ai-docs-toolkit run build   # populates dist/cli.js
- pnpm install --frozen-lockfile          # 2nd: hoping pnpm wires the bin link
```

Reproducing on a clean `git clone` of `main` HEAD with pnpm v11.0.8:

```
[WARN] Failed to create bin at .../node_modules/.bin/docs-toolkit.
       ENOENT: no such file or directory, open '.../backend.ai-docs-toolkit/dist/cli.js'
...
$ pnpm install --frozen-lockfile           # 2nd run
Scope: all 8 workspace projects
Already up to date
Done in 113ms using pnpm v11.0.8
$ pnpm --filter backend.ai-webui-docs exec docs-toolkit --help
undefined
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "docs-toolkit" not found
```

In pnpm v11, the second install sees the lockfile already satisfied and exits in ~100 ms without re-running bin link creation. The first install's warning-skipped link stays broken. `--force` does not help (it still short-circuits on the satisfied lockfile). The v10→v11 bump in #7307 silently regressed this dance — v10 was apparently lenient here.

## Fix

Replace the second `pnpm install --frozen-lockfile` with `pnpm rebuild`, which is the documented mechanism for re-running link creation against the current `node_modules`. After this:

```
$ pnpm rebuild
$ ls node_modules/.bin/docs-toolkit
-rwxr-xr-x  1 codejong  wheel  802 ... node_modules/.bin/docs-toolkit
$ pnpm --filter backend.ai-webui-docs exec docs-toolkit build:web --lang all --no-strict
[next/en] Done: 29 pages generated (2.1s)
[next/ko] Done: 29 pages generated (2.1s)
[next/ja] Done: 29 pages generated (2.1s)
[next/th] Done: 29 pages generated (2.1s)
Website generated at: .../dist/web
```

`dist/web/` contains `index.html`, `next/`, `assets/`, `robots.txt`, etc. — exactly the artifact Amplify expects.

## Why not just bake it into a postinstall

A `prepare` / `postinstall` on `backend.ai-docs-toolkit` would invoke `tsc` for every consumer, including local dev. Keeping the build orchestration in the deployment manifest is consistent with how the package.yml / docs-archive workflows already do it (the inline comment in `amplify.yml` cross-references those). Only the second `install` was load-bearing for bin linking, and `pnpm rebuild` is the smaller, more honest tool for that job.