### PR TITLE
feat(FR-2888): add BAIRuntimeVariantSelect and remove runtimeVariants block from DeploymentAddRevisionModalQuery

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantSelect.tsx
@@ -1,0 +1,281 @@
+import { BAIRuntimeVariantSelectPaginatedQuery } from '../../__generated__/BAIRuntimeVariantSelectPaginatedQuery.graphql';
+import { BAIRuntimeVariantSelectValueQuery } from '../../__generated__/BAIRuntimeVariantSelectValueQuery.graphql';
+import { convertToUUID, toLocalId } from '../../helper';
+import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import * as _ from 'lodash-es';
+import {
+  useDeferredValue,
+  useEffect,
+  useEffectEvent,
+  useImperativeHandle,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type RuntimeVariantNode = NonNullable<
+  NonNullable<
+    BAIRuntimeVariantSelectPaginatedQuery['response']['runtimeVariants']
+  >['edges'][number]
+>['node'];
+
+export interface BAIRuntimeVariantSelectRef {
+  refetch: () => void;
+}
+
+export interface BAIRuntimeVariantSelectProps extends Omit<
+  BAISelectProps,
+  'options' | 'labelInValue' | 'ref'
+> {
+  /**
+   * Notifies the parent of resolved id→name pairs as the paginated list and
+   * selected-value point lookup fan in. The parent typically merges these
+   * into a local map so it can resolve the *currently selected* variant id
+   * back to its name elsewhere in the form (e.g., for `variantName === 'custom'`
+   * branching) without re-querying.
+   */
+  onResolvedNamesChange?: (nameMap: Record<string, string>) => void;
+  ref?: React.Ref<BAIRuntimeVariantSelectRef>;
+}
+
+const BAIRuntimeVariantSelect: React.FC<BAIRuntimeVariantSelectProps> = ({
+  loading,
+  onResolvedNamesChange,
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | undefined
+  >(selectProps);
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
+    },
+  );
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const deferredSearchStr = useDebouncedDeferredValue(searchStr);
+  const [optimisticSearchStr, setOptimisticSearchStr] =
+    useOptimistic(searchStr);
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  // Selected-value name lookup. `RuntimeVariantFilter` only exposes `name` —
+  // no id filter — so we resolve the single selected variant via the
+  // `runtimeVariant(id:)` point lookup. `@skip` collapses the request when
+  // nothing is selected.
+  const selectedUuid = deferredControllableValue
+    ? convertToUUID(_.toString(deferredControllableValue))
+    : '';
+  const { runtimeVariant: selectedVariant } =
+    useLazyLoadQuery<BAIRuntimeVariantSelectValueQuery>(
+      graphql`
+        query BAIRuntimeVariantSelectValueQuery($id: UUID!, $skip: Boolean!) {
+          runtimeVariant(id: $id) @skip(if: $skip) {
+            id
+            name
+          }
+        }
+      `,
+      {
+        id: selectedUuid,
+        skip: !selectedUuid,
+      },
+      {
+        fetchPolicy: selectedUuid ? 'store-or-network' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  const mergedFilter: NonNullable<
+    BAIRuntimeVariantSelectPaginatedQuery['variables']['filter']
+  > | null = deferredSearchStr
+    ? { name: { iContains: deferredSearchStr } }
+    : null;
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<
+      BAIRuntimeVariantSelectPaginatedQuery,
+      RuntimeVariantNode
+    >(
+      graphql`
+        query BAIRuntimeVariantSelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $filter: RuntimeVariantFilter
+        ) {
+          runtimeVariants(
+            offset: $offset
+            limit: $limit
+            filter: $filter
+            orderBy: [{ field: NAME, direction: "ASC" }]
+          ) {
+            count
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      `,
+      { limit: 20 },
+      {
+        filter: mergedFilter,
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (r) => r.runtimeVariants?.count ?? undefined,
+        getItem: (r) => r.runtimeVariants?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  // Notify parent of resolved id→name pairs. We feed *both* the currently
+  // selected variant (from the point lookup) and the visible page (from the
+  // paginated list), so callers get name resolution as soon as either lands.
+  const notifyResolvedNames = useEffectEvent(() => {
+    if (!onResolvedNamesChange) return;
+    const nameMap: Record<string, string> = {};
+    if (selectedVariant?.id && selectedVariant.name) {
+      const uuid = toLocalId(selectedVariant.id);
+      if (uuid) nameMap[uuid] = selectedVariant.name;
+    }
+    for (const node of paginationData ?? []) {
+      if (node?.id && node.name) {
+        const uuid = toLocalId(node.id);
+        if (uuid) nameMap[uuid] = node.name;
+      }
+    }
+    if (!_.isEmpty(nameMap)) onResolvedNamesChange(nameMap);
+  });
+
+  useEffect(() => {
+    notifyResolvedNames();
+  }, [selectedVariant, paginationData]);
+
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: item?.name,
+    value: item?.id ? toLocalId(item.id) : undefined,
+  }));
+
+  const selectedLabel = selectedVariant?.name;
+  const controllableValueWithLabel = deferredControllableValue
+    ? {
+        label: selectedLabel ?? _.toString(deferredControllableValue),
+        value: _.toString(deferredControllableValue),
+      }
+    : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIRuntimeVariantSelect.SelectRuntimeVariant')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        searchStr !== deferredSearchStr ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setOptimisticSearchStr(value);
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={
+        selectProps.showSearch === false
+          ? false
+          : {
+              searchValue: optimisticSearchStr,
+              autoClearSearchValue: true,
+              ...(_.isObject(selectProps.showSearch)
+                ? _.omit(selectProps.showSearch, ['searchValue'])
+                : {}),
+              filterOption: false,
+            }
+      }
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        if (_.isUndefined(value) || _.isNull(value)) {
+          setOptimisticValueWithLabel(undefined);
+          setControllableValue(undefined, option);
+          return;
+        }
+        const v = _.castArray(value)[0];
+        const label = _.isString(v.label)
+          ? v.label
+          : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+            _.toString(v.value));
+        const next = { label, value: _.toString(v.value) };
+        setOptimisticValueWithLabel(next);
+        setControllableValue(next.value, option);
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.runtimeVariants?.count) &&
+        result.runtimeVariants.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.runtimeVariants.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIRuntimeVariantSelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -101,6 +101,12 @@ export type {
   BAIAvailablePresetSelectRef,
   DeploymentRevisionPresetNode,
 } from './BAIAvailablePresetSelect';
