### PR TITLE
fix(FR-2870): catch storage host fetch errors in session launcher

### DIFF
--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -166,5 +166,8 @@ export {
 } from './useBAILogger';
 export type { LoggerPlugin, LogContext, BAILogger } from './useBAILogger';
 export { useEventNotStable } from './useEventNotStable';
-export { useProjectResourceGroups } from './useProjectResourceGroups';
+export {
+  useProjectResourceGroups,
+  StorageHostFetchError,
+} from './useProjectResourceGroups';
 export type { ScalingGroupItem } from './useProjectResourceGroups';

--- a/packages/backend.ai-ui/src/hooks/useProjectResourceGroups.ts
+++ b/packages/backend.ai-ui/src/hooks/useProjectResourceGroups.ts
@@ -6,6 +6,27 @@ export interface ScalingGroupItem {
   name: string;
 }
 
+/**
+ * Thrown when the vfolder host info fetch (`/folders/_/hosts`) inside
+ * `useProjectResourceGroups` fails. Tagging the failure lets callers wrap
+ * the hook with a dedicated error boundary that can distinguish this
+ * specific case from unrelated render errors and surface a targeted
+ * message (and discriminate it from the parallel scaling-groups fetch
+ * failure, which is re-thrown as-is so an outer boundary handles it).
+ */
+export class StorageHostFetchError extends Error {
+  readonly originalError: unknown;
+  constructor(originalError: unknown) {
+    super(
+      originalError instanceof Error
+        ? originalError.message
+        : 'Failed to fetch storage host information.',
+    );
+    this.name = 'StorageHostFetchError';
+    this.originalError = originalError;
+  }
+}
+
 interface VolumeInfo {
   backend: string;
   capabilities: string[];
@@ -15,19 +36,20 @@ interface VolumeInfo {
   sftp_scaling_groups?: string[];
 }
 
+interface ScalingGroupsResponse {
+  scaling_groups: ScalingGroupItem[];
+}
+
+interface StorageHostsResponse {
+  allowed: string[];
+  default: string;
+  volume_info: {
+    [key: string]: VolumeInfo;
+  };
+}
+
 type ProjectResourceGroupsQueryResult =
-  | [
-      {
-        scaling_groups: ScalingGroupItem[];
-      },
-      {
-        allowed: string[];
-        default: string;
-        volume_info: {
-          [key: string]: VolumeInfo;
-        };
-      },
-    ]
+  | [ScalingGroupsResponse, StorageHostsResponse]
   | null;
 
 interface UseProjectResourceGroupsOptions {
@@ -60,24 +82,37 @@ export const useProjectResourceGroups = (
 
   const { data } = useSuspenseTanQuery<ProjectResourceGroupsQueryResult>({
     queryKey: ['ResourceGroupSelectQuery', projectName],
-    queryFn: () => {
+    queryFn: async () => {
       // Short-circuit when there is no project context yet — avoids hitting
       // `/scaling-groups?group=` and `/folders/_/hosts` with an unscoped query.
       if (!projectName) {
-        return Promise.resolve(null);
+        return null;
       }
       const search = new URLSearchParams();
       search.set('group', projectName);
-      return Promise.all([
+      // Run both fetches concurrently but discriminate failures: a host-info
+      // failure is tagged with `StorageHostFetchError` so a dedicated boundary
+      // can surface it, while a scaling-groups failure is re-thrown as-is and
+      // bubbles up to the generic error boundary. Host-info failure takes
+      // precedence when both fail because SFTP filtering depends on it and
+      // the result is otherwise unusable.
+      const [scalingGroupsResult, hostsResult] = await Promise.allSettled([
         baiRequestWithPromise({
           method: 'GET',
           url: `/scaling-groups?${search.toString()}`,
-        }),
+        }) as Promise<ScalingGroupsResponse>,
         baiRequestWithPromise({
           method: 'GET',
           url: `/folders/_/hosts`,
-        }),
+        }) as Promise<StorageHostsResponse>,
       ]);
+      if (hostsResult.status === 'rejected') {
+        throw new StorageHostFetchError(hostsResult.reason);
+      }
+      if (scalingGroupsResult.status === 'rejected') {
+        throw scalingGroupsResult.reason;
+      }
+      return [scalingGroupsResult.value, hostsResult.value];
     },
     staleTime: 1000 * 60 * 5, // Cache for 5 minutes
   });

--- a/react/src/components/StorageHostFetchErrorBoundary.tsx
+++ b/react/src/components/StorageHostFetchErrorBoundary.tsx
@@ -1,0 +1,59 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { Button, Result } from 'antd';
+import { BAIFlex, StorageHostFetchError } from 'backend.ai-ui';
+import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { useTranslation } from 'react-i18next';
+
+interface StorageHostFetchErrorBoundaryProps {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+const StorageHostFetchErrorBoundary: React.FC<
+  StorageHostFetchErrorBoundaryProps
+> = ({ children, style }) => {
+  'use memo';
+  const { t } = useTranslation();
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error }) => {
+        if (!(error instanceof StorageHostFetchError)) {
+          // Re-throw non-storage errors so the outer BAIErrorBoundary handles them.
+          throw error;
+        }
+        return (
+          <BAIFlex
+            style={{ margin: 'auto', ...style }}
+            justify="center"
+            align="center"
+          >
+            <Result
+              status="warning"
+              title={t('errorBoundary.StorageHostFetchFailedTitle')}
+              extra={
+                <BAIFlex direction="column" gap="md">
+                  <Button
+                    type="primary"
+                    onClick={() => {
+                      globalThis.history.back();
+                    }}
+                  >
+                    {t('button.GoBackToPreviousPage')}
+                  </Button>
+                </BAIFlex>
+              }
+            />
+          </BAIFlex>
+        );
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+};
+
+export default StorageHostFetchErrorBoundary;

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -13,6 +13,7 @@ import LocationStateBreadCrumb from './components/LocationStateBreadCrumb';
 import LoginView from './components/LoginView';
 import MainLayout from './components/MainLayout/MainLayout';
 import { STokenLoginBoundary } from './components/STokenLoginBoundary';
+import StorageHostFetchErrorBoundary from './components/StorageHostFetchErrorBoundary';
 import WebUINavigate from './components/WebUINavigate';
 import { persistPostLoginState } from './helper/loginSessionAuth';
 import { useSuspendedBackendaiClient } from './hooks';
@@ -258,15 +259,17 @@ export const mainLayoutChildRoutes: RouteObject[] = [
               style={{ paddingBottom: token.paddingContentVerticalLG }}
             >
               <LocationStateBreadCrumb />
-              <Suspense
-                fallback={
-                  <BAIFlex direction="column" style={{ maxWidth: 700 }}>
-                    <Skeleton active />
-                  </BAIFlex>
-                }
-              >
-                <SessionLauncherPage />
-              </Suspense>
+              <StorageHostFetchErrorBoundary>
+                <Suspense
+                  fallback={
+                    <BAIFlex direction="column" style={{ maxWidth: 700 }}>
+                      <Skeleton active />
+                    </BAIFlex>
+                  }
+                >
+                  <SessionLauncherPage />
+                </Suspense>
+              </StorageHostFetchErrorBoundary>
             </BAIFlex>
           );
         },

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -368,6 +368,7 @@
     "Finish": "Fertig",
     "ForceTerminate": "Beenden erzwingen",
     "Generate": "Generieren",
+    "GoBackToPreviousPage": "Zurück zur vorherigen Seite",
     "GoBackToStartPage": "Zurück zur Seite {{title}}",
     "Info": "Info",
     "More": "Mehr",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Laden Sie die Seite neu",
     "ResetErrorBoundary": "ErrorBoundary zurücksetzen",
     "StackTrace": "Stack-Trace:",
+    "StorageHostFetchFailedTitle": "Speicher-Host-Informationen konnten nicht abgerufen werden.",
     "Title": "Es ist ein Fehler aufgetreten."
   },
   "explorer": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -368,6 +368,7 @@
     "Finish": "Φινίρισμα",
     "ForceTerminate": "Δύναμη τερματισμού",
     "Generate": "Παράγω",
