### PR TITLE
Security: Path Traversal Vulnerability in Asset Hasher

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/asset-hasher.ts
+++ b/packages/backend.ai-docs-toolkit/src/asset-hasher.ts
@@ -45,7 +45,12 @@ export function writeHashedAsset(
   const hash = contentHash(bytes);
   const hashedName = hashedFilename(logicalName, hash);
   fs.mkdirSync(assetsDir, { recursive: true });
-  fs.writeFileSync(path.join(assetsDir, hashedName), bytes);
+  const targetPath = path.resolve(assetsDir, hashedName);
+  const resolvedAssetsDir = path.resolve(assetsDir);
+  if (!targetPath.startsWith(resolvedAssetsDir + path.sep)) {
+    throw new Error('Invalid asset path: path traversal detected');
+  }
+  fs.writeFileSync(targetPath, bytes);
   manifest[logicalName] = hashedName;
   return hashedName;
 }


### PR DESCRIPTION
## Summary

Security: Path Traversal Vulnerability in Asset Hasher

## Problem

**Severity**: `Critical` | **File**: `packages/backend.ai-docs-toolkit/src/asset-hasher.ts:L48`

The writeHashedAsset function in asset-hasher.ts does not validate the logicalName parameter. An attacker could provide paths like '../../../etc/passwd' to write files outside the intended assets directory.

## Solution

Add path validation to ensure logicalName does not contain path traversal sequences. Use path.resolve() to normalize paths and verify the result stays within the assetsDir.

## Changes

- `packages/backend.ai-docs-toolkit/src/asset-hasher.ts` (modified)