### PR TITLE
fix(FR-2935): allow FairShare resource weight to accept 0

### DIFF
--- a/react/src/components/FairShareItems/DomainFairShareTable.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareTable.tsx
@@ -158,7 +158,9 @@ const DomainFairShareTable: React.FC<DomainFairShareTableProps> = ({
         return (
           <BAIFlex gap="xxs">
             <Typography.Text>
-              {weight ? toFixedFloorWithoutTrailingZeros(weight, 1) : '-'}
+              {_.isNil(weight)
+                ? '-'
+                : toFixedFloorWithoutTrailingZeros(weight, 1)}
             </Typography.Text>
             <Typography.Text
               type="secondary"

--- a/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
+++ b/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
@@ -258,10 +258,10 @@ const FairShareWeightSettingModal: React.FC<
     userEmail: userFairShares?.[0]?.user?.basicInfo?.email || '',
     weight: isBulkEdit
       ? undefined
-      : domainsFairShares?.[0]?.spec?.weight ||
-        projectFairShares?.[0]?.spec?.weight ||
-        userFairShares?.[0]?.spec?.weight ||
-        1,
+      : (domainsFairShares?.[0]?.spec?.weight ??
+        projectFairShares?.[0]?.spec?.weight ??
+        userFairShares?.[0]?.spec?.weight ??
+        1),
   };
 
   const formRef = useRef<FormInstance<typeof INITIAL_FORM_VALUES>>(null);
@@ -640,7 +640,7 @@ const FairShareWeightSettingModal: React.FC<
               }
               name="weight"
             >
-              <InputNumber min={1} step={0.1} style={{ width: '100%' }} />
+              <InputNumber min={0} step={0.1} style={{ width: '100%' }} />
             </BAIBulkEditFormItem>
           ) : (
             <Form.Item
@@ -654,7 +654,7 @@ const FairShareWeightSettingModal: React.FC<
               }
               name="weight"
             >
-              <InputNumber min={1} step={0.1} style={{ width: '100%' }} />
+              <InputNumber min={0} step={0.1} style={{ width: '100%' }} />
             </Form.Item>
           )}
         </Form>

--- a/react/src/components/FairShareItems/ProjectFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareTable.tsx
@@ -151,7 +151,9 @@ const ProjectFairShareTable: React.FC<ProjectFairShareTableProps> = ({
       render: (weight, record) => (
         <BAIFlex gap="xxs">
           <Typography.Text>
-            {weight ? toFixedFloorWithoutTrailingZeros(weight, 1) : '-'}
+            {_.isNil(weight)
+              ? '-'
+              : toFixedFloorWithoutTrailingZeros(weight, 1)}
           </Typography.Text>
           <Typography.Text
             type="secondary"

--- a/react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx
@@ -291,7 +291,7 @@ const ResourceGroupFairShareSettingModal: React.FC<
                 },
               ]}
             >
-              <InputNumber min={1} step={0.1} style={{ width: '100%' }} />
+              <InputNumber min={0} step={0.1} style={{ width: '100%' }} />
             </Form.Item>
           </Col>
         </Row>
@@ -327,7 +327,7 @@ const ResourceGroupFairShareSettingModal: React.FC<
                       name={['resourceWeights', entry?.resourceType]}
                     >
                       <InputNumber
-                        min={1}
+                        min={0}
                         step={0.1}
                         style={{ width: '100%' }}
                       />

--- a/react/src/components/FairShareItems/UserFairShareTable.tsx
+++ b/react/src/components/FairShareItems/UserFairShareTable.tsx
@@ -155,7 +155,9 @@ const UserFairShareTable: React.FC<UserFairShareTableProps> = ({
       render: (weight, record) => (
         <BAIFlex gap="xxs">
           <Typography.Text>
-            {weight ? toFixedFloorWithoutTrailingZeros(weight, 1) : '-'}
+            {_.isNil(weight)
+              ? '-'
+              : toFixedFloorWithoutTrailingZeros(weight, 1)}
           </Typography.Text>
           <Typography.Text
             type="secondary"


### PR DESCRIPTION
Resolves #7515 (FR-2935)

## Summary

The FairShare weight UI rejected `0` as a valid weight value across multiple scopes (domain / project / user, and per-resource / default within a resource group). A weight of `0` is a legitimate value (e.g., to temporarily disable a share without removing the row), so all the relevant input minimums, initial-value derivations, and table displays were fixed to accept and preserve `0`.

## Changes

`react/src/components/FairShareItems/FairShareWeightSettingModal.tsx`
- Bulk edit `BAIBulkEditFormItem` weight input: `min={1}` → `min={0}`
- Single edit `Form.Item` weight input: `min={1}` → `min={0}` (`step={0.1}` preserved on both)
- `INITIAL_FORM_VALUES.weight` switched to `??` (nullish coalescing) so an existing row with `weight === 0` is not silently replaced with `1` when opening the modal. The final `?? 1` fallback for the "no spec at all" case is kept.

`react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx`
- Per-resource `resourceWeights` input (`자원별 가중치`): `min={1}` → `min={0}`
- `defaultWeight` input (`가중치 기본값`): `min={1}` → `min={0}`
- Day-based fields (`decayUnitDays`, `halfLifeDays`, `lookbackDays`) are intentionally left at `min={1}` (time durations).

`react/src/components/FairShareItems/DomainFairShareTable.tsx` / `ProjectFairShareTable.tsx` / `UserFairShareTable.tsx`
- Weight column render: `weight ? toFixed(weight) : '-'` → `_.isNil(weight) ? '-' : toFixed(weight)` so a row with `weight === 0` displays `0` instead of `-`.

## Test plan

- [ ] Domain / Project / User fair share tables: a row with `weight = 0` shows `0` in the Weight column (not `-`).
- [ ] Click Settings on a row with `weight = 0` — the modal opens with the field pre-filled to `0`, not `1`.
- [ ] Single edit modal accepts `0` in the Weight field.
- [ ] Bulk edit modal accepts `0` in the Weight field.
- [ ] Resource group fair share setting modal: per-resource weight (`자원별 가중치`) and default weight (`가중치 기본값`) both accept `0`.
- [ ] Values `> 0` still display and edit as before.
- [ ] Pre-existing TS errors in `SessionLauncherPage.tsx`, `StatisticsPage.tsx` etc. and a Relay artifact drift in `DeploymentAddRevisionModalQuery.graphql.ts` exist on `main` and are unrelated to this PR.