### PR TITLE
fix(FR-2864): place primary action button rightmost when paired with refresh

### DIFF
--- a/react/src/components/AdminDeploymentPresetModelConfigItem.tsx
+++ b/react/src/components/AdminDeploymentPresetModelConfigItem.tsx
@@ -6,7 +6,6 @@ import type { AdminDeploymentPresetFormValue } from './AdminDeploymentPresetForm
 import {
   DownOutlined,
   MinusCircleOutlined,
-  PlusOutlined,
   RightOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
@@ -20,7 +19,8 @@ import {
   theme,
 } from 'antd';
 import type { FormInstance } from 'antd';
-import { BAICard, BAIFlex } from 'backend.ai-ui';
+import { BAIButton, BAICard, BAIFlex } from 'backend.ai-ui';
+import { PlusIcon } from 'lucide-react';
 import React, { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -247,16 +247,16 @@ const ModelConfigItem: React.FC<{
                         </BAIFlex>
                       ))}
                       <Form.Item noStyle>
-                        <Button
+                        <BAIButton
                           type="dashed"
                           onClick={() => add({ action: '', args: '{}' })}
-                          icon={<PlusOutlined />}
+                          icon={<PlusIcon />}
                           block
                         >
                           {t(
                             'adminDeploymentPreset.modelDef.AddPreStartAction',
                           )}
-                        </Button>
+                        </BAIButton>
                       </Form.Item>
                     </BAIFlex>
                   )}

--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -21,7 +21,6 @@ import {
   DoubleRightOutlined,
   LeftOutlined,
   MinusCircleOutlined,
-  PlusOutlined,
   RightOutlined,
 } from '@ant-design/icons';
 import { useDebounceFn } from 'ahooks';
@@ -48,6 +47,7 @@ import {
   toLocalId,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, {
   Suspense,
@@ -588,14 +588,14 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                         />
                       ))}
                       <Form.Item noStyle>
-                        <Button
+                        <BAIButton
                           type="dashed"
                           onClick={() => add()}
-                          icon={<PlusOutlined />}
+                          icon={<PlusIcon />}
                           block
                         >
                           {t('adminDeploymentPreset.AddResourceSlot')}
-                        </Button>
+                        </BAIButton>
                       </Form.Item>
                     </>
                   )}
@@ -644,14 +644,14 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                       </BAIFlex>
                     ))}
                     <Form.Item noStyle>
-                      <Button
+                      <BAIButton
                         type="dashed"
                         onClick={() => add()}
-                        icon={<PlusOutlined />}
+                        icon={<PlusIcon />}
                         block
                       >
                         {t('adminDeploymentPreset.AddResourceOpt')}
-                      </Button>
+                      </BAIButton>
                     </Form.Item>
                   </BAIFlex>
                 )}
@@ -765,14 +765,14 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                         onRemove={() => remove(name)}
                       />
                     ))}
-                    <Button
+                    <BAIButton
                       type="dashed"
                       onClick={() => add({ name: '', modelPath: '' })}
-                      icon={<PlusOutlined />}
+                      icon={<PlusIcon />}
                       block
                     >
                       {t('adminDeploymentPreset.modelDef.AddModel')}
-                    </Button>
+                    </BAIButton>
                   </BAIFlex>
                 )}
               </Form.List>

--- a/react/src/components/AdminModelCardSettingModal.tsx
+++ b/react/src/components/AdminModelCardSettingModal.tsx
@@ -14,7 +14,6 @@ import FolderLink from './FolderLink';
 import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
 import {
   App,
-  Button,
   Form,
   type FormInstance,
   Input,
@@ -341,7 +340,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
                 </Suspense>
                 {isModelStoreProject ? (
                   <BAIButton
-                    icon={<PlusIcon size={16} />}
+                    icon={<PlusIcon />}
                     onClick={() => setIsOpenCreateFolderModal(true)}
                   />
                 ) : (
@@ -377,7 +376,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
                       }
                     }}
                   >
-                    <Button icon={<PlusIcon size={16} />} />
+                    <BAIButton icon={<PlusIcon />} />
                   </Popconfirm>
                 )}
               </BAIFlex>

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -24,6 +24,7 @@ import { App, Button, Tag, Tooltip, Typography, theme } from 'antd';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
+  BAIButton,
   BAITable,
   BAIFlex,
   BAIPropertyFilter,
