### PR TITLE
fix(FR-2945): pin pnpm to 10.16.0 in 26.2 release workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,11 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: latest
+          # Pin to the version that satisfies this branch's engines.pnpm (^10.16.0).
+          # `version: latest` resolves to pnpm 11.x, which requires Node >=22.13 and
+          # is installed before setup-node runs (on the runner's bundled Node 20),
+          # causing ERR_PNPM_UNSUPPORTED_ENGINE. See FR-2945.
+          version: 10.16.0
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Resolves #7534 (FR-2945)

## Problem

The **Build and Release Packages** workflow fails immediately (~15s) when a release is published from the `26.2` branch. Release builds run the workflow from the **tagged ref's branch**, not `main`, so this old branch runs its own outdated `package.yml`.

```
ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
Your Node version is incompatible with "registry.npmjs.org/pnpm/11.1.3".
Expected version: >=22.13  /  Got: v20.20.2
```

## Root cause

The job installs pnpm **before** Node is set up:

```yaml
- uses: pnpm/action-setup@v4   # runs first, on the runner's bundled Node v20.20.2
  with: { version: latest }
- uses: actions/setup-node@v4  # runs after (.nvmrc = 24)
```

`version: latest` now resolves to **pnpm 11.1.3** (`engines.node >= 22.13`), which the macOS runner's default Node 20 cannot satisfy — a latent time-bomb that detonated when pnpm 11.x raised its Node floor. Secondary issue: even if pnpm 11 installed, this branch's `engines.pnpm: ^10.16.0` + `engine-strict=true` would reject it during `pnpm install`.

## Fix

Pin pnpm to `10.16.0` (matches `engines.pnpm: ^10.16.0`, and `engines.node >= 18.12` installs fine on the runner's Node 20). This restores the known-good pipeline that built v26.2.5 — no Makefile/architecture changes needed.

Note: a literal backport of `main`'s modern multi-job workflow is **not** viable here because it calls `make dep_web` / `make dep_electron` targets that don't exist on this branch's older Makefile.

## Scope

`26.2` only. Older maintenance branches (25.x) carry the same outdated workflow and may need the same one-line fix when they next cut a release.

## Context

Found while manually building & uploading the v26.2.6 web bundle after the auto-release failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)