### PR TITLE
feat: add model folder picker actions in deployment add-revision modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
@@ -296,22 +296,24 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
         ) : (
           <>
             {label}
-            <BAIText type="secondary">
-              &nbsp; (
-              <BAIText
-                ellipsis
-                type="secondary"
-                style={{
-                  width: 80,
-                }}
-                monospace
-              >
-                {valuePropName === 'id'
-                  ? toLocalId(_.toString(value))
-                  : _.toString(value)}
+            {!optimisticSearchStr && (
+              <BAIText type="secondary">
+                &nbsp; (
+                <BAIText
+                  ellipsis
+                  type="secondary"
+                  style={{
+                    width: 80,
+                  }}
+                  monospace
+                >
+                  {valuePropName === 'id'
+                    ? toLocalId(_.toString(value))
+                    : _.toString(value)}
+                </BAIText>
+                )
               </BAIText>
-              )
-            </BAIText>
+            )}
           </>
         );
       }}

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -32,6 +32,8 @@ import {
 } from '../hooks/useRuntimeParameterSchema';
 import DeploymentPresetDetailModal from './DeploymentPresetDetailModal';
 import EnvVarFormList, { type EnvVarFormListValue } from './EnvVarFormList';
+import FolderCreateModalV2 from './FolderCreateModalV2';
+import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import ImageEnvironmentSelectFormItems, {
   type ImageEnvironmentFormInput,
 } from './ImageEnvironmentSelectFormItems';
