### PR TITLE
feat(FR-2893): disable upload button when host lacks upload-file permission

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -58,6 +58,11 @@ export interface BAIFileExplorerProps {
   enableDownload?: boolean;
   enableDelete?: boolean;
   enableWrite?: boolean;
+  // Gates upload entry points (upload dropdown + drag-drop). Defaults to
+  // `enableWrite` for backwards compatibility — callers that need to gate
+  // upload independently (e.g., on the `upload-file` host permission) should
+  // pass this explicitly.
+  enableUpload?: boolean;
   enableEdit?: boolean;
   onChangeFetchKey?: (fetchKey: string) => void;
   ref?: React.Ref<BAIFileExplorerRef>;
@@ -81,6 +86,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
   enableDownload = false,
   enableDelete = false,
   enableWrite = false,
+  enableUpload = false,
   enableEdit = false,
   onDeleteFilesInBackground,
   deletingFilePaths,
@@ -301,7 +307,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
         currentPath,
       }}
     >
-      {isDragMode && (
+      {isDragMode && enableUpload && (
         <DragAndDrop
           portalContainer={fileDropContainerRef?.current || undefined}
           onUpload={(files, currentPath) => onUpload(files, currentPath)}
@@ -326,6 +332,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
             enableDownload={enableDownload}
             enableDelete={enableDelete}
             enableWrite={enableWrite}
+            enableUpload={enableUpload}
             onUpload={(files, currentPath) => onUpload(files, currentPath)}
             onDeleteFilesInBackground={onDeleteFilesInBackground}
             onClearSelection={() => setSelectedItems([])}

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -51,6 +51,13 @@ interface ExplorerActionControlsProps {
   enableDownload?: boolean;
   enableDelete?: boolean;
   enableWrite?: boolean;
+  // Gates the upload entry points (dropdown + drag-drop). The corresponding
+  // server operation is `upload-file` on the storage host, which is distinct
+  // from generic write capability (mkdir / create-file / rename) and from
+  // file edit (which is also an upload underneath). Defaults to `enableWrite`
+  // so callers that don't pass it explicitly keep the previous bundled
+  // behavior.
+  enableUpload?: boolean;
   // onClickRefresh?: (key: string) => void;
   extra?: React.ReactNode;
 }
@@ -64,6 +71,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
   enableDownload = false,
   enableDelete = false,
   enableWrite = false,
+  enableUpload = enableWrite,
   extra,
 }) => {
   const { t } = useTranslation();
@@ -178,7 +186,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
           </Button>
         </Tooltip>
         <Dropdown
-          disabled={!enableWrite}
+          disabled={!enableUpload}
           trigger={['click']}
           open={openUploadDropdown}
           onOpenChange={toggleUploadDropdown}
@@ -237,8 +245,16 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
             );
           }}
         >
-          <Tooltip title={!lg && t('general.button.Upload')}>
-            <Button icon={<UploadOutlined />} disabled={!enableWrite}>
+          <Tooltip
+            title={
+              !enableUpload
+                ? t('comp:FileExplorer.NoUploadPermissionForHost')
+                : !lg
+                  ? t('general.button.Upload')
+                  : undefined
+            }
+          >
+            <Button icon={<UploadOutlined />} disabled={!enableUpload}>
               {lg && t('general.button.Upload')}
             </Button>
           </Tooltip>

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Modifiziert bei",
     "MoreOptions": "Weitere Optionen",
     "Name": "Name",
+    "NoUploadPermissionForHost": "Sie haben keine Hochlade-Berechtigung für diesen Host.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Bitte geben Sie den Ordneramen ein.",
     "RenameSuccess": "Der Name wurde erfolgreich geändert.",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Τροποποιημένος",
     "MoreOptions": "Περισσότερες επιλογές",
     "Name": "Ονομα",
+    "NoUploadPermissionForHost": "Δεν έχετε άδεια μεταφόρτωσης για αυτόν τον κεντρικό χώρο αποθήκευσης.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Εισαγάγετε το όνομα του φακέλου.",
     "RenameSuccess": "Το όνομα έχει αλλάξει με επιτυχία.",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -339,6 +339,7 @@
     "ModifiedAt": "Modified At",
     "MoreOptions": "More options",
     "Name": "Name",
