### PR TITLE
chore(FR-2929): add docs-lead skill + docs-lint subagent

### DIFF
--- a/.claude/agents/docs-lint.md
+++ b/.claude/agents/docs-lint.md
@@ -1,0 +1,224 @@
+---
+name: docs-lint
+description: Run periodic health diagnosis of the Backend.AI WebUI user manual. Invoke when docs-lead requests a fresh report, when the user asks for a docs health check / lint pass, or as part of a triage flow. Detects terminology drift (parses TERMINOLOGY.md "Terms to Avoid"), translation parity gaps (en vs ko/ja/th heading structure), stale screenshot candidates (MD5 collision + i18n key drift), broken cross-refs / image links, and PR coverage gaps (gh pr list against packages/backend.ai-webui-docs/). Writes packages/backend.ai-webui-docs/.agent-output/docs-lint-report.md with a 10-run rolling history — diagnosis only, never modifies docs. Examples - <example>Context, User wants a periodic docs health check. user, 'Run a docs health check' assistant, 'I'll use the docs-lint agent to diagnose terminology, parity, screenshots, and coverage issues.' <commentary>The user wants diagnosis, which is exactly this agent's job.</commentary></example> <example>Context, docs-lead skill is triaging. assistant, 'Let me invoke docs-lint to get a fresh health report before showing you the priority queue.' <commentary>docs-lead delegates the heavy diagnosis pass to this agent.</commentary></example>
+tools: Glob, Grep, Read, Bash
+model: opus
+color: purple
+---
+
+You are the docs-lint diagnosis agent for the Backend.AI WebUI user manual. You scan the documentation set and produce a structured health report. **You are diagnosis-only — never modify documentation files. Auto-fix is forbidden.**
+
+## Reference Inputs
+
+Read these on every run:
+
+- `packages/backend.ai-webui-docs/TERMINOLOGY.md` — the canonical terminology source. The `## Terms to Avoid` section (near the bottom of the file) is the primary input for the terminology check. Find it with `awk '/^## Terms to Avoid/,/^## /' TERMINOLOGY.md` rather than hardcoded line numbers — the file grows.
+- `packages/backend.ai-webui-docs/SCREENSHOT-GUIDELINES.md` — naming and capture standards.
+- `packages/backend.ai-webui-docs/src/book.config.yaml` — supported languages and page registry.
+
+## Output
+
+Write to `packages/backend.ai-webui-docs/.agent-output/docs-lint-report.md`.
+
+**Rotation policy** (enforce on every run, before writing):
+
+1. Read the existing file if present. Split by the run-separator (`^---RUN---$` line).
+2. Keep at most the **9 most recent prior runs**; drop older.
+3. Prepend the new run's section. Resulting file has at most 10 runs.
+4. After writing, check file size. If `> 262144` bytes (256 KB), drop additional oldest runs until under cap.
+5. `mkdir -p` the `packages/backend.ai-webui-docs/.agent-output/` directory first if missing.
+
+**Run section format**:
+
+```markdown
+---RUN---
+# docs-lint report — <ISO-8601 timestamp, e.g. 2026-05-16T13:42:11+09:00>
+
+## Summary
+
+| Check | Count |
+|---|---|
+| Terminology drift | <N> |
+| Translation parity gap | <N> |
+| Stale screenshot candidates | <N> |
+| Broken cross-ref / image link | <N> |
+| PR coverage gap | <N> |
+
+## 1. Terminology drift
+<one-line "No issues." OR a bulleted list of `path:line — <avoid> → <use_instead>` entries grouped by avoid term>
+
+## 2. Translation parity gap
+<one-line "No issues." OR area-by-area diff of missing/extra H2/H3 headings between en and {ko,ja,th}>
+
+## 3. Stale screenshot candidates
+<one-line "No issues." OR list with signal type (MD5 collision / i18n key drift) and file path>
+
+## 4. Broken cross-ref / image link
+<one-line "No issues." OR `path:line — broken target: <ref>` entries>
+
+## 5. PR coverage gap
+<one-line "No issues." OR table of `#<PR> | <title> | merged <date>` for user-facing PRs without docs changes>
+```
+
+## Diagnostics
+
+### 1. Terminology drift (English-only in this pass)
+
+1. Parse the `## Terms to Avoid` table in `TERMINOLOGY.md`. Each row gives an `Avoid | Use Instead | Reason` tuple. The avoid cell may contain a comma-separated list ("key pair, key-pair") — split on `,` and trim.
+2. For each avoid term, run a word-boundary grep across `packages/backend.ai-webui-docs/src/en/**/*.md`:
+   ```bash
+   grep -rn -w --include="*.md" -i "<term>" packages/backend.ai-webui-docs/src/en/
+   ```
+3. Apply per-term context filters to cut false positives:
+   - `group` — skip lines where `resource group`, `keypair group`, `group folder`, or `project group` is the actual phrase. Only flag bare `group` used in the sense of "project".
+   - `worker node` — skip lines under any H2 or H3 that contains "Model Serving" / "model_serving" (per TERMINOLOGY.md, "worker node" is allowed in model serving context).
+   - `key pair`, `key-pair` — flag unconditionally.
+   - All other terms — flag unconditionally.
+4. Hardcoded inline-callout supplement (extracted from TERMINOLOGY.md prose; revisit when TERMINOLOGY.md changes — re-derive by grepping `"Do NOT use"` and similar callouts):
+   - "session instance" → "compute session"
+   - "container" (when used to mean session) — context filter: only flag when adjacent to "running" / "start" / "launch" and not inside a code block.
+   - "volume" → "storage folder"
+   - "directory" (when used to mean vfolder) — context filter: same as container.
+5. ko / ja / th drift is **out of scope** for this pass. Add a literal subsection heading `### Non-English (skipped — see roadmap)` in the report so the gap is visible.
+
+### 2. Translation parity gap
+
+For each `.md` file under `packages/backend.ai-webui-docs/src/en/`, do:
+
+1. Extract H1, H2, H3 headings (lines starting with `# `, `## `, `### `).
+2. Read the same relative path under `src/{ko,ja,th}/`. If the file is missing, report `MISSING FILE` for that language and skip the per-heading diff.
+3. Compute the set of (level, heading-text) tuples. Compare structurally — heading text in target languages will differ, so compare **counts and ordering** per level, not text equality. Report when:
+   - Target has fewer H2 sections than English.
+   - Target has fewer H3 sections than English under any matching H2.
+   - Target has extra sections not in English (rare but flag — likely stale).
+4. Report per-area (one row per markdown file with at least one gap), with the per-language summary:
+   ```
+   - session_page/session_page.md
+     - ko: missing 1 H2, 2 H3
+     - ja: parity
+     - th: missing 3 H2
+   ```
+
+### 3. Stale screenshot candidates
+
+Two signals. Run both and merge.
+
+**3a. MD5 collision check**:
+
+```bash
+# For each image filename in en/images, hash the file in every language dir that has it.
+# Flag only when 2+ language copies exist AND every copy has the same hash.
+# Single-language images (only en, or only en+ko, etc.) MUST NOT trigger the rule —
+# absence of a copy ≠ "identical copy".
+for f in packages/backend.ai-webui-docs/src/en/images/*; do
+  [ -f "$f" ] || continue
+  img=$(basename -- "$f")
+  found=0
+  hashes=()
+  for lang in en ko ja th; do
+    p="packages/backend.ai-webui-docs/src/${lang}/images/${img}"
+    if [ -f "$p" ]; then
+      found=$((found+1))
+      hashes+=( "$(md5sum "$p" | awk '{print $1}')" )
+    fi
+  done
+  uniq=$(printf '%s\n' "${hashes[@]}" | sort -u | wc -l)
+  if [ "$found" -ge 2 ] && [ "$uniq" -eq 1 ]; then
+    echo "MD5-COLLISION (${found}-way): ${img}"
+  fi
+done
+```
+
+An N-way identical hash (N ≥ 2) means the image is reused across that many languages — likely captured once in English and copied. The per-language uniqueness contract is documented in the "File Location and Localization" section of `SCREENSHOT-GUIDELINES.md` and enforced by `docs-screenshot-capturer`.
+
+Apply a whitelist read from `packages/backend.ai-webui-docs/.docs-lint-ignore-md5` (one filename per line). If the whitelist file does not exist, treat as empty. Diagrams, logos, and screenshots with no translatable UI text belong here.
+
+**3b. i18n key drift heuristic**:
+
+For each `![](images/<file>.png)` reference in `src/en/**/*.md`:
+
+1. Capture the surrounding ±20 lines as `context`.
+2. Extract short noun-phrase candidates from `context` — uppercase tokens, button-like words, words followed by "button" or "dialog" or "menu". This is a coarse heuristic.
+3. Search `resources/i18n/en.json` for matching string values. Use `grep -F` (literal, not regex) and quote the phrase to keep shell metacharacters safe:
+   ```bash
+   grep -nF -i -- "<candidate phrase>" resources/i18n/en.json
+   ```
+4. If at least one i18n match exists, capture the line number from `grep -n` (do NOT feed `<key>` into `git log -L /regex/` — keys can contain `/`, `.`, `*`, and other regex metacharacters that will break the search or, worse, match unintended lines). Then ask git for that single line's last-modification time:
+   ```bash
+   line=$(grep -nF -i -- "<candidate phrase>" resources/i18n/en.json | head -1 | cut -d: -f1)
+   [ -n "$line" ] && git log -1 --format=%cI -L "${line},+1:resources/i18n/en.json"
+   ```
+   Compare to the image's last commit time:
+   ```bash
+   git log -1 --format=%cI -- packages/backend.ai-webui-docs/src/en/images/<file>.png
+   ```
+5. If the i18n entry is **newer** than the image, flag as a stale candidate. Report which phrase matched, which line, and the two timestamps so the reviewer can sanity-check the heuristic.
+
+Both signals: report as **candidates** (not confirmed). Format:
+
+```
+- session_launch_dialog.png — signal: MD5-collision (4-way identical) + i18n-drift (key `session.LaunchSession` modified 2026-04-22, image last touched 2025-11-08)
+```
+
+### 4. Broken cross-ref / image link
+
+Across all `.md` files under `packages/backend.ai-webui-docs/src/{en,ko,ja,th}/`:
+
+1. Image refs — match `!\[[^]]*\]\(([^)]+)\)`. For each capture, resolve relative to the markdown file's directory. Report if the target file does not exist.
+2. Markdown links — match `\[[^\]]+\]\(([^)#?]+)\)`. Skip external URLs (`http://`, `https://`, `mailto:`). For relative paths, resolve and check existence.
+3. Anchors (`[text](other.md#section)`) — only verify the file portion exists. Anchor-level verification is out of scope (heading text differs per language).
+
+Report `file:line — broken: <target>` entries, capped at 100 per run with a `(N more truncated)` tail if exceeded.
+
+### 5. PR coverage gap
+
+Squash-merge environment — `git log --merges` is unreliable. Use `gh` with a since-date scoped to whatever ground the previous run already covered (fall back to a 60-day window for the first run):
+
+```bash
+# Reuse the last scan date to keep this scan incremental; otherwise look back 60 days.
+state_dir="packages/backend.ai-webui-docs/.agent-output"
+since_file="${state_dir}/.last-pr-coverage-scan"
+since=$(cat "$since_file" 2>/dev/null || date -u -d '60 days ago' '+%Y-%m-%d')
+gh pr list --state merged --base main \
+  --search "merged:>=${since}" \
+  --json number,title,files,mergedAt --limit 200
+# Record this run's date for the next scan (overwrite is intentional).
+mkdir -p "$state_dir" && date -u '+%Y-%m-%d' > "$since_file"
+```
+
+`--limit 50` was insufficient for this repo's velocity (it covered ~2 weeks); a since-date scoped scan with `--limit 200` is safer and stays incremental on repeated runs.
+
+Parse JSON. A PR is a "user-facing-without-docs" gap when **all** of:
+
+1. Title matches `^(feat|fix|style)\(FR-\d+\)`.
+2. No file path in `files[].path` starts with `packages/backend.ai-webui-docs/`.
+3. At least one file path is **not** in the non-user-facing exclude set:
+   - `^e2e/`
+   - `^scripts/`
+   - `^\.github/`
+   - `\.test\.(ts|tsx|js)$`
+   - `^configs/`
+   - `^src/wsproxy/`
+   - `^electron-app/`
+   - `^packages/eslint-config-bai/`
+   - `^packages/backend.ai-ui/.*\.stories\.(ts|tsx)$`
+
+Skip the gap report quietly (single "gh CLI unavailable" line) when `gh` is not installed or not authenticated, instead of failing the whole run.
+
+Output a table with PR number, title, merge date. Most recent first.
+
+## Run Procedure
+
+1. `mkdir -p packages/backend.ai-webui-docs/.agent-output/`
+2. Run the 5 diagnostics. If any single diagnostic raises an unexpected error, write its section as `ERROR: <message>` and continue — do not abort the whole run.
+3. Apply the rotation policy on the existing report file.
+4. Prepend the new run section. Write the file.
+5. Print a 1-line summary to stdout: `docs-lint: <total> findings (<terms> term / <parity> parity / <shot> shot / <ref> ref / <pr> pr) → packages/backend.ai-webui-docs/.agent-output/docs-lint-report.md`.
+
+## Hard Rules
+
+- **Diagnosis only.** Never `Edit`, `Write`, or `MultiEdit` documentation files. Your only `Write` targets are `packages/backend.ai-webui-docs/.agent-output/docs-lint-report.md` and `packages/backend.ai-webui-docs/.agent-output/.last-pr-coverage-scan`.
+- **No prompts.** This agent runs unattended. Do not ask the user clarifying questions.
+- **No network beyond `gh`.** `WebFetch` / `WebSearch` are not in your tool list. The only network call is `gh pr list`, and that is allowed to fail soft.
+- **Idempotent.** Two runs in a row with no repo changes should produce the same findings (timestamps aside).
+- **Single-runner per worktree.** The rotation policy on `docs-lint-report.md` is read-modify-write without locking; do not invoke this agent from two terminals at once against the same `packages/backend.ai-webui-docs/.agent-output/`. Within a single worktree this is the normal call pattern — just do not fan out.

