### PR TITLE
fix(FR-2885): remove hard-coded fontSize on UserDropdownMenu avatar icon

### DIFF
--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -234,9 +234,7 @@ const UserDropdownMenu: React.FC<{
                   backgroundColor: token.colorBgBase,
                 }}
               >
-                <UserOutlined
-                  style={{ fontSize: 10, color: token.colorPrimary }}
-                />
+                <UserOutlined style={{ color: token.colorPrimary }} />
               </Avatar>
             }
           >


### PR DESCRIPTION
Resolves #7393 ([FR-2885](https://lablup.atlassian.net/browse/FR-2885))

## Summary
- Remove the hard-coded `fontSize: 10` on `<UserOutlined />` inside the `UserDropdownMenu` avatar so the icon scales naturally with the 17px Avatar instead of rendering as a tiny glyph.

## Test plan
- [x] Verify the user icon in the header dropdown renders at a normal size and is centered within the avatar.

[FR-2885]: https://lablup.atlassian.net/browse/FR-2885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