### PR TITLE
feat(FR-2905): deployment list polish — projectV2 display, revision drawer link, drop createdUserId, strictSelection on enum filters

### DIFF
--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -22,7 +22,6 @@ import {
   MoreOutlined,
   PlusOutlined,
 } from '@ant-design/icons';
-import { useToggle } from 'ahooks';
 import {
   Alert,
   App,
@@ -250,10 +249,7 @@ const DeploymentConfigurationSection: React.FC<
       scroll: false,
     },
   );
-  const [
-    settingModalOpen,
-    { setLeft: closeSettingModal, setRight: openSettingModal },
-  ] = useToggle(false);
+  const [settingModalOpen, setSettingModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const [commitDeleteMutation, isInFlightDeleteMutation] =
@@ -327,13 +323,15 @@ const DeploymentConfigurationSection: React.FC<
               onChange={onRefetch}
             />
             <Space.Compact>
-              <Button
+              <BAIButton
                 icon={<EditOutlined />}
                 disabled={isDeploymentDestroying}
-                onClick={openSettingModal}
+                action={async () => {
+                  setSettingModalOpen(true);
+                }}
               >
                 {t('button.Edit')}
-              </Button>
+              </BAIButton>
               <Dropdown
                 trigger={['click']}
                 menu={{
@@ -455,7 +453,7 @@ const DeploymentConfigurationSection: React.FC<
         open={settingModalOpen}
         deploymentFrgmt={deployment}
         onRequestClose={(success) => {
-          closeSettingModal();
+          setSettingModalOpen(false);
           if (success) onRefetch();
         }}
       />

--- a/react/src/components/DeploymentList.tsx
+++ b/react/src/components/DeploymentList.tsx
@@ -7,10 +7,12 @@ import {
   DeploymentList_modelDeploymentConnection$data,
   DeploymentList_modelDeploymentConnection$key,
 } from '../__generated__/DeploymentList_modelDeploymentConnection.graphql';
+import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import { DeploymentSettingModal_deployment$key } from '../__generated__/DeploymentSettingModal_deployment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import BAIRadioGroup from './BAIRadioGroup';
 import DeploymentOwnerInfo from './DeploymentOwnerInfo';
+import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
 import DeploymentStatusTag, { DeploymentStatus } from './DeploymentStatusTag';
 import DeploymentTagChips from './DeploymentTagChips';
 import QuestionIconWithTooltip from './QuestionIconWithTooltip';
@@ -23,6 +25,7 @@ import {
   BAIId,
   BAINameActionCell,
   BAITable,
+  BAIUnmountAfterClose,
   filterOutEmpty,
   filterOutNullAndUndefined,
   isValidUUID,
@@ -151,6 +154,8 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
     id: string;
     name: string;
   } | null>(null);
+  const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
+    useState<DeploymentRevisionDetail_revision$key | null>(null);
 
   const [commitDeleteMutation, isInFlightDeleteMutation] =
     useMutation<DeploymentListDeleteMutation>(graphql`
@@ -168,7 +173,6 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
         edges {
           node {
             id
-            createdUserId
             metadata {
               name
               status
@@ -176,6 +180,12 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
               updatedAt
               domainName
               projectId
+              projectV2 @since(version: "26.4.3") {
+                basicInfo {
+                  name
+                }
+                id
+              }
               resourceGroupName
               ...DeploymentTagChips_metadata
             }
@@ -202,6 +212,7 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
                   name
                 }
               }
+              ...DeploymentRevisionDetail_revision
             }
             ...DeploymentOwnerInfo_deployment
           }
@@ -264,13 +275,6 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
           {
             key: 'projectId',
             propertyLabel: t('deployment.filter.ProjectId'),
-            type: 'uuid' as const,
-            fixedOperator: 'equals' as const,
-            rule: uuidRule,
-          },
-          {
-            key: 'createdUserId',
-            propertyLabel: t('deployment.filter.CreatedUserId'),
             type: 'uuid' as const,
             fixedOperator: 'equals' as const,
             rule: uuidRule,
@@ -349,10 +353,14 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
         </BAIFlex>
       ),
       render: (_text, row) => {
-        const revisionNumber = row.currentRevision?.revisionNumber;
-        if (revisionNumber == null)
+        const revision = row.currentRevision;
+        if (revision?.revisionNumber == null)
           return <Typography.Text type="secondary">-</Typography.Text>;
-        return <Typography.Text>{`#${revisionNumber}`}</Typography.Text>;
+        return (
+          <Typography.Link
+            onClick={() => setDrawerRevisionFrgmt(revision)}
+          >{`#${revision.revisionNumber}`}</Typography.Link>
+        );
       },
     },
     {
@@ -505,28 +513,31 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
     },
     isAdminMode && {
       key: 'projectId',
-      title: t('deployment.ProjectId'),
+      title: t('deployment.Project'),
       defaultHidden: true,
       sorter: true,
       render: (_text, row) => {
         const projectId = row.metadata?.projectId;
-        return projectId ? (
-          <BAIId globalId={projectId} copyable />
-        ) : (
-          <Typography.Text type="secondary">-</Typography.Text>
-        );
-      },
-    },
-    isAdminMode && {
-      key: 'createdUserId',
-      title: t('deployment.CreatedBy'),
-      defaultHidden: true,
-      render: (_text, row) => {
-        const userId = row.createdUserId;
-        return userId ? (
-          <BAIId globalId={userId} copyable />
-        ) : (
-          <Typography.Text type="secondary">-</Typography.Text>
+        if (!projectId) {
+          return <Typography.Text type="secondary">-</Typography.Text>;
+        }
+        const projectName = row.metadata?.projectV2?.basicInfo?.name;
+        if (!projectName) {
+          return <BAIId globalId={projectId} copyable />;
+        }
+        return (
+          <>
+            <Typography.Text
+              ellipsis={{ tooltip: projectName }}
+              style={{ maxWidth: 160 }}
+            >
+              {projectName}
+            </Typography.Text>
+            &nbsp;
+            <Typography.Text type="secondary">
+              (<BAIId globalId={projectId} copyable type="secondary" />)
+            </Typography.Text>
+          </>
         );
       },
     },
@@ -628,6 +639,13 @@ const DeploymentList: React.FC<DeploymentListProps> = ({
         }}
         onCancel={() => setDeletingDeployment(null)}
       />
+      <BAIUnmountAfterClose>
+        <DeploymentRevisionDetailDrawer
+          open={!!drawerRevisionFrgmt}
+          revisionFrgmt={drawerRevisionFrgmt}
+          onClose={() => setDrawerRevisionFrgmt(null)}
+        />
+      </BAIUnmountAfterClose>
     </>
   );
 };

--- a/react/src/components/DeploymentReplicasTab.tsx
+++ b/react/src/components/DeploymentReplicasTab.tsx
@@ -239,6 +239,7 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
       propertyLabel: t('deployment.TrafficStatus'),
       type: 'enum' as const,
       options: trafficStatusOptions,
+      strictSelection: true,
     },
   ];
 