@@ -254,7 +255,7 @@ const AdminUserCredentialList: React.FC = () => {
               icon={<ReloadOutlined />}
             />
           </Tooltip>
-          <Button
+          <BAIButton
             type="primary"
             icon={<PlusIcon />}
             onClick={() => {
@@ -262,7 +263,7 @@ const AdminUserCredentialList: React.FC = () => {
             }}
           >
             {t('credential.AddCredential')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
       <BAITable<Keypair>

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -483,7 +483,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
             onChange={updateFetchKey}
           />
           <Space.Compact>
-            <Button
+            <BAIButton
               type="primary"
               icon={<PlusIcon />}
               onClick={() => {
@@ -491,7 +491,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
               }}
             >
               {t('credential.CreateUser')}
-            </Button>
+            </BAIButton>
             {bailClient.supports('bulk-create-user') && (
               <Dropdown
                 trigger={['click']}

--- a/react/src/components/AutoScalingRuleList.tsx
+++ b/react/src/components/AutoScalingRuleList.tsx
@@ -12,9 +12,10 @@ import { AutoScalingRuleListQuery } from '../__generated__/AutoScalingRuleListQu
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import AutoScalingRuleEditorModal from './AutoScalingRuleEditorModal';
-import { DeleteFilled, PlusOutlined, SettingOutlined } from '@ant-design/icons';
-import { App, Button, Tag, Tooltip, Typography } from 'antd';
+import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
+import { App, Tag, Tooltip, Typography } from 'antd';
 import {
+  BAIButton,
   BAIQuestionIconWithTooltip,
   BAIDeleteConfirmModal,
   BAIFetchKeyButton,
@@ -31,6 +32,7 @@ import {
 import type { BAITableProps, GraphQLFilter } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { useDeferredValue, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -559,9 +561,9 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
               startRefetchTransition(() => updateFetchKey());
             }}
           />
-          <Button
+          <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             disabled={isEndpointDestroying || !isOwnedByCurrentUser}
             onClick={() => {
               setEditingRuleId(null);
@@ -569,7 +571,7 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
             }}
           >
             {t('modelService.AddRules')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
         <AutoScalingRuleListNodes
           autoScalingRulesFrgmt={autoScalingRuleNodes}

--- a/react/src/components/AutoScalingRuleListLegacy.tsx
+++ b/react/src/components/AutoScalingRuleListLegacy.tsx
@@ -7,9 +7,10 @@ import { AutoScalingRuleListLegacyDeleteMutation } from '../__generated__/AutoSc
 import AutoScalingRuleEditorModalLegacy, {
   COMPARATOR_LABELS,
 } from './AutoScalingRuleEditorModalLegacy';
-import { DeleteFilled, PlusOutlined, SettingOutlined } from '@ant-design/icons';
+import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
 import { App, Button, Tag, Tooltip, Typography, theme } from 'antd';
 import {
+  BAIButton,
   BAICard,
   BAIDeleteConfirmModal,
   BAIFlex,
@@ -18,7 +19,7 @@ import {
 } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import * as _ from 'lodash-es';
-import { CircleArrowDownIcon, CircleArrowUpIcon } from 'lucide-react';
+import { CircleArrowDownIcon, CircleArrowUpIcon, PlusIcon } from 'lucide-react';
 import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation } from 'react-relay';
@@ -120,16 +121,16 @@ const AutoScalingRuleListLegacy: React.FC<AutoScalingRuleListLegacyProps> = ({
       <BAICard
         title={t('modelService.AutoScalingRules')}
         extra={
-          <Button
+          <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             disabled={isEndpointDestroying}
             onClick={() => {
               setIsOpenAutoScalingRuleModal(true);
             }}
           >
             {t('modelService.AddRules')}
-          </Button>
+          </BAIButton>
         }
         styles={{ body: { paddingTop: 0 } }}
       >

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -17,7 +17,6 @@ import ContainerRegistryEditorModal from './ContainerRegistryEditorModal';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
   DeleteFilled,
-  PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
   SyncOutlined,
@@ -28,6 +27,7 @@ import { AnyObject } from 'antd/es/_util/type';
 import type { ColumnsType, ColumnType } from 'antd/es/table';
 import {
   filterOutNullAndUndefined,
+  BAIButton,
   BAITable,
   BAIFlex,
   BAIPropertyFilter,
@@ -38,6 +38,7 @@ import {
   INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import { useState, useDeferredValue, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -446,15 +447,15 @@ const ContainerRegistryList: React.FC<{
               }}
             />
           </Tooltip>
-          <Button
+          <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             onClick={() => {
               setIsNewModalOpen(true);
             }}
           >
             {t('registry.AddRegistry')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
       <BAITable

--- a/react/src/components/DeploymentAccessTokensTab.tsx
+++ b/react/src/components/DeploymentAccessTokensTab.tsx
@@ -8,13 +8,11 @@ import { DeploymentAccessTokensTabListQuery } from '../__generated__/DeploymentA
 import { DeploymentAccessTokensTab_deployment$key } from '../__generated__/DeploymentAccessTokensTab_deployment.graphql';
 import {
   DeleteFilled,
-  PlusOutlined,
   QuestionCircleOutlined,
 } from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
 import {
   App,
-  Button,
   DatePicker,
   Form,
   Select,
@@ -24,6 +22,7 @@ import {
   theme,
 } from 'antd';
 import {
+  BAIButton,
   BAICard,
   BAIDeleteConfirmModal,
   BAIFetchKeyButton,
@@ -39,6 +38,7 @@ import {
   useMutationWithPromise,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
+import { PlusIcon } from 'lucide-react';
 import React, {
   Suspense,
   useDeferredValue,
@@ -170,14 +170,14 @@ const DeploymentAccessTokensTab: React.FC<DeploymentAccessTokensTabProps> = ({
                   : ''
               }
             >
-              <Button
+              <BAIButton
                 type="primary"
-                icon={<PlusOutlined />}
+                icon={<PlusIcon />}
                 disabled={isCreateDisabled}
                 onClick={() => setIsCreateModalOpen(true)}
               >
                 {t('deployment.accessToken.Create')}
-              </Button>
+              </BAIButton>
             </Tooltip>
           </BAIFlex>
         }

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -25,7 +25,6 @@ import {
   HistoryOutlined,
   LoadingOutlined,
   MoreOutlined,
-  PlusOutlined,
 } from '@ant-design/icons';
 import {
   Alert,
@@ -60,6 +59,7 @@ import {
   useInterval,
 } from 'backend.ai-ui';
 import type { BAIDeploymentStatus } from 'backend.ai-ui';
+import { PlusIcon } from 'lucide-react';
 import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -484,7 +484,7 @@ const DeploymentConfigurationSection: React.FC<
           <BAIFlex gap="xs" align="center">
             <BAIButton
               type="primary"
-              icon={<PlusOutlined />}
+              icon={<PlusIcon />}
               disabled={
                 isDeploymentInStoppedCategory(deploymentStatus) ||
                 isProjectMismatch

--- a/react/src/components/EnvVarFormList.tsx
+++ b/react/src/components/EnvVarFormList.tsx
@@ -2,18 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
-import {
-  AutoComplete,
-  Button,
-  Form,
-  FormItemProps,
-  Input,
-  InputRef,
-} from 'antd';
+import { MinusCircleOutlined } from '@ant-design/icons';
+import { AutoComplete, Form, FormItemProps, Input, InputRef } from 'antd';
 import { FormListProps } from 'antd/lib/form';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAIButton, BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -240,7 +234,7 @@ const EnvVarFormList: React.FC<EnvVarFormListProps> = ({
               </BAIFlex>
             ))}
             <Form.Item noStyle>
-              <Button
+              <BAIButton
                 type="dashed"
                 onClick={() => {
                   add();
@@ -250,11 +244,11 @@ const EnvVarFormList: React.FC<EnvVarFormListProps> = ({
                     }
                   }, 0);
                 }}
-                icon={<PlusOutlined />}
+                icon={<PlusIcon />}
                 block
               >
                 {t('session.launcher.AddEnvironmentVariable')}
-              </Button>
+              </BAIButton>
             </Form.Item>
             <Form.ErrorList errors={errors} />
           </BAIFlex>

--- a/react/src/components/ImportArtifactRevisionToFolderModal.tsx
+++ b/react/src/components/ImportArtifactRevisionToFolderModal.tsx
@@ -11,16 +11,9 @@ import {
 } from '../hooks/useCurrentProject';
 import FolderCreateModalV2 from './FolderCreateModalV2';
 import { useToggle } from 'ahooks';
+import { Alert, App, Form, FormInstance, Popconfirm, theme } from 'antd';
 import {
-  Alert,
-  App,
-  Button,
-  Form,
-  FormInstance,
-  Popconfirm,
-  theme,
-} from 'antd';
-import {
+  BAIButton,
   BAIModalProps,
   BAIVFolderSelectRef,
   BAIModal,
@@ -276,7 +269,7 @@ const ImportArtifactRevisionToFolderModal = ({
                   />
                 </Form.Item>
                 {currentProject.id === modelStoreProject?.id ? (
-                  <Button
+                  <BAIButton
                     icon={<PlusIcon />}
                     onClick={() => {
                       toggleIsOpenCreateModal();
@@ -319,7 +312,7 @@ const ImportArtifactRevisionToFolderModal = ({
                       }
                     }}
                   >
-                    <Button icon={<PlusIcon />} />
+                    <BAIButton icon={<PlusIcon />} />
                   </Popconfirm>
                 )}
               </BAIFlex>

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -18,7 +18,6 @@ import KeypairResourcePolicySettingModal from './KeypairResourcePolicySettingMod
 import {
   DeleteFilled,
   InfoCircleOutlined,
-  PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
@@ -28,6 +27,7 @@ import type { ColumnsType, ColumnType } from 'antd/es/table';
 import {
   useUpdatableState,
   filterOutEmpty,
+  BAIButton,
   BAITable,
   BAIFlex,
   BAIAllowedVfolderHostsWithPermission,
@@ -36,6 +36,7 @@ import {
   BAIDeleteConfirmModal,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -315,15 +316,15 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
               }}
             />
           </Tooltip>
-          <Button
+          <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             onClick={() => {
               setIsCreatingPolicySetting(true);
             }}
           >
             {t('button.Create')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
       <BAITable

--- a/react/src/components/ManageAppsModal.tsx
+++ b/react/src/components/ManageAppsModal.tsx
@@ -4,7 +4,7 @@
  */
 import { ManageAppsModalMutation } from '../__generated__/ManageAppsModalMutation.graphql';
 import { ManageAppsModal_image$key } from '../__generated__/ManageAppsModal_image.graphql';
-import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { DeleteOutlined } from '@ant-design/icons';
 import {
   Input,
   Button,
@@ -14,8 +14,9 @@ import {
   FormInstance,
   theme,
 } from 'antd';
-import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import { BAIButton, BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
@@ -304,15 +305,15 @@ const ManageAppsModal: React.FC<ManageAppsModalProps> = ({
                     </BAIFlex>
                   </Form.Item>
                 ))}
-                <Button
+                <BAIButton
                   type="dashed"
                   onClick={() => add()}
                   block
-                  icon={<PlusOutlined />}
+                  icon={<PlusIcon />}
                   disabled={!image}
                 >
                   {t('button.Add')}
-                </Button>
+                </BAIButton>
               </BAIFlex>
             )}
           </Form.List>

--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -419,13 +419,6 @@ const MyKeypairManagementModal: React.FC<MyKeypairManagementModalProps> = ({
               />
             </BAIFlex>
             <BAIFlex gap="xs">
-              <BAIButton
-                type="primary"
-                icon={<PlusIcon />}
-                onClick={handleIssueKeypair}
-              >
-                {t('credential.IssueNewKeypair')}
-              </BAIButton>
               <BAIFetchKeyButton
                 loading={
                   deferredQueryVariables !== queryVariables ||
@@ -436,6 +429,13 @@ const MyKeypairManagementModal: React.FC<MyKeypairManagementModalProps> = ({
                   updateFetchKey(newFetchKey);
                 }}
               />
+              <BAIButton
+                type="primary"
+                icon={<PlusIcon />}
+                onClick={handleIssueKeypair}
+              >
+                {t('credential.IssueNewKeypair')}
+              </BAIButton>
             </BAIFlex>
           </BAIFlex>
           <BAITable<KeypairNode>

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -19,7 +19,6 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 import ProjectResourcePolicySettingModal from './ProjectResourcePolicySettingModal';
 import {
   DeleteFilled,
-  PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
@@ -28,6 +27,7 @@ import type { ColumnType } from 'antd/es/table';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
+  BAIButton,
   BAITable,
   BAIFlex,
   useUpdatableState,
@@ -36,6 +36,7 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -235,15 +236,15 @@ const ProjectResourcePolicyList: React.FC<
               }}
             />
           </Tooltip>
-          <Button
+          <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             onClick={() => {
               setIsCreatingPolicySetting(true);
             }}
           >
             {t('button.Create')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
       <BAITable

--- a/react/src/components/PrometheusPresetTab.tsx
+++ b/react/src/components/PrometheusPresetTab.tsx
@@ -13,7 +13,6 @@ import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginati
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import PrometheusQueryPresetEditorModal from './PrometheusQueryPresetEditorModal';
 import PrometheusQueryPresetNodes from './PrometheusQueryPresetNodes';
-import { PlusOutlined } from '@ant-design/icons';
 import { App } from 'antd';
 import {
   BAIButton,
@@ -27,6 +26,7 @@ import {
   useFetchKey,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
 import React, { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -157,7 +157,7 @@ const PrometheusPresetTab: React.FC = () => {
           />
           <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             onClick={() => setIsOpenEditorModal(true)}
           >
             {t('prometheusQueryPreset.AddPreset')}

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -16,16 +16,16 @@ import {
   CloseOutlined,
   DeleteFilled,
   InfoCircleOutlined,
-  PlusOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { App, Button, theme } from 'antd';
+import { App, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
   useUpdatableState,
   filterOutEmpty,
   filterOutNullAndUndefined,
+  BAIButton,
   BAITable,
   BAIFlex,
   BAIDeleteConfirmModal,
@@ -33,7 +33,7 @@ import {
   BAINameActionCell,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { BanIcon, UndoIcon } from 'lucide-react';
+import { BanIcon, PlusIcon, UndoIcon } from 'lucide-react';
 import { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -290,13 +290,13 @@ const ResourceGroupList: React.FC = () => {
               });
             }}
           />
-          <Button
+          <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             onClick={() => toggleOpenCreateModal()}
           >
             {t('button.Create')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
 

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -13,7 +13,6 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import ResourcePresetSettingModal from './ResourcePresetSettingModal';
 import {
   ReloadOutlined,
-  PlusOutlined,
   SettingOutlined,
   DeleteFilled,
 } from '@ant-design/icons';
@@ -21,6 +20,7 @@ import { Tooltip, Button, App, TableColumnsType } from 'antd';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
+  BAIButton,
   BAITable,
   BAIFlex,
   BAINumberWithUnit,
@@ -30,6 +30,7 @@ import {
   BAIDeleteConfirmModal,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -177,15 +178,15 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
               }}
             />
           </Tooltip>
-          <Button
+          <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             onClick={() => {
               setIsCreating(true);
             }}
           >
             {t('resourcePreset.CreatePreset')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
       <BAITable

--- a/react/src/components/RoleFormModal.tsx
+++ b/react/src/components/RoleFormModal.tsx
@@ -9,7 +9,7 @@ import { RoleFormModalFragment$key } from '../__generated__/RoleFormModalFragmen
 import { RoleFormModalPermissionMatrixQuery } from '../__generated__/RoleFormModalPermissionMatrixQuery.graphql';
 import { RoleFormModalResourceGroupQuery } from '../__generated__/RoleFormModalResourceGroupQuery.graphql';
 import { RoleFormModalUpdateMutation } from '../__generated__/RoleFormModalUpdateMutation.graphql';
-import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { DeleteOutlined } from '@ant-design/icons';
 import { App, Button, Form, Input, type SelectProps } from 'antd';
 import {
   BAIAdminContainerRegistrySelect,
@@ -17,6 +17,7 @@ import {
   BAIAdminProjectSelect,
   BAIAdminResourceGroupSelect,
   BAIAdminSessionSelect,
+  BAIButton,
   BAIFlex,
   BAIKeypairSelect,
   BAIModal,
@@ -28,6 +29,7 @@ import {
   toLocalId,
   useBAILogger,
 } from 'backend.ai-ui';
+import { PlusIcon } from 'lucide-react';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -572,14 +574,14 @@ const RoleFormModal: React.FC<RoleFormModalProps> = ({
                       onRemove={() => remove(name)}
                     />
                   ))}
-                  <Button
+                  <BAIButton
                     type="dashed"
                     block
-                    icon={<PlusOutlined />}
+                    icon={<PlusIcon />}
                     onClick={() => add({})}
                   >
                     {t('button.Add')}
-                  </Button>
+                  </BAIButton>
                   <Form.ErrorList errors={errors} />
                 </BAIFlex>
               )}

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -18,7 +18,6 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 import UserResourcePolicySettingModal from './UserResourcePolicySettingModal';
 import {
   DeleteFilled,
-  PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
@@ -28,6 +27,7 @@ import {
   useUpdatableState,
   filterOutEmpty,
   filterOutNullAndUndefined,
+  BAIButton,
   BAITable,
   BAIFlex,
   BAINameActionCell,
@@ -35,6 +35,7 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -236,15 +237,15 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
               }}
             />
           </Tooltip>
-          <Button
+          <BAIButton
             type="primary"
-            icon={<PlusOutlined />}
+            icon={<PlusIcon />}
             onClick={() => {
               setIsCreatingPolicySetting(true);
             }}
           >
             {t('button.Create')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
       <BAITable

--- a/react/src/components/VFolderMountFormItem.tsx
+++ b/react/src/components/VFolderMountFormItem.tsx
@@ -21,6 +21,7 @@ import {
   theme,
 } from 'antd';
 import {
+  BAIButton,
   BAIFlex,
   BAIVFolderSelect,
   BAIVFolderSelectRef,
@@ -188,7 +189,7 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
                     />
                   </Tooltip>
                   <Tooltip title={t('data.CreateANewStorageFolder')}>
-                    <Button
+                    <BAIButton
                       type="text"
                       size="small"
                       icon={<PlusIcon />}

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -13,6 +13,7 @@ import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import { ReloadOutlined } from '@ant-design/icons';
 import { Button, Select, type SelectProps, Space, Tooltip } from 'antd';
 import {
+  BAIButton,
   useUpdatableState,
   BAIFlex,
   toGlobalId,
@@ -286,7 +287,7 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
         ) : null}
         {showCreateButton ? (
           <Tooltip title={t('data.CreateANewStorageFolder')}>
-            <Button
+            <BAIButton
               icon={<PlusIcon />}
               variant="text"
               onClick={() => {

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -33,6 +33,7 @@ import {
 } from 'antd';
 import type { ColumnsType } from 'antd/lib/table';
 import {
+  BAIButton,
   BAIUserUnionIcon,
   BAIFlex,
   BAILink,
@@ -645,7 +646,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
         />
         <Space.Compact>
           <Tooltip title={t('data.CreateANewStorageFolder')}>
-            <Button
+            <BAIButton
               icon={<PlusIcon />}
               onClick={() => {
                 setIsOpenCreateModal(true);

--- a/react/src/pages/AIAgentPage.tsx
+++ b/react/src/pages/AIAgentPage.tsx
@@ -10,7 +10,6 @@ import {
   DeleteFilled,
   EditOutlined,
   MoreOutlined,
-  PlusOutlined,
   UndoOutlined,
 } from '@ant-design/icons';
 import {
@@ -25,12 +24,14 @@ import {
 } from 'antd';
 import { createStyles } from 'antd-style';
 import {
+  BAIButton,
   BAICard,
   BAIFlex,
   BAIUnmountAfterClose,
   BAIDeleteConfirmModal,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -217,15 +218,15 @@ const AIAgentPage: React.FC = () => {
     >
       <BAIFlex direction="column" align="stretch" justify="center" gap="sm">
         <BAIFlex direction="row" justify="end" align="center">
-          <Button
-            icon={<PlusOutlined />}
+          <BAIButton
+            icon={<PlusIcon />}
             onClick={() => {
               setEditingAgent(undefined);
               setIsEditorOpen(true);
             }}
           >
             {t('button.Add')}
-          </Button>
+          </BAIButton>
         </BAIFlex>
         <Row gutter={[16, 16]} className={styles.cardList}>
           {agents.map((agent) => {

--- a/react/src/pages/AdminDeploymentPresetListPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetListPage.tsx
@@ -16,7 +16,7 @@ import { convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
-import { App } from 'antd';
+import { App, theme } from 'antd';
 import {
   BAIButton,
   BAIDeleteConfirmModal,
@@ -31,6 +31,7 @@ import {
   filterOutNullAndUndefined,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
 import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
 import React, { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -42,6 +43,7 @@ const AdminDeploymentPresetListPage: React.FC = () => {
   const { t } = useTranslation();
   const { message } = App.useApp();
   const { logger } = useBAILogger();
+  const { token } = theme.useToken();
   const baiClient = useSuspendedBackendaiClient();
   const webuiNavigate = useWebUINavigate();
 
@@ -176,9 +178,6 @@ const AdminDeploymentPresetListPage: React.FC = () => {
           />
         </BAIFlex>
         <BAIFlex gap={'sm'}>
-          <BAIButton type="primary" onClick={handleOpenCreateModal}>
-            {t('adminDeploymentPreset.CreatePreset')}
-          </BAIButton>
           <BAIFetchKeyButton
             loading={isLoading}
             value={fetchKey}
@@ -186,6 +185,13 @@ const AdminDeploymentPresetListPage: React.FC = () => {
               updateFetchKey(newFetchKey);
             }}
           />
+          <BAIButton
+            type="primary"
+            onClick={handleOpenCreateModal}
+            icon={<PlusIcon />}
+          >
+            {t('adminDeploymentPreset.CreatePreset')}
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
       {isSupported ? (
@@ -216,7 +222,7 @@ const AdminDeploymentPresetListPage: React.FC = () => {
           }}
         />
       ) : (
-        <BAIFlex justify="center" style={{ padding: 32 }}>
+        <BAIFlex justify="center" style={{ padding: token.paddingXL }}>
           {t('adminDeploymentPreset.NotSupported')}
         </BAIFlex>
       )}

--- a/react/src/pages/AdminModelCardListPage.tsx
+++ b/react/src/pages/AdminModelCardListPage.tsx
@@ -385,13 +385,6 @@ const AdminModelCardListPage: React.FC = () => {
               />
             </>
           )}
-          <BAIButton
-            type="primary"
-            icon={<PlusIcon size={16} />}
-            onClick={handleOpenCreateModal}
-          >
-            {t('adminModelCard.CreateModelCard')}
-          </BAIButton>
           <BAIFetchKeyButton
             loading={
               deferredQueryVariables !== queryVariables ||
@@ -402,6 +395,13 @@ const AdminModelCardListPage: React.FC = () => {
               updateFetchKey(newFetchKey);
             }}
           />
+          <BAIButton
+            type="primary"
+            icon={<PlusIcon />}
+            onClick={handleOpenCreateModal}
+          >
+            {t('adminModelCard.CreateModelCard')}
+          </BAIButton>
         </BAIFlex>
       </BAIFlex>
       <BAITable<ModelCardNode>

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -15,7 +15,7 @@ import WebUINavigate from '../components/WebUINavigate';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { Badge, Button, Card, Drawer, theme, Tooltip, Typography } from 'antd';
 import { createStyles } from 'antd-style';
-import { BAIFlex, BAICard, BAITable } from 'backend.ai-ui';
+import { BAIButton, BAIFlex, BAICard, BAITable } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import { t } from 'i18next';
 import * as _ from 'lodash-es';
@@ -227,7 +227,7 @@ const PureChatPage = ({ id }: { id: string }) => {
         extra={
           <BAIFlex>
             <Tooltip title={t('chatui.NewChat')}>
-              <Button
+              <BAIButton
                 type="text"
                 icon={<PlusIcon />}
                 onClick={() => {

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -19,7 +19,7 @@ import {
   getPathFromMenuKey,
   useWebUIMenuItems,
 } from '../hooks/useWebUIMenuItems';
-import { PlusOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { QuestionCircleOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import {
   Alert,
@@ -43,7 +43,7 @@ import {
   useFetchKey,
 } from 'backend.ai-ui';
 import type { GraphQLFormattedError } from 'graphql';
-import { BotMessageSquareIcon } from 'lucide-react';
+import { BotMessageSquareIcon, PlusIcon } from 'lucide-react';
 import React, { Suspense, useRef, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
@@ -187,7 +187,8 @@ const DeploymentDetailPage: React.FC = () => {
     !deployment.currentRevision && !deployment.deployingRevision;
   const hasEndpointUrl = !!deployment.networkAccess.endpointUrl;
   const hasAccessTokens = (deployment.accessTokens?.count ?? 0) > 0;
-  const isDeploymentDestroying = isDeploymentInStoppedCategory(deploymentStatus);
+  const isDeploymentDestroying =
+    isDeploymentInStoppedCategory(deploymentStatus);
   // The private-deployment alert prompts the user to create a token so the
   // endpoint is actually reachable. Suppress it when the endpoint has not
   // been issued yet (creating a token would be premature) or when the user
@@ -279,7 +280,7 @@ const DeploymentDetailPage: React.FC = () => {
             action={
               <BAIButton
                 type="primary"
-                icon={<PlusOutlined />}
+                icon={<PlusIcon />}
                 // `action` (not `onClick`) wraps the open state update in
                 // `startTransition` so the page stays interactive while
                 // the modal mounts.
@@ -300,7 +301,7 @@ const DeploymentDetailPage: React.FC = () => {
           action={
             <BAIButton
               type="primary"
-              icon={<PlusOutlined />}
+              icon={<PlusIcon />}
               // `action` (not `onClick`) defers the mount in a transition
               // so the page stays interactive.
               action={async () => {

--- a/react/src/pages/ProjectPage.tsx
+++ b/react/src/pages/ProjectPage.tsx
@@ -13,7 +13,7 @@ import {
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCSVExport } from '../hooks/useCSVExport';
-import { DeleteFilled, PlusOutlined, SettingOutlined } from '@ant-design/icons';
+import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import { App, theme, Tooltip } from 'antd';
 import {
@@ -39,7 +39,7 @@ import {
   useUpdatableState,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { BanIcon, UndoIcon } from 'lucide-react';
+import { BanIcon, PlusIcon, UndoIcon } from 'lucide-react';
 import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -390,7 +390,7 @@ const ProjectPage = () => {
             />
             <BAIButton
               type="primary"
-              icon={<PlusOutlined />}
+              icon={<PlusIcon />}
               onClick={toggleSettingModal}
             >
               {t('project.CreateProject')}


### PR DESCRIPTION
Resolves #7351 ([FR-2864](https://lablup.atlassian.net/browse/FR-2864))

## Summary
- Project rule `.claude/rules/use-bai-card.md` requires the primary "Create / Add" button to be rightmost when sharing a header row with `BAIFetchKeyButton`. Three places violated this; this PR aligns them with the convention.
  - `react/src/pages/AdminModelCardListPage.tsx` — Create Model Card
  - `react/src/pages/AdminDeploymentPresetListPage.tsx` — Create Preset
  - `react/src/components/MyKeypairManagementModal.tsx` — Issue New Keypair
- **Unify primary action button form across the app.** Standardize every `type="primary"` button paired with a plus icon to `<BAIButton type="primary" icon={<PlusIcon />}>` (BAIButton from `backend.ai-ui` + `PlusIcon` from `lucide-react`). Previously the same primary action was rendered three different ways (antd `<Button>` + `PlusOutlined`, antd `<Button>` + `PlusIcon`, `<BAIButton>` + `PlusOutlined`) depending on the file.
  - `AutoScalingRuleList.tsx`, `AutoScalingRuleListLegacy.tsx`, `ContainerRegistryList.tsx`, `DeploymentAccessTokensTab.tsx`, `DeploymentAutoScalingTab.tsx`, `ResourceGroupList.tsx`, `ResourcePresetList.tsx`, `UserCredentialList.tsx`, `UserManagement.tsx`, `UserResourcePolicyList.tsx`, `PrometheusPresetTab.tsx` and the three files above.
- **Extend unification to non-primary "Add" buttons.** Standardize the remaining `<Button>` + plus-icon call sites (`dashed`, `text`, no-type, icon-only) to `<BAIButton>` + `<PlusIcon />` so the entire app shares a single button + plus-icon form. Convert any lingering `PlusOutlined` to `PlusIcon`.
  - `AdminDeploymentPresetSettingPageContent.tsx` (3 dashed "Add" buttons in Form.List sections)
  - `ManageAppsModal.tsx`, `RoleFormModal.tsx`, `EnvVarFormList.tsx` (dashed "Add" buttons)
  - `AIAgentPage.tsx`, `QuotaScopeCard.tsx` (default-type "Add" buttons)
  - `VFolderTable.tsx`, `ImportArtifactRevisionToFolderModal.tsx`, `VFolderMountFormItem.tsx`, `VFolderSelect.tsx`, `ChatPage.tsx` (icon-only / text "Create" or "New" buttons that already used `PlusIcon` — antd Button → BAIButton)
- In the touched lines, replaced hardcoded pixel values with theme tokens for consistency:
  - `padding: 32` → `padding: token.paddingXL` (deployment preset list, no-support state)

## Test plan
- [ ] Admin Model Card list — **Create Model Card** primary button sits to the right of the refresh button.
- [ ] Admin > Deployment > Presets — **Create Preset** primary button sits to the right of the refresh button.
- [ ] My Keypair management modal — **Issue New Keypair** primary button sits to the right of the refresh button.
- [ ] All converted pages render the same primary button form (BAIButton + lucide PlusIcon, no \`size\` prop) with no visual regressions: Resource Groups, Container Registries, Resource Presets, Deployment Access Tokens / Auto Scaling, Auto Scaling rules (legacy + new), User Resource Policies, Users, User Credentials, Prometheus Presets.
- [ ] Non-primary "Add" buttons render correctly with the lucide `PlusIcon`: Admin Deployment Preset setting (resource slot / opt / model rows), Manage Apps modal, Role Form modal scope rows, env-var form list, AI Agent page header, Quota Scope empty-state, VFolder table / mount form / select dropdowns, Import Artifact modal, Chat page new-chat button.
- [ ] Tooltip-wrapped icon-only Buttons (VFolder Create / Refresh, etc.) still position correctly inside `Space.Compact` after the BAIButton swap.

[FR-2864]: https://lablup.atlassian.net/browse/FR-2864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