### PR TITLE
feat(FR-2918): bump XXXL breakpoint to 2560 (QHD) and add responsive grid for ModelStoreListPage cards

### DIFF
--- a/packages/backend.ai-ui/.storybook/theme.json
+++ b/packages/backend.ai-ui/.storybook/theme.json
@@ -11,9 +11,9 @@
       "screenXLMax": 1919,
       "screenXXLMin": 1920,
       "screenXXL": 1920,
-      "screenXXLMax": 2047,
-      "screenXXXLMin": 2048,
-      "screenXXXL": 2048
+      "screenXXLMax": 2559,
+      "screenXXXLMin": 2560,
+      "screenXXXL": 2560
     },
     "components": {
       "Tag": {
@@ -46,9 +46,9 @@
       "screenXLMax": 1919,
       "screenXXLMin": 1920,
       "screenXXL": 1920,
-      "screenXXLMax": 2047,
-      "screenXXXLMin": 2048,
-      "screenXXXL": 2048
+      "screenXXLMax": 2559,
+      "screenXXXLMin": 2560,
+      "screenXXXL": 2560
     },
     "components": {
       "Tag": {

--- a/react/src/pages/ModelStoreListPageV2.tsx
+++ b/react/src/pages/ModelStoreListPageV2.tsx
@@ -286,7 +286,7 @@ const ModelCardV2Grid: React.FC<{
         const item = edge?.node;
         if (!item) return null;
         return (
-          <Col key={item.id} xs={24} sm={24} lg={12}>
+          <Col key={item.id} xs={24} sm={24} lg={12} xl={12} xxl={8} xxxl={6}>
             <ModelCardV2Card
               modelCardV2Frgmt={item}
               searchKeyword={searchKeyword}

--- a/resources/theme.json
+++ b/resources/theme.json
@@ -12,9 +12,9 @@
       "screenXLMax": 1919,
       "screenXXLMin": 1920,
       "screenXXL": 1920,
-      "screenXXLMax": 2047,
-      "screenXXXLMin": 2048,
-      "screenXXXL": 2048
+      "screenXXLMax": 2559,
+      "screenXXXLMin": 2560,
+      "screenXXXL": 2560
     },
     "components": {
       "Tag": {
@@ -46,9 +46,9 @@
       "screenXLMax": 1919,
       "screenXXLMin": 1920,
       "screenXXL": 1920,
-      "screenXXLMax": 2047,
-      "screenXXXLMin": 2048,
-      "screenXXXL": 2048
+      "screenXXLMax": 2559,
+      "screenXXXLMin": 2560,
+      "screenXXXL": 2560
     },
     "components": {
       "Tag": {


### PR DESCRIPTION
Resolves #7473 ([FR-2918](https://lablup.atlassian.net/browse/FR-2918))

## Summary

- Bump XXXL breakpoint from 2048 → **2560** (QHD) and widen XXL band to 1920–2559 in both `resources/theme.json` and `packages/backend.ai-ui/.storybook/theme.json` (light + dark)
- Add responsive `xl={12} xxl={8} xxxl={6}` to `ModelCardV2Grid` so model store cards reflow to 2/3/4 per row as viewport widens

## Why

The previous XXXL=2048 sat only 128px above FHD, lumping QHD, UWQHD, and 4K into the same bucket without a meaningful jump from FHD. Aligning XXXL with QHD (2560) gives a 640px tier that justifies a distinct multi-column layout, while XXL (1920–2559) now naturally absorbs windowed-mode usage on QHD/4K monitors.

## Test plan

- [ ] Resize browser to 1920px — model store grid shows 2 cards per row
- [ ] Resize to 2200px (XXL band) — still 3 cards per row
- [ ] Resize to ≥2560px — 4 cards per row
- [ ] Storybook builds without antd screen-token invariant errors

[FR-2918]: https://lablup.atlassian.net/browse/FR-2918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