+    "GoBackToPreviousPage": "Επιστροφή στην προηγούμενη σελίδα",
     "GoBackToStartPage": "Επιστροφή στη σελίδα {{title}}",
     "Info": "Πληροφορίες",
     "More": "Περισσότερα",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Επαναφόρτωση της σελίδας",
     "ResetErrorBoundary": "Επαναφορά ErrorBoundary",
     "StackTrace": "Ιχνη στοίβας:",
+    "StorageHostFetchFailedTitle": "Αποτυχία ανάκτησης πληροφοριών κεντρικού υπολογιστή αποθήκευσης.",
     "Title": "Εμφανίστηκε σφάλμα."
   },
   "explorer": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -385,6 +385,7 @@
     "Finish": "Finish",
     "ForceTerminate": "Force Terminate",
     "Generate": "Generate",
+    "GoBackToPreviousPage": "Go back to the previous page",
     "GoBackToStartPage": "Go back to the {{title}} page",
     "Info": "Info",
     "More": "More",
@@ -1403,6 +1404,7 @@
     "ReloadPage": "Reload the page",
     "ResetErrorBoundary": "Reset ErrorBoundary",
     "StackTrace": "Stack Trace:",
+    "StorageHostFetchFailedTitle": "Failed to fetch storage host information.",
     "Title": "An error has occurred."
   },
   "explorer": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -368,6 +368,7 @@
     "Finish": "Acabado",
     "ForceTerminate": "Forzar finalización",
     "Generate": "Genere",
