### PR TITLE
fix: regenerate pnpm-lock.yaml for backend.ai-client eslint deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,12 +390,21 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.39.4
+      eslint-config-bai:
+        specifier: workspace:*
+        version: link:../eslint-config-bai
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(@microsoft/api-extractor@7.52.8(@types/node@25.3.5))(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.59.1(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@6.4.2(@types/node@25.3.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -24236,3 +24245,7 @@ snapshots:
       react: 19.2.6
 
   zwitch@2.0.4: {}
+
+time:
+  '@eslint/js@9.39.4': '2026-03-06T21:21:15.041Z'
+  typescript-eslint@8.59.1: '2026-04-27T17:31:57.870Z'


### PR DESCRIPTION
## Problem

Amplify (and any CI) deploy of webui fails at the install step:

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with packages/backend.ai-client/package.json
* 3 dependencies were added: @eslint/js@catalog:, eslint-config-bai@workspace:*, typescript-eslint@catalog:
```

## Root cause

PR #7204 (`6f34664dc`, "chore(FR-2790): add ESLint flat config to backend.ai-client") added three devDependencies — `@eslint/js@catalog:`, `eslint-config-bai@workspace:*`, `typescript-eslint@catalog:` — to `packages/backend.ai-client/package.json`, but **did not regenerate `pnpm-lock.yaml`**. The lockfile's `backend.ai-client` importer still listed only `tsup`/`typescript`/`vitest`.

CI environments (Amplify included) run `pnpm install --frozen-lockfile` (frozen is the default in CI), which refuses to install when the lockfile and `package.json` diverge — hence the build failure.

> This wasn't caught earlier because `backend-ai-client-ci.yml` likely didn't exercise a frozen install on that PR, and local installs default to non-frozen.

## Fix

Regenerate `pnpm-lock.yaml` (`pnpm install --lockfile-only`). Only the lockfile changes — the three missing specifiers are added to the `backend.ai-client` importer plus their resolution entries. No `package.json` changes.

## Verification

Reproduced the exact Amplify command on this branch:

```
$ pnpm install --frozen-lockfile
Done in 2.3s using pnpm v11.1.1   # exit 0 ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)