@@ -326,23 +327,23 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
           return <Typography.Text type="secondary">—</Typography.Text>;
         }
         const name = session.metadata?.name;
+        if (!name) {
+          return <BAIId globalId={session.id} />;
+        }
         return (
-          <BAIFlex gap="xs" align="center" wrap="nowrap">
-            {name ? (
-              <Typography.Link
-                ellipsis={{ tooltip: name }}
-                onClick={() => setSelectedSessionId(toLocalId(session.id))}
-                style={{ maxWidth: 160 }}
-              >
-                {name}
-              </Typography.Link>
-            ) : null}
-            <BAIFlex gap={0} align="center">
-              {'('}
-              <BAIId globalId={session.id} />
-              {')'}
-            </BAIFlex>
-          </BAIFlex>
+          <>
+            <Typography.Link
+              ellipsis={{ tooltip: name }}
+              onClick={() => setSelectedSessionId(toLocalId(session.id))}
+              style={{ maxWidth: 160 }}
+            >
+              {name}
+            </Typography.Link>
+            &nbsp;
+            <Typography.Text type="secondary">
+              (<BAIId globalId={session.id} type="secondary" />)
+            </Typography.Text>
+          </>
         );
       },
     },
@@ -362,7 +363,7 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
           return <Typography.Text type="secondary">—</Typography.Text>;
         }
         return (
-          <BAIFlex gap="xs" align="center">
+          <>
             <Typography.Link
               onClick={() =>
                 setDrawerRevisionFrgmt(
@@ -374,12 +375,11 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
                 ? `#${revision.revisionNumber}`
                 : '-'}
             </Typography.Link>
-            <BAIFlex gap={0} align="center">
-              {'('}
-              <BAIId globalId={revision.id} />
-              {')'}
-            </BAIFlex>
-          </BAIFlex>
+            &nbsp;
+            <Typography.Text type="secondary">
+              (<BAIId globalId={revision.id} type="secondary" />)
+            </Typography.Text>
+          </>
         );
       },
     },