+    "GoBackToPreviousPage": "Volver a la página anterior",
     "GoBackToStartPage": "Volver a la página {{title}}",
     "Info": "Info",
     "More": "Más",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Recargar la página",
     "ResetErrorBoundary": "Restablecer ErrorBoundary",
     "StackTrace": "Traza de pila:",
+    "StorageHostFetchFailedTitle": "No se pudo obtener la información del host de almacenamiento.",
     "Title": "Se ha producido un error."
   },
   "explorer": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -368,6 +368,7 @@
     "Finish": "Viimeistely",
     "ForceTerminate": "Pakota lopettamaan",
     "Generate": "Luo",
+    "GoBackToPreviousPage": "Palaa edelliselle sivulle",
     "GoBackToStartPage": "Palaa sivulle {{title}}",
     "Info": "Tiedot",
     "More": "Lisää",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Lataa sivu uudelleen",
     "ResetErrorBoundary": "Nollaa ErrorBoundary",
     "StackTrace": "Pinon jäljitys:",
+    "StorageHostFetchFailedTitle": "Tallennusisännän tietojen hakeminen epäonnistui.",
     "Title": "On tapahtunut virhe."
   },
   "explorer": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -368,6 +368,7 @@
     "Finish": "Finir",
     "ForceTerminate": "Forcer l'arrêt",
     "Generate": "produire",
+    "GoBackToPreviousPage": "Retour à la page précédente",
     "GoBackToStartPage": "Retour à la page {{title}}",
     "Info": "Info",
     "More": "Plus",
@@ -1385,6 +1386,7 @@
     "ReloadPage": "Recharger la page",
     "ResetErrorBoundary": "Réinitialisation de la limite d'erreur",
     "StackTrace": "Trace de la pile :",
+    "StorageHostFetchFailedTitle": "Échec de la récupération des informations sur l'hôte de stockage.",
     "Title": "Une erreur s'est produite."
   },
   "explorer": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -368,6 +368,7 @@
     "Finish": "Selesai",
     "ForceTerminate": "Hentikan paksa",
     "Generate": "Hasilkan",