+    "NoUploadPermissionForHost": "You don't have upload permission for this host.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Please enter the folder name.",
     "RenameSuccess": "The name has been successfully changed.",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Modificado en",
     "MoreOptions": "Más opciones",
     "Name": "Nombre",
+    "NoUploadPermissionForHost": "No tiene permiso de carga para este host.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Ingrese el nombre de la carpeta.",
     "RenameSuccess": "El nombre ha sido cambiado con éxito.",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Muutettu",
     "MoreOptions": "Lisää vaihtoehtoja",
     "Name": "Nimi",
+    "NoUploadPermissionForHost": "Sinulla ei ole latausoikeutta tälle tallennuspalvelimelle.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Anna kansionimi.",
     "RenameSuccess": "Nimi on muutettu onnistuneesti.",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Modifié à",
     "MoreOptions": "Plus d'options",
     "Name": "Nom",
+    "NoUploadPermissionForHost": "Vous n'avez pas la permission de téléverser sur cet hôte.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Veuillez saisir le nom du dossier.",
     "RenameSuccess": "Le nom a été modifié avec succès.",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Dimodifikasi di",
     "MoreOptions": "Opsi lainnya",
     "Name": "Nama",
+    "NoUploadPermissionForHost": "Anda tidak memiliki izin unggah untuk host ini.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Harap masukkan nama folder.",
     "RenameSuccess": "Namanya telah berhasil diubah.",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Modificato a",
     "MoreOptions": "Più opzioni",
     "Name": "Nome",
+    "NoUploadPermissionForHost": "Non si dispone del permesso di caricamento per questo host.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Immettere il nome della cartella.",
     "RenameSuccess": "Il nome è stato cambiato con successo.",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "で変更されました",
     "MoreOptions": "その他のオプション",
     "Name": "名前",
+    "NoUploadPermissionForHost": "このホストへのアップロード権限がありません。",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "フォルダー名を入力してください。",
     "RenameSuccess": "名前は正常に変更されました。",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -336,6 +336,7 @@
     "ModifiedAt": "수정일",
     "MoreOptions": "더 많은 옵션",
     "Name": "이름",
+    "NoUploadPermissionForHost": "호스트에 대한 업로드 권한이 없습니다.",
     "PleaseEnterAFileName": "파일 이름을 입력해 주세요.",
     "PleaseEnterAFolderName": "폴더 이름을 입력해 주세요.",
     "RenameSuccess": "이름이 성공적으로 변경되었습니다.",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Өөрчлөгдсөн",
     "MoreOptions": "Нэмэлт сонголтууд",
     "Name": "Нэр",
+    "NoUploadPermissionForHost": "Энэ хостод байршуулах эрх байхгүй байна.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Фолдерын нэрийг оруулна уу.",
     "RenameSuccess": "Энэ нэр амжилттай өөрчлөгдсөн байна.",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Diubahsuai di",
     "MoreOptions": "Pilihan lanjut",
     "Name": "Nama",
+    "NoUploadPermissionForHost": "Anda tidak mempunyai kebenaran muat naik untuk hos ini.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Sila masukkan nama folder.",
     "RenameSuccess": "Nama telah berjaya diubah.",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Zmodyfikowany przy",
     "MoreOptions": "Więcej opcji",
     "Name": "Nazwa",
+    "NoUploadPermissionForHost": "Nie masz uprawnień do przesyłania plików na ten host.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Wprowadź nazwę folderu.",
     "RenameSuccess": "Nazwa została pomyślnie zmieniona.",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -330,6 +330,7 @@
     "ModifiedAt": "Modificado em",
     "MoreOptions": "Mais opções",
     "Name": "Nome",
+    "NoUploadPermissionForHost": "Você não tem permissão de upload para este host.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Por favor, insira o nome da pasta.",
     "RenameSuccess": "O nome foi alterado com sucesso.",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Modificado em",
     "MoreOptions": "Mais opções",
     "Name": "Nome",
