### PR TITLE
docs(FR-2912): document web commands and fix preview:html sidebar scroll

### DIFF
--- a/packages/backend.ai-docs-toolkit/README.md
+++ b/packages/backend.ai-docs-toolkit/README.md
@@ -18,6 +18,23 @@ pnpm build:web
 
 > See the example's [`README.md`](../backend.ai-docs-toolkit-example/README.md#using-the-example-outside-this-monorepo) for the standalone-repo recipe (the `pnpm --filter` build step needs to be replaced).
 
+### Troubleshooting: `docs-toolkit: not found`
+
+`docs-toolkit` is the `bin` of this workspace package. pnpm creates the `node_modules/.bin/docs-toolkit` symlink **at install time**, and only if the toolkit's compiled entrypoint (`dist/cli.js`) already exists. In a fresh clone or new git worktree, `pnpm install` usually runs *before* the toolkit is built, so pnpm skips the symlink. Building the toolkit afterwards (`pnpm --filter backend.ai-docs-toolkit build`) produces `dist/cli.js` but does **not** re-link the bin — so every `docs-toolkit …` invocation (including the `preview:html`, `build:web`, `serve:web` scripts) fails with `docs-toolkit: not found`.
+
+A plain `pnpm install` (even `pnpm install --force`) reports *"Already up to date"* and skips bin-linking, so it does not fix this. Re-link the bin by rebuilding the **consumer** package that depends on the toolkit:
+
+```bash
+# from the monorepo root — replace the package name with your docs package
+pnpm --filter backend.ai-webui-docs rebuild
+```
+
+Verify the command resolves:
+
+```bash
+pnpm --filter backend.ai-webui-docs exec docs-toolkit --help
+```
+
 ## Quick Start
 
 ```bash
@@ -34,6 +51,13 @@ docs-toolkit preview --mode document --lang ko
 
 # Preview (HTML, live-reload)
 docs-toolkit preview:html --lang en
+
+# Build a static multi-page website
+docs-toolkit build:web --lang all
+docs-toolkit build:web --lang en --optimize-images
+
+# Serve the static website (live-reload)
+docs-toolkit serve:web --lang en
 
 # Generate Claude AI agent files
 docs-toolkit agents
@@ -80,25 +104,44 @@ agents:
 |---------|-------------|
 | `docs-toolkit pdf` | Generate PDF documents |
 | `docs-toolkit preview` | PDF preview server with live-reload |
-| `docs-toolkit preview:html` | HTML preview server with live-reload |
+| `docs-toolkit preview:html` | HTML preview server with live-reload (no PDF) |
+| `docs-toolkit build:web` | Generate a static multi-page website |
+| `docs-toolkit serve:web` | Static website dev server with live-reload |
 | `docs-toolkit init` | Scaffold a new documentation project |
 | `docs-toolkit agents` | Generate Claude AI agent files from templates |
+| `docs-toolkit help` | Show the CLI help message |
 
 ### Common Options
 
 ```bash
 # PDF generation
-docs-toolkit pdf --lang <all|en|ko|...> --theme <name>
+docs-toolkit pdf --lang <all|en|ko|...> --theme <name> \
+  --chapters <comma,separated,names> --note <cover-page note>
 
 # PDF preview
 docs-toolkit preview --mode <sample|catalog|document> --lang <lang> --port <port>
 
 # HTML preview
-docs-toolkit preview:html --lang <lang> --port <port>
+docs-toolkit preview:html --mode <document|catalog> --lang <lang> --port <port>
+
+# Static website build
+docs-toolkit build:web --lang <all|en|ko|...> \
+  --strict|--no-strict --optimize-images --optimize-images-avif
+
+# Static website dev server
+docs-toolkit serve:web --lang <lang> --port <port>
 
 # Agent generation
 docs-toolkit agents --force   # overwrite existing files
 ```
+
+Notes:
+
+- `pdf --chapters` limits the build to the listed chapter names (default: all chapters).
+- `pdf --note` prints a short note on the cover page (e.g. `"Draft — internal review"`).
+- `build:web --strict` (default) fails the build on broken links; `--no-strict` downgrades them to warnings.
+- `build:web --optimize-images` generates `.webp` variants for PNGs over 50 KB and wraps them in `<picture>`; `--optimize-images-avif` adds `.avif` variants. Both require the optional `sharp` peer dependency.
+- Default ports: `preview` → `3456`, `preview:html` → `3457`, `serve:web` → `3458`.
 
 ## Agent Template System
 
@@ -171,12 +214,18 @@ import {
   loadToolkitConfig,
   resolveConfig,
   generatePdf,
+  generateWebsite,
   startPreviewServer,
   startHtmlPreviewServer,
 } from 'backend.ai-docs-toolkit';
 
 const config = resolveConfig(loadToolkitConfig(process.cwd()));
+
+// PDF (CLI equivalent: docs-toolkit pdf --lang en)
 await generatePdf(config, { lang: 'en' });
+
+// Static website (CLI equivalent: docs-toolkit build:web --lang all)
+await generateWebsite(config, { lang: 'all', optimizeImages: true });
 ```
 
 ## Consumer Project Structure