+export { default as BAIRuntimeVariantSelect } from './BAIRuntimeVariantSelect';
+export type {
+  BAIRuntimeVariantSelectProps,
+  BAIRuntimeVariantSelectRef,
+  RuntimeVariantNode,
+} from './BAIRuntimeVariantSelect';
 export { default as BAIUserSelect } from './BAIUserSelect';
 export type {
   BAIUserSelectProps,

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Traffic-Anteil",
     "TrafficStatus": "Datenverkehrsstatus"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Laufzeitvariante auswählen"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Versuche",
     "CreatedAt": "Erstellt am",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Αναλογία κυκλοφορίας",
     "TrafficStatus": "Κατάσταση δικτύου"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Επιλογή παραλλαγής χρόνου εκτέλεσης"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Προσπάθειες",
     "CreatedAt": "Δημιουργήθηκε στις",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -274,6 +274,9 @@
     "TrafficRatio": "Traffic Ratio",
     "TrafficStatus": "Traffic Status"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Select Runtime Variant"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Attempts",
     "CreatedAt": "Created At",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Proporción de tráfico",
     "TrafficStatus": "Estado del tráfico"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Seleccionar variante de tiempo de ejecución"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Intentos",
     "CreatedAt": "Creado el",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Liikenteen suhde",
     "TrafficStatus": "Liikenteen tila"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Valitse ajonaikainen variantti"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Yritykset",
     "CreatedAt": "Luotu",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Ratio de trafic",
     "TrafficStatus": "État du trafic"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Sélectionner la variante d'exécution"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Tentatives",
     "CreatedAt": "Créé le",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Rasio Lalu Lintas",
     "TrafficStatus": "Status Trafik"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Pilih Varian Runtime"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Percobaan",
     "CreatedAt": "Dibuat pada",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Rapporto di traffico",
     "TrafficStatus": "Stato del traffico"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Seleziona variante runtime"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Tentativi",
     "CreatedAt": "Creato il",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "トラフィック比率",
     "TrafficStatus": "トラフィック状況"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "ランタイムバリアントを選択"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "試行回数",
     "CreatedAt": "作成日時",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -271,6 +271,9 @@
     "TrafficRatio": "트래픽 비율",
     "TrafficStatus": "트래픽 상태"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "런타임 변형을 선택해주세요"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "시도 횟수",
     "CreatedAt": "생성일",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Трафикийн харьцаа",
     "TrafficStatus": "Трафикийн төлөв"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Ажиллах хувилбар сонгох"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Оролдлого",
     "CreatedAt": "Үүссэн огноо",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Nisbah Trafik",
     "TrafficStatus": "Status Trafik"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Pilih Varian Runtime"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Percubaan",
     "CreatedAt": "Dicipta pada",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Udział ruchu",
     "TrafficStatus": "Status ruchu"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Wybierz wariant środowiska uruchomieniowego"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Próby",
     "CreatedAt": "Utworzono",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -267,6 +267,9 @@
     "TrafficRatio": "Proporção de Tráfego",
     "TrafficStatus": "Status do Tráfego"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Selecionar variante de execução"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Tentativas",
     "CreatedAt": "Criado em",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Proporção de tráfego",
     "TrafficStatus": "Status do tráfego"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Selecionar variante de execução"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Tentativas",
     "CreatedAt": "Criado em",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Доля трафика",
     "TrafficStatus": "Состояние трафика"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Выбрать вариант среды выполнения"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Попытки",
     "CreatedAt": "Дата создания",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "สัดส่วนทราฟฟิก",
     "TrafficStatus": "สถานะการรับส่งข้อมูล"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "เลือกตัวแปรรันไทม์"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "จำนวนครั้งที่ลอง",
     "CreatedAt": "สร้างเมื่อ",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Trafik Oranı",
     "TrafficStatus": "Trafik Durumu"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Çalışma Zamanı Varyantını Seç"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Denemeler",
     "CreatedAt": "Oluşturulma Tarihi",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "Tỷ lệ lưu lượng",
     "TrafficStatus": "Trạng thái lưu lượng"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "Chọn biến thể runtime"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Số lần thử",
     "CreatedAt": "Ngày tạo",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "流量比例",
     "TrafficStatus": "流量状态"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "选择运行时变体"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "尝试次数",
     "CreatedAt": "创建时间",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -268,6 +268,9 @@
     "TrafficRatio": "流量比例",
     "TrafficStatus": "流量狀態"
   },
