### PR TITLE
fix(FR-2922): honor CLAUDE_STATUSLINE_SSH_HOST when SSH_CONNECTION is unset

### DIFF
--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -98,7 +98,9 @@ except Exception: pass
 #          invokes ssh which only matches `Host <alias>` blocks against the literal string,
 #          so an alias keeps your IdentityFile, ControlMaster, keepalive, etc.
 #       2. `<whoami>@<server-ip>` from SSH_CONNECTION — zero-config default; the third field is
-#          the exact address the client connected to, which is always reachable back.
+#          the server-side address of the SSH TCP connection. It is usually reachable from the
+#          client, but on NATed / multi-homed / DNAT'd hosts it may be an internal address that
+#          the client cannot route back to — set CLAUDE_STATUSLINE_SSH_HOST in that case.
 #   Local (no SSH and no override): vscode://file<path>
 VSCODE_PART=""
 if [[ -n "$WORKSPACE" ]]; then

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -91,12 +91,15 @@ except Exception: pass
 # URL scheme:
 #   Remote (SSH): vscode://vscode-remote/ssh-remote+<host><path>
 #     Host resolution (first match wins):
-#       1. $CLAUDE_STATUSLINE_SSH_HOST — explicit override (ssh-config alias or public hostname),
-#          useful when the server IP from SSH_CONNECTION isn't reachable from the client
-#          (NAT, VPN, port forwarding) or when key-based auth is tied to a hostname.
+#       1. $CLAUDE_STATUSLINE_SSH_HOST — explicit override (ssh-config alias or public hostname).
+#          Honored even when SSH_CONNECTION is unset (tmux/screen detach, systemd, sudo -i,
+#          background jobs, etc. all drop SSH_CONNECTION but the host is still remote).
+#          Prefer an ssh-config alias (e.g. `jongeun2`) over a bare IP — VS Code Remote-SSH
+#          invokes ssh which only matches `Host <alias>` blocks against the literal string,
+#          so an alias keeps your IdentityFile, ControlMaster, keepalive, etc.
 #       2. `<whoami>@<server-ip>` from SSH_CONNECTION — zero-config default; the third field is
 #          the exact address the client connected to, which is always reachable back.
-#   Local (no SSH): vscode://file<path>
+#   Local (no SSH and no override): vscode://file<path>
 VSCODE_PART=""
 if [[ -n "$WORKSPACE" ]]; then
   VSCODE_WS=$(find "$WORKSPACE" -maxdepth 1 -name '*.code-workspace' -print -quit 2>/dev/null) || true
@@ -104,13 +107,15 @@ if [[ -n "$WORKSPACE" ]]; then
   # %-encode path segments (preserve /) so spaces and reserved chars survive OSC 8 / URI parsing.
   VSCODE_TARGET=$(python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1], safe="/"))' "$VSCODE_TARGET_RAW" 2>/dev/null) || VSCODE_TARGET="$VSCODE_TARGET_RAW"
   VSCODE_URL=""
-  if [[ -n "${SSH_CONNECTION:-}" ]]; then
-    VSCODE_HOST="${CLAUDE_STATUSLINE_SSH_HOST:-}"
-    if [[ -z "$VSCODE_HOST" ]]; then
-      VSCODE_IP=$(awk '{print $3}' <<< "$SSH_CONNECTION")
-      [[ -n "$VSCODE_IP" ]] && VSCODE_HOST="$(whoami)@${VSCODE_IP}"
-    fi
-    [[ -n "$VSCODE_HOST" ]] && VSCODE_URL="vscode://vscode-remote/ssh-remote+${VSCODE_HOST}${VSCODE_TARGET}"
+  VSCODE_HOST=""
+  if [[ -n "${CLAUDE_STATUSLINE_SSH_HOST:-}" ]]; then
+    VSCODE_HOST="$CLAUDE_STATUSLINE_SSH_HOST"
+  elif [[ -n "${SSH_CONNECTION:-}" ]]; then
+    VSCODE_IP=$(awk '{print $3}' <<< "$SSH_CONNECTION")
+    [[ -n "$VSCODE_IP" ]] && VSCODE_HOST="$(whoami)@${VSCODE_IP}"
+  fi
+  if [[ -n "$VSCODE_HOST" ]]; then
+    VSCODE_URL="vscode://vscode-remote/ssh-remote+${VSCODE_HOST}${VSCODE_TARGET}"
   else
     VSCODE_URL="vscode://file${VSCODE_TARGET}"
   fi


### PR DESCRIPTION
Resolves #7481(FR-2922)

## Summary

The statusline VS Code link only consulted `CLAUDE_STATUSLINE_SSH_HOST` *inside* the `SSH_CONNECTION` branch, so contexts that strip the SSH env (tmux/screen detach, systemd, `sudo -i`, background jobs, cron) fell through to the local fallback (`vscode://file<path>`) and opened the path on the **client** machine instead of via Remote-SSH — even when the override was set.

This PR evaluates `CLAUDE_STATUSLINE_SSH_HOST` **before** `SSH_CONNECTION` so an explicit override wins regardless of whether the SSH env was inherited.

## Changes

- `.claude/scripts/statusline.sh`: check `CLAUDE_STATUSLINE_SSH_HOST` first, then fall back to `SSH_CONNECTION`, then local.
- Update header comment to recommend ssh-config aliases (e.g. `jongeun2`) over bare IPs. VS Code Remote-SSH invokes `ssh <host>` under the hood, and SSH config `Host <alias>` blocks only match against the literal string — using the alias preserves `IdentityFile`, `ControlMaster`, keepalive, etc.

## Usage

Set the override in `~/.claude/settings.json` (**not** via shell `export`):

```jsonc
{
  "env": {
    "CLAUDE_STATUSLINE_SSH_HOST": "jongeun2"
  }
}
```

This is the only form that propagates to **every** Claude Code session — including background sessions spawned from the `claude agents` view, where the parent shell's environment is not inherited. A shell `export` only reaches interactive sessions launched from that same shell and would leave agent sessions falling through to the local-file fallback.

Docs: <https://code.claude.com/docs/en/settings> — "Variables defined in `env` are automatically applied to all Claude Code sessions."

With the override set this way, the statusline produces `vscode://vscode-remote/ssh-remote+jongeun2<path>` correctly in every session type.

## Test plan

- [x] Bash syntax check: `bash -n .claude/scripts/statusline.sh`
- [x] Manual: run statusline with `CLAUDE_STATUSLINE_SSH_HOST=jongeun2` and `SSH_CONNECTION` unset — confirmed URL becomes `vscode://vscode-remote/ssh-remote+jongeun2/<path>`.
- [x] Manual: run with neither set — confirmed falls back to `vscode://file<path>` (unchanged behavior for purely local sessions).
- [ ] Launch a new `claude agents` background session after declaring `CLAUDE_STATUSLINE_SSH_HOST` in `~/.claude/settings.json` `env` and confirm the value is visible via `echo $CLAUDE_STATUSLINE_SSH_HOST` (existing sessions started before the settings edit will still see it empty).