### PR TITLE
fix(FR-2928): allow pnpm global virtual store path in Vite dev server fs.allow

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,6 +67,10 @@ catalog:
   uuid: ^13.0.0
   webpack: ^5.106.1
 
+# Dependencies hard-link into a global store outside this repo
+# (e.g. `~/Library/pnpm/store/v11/...`). `react/vite.config.ts` extends
+# `server.fs.allow` with `pnpm store path` so Vite can serve assets from
+# the store; do not remove that extension without also reverting this flag.
 enableGlobalVirtualStore: true
 
 minimumReleaseAge: 10080

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import { execSync } from 'node:child_process';
 import { createReadStream, existsSync, readFileSync, statSync } from 'node:fs';
 import {
   basename,
@@ -20,6 +21,31 @@ import svgr from 'vite-plugin-svgr';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, '..');
 const require = createRequire(import.meta.url);
+
+// With `enableGlobalVirtualStore: true` (pnpm-workspace.yaml), pnpm hard-links
+// every dependency into a single global store outside this repo
+// (e.g. `~/Library/pnpm/store/v11/links/...` on macOS,
+// `~/.local/share/pnpm/store/v11/links/...` on Linux). Vite resolves
+// `server.fs.allow` against each request's realpath, so allowing only
+// `projectRoot` rejects every dependency CSS/asset served from that store
+// with "outside of Vite serving allow list".
+//
+// Resolve the store root dynamically via `pnpm store path` (pnpm's officially
+// supported way to discover it) and add it to `fs.allow` below. We resolve
+// once at config load — the path is stable for the lifetime of the dev
+// server, and falling back to `undefined` keeps non-pnpm environments
+// working.
+function resolvePnpmStorePath(): string | undefined {
+  try {
+    return execSync('pnpm store path --silent', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+const pnpmStorePath = resolvePnpmStorePath();
 
 // `vite-plugin-node-polyfills` injects bare-specifier imports of its own shim
 // paths (`vite-plugin-node-polyfills/shims/{buffer,global,process}`) during
@@ -569,8 +595,11 @@ export default defineConfig(({ mode }) => {
       fs: {
         // Allow Vite to read files from the whole monorepo so that the
         // alias to `../dist/lib/...` and `../packages/backend.ai-ui/src`
-        // resolves without FS sandbox 403s.
-        allow: [projectRoot],
+        // resolves without FS sandbox 403s. Additionally allow the pnpm
+        // global virtual store root (resolved dynamically above) so that
+        // dependencies hard-linked outside the repo can be served — see
+        // `resolvePnpmStorePath` for the full rationale.
+        allow: [projectRoot, ...(pnpmStorePath ? [pnpmStorePath] : [])],
       },
       watch: {
         ignored: [

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -23,29 +23,37 @@ const projectRoot = resolve(__dirname, '..');
 const require = createRequire(import.meta.url);
 
 // With `enableGlobalVirtualStore: true` (pnpm-workspace.yaml), pnpm hard-links
-// every dependency into a single global store outside this repo
-// (e.g. `~/Library/pnpm/store/v11/links/...` on macOS,
-// `~/.local/share/pnpm/store/v11/links/...` on Linux). Vite resolves
-// `server.fs.allow` against each request's realpath, so allowing only
-// `projectRoot` rejects every dependency CSS/asset served from that store
+// every dependency into a single global store outside this repo, with the
+// virtual `links/` directory living under the store root reported by
+// `pnpm store path` (e.g. `~/Library/pnpm/store/v11` on macOS,
+// `~/.local/share/pnpm/store/v11` on Linux — `links/<pkg>/...` lives inside).
+// Vite resolves `server.fs.allow` against each request's realpath, so allowing
+// only `projectRoot` rejects every dependency CSS/asset served from that store
 // with "outside of Vite serving allow list".
 //
-// Resolve the store root dynamically via `pnpm store path` (pnpm's officially
-// supported way to discover it) and add it to `fs.allow` below. We resolve
-// once at config load — the path is stable for the lifetime of the dev
-// server, and falling back to `undefined` keeps non-pnpm environments
-// working.
+// `pnpm store path` is pnpm's officially supported discovery command; its
+// output is an ancestor of the `links/` realpaths, so adding it to `fs.allow`
+// admits every hard-linked dependency. We resolve once at dev-server start
+// (the path is stable for that lifetime) and only when actually serving —
+// `vite build` never reads `server.fs.allow`, so we skip the subprocess there.
+// `shell: true` makes the call work on Windows where `pnpm` is a `.cmd` shim.
 function resolvePnpmStorePath(): string | undefined {
   try {
     return execSync('pnpm store path --silent', {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      shell: true,
     }).trim();
-  } catch {
+  } catch (err) {
+    // Leave a breadcrumb so the resulting "outside of Vite serving allow list"
+    // errors are self-diagnosing instead of looking like a fresh regression.
+    console.warn(
+      '[vite] could not resolve pnpm store path; dependencies served from outside projectRoot may be rejected by server.fs.allow:',
+      err instanceof Error ? err.message : err,
+    );
     return undefined;
   }
 }
-const pnpmStorePath = resolvePnpmStorePath();
 
 // `vite-plugin-node-polyfills` injects bare-specifier imports of its own shim
 // paths (`vite-plugin-node-polyfills/shims/{buffer,global,process}`) during
@@ -406,9 +414,15 @@ function monacoStaticPlugin(): Plugin {
   };
 }
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, projectRoot, '');
   Object.assign(process.env, env);
+
+  // Only resolve the pnpm store when actually serving — `vite build` does not
+  // use `server.fs.allow`, so the subprocess is wasted there. See the
+  // `resolvePnpmStorePath` definition above for the full rationale.
+  const pnpmStorePath =
+    command === 'serve' ? resolvePnpmStorePath() : undefined;
 
   // Comma-separated list of additional hostnames to whitelist for the dev
   // server's host check (Vite 6 default-blocks anything outside localhost

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -36,14 +36,22 @@ const require = createRequire(import.meta.url);
 // admits every hard-linked dependency. We resolve once at dev-server start
 // (the path is stable for that lifetime) and only when actually serving —
 // `vite build` never reads `server.fs.allow`, so we skip the subprocess there.
-// `shell: true` makes the call work on Windows where `pnpm` is a `.cmd` shim.
+// We only shell out on Windows (where `pnpm` is typically a `.cmd` shim that
+// Node cannot execute directly); on POSIX a direct exec avoids the shell's
+// quoting and overhead. The result is also sanity-checked — an empty or
+// non-absolute path would silently widen the allowlist, which is the bug we
+// are trying to fix in the first place.
 function resolvePnpmStorePath(): string | undefined {
   try {
-    return execSync('pnpm store path --silent', {
+    const raw = execSync('pnpm store path --silent', {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
-      shell: true,
+      shell: process.platform === 'win32',
     }).trim();
+    if (!raw || !isAbsolute(raw) || !existsSync(raw) || !statSync(raw).isDirectory()) {
+      return undefined;
+    }
+    return raw;
   } catch (err) {
     // Leave a breadcrumb so the resulting "outside of Vite serving allow list"
     // errors are self-diagnosing instead of looking like a fresh regression.


### PR DESCRIPTION
Resolves #7496 ([FR-2928](https://lablup.atlassian.net/browse/FR-2928))

## Summary

- `react/vite.config.ts`: resolve the pnpm global store root at config load via `pnpm store path --silent` and add it to `server.fs.allow`. Falls back gracefully when the command is unavailable (non-pnpm / older environments).
- `pnpm-workspace.yaml`: add a cross-reference comment next to `enableGlobalVirtualStore: true` so future maintainers do not silently break the Vite-side allowlist extension without also reverting the flag.

## Why

`pnpm-workspace.yaml` enables `enableGlobalVirtualStore: true`, so on pnpm v11 machines dependencies live under the user's global pnpm store (e.g. `~/Library/pnpm/store/v11/links/...` on macOS, `~/.local/share/pnpm/store/v11/links/...` on Linux). Vite resolves `server.fs.allow` against each request's realpath, and the current allowlist of just `projectRoot` rejects every dependency served from that store — reproduced on macOS as repeated *"The request url ... is outside of Vite serving allow list"* errors for `@cloudscape-design/components` `*.scoped.css` and similar.

Neither pnpm nor Vite ships an automatic fix today (related: [pnpm/pnpm#10681](https://github.com/pnpm/pnpm/issues/10681), [vitejs/vite#12422](https://github.com/vitejs/vite/discussions/12422)). The current best-practice recipe is to query the store path via `pnpm store path` (pnpm's official discovery command) and extend `server.fs.allow` ourselves.

## Test plan

- [ ] On macOS with `enableGlobalVirtualStore: true` and a fresh `pnpm install`, run `pnpm dev` and confirm no `outside of Vite serving allow list` warnings appear on initial load
- [ ] On Linux confirm `pnpm dev` still starts cleanly (regression check)
- [ ] In a non-pnpm environment (or with `pnpm store path` mocked to fail), confirm dev server still starts — `resolvePnpmStorePath` falls back to `undefined` and `fs.allow` keeps `projectRoot` only
- [ ] `bash scripts/verify.sh` — the only failing TypeScript diagnostics are pre-existing on files not touched by this PR

[FR-2928]: https://lablup.atlassian.net/browse/FR-2928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