### PR TITLE
chore(FR-2865): disable scheduled runs for E2E Watchdog and Healer

### DIFF
--- a/.github/workflows/e2e-healer.lock.yml
+++ b/.github/workflows/e2e-healer.lock.yml
@@ -28,8 +28,6 @@ name: "E2E Watchdog & Healer"
     paths:
     - .github/workflows/e2e-healer.md
     - .github/workflows/e2e-healer.lock.yml
-  schedule:
-  - cron: "0 0 * * 1-5"
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/e2e-healer.md
+++ b/.github/workflows/e2e-healer.md
@@ -9,8 +9,6 @@ on:
     paths:
       - '.github/workflows/e2e-healer.md'
       - '.github/workflows/e2e-healer.lock.yml'
-  schedule:
-    - cron: "0 0 * * 1-5"
 
 permissions: read-all
 

--- a/.github/workflows/e2e-watchdog.lock.yml
+++ b/.github/workflows/e2e-watchdog.lock.yml
@@ -23,8 +23,6 @@
 
 name: "E2E Watchdog"
 "on":
-  schedule:
-  - cron: "0 0 * * 1-5"
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/e2e-watchdog.md
+++ b/.github/workflows/e2e-watchdog.md
@@ -4,8 +4,6 @@ description: |
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1-5"
 
 permissions: read-all
 


### PR DESCRIPTION
Resolves #7355(FR-2865)

## Summary

Disable the weekday cron (`0 0 * * 1-5`, 09:00 KST) that drives the **E2E Watchdog** and **E2E Healer** agentic workflows. They become manual-only (still launchable via `workflow_dispatch` from the Actions tab).

## Why

These scheduled runs are currently noisy / not actively maintained. We'd rather suspend the cron than keep filing automated failure issues. Re-enabling is a one-line revert.

## Changes

- `.github/workflows/e2e-healer.md` — drop the `schedule:` trigger from the gh-aw source.
- `.github/workflows/e2e-healer.lock.yml` — drop the `schedule:` trigger from the generated lock.
- `.github/workflows/e2e-watchdog.md` — same.
- `.github/workflows/e2e-watchdog.lock.yml` — same.

`workflow_dispatch:` and the e2e-healer self-test `pull_request:` (path-scoped to the healer files) are kept.

## Verification

- `grep -n "schedule:\|cron:" .github/workflows/e2e-{healer,watchdog}.{md,lock.yml}` returns nothing.
- After merge, the workflows should not appear in the next day's scheduled run list.