### PR TITLE
refactor(FR-2930): migrate AdminDeploymentListPage to BAIModelDeploymentNodes

### DIFF
--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import type { AdminDeploymentListPageDeleteMutation } from '../__generated__/AdminDeploymentListPageDeleteMutation.graphql';
 import type {
   AdminDeploymentListPageQuery,
   DeploymentFilter,
@@ -9,14 +10,10 @@ import type {
   DeploymentStatus,
   OrderDirection,
 } from '../__generated__/AdminDeploymentListPageQuery.graphql';
-import { DeploymentSettingModal_deployment$key } from '../__generated__/DeploymentSettingModal_deployment.graphql';
+import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
-import DeploymentList, {
-  availableDeploymentOrderValues,
-  tableOrderToSort,
-  type DeploymentOrderValue,
-  type DeploymentStatusCategory,
-} from '../components/DeploymentList';
+import BAIRadioGroup from '../components/BAIRadioGroup';
+import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import DeploymentSettingModal from '../components/DeploymentSettingModal';
 import PrometheusPresetTab from '../components/PrometheusPresetTab';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
@@ -24,28 +21,62 @@ import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginati
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import AdminDeploymentPresetListPage from './AdminDeploymentPresetListPage';
 import AdminModelCardListPage from './AdminModelCardListPage';
-import { Skeleton } from 'antd';
+import { DeleteFilled, EditOutlined } from '@ant-design/icons';
+import { App, Skeleton, Typography } from 'antd';
 import type { CardTabListType } from 'antd/es/card';
 import {
   BAICard,
+  BAIDeleteConfirmModal,
+  BAIDeploymentTagChips,
   BAIFetchKeyButton,
-  filterOutEmpty,
+  BAIFlex,
+  BAIGraphQLFilterProperty,
+  BAIGraphQLPropertyFilter,
+  BAIModelDeploymentNodes,
+  BAINameActionCell,
+  BAIUnmountAfterClose,
+  DeploymentOrderValue,
   GraphQLFilter,
   INITIAL_FETCH_KEY,
+  ModelDeploymentNodeInList,
+  availableDeploymentSorterValues,
+  deploymentTableOrderToSort,
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+  isValidUUID,
   toLocalId,
+  useBAILogger,
   useFetchKey,
 } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery } from 'react-relay';
