### PR TITLE
fix(FR-2873): avoid esbuild glob analysis of plugin import path in LoginView

### DIFF
--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -189,14 +189,14 @@ const LoginView: React.FC<{
     const sanitizedPlugin = loginPlugin.replace(/[^a-zA-Z0-9_-]/g, '');
     if (!sanitizedPlugin || sanitizedPlugin !== loginPlugin) return;
 
-    import(
-      // `@vite-ignore` = Vite's equivalent of webpack's `webpackIgnore`.
-      // The path interpolates a user-config'd plugin name at runtime and
-      // sits OUTSIDE react/src — Vite would otherwise warn about the
-      // un-analyzable specifier on every dev rebuild.
-      /* @vite-ignore */
-      `../../../src/plugins/${sanitizedPlugin}`
-    ).catch(() => {
+    // Build the plugin path at runtime, in a variable, so neither Vite nor
+    // esbuild's optimizeDeps scanner can statically analyze the specifier.
+    // A template-literal with a static prefix (e.g. `../../../src/plugins/…`)
+    // is treated by esbuild as a glob and fails to resolve in dev because
+    // `webui-ai/src/plugins/` only exists in production builds. `@vite-ignore`
+    // alone is not enough — esbuild's scanner does not honor that comment.
+    const pluginUrl = `../../../src/plugins/${sanitizedPlugin}`;
+    import(/* @vite-ignore */ pluginUrl).catch(() => {
       setLoginError({ message: t('error.LoginFailed') });
     });
   }, [isConfigLoaded, loginPlugin, t]);


### PR DESCRIPTION
Resolves #7376(FR-2873)

## Summary

`pnpm dev` started failing on `main` after #7332 (FR-2856) with:

```
✘ [ERROR] Could not resolve import("../../../src/plugins/**/*")

    src/components/LoginView.tsx:198:6:
      198 │       `../../../src/plugins/${sanitizedPlugin}`
          ╵       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Root cause

`LoginView.tsx`'s dynamic `import()` was a template literal with a static prefix (`` `../../../src/plugins/${sanitizedPlugin}` ``). esbuild's `optimizeDeps` scanner treats this as a glob (`../../../src/plugins/**/*`) and fails because `webui-ai/src/plugins/` only exists in production builds.

`@vite-ignore` suppresses **Vite's** static-analysis warning, but **esbuild's scanner does not honor it** — so the latent issue surfaced as soon as #7332 invalidated the install / Vite cache and the scanner re-ran.

The companion file `PluginLoader.tsx` already uses the correct pattern (assign to a variable first, then `import(/* @vite-ignore */ pluginUrl)`); only `LoginView.tsx` had the inline template literal.

## Fix

Match `PluginLoader.tsx`: assign the path to a variable first so neither Vite nor esbuild can statically analyze the specifier.

```tsx
const pluginUrl = `../../../src/plugins/${sanitizedPlugin}`;
import(/* @vite-ignore */ pluginUrl).catch(() => {
  setLoginError({ message: t('error.LoginFailed') });
});
```

Runtime behavior is unchanged — sanitization still happens before path interpolation, and the production loader (`<base>/dist/plugins/<name>.js`) is unaffected (different code path in `PluginLoader.tsx`).

## Test plan

- [x] `pnpm dev` boots without the `Could not resolve import("../../../src/plugins/**/*")` esbuild error
- [x] Login page renders normally with no `loginPlugin` configured
- [ ] With `loginPlugin = "<some-plugin>"` in `config.toml`, the dynamic import still resolves at runtime (path-traversal sanitization unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)