@@ -46,7 +48,7 @@ import ResourceAllocationFormItems, {
 import VFolderTableFormItem, {
   type VFolderTableFormValues,
 } from './VFolderTableFormItem';
-import { InfoCircleOutlined } from '@ant-design/icons';
+import { InfoCircleOutlined, ReloadOutlined } from '@ant-design/icons';
 import {
   Alert,
   App,
@@ -73,6 +75,7 @@ import {
   BAIModalProps,
   BAIRuntimeVariantSelect,
   BAIVFolderSelect,
+  BAIVFolderSelectRef,
   convertToUUID,
   safeDecodeUuid,
   toGlobalId,
@@ -80,8 +83,10 @@ import {
   useBAILogger,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { FolderOpenIcon, PlusIcon } from 'lucide-react';
 import React, {
   Suspense,
+  startTransition,
   useDeferredValue,
   useEffect,
   useEffectEvent,
@@ -187,6 +192,15 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
   // (ServiceLauncherPageContent, ModelCardDeployModal).
   const { id: currentProjectId } = useCurrentProjectValue();
   const { logger } = useBAILogger();
+  const { open: openFolderExplorer } = useFolderExplorerOpener();
+
+  // Refs to refetch each form's model folder select after creating a new
+  // model-usage folder, or via the manual refresh button. Two refs because
+  // the Preset and Custom forms each mount their own BAIVFolderSelect.
+  const presetVFolderSelectRef = useRef<BAIVFolderSelectRef>(null);
+  const customVFolderSelectRef = useRef<BAIVFolderSelectRef>(null);
+  const [isModelFolderCreateModalOpen, setIsModelFolderCreateModalOpen] =
+    useState(false);
 
   // Defer `open` so the lazy query only fires once the modal has actually
   // committed to opening. `loading={deferredOpen !== open}` then lets the
@@ -1272,18 +1286,64 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
             </Form.Item>
 
             <Form.Item
-              name="modelFolderId"
               label={t('deployment.ModelFolder')}
               tooltip={t('deployment.ModelFolderTooltip')}
-              rules={[{ required: true }]}
+              required
             >
-              <BAIVFolderSelect
-                currentProjectId={currentProjectId ?? undefined}
-                disabled={!currentProjectId}
-                excludeDeleted
-                filter='usage_mode == "model"'
-                style={{ width: '100%' }}
-              />
+              <BAIFlex direction="row" gap="xs">
+                <Form.Item
+                  name="modelFolderId"
+                  noStyle
+                  rules={[{ required: true }]}
+                >
+                  <BAIVFolderSelect
+                    ref={presetVFolderSelectRef}
+                    currentProjectId={currentProjectId ?? undefined}
+                    disabled={!currentProjectId}
+                    excludeDeleted
+                    filter='usage_mode == "model"'
+                    style={{ flex: 1 }}
+                  />
+                </Form.Item>
+                <Form.Item dependencies={['modelFolderId']} noStyle>
+                  {({ getFieldValue }: FormInstance<PresetFormValues>) => {
+                    const modelFolderId = getFieldValue('modelFolderId');
+                    return (
+                      <Space.Compact>
+                        <Tooltip title={t('modelService.OpenFolder')}>
+                          <Button
+                            icon={<FolderOpenIcon />}
+                            disabled={!modelFolderId}
+                            onClick={() => {
+                              if (modelFolderId) {
+                                openFolderExplorer(toLocalId(modelFolderId));
+                              }
+                            }}
+                          />
+                        </Tooltip>
+                        <Tooltip title={t('data.CreateANewStorageFolder')}>
+                          <Button
+                            icon={<PlusIcon />}
+                            onClick={() =>
+                              setIsModelFolderCreateModalOpen(true)
+                            }
+                          />
+                        </Tooltip>
+                        <Tooltip title={t('button.Refresh')}>
+                          <Button
+                            icon={<ReloadOutlined />}
+                            onClick={() => {
+                              startTransition(() => {
+                                presetVFolderSelectRef.current?.refetch();
+                              });
+                            }}
+                          />
+                        </Tooltip>
+                      </Space.Compact>
+                    );
+                  }}
+                </Form.Item>
+              </BAIFlex>
             </Form.Item>
           </Form>
         )
@@ -1329,18 +1389,62 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
 
           <SectionHeader>{t('deployment.step.ModelAndRuntime')}</SectionHeader>
           <Form.Item
-            name="modelFolderId"
             label={t('deployment.ModelFolder')}
             tooltip={t('deployment.ModelFolderTooltip')}
-            rules={[{ required: true }]}
+            required
           >
-            <BAIVFolderSelect
-              currentProjectId={currentProjectId ?? undefined}
-              disabled={!currentProjectId}
-              excludeDeleted
-              filter='usage_mode == "model"'
-              style={{ width: '100%' }}
-            />
+            <BAIFlex direction="row" gap="xs">
+              <Form.Item
+                name="modelFolderId"
+                noStyle
+                rules={[{ required: true }]}
+              >
+                <BAIVFolderSelect
+                  ref={customVFolderSelectRef}
+                  currentProjectId={currentProjectId ?? undefined}
+                  disabled={!currentProjectId}
+                  excludeDeleted
+                  filter='usage_mode == "model"'
+                  style={{ flex: 1 }}
+                />
+              </Form.Item>
+              <Form.Item dependencies={['modelFolderId']} noStyle>
+                {({ getFieldValue }: FormInstance<FormValues>) => {
+                  const modelFolderId = getFieldValue('modelFolderId');
+                  return (
+                    <Space.Compact>
+                      <Tooltip title={t('modelService.OpenFolder')}>
+                        <Button
+                          icon={<FolderOpenIcon />}
+                          disabled={!modelFolderId}
+                          onClick={() => {
+                            if (modelFolderId) {
+                              openFolderExplorer(toLocalId(modelFolderId));
+                            }
+                          }}
+                        />
+                      </Tooltip>
+                      <Tooltip title={t('data.CreateANewStorageFolder')}>
+                        <Button
+                          icon={<PlusIcon />}
+                          onClick={() => setIsModelFolderCreateModalOpen(true)}
+                        />
+                      </Tooltip>
+                      <Tooltip title={t('button.Refresh')}>
+                        <Button
+                          icon={<ReloadOutlined />}
+                          onClick={() => {
+                            startTransition(() => {
+                              customVFolderSelectRef.current?.refetch();
+                            });
+                          }}
+                        />
+                      </Tooltip>
+                    </Space.Compact>
+                  );
+                }}
+              </Form.Item>
+            </BAIFlex>
           </Form.Item>
           <Form.Item
             name="runtimeVariantId"
@@ -1630,6 +1734,38 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
           />
         </Suspense>
       )}
+      <FolderCreateModalV2
+        open={isModelFolderCreateModalOpen}
+        initialValues={{ usage_mode: 'model' }}
+        onRequestClose={(result) => {
+          setIsModelFolderCreateModalOpen(false);
+          if (result?.id) {
+            // `createVfolderV2` returns a `VFolder` (Strawberry) global ID,
+            // but BAIVFolderSelect's value query reads from `vfolder_nodes`
+            // (`VirtualFolderNode`, Graphene). Both encode the same UUID
+            // but with different `__typename:` prefixes, so the select's
+            // option matching (`edge.node.id === value`) would fail if we
+            // set the raw mutation id directly. Re-encode to the
+            // VirtualFolderNode global ID form.
+            const newFolderUuid = safeDecodeUuid(result.id);
+            if (!newFolderUuid) return;
+            const newFolderGlobalId = toGlobalId(
+              'VirtualFolderNode',
+              newFolderUuid,
+            );
+            const activeForm =
+              effectiveMode === 'preset' ? presetForm : customForm;
+            const activeRef =
+              effectiveMode === 'preset'
+                ? presetVFolderSelectRef
+                : customVFolderSelectRef;
+            activeForm.setFieldValue('modelFolderId', newFolderGlobalId);
+            startTransition(() => {
+              activeRef.current?.refetch();
+            });
+          }
+        }}
+      />
     </BAIModal>
   );
 };