+    "GoBackToPreviousPage": "Kembali ke halaman sebelumnya",
     "GoBackToStartPage": "Kembali ke halaman {{title}}",
     "Info": "Info",
     "More": "Selengkapnya",
@@ -1385,6 +1386,7 @@
     "ReloadPage": "Muat ulang halaman",
     "ResetErrorBoundary": "Setel Ulang Batas Kesalahan",
     "StackTrace": "Jejak tumpukan:",
+    "StorageHostFetchFailedTitle": "Gagal mengambil informasi host penyimpanan.",
     "Title": "Telah terjadi kesalahan."
   },
   "explorer": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -368,6 +368,7 @@
     "Finish": "finire",
     "ForceTerminate": "Termina forzata",
     "Generate": "creare",
+    "GoBackToPreviousPage": "Torna alla pagina precedente",
     "GoBackToStartPage": "Torna alla pagina {{title}}",
     "Info": "Info",
     "More": "Altro",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Ricarica la pagina",
     "ResetErrorBoundary": "Azzeramento di ErrorBoundary",
     "StackTrace": "Traccia dello stack:",
+    "StorageHostFetchFailedTitle": "Impossibile recuperare le informazioni sull'host di archiviazione.",
     "Title": "Si è verificato un errore."
   },
   "explorer": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -368,6 +368,7 @@
     "Finish": "終了",
     "ForceTerminate": "強制終了",
     "Generate": "生む",
+    "GoBackToPreviousPage": "前のページに戻る",
     "GoBackToStartPage": "{{title}}ページに戻る",
     "Info": "情報",
     "More": "その他",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "ページの更新",
     "ResetErrorBoundary": "ErrorBoundaryの初期化",
     "StackTrace": "スタックトレース:",
+    "StorageHostFetchFailedTitle": "ストレージホスト情報の取得に失敗しました。",
     "Title": "エラーが発生しました。"
   },
   "explorer": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -368,6 +368,7 @@
     "Finish": "완료",
     "ForceTerminate": "강제 종료",
     "Generate": "생성하기",
+    "GoBackToPreviousPage": "이전 페이지로 이동",
     "GoBackToStartPage": "{{title}} 페이지로 돌아가기",
     "Info": "정보",
     "More": "더보기",
@@ -1385,6 +1386,7 @@
     "ReloadPage": "페이지 새로고침",
     "ResetErrorBoundary": "ErrorBoundary 초기화",
     "StackTrace": "스택 트레이스:",
+    "StorageHostFetchFailedTitle": "스토리지 호스트 정보를 가져오는데 실패했습니다.",
     "Title": "에러가 발생했습니다."
   },
   "explorer": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -368,6 +368,7 @@
     "Finish": "Дуусах",
     "ForceTerminate": "Хүчээр цуцлах",
     "Generate": "Үүсгэх",
+    "GoBackToPreviousPage": "Өмнөх хуудас руу буцах",
     "GoBackToStartPage": "{{title}} хуудас руу буцах",
     "Info": "Мэдээлэл",
     "More": "Дэлгэрэнгүй",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Хуудсыг дахин ачаална уу",
     "ResetErrorBoundary": "Алдааны хил хязгаарыг дахин тохируулах",
     "StackTrace": "Стэк мөр:",
+    "StorageHostFetchFailedTitle": "Хадгалалтын хостын мэдээллийг авах амжилтгүй боллоо.",
     "Title": "Алдаа гарсан байна."
   },
   "explorer": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -368,6 +368,7 @@
     "Finish": "Selesai",
     "ForceTerminate": "Paksa Tamatkan",
     "Generate": "Menjana",