+import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 import { useSearchParams } from 'react-router-dom';
+
+type DeploymentStatusCategory = 'running' | 'finished';
 
 const AdminDeploymentListPageContent: React.FC = () => {
   'use memo';
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const { logger } = useBAILogger();
+  const baiClient = useSuspendedBackendaiClient();
   const webUINavigate = useWebUINavigate();
-  const [editingDeploymentFrgmt, setEditingDeploymentFrgmt] =
-    useState<DeploymentSettingModal_deployment$key | null>(null);
+
+  const [editingDeploymentId, setEditingDeploymentId] = useState<string | null>(
+    null,
+  );
+  const [deletingDeploymentId, setDeletingDeploymentId] = useState<
+    string | null
+  >(null);
+  const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
+    useState<DeploymentRevisionDetail_revision$key | null>(null);
+
+  const supportsExtendedFilter = baiClient.supports(
+    'model-deployment-extended-filter',
+  );
 
   const {
     baiPaginationOption,
@@ -63,7 +94,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
           ? (value as GraphQLFilter)
           : ({} as GraphQLFilter),
       ),
-      order: parseAsStringLiteral(availableDeploymentOrderValues),
+      order: parseAsStringLiteral(availableDeploymentSorterValues),
       statusCategory: parseAsStringLiteral<DeploymentStatusCategory>([
         'running',
         'finished',
@@ -78,12 +109,13 @@ const AdminDeploymentListPageContent: React.FC = () => {
 
   const [fetchKey, updateFetchKey] = useFetchKey();
 
-  const sort = tableOrderToSort(queryParams.order);
   const finishedStatuses: ReadonlyArray<DeploymentStatus> = ['STOPPED'];
   const statusCategoryFilter: DeploymentFilter =
     queryParams.statusCategory === 'finished'
       ? { status: { in: finishedStatuses } }
       : { status: { notIn: finishedStatuses } };
+
+  const sort = deploymentTableOrderToSort(queryParams.order);
   const queryVariables = {
     filter: {
       ...((queryParams.filter ?? {}) as DeploymentFilter),
@@ -118,7 +150,23 @@ const AdminDeploymentListPageContent: React.FC = () => {
           limit: $limit
           offset: $offset
         ) {
-          ...DeploymentList_modelDeploymentConnection
+          count
+          edges {
+            node {
+              id
+              ...BAIModelDeploymentNodesFragment
+              ...DeploymentSettingModal_deployment
+              metadata {
+                name
+                status
+              }
+              currentRevision @since(version: "26.4.3") {
+                id
+                revisionNumber
+                ...DeploymentRevisionDetail_revision
+              }
+            }
+          }
         }
       }
     `,
@@ -132,61 +180,306 @@ const AdminDeploymentListPageContent: React.FC = () => {
     },
   );
 
+  const deploymentNodes = filterOutNullAndUndefined(
+    _.map(adminDeployments?.edges, 'node'),
+  );
+  const total = adminDeployments?.count ?? 0;
+  const editingDeployment =
+    editingDeploymentId == null
+      ? null
+      : (deploymentNodes.find((n) => n.id === editingDeploymentId) ?? null);
+  const deletingDeployment =
+    deletingDeploymentId == null
+      ? null
+      : (deploymentNodes.find((n) => n.id === deletingDeploymentId) ?? null);
+
   const isLoading =
     deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
 
+  const [commitDeleteMutation, isInFlightDeleteMutation] =
+    useMutation<AdminDeploymentListPageDeleteMutation>(graphql`
+      mutation AdminDeploymentListPageDeleteMutation(
+        $input: DeleteDeploymentInput!
+      ) {
+        deleteModelDeployment(input: $input) {
+          id
+        }
+      }
+    `);
+
+  const uuidRule = {
+    message: t('general.InvalidUUID'),
+    validate: (value: string) => isValidUUID(value.toLowerCase()),
+  };
+
+  const filterProperties: Array<BAIGraphQLFilterProperty> = filterOutEmpty([
+    {
+      key: 'name',
+      propertyLabel: t('deployment.filter.Name'),
+      type: 'string',
+    },
+    {
+      key: 'tags',
+      propertyLabel: t('deployment.filter.Tags'),
+      type: 'string',
+    },
+    {
+      key: 'endpointUrl',
+      propertyLabel: t('deployment.filter.EndpointUrl'),
+      type: 'string',
+    },
+    {
+      key: 'openToPublic',
+      propertyLabel: t('deployment.filter.OpenToPublic'),
+      type: 'boolean',
+    },
+    supportsExtendedFilter && {
+      key: 'domainName',
+      propertyLabel: t('deployment.filter.DomainName'),
+      type: 'string' as const,
+    },
+    supportsExtendedFilter && {
+      key: 'resourceGroup',
+      propertyLabel: t('deployment.filter.ResourceGroup'),
+      type: 'string' as const,
+    },
+    supportsExtendedFilter && {
+      key: 'projectId',
+      propertyLabel: t('deployment.filter.ProjectId'),
+      type: 'uuid' as const,
+      fixedOperator: 'equals' as const,
+      rule: uuidRule,
+    },
+    supportsExtendedFilter && {
+      key: 'createdAt',
+      propertyLabel: t('deployment.filter.CreatedAt'),
+      type: 'datetime' as const,
+      operators: ['after' as const, 'before' as const],
+      defaultOperator: 'after' as const,
+    },
+    supportsExtendedFilter && {
+      key: 'destroyedAt',
+      propertyLabel: t('deployment.filter.DestroyedAt'),
+      type: 'datetime' as const,
+      operators: ['after' as const, 'before' as const],
+      defaultOperator: 'after' as const,
+    },
+  ]);
+
+  const isDestroying = (
+    status: ModelDeploymentNodeInList['metadata']['status'],
+  ): boolean => {
+    if (!status || status === '%future added value') return false;
+    return ['STOPPING', 'STOPPED', 'TERMINATED'].includes(status);
+  };
+
   return (
     <>
-      <DeploymentList
-        mode="admin"
-        deploymentsFrgmt={adminDeployments}
-        filter={queryParams.filter ?? undefined}
-        setFilter={(value) => {
-          setQueryParams({ filter: value ?? null });
-          setTablePaginationOption({ current: 1 });
-        }}
-        order={queryParams.order ?? undefined}
-        onChangeOrder={(order) => {
-          setQueryParams({ order: (order as DeploymentOrderValue) ?? null });
-        }}
-        statusCategory={queryParams.statusCategory}
-        onStatusCategoryChange={(value) => {
-          setQueryParams({ statusCategory: value });
-          setTablePaginationOption({ current: 1 });
-        }}
-        pagination={{
-          ...tablePaginationOption,
-          onChange: (current, pageSize) => {
-            setTablePaginationOption({ current, pageSize });
-          },
-        }}
-        tableSettings={{
-          columnOverrides,
-          onColumnOverridesChange: setColumnOverrides,
-        }}
-        loading={isLoading}
-        onRowClick={(deploymentId) => {
-          webUINavigate(`/admin-deployments/${toLocalId(deploymentId)}`);
-        }}
-        onEditClick={(frgmt) => setEditingDeploymentFrgmt(frgmt)}
-        onDeleteComplete={updateFetchKey}
-        toolbarEnd={
+      <BAIFlex direction="column" align="stretch" gap="sm">
+        <BAIFlex justify="between" wrap="wrap" gap="sm">
+          <BAIFlex gap="sm" align="start" wrap="wrap" style={{ flexShrink: 1 }}>
+            <BAIRadioGroup
+              value={queryParams.statusCategory}
+              onChange={(e) => {
+                setQueryParams({ statusCategory: e.target.value });
+                setTablePaginationOption({ current: 1 });
+              }}
+              options={[
+                { label: t('deployment.Running'), value: 'running' },
+                {
+                  label: t('deployment.status.Terminated'),
+                  value: 'finished',
+                },
+              ]}
+            />
+            <BAIGraphQLPropertyFilter
+              filterProperties={filterProperties}
+              value={queryParams.filter ?? undefined}
+              onChange={(value) => {
+                setQueryParams({ filter: value ?? null });
+                setTablePaginationOption({ current: 1 });
+              }}
+            />
+          </BAIFlex>
           <BAIFetchKeyButton
             value={fetchKey}
             onChange={updateFetchKey}
             autoUpdateDelay={15_000}
             loading={isLoading}
           />
-        }
-      />
+        </BAIFlex>
+        <BAIModelDeploymentNodes
+          deploymentsFrgmt={deploymentNodes}
+          loading={isLoading}
+          order={queryParams.order}
+          onChangeOrder={(order) => {
+            setQueryParams({ order: (order as DeploymentOrderValue) ?? null });
+          }}
+          pagination={{
+            current: tablePaginationOption.current,
+            pageSize: tablePaginationOption.pageSize,
+            total,
+            onChange: (current, pageSize) =>
+              setTablePaginationOption({ current, pageSize }),
+          }}
+          tableSettings={{
+            columnOverrides,
+            onColumnOverridesChange: setColumnOverrides,
+          }}
+          customizeColumns={(base) =>
+            base.map((col) => {
+              if (col.key === 'name') {
+                return {
+                  ...col,
+                  render: (_value, record) => {
+                    const destroying = isDestroying(record.metadata?.status);
+                    return (
+                      <BAINameActionCell
+                        title={record.metadata?.name ?? '-'}
+                        onTitleClick={() =>
+                          webUINavigate(
+                            `/admin-deployments/${toLocalId(record.id)}`,
+                          )
+                        }
+                        copyable
+                        showActions="always"
+                        actions={[
+                          {
+                            key: 'edit',
+                            title: t('deployment.EditDeployment'),
+                            icon: <EditOutlined />,
+                            disabled: destroying,
+                            onClick: () => setEditingDeploymentId(record.id),
+                          },
+                          {
+                            key: 'delete',
+                            title: t('deployment.DeleteDeployment'),
+                            icon: <DeleteFilled />,
+                            type: 'danger',
+                            disabled: destroying,
+                            onClick: () => setDeletingDeploymentId(record.id),
+                          },
+                        ]}
+                      />
+                    );
+                  },
+                };
+              }
+              if (col.key === 'currentRevisionNumber') {
+                return {
+                  ...col,
+                  render: (_value, record) => {
+                    // `record` here is narrowed to BAIModelDeploymentNodesFragment;
+                    // recover the wider node (with `...DeploymentRevisionDetail_revision`
+                    // on `currentRevision`) from the page-level query result so
+                    // the drawer receives a fragment ref it can consume.
+                    const wider = deploymentNodes.find(
+                      (n) => n.id === record.id,
+                    );
+                    const revision = wider?.currentRevision;
+                    if (revision?.revisionNumber == null) {
+                      return (
+                        <Typography.Text type="secondary">-</Typography.Text>
+                      );
+                    }
+                    return (
+                      <Typography.Link
+                        onClick={() => setDrawerRevisionFrgmt(revision)}
+                      >{`#${revision.revisionNumber}`}</Typography.Link>
+                    );
+                  },
+                };
+              }
+              if (col.key === 'tags') {
+                return {
+                  ...col,
+                  render: (_value, record) => (
+                    <BAIDeploymentTagChips
+                      metadataFrgmt={record.metadata}
+                      stopRowClick
+                      onTagClick={(tag) => {
+                        webUINavigate({
+                          pathname: '/admin-deployments',
+                          search: new URLSearchParams({
+                            filter: JSON.stringify({
+                              tags: { iContains: tag },
+                            }),
+                          }).toString(),
+                        });
+                      }}
+                      fallback={
+                        <Typography.Text type="secondary">-</Typography.Text>
+                      }
+                    />
+                  ),
+                };
+              }
+              return col;
+            })
+          }
+        />
+      </BAIFlex>
       <DeploymentSettingModal
