### PR TITLE
fix(FR-2925): jsx type error and update typescript to v6

### DIFF
--- a/.github/workflows/backend-ai-client-ci.yml
+++ b/.github/workflows/backend-ai-client-ci.yml
@@ -3,14 +3,14 @@ name: backend.ai-client CI
 on:
   pull_request:
     paths:
-      - 'packages/backend.ai-client/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/backend-ai-client-ci.yml'
+      - "packages/backend.ai-client/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/backend-ai-client-ci.yml"
   push:
     branches: [main]
     paths:
-      - 'packages/backend.ai-client/**'
-      - 'pnpm-lock.yaml'
+      - "packages/backend.ai-client/**"
+      - "pnpm-lock.yaml"
 
 permissions:
   contents: read
@@ -33,8 +33,8 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - name: Get pnpm store directory
         shell: bash
@@ -50,7 +50,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm --filter backend.ai-client run lint

--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -112,7 +112,7 @@
     "prettier-plugin-sort-json": "catalog:",
     "relay-test-utils": "catalog:",
     "storybook": "^10.3.5",
-    "typescript": "^5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "catalog:",
     "vite": "^6.4.2",
     "vite-plugin-dts": "^4.5.4",

--- a/packages/backend.ai-ui/tsconfig.json
+++ b/packages/backend.ai-ui/tsconfig.json
@@ -14,7 +14,13 @@
     "noEmit": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "types": ["vite-plugin-svgr/client"]
+    "types": ["vite-plugin-svgr/client"],
+    "paths": {
+      "react": ["./node_modules/@types/react"],
+      "react/*": ["./node_modules/@types/react/*"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react-dom/*": ["./node_modules/@types/react-dom/*"]
+    }
   },
   "include": ["src/**/*", "svg.d.ts", "vite-env.d.ts", "vite.config.ts", "setupTests.ts"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,7 +505,7 @@ importers:
         version: 16.13.2
       i18next:
         specifier: 'catalog:'
-        version: 25.10.10(typescript@5.9.3)
+        version: 25.10.10(typescript@6.0.3)
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
@@ -529,7 +529,7 @@ importers:
         version: 6.1.1(react@19.2.6)
       react-i18next:
         specifier: 'catalog:'
-        version: 16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 16.6.6(i18next@25.10.10(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       react-relay:
         specifier: 'catalog:'
         version: 20.1.1(react@19.2.6)
@@ -560,7 +560,7 @@ importers:
         version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))
       '@storybook/react-vite':
         specifier: ^10.3.5
-        version: 10.3.6(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.3)(webpack-cli@6.0.1(webpack@5.106.2)))
+        version: 10.3.6(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.3)(webpack-cli@6.0.1(webpack@5.106.2)))
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -632,7 +632,7 @@ importers:
         version: 7.0.1(eslint@9.39.4)
       eslint-plugin-storybook:
         specifier: ^10.3.5
