### PR TITLE
feat(FR-2867): add unified memory accelerator UX in Resource Allocation

### DIFF
--- a/packages/backend.ai-client/src/types.ts
+++ b/packages/backend.ai-client/src/types.ts
@@ -18,6 +18,8 @@ export interface SessionResources {
   bootstrap_script?: string;
   owner_access_key?: string;
   reuseIfExists?: boolean;
+  /** Free-form session tag (Backend.AI session `tag` attribute). */
+  tag?: string;
   dependencies?: string[];
   config?: {
     resources?: {

--- a/react/src/components/InputNumberWithSlider.tsx
+++ b/react/src/components/InputNumberWithSlider.tsx
@@ -23,6 +23,20 @@ interface InputNumberWithSliderProps {
   max?: number;
   step?: number | null;
   disabled?: boolean;
+  /**
+   * Controls how the control looks while non-interactive.
+   * - `'normal'` (default): standard antd `disabled` styling; the current
+   *   value and slider handle remain visible.
+   * - `'empty'`: render the control as disabled AND visually empty — the
+   *   number input shows no value, the slider hides its handle and filled
+   *   track (only the muted rail remains), and no marks are shown. Use this
+   *   for derived / auto-allocated fields that have no user-settable value
+   *   (e.g. unified-memory accelerators).
+   *
+   * Note: `'empty'` only affects presentation. Clear the bound form value
+   * separately if it must also be excluded from submission.
+   */
+  disableMode?: 'normal' | 'empty';
   value?: number;
   allowNegative?: boolean;
   onChange?: (value: number) => void;
@@ -38,6 +52,7 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
   max,
   step,
   disabled,
+  disableMode = 'normal',
   inputNumberProps,
   sliderProps,
   allowNegative,
@@ -47,8 +62,14 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
 }) => {
   const [value, setValue] = useControllableState_deprecated(otherProps);
   const inputRef = React.useRef<GetRef<typeof InputNumber>>(null);
+
+  // `'empty'` renders the control as disabled with no value, handle, or marks.
+  const isEmptyMode = disableMode === 'empty';
+  const isDisabled = disabled || isEmptyMode;
+  const displayValue = isEmptyMode ? undefined : value;
+
   useEffect(() => {
-    if (!allowNegative) {
+    if (!allowNegative && _.isNumber(value)) {
       // when step is 1, make sure the value is integer
       if (step === 1 && value % 1 !== 0) {
         setValue(_.max([Math.round(value), min]));
@@ -84,8 +105,8 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
             max={max}
             min={min}
             step={step ?? undefined}
-            disabled={disabled}
-            value={value}
+            disabled={isDisabled}
+            value={displayValue}
             onChange={setValue}
             onBlur={() => {
               if (_.isNumber(step) && step > 0) {
@@ -124,8 +145,8 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
           max={max}
           min={min}
           step={step}
-          disabled={disabled}
-          value={value}
+          disabled={isDisabled}
+          value={displayValue}
           onChange={(value: any) => {
             if (min !== undefined && value < min) {
               return;
@@ -134,10 +155,22 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
             }
           }}
           {...sliderProps}
-          // remove marks that are greater than max
-          marks={_.omitBy(sliderProps?.marks, (_option, key) => {
-            return _.isNumber(max) ? _.parseInt(key) > max : false;
-          })}
+          // In empty mode, hide the handle and filled track (only the muted
+          // rail remains) so the slider implies no value.
+          styles={{
+            ...sliderProps?.styles,
+            ...(isEmptyMode
+              ? { handle: { display: 'none' }, track: { display: 'none' } }
+              : {}),
+          }}
+          // remove marks that are greater than max; empty mode shows none
+          marks={
+            isEmptyMode
+              ? {}
+              : _.omitBy(sliderProps?.marks, (_option, key) => {
+                  return _.isNumber(max) ? _.parseInt(key) > max : false;
+                })
+          }
         />
       </BAIFlex>
     </BAIFlex>

--- a/react/src/components/LaunchMultipleSessionsModal.tsx
+++ b/react/src/components/LaunchMultipleSessionsModal.tsx
@@ -252,7 +252,12 @@ const LaunchMultipleSessionsModal: React.FC<
                       'session.launcher.LaunchMultipleSessionsPerSession',
                     )}
                   >
-                    <BAIFlex direction="row" gap="xxs" wrap="wrap">
+                    <BAIFlex
+                      direction="row"
+                      gap="xxs"
+                      wrap="wrap"
+                      style={{ width: '100%' }}
+                    >
                       <ResourcePreview
                         resource={resource}
                         containerCount={safeClusterSize}
@@ -262,7 +267,12 @@ const LaunchMultipleSessionsModal: React.FC<
                   <Descriptions.Item
                     label={t('session.launcher.LaunchMultipleSessionsTotal')}
                   >
-                    <BAIFlex direction="row" gap="xxs" wrap="wrap">
+                    <BAIFlex
+                      direction="row"
+                      gap="xxs"
+                      wrap="wrap"
+                      style={{ width: '100%' }}
+                    >
                       <ResourcePreview
                         resource={resource}
                         containerCount={totalContainers}

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
@@ -8,7 +8,30 @@ import {
   ResourcePreset,
 } from '../../hooks/useResourceLimitAndRemaining';
 import { Image } from '../ImageEnvironmentSelectFormItems';
-import { getAllocatablePresetNames } from './ResourceAllocationFormItems';
+import {
+  getAllocatablePresetNames,
+  isUnifiedAcceleratorSlot,
+} from './ResourceAllocationFormItems';
+
+describe('isUnifiedAcceleratorSlot', () => {
+  it('returns true for slot names ending with .unified', () => {
+    expect(isUnifiedAcceleratorSlot('cuda.unified')).toBe(true);
+    expect(isUnifiedAcceleratorSlot('rocm.unified')).toBe(true);
+  });
+
+  it('returns false for discrete accelerator slot names', () => {
+    expect(isUnifiedAcceleratorSlot('cuda.shares')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('cuda.device')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('cuda.mem')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('rocm.device')).toBe(false);
+  });
+
+  it('returns false for nullish or empty input', () => {
+    expect(isUnifiedAcceleratorSlot(undefined)).toBe(false);
+    expect(isUnifiedAcceleratorSlot(null)).toBe(false);
+    expect(isUnifiedAcceleratorSlot('')).toBe(false);
+  });
+});
 
 describe('getAllocatablePresetNames', () => {
   const presets: Array<ResourcePreset> = [

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -62,6 +62,16 @@ export const isMinOversMaxValue = (min: number, max: number) => {
   return min >= max;
 };
 
+/**
+ * Returns true when the given accelerator slot name represents a unified
+ * memory architecture, where the accelerator memory and the host memory
+ * share a single physical pool. Identified by a `.unified` suffix on the
+ * slot name (e.g. `cuda.unified`).
+ */
+export const isUnifiedAcceleratorSlot = (slotName?: string | null): boolean => {
+  return !!slotName && _.endsWith(slotName, '.unified');
+};
+
 export interface ResourceAllocationFormValue {
   resource: {
     cpu: number;
@@ -289,6 +299,23 @@ const ResourceAllocationFormItems: React.FC<
     }
   };
 
+  // Centralized helper that CLEARS the `resource.accelerator` field whenever
+  // the active accelerator slot is a unified one. Unified-memory slots
+  // auto-allocate accelerator memory from the shared host pool, so the
+  // launcher neither sends nor displays an accelerator quantity. Call this
+  // from every code path that mutates `resource.mem` or
+  // `resource.acceleratorType`.
+  const syncUnifiedAcceleratorIfNeeded = useEventNotStable(() => {
+    const activeAcceleratorType = form.getFieldValue([
+      'resource',
+      'acceleratorType',
+    ]);
+    if (!isUnifiedAcceleratorSlot(activeAcceleratorType)) {
+      return;
+    }
+    form.setFieldValue(['resource', 'accelerator'], undefined);
+  });
+
   const ensureValidAcceleratorType = useEventNotStable(() => {
     const currentAcceleratorType = form.getFieldValue([
       'resource',
@@ -305,6 +332,9 @@ const ResourceAllocationFormItems: React.FC<
         acceleratorType: nextAcceleratorType || currentAcceleratorType,
       },
     });
+    // The accelerator type may have changed; clear the accelerator field if
+    // the resolved type is a unified slot.
+    syncUnifiedAcceleratorIfNeeded();
   });
 
   const updateResourceFieldsBasedOnImage = useEventNotStable(
@@ -410,6 +440,9 @@ const ResourceAllocationFormItems: React.FC<
       if (form.getFieldValue('enabledAutomaticShmem')) {
         runShmemAutomationRule(form.getFieldValue(['resource', 'mem']) || '0g');
       }
+      // mem and/or acceleratorType may have changed above; keep the
+      // accelerator field consistent for unified slots.
+      syncUnifiedAcceleratorIfNeeded();
       form
         .validateFields(['resource'], {
           recursive: true,
@@ -467,6 +500,9 @@ const ResourceAllocationFormItems: React.FC<
       if (!hasPresetShmem) {
         runShmemAutomationRule(mem || '0g');
       }
+      // mem and/or acceleratorType may have changed above; keep the
+      // accelerator field consistent for unified slots.
+      syncUnifiedAcceleratorIfNeeded();
 
       form
         .validateFields(['resource'], {
@@ -888,6 +924,13 @@ const ResourceAllocationFormItems: React.FC<
                                 ) {
                                   runShmemAutomationRule(M_plus_S || '0g');
                                 }
+                                // When the active accelerator slot is a
+                                // unified-memory slot, accelerator memory is
+                                // auto-allocated from the shared host pool, so
+                                // clear any accelerator value at the source of
+                                // change to keep submit-time form state
+                                // consistent.
+                                syncUnifiedAcceleratorIfNeeded();
                               }}
                             />
                           </Form.Item>
@@ -945,6 +988,17 @@ const ResourceAllocationFormItems: React.FC<
                         currentAcceleratorType as keyof typeof resourceSlots
                       ] === 'unique';
 
+                    const isUnifiedType = isUnifiedAcceleratorSlot(
+                      currentAcceleratorType,
+                    );
+
+                    // For unified slots, surface the device's own description
+                    // (from resource-slot metadata) instead of a generic note.
+                    const unifiedAcceleratorDescription = isUnifiedType
+                      ? mergedResourceSlots?.[currentAcceleratorType]
+                          ?.description
+                      : undefined;
+
                     const isSingleCluster =
                       form.getFieldValue('cluster_size') < 2;
                     const hasQuantumSize = _.isNumber(
@@ -989,136 +1043,172 @@ const ResourceAllocationFormItems: React.FC<
                             />
                           ),
                         }}
+                        extra={
+                          unifiedAcceleratorDescription
+                            ? t(
+                                'session.launcher.UnifiedAcceleratorMemoryNote',
+                                {
+                                  description: unifiedAcceleratorDescription,
+                                },
+                              )
+                            : undefined
+                        }
                         dependencies={[
                           ['resource', 'acceleratorType'],
                           'cluster_size',
+                          ['resource', 'mem'],
                         ]}
-                        rules={[
-                          {
-                            required:
-                              currentImageAcceleratorLimits &&
-                              currentImageAcceleratorLimits.length > 0,
-                          },
-                          {
-                            type: 'number',
-                            min:
-                              resourceLimits.accelerators[
-                                currentAcceleratorType
-                              ]?.min || 0,
-                            // Unique type should only allow 0 or 1
-                            max: isUniqueType
-                              ? 1
-                              : resourceLimits.accelerators[
-                                  currentAcceleratorType
-                                ]?.max,
-                          },
-                          {
-                            validator: async (_rule: any, value: number) => {
-                              if (
-                                _.endsWith(currentAcceleratorType, 'shares') &&
-                                form.getFieldValue('cluster_size') >= 2 &&
-                                value % 1 !== 0
-                              ) {
-                                return Promise.reject(
-                                  t(
-                                    'session.launcher.OnlyAllowsDiscreteNumberByClusterSize',
-                                  ),
-                                );
-                              } else {
-                                return Promise.resolve();
-                              }
-                            },
-                          },
-                          {
-                            validator: async (_rule: any, value: number) => {
-                              if (
-                                _.isNumber(currentAcceleratorStep) &&
-                                ![0, currentAcceleratorStep].includes(
-                                  _.round(value % currentAcceleratorStep, 5),
-                                )
-                              ) {
-                                return Promise.reject(
-                                  t(
-                                    'session.launcher.OnlyAllowsDiscreteNumberByQuantumSize',
-                                    {
-                                      stepSize: currentAcceleratorStep,
-                                    },
-                                  ),
-                                );
-                              } else {
-                                return Promise.resolve();
-                              }
-                            },
-                          },
-                          {
-                            warningOnly: true,
-                            validator: async (_rule: any, value: number) => {
-                              if (
-                                _.isNumber(
-                                  resourceLimits.accelerators[
-                                    currentAcceleratorType
-                                  ]?.min,
-                                ) &&
-                                _.isNumber(
-                                  resourceLimits.accelerators[
-                                    currentAcceleratorType
-                                  ]?.max,
-                                ) &&
-                                isMinOversMaxValue(
-                                  resourceLimits.accelerators[
-                                    currentAcceleratorType
-                                  ]?.min,
-                                  resourceLimits.accelerators[
-                                    currentAcceleratorType
-                                  ]?.max,
-                                )
-                              ) {
-                                return Promise.reject(
-                                  t(
-                                    'session.launcher.InsufficientAllocationOfResourcesWarning',
-                                  ),
-                                );
-                              }
-                              if (showRemainingWarning) {
-                                if (
-                                  _.isNumber(
-                                    remaining.accelerators[
+                        // Unified-memory slots clear the accelerator field
+                        // (it stays empty, not mirrored) and disable direct
+                        // edits, so none of the discrete accelerator
+                        // constraints (required, min/max, step,
+                        // remaining/unique warnings, caller-provided rules)
+                        // apply. Skip all validation in that mode.
+                        rules={
+                          isUnifiedType
+                            ? []
+                            : [
+                                {
+                                  required:
+                                    currentImageAcceleratorLimits &&
+                                    currentImageAcceleratorLimits.length > 0,
+                                },
+                                {
+                                  type: 'number',
+                                  min:
+                                    resourceLimits.accelerators[
                                       currentAcceleratorType
-                                    ],
-                                  ) &&
-                                  value >
-                                    remaining.accelerators[
-                                      currentAcceleratorType
-                                    ]
-                                ) {
-                                  return Promise.reject(
-                                    t(
-                                      'session.launcher.EnqueueComputeSessionWarning',
-                                    ),
-                                  );
-                                }
-                              }
-                              return Promise.resolve();
-                            },
-                          },
-                          {
-                            warningOnly: true,
-                            validator: async (_rule, _value) => {
-                              if (isUniqueType) {
-                                return Promise.reject(
-                                  t(
-                                    'session.launcher.CurrentAcceleratorTypeAllowsMaxOne',
-                                    {
-                                      accelerator: currentAcceleratorType,
-                                    },
-                                  ),
-                                );
-                              }
-                              return Promise.resolve();
-                            },
-                          },
-                          ...(extraAcceleratorRules ?? []),
-                        ]}
+                                    ]?.min || 0,
+                                  // Unique type should only allow 0 or 1
+                                  max: isUniqueType
+                                    ? 1
+                                    : resourceLimits.accelerators[
+                                        currentAcceleratorType
+                                      ]?.max,
+                                },
+                                {
+                                  validator: async (
+                                    _rule: any,
+                                    value: number,
+                                  ) => {
+                                    if (
+                                      _.endsWith(
+                                        currentAcceleratorType,
+                                        'shares',
+                                      ) &&
+                                      form.getFieldValue('cluster_size') >= 2 &&
+                                      value % 1 !== 0
+                                    ) {
+                                      return Promise.reject(
+                                        t(
+                                          'session.launcher.OnlyAllowsDiscreteNumberByClusterSize',
+                                        ),
+                                      );
+                                    } else {
+                                      return Promise.resolve();
+                                    }
+                                  },
+                                },
+                                {
+                                  validator: async (
+                                    _rule: any,
+                                    value: number,
+                                  ) => {
+                                    if (
+                                      _.isNumber(currentAcceleratorStep) &&
+                                      ![0, currentAcceleratorStep].includes(
+                                        _.round(
+                                          value % currentAcceleratorStep,
+                                          5,
+                                        ),
+                                      )
+                                    ) {
+                                      return Promise.reject(
+                                        t(
+                                          'session.launcher.OnlyAllowsDiscreteNumberByQuantumSize',
+                                          {
+                                            stepSize: currentAcceleratorStep,
+                                          },
+                                        ),
+                                      );
+                                    } else {
+                                      return Promise.resolve();
+                                    }
+                                  },
+                                },
+                                {
+                                  warningOnly: true,
+                                  validator: async (
+                                    _rule: any,
+                                    value: number,
+                                  ) => {
+                                    if (
+                                      _.isNumber(
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.min,
+                                      ) &&
+                                      _.isNumber(
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.max,
+                                      ) &&
+                                      isMinOversMaxValue(
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.min,
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.max,
+                                      )
+                                    ) {
+                                      return Promise.reject(
+                                        t(
+                                          'session.launcher.InsufficientAllocationOfResourcesWarning',
+                                        ),
+                                      );
+                                    }
+                                    if (showRemainingWarning) {
+                                      if (
+                                        _.isNumber(
+                                          remaining.accelerators[
+                                            currentAcceleratorType
+                                          ],
+                                        ) &&
+                                        value >
+                                          remaining.accelerators[
+                                            currentAcceleratorType
+                                          ]
+                                      ) {
+                                        return Promise.reject(
+                                          t(
+                                            'session.launcher.EnqueueComputeSessionWarning',
+                                          ),
+                                        );
+                                      }
+                                    }
+                                    return Promise.resolve();
+                                  },
+                                },
+                                {
+                                  warningOnly: true,
+                                  validator: async (_rule, _value) => {
+                                    if (isUniqueType) {
+                                      return Promise.reject(
+                                        t(
+                                          'session.launcher.CurrentAcceleratorTypeAllowsMaxOne',
+                                          {
+                                            accelerator: currentAcceleratorType,
+                                          },
+                                        ),
+                                      );
+                                    }
+                                    return Promise.resolve();
+                                  },
+                                },
+                                ...(extraAcceleratorRules ?? []),
+                              ]
+                        }
                       >
                         <InputNumberWithSlider
                           inputContainerMinWidth={190}
@@ -1165,6 +1255,7 @@ const ResourceAllocationFormItems: React.FC<
                           disabled={
                             supportedAcceleratorTypesInRGByImage?.length === 0
                           }
+                          disableMode={isUnifiedType ? 'empty' : 'normal'}
                           min={0}
                           max={
                             // Unique type should only allow 0 or 1
@@ -1220,6 +1311,56 @@ const ResourceAllocationFormItems: React.FC<
                                         };
                                       },
                                     )}
+                                    onChange={(nextType: string) => {
+                                      // Changing the slot type mutates the
+                                      // active allocation; the previously
+                                      // selected preset no longer matches.
+                                      form.setFieldValue(
+                                        'allocationPreset',
+                                        'custom',
+                                      );
+                                      // Keep the accelerator field consistent
+                                      // at the moment the slot type changes,
+                                      // rather than relying on a watcher
+                                      // effect that runs after render.
+                                      if (isUnifiedAcceleratorSlot(nextType)) {
+                                        // Switching INTO a unified slot: clear
+                                        // the accelerator field since unified
+                                        // memory is auto-allocated. Write
+                                        // acceleratorType first so the shared
+                                        // helper sees the new active slot when
+                                        // it reads from the form.
+                                        form.setFieldValue(
+                                          ['resource', 'acceleratorType'],
+                                          nextType,
+                                        );
+                                        syncUnifiedAcceleratorIfNeeded();
+                                      } else if (
+                                        isUnifiedAcceleratorSlot(
+                                          currentAcceleratorType,
+                                        )
+                                      ) {
+                                        // Switching OUT of a unified slot
+                                        // into a discrete one: reset to the
+                                        // discrete slot's min so the empty
+                                        // unified-mode value does not bleed
+                                        // through as a device count.
+                                        //
+                                        // Discrete-to-discrete switches are
+                                        // intentionally NOT reset here:
+                                        // ensureValidAcceleratorType clamps
+                                        // the existing value if it falls
+                                        // outside the new slot's range, so
+                                        // the user's current allocation is
+                                        // preserved across discrete slot
+                                        // changes.
+                                        form.setFieldValue(
+                                          ['resource', 'accelerator'],
+                                          resourceLimits.accelerators[nextType]
+                                            ?.min ?? 0,
+                                        );
+                                      }
+                                    }}
                                   />
                                 </Form.Item>
                               ) : undefined,

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -539,7 +539,7 @@ const SessionLauncherPreview: React.FC<{
             type="inner"
             title={t('session.launcher.TotalAllocation')}
           >
-            <BAIFlex direction="row" gap="xxs">
+            <BAIFlex direction="row" gap="xxs" wrap="wrap">
               <ResourceNumbersOfSession
                 resource={form.getFieldValue('resource')}
                 containerCount={

--- a/react/src/hooks/useStartSession.tsx
+++ b/react/src/hooks/useStartSession.tsx
@@ -5,7 +5,10 @@
 import { useSuspendedBackendaiClient } from '.';
 import { useStartSessionCreationQuery } from '../__generated__/useStartSessionCreationQuery.graphql';
 import { transformPortValuesToNumbers } from '../components/PortSelectFormItem';
-import { RESOURCE_ALLOCATION_INITIAL_FORM_VALUES } from '../components/SessionFormItems/ResourceAllocationFormItems';
+import {
+  RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
+  isUnifiedAcceleratorSlot,
+} from '../components/SessionFormItems/ResourceAllocationFormItems';
 import {
   SessionLauncherFormValue,
   SessionResources,
@@ -230,16 +233,27 @@ export const useStartSession = () => {
           ? { dependencies: values.dependencies }
           : {}),
 
+        // Temporary marker for unified-memory sessions. There is currently no
+        // dedicated field to tell from session info alone whether a session
+        // uses a unified-memory accelerator, so tag it as
+        // `unified-slot:<accelerator slot name>` (e.g. `unified-slot:cuda.unified`).
+        ...(isUnifiedAcceleratorSlot(values.resource?.acceleratorType)
+          ? { tag: `unified-slot:${values.resource?.acceleratorType}` }
+          : {}),
+
         config: {
           // Resource allocation
           ...(values?.resource && {
             resources: {
               cpu: values?.resource?.cpu,
               mem: values?.resource?.mem,
-              // Add accelerator only if specified
+              // Add accelerator only if specified. Unified-memory slots
+              // auto-allocate from the shared host pool, so never send an
+              // accelerator quantity for them.
               ...(values.resource?.acceleratorType &&
               values.resource?.accelerator &&
-              values.resource?.accelerator > 0
+              values.resource?.accelerator > 0 &&
+              !isUnifiedAcceleratorSlot(values.resource.acceleratorType)
                 ? {
                     [values.resource.acceleratorType]:
                       values.resource.accelerator,

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -15,9 +15,11 @@ import { mainContentDivRefState } from '../components/MainLayout/MainLayout';
 import PortSelectFormItem, {
   PortSelectFormValues,
 } from '../components/PortSelectFormItem';
+import { ResourceTypeIcon } from '../components/ResourceNumber';
 import ResourceAllocationFormItems, {
   RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
   ResourceAllocationFormValue,
+  isUnifiedAcceleratorSlot,
 } from '../components/SessionFormItems/ResourceAllocationFormItems';
 import SessionLauncherValidationTour from '../components/SessionLauncherErrorTourProps';
 import SessionLauncherFormIncompatibleValueChecker from '../components/SessionLauncherFormIncompatibleValueChecker';
@@ -84,6 +86,7 @@ import {
   BAIUnmountAfterClose,
   useUpdatableState,
   BAIIntervalView,
+  useResourceSlotsDetails,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import { useAtomValue } from 'jotai';
@@ -1449,6 +1452,56 @@ type FormOrResourceRequired = {
   containerCount?: number;
 };
 
+// Renders a unified-memory accelerator as "<device description>" with the same
+// explanatory tooltip as the launcher's accelerator field. Kept as a separate
+// component so its resource-slot metadata query runs only where it is used, and
+// so a long description wraps gracefully: the icon + text wrap as a unit, and
+// the text breaks onto multiple lines instead of overflowing.
+const UnifiedAcceleratorChip: React.FC<{ type: string }> = ({ type }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  // Query slot details across all resource groups (no sgroup) so the unified
+  // slot's description is found regardless of the form's selected group — the
+  // description lives only in the backend slot-details response (it is not in
+  // the local device_metadata.json), so a group mismatch would otherwise drop
+  // it and fall back to the slot name.
+  const { mergedResourceSlots } = useResourceSlotsDetails();
+  const description = mergedResourceSlots?.[type]?.description ?? type;
+  // One line of the description text, so the icon can be vertically centered
+  // against the first line (not the whole wrapped block).
+  const lineHeightPx = token.fontSize * token.lineHeight;
+  return (
+    <Tooltip
+      title={t('session.launcher.UnifiedAcceleratorMemoryNote', {
+        description,
+      })}
+    >
+      <BAIFlex
+        direction="row"
+        gap="xxs"
+        align="start"
+        style={{ minWidth: 0, maxWidth: '100%' }}
+      >
+        {/* Match the icon box to one text line and center the icon so it stays
+            aligned with the first line when the description wraps. */}
+        <BAIFlex align="center" style={{ flexShrink: 0, height: lineHeightPx }}>
+          <ResourceTypeIcon type={type} showTooltip={false} />
+        </BAIFlex>
+        <Typography.Text
+          style={{
+            minWidth: 0,
+            whiteSpace: 'normal',
+            overflowWrap: 'anywhere',
+          }}
+        >
+          {description}
+        </Typography.Text>
+      </BAIFlex>
+    </Tooltip>
+  );
+};
+
 export const ResourceNumbersOfSession: React.FC<FormOrResourceRequired> = ({
   resource,
   containerCount = 1,
@@ -1480,10 +1533,16 @@ export const ResourceNumbersOfSession: React.FC<FormOrResourceRequired> = ({
           );
         },
       )}
-      {resource &&
-      resource.accelerator &&
-      resource.acceleratorType &&
-      _.isNumber(resource.accelerator) ? (
+      {resource?.acceleratorType &&
+      isUnifiedAcceleratorSlot(resource.acceleratorType) ? (
+        // Unified-memory accelerator: show the device description regardless of
+        // amount, with the same explanatory tooltip as the launcher's
+        // accelerator field on hover.
+        <UnifiedAcceleratorChip type={resource.acceleratorType} />
+      ) : resource &&
+        resource.accelerator &&
+        resource.acceleratorType &&
+        _.isNumber(resource.accelerator) ? (
         <BAIResourceNumberWithIcon
           // @ts-ignore
           type={resource.acceleratorType}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard-App ist bereit.",
       "TitleSession": "Sitzung (Backend.AI)",
       "TotalAllocation": "Gesamtzuweisung",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" hat keinen separaten Beschleunigerspeicher; es nutzt den Hostspeicher-Pool und kann nicht separat festgelegt werden.",
       "UserResourceLimit": "Beschränkung der Benutzerressourcen",
       "UsingBootstrapScriptInfo": "Bootstrap-Skript ist enthalten.",
       "Version": "Ausführung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Η εφαρμογή TensorBoard είναι έτοιμη.",
       "TitleSession": "Συνεδρία (Backend.AI)",
       "TotalAllocation": "Συνολική κατανομή",
+      "UnifiedAcceleratorMemoryNote": "Η \"{{description}}\" δεν διαθέτει ξεχωριστή μνήμη επιταχυντή· χρησιμοποιεί τη δεξαμενή μνήμης του κεντρικού υπολογιστή και δεν μπορεί να οριστεί ξεχωριστά.",
       "UserResourceLimit": "Όριο πόρων χρήστη",
       "UsingBootstrapScriptInfo": "Το Bootstrap script περιλαμβάνεται.",
       "Version": "Εκδοχή",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2977,6 +2977,7 @@
       "TensorBoardPrepared": "TensorBoard app prepared.",
       "TitleSession": "Session (Backend.AI)",
       "TotalAllocation": "Total Allocation",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" has no separate accelerator memory; it uses the host memory pool and cannot be set separately.",
       "UserResourceLimit": "User Resource Limit",
       "UsingBootstrapScriptInfo": "Bootstrap script is included.",
       "Version": "Version",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplicación TensorBoard preparada.",
       "TitleSession": "Sesión (Backend.AI)",
       "TotalAllocation": "Asignación total",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" no tiene memoria de acelerador independiente; utiliza el grupo de memoria del host y no se puede configurar por separado.",
       "UserResourceLimit": "Límite de recursos de usuario",
       "UsingBootstrapScriptInfo": "Script de arranque incluido.",
       "Version": "Versión",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "TensorBoard-sovellus valmis.",
       "TitleSession": "Istunto (Backend.AI)",
       "TotalAllocation": "Kokonaismääräraha",
+      "UnifiedAcceleratorMemoryNote": "Laitteessa \"{{description}}\" ei ole erillistä kiihdyttimen muistia; se käyttää isäntämuistivarantoa, eikä sitä voi määrittää erikseen.",
       "UserResourceLimit": "Käyttäjän resurssirajoitus",
       "UsingBootstrapScriptInfo": "Bootstrap-skripti on mukana.",
       "Version": "Versio",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "Application TensorBoard prête.",
       "TitleSession": "Session (Backend.AI)",
       "TotalAllocation": "Allocation totale",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" n'a pas de mémoire d'accélérateur distincte ; il utilise le pool de mémoire de l'hôte et ne peut pas être défini séparément.",
       "UserResourceLimit": "Limite de ressources utilisateur",
       "UsingBootstrapScriptInfo": "Le script de démarrage est inclus.",
       "Version": "Version",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2994,6 +2994,7 @@
       "TensorBoardPrepared": "Aplikasi TensorBoard siap.",
       "TitleSession": "Sesi (Backend.AI)",
       "TotalAllocation": "Alokasi Total",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" tidak memiliki memori akselerator terpisah; perangkat menggunakan kumpulan memori host dan tidak dapat diatur secara terpisah.",
       "UserResourceLimit": "Batas Sumber Daya Pengguna",
       "UsingBootstrapScriptInfo": "Skrip bootstrap disertakan.",
       "Version": "Versi",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "App TensorBoard pronta.",
       "TitleSession": "Sessione (Backend.AI)",
       "TotalAllocation": "Allocazione totale",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" non dispone di memoria dell'acceleratore separata; utilizza il pool di memoria host e non può essere impostata separatamente.",
       "UserResourceLimit": "Limite risorse utente",
       "UsingBootstrapScriptInfo": "Lo script di bootstrap è incluso.",
       "Version": "Versione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard アプリの準備ができました。",
       "TitleSession": "セッション（Backend.AI）",
       "TotalAllocation": "総割り当て",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\"には専用のアクセラレータメモリがなく、ホストメモリプールを共用するため、個別に設定できません。",
       "UserResourceLimit": "ユーザーリソース制限",
       "UsingBootstrapScriptInfo": "ブートストラップスクリプトが含まれています。",
       "Version": "バージョン",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "TensorBoard 앱이 준비되었습니다.",
       "TitleSession": "세션 (Backend.AI)",
       "TotalAllocation": "총 자원 할당량",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\"는 별도의 가속기 메모리가 없으며, 호스트 메모리 풀을 함께 사용하므로 따로 설정할 수 없습니다.",
       "UserResourceLimit": "사용자 자원 제한",
       "UsingBootstrapScriptInfo": "부트스트랩 스크립트가 포함되어 있습니다.",
       "Version": "버전",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard програм бэлэн боллоо.",
       "TitleSession": "Чуулган (Backend.AI)",
       "TotalAllocation": "Нийт хуваарилалт",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\"-д тусдаа хурдасгуурын санах ой байхгүй бөгөөд хостын санах ойн санг ашигладаг тул тусад нь тохируулах боломжгүй.",
       "UserResourceLimit": "Хэрэглэгчийн нөөцийн хязгаарлалт",
       "UsingBootstrapScriptInfo": "Bootstrap скрипт багтсан.",
       "Version": "Хувилбар",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplikasi TensorBoard disediakan.",
       "TitleSession": "Sesi (Backend.AI)",
       "TotalAllocation": "Jumlah Peruntukan",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" tidak mempunyai memori pemecut yang berasingan; ia menggunakan kumpulan memori hos dan tidak boleh ditetapkan secara berasingan.",
       "UserResourceLimit": "Had Sumber Pengguna",
       "UsingBootstrapScriptInfo": "Skrip bootstrap disertakan.",
       "Version": "Versi",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "Aplikacja TensorBoard jest gotowa.",
       "TitleSession": "Sesja (Backend.AI)",
       "TotalAllocation": "Całkowity przydział",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" nie ma osobnej pamięci akceleratora; korzysta z puli pamięci hosta i nie można jej ustawić osobno.",
       "UserResourceLimit": "Limit zasobów użytkownika",
       "UsingBootstrapScriptInfo": "Skrypt bootstrap jest dołączony.",
       "Version": "Wersja",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplicativo TensorBoard preparado.",
       "TitleSession": "Sessão (Backend.AI)",
       "TotalAllocation": "Alocação Total",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" não tem memória de acelerador separada; usa o pool de memória do host e não pode ser definida separadamente.",
       "UserResourceLimit": "Limite de recursos do usuário",
       "UsingBootstrapScriptInfo": "O script de bootstrap está incluído.",
       "Version": "Versão",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "Aplicação TensorBoard preparada.",
       "TitleSession": "Sessão (Backend.AI)",
       "TotalAllocation": "Alocação Total",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" não tem memória de acelerador separada; usa o pool de memória do host e não pode ser definida separadamente.",
       "UserResourceLimit": "Limite de recursos do usuário",
       "UsingBootstrapScriptInfo": "Script de bootstrap incluído.",
       "Version": "Versão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Приложение TensorBoard готово.",
       "TitleSession": "Сессия (Backend.AI)",
       "TotalAllocation": "Итого распределено",
+      "UnifiedAcceleratorMemoryNote": "На устройстве \"{{description}}\" нет отдельной памяти ускорителя; оно использует пул памяти хоста, поэтому её нельзя задать отдельно.",
       "UserResourceLimit": "Лимит ресурсов пользователя",
       "UsingBootstrapScriptInfo": "Скрипт Bootstrap включён.",
       "Version": "Версия",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "แอป TensorBoard พร้อมแล้ว.",
       "TitleSession": "เซสชัน (Backend.AI)",
       "TotalAllocation": "การจัดสรรทั้งหมด",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" ไม่มีหน่วยความจำของตัวเร่งแยกต่างหาก แต่ใช้พูลหน่วยความจำของโฮสต์ จึงไม่สามารถตั้งค่าแยกต่างหากได้",
       "UserResourceLimit": "ขีดจำกัดทรัพยากรผู้ใช้",
       "UsingBootstrapScriptInfo": "สคริปต์ Bootstrap ถูกรวมไว้",
       "Version": "เวอร์ชัน",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "TensorBoard uygulaması hazır.",
       "TitleSession": "Oturum (Arka Uç.AI)",
       "TotalAllocation": "Toplam Tahsis",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" cihazında ayrı bir hızlandırıcı belleği yoktur; ana makine bellek havuzunu kullanır ve ayrı olarak ayarlanamaz.",
       "UserResourceLimit": "Kullanıcı Kaynak Sınırı",
       "UsingBootstrapScriptInfo": "Bootstrap betiği dahil edildi.",
       "Version": "Sürüm",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "Ứng dụng TensorBoard đã sẵn sàng.",
       "TitleSession": "Phiên (Backend.AI)",
       "TotalAllocation": "Tổng phân bổ",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\" không có bộ nhớ máy gia tốc riêng; nó sử dụng nhóm bộ nhớ máy chủ và không thể được đặt riêng.",
       "UserResourceLimit": "Giới hạn tài nguyên người dùng",
       "UsingBootstrapScriptInfo": "Đã bao gồm tập lệnh khởi tạo.",
       "Version": "Phiên bản",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard 应用已准备就绪。",
       "TitleSession": "会话（后端.AI）",
       "TotalAllocation": "总分配",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\"没有独立的加速器内存，它使用主机内存池，因此无法单独设置。",
       "UserResourceLimit": "用户资源限制",
       "UsingBootstrapScriptInfo": "已包含引导脚本。",
       "Version": "版本",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2994,6 +2994,7 @@
       "TensorBoardPrepared": "TensorBoard 應用程式已準備就緒。",
       "TitleSession": "會話（後端.AI）",
       "TotalAllocation": "總分配",
+      "UnifiedAcceleratorMemoryNote": "\"{{description}}\"沒有獨立的加速器記憶體，它使用主機記憶體池，因此無法單獨設定。",
       "UserResourceLimit": "用戶資源限制",
       "UsingBootstrapScriptInfo": "已包含啟動腳本。",
       "Version": "版本",


### PR DESCRIPTION
Resolves #7358 (FR-2867)

![image.png](https://app.graphite.com/user-attachments/assets/942072a8-583d-42fc-8a5b-b99eeb5d44d9.png)

![image.png](https://app.graphite.com/user-attachments/assets/9477c93a-831d-4309-b19b-4f3a24f4cff8.png)

## Summary

Adds Session Launcher UX for **unified-memory accelerators** — slots whose name ends in `.unified` (e.g. `cuda.unified`), such as NVIDIA Jetson where the CPU and GPU share one physical DRAM pool with no dedicated VRAM.

A `.unified` slot has **no user-settable accelerator quantity** — the backend auto-allocates from the shared host-memory pool. The launcher reflects this: the accelerator amount field is **empty and disabled**, the slider shows **no value, no handle, and no marks**, and all accelerator validations are skipped. The session is **tagged** so it can be recognized as unified, and the launcher field note / review step surface the **device's own description**.

Detection is by the `.unified` suffix only, so it generalizes to any future unified-memory family. Discrete slots are unchanged.

## Approach

- **Empty, not mirrored.** (Requirement changed from the initial draft, which mirrored host memory into the field.) A unified accelerator has no meaningful per-device amount, so the form field is **cleared** — event-driven, in the same callbacks that change `mem` or the accelerator type — keeping submit-time state consistent so the create request omits the quantity.
- **`disableMode` on `InputNumberWithSlider`.** New `disableMode?: 'normal' | 'empty'` prop. `'empty'` renders the control disabled with no value, a hidden slider handle/track, and no marks. The slot-details query and rendering for the unified case are isolated in a small `UnifiedAcceleratorChip`, so the metadata fetch runs only when a unified accelerator is actually displayed.
- **Temporary unified tag.** There is currently no field to tell from session info alone whether a session is unified, so a `.unified` session is tagged `unified-slot:<slot name>` — a top-level session `tag` the manager persists and exposes via GraphQL.
- **Device description in launcher + review.** The accelerator field note and the review/confirm step (and the "launch multiple sessions" modal) show the slot's `description` (from resource-slot metadata) with an explanatory tooltip. The note's i18n value wraps the description in quotes (`session.launcher.UnifiedAcceleratorMemoryNote`).

## Changes

- `ResourceAllocationFormItems.tsx` — `.unified` handling: clear the accelerator field (event-driven), `disableMode="empty"`, no marks, validation skip; the field note renders the device `description` in quotes.
- `InputNumberWithSlider.tsx` — `disableMode` prop (`'normal' | 'empty'`) + a guard so an empty (`undefined`) value no longer triggers the step-rounding effect.
- `useStartSession.tsx` — omit the accelerator quantity for `.unified`; set `tag: unified-slot:<slot>`.
- `packages/backend.ai-client/src/types.ts` — `SessionResources.tag?: string`.
- `SessionLauncherPage.tsx` (`ResourceNumbersOfSession` / `UnifiedAcceleratorChip`) — resource summaries render a unified accelerator as the device description + tooltip regardless of amount, gated purely by `isUnifiedAcceleratorSlot`. Layout: icon + text wrap as a unit, long text wraps onto multiple lines, and the icon is vertically aligned to the first line.
- `SessionLauncherPreview.tsx`, `LaunchMultipleSessionsModal.tsx` — container wrap / width tweaks so the description chip wraps gracefully.
- `resources/i18n/*.json` (21 languages) — `UnifiedAcceleratorMemoryNote` now reads `"{{description}}" …`, with the device description substituted for the subject and wrapped in quotes.
- Tests — removed the obsolete mem-mirroring helper test; kept the `isUnifiedAcceleratorSlot` tests.

## Verification

Lint (0 errors) / Format / TypeScript (0 errors) pass on the changed files (in-worktree tsc watch + eslint/prettier). Unit tests for the touched helpers pass.

> Note: not runtime-verifiable in the current dev environment because the test backend exposes no `.unified` resource slot; needs a backend with a unified-memory slot to visually confirm the launcher/review rendering and the `unified-slot:` tag on a created session.

## Out of scope

A first-class field/flag on the session model for unified-memory sessions (the `unified-slot:` tag is a temporary marker), and resource-group unified-agent filtering.

## Test plan

- [ ] `.unified` slot → accelerator field empty & disabled; slider shows no value/handle and no marks
- [ ] Switch back to a discrete slot → editable again, resets to that slot's min
- [ ] Accelerator field note shows the device description in quotes; no validation errors/warnings in unified mode even when host memory exceeds the device max
- [ ] Submitting a `.unified` session sends **no** accelerator quantity and tags the session `unified-slot:<slot>`
- [ ] Review/confirm step and "launch multiple sessions" modal show the device description + tooltip for unified regardless of amount; long descriptions wrap with the icon aligned to the first line