### PR TITLE
feat(FR-26): show error state on ProjectSelect when no accessible projects

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -43,6 +43,24 @@ const useStyles = createStyles(({ css, token }) => ({
         color: ${token.colorBgBase};
       }
     }
+
+    /* In ghost mode the border-color is hard-overridden with !important,
+       which would otherwise swallow antd's status="error" red border.
+       Restore the error treatment with a higher-specificity rule so a
+       ghost select (e.g. the header ProjectSelect) can still surface an
+       error state. */
+    &.ant-select.ant-select-status-error {
+      border-color: ${token.colorError} !important;
+
+      .ant-select-suffix {
+        color: ${token.colorError};
+      }
+
+      &:hover .ant-select-suffix,
+      &:active .ant-select-suffix {
+        color: ${token.colorError};
+      }
+    }
   `,
   customStyle: css`
     /* Hide selected value content (except search input) when the user is typing a search query.

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -7,6 +7,7 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
 import useControllableState_deprecated from '../hooks/useControllableState';
 import { useCurrentUserProjectRoles } from '../hooks/useCurrentUserProjectRoles';
+import { InfoCircleOutlined } from '@ant-design/icons';
 import { theme, Tooltip } from 'antd';
 import { BAIFlex, BAISelect, BAISelectProps } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -28,6 +29,7 @@ export interface ProjectSelectProps extends BAISelectProps {
   autoSelectDefault?: boolean;
   disableDefaultFilter?: boolean;
   lockedProjectTypes?: string[];
+  'aria-label'?: string;
 }
 
 const ProjectSelect: React.FC<ProjectSelectProps> = ({
@@ -35,6 +37,7 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
   domain,
   disableDefaultFilter,
   lockedProjectTypes,
+  'aria-label': ariaLabel,
   ...selectProps
 }) => {
   const { t } = useTranslation();
@@ -153,6 +156,13 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
     },
   );
 
+  const showNoProjectError =
+    !accessibleProjects?.length &&
+    !selectProps.disabled &&
+    !selectProps.loading;
+
+  const noAccessibleProjectsMessage = t('projectSelect.NoAccessibleProjects');
+
   return (
     <BAISelect
       onChange={(value, option) => {
@@ -169,6 +179,25 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
       options={
         _.size(groupOptions) > 1 ? groupOptions : groupOptions[0]?.options
       }
+      status={showNoProjectError ? 'error' : selectProps.status}
+      // Surface the empty-state reason on the focusable control itself,
+      // not only on the non-focusable suffix icon. `tooltip` wraps the
+      // whole BAISelect in an antd Tooltip (hover over the entire control,
+      // not just the tiny icon), and `aria-label` gives keyboard /
+      // screen-reader users a persistent accessible description that does
+      // not depend on the tooltip being open.
+      tooltip={
+        showNoProjectError ? noAccessibleProjectsMessage : selectProps.tooltip
+      }
+      aria-label={showNoProjectError ? noAccessibleProjectsMessage : ariaLabel}
+      suffixIcon={
+        showNoProjectError ? <InfoCircleOutlined /> : selectProps.suffixIcon
+      }
+      // Prevent the dropdown from opening in the empty-error state so it
+      // does not visually overlap the explanation tooltip. The tooltip
+      // alone communicates why the control is unusable; an empty popup
+      // beneath it just looks broken.
+      open={showNoProjectError ? false : selectProps.open}
     />
   );
 };

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2117,6 +2117,7 @@
     "RoleMember": "Mitglied"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Keine zugänglichen Projekte.",
     "ProjectAdminBadge": "Projektadministrator"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Μέλος"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Δεν υπάρχουν προσβάσιμα έργα.",
     "ProjectAdminBadge": "Διαχειριστής έργου"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2134,6 +2134,7 @@
     "RoleMember": "Member"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "No accessible projects.",
     "ProjectAdminBadge": "Project Admin"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Miembro"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "No hay proyectos accesibles.",
     "ProjectAdminBadge": "Administrador del proyecto"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Jäsen"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Ei saatavilla olevia projekteja.",
     "ProjectAdminBadge": "Projektin ylläpitäjä"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2117,6 +2117,7 @@
     "RoleMember": "Membre"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Aucun projet accessible.",
     "ProjectAdminBadge": "Administrateur de projet"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2118,6 +2118,7 @@
     "RoleMember": "Anggota"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Tidak ada proyek yang dapat diakses.",
     "ProjectAdminBadge": "Admin Proyek"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Nessun progetto accessibile.",
     "ProjectAdminBadge": "Amministratore del progetto"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2117,6 +2117,7 @@
     "RoleMember": "メンバー"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "アクセス可能なプロジェクトがありません。",
     "ProjectAdminBadge": "プロジェクト管理者"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2118,6 +2118,7 @@
     "RoleMember": "구성원"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "선택 가능한 프로젝트가 없습니다.",
     "ProjectAdminBadge": "프로젝트 관리자"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2116,6 +2116,7 @@
     "RoleMember": "Гишүүн"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Боломжтой төсөл байхгүй байна.",
     "ProjectAdminBadge": "Төслийн администратор"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Ahli"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Tiada projek yang boleh diakses.",
     "ProjectAdminBadge": "Pentadbir Projek"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2117,6 +2117,7 @@
     "RoleMember": "Członek"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Brak dostępnych projektów.",
     "ProjectAdminBadge": "Administrator projektu"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Nenhum projeto acessível.",
     "ProjectAdminBadge": "Administrador do projeto"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2117,6 +2117,7 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Nenhum projeto acessível.",
     "ProjectAdminBadge": "Administrador do projeto"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Участник"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Нет доступных проектов.",
     "ProjectAdminBadge": "Администратор проекта"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2117,6 +2117,7 @@
     "RoleMember": "สมาชิก"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "ไม่มีโปรเจกต์ที่สามารถเข้าถึงได้",
     "ProjectAdminBadge": "ผู้ดูแลโปรเจกต์"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Üye"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Erişilebilir proje bulunmuyor.",
     "ProjectAdminBadge": "Proje Yöneticisi"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2117,6 +2117,7 @@
     "RoleMember": "Thành viên"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "Không có dự án nào có thể truy cập.",
     "ProjectAdminBadge": "Quản trị dự án"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2117,6 +2117,7 @@
     "RoleMember": "成员"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "没有可访问的项目。",
     "ProjectAdminBadge": "项目管理员"
   },
   "prometheusQueryPreset": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2119,6 +2119,7 @@
     "RoleMember": "成員"
   },
   "projectSelect": {
+    "NoAccessibleProjects": "沒有可存取的專案。",
     "ProjectAdminBadge": "專案管理員"
   },
   "prometheusQueryPreset": {


### PR DESCRIPTION
> **Stacked on** #7469 (`chore: remove unused Alert import in VFolderNodes.tsx`) — merge that first.

Resolves #2933(FR-26)

## Summary

When the current user has no accessible projects in the current domain, `ProjectSelect` now visually and **accessibly** communicates the empty state:

- The select border switches to the error color via `status="error"`.
- The suffix arrow is replaced with an `InfoCircleOutlined` icon (visual cue).
- The explanation **"No accessible projects available."** (ko: "선택 가능한 프로젝트가 없습니다.") is attached to the focusable select control itself — via BAISelect's `tooltip` (hover over the whole control) and a persistent `aria-label` — so keyboard and screen-reader users can discover *why* it is in an error state, not just *that* it is.

The error treatment is suppressed while the select is `disabled` or `loading`, so existing UX is preserved:

- `WebUIHeader.tsx` — during project switching (`isProjectChanging`), the select is disabled+loading, so the error never flashes mid-switch.
- `UpdateUsersModal.tsx` — when no domain is picked yet, the field is disabled and the form-item already shows a "Please select a domain" warning; we don't compete with that.

## Why

`ProjectSelect` previously rendered as an empty dropdown with no indication of *why* it was empty. Users with no project membership (a real case after onboarding, after losing a project, or in a fresh domain) saw a normal-looking selector with nothing inside it. This change makes the empty state legible at a glance without a heavy error boundary fallback.

### Ghost-mode border fix (`BAISelect`)

The header `ProjectSelect` is rendered with `ghost`. `BAISelect`'s `ghostSelect` style hard-overrides `border-color` with `!important`, which swallowed antd's `status="error"` red border — so in the header (the primary use case) only the info icon appeared and the border stayed the ghost color. Added a higher-specificity `&.ant-select.ant-select-status-error` rule inside `ghostSelect` that restores the error border + suffix color. Normal (non-error) ghost selects are unaffected; no other ghost select uses `status="error"` today.

### Accessibility (Copilot review feedback)

The first revision exposed the reason only through a tooltip on the **non-focusable** suffix icon, so keyboard / screen-reader users got the error state without the reason. The message is now attached to the focusable control: `tooltip` (antd Tooltip over the whole select) for pointer users and a persistent `aria-label` (independent of tooltip open state) for assistive tech. The icon stays as a pure visual affordance.

## Changes

- `react/src/components/ProjectSelect.tsx` — derive `showNoProjectError = !accessibleProjects?.length && !disabled && !loading`; in the empty state forward `status="error"`, the `InfoCircleOutlined` suffix, and the explanation via BAISelect `tooltip` + `aria-label`. Preserves caller-supplied `status` / `suffixIcon` / `tooltip` / `aria-label` when not in the empty state.
- `packages/backend.ai-ui/src/components/BAISelect.tsx` — add an error-status override to the `ghostSelect` style so a ghost select can still surface a red error border (root cause of the header border not turning red).
- `resources/i18n/en.json`, `resources/i18n/ko.json` — add `projectSelect.NoAccessibleProjects` key. Other languages will be filled in by `/fw:i18n`.

## Test plan

- [ ] Header `ProjectSelect` in a domain with no accessible projects → red error border + info icon; hovering anywhere on the select shows the tooltip; the control exposes the reason as its accessible name.
- [ ] Tab to the header `ProjectSelect` with a screen reader in the no-project state → the reason is announced (not just "invalid").
- [ ] Header `ProjectSelect` during project switching (loading) → no error styling.
- [ ] `UpdateUsersModal` with no domain selected → field disabled, existing "Please select a domain" warning, no project-select error styling.
- [ ] `UpdateUsersModal` with a domain that has projects → normal selector, no error styling.
- [ ] `UserSettingModal` admin-edit flow with no accessible projects → error border + accessible reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