### PR DESCRIPTION
Stacked on #7458 (FR-2914)

<img width="710" height="86" alt="image" src="https://github.com/user-attachments/assets/baa61f84-c2bf-4e40-90d9-f1677487cf2f" />


## Summary

Adds model folder picker actions to the deployment add-revision modal and tweaks `BAIVFolderSelect`'s search-time label rendering.

### `DeploymentAddRevisionModal`

- Add a `Space.Compact` action group next to the model folder select in **both Preset and Custom modes**:
  - **Open**: open the selected folder in the Folder Explorer (via `useFolderExplorerOpener`, decoded with `toLocalId`).
  - **Create**: open a shared `FolderCreateModalV2` with `initialValues={{ usage_mode: 'model' }}` so users can create a model-mode vfolder without leaving the modal.
  - **Refresh**: call the form's corresponding `BAIVFolderSelectRef.refetch()` (per-form refs so Preset and Custom forms refetch independently).
- After folder creation, **auto-select the newly created folder** in the active form. The mutation returns a `VFolder` (Strawberry) global id, but `BAIVFolderSelect`'s value query reads from `vfolder_nodes` (`VirtualFolderNode`, Graphene). Both encode the same UUID but with different `__typename:` prefixes, so the select's option matching would fail if we set the raw mutation id directly. Decode with `safeDecodeUuid` and re-encode with `toGlobalId('VirtualFolderNode', uuid)`.

### `BAIVFolderSelect`

- Hide the trailing `(id)` on the selected label while the user is typing a search query. The search input visually collides with the parenthetical id; the id is still shown in the dropdown options (`optionRender`) for disambiguation when picking.

## Test plan

- [ ] In Preset mode: Open → opens explorer; Create → opens FolderCreateModalV2 with usage_mode locked to model; after Create succeeds, the new folder is auto-selected; Refresh bumps the list (effect visible the next time the dropdown is opened).
- [ ] In Custom mode: same as above with the Custom form's select.
- [ ] When searching in the model folder dropdown, the selected label no longer shows the `(id)` suffix; clearing the search restores it.
- [ ] Existing consumers of `BAIVFolderSelect` (VFolderMountFormItem, RoleFormModal, AdminModelCardSettingModal, ImportArtifactRevisionToFolderModal) still render the selected label as expected when not searching.