### PR TITLE
fix(FR-2914): scope deployment add-revision model folder picker to current project

### DIFF
--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -21,7 +21,7 @@ import {
   reverseMapExtraArgs,
 } from '../helper/runtimeExtraArgsParser';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
-import { useModelStoreProject } from '../hooks/useModelStoreProject';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import {
   buildArgsSchemaKeySet,
   buildDefaultsMap,
@@ -71,10 +71,11 @@ import {
   BAIFlex,
   BAIModal,
   BAIModalProps,
-  BAIProjectVfolderSelect,
   BAIRuntimeVariantSelect,
+  BAIVFolderSelect,
   convertToUUID,
   safeDecodeUuid,
+  toGlobalId,
   toLocalId,
   useBAILogger,
 } from 'backend.ai-ui';
@@ -180,10 +181,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
   const { token } = theme.useToken();
   const { message } = App.useApp();
   const relayEnvironment = useRelayEnvironment();
-  // The model folder picker scopes to the MODEL_STORE project, not the
-  // deployment's own project — model cards live in the domain-wide model
-  // store regardless of which project owns the deployment.
-  const { id: modelStoreProjectId } = useModelStoreProject();
+  // The model folder picker scopes to the user's current project so the
+  // listing matches what the user has access to in the active project
+  // context, consistent with the rest of the model-deployment UI
+  // (ServiceLauncherPageContent, ModelCardDeployModal).
+  const { id: currentProjectId } = useCurrentProjectValue();
   const { logger } = useBAILogger();
 
   // Defer `open` so the lazy query only fires once the modal has actually
@@ -263,7 +265,6 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
       query DeploymentAddRevisionModalQuery($deploymentId: ID!) {
         deployment(id: $deploymentId) {
           metadata {
-            projectId
             resourceGroupName
           }
           currentRevision {
@@ -392,8 +393,12 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
   // The parent deployment's vfolder is the default Model Folder. Users can
   // override it in this mode (in contrast to the VFolder/ModelStore entry
   // point where the folder is locked in by context).
-  const defaultModelFolderId =
-    currentRevision?.modelMountConfig?.vfolderId ?? undefined;
+  const defaultModelFolderId = currentRevision?.modelMountConfig?.vfolderId
+    ? toGlobalId(
+        'VirtualFolderNode',
+        currentRevision?.modelMountConfig?.vfolderId,
+      )
+    : undefined;
 
   // The `BAIAvailablePresetSelect` paginates independently of this modal's
   // main query (it can scroll past the first page on demand), so the user
@@ -758,10 +763,9 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
           ]),
       ),
       runtimeVariantId: rev.modelRuntimeConfig?.runtimeVariantId ?? undefined,
-      // BAIProjectVfolderSelect returns the canonical dashed UUID, which
-      // matches `rev.modelMountConfig.vfolderId` directly. `convertToUUID`
-      // in the submit is idempotent on already-dashed values.
-      modelFolderId: rev.modelMountConfig?.vfolderId ?? undefined,
+      modelFolderId: rev.modelMountConfig?.vfolderId
+        ? toGlobalId('VirtualFolderNode', rev.modelMountConfig.vfolderId)
+        : undefined,
       mountDestination: rev.modelMountConfig?.mountDestination ?? '/models',
       definitionPath: rev.modelMountConfig?.definitionPath ?? undefined,
       // `ImageEnvironmentSelectFormItems` matches the form's
@@ -1021,7 +1025,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
               environEntries.length > 0 ? { entries: environEntries } : null,
           },
           modelMountConfig: {
-            vfolderId: convertToUUID(values.modelFolderId),
+            vfolderId: toLocalId(values.modelFolderId),
             mountDestination,
             definitionPath: values.definitionPath,
           },
@@ -1072,7 +1076,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
           deploymentId: toLocalId(deploymentId) ?? deploymentId,
           revisionPresetId: values.revisionPresetId,
           modelMountConfig: {
-            vfolderId: convertToUUID(values.modelFolderId),
+            vfolderId: toLocalId(values.modelFolderId),
             mountDestination: '/models',
           },
           options: { autoActivate },
