### PR TITLE
feat(FR-2872): add WebUI Smoke CLI feature spec

### DIFF
--- a/.specs/FR-2871-webui-smoke-cli/metadata.json
+++ b/.specs/FR-2871-webui-smoke-cli/metadata.json
@@ -1,0 +1,24 @@
+{
+  "epicKey": "FR-2871",
+  "epicUrl": "https://lablup.atlassian.net/browse/FR-2871",
+  "slug": "webui-smoke-cli",
+  "specTaskKey": "FR-2872",
+  "specTaskUrl": "https://lablup.atlassian.net/browse/FR-2872",
+  "stories": [],
+  "sourceIssues": [],
+  "createdAt": "2026-05-12T00:00:00Z",
+  "verification": {
+    "verifiedAt": "2026-05-12T11:30:00Z",
+    "againstPRs": [7391, 7392],
+    "results": {
+      "FR-A": "PASS",
+      "FR-B": "PASS",
+      "FR-C": "PARTIAL",
+      "NFR-air-gap": "DEFERRED-Phase2",
+      "NFR-single-account": "PASS",
+      "NFR-role-detection": "PASS",
+      "NFR-report-shape": "PASS"
+    },
+    "notes": "FR-C is PARTIAL because storage-state reuse, doctor command, and rich diagnostic block are intentionally deferred to Phase 2 (FR-2878 / FR-2879). The @smoke-any tag from FR-A was dropped — see spec FR-A NOTE. Live staging smoke run confirmed runner pipeline works end-to-end."
+  }
+}