+    "GoBackToPreviousPage": "Kembali ke halaman sebelumnya",
     "GoBackToStartPage": "Kembali ke halaman {{title}}",
     "Info": "Info",
     "More": "Lagi",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Muat semula halaman",
     "ResetErrorBoundary": "Tetapkan Semula ErrorBoundary",
     "StackTrace": "Jejak ralat:",
+    "StorageHostFetchFailedTitle": "Gagal mendapatkan maklumat hos storan.",
     "Title": "Ralat telah berlaku."
   },
   "explorer": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -368,6 +368,7 @@
     "Finish": "koniec",
     "ForceTerminate": "Wymuś zakończenie",
     "Generate": "Generować",
+    "GoBackToPreviousPage": "Wróć do poprzedniej strony",
     "GoBackToStartPage": "Wróć do strony {{title}}",
     "Info": "Info",
     "More": "Więcej",
@@ -1385,6 +1386,7 @@
     "ReloadPage": "Przeładuj stronę",
     "ResetErrorBoundary": "Reset ErrorBoundary",
     "StackTrace": "Stos wywołań:",
+    "StorageHostFetchFailedTitle": "Nie udało się pobrać informacji o hoście pamięci masowej.",
     "Title": "Wystąpił błąd."
   },
   "explorer": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -368,6 +368,7 @@
     "Finish": "Terminar",
     "ForceTerminate": "Forçar Encerramento",
     "Generate": "Gerar",
+    "GoBackToPreviousPage": "Voltar para a página anterior",
     "GoBackToStartPage": "Voltar para a página {{title}}",
     "Info": "Info",
     "More": "Mais",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Recarregar a página",
     "ResetErrorBoundary": "Repor ErrorBoundary",
     "StackTrace": "Pilha de chamadas:",
+    "StorageHostFetchFailedTitle": "Falha ao buscar informações do host de armazenamento.",
     "Title": "Ocorreu um erro."
   },
   "explorer": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -368,6 +368,7 @@
     "Finish": "Terminar",
     "ForceTerminate": "Forçar Encerramento",
     "Generate": "Gerar",
+    "GoBackToPreviousPage": "Voltar para a página anterior",
     "GoBackToStartPage": "Voltar à página {{title}}",
     "Info": "Info",
     "More": "Mais",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Recarregar a página",
     "ResetErrorBoundary": "Repor ErrorBoundary",
     "StackTrace": "Rastreamento da pilha:",
+    "StorageHostFetchFailedTitle": "Falha ao obter informações do host de armazenamento.",
     "Title": "Ocorreu um erro."
   },
   "explorer": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -368,6 +368,7 @@
     "Finish": "Заканчивать",
     "ForceTerminate": "Принудительно завершить",
     "Generate": "Генерировать",
+    "GoBackToPreviousPage": "Вернуться на предыдущую страницу",
     "GoBackToStartPage": "Вернуться на страницу {{title}}",
     "Info": "Информация",
     "More": "Ещё",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Перезагрузить страницу",
     "ResetErrorBoundary": "Сброс границы ошибки",
     "StackTrace": "Стек вызовов:",
+    "StorageHostFetchFailedTitle": "Не удалось получить информацию о хосте хранилища.",
     "Title": "Произошла ошибка."
   },
   "explorer": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -368,6 +368,7 @@
     "Finish": "เสร็จสิ้น",
     "ForceTerminate": "บังคับยุติ",
     "Generate": "สร้าง",
+    "GoBackToPreviousPage": "กลับไปยังหน้าก่อนหน้า",
     "GoBackToStartPage": "กลับไปยังหน้า {{title}}",
     "Info": "ข้อมูล",
     "More": "เพิ่มเติม",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "โหลดหน้าใหม่",
     "ResetErrorBoundary": "รีเซ็ต ErrorBoundary",
     "StackTrace": "รายละเอียด Stack Trace:",