+  "comp:BAIRuntimeVariantSelect": {
+    "SelectRuntimeVariant": "選擇執行階段變體"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "嘗試次數",
     "CreatedAt": "建立時間",

--- a/react/src/components/DeploymentAddRevisionCustomContent.tsx
+++ b/react/src/components/DeploymentAddRevisionCustomContent.tsx
@@ -4,7 +4,6 @@
  */
 import { DeploymentAddRevisionCustomContentAddMutation } from '../__generated__/DeploymentAddRevisionCustomContentAddMutation.graphql';
 import type { DeploymentAddRevisionCustomContentFragment$key } from '../__generated__/DeploymentAddRevisionCustomContentFragment.graphql';
-import type { DeploymentAddRevisionModalQuery$data } from '../__generated__/DeploymentAddRevisionModalQuery.graphql';
 import { convertToBinaryUnit } from '../helper';
 import {
   formatShellCommand,
@@ -49,7 +48,6 @@ import {
   Input,
   InputNumber,
   Segmented,
-  Select,
   Skeleton,
   Typography,
   theme,
@@ -57,8 +55,8 @@ import {
 import {
   BAIFlex,
   BAIProjectVfolderSelect,
+  BAIRuntimeVariantSelect,
   convertToUUID,
-  filterOutNullAndUndefined,
   safeDecodeUuid,
   toLocalId,
 } from 'backend.ai-ui';
@@ -111,7 +109,6 @@ interface DeploymentAddRevisionCustomContentProps {
     | DeploymentAddRevisionCustomContentFragment$key
     | null
     | undefined;
-  runtimeVariantsData: DeploymentAddRevisionModalQuery$data['runtimeVariants'];
   form: FormInstance<FormValues>;
   onRequestClose: (success?: boolean) => void;
   onIsAddingChange: (v: boolean) => void;
@@ -134,7 +131,6 @@ export const DeploymentAddRevisionCustomContent: React.FC<
 > = ({
   deploymentId,
   deploymentFrgmt,
-  runtimeVariantsData,
   form,
   onRequestClose,
   onIsAddingChange,
@@ -214,6 +210,9 @@ export const DeploymentAddRevisionCustomContent: React.FC<
           }
           modelRuntimeConfig {
             runtimeVariantId
+            runtimeVariant {
+              name
+            }
             environ {
               entries {
                 name
@@ -334,9 +333,14 @@ export const DeploymentAddRevisionCustomContent: React.FC<
 
   const currentRevision = deployment?.currentRevision;
 
-  const runtimeVariantOptions = filterOutNullAndUndefined(
-    (runtimeVariantsData?.edges ?? []).map((e) => e?.node),
-  ).map((node) => ({ value: toLocalId(node.id) ?? node.id, label: node.name }));
+  // Map of runtime variant id → name, populated by `BAIRuntimeVariantSelect`
+  // as it resolves the currently selected value (via its `runtimeVariant(id:)`
+  // point lookup) and the visible page of the paginated list. Used by the
+  // form to branch on `variantName === 'custom'` and to look up the human-
+  // readable name at submit time, without the parent owning the variant list.
+  const [runtimeVariantNameMap, setRuntimeVariantNameMap] = useState<
+    Record<string, string>
+  >({});
 
   // Build the form values that mirror the deployment's current revision and
   // push them into the antd Form. Called from the "Load current revision"
@@ -357,11 +361,21 @@ export const DeploymentAddRevisionCustomContent: React.FC<
       (e) => e.name === 'shmem',
     );
 
-    const variantName =
-      runtimeVariantOptions.find(
-        (o) => o.value === rev.modelRuntimeConfig?.runtimeVariantId,
-      )?.label ?? '';
+    // The fragment selects `modelRuntimeConfig.runtimeVariant.name`, so the
+    // prefill path knows the variant name without waiting for
+    // `BAIRuntimeVariantSelect` to resolve it.
+    const variantName = rev.modelRuntimeConfig?.runtimeVariant?.name ?? '';
     const isCustom = variantName === 'custom';
+    // Seed `runtimeVariantNameMap` so submit (line ~692) and any other
+    // consumers can resolve `runtimeVariantId → name` immediately, without
+    // waiting for `BAIRuntimeVariantSelect`'s point lookup to finish.
+    const variantId = rev.modelRuntimeConfig?.runtimeVariantId;
+    if (variantId && variantName) {
+      setRuntimeVariantNameMap((prev) => ({
+        ...prev,
+        [variantId]: variantName,
+      }));
+    }
     const service = rev.modelDefinition?.models?.[0]?.service;
     const customModelPath = rev.modelDefinition?.models?.[0]?.modelPath;
     // For custom + command mode: the saved revision carries a populated
@@ -685,9 +699,7 @@ export const DeploymentAddRevisionCustomContent: React.FC<
       };
     });
 
-    const variantName =
-      runtimeVariantOptions.find((o) => o.value === values.runtimeVariantId)
-        ?.label ?? '';
+    const variantName = runtimeVariantNameMap[values.runtimeVariantId] ?? '';
     const isCustom = variantName === 'custom';
     const isCommandMode = values.customDefinitionMode === 'command';
 
@@ -905,9 +917,7 @@ export const DeploymentAddRevisionCustomContent: React.FC<
           {
             warningOnly: true,
             validator: async (_rule, value: string) => {
-              const variantName = runtimeVariantOptions.find(
-                (o) => o.value === value,
-              )?.label;
+              const variantName = runtimeVariantNameMap[value];
               if (variantName && variantName !== 'custom') {
                 return Promise.reject(
                   t('modelService.RuntimeVariantDefaultCommandAppliedNote'),
@@ -918,16 +928,18 @@ export const DeploymentAddRevisionCustomContent: React.FC<
           },
         ]}
       >
-        <Select options={runtimeVariantOptions} showSearch />
+        <BAIRuntimeVariantSelect
+          onResolvedNamesChange={(map) =>
+            setRuntimeVariantNameMap((prev) => ({ ...prev, ...map }))
+          }
+        />
       </Form.Item>
 
       {/* Runtime parameter section — shown for non-custom variants */}
       <Form.Item dependencies={['runtimeVariantId']} noStyle>
         {({ getFieldValue }) => {
           const variantId = getFieldValue('runtimeVariantId');
-          const variantName = runtimeVariantOptions.find(
-            (o) => o.value === variantId,
-          )?.label;
+          const variantName = runtimeVariantNameMap[variantId];
           if (!variantName || variantName === 'custom') return null;
           return (
             <div style={{ marginBottom: token.marginMD }}>
@@ -959,9 +971,7 @@ export const DeploymentAddRevisionCustomContent: React.FC<
       <Form.Item dependencies={['runtimeVariantId']} noStyle>
         {({ getFieldValue }) => {
           const variantId = getFieldValue('runtimeVariantId');
-          const variantName = runtimeVariantOptions.find(
-            (o) => o.value === variantId,
-          )?.label;
+          const variantName = runtimeVariantNameMap[variantId];
           if (variantName !== 'custom') {
             return null;
           }

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -261,14 +261,6 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
           ...DeploymentAddRevisionPresetContentFragment
           ...DeploymentAddRevisionCustomContentFragment
         }
-        runtimeVariants {
-          edges {
-            node {
-              id
-              name
-            }
-          }
-        }
         deploymentRevisionPresets(
           orderBy: [{ field: RANK, direction: "ASC" }]
         ) {
@@ -366,7 +358,6 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
         <DeploymentAddRevisionCustomContent
           deploymentId={deploymentId}
           deploymentFrgmt={data.deployment}
-          runtimeVariantsData={data.runtimeVariants}
           form={customForm}
           autoActivate={autoActivate}
           onRequestClose={onRequestClose}


### PR DESCRIPTION
Resolves #7399 ([FR-2888](https://lablup.atlassian.net/browse/FR-2888))

## Summary

- Add `BAIRuntimeVariantSelect` to `backend.ai-ui` — self-paginated runtime variant select backed by Strawberry V2 `runtimeVariants(...)` + `runtimeVariant(id:)` point lookup, mirroring the `BAIAvailablePresetSelect` / `BAIProjectVfolderSelect` shape from FR-2886. Exposes an `onResolvedNamesChange(map)` callback so parents can maintain a tiny id→name map for branching logic without re-querying.
- Migrate `DeploymentAddRevisionCustomContent` to consume `BAIRuntimeVariantSelect` in place of the inline antd `<Select>`. The "Load current revision" prefill reads the name directly from the fragment via a new `runtimeVariant { name }` selection on `modelRuntimeConfig` — no name-map round-trip needed at prefill time.
- Drop the `runtimeVariants { edges { node { id name } } }` block from `DeploymentAddRevisionModalQuery` and the corresponding `runtimeVariantsData` prop pass from `DeploymentAddRevisionModal` to the Custom body — no remaining consumer needs the full preload.
- Add `comp:BAIRuntimeVariantSelect.SelectRuntimeVariant` to all 21 BAI UI locale files (English + 20 translations).

## Test plan

- [ ] Open the Add Revision modal → Custom mode: runtime variant picker paginates and searches server-side; selected value name resolves via the point lookup.
- [ ] Click "Load current revision": form prefills with the saved revision's variant; `variantName === 'custom'` branching (command/file segmented, runtime parameter section visibility) behaves identically to pre-migration.
- [ ] Switch Preset → Custom: the preset-transfer prefill still applies the variant id and the picker shows the resolved label.
- [ ] `bash scripts/verify.sh` — Relay / Lint / Format PASS. TypeScript baseline (SessionLauncherPage / StatisticsPage / StorageHostSettingPage / UserCredentialsPage / UserSettingsPage / VFolderNodeListPage) unchanged.

[FR-2888]: https://lablup.atlassian.net/browse/FR-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