+    "NoUploadPermissionForHost": "Não tem permissão de upload para este anfitrião.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Por favor, insira o nome da pasta.",
     "RenameSuccess": "O nome foi alterado com sucesso.",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Модифицирован в",
     "MoreOptions": "Дополнительные параметры",
     "Name": "Имя",
+    "NoUploadPermissionForHost": "У вас нет разрешения на загрузку для данного хоста.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Пожалуйста, введите имя папки.",
     "RenameSuccess": "Имя было успешно изменено.",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "ดัดแปลงที่",
     "MoreOptions": "ตัวเลือกเพิ่มเติม",
     "Name": "ชื่อ",
+    "NoUploadPermissionForHost": "คุณไม่มีสิทธิ์อัปโหลดสำหรับโฮสต์นี้",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "กรุณากรอกชื่อโฟลเดอร์",
     "RenameSuccess": "ชื่อได้รับการเปลี่ยนแปลงสำเร็จ",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -331,6 +331,7 @@
     "ModifiedAt": "Değiştirildi",
     "MoreOptions": "Daha fazla seçenek",
     "Name": "İsim",
+    "NoUploadPermissionForHost": "Bu depolama sunucusuna yükleme izniniz yok.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Lütfen klasör adını girin.",
     "RenameSuccess": "İsim başarıyla değiştirildi.",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "Sửa đổi tại",
     "MoreOptions": "Thêm tùy chọn",
     "Name": "Tên",
+    "NoUploadPermissionForHost": "Bạn không có quyền tải lên cho máy chủ lưu trữ này.",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "Vui lòng nhập tên thư mục.",
     "RenameSuccess": "Tên đã được thay đổi thành công.",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "修改为",
     "MoreOptions": "更多选项",
     "Name": "姓名",
+    "NoUploadPermissionForHost": "您没有此存储主机的上传权限。",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "请输入文件夹名称。",
     "RenameSuccess": "该名称已成功更改。",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -333,6 +333,7 @@
     "ModifiedAt": "修改為",
     "MoreOptions": "更多選項",
     "Name": "姓名",
+    "NoUploadPermissionForHost": "您沒有此儲存主機的上傳權限。",
     "PleaseEnterAFileName": "Please enter the file name.",
     "PleaseEnterAFolderName": "請輸入文件夾名稱。",
     "RenameSuccess": "該名稱已成功更改。",

