### PR TITLE
fix(FR-2850): show friendly error when model-definition file is missing in Add Revision

### DIFF
--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -815,13 +815,19 @@ const DeploymentAddRevisionModalFormBody: React.FC<
         onIsAddingChange(false);
         if (errors && errors.length > 0) {
           const err = errors[0];
-          const isInProgress = err?.message?.includes(
+          const errMsg = err?.message ?? '';
+          const isInProgress = errMsg.includes(
             'Another deployment is already in progress',
+          );
+          const isModelDefMissing = errMsg.includes(
+            'ModelConfig.name is required',
           );
           message.error(
             isInProgress
               ? t('deployment.AnotherDeploymentInProgress')
-              : (err?.message ?? t('general.ErrorOccurred')),
+              : isModelDefMissing
+                ? t('deployment.ModelDefinitionNotFound')
+                : errMsg || t('general.ErrorOccurred'),
           );
           return;
         }
@@ -845,13 +851,19 @@ const DeploymentAddRevisionModalFormBody: React.FC<
       },
       onError: (err) => {
         onIsAddingChange(false);
-        const isInProgress = err.message?.includes(
+        const errMsg = err.message ?? '';
+        const isInProgress = errMsg.includes(
           'Another deployment is already in progress',
+        );
+        const isModelDefMissing = errMsg.includes(
+          'ModelConfig.name is required',
         );
         message.error(
           isInProgress
             ? t('deployment.AnotherDeploymentInProgress')
-            : (err.message ?? t('general.ErrorOccurred')),
+            : isModelDefMissing
+              ? t('deployment.ModelDefinitionNotFound')
+              : errMsg || t('general.ErrorOccurred'),
         );
       },
     });

--- a/react/src/pages/DeploymentLauncherPage.tsx
+++ b/react/src/pages/DeploymentLauncherPage.tsx
@@ -586,6 +586,7 @@ const DeploymentLauncherPageLayout: React.FC<
         const isInProgress = msg.includes(
           'Another deployment is already in progress',
         );
