### PR TITLE
chore(FR-2900): show Portless dev server status in Claude Code status line

### DIFF
--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -117,6 +117,97 @@ if [[ -n "$WORKSPACE" ]]; then
   [[ -n "$VSCODE_URL" ]] && VSCODE_PART=$(link "$VSCODE_URL" "⧉ VS Code")
 fi
 
+# ── Portless URL detection ─────────────────────────────────
+# Maps the current workspace to its Portless route by checking each route
+# process's cwd. Subdomain-based guessing breaks when multiple worktrees
+# run dev servers concurrently (e.g. one auto-named route can match a
+# different worktree's slug). cwd is the source of truth — `dev.mjs` is
+# spawned from the workspace, so its portless child's cwd equals it.
+#
+# Cache: pid → cwd in CACHE_DIR for 30s. Portless restarts cycle pids
+# quickly, so a short TTL trades minimal staleness for avoiding lsof per
+# tick (lsof on macOS spawns ~30–100ms per call).
+PORTLESS_PART=""
+if [[ -n "$WORKSPACE" ]] && command -v portless >/dev/null 2>&1 && command -v lsof >/dev/null 2>&1; then
+  PORTLESS_TTL=30
+  WS_REAL=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$WORKSPACE" 2>/dev/null || printf '%s' "$WORKSPACE")
+  PORTLESS_LIST=$(portless list 2>/dev/null || true)
+
+  PORTLESS_URL=""
+  PORTLESS_NOTE=""
+  if [[ -n "$PORTLESS_LIST" ]]; then
+    while IFS= read -r _line; do
+      [[ "$_line" =~ pid\ ([0-9]+) ]] || continue
+      _pid="${BASH_REMATCH[1]}"
+      _pid_cache="${CACHE_DIR}/portless-pid-${_pid}.cwd"
+      _cwd=""
+      if [[ -f "$_pid_cache" ]]; then
+        _age=$(( $(date +%s) - $(file_mtime "$_pid_cache") ))
+        if (( _age < PORTLESS_TTL )); then
+          _cwd=$(cat "$_pid_cache" 2>/dev/null) || _cwd=""
+        fi
+      fi
+      if [[ -z "$_cwd" ]]; then
+        _cwd=$(lsof -p "$_pid" -a -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2); exit}' || true)
+        if [[ -n "$_cwd" ]]; then
+          printf '%s' "$_cwd" > "$_pid_cache" 2>/dev/null || true
+        fi
+      fi
+      [[ -z "$_cwd" ]] && continue
+      _cwd_real=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$_cwd" 2>/dev/null || printf '%s' "$_cwd")
+      if [[ "$_cwd_real" == "$WS_REAL" ]]; then
+        PORTLESS_URL=$(printf '%s' "$_line" | grep -oE 'https?://[a-z0-9-]+\.localhost:[0-9]+' | head -1 || true)
+        break
+      fi
+    done <<< "$PORTLESS_LIST"
+  fi
+
+  # Fallback: portless route not registered (e.g. lost via the 0.10.x race
+  # where a dying prior owner's onCleanup wipes the new owner's entry).
+  # Scan for any `portless` CLI process whose cwd matches this workspace —
+  # if found, the dev server IS running, just unrouted. Derive subdomain
+  # from argv (explicit `portless <name>`) or package.json (auto-name).
+  if [[ -z "$PORTLESS_URL" ]]; then
+    for _pid in $(pgrep -f 'portless/dist/cli\.js' 2>/dev/null || true); do
+      _cwd=$(lsof -p "$_pid" -a -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2); exit}' || true)
+      [[ -z "$_cwd" ]] && continue
+      _cwd_real=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$_cwd" 2>/dev/null || printf '%s' "$_cwd")
+      [[ "$_cwd_real" != "$WS_REAL" ]] && continue
+      _argv=$(ps -o command= -p "$_pid" 2>/dev/null || true)
+      # Skip the proxy daemon itself (`portless proxy start ...`)
+      [[ "$_argv" =~ cli\.js[[:space:]]+proxy ]] && continue
+      _sub=$(printf '%s' "$_argv" | grep -oE 'cli\.js[[:space:]]+[a-zA-Z0-9_.-]+' | awk '{print $2}' | head -1 || true)
+      if [[ -z "$_sub" || "$_sub" == "run" ]]; then
+        if [[ -f "$WS_REAL/package.json" ]]; then
+          _sub=$(python3 - "$WS_REAL/package.json" <<'PYEOF' 2>/dev/null || true
+import json, re, sys
+try:
+    name = json.load(open(sys.argv[1])).get("name", "") or ""
+    name = re.sub(r"[^a-z0-9-]+", "-", name.lower())
+    name = re.sub(r"-+", "-", name).strip("-")
+    print(name)
+except Exception:
+    print("")
+PYEOF
+)
+        fi
+      fi
+      if [[ -n "$_sub" ]]; then
+        PORTLESS_URL="https://${_sub}.localhost:1355"
+        PORTLESS_NOTE=" (route lost)"
+        break
+      fi
+    done
+  fi
+
+  if [[ -n "$PORTLESS_URL" ]]; then
+    PORTLESS_LABEL=$(printf '\033[32mPortless\033[0m')
+    PORTLESS_PART=$(link "$PORTLESS_URL" "$PORTLESS_LABEL")
+  else
+    PORTLESS_PART=$(printf '\033[90mPortless\033[0m')
+  fi
+fi
+
 # Fallback output when there is no Jira/Teams context:
 #   line 1 = worktree info + VS Code link (if available), line 2 = model/tokens.
 emit_fallback() {
@@ -127,6 +218,10 @@ emit_fallback() {
   if [[ -n "$VSCODE_PART" ]]; then
     [[ -n "$line1" ]] && line1+="  "
     line1+="$VSCODE_PART"
+  fi
+  if [[ -n "${PORTLESS_PART:-}" ]]; then
+    [[ -n "$line1" ]] && line1+="  "
+    line1+="$PORTLESS_PART"
   fi
   if [[ -n "$line1" ]]; then
     printf '%b\n%b' "$line1" "$MODEL_PART"
@@ -250,6 +345,11 @@ fi
 
 if [[ -n "$VSCODE_PART" ]]; then
   LINE1+="$VSCODE_PART"
+  LINE1+="  "
+fi
+
+if [[ -n "${PORTLESS_PART:-}" ]]; then
+  LINE1+="$PORTLESS_PART"
   LINE1+="  "
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,8 @@
   "statusLine": {
     "type": "command",
     "command": ".claude/scripts/statusline.sh",
-    "padding": 0
+    "padding": 0,
+    "refreshInterval": 10
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [


### PR DESCRIPTION
Resolves #7425 (FR-2900)

## Summary

Adds a `Portless` segment to the Claude Code status line that surfaces whether a Portless-fronted dev server is currently running for the active workspace. Also enables idle-time polling (`refreshInterval: 10` in `.claude/settings.json`) so the segment refreshes without requiring a new user message.

Two-state output:

- **Green `Portless`** — a dev server is detected for this workspace; the label is a clickable OSC 8 hyperlink to its `https://<sub>.localhost:1355` URL.
- **Grey `Portless`** — no dev server detected for this workspace.

The motivation: when several worktrees of this repo each run `pnpm dev` concurrently, it is easy to lose track of which Portless subdomain belongs to which folder. The status line answers that question at a glance for the workspace Claude Code is attached to.

## How it works

Detection happens in two stages, each anchored to OS-observable facts (no name-guessing).

### Stage A — match against `portless list`

```
portless list  →  one or more "https://<sub>.localhost:1355 -> localhost:<port> (pid N)" lines
```

For each route, the script extracts the `pid`, then asks `lsof -p PID -a -d cwd -Fn` for that process's working directory. If the resolved cwd matches the workspace (`realpath`-normalized on both sides), that route is the answer. The `pid → cwd` lookup is cached in `~/.cache/claude-statusline/portless-pid-<pid>.cwd` for 30s, because pids never change cwd within their lifetime (and cycle on restart anyway), so the cache is effectively never stale.

This works correctly even when Portless's auto-derived subdomain has no relation to the directory name. For example, a worktree on an `FR-2891` branch maps to `fr-2891.localhost`, not `<dir>.localhost` — the cwd check ignores naming and trusts the OS instead.

### Stage B — fallback when route is missing

Portless 0.10.x has a race condition: when one `portless run --force` takes over a hostname from another, the dying prior owner's `onCleanup` calls `removeRoute(hostname)` without checking pid ownership, wiping the new owner's freshly-registered entry. The dev process keeps running normally (vite on its assigned port), but `portless list` no longer knows about it.

Stage B detects this case: if Stage A finds nothing, `pgrep -f portless/dist/cli.js` enumerates live Portless CLI processes. For each, the same cwd matching applies. The proxy daemon (`portless proxy start ...`) is explicitly skipped via an argv guard so it does not get mis-identified as a dev server.

When a match is found, the subdomain is derived from:
1. **argv** — if the process is `portless <name> --force ...`, take `<name>` directly.
2. **package.json** — if the process is `portless run --force ...` (auto-name), read the workspace's `package.json` `name` field and apply Portless's sanitization rule: lowercase, `[^a-z0-9-]+` → `-`, collapse repeats, trim. `backend.ai-webui` becomes `backend-ai-webui`.

In the current implementation both Stage A and Stage B map to the same green output. The fallback is invisible to the user — they just see Portless as running. The branching is kept for future use (e.g., a yellow "route lost — restart `pnpm dev`" hint).

## Polling

`refreshInterval: 10` is added to `statusLine` config. Per [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code/statusline), this re-runs the script every 10 seconds *in addition* to event-driven updates (assistant message complete, mode change, etc.). With this in place, starting/stopping `pnpm dev` is reflected in the status line within 10s, even while the session sits idle.

10s was chosen over 5s after measurement showed ~910ms per execution on this hardware (dominated by Python spawns + lsof + git). At 5s polling that is ~18% of a single core sustained during idle; 10s halves that to ~9% (≈0.65% of a 14-core Mac), and the user-visible latency difference is imperceptible for a state change tied to a manual command.

## Color & UX details

- Green (`\033[32m`) for running matches the convention used by the existing worktree-safety indicator (`✓`).
- Grey (`\033[90m`) for absent uses the same "dim, informational" treatment as `(in:N out:N)` token counts.
- The clickable OSC 8 link (`\033]8;;URL\033\\TEXT\033]8;;\033\\`) is rendered as cmd-clickable in iTerm2 / WezTerm / Terminal.app; older terminals show plain colored text and ignore the escape — graceful degradation.
- `PORTLESS_PART` is injected into both the `emit_fallback()` output (no Jira context) and the full LINE1 build (with Jira), in the same slot between VS Code and Teams. Two-space separator matches the existing link layout.

## Files changed

- `.claude/scripts/statusline.sh` — adds the Portless detection block (~100 lines, between the VS Code link block and `emit_fallback()`) and wires `PORTLESS_PART` into both output paths.
- `.claude/settings.json` — adds `refreshInterval: 10` to `statusLine`.

## Test plan

- [ ] On a workspace with `pnpm dev` running and a matching route in `portless list`, status line shows green clickable `Portless` and the link opens the registered subdomain.
- [ ] On a workspace with no dev server, status line shows grey `Portless`.
- [ ] On a workspace where the dev server is alive but `portless list` has no entry (Stage B path), green still shows, derived from `package.json` or argv.
- [ ] When concurrently running dev servers in two worktrees of this repo (e.g., main checkout + `backend.ai-webui-2`), each session's status line points to its own subdomain — no cross-matching.
- [ ] Start `pnpm dev` while Claude Code session is idle; grey flips to green within ~10s with no user input.
- [ ] Kill the proxy daemon (`portless proxy stop`): status line falls back to grey gracefully (no error in output).
- [ ] Run on a non-portless project (`portless` not installed): the segment is omitted entirely; no failure.