### PR TITLE
feat(FR-2877): implement webui-smoke-cli runner with tag filter and external endpoint

### DIFF
--- a/.specs/FR-2871-webui-smoke-cli/metadata.json
+++ b/.specs/FR-2871-webui-smoke-cli/metadata.json
@@ -7,20 +7,20 @@
   "stories": [],
   "sourceIssues": [],
   "subtasks": [
-    { "key": "FR-2875", "label": "A", "title": "feat(FR-2871 / A): @smoke tag convention" },
-    { "key": "FR-2876", "label": "B", "title": "feat(FR-2871 / B): backend.ai-webui-smoke-cli workspace scaffold" },
-    { "key": "FR-2877", "label": "C", "title": "feat(FR-2871 / C): playwright.smoke.config.ts + runner" },
-    { "key": "FR-2878", "label": "D", "title": "feat(FR-2871 / D): preflight/doctor subcommand + role auto-detection" },
-    { "key": "FR-2879", "label": "E", "title": "feat(FR-2871 / E): smoke spec set expansion" },
-    { "key": "FR-2880", "label": "F", "title": "feat(FR-2871 / F): HTML+JSON report directory + summary" },
-    { "key": "FR-2881", "label": "G", "title": "feat(FR-2871 / G): single-binary build (pkg/sea)" },
-    { "key": "FR-2882", "label": "H", "title": "feat(FR-2871 / H): air-gap bundle (browsers + assets)" },
-    { "key": "FR-2883", "label": "I", "title": "feat(FR-2871 / I): app launcher / wsproxy smoke scenarios" },
-    { "key": "FR-2884", "label": "J", "title": "docs(FR-2871 / J): Field-Ops handoff guide" }
+    { "key": "FR-2875", "label": "A", "title": "chore(WebUI Smoke CLI): introduce @smoke tag convention for e2e specs" },
+    { "key": "FR-2876", "label": "B", "title": "feat(WebUI Smoke CLI): scaffold backend.ai-webui-smoke-cli workspace package" },
+    { "key": "FR-2877", "label": "C", "title": "feat(WebUI Smoke CLI): implement runner with tag filter and external endpoint support" },
+    { "key": "FR-2878", "label": "D", "title": "feat(WebUI Smoke CLI): add preflight/doctor subcommand and role auto-detection" },
+    { "key": "FR-2879", "label": "E", "title": "feat(WebUI Smoke CLI): post-process report with summary.json and diagnostic block" },
+    { "key": "FR-2880", "label": "F", "title": "refactor(WebUI Smoke CLI): extract single-account-safe e2e utilities" },
+    { "key": "FR-2881", "label": "G", "title": "feat(WebUI Smoke CLI): bundle Chromium and add air-gap + insecure-tls support" },
+    { "key": "FR-2882", "label": "H", "title": "chore(WebUI Smoke CLI): SEA/pkg binary build and internal release workflow" },
+    { "key": "FR-2883", "label": "I", "title": "docs(WebUI Smoke CLI): operator README in English and Korean" },
+    { "key": "FR-2884", "label": "J", "title": "feat(WebUI Smoke CLI): expand smoke coverage (App launcher P1, model serving, RBAC basics)" }
   ],
   "createdAt": "2026-05-12T00:00:00Z",
   "verification": {
-    "verifiedAt": "2026-05-12T11:30:00Z",
+    "verifiedAt": "2026-06-11T02:40:00Z",
     "againstPRs": [7391, 7392],
     "results": {
       "FR-A": "PASS",
@@ -31,6 +31,11 @@
       "NFR-role-detection": "PASS",
       "NFR-report-shape": "PASS"
     },
-    "notes": "FR-C is PARTIAL because storage-state reuse, doctor command, and rich diagnostic block are intentionally deferred to Phase 2 (FR-2878 / FR-2879). The @smoke-any tag from FR-A was dropped — see spec FR-A NOTE. Live staging smoke run confirmed runner pipeline works end-to-end."
+    "liveRuns": {
+      "endpoint": "2FA-enabled staging (webui v26.1.0-alpha, ~1 month older than this branch)",
+      "admin": { "passed": 14, "failed": 1, "skipped": 2, "note": "session lifecycle (create→RUNNING→terminate) PASSED; 1 failure + later 5 user-run failures are cross-version UI skew vs the older staging, expected to pass against a version-matched install (doctor in FR-2878 will warn on mismatch); 2 skips are documented version-gated Agent Stats widget guards" },
+      "user": { "passed": 2, "failed": 5, "skipped": 0, "note": "role auto-detection resolved 'user'; failures are the vfolder explorer cross-version skew" }
+    },
+    "notes": "FR-C is PARTIAL because storage-state reuse, doctor command, and rich diagnostic block are intentionally deferred to Phase 2 (FR-2878 / FR-2879). The @smoke-any tag from FR-A was dropped — see spec FR-A NOTE. verify.sh ALL PASS (Relay/Lint/Format/TypeScript/Vite). Role-exclusive grep partition verified via playwright --list (admin 17 / user 7, zero cross-role contamination) and 13 regex unit cases."
   }
 }

--- a/packages/backend.ai-webui-smoke-cli/README.md
+++ b/packages/backend.ai-webui-smoke-cli/README.md
@@ -7,12 +7,51 @@ for the full spec. The operator-facing README (EN + KO) lands in FR-2883
 
 ## Usage (alpha)
 
+Prefer reading the password from stdin or an env var — passing
+`--password` on the command line exposes the secret to anything that
+can read the host process's argv. The CLI scrubs the argv value at
+startup, but the original invocation may still surface in shell history
+or process listings before the scrub runs.
+
+```sh
+# Option 1 — password from stdin (recommended)
+printf '%s' "$BAI_PASSWORD" | bai-smoke run \
+  --endpoint https://webui.example.com \
+  --webserver https://webui.example.com \
+  --email admin@example.com \
+  --password-stdin \
+  --output ./smoke-report
+
+# Option 2 — password from env var
+BAI_SMOKE_PASSWORD="$BAI_PASSWORD" bai-smoke run \
+  --endpoint https://webui.example.com \
+  --webserver https://webui.example.com \
+  --email admin@example.com \
+  --output ./smoke-report
+```
+
+To widen the selection beyond the default `@smoke*` set, use
+`--also-include`. To narrow the run, use `--pages`:
+
 ```sh
 bai-smoke run \
   --endpoint https://webui.example.com \
   --email admin@example.com \
-  --password "***" \
-  --output ./smoke-report
+  --password-stdin \
+  --also-include "@critical" \
+  --pages session,vfolder
 ```
 
-This is an alpha MVP. Full operator docs land with FR-2883.
+## Limitations (alpha MVP)
+
+- Must be run from a `backend.ai-webui` monorepo checkout — the e2e
+  specs are not bundled yet. Tarball / single-binary distribution is
+  tracked in FR-2881.
+- Air-gap binary, `doctor` command, and rich diagnostic reports → Phase 2.
+- `--also-include` widens the smoke set; to narrow it, use `--pages`
+  instead. The legacy `--include` flag is a deprecated hidden alias and
+  will be removed in a future release.
+- `--insecure-tls` accepts self-signed certs but does not pin
+  fingerprints — only enable on trusted networks.
+
+This is an alpha MVP. Full operator docs (EN + KO) land with FR-2883.

--- a/packages/backend.ai-webui-smoke-cli/README.md
+++ b/packages/backend.ai-webui-smoke-cli/README.md
@@ -4,3 +4,15 @@ Post-install smoke verification CLI for Backend.AI WebUI. See
 [`.specs/FR-2871-webui-smoke-cli/spec.md`](../../.specs/FR-2871-webui-smoke-cli/spec.md)
 for the full spec. The operator-facing README (EN + KO) lands in FR-2883
 (Phase 2).
+
+## Usage (alpha)
+
+```sh
+bai-smoke run \
+  --endpoint https://webui.example.com \
+  --email admin@example.com \
+  --password "***" \
+  --output ./smoke-report
+```
+
+This is an alpha MVP. Full operator docs land with FR-2883.

