### PR TITLE
chore(FR-2946): move release runbook into webui-docs package and remove root /docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,9 +109,6 @@ src/lib/webcomponents-loader.js
 **/*.js-E
 **/*.ts-E
 **/*.json-E
-# Documentation
-
-docs/
 # backend.ai app directory
 backend.ai-app/
 

--- a/README.md
+++ b/README.md
@@ -136,11 +136,6 @@ You can debug the app.
 - feature/[feature-branch] : Feature branch. Uses `git flow` development scheme.
 - tags/v[versions] : version tags. Each tag represents release versions.
 
-## Release Runbook
-
-For the release manager checklist (including the docs site multi-version
-deployment steps), see [`docs/release-runbook.md`](docs/release-runbook.md).
-
 ## Development Guide
 
 Backend.AI Web UI is built with

--- a/docs/DOCUMENTATION_GUIDE.md
+++ b/docs/DOCUMENTATION_GUIDE.md
@@ -1,1 +1,0 @@
-If you need documentation, generate it by running `npm run docs` in the project root directory.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,6 @@ export default [
     ignores: [
       'node_modules/**',
       'dist/**',
-      'docs/**',
       'src/app/**',
       'src/plugin*/**',
       'src/wsproxy*/**',

--- a/packages/backend.ai-webui-docs/README.md
+++ b/packages/backend.ai-webui-docs/README.md
@@ -129,6 +129,13 @@ The document version is derived from the monorepo root `package.json` version fi
 
 For pre-release versions, the git short hash is appended so that PDFs generated from different commits are distinguishable.
 
+## Release Runbook
+
+When publishing a new version, the docs site requires a few release-time steps
+(archive the released minor on its orphan branch, verify the per-language PDFs,
+and update `versions:` in `docs-toolkit.config.yaml`). See
+[`RELEASE-RUNBOOK.md`](RELEASE-RUNBOOK.md) for the full release-manager checklist.
+
 ## Project Structure
 
 ```

--- a/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
+++ b/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
@@ -2,8 +2,8 @@
 
 Operational checklist for the release manager. This file documents what to
 do *during* a release that goes beyond "tag the commit". Background and
-design decisions live in the spec docs under `.specs/`; this file is the
-short, testable checklist.
+design decisions live in the spec docs under `.specs/` (at the repo root);
+this file is the short, testable checklist.
 
 ---
 

--- a/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
+++ b/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
@@ -48,7 +48,7 @@ pdfMetadata:
 #   3. Keep the `next` entry at the TOP of the list (FR-2765 — surfaces
 #      `next` at the top of the version <select>); it never carries
 #      `latest: true`.
-#   See the docs release runbook for the full procedure.
+#   See RELEASE-RUNBOOK.md (in this package) for the full procedure.
 versions:
   # FR-2765: `next` is intentionally listed first so it appears at the
   # top of the version `<select>` dropdown. Readers visiting `next` see


### PR DESCRIPTION
Resolves #7544 (FR-2946)

## Summary

The repo's GitHub Pages is configured with `build_type: legacy`, source = `main` branch `/docs` folder, but the published site root **returns 404** and has no index/navigation. The deployments under the `github-pages` environment are just GitHub auto-rebuilding the Jekyll site on every push to `main` (legacy behavior) — not driven by any workflow.

The root `/docs` folder contained only two markdown files:

- **`DOCUMENTATION_GUIDE.md`** — a one-line file pointing at `npm run docs`, which no longer exists in any `package.json` (dead leftover from the old JSDoc era).
- **`release-runbook.md`** — a current, valid release-manager checklist (added in FR-2736) whose content (orphan-branch archive, per-language PDF verification, `versions:` update) is **entirely about the `backend.ai-webui-docs` package**.

## Changes

- Move `docs/release-runbook.md` → `packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md` (co-located with the docs toolkit config and sibling guide docs it describes; history preserved via `git mv`, 100% rename).
- Delete the dead `docs/DOCUMENTATION_GUIDE.md`, which empties the root `/docs` folder.
- Remove the awkward top-level `## Release Runbook` section from the root `README.md` (a narrow release-manager audience did not belong in the app's main README).
- Add a `## Release Runbook` pointer section to `packages/backend.ai-webui-docs/README.md`.
- Update the `docs-toolkit.config.yaml` comment to point at the co-located `RELEASE-RUNBOOK.md`.
- Remove the now-vestigial `docs/` entry from `.gitignore`.

`.specs/FR-2729/` planning docs are intentionally left unchanged — they are point-in-time records of the original plan.

## Follow-up

- GitHub Pages will be disabled separately (Settings → Pages → Source = None), since the `/docs` source is gone and the site was effectively unused (root 404).

## Test plan

- [x] `git mv` recorded as a 100% rename; runbook content intact (142 lines).
- [x] `docs-toolkit.config.yaml` still parses as valid YAML.
- [x] Root `/docs` folder removed.
- [x] No remaining live references to the old `docs/release-runbook.md` / `DOCUMENTATION_GUIDE.md` paths (only `.specs/` historical records, left intentionally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)