### PR TITLE
fix(FR-2906): invoke docs-toolkit CLI by node path so build_docs survives pnpm v11 bin-link gap

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -242,17 +242,6 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      # backend.ai-docs-toolkit ships its `docs-toolkit` CLI as the package
-      # bin, but it lives at dist/cli.js which only exists after `tsc` runs.
-      # On a fresh `pnpm install` the dist directory is empty, so pnpm
-      # cannot create the .bin/docs-toolkit symlink and later `pdf:all`
-      # fails with `spawn ENOENT`. Building the toolkit and re-running
-      # install populates dist/ and lets pnpm wire the bin link.
-      - name: Build docs-toolkit and link CLI
-        run: |
-          pnpm --filter backend.ai-docs-toolkit run build
-          pnpm install --frozen-lockfile
-
       # Cache the Playwright browser binaries (~150 MB Chromium download).
       # The lockfile hash keys the cache so a Playwright version bump
       # naturally invalidates the cache without manual intervention.

--- a/packages/backend.ai-docs-toolkit/bin/docs-toolkit.js
+++ b/packages/backend.ai-docs-toolkit/bin/docs-toolkit.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// Stable bin entry committed to the repo so `pnpm install` can always create
+// the `node_modules/.bin/docs-toolkit` symlink, regardless of whether
+// `tsc` has produced `dist/cli.js` yet. The real CLI lives at ../dist/cli.js
+// and is built by `pnpm --filter backend.ai-docs-toolkit build` before use.
+//
+// See pnpm/pnpm#10524 for the upstream discussion of this pattern.
+import '../dist/cli.js';

--- a/packages/backend.ai-docs-toolkit/package.json
+++ b/packages/backend.ai-docs-toolkit/package.json
@@ -23,7 +23,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "docs-toolkit": "./dist/cli.js"
+    "docs-toolkit": "./bin/docs-toolkit.js"
   },
   "exports": {
     ".": {
@@ -32,6 +32,7 @@
     }
   },
   "files": [
+    "bin",
     "dist",
     "templates"
   ],


### PR DESCRIPTION
Resolves #7440(FR-2906)

## Problem

The `build_docs` job in `.github/workflows/package.yml` has been failing during release builds, e.g. v26.4.8-rc.4: https://github.com/lablup/backend.ai-webui/actions/runs/25917622880/job/76178117083

```
$ pnpm run build:toolkit && docs-toolkit pdf --lang all
$ pnpm --filter backend.ai-docs-toolkit build
$ tsc
sh: 1: docs-toolkit: not found
```

No PDFs are produced, so `Stage PDFs for upload` / `Upload PDF release assets` are skipped and the job exits 1.

## Root cause

`backend.ai-docs-toolkit` ships its CLI as a package `bin` pointing at `./dist/cli.js`, which only exists after `tsc` runs. On a fresh checkout under **pnpm v11** (since #7307 / #7345):

1. `pnpm install --frozen-lockfile` cannot create the `node_modules/.bin/docs-toolkit` symlink because the target file does not yet exist. pnpm v11 logs `[WARN] Failed to create bin … ENOENT` and skips it. (Older pnpm silently created a dangling symlink, which is what the previous CI workaround implicitly relied on.)
2. The workflow then ran `pnpm --filter backend.ai-docs-toolkit run build` to produce `dist/cli.js`, followed by another `pnpm install --frozen-lockfile` hoping the bin would be re-linked.
3. pnpm v11 sees `node_modules` as `Already up to date` and does **not** retry bin linking. Even `pnpm install --force` is a no-op once the lockfile and `node_modules` agree.

Result: the `docs-toolkit` bin symlink stays missing for the entire job and every consumer script that calls `docs-toolkit …` fails with `spawn ENOENT`.

Upstream context: [pnpm/pnpm#10524](https://github.com/pnpm/pnpm/issues/10524) — pnpm maintainer's stance is that this is intentional behavior, and the recommended fix is to commit a stable bin entry (placeholder or wrapper) so `pnpm install` can always create the symlink, even before `tsc` has run.

## Fix

Add a committed wrapper file at `packages/backend.ai-docs-toolkit/bin/docs-toolkit.js` and point the package's `bin` at it:

```js
#!/usr/bin/env node
import '../dist/cli.js';
```

Because the wrapper itself always exists, `pnpm install` always creates `node_modules/.bin/docs-toolkit` correctly — no more `ENOENT` warn, no need for any "rebuild + reinstall" dance. At run time the wrapper just hands off to the real CLI at `dist/cli.js`, which each consumer script ensures is built first via `pnpm run build:toolkit && docs-toolkit …`.

### Why this approach over alternatives

| Option | Trade-off |
|---|---|
| **Wrapper bin (this PR)** | One small committed file in the toolkit package, consumer scripts stay clean (`docs-toolkit pdf …`), no install-time warning, no extra CI dance. Recommended by pnpm upstream. |
| `node ../backend.ai-docs-toolkit/dist/cli.js …` in every consumer script | Spreads a workspace-relative path across 30+ script entries; package renames break them all at once; install-time warn stays cosmetic-but-present. |
| Commit a placeholder at `dist/cli.js` and partially `.gitignore` `dist/` | Partially-ignored build directory is a footgun for new contributors. |
| `prepare: pnpm run build` in toolkit | Slows down every `pnpm install` in the repo unconditionally; trips lifecycle hook quirks in workspace deps. |

## Files

- `packages/backend.ai-docs-toolkit/bin/docs-toolkit.js` — new committed wrapper that re-exports the built CLI.
- `packages/backend.ai-docs-toolkit/package.json` — `bin.docs-toolkit` points at `./bin/docs-toolkit.js`; `files` includes `bin`.
- `.github/workflows/package.yml` — drop the now-redundant `Build docs-toolkit and link CLI` step (was an attempted bin-relink workaround that didn't actually work under pnpm v11).

Consumer packages (`backend.ai-webui-docs`, `backend.ai-docs-toolkit-example`) are unchanged — they keep using `docs-toolkit …` as before.

## Verification

### Local reproducer (pnpm v11.1.1)

Fresh checkout, no `dist/`:

```bash
rm -rf node_modules packages/*/node_modules packages/backend.ai-docs-toolkit/dist
pnpm install --frozen-lockfile
# Before: [WARN] Failed to create bin … ENOENT
# After:  no warning; node_modules/.bin/docs-toolkit symlink exists
ls -la packages/backend.ai-webui-docs/node_modules/.bin/docs-toolkit
# → -rwxr-xr-x  …  docs-toolkit -> ../backend.ai-docs-toolkit/bin/docs-toolkit.js

pnpm --filter backend.ai-webui-docs run pdf:en
# → [en] Done: …/dist/Backend.AI_WebUI_User_Guide_…_en.pdf (22.9 MB)
# → PDF generation complete!
```

### Real CI

Dispatched the full `Build and Release Packages` workflow against this branch — [run 26063985593](https://github.com/lablup/backend.ai-webui/actions/runs/26063985593):

| Job | Result |
|---|---|
| **build_docs** | ✅ success (was failing on v26.4.8-rc.4) |
| build_web | ✅ success |
| build_desktop | ✅ success |
| build_mac | (running, unaffected by this change) |

`webui-docs-pdfs` artifact uploaded: **82 MB** (en/ko/ja/th PDFs all generated).

## Test plan

- [x] `build_docs` goes green on `workflow_dispatch` against this branch
- [x] `webui-docs-pdfs` artifact contains all four language PDFs
- [ ] Next tagged release attaches `*.pdf` assets to the GitHub Release