### PR TITLE
fix(FR-2932): disable SW navigateFallback to allow OIDC/SAML callback navigations

### DIFF
--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -788,6 +788,12 @@ export default defineConfig(({ command, mode }) => {
           clientsClaim: true,
           maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
           globIgnores: ['**/*.map', '**/asset-manifest.json'],
+          // vite-plugin-pwa defaults navigateFallback to 'index.html', which
+          // makes the SW serve cached HTML for ANY GET navigation that doesn't
+          // match a precached asset — including OIDC/SAML callbacks like
+          // /func/openid/redirect. The retired workbox-webpack-plugin had no
+          // such default, so this restores pre-FR-2611 behavior.
+          navigateFallback: null,
         },
       }),
     ],


### PR DESCRIPTION
Resolves #7508 (FR-2932)

## Summary

The Vite migration (FR-2611, #6876) silently changed the SW's navigation behavior:

- `vite-plugin-pwa@1.2.0` defaults `workbox.navigateFallback` to `"index.html"` (`dist/index.js:838`).
- The retired `workbox-webpack-plugin` `GenerateSW` had no such default (`undefined`).
- The migration preserved every explicitly set option but didn't account for the differing implicit defaults between the two workbox wrappers.

In production, the registered SW now runs a `NavigationRoute` that responds to every same-origin GET navigation with the cached `index.html` — *including* the OIDC/SAML callbacks the IdP redirects back to our origin (`/func/openid/redirect`, `/func/saml/redirect`). The webserver's callback handler is never invoked, so no session cookie is set and SSO login silently fails (the user is re-rendered into the login page).

This is a cache-only handler, so being online does not save us — the network is never even attempted.

## Fix

Set `navigateFallback: null` in `react/vite.config.ts`'s `workbox` block to restore pre-FR-2611 behavior. With `navigateFallback` falsy, `workbox-build`'s SW template (`workbox-build/.../sw-template.ts:50`) gates out the `NavigationRoute` registration entirely, so navigation requests pass through to the network. Precaching of build assets is unaffected.

Value choice — workbox's schema is `string | null`. `undefined` leaves the plugin default `"index.html"` in place via `Object.assign`; `false` is rejected by the type checker; `null` is the correct opt-out.

Alternative considered: `navigateFallbackDenylist: [/^\/func\//, /^\/server\//, /^\/openid\//, /^\/saml\//]`. Rejected because the craco-era build never had offline navigation fallback anyway, so `null` is the smaller behavioral delta and matches the implicit contract this project already shipped on.

## Test plan

- [ ] Build the production bundle (`pnpm run build`) and deploy to a non-localhost environment. `index.html:122-131` gates SW registration to non-localhost hosts, so `pnpm dev` and Electron cannot reproduce.
- [ ] On the deployed environment, force-refresh the SW (DevTools → Application → Service Workers → Unregister, or "Update on reload").
- [ ] Attempt OIDC login (or SAML if configured). Authenticate at the IdP.
- [ ] In the Network tab, confirm the response to `/func/openid/redirect` does NOT show `(ServiceWorker)` in the Size column and is a 302 redirect (not an HTML body).
- [ ] Confirm login completes — session cookie is set and the user lands on the post-login page instead of the login page.
- [ ] Sanity-check that SPA routes (`/sessions`, `/folders`, etc.) still load normally on hard refresh in the same environment — the webserver's catch-all serves `index.html` on these, so behavior should be identical.
