### PR TITLE
fix(FR-2945): pin pnpm to 10.16.0 in 25.19 release workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,10 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: latest
+          # Pin pnpm: `version: latest` resolves to pnpm 11.x (requires Node >=22.13)
+          # and is installed before setup-node, on the runner's bundled Node 20 ->
+          # ERR_PNPM_UNSUPPORTED_ENGINE. 10.16.0 installs on Node 20. See FR-2945.
+          version: 10.16.0
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Part of #7534 (FR-2945)

## Problem

The **Build and Release Packages** workflow fails on a `release: published` from the `25.19` branch — releases run the workflow from the tagged ref's branch, not `main`, so this branch runs its own outdated `package.yml`:

```
ERR_PNPM_UNSUPPORTED_ENGINE
Your Node version is incompatible with "registry.npmjs.org/pnpm/11.1.3".
Expected version: >=22.13  /  Got: v20.20.2
```

`pnpm/action-setup@v4` with `version: latest` installs pnpm **before** `setup-node`, on the macOS runner's bundled Node 20. `latest` now resolves to pnpm 11.x (`engines.node >= 22.13`) → immediate failure.

## Fix

Pin `version: latest` → `version: 10.16.0`. This branch enforces `engines.pnpm: ^10.16.0` with `engine-strict=true`, so `10.16.0` is required.

This is the same one-line fix applied to `26.2` (#7535). A literal backport of `main`'s modern workflow is not viable here (it calls `make dep_web` / `dep_electron` targets absent on this branch's Makefile).

> Part of a batch fixing all actively-released branches with the pre-pnpm-11 `version: latest` workflow (FR-2945).

🤖 Generated with [Claude Code](https://claude.com/claude-code)