-        open={!!editingDeploymentFrgmt}
-        deploymentFrgmt={editingDeploymentFrgmt}
+        open={!!editingDeployment}
+        deploymentFrgmt={editingDeployment ?? null}
         onRequestClose={(success) => {
-          setEditingDeploymentFrgmt(null);
+          setEditingDeploymentId(null);
           if (success) updateFetchKey();
         }}
       />
+      <BAIDeleteConfirmModal
+        open={!!deletingDeployment}
+        title={t('deployment.DeleteDeployment')}
+        target={t('deployment.Deployment')}
+        items={
+          deletingDeployment
+            ? [
+                {
+                  key: deletingDeployment.id,
+                  label: deletingDeployment.metadata?.name ?? '',
+                },
+              ]
+            : []
+        }
+        confirmText={deletingDeployment?.metadata?.name ?? ''}
+        requireConfirmInput
+        inputProps={{
+          placeholder: deletingDeployment?.metadata?.name ?? '',
+        }}
+        okButtonProps={{ loading: isInFlightDeleteMutation }}
+        onOk={() => {
+          if (!deletingDeployment) return;
+          commitDeleteMutation({
+            variables: {
+              input: {
+                id: toLocalId(deletingDeployment.id) ?? deletingDeployment.id,
+              },
+            },
+            onCompleted: (_response, errors) => {
+              if (errors && errors.length > 0) {
+                logger.error('Failed to delete deployment', errors);
+                message.error(t('deployment.FailedToDeleteDeployment'));
+                return;
+              }
+              message.success(t('deployment.DeploymentDeleted'));
+              setDeletingDeploymentId(null);
+              updateFetchKey();
+            },
+            onError: (error) => {
+              logger.error('Failed to delete deployment', error);
+              message.error(t('deployment.FailedToDeleteDeployment'));
+            },
+          });
+        }}
+        onCancel={() => setDeletingDeploymentId(null)}
+      />
+      <BAIUnmountAfterClose>
+        <DeploymentRevisionDetailDrawer
+          open={!!drawerRevisionFrgmt}
+          revisionFrgmt={drawerRevisionFrgmt}
+          onClose={() => setDrawerRevisionFrgmt(null)}
+        />
+      </BAIUnmountAfterClose>
     </>
   );
 };