--- a/packages/backend.ai-webui-smoke-cli/package.json
+++ b/packages/backend.ai-webui-smoke-cli/package.json
@@ -19,6 +19,7 @@
   "files": [
     "bin",
     "dist",
+    "playwright.smoke.config.ts",
     "README.md"
   ],
   "scripts": {
@@ -30,6 +31,7 @@
     "version:print": "node ./bin/bai-smoke.cjs version"
   },
   "dependencies": {
+    "@playwright/test": "^1.58.2",
     "commander": "^12.1.0"
   },
   "devDependencies": {

--- a/packages/backend.ai-webui-smoke-cli/playwright.smoke.config.ts
+++ b/packages/backend.ai-webui-smoke-cli/playwright.smoke.config.ts
@@ -1,0 +1,86 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Playwright configuration for the `bai-smoke` runner.
+ *
+ * This config is invoked by `bai-smoke run` (`src/runner.ts`) via
+ * `npx playwright test --config <this-file>`. The runner is the single
+ * place that translates CLI arguments into the env vars consumed here —
+ * we deliberately do NOT load `e2e/envs/.env.playwright` from this file
+ * because the smoke CLI runs against arbitrary customer endpoints, not
+ * the dev fixtures the e2e suite assumes.
+ *
+ * Env contract (set by the runner):
+ *   BAI_SMOKE_REPORT_DIR    — output directory for html / json reports
+ *   BAI_SMOKE_WORKERS       — playwright worker count (optional)
+ *   BAI_SMOKE_TIMEOUT_MS    — per-test timeout in ms (default 180000)
+ *   BAI_SMOKE_GREP          — grep regex source (no slashes), e.g. `@smoke(-any|-admin)?\b`
+ *   BAI_SMOKE_GREP_INVERT   — grepInvert regex source (optional)
+ *   BAI_SMOKE_PAGES         — comma-separated page directory names (optional)
+ *   BAI_SMOKE_HEADED        — '1' to launch a headed browser
+ *
+ * Test credentials (E2E_*) are set by the runner as well — see
+ * `src/config.ts#buildPlaywrightEnv`.
+ */
+
+// Resolve repo root e2e/ directory relative to this config file.
+// File layout: <repo>/packages/backend.ai-webui-smoke-cli/playwright.smoke.config.ts
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const E2E_DIR = path.resolve(__dirname, '..', '..', 'e2e');
+
+const reportDir = process.env.BAI_SMOKE_REPORT_DIR ?? path.resolve(process.cwd(), 'smoke-report');
+
+const workersEnv = process.env.BAI_SMOKE_WORKERS;
+const workers = workersEnv ? Number.parseInt(workersEnv, 10) : undefined;
+
+const timeoutEnv = process.env.BAI_SMOKE_TIMEOUT_MS;
+const timeout = timeoutEnv ? Number.parseInt(timeoutEnv, 10) : 180000;
+
+const grepSource = process.env.BAI_SMOKE_GREP;
+const grepInvertSource = process.env.BAI_SMOKE_GREP_INVERT;
+
+// Pages filter — match by directory under e2e/. e.g. BAI_SMOKE_PAGES="session,vfolder"
+// turns into testMatch ['**/session/**', '**/vfolder/**'].
+const pagesEnv = process.env.BAI_SMOKE_PAGES;
+const pages = pagesEnv
+  ? pagesEnv
+      .split(',')
+      .map((p) => p.trim())
+      .filter(Boolean)
+  : undefined;
+const testMatch = pages && pages.length > 0 ? pages.map((p) => `**/${p}/**`) : undefined;
+
+const headed = process.env.BAI_SMOKE_HEADED === '1';
+
+export default defineConfig({
+  testDir: E2E_DIR,
+  testMatch,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: workers && Number.isFinite(workers) && workers > 0 ? workers : undefined,
+  timeout: Number.isFinite(timeout) && timeout > 0 ? timeout : 180000,
+  grep: grepSource ? new RegExp(grepSource) : undefined,
+  grepInvert: grepInvertSource ? new RegExp(grepInvertSource) : undefined,
+  reporter: [
+    ['html', { outputFolder: path.join(reportDir, 'html'), open: 'never' }],
+    ['json', { outputFile: path.join(reportDir, 'results.json') }],
+    ['list'],
+  ],
+  snapshotPathTemplate: `${E2E_DIR}/{testFileDir}/snapshot/{arg}{ext}`,
+  use: {
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    headless: !headed,
+    ignoreHTTPSErrors: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], locale: 'en-US' },
+    },
+  ],
+});

--- a/packages/backend.ai-webui-smoke-cli/playwright.smoke.config.ts
+++ b/packages/backend.ai-webui-smoke-cli/playwright.smoke.config.ts
@@ -1,12 +1,15 @@
 import { defineConfig, devices } from '@playwright/test';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
  * Playwright configuration for the `bai-smoke` runner.
  *
- * This config is invoked by `bai-smoke run` (`src/runner.ts`) via
- * `npx playwright test --config <this-file>`. The runner is the single
+ * This config is invoked by `bai-smoke run` (`src/runner.ts`), which
+ * spawns Node directly with the resolved `@playwright/test` CLI
+ * entrypoint and passes `--config <this-file>`. No `npx` is involved.
+ * The runner is the single
  * place that translates CLI arguments into the env vars consumed here —
  * we deliberately do NOT load `e2e/envs/.env.playwright` from this file
  * because the smoke CLI runs against arbitrary customer endpoints, not
@@ -16,7 +19,7 @@ import { fileURLToPath } from 'node:url';
  *   BAI_SMOKE_REPORT_DIR    — output directory for html / json reports
  *   BAI_SMOKE_WORKERS       — playwright worker count (optional)
  *   BAI_SMOKE_TIMEOUT_MS    — per-test timeout in ms (default 180000)
- *   BAI_SMOKE_GREP          — grep regex source (no slashes), e.g. `@smoke(-any|-admin)?\b`
+ *   BAI_SMOKE_GREP          — grep regex source (no slashes), e.g. `@smoke\b|@smoke-admin\b`
  *   BAI_SMOKE_GREP_INVERT   — grepInvert regex source (optional)
  *   BAI_SMOKE_PAGES         — comma-separated page directory names (optional)
  *   BAI_SMOKE_HEADED        — '1' to launch a headed browser
@@ -30,6 +33,18 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const E2E_DIR = path.resolve(__dirname, '..', '..', 'e2e');
+
+// FR-2877 MVP limitation: the smoke runner discovers specs from the
+// monorepo's e2e/ tree. A bundled tarball / standalone binary distribution
+// is tracked in FR-2881. Fail loudly when the directory is missing so the
+// user gets a clear message instead of a cryptic Playwright "no tests
+// found" output.
+if (!existsSync(E2E_DIR)) {
+  throw new Error(
+    `bai-smoke MVP requires running from a backend.ai-webui checkout. Expected e2e dir at: ${E2E_DIR}. ` +
+      `Tarball / single-binary distribution lands in FR-2881.`,
+  );
+}
 
 const reportDir = process.env.BAI_SMOKE_REPORT_DIR ?? path.resolve(process.cwd(), 'smoke-report');
 
@@ -75,7 +90,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
     video: 'retain-on-failure',
     headless: !headed,
