### PR TITLE
feat(FR-2904): expose all DeploymentFilter fields, ordering, and table columns in deployment list

### DIFF
--- a/react/src/components/DeploymentList.tsx
+++ b/react/src/components/DeploymentList.tsx
@@ -25,6 +25,7 @@ import {
   BAITable,
   filterOutEmpty,
   filterOutNullAndUndefined,
+  isValidUUID,
   toLocalId,
   useBAILogger,
   type BAIColumnType,
@@ -53,9 +54,9 @@ const COLUMN_KEY_TO_FIELD: Record<string, string> = {
   name: 'NAME',
   createdAt: 'CREATED_AT',
   domainName: 'DOMAIN',
-  projectName: 'PROJECT',
+  projectId: 'PROJECT',
   resourceGroup: 'RESOURCE_GROUP',
-  tag: 'TAG',
+  tags: 'TAG',
 };
 
 /** All valid order strings accepted by BAITable for deployments. */
@@ -64,6 +65,14 @@ export const availableDeploymentOrderValues = [
   '-name',
   'createdAt',
   '-createdAt',
+  'domainName',
+  '-domainName',
+  'projectId',
+  '-projectId',
+  'resourceGroup',
+  '-resourceGroup',
+  'tags',
+  '-tags',
 ] as const;
 
 export type DeploymentOrderValue =
@@ -159,16 +168,20 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
         edges {
           node {
             id
+            createdUserId
             metadata {
               name
               status
               createdAt
+              updatedAt
               domainName
               projectId
+              resourceGroupName
               ...DeploymentTagChips_metadata
             }
             networkAccess {
               endpointUrl
+              openToPublic
             }
             replicaState {
               desiredReplicaCount
@@ -207,6 +220,11 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
   const supportsExtendedFilter =
     baiClient?.supports('model-deployment-extended-filter') ?? false;
 
+  const uuidRule = {
+    message: t('general.InvalidUUID'),
+    validate: (value: string) => isValidUUID(value.toLowerCase()),
+  };
+
   const baseFilterProperties = [
     {
       key: 'name',
@@ -222,6 +240,11 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
       key: 'endpointUrl',
       propertyLabel: t('deployment.filter.EndpointUrl'),
       type: 'string' as const,
+    },
+    {
+      key: 'openToPublic',
+      propertyLabel: t('deployment.filter.OpenToPublic'),
+      type: 'boolean' as const,
     },
   ];
 
@@ -239,8 +262,29 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
             type: 'string' as const,
           },
           {
+            key: 'projectId',
+            propertyLabel: t('deployment.filter.ProjectId'),
+            type: 'uuid' as const,
+            fixedOperator: 'equals' as const,
+            rule: uuidRule,
+          },
+          {
+            key: 'createdUserId',
+            propertyLabel: t('deployment.filter.CreatedUserId'),
+            type: 'uuid' as const,
+            fixedOperator: 'equals' as const,
+            rule: uuidRule,
+          },
+          {
             key: 'createdAt',
             propertyLabel: t('deployment.filter.CreatedAt'),
+            type: 'datetime' as const,
+            operators: ['after' as const, 'before' as const],
+            defaultOperator: 'after' as const,
+          },
+          {
+            key: 'destroyedAt',
+            propertyLabel: t('deployment.filter.DestroyedAt'),
             type: 'datetime' as const,
             operators: ['after' as const, 'before' as const],
             defaultOperator: 'after' as const,
@@ -388,6 +432,7 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
       key: 'tags',
       title: t('deployment.Tags'),
       defaultHidden: true,
+      sorter: true,
       render: (_text, row) => (
         <DeploymentTagChips
           metadataFrgmt={row.metadata}
@@ -406,14 +451,80 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
         return createdAt ? dayjs(createdAt).format('ll LT') : '-';
       },
     },
+    {
+      key: 'updatedAt',
+      title: t('deployment.UpdatedAt'),
+      defaultHidden: true,
+      render: (_text, row) => {
+        const updatedAt = row.metadata?.updatedAt;
+        return updatedAt ? dayjs(updatedAt).format('ll LT') : '-';
+      },
+    },
+    {
+      key: 'openToPublic',
+      title: t('deployment.OpenToPublic'),
+      defaultHidden: true,
+      render: (_text, row) => {
+        const isPublic = row.networkAccess?.openToPublic;
+        return isPublic == null ? (
+          <Typography.Text type="secondary">-</Typography.Text>
+        ) : (
+          <Typography.Text>
+            {isPublic ? t('deployment.Public') : t('deployment.Private')}
+          </Typography.Text>
+        );
+      },
+    },
+    {
+      key: 'resourceGroup',
+      title: t('deployment.ResourceGroup'),
+      defaultHidden: true,
+      sorter: true,
+      render: (_text, row) => {
+        const resourceGroup = row.metadata?.resourceGroupName;
+        return resourceGroup ? (
+          <Typography.Text>{resourceGroup}</Typography.Text>
+        ) : (
+          <Typography.Text type="secondary">-</Typography.Text>
+        );
+      },
+    },
     isAdminMode && {
       key: 'domainName',
       title: t('deployment.Domain'),
       defaultHidden: true,
+      sorter: true,
       render: (_text, row) => {
         const domain = row.metadata?.domainName;
         return domain ? (
           <Typography.Text>{domain}</Typography.Text>
+        ) : (
+          <Typography.Text type="secondary">-</Typography.Text>
+        );
+      },
+    },
+    isAdminMode && {
+      key: 'projectId',
+      title: t('deployment.ProjectId'),
+      defaultHidden: true,
+      sorter: true,
+      render: (_text, row) => {
+        const projectId = row.metadata?.projectId;
+        return projectId ? (
+          <BAIId globalId={projectId} copyable />
+        ) : (
+          <Typography.Text type="secondary">-</Typography.Text>
+        );
+      },
+    },
+    isAdminMode && {
+      key: 'createdUserId',
+      title: t('deployment.CreatedBy'),
+      defaultHidden: true,
+      render: (_text, row) => {
+        const userId = row.createdUserId;
+        return userId ? (
+          <BAIId globalId={userId} copyable />
         ) : (
           <Typography.Text type="secondary">-</Typography.Text>
         );

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -19,6 +19,7 @@ import DeploymentSettingModal from '../components/DeploymentSettingModal';
 import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useToggle } from 'ahooks';
 import { Button, Skeleton } from 'antd';
 import {
@@ -72,6 +73,8 @@ const DeploymentListPageContent: React.FC = () => {
 
   const [fetchKey, updateFetchKey] = useFetchKey();
 
+  const currentProject = useCurrentProjectValue();
+
   const sort = tableOrderToSort(queryParams.order);
   const orderBy: DeploymentOrderBy[] | undefined = sort
     ? [
@@ -86,10 +89,14 @@ const DeploymentListPageContent: React.FC = () => {
     queryParams.statusCategory === 'finished'
       ? { status: { in: finishedStatuses } }
       : { status: { notIn: finishedStatuses } };
+  const projectFilter: DeploymentFilter = currentProject.id
+    ? { projectId: { equals: currentProject.id } }
+    : {};
   const queryVariables = {
     filter: {
       ...((queryParams.filter ?? {}) as DeploymentFilter),
       ...statusCategoryFilter,
+      ...projectFilter,
     },
     orderBy,
     limit: baiPaginationOption.limit,

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -996,6 +996,7 @@
     "Private": "Privat",
     "PrivateDeploymentAlertTitle": "Private Bereitstellung — verwenden Sie ein Zugriffstoken, um auf den Endpunkt zuzugreifen.",
     "Project": "Projekt",
+    "ProjectId": "Projekt-ID",
     "Public": "Öffentlich",
     "QuickDeploy": "Bereitstellen",
     "QuickDeployDetailed": "Konfigurieren und bereitstellen...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Erstellt am",
+      "CreatedUserId": "Ersteller-ID",
+      "DestroyedAt": "Gelöscht am",
       "DomainName": "Domäne",
       "EndpointUrl": "Endpunkt-URL",
       "Name": "Name",
       "OpenToPublic": "Öffentlich",
+      "ProjectId": "Projekt-ID",
       "ResourceGroup": "Ressourcengruppe",
       "Status": "Status",
       "Tags": "Tags"

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -996,6 +996,7 @@
     "Private": "Ιδιωτικό",
     "PrivateDeploymentAlertTitle": "Ιδιωτική ανάπτυξη — χρησιμοποιήστε ένα διακριτικό πρόσβασης για να αποκτήσετε πρόσβαση στο τελικό σημείο.",
     "Project": "Έργο",
+    "ProjectId": "ID έργου",
     "Public": "Δημόσιο",
     "QuickDeploy": "Ανάπτυξη",
     "QuickDeployDetailed": "Διαμόρφωση και ανάπτυξη...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Δημιουργήθηκε",
+      "CreatedUserId": "ID δημιουργού",
+      "DestroyedAt": "Καταστράφηκε στις",
       "DomainName": "Τομέας",
       "EndpointUrl": "URL τελικού σημείου",
       "Name": "Όνομα",
       "OpenToPublic": "Δημόσιο",
+      "ProjectId": "ID έργου",
       "ResourceGroup": "Ομάδα πόρων",
       "Status": "Κατάσταση",
       "Tags": "Ετικέτες"

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1015,6 +1015,7 @@
     "Private": "Private",
     "PrivateDeploymentAlertTitle": "Private deployment — use an access token to access the endpoint.",
     "Project": "Project",
+    "ProjectId": "Project ID",
     "Public": "Public",
     "QuickDeploy": "Deploy",
     "QuickDeployDetailed": "Configure and deploy",
@@ -1067,10 +1068,13 @@
     },
     "filter": {
       "CreatedAt": "Created At",
+      "CreatedUserId": "Creator ID",
+      "DestroyedAt": "Destroyed At",
       "DomainName": "Domain",
       "EndpointUrl": "Endpoint URL",
       "Name": "Name",
       "OpenToPublic": "Public",
+      "ProjectId": "Project ID",
       "ResourceGroup": "Resource Group",
       "Status": "Status",
       "Tags": "Tags"

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -996,6 +996,7 @@
     "Private": "Privado",
     "PrivateDeploymentAlertTitle": "Despliegue privado — use un token de acceso para acceder al endpoint.",
     "Project": "Proyecto",
+    "ProjectId": "ID del proyecto",
     "Public": "Público",
     "QuickDeploy": "Desplegar",
     "QuickDeployDetailed": "Configurar y desplegar...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Creado el",
+      "CreatedUserId": "ID del creador",
+      "DestroyedAt": "Eliminado el",
       "DomainName": "Dominio",
       "EndpointUrl": "URL del endpoint",
       "Name": "Nombre",
       "OpenToPublic": "Público",
+      "ProjectId": "ID del proyecto",
       "ResourceGroup": "Grupo de recursos",
       "Status": "Estado",
       "Tags": "Etiquetas"

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -996,6 +996,7 @@
     "Private": "Yksityinen",
     "PrivateDeploymentAlertTitle": "Yksityinen käyttöönotto — käytä käyttöoikeustunnusta päätepisteen käyttämiseen.",
     "Project": "Projekti",
+    "ProjectId": "Projektin tunnus",
     "Public": "Julkinen",
     "QuickDeploy": "Ota käyttöön",
     "QuickDeployDetailed": "Määritä ja ota käyttöön...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Luotu",
+      "CreatedUserId": "Luojan tunnus",
+      "DestroyedAt": "Tuhottu",
       "DomainName": "Verkkotunnus",
       "EndpointUrl": "Päätepisteen URL",
       "Name": "Nimi",
       "OpenToPublic": "Julkinen",
+      "ProjectId": "Projektin tunnus",
       "ResourceGroup": "Resurssiryhmä",
       "Status": "Tila",
       "Tags": "Tunnisteet"

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -996,6 +996,7 @@
     "Private": "Privé",
     "PrivateDeploymentAlertTitle": "Déploiement privé — utilisez un jeton d'accès pour accéder au point de terminaison.",
     "Project": "Projet",
+    "ProjectId": "ID du projet",
     "Public": "Public",
     "QuickDeploy": "Déployer",
     "QuickDeployDetailed": "Configurer et déployer...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Créé le",
+      "CreatedUserId": "ID du créateur",
+      "DestroyedAt": "Supprimé le",
       "DomainName": "Domaine",
       "EndpointUrl": "URL du point de terminaison",
       "Name": "Nom",
       "OpenToPublic": "Public",
+      "ProjectId": "ID du projet",
       "ResourceGroup": "Groupe de ressources",
       "Status": "Statut",
       "Tags": "Étiquettes"

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -996,6 +996,7 @@
     "Private": "Privat",
     "PrivateDeploymentAlertTitle": "Penerapan privat — gunakan token akses untuk mengakses endpoint.",
     "Project": "Proyek",
+    "ProjectId": "ID proyek",
     "Public": "Publik",
     "QuickDeploy": "Terapkan",
     "QuickDeployDetailed": "Konfigurasi dan terapkan...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Dibuat Pada",
+      "CreatedUserId": "ID Pembuat",
+      "DestroyedAt": "Dihancurkan Pada",
       "DomainName": "Domain",
       "EndpointUrl": "URL Titik Akhir",
       "Name": "Nama",
       "OpenToPublic": "Publik",
+      "ProjectId": "ID proyek",
       "ResourceGroup": "Grup Sumber Daya",
       "Status": "Status",
       "Tags": "Tag"

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -996,6 +996,7 @@
     "Private": "Privato",
     "PrivateDeploymentAlertTitle": "Distribuzione privata — usa un token di accesso per accedere all'endpoint.",
     "Project": "Progetto",
+    "ProjectId": "ID progetto",
     "Public": "Pubblico",
     "QuickDeploy": "Distribuisci",
     "QuickDeployDetailed": "Configura e distribuisci...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Creato il",
+      "CreatedUserId": "ID creatore",
+      "DestroyedAt": "Eliminato il",
       "DomainName": "Dominio",
       "EndpointUrl": "URL endpoint",
       "Name": "Nome",
       "OpenToPublic": "Pubblico",
+      "ProjectId": "ID progetto",
       "ResourceGroup": "Gruppo di risorse",
       "Status": "Stato",
       "Tags": "Tag"

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -996,6 +996,7 @@
     "Private": "非公開",
     "PrivateDeploymentAlertTitle": "非公開デプロイメントです。エンドポイントの使用にはアクセストークンが必要です。",
     "Project": "プロジェクト",
+    "ProjectId": "プロジェクトID",
     "Public": "公開",
     "QuickDeploy": "デプロイ",
     "QuickDeployDetailed": "設定してデプロイ...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "作成日時",
+      "CreatedUserId": "作成者ID",
+      "DestroyedAt": "削除日時",
       "DomainName": "ドメイン",
       "EndpointUrl": "エンドポイントURL",
       "Name": "名前",
       "OpenToPublic": "公開",
+      "ProjectId": "プロジェクトID",
       "ResourceGroup": "リソースグループ",
       "Status": "状態",
       "Tags": "タグ"

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -997,6 +997,7 @@
     "Private": "비공개",
     "PrivateDeploymentAlertTitle": "비공개 배포입니다. 엔드포인트를 사용하려면 액세스 토큰을 사용해야 합니다.",
     "Project": "프로젝트",
+    "ProjectId": "프로젝트 ID",
     "Public": "공개",
     "QuickDeploy": "배포",
     "QuickDeployDetailed": "구성 및 배포...",
@@ -1049,10 +1050,13 @@
     },
     "filter": {
       "CreatedAt": "생성일",
+      "CreatedUserId": "생성자 ID",
+      "DestroyedAt": "삭제일",
       "DomainName": "도메인",
       "EndpointUrl": "엔드포인트 URL",
       "Name": "이름",
       "OpenToPublic": "공개",
+      "ProjectId": "프로젝트 ID",
       "ResourceGroup": "리소스 그룹",
       "Status": "상태",
       "Tags": "태그"

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -996,6 +996,7 @@
     "Private": "Хувийн",
     "PrivateDeploymentAlertTitle": "Хувийн хэрэгжүүлэлт — төгсгөлийн цэгт хандахын тулд хандалтын токен ашиглана уу.",
     "Project": "Төсөл",
+    "ProjectId": "Төслийн ID",
     "Public": "Нийтийн",
     "QuickDeploy": "Байршуулах",
     "QuickDeployDetailed": "Тохиргоо хийж байршуулах...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Үүсгэсэн огноо",
+      "CreatedUserId": "Үүсгэгчийн ID",
+      "DestroyedAt": "Устгасан огноо",
       "DomainName": "Домайн",
       "EndpointUrl": "Endpoint URL",
       "Name": "Нэр",
       "OpenToPublic": "Нийтэд нээлттэй",
+      "ProjectId": "Төслийн ID",
       "ResourceGroup": "Нөөцийн бүлэг",
       "Status": "Төлөв",
       "Tags": "Шошго"

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -996,6 +996,7 @@
     "Private": "Peribadi",
     "PrivateDeploymentAlertTitle": "Penerapan persendirian — gunakan token akses untuk mengakses titik akhir.",
     "Project": "Projek",
+    "ProjectId": "ID projek",
     "Public": "Awam",
     "QuickDeploy": "Gunakan",
     "QuickDeployDetailed": "Konfigurasi dan gunakan...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Dicipta Pada",
+      "CreatedUserId": "ID Pencipta",
+      "DestroyedAt": "Dimusnahkan Pada",
       "DomainName": "Domain",
       "EndpointUrl": "URL Titik Akhir",
       "Name": "Nama",
       "OpenToPublic": "Awam",
+      "ProjectId": "ID projek",
       "ResourceGroup": "Kumpulan Sumber",
       "Status": "Status",
       "Tags": "Tag"

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -996,6 +996,7 @@
     "Private": "Prywatne",
     "PrivateDeploymentAlertTitle": "Wdrożenie prywatne — użyj tokenu dostępu, aby uzyskać dostęp do punktu końcowego.",
     "Project": "Projekt",
+    "ProjectId": "ID projektu",
     "Public": "Publiczny",
     "QuickDeploy": "Wdróż",
     "QuickDeployDetailed": "Konfiguruj i wdróż...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Utworzono",
+      "CreatedUserId": "ID twórcy",
+      "DestroyedAt": "Usunięto",
       "DomainName": "Domena",
       "EndpointUrl": "URL punktu końcowego",
       "Name": "Nazwa",
       "OpenToPublic": "Publiczne",
+      "ProjectId": "ID projektu",
       "ResourceGroup": "Grupa zasobów",
       "Status": "Status",
       "Tags": "Tagi"

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -996,6 +996,7 @@
     "Private": "Privado",
     "PrivateDeploymentAlertTitle": "Implantação privada — use um token de acesso para acessar o endpoint.",
     "Project": "Projeto",
+    "ProjectId": "ID do projeto",
     "Public": "Público",
     "QuickDeploy": "Implantar",
     "QuickDeployDetailed": "Configurar e implantar...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Criado em",
+      "CreatedUserId": "ID do criador",
+      "DestroyedAt": "Excluído em",
       "DomainName": "Domínio",
       "EndpointUrl": "URL do endpoint",
       "Name": "Nome",
       "OpenToPublic": "Público",
+      "ProjectId": "ID do projeto",
       "ResourceGroup": "Grupo de recursos",
       "Status": "Status",
       "Tags": "Tags"

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -996,6 +996,7 @@
     "Private": "Privado",
     "PrivateDeploymentAlertTitle": "Implementação privada — utilize um token de acesso para aceder ao endpoint.",
     "Project": "Projeto",
+    "ProjectId": "ID do projeto",
     "Public": "Público",
     "QuickDeploy": "Implementar",
     "QuickDeployDetailed": "Configurar e implementar...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Criado em",
+      "CreatedUserId": "ID do criador",
+      "DestroyedAt": "Eliminado em",
       "DomainName": "Domínio",
       "EndpointUrl": "URL do endpoint",
       "Name": "Nome",
       "OpenToPublic": "Público",
+      "ProjectId": "ID do projeto",
       "ResourceGroup": "Grupo de recursos",
       "Status": "Estado",
       "Tags": "Etiquetas"

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -996,6 +996,7 @@
     "Private": "Приватный",
     "PrivateDeploymentAlertTitle": "Приватное развертывание — используйте токен доступа для обращения к конечной точке.",
     "Project": "Проект",
+    "ProjectId": "ID проекта",
     "Public": "Публичный",
     "QuickDeploy": "Развернуть",
     "QuickDeployDetailed": "Настроить и развернуть...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Создано",
+      "CreatedUserId": "ID создателя",
+      "DestroyedAt": "Удалено",
       "DomainName": "Домен",
       "EndpointUrl": "URL конечной точки",
       "Name": "Имя",
       "OpenToPublic": "Публичное",
+      "ProjectId": "ID проекта",
       "ResourceGroup": "Группа ресурсов",
       "Status": "Статус",
       "Tags": "Теги"

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -996,6 +996,7 @@
     "Private": "ส่วนตัว",
     "PrivateDeploymentAlertTitle": "การปรับใช้แบบส่วนตัว — ใช้โทเค็นการเข้าถึงเพื่อเข้าถึงปลายทาง",
     "Project": "โปรเจกต์",
+    "ProjectId": "ID โปรเจกต์",
     "Public": "สาธารณะ",
     "QuickDeploy": "ปรับใช้",
     "QuickDeployDetailed": "กำหนดค่าและปรับใช้...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "สร้างเมื่อ",
+      "CreatedUserId": "ID ผู้สร้าง",
+      "DestroyedAt": "ลบเมื่อ",
       "DomainName": "โดเมน",
       "EndpointUrl": "URL ปลายทาง",
       "Name": "ชื่อ",
       "OpenToPublic": "สาธารณะ",
+      "ProjectId": "ID โปรเจกต์",
       "ResourceGroup": "กลุ่มทรัพยากร",
       "Status": "สถานะ",
       "Tags": "แท็ก"

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -996,6 +996,7 @@
     "Private": "Özel",
     "PrivateDeploymentAlertTitle": "Özel dağıtım — uç noktasına erişmek için bir erişim belirteci kullanın.",
     "Project": "Proje",
+    "ProjectId": "Proje kimliği",
     "Public": "Genel",
     "QuickDeploy": "Dağıt",
     "QuickDeployDetailed": "Yapılandır ve dağıt...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Oluşturulma Tarihi",
+      "CreatedUserId": "Oluşturan ID",
+      "DestroyedAt": "Silinme Tarihi",
       "DomainName": "Etki Alanı",
       "EndpointUrl": "Uç Nokta URL'si",
       "Name": "Ad",
       "OpenToPublic": "Herkese Açık",
+      "ProjectId": "Proje kimliği",
       "ResourceGroup": "Kaynak Grubu",
       "Status": "Durum",
       "Tags": "Etiketler"

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -996,6 +996,7 @@
     "Private": "Riêng tư",
     "PrivateDeploymentAlertTitle": "Triển khai riêng tư — sử dụng mã thông báo truy cập để truy cập điểm cuối.",
     "Project": "Dự án",
+    "ProjectId": "ID dự án",
     "Public": "Công khai",
     "QuickDeploy": "Triển khai",
     "QuickDeployDetailed": "Cấu hình và triển khai...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "Ngày tạo",
+      "CreatedUserId": "ID người tạo",
+      "DestroyedAt": "Ngày xóa",
       "DomainName": "Miền",
       "EndpointUrl": "URL điểm cuối",
       "Name": "Tên",
       "OpenToPublic": "Công khai",
+      "ProjectId": "ID dự án",
       "ResourceGroup": "Nhóm tài nguyên",
       "Status": "Trạng thái",
       "Tags": "Thẻ"

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -996,6 +996,7 @@
     "Private": "私有",
     "PrivateDeploymentAlertTitle": "私有部署 — 使用访问令牌访问端点。",
     "Project": "项目",
+    "ProjectId": "项目 ID",
     "Public": "公开",
     "QuickDeploy": "部署",
     "QuickDeployDetailed": "配置并部署...",
@@ -1048,10 +1049,13 @@
     },
     "filter": {
       "CreatedAt": "创建时间",
+      "CreatedUserId": "创建者 ID",
+      "DestroyedAt": "删除时间",
       "DomainName": "域",
       "EndpointUrl": "端点 URL",
       "Name": "名称",
       "OpenToPublic": "公开",
+      "ProjectId": "项目 ID",
       "ResourceGroup": "资源组",
       "Status": "状态",
       "Tags": "标签"

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -997,6 +997,7 @@
     "Private": "私有",
     "PrivateDeploymentAlertTitle": "私有部署 — 使用存取權杖存取端點。",
     "Project": "專案",
+    "ProjectId": "專案 ID",
     "Public": "公開",
     "QuickDeploy": "部署",
     "QuickDeployDetailed": "設定並部署...",
@@ -1049,10 +1050,13 @@
     },
     "filter": {
       "CreatedAt": "建立時間",
+      "CreatedUserId": "建立者 ID",
+      "DestroyedAt": "刪除時間",
       "DomainName": "網域",
       "EndpointUrl": "端點 URL",
       "Name": "名稱",
       "OpenToPublic": "公開",
+      "ProjectId": "專案 ID",
       "ResourceGroup": "資源群組",
       "Status": "狀態",
       "Tags": "標籤"


### PR DESCRIPTION
Resolves #7434 ([FR-2904](https://lablup.atlassian.net/browse/FR-2904))

## Summary
- Added every remaining `DeploymentFilter` field to the property filter — `openToPublic` for both user and admin lists, plus `projectId`, `createdUserId`, and `destroyedAt` for the admin list.
- Added every remaining `DeploymentOrderField` value as a sortable column — `domainName`, `projectId` (admin), `resourceGroup`, and `tags`.
- Added 4 hidden-by-default columns so users can opt in via column settings — `Updated At`, `Open To Public` (both lists), `Project ID`, and `Creator ID` (admin).
- `DeploymentListPage` keeps the `myDeployments` query and now scopes it to the current project by injecting `{ projectId: { equals: currentProject.id } }` from `useCurrentProjectValue`.
- Translated new i18n keys (`filter.OpenToPublic`, `filter.ProjectId`, `filter.CreatedUserId`, `filter.DestroyedAt`, `ProjectId`) across all 21 languages.

## Test plan
- [ ] Open the user deployment list — verify `Public` filter works and the new columns appear in the column settings (hidden by default).
- [ ] Switch projects — verify the user list scopes correctly to the selected project.
- [ ] Open the admin deployment list — verify `Public`, `Project ID`, `Creator ID`, and `Destroyed At` filters work; verify the four new sortable columns sort against the backend.
- [ ] Toggle the new defaultHidden columns on and confirm values render.
- [ ] `bash scripts/verify.sh` passes.

[FR-2904]: https://lablup.atlassian.net/browse/FR-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