### PR TITLE
docs: require space in `Resolves #N (KEY)` PR body convention

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,7 +82,7 @@ Follow conventional commit format:
 ### PR Guidelines
 
 - PR titles follow format: `prefix(JIRA-ISSUE-NUMBER): title`
-- PR description starts with: `Resolves #1234(FR-1234)`
+- PR description starts with: `Resolves #1234 (FR-1234)` — the space between `#1234` and `(FR-1234)` is required so GitHub auto-links the issue and the `project-status-sync` workflow can parse the reference
 - Use **Squash merge** as default merge strategy
 - Follow Graphite's Stacked PR strategy for complex features
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ Production build (`pnpm run build`) runs these steps sequentially:
     - style: Design changes without functional changes
     - chore: Other small tasks
   - Format: `prefix(JIRA-ISSUE-NUMBER): title`
-  - GitHub PR content starts with `Resolves #1234(FR-1234)` where #1234 is the cloned issue number and FR-1234 is the Jira issue number
+  - GitHub PR content starts with `Resolves #1234 (FR-1234)` where #1234 is the cloned issue number and FR-1234 is the Jira issue number. The space between `#1234` and `(FR-1234)` is required — without it GitHub does not auto-link the issue reference and downstream tooling (Graphite, the `.github/workflows/project-status-sync.yml` workflow) fails to detect the link.
 
 - **Tool Requirements**:
   - **Jira**: Use `jira-workflow` skill (fw plugin). Project config in `.jira.config`.


### PR DESCRIPTION
## Summary

Document that the space in `Resolves #N (KEY)` PR-body convention is **required**, not optional.

The previously documented format `Resolves #1234(FR-1234)` (no space) silently broke two consumers:

- **GitHub auto-link**: `#1234(` is not recognized as an issue reference because the trailing `(` is treated as part of the token. The issue does not get linked from the PR, and the auto-close-on-merge hook does not fire.
- **Graphite stack tracking** and the `.github/workflows/project-status-sync.yml` workflow parse `Resolves #N` with a whitespace boundary and fail to detect the reference without it.

Agents (and humans) who followed the documented examples verbatim kept producing PRs with broken issue references. Fixing the *examples* in the canonical instruction files removes the upstream cause.

## Changes

- `AGENTS.md` — switch example to `Resolves #1234 (FR-1234)` and call out the space requirement
- `.github/copilot-instructions.md` — same

A companion change in the fw plugin (`claude-mp`) updates the `jira-github-bridge` skill and all references in fw commands/skills.

## Test plan

- [x] No code change; documentation only.
- [x] Conventions match what GitHub and Graphite actually parse.
