### PR TITLE
feat(FR-2931): disable add-revision buttons and show alert when deployment belongs to different project

### DIFF
--- a/react/src/__generated__/DeploymentAddRevisionModalQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentAddRevisionModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f646eece35b528604f228cf08be07b27>>
+ * @generated SignedSource<<b374ced1535380d46d6cd4e67f3a7ccd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -78,7 +78,6 @@ export type DeploymentAddRevisionModalQuery$data = {
       }> | null | undefined;
     } | null | undefined;
     readonly metadata: {
-      readonly projectId: string;
       readonly resourceGroupName: string;
     };
   } | null | undefined;
@@ -111,13 +110,6 @@ v2 = {
   "name": "metadata",
   "plural": false,
   "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "projectId",
-      "storageKey": null
-    },
     {
       "alias": null,
       "args": null,
@@ -573,16 +565,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "866cfab3340f261e3ea0c333ba2d8f67",
+    "cacheID": "41e3a773e5a73cca06b5dfb852a433a6",
     "id": null,
     "metadata": {},
     "name": "DeploymentAddRevisionModalQuery",
     "operationKind": "query",
-    "text": "query DeploymentAddRevisionModalQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    metadata {\n      projectId\n      resourceGroupName\n    }\n    currentRevision {\n      clusterConfig {\n        mode\n        size\n      }\n      resourceConfig {\n        resourceOpts {\n          entries {\n            name\n            value\n          }\n        }\n      }\n      resourceSlots {\n        slotName\n        quantity\n      }\n      extraMounts {\n        vfolderId\n        mountDestination\n      }\n      modelRuntimeConfig {\n        runtimeVariantId\n        runtimeVariant {\n          name\n          id\n        }\n        environ {\n          entries {\n            name\n            value\n          }\n        }\n      }\n      modelMountConfig {\n        vfolderId\n        mountDestination\n        definitionPath\n      }\n      modelDefinition {\n        models {\n          name\n          modelPath\n          service {\n            startCommand\n            port\n            healthCheck {\n              path\n              maxRetries\n              initialDelay\n              interval\n              maxWaitTime\n            }\n          }\n        }\n      }\n      imageV2 {\n        id\n        identity {\n          canonicalName\n        }\n      }\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query DeploymentAddRevisionModalQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    metadata {\n      resourceGroupName\n    }\n    currentRevision {\n      clusterConfig {\n        mode\n        size\n      }\n      resourceConfig {\n        resourceOpts {\n          entries {\n            name\n            value\n          }\n        }\n      }\n      resourceSlots {\n        slotName\n        quantity\n      }\n      extraMounts {\n        vfolderId\n        mountDestination\n      }\n      modelRuntimeConfig {\n        runtimeVariantId\n        runtimeVariant {\n          name\n          id\n        }\n        environ {\n          entries {\n            name\n            value\n          }\n        }\n      }\n      modelMountConfig {\n        vfolderId\n        mountDestination\n        definitionPath\n      }\n      modelDefinition {\n        models {\n          name\n          modelPath\n          service {\n            startCommand\n            port\n            healthCheck {\n              path\n              maxRetries\n              initialDelay\n              interval\n              maxWaitTime\n            }\n          }\n        }\n      }\n      imageV2 {\n        id\n        identity {\n          canonicalName\n        }\n      }\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "67c95f213fb1beea3d27a257efda7f14";
+(node as any).hash = "3cbc34145af86f08792b27b9e14fd580";
 
 export default node;

--- a/react/src/__generated__/DeploymentDetailPageQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentDetailPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<81cdca8bbc7ae9fb5a6637da658e2605>>
+ * @generated SignedSource<<ffcf46f4839958aca53e7833413006a8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,7 @@ export type DeploymentDetailPageQuery$data = {
     readonly id: string;
     readonly metadata: {
       readonly name: string;
+      readonly projectId: string;
       readonly status: DeploymentStatus;
     };
     readonly networkAccess: {
@@ -83,13 +84,20 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "projectId",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "openToPublic",
   "storageKey": null
 },
-v6 = [
+v7 = [
   (v2/*: any*/)
 ],
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "UserV2BasicInfo",
@@ -107,21 +115,21 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "vfolderId",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mountDestination",
   "storageKey": null
 },
-v10 = [
+v11 = [
   (v2/*: any*/),
   {
     "alias": null,
@@ -249,8 +257,8 @@ v10 = [
     "name": "modelMountConfig",
     "plural": false,
     "selections": [
-      (v8/*: any*/),
       (v9/*: any*/),
+      (v10/*: any*/),
       {
         "alias": null,
         "args": null,
@@ -282,8 +290,8 @@ v10 = [
     "name": "extraMounts",
     "plural": true,
     "selections": [
-      (v8/*: any*/),
       (v9/*: any*/),
+      (v10/*: any*/),
       {
         "alias": null,
         "args": null,
@@ -471,7 +479,8 @@ return {
             "plural": false,
             "selections": [
               (v3/*: any*/),
-              (v4/*: any*/)
+              (v4/*: any*/),
+              (v5/*: any*/)
             ],
             "storageKey": null
           },
@@ -483,7 +492,7 @@ return {
             "name": "networkAccess",
             "plural": false,
             "selections": [
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
@@ -494,7 +503,7 @@ return {
             "kind": "LinkedField",
             "name": "currentRevision",
             "plural": false,
-            "selections": (v6/*: any*/),
+            "selections": (v7/*: any*/),
             "storageKey": null
           },
           {
@@ -504,7 +513,7 @@ return {
             "kind": "LinkedField",
             "name": "deployingRevision",
             "plural": false,
-            "selections": (v6/*: any*/),
+            "selections": (v7/*: any*/),
             "storageKey": null
           },
           {
@@ -515,7 +524,7 @@ return {
             "name": "creator",
             "plural": false,
             "selections": [
-              (v7/*: any*/)
+              (v8/*: any*/)
             ],
             "storageKey": null
           },
@@ -571,6 +580,7 @@ return {
             "selections": [
               (v3/*: any*/),
               (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -583,13 +593,6 @@ return {
                 "args": null,
                 "kind": "ScalarField",
                 "name": "resourceGroupName",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "projectId",
                 "storageKey": null
               },
               {
@@ -634,7 +637,7 @@ return {
             "name": "networkAccess",
             "plural": false,
             "selections": [
-              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -652,7 +655,7 @@ return {
             "kind": "LinkedField",
             "name": "currentRevision",
             "plural": false,
-            "selections": (v10/*: any*/),
+            "selections": (v11/*: any*/),
             "storageKey": null
           },
           {
@@ -662,7 +665,7 @@ return {
             "kind": "LinkedField",
             "name": "deployingRevision",
             "plural": false,
-            "selections": (v10/*: any*/),
+            "selections": (v11/*: any*/),
             "storageKey": null
           },
           {
@@ -673,7 +676,7 @@ return {
             "name": "creator",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": null
@@ -702,16 +705,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d3e7112ef9cb1308b807bdb05132fd54",
+    "cacheID": "2148ac335e3326b1eee8b62f1a42475f",
     "id": null,
     "metadata": {},
     "name": "DeploymentDetailPageQuery",
     "operationKind": "query",
-    "text": "query DeploymentDetailPageQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    id\n    metadata {\n      name\n      status\n    }\n    networkAccess {\n      openToPublic\n    }\n    currentRevision @since(version: \"26.4.3\") {\n      id\n    }\n    deployingRevision @since(version: \"26.4.3\") {\n      id\n    }\n    creator @since(version: \"26.4.3\") {\n      basicInfo {\n        email\n      }\n      id\n    }\n    ...DeploymentConfigurationSection_deployment\n    ...DeploymentReplicasTab_deployment\n    ...DeploymentAccessTokensTab_deployment\n    ...DeploymentAutoScalingTab_deployment\n  }\n}\n\nfragment DeploymentAccessTokensTab_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentAutoScalingTab_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  creator @since(version: \"26.4.3\") {\n    basicInfo {\n      email\n    }\n    id\n  }\n}\n\nfragment DeploymentConfigurationSection_deployment on ModelDeployment {\n  id\n  ...DeploymentSettingModal_deployment\n  metadata {\n    name\n    projectId\n    domainName\n    status\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...DeploymentTagChips_metadata\n  }\n  networkAccess {\n    openToPublic\n    endpointUrl\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n  deployingRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n  ...DeploymentRevisionHistoryTab_deployment\n}\n\nfragment DeploymentReplicasTab_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        port\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentRevisionHistoryTab_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment DeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n}\n"
+    "text": "query DeploymentDetailPageQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    id\n    metadata {\n      name\n      status\n      projectId\n    }\n    networkAccess {\n      openToPublic\n    }\n    currentRevision @since(version: \"26.4.3\") {\n      id\n    }\n    deployingRevision @since(version: \"26.4.3\") {\n      id\n    }\n    creator @since(version: \"26.4.3\") {\n      basicInfo {\n        email\n      }\n      id\n    }\n    ...DeploymentConfigurationSection_deployment\n    ...DeploymentReplicasTab_deployment\n    ...DeploymentAccessTokensTab_deployment\n    ...DeploymentAutoScalingTab_deployment\n  }\n}\n\nfragment DeploymentAccessTokensTab_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentAutoScalingTab_deployment on ModelDeployment {\n  id\n  metadata {\n    status\n  }\n  creator @since(version: \"26.4.3\") {\n    basicInfo {\n      email\n    }\n    id\n  }\n}\n\nfragment DeploymentConfigurationSection_deployment on ModelDeployment {\n  id\n  ...DeploymentSettingModal_deployment\n  metadata {\n    name\n    projectId\n    domainName\n    status\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...DeploymentTagChips_metadata\n  }\n  networkAccess {\n    openToPublic\n    endpointUrl\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n  deployingRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    ...DeploymentRevisionDetail_revision\n  }\n  ...DeploymentRevisionHistoryTab_deployment\n}\n\nfragment DeploymentReplicasTab_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        port\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentRevisionHistoryTab_deployment on ModelDeployment {\n  id\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment DeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e560e46f065f52f67a0ba290d440fc26";
+(node as any).hash = "34d6b01c2963997caff182213908d483";
 
 export default node;

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -58,6 +58,7 @@ import { useLocation } from 'react-router-dom';
 interface DeploymentConfigurationSectionProps {
   deploymentFrgmt: DeploymentConfigurationSection_deployment$key | null;
   isDeploymentDestroying?: boolean;
+  isNotCurrentProject?: boolean;
   revisionFetchKey: string;
   isPendingRefetch: boolean;
   onRefetch: () => void;
@@ -177,6 +178,7 @@ const DeploymentConfigurationSection: React.FC<
 > = ({
   deploymentFrgmt,
   isDeploymentDestroying = false,
+  isNotCurrentProject = false,
   revisionFetchKey,
   isPendingRefetch,
   onRefetch,
@@ -379,7 +381,7 @@ const DeploymentConfigurationSection: React.FC<
             <BAIButton
               type="primary"
               icon={<PlusOutlined />}
-              disabled={isDeploymentDestroying}
+              disabled={isDeploymentDestroying || isNotCurrentProject}
               // `action` (not `onClick`) wraps the state update that mounts
               // `<DeploymentAddRevisionModal>` (which suspends on its Relay
               // queries) in `startTransition`, so the page stays interactive

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -12,6 +12,7 @@ import DeploymentReplicasTab from '../components/DeploymentReplicasTab';
 import DeploymentStatusTag, {
   DeploymentStatus,
 } from '../components/DeploymentStatusTag';
+import SwitchToProjectButton from '../components/SwitchToProjectButton';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
@@ -167,6 +168,13 @@ const DeploymentDetailPage: React.FC = () => {
           showIcon
           title={t('deployment.NotCurrentProjectAlertTitle')}
           description={t('deployment.NotCurrentProjectAlertDescription')}
+          action={
+            deployment.metadata.projectId ? (
+              <SwitchToProjectButton
+                projectId={deployment.metadata.projectId}
+              />
+            ) : undefined
+          }
         />
       )}
       {isDeploymentReady && !hasNoRevision && (

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -14,6 +14,7 @@ import DeploymentStatusTag, {
 } from '../components/DeploymentStatusTag';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { PlusOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import { Alert, Button, Skeleton, Tooltip, Typography, theme } from 'antd';
@@ -37,6 +38,7 @@ const DeploymentDetailPage: React.FC = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [currentUser] = useCurrentUserInfo();
+  const currentProject = useCurrentProjectValue();
   const webuiNavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const isChatBlocked = !!baiClient?._config?.blockList?.includes('chat');
@@ -63,6 +65,7 @@ const DeploymentDetailPage: React.FC = () => {
           metadata {
             name
             status
+            projectId
           }
           networkAccess {
             openToPublic
@@ -122,6 +125,14 @@ const DeploymentDetailPage: React.FC = () => {
   const isOwnedByCurrentUser =
     !creatorEmail || creatorEmail === currentUser.email;
 
+  // Folder selection inside the add-revision flow is scoped to the currently
+  // selected project. Disable revision addition when the deployment belongs to
+  // a different project so the user isn't shown an incorrect folder list.
+  const isNotCurrentProject =
+    !!currentProject.id &&
+    !!deployment.metadata.projectId &&
+    deployment.metadata.projectId !== currentProject.id;
+
   const handleRefetch = () => {
     startRefetchTransition(() => updateFetchKey());
   };
@@ -150,6 +161,14 @@ const DeploymentDetailPage: React.FC = () => {
         </Typography.Title>
         <DeploymentStatusTag status={deploymentStatus} />
       </BAIFlex>
+      {isNotCurrentProject && (
+        <Alert
+          type="warning"
+          showIcon
+          title={t('deployment.NotCurrentProjectAlertTitle')}
+          description={t('deployment.NotCurrentProjectAlertDescription')}
+        />
+      )}
       {isDeploymentReady && !hasNoRevision && (
         <Alert
           type="success"
@@ -191,7 +210,7 @@ const DeploymentDetailPage: React.FC = () => {
               action={async () => {
                 openAddRevision();
               }}
-              disabled={isDeploymentDestroying}
+              disabled={isDeploymentDestroying || isNotCurrentProject}
             >
               {t('deployment.AddRevision')}
             </BAIButton>
@@ -213,6 +232,7 @@ const DeploymentDetailPage: React.FC = () => {
       <DeploymentConfigurationSection
         deploymentFrgmt={deployment}
         isDeploymentDestroying={isDeploymentDestroying}
+        isNotCurrentProject={isNotCurrentProject}
         revisionFetchKey={revisionFetchKey}
         isPendingRefetch={isPendingRefetch}
         onRefetch={handleRefetch}

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1001,6 +1001,8 @@
     "NoPresetsAvailable": "No deployment preset available",
     "NoPresetsAvailableDescription": "There is no preset to deploy with. Create a new deployment instead.",
     "NoPresetsAvailableSwitchToCustom": "There is no preset available. Switch to Custom mode to add a revision manually.",
+    "NotCurrentProjectAlertDescription": "Switch to the project this deployment belongs to in order to add a revision.",
+    "NotCurrentProjectAlertTitle": "This deployment belongs to a different project.",
     "NumberOfReplicas": "Number of Replicas",
     "OpenCreateDeploymentModal": "Open create deployment modal",
     "OpenToPublic": "Open To Public",


### PR DESCRIPTION
Resolves #7506 (FR-2931)

## Summary

- Show a warning `Alert` at the top of the deployment detail page when the deployment's `projectId` differs from the currently selected project
- Disable the **Add Revision** button in the no-revision alert
- Disable the **Add Revision** button in the revision card tab bar extra content

## Why

The folder selector inside `DeploymentAddRevisionModal` is scoped to the currently selected project. If a user is viewing a deployment from a different project, the folder list shown would reflect the wrong project's folders — leading to confusion and potential misconfiguration.

## Test plan

- [ ] View a deployment that belongs to a different project → warning alert appears at top
- [ ] Both "Add Revision" buttons are disabled
- [ ] View a deployment that belongs to the current project → no alert, buttons enabled as normal
- [ ] Buttons remain disabled regardless of deployment status (READY, STOPPED, etc.)