### PR TITLE
feat(FR-2915): add showOpen/showCreate/showRefresh buttons to BAIVFolderSelect

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.stories.tsx
@@ -111,6 +111,9 @@ const meta: Meta<typeof BAIVFolderSelect> = {
 | \`filter\` | \`string\` | - | Additional filter string for vfolder query |
 | \`valuePropName\` | \`'id' \\| 'row_id'\` | \`'id'\` | Which field to use as option value |
 | \`excludeDeleted\` | \`boolean\` | \`false\` | Exclude deleted or deleting vfolders |
+| \`showOpenButton\` | \`boolean\` | \`false\` | Show button that opens the selected folder in the explorer |
+| \`showCreateButton\` | \`boolean\` | \`false\` | Show button that opens \`FolderCreateModalV2\` to create a new folder |
+| \`showRefreshButton\` | \`boolean\` | \`false\` | Show button that re-fetches the vfolder list |
 | \`ref\` | \`React.Ref<BAIVFolderSelectRef>\` | - | Ref exposing \`refetch()\` method |
 
 ## Features
@@ -249,6 +252,31 @@ For all other props, refer to [BAISelect](/?path=/docs/components-input-baiselec
     excludeDeleted: {
       control: { type: 'boolean' },
       description: 'Exclude deleted or deleting vfolders from the list',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    showOpenButton: {
+      control: { type: 'boolean' },
+      description: 'Show button that opens the selected folder in the explorer',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    showCreateButton: {
+      control: { type: 'boolean' },
+      description:
+        'Show button that opens FolderCreateModalV2 to create a new folder',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    showRefreshButton: {
+      control: { type: 'boolean' },
+      description: 'Show button that re-fetches the vfolder list',
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'false' },
@@ -414,6 +442,41 @@ export const WithClickableNames: Story = {
         onClickVFolder={(id: string) => alert(`Clicked vfolder: ${id}`)}
         style={{ width: '400px' }}
       />
+    </VFolderRelayResolver>
+  ),
+};
+
+/**
+ * Select with the open, create, and refresh action buttons enabled.
+ */
+export const WithActionButtons: Story = {
+  name: 'WithActionButtons',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates `showOpenButton`, `showCreateButton`, and `showRefreshButton`. The open button writes a `folder` query param via `react-router-dom`. The create button opens the project `FolderCreateModalV2`. The refresh button re-fetches the paginated list.',
+      },
+    },
+  },
+  args: {
+    allowClear: true,
+    showOpenButton: true,
+    showCreateButton: true,
+    showRefreshButton: true,
+  },
+  render: (args) => (
+    <VFolderRelayResolver
+      mockResolvers={{
+        Query: () => ({
+          vfolder_nodes: {
+            count: 5,
+            edges: sampleVFolders,
+          },
+        }),
+      }}
+    >
+      <BAIVFolderSelect {...args} style={{ width: '400px' }} />
     </VFolderRelayResolver>
   ),
 };

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
@@ -1,17 +1,21 @@
+import FolderCreateModalV2 from '../../../../../react/src/components/FolderCreateModalV2';
 import { BAIVFolderSelectPaginatedQuery } from '../../__generated__/BAIVFolderSelectPaginatedQuery.graphql';
 import { BAIVFolderSelectValueQuery } from '../../__generated__/BAIVFolderSelectValueQuery.graphql';
 import { toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAIFlex from '../BAIFlex';
 import BAILink from '../BAILink';
 import { mergeFilterValues } from '../BAIPropertyFilter';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import BAIText from '../BAIText';
 import TotalFooter from '../TotalFooter';
+import { ReloadOutlined } from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
-import { GetRef, Skeleton } from 'antd';
+import { Button, GetRef, Skeleton, Space, Tooltip } from 'antd';
 import * as _ from 'lodash-es';
+import { FolderOpenIcon, PlusIcon } from 'lucide-react';
 import {
   useDeferredValue,
   useEffect,
@@ -23,6 +27,7 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import { useSearchParams } from 'react-router-dom';
 
 export type VFolderNode = NonNullable<
   NonNullable<
@@ -44,6 +49,9 @@ export interface BAIVFolderSelectProps extends Omit<
   valuePropName?: 'id' | 'row_id';
   excludeDeleted?: boolean;
   onResolvedNamesChange?: (nameMap: Record<string, string>) => void;
+  showOpenButton?: boolean;
+  showCreateButton?: boolean;
+  showRefreshButton?: boolean;
   ref?: React.Ref<BAIVFolderSelectRef>;
 }
 
@@ -59,6 +67,9 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
   excludeDeleted,
   valuePropName = 'id',
   onResolvedNamesChange,
+  showOpenButton,
+  showCreateButton,
+  showRefreshButton,
   ref,
   labelRender: userLabelRender,
   ...selectProps
@@ -66,6 +77,8 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
   'use memo';
   const { t } = useTranslation();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [, setSearchParams] = useSearchParams();
+  const [isOpenCreateModal, setIsOpenCreateModal] = useState(false);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined
   >(selectProps);
@@ -261,7 +274,13 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
     controllableValueWithLabel,
   );
 
-  return (
+  const hasActionButton =
+    showOpenButton || showCreateButton || showRefreshButton;
+  const singleValueForOpen = _.toString(
+    _.isArray(controllableValue) ? controllableValue[0] : controllableValue,
+  );
+
+  const baiSelectElement = (
     <BAISelect
       ref={selectRef}
       placeholder={t('comp:BAIVFolderSelect.SelectFolder')}
@@ -391,6 +410,79 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
         ) : undefined
       }
     />
+  );
+
+  if (!hasActionButton) {
+    return baiSelectElement;
+  }
+
+  return (
+    <BAIFlex direction="row" gap="xs">
+      {baiSelectElement}
+      <Space.Compact>
+        {showOpenButton ? (
+          <Tooltip title={t('comp:BAIVFolderSelect.OpenFolder')}>
+            <Button
+              icon={<FolderOpenIcon />}
+              disabled={!singleValueForOpen}
+              onClick={() => {
+                const folderId =
+                  valuePropName === 'id'
+                    ? toLocalId(singleValueForOpen)
+                    : singleValueForOpen;
+                if (folderId) {
+                  setSearchParams(
+                    (prev) => {
+                      prev.set('folder', folderId);
+                      return prev;
+                    },
+                    { replace: false },
+                  );
+                }
+              }}
+            />
+          </Tooltip>
+        ) : null}
+        {showCreateButton ? (
+          <Tooltip title={t('comp:BAIVFolderSelect.CreateANewStorageFolder')}>
+            <Button
+              icon={<PlusIcon />}
+              variant="text"
+              onClick={() => {
+                setIsOpenCreateModal(true);
+              }}
+            />
+          </Tooltip>
+        ) : null}
+        {showRefreshButton ? (
+          <Tooltip title={t('comp:BAIVFolderSelect.Refresh')}>
+            <Button
+              icon={<ReloadOutlined />}
+              variant="text"
+              onClick={() => {
+                startRefetchTransition(() => {
+                  updateFetchKey();
+                });
+              }}
+            />
+          </Tooltip>
+        ) : null}
+      </Space.Compact>
+      {showCreateButton ? (
+        <FolderCreateModalV2
+          open={isOpenCreateModal}
+          initialValues={{ usage_mode: 'model' }}
+          onRequestClose={(result) => {
+            setIsOpenCreateModal(false);
+            if (result) {
+              startRefetchTransition(() => {
+                updateFetchKey();
+              });
+            }
+          }}
+        />
+      ) : null}
+    </BAIFlex>
   );
 };
 

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -310,6 +310,9 @@
     "SelectUser": "Benutzer auswählen"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Erstellen Sie einen neuen Speicherordner",
+    "OpenFolder": "Zum Ordner gehen",
+    "Refresh": "Aktualisierung",
     "SelectFolder": "Ordner auswählen"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -310,6 +310,9 @@
     "SelectUser": "Επιλογή χρήστη"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Δημιουργήστε έναν νέο φάκελο αποθήκευσης",
+    "OpenFolder": "Μετάβαση στον φάκελο",
+    "Refresh": "Φρεσκάρω",
     "SelectFolder": "Επιλογή φακέλου"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -316,6 +316,9 @@
     "SelectUser": "Select User"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Create a new storage folder",
+    "OpenFolder": "Open Folder",
+    "Refresh": "Refresh",
     "SelectFolder": "Select Folder"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -310,6 +310,9 @@
     "SelectUser": "Seleccionar usuario"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Crear una nueva carpeta de almacenamiento",
+    "OpenFolder": "Ir a la carpeta",
+    "Refresh": "Actualizar",
     "SelectFolder": "Seleccionar carpeta"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -310,6 +310,9 @@
     "SelectUser": "Valitse käyttäjä"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Luo uusi tallennuskansio",
+    "OpenFolder": "Siirry kansioon",
+    "Refresh": "Päivitä",
     "SelectFolder": "Valitse kansio"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -310,6 +310,9 @@
     "SelectUser": "Sélectionner un utilisateur"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Créer un nouveau dossier de stockage",
+    "OpenFolder": "Aller au dossier",
+    "Refresh": "Rafraîchir",
     "SelectFolder": "Sélectionner un dossier"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -310,6 +310,9 @@
     "SelectUser": "Pilih Pengguna"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Buat folder penyimpanan baru",
+    "OpenFolder": "Buka folder",
+    "Refresh": "Segarkan",
     "SelectFolder": "Pilih Folder"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -310,6 +310,9 @@
     "SelectUser": "Seleziona utente"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Crea una nuova cartella di archiviazione",
+    "OpenFolder": "Vai alla cartella",
+    "Refresh": "ricaricare",
     "SelectFolder": "Seleziona cartella"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -310,6 +310,9 @@
     "SelectUser": "ユーザーを選択"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "新規ストレージフォルダー作成",
+    "OpenFolder": "フォルダーに移動",
+    "Refresh": "更新",
     "SelectFolder": "フォルダを選択"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -313,6 +313,9 @@
     "SelectUser": "사용자를 선택해주세요"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "새 폴더 추가",
+    "OpenFolder": "폴더 열기",
+    "Refresh": "새로고침",
     "SelectFolder": "폴더를 선택해주세요"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -310,6 +310,9 @@
     "SelectUser": "Хэрэглэгч сонгох"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Шинэ хадгалах фолдер үүсгэх",
+    "OpenFolder": "Хавтас руу очих",
+    "Refresh": "Сэргээх",
     "SelectFolder": "Хавтас сонгох"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -310,6 +310,9 @@
     "SelectUser": "Pilih Pengguna"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Buat folder storan baru",
+    "OpenFolder": "Pergi ke folder",
+    "Refresh": "Segarkan",
     "SelectFolder": "Pilih Folder"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -310,6 +310,9 @@
     "SelectUser": "Wybierz użytkownika"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Utwórz nowy folder przechowywania",
+    "OpenFolder": "Przejdź do folderu",
+    "Refresh": "Odświeżać",
     "SelectFolder": "Wybierz folder"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -307,6 +307,9 @@
     "SelectUser": "Selecionar usuário"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Crie uma nova pasta de armazenamento",
+    "OpenFolder": "Ir para a pasta",
+    "Refresh": "Atualizar",
     "SelectFolder": "Selecionar pasta"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -310,6 +310,9 @@
     "SelectUser": "Selecionar usuário"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Crie uma nova pasta de armazenamento",
+    "OpenFolder": "Ir para a pasta",
+    "Refresh": "Atualizar",
     "SelectFolder": "Selecionar pasta"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -310,6 +310,9 @@
     "SelectUser": "Выберите пользователя"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Создать новую папку для хранения",
+    "OpenFolder": "Перейти в папку",
+    "Refresh": "Обновить",
     "SelectFolder": "Выбрать папку"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -310,6 +310,9 @@
     "SelectUser": "เลือกผู้ใช้"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "สร้างโฟลเดอร์จัดเก็บใหม่",
+    "OpenFolder": "ไปยังโฟลเดอร์",
+    "Refresh": "รีเฟรช",
     "SelectFolder": "เลือกโฟลเดอร์"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -310,6 +310,9 @@
     "SelectUser": "Kullanıcıyı Seç"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Yeni bir depolama klasörü oluşturun",
+    "OpenFolder": "Klasöre git",
+    "Refresh": "Yenile",
     "SelectFolder": "Klasör Seç"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -310,6 +310,9 @@
     "SelectUser": "Chọn người dùng"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "Tạo một thư mục lưu trữ mới",
+    "OpenFolder": "Đi tới thư mục",
+    "Refresh": "Làm tươi",
     "SelectFolder": "Chọn thư mục"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -310,6 +310,9 @@
     "SelectUser": "选择用户"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "创建一个新的存储文件夹",
+    "OpenFolder": "前往文件夹",
+    "Refresh": "刷新",
     "SelectFolder": "选择文件夹"
   },
   "comp:FileExplorer": {

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -310,6 +310,9 @@
     "SelectUser": "選擇使用者"
   },
   "comp:BAIVFolderSelect": {
+    "CreateANewStorageFolder": "創建一個新的存儲文件夾",
+    "OpenFolder": "前往資料夾",
+    "Refresh": "刷新",
     "SelectFolder": "選擇資料夾"
   },
   "comp:FileExplorer": {

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -1281,6 +1281,9 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                 valuePropName="row_id"
                 labelRender={({ label, value }) => label ?? value}
                 style={{ width: '100%' }}
+                showOpenButton
+                showCreateButton
+                showRefreshButton
               />
             </Form.Item>
           </Form>
@@ -1339,6 +1342,9 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
               valuePropName="row_id"
               labelRender={({ label, value }) => label ?? value}
               style={{ width: '100%' }}
+              showOpenButton
+              showCreateButton
+              showRefreshButton
             />
           </Form.Item>
           <Form.Item


### PR DESCRIPTION
Resolves #7467 ([FR-2915](https://lablup.atlassian.net/browse/FR-2915))

## Summary

Adds the three action-button props (`showOpenButton`, `showCreateButton`, `showRefreshButton`) from the legacy `react/src/components/VFolderSelect.tsx` onto the shared `BAIVFolderSelect` fragment in `backend.ai-ui`, and wires them in both modes of `DeploymentAddRevisionModal`.

- `BAIVFolderSelect`
  - New boolean props render a `Space.Compact` with up to three buttons next to the select.
  - **Open**: writes the selected folder UUID (local id, via `toLocalId` when `valuePropName === 'id'`) to the `folder` URL search param (`react-router-dom`'s `useSearchParams` — mirrors `useFolderExplorerOpener`).
  - **Create**: opens `FolderCreateModalV2` (cross-package import, same pattern as `BAIDynamicStepInputNumber`) pre-filled with `usage_mode: 'model'`. On success the paginated query refetches under a transition.
  - **Refresh**: re-runs the paginated query via the existing `useFetchKey`/`startRefetchTransition` plumbing.
- Storybook
  - Documents the three new props in the BAI-Specific Props table.
  - Adds `WithActionButtons` story.
- i18n
  - Adds `comp:BAIVFolderSelect.OpenFolder`, `CreateANewStorageFolder`, `Refresh` to all 21 `backend.ai-ui` locale files, reusing wording from the main `resources/i18n` translations where they already exist.
- `DeploymentAddRevisionModal`
  - Both `BAIVFolderSelect` usages (preset and advanced modes) now pass `showOpenButton showCreateButton showRefreshButton`.

Stacked on top of #7465 (FR-2914 — scope add-revision model folder picker to the current project).

## Test plan

- [ ] Storybook `Fragments/BAIVFolderSelect` `WithActionButtons` story renders the three buttons next to the select.
- [ ] In `DeploymentAddRevisionModal` (preset and advanced modes):
  - [ ] Refresh button re-runs the paginated query.
  - [ ] Create button opens `FolderCreateModalV2`; creating a new model folder refetches and the new folder appears in the list.
  - [ ] Open button is disabled when no folder is selected; once selected, clicking sets `?folder=<uuid>` so the explorer opens that folder.
- [ ] All 21 locale files include the three new keys.

[FR-2915]: https://lablup.atlassian.net/browse/FR-2915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