--- a/.claude/skills/docs-lead/SKILL.md
+++ b/.claude/skills/docs-lead/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: docs-lead
+description: >
+  Use whenever the user mentions docs, the manual, documentation, terminology,
+  translations, or screenshots — including indirect mentions like "이 PR 문서
+  영향 봐줘", "문서 점검", "용어 통일", "/docs-lead", or any phrasing about
+  updating the Backend.AI WebUI user manual under
+  packages/backend.ai-webui-docs/. Single entry point that runs docs-lint
+  diagnosis, surfaces a prioritized queue via AskUserQuestion, and orchestrates
+  the four docs worker subagents (planner / writer / screenshot-capturer /
+  reviewer) through approval gates.
+---
+
+# docs-lead — Documentation Team Lead
+
+> **Category note**: This is a *skill* (runs in the main context with full
+> access to `AskUserQuestion` and the `Agent` tool), **not a subagent**. The
+> "Team Lead" metaphor describes the *role*, not the technical type — do not
+> look for this under `.claude/agents/`. The skill lives at
+> `.claude/skills/docs-lead/`. The `lead-*` prefix on agents like
+> `fw:lead-frontend-coder` is a separate convention (lead-as-adjective);
+> `docs-lead` is lead-as-noun.
+
+You are the docs team lead. The user makes one request and you handle the
+docs lifecycle — diagnosis, prioritization, planning, writing, screenshots,
+review — with explicit decision gates at every irreversible step. **You are
+the only caller of the docs worker agents.** Users should not invoke the
+workers directly while this skill is active. If they did (rare), take over:
+read the worker's output file, restore orchestration, and continue.
+
+## Reference files
+
+Read these on demand — they hold the bulk of the patterns so this SKILL.md
+stays scannable.
+
+- `references/karpathy-mapping.md` — three-layer/three-op model and why
+  Query is excluded. Read when reasoning about design or extension.
+- `references/worker-invocation-templates.md` — copy-ready `Agent(...)`
+  prompts for the four workers. Read in step 5 of the workflow.
+- `references/decision-gate-templates.md` — `AskUserQuestion` shape rules
+  and examples for the four gates. Read in step 4 / 5a / 5c / 6.
+- `references/anti-patterns.md` — shortcuts that corrupt the workflow over
+  time. Read when you're tempted to skip a gate or chain topics.
+
+## Domain context
+
+- Documentation root: `packages/backend.ai-webui-docs/src/{en,ko,ja,th}/`
+- Schema files (the editorial contract):
+  - `packages/backend.ai-webui-docs/TERMINOLOGY.md`
+  - `packages/backend.ai-webui-docs/DOCUMENTATION-STYLE-GUIDE.md`
+  - `packages/backend.ai-webui-docs/TRANSLATION-GUIDE.md`
+  - `packages/backend.ai-webui-docs/SCREENSHOT-GUIDELINES.md`
+  - `packages/backend.ai-webui-docs/src/book.config.yaml`
+- State files (you own these): `packages/backend.ai-webui-docs/.agent-output/`
+  - `docs-state.md` — append-only work log (rotates at 30 blocks)
+  - `docs-lint-report.md` — last 10 lint runs (rewrite-with-rotation, 256 KB cap)
+  - `docs-update-plan-{topic}.md`, `docs-review-report-{topic}.md` — per-topic worker outputs
+  - `archive/` — rotated entries
+
+**Why project-local state, not user-level `~/.claude/plugins/data/...`?**
+docs state is project-and-worktree-bound: the queue references PR numbers,
+file paths, and topic slugs that only make sense in this repo. It must live
+alongside the existing `docs-update-plan-{topic}.md` /
+`docs-review-report-{topic}.md` files the workers already produce, so
+hand-offs are coherent.
+
+## Karpathy mapping (one-line)
+
+Partial adoption of the LLM Wiki pattern (gist `442a6bf555914893e9891c11519de94f`):
+**Ingest** and **Lint** ops adopted, **Query** intentionally excluded. See
+`references/karpathy-mapping.md` for the full mapping and rationale.
+
+## Workflow
+
+Execute in order. Do not skip steps.
+
+### Step 1 — Load prior state
+
+```bash
+cat packages/backend.ai-webui-docs/.agent-output/docs-state.md 2>/dev/null || echo "(no prior state)"
+```
+
+Read what was last worked on, what is in flight, what was deferred. Missing
+file = empty queue.
+
+### Step 2 — Fresh health diagnosis
+
+**Reuse rule first**: if `docs-lint-report.md` exists with a top-section ISO
+timestamp within the last 10 minutes AND `git status --short -- packages/backend.ai-webui-docs/src/` is clean,
+skip the lint pass and reuse the existing report. Lint reads dozens of files;
+don't burn that cost twice in a row.
+
+Otherwise, invoke `docs-lint` via the Agent tool with `subagent_type: "docs-lint"`.
+Prompt: "Run a full lint pass and update `packages/backend.ai-webui-docs/.agent-output/docs-lint-report.md`
+per your rotation policy. Then summarize the top of the new run section (counts
+only) in your response."
+
+Then read just the top run section:
+
+```bash
+sed -n '/^---RUN---/,/^---RUN---/p' packages/backend.ai-webui-docs/.agent-output/docs-lint-report.md | head -120
+```
+
+### Step 3 — Build the work queue
+
+Merge three sources into one prioritized list:
+
+1. **User-explicit ask** (highest priority) — specific PR, feature, or area
+   the user pointed at.
+2. **Lint findings** — group by check type. PR coverage gaps are usually
+   highest-leverage; terminology drift is lowest-effort.
+3. **In-flight from state** — items marked `status: in-progress` or
+   `status: deferred`.
+
+Attach a one-line scope estimate to each item: which files change, which
+worker chain runs, whether screenshots are needed (live app required), which
+languages.
+
+### Step 4 — Decision gate
+
+Present 2–4 prioritized options via `AskUserQuestion`. **Shape rules and
+examples live in `references/decision-gate-templates.md` (Gate 1)**. Read
+that file when constructing this gate.
+
+Special cases:
+- Queue empty → do not call `AskUserQuestion`. Report "no work needed —
+  most recent lint on `<timestamp>` is clean" and stop.
+- More than 4 candidates → bundle lower-priority into "기타 N건 일괄 처리".
+- More than 5 lint findings → include a "전체 lint 리포트 먼저 보여줘"
+  option so the user can self-triage.
+
+### Step 5 — Orchestrate the chosen item
+
+The chain: `planner → [user confirm] → writer → [user confirm if screenshots] → screenshot-capturer → reviewer`.
+Reviewer runs automatically after writer; every other transition needs an
+explicit `AskUserQuestion` confirmation.
+
+For the actual `Agent(...)` invocation prompts for each worker, see
+`references/worker-invocation-templates.md`. Each prompt must be
+self-contained (workers don't see your context) and use a consistent
+kebab-case topic slug across the whole chain.
+
+#### 5a. Planner → plan confirmation gate
+
+1. Invoke `docs-update-planner` (see template).
+2. Read the resulting `packages/backend.ai-webui-docs/.agent-output/docs-update-plan-{topic}.md`.
+3. Summarize to the user in ≤4 bullets: files that will change, new sections,
+   screenshots needed, languages targeted.
+4. Decision gate — see `references/decision-gate-templates.md` Gate 2.
+
+#### 5b. Writer
+
+Only after the user confirms 5a. Invoke `docs-update-writer` (see template).
+After it returns, run `git status --short -- packages/backend.ai-webui-docs/src/`
+yourself to see what actually changed — do not trust the worker's claimed
+file list.
+
+#### 5c. Screenshot capture — live-app gate
+
+Only if the plan calls for screenshots. Decision gate first — see
+`references/decision-gate-templates.md` Gate 3. If user picks "지금 캡처",
+invoke `docs-screenshot-capturer` (see template). Skip this entire substep
+if the plan listed zero screenshots and writer left no TODO markers.
+
+#### 5d. Reviewer (automatic)
+
+Invoke `docs-update-reviewer` (see template). Summarize the report — critical
+/ warning / minor counts. If any "critical" exists, surface it to the user
+before declaring the topic complete.
+
+### Step 6 — Persist state, decide what's next
+
+Append a single block to `packages/backend.ai-webui-docs/.agent-output/docs-state.md`:
+
+```markdown
+## <ISO-8601 timestamp> — <topic slug>
+
+- Source: <PR # / feature description / lint-driven>
+- Status: completed | partial | deferred
+- Plan: packages/backend.ai-webui-docs/.agent-output/docs-update-plan-<topic>.md
+- Review: packages/backend.ai-webui-docs/.agent-output/docs-review-report-<topic>.md
+- Worker chain: planner → writer → [screenshot-capturer] → reviewer
+- Files changed: <count> across <languages>
+- Outstanding: <one-line if partial; omit otherwise>
+```
+
+**Rotation**: if `docs-state.md` now has more than 30 `## ` blocks, move the
+oldest blocks into `packages/backend.ai-webui-docs/.agent-output/archive/docs-state-YYYY-QN.md` (calendar
+quarter of the moved entries' first timestamp; append to the archive if it
+exists).
+
+Then decide what's next — see `references/decision-gate-templates.md` Gate 4.
+If queue is empty, do not gate; just report and stop.
+
+## Hard rules
+
+- **Approval gate before writing.** Never call `docs-update-writer` without
+  an explicit `AskUserQuestion` confirmation immediately preceding it. Lint
+  findings alone are not consent.
+- **Live-app gate before screenshots.** Never call `docs-screenshot-capturer`
+  without an explicit live-app readiness confirmation.
+- **Workers never call other workers.** Each worker invocation is
+  independent; hand-off goes through this skill and `packages/backend.ai-webui-docs/.agent-output/`.
+- **No silent edits.** This skill itself must not `Edit` docs files. Mutation
+  is delegated to `docs-update-writer`. The only files this skill writes
+  directly are `packages/backend.ai-webui-docs/.agent-output/docs-state.md` (and its `archive/` rotations).
+- **Idempotency.** Re-invoking with no new changes produces no new queue
+  items beyond what is already in state.
+- **One topic per chain.** Always return to the decision gate (step 4 or
+  step 6) between topics. Multi-topic chains make rollback impossible and
+  inflate context catastrophically.
+- **Match the user's language.** Reply in the language the user is using —
+  Korean if they speak Korean, English if they switch. Worker outputs (plan
+  files, lint reports, PR bodies) stay in English regardless; that is a
+  documentation convention, not a conversation rule.
+
+## Gotchas
+
+Real failure modes you will hit if you don't think about them up front.
+
+- **`docs-lint`'s i18n-key-drift signal is heuristic** — it produces
+  candidates, not confirmed stales. Never auto-recapture based on it alone.
+  Surface to user, let them eyeball before triggering
+  `docs-screenshot-capturer`.
+
+- **`docs-update-planner` overwrites `docs-update-plan-{topic}.md`** if you
+  call it twice with the same topic slug. Before invoking, check:
+
+  ```bash
+  ls packages/backend.ai-webui-docs/.agent-output/docs-update-plan-<topic>.md 2>/dev/null
+  ```
+
+  If a plan exists, ask the user: continue from it, overwrite, or pick a
+  different slug (e.g., suffix with `-v2`).
+
+- **`docs-screenshot-capturer` requires the dev server live** at
+  `https://<branch>.localhost:1355` (Portless — see project root
+  `CLAUDE.md`). If `pnpm dev` isn't running, the worker fails partway and
+  leaves orphan files in `.playwright-mcp/`. Always confirm liveness in
+  Gate 3 and remind the user how to start the server if they're unsure.
+
+- **`git log --merges` is empty in this repo** because PRs are
+  squash-merged via Graphite. `docs-lint` already uses `gh pr list` for
+  coverage gaps; if you ever extend coverage detection yourself, use the
+  same path — not `git log --merges`.
+
+- **`fw:docs-plan` (plugin slash command) is *not* this skill.** It only
+  runs `docs-planner` once, without lint, without orchestration, without
+  state. If a user invokes `/fw:docs-plan` directly, that's fine — but
+  don't conflate it with `/docs-lead`. If they ask "어떻게 다른가?",
+  explain: `fw:docs-plan` = single planner shot; `docs-lead` = full lint
+  + queue + chain + state.
+
+- **`AskUserQuestion` always offers "Other".** The user can type a free-text
+  response even when your options don't cover their case. If they pick
+  "Other" with a custom intent (e.g., "PR #7430 먼저 처리해줘"), treat that
+  as a queue override and rebuild from step 3 — don't try to fit it into the
+  closest existing option.

--- a/.claude/skills/docs-lead/references/anti-patterns.md
+++ b/.claude/skills/docs-lead/references/anti-patterns.md
@@ -1,0 +1,91 @@
+# Anti-patterns
+
+Patterns that look reasonable but corrupt the docs-lead workflow over time.
+Read this when you're tempted to take a shortcut that "obviously" saves a
+turn.
+
+## Workflow shortcuts
+
+- **Calling `docs-update-planner` and `docs-update-writer` in the same turn
+  without showing the plan to the user.** Skips the editorial gate. Even if
+  the plan is "obviously fine", surfacing it is what teaches the user trust
+  in the system. Without trust, the user starts second-guessing every output.
+
+- **Showing the user a 200-line lint report dump instead of a 4-option
+  AskUserQuestion summary.** Defeats the purpose of having a triage agent.
+  Lint output goes to `packages/backend.ai-webui-docs/.agent-output/docs-lint-report.md`; the user gets a
+  decision gate, not a wall of text.
+
+- **Re-running `docs-lint` when a fresh report exists from the last few
+  minutes.** Check the timestamp of the top run section — if within 10
+  minutes and the user hasn't made changes since (`git status --short` is
+  clean for `src/`), reuse the existing report. Each lint run reads dozens
+  of files; rerunning is expensive.
+
+- **Treating a worker's "completed" signal as proof of correctness.** Always
+  look at the actual diff via `git status --short -- packages/backend.ai-webui-docs/src/`
+  and read the reviewer's report. Workers can mis-report what they did.
+
+- **Chaining step 5 for multiple topics in one uninterrupted run.** Even
+  when the user picks "all of the above" implicitly, return to the decision
+  gate (step 4 or step 6) between topics. Multi-topic runs make rollback
+  impossible and inflate context catastrophically.
+
+- **Running two docs-lead invocations against the same `packages/backend.ai-webui-docs/.agent-output/`
+  simultaneously.** `docs-lint`'s rotation and `docs-state.md`'s append are
+  both read-modify-write without locking. Two parallel runs can clobber
+  each other's writes. Within a single worktree the skill is single-runner
+  by design — do not fan it out from two terminals.
+
+- **Treating the approval gates as enforced.** The "never call writer
+  without AskUserQuestion confirmation" and "never call screenshot-capturer
+  without live-app confirmation" rules are honor-system. There is no
+  middleware blocking a worker call; the only safeguard is this skill
+  reading and following its own Hard Rules. If you find yourself thinking
+  "the user obviously wants me to skip this gate", stop and ask anyway —
+  the gate is what makes the workflow trustworthy.
+
+## Queue shape
+
+- **Letting the work queue grow without bound.** If step 4 surfaces more
+  than 4 options, group lower-priority items into one bundled option
+  ("기타 N건 일괄 처리"). The bundle option, when selected, becomes its
+  own sub-triage.
+
+- **Skipping the "no work needed" verdict.** When lint + state both come up
+  empty, the right output is *"no work needed — most recent run on <date>
+  covered everything"*. Do not invent work to justify the invocation.
+
+## Editorial control
+
+- **Auto-fixing terminology drift via the skill.** Even though it's trivial,
+  the rule is workers do mutations, the skill does orchestration. Route
+  through `docs-update-writer` with a one-line "fix terminology drift listed
+  in lint report" plan.
+
+- **`docs-lint` auto-fixing anything.** Lint is diagnosis-only. If you find
+  yourself adding `Edit` or `Write` (to docs files) capability to docs-lint,
+  stop — that's a `docs-update-writer` job.
+
+- **Re-introducing a Query op.** The skill explicitly excludes Karpathy's
+  Query operation. If users ask "can it answer questions about the manual
+  too?", point them at the manual itself or escalate to a human writer.
+  Adding Query without the same approval-gate pattern as Ingest will erode
+  human editorial control over time.
+
+## Data hygiene
+
+- **Writing to user-level `~/.claude/plugins/data/...` instead of
+  `packages/backend.ai-webui-docs/.agent-output/`.** docs state is project-and-worktree-bound. User-level
+  storage means another worktree on the same machine, or another machine
+  entirely, can't see it. Stick with `packages/backend.ai-webui-docs/.agent-output/`.
+
+- **Skipping the rotation policy.** `docs-state.md` rotates at 30 blocks
+  into quarterly archives. `docs-lint-report.md` keeps 10 runs with a 256
+  KB cap. Don't let either file grow unbounded — git status churn and
+  context cost will both bite.
+
+- **Manually editing `docs-state.md` to "clean it up".** It is the
+  permanent log. Append-only is the contract. If something needs
+  correcting, append a new block describing the correction; don't rewrite
+  history.

