### PR TITLE
fix(FR-2910): include FAILED_TO_START status in terminated replica filter

### DIFF
--- a/react/src/components/DeploymentReplicasTab.tsx
+++ b/react/src/components/DeploymentReplicasTab.tsx
@@ -43,7 +43,7 @@ import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 
 type ReplicaStatusCategory = 'running' | 'terminated';
 
-const TERMINATED_STATUSES = ['TERMINATED'] as const;
+const TERMINATED_STATUSES = ['TERMINATED', 'FAILED_TO_START'] as const;
 
 const buildStatusFilter = (category: ReplicaStatusCategory) =>
   category === 'terminated'


### PR DESCRIPTION
Resolves #7456 ([FR-2910](https://lablup.atlassian.net/browse/FR-2910))

## Summary

- Add `FAILED_TO_START` to `TERMINATED_STATUSES` in `DeploymentReplicasTab`
- Replicas that failed to start now appear under the terminated tab instead of the running tab
<img width="1499" height="662" alt="image" src="https://github.com/user-attachments/assets/898c4710-0ebc-459d-8837-422766dd80cb" />


## Test plan

- [ ] Open a deployment with replicas in FAILED_TO_START state
- [ ] Verify those replicas appear under the "Terminated" tab
- [ ] Verify the "Running" tab no longer shows FAILED_TO_START replicas

[FR-2910]: https://lablup.atlassian.net/browse/FR-2910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