+        const isModelDefMissing = msg.includes('ModelConfig.name is required');
         if (mode === 'edit' && isInProgress) {
           upsertNotification({
             key: notificationKey,
@@ -605,7 +606,9 @@ const DeploymentLauncherPageLayout: React.FC<
               mode === 'edit'
                 ? t('deployment.FailedToUpdateDeployment')
                 : t('deployment.FailedToCreateDeployment'),
-            description: msg,
+            description: isModelDefMissing
+              ? t('deployment.ModelDefinitionNotFound')
+              : msg,
             duration: 0,
             backgroundTask: { status: 'rejected', percent: 99 },
           });

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Liveness-Status",
     "ManageAccessTokens": "Zugriffstoken verwalten",
     "Model": "Modell",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Pfad zur Modelldefinitionsdatei",
     "ModelFolder": "Modellordner",
     "ModelMountDestination": "Einhängeziel für Modellordner",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Κατάσταση Liveness",
     "ManageAccessTokens": "Διαχείριση διακριτικών πρόσβασης",
     "Model": "Μοντέλο",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Διαδρομή αρχείου ορισμού μοντέλου",
     "ModelFolder": "Φάκελος μοντέλου",
     "ModelMountDestination": "Προορισμός τοποθέτησης για φάκελο μοντέλου",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -971,6 +971,7 @@
     "LivenessStatus": "Liveness Status",
     "ManageAccessTokens": "Manage Access Tokens",
     "Model": "Model",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Model Definition File Path",
     "ModelFolder": "Model Folder",
     "ModelMountDestination": "Mount Destination For Model Folder",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Estado de Liveness",
     "ManageAccessTokens": "Administrar tokens de acceso",
     "Model": "Modelo",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Ruta del archivo de definición del modelo",
     "ModelFolder": "Carpeta del modelo",
     "ModelMountDestination": "Destino de montaje para la carpeta del modelo",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Liveness-tila",
     "ManageAccessTokens": "Hallitse käyttöoikeustunnuksia",
     "Model": "Malli",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Mallimäärittelytiedoston polku",
     "ModelFolder": "Mallikansio",
     "ModelMountDestination": "Mallikansion liitäntäkohde",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "État Liveness",
     "ManageAccessTokens": "Gérer les jetons d'accès",
     "Model": "Modèle",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Chemin du fichier de définition du modèle",
     "ModelFolder": "Dossier du modèle",
     "ModelMountDestination": "Destination de montage pour le dossier du modèle",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Status Liveness",
     "ManageAccessTokens": "Kelola token akses",
     "Model": "Model",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Jalur File Definisi Model",
     "ModelFolder": "Folder Model",
     "ModelMountDestination": "Tujuan Mount untuk Folder Model",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Stato Liveness",
     "ManageAccessTokens": "Gestisci token di accesso",
     "Model": "Modello",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Percorso file di definizione modello",
     "ModelFolder": "Cartella modello",
     "ModelMountDestination": "Destinazione mount per cartella modello",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Liveness 状態",
     "ManageAccessTokens": "アクセストークンを管理",
     "Model": "モデル",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "モデル定義ファイルパス",
     "ModelFolder": "モデルフォルダー",
     "ModelMountDestination": "モデルフォルダーのマウント先",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -953,6 +953,7 @@
     "LivenessStatus": "활성 상태 (Liveness)",
     "ManageAccessTokens": "액세스 토큰 관리",
     "Model": "모델",
+    "ModelDefinitionNotFound": "선택한 모델 폴더에 설정된 경로에 model-definition.yaml (또는 .yml) 파일이 없습니다. 파일을 추가하거나 모델 정의 경로를 수정한 후 다시 시도해 주세요.",
     "ModelDefinitionPath": "모델 정의 파일 경로",
     "ModelFolder": "모델 폴더",
     "ModelMountDestination": "모델 폴더 마운트 대상",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Liveness төлөв",
     "ManageAccessTokens": "Хандалтын токен удирдах",
     "Model": "Загвар",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Загварын тодорхойлолтын файлын зам",
     "ModelFolder": "Загварын хавтас",
     "ModelMountDestination": "Загварын хавтасны маунтын зорилтот хавтас",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Status Liveness",
     "ManageAccessTokens": "Urus token akses",
     "Model": "Model",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Laluan Fail Definisi Model",
     "ModelFolder": "Folder Model",
     "ModelMountDestination": "Destinasi Mount untuk Folder Model",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Status Liveness",
     "ManageAccessTokens": "Zarządzaj tokenami dostępu",
     "Model": "Model",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Ścieżka pliku definicji modelu",
     "ModelFolder": "Folder modelu",
     "ModelMountDestination": "Cel montowania dla folderu modelu",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Status de Liveness",
     "ManageAccessTokens": "Gerenciar tokens de acesso",
     "Model": "Modelo",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Caminho do arquivo de definição do modelo",
     "ModelFolder": "Pasta do modelo",
     "ModelMountDestination": "Destino de montagem para a pasta do modelo",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Estado de Liveness",
     "ManageAccessTokens": "Gerir tokens de acesso",
     "Model": "Modelo",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Caminho do ficheiro de definição do modelo",
     "ModelFolder": "Pasta do modelo",
     "ModelMountDestination": "Destino de montagem para a pasta do modelo",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Статус Liveness",
     "ManageAccessTokens": "Управление токенами доступа",
     "Model": "Модель",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Путь к файлу определения модели",
     "ModelFolder": "Папка модели",
     "ModelMountDestination": "Точка монтирования для папки модели",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "สถานะ Liveness",
     "ManageAccessTokens": "จัดการโทเค็นการเข้าถึง",
     "Model": "โมเดล",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "เส้นทางไฟล์นิยามโมเดล",
     "ModelFolder": "โฟลเดอร์โมเดล",
     "ModelMountDestination": "ปลายทางการเมาท์สำหรับโฟลเดอร์โมเดล",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Liveness Durumu",
     "ManageAccessTokens": "Erişim belirteçlerini yönet",
     "Model": "Model",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Model Tanım Dosyası Yolu",
     "ModelFolder": "Model Klasörü",
     "ModelMountDestination": "Model Klasörü için Bağlama Hedefi",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Trạng thái Liveness",
     "ManageAccessTokens": "Quản lý mã thông báo truy cập",
     "Model": "Mô hình",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "Đường dẫn tệp định nghĩa mô hình",
     "ModelFolder": "Thư mục mô hình",
     "ModelMountDestination": "Điểm gắn kết cho thư mục mô hình",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -952,6 +952,7 @@
     "LivenessStatus": "Liveness 状态",
     "ManageAccessTokens": "管理访问令牌",
     "Model": "模型",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "模型定义文件路径",
     "ModelFolder": "模型文件夹",
     "ModelMountDestination": "模型文件夹挂载目标",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -953,6 +953,7 @@
     "LivenessStatus": "Liveness 狀態",
     "ManageAccessTokens": "管理存取權杖",
     "Model": "模型",
+    "ModelDefinitionNotFound": "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying.",
     "ModelDefinitionPath": "模型定義檔案路徑",
     "ModelFolder": "模型資料夾",
     "ModelMountDestination": "模型資料夾掛載目標",


### PR DESCRIPTION
Resolves #7317(FR-2850)

## Summary

When `addModelRevision` fails with `ModelConfig.name is required` (the error produced when the model folder does not contain a `model-definition.yaml` / `.yml` file), the WebUI previously displayed the raw backend error message verbatim, which gives the user no actionable guidance.

This PR detects that specific error pattern and surfaces a friendlier, translatable message:

> "The selected model folder does not contain a model-definition.yaml (or .yml) at the configured path. Please add the file or update the model-definition path before retrying."

### Changes

- **`DeploymentAddRevisionModal.tsx`** -- detect `ModelConfig.name is required` in both `onCompleted` and `onError` handlers; show `deployment.ModelDefinitionNotFound` instead of the raw error
- **`DeploymentLauncherPage.tsx`** -- detect the same pattern in the catch block of `handleSubmit`; replace the notification description with the friendly message
- **`resources/i18n/en.json`** -- added `deployment.ModelDefinitionNotFound` key
- **`resources/i18n/ko.json`** -- added `deployment.ModelDefinitionNotFound` key

### Verification

`scripts/verify.sh` passes Relay, Lint, and Format. TypeScript errors are all pre-existing in unrelated files.