-    ignoreHTTPSErrors: true,
+    ignoreHTTPSErrors: process.env.BAI_SMOKE_INSECURE_TLS === '1',
   },
   projects: [
     {

--- a/packages/backend.ai-webui-smoke-cli/playwright.smoke.config.ts
+++ b/packages/backend.ai-webui-smoke-cli/playwright.smoke.config.ts
@@ -19,10 +19,20 @@ import { fileURLToPath } from 'node:url';
  *   BAI_SMOKE_REPORT_DIR    — output directory for html / json reports
  *   BAI_SMOKE_WORKERS       — playwright worker count (optional)
  *   BAI_SMOKE_TIMEOUT_MS    — per-test timeout in ms (default 180000)
- *   BAI_SMOKE_GREP          — grep regex source (no slashes), e.g. `@smoke\b|@smoke-admin\b`
- *   BAI_SMOKE_GREP_INVERT   — grepInvert regex source (optional)
+ *   BAI_SMOKE_GREP          — grep regex source (no slashes), e.g.
+ *                             `(@smoke(?![\w-])|@smoke-admin(?![\w-]))`
+ *                             (negative lookahead — a naive `@smoke\b`
+ *                             matches inside `@smoke-user`)
+ *   BAI_SMOKE_GREP_INVERT   — grepInvert regex source (always set; carries
+ *                             the opposite-role exclusion + --exclude tags)
  *   BAI_SMOKE_PAGES         — comma-separated page directory names (optional)
  *   BAI_SMOKE_HEADED        — '1' to launch a headed browser
+ *   BAI_SMOKE_INSECURE_TLS  — '1' to set `ignoreHTTPSErrors: true`
+ *
+ * Note: WORKERS / PAGES / HEADED / INSECURE_TLS double as operator-facing
+ * CLI env inputs; `buildPlaywrightEnv` re-normalizes them onto the child
+ * env so both layers always agree. This file only ever reads the values
+ * the runner set.
  *
  * Test credentials (E2E_*) are set by the runner as well — see
  * `src/config.ts#buildPlaywrightEnv`.
@@ -35,8 +45,8 @@ const __dirname = path.dirname(__filename);
 const E2E_DIR = path.resolve(__dirname, '..', '..', 'e2e');
 
 // FR-2877 MVP limitation: the smoke runner discovers specs from the
-// monorepo's e2e/ tree. A bundled tarball / standalone binary distribution
-// is tracked in FR-2881. Fail loudly when the directory is missing so the
+// monorepo's e2e/ tree. The packaged distribution that bundles the e2e
+// tree ships with FR-2881/FR-2882. Fail loudly when the directory is missing so the
 // user gets a clear message instead of a cryptic Playwright "no tests
 // found" output.
 if (!existsSync(E2E_DIR)) {

--- a/packages/backend.ai-webui-smoke-cli/src/cli.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/cli.ts
@@ -96,7 +96,16 @@ program
       .choices(['auto', 'admin', 'user'])
       .default('auto'),
   )
-  .option('--include <tags>', 'Comma-separated extra tags to include (e.g. "@critical").')
+  .option(
+    '--also-include <tags>',
+    'Additional tag pattern(s) to OR onto the smoke selection (e.g. "@critical"). ' +
+      'To NARROW the smoke set, use --pages instead.',
+  )
+  // Backwards-compat alias for the original `--include` name. Deprecated —
+  // will be removed in a future release. Kept hidden from the main help.
+  .addOption(
+    new Option('--include <tags>', '(deprecated) alias for --also-include.').hideHelp(),
+  )
   .option('--exclude <tags>', 'Comma-separated tags to exclude.')
   .option(
     '--pages <names>',
@@ -108,12 +117,7 @@ program
     'Per-test timeout. Accepts "180s", "3m", or raw ms.',
     '180s',
   )
-  .option(
-    '--output <dir>',
-    'Output directory for the smoke report.',
-    () => defaultOutputDir(),
-    defaultOutputDir(),
-  )
+  .option('--output <dir>', 'Output directory for the smoke report.')
   .option('--headed', 'Run the browser in headed mode (debugging only).', false)
   .option('--insecure-tls', 'Accept self-signed TLS certificates.', false)
   .action(async (raw: Record<string, unknown>) => {
@@ -124,6 +128,9 @@ program
       );
       process.exit(2);
     }
+    // Scrub the password value from process.argv so accidental introspection
+    // (logs, crash dumps, `ps`-style helpers reading argv) cannot leak it.
+    scrubPasswordFromArgv();
 
     const endpoint = String(raw.endpoint);
     const webserver =
@@ -145,18 +152,25 @@ program
       return;
     }
 
+    // `--also-include` is the canonical flag; `--include` is a hidden alias.
+    const alsoIncludeRaw =
+      (raw.alsoInclude as string | string[] | undefined) ??
+      (raw.include as string | string[] | undefined);
+
+    const outputDir = path.resolve(String(raw.output ?? defaultOutputDir()));
+
     const opts: SmokeRunOptions = {
       endpoint,
       webserver,
       email: String(raw.email),
       password,
       role: (raw.role as SmokeRoleSelection) ?? 'auto',
-      include: splitCsvArg(raw.include as string | string[] | undefined),
+      include: splitCsvArg(alsoIncludeRaw),
       exclude: splitCsvArg(raw.exclude as string | string[] | undefined),
       pages: splitCsvArg(raw.pages as string | string[] | undefined),
       workers: typeof raw.workers === 'number' && raw.workers > 0 ? raw.workers : undefined,
       timeoutMs,
-      outputDir: path.resolve(String(raw.output ?? defaultOutputDir())),
+      outputDir,
       headed: raw.headed === true,
       insecureTls: raw.insecureTls === true,
     };
@@ -201,6 +215,27 @@ async function resolvePassword(raw: Record<string, unknown>): Promise<string | u
     return readStdin();
   }
   return undefined;
+}
+
+/**
+ * Replace the resolved password value in `process.argv` with `***` so
+ * downstream introspection (crash dumps, logs that dump argv, child
+ * processes inheriting argv via APIs that read the parent's command
+ * line) cannot leak the secret. Covers both `--password VALUE` and
+ * `--password=VALUE` forms.
+ */
+function scrubPasswordFromArgv(): void {
+  for (let i = 0; i < process.argv.length; i++) {
+    const a = process.argv[i];
+    if (a == null) continue;
+    if (a.startsWith('--password=')) {
+      process.argv[i] = '--password=***';
+      continue;
+    }
+    if (a === '--password' && process.argv[i + 1] != null) {
+      process.argv[i + 1] = '***';
+    }
+  }
 }
 
 function readStdin(): Promise<string> {

--- a/packages/backend.ai-webui-smoke-cli/src/cli.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/cli.ts
@@ -1,18 +1,24 @@
 /**
  * Entrypoint for the `bai-smoke` CLI.
  *
- * MVP scaffold (FR-2876):
- * - `list`    — print the catalog of smoke categories. Functional.
- * - `version` — print CLI version + bundled SHA + Playwright version. Functional.
- * - `run`     — stub. The actual Playwright runner ships in FR-2877.
+ * Subcommands (FR-2877 MVP):
+ *   - `list`    — print the catalog of smoke categories.
+ *   - `version` — print CLI + WebUI + Playwright version info.
+ *   - `run`     — execute the smoke suite against a customer endpoint.
  *
- * Global option parsing (`--endpoint`, `--email`, etc.) is declared on `run`
- * so `--help` documents the eventual flag surface, but every flag is a no-op
- * at this stage.
+ * Phase 2 subcommands (`doctor`, `preflight`) ship under FR-2878+.
  */
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
+import path from 'node:path';
 
 import { SMOKE_CATALOG } from './catalog.js';
+import {
+  parseDuration,
+  splitCsvArg,
+  type SmokeRoleSelection,
+  type SmokeRunOptions,
+} from './config.js';
+import { runSmoke } from './runner.js';
 import {
   CLI_NAME,
   CLI_VERSION,
@@ -61,35 +67,119 @@ program
     process.stdout.write(`  platform           : ${process.platform}-${process.arch}\n`);
   });
 
-// `run` is a stub until FR-2877 wires the Playwright runner.
 program
   .command('run')