+    "StorageHostFetchFailedTitle": "ไม่สามารถดึงข้อมูลโฮสต์พื้นที่จัดเก็บได้",
     "Title": "เกิดข้อผิดพลาด"
   },
   "explorer": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -368,6 +368,7 @@
     "Finish": "Bitiş",
     "ForceTerminate": "Sonlandırmaya Zorla",
     "Generate": "üret",
+    "GoBackToPreviousPage": "Önceki sayfaya geri dön",
     "GoBackToStartPage": "{{title}} sayfasına geri dönün",
     "Info": "Bilgi",
     "More": "Daha fazla",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Sayfayı yeniden yükle",
     "ResetErrorBoundary": "ErrorBoundary'yi Sıfırla",
     "StackTrace": "Yığın İzleme:",
+    "StorageHostFetchFailedTitle": "Depolama ana bilgisayar bilgileri alınamadı.",
     "Title": "Bir hata oluştu."
   },
   "explorer": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -368,6 +368,7 @@
     "Finish": "Hoàn thành",
     "ForceTerminate": "Buộc chấm dứt",
     "Generate": "Tạo ra",
+    "GoBackToPreviousPage": "Quay lại trang trước",
     "GoBackToStartPage": "Quay lại trang {{title}}",
     "Info": "Thông tin",
     "More": "Thêm",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "Tải lại trang",
     "ResetErrorBoundary": "Đặt lại ranh giới lỗi",
     "StackTrace": "Dấu vết ngăn xếp:",
+    "StorageHostFetchFailedTitle": "Không thể tải thông tin máy chủ lưu trữ.",
     "Title": "Một lỗi đã xảy ra."
   },
   "explorer": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -368,6 +368,7 @@
     "Finish": "结束",
     "ForceTerminate": "强制终止",
     "Generate": "产生",
+    "GoBackToPreviousPage": "返回上一页",
     "GoBackToStartPage": "返回 {{title}} 页面",
     "Info": "详情",
     "More": "更多",
@@ -1384,6 +1385,7 @@
     "ReloadPage": "重新载入页面",
     "ResetErrorBoundary": "重置错误边界",
     "StackTrace": "堆栈跟踪：",
+    "StorageHostFetchFailedTitle": "无法获取存储主机信息。",
     "Title": "发生错误。"
   },
   "explorer": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -368,6 +368,7 @@
     "Finish": "結束",
     "ForceTerminate": "強制終止",
     "Generate": "產生",
+    "GoBackToPreviousPage": "返回上一頁",
     "GoBackToStartPage": "返回 {{title}} 頁面",
     "Info": "詳情",
     "More": "更多",
@@ -1385,6 +1386,7 @@
     "ReloadPage": "重新载入页面",
     "ResetErrorBoundary": "重置错误边界",
     "StackTrace": "堆疊追蹤：",