--- a/packages/backend.ai-docs-toolkit/src/html-builder-web.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/html-builder-web.test.ts
@@ -59,3 +59,23 @@ test("buildWebDocument — works without config (preview-mode default branding)"
   const html = buildWebDocument(sampleChapters, meta);
   assert.ok(html.length > 0);
 });
+
+test("buildWebDocument — wraps sidebar nav inside .doc-sidebar__scroll (FR-2768 regression guard)", () => {
+  // FR-2768 made .doc-sidebar a fixed-height, overflow:hidden flex column and
+  // delegated scrolling to an inner .doc-sidebar__scroll element. If the nav
+  // is not wrapped in that element, the sidebar can't scroll on overflow.
+  const html = buildWebDocument(sampleChapters, meta);
+
+  const sidebarMatch = html.match(/<aside class="doc-sidebar">[\s\S]*?<\/aside>/);
+  assert.ok(sidebarMatch, ".doc-sidebar aside not found");
+  const sidebarHtml = sidebarMatch[0];
+
+  const scrollIdx = sidebarHtml.indexOf('class="doc-sidebar__scroll"');
+  const navIdx = sidebarHtml.indexOf('class="doc-sidebar-nav"');
+  assert.notStrictEqual(scrollIdx, -1, ".doc-sidebar__scroll wrapper missing from sidebar");
+  assert.notStrictEqual(navIdx, -1, ".doc-sidebar-nav missing from sidebar");
+  assert.ok(
+    scrollIdx < navIdx,
+    ".doc-sidebar-nav must be nested inside the .doc-sidebar__scroll wrapper",
+  );
+});

--- a/packages/backend.ai-docs-toolkit/src/html-builder-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/html-builder-web.ts
@@ -3,6 +3,7 @@
  * Builds a styled page layout with sidebar TOC and main content.
  */
 
+import fs from 'fs';
 import type { Chapter } from './markdown-processor.js';
 import { generateWebStyles } from './styles-web.js';
 import type { ResolvedDocConfig } from './config.js';
@@ -11,6 +12,64 @@ export interface WebDocMetadata {
   title: string;
   version: string;
   lang: string;
+}
+
+function buildPreviewTopbar(
+  metadata: WebDocMetadata,
+  config?: ResolvedDocConfig,
+): string {
+  // Read logo SVG from the filesystem and inline as a base64 data URI so
+  // the preview server doesn't need a separate static-asset route.
+  const readLogoB64 = (absPath: string | null): string | null => {
+    if (!absPath) return null;
+    try {
+      return Buffer.from(fs.readFileSync(absPath, 'utf-8')).toString('base64');
+    } catch {
+      return null;
+    }
+  };
+
+  const lightB64 = config ? readLogoB64(config.branding.logoLight) : null;
+  const darkB64 = config ? readLogoB64(config.branding.logoDark) : null;
+
+  let brandLogoHtml: string;
+  if (lightB64) {
+    const lightSrc = `data:image/svg+xml;base64,${lightB64}`;
+    const alt = metadata.title;
+    if (darkB64 && darkB64 !== lightB64) {
+      const darkSrc = `data:image/svg+xml;base64,${darkB64}`;
+      brandLogoHtml =
+        `<img class="bai-brand-logo bai-brand-logo--light" src="${lightSrc}" alt="${alt}" />` +
+        `<img class="bai-brand-logo bai-brand-logo--dark" src="${darkSrc}" alt="${alt}" />`;
+    } else {
+      brandLogoHtml = `<img class="bai-brand-logo" src="${lightSrc}" alt="${alt}" />`;
+    }
+  } else {
+    brandLogoHtml = `<span class="bai-brand-fallback">${metadata.title}</span>`;
+  }
+
+  const subLabelMap = config?.branding.subLabel ?? {};
+  const subLabel = subLabelMap[metadata.lang] ?? subLabelMap['default'] ?? '';
+  const subLabelHtml = subLabel
+    ? `<span class="bai-brand-divider" aria-hidden="true"></span><span class="bai-brand-sub">${subLabel}</span>`
+    : '';
+
+  const versionPillHtml = `<span class="bai-brand-version">${metadata.version}</span>`;
+
+  const themeIconLight = `<svg class="bai-theme-icon bai-theme-icon--light" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.8"/><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" d="M12 3v2M12 19v2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M3 12h2M19 12h2M5.6 18.4 7 17M17 7l1.4-1.4"/></svg>`;
+  const themeIconDark = `<svg class="bai-theme-icon bai-theme-icon--dark" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"/></svg>`;
+  const themeToggleHtml = `<button class="bai-iconbtn" type="button" data-theme-toggle aria-label="Toggle dark mode">${themeIconLight}${themeIconDark}</button>`;
+
+  return `<header class="bai-topbar" role="banner">
+  <a class="bai-topbar__brand" href="#">
+    ${brandLogoHtml}
+    ${subLabelHtml}
+    ${versionPillHtml}
+  </a>
+  <div class="bai-topbar__actions">
+    ${themeToggleHtml}
+  </div>
+</header>`;
 }
 
 function buildSidebarHtml(
@@ -44,15 +103,24 @@ function buildSidebarHtml(
     })
     .join('\n');
 
