### PR TITLE
feat(FR-2886): add BAIAvailablePresetSelect and BAIProjectVfolderSelect, migrate deployment callers

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -95,7 +95,7 @@ const useStyles = createStyles(({ css, token }) => ({
 export interface BAISelectProps<
   ValueType = any,
   OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
-> extends Omit<SelectProps<ValueType, OptionType>, 'onSearch'> {
+> extends Omit<SelectProps<ValueType, OptionType>, 'onSearch' | 'role'> {
   ref?: React.RefObject<GetRef<typeof Select<ValueType, OptionType>> | null>;
   ghost?: boolean;
   autoSelectOption?:
@@ -108,6 +108,11 @@ export interface BAISelectProps<
   footer?: React.ReactNode;
   endReached?: () => void; // New prop for endReached
   searchAction?: (value: string) => Promise<void>;
+  // antd v6 made `role` required on SelectProps. We Omit it from the
+  // extended props and re-add it as optional with a sensible default so
+  // callers don't have to spell it out at every call site. Override
+  // (e.g. `role="listbox"`) when a specific ARIA role is needed.
+  role?: SelectProps<ValueType, OptionType>['role'];
 }
 
 function BAISelect<
@@ -123,6 +128,7 @@ function BAISelect<
   footer,
   endReached, // Destructure the new prop
   searchAction,
+  role = 'combobox',
   ...selectProps
 }: BAISelectProps<ValueType, OptionType>): React.ReactElement {
   const { value, options, onChange } = selectProps;
@@ -196,6 +202,7 @@ function BAISelect<
     <Tooltip title={tooltip}>
       <Select<ValueType, OptionType>
         {...selectProps}
+        role={role}
         loading={isPending || selectProps.loading}
         showSearch={composedShowSearch}
         ref={ref}

--- a/packages/backend.ai-ui/src/components/fragments/BAIAvailablePresetSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAvailablePresetSelect.tsx
@@ -1,0 +1,369 @@
+import { BAIAvailablePresetSelectPaginatedQuery } from '../../__generated__/BAIAvailablePresetSelectPaginatedQuery.graphql';
+import { BAIAvailablePresetSelectValueQuery } from '../../__generated__/BAIAvailablePresetSelectValueQuery.graphql';
+import { convertToUUID, toLocalId } from '../../helper';
+import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAIFlex from '../BAIFlex';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton, Typography, theme } from 'antd';
+import type { DefaultOptionType } from 'antd/es/select';
+import * as _ from 'lodash-es';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type DeploymentRevisionPresetNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      BAIAvailablePresetSelectPaginatedQuery['response']['deploymentRevisionPresets']
+    >['edges'][number]
+  >['node']
+>;
+
+export interface BAIAvailablePresetSelectRef {
+  refetch: () => void;
+}
+
+export interface BAIAvailablePresetSelectProps extends Omit<
+  BAISelectProps,
+  'options' | 'labelInValue' | 'ref'
+> {
+  runtimeVariantId?: string;
+  ref?: React.Ref<BAIAvailablePresetSelectRef>;
+}
+
+const BAIAvailablePresetSelect: React.FC<BAIAvailablePresetSelectProps> = ({
+  loading,
+  runtimeVariantId,
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | string[] | undefined
+  >(selectProps);
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
+    },
+  );
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const deferredSearchStr = useDebouncedDeferredValue(searchStr);
+  const [optimisticSearchStr, setOptimisticSearchStr] =
+    useOptimistic(searchStr);
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Defer query refetch to prevent flickering during user selection
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  // Resolved (typed) UUIDs of currently selected presets. Each entry should be
+  // a raw UUID so it can be fed into `DeploymentRevisionPresetFilter.id.in`.
+  const selectedIds = _.compact(
+    _.castArray(deferredControllableValue).map((v) =>
+      v ? convertToUUID(_.toString(v)) : null,
+    ),
+  );
+
+  // Fetch labels for the currently selected preset ids in one round-trip via
+  // the `id: { in: [...] }` filter. `@skip(if: $skip)` collapses the request
+  // when nothing is selected. We do not paginate this query — `first` is
+  // sized exactly to the selection so all labels arrive together.
+  const { deploymentRevisionPresets: selectedPresets } =
+    useLazyLoadQuery<BAIAvailablePresetSelectValueQuery>(
+      graphql`
+        query BAIAvailablePresetSelectValueQuery(
+          $ids: [UUID!]
+          $first: Int!
+          $skip: Boolean!
+        ) {
+          deploymentRevisionPresets(
+            filter: { id: { in: $ids } }
+            first: $first
+          ) @skip(if: $skip) {
+            edges {
+              node {
+                id
+                name
+                description
+                runtimeVariantId
+                runtimeVariant {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      {
+        ids: selectedIds,
+        first: Math.max(selectedIds.length, 1),
+        skip: selectedIds.length === 0,
+      },
+      {
+        fetchPolicy: selectedIds.length > 0 ? 'store-or-network' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  // `DeploymentRevisionPresetFilter` has no AND/OR combinators — its fields
+  // already AND together — so we merge by setting each field on a single
+  // object. `null` when no filter is active so the query field receives the
+  // schema default.
+  const mergedFilter: NonNullable<
+    BAIAvailablePresetSelectPaginatedQuery['variables']['filter']
+  > | null =
+    runtimeVariantId || deferredSearchStr
+      ? {
+          ...(runtimeVariantId
+            ? { runtimeVariantId: { equals: convertToUUID(runtimeVariantId) } }
+            : {}),
+          ...(deferredSearchStr
+            ? { name: { iContains: deferredSearchStr } }
+            : {}),
+        }
+      : null;
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<
+      BAIAvailablePresetSelectPaginatedQuery,
+      DeploymentRevisionPresetNode
+    >(
+      graphql`
+        query BAIAvailablePresetSelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $filter: DeploymentRevisionPresetFilter
+        ) {
+          deploymentRevisionPresets(
+            offset: $offset
+            limit: $limit
+            filter: $filter
+            orderBy: [{ field: RANK, direction: "ASC" }]
+          ) {
+            count
+            edges {
+              node {
+                id
+                name
+                description
+                rank
+                runtimeVariantId
+                runtimeVariant {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      { limit: 10 },
+      {
+        filter: mergedFilter,
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (r) => r.deploymentRevisionPresets?.count ?? undefined,
+        getItem: (r) =>
+          r.deploymentRevisionPresets?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  // Expose refetch function through ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  // Build base option list (raw UUID values + name/description metadata).
+  type PresetOption = DefaultOptionType & {
+    description?: string | null;
+    runtimeVariantId?: string | null;
+    runtimeVariantName?: string | null;
+  };
+  const flatOptions: PresetOption[] = _.compact(
+    _.map(paginationData, (item) => {
+      if (!item?.id) return null;
+      return {
+        label: item.name,
+        value: toLocalId(item.id) ?? item.id,
+        description: item.description,
+        runtimeVariantId: item.runtimeVariantId,
+        runtimeVariantName: item.runtimeVariant?.name,
+      };
+    }),
+  );
+
+  // Group options by runtime variant. When only one variant is present in the
+  // current page we render a flat list — otherwise an optgroup per variant.
+  const grouped = _.groupBy(flatOptions, 'runtimeVariantId');
+  const variantIds = Object.keys(grouped);
+  const availableOptions: DefaultOptionType[] =
+    variantIds.length <= 1
+      ? flatOptions
+      : variantIds.map((variantId) => {
+          const group = grouped[variantId];
+          // Fall back to the variant id when the joined `runtimeVariant` is
+          // missing (e.g., the variant row was deleted).
+          const variantLabel = group[0]?.runtimeVariantName ?? variantId;
+          return {
+            label: variantLabel,
+            options: group,
+          };
+        });
+
+  // Whether the underlying Select is multi-select. In single mode antd's
+  // `labelInValue` expects a single `{label, value}` object, not an array;
+  // multi/tags modes expect an array. We must unwrap accordingly.
+  const isMultiple =
+    selectProps.mode === 'multiple' || selectProps.mode === 'tags';
+
+  // Reconstruct labeled value objects for `labelInValue`. Falls back to the
+  // raw id string when the label hasn't resolved yet.
+  const selectedLabelMap: Record<string, string> = {};
+  for (const edge of selectedPresets?.edges ?? []) {
+    const node = edge?.node;
+    if (!node?.id) continue;
+    const uuid = toLocalId(node.id) ?? node.id;
+    if (node.name) selectedLabelMap[uuid] = node.name;
+  }
+  const controllableValueWithLabelArray = !_.isEmpty(deferredControllableValue)
+    ? _.castArray(deferredControllableValue).map((value) => {
+        const v = _.toString(value);
+        return { label: selectedLabelMap[v] ?? v, value: v };
+      })
+    : undefined;
+  const controllableValueWithLabel = controllableValueWithLabelArray
+    ? isMultiple
+      ? controllableValueWithLabelArray
+      : controllableValueWithLabelArray[0]
+    : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIAvailablePresetSelect.SelectPreset')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        searchStr !== deferredSearchStr ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setOptimisticSearchStr(value);
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={
+        selectProps.showSearch === false
+          ? false
+          : {
+              searchValue: optimisticSearchStr,
+              autoClearSearchValue: true,
+              ...(_.isObject(selectProps.showSearch)
+                ? _.omit(selectProps.showSearch, ['searchValue'])
+                : {}),
+              filterOption: false,
+            }
+      }
+      optionRender={(option) => (
+        <BAIFlex direction="column" align="start">
+          {option.label}
+          {option.data.description && (
+            <Typography.Text
+              type="secondary"
+              style={{ fontSize: token.fontSizeSM }}
+              ellipsis
+            >
+              {option.data.description}
+            </Typography.Text>
+          )}
+        </BAIFlex>
+      )}
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        const castedValue = _.isEmpty(value) ? [] : _.castArray(value);
+        const valueWithOriginalLabel = castedValue.map((v) => {
+          const label = _.isString(v.label)
+            ? v.label
+            : (flatOptions.find((opt) => opt.value === v.value)?.label ??
+              v.value);
+          return { label, value: v.value };
+        });
+        setOptimisticValueWithLabel(
+          _.isEmpty(valueWithOriginalLabel)
+            ? undefined
+            : isMultiple
+              ? valueWithOriginalLabel
+              : valueWithOriginalLabel[0],
+        );
+        const idArray = castedValue.map((v) => _.toString(v.value));
+        setControllableValue(
+          isMultiple ? idArray : (idArray[0] ?? undefined),
+          option,
+        );
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.deploymentRevisionPresets?.count) &&
+        result.deploymentRevisionPresets.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.deploymentRevisionPresets.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIAvailablePresetSelect;

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectVfolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectVfolderSelect.tsx
@@ -1,0 +1,342 @@
+import { BAIProjectVfolderSelectPaginatedQuery } from '../../__generated__/BAIProjectVfolderSelectPaginatedQuery.graphql';
+import { BAIProjectVfolderSelectValueQuery } from '../../__generated__/BAIProjectVfolderSelectValueQuery.graphql';
+import { convertToUUID, toLocalId } from '../../helper';
+import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAILink from '../BAILink';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import BAIText from '../BAIText';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import * as _ from 'lodash-es';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type ProjectVfolderNode = NonNullable<
+  NonNullable<
+    BAIProjectVfolderSelectPaginatedQuery['response']['projectVfolders']
+  >['edges'][number]
+>['node'];
+
+export type BAIProjectVfolderSelectFilter = NonNullable<
+  BAIProjectVfolderSelectPaginatedQuery['variables']['filter']
+>;
+
+export interface BAIProjectVfolderSelectRef {
+  refetch: () => void;
+}
+
+export interface BAIProjectVfolderSelectProps extends Omit<
+  BAISelectProps,
+  'options' | 'labelInValue' | 'ref'
+> {
+  projectId: string;
+  onClickVFolder?: (value: string) => void;
+  filter?: BAIProjectVfolderSelectFilter | null;
+  excludeDeleted?: boolean;
+  ref?: React.Ref<BAIProjectVfolderSelectRef>;
+}
+
+const EXCLUDED_DELETION_STATUSES = [
+  'DELETE_PENDING',
+  'DELETE_ONGOING',
+  'DELETE_ERROR',
+  'DELETE_COMPLETE',
+] as const;
+
+const BAIProjectVfolderSelect: React.FC<BAIProjectVfolderSelectProps> = ({
+  loading,
+  projectId,
+  onClickVFolder,
+  filter,
+  excludeDeleted,
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | undefined
+  >(selectProps);
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
+    },
+  );
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const deferredSearchStr = useDebouncedDeferredValue(searchStr);
+  const [optimisticSearchStr, setOptimisticSearchStr] =
+    useOptimistic(searchStr);
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  // `VFolderFilter` allows each field at most once at the top level. We
+  // compose the caller's `filter` with the search and `excludeDeleted`
+  // shortcuts via the `AND` combinator so they cannot clobber each other
+  // (e.g., caller passing `status: { equals: READY }` while we also want to
+  // add `status: { notIn: [DELETE_*] }`).
+  const subFilters: BAIProjectVfolderSelectFilter[] = [];
+  if (filter) subFilters.push(filter);
+  if (excludeDeleted) {
+    subFilters.push({
+      status: { notIn: EXCLUDED_DELETION_STATUSES },
+    });
+  }
+  if (deferredSearchStr) {
+    subFilters.push({ name: { iContains: deferredSearchStr } });
+  }
+  const mergedFilter: BAIProjectVfolderSelectFilter | null =
+    subFilters.length === 0
+      ? null
+      : subFilters.length === 1
+        ? subFilters[0]
+        : { AND: subFilters };
+
+  // Selected-value name lookup. `VFolderFilter` does not expose an id
+  // filter, so we resolve the single selected vfolder via the
+  // `vfolderV2(vfolderId:)` point lookup. The `@skip` directive collapses
+  // the request when nothing is selected.
+  const selectedUuid = deferredControllableValue
+    ? convertToUUID(_.toString(deferredControllableValue))
+    : '';
+  const { vfolderV2: selectedVfolder } =
+    useLazyLoadQuery<BAIProjectVfolderSelectValueQuery>(
+      graphql`
+        query BAIProjectVfolderSelectValueQuery(
+          $vfolderId: UUID!
+          $skip: Boolean!
+        ) {
+          vfolderV2(vfolderId: $vfolderId) @skip(if: $skip) {
+            id
+            metadata {
+              name
+            }
+          }
+        }
+      `,
+      {
+        vfolderId: selectedUuid,
+        skip: !selectedUuid,
+      },
+      {
+        fetchPolicy: selectedUuid ? 'store-or-network' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<
+      BAIProjectVfolderSelectPaginatedQuery,
+      ProjectVfolderNode
+    >(
+      graphql`
+        query BAIProjectVfolderSelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $projectId: UUID!
+          $filter: VFolderFilter
+        ) {
+          projectVfolders(
+            projectId: $projectId
+            offset: $offset
+            limit: $limit
+            filter: $filter
+            orderBy: [{ field: CREATED_AT, direction: DESC }]
+          ) {
+            count
+            edges {
+              node {
+                id
+                metadata {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      { limit: 10 },
+      {
+        projectId: convertToUUID(projectId),
+        filter: mergedFilter,
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (r) => r.projectVfolders?.count ?? undefined,
+        getItem: (r) => r.projectVfolders?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: item?.metadata?.name,
+    // Emit the raw (dashed) local UUID — matches the
+    // `vfolderV2(vfolderId: UUID!)` shape and is what mutation callers feed
+    // to `deployVfolderV2` etc.
+    value: item?.id ? toLocalId(item.id) : undefined,
+  }));
+
+  const selectedLabel = selectedVfolder?.metadata?.name;
+  const controllableValueWithLabel = deferredControllableValue
+    ? {
+        label: selectedLabel ?? _.toString(deferredControllableValue),
+        value: _.toString(deferredControllableValue),
+      }
+    : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIProjectVfolderSelect.SelectFolder')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        searchStr !== deferredSearchStr ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setOptimisticSearchStr(value);
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={
+        selectProps.showSearch === false
+          ? false
+          : {
+              searchValue: optimisticSearchStr,
+              autoClearSearchValue: true,
+              ...(_.isObject(selectProps.showSearch)
+                ? _.omit(selectProps.showSearch, ['searchValue'])
+                : {}),
+              filterOption: false,
+            }
+      }
+      labelRender={({ label, value }) => {
+        // While the dropdown is open antd renders the search input on
+        // top of the selected label. The input overlay only covers the
+        // label node — the trailing `(id)` lives in a sibling span and
+        // would visually leak alongside the user's typed query — so
+        // suppress the suffix during search.
+        if (controllableOpen) {
+          return label;
+        }
+        return onClickVFolder ? (
+          <BAILink onClick={() => onClickVFolder(_.toString(value))}>
+            {label}
+          </BAILink>
+        ) : (
+          <>
+            {label}
+            <BAIText type="secondary">
+              &nbsp; (
+              <BAIText
+                ellipsis
+                type="secondary"
+                style={{ width: 80 }}
+                monospace
+              >
+                {_.toString(value)}
+              </BAIText>
+              )
+            </BAIText>
+          </>
+        );
+      }}
+      optionRender={({ label, value }) => (
+        <>
+          {label}
+          <BAIText type="secondary">
+            &nbsp; (
+            <BAIText ellipsis style={{ width: 80 }} type="secondary" monospace>
+              {_.toString(value)}
+            </BAIText>
+            )
+          </BAIText>
+        </>
+      )}
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        // Single-value select only — `labelInValue` returns a single object
+        // (or undefined when cleared).
+        if (_.isUndefined(value) || _.isNull(value)) {
+          setOptimisticValueWithLabel(undefined);
+          setControllableValue(undefined, option);
+          return;
+        }
+        const v = _.castArray(value)[0];
+        const label = _.isString(v.label)
+          ? v.label
+          : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+            _.toString(v.value));
+        const next = { label, value: _.toString(v.value) };
+        setOptimisticValueWithLabel(next);
+        setControllableValue(next.value, option);
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.projectVfolders?.count) &&
+        result.projectVfolders.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.projectVfolders.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIProjectVfolderSelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -88,6 +88,19 @@ export type {
   VFolderNode,
   BAIVFolderSelectRef,
 } from './BAIVFolderSelect';
+export { default as BAIProjectVfolderSelect } from './BAIProjectVfolderSelect';
+export type {
+  BAIProjectVfolderSelectProps,
+  BAIProjectVfolderSelectFilter,
+  ProjectVfolderNode,
+  BAIProjectVfolderSelectRef,
+} from './BAIProjectVfolderSelect';
+export { default as BAIAvailablePresetSelect } from './BAIAvailablePresetSelect';
+export type {
+  BAIAvailablePresetSelectProps,
+  BAIAvailablePresetSelectRef,
+  DeploymentRevisionPresetNode,
+} from './BAIAvailablePresetSelect';
 export { default as BAIUserSelect } from './BAIUserSelect';
 export type {
   BAIUserSelectProps,

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -63,6 +63,9 @@
     "Updated": "Aktualisiert",
     "Version": "Version"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Voreinstellung auswählen"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut oder kontaktieren Sie den Support, wenn das Problem weiterhin besteht."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Speicherknoten",
     "TotalResourceSlots": "Gesamtanzahl der Ressourcen-Slots",
     "Type": "Typ"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Ordner auswählen"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Suche",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -63,6 +63,9 @@
     "Updated": "Ενημερωμένος",
     "Version": "Εκδοχή"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Επιλέξτε προεπιλογή"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Προέκυψε απρόσμενο σφάλμα. Δοκιμάστε ξανά αργότερα ή επικοινωνήστε με την υποστήριξη εάν το πρόβλημα επιμένει."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Κόμβοι Αποθήκευσης",
     "TotalResourceSlots": "Συνολικές θέσεις πόρων",
     "Type": "Τύπος"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Επιλογή φακέλου"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Αναζήτηση",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -63,6 +63,9 @@
     "Updated": "Updated",
     "Version": "Version"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Select Preset"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "An unexpected error occurred. Please try again later or contact support if the problem persists."
   },
@@ -239,6 +242,9 @@
     "StorageNodes": "Storage Nodes",
     "TotalResourceSlots": "Total Resource Slots",
     "Type": "Type"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Select Folder"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Search",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -63,6 +63,9 @@
     "Updated": "Actualizado",
     "Version": "Versión"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Seleccionar preset"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Se produjo un error inesperado. Inténtelo de nuevo más tarde o contacte con el soporte si el problema persiste."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Nodos de almacenamiento",
     "TotalResourceSlots": "Total de ranuras de recursos",
     "Type": "Tipo"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Seleccionar carpeta"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Buscar en",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -63,6 +63,9 @@
     "Updated": "Päivitetty",
     "Version": "Versio"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Valitse esiasetus"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Tapahtui odottamaton virhe. Yritä uudelleen myöhemmin tai ota yhteyttä tukeen, jos ongelma jatkuu."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Tallennussolmut",
     "TotalResourceSlots": "Resurssipaikat yhteensä",
     "Type": "Tyyppi"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Valitse kansio"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Etsi",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -63,6 +63,9 @@
     "Updated": "Mis à jour",
     "Version": "Version"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Sélectionner un preset"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Une erreur inattendue s'est produite. Veuillez réessayer plus tard ou contacter le support si le problème persiste."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Nœuds de stockage",
     "TotalResourceSlots": "Nombre total de créneaux de ressources",
     "Type": "Type"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Sélectionner un dossier"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Recherche",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -63,6 +63,9 @@
     "Updated": "Diperbarui",
     "Version": "Versi"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Pilih Preset"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Terjadi kesalahan tak terduga. Silakan coba lagi nanti atau hubungi dukungan jika masalah berlanjut."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Node Penyimpanan",
     "TotalResourceSlots": "Jumlah Slot Sumber Daya",
     "Type": "Tipe"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Pilih Folder"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pencarian",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -63,6 +63,9 @@
     "Updated": "Aggiornato",
     "Version": "Versione"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Seleziona preset"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Si è verificato un errore imprevisto. Riprova più tardi o contatta l'assistenza se il problema persiste."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Nodi di archiviazione",
     "TotalResourceSlots": "Slot risorse totali",
     "Type": "Tipo"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Seleziona cartella"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Ricerca",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -63,6 +63,9 @@
     "Updated": "更新",
     "Version": "バージョン"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "プリセットを選択"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "予期しないエラーが発生しました。しばらくしてから再度お試しください。それでも問題が解決しない場合はサポートにお問い合わせください。"
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "ストレージノード",
     "TotalResourceSlots": "合計リソーススロット数",
     "Type": "種類"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "フォルダを選択"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "検索",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -63,6 +63,9 @@
     "Updated": "업데이트",
     "Version": "버전"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "프리셋을 선택해주세요"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "예기치 못한 오류가 발생했습니다. 잠시 후 다시 시도하거나 문제가 지속되면 지원팀에 문의하세요."
   },
@@ -239,6 +242,9 @@
     "StorageNodes": "저장소 노드",
     "TotalResourceSlots": "총 리소스 슬롯",
     "Type": "타입"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "폴더를 선택해주세요"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "검색",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -63,6 +63,9 @@
     "Updated": "Шинэчилсэн цаг нь",
     "Version": "Таамаглал"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Урьдчилан тохиргоо сонгох"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Гэнэтийн алдаа гарлаа. Дахин оролдоно уу эсвэл асуудал үргэлжилбэл дэмжлэгт хандана уу."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Хадгалах зангилаанууд",
     "TotalResourceSlots": "Нийт нөөцийн слотууд",
     "Type": "Төрөл"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Хавтас сонгох"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Хайх",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -63,6 +63,9 @@
     "Updated": "Dikemas kini",
     "Version": "Versi"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Pilih Pratetap"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Ralat tidak dijangka berlaku. Sila cuba lagi nanti atau hubungi sokongan jika masalah berterusan."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Nod Storan",
     "TotalResourceSlots": "Jumlah Slot Sumber",
     "Type": "Jenis"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Pilih Folder"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Cari",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -63,6 +63,9 @@
     "Updated": "Zaktualizowane",
     "Version": "Wersja"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Wybierz preset"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie później lub skontaktuj się z pomocą techniczną, jeśli problem będzie się powtarzał."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Węzły pamięci masowej",
     "TotalResourceSlots": "Całkowita liczba slotów zasobów",
     "Type": "Typ"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Wybierz folder"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Wyszukiwanie",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -63,6 +63,9 @@
     "Updated": "Atualizado",
     "Version": "Versão"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Selecionar preset"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Ocorreu um erro inesperado. Tente novamente mais tarde ou entre em contato com o suporte se o problema persistir."
   },
@@ -235,6 +238,9 @@
     "StorageNodes": "Nós de Armazenamento",
     "TotalResourceSlots": "Total de slots de recursos",
     "Type": "Tipo"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Selecionar pasta"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pesquisar",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -63,6 +63,9 @@
     "Updated": "Atualizado",
     "Version": "Versão"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Selecionar preset"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Ocorreu um erro inesperado. Tente novamente mais tarde ou entre em contato com o suporte se o problema persistir."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Nós de Armazenamento",
     "TotalResourceSlots": "Total de slots de recursos",
     "Type": "Tipo"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Selecionar pasta"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pesquisar",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -63,6 +63,9 @@
     "Updated": "Обновлено",
     "Version": "Версия"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Выберите пресет"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Произошла непредвиденная ошибка. Попробуйте ещё раз позже или обратитесь в службу поддержки, если проблема сохраняется."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Узлы хранения",
     "TotalResourceSlots": "Всего ресурсных слотов",
     "Type": "Тип"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Выбрать папку"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Поиск",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -63,6 +63,9 @@
     "Updated": "อัปเดต",
     "Version": "รุ่น"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "เลือกการตั้งค่าล่วงหน้า"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "เกิดข้อผิดพลาดที่ไม่คาดคิด กรุณาลองอีกครั้งภายหลัง หากปัญหายังคงมีอยู่ โปรดติดต่อฝ่ายสนับสนุน"
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "โหนดจัดเก็บข้อมูล",
     "TotalResourceSlots": "ช่องทรัพยากรทั้งหมด",
     "Type": "ประเภท"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "เลือกโฟลเดอร์"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "ค้นหา",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -63,6 +63,9 @@
     "Updated": "Güncellenmiş",
     "Version": "Versiyon"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Ön ayar seçin"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Beklenmeyen bir hata oluştu. Lütfen daha sonra tekrar deneyin veya sorun devam ederse destekle iletişime geçin."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Depolama Düğümleri",
     "TotalResourceSlots": "Toplam Kaynak Slotları",
     "Type": "Tür"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Klasör Seç"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Arama",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -63,6 +63,9 @@
     "Updated": "Cập nhật",
     "Version": "Phiên bản"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "Chọn cài đặt sẵn"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "Đã xảy ra lỗi bất ngờ. Vui lòng thử lại sau hoặc liên hệ bộ phận hỗ trợ nếu vấn đề vẫn tiếp diễn."
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "Nút lưu trữ",
     "TotalResourceSlots": "Tổng số khe tài nguyên",
     "Type": "Loại"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "Chọn thư mục"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Tìm kiếm",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -63,6 +63,9 @@
     "Updated": "更新",
     "Version": "版本"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "选择预设"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "发生意外错误。请稍后重试，若问题仍然存在，请联系支持。"
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "存储节点",
     "TotalResourceSlots": "资源插槽总数",
     "Type": "类型"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "选择文件夹"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "搜索",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -63,6 +63,9 @@
     "Updated": "更新",
     "Version": "版本"
   },
+  "comp:BAIAvailablePresetSelect": {
+    "SelectPreset": "選擇預設"
+  },
   "comp:BAIBoardItemErrorBoundary": {
     "UnexpectedError": "發生未預期的錯誤。請稍後再試，若問題持續，請聯絡支援。"
   },
@@ -236,6 +239,9 @@
     "StorageNodes": "儲存節點",
     "TotalResourceSlots": "資源總槽位",
     "Type": "類型"
+  },
+  "comp:BAIProjectVfolderSelect": {
+    "SelectFolder": "選擇資料夾"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "搜索",

--- a/react/src/components/DeploymentAddRevisionCustomContent.tsx
+++ b/react/src/components/DeploymentAddRevisionCustomContent.tsx
@@ -14,6 +14,7 @@ import {
   mergeExtraArgs,
   reverseMapExtraArgs,
 } from '../helper/runtimeExtraArgsParser';
+import { useModelStoreProject } from '../hooks/useModelStoreProject';
 import {
   buildArgsSchemaKeySet,
   buildDefaultsMap,
@@ -34,7 +35,6 @@ import ResourceAllocationFormItems, {
   RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
   type ResourceAllocationFormValue,
 } from './SessionFormItems/ResourceAllocationFormItems';
-import VFolderSelect from './VFolderSelect';
 import VFolderTableFormItem, {
   type VFolderTableFormValues,
 } from './VFolderTableFormItem';
@@ -56,6 +56,7 @@ import {
 } from 'antd';
 import {
   BAIFlex,
+  BAIProjectVfolderSelect,
   convertToUUID,
   filterOutNullAndUndefined,
   safeDecodeUuid,
@@ -145,6 +146,10 @@ export const DeploymentAddRevisionCustomContent: React.FC<
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  // The model folder picker scopes to the MODEL_STORE project, not the
+  // deployment's own project — model cards live in the domain-wide model
+  // store regardless of which project owns the deployment.
+  const { id: modelStoreProjectId } = useModelStoreProject();
 
   // Runtime parameter refs — kept outside form state so slider/input changes
   // don't re-render the modal. Read at submit time via serializeRuntimeParamsToEnviron.
@@ -448,18 +453,10 @@ export const DeploymentAddRevisionCustomContent: React.FC<
           ]),
       ),
       runtimeVariantId: rev.modelRuntimeConfig?.runtimeVariantId ?? undefined,
-      // VFolderSelect / VFolderTable's row data come from REST `/folders`
-      // which exposes `id` as 32-char hex without dashes, while the
-      // GraphQL `modelMountConfig.vfolderId` and `extraMounts.vfolderId`
-      // come back as canonical UUIDs. Strip dashes here so the form
-      // value matches existing options (and selectedRowKeys for the
-      // additional-mounts table) directly — without it, VFolderTable
-      // never highlights the prefilled rows and the alias map keys
-      // can't be looked up. `convertToUUID` in the submit re-adds
-      // dashes for the GraphQL input.
-      modelFolderId: rev.modelMountConfig?.vfolderId
-        ? rev.modelMountConfig.vfolderId.replace(/-/g, '')
-        : undefined,
+      // BAIProjectVfolderSelect returns the canonical dashed UUID, which
+      // matches `rev.modelMountConfig.vfolderId` directly. `convertToUUID`
+      // in the submit is idempotent on already-dashed values.
+      modelFolderId: rev.modelMountConfig?.vfolderId ?? undefined,
       mountDestination: rev.modelMountConfig?.mountDestination ?? '/models',
       definitionPath: rev.modelMountConfig?.definitionPath ?? undefined,
       // `ImageEnvironmentSelectFormItems` matches the form's
@@ -890,19 +887,14 @@ export const DeploymentAddRevisionCustomContent: React.FC<
         label={t('deployment.ModelFolder')}
         rules={[{ required: true }]}
       >
-        <VFolderSelect
-          // `autoSelectDefault` runs a mount-time effect inside
-          // VFolderSelect that writes the *first available* folder into
-          // the form, which races with `prefillFromCurrentRevision` and
-          // can clobber the deployment's actual model folder when more
-          // than one is available. We always have the model folder from
-          // the current revision here, so leave the field empty when
-          // the revision somehow lacks one rather than auto-picking.
-          valuePropName="id"
-          filter={(vf) => vf.usage_mode === 'model' && vf.status === 'ready'}
-          showOpenButton
-          showCreateButton
-          showRefreshButton
+        <BAIProjectVfolderSelect
+          projectId={modelStoreProjectId ?? ''}
+          disabled={!modelStoreProjectId}
+          filter={{
+            usageMode: { equals: 'MODEL' },
+            status: { equals: 'READY' },
+          }}
+          style={{ width: '100%' }}
         />
       </Form.Item>
       <Form.Item
@@ -1158,6 +1150,15 @@ export const DeploymentAddRevisionCustomContent: React.FC<
                   >
                     {({ getFieldValue }) => {
                       const modelFolderId = getFieldValue('modelFolderId');
+                      // `modelFolderId` comes from BAIProjectVfolderSelect
+                      // as a dashed UUID, while `vfolder.id` from
+                      // VFolderTable's REST source is 32-char hex without
+                      // dashes. Strip dashes for the
+                      // comparison so the model folder is correctly excluded
+                      // from the additional-mounts table.
+                      const modelFolderIdNoDash = modelFolderId
+                        ? String(modelFolderId).replace(/-/g, '')
+                        : undefined;
                       return (
                         <VFolderTableFormItem
                           label={t('modelService.AdditionalMounts')}
@@ -1169,7 +1170,7 @@ export const DeploymentAddRevisionCustomContent: React.FC<
                             vfolder.usage_mode !== 'model' &&
                             vfolder.status === 'ready' &&
                             !vfolder.name?.startsWith('.') &&
-                            vfolder.id !== modelFolderId
+                            vfolder.id !== modelFolderIdNoDash
                           }
                         />
                       );

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -357,7 +357,6 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
         <DeploymentAddRevisionPresetContent
           deploymentFrgmt={data.deployment}
           deploymentRevisionPresetsData={data.deploymentRevisionPresets}
-          runtimeVariantsData={data.runtimeVariants}
           form={presetForm}
           onRequestClose={onRequestClose}
           onIsDeployingChange={setIsSubmitting}

--- a/react/src/components/DeploymentAddRevisionPresetContent.tsx
+++ b/react/src/components/DeploymentAddRevisionPresetContent.tsx
@@ -9,8 +9,8 @@ import type { DeploymentAddRevisionPresetContentFragment$key } from '../__genera
 import type { DeploymentPresetDetailContentFragment$key } from '../__generated__/DeploymentPresetDetailContentFragment.graphql';
 import { useWebUINavigate } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useModelStoreProject } from '../hooks/useModelStoreProject';
 import DeploymentPresetDetailContent from './DeploymentPresetDetailContent';
-import VFolderSelect from './VFolderSelect';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import {
   Alert,
@@ -20,20 +20,18 @@ import {
   type FormInstance,
   Space,
   Tooltip,
-  Typography,
   theme,
 } from 'antd';
-import type { DefaultOptionType } from 'antd/es/select';
 import {
+  BAIAvailablePresetSelect,
   BAIFlex,
   BAIModal,
   BAIProjectResourceGroupSelect,
-  BAISelect,
+  BAIProjectVfolderSelect,
   convertToUUID,
   toLocalId,
   useBAILogger,
 } from 'backend.ai-ui';
-import * as _ from 'lodash-es';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
@@ -50,7 +48,6 @@ interface DeploymentAddRevisionPresetContentProps {
     | null
     | undefined;
   deploymentRevisionPresetsData: DeploymentAddRevisionModalQuery$data['deploymentRevisionPresets'];
-  runtimeVariantsData: DeploymentAddRevisionModalQuery$data['runtimeVariants'];
   form: FormInstance<PresetFormValues>;
   onRequestClose: (success?: boolean) => void;
   onIsDeployingChange: (v: boolean) => void;
@@ -70,7 +67,6 @@ export const DeploymentAddRevisionPresetContent: React.FC<
 > = ({
   deploymentFrgmt,
   deploymentRevisionPresetsData,
-  runtimeVariantsData,
   form,
   onRequestClose,
   onIsDeployingChange,
@@ -83,6 +79,11 @@ export const DeploymentAddRevisionPresetContent: React.FC<
   const { message } = App.useApp();
   const navigate = useWebUINavigate();
   const { id: projectId, name: projectName } = useCurrentProjectValue();
+  // The model folder picker scopes to the MODEL_STORE project, not the
+  // user's currently selected project — model cards live in the
+  // domain-wide model store regardless of which project the user is
+  // browsing right now.
+  const { id: modelStoreProjectId } = useModelStoreProject();
   const { logger } = useBAILogger();
 
   // Preset-mode slice of the wrapper's `DeploymentAddRevisionModalQuery`.
@@ -111,39 +112,11 @@ export const DeploymentAddRevisionPresetContent: React.FC<
 
   const hasNoPresets = availablePresets.length === 0;
 
-  // Build runtime variant ID → name map for optgroup display
-  const runtimeVariantNameMap = new Map<string, string>();
-  for (const edge of runtimeVariantsData?.edges ?? []) {
-    const node = edge?.node;
-    if (node?.id) {
-      runtimeVariantNameMap.set(toLocalId(node.id), node.name ?? '');
-    }
-  }
-
-  // Group presets by runtime variant for optgroup display
-  const groupedPresets = _.groupBy(availablePresets, 'runtimeVariantId');
-  const variantIds = Object.keys(groupedPresets);
-  const toOption = (p: (typeof availablePresets)[number]) => ({
-    label: p.name,
-    value: toLocalId(p.id) ?? p.id,
-    description: p.description,
-  });
-  const presetOptions: DefaultOptionType[] =
-    variantIds.length <= 1
-      ? availablePresets.map(toOption)
-      : variantIds.map((variantId) => ({
-          label: runtimeVariantNameMap.get(variantId) ?? variantId,
-          options: groupedPresets[variantId].map(toOption),
-        }));
-
   // The parent deployment's vfolder is the default Model Folder. Users can
   // override it in this mode (in contrast to the VFolder/ModelStore entry
   // point where the folder is locked in by context).
-  const parentDeploymentVfolderId =
-    deployment?.currentRevision?.modelMountConfig?.vfolderId;
-  const defaultModelFolderId = parentDeploymentVfolderId
-    ? parentDeploymentVfolderId.replace(/-/g, '')
-    : undefined;
+  const defaultModelFolderId =
+    deployment?.currentRevision?.modelMountConfig?.vfolderId ?? undefined;
 
   const [commitDeploy] =
     useMutation<DeploymentAddRevisionPresetContentDeployMutation>(graphql`
@@ -254,23 +227,8 @@ export const DeploymentAddRevisionPresetContent: React.FC<
             noStyle
             rules={[{ required: true }]}
           >
-            <BAISelect
+            <BAIAvailablePresetSelect
               onChange={handlePresetChange}
-              options={presetOptions}
-              optionRender={(option) => (
-                <BAIFlex direction="column" align="start">
-                  {option.label}
-                  {option.data.description && (
-                    <Typography.Text
-                      type="secondary"
-                      style={{ fontSize: token.fontSizeSM }}
-                      ellipsis
-                    >
-                      {option.data.description}
-                    </Typography.Text>
-                  )}
-                </BAIFlex>
-              )}
               style={{ flex: 1 }}
             />
           </Form.Item>
@@ -315,12 +273,14 @@ export const DeploymentAddRevisionPresetContent: React.FC<
         label={t('deployment.ModelFolder')}
         rules={[{ required: true }]}
       >
-        <VFolderSelect
-          valuePropName="id"
-          filter={(vf) => vf.usage_mode === 'model' && vf.status === 'ready'}
-          showOpenButton
-          showCreateButton
-          showRefreshButton
+        <BAIProjectVfolderSelect
+          projectId={modelStoreProjectId ?? ''}
+          disabled={!modelStoreProjectId}
+          filter={{
+            usageMode: { equals: 'MODEL' },
+            status: { equals: 'READY' },
+          }}
+          style={{ width: '100%' }}
         />
       </Form.Item>
 

--- a/react/src/components/ModelCardDeployModal.tsx
+++ b/react/src/components/ModelCardDeployModal.tsx
@@ -4,43 +4,30 @@
  */
 import type { DeploymentPresetDetailContentFragment$key } from '../__generated__/DeploymentPresetDetailContentFragment.graphql';
 import { ModelCardDeployModalMutation } from '../__generated__/ModelCardDeployModalMutation.graphql';
-import { ModelCardDeployModalQuery } from '../__generated__/ModelCardDeployModalQuery.graphql';
 import { useWebUINavigate } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import DeploymentPresetDetailContent from './DeploymentPresetDetailContent';
 import { InfoCircleOutlined } from '@ant-design/icons';
+import { Alert, App, Button, Form, Space, Tooltip, theme } from 'antd';
 import {
-  Alert,
-  App,
-  Button,
-  Form,
-  Space,
-  Tooltip,
-  Typography,
-  theme,
-} from 'antd';
-import type { DefaultOptionType } from 'antd/es/select';
-import {
+  BAIAvailablePresetSelect,
   BAIButton,
   BAIFlex,
   BAIModal,
   BAIProjectResourceGroupSelect,
-  BAISelect,
   toLocalId,
   useProjectResourceGroups,
 } from 'backend.ai-ui';
-import * as _ from 'lodash-es';
 import { PlusIcon } from 'lucide-react';
 import React, {
   Suspense,
   useEffect,
   useEffectEvent,
-  useMemo,
   useRef,
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import { graphql, useMutation } from 'react-relay';
 import type { FragmentRefs } from 'relay-runtime';
 
 interface AvailablePreset {
@@ -91,23 +78,6 @@ const ModelCardDeployModalContent: React.FC<
   // to render the selection UI or auto-deploy.
   const { resourceGroups } = useProjectResourceGroups(projectName ?? '');
 
-  const { runtimeVariants } = useLazyLoadQuery<ModelCardDeployModalQuery>(
-    graphql`
-      query ModelCardDeployModalQuery {
-        runtimeVariants {
-          edges {
-            node {
-              id
-              name
-            }
-          }
-        }
-      }
-    `,
-    {},
-    {},
-  );
-
   const [commitDeploy] = useMutation<ModelCardDeployModalMutation>(graphql`
     mutation ModelCardDeployModalMutation(
       $cardId: UUID!
@@ -119,41 +89,6 @@ const ModelCardDeployModalContent: React.FC<
       }
     }
   `);
-
-  // Build runtime variant ID → name map for preset grouping
-  const runtimeVariantNameMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const edge of runtimeVariants?.edges ?? []) {
-      const node = edge?.node;
-      if (node?.id) {
-        map.set(toLocalId(node.id), node.name ?? '');
-      }
-    }
-    return map;
-  }, [runtimeVariants]);
-
-  // Group presets by runtime variant for optgroup display
-  const presetOptions: DefaultOptionType[] = useMemo(() => {
-    const grouped = _.groupBy(availablePresets, 'runtimeVariantId');
-    const variantIds = Object.keys(grouped);
-
-    const toOption = (p: AvailablePreset) => ({
-      label: p.name,
-      value: toLocalId(p.id),
-      description: p.description,
-    });
-
-    // If all presets belong to the same runtime variant, show flat list
-    if (variantIds.length <= 1) {
-      return availablePresets.map(toOption);
-    }
-
-    // Multiple runtime variants: show grouped options
-    return variantIds.map((variantId) => ({
-      label: runtimeVariantNameMap.get(variantId) ?? variantId,
-      options: grouped[variantId].map(toOption),
-    }));
-  }, [availablePresets, runtimeVariantNameMap]);
 
   // Determine scenario: auto-deploy (scenario 2) vs selection (scenario 3)
   const isAutoDeployScenario =
@@ -297,24 +232,23 @@ const ModelCardDeployModalContent: React.FC<
           required
         >
           <BAIFlex direction="row" gap="xs">
-            <BAISelect
+            {/*
+              TODO(needs-backend): `BAIAvailablePresetSelect` fetches presets
+              from `deploymentRevisionPresets`, which currently has no
+              model-card-scoped filter (`DeploymentRevisionPresetFilter` only
+              supports `name` and `runtimeVariantId`). The `availablePresets`
+              prop passed by the parent is the server-filtered list scoped to
+              this specific model card. Once a model-card scope is exposed on
+              `DeploymentRevisionPresetFilter`, pass it to this select so the
+              dropdown matches the card's compatible-presets list. For now the
+              dropdown shows the full project-accessible list — auto-deploy
+              and the empty-state still use the scoped `availablePresets`.
+            */}
+            <BAIAvailablePresetSelect
               value={effectivePresetId}
-              onChange={(value: string) => setUserSelectedPresetId(value)}
-              options={presetOptions}
-              optionRender={(option) => (
-                <BAIFlex direction="column" align="start">
-                  {option.label}
-                  {option.data.description && (
-                    <Typography.Text
-                      type="secondary"
-                      style={{ fontSize: token.fontSizeSM }}
-                      ellipsis
-                    >
-                      {option.data.description}
-                    </Typography.Text>
-                  )}
-                </BAIFlex>
-              )}
+              onChange={(value) =>
+                setUserSelectedPresetId(value as string | undefined)
+              }
               style={{ flex: 1 }}
             />
             <Space.Compact>

--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -19,26 +19,22 @@ import {
   Skeleton,
   Space,
   Tooltip,
-  Typography,
   theme,
 } from 'antd';
-import type { DefaultOptionType } from 'antd/es/select';
 import {
+  BAIAvailablePresetSelect,
   BAIButton,
   BAIFlex,
   BAIModal,
   BAIProjectResourceGroupSelect,
-  BAISelect,
   toLocalId,
   useProjectResourceGroups,
 } from 'backend.ai-ui';
-import * as _ from 'lodash-es';
 import { PlusIcon } from 'lucide-react';
 import React, {
   Suspense,
   useEffect,
   useEffectEvent,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -89,7 +85,13 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
   // available (e.g. a scope input similar to `modelCardAvailablePresets`),
   // filter by this vfolder's compatible presets here. For now we show the
   // full project-accessible list so the user can still select a preset.
-  const { deploymentRevisionPresets, runtimeVariants } =
+  //
+  // This top-level fetch is kept (rather than relying solely on the paginated
+  // query inside `BAIAvailablePresetSelect`) because we need:
+  //   • the total count to decide between the empty-state, auto-deploy, and
+  //     the selection-UI render paths,
+  //   • the preset node fragment refs for the detail-modal lookup.
+  const { deploymentRevisionPresets } =
     useLazyLoadQuery<VFolderDeployModalQuery>(
       graphql`
         query VFolderDeployModalQuery {
@@ -99,34 +101,7 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
             edges {
               node {
                 id
-                name
-                description
-                rank
-                runtimeVariantId
-                runtimeVariant {
-                  name
-                }
-                execution {
-                  imageId
-                  startupCommand
-                }
-                cluster {
-                  clusterMode
-                  clusterSize
-                }
-                deploymentDefaults {
-                  openToPublic
-                  replicaCount
-                }
                 ...DeploymentPresetDetailContentFragment
-              }
-            }
-          }
-          runtimeVariants {
-            edges {
-              node {
-                id
-                name
               }
             }
           }
@@ -136,13 +111,10 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
       {},
     );
 
-  const availablePresets = useMemo(() => {
-    return (
-      deploymentRevisionPresets?.edges
-        ?.map((edge) => edge?.node)
-        .filter((node): node is NonNullable<typeof node> => node != null) ?? []
-    );
-  }, [deploymentRevisionPresets]);
+  const availablePresets =
+    deploymentRevisionPresets?.edges
+      ?.map((edge) => edge?.node)
+      .filter((node): node is NonNullable<typeof node> => node != null) ?? [];
 
   const [commitDeploy] = useMutation<VFolderDeployModalMutation>(graphql`
     mutation VFolderDeployModalMutation(
@@ -155,41 +127,6 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
       }
     }
   `);
-
-  // Build runtime variant ID → name map for preset grouping
-  const runtimeVariantNameMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const edge of runtimeVariants?.edges ?? []) {
-      const node = edge?.node;
-      if (node?.id) {
-        map.set(toLocalId(node.id), node.name ?? '');
-      }
-    }
-    return map;
-  }, [runtimeVariants]);
-
-  // Group presets by runtime variant for optgroup display
-  const presetOptions: DefaultOptionType[] = useMemo(() => {
-    const grouped = _.groupBy(availablePresets, 'runtimeVariantId');
-    const variantIds = Object.keys(grouped);
-
-    const toOption = (p: (typeof availablePresets)[number]) => ({
-      label: p.name,
-      value: toLocalId(p.id),
-      description: p.description,
-    });
-
-    // If all presets belong to the same runtime variant, show flat list
-    if (variantIds.length <= 1) {
-      return availablePresets.map(toOption);
-    }
-
-    // Multiple runtime variants: show grouped options
-    return variantIds.map((variantId) => ({
-      label: runtimeVariantNameMap.get(variantId) ?? variantId,
-      options: grouped[variantId].map(toOption),
-    }));
-  }, [availablePresets, runtimeVariantNameMap]);
 
   const hasNoPresets = availablePresets.length === 0;
 
@@ -336,28 +273,15 @@ const VFolderDeployModalContent: React.FC<VFolderDeployModalContentProps> = ({
           required
         >
           <BAIFlex direction="row" gap="xs">
-            <BAISelect
+            <BAIAvailablePresetSelect
               value={effectivePresetId}
-              onChange={(value: string) => setUserSelectedPresetId(value)}
-              options={presetOptions}
+              onChange={(value) =>
+                setUserSelectedPresetId(value as string | undefined)
+              }
               disabled={hasNoPresets}
               placeholder={
                 hasNoPresets ? t('modelStore.NoCompatiblePresets') : undefined
               }
-              optionRender={(option) => (
-                <BAIFlex direction="column" align="start">
-                  {option.label}
-                  {option.data.description && (
-                    <Typography.Text
-                      type="secondary"
-                      style={{ fontSize: token.fontSizeSM }}
-                      ellipsis
-                    >
-                      {option.data.description}
-                    </Typography.Text>
-                  )}
-                </BAIFlex>
-              )}
               style={{ flex: 1 }}
             />
             <Space.Compact>


### PR DESCRIPTION
Resolves #7395 ([FR-2886](https://lablup.atlassian.net/browse/FR-2886))

## Summary

- Add `BAIAvailablePresetSelect` to `backend.ai-ui` — self-paginated deployment-preset select with `runtimeVariant` optgroup grouping and a `name + description` `optionRender`. Uses the package-local i18n key `comp:BAIAvailablePresetSelect.SelectPreset` (the previous inline call sites reused the main app's `modelStore.Preset`, which the library namespace doesn't expose and rendered as raw text).
- Add `BAIProjectVfolderSelect` to `backend.ai-ui` — replaces the V1 `vfolder_nodes` string-DSL filter with the V2 `projectVfolders(projectId:)` GraphQL query and accepts a structured `VFolderFilter` input. Single-value selected-name resolution uses the `vfolderV2(vfolderId:)` point lookup, gated by `@skip` when nothing is selected. Suppresses the trailing `(id)` suffix on the selected label while the dropdown is open so it doesn't leak alongside the antd search input overlay.
- Migrate consumers:
  - `VFolderDeployModal.tsx` and `ModelCardDeployModal.tsx` — inline preset `BAISelect` → `BAIAvailablePresetSelect`. The model-card-scoped dropdown is temporarily wired to the full project preset list with a `TODO(needs-backend)` marker until a model-card-scoped preset list lands.
  - `DeploymentAddRevisionPresetContent.tsx` and `DeploymentAddRevisionCustomContent.tsx` — `BAIVFolderSelect` (V1) → `BAIProjectVfolderSelect` (V2). The `projectId` is scoped to the MODEL_STORE project via `useModelStoreProject()`, not the user's currently selected project — model cards live in the domain-wide model store regardless of which project the user is browsing.
  - `DeploymentAddRevisionModal.tsx` — drop the stale `runtimeVariantsData` prop pass to the Preset child (no longer needed now that `BAIAvailablePresetSelect` paginates its own data).
- Fix `BAIVFolderSelect` row_id filter rejection (carried in the parent stack): when `valuePropName="row_id"`, the selected-name resolver was emitting `row_id == "..."` filters which the backend DSL doesn't expose as a filterable column. Always emit `id == "<local-uuid>"` instead; `valuePropName` only affects the value shape, not the filter field name.
- i18n: 2 new keys (`comp:BAIAvailablePresetSelect.SelectPreset`, `comp:BAIProjectVfolderSelect.SelectFolder`) added to all 21 BAI UI locales (English + 20 translations).

## Verification

`bash scripts/verify.sh` — Relay, Lint, Format **PASS**. TypeScript baseline noise unchanged from prior to this branch (`SessionLauncherPage`, `StatisticsPage`, `StorageHostSettingPage`, `UserCredentialsPage`, `UserSettingsPage`, `VFolderNodeListPage` — all unrelated to these changes).

## Test plan

- [ ] Open `DeploymentAddRevisionModal` (Preset mode): preset dropdown populates with optgroups; selecting a preset reflects in the preset detail modal; resource group + model folder selects are usable; deploy proceeds.
- [ ] Switch to Custom mode in the same modal: model folder select continues to show the same MODEL_STORE-scoped vfolders; prefill from the previously selected preset still populates as expected.
- [ ] Open `VFolderDeployModal` and `ModelCardDeployModal`: preset dropdown loads, scrolls (pagination), searches by name, and clears correctly.
- [ ] Open `BAIProjectVfolderSelect` dropdown, type a search query — the trailing `(id)` suffix on the selected label is hidden while typing and reappears once the dropdown closes.
- [ ] Confirm 21 locale files render the new placeholders correctly (spot-check at least `ko`, `ja`, `zh-CN`).

[FR-2886]: https://lablup.atlassian.net/browse/FR-2886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