--- a/.claude/skills/docs-lead/references/decision-gate-templates.md
+++ b/.claude/skills/docs-lead/references/decision-gate-templates.md
@@ -1,0 +1,120 @@
+# Decision-gate templates
+
+Patterns for `AskUserQuestion` calls in the docs-lead workflow. Read this when
+you are about to surface a decision gate to the user and need a template
+matching the situation.
+
+## Rules for every option
+
+- **Label**: very short (≤12 chars where possible). Action-y. Avoid full
+  sentences.
+- **Description**: one sentence. Must cover *scope* (which files/sections),
+  *worker chain* (which workers will run), and *live-app need* (yes/no).
+- **Order**: highest-priority / recommended option first, with "(Recommended)"
+  suffix in the label.
+- **Number**: 2 minimum, 4 maximum. If you have more candidates, bundle the
+  lower-priority ones into one "기타 N건 일괄 처리" option.
+- **Always include an escape hatch** for the user to ask for more detail
+  before deciding (e.g., "전체 lint 리포트 먼저 보여줘") when there are
+  more than 5 underlying findings.
+- **Language match.** Reply in the language the user is using (usually
+  Korean for this team's day-to-day requests). Artifact names — issue keys,
+  file paths, PR titles, worker output filenames — stay in English regardless.
+
+## Gate 1 — Top-level priority queue (Step 4)
+
+After lint + state load + queue build. Example for a typical day:
+
+```yaml
+question: "다음 docs 작업 중 어디부터 진행할까요?"
+header: "우선순위"
+multiSelect: false
+options:
+  - label: "PR #<N> 반영 (Recommended)"
+    description: "feat(FR-XXXX) docs 미반영. <area1> + <area2> 영향. 4개 언어. 스크린샷 <N>장 필요(라이브 앱)."
+  - label: "용어 drift 일괄"
+    description: "TERMINOLOGY 위반 <N>건. en만. planner→writer→reviewer, 스크린샷 불필요."
+  - label: "th parity 갭"
+    description: "th에 누락된 H2 <N>개. writer만 호출. 스크린샷 불필요."
+  - label: "리포트 먼저 보기"
+    description: "결정 보류, 전체 lint 리포트 출력."
+```
+
+If the queue has only one item and the next step is mutation (writer /
+screenshot-capturer): **do not add a redundant top-level Gate 1.** Proceed
+in prose ("The only item is X; running planner next") and rely on the
+per-worker confirmation gates (Gate 2 before writer, Gate 3 before
+screenshot-capturer). Top-level gates are for branching points, not status
+announcements — see `anti-patterns.md` → "Asking for confirmation when there
+is nothing to confirm."
+
+If the queue is empty: do not call `AskUserQuestion` at all — report "no
+work needed" and stop.
+
+## Gate 2 — Plan confirmation (after planner, Step 5a → 5b)
+
+```yaml
+question: "<topic> plan을 확인했습니다. 다음 단계는?"
+header: "Plan 결정"
+multiSelect: false
+options:
+  - label: "Writer 호출 (Recommended)"
+    description: "plan대로 진행. en → ko → ja → th 순으로 작성."
+  - label: "Plan 수정"
+    description: "어디를 바꿀지 알려주세요 (scope / sections / screenshots / languages)."
+  - label: "보류"
+    description: "docs-state에 deferred로 기록하고 중단."
+```
+
+Plan summary (4 bullets max — files, new sections, screenshots, languages) MUST
+appear in the same turn as this question, immediately above it. Do not ask
+without showing the summary first.
+
+## Gate 3 — Live-app readiness (before screenshot-capturer, Step 5c)
+
+```yaml
+question: "스크린샷 캡처는 라이브 앱이 필요합니다. 지금 진행할까요?"
+header: "스크린샷"
+multiSelect: false
+options:
+  - label: "지금 캡처"
+    description: "앱이 실행 중이면 진행 (보통 https://*.localhost:1355). 캡처 완료 후 reviewer로."
+  - label: "나중에 캡처"
+    description: "writer가 남긴 TODO 마커 유지, reviewer 단계로 바로 이동."
+  - label: "건너뛰기 (별도 PR)"
+    description: "이번 topic에선 캡처 생략, 스크린샷용 별도 후속 PR로 분리."
+```
+
+If writer already left no TODO markers and plan listed zero screenshots, skip
+this gate entirely.
+
+## Gate 4 — Continue or stop (Step 6)
+
+```yaml
+question: "<topic> 완료. 다음 큐 항목으로 계속할까요?"
+header: "계속"
+multiSelect: false
+options:
+  - label: "다음 항목 진행"
+    description: "<next-topic-summary>"
+  - label: "여기서 중단"
+    description: "docs-state에 기록 완료. 나머지는 다음 번에."
+```
+
+If queue is now empty after the completed topic: do not call this gate. Just
+report "큐가 비었습니다. 다음 invocation 때 다시 진단하겠습니다." and stop.
+
+## Anti-patterns
+
+- **Too-concrete examples in the prompt context window.** When generating the
+  actual options, derive them from current state — do not paste templates
+  verbatim. Templates here are *shape* not *content*.
+- **Skipping the recommended marker.** "(Recommended)" matters; it sets user
+  expectation and reduces decision fatigue.
+- **Hiding live-app requirement in option description.** It must be in the
+  description — users who skim labels still see it in the description column
+  before clicking.
+- **Asking for confirmation when there is nothing to confirm.** If the queue
+  has one item with one obvious next step, say what you're going to do in
+  prose and proceed. Decision gates exist for branching points, not for
+  status announcements.

--- a/.claude/skills/docs-lead/references/karpathy-mapping.md
+++ b/.claude/skills/docs-lead/references/karpathy-mapping.md
@@ -1,0 +1,68 @@
+# Karpathy LLM Wiki — mapping for docs-lead
+
+docs-lead is a partial adoption of Andrej Karpathy's "LLM Wiki" pattern
+(gist `442a6bf555914893e9891c11519de94f`, April 2026). Read this file when you
+need to reason about why the skill is shaped the way it is, or when extending
+the skill in ways that touch the layer/op model.
+
+## Three-layer architecture
+
+| Layer | In Karpathy's pattern | In Backend.AI WebUI docs |
+|---|---|---|
+| Raw Sources | Immutable reference docs (articles, papers, PDFs) | React source, i18n JSON, PR history, Jira issues — **not** owned by docs-lead |
+| Wiki | LLM-generated markdown with cross-refs, summaries, entity pages | `packages/backend.ai-webui-docs/src/{en,ko,ja,th}/**` — sometimes human-edited, but the LLM is the primary writer |
+| Schema | Configuration documenting wiki structure and workflows | `TERMINOLOGY.md`, `DOCUMENTATION-STYLE-GUIDE.md`, `TRANSLATION-GUIDE.md`, `SCREENSHOT-GUIDELINES.md`, `book.config.yaml` |
+
+## Three operations — what we adopted
+
+### Ingest (✅ adopted)
+
+In Karpathy's pattern: when a new raw source arrives, the LLM extracts key info
+and integrates it across 10–15 wiki pages simultaneously.
+
+In docs-lead: a user-facing PR (or feature description) triggers the
+`docs-update-planner` → `docs-update-writer` chain. The planner identifies which
+pages are affected (matching Karpathy's "across N pages" insight); the writer
+produces the multi-page updates. Approval gate sits between planner and writer
+because the user manual is human-curated, not autonomously rewritten.
+
+### Lint (✅ adopted)
+
+In Karpathy's pattern: periodic health checks identify contradictions, stale
+claims, orphaned pages, and data gaps.
+
+In docs-lead: the `docs-lint` subagent runs five checks (terminology drift,
+translation parity gap, stale screenshot candidates, broken cross-ref / image
+link, PR coverage gap). Output is diagnosis-only — auto-fix is forbidden, even
+when the fix is trivial. The user remains the editorial gate.
+
+### Query (❌ not adopted — by design)
+
+In Karpathy's pattern: ask questions against the wiki; valuable answers become
+new pages, compounding value.
+
+Why we skipped it for docs-lead:
+
+- The user manual is a *curated* artifact with editorial constraints (release
+  cuts, version pinning, translation parity). Auto-generated pages would
+  violate these constraints.
+- Users reading the manual go through the website / PDF, not through a query
+  agent. No clear user demand.
+- "Query → new page" is the part of Karpathy's pattern that most easily drifts
+  away from human oversight. Excluding it keeps the skill aligned with the
+  user-controls-final-output requirement.
+
+If a Query channel is added later, gate it the same way Ingest is gated:
+proposed-page output goes through user approval (and likely the
+docs-update-reviewer pass) before landing in `src/`.
+
+## Why this matters for future maintainers
+
+- **Do not let workers create pages without going through the planner.** The
+  planner is what enforces "across N pages" + book.config.yaml registration.
+- **Do not weaken the lint→diagnosis-only rule.** That is what keeps human
+  editors in control. The auto-fix temptation is real (terminology drift looks
+  trivially fixable) but it is the path that turns a user manual into an
+  LLM-curated wiki, which is not what the project wants.
+- **If you add a Query op, copy the Ingest approval-gate pattern.** Don't ship
+  it as a side door.

--- a/.claude/skills/docs-lead/references/worker-invocation-templates.md
+++ b/.claude/skills/docs-lead/references/worker-invocation-templates.md
@@ -1,0 +1,117 @@
+# Worker invocation templates
+
+Copy-ready `Agent` invocation prompts for the four docs workers. Read this when
+you (docs-lead) are about to call a worker and want the prompt to be
+self-contained, idempotent, and aligned with how each worker expects to be
+briefed.
+
+## Conventions for every worker prompt
+
+- **The templates below are illustrative shapes, not literal JS strings.**
+  When constructing the actual `Agent({...})` call, build the `prompt` value
+  as plain prompt text and substitute values (topic slug, PR title, lint
+  excerpts, file lists) directly into that string. The backtick-quoted
+  templates below read like JS template literals, but a PR title containing
+  a backtick or `${…}` would break a verbatim template-literal copy. Treat
+  these blocks as a *shape contract* — what to include, in what order, with
+  what tone — not as code to paste.
+- **Self-contained.** Workers see a fresh context window — repeat anything they
+  need, including the topic slug, the source PR / feature description, the
+  affected sections, and the lint findings (if lint-driven). Do not assume the
+  worker can read prior conversation.
+- **Topic slug consistency.** Use the same kebab-case slug across all four
+  workers in a chain (`vfolder-bulk-delete`, `model-serving-revisions`, etc.).
+  This is what makes `docs-update-plan-{topic}.md` and
+  `docs-review-report-{topic}.md` line up.
+- **Explicit output paths.** Tell each worker where its output goes, even
+  though the worker's own SKILL.md/agent.md already specifies it. Belt and
+  suspenders.
+
+## `docs-update-planner`
+
+```
+Agent({
+  description: "Plan docs update for <topic>",
+  subagent_type: "docs-update-planner",
+  prompt: `Source: <PR # / feature description / lint-driven>
+Topic slug: <kebab-case>
+<If lint-driven:> Motivating lint findings (verbatim from latest docs-lint-report.md):
+<paste 3–10 line excerpt>
+<If PR-driven:> PR title / FR-XXXX / summary of user-facing change
+<If feature-driven:> Free-text description of the feature
+
+Produce a plan at packages/backend.ai-webui-docs/.agent-output/docs-update-plan-<topic>.md following your
+standard format (target sections, screenshots needed, languages, navigation
+updates). Then report the exact filename you wrote so I can read it.`
+})
+```
+
+## `docs-update-writer`
+
+```
+Agent({
+  description: "Write docs from plan",
+  subagent_type: "docs-update-writer",
+  prompt: `Read packages/backend.ai-webui-docs/.agent-output/docs-update-plan-<topic>.md and execute it end to
+end. Write English (src/en/) first, then ko/ja/th. Apply terminology from
+TERMINOLOGY.md, formatting from DOCUMENTATION-STYLE-GUIDE.md, and translation
+rules from TRANSLATION-GUIDE.md. Leave TODO markers for any screenshots that
+the plan requests but cannot yet be captured. When done, list (file path,
+language, change type) for every file you touched.`
+})
+```
+
+## `docs-screenshot-capturer`
+
+```
+Agent({
+  description: "Capture docs screenshots",
+  subagent_type: "docs-screenshot-capturer",
+  prompt: `Live app: <URL — typically https://<branch>.localhost:1355>
+Sample creds (read from e2e/envs/.env.playwright): use admin or user as the
+target screenshot's audience requires.
+
+Capture:
+- images/<filename>.png — <one-line description, navigation path, UI state to
+  prepare>
+- images/<filename2>.png — ...
+
+Capture in all 4 language UI locales (en, ko, ja, th) using window.switchLanguage
+per SCREENSHOT-GUIDELINES.md. Use 2× zoom. Crop to the relevant element via
+'ref' parameter unless a page-overview capture is explicitly requested. Verify
+per-language MD5 uniqueness at the end and report results. Clean up any test
+resources created during capture.`
+})
+```
+
+## `docs-update-reviewer`
+
+```
+Agent({
+  description: "Review docs changes",
+  subagent_type: "docs-update-reviewer",
+  prompt: `Topic: <kebab-case>
+Plan file: packages/backend.ai-webui-docs/.agent-output/docs-update-plan-<topic>.md
+Files touched by writer (from git status --short):
+<paste short list>
+
+Run the standard accuracy / consistency / style / translation-quality review.
+Write the report to packages/backend.ai-webui-docs/.agent-output/docs-review-report-<topic>.md. Apply
+auto-fixable issues directly. In your response, summarize counts by severity
+(critical / warning / minor) and call out anything that requires human
+attention.`
+})
+```
+
+## What to do with worker output
+
+- **Planner** — read the plan file, summarize to user in ≤4 bullets, then
+  decision-gate via `AskUserQuestion` (see `decision-gate-templates.md`).
+- **Writer** — run `git status --short -- packages/backend.ai-webui-docs/src/`
+  yourself; don't trust the worker's claimed file list. Real diff is ground
+  truth.
+- **Screenshot-capturer** — verify the per-language MD5 uniqueness report. If
+  the worker silently skipped a language, push back.
+- **Reviewer** — read the report file. Surface severity counts; if any
+  "critical" exists, surface it to the user before declaring the topic
+  completed.

--- a/packages/backend.ai-webui-docs/CLAUDE.md
+++ b/packages/backend.ai-webui-docs/CLAUDE.md
@@ -49,16 +49,22 @@ Each language directory mirrors the same structure:
 
 ## AI Agent Workflow
 
-Four agents handle the documentation lifecycle:
+**Single entry point**: For any docs work (updates, periodic health checks, terminology cleanup, translation parity), invoke the **`docs-lead`** skill from the main context. docs-lead runs `docs-lint` for diagnosis, surfaces a prioritized work queue via `AskUserQuestion`, and then orchestrates the four workers below with explicit approval gates. **Do not invoke the workers directly** — go through docs-lead so prior state, lint findings, and worker hand-offs stay coherent.
 
-1. **docs-update-planner** - Analyzes PR changes or feature descriptions to create a documentation update plan (`.agent-output/docs-update-plan-{topic}.md`)
-2. **docs-update-writer** - Writes documentation content across all 4 languages following the plan
-3. **docs-update-reviewer** - Reviews for accuracy, consistency, style, and translation quality; auto-fixes issues (`.agent-output/docs-review-report-{topic}.md`)
-4. **docs-screenshot-capturer** - Captures screenshots using Playwright MCP by navigating the live application, saves to all language image directories
+The full agent set:
+
+- **`docs-lead`** (skill, main context) — Triage, prioritization, decision gates, worker orchestration, accumulating state in `.agent-output/docs-state.md`. The single entry point. Adopts Karpathy's LLM Wiki Ingest + Lint operations (Query is intentionally not adopted — the manual stays human-curated).
+- **`docs-lint`** (subagent, diagnosis-only) — Health diagnosis across five checks: terminology drift (parses `TERMINOLOGY.md` "Terms to Avoid"), translation parity gap, stale screenshot candidates, broken cross-ref / image link, PR coverage gap. Writes `.agent-output/docs-lint-report.md` with a 10-run rolling history. **Never modifies docs.**
+- **`docs-update-planner`** (subagent) — Analyzes PR changes or feature descriptions to create a documentation update plan (`.agent-output/docs-update-plan-{topic}.md`)
+- **`docs-update-writer`** (subagent) — Writes documentation content across all 4 languages following the plan
+- **`docs-update-reviewer`** (subagent) — Reviews for accuracy, consistency, style, and translation quality; auto-fixes issues (`.agent-output/docs-review-report-{topic}.md`)
+- **`docs-screenshot-capturer`** (subagent) — Captures screenshots using Playwright MCP by navigating the live application, saves to all language image directories
 
 ### Agent Working Files
 
-Agent output files (plans, review reports) are stored in `.agent-output/` (gitignored). Files use topic-specific names to avoid collisions:
+Agent output files (plans, review reports, lint reports, state) are stored in `.agent-output/` (gitignored). Files use topic-specific names where applicable to avoid collisions:
+- `.agent-output/docs-state.md` — docs-lead's accumulating work log (last 30 entries; older entries rotated to `.agent-output/archive/docs-state-YYYY-QN.md`)
+- `.agent-output/docs-lint-report.md` — last 10 lint runs (rewrite-with-rotation, 256 KB cap)
 - `.agent-output/docs-update-plan-{topic}.md` — Documentation update plans
 - `.agent-output/docs-review-report-{topic}.md` — Review reports
 


### PR DESCRIPTION
Resolves #7498 (FR-2929)

## Summary

- Introduce `docs-lead` skill (`.claude/skills/docs-lead/`) as the **single entry point** for all Backend.AI WebUI user-manual work. It runs `docs-lint` for diagnosis, surfaces a prioritized work queue via `AskUserQuestion`, and orchestrates the four existing docs worker subagents (`docs-update-planner` → `docs-update-writer` → `docs-screenshot-capturer` → `docs-update-reviewer`) through explicit approval gates. State accumulates in `.agent-output/docs-state.md`.
- Introduce `docs-lint` subagent (`.claude/agents/docs-lint.md`) for periodic health diagnosis. Five checks: terminology drift (parses `TERMINOLOGY.md` "Terms to Avoid"), translation parity gap (en vs ko/ja/th heading structure), stale screenshot candidates (MD5 collision + i18n key drift), broken cross-ref / image link, PR coverage gap (`gh pr list` against `packages/backend.ai-webui-docs/` paths). Writes `.agent-output/docs-lint-report.md` with a 10-run rolling history. **Diagnosis-only — never modifies docs.**
- Partial adoption of Andrej Karpathy's "LLM Wiki" pattern (gist `442a6bf555914893e9891c11519de94f`): **Ingest** and **Lint** operations adopted; **Query** intentionally excluded so the user manual stays human-curated. See `.claude/skills/docs-lead/references/karpathy-mapping.md` for the full mapping.
- `docs-lead` is a *skill* (runs in main context with `AskUserQuestion` + `Agent` tool access), not a subagent. The "Team Lead" naming describes the role, not the technical type — the `lead-*` prefix on agents like `fw:lead-frontend-coder` is a separate convention (lead-as-adjective vs lead-as-noun here).
- `packages/backend.ai-webui-docs/CLAUDE.md` updated to point future agents at `docs-lead` as the canonical entry point and lists the new agent set (six entries: lead + lint + the four workers).
- No changes to the four existing docs workers; they remain the units `docs-lead` orchestrates.

## Test plan

- [ ] Invoke `/docs-lead` (or say "docs 봐줘" / "문서 점검") and verify the skill activates from the available-skills list with the new trigger-style description.
- [ ] Verify `docs-lint` subagent runs end-to-end on this branch and writes `packages/backend.ai-webui-docs/.agent-output/docs-lint-report.md` with the five-section structure and a rotation header.
- [ ] Confirm `docs-lead` surfaces a decision gate via `AskUserQuestion` with 2–4 prioritized options derived from lint findings + state.
- [ ] Confirm the approval-gate enforcement: `docs-update-writer` cannot be invoked without an immediately-preceding `AskUserQuestion` confirmation, and `docs-screenshot-capturer` cannot be invoked without an explicit live-app readiness confirmation.
- [ ] Read `packages/backend.ai-webui-docs/CLAUDE.md` in the GitHub UI and verify the "AI Agent Workflow" section renders the single-entry-point paragraph plus the six-entry agent list correctly.
- [ ] Inspect `.claude/skills/docs-lead/references/` — four reference files (karpathy-mapping, worker-invocation-templates, decision-gate-templates, anti-patterns) load on demand, keeping the SKILL.md context cost bounded.