--- a/react/src/components/DeploymentSettingModal.tsx
+++ b/react/src/components/DeploymentSettingModal.tsx
@@ -15,6 +15,7 @@ import {
   Input,
   InputNumber,
   Select,
+  Skeleton,
   theme,
   Typography,
 } from 'antd';
@@ -26,7 +27,7 @@ import {
   BAIProjectResourceGroupSelect,
   toLocalId,
 } from 'backend.ai-ui';
-import React from 'react';
+import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
@@ -215,94 +216,97 @@ const DeploymentSettingModal: React.FC<DeploymentSettingModalProps> = ({
         </BAIFlex>
       }
     >
-      <Form<FormValues>
-        form={form}
-        layout="vertical"
-        preserve={false}
-        initialValues={
-          deployment
-            ? {
-                name: deployment.metadata.name ?? '',
-                tags: (deployment.metadata.tags ?? []).flatMap((tag) =>
-                  tag
-                    .split(',')
-                    .map((t) => t.trim())
-                    .filter(Boolean),
-                ),
-                openToPublic: deployment.networkAccess.openToPublic ?? false,
-                replicaCount: deployment.replicaState?.desiredReplicaCount ?? 1,
-              }
-            : { openToPublic: false, replicaCount: 1, tags: [] }
-        }
-        style={{ marginTop: token.marginXS }}
-      >
-        <Form.Item
-          name="name"
-          label={t('deployment.DeploymentName')}
-          tooltip={t('deployment.DeploymentNameTooltip')}
-          rules={[{ required: true, message: t('deployment.NameRequired') }]}
+      <Suspense fallback={<Skeleton active />}>
+        <Form<FormValues>
+          form={form}
+          layout="vertical"
+          preserve={false}
+          initialValues={
+            deployment
+              ? {
+                  name: deployment.metadata.name ?? '',
+                  tags: (deployment.metadata.tags ?? []).flatMap((tag) =>
+                    tag
+                      .split(',')
+                      .map((t) => t.trim())
+                      .filter(Boolean),
+                  ),
+                  openToPublic: deployment.networkAccess.openToPublic ?? false,
+                  replicaCount:
+                    deployment.replicaState?.desiredReplicaCount ?? 1,
+                }
+              : { openToPublic: false, replicaCount: 1, tags: [] }
+          }
+          style={{ marginTop: token.marginXS }}
         >
-          <Input placeholder={t('deployment.NamePlaceholder')} />
-        </Form.Item>
-        {deployment ? (
           <Form.Item
-            label={t('modelStore.ResourceGroup')}
-            tooltip={t('modelStore.ResourceGroupTooltip')}
+            name="name"
+            label={t('deployment.DeploymentName')}
+            tooltip={t('deployment.DeploymentNameTooltip')}
+            rules={[{ required: true, message: t('deployment.NameRequired') }]}
           >
-            {currentResourceGroup ? (
-              <Typography.Text>{currentResourceGroup}</Typography.Text>
-            ) : (
-              <Typography.Text type="secondary">—</Typography.Text>
-            )}
+            <Input placeholder={t('deployment.NamePlaceholder')} />
           </Form.Item>
-        ) : (
+          {deployment ? (
+            <Form.Item
+              label={t('modelStore.ResourceGroup')}
+              tooltip={t('modelStore.ResourceGroupTooltip')}
+            >
+              {currentResourceGroup ? (
+                <Typography.Text>{currentResourceGroup}</Typography.Text>
+              ) : (
+                <Typography.Text type="secondary">—</Typography.Text>
+              )}
+            </Form.Item>
+          ) : (
+            <Form.Item
+              name="resourceGroup"
+              label={t('modelStore.ResourceGroup')}
+              tooltip={t('modelStore.ResourceGroupTooltip')}
+              rules={[{ required: true }]}
+            >
+              <BAIProjectResourceGroupSelect
+                projectName={projectName ?? ''}
+                autoSelectDefault
+                style={{ width: '100%' }}
+              />
+            </Form.Item>
+          )}
           <Form.Item
-            name="resourceGroup"
-            label={t('modelStore.ResourceGroup')}
-            tooltip={t('modelStore.ResourceGroupTooltip')}
-            rules={[{ required: true }]}
+            name="replicaCount"
+            label={t('deployment.DesiredReplicas')}
+            tooltip={t('deployment.DesiredReplicasTooltip')}
+            rules={[
+              {
+                required: true,
+                message: t('deployment.DesiredReplicasRequired'),
+              },
+            ]}
           >
-            <BAIProjectResourceGroupSelect
-              projectName={projectName ?? ''}
-              autoSelectDefault
-              style={{ width: '100%' }}
+            <InputNumber min={1} style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item
+            name="tags"
+            label={t('deployment.Tags')}
+            tooltip={t('deployment.TagsTooltip')}
+          >
+            <Select
+              mode="tags"
+              placeholder={t('deployment.TagsPlaceholder')}
+              tokenSeparators={[',', '\n']}
+              notFoundContent={null}
             />
           </Form.Item>
-        )}
-        <Form.Item
-          name="replicaCount"
-          label={t('deployment.DesiredReplicas')}
-          tooltip={t('deployment.DesiredReplicasTooltip')}
-          rules={[
-            {
-              required: true,
-              message: t('deployment.DesiredReplicasRequired'),
-            },
-          ]}
-        >
-          <InputNumber min={1} style={{ width: '100%' }} />
-        </Form.Item>
-        <Form.Item
-          name="tags"
-          label={t('deployment.Tags')}
-          tooltip={t('deployment.TagsTooltip')}
-        >
-          <Select
-            mode="tags"
-            placeholder={t('deployment.TagsPlaceholder')}
-            tokenSeparators={[',', '\n']}
-            notFoundContent={null}
-          />
-        </Form.Item>
-        <Form.Item
-          name="openToPublic"
-          valuePropName="checked"
-          label={t('deployment.OpenToPublic')}
-          tooltip={t('deployment.OpenToPublicTooltip')}
-        >
-          <Checkbox>{t('deployment.Public')}</Checkbox>
-        </Form.Item>
-      </Form>
+          <Form.Item
+            name="openToPublic"
+            valuePropName="checked"
+            label={t('deployment.OpenToPublic')}
+            tooltip={t('deployment.OpenToPublicTooltip')}
+          >
+            <Checkbox>{t('deployment.Public')}</Checkbox>
+          </Form.Item>
+        </Form>
+      </Suspense>
     </BAIModal>
   );
 };

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Erstellt am",
-      "CreatedUserId": "Ersteller-ID",
       "DestroyedAt": "Gelöscht am",
       "DomainName": "Domäne",
       "EndpointUrl": "Endpunkt-URL",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Δημιουργήθηκε",