-        version: 10.3.6(eslint@9.39.4)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)
+        version: 10.3.6(eslint@9.39.4)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@6.0.3)
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
@@ -655,23 +655,23 @@ importers:
         specifier: ^10.3.5
         version: 10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.59.1(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.59.1(eslint@9.39.4)(typescript@6.0.3)
       vite:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@25.3.5)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@25.3.5)(rollup@4.59.0)(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-relay-lite:
         specifier: ^0.11.0
-        version: 0.11.0(graphql@16.13.2)(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.11.0(graphql@16.13.2)(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.5.0(rollup@4.59.0)(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -704,7 +704,7 @@ importers:
         version: 7.0.1(eslint@9.39.4)
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.59.1(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.59.1(eslint@9.39.4)(typescript@6.0.3)
 
   react:
     dependencies:
@@ -818,7 +818,7 @@ importers:
         version: 2.6.0(graphql@16.13.2)
       i18next:
         specifier: 'catalog:'
-        version: 25.10.10(typescript@5.7.3)
+        version: 25.10.10(typescript@6.0.3)
       i18next-http-backend:
         specifier: ^3.0.4
         version: 3.0.6
@@ -878,7 +878,7 @@ importers:
         version: 6.1.1(react@19.2.6)
       react-i18next:
         specifier: 'catalog:'
-        version: 16.6.6(i18next@25.10.10(typescript@5.7.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.7.3)
+        version: 16.6.6(i18next@25.10.10(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.6)
@@ -922,8 +922,8 @@ importers:
         specifier: 'catalog:'
         version: 4.3.1
       typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
+        specifier: ~6.0.3
+        version: 6.0.3
       use-query-params:
         specifier: ^2.2.2
         version: 2.2.2(react-dom@19.2.6(react@19.2.6))(react-router-dom@6.30.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -963,7 +963,7 @@ importers:
         version: 9.39.4
       '@tanstack/eslint-plugin-query':
         specifier: ^5.99.0
-        version: 5.100.7(eslint@9.39.4)(typescript@5.7.3)
+        version: 5.100.7(eslint@9.39.4)(typescript@6.0.3)
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1074,7 +1074,7 @@ importers:
         version: 20.1.1
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.59.1(eslint@9.39.4)(typescript@5.7.3)
+        version: 8.59.1(eslint@9.39.4)(typescript@6.0.3)
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.17)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -1086,7 +1086,7 @@ importers:
         version: 1.2.0(vite@6.4.1(@types/node@22.19.17)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(rollup@2.80.0)(typescript@5.7.3)(vite@6.4.1(@types/node@22.19.17)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.5.0(rollup@2.80.0)(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.17)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@6.4.1(@types/node@22.19.17)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -10747,11 +10747,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -10759,6 +10754,11 @@ packages:
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -13531,13 +13531,13 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
-      react-docgen-typescript: 2.2.2(typescript@5.9.3)
+      react-docgen-typescript: 2.2.2(typescript@6.0.3)
       vite: 6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -15084,12 +15084,12 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       storybook: 10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6)
 
-  '@storybook/react-vite@10.3.6(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.3)(webpack-cli@6.0.1(webpack@5.106.2)))':
+  '@storybook/react-vite@10.3.6(esbuild@0.27.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.3)(webpack-cli@6.0.1(webpack@5.106.2)))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@storybook/builder-vite': 10.3.6(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.3)(webpack-cli@6.0.1(webpack@5.106.2)))
-      '@storybook/react': 10.3.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)
+      '@storybook/react': 10.3.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.6
@@ -15106,17 +15106,17 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.3.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3)':
+  '@storybook/react@10.3.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.3.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))
       react: 19.2.6
       react-docgen: 8.0.2
-      react-docgen-typescript: 2.2.2(typescript@5.9.3)
+      react-docgen-typescript: 2.2.2(typescript@6.0.3)
       react-dom: 19.2.6(react@19.2.6)
       storybook: 10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15171,23 +15171,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
-  '@svgr/core@8.1.0(typescript@5.7.3)':
+  '@svgr/core@8.1.0(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.7.3)
-      snake-case: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@svgr/core@8.1.0(typescript@5.9.3)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -15198,21 +15187,11 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.7.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.7.3)
-      '@svgr/hast-util-to-babel-ast': 8.0.0
-      svg-parser: 2.0.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -15222,12 +15201,12 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/eslint-plugin-query@5.100.7(eslint@9.39.4)(typescript@5.7.3)':
+  '@tanstack/eslint-plugin-query@5.100.7(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15657,22 +15636,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4)(typescript@5.7.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/type-utils': 8.59.1(eslint@9.39.4)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.59.1
-      eslint: 9.39.4
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -15689,6 +15652,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/type-utils': 8.59.1(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.1
+      eslint: 9.39.4
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@7.18.0(eslint@9.39.4)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
@@ -15699,18 +15678,6 @@ snapshots:
       eslint: 9.39.4
     optionalDependencies:
       typescript: 5.5.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.59.1
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4
-      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15726,21 +15693,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.1
       '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3(supports-color@5.5.0)
-      typescript: 5.9.3
+      eslint: 9.39.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.1(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.57.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.1
       debug: 4.4.3(supports-color@5.5.0)
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15750,6 +15720,15 @@ snapshots:
       '@typescript-eslint/types': 8.59.1
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.1(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.1
+      debug: 4.4.3(supports-color@5.5.0)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15768,17 +15747,17 @@ snapshots:
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/visitor-keys': 8.59.1
 
-  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
-
-  '@typescript-eslint/tsconfig-utils@8.59.1(typescript@5.7.3)':
-    dependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
   '@typescript-eslint/tsconfig-utils@8.59.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.59.1(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@typescript-eslint/type-utils@7.18.0(eslint@9.39.4)(typescript@5.5.4)':
     dependencies:
@@ -15792,18 +15771,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.59.1(eslint@9.39.4)(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@5.7.3)
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4
-      ts-api-utils: 2.5.0(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@8.59.1(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.1
@@ -15813,6 +15780,18 @@ snapshots:
       eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.59.1(eslint@9.39.4)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.4
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15837,33 +15816,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.57.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.57.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/visitor-keys': 8.57.1
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.59.1(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/visitor-keys': 8.59.1
-      debug: 4.4.3(supports-color@5.5.0)
-      minimatch: 10.2.4
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.4.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15882,6 +15846,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.59.1(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/visitor-keys': 8.59.1
+      debug: 4.4.3(supports-color@5.5.0)
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@7.18.0(eslint@9.39.4)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
@@ -15893,25 +15872,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.57.1(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.1(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@6.0.3)
       eslint: 9.39.4
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.59.1(eslint@9.39.4)(typescript@5.7.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
-      eslint: 9.39.4
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15923,6 +15891,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.1(eslint@9.39.4)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
+      eslint: 9.39.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16115,7 +16094,7 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/language-core@2.2.0(typescript@5.9.3)':
+  '@vue/language-core@2.2.0(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.29
@@ -16126,7 +16105,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@vue/shared@3.5.29': {}
 
@@ -17345,32 +17324,23 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  cosmiconfig@8.3.6(typescript@5.7.3):
+  cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
-  cosmiconfig@8.3.6(typescript@5.9.3):
-    dependencies:
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-    optionalDependencies:
-      typescript: 5.9.3
-
-  cosmiconfig@9.0.0(typescript@5.9.3):
+  cosmiconfig@9.0.0(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   create-ecdh@4.0.4:
     dependencies:
@@ -18248,9 +18218,9 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
-  eslint-plugin-storybook@10.3.6(eslint@9.39.4)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.9.3):
+  eslint-plugin-storybook@10.3.6(eslint@9.39.4)(storybook@10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.57.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
       storybook: 10.3.6(@testing-library/dom@10.4.0)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
@@ -19240,17 +19210,11 @@ snapshots:
       - react-native-b4a
       - typescript
 
-  i18next@25.10.10(typescript@5.7.3):
+  i18next@25.10.10(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
     optionalDependencies:
-      typescript: 5.7.3
-
-  i18next@25.10.10(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
-    optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   i18next@25.10.5(typescript@5.5.4):
     dependencies:
@@ -21584,9 +21548,9 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.6
 
-  react-docgen-typescript@2.2.2(typescript@5.9.3):
+  react-docgen-typescript@2.2.2(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   react-docgen@8.0.2:
     dependencies:
@@ -21657,27 +21621,16 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  react-i18next@16.6.6(i18next@25.10.10(typescript@5.7.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.7.3):
+  react-i18next@16.6.6(i18next@25.10.10(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
-      i18next: 25.10.10(typescript@5.7.3)
+      i18next: 25.10.10(typescript@6.0.3)
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
-      typescript: 5.7.3
-
-  react-i18next@16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      html-parse-stringify: 3.0.1
-      i18next: 25.10.10(typescript@5.9.3)
-      react: 19.2.6
-      use-sync-external-store: 1.6.0(react@19.2.6)
-    optionalDependencies:
-      react-dom: 19.2.6(react@19.2.6)
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   react-is@16.13.1: {}
 
@@ -23104,17 +23057,17 @@ snapshots:
     dependencies:
       typescript: 5.5.4
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
-
-  ts-api-utils@2.5.0(typescript@5.7.3):
-    dependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   ts-dedent@2.2.0: {}
 
@@ -23246,17 +23199,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.59.1(eslint@9.39.4)(typescript@5.7.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@5.7.3)
-      eslint: 9.39.4
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
   typescript-eslint@8.59.1(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
@@ -23268,13 +23210,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.5.4: {}
+  typescript-eslint@8.59.1(eslint@9.39.4)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4)(typescript@6.0.3)
+      eslint: 9.39.4
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
-  typescript@5.7.3: {}
+  typescript@5.5.4: {}
 
   typescript@5.8.2: {}
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   ua-parser-js@1.0.41: {}
 
@@ -23545,18 +23498,18 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  vite-plugin-dts@4.5.4(@types/node@25.3.5)(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-dts@4.5.4(@types/node@25.3.5)(rollup@4.59.0)(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@25.3.5)
       '@rollup/pluginutils': 5.1.4(rollup@4.59.0)
       '@volar/typescript': 2.4.14
-      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      '@vue/language-core': 2.2.0(typescript@6.0.3)
       compare-versions: 6.1.1
       debug: 4.4.1
       kolorist: 1.8.0
       local-pkg: 1.1.1
       magic-string: 0.30.17
-      typescript: 5.9.3
+      typescript: 6.0.3
     optionalDependencies:
       vite: 6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -23583,9 +23536,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-relay-lite@0.11.0(graphql@16.13.2)(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-relay-lite@0.11.0(graphql@16.13.2)(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig: 9.0.0(typescript@6.0.3)
       graphql: 16.13.2
       kleur: 4.1.5
       magic-string: 0.30.17
@@ -23593,22 +23546,22 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  vite-plugin-svgr@4.5.0(rollup@2.80.0)(typescript@5.7.3)(vite@6.4.1(@types/node@22.19.17)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-svgr@4.5.0(rollup@2.80.0)(typescript@6.0.3)(vite@6.4.1(@types/node@22.19.17)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@2.80.0)
-      '@svgr/core': 8.1.0(typescript@5.7.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))
+      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       vite: 6.4.1(@types/node@22.19.17)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-plugin-svgr@4.5.0(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-svgr@4.5.0(rollup@4.59.0)(typescript@6.0.3)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       vite: 6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
@@ -24211,3 +24164,4 @@ snapshots:
 time:
   '@eslint/js@9.39.4': '2026-03-06T21:21:15.041Z'
   typescript-eslint@8.59.1: '2026-04-27T17:31:57.870Z'
+  typescript@6.0.3: '2026-04-16T23:38:27.905Z'

--- a/react/package.json
+++ b/react/package.json
@@ -75,7 +75,7 @@
     "swr": "^2.4.1",
     "ts-md5": "^2.0.1",
     "tus-js-client": "catalog:",
-    "typescript": "~5.7.3",
+    "typescript": "~6.0.3",
     "use-query-params": "^2.2.2",
     "uuid": "catalog:",
     "web-vitals": "^3.5.2",

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -15,16 +15,23 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "backend.ai-ui": ["../packages/backend.ai-ui/src/index.ts"],
       "backend.ai-ui/*": ["../packages/backend.ai-ui/src/*"],
       "backend.ai-ui/dist/locale/*": ["../packages/backend.ai-ui/src/locale/*"],
       "backend.ai-client": ["../packages/backend.ai-client/src/index.ts"],
-      "backend.ai-client/*": ["../packages/backend.ai-client/src/*"]
+      "backend.ai-client/*": ["../packages/backend.ai-client/src/*"],
+      "react": ["./node_modules/@types/react"],
+      "react/*": ["./node_modules/@types/react/*"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react-dom/*": ["./node_modules/@types/react-dom/*"]
     }
   },
-  "include": ["src", "../packages/backend.ai-ui/src", "../packages/backend.ai-client/src"],
+  "include": [
+    "src",
+    "../packages/backend.ai-ui/src",
+    "../packages/backend.ai-client/src"
+  ],
   "exclude": [
     "../packages/backend.ai-ui/src/**/*.test.*",
     "../packages/backend.ai-ui/src/**/*.stories.*",


### PR DESCRIPTION
resolves #7490 (FR-2925)

## Problem

Several antd components (e.g. `Card`) raise TypeScript errors when used directly in JSX:

```
TS2604: JSX element type 'Card' does not have any construct or call signatures.
TS2786: 'Card' cannot be used as a JSX component.
  Its type 'CardInterface' is not a valid JSX element type.
```

The error appears for any antd component declared via the
`interface XInterface extends typeof InternalForwardRefComponent` pattern.
It is visible in the IDE and via `tsc --noEmit` / `scripts/verify.sh`, but
the Vite dev server passes (it strips types instead of checking them) and
the ESLint-only pre-commit hook does not catch it either.

## Root Cause

`enableGlobalVirtualStore: true` (introduced in FR-2856) puts antd at a
global pnpm store path:

```
~/Library/pnpm/store/v11/links/@/antd/6.3.7/HASH/node_modules/antd/...
```

When antd's `.d.ts` does `import * as React from 'react'`, TypeScript
walks up `node_modules/@types/` from antd's location to find
`@types/react`. The global store path and the project path share no
common ancestor that contains `@types/react`, and antd does not declare
`@types/react` as a peer dependency, so pnpm does not install it
alongside antd in the global store.

As a result antd's `.d.ts` resolves `React` to a partially-`any` type.
`skipLibCheck: true` hides the underlying "Could not find declaration
file for module 'react'" errors. The cascade then breaks JSX type
checking specifically for components built via the
`interface X extends typeof InternalCard` pattern (direct
`<InternalCard>` usage still works because TS treats `any` as callable
in JSX, but `interface extends typeof <any-like>` loses its call
signature in TS's JSX checker).

Verified by running `tsc --noEmit` with `skipLibCheck: false` against a
minimal reproduction: every antd `.d.ts` file emits
`TS7016: Could not find a declaration file for module 'react'`.

## Fix

Add explicit `paths` entries to `react/tsconfig.json` so TypeScript
short-circuits the walk-up algorithm and resolves `react` / `react-dom`
directly to the project's `@types/react` / `@types/react-dom`:

```jsonc
"paths": {
  ...
  "react":       ["./node_modules/@types/react"],
  "react/*":     ["./node_modules/@types/react/*"],
  "react-dom":   ["./node_modules/@types/react-dom"],
  "react-dom/*": ["./node_modules/@types/react-dom/*"]
}
```

This applies to all `.d.ts` files processed during compilation —
including antd's — so antd's `import * as React from 'react'` now
resolves to a real `React` namespace instead of `any`.

Also bumps `typescript` to `~6.0.3` in both workspace packages so the
TS used to compile the app matches the TS used by antd's published type
declarations (antd 6.3.x emits its `.d.ts` with TS 6.0.x). This is not
strictly required to make the `paths` workaround work, but keeps the
toolchain aligned and avoids unrelated downstream surprises.

## Alternatives Considered

- `enableGlobalVirtualStore: false` — reverts FR-2856; impact is large
  (re-introduces the per-worktree virtual store cost FR-2856 fixed).
- `.npmrc` with `public-hoist-pattern[]=*@types*` — would also work but
  requires a full reinstall and broadens hoisting beyond what is needed
  here.

## Effect on Users / Developers

- No user-visible change.
- IDE / `tsc` no longer reports false-positive JSX errors on antd
  components, so contributors no longer need to silence them or go
  through `BAICard` solely to dodge the type error.
- `scripts/verify.sh` and CI `tsc` step pass on touched files that
  previously failed.

**Checklist:** (if applicable)

- [x] Verified with `bash scripts/verify.sh` — `Card`-related diagnostics drop to zero
- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