-  .description(
-    'Run the smoke suite against an endpoint. Not yet implemented — coming in FR-2877.',
+  .description('Run the smoke suite against a Backend.AI WebUI endpoint.')
+  .addOption(
+    new Option('--endpoint <url>', 'Backend.AI WebUI endpoint URL.')
+      .env('BAI_SMOKE_ENDPOINT')
+      .makeOptionMandatory(true),
   )
-  .option('--endpoint <url>', 'Backend.AI webui endpoint URL.')
-  .option('--webserver <url>', 'Backend.AI webserver endpoint URL.')
-  .option('--email <email>', 'Account email or username.')
-  .option('--password <password>', 'Account password (prefer --password-stdin).')
-  .option('--password-stdin', 'Read the password from stdin.')
   .option(
-    '--role <role>',
-    'Force role selection: auto | admin | user | monitor.',
-    'auto',
+    '--webserver <url>',
+    'Backend.AI webserver endpoint URL. Defaults to --endpoint when omitted.',
   )
-  .option('--include <tags...>', 'Additional tags to include in the run.')
-  .option('--exclude <tags...>', 'Tags to exclude from the run.')
-  .option('--pages <pages...>', 'Restrict the run to specific page categories.')
-  .option('--workers <n>', 'Playwright worker count.', '1')
-  .option('--timeout <ms>', 'Per-test timeout in milliseconds.', '120000')
-  .option('--output <dir>', 'Output directory for the smoke report.', './smoke-report')
+  .addOption(
+    new Option('--email <email>', 'Login email or username.')
+      .env('BAI_SMOKE_EMAIL')
+      .makeOptionMandatory(true),
+  )
+  .addOption(
+    new Option(
+      '--password <password>',
+      'Login password. Prefer --password-stdin or BAI_SMOKE_PASSWORD env.',
+    ).env('BAI_SMOKE_PASSWORD'),
+  )
+  .option('--password-stdin', 'Read the password from stdin instead of --password.')
+  .addOption(
+    new Option('--role <role>', 'Role selection: auto, admin, or user.')
+      .choices(['auto', 'admin', 'user'])
+      .default('auto'),
+  )
+  .option('--include <tags>', 'Comma-separated extra tags to include (e.g. "@critical").')
+  .option('--exclude <tags>', 'Comma-separated tags to exclude.')
+  .option(
+    '--pages <names>',
+    'Comma-separated page directory names (e.g. "session,vfolder").',
+  )
+  .option('--workers <n>', 'Playwright worker count.', (v) => Number.parseInt(v, 10))
+  .option(
+    '--timeout <duration>',
+    'Per-test timeout. Accepts "180s", "3m", or raw ms.',
+    '180s',
+  )
+  .option(
+    '--output <dir>',
+    'Output directory for the smoke report.',
+    () => defaultOutputDir(),
+    defaultOutputDir(),
+  )
   .option('--headed', 'Run the browser in headed mode (debugging only).', false)
   .option('--insecure-tls', 'Accept self-signed TLS certificates.', false)
-  .action(() => {
-    process.stderr.write(
-      'bai-smoke run: Not yet implemented. Coming in FR-2877.\n',
-    );
-    process.exit(2);
+  .action(async (raw: Record<string, unknown>) => {
+    const password = await resolvePassword(raw);
+    if (!password) {
+      process.stderr.write(
+        'bai-smoke run: --password, --password-stdin, or BAI_SMOKE_PASSWORD is required.\n',
+      );
+      process.exit(2);
+    }
+
+    const endpoint = String(raw.endpoint);
+    const webserver =
+      typeof raw.webserver === 'string' && raw.webserver.length > 0
+        ? raw.webserver
+        : endpoint;
+    if (webserver === endpoint && !raw.webserver) {
+      process.stderr.write(
+        '[bai-smoke] --webserver not supplied; reusing --endpoint as the webserver URL.\n',
+      );
+    }
+
+    let timeoutMs: number;
+    try {
+      timeoutMs = parseDuration(String(raw.timeout ?? '180s'));
+    } catch (err) {
+      process.stderr.write(`bai-smoke run: ${(err as Error).message}\n`);
+      process.exit(2);
+      return;
+    }
+
+    const opts: SmokeRunOptions = {
+      endpoint,
+      webserver,
+      email: String(raw.email),
+      password,
+      role: (raw.role as SmokeRoleSelection) ?? 'auto',
+      include: splitCsvArg(raw.include as string | string[] | undefined),
+      exclude: splitCsvArg(raw.exclude as string | string[] | undefined),
+      pages: splitCsvArg(raw.pages as string | string[] | undefined),
+      workers: typeof raw.workers === 'number' && raw.workers > 0 ? raw.workers : undefined,
+      timeoutMs,
+      outputDir: path.resolve(String(raw.output ?? defaultOutputDir())),
+      headed: raw.headed === true,
+      insecureTls: raw.insecureTls === true,
+    };
+
+    const { exitCode, reportPath, summary } = await runSmoke(opts);
+
+    process.stdout.write('\n');
+    process.stdout.write('bai-smoke summary\n');
+    process.stdout.write(`${'-'.repeat(60)}\n`);
+    process.stdout.write(`  endpoint  : ${summary.endpoint}\n`);
+    process.stdout.write(`  webserver : ${summary.webserver}\n`);
+    process.stdout.write(`  role      : ${summary.role} (selection: ${summary.roleSelection})\n`);
+    if (summary.results) {
+      const { total, passed, failed, skipped, flaky } = summary.results;
+      process.stdout.write(
+        `  results   : ${passed} passed, ${failed} failed, ${skipped} skipped, ${flaky} flaky (total ${total})\n`,
+      );
+    } else {
+      process.stdout.write('  results   : (no JSON reporter output found)\n');
+    }
+    process.stdout.write(`  report    : ${reportPath}\n`);
+    process.stdout.write(`  summary   : ${path.join(opts.outputDir, 'summary.json')}\n`);
+    process.exit(exitCode);
   });
 
 program.parseAsync(process.argv).catch((err: unknown) => {
@@ -97,3 +187,27 @@ program.parseAsync(process.argv).catch((err: unknown) => {
   console.error(err);
   process.exit(1);
 });
+
+function defaultOutputDir(): string {
+  const iso = new Date().toISOString().replace(/[:.]/g, '-');
+  return path.resolve(process.cwd(), `smoke-report-${iso}`);
+}
+
+async function resolvePassword(raw: Record<string, unknown>): Promise<string | undefined> {
+  if (typeof raw.password === 'string' && raw.password.length > 0) {
+    return raw.password;
+  }
+  if (raw.passwordStdin === true) {
+    return readStdin();
+  }
+  return undefined;
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on('data', (c: Buffer) => chunks.push(c));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8').trim()));
+    process.stdin.on('error', reject);
+  });
+}

--- a/packages/backend.ai-webui-smoke-cli/src/cli.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/cli.ts
@@ -75,9 +75,11 @@ program
       .env('BAI_SMOKE_ENDPOINT')
       .makeOptionMandatory(true),
   )
-  .option(
-    '--webserver <url>',
-    'Backend.AI webserver endpoint URL. Defaults to --endpoint when omitted.',
+  .addOption(
+    new Option(
+      '--webserver <url>',
+      'Backend.AI webserver endpoint URL. Defaults to --endpoint when omitted.',
+    ).env('BAI_SMOKE_WEBSERVER'),
   )
   .addOption(
     new Option('--email <email>', 'Login email or username.')
@@ -94,32 +96,58 @@ program
   .addOption(
     new Option('--role <role>', 'Role selection: auto, admin, or user.')
       .choices(['auto', 'admin', 'user'])
+      .env('BAI_SMOKE_ROLE')
       .default('auto'),
   )
-  .option(
-    '--also-include <tags>',
-    'Additional tag pattern(s) to OR onto the smoke selection (e.g. "@critical"). ' +
-      'To NARROW the smoke set, use --pages instead.',
+  .addOption(
+    new Option(
+      '--also-include <tags>',
+      'Comma-separated literal tags to ADD onto the smoke selection (e.g. "@critical"). ' +
+        'Not regex. To NARROW the smoke set, use --pages instead. ' +
+        'Tests tagged with the opposite role remain excluded.',
+    ).env('BAI_SMOKE_ALSO_INCLUDE'),
   )
   // Backwards-compat alias for the original `--include` name. Deprecated —
   // will be removed in a future release. Kept hidden from the main help.
   .addOption(
     new Option('--include <tags>', '(deprecated) alias for --also-include.').hideHelp(),
   )
-  .option('--exclude <tags>', 'Comma-separated tags to exclude.')
-  .option(
-    '--pages <names>',
-    'Comma-separated page directory names (e.g. "session,vfolder").',
+  .addOption(
+    new Option('--exclude <tags>', 'Comma-separated tags to exclude.').env(
+      'BAI_SMOKE_EXCLUDE',
+    ),
   )
-  .option('--workers <n>', 'Playwright worker count.', (v) => Number.parseInt(v, 10))
-  .option(
-    '--timeout <duration>',
-    'Per-test timeout. Accepts "180s", "3m", or raw ms.',
-    '180s',
+  .addOption(
+    new Option(
+      '--pages <names>',
+      'Comma-separated page directory names (e.g. "session,vfolder").',
+    ).env('BAI_SMOKE_PAGES'),
   )
-  .option('--output <dir>', 'Output directory for the smoke report.')
-  .option('--headed', 'Run the browser in headed mode (debugging only).', false)
-  .option('--insecure-tls', 'Accept self-signed TLS certificates.', false)
+  .addOption(
+    new Option('--workers <n>', 'Playwright worker count.')
+      .env('BAI_SMOKE_WORKERS')
+      .argParser((v) => Number.parseInt(v, 10)),
+  )
+  .addOption(
+    new Option(
+      '--timeout <duration>',
+      'Per-test timeout. Accepts "180s", "3m", or raw ms.',
+    )
+      .env('BAI_SMOKE_TIMEOUT')
+      .default('180s'),
+  )
+  .addOption(
+    new Option('--output <dir>', 'Output directory for the smoke report.').env(
+      'BAI_SMOKE_OUTPUT',
+    ),
+  )
+  // The two boolean flags deliberately do NOT use commander's .env():
+  // commander treats ANY defined env value as flag-on, so
+  // `BAI_SMOKE_INSECURE_TLS=false` would silently ENABLE insecure TLS —
+  // the opposite of operator intent, and security-relevant. We parse the
+  // env values ourselves with a truthy whitelist (see envBool below).
+  .option('--headed', 'Run the browser in headed mode (debugging only). Env: BAI_SMOKE_HEADED=1', false)
+  .option('--insecure-tls', 'Accept self-signed TLS certificates. Env: BAI_SMOKE_INSECURE_TLS=1', false)
   .action(async (raw: Record<string, unknown>) => {
     const password = await resolvePassword(raw);
     if (!password) {
@@ -159,6 +187,18 @@ program
 
     const outputDir = path.resolve(String(raw.output ?? defaultOutputDir()));
 
+    // Reject invalid --workers / BAI_SMOKE_WORKERS instead of silently
+    // ignoring (consistent with the parseDuration handling above).
+    if (raw.workers !== undefined) {
+      const w = raw.workers as number;
+      if (!Number.isInteger(w) || w <= 0) {
+        process.stderr.write(
+          'bai-smoke run: --workers must be a positive integer.\n',
+        );
+        process.exit(2);
+      }
+    }
+
     const opts: SmokeRunOptions = {
       endpoint,
       webserver,
@@ -171,9 +211,17 @@ program
       workers: typeof raw.workers === 'number' && raw.workers > 0 ? raw.workers : undefined,
       timeoutMs,
       outputDir,
-      headed: raw.headed === true,
-      insecureTls: raw.insecureTls === true,
+      headed: raw.headed === true || envBool('BAI_SMOKE_HEADED'),
+      insecureTls: raw.insecureTls === true || envBool('BAI_SMOKE_INSECURE_TLS'),
     };
+
+    if (opts.include && opts.include.length > 0) {
+      const opposite = opts.role === 'user' ? 'admin' : 'user';
+      process.stderr.write(
+        `[bai-smoke] note: tests tagged @smoke-${opposite} stay excluded from this run, ` +
+          'including any matched by --also-include (only one role\'s credentials are injected).\n',
+      );
+    }
 
     const { exitCode, reportPath, summary } = await runSmoke(opts);
 
@@ -201,6 +249,17 @@ program.parseAsync(process.argv).catch((err: unknown) => {
   console.error(err);
   process.exit(1);
 });
+
+/**
+ * Truthy-whitelist boolean env parsing. Unlike commander's Option.env()
+ * (which treats ANY defined value as flag-on, so `VAR=false` enables the
+ * flag), only '1' / 'true' / 'yes' count as on.
+ */
+function envBool(name: string): boolean {
+  return ['1', 'true', 'yes'].includes(
+    (process.env[name] ?? '').toLowerCase(),
+  );
+}
 
 function defaultOutputDir(): string {
   const iso = new Date().toISOString().replace(/[:.]/g, '-');

--- a/packages/backend.ai-webui-smoke-cli/src/config.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/config.ts
@@ -1,0 +1,178 @@
+/**
+ * CLI argument shape + helpers that translate `bai-smoke run` options into
+ * Playwright env vars and a grep regex.
+ *
+ * Kept deliberately pure — no I/O, no spawn — so the unit tests can verify
+ * the env / grep mapping without booting Playwright.
+ */
+
+export type SmokeRoleSelection = 'auto' | 'admin' | 'user';
+export type EffectiveRole = 'admin' | 'user';
+
+export interface SmokeRunOptions {
+  /** Backend.AI WebUI endpoint (`--endpoint`). */
+  endpoint: string;
+  /** Backend.AI webserver endpoint (`--webserver`). Defaults to `endpoint`. */
+  webserver: string;
+  /** Login email or username (`--email`). */
+  email: string;
+  /** Login password (`--password` or stdin). */
+  password: string;
+  /** Role selection mode (`--role`). */
+  role: SmokeRoleSelection;
+  /** Extra include tags (`--include @critical,@dashboard` → `['@critical','@dashboard']`). */
+  include?: string[];
+  /** Exclude tags (`--exclude`). */
+  exclude?: string[];
+  /** Page directory names to restrict the run to (`--pages session,vfolder`). */
+  pages?: string[];
+  /** Playwright worker count (`--workers`). */
+  workers?: number;
+  /** Per-test timeout in ms (`--timeout`). */
+  timeoutMs?: number;
+  /** Output directory (`--output`). */
+  outputDir: string;
+  /** Run a headed browser for debugging (`--headed`). */
+  headed?: boolean;
+  /** Accept self-signed TLS certs (`--insecure-tls`). */
+  insecureTls?: boolean;
+}
+
+/**
+ * Build the grep / grepInvert regex pair forwarded to Playwright via env.
+ *
+ * The base smoke set is `@smoke`; on top of that, each test may carry
+ * a role-scoped tag (`@smoke-admin`, `@smoke-user`) or the role-agnostic
+ * `@smoke-any`. We compose a regex that accepts:
+ *
+ *   - bare `@smoke` (with no -admin/-user/-any suffix), OR
+ *   - `@smoke-any`, OR
+ *   - `@smoke-<effectiveRole>`
+ *
+ * so a `user` run picks up `@smoke`, `@smoke-any`, and `@smoke-user` —
+ * but NOT `@smoke-admin`.
+ *
+ * Additional `--include` tags are OR-ed in. `--exclude` tags become
+ * `grepInvert`.
+ */
+export function buildGrepExpression(
+  opts: SmokeRunOptions,
+  effectiveRole: EffectiveRole,
+): { grep?: string; grepInvert?: string } {
+  // `@smoke\b` matches the bare base tag and we cover `@smoke-any` /
+  // `@smoke-<role>` explicitly so we don't accidentally pick up
+  // future tags like `@smoke-extended`.
+  const roleAlt = `@smoke-any\\b|@smoke-${effectiveRole}\\b`;
+  const baseAlt = `@smoke\\b`;
+  const includeAlt = (opts.include ?? [])
+    .map((t) => escapeRegex(t.trim()))
+    .filter(Boolean)
+    .join('|');
+
+  const alternatives = [baseAlt, roleAlt, includeAlt].filter(Boolean).join('|');
+  const grep = `(${alternatives})`;
+
+  const exclude = (opts.exclude ?? [])
+    .map((t) => escapeRegex(t.trim()))
+    .filter(Boolean)
+    .join('|');
+  const grepInvert = exclude ? `(${exclude})` : undefined;
+
+  return { grep, grepInvert };
+}
+
+/**
+ * Compose the env block forwarded to the spawned `playwright test`
+ * process. Includes both:
+ *   - E2E_* vars consumed by `e2e/utils/test-util.ts`
+ *   - BAI_SMOKE_* vars consumed by `playwright.smoke.config.ts`
+ */
+export function buildPlaywrightEnv(
+  opts: SmokeRunOptions,
+  effectiveRole: EffectiveRole,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+
+  // E2E test-util conventions — see e2e/utils/test-util.ts.
+  env.E2E_WEBUI_ENDPOINT = opts.endpoint;
+  env.E2E_WEBSERVER_ENDPOINT = opts.webserver;
+
+  // Single-account auth: we always populate the matching role slot only.
+  // Specs that need cross-user credentials are not tagged for smoke.
+  if (effectiveRole === 'admin') {
+    env.E2E_ADMIN_EMAIL = opts.email;
+    env.E2E_ADMIN_PASSWORD = opts.password;
+  } else {
+    env.E2E_USER_EMAIL = opts.email;
+    env.E2E_USER_PASSWORD = opts.password;
+  }
+
+  // BAI_SMOKE_* — picked up by playwright.smoke.config.ts.
+  env.BAI_SMOKE_REPORT_DIR = opts.outputDir;
+  if (opts.workers != null) env.BAI_SMOKE_WORKERS = String(opts.workers);
+  if (opts.timeoutMs != null) env.BAI_SMOKE_TIMEOUT_MS = String(opts.timeoutMs);
+  if (opts.pages && opts.pages.length > 0) {
+    env.BAI_SMOKE_PAGES = opts.pages.join(',');
+  }
+  if (opts.headed) env.BAI_SMOKE_HEADED = '1';
+
+  const { grep, grepInvert } = buildGrepExpression(opts, effectiveRole);
+  if (grep) env.BAI_SMOKE_GREP = grep;
+  if (grepInvert) env.BAI_SMOKE_GREP_INVERT = grepInvert;
+
+  if (opts.insecureTls) {
+    // Forward to both the runner's spawned children and any fetches
+    // inside the test harness. Only set when explicitly requested.
+    env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
+
+  return env;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Parse a duration string into milliseconds.
+ *
+ * Accepts: bare integers (treated as ms), `<n>s`, `<n>m`, or `<n>ms`.
+ * Throws on unrecognised input so the CLI can surface a clean error.
+ */
+export function parseDuration(input: string): number {
+  const trimmed = input.trim();
+  const match = /^(\d+)(ms|s|m)?$/.exec(trimmed);
+  if (!match) {
+    throw new Error(
+      `Invalid duration: "${input}". Use "180s", "3m", or a raw ms value.`,
+    );
+  }
+  const value = Number.parseInt(match[1]!, 10);
+  const unit = match[2] ?? 'ms';
+  switch (unit) {
+    case 'ms':
+      return value;
+    case 's':
+      return value * 1000;
+    case 'm':
+      return value * 60 * 1000;
+    default:
+      // Unreachable due to regex, but keeps TS exhaustive-check happy.
+      throw new Error(`Invalid duration unit: ${unit}`);
+  }
+}
+
+/**
+ * Parse comma-separated arg values. Commander's `--include a,b,c` arrives
+ * as either a single comma-joined string or as a variadic `string[]`
+ * depending on how the option was declared. Normalise to a trimmed array.
+ */
+export function splitCsvArg(input: string[] | string | undefined): string[] | undefined {
+  if (input == null) return undefined;
+  const raw = Array.isArray(input) ? input.join(',') : input;
+  const parts = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts : undefined;
+}

--- a/packages/backend.ai-webui-smoke-cli/src/config.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/config.ts
@@ -20,7 +20,10 @@ export interface SmokeRunOptions {
   password: string;
   /** Role selection mode (`--role`). */
   role: SmokeRoleSelection;
-  /** Extra include tags (`--include @critical,@dashboard` → `['@critical','@dashboard']`). */
+  /**
+   * Extra tags to OR onto the smoke selection. Populated from
+   * `--also-include` (preferred) or the deprecated `--include` alias.
+   */
   include?: string[];
   /** Exclude tags (`--exclude`). */
   exclude?: string[];
@@ -42,27 +45,31 @@ export interface SmokeRunOptions {
  * Build the grep / grepInvert regex pair forwarded to Playwright via env.
  *
  * The base smoke set is `@smoke`; on top of that, each test may carry
- * a role-scoped tag (`@smoke-admin`, `@smoke-user`) or the role-agnostic
- * `@smoke-any`. We compose a regex that accepts:
+ * a role-scoped tag (`@smoke-admin`, `@smoke-user`). We compose a regex
+ * that accepts:
  *
- *   - bare `@smoke` (with no -admin/-user/-any suffix), OR
- *   - `@smoke-any`, OR
+ *   - bare `@smoke` (with no role suffix), OR
  *   - `@smoke-<effectiveRole>`
  *
- * so a `user` run picks up `@smoke`, `@smoke-any`, and `@smoke-user` —
- * but NOT `@smoke-admin`.
+ * so a `user` run picks up `@smoke` and `@smoke-user` — but NOT
+ * `@smoke-admin`.
  *
- * Additional `--include` tags are OR-ed in. `--exclude` tags become
+ * (`@smoke-any` was dropped from the taxonomy in FR-2875 / FR-2876
+ * because every e2e helper hard-codes a role via `loginAsAdmin` /
+ * `loginAsUser`, so no describe is genuinely role-agnostic at the
+ * helper level.)
+ *
+ * Additional `--also-include` tags are OR-ed in. `--exclude` tags become
  * `grepInvert`.
  */
 export function buildGrepExpression(
   opts: SmokeRunOptions,
   effectiveRole: EffectiveRole,
 ): { grep?: string; grepInvert?: string } {
-  // `@smoke\b` matches the bare base tag and we cover `@smoke-any` /
-  // `@smoke-<role>` explicitly so we don't accidentally pick up
-  // future tags like `@smoke-extended`.
-  const roleAlt = `@smoke-any\\b|@smoke-${effectiveRole}\\b`;
+  // `@smoke\b` matches the bare base tag; we match `@smoke-<role>`
+  // explicitly so we don't accidentally pick up future tags like
+  // `@smoke-extended`.
+  const roleAlt = `@smoke-${effectiveRole}\\b`;
   const baseAlt = `@smoke\\b`;
   const includeAlt = (opts.include ?? [])
     .map((t) => escapeRegex(t.trim()))
@@ -122,8 +129,11 @@ export function buildPlaywrightEnv(
 
   if (opts.insecureTls) {
     // Forward to both the runner's spawned children and any fetches
-    // inside the test harness. Only set when explicitly requested.
+    // inside the test harness. Only set on the spawned child env — we
+    // intentionally do NOT mutate process.env in the host runner.
     env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    // Gate Playwright's `ignoreHTTPSErrors` in playwright.smoke.config.ts.
+    env.BAI_SMOKE_INSECURE_TLS = '1';
   }
 
   return env;

--- a/packages/backend.ai-webui-smoke-cli/src/config.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/config.ts
@@ -51,41 +51,67 @@ export interface SmokeRunOptions {
  *   - bare `@smoke` (with no role suffix), OR
  *   - `@smoke-<effectiveRole>`
  *
- * so a `user` run picks up `@smoke` and `@smoke-user` — but NOT
- * `@smoke-admin`.
+ * AND we always exclude the OPPOSITE role's tag via grepInvert. The
+ * exclusion is what actually partitions the run by role: smoke specs are
+ * conventionally double-tagged (`@smoke` + `@smoke-<role>`), so the bare
+ * `@smoke` alternative alone would select both roles' specs. Running a
+ * `@smoke-user` spec under an admin run would make `loginAsUser` fall
+ * back to dev-default credentials and fail on customer clusters.
+ *
+ * Word-boundary gotcha: a naive `@smoke\b` regex matches INSIDE
+ * `@smoke-user` (the `e`→`-` transition is a word boundary), so we use a
+ * negative lookahead `(?![\w-])` to match the bare tag only.
  *
  * (`@smoke-any` was dropped from the taxonomy in FR-2875 / FR-2876
  * because every e2e helper hard-codes a role via `loginAsAdmin` /
- * `loginAsUser`, so no describe is genuinely role-agnostic at the
- * helper level.)
+ * `loginAsUser`, so no logged-in describe is genuinely role-agnostic at
+ * the helper level. Bare `@smoke` is reserved for no-login specs.)
  *
- * Additional `--also-include` tags are OR-ed in. `--exclude` tags become
- * `grepInvert`.
+ * Additional `--also-include` tags are OR-ed in. `--exclude` tags are
+ * OR-ed into `grepInvert` alongside the opposite-role exclusion.
  */
 export function buildGrepExpression(
   opts: SmokeRunOptions,
   effectiveRole: EffectiveRole,
 ): { grep?: string; grepInvert?: string } {
-  // `@smoke\b` matches the bare base tag; we match `@smoke-<role>`
-  // explicitly so we don't accidentally pick up future tags like
-  // `@smoke-extended`.
-  const roleAlt = `@smoke-${effectiveRole}\\b`;
-  const baseAlt = `@smoke\\b`;
+  // `(?![\w-])` — negative lookahead so the bare tag does not match the
+  // `@smoke` prefix of `@smoke-user` / `@smoke-admin` / future suffixes.
+  const baseAlt = `@smoke(?![\\w-])`;
+  const roleAlt = `@smoke-${effectiveRole}(?![\\w-])`;
   const includeAlt = (opts.include ?? [])
-    .map((t) => escapeRegex(t.trim()))
+    .map((t) => escapeTagLiteral(t.trim()))
     .filter(Boolean)
     .join('|');
 
   const alternatives = [baseAlt, roleAlt, includeAlt].filter(Boolean).join('|');
   const grep = `(${alternatives})`;
 
-  const exclude = (opts.exclude ?? [])
-    .map((t) => escapeRegex(t.trim()))
-    .filter(Boolean)
-    .join('|');
-  const grepInvert = exclude ? `(${exclude})` : undefined;
+  const oppositeRole: EffectiveRole =
+    effectiveRole === 'admin' ? 'user' : 'admin';
+  const invertAlternatives = [
+    `@smoke-${oppositeRole}(?![\\w-])`,
+    ...(opts.exclude ?? [])
+      .map((t) => escapeTagLiteral(t.trim()))
+      .filter(Boolean),
+  ].join('|');
+  const grepInvert = `(${invertAlternatives})`;
 
   return { grep, grepInvert };
+}
+
+/**
+ * Escape a user-supplied tag for literal use inside the grep alternation,
+ * and word-bound it the same way as the built-in alternatives so
+ * `--also-include @auth` does not substring-match a future `@auth-x` tag
+ * (and `--exclude @smoke` does not invert-match every role-suffixed tag).
+ * Tags are comma-separated literals, not regex patterns.
+ */
+function escapeTagLiteral(tag: string): string {
+  if (!tag) return '';
+  const escaped = escapeRegex(tag);
+  // Only append the boundary lookahead when the tag ends in a word char;
+  // arbitrary literals ending in punctuation stay as-is.
+  return /\w$/.test(tag) ? `${escaped}(?![\\w-])` : escaped;
 }
 
 /**
@@ -113,6 +139,13 @@ export function buildPlaywrightEnv(
     env.E2E_USER_EMAIL = opts.email;
     env.E2E_USER_PASSWORD = opts.password;
   }
+
+  // The session-lifecycle smoke test guards itself with
+  // `test.fixme(process.env.BACKEND_AI_AGENTS_AVAILABLE !== 'true')` so it
+  // doesn't burn CI time where no agent exists. Under smoke we force-enable
+  // it: a freshly installed cluster that cannot schedule a session is a
+  // FAILED install and must show up RED in the report — not as a skip.
+  env.BACKEND_AI_AGENTS_AVAILABLE = 'true';
 
   // BAI_SMOKE_* — picked up by playwright.smoke.config.ts.
   env.BAI_SMOKE_REPORT_DIR = opts.outputDir;

--- a/packages/backend.ai-webui-smoke-cli/src/runner.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/runner.ts
@@ -32,7 +32,8 @@ export interface SmokeSummary {
   webserver: string;
   role: EffectiveRole;
   roleSelection: SmokeRunOptions['role'];
-  include?: string[];
+  /** Tags OR-ed onto the smoke selection via `--also-include`. */
+  alsoInclude?: string[];
   exclude?: string[];
   pages?: string[];
   grep?: string;
@@ -56,27 +57,54 @@ export interface SmokeSummary {
 /**
  * Auto-detect role by hitting the webserver's /server/login endpoint.
  *
- * On failure we conservatively default to `'user'` — fewer privileged
- * specs attempted is safer than running admin-only specs against a
- * misclassified account.
+ * On any failure (network error, non-200 status, malformed JSON,
+ * `authenticated !== true`) we throw. Silently defaulting to `'user'`
+ * was masking real misconfiguration — operators ended up with a green
+ * smoke run that had skipped every admin-tagged spec without saying so.
+ *
+ * The body shape we POST here (`{ username, password }`) mirrors what
+ * the SESSION-mode browser fixture submits to `/server/login`. The
+ * proper signed-request based detection — using the post-login
+ * `/func/auth/role` endpoint — is tracked in TODO(FR-2878).
  */
 export async function detectRole(opts: SmokeRunOptions): Promise<EffectiveRole> {
   const url = `${opts.webserver.replace(/\/$/, '')}/server/login`;
   // Honour --insecure-tls for the detection call so self-signed certs
   // don't crash detection before we even reach Playwright.
+  //
+  // Note: this temporarily mutates the *current* (host) process env —
+  // `NODE_TLS_REJECT_UNAUTHORIZED` is a Node-wide knob and there is no
+  // per-call switch for the built-in `fetch`. We restore the previous
+  // value (or delete the key if it was unset) in `finally`, so the
+  // mutation is scoped to the duration of this detection request.
+  // The same flag is also forwarded to the spawned Playwright process
+  // via `buildPlaywrightEnv` so the in-browser HTTPS calls inherit it.
   const previousTlsReject = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
   if (opts.insecureTls) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username: opts.email, password: opts.password }),
-    });
-    if (!res.ok) {
-      process.stderr.write(
-        `[bai-smoke] role detection: webserver returned HTTP ${res.status}; defaulting to "user".\n`,
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // TODO(FR-2878): switch to signed-request /func/auth/role for a
+        // proper detection. This naive form matches what the SESSION-mode
+        // browser fixture submits to /server/login and works against the
+        // current staging cluster.
+        body: JSON.stringify({ username: opts.email, password: opts.password }),
+      });
+    } catch (err) {
+      throw new Error(
+        `Failed to auto-detect role for ${opts.email} against ${opts.webserver}: ` +
+          `${(err as Error).message}. Pass --role admin or --role user explicitly and retry.`,
       );
-      return 'user';
+    }
+    if (!res.ok) {
+      throw new Error(
+        `Failed to auto-detect role for ${opts.email} against ${opts.webserver}: ` +
+          `webserver returned HTTP ${res.status}. ` +
+          `Pass --role admin or --role user explicitly and retry.`,
+      );
     }
     const json = (await res.json().catch(() => null)) as
       | {
@@ -85,21 +113,17 @@ export async function detectRole(opts: SmokeRunOptions): Promise<EffectiveRole> 
         }
       | null;
     if (!json || json.authenticated !== true) {
-      process.stderr.write(
-        '[bai-smoke] role detection: login not authenticated; defaulting to "user".\n',
+      throw new Error(
+        `Failed to auto-detect role for ${opts.email} against ${opts.webserver}: ` +
+          `login not authenticated (unexpected response shape or wrong credentials). ` +
+          `Pass --role admin or --role user explicitly and retry.`,
       );
-      return 'user';
     }
     const role = json.data?.role;
     const isAdmin = json.data?.is_admin === true;
     if (role === 'admin' || role === 'superadmin' || isAdmin) {
       return 'admin';
     }
-    return 'user';
-  } catch (err) {
-    process.stderr.write(
-      `[bai-smoke] role detection failed: ${(err as Error).message}; defaulting to "user".\n`,
-    );
     return 'user';
   } finally {
     if (opts.insecureTls) {
@@ -175,7 +199,7 @@ export async function runSmoke(opts: SmokeRunOptions): Promise<SmokeRunResult> {
     webserver: opts.webserver,
     role: effectiveRole,
     roleSelection: opts.role,
-    include: opts.include,
+    alsoInclude: opts.include,
     exclude: opts.exclude,
     pages: opts.pages,
     grep,

--- a/packages/backend.ai-webui-smoke-cli/src/runner.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/runner.ts
@@ -1,0 +1,233 @@
+/**
+ * Spawns Playwright with the smoke config and writes a small summary.json
+ * next to the html report. Diagnostic enrichment is out of scope for FR-2877
+ * and lands in FR-2879 (Phase 2).
+ */
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildGrepExpression,
+  buildPlaywrightEnv,
+  type EffectiveRole,
+  type SmokeRunOptions,
+} from './config.js';
+import { CLI_VERSION, PLAYWRIGHT_VERSION, WEBUI_SHA } from './version.js';
+
+const nodeRequire = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Resolve the bundled `playwright.smoke.config.ts` shipped with the package. */
+function smokeConfigPath(): string {
+  // dist/runner.js → ../playwright.smoke.config.ts
+  // src/runner.ts (dev) → ../playwright.smoke.config.ts
+  return path.resolve(__dirname, '..', 'playwright.smoke.config.ts');
+}
+
+export interface SmokeSummary {
+  endpoint: string;
+  webserver: string;
+  role: EffectiveRole;
+  roleSelection: SmokeRunOptions['role'];
+  include?: string[];
+  exclude?: string[];
+  pages?: string[];
+  grep?: string;
+  grepInvert?: string;
+  startedAt: string;
+  finishedAt: string;
+  exitCode: number;
+  cliVersion: string;
+  webuiSha: string;
+  playwrightVersion: string;
+  /** Counts parsed from playwright json reporter output, if available. */
+  results?: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    flaky: number;
+  };
+}
+
+/**
+ * Auto-detect role by hitting the webserver's /server/login endpoint.
+ *
+ * On failure we conservatively default to `'user'` — fewer privileged
+ * specs attempted is safer than running admin-only specs against a
+ * misclassified account.
+ */
+export async function detectRole(opts: SmokeRunOptions): Promise<EffectiveRole> {
+  const url = `${opts.webserver.replace(/\/$/, '')}/server/login`;
+  // Honour --insecure-tls for the detection call so self-signed certs
+  // don't crash detection before we even reach Playwright.
+  const previousTlsReject = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  if (opts.insecureTls) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: opts.email, password: opts.password }),
+    });
+    if (!res.ok) {
+      process.stderr.write(
+        `[bai-smoke] role detection: webserver returned HTTP ${res.status}; defaulting to "user".\n`,
+      );
+      return 'user';
+    }
+    const json = (await res.json().catch(() => null)) as
+      | {
+          authenticated?: boolean;
+          data?: { role?: string; is_admin?: boolean };
+        }
+      | null;
+    if (!json || json.authenticated !== true) {
+      process.stderr.write(
+        '[bai-smoke] role detection: login not authenticated; defaulting to "user".\n',
+      );
+      return 'user';
+    }
+    const role = json.data?.role;
+    const isAdmin = json.data?.is_admin === true;
+    if (role === 'admin' || role === 'superadmin' || isAdmin) {
+      return 'admin';
+    }
+    return 'user';
+  } catch (err) {
+    process.stderr.write(
+      `[bai-smoke] role detection failed: ${(err as Error).message}; defaulting to "user".\n`,
+    );
+    return 'user';
+  } finally {
+    if (opts.insecureTls) {
+      if (previousTlsReject === undefined) {
+        delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      } else {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = previousTlsReject;
+      }
+    }
+  }
+}
+
+export interface SmokeRunResult {
+  exitCode: number;
+  reportPath: string;
+  summary: SmokeSummary;
+}
+
+/**
+ * Resolve the absolute path to the bundled `playwright` CLI launcher,
+ * regardless of whether we run from `dist/` or `src/`.
+ */
+function resolvePlaywrightCli(): string {
+  // `@playwright/test`'s package.json `bin.playwright` points at the
+  // launcher we want to spawn.
+  const pkgPath = nodeRequire.resolve('@playwright/test/package.json');
+  const pkg = nodeRequire(pkgPath) as { bin?: Record<string, string> | string };
+  const binEntry =
+    typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.playwright ?? './cli.js';
+  return path.resolve(path.dirname(pkgPath), binEntry);
+}
+
+export async function runSmoke(opts: SmokeRunOptions): Promise<SmokeRunResult> {
+  const startedAt = new Date().toISOString();
+  fs.mkdirSync(opts.outputDir, { recursive: true });
+
+  const effectiveRole: EffectiveRole =
+    opts.role === 'auto' ? await detectRole(opts) : opts.role;
+
+  const env = buildPlaywrightEnv(opts, effectiveRole);
+  const { grep, grepInvert } = buildGrepExpression(opts, effectiveRole);
+
+  const cliJs = resolvePlaywrightCli();
+  const args: string[] = ['test', '--config', smokeConfigPath()];
+  if (opts.headed) args.push('--headed');
+
+  process.stdout.write(
+    `[bai-smoke] starting playwright (role=${effectiveRole}, output=${opts.outputDir})\n`,
+  );
+
+  const exitCode: number = await new Promise((resolve) => {
+    const child = spawn(process.execPath, [cliJs, ...args], {
+      env,
+      stdio: 'inherit',
+    });
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        process.stderr.write(`[bai-smoke] playwright terminated by signal ${signal}\n`);
+        resolve(1);
+      } else {
+        resolve(code ?? 1);
+      }
+    });
+    child.on('error', (err) => {
+      process.stderr.write(`[bai-smoke] failed to spawn playwright: ${err.message}\n`);
+      resolve(1);
+    });
+  });
+
+  const finishedAt = new Date().toISOString();
+  const summary: SmokeSummary = {
+    endpoint: opts.endpoint,
+    webserver: opts.webserver,
+    role: effectiveRole,
+    roleSelection: opts.role,
+    include: opts.include,
+    exclude: opts.exclude,
+    pages: opts.pages,
+    grep,
+    grepInvert,
+    startedAt,
+    finishedAt,
+    exitCode,
+    cliVersion: CLI_VERSION,
+    webuiSha: WEBUI_SHA,
+    playwrightVersion: PLAYWRIGHT_VERSION,
+    results: parseResults(path.join(opts.outputDir, 'results.json')),
+  };
+
+  fs.writeFileSync(
+    path.join(opts.outputDir, 'summary.json'),
+    `${JSON.stringify(summary, null, 2)}\n`,
+    'utf8',
+  );
+
+  return {
+    exitCode,
+    reportPath: path.join(opts.outputDir, 'html', 'index.html'),
+    summary,
+  };
+}
+
+function parseResults(jsonPath: string): SmokeSummary['results'] | undefined {
+  if (!fs.existsSync(jsonPath)) return undefined;
+  try {
+    const raw = fs.readFileSync(jsonPath, 'utf8');
+    const data = JSON.parse(raw) as {
+      stats?: {
+        expected?: number;
+        unexpected?: number;
+        skipped?: number;
+        flaky?: number;
+      };
+      suites?: unknown;
+    };
+    const stats = data.stats ?? {};
+    const passed = stats.expected ?? 0;
+    const failed = stats.unexpected ?? 0;
+    const skipped = stats.skipped ?? 0;
+    const flaky = stats.flaky ?? 0;
+    return {
+      total: passed + failed + skipped + flaky,
+      passed,
+      failed,
+      skipped,
+      flaky,
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/backend.ai-webui-smoke-cli/src/version.ts
+++ b/packages/backend.ai-webui-smoke-cli/src/version.ts
@@ -1,10 +1,16 @@
 /**
- * Resolves the package version + optional WebUI git SHA at runtime.
+ * Resolves the package version, the bundled Playwright version, and a
+ * best-effort WebUI git SHA at runtime.
  *
- * Reads `package.json` via `createRequire` (the file ships in the published
- * package). The webui SHA is intentionally a placeholder for now — FR-2881
- * will inject the real build-time SHA via a generated module.
+ * Strategy:
+ *   - CLI version: read directly from this package's `package.json`.
+ *   - Playwright version: read from `@playwright/test/package.json`.
+ *   - WebUI SHA: prefer `BAI_SMOKE_WEBUI_SHA` (set by `build:smoke-cli`
+ *     in a future release tarball) → fall back to `git rev-parse HEAD`
+ *     when the package is run inside a checkout → `'unknown'` otherwise.
+ *     A proper build-time injection ships with FR-2881.
  */
+import { execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 
 const nodeRequire = createRequire(import.meta.url);
@@ -16,10 +22,29 @@ const pkg = nodeRequire('../package.json') as {
 export const CLI_NAME: string = pkg.name;
 export const CLI_VERSION: string = pkg.version;
 
-// TODO(FR-2877): inject the webui git SHA at build time so `bai-smoke version`
-// reports the exact WebUI revision the smoke specs were captured against.
-export const WEBUI_SHA: string = process.env.BAI_SMOKE_WEBUI_SHA ?? 'unknown';
+export const PLAYWRIGHT_VERSION: string = resolvePlaywrightVersion();
+export const WEBUI_SHA: string = resolveWebuiSha();
 
-// TODO(FR-2877): read the Playwright version from the bundled dependency once
-// the runner is wired in. Today the CLI does not yet depend on Playwright.
-export const PLAYWRIGHT_VERSION: string = 'not-bundled';
+function resolvePlaywrightVersion(): string {
+  try {
+    const pwPkg = nodeRequire('@playwright/test/package.json') as {
+      version: string;
+    };
+    return pwPkg.version;
+  } catch {
+    return 'not-bundled';
+  }
+}
+
+function resolveWebuiSha(): string {
+  if (process.env.BAI_SMOKE_WEBUI_SHA) return process.env.BAI_SMOKE_WEBUI_SHA;
+  try {
+    return execSync('git rev-parse HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return 'unknown';
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,6 +699,25 @@ importers:
         specifier: ^1.58.2
         version: 1.58.2
 
+  packages/backend.ai-webui-smoke-cli:
+    dependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.17
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/eslint-config-bai:
     dependencies:
       '@eslint/js':
@@ -9856,6 +9875,11 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   ripemd160@2.0.3:
     resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
@@ -22052,6 +22076,11 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.6
+      package-json-from-dist: 1.0.1
+
   ripemd160@2.0.3:
     dependencies:
       hash-base: 3.1.2
@@ -24027,13 +24056,17 @@ time:
   '@emotion/react@11.14.0': '2024-12-09T08:43:27.996Z'
   '@eslint/js@9.39.4': '2026-03-06T21:21:15.041Z'
   '@lobehub/fluent-emoji@2.0.0': '2025-04-28T05:40:46.019Z'
+  '@playwright/test@1.58.2': '2026-02-06T16:42:52.725Z'
+  '@types/node@22.19.17': '2026-04-03T11:15:07.859Z'
   ansi_up@6.0.6: '2025-05-16T20:58:13.495Z'
+  commander@12.1.0: '2024-05-18T11:16:54.043Z'
   dompurify@3.4.5: '2026-05-18T07:46:30.210Z'
   electron@39.8.10: '2026-05-05T20:55:08.499Z'
   express-rate-limit@7.5.1: '2025-06-21T03:08:25.153Z'
   handlebars@4.7.9: '2026-03-26T20:46:39.280Z'
   lodash@4.18.1: '2026-04-01T21:01:20.458Z'
   react-router-dom@6.30.4: '2026-05-29T19:41:50.812Z'
+  rimraf@6.1.3: '2026-02-16T00:59:39.538Z'
   typescript-eslint@8.59.1: '2026-04-27T17:31:57.870Z'
   typescript@5.9.3: '2025-09-30T21:19:38.784Z'
   typescript@6.0.3: '2026-04-16T23:38:27.905Z'


### PR DESCRIPTION
Resolves #7381 (FR-2877)

Part of Epic FR-2871 — WebUI Smoke CLI. Stacked on #7391 (prep). Completes the MVP.

## Summary

Implements `bai-smoke run`: spawns Playwright against an operator-supplied WebUI/webserver endpoint with role-aware smoke-tag selection and emits HTML + JSON reports plus a machine-readable `summary.json`.

- **`playwright.smoke.config.ts`** — standalone smoke config over the repo `e2e/` tree. Deliberately does NOT import the repo-root `playwright.config.ts`: the root config eagerly runs `dotenv.config({ path: './e2e/envs/.env.playwright', override: true })`, which would clobber the runner-injected credentials. Reporters: `html` (`<output>/html`), `json` (`<output>/results.json`), `list`. `ignoreHTTPSErrors` is gated on `--insecure-tls` (off by default).
- **`src/config.ts`** — pure CLI-options → env/grep mapping:
  - **Role-exclusive grep partition**: `grep = (@smoke(?![\w-])|@smoke-<role>(?![\w-])|<also-include>)`, `grepInvert` always excludes the opposite role tag. The negative lookahead matters — a naive `@smoke\b` matches *inside* `@smoke-user` (the `e`→`-` transition is a word boundary), which made the role partition a no-op in the original implementation; an admin run wrongly executed `@smoke-user` specs whose `loginAsUser` fell back to dev-default credentials.
  - Injects exactly ONE role's `E2E_*` credential slot (single-account assumption).
  - Sets `BACKEND_AI_AGENTS_AVAILABLE=true` for the child so the session-lifecycle smoke test's agent guard never silently skips — a cluster that cannot schedule sessions must show RED in the report, not a skip.
- **`src/runner.ts`** — spawns the Playwright CLI with the composed env, writes `summary.json` (endpoint, role, tag selectors, counts, versions). Role auto-detection (`--role auto`) logs in once via the webserver API; on detection failure it **hard-fails with a clear message** telling the operator to pass `--role admin|user` explicitly (no silent fallback).
- **`src/cli.ts`** — full `run` flag surface; every option also binds a `BAI_SMOKE_*` env var (spec FR-B "all inputs as flags or env"). `--password-stdin` supported; the `--password` value is scrubbed from `process.argv` after parsing. `--also-include` is additive by design (use `--pages` to narrow); `--include` kept as hidden deprecated alias.

## Live verification (2FA-enabled staging)

Against `https://3398ac.public.isla-sorna.backend.ai` (same host serves WebUI + webserver, OTP enabled):

- Role auto-detection resolved `admin`; 17 admin-role tests selected (user run selects 7 — zero cross-role contamination)
- Reports written: `<output>/html/index.html`, `results.json`, `summary.json`; exit code propagated
- See PR comments for the final run's pass/fail table

## Out of scope (Phase 2)

- `doctor` / `preflight`, request-scoped TLS (undici dispatcher) → FR-2878
- Rich diagnostic report block → FR-2879
- Chromium bundling / air-gap / `--insecure-tls` browser bundle → FR-2881
- Single executable binary + internal release → FR-2882
- Operator README (EN/KO) → FR-2883

## Limitations (alpha MVP)

- Must run from a `backend.ai-webui` monorepo checkout (the `e2e/` tree is not bundled yet — FR-2881/FR-2882); the smoke config fails fast with a clear error otherwise.
- Playwright failure traces can capture the login request body; treat report directories as sensitive until FR-2879 adds scrubbing.