-      "CreatedUserId": "ID δημιουργού",
       "DestroyedAt": "Καταστράφηκε στις",
       "DomainName": "Τομέας",
       "EndpointUrl": "URL τελικού σημείου",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1068,7 +1068,6 @@
     },
     "filter": {
       "CreatedAt": "Created At",
-      "CreatedUserId": "Creator ID",
       "DestroyedAt": "Destroyed At",
       "DomainName": "Domain",
       "EndpointUrl": "Endpoint URL",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Creado el",
-      "CreatedUserId": "ID del creador",
       "DestroyedAt": "Eliminado el",
       "DomainName": "Dominio",
       "EndpointUrl": "URL del endpoint",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Luotu",
-      "CreatedUserId": "Luojan tunnus",
       "DestroyedAt": "Tuhottu",
       "DomainName": "Verkkotunnus",
       "EndpointUrl": "Päätepisteen URL",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Créé le",
-      "CreatedUserId": "ID du créateur",
       "DestroyedAt": "Supprimé le",
       "DomainName": "Domaine",
       "EndpointUrl": "URL du point de terminaison",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Dibuat Pada",
-      "CreatedUserId": "ID Pembuat",
       "DestroyedAt": "Dihancurkan Pada",
       "DomainName": "Domain",
       "EndpointUrl": "URL Titik Akhir",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Creato il",
-      "CreatedUserId": "ID creatore",
       "DestroyedAt": "Eliminato il",
       "DomainName": "Dominio",
       "EndpointUrl": "URL endpoint",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "作成日時",
-      "CreatedUserId": "作成者ID",
       "DestroyedAt": "削除日時",
       "DomainName": "ドメイン",
       "EndpointUrl": "エンドポイントURL",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1050,7 +1050,6 @@
     },
     "filter": {
       "CreatedAt": "생성일",
-      "CreatedUserId": "생성자 ID",
       "DestroyedAt": "삭제일",
       "DomainName": "도메인",
       "EndpointUrl": "엔드포인트 URL",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Үүсгэсэн огноо",
-      "CreatedUserId": "Үүсгэгчийн ID",
       "DestroyedAt": "Устгасан огноо",
       "DomainName": "Домайн",
       "EndpointUrl": "Endpoint URL",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Dicipta Pada",
-      "CreatedUserId": "ID Pencipta",
       "DestroyedAt": "Dimusnahkan Pada",
       "DomainName": "Domain",
       "EndpointUrl": "URL Titik Akhir",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Utworzono",
-      "CreatedUserId": "ID twórcy",
       "DestroyedAt": "Usunięto",
       "DomainName": "Domena",
       "EndpointUrl": "URL punktu końcowego",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Criado em",
-      "CreatedUserId": "ID do criador",
       "DestroyedAt": "Excluído em",
       "DomainName": "Domínio",
       "EndpointUrl": "URL do endpoint",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Criado em",
-      "CreatedUserId": "ID do criador",
       "DestroyedAt": "Eliminado em",
       "DomainName": "Domínio",
       "EndpointUrl": "URL do endpoint",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Создано",
-      "CreatedUserId": "ID создателя",
       "DestroyedAt": "Удалено",
       "DomainName": "Домен",
       "EndpointUrl": "URL конечной точки",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "สร้างเมื่อ",
-      "CreatedUserId": "ID ผู้สร้าง",
       "DestroyedAt": "ลบเมื่อ",
       "DomainName": "โดเมน",
       "EndpointUrl": "URL ปลายทาง",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Oluşturulma Tarihi",
-      "CreatedUserId": "Oluşturan ID",
       "DestroyedAt": "Silinme Tarihi",
       "DomainName": "Etki Alanı",
       "EndpointUrl": "Uç Nokta URL'si",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "Ngày tạo",
-      "CreatedUserId": "ID người tạo",
       "DestroyedAt": "Ngày xóa",
       "DomainName": "Miền",
       "EndpointUrl": "URL điểm cuối",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1049,7 +1049,6 @@
     },
     "filter": {
       "CreatedAt": "创建时间",
-      "CreatedUserId": "创建者 ID",
       "DestroyedAt": "删除时间",
       "DomainName": "域",
       "EndpointUrl": "端点 URL",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1050,7 +1050,6 @@
     },
     "filter": {
       "CreatedAt": "建立時間",
-      "CreatedUserId": "建立者 ID",
       "DestroyedAt": "刪除時間",
       "DomainName": "網域",
       "EndpointUrl": "端點 URL",


### PR DESCRIPTION
Resolves #7438([FR-2905](https://lablup.atlassian.net/browse/FR-2905))

Stacked on top of #7437.

## Summary

Follow-up polish on the deployment list & replicas tab (FR-2904 series). Bundled as one PR per the project's "avoid excessive PR splitting" convention.

- **Admin deployment list — Project column.** Replaced the raw project-ID cell with a `project name (BAIId)` cell. Name comes from `metadata.projectV2.basicInfo.name @since(version: "26.4.3")` (DataLoader-resolved). ID stays copyable + ellipsis via `BAIId`.
- **Deployment list — Revision number drawer link.** The Applied-Revision column now opens `DeploymentRevisionDetailDrawer` on click, matching the pattern used in `DeploymentReplicasTab`. The `currentRevision` fragment ref is spread into `...DeploymentRevisionDetail_revision` for the drawer.
- **Drop `createdUserId` from the deployment list.** Both the admin column and the matching filter property were removed — the existing Owner / Creator column already surfaces the same information via `DeploymentOwnerInfo`. Orphan i18n key `deployment.filter.CreatedUserId` was removed from all 21 locale files.
- **Property filter — `strictSelection: true` on enum types.** Applied to the `trafficStatus` enum filter in `DeploymentReplicasTab` so the value must come from the provided options.

## Test plan

- [ ] Admin deployment list: open column settings, toggle the `Project` column on → confirm `project name (ID)` renders for deployments that have a project, and only the ID shows when name is unavailable (≤ 26.4.2 manager).
- [ ] Deployment list: enable the Revision Number column → click the link → confirm `DeploymentRevisionDetailDrawer` opens with the right revision.
- [ ] Admin deployment list: confirm the `Creator ID` column and the `Creator ID` admin filter are no longer present.
- [ ] Replicas tab: open the property filter, choose `TrafficStatus` → confirm input requires selection from `Active` / `Inactive` (typing arbitrary text is rejected).
- [ ] `bash scripts/verify.sh` — Relay / Lint / Format pass; TypeScript only reports pre-existing errors in unrelated pages.

[FR-2905]: https://lablup.atlassian.net/browse/FR-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