@@ -1273,13 +1277,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
               tooltip={t('deployment.ModelFolderTooltip')}
               rules={[{ required: true }]}
             >
-              <BAIProjectVfolderSelect
-                projectId={modelStoreProjectId ?? ''}
-                disabled={!modelStoreProjectId}
-                filter={{
-                  usageMode: { equals: 'MODEL' },
-                  status: { equals: 'READY' },
-                }}
+              <BAIVFolderSelect
+                currentProjectId={currentProjectId ?? undefined}
+                disabled={!currentProjectId}
+                excludeDeleted
+                filter='usage_mode == "model"'
                 style={{ width: '100%' }}
               />
             </Form.Item>
@@ -1332,13 +1334,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
             tooltip={t('deployment.ModelFolderTooltip')}
             rules={[{ required: true }]}
           >
-            <BAIProjectVfolderSelect
-              projectId={modelStoreProjectId ?? ''}
-              disabled={!modelStoreProjectId}
-              filter={{
-                usageMode: { equals: 'MODEL' },
-                status: { equals: 'READY' },
-              }}
+            <BAIVFolderSelect
+              currentProjectId={currentProjectId ?? undefined}
+              disabled={!currentProjectId}
+              excludeDeleted
+              filter='usage_mode == "model"'
               style={{ width: '100%' }}
             />
           </Form.Item>
@@ -1592,7 +1592,10 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                       {({ getFieldValue }: FormInstance<FormValues>) => {
                         const modelFolderId = getFieldValue('modelFolderId');
                         const modelFolderIdNoDash = modelFolderId
-                          ? String(modelFolderId).replace(/-/g, '')
+                          ? safeDecodeUuid(String(modelFolderId))?.replace(
+                              /-/g,
+                              '',
+                            )
                           : undefined;
                         return (
                           <VFolderTableFormItem


### PR DESCRIPTION
Resolves #7464 ([FR-2914](https://lablup.atlassian.net/browse/FR-2914))

## Summary
- Switch both the preset-mode and advanced (custom)-mode model folder pickers in `DeploymentAddRevisionModal` from `BAIProjectVfolderSelect` (which forces the MODEL_STORE project) to `BAIVFolderSelect` scoped to the user's current project.
- Call signature: `currentProjectId={useCurrentProjectValue().id}`, `filter='usage_mode == "model"'`, `excludeDeleted`. The add-revision flow is part of an existing deployment in the user's active project, so listing the user's current-project vfolders is the natural choice and matches the rest of the model-deployment UI (`ServiceLauncherPageContent`, `ModelCardDeployModal`).
- `BAIVFolderSelect` works in GlobalID space (`VirtualFolderNode:<uuid>`), so prefill now wraps `rev.modelMountConfig.vfolderId` with `toGlobalId('VirtualFolderNode', ...)` and submit unwraps it back with `toLocalId(values.modelFolderId)` to get the dashed UUID the backend expects. The old `convertToUUID` call is dropped.
- The advanced tab's `VFolderTableFormItem` also needs `modelFolderIdNoDash` to be a real UUID, so the `String(modelFolderId).replace(/-/g, '')` path is replaced with `safeDecodeUuid(...)?.replace(/-/g, '')` to decode the GlobalID first.
- Drop the now-dead `deployment.metadata.projectId` field from the query.
- (Drive-by) Remove the unused `Alert` import from `VFolderNodes.tsx` so the pre-commit lint-staged hook (`eslint --max-warnings=0` over `./src`) does not block the commit.

## Test plan
- [ ] Open the "Add Revision" modal from a deployment detail page and verify that the **Preset** tab's Model Folder dropdown lists vfolders from the user's current project.
- [ ] In the same modal, verify the **Advanced** (custom) tab lists the same set of current-project vfolders.
- [ ] In both modes, pick a vfolder, fill in preset/custom inputs, and confirm Add succeeds (the submit payload's `vfolderId` should be a plain dashed UUID).
- [ ] In the Advanced tab, hit "Load current revision" and confirm the existing revision's vfolder is prefilled correctly.
- [ ] In the Advanced tab, confirm the model file picker (`VFolderTableFormItem`) still renders the selected vfolder's file list.

[FR-2914]: https://lablup.atlassian.net/browse/FR-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