--- a/react/src/components/FolderExplorerModal.tsx
+++ b/react/src/components/FolderExplorerModal.tsx
@@ -215,6 +215,7 @@ const FolderExplorerModal: React.FC<FolderExplorerProps> = ({
       enableDownload={hasDownloadContentPermission}
       enableDelete={hasDeleteContentPermission}
       enableWrite={hasWriteContentPermission}
+      enableUpload={hasWriteContentPermission}
       enableEdit={hasWriteContentPermission}
       tableProps={{
         scroll: xl

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -159,6 +159,16 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
     unitedAllowedPermissionByVolume[vfolderNode?.host ?? ''],
     'download-file',
   );
+  // `upload-file` on the storage host gates the actual upload pipeline:
+  // upload buttons (file/folder), drag-drop, and the in-app text editor save
+  // (which overwrites the file via the upload API). mkdir / create-file /
+  // rename are kept enabled — there is no corresponding host-level
+  // capability for them today, and FR-2619 will revisit the effective
+  // permission set.
+  const hasUploadContentPermission = _.includes(
+    unitedAllowedPermissionByVolume[vfolderNode?.host ?? ''],
+    'upload-file',
+  );
   // TODO(needs-backend): write/delete capability should be derived from the
   // caller's *effective* permission set on this entity (e.g.,
   // `delete_content`, `write_content`), not from the folder's mount
@@ -230,7 +240,8 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
       enableDownload={hasDownloadContentPermission}
       enableDelete={hasDeleteContentPermission}
       enableWrite={hasWriteContentPermission}
-      enableEdit={hasWriteContentPermission}
+      enableUpload={hasUploadContentPermission}
+      enableEdit={hasUploadContentPermission}
       tableProps={{
         scroll: xl
           ? { x: 'max-content' }


### PR DESCRIPTION
Resolves #7411(FR-2893)

test-server: 10.122.10.107

## Summary

`FolderExplorerModalV2` already fetches the caller's host-level permission set via `useMergedAllowedStorageHostPermission`, and that set carries both `download-file` and `upload-file`. Until now only `download-file` was consumed; write/upload/edit were hard-coded to `true` and stayed enabled regardless of host permission. This PR splits the upload gate from the generic write gate, wires V2 to the host `upload-file` capability, and surfaces _why_ the button is disabled via a tooltip.

## Component changes (`BAIFileExplorer` / `ExplorerActionControls`)

- New optional `enableUpload?: boolean` prop on `BAIFileExplorer` and `ExplorerActionControls`.
- `enableUpload` gates: upload dropdown, mobile upload button, drag-drop overlay.
- `enableWrite` continues to gate: mkdir, create-file, inline rename.
- Default is `enableUpload = false` (opt-in), matching the convention of the other capability props (`enableDownload` / `enableDelete` / `enableWrite` / `enableEdit`).
- When `enableUpload` is falsy, the upload button's tooltip shows `comp:FileExplorer.NoUploadPermissionForHost` so users understand why the action is disabled.

## V2 wiring (`FolderExplorerModalV2`)

```tsx
const hasUploadContentPermission = _.includes(
  unitedAllowedPermissionByVolume[vfolderNode?.host ?? ''],
  'upload-file',
);
...
enableWrite={hasWriteContentPermission}    // = true (unchanged; FR-2619 follow-up)
enableUpload={hasUploadContentPermission}  // new gate
enableEdit={hasUploadContentPermission}    // edit save = overwrite upload
```

`enableEdit` is gated by `upload-file` because the in-app text editor saves by overwriting the file via the upload API (`VFolderTextFileEditorModal` → `uploadFiles`). If the user lacks `upload-file`, the save would fail server-side anyway; disabling upfront keeps the UX honest.

## V1 wiring (`FolderExplorerModal`)

Since the new default is opt-in (`enableUpload = false`), V1 now explicitly passes `enableUpload={hasWriteContentPermission}` to preserve its previous bundled behavior. V1 still gates by `write_content` from the vfolder entity permission — adopting the host `upload-file` check would broaden V1's behavior change and is out of scope for this PR.

## i18n

New key `comp:FileExplorer.NoUploadPermissionForHost` added to `en.json` (source) and translated into all 20 target languages via the `fw:i18n-translator` agent (de, el, es, fi, fr, id, it, ja, ko, mn, ms, pl, pt, pt-BR, ru, th, tr, vi, zh-CN, zh-TW).

Korean: "호스트에 대한 업로드 권한이 없습니다."

## Out of scope

- `hasWriteContentPermission` and `hasDeleteContentPermission` remain hard-coded to `true`. There is no host-level permission for mkdir / create-file / rename / delete today; FR-2619 will revisit when the backend exposes the effective permission set.
- Separately, the storage host currently accepts uploads even when `upload-file` is not granted (server-side gap, observed during the Hyundai Mobis investigation). That belongs on the backend and is being tracked separately.

## Test plan

- [ ] V2 explorer — user without `upload-file` on the folder's host:
    - Upload dropdown, mobile upload button, drag-drop overlay, and file-edit save are all disabled.
    - Hovering the upload button shows the "no upload permission" tooltip (and the localized version when the UI language is switched).
- [ ] V2 explorer — mkdir / create-file / inline rename remain enabled regardless of `upload-file`.
- [ ] V2 explorer — user with `upload-file`: all upload and edit actions behave as before.
- [ ] V2 explorer — `download-file` gating is unchanged.
- [ ] V1 `FolderExplorerModal` — no behavior change: `write_content` continues to gate upload, mkdir, create-file, rename, and edit. Same disabled-vs-enabled outcome as `main`.