### PR TITLE
chore(FR-2933): disable vitest cache in CI

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run relay-compiler
         run: pnpm run relay
       - name: Run Vitest with coverage
-        run: pnpm exec vitest run --coverage
+        run: pnpm exec vitest run --no-cache --coverage
       - name: Report coverage on PR
         if: always()
         uses: davelosert/vitest-coverage-report-action@v2
@@ -127,7 +127,7 @@ jobs:
       - name: Run relay-compiler
         run: cd ../.. && pnpm run relay
       - name: Run Vitest with coverage
-        run: pnpm exec vitest run --coverage
+        run: pnpm exec vitest run --no-cache --coverage
       - name: Report coverage on PR
         if: always()
         uses: davelosert/vitest-coverage-report-action@v2
@@ -163,7 +163,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Vitest with coverage
-        run: pnpm exec vitest run --coverage
+        run: pnpm exec vitest run --no-cache --coverage
       - name: Report coverage on PR
         if: always()
         uses: davelosert/vitest-coverage-report-action@v2


### PR DESCRIPTION
Resolves #7510 (FR-2933)

Adds `--no-cache` to the three `pnpm exec vitest run --coverage` invocations in `.github/workflows/vitest.yml` (jobs `react-vitest`, `backend-ai-ui-vitest`, `root-vitest`).

Vitest's default on-disk cache (`node_modules/.vitest/`) is unnecessary in CI — each run starts from a fresh checkout, so the cache cannot meaningfully speed up runs, and a partial cache restore could mask test-selection or skip changes. Disabling it on CI only makes runs explicitly reproducible while keeping local-dev caching unchanged (no edits to any `vitest.config.ts`).

## Verification

- `bash scripts/verify.sh` — no new failures from this change (the YAML edit is not on any TypeScript, Relay, or Vite path). Pre-existing failures on `main` (TS `ERR_UNKNOWN_BUILTIN_MODULE`, Vite warmup paths) are unrelated.
- Workflow YAML is exercised by GitHub Actions on PR open.