+    "StorageHostFetchFailedTitle": "無法取得儲存主機資訊。",
     "Title": "发生错误。"
   },
   "explorer": {


### PR DESCRIPTION
Resolves #7364(FR-2870)

## Summary

When the manager's vfolder host info fetch (`/folders/_/hosts`) fails (storage proxy 500, manager unreachable, etc.), the Session Launcher previously surfaced a generic page-level error from `BAIErrorBoundary` ("An error has occurred.") with a reload button — the user could not tell what was actually wrong and reloading didn't help.

This PR replaces that experience with a dedicated, recognizable error UI at the **exact existing fetch site**:

- `useProjectResourceGroups` (`packages/backend.ai-ui/src/hooks/useProjectResourceGroups.ts`) is the live host-fetch path on the Session Launcher page — it powers `BAIProjectResourceGroupSelect`, which the launcher renders inside `ResourceAllocationFormItems`. It already runs `/scaling-groups` and `/folders/_/hosts` in parallel and the `useSuspenseTanQuery` underneath throws on any failure; before this change both failures were indistinguishable.
- Switch the parallel fetch from `Promise.all` to `Promise.allSettled`, then discriminate: a host-info failure is re-thrown as a tagged `StorageHostFetchError`, while a scaling-groups failure is re-thrown as-is and bubbles to the generic boundary. Host-info failure takes precedence when both fail because SFTP filtering depends on it.
- Wrap the `/session/start` route with a new `StorageHostFetchErrorBoundary` whose fallback matches the `BAIErrorBoundary` look (`<Result status="warning">`) but shows the message **"Failed to fetch storage host information."** (KO: **"스토리지 호스트 정보를 가져오는데 실패했습니다."**) and a **"Go back to the previous page"** primary button that calls `history.back()`. Any non-`StorageHostFetchError` is re-thrown so the outer `BAIErrorBoundary` continues to render its generic UI for unrelated failures.

The `useCurrentProject` atom's `Promise.allSettled` path (which silently swallows host failure into `vhostInfo = undefined`) is intentionally **out of scope** for this PR.

## Implementation

- `packages/backend.ai-ui/src/hooks/useProjectResourceGroups.ts`: introduce `StorageHostFetchError extends Error`; rewrite the `queryFn` to await `Promise.allSettled`, throw `StorageHostFetchError(hostsResult.reason)` when the host fetch rejects, re-throw the scaling-groups rejection otherwise. The success return shape is unchanged.
- `packages/backend.ai-ui/src/hooks/index.ts`: export the new `StorageHostFetchError` class alongside the existing `useProjectResourceGroups` export.
- `react/src/components/StorageHostFetchErrorBoundary.tsx` (new): wraps children with `react-error-boundary`'s `ErrorBoundary`. The fallback imports `StorageHostFetchError` from `backend.ai-ui`, checks `error instanceof StorageHostFetchError`, and either renders the dedicated `Result` UI or re-throws so the outer `BAIErrorBoundary` handles unrelated errors.
- `react/src/routes.tsx`: wraps `<SessionLauncherPage />` at the `/session/start` route with `StorageHostFetchErrorBoundary` so the dedicated UI replaces the page body while the breadcrumb and outer layout remain intact.
- `resources/i18n/en.json`, `resources/i18n/ko.json`: add `errorBoundary.StorageHostFetchFailedTitle` and `button.GoBackToPreviousPage`. Other locales fall back to English (`fallbackLng: 'en'`); `/fw:i18n` can fill them in.

## How to test

1. Force the storage host fetch to fail (e.g. kill the storage proxy or break the manager's `/folders/_/hosts` route).
2. Open the Session Launcher at `/session/start`.
3. Expected: the page body renders a warning `Result` with the title "Failed to fetch storage host information." and a "Go back to the previous page" button. The breadcrumb above remains visible.
4. Click the button — the browser navigates back via `history.back()`.
5. Trigger an unrelated error elsewhere on the launcher (or break only `/scaling-groups`) — the existing `BAIErrorBoundary` behavior (page reload prompt, debug info under `globalThis.backendaiwebui.debug`) is unchanged.

## Verification

`bash scripts/verify.sh`:

```
--- Relay: PASS ---
--- Lint: PASS ---
--- Format: PASS ---
--- TypeScript: FAIL ---  (pre-existing, unrelated files only — identical on main)
```

The TypeScript failures are pre-existing errors on `main` (`StatisticsPage.tsx`, `StorageHostSettingPage.tsx`, `UserCredentialsPage.tsx`, `UserSettingsPage.tsx`, `VFolderNodeListPage.tsx`, plus the pre-existing `ErrorBoundary` JSX type error at `SessionLauncherPage.tsx:1433`) — none introduced by this change.

## Follow-ups

- Translate the new i18n keys for the remaining 19 locales via `/fw:i18n`.
- Address the silently-swallowed host failure in `useCurrentProject`'s `resourceGroupsForCurrentProjectAtom` (`Promise.allSettled` → `vhostInfo = undefined` masks the failure and produces an empty `nonSftpResourceGroups`). Deliberately out of scope for this PR.