### PR DESCRIPTION
> Stacked on #7502 (which is on #7501). Children: #7504. Part of the FR-2930 series.

## Summary

Replace the in-app `DeploymentList` wrapper with the now feature-complete `BAIModelDeploymentNodes` from `backend.ai-ui`. The status radio, property filter, refresh button, delete confirmation, edit modal and revision detail drawer all move into the page (where they belong per the `*Nodes*` pattern established by `BAIUserNodes` / `UserManagement`). The library Nodes component is left to own only the base column set, the fragment, and the typed sort surface.

## Page query

`adminDeployments` now spreads the page-side fragments the moved modals need:

- `...BAIModelDeploymentNodesFragment` — for the table itself
- `...DeploymentSettingModal_deployment` — for the edit modal, accessed by looking up the wider node from the page-typed query result via `deploymentNodes.find(n => n.id === editingDeploymentId)`
- `currentRevision @since(26.4.3) { ...DeploymentRevisionDetail_revision }` — for the drawer, looked up the same way

## customizeColumns

Three base columns are overridden:

- **`name`** — wire `onTitleClick` to navigate to `/admin-deployments/:id` (preserves FR-2847 admin URL space) and inject edit + delete actions on `BAINameActionCell`.
- **`currentRevisionNumber`** — render as a clickable `Typography.Link` that opens `DeploymentRevisionDetailDrawer`.
- **`tags`** — wire `onTagClick` to navigate to `/admin-deployments?filter=...` (the legacy behaviour that `DeploymentList` had inlined).

## Sorter wiring

Uses `availableDeploymentSorterValues` + `deploymentTableOrderToSort` exported from `backend.ai-ui`, so the camelCase → `DeploymentOrderBy` enum mapping no longer lives on the page side.

## Column overrides

Remain persisted via `useBAISettingUserState('table_column_overrides.AdminDeploymentListPage')`.

## Checklist

- [x] No behaviour change vs. the old `DeploymentList mode="admin"` rendering — same name navigation, edit / delete actions, status radio, refresh, property filter (with the admin-extended fields gated on `model-deployment-extended-filter`), revision drawer
- [x] Column override key (`table_column_overrides.AdminDeploymentListPage`) preserved → existing persisted column settings round-trip unchanged
- [x] `bash scripts/verify.sh` — Relay / Lint / Format / Vite warmup PASS (TypeScript pre-existing failures on `main` unchanged)