+  // FR-2768 made .doc-sidebar a fixed-height, overflow:hidden flex column
+  // and delegated scrolling to an inner .doc-sidebar__scroll element (see
+  // styles-web.ts). website-builder.ts emits that wrapper; this legacy
+  // single-page preview builder must too, otherwise the nav overflows a
+  // clipped container with no scrollport and the sidebar can't scroll.
+  // .doc-sidebar-header is display:none in Phase 2, so leaving it outside
+  // the scrollport mirrors the pinned version block in website-builder.ts.
   return `
 <aside class="doc-sidebar">
   <div class="doc-sidebar-header">
     <h2>${metadata.title}</h2>
     <div class="doc-meta">${metadata.version} &middot; ${langLabel}</div>
   </div>
-  <ul class="doc-sidebar-nav">
-    ${navItems}
-  </ul>
+  <div class="doc-sidebar__scroll">
+    <ul class="doc-sidebar-nav">
+      ${navItems}
+    </ul>
+  </div>
 </aside>`;
 }
 
@@ -70,6 +138,17 @@ function buildLiveReloadScript(): string {
   return `
 <script>
 (function() {
+  // Theme toggle — production uses interactions.js; preview uses this inline stub.
+  const stored = localStorage.getItem('bai-theme');
+  if (stored) document.documentElement.setAttribute('data-theme', stored);
+  document.addEventListener('click', function(e) {
+    if (e.target.closest('[data-theme-toggle]')) {
+      const next = (document.documentElement.getAttribute('data-theme') || 'light') === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('bai-theme', next);
+    }
+  });
+
   let lastEtag = '';
   async function poll() {
     try {
@@ -123,6 +202,7 @@ export function buildWebDocument(
         }
       : undefined,
   );
+  const topbar = buildPreviewTopbar(metadata, config);
   const sidebar = buildSidebarHtml(chapters, metadata, config);
   const content = buildContentHtml(chapters);
   const liveReload = buildLiveReloadScript();
@@ -143,6 +223,7 @@ export function buildWebDocument(
   <style>${styles}</style>
 </head>
 <body>
+${topbar}
 <div class="doc-page">
   ${sidebar}
   <main class="doc-main">


### PR DESCRIPTION
Resolves #7461 ([FR-2912](https://lablup.atlassian.net/browse/FR-2912))

> **Stacked on** #7450 (`docs(misc): document Re-Login Required notification after main keypair change`).

## Summary

Documentation update to the `backend.ai-docs-toolkit` package README, plus a small fix for the `preview:html` sidebar that broke after FR-2768.

### README updates

- Add `docs-toolkit build:web` and `docs-toolkit serve:web` to the usage block and the command table.
- Expand **Common Options**: `pdf --chapters/--note`, `build:web --strict/--no-strict/--optimize-images/--optimize-images-avif`, and default ports for `preview`/`preview:html`/`serve:web`.
- Add a `generateWebsite` example to the programmatic API section.
- Clarify `preview:html` (no PDF) and add `docs-toolkit help` to the table.
- Add a **Troubleshooting: `docs-toolkit: not found`** subsection — explains why pnpm skips the `docs-toolkit` bin symlink on fresh clones/worktrees (install runs before `dist/cli.js` is built), why `pnpm install`/`--force` does not fix it ("Already up to date" skips bin-linking), and the `pnpm --filter <docs-pkg> rebuild` fix plus a verify command.

### preview:html sidebar fix

- Wrap the nav list in `.doc-sidebar__scroll` in `html-builder-web.ts` to mirror `website-builder.ts`. FR-2768 made `.doc-sidebar` a fixed-height `overflow:hidden` flex column and delegated scrolling to an inner `.doc-sidebar__scroll` element (`styles-web.ts`). `website-builder.ts` (`build:web`/`serve:web`) emits that wrapper, but the legacy single-page preview builder (`html-builder-web.ts`, used by `preview:html`/`preview:html:ko`) was never updated, so the nav overflowed a clipped container with no scrollport and the sidebar could not scroll.

[FR-2912]: https://lablup.atlassian.net/browse/FR-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