### PR TITLE
chore(FR-2917): remove unused Alert import in VFolderNodes.tsx

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -21,7 +21,7 @@ import VFolderNodeIdenticon from './VFolderNodeIdenticon';
 import VFolderPermissionCell from './VFolderPermissionCell';
 import { DeleteFilled, DeleteOutlined, UserOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { Alert, App, theme, Typography } from 'antd';
+import { App, theme, Typography } from 'antd';
 import {
   filterOutNullAndUndefined,
   BAIEndpointsIcon,


### PR DESCRIPTION
Resolves #7471(FR-2917)

## Summary

Removes an unused `Alert` import from `react/src/components/VFolderNodes.tsx`.

`Alert` was left in the `antd` import after its last usage was removed (in `0ca1f8b1d`, FR-2819 / #7370) but the import line was not cleaned up. It is now dead.

## Why split out

This is **not** part of any feature work. It surfaced because the strict pre-commit hook (`eslint ./src --max-warnings=0` via lint-staged) lints the whole `react/src` tree, so this pre-existing `no-unused-vars` warning on `main` blocks *unrelated* commits. Splitting it into its own one-line PR keeps the FR-26 PR (#7455, stacked on top of this) scope-clean while unblocking the strict hook.

## Changes

- `react/src/components/VFolderNodes.tsx` — drop `Alert` from the `antd` import (no behavior change; the symbol had no remaining references).

## Test plan

- [x] `eslint ./src --max-warnings=0` no longer reports the `'Alert' is defined but never used` warning.
- [x] No runtime behavior change (import-only removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