--- a/.specs/FR-2871-webui-smoke-cli/spec.md
+++ b/.specs/FR-2871-webui-smoke-cli/spec.md
@@ -1,0 +1,263 @@
+# WebUI Smoke CLI — installation verification e2e runner
+
+> **Epic**: FR-2871 ([link](https://lablup.atlassian.net/browse/FR-2871))
+> **Spec Task**: FR-2872 ([link](https://lablup.atlassian.net/browse/FR-2872))
+> **Source plan**: `.specs/FR-2871-webui-smoke-cli/webui-smoke-cli.md`
+
+## Overview
+
+A new workspace package, `backend.ai-webui-smoke-cli`, that lets Field-Ops engineers verify Backend.AI WebUI functionality immediately after an on-prem or air-gapped install. The CLI re-uses the existing `e2e/` Playwright assets — selecting only specs tagged `@smoke` — runs them against a customer-provided endpoint, and emits a self-contained HTML + JSON report directory that can be handed off as the install acceptance artifact.
+
+The CLI takes its endpoint and credentials via command-line arguments / environment variables only (no `.env` file editing), auto-detects the logged-in account's role, and operates without contacting the public internet at test-execution time.
+
+## Problem Statement
+
+Field-Ops engineers regularly perform on-prem and air-gapped Backend.AI installs. The current `e2e/` Playwright suite is excellent for CI and developer environments, but it assumes a full developer toolchain: pnpm, the monorepo checkout, Relay compilation, hand-edited `e2e/envs/.env.playwright`, an internet-connected `npx playwright install`, and multiple cross-user accounts (admin + user + user2 + monitor) provisioned for cross-RBAC scenarios.
+
+Customer sites typically provide:
+
+- One endpoint URL (often with a self-signed certificate)
+- One service account (often only admin **or** only user — not both)
+- No outbound internet for the installation host
+- No developer tooling, sometimes not even Node.js
+
+The result today is that post-install verification is done by hand-clicking through the UI, which is slow, inconsistent across engineers, and frequently misses the most common failure mode at customer sites: the app launcher / wsproxy / app-proxy path. We need a single deliverable that a Field-Ops engineer can drop on the install host, run with one command, and hand the resulting report directory to the customer as proof of acceptance.
+
+## Requirements
+
+Functional requirements are grouped by FR-A through FR-J. **FR-A, FR-B, FR-C are MVP.** FR-D through FR-J are Phase 2 and are listed here so this spec remains the single source of truth.
+
+### FR-A — `@smoke` tag convention (MVP)
+
+Introduce a Playwright tag taxonomy and apply it to a starter set of existing e2e specs.
+
+- [ ] Document the tag taxonomy in `e2e/E2E-TEST-NAMING-GUIDELINES.md`:
+  - `@smoke` — base smoke marker; single account; whole set must complete in 5–10 minutes. A spec carrying ONLY `@smoke` (no role tag) must perform **no login at all** (e.g., login-form render checks) — it runs under every role.
+  - `@smoke` + `@smoke-admin` — requires admin credentials (`loginAsAdmin`): user mgmt, resource policies, agent list, session lifecycle
+  - `@smoke` + `@smoke-user` — requires user credentials (`loginAsUser`): vfolder, session launcher
+  - Role selection is **exclusive**: an admin run excludes `@smoke-user` specs (their `loginAsUser` would fall back to dev-default credentials and fail on customer clusters), and vice versa.
+  - NOTE: an earlier `@smoke-any` tag was considered for role-agnostic specs, but
+    every existing e2e login helper (`loginAsAdmin` / `loginAsUser`) hard-codes a
+    named credential. There is no genuinely role-agnostic logged-in smoke spec at the
+    helper level, so MVP uses only the two role-scoped tags plus bare `@smoke` for
+    no-login specs.
+- [ ] Tag the following existing specs (no-op functional change) — the curated MVP set:
+  - Login form render (no login → bare `@smoke`) and admin login (`@smoke-admin`)
+  - Dashboard render (admin describe; `@smoke-admin`)
+  - Session lifecycle, core test only (create → RUNNING → terminate; test-level `@smoke-admin`)
+  - VFolder file creation in the folder explorer (`@smoke-user`)
+  - (admin) Agent list, bulk-user-creation modal open (`@smoke-admin`)
+  - Session launcher cluster-mode sanity, single deterministic test (`@smoke-user`)
+- [ ] Broader coverage — logout / token expiry, VFolder upload/download/delete, environment & image list, user list, resource-policy list — is expansion territory under FR-J, not MVP.
+- [ ] Legacy bare-`@smoke` tags that predate this convention and don't qualify (mocked-backend or version-gated specs) are removed as part of introducing the convention.
+
+Acceptance:
+
+- [ ] `pnpm exec playwright test --grep @smoke --list` (run at the repo root, where `playwright.config.ts` lives) lists at minimum the curated set above.
+- [ ] No existing e2e CI job changes behaviour (tags are additive metadata).
+
+### FR-B — `backend.ai-webui-smoke-cli` workspace scaffold (MVP)
+
+Create the new workspace package with read-only subcommands first.
+
+- [ ] New package at `packages/backend.ai-webui-smoke-cli/` registered in the pnpm workspace.
+- [ ] `package.json` exposes a `smoke` bin and a `build` script (tsup or equivalent — implementation choice).
+- [ ] `bai-smoke list` prints the available categories and tags resolved from a catalog file.
+- [ ] `bai-smoke version` prints CLI version, bundled webui SHA placeholder, and Playwright version.
+- [ ] CLI argument parsing layer accepts run options: `--endpoint`, `--webserver`, `--email`, `--password`, `--password-stdin`, `--role`, `--also-include`, `--exclude`, `--pages`, `--workers`, `--timeout`, `--output`, `--headed`, `--insecure-tls`. (`--also-include` ADDS tag patterns on top of the smoke selection — it does not narrow; use `--pages` to narrow. `--include` is retained as a hidden deprecated alias.)
+- [ ] All inputs are accepted as CLI flags **or** as `BAI_SMOKE_*` environment variables. The CLI must **not** require editing any `.env` file.
+
+Acceptance:
+
+- [ ] `pnpm --filter backend.ai-webui-smoke-cli run smoke -- list` prints the catalog.
+- [ ] `pnpm --filter backend.ai-webui-smoke-cli run smoke -- version` prints version info.
+- [ ] `pnpm --filter backend.ai-webui-smoke-cli run smoke -- run --help` documents every option above.
+
+### FR-C — `playwright.smoke.config.ts` + runner (MVP)
+
+Wire the CLI to actually run tagged specs against the supplied endpoint.
+
+- [ ] `playwright.smoke.config.ts` is a **standalone** config that reuses the repo's `e2e/` spec tree. It deliberately does NOT import the repo-root `playwright.config.ts`: the root config eagerly runs `dotenv.config({ path: './e2e/envs/.env.playwright', override: true })` at module load, which would clobber the credentials the runner injects via process env. The smoke config sets:
+  - `testDir` to point at the existing `e2e/` directory
+  - `grep` / `grepInvert` to apply role-scoped smoke selection plus `--also-include` / `--exclude` tag filters. Role scoping is exclusive: an `admin` run selects bare-`@smoke` + `@smoke-admin` specs and excludes `@smoke-user` specs (and vice versa), so a spec is never run with the wrong role's credentials.
+  - `reporter` to `[['html', { outputFolder: <output>/html, open: 'never' }], ['json', { outputFile: <output>/results.json }], ['list']]`
+  - `use.baseURL` from `--endpoint`
+  - `use.ignoreHTTPSErrors` from `--insecure-tls`
+  - `use.video: 'retain-on-failure'`, `use.trace: 'retain-on-failure'`
+- [ ] `runner.ts` programmatically invokes Playwright with the smoke config, injecting credentials via process env (never written to disk).
+- [ ] Single-account authentication: the runner injects exactly one role's credentials (`E2E_ADMIN_*` or `E2E_USER_*`) into the spawned Playwright env; specs authenticate via the existing e2e login helpers. NOTE: login-once storage-state reuse was deferred — the existing helpers re-login per test, which is acceptable within the smoke time budget. Revisit alongside FR-2880 (single-account-safe utilities).
+- [ ] Specs requiring multiple accounts (cross-user RBAC) are excluded from the `@smoke` selection by tag convention.
+
+Acceptance (verifiable in staging):
+
+- [ ] Running `pnpm --filter backend.ai-webui-smoke-cli run smoke -- run --endpoint <staging> --email <email> --password <pw> --output ./report` against a staging Backend.AI cluster:
+  - Logs in successfully with the supplied credentials
+  - Loads the dashboard
+  - Completes at minimum **one session lifecycle** (create session → polled to `RUNNING` → terminate cleanly). The runner sets `BACKEND_AI_AGENTS_AVAILABLE=true` for the spawned Playwright process so the lifecycle spec's agent-availability guard never silently skips under smoke — a cluster that cannot run sessions must show up RED in the report, not as a skip.
+  - Writes a Playwright HTML report at `./report/html/index.html` plus machine-readable `./report/results.json` and `./report/summary.json`
+  - Exits with code `0` on all-pass, non-zero on any failure
+- [ ] No single binary or air-gap bundling is required for MVP — those are FR-G and FR-H.
+
+---
+
+### FR-D — `preflight` / `doctor` subcommand + role auto-detection (Phase 2)
+
+- [ ] `bai-smoke doctor` checks: endpoint reachability, TLS, login succeeds, browser binary present at expected path, free disk space ≥ configured minimum, and warns on webui-version-vs-CLI-version mismatch by reading the webui SHA from `/manifest.json` or `index.html` meta.
+- [ ] `bai-smoke preflight` (or a `--preflight-only` flag on `run`) performs the doctor checks then exits without running specs.
+- [ ] Role auto-detection: after login, the runner inspects the existing login response / `/server/login-check` signal to classify the account as `admin`, `user`, or `monitor`, and includes only tags compatible with the detected role.
+- [ ] `--role auto` (default) uses detection; explicit `--role admin|user|monitor` overrides.
+- [ ] Detection must not introduce new backend APIs.
+
+Acceptance:
+
+- [ ] Running `doctor` against an unreachable endpoint exits non-zero with a precise reason.
+- [ ] Running `doctor` against a wrong-credential endpoint reports "login failed" distinctly from "endpoint unreachable".
+- [ ] With `--role auto`, an admin login runs `@smoke + @smoke-admin`; a user login runs `@smoke + @smoke-user`. (See FR-A note: the originally-proposed `@smoke-any` tag was dropped because no genuinely role-agnostic smoke spec exists at the helper level.)
+
+### FR-E — Report post-processing (Phase 2)
+
+- [ ] After Playwright finishes, the runner generates the following inside `--output`:
+
+  ```
+  smoke-report-<timestamp>/
+  ├── html/                 # Playwright html reporter output
+  │   └── index.html
+  ├── summary.json          # machine-readable {total, passed, failed, skipped, durationMs, byCategory: {...}}
+  ├── environment.json      # {endpoint, role, cliVersion, webuiSha, os, playwrightVersion, chromiumVersion}
+  ├── traces/               # failed cases only
+  ├── videos/               # failed cases only (passing cases pruned)
+  └── logs/
+      ├── console-*.log
+      └── network-*.har     # failures only
+  ```
+- [ ] Each failed case includes a copy-pasteable diagnostic block: endpoint, role, webui SHA, last 20 console lines, 4xx/5xx network summary.
+- [ ] The runner does **not** write any custom Playwright reporter; post-processing reads the JSON reporter output and augments it.
+- [ ] **Credential scrubbing**: Playwright failure traces capture network payloads, so a failed login test's `trace.zip` contains the login POST body (operator password). Post-processing must scrub or drop traces containing the login request before the report is handed off. (Until FR-E ships, MVP report directories must be treated as sensitive — noted in the runner PR and the operator README.)
+
+Acceptance:
+
+- [ ] `summary.json` round-trips through `JSON.parse` and contains all fields above.
+- [ ] After a forced failure, `traces/` and `videos/` for that case are non-empty; for passing cases, `videos/` is empty.
+
+### FR-F — Single-account safe utils (Phase 2)
+
+- [ ] Audit `e2e/utils/test-util.ts` for assumptions requiring multiple seeded accounts (admin, user, user2, monitor).
+- [ ] Extract single-account-safe helpers into a separate module that smoke specs use.
+- [ ] No smoke spec may import a helper that requires more than one account.
+
+Acceptance:
+
+- [ ] Smoke specs run green against a fixture environment provisioned with exactly one account.
+
+### FR-G — Chromium bundling + air-gap runtime + `--insecure-tls` (Phase 2)
+
+- [ ] Build artifact ships a `browsers/` directory with the platform-matched Playwright Chromium.
+- [ ] At runtime, the CLI sets `PLAYWRIGHT_BROWSERS_PATH` to that bundled path before launching Playwright.
+- [ ] `--insecure-tls` flag (default `false`) maps to Playwright `ignoreHTTPSErrors: true`.
+- [ ] All external-origin requests (CDNs, Google Fonts) are blocked via `context.route('**/*', …)` allow-list during spec execution.
+- [ ] No `npx playwright install` is invoked at runtime.
+
+Acceptance:
+
+- [ ] On a host with outbound traffic blocked (verified via firewall rules), the CLI completes a smoke run successfully against an in-network endpoint.
+
+### FR-H — SEA / pkg binary build + internal release workflow (Phase 2)
+
+- [ ] Build scripts produce platform binaries: `bai-smoke-linux-x64`, `bai-smoke-mac-arm64`, `bai-smoke-win-x64.exe`.
+- [ ] Bundled artifact is `.tar.gz` (linux/mac) or `.zip` (win) containing the binary + `browsers/` + `tests/` + `LICENSES.md` + `README.md`.
+- [ ] Release publishes to **internal artifact storage only** (private GitHub Release with restricted access is acceptable). No public release.
+- [ ] Release tag format: `webui-vX.Y.Z+smoke.N`.
+
+Acceptance:
+
+- [ ] An engineer with no Node.js installed can extract the archive on each supported platform and run `./bai-smoke run …` successfully.
+
+### FR-I — Operator README (Phase 2)
+
+- [ ] One-page README in **English and Korean** covering: extract → chmod → run → read report → known issues.
+- [ ] Troubleshooting section covers: self-signed cert, macOS quarantine workaround, Windows SmartScreen workaround, "login failed" vs "endpoint unreachable" disambiguation, leftover resource cleanup (`bai-smoke cleanup --prefix bai-smoke-`).
+
+Acceptance:
+
+- [ ] README fits on one printed page in either language.
+
+### FR-J — Coverage expansion (Phase 2)
+
+Expand the `@smoke` catalog beyond the FR-A starter set. **App launcher is priority 1.**
+
+- [ ] **App launcher (P1)** — start a session, launch one app (jupyter or terminal), confirm the app page actually opens through the app-proxy. This is the most frequent failure mode at customer sites.
+- [ ] Model serving — basic serving endpoint deploy + invocation.
+- [ ] Basic RBAC — single-account-safe permission checks (no cross-user assertions).
+
+Acceptance:
+
+- [ ] App launcher smoke fails loudly when wsproxy / app-proxy is misconfigured (distinguish "session never reached RUNNING" from "session running, app proxy 502").
+
+## Non-Functional Requirements
+
+All of the following are **mandatory** for the final delivered artifact (Phase 2 completion). MVP relaxes the air-gap and packaging requirements.
+
+- [ ] **Air-gap operation** — at test execution time the CLI must not contact any host other than the supplied webserver / webui endpoint. Verified by running on a host with outbound traffic blocked.
+- [ ] **Single-account assumption** — `@smoke` specs must succeed with exactly one provided account. Cross-user RBAC scenarios are excluded from `@smoke` by convention.
+- [ ] **Role auto-detection** — login response is the source of truth. No new backend API.
+- [ ] **Self-contained report** — the `--output` directory must be portable (zip → email → open). Assets are local; no CDN dependencies in `index.html`.
+- [ ] **Failure-only retention** — traces, videos, HAR captures are retained for failed cases only to keep report size manageable.
+- [ ] **No secrets to disk** — credentials supplied via flag, env, or `--password-stdin` never end up in the report directory or on disk.
+
+## User Stories
+
+- As a Field-Ops engineer, I want to run one command against a freshly installed Backend.AI cluster so that I can confirm the WebUI works without clicking through it by hand.
+- As a Field-Ops engineer working on an air-gapped customer site, I want the CLI to run without internet access so that I do not need to coordinate temporary outbound rules.
+- As a Field-Ops engineer holding only one customer-issued account, I want the CLI to auto-adapt to that account's role so that I do not need to ask the customer for additional admin/user pairs.
+- As a Field-Ops engineer, I want to hand the customer a report directory so that we have a written acceptance artifact for the install.
+- As a Support engineer triaging a failed install, I want each failed case to include a copy-pasteable diagnostic block so that I can open a ticket without re-reproducing locally.
+- As a Backend.AI maintainer, I want every PR that touches the WebUI to run the smoke CLI against the dev cluster so that smoke regressions are caught before customer delivery.
+
+## Acceptance Criteria
+
+### MVP (FR-A + FR-B + FR-C) — verifiable in staging
+
+- [ ] `pnpm --filter backend.ai-webui-smoke-cli run smoke -- run --endpoint <staging-url> --email <email> --password <pw> --output ./report` against staging:
+  - Logs in successfully
+  - Loads the dashboard
+  - Completes one full session lifecycle (create → RUNNING → terminate)
+  - Writes a Playwright HTML report at `./report/html/index.html` plus machine-readable `./report/results.json` and `./report/summary.json`
+  - Exits `0` on all-pass, non-zero on any failure
+- [ ] `bai-smoke list` and `bai-smoke version` work without an endpoint argument.
+- [ ] No CI job in the existing pipeline breaks from the introduction of `@smoke` tags.
+
+### Phase 2 (FR-D … FR-J)
+
+- [ ] A Field-Ops engineer with only the produced archive can complete a smoke run on a fresh, internet-disconnected host on each of: linux-x64, mac-arm64, win-x64.
+- [ ] Report directory `summary.json` and `environment.json` schemas are stable and documented.
+- [ ] App-launcher smoke distinguishes between session-runtime failures and app-proxy failures in the report.
+- [ ] Operator README (KR/EN) is published with the release archive.
+
+## Out of Scope
+
+- Visual regression testing.
+- Backend.AI Manager / Agent / Storage health checks — owned by separate diagnostic tooling.
+- Load and performance testing.
+- SSO / SAML authentication in v1 — deferred. A future `--cookie-file` flag will support pre-issued session cookies; not in this Epic.
+- macOS / Windows code signing — first release ships unsigned with documented quarantine workaround.
+- Public distribution — internal artifact storage only.
+- Custom Playwright reporter — we wrap the bundled HTML reporter and post-process the JSON reporter output instead.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| SSO / SAML environments block ID+password login | v1 supports basic auth only; cookie-file injection deferred and documented |
+| Customer plugin/theme variants break selectors | `@smoke` specs must prefer `data-testid` and role/text selectors over CSS / XPath |
+| WebUI version vs CLI version mismatch causes false failures | `bai-smoke doctor` reads webui SHA from `/manifest.json` and warns against a compat matrix |
+| Unsigned binary triggers macOS Gatekeeper / Windows SmartScreen | Document `xattr -d com.apple.quarantine` and SmartScreen "Run anyway" path in README; pursue signing in a follow-up |
+| Smoke runs create real sessions/vfolders and pollute customer data | All created resources use a `bai-smoke-<timestamp>-` prefix; `bai-smoke cleanup --prefix bai-smoke-` subcommand handles leftover resources after crashes |
+| Self-signed customer certs block TLS | `--insecure-tls` flag maps to `ignoreHTTPSErrors: true`; off by default |
+| App launcher failures are hard to attribute (session vs proxy) | App-launcher smoke (FR-J) emits distinct failure reasons for "session never RUNNING" vs "session running, app-proxy non-2xx" |
+| Customer outbound is blocked, breaking `npx playwright install` | Chromium is bundled in the release archive (FR-G); CLI sets `PLAYWRIGHT_BROWSERS_PATH` at runtime |
+
+## Related Issues
+
+- FR-2871 — Epic: WebUI Smoke CLI — installation verification e2e runner
+- FR-2872 — Spec definition task (this work)
+- `.specs/FR-2871-webui-smoke-cli/webui-smoke-cli.md` — original approved plan

--- a/.specs/FR-2871-webui-smoke-cli/webui-smoke-cli.md
+++ b/.specs/FR-2871-webui-smoke-cli/webui-smoke-cli.md
@@ -1,0 +1,193 @@
+# WebUI Smoke CLI — 설치 검증용 E2E 러너 계획
+
+## 1. 배경 / 목적
+
+Field-Ops 엔지니어가 고객사에 Backend.AI를 설치한 직후, **WebUI 상의 핵심 기능이 실제로 동작하는지** 빠르게 검증할 수단이 필요하다. 현재 `e2e/` 디렉터리에는 Playwright 기반의 풍부한 테스트가 있지만, 그것은 **CI / 개발자 환경**을 전제로 설계되어 있다 (`pnpm`, monorepo, `e2e/envs/.env.playwright` 직접 편집, dev server 동시 기동 등).
+
+이 계획의 목적은 그 자산을 재사용하되, **에어갭 고객사 환경에서 단일 바이너리(또는 단일 아카이브) 하나로 실행할 수 있는 smoke-test CLI**를 별도 sub-project로 추가하는 것이다.
+
+비-목적 (out of scope):
+- **비주얼 리그레션 테스트**는 포함하지 않는다. 기능 검증만.
+- Backend.AI 백엔드 자체의 설치/헬스체크 — 그건 Manager/Agent 진단 도구가 별도로 다룸. 이 CLI는 어디까지나 **WebUI에서 본 동작**을 검증한다.
+- 부하/성능 테스트.
+
+## 2. 핵심 요구사항 (사용자 요청에서 도출)
+
+1. **CLI 한 번 실행**으로 끝나야 한다.
+2. **인자**로 webserver/webui endpoint + 계정정보를 받는다.
+3. **에어갭 환경**에서 동작해야 한다 → 인터넷에서 브라우저 / 의존성을 받아오면 안 된다.
+4. **계정의 권한**(admin vs user)에 따라 실행될 테스트가 자동 분기된다.
+5. **리포트**가 산출물로 떨어진다 (HTML + JSON, 디렉터리째 고객에게 전달 가능).
+6. **선택 옵션**: 페이지/카테고리/태그 단위로 부분 실행.
+
+## 3. 산출물 개요
+
+새 워크스페이스 패키지 하나 추가:
+
+```
+packages/backend.ai-smoke-cli/        # (가칭)
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── cli.ts                        # 엔트리포인트 (commander 기반)
+│   ├── runner.ts                     # Playwright 프로그래매틱 실행 래퍼
+│   ├── config.ts                     # CLI 인자 → env / playwright 옵션 변환
+│   ├── report.ts                     # HTML/JSON 후처리, 요약 생성
+│   ├── catalog.ts                    # 카테고리/태그 메타데이터 (도움말, --list용)
+│   └── preflight.ts                  # endpoint 도달성 / 로그인 가능성 사전 체크
+├── playwright.smoke.config.ts        # smoke 전용 config (e2e의 것을 import 후 override)
+├── tests/                            # smoke 전용 신규 spec (재사용 어려운 항목만)
+└── dist/                             # tsup/esbuild 번들 산출물 (pkg/SEA 입력)
+```
+
+기존 `e2e/` 디렉터리는 **그대로 둔다**. Smoke CLI는 그 spec들 중 **smoke 태그가 붙은 것만 골라서** 실행한다 (§6 참조).
+
+배포 형태:
+- 1순위: **Node.js SEA(Single Executable Application)** 또는 `pkg`로 빌드한 단일 바이너리 (`bai-smoke-linux-x64`, `bai-smoke-mac-arm64`, `bai-smoke-win-x64.exe`).
+- 함께 동봉할 자원:
+  - `browsers/` — Playwright Chromium 번들 (플랫폼별)
+  - `tests/` — 컴파일된 spec js 파일 (또는 바이너리에 내장)
+  - `LICENSES.md`, `README.md` (운영자용 1페이지)
+
+전체를 `.tar.gz` / `.zip` 하나로 패키징하여 USB로 옮길 수 있게 한다.
+
+## 4. CLI UX
+
+```
+bai-smoke run \
+  --endpoint https://webui.customer.local \
+  --webserver https://api.customer.local \
+  --email admin@customer.local \
+  --password '****' \
+  --role auto \                       # auto | admin | user (기본 auto)
+  --include @critical,@dashboard \    # 태그 OR
+  --exclude @visual,@flaky \
+  --pages session,vfolder \           # 카테고리(디렉터리) 단위
+  --workers 2 \
+  --timeout 180s \
+  --output ./smoke-report-2026-05-12 \
+  --headed                            # 디버깅용 (기본 headless)
+```
+
+추가 서브커맨드:
+- `bai-smoke list` — 사용 가능한 카테고리/태그 출력 (catalog.ts).
+- `bai-smoke doctor` — endpoint 도달성, 로그인, 브라우저 바이너리 존재, 디스크 공간만 점검 (테스트는 안 돌림). air-gap 환경에서 "이게 왜 안 돼?" 진단용.
+- `bai-smoke version` — CLI / 번들된 webui git sha / playwright 버전.
+
+설계 원칙:
+- **모든 입력은 CLI 인자 또는 ENV** (`BAI_SMOKE_*`). `.env` 파일을 편집하라고 요구하지 않는다 (고객사에서 부담).
+- 비밀번호는 `--password-stdin` 도 지원해서 shell history에 남지 않게.
+- `--role auto` 가 기본. CLI가 로그인 직후 `is_admin` 같은 신호를 보고 admin/user 경로를 자동 선택. 명시적 override도 허용.
+
+## 5. 권한 분기 (admin / user)
+
+현재 `e2e/utils/test-util.ts` 는 admin/user/user2/monitor 계정을 **동시에** 요구한다 (cross-user 시나리오 때문). Smoke 시나리오는 그렇게 못 한다 — 고객은 보통 계정 하나만 줄 수 있다.
+
+해결:
+1. **smoke spec은 단일 계정만 사용**하도록 작성. 두 계정이 필요한 RBAC 교차 시나리오는 smoke 범주에서 제외.
+2. CLI가 로그인 후 사용자 role을 감지 → 해당 role에 매칭된 태그(`@smoke-admin`, `@smoke-user`, `@smoke-any`)만 실행.
+3. role 감지는 webserver의 기존 API(로그인 응답 또는 `/server/login-check` 류)를 재사용. 새 백엔드 API를 만들지 않는다.
+
+## 6. 테스트 큐레이션 — `@smoke` 태그 도입
+
+기존 e2e spec에 점진적으로 태그를 부여한다:
+
+| 태그 | 의미 |
+|---|---|
+| `@smoke` | smoke CLI 기본 셋. 단일 계정으로 5–10분 내 끝나야 함. |
+| `@smoke-admin` | admin 계정으로만 의미 있는 검증 (사용자 관리, 자원 정책, 등) |
+| `@smoke-user` | 일반 사용자 시점 검증 (세션 생성, vfolder, 등) |
+| `@smoke-any` | role 무관 |
+| `@smoke-extended` | 옵셔널 — `--profile extended` 일 때만 |
+
+initial coverage 후보 (전부 신규 작성 아님, 기존 spec에 태그만 추가):
+- 로그인/로그아웃, 토큰 만료 핸들링
+- Dashboard 로딩, 주요 카드 렌더링
+- Session 라이프사이클: create batch session → 상태 polling → terminate
+- VFolder: 생성, 파일 업로드 1개, 다운로드, 삭제
+- Environment/Image 목록 로딩
+- (admin) User 목록, Resource policy 목록, Agent 목록
+- App launcher: 세션에 jupyter/terminal 1개 띄우고 페이지 열림 확인 (proxy 동작 검증)
+
+App launcher는 **고객사에서 가장 자주 깨지는 곳**이므로 smoke의 핵심.
+
+## 7. 에어갭 대응
+
+문제는 Playwright가 평소엔 `npx playwright install` 로 브라우저를 받는다는 점.
+
+해결:
+1. **빌드 시점에 Chromium을 함께 번들**한다. `PLAYWRIGHT_BROWSERS_PATH=0` 를 쓰면 `node_modules/playwright-core/.local-browsers` 에 들어가는데, 우리는 명시적인 `<bundle>/browsers/` 경로를 가리키도록 런타임에 `PLAYWRIGHT_BROWSERS_PATH` 환경변수를 세팅한다.
+2. SEA / pkg 빌드 시 브라우저는 **바이너리에 내장하지 않고** 같은 디렉터리에 동봉. 바이너리 크기·서명 이슈 회피.
+3. 어떤 origin도 외부로 나가지 않게 spec에서 `cdn.jsdelivr.net`, Google Fonts 등 외부 호출을 차단(이미 e2e가 그렇게 동작) — `context.route('**/*', …)` 화이트리스트 적용.
+4. HTTPS 인증서 검증 옵션: 고객사가 self-signed 인증서를 쓰는 경우가 많음 → `--insecure-tls` 플래그로 `ignoreHTTPSErrors: true`. 기본은 검증.
+
+## 8. 리포트
+
+`--output` 디렉터리에 다음을 생성:
+
+```
+smoke-report-2026-05-12/
+├── index.html              # 자체 완결 (이미지/CSS 인라인 또는 동일 폴더)
+├── summary.json            # 기계가 읽을 결과 (배포 자동화에서 활용 가능)
+├── environment.json        # endpoint, role, CLI ver, webui ver, OS, browser ver
+├── traces/                 # 실패한 케이스의 Playwright trace
+├── videos/                 # 실패한 케이스만 (성공은 즉시 삭제, 용량 절약)
+└── logs/
+    ├── console-*.log       # 브라우저 콘솔
+    └── network-*.har       # HAR (실패 시에만)
+```
+
+리포트 핵심 화면 (index.html):
+- 상단: PASS/FAIL 개수, 총 시간, 환경 요약.
+- 카테고리별 그리드 (세션/VFolder/유저/…)
+- 각 케이스: 상태 + 첫 실패 스크린샷 + "trace 열기" 링크.
+- 실패 케이스에는 **고객/지원 엔지니어가 그대로 복사해 보낼 수 있는 진단 블록** — endpoint, role, webui sha, 콘솔 마지막 20줄, 네트워크 4xx/5xx 요약.
+
+구현: Playwright `html` reporter를 1차 산출물로 쓰되, `runner.ts` 가 끝난 뒤 `summary.json` 과 진단 블록을 후처리로 추가. (자체 reporter를 굳이 새로 만들지 않는다.)
+
+## 9. 빌드 / 배포 파이프라인
+
+1. `pnpm --filter backend.ai-smoke-cli build` — tsup으로 ESM/CJS 번들.
+2. `pnpm --filter backend.ai-smoke-cli bundle:linux|mac|win` — Node SEA 또는 pkg.
+3. 동일 스크립트가 플랫폼별 Chromium을 `playwright install --dry-run` 으로 경로만 얻은 뒤 복사.
+4. `tar.gz` / `zip` 패키징.
+5. GitHub Release 또는 내부 artifact storage로 업로드 (`@smoke-cli-vX.Y.Z`).
+6. CI: 새로운 e2e spec이 `@smoke` 태그를 갖는다면 매 PR마다 smoke CLI 자체-검증을 dev 클러스터 대상으로 1회 실행 (회귀 방지).
+
+버전 표기는 `webui-vX.Y.Z+smoke.N` 처럼 webui 버전을 prefix로. 고객사에서 webui 버전과 smoke 결과를 매칭하기 쉽게.
+
+## 10. 단계별 이슈 분해 (Jira)
+
+각 항목은 별도 Jira issue (FR-XXXX)로 끊고 stacked PR로 진행한다. 의존성 순서:
+
+1. **FR-A**: `@smoke` 태그 컨벤션 도입, `E2E-TEST-NAMING-GUIDELINES.md` 보강. 기존 spec 5–10개에 태그 부여 (no-op 변경).
+2. **FR-B**: `packages/backend.ai-smoke-cli` 워크스페이스 스캐폴드. `bai-smoke list`, `bai-smoke version` 만 먼저.
+3. **FR-C**: `playwright.smoke.config.ts` + `runner.ts` — 기존 e2e spec을 태그로 골라 실행, env 주입.
+4. **FR-D**: `preflight` / `doctor` 서브커맨드 + role 자동 감지.
+5. **FR-E**: 리포트 후처리 (`summary.json`, 진단 블록).
+6. **FR-F**: 단일 계정 가정에 맞춰 cross-user 의존성 있는 utility를 분리, smoke-safe 단일 계정 헬퍼 추가.
+7. **FR-G**: Chromium 번들링 + air-gap 모드(`PLAYWRIGHT_BROWSERS_PATH` 런타임 주입) + `--insecure-tls`.
+8. **FR-H**: SEA/pkg 바이너리 빌드 + 릴리스 워크플로.
+9. **FR-I**: 운영자용 1페이지 README (한/영) + 트러블슈팅.
+10. **FR-J** (이후): smoke coverage 확장 — App launcher, model serving, RBAC 기본 케이스.
+
+FR-A ~ FR-C 가 MVP. 이 셋만 머지되어도 사내 staging 검증용으로는 쓸 수 있음. FR-G/H 가 끝나야 실제 고객사 전달 가능.
+
+## 11. 리스크 / 미해결 질문
+
+- **계정 부작용**: smoke가 진짜 세션을 만들고 vfolder를 만든다. 고객 운영 데이터를 더럽히지 않으려면 모든 리소스를 `bai-smoke-<timestamp>-` prefix로 만들고 종료 시 cleanup. 실패해 남은 잔재를 위해 `bai-smoke cleanup --prefix bai-smoke-` 도 제공.
+- **Plugin 변형**: 고객사마다 webui 플러그인/테마 구성이 다름 → 셀렉터가 깨질 수 있음. smoke spec은 **role/text 기반 셀렉터**를 더 엄격히 강제 (data-testid 우선).
+- **인증 방식**: SSO / SAML 환경에서 ID/PW 직접 로그인이 막혀 있는 케이스. v1은 기본 로그인만 지원, SSO는 `--cookie-file` 로 사전 발급한 세션 쿠키 주입을 옵션으로 추후.
+- **바이너리 서명**: macOS Gatekeeper / Windows SmartScreen. 사내 코드서명 인증서 필요. 첫 릴리스는 "압축 해제 후 chmod +x" 로 시작하되 quarantine 우회 가이드를 README에 명시.
+- **WebUI 버전과 smoke 버전 미스매치**: 고객이 구버전 webui에 신버전 smoke를 돌리면 셀렉터 미스. `bai-smoke doctor` 가 webui `/manifest.json` 또는 `index.html` 메타에서 sha를 읽어 호환 매트릭스와 비교, 경고.
+
+## 12. 결정 요청
+
+진행하기 전에 합의가 필요한 항목:
+
+1. **패키지 이름**: `backend.ai-smoke-cli` / `bai-field-check` / 다른 안?
+2. **배포 채널**: GitHub Release public / 내부 artifact only?
+3. **App launcher smoke**가 핵심이라는 데 동의? (앱 프록시 의존이 커서 가장 자주 깨지는 곳이라 우선순위 1로 봤다.)
+4. **MVP 범위를 FR-A ~ FR-C** 로 시작해도 되는지 — 즉, "staging에서 돌아가는 CLI" 까지가 1차 마일스톤.
+
+위 4개에 대해 답이 나오면 바로 FR-A Jira 이슈부터 만들겠다.


### PR DESCRIPTION
Resolves #7374 (FR-2872)

Part of Epic FR-2871 — WebUI Smoke CLI (installation verification e2e runner).

## Summary

Adds the feature specification for the WebUI Smoke CLI: a workspace CLI that lets Field-Ops engineers verify Backend.AI WebUI functionality right after an on-prem / air-gapped install, by running a curated `@smoke`-tagged subset of the existing Playwright e2e suite against a customer endpoint and emitting a self-contained HTML + JSON report.

- `.specs/FR-2871-webui-smoke-cli/spec.md` — requirements FR-A..FR-J with acceptance criteria. **MVP = FR-A (tag convention) + FR-B (package scaffold) + FR-C (runner)**; FR-D..FR-J are Phase 2.
- `.specs/FR-2871-webui-smoke-cli/webui-smoke-cli.md` — the original approved plan document (committed so the spec's "Source plan" reference resolves).
- `.specs/FR-2871-webui-smoke-cli/metadata.json` — Epic/task mapping.

## Spec realignments folded in during MVP finalization

The spec was updated to match deliberate implementation decisions made during review:

- `@smoke-any` dropped from the taxonomy — every e2e login helper hard-codes a role, so bare `@smoke` is reserved for **no-login** specs and role selection is **exclusive** (an admin run excludes `@smoke-user` specs and vice versa).
- `--include` renamed to `--also-include` (additive semantics made explicit; hidden deprecated alias retained).
- HTML report path corrected to `<output>/html/index.html` + `results.json` + `summary.json`.
- `playwright.smoke.config.ts` documented as a deliberate standalone config: importing the repo-root config would execute its eager `dotenv.config({ override: true })` and clobber the runner-injected credentials.
- Storage-state login reuse deferred (helpers re-login per test, acceptable within the smoke time budget; revisit with FR-2880).
- Session-lifecycle acceptance kept in MVP: the runner force-sets `BACKEND_AI_AGENTS_AVAILABLE=true` so a session-incapable cluster shows up RED, not skipped.

## Review notes

- Spec compliance verification results are recorded in `metadata.json` (`verification` block).