### PR TITLE
feat(FR-2948): render image metadata in BAISessionNodesV2 and add v2 session tag components

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIImageNodeSimpleTagV2Fragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIImageNodeSimpleTagV2Fragment.graphql.ts
@@ -1,0 +1,130 @@
+/**
+ * @generated SignedSource<<7c217021eacb1aa06f12d8cc39ba9de9>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type BAIImageNodeSimpleTagV2Fragment$data = {
+  readonly identity: {
+    readonly architecture: string;
+    readonly canonicalName: string;
+    readonly namespace: string;
+  };
+  readonly metadata: {
+    readonly labels: ReadonlyArray<{
+      readonly key: string;
+      readonly value: string;
+    }>;
+    readonly tags: ReadonlyArray<{
+      readonly key: string;
+      readonly value: string;
+    }>;
+  };
+  readonly " $fragmentType": "BAIImageNodeSimpleTagV2Fragment";
+};
+export type BAIImageNodeSimpleTagV2Fragment$key = {
+  readonly " $data"?: BAIImageNodeSimpleTagV2Fragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIImageNodeSimpleTagV2Fragment">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "key",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "value",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "BAIImageNodeSimpleTagV2Fragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ImageV2IdentityInfo",
+      "kind": "LinkedField",
+      "name": "identity",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "canonicalName",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "namespace",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "architecture",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ImageV2MetadataInfo",
+      "kind": "LinkedField",
+      "name": "metadata",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ImageV2TagEntry",
+          "kind": "LinkedField",
+          "name": "tags",
+          "plural": true,
+          "selections": (v0/*: any*/),
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ImageV2LabelEntry",
+          "kind": "LinkedField",
+          "name": "labels",
+          "plural": true,
+          "selections": (v0/*: any*/),
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ImageV2",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "56f20360b700b9a175cc1583a5f1d5d8";
+
+export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAISessionClusterModeV2Fragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISessionClusterModeV2Fragment.graphql.ts
@@ -1,0 +1,51 @@
+/**
+ * @generated SignedSource<<9715c40b082f23fab2c837a68198c5cb>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type ClusterMode = "MULTI_NODE" | "SINGLE_NODE" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type BAISessionClusterModeV2Fragment$data = {
+  readonly clusterMode: ClusterMode;
+  readonly clusterSize: number;
+  readonly " $fragmentType": "BAISessionClusterModeV2Fragment";
+};
+export type BAISessionClusterModeV2Fragment$key = {
+  readonly " $data"?: BAISessionClusterModeV2Fragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAISessionClusterModeV2Fragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "BAISessionClusterModeV2Fragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "clusterMode",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "clusterSize",
+      "storageKey": null
+    }
+  ],
+  "type": "SessionV2MetadataInfo",
+  "abstractKey": null
+};
+
+(node as any).hash = "2b8a355b669f0c9c9b84fcbebcc6b331";
+
+export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAISessionNodesV2Fragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISessionNodesV2Fragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<53568254ff3c580c8d2fa5096bddcec3>>
+ * @generated SignedSource<<7cec1366267d17cbf491b178a06b167a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,9 +9,7 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
-export type ClusterMode = "MULTI_NODE" | "SINGLE_NODE" | "%future added value";
 export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREEMPTED" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
-export type SessionV2Type = "BATCH" | "INFERENCE" | "INTERACTIVE" | "SYSTEM" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type BAISessionNodesV2Fragment$data = ReadonlyArray<{
   readonly id: string;
@@ -19,10 +17,7 @@ export type BAISessionNodesV2Fragment$data = ReadonlyArray<{
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id: string;
-        readonly identity: {
-          readonly canonicalName: string;
-          readonly namespace: string;
-        };
+        readonly " $fragmentSpreads": FragmentRefs<"BAIImageNodeSimpleTagV2Fragment">;
       };
     }>;
   } | null | undefined;
@@ -32,10 +27,8 @@ export type BAISessionNodesV2Fragment$data = ReadonlyArray<{
     readonly terminatedAt: string | null | undefined;
   };
   readonly metadata: {
-    readonly clusterMode: ClusterMode;
-    readonly clusterSize: number;
     readonly name: string;
-    readonly sessionType: SessionV2Type;
+    readonly " $fragmentSpreads": FragmentRefs<"BAISessionClusterModeV2Fragment" | "BAISessionTypeTagV2Fragment">;
   };
   readonly project: {
     readonly basicInfo: {
@@ -162,25 +155,14 @@ return {
       "selections": [
         (v1/*: any*/),
         {
-          "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "sessionType",
-          "storageKey": null
+          "kind": "FragmentSpread",
+          "name": "BAISessionTypeTagV2Fragment"
         },
         {
-          "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "clusterMode",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "clusterSize",
-          "storageKey": null
+          "kind": "FragmentSpread",
+          "name": "BAISessionClusterModeV2Fragment"
         }
       ],
       "storageKey": null
@@ -292,29 +274,9 @@ return {
               "selections": [
                 (v0/*: any*/),
                 {
-                  "alias": null,
                   "args": null,
-                  "concreteType": "ImageV2IdentityInfo",
-                  "kind": "LinkedField",
-                  "name": "identity",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "canonicalName",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "namespace",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
+                  "kind": "FragmentSpread",
+                  "name": "BAIImageNodeSimpleTagV2Fragment"
                 }
               ],
               "storageKey": null
@@ -361,6 +323,6 @@ return {
 };
 })();
 
-(node as any).hash = "7b2489642946a3bce33fba24eb5f1c23";
+(node as any).hash = "8a95f29a56c4f590b7cf7269949d9396";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAISessionTypeTagV2Fragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISessionTypeTagV2Fragment.graphql.ts
@@ -1,0 +1,43 @@
+/**
+ * @generated SignedSource<<5fe9033aa83b39e2aa744e5ec2ce37b9>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type SessionV2Type = "BATCH" | "INFERENCE" | "INTERACTIVE" | "SYSTEM" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type BAISessionTypeTagV2Fragment$data = {
+  readonly sessionType: SessionV2Type;
+  readonly " $fragmentType": "BAISessionTypeTagV2Fragment";
+};
+export type BAISessionTypeTagV2Fragment$key = {
+  readonly " $data"?: BAISessionTypeTagV2Fragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAISessionTypeTagV2Fragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "BAISessionTypeTagV2Fragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "sessionType",
+      "storageKey": null
+    }
+  ],
+  "type": "SessionV2MetadataInfo",
+  "abstractKey": null
+};
+
+(node as any).hash = "b9a2cdd831c5dcdc398274bc5081c60b";
+
+export default node;

--- a/packages/backend.ai-ui/src/components/BAIImageMetaIcon.tsx
+++ b/packages/backend.ai-ui/src/components/BAIImageMetaIcon.tsx
@@ -1,0 +1,42 @@
+import { useBAIImageMetaData } from './provider';
+import React from 'react';
+
+export interface BAIImageMetaIconProps {
+  /** Full image name (e.g. `cr.backend.ai/multiarch/python:3.9-ubuntu20.04@x86_64`). */
+  image?: string | null;
+  style?: React.CSSProperties;
+  alt?: string;
+}
+
+/**
+ * v2/package counterpart of the React app's `ImageMetaIcon`. Resolves the
+ * framework icon URL for an image by joining the `imagePath` provided via
+ * `BAIMetaDataProvider` with the icon filename declared in the image metadata
+ * (`imageInfo[].icon`, falling back to `default.png`). Renders nothing when
+ * the host app has not provided an `imagePath` — the package never bundles or
+ * resolves app asset paths on its own.
+ */
+const BAIImageMetaIcon: React.FC<BAIImageMetaIconProps> = ({
+  image,
+  style,
+  alt = '',
+}) => {
+  'use memo';
+  const [, { getImageIcon }] = useBAIImageMetaData();
+  const src = getImageIcon(image);
+
+  return src ? (
+    <img
+      src={src}
+      style={{
+        width: '1em',
+        height: '1em',
+        verticalAlign: 'middle',
+        ...style,
+      }}
+      alt={alt}
+    />
+  ) : null;
+};
+
+export default BAIImageMetaIcon;

--- a/packages/backend.ai-ui/src/components/BAISessionNodesV2.tsx
+++ b/packages/backend.ai-ui/src/components/BAISessionNodesV2.tsx
@@ -6,9 +6,10 @@ import {
   BAIColumnType,
   BAIFlex,
   BAIId,
+  BAIImageNodeSimpleTagV2,
   BAIIntervalView,
-  BAISessionClusterMode,
-  BAISessionTypeTag,
+  BAISessionClusterModeV2,
+  BAISessionTypeTagV2,
   BAITable,
   BAITableProps,
   BAITag,
@@ -159,9 +160,8 @@ const BAISessionNodesV2: React.FC<BAISessionNodesV2Props> = ({
         }
         metadata {
           name
-          sessionType
-          clusterMode
-          clusterSize
+          ...BAISessionTypeTagV2Fragment
+          ...BAISessionClusterModeV2Fragment
         }
         lifecycle {
           status
@@ -189,10 +189,7 @@ const BAISessionNodesV2: React.FC<BAISessionNodesV2Props> = ({
           edges {
             node {
               id
-              identity {
-                canonicalName
-                namespace
-              }
+              ...BAIImageNodeSimpleTagV2Fragment
             }
           }
         }
@@ -314,11 +311,13 @@ const BAISessionNodesV2: React.FC<BAISessionNodesV2Props> = ({
         render: (__, session) => {
           const firstImage = session.images?.edges?.[0]?.node;
           if (!firstImage) return '-';
-          const displayName =
-            firstImage.identity?.canonicalName ||
-            firstImage.identity?.namespace ||
-            '-';
-          return <BAITag>{displayName}</BAITag>;
+          return (
+            <BAIImageNodeSimpleTagV2
+              imageFrgmt={firstImage}
+              copyable={false}
+              withoutTag
+            />
+          );
         },
       },
       {
@@ -327,17 +326,13 @@ const BAISessionNodesV2: React.FC<BAISessionNodesV2Props> = ({
         defaultHidden: true,
         render: (__, session) => session.resource?.resourceGroupName || '-',
       },
-      // TODO: `BAISessionTypeTag` / `BAISessionClusterMode` are v1
-      // (`ComputeSessionNode`) fragment components and currently receive the
-      // values via props. They should be reworked to consume the v2 `SessionV2`
-      // query/fragment directly.
       {
         key: 'sessionType',
         title: t('comp:SessionV2Nodes.SessionType'),
         defaultHidden: true,
         render: (__, session) =>
-          session.metadata?.sessionType ? (
-            <BAISessionTypeTag type={session.metadata.sessionType} />
+          session.metadata ? (
+            <BAISessionTypeTagV2 metadataFrgmt={session.metadata} />
           ) : (
             '-'
           ),
@@ -347,11 +342,8 @@ const BAISessionNodesV2: React.FC<BAISessionNodesV2Props> = ({
         title: t('comp:SessionV2Nodes.ClusterMode'),
         defaultHidden: true,
         render: (__, session) =>
-          session.metadata?.clusterMode ? (
-            <BAISessionClusterMode
-              clusterMode={session.metadata.clusterMode}
-              clusterSize={session.metadata.clusterSize}
-            />
+          session.metadata ? (
+            <BAISessionClusterModeV2 metadataFrgmt={session.metadata} />
           ) : (
             '-'
           ),

--- a/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
@@ -28,13 +28,7 @@ import {
 import type { TableColumnsType } from 'antd';
 import { FormInstance } from 'antd/lib';
 import * as _ from 'lodash-es';
-import React, {
-  useRef,
-  useState,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
+import React, { use, useRef, useState, useCallback, useMemo } from 'react';
 
 /**
  * Form values interface for the table setting modal
@@ -102,7 +96,7 @@ const RowContext = React.createContext<RowContextProps>({});
  */
 const DragHandle: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
   'use memo';
-  const { setActivatorNodeRef, listeners } = useContext(RowContext);
+  const { setActivatorNodeRef, listeners } = use(RowContext);
   const { token } = theme.useToken();
   return (
     <Typography.Text

--- a/packages/backend.ai-ui/src/components/fragments/BAIImageNodeSimpleTagV2.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIImageNodeSimpleTagV2.tsx
@@ -1,0 +1,125 @@
+import { BAIImageNodeSimpleTagV2Fragment$key } from '../../__generated__/BAIImageNodeSimpleTagV2Fragment.graphql';
+import { preserveDotStartCase } from '../../helper';
+import BAIDoubleTag from '../BAIDoubleTag';
+import BAIFlex from '../BAIFlex';
+import BAIImageMetaIcon from '../BAIImageMetaIcon';
+import { useBAIImageMetaData } from '../provider/BAIMetaDataProvider';
+import { Divider, Tag, Typography, theme } from 'antd';
+import * as _ from 'lodash-es';
+import React from 'react';
+import { graphql, useFragment } from 'react-relay';
+
+export interface BAIImageNodeSimpleTagV2Props {
+  /** v2 `ImageV2` fragment. */
+  imageFrgmt: BAIImageNodeSimpleTagV2Fragment$key | null;
+  withoutTag?: boolean;
+  copyable?: boolean;
+}
+
+/**
+ * v2 counterpart of the React app's `ImageNodeSimpleTag`. Renders the image
+ * icon, base name, version and architecture in the same format as the v1
+ * session list, resolving icons and tag aliases from the image metadata
+ * provided via `BAIMetaDataProvider`.
+ */
+const BAIImageNodeSimpleTagV2: React.FC<BAIImageNodeSimpleTagV2Props> = ({
+  imageFrgmt,
+  withoutTag = false,
+  copyable = true,
+}) => {
+  'use memo';
+  const [, { tagAlias, getBaseImage, getBaseVersion }] = useBAIImageMetaData();
+  const { token } = theme.useToken();
+  const image = useFragment(
+    graphql`
+      fragment BAIImageNodeSimpleTagV2Fragment on ImageV2 {
+        identity {
+          canonicalName
+          namespace
+          architecture
+        }
+        metadata {
+          tags {
+            key
+            value
+          }
+          labels {
+            key
+            value
+          }
+        }
+      }
+    `,
+    imageFrgmt ?? null,
+  );
+
+  if (!image) return null;
+
+  const fullName = image.identity?.canonicalName ?? '';
+  const architecture = image.identity?.architecture ?? '';
+
+  return (
+    <BAIFlex direction="row" gap={'xs'} wrap="wrap">
+      <BAIImageMetaIcon image={fullName} />
+      <Typography.Text>{tagAlias(getBaseImage(fullName))}</Typography.Text>
+      <Divider orientation="vertical" style={{ marginInline: 0 }} />
+      <Typography.Text>{getBaseVersion(fullName)}</Typography.Text>
+      <Divider orientation="vertical" style={{ marginInline: 0 }} />
+      <Typography.Text>{architecture}</Typography.Text>
+      {withoutTag ? null : (
+        <>
+          <Divider orientation="vertical" style={{ marginInline: 0 }} />
+          {_.map(image.metadata?.tags, (tag, index) => {
+            if (!tag) return null;
+            const isCustomized = tag.key && _.includes(tag.key, 'customized_');
+            const tagValue =
+              (isCustomized
+                ? _.find(image?.metadata?.labels, {
+                    key: 'ai.backend.customized-image.name',
+                  })?.value
+                : tag?.value) || '';
+            const aliasedTag = tag?.key
+              ? tagAlias(tag.key + tagValue)
+              : undefined;
+            return tag?.key &&
+              _.isEqual(
+                aliasedTag,
+                preserveDotStartCase(tag.key + tagValue),
+              ) ? (
+              <BAIDoubleTag
+                key={`${tag.key}-${index}`}
+                values={[
+                  {
+                    label: tagAlias(tag.key),
+                    color: isCustomized ? 'cyan' : undefined,
+                  },
+                  {
+                    label: tagValue,
+                    color: isCustomized ? 'cyan' : undefined,
+                  },
+                ]}
+              />
+            ) : (
+              <Tag
+                key={`${tag.key}-${index}`}
+                color={isCustomized ? 'cyan' : undefined}
+              >
+                {aliasedTag}
+              </Tag>
+            );
+          })}
+        </>
+      )}
+      {copyable && (
+        <Typography.Text
+          style={{ color: token.colorLink }}
+          copyable={{
+            text: fullName,
+          }}
+        />
+      )}
+    </BAIFlex>
+  );
+};
+
+export default BAIImageNodeSimpleTagV2;

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionClusterModeV2.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionClusterModeV2.tsx
@@ -1,0 +1,79 @@
+import { BAISessionClusterModeV2Fragment$key } from '../../__generated__/BAISessionClusterModeV2Fragment.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
+import { Tag, theme, Typography } from 'antd';
+import * as _ from 'lodash-es';
+import React from 'react';
+import { useFragment, graphql } from 'react-relay';
+
+export interface BAISessionClusterModeV2Props {
+  /** v2 `SessionV2MetadataInfo` fragment. */
+  metadataFrgmt: BAISessionClusterModeV2Fragment$key | null;
+  showSize?: boolean;
+  mode?: 'text' | 'tag';
+}
+
+/**
+ * v2 counterpart of `BAISessionClusterMode`. Consumes the
+ * `SessionV2MetadataInfo` fragment directly instead of receiving the cluster
+ * mode/size via props. The v2 `ClusterMode` enum (`SINGLE_NODE`/`MULTI_NODE`)
+ * is matched by prefix, mirroring the v1 component.
+ */
+const BAISessionClusterModeV2: React.FC<BAISessionClusterModeV2Props> = ({
+  metadataFrgmt,
+  showSize = true,
+  mode = 'text',
+}) => {
+  'use memo';
+  const { t } = useBAIi18n();
+  const { token } = theme.useToken();
+  const metadata = useFragment(
+    graphql`
+      fragment BAISessionClusterModeV2Fragment on SessionV2MetadataInfo {
+        clusterMode
+        clusterSize
+      }
+    `,
+    metadataFrgmt ?? null,
+  );
+
+  const clusterMode = metadata?.clusterMode;
+  const clusterSize = metadata?.clusterSize;
+  const canShowSize = showSize && !_.isNil(clusterSize);
+
+  const modeTitle = _.startsWith(clusterMode?.toUpperCase() || '', 'SINGLE')
+    ? t('comp:BAISessionClusterMode.SingleNodeShort')
+    : _.startsWith(clusterMode?.toUpperCase() || '', 'MULTI')
+      ? t('comp:BAISessionClusterMode.MultiNodeShort')
+      : '-';
+
+  return mode === 'text' ? (
+    <Typography.Text>
+      {modeTitle}
+      {canShowSize && (
+        <>
+          &nbsp;
+          <Typography.Text type="secondary">({clusterSize})</Typography.Text>
+        </>
+      )}
+    </Typography.Text>
+  ) : (
+    <Tag>
+      {modeTitle}
+      {canShowSize && (
+        <>
+          &nbsp;
+          <Typography.Text
+            type="secondary"
+            style={{
+              fontSize: token.fontSizeSM,
+            }}
+          >
+            ({clusterSize})
+          </Typography.Text>
+        </>
+      )}
+    </Tag>
+  );
+};
+
+export default BAISessionClusterModeV2;

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionTypeTag.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionTypeTag.tsx
@@ -11,18 +11,11 @@ const typeTagColor = {
 };
 
 export interface BAISessionTypeTagProps {
-  /** v1 `ComputeSessionNode` fragment. Omit when passing `type` directly. */
-  sessionFrgmt?: BAISessionTypeTagFragment$key | null;
-  /**
-   * Session type value (e.g. from the v2 `SessionV2` API). Takes precedence
-   * over `sessionFrgmt` when provided.
-   */
-  type?: string | null;
+  sessionFrgmt: BAISessionTypeTagFragment$key;
 }
 
 const BAISessionTypeTag: React.FC<BAISessionTypeTagProps> = ({
   sessionFrgmt,
-  type,
 }) => {
   const session = useFragment(
     graphql`
@@ -30,18 +23,16 @@ const BAISessionTypeTag: React.FC<BAISessionTypeTagProps> = ({
         type
       }
     `,
-    sessionFrgmt ?? null,
+    sessionFrgmt,
   );
 
-  const resolvedType = type ?? session?.type;
-
-  if (_.isEmpty(resolvedType)) {
+  if (_.isEmpty(session.type)) {
     return <>-</>;
   }
 
   return (
-    <Tag color={_.get(typeTagColor, _.toUpper(resolvedType || ''))}>
-      {_.toUpper(resolvedType || '')}
+    <Tag color={_.get(typeTagColor, _.toUpper(session.type || ''))}>
+      {_.toUpper(session.type || '')}
     </Tag>
   );
 };

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionTypeTagV2.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionTypeTagV2.tsx
@@ -1,0 +1,48 @@
+import { BAISessionTypeTagV2Fragment$key } from '../../__generated__/BAISessionTypeTagV2Fragment.graphql';
+import { Tag } from 'antd';
+import * as _ from 'lodash-es';
+import React from 'react';
+import { useFragment, graphql } from 'react-relay';
+
+const typeTagColor = {
+  INTERACTIVE: 'geekblue',
+  BATCH: 'cyan',
+  INFERENCE: 'purple',
+};
+
+export interface BAISessionTypeTagV2Props {
+  /** v2 `SessionV2MetadataInfo` fragment. */
+  metadataFrgmt: BAISessionTypeTagV2Fragment$key | null;
+}
+
+/**
+ * v2 counterpart of `BAISessionTypeTag`. Consumes the `SessionV2MetadataInfo`
+ * fragment directly instead of receiving the session type via a prop.
+ */
+const BAISessionTypeTagV2: React.FC<BAISessionTypeTagV2Props> = ({
+  metadataFrgmt,
+}) => {
+  'use memo';
+  const metadata = useFragment(
+    graphql`
+      fragment BAISessionTypeTagV2Fragment on SessionV2MetadataInfo {
+        sessionType
+      }
+    `,
+    metadataFrgmt ?? null,
+  );
+
+  const type = metadata?.sessionType;
+
+  if (_.isEmpty(type)) {
+    return <>-</>;
+  }
+
+  return (
+    <Tag color={_.get(typeTagColor, _.toUpper(type || ''))}>
+      {_.toUpper(type || '')}
+    </Tag>
+  );
+};
+
+export default BAISessionTypeTagV2;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -1,6 +1,12 @@
 export { default as BAISessionTypeTag } from './BAISessionTypeTag';
 export { default as BAISessionAgentIds } from './BAISessionAgentIds';
 export type { BAISessionTypeTagProps } from './BAISessionTypeTag';
+export { default as BAISessionTypeTagV2 } from './BAISessionTypeTagV2';
+export type { BAISessionTypeTagV2Props } from './BAISessionTypeTagV2';
+export { default as BAISessionClusterModeV2 } from './BAISessionClusterModeV2';
+export type { BAISessionClusterModeV2Props } from './BAISessionClusterModeV2';
+export { default as BAIImageNodeSimpleTagV2 } from './BAIImageNodeSimpleTagV2';
+export type { BAIImageNodeSimpleTagV2Props } from './BAIImageNodeSimpleTagV2';
 export { default as BAIArtifactRevisionTable } from './BAIArtifactRevisionTable';
 export type {
   BAIArtifactRevisionTableProps,

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -144,6 +144,8 @@ export type {
   BAIDeploymentStatus,
 } from './BAIDeploymentStatusTag';
 export { default as BAIIntervalView } from './BAIIntervalView';
+export { default as BAIImageMetaIcon } from './BAIImageMetaIcon';
+export type { BAIImageMetaIconProps } from './BAIImageMetaIcon';
 export { default as BAIDoubleTag } from './BAIDoubleTag';
 export type { DoubleTagObjectValue, BAIDoubleTagProps } from './BAIDoubleTag';
 export { default as BAIProgressWithLabel } from './BAIProgressWithLabel';

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useAnonymousBAIClient.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useAnonymousBAIClient.ts
@@ -1,13 +1,14 @@
 import useBAILogger from '../../../../hooks/useBAILogger';
 import { BAIAnonymousClientContext } from '../context';
 import { BAIClient } from '../types';
-import { useContext } from 'react';
+import { use } from 'react';
 
 const useBAIAnonymousClient = (apiEndpoint: string): BAIClient => {
   const { logger } = useBAILogger();
+  // `use` cannot be called inside try/catch, so read the context first.
+  const baiAnonymousClient = use(BAIAnonymousClientContext);
 
   try {
-    const baiAnonymousClient = useContext(BAIAnonymousClientContext);
     if (!baiAnonymousClient) {
       throw new Error(
         'useBAIAnonymousClient must be used within a BAIClientProvider',

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useConnectedBAIClient.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useConnectedBAIClient.ts
@@ -1,9 +1,9 @@
 import { BAIClientContext } from '../context';
 import { BAIClient } from '../types';
-import { use, useContext } from 'react';
+import { use } from 'react';
 
 const useConnectedBAIClient = (): BAIClient => {
-  const baiClientPromise = useContext(BAIClientContext);
+  const baiClientPromise = use(BAIClientContext);
   if (!baiClientPromise) {
     throw new Error('useBAIClient must be used within a BAIClientProvider');
   }

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/BAIMetaDataProvider.tsx
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/BAIMetaDataProvider.tsx
@@ -1,19 +1,36 @@
-import { BAIDeviceMetaDataContext } from './context';
-import type { DeviceMetaData } from './types';
+import {
+  BAIDeviceMetaDataContext,
+  BAIImageMetaDataContext,
+  BAIImagePathContext,
+} from './context';
+import type { DeviceMetaData, ImageMetaData } from './types';
 import type { ReactNode } from 'react';
 
 export interface BAIMetaDataProviderProps {
   deviceMetaData?: DeviceMetaData;
+  imageMetaData?: ImageMetaData;
+  /**
+   * Base path where the host app serves the icon files referenced by
+   * `imageMetaData.imageInfo[].icon` (e.g. `resources/icons`). The package
+   * never bundles or resolves app asset paths on its own.
+   */
+  imagePath?: string;
   children?: ReactNode;
 }
 
 const BAIMetaDataProvider = ({
   deviceMetaData,
+  imageMetaData,
+  imagePath,
   children,
 }: BAIMetaDataProviderProps) => {
   return (
     <BAIDeviceMetaDataContext.Provider value={deviceMetaData}>
-      {children}
+      <BAIImageMetaDataContext.Provider value={imageMetaData}>
+        <BAIImagePathContext.Provider value={imagePath}>
+          {children}
+        </BAIImagePathContext.Provider>
+      </BAIImageMetaDataContext.Provider>
     </BAIDeviceMetaDataContext.Provider>
   );
 };

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/context.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/context.ts
@@ -1,6 +1,18 @@
-import type { DeviceMetaData } from './types';
+import type { DeviceMetaData, ImageMetaData } from './types';
 import { createContext } from 'react';
 
 export const BAIDeviceMetaDataContext = createContext<
   DeviceMetaData | undefined
 >(undefined);
+
+export const BAIImageMetaDataContext = createContext<ImageMetaData | undefined>(
+  undefined,
+);
+
+/**
+ * Base path (URL prefix) where the host app serves the image icon files
+ * referenced by `image_metadata.json`'s `imageInfo[].icon` (e.g.
+ * `resources/icons`). Combined with the icon filename by
+ * `useBAIImageMetaData`'s `getImageIcon` helper.
+ */
+export const BAIImagePathContext = createContext<string | undefined>(undefined);

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIDeviceMetaData.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIDeviceMetaData.ts
@@ -1,11 +1,12 @@
 import useBAILogger from '../../../../hooks/useBAILogger';
 import { BAIDeviceMetaDataContext } from '../context';
-import { useContext } from 'react';
+import { use } from 'react';
 
 const useBAIDeviceMetaData = () => {
   const { logger } = useBAILogger();
+  // `use` cannot be called inside try/catch, so read the context first.
+  const context = use(BAIDeviceMetaDataContext);
   try {
-    const context = useContext(BAIDeviceMetaDataContext);
     if (!context) {
       throw new Error(
         'useBAIDeviceMetaData must be used within a BAIMetaDataProvider',

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIImageMetaData.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIImageMetaData.ts
@@ -1,0 +1,88 @@
+import { preserveDotStartCase } from '../../../../helper';
+import { BAIImageMetaDataContext, BAIImagePathContext } from '../context';
+import * as _ from 'lodash-es';
+import { use } from 'react';
+
+/**
+ * Access the image metadata (`resources/image_metadata.json`) provided by
+ * `BAIMetaDataProvider`, together with a set of helpers for resolving image
+ * icons and humanized tag/name aliases.
+ *
+ * This mirrors the v1 `useBackendAIImageMetaData` hook from the React app, but
+ * reads the metadata from React context (provided by the host app) instead of
+ * fetching it, so `backend.ai-ui` stays free of a data-fetching dependency.
+ *
+ * The returned helpers are null-safe: when no metadata has been provided yet
+ * they fall back to sensible defaults (`default.png` icon, identity aliasing).
+ */
+const useBAIImageMetaData = () => {
+  'use memo';
+  const metadata = use(BAIImageMetaDataContext);
+  const imagePath = use(BAIImagePathContext);
+
+  const getImageMeta = (imageName: string) => {
+    // registry/name:tag@architecture
+    // cr.backend.ai/multiarch/python:3.9-ubuntu20.04
+    // key = python, tags = [3.9, ubuntu20.04]
+    if (_.isEmpty(imageName)) {
+      return { key: '', tags: [] as string[] };
+    }
+    const specs = imageName.split('/');
+    try {
+      const [key, tag] = (
+        specs[specs.length - 1] ||
+        specs[specs.length - 2] ||
+        ''
+      ).split(':');
+      // remove architecture string and split by '-'
+      const tags = _.split(_.first(_.split(tag, '@')), '-');
+      return { key, tags };
+    } catch {
+      return { key: '', tags: [] as string[] };
+    }
+  };
+
+  const helpers = {
+    getImageMeta,
+    /**
+     * Full icon URL for the image: the `imagePath` provided via
+     * `BAIMetaDataProvider` joined with the icon filename declared in
+     * `imageInfo` (falling back to `default.png` for unknown images).
+     * Returns `undefined` when no `imagePath` has been provided — the
+     * package never resolves an app asset path on its own.
+     */
+    getImageIcon: (imageName?: string | null) => {
+      if (_.isUndefined(imagePath)) return undefined;
+      const iconFileName =
+        (imageName && metadata?.imageInfo[getImageMeta(imageName).key]?.icon) ||
+        'default.png';
+      return `${_.trimEnd(imagePath, '/')}/${iconFileName}`;
+    },
+    getBaseVersion: (imageName: string) => {
+      return (
+        _.first(_.split(_.last(_.split(imageName, ':')), /[^a-zA-Z\d.]+/)) || ''
+      );
+    },
+    getBaseImage: (imageName: string) => {
+      const splitByColon = _.split(imageName, ':');
+      const beforeLastColon = _.join(_.initial(splitByColon), ':');
+      const lastItemAfterSplitBySlash = _.last(_.split(beforeLastColon, '/'));
+      return lastItemAfterSplitBySlash || '';
+    },
+    tagAlias: (tag: string) => {
+      if (!metadata) return preserveDotStartCase(tag);
+      const matchedPair = _.find(
+        _.toPairs(metadata.tagReplace),
+        ([regExpStr]) => new RegExp(regExpStr).test(tag),
+      );
+      const replaced = matchedPair
+        ? _.replace(tag, new RegExp(matchedPair[0]), matchedPair[1] as string)
+        : undefined;
+      return metadata.tagAlias[tag] ?? replaced ?? preserveDotStartCase(tag);
+    },
+  };
+
+  return [metadata, helpers] as const;
+};
+
+export default useBAIImageMetaData;

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/index.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/index.ts
@@ -1,5 +1,10 @@
 export { default as BAIMetaDataProvider } from './BAIMetaDataProvider';
 export type { BAIMetaDataProviderProps } from './BAIMetaDataProvider';
-export { BAIDeviceMetaDataContext } from './context';
+export {
+  BAIDeviceMetaDataContext,
+  BAIImageMetaDataContext,
+  BAIImagePathContext,
+} from './context';
 export { default as useBAIDeviceMetaData } from './hooks/useBAIDeviceMetaData';
+export { default as useBAIImageMetaData } from './hooks/useBAIImageMetaData';
 export type * from './types';

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/types.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/types.ts
@@ -27,3 +27,37 @@ export type KnownAcceleratorResourceSlotName =
 export type ResourceSlotName =
   | BaseResourceSlotName
   | KnownAcceleratorResourceSlotName;
+
+/**
+ * A single label entry attached to an image in `image_metadata.json`.
+ */
+export interface ImageMetadataLabel {
+  category?: string;
+  tag: string;
+  color: string;
+}
+
+/**
+ * Per-image metadata entry keyed by the parsed image key (e.g. `python`,
+ * `ngc-pytorch`) inside `image_metadata.json`'s `imageInfo`.
+ */
+export interface ImageMetadataInfo {
+  name: string;
+  description: string;
+  group: string;
+  tags: string[];
+  icon?: string;
+  label?: ImageMetadataLabel[];
+}
+
+/**
+ * Shape of `resources/image_metadata.json`. Provided to `backend.ai-ui`
+ * components via `BAIMetaDataProvider` so they can resolve image icons and
+ * humanized tag/name aliases without a Relay dependency.
+ */
+export interface ImageMetaData {
+  imageInfo: { [key: string]: ImageMetadataInfo | undefined };
+  tagAlias: { [key: string]: string };
+  tagReplace: { [key: string]: string };
+  groupSortKeyMap?: { [key: string]: string };
+}

--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -357,6 +357,24 @@ export const filterOutEmpty = <T>(
 ): Array<T> => _.filter(arr, (item) => !_.isEmpty(item)) as Array<T>;
 
 /**
+ * Start-cases a string while preserving dot (`.`) separators, so version-like
+ * tokens (e.g. `py3.9`) keep their dots instead of being split into words.
+ *
+ * Mirrors the v1 `preserveDotStartCase` helper used by the image metadata
+ * tag aliasing logic.
+ */
+export function preserveDotStartCase(str: string = '') {
+  // Temporarily replace periods with a unique placeholder
+  const placeholder = '<<<DOT>>>';
+  const tempStr = str.replace(/\./g, placeholder);
+
+  const startCased = _.startCase(tempStr);
+
+  // Replace the placeholder back with periods
+  return startCased.replace(new RegExp(placeholder, 'g'), '.');
+}
+
+/**
  * Filters out `null` and `undefined` values from an array of objects.
  *
  * @template T - The type of objects in the array.

--- a/react/src/__generated__/ProjectAdminSessionPageQuery.graphql.ts
+++ b/react/src/__generated__/ProjectAdminSessionPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<56d259d066433fba3b4e12f0a61b1d17>>
+ * @generated SignedSource<<0ff02c93c929880a2583b3de696e741d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -195,6 +195,22 @@ v10 = [
         "storageKey": null
       }
     ],
+    "storageKey": null
+  }
+],
+v11 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "key",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "value",
     "storageKey": null
   }
 ];
@@ -490,6 +506,44 @@ return {
                                     "kind": "ScalarField",
                                     "name": "namespace",
                                     "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "architecture",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ImageV2MetadataInfo",
+                                "kind": "LinkedField",
+                                "name": "metadata",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "ImageV2TagEntry",
+                                    "kind": "LinkedField",
+                                    "name": "tags",
+                                    "plural": true,
+                                    "selections": (v11/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "ImageV2LabelEntry",
+                                    "kind": "LinkedField",
+                                    "name": "labels",
+                                    "plural": true,
+                                    "selections": (v11/*: any*/),
+                                    "storageKey": null
                                   }
                                 ],
                                 "storageKey": null
@@ -604,12 +658,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3dc36b0a32a18fe9f40af29bef580c64",
+    "cacheID": "ce21c7ce05a652ddcd879723a7162834",
     "id": null,
     "metadata": {},
     "name": "ProjectAdminSessionPageQuery",
     "operationKind": "query",
-    "text": "query ProjectAdminSessionPageQuery(\n  $projectId: UUID!\n  $filter: SessionV2Filter\n  $orderBy: [SessionV2OrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  projectSessionsV2(scope: {projectId: $projectId}, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        metadata {\n          name\n        }\n        ...BAISessionNodesV2Fragment\n        ...TerminateSessionModalForProjectAdminFragment\n      }\n    }\n  }\n}\n\nfragment BAISessionNodesV2Fragment on SessionV2 {\n  id\n  project {\n    id\n    basicInfo {\n      name\n    }\n  }\n  metadata {\n    name\n    sessionType\n    clusterMode\n    clusterSize\n  }\n  lifecycle {\n    status\n    createdAt\n    terminatedAt\n  }\n  resource {\n    resourceGroupName\n    allocation {\n      requested {\n        entries {\n          resourceType\n          quantity\n        }\n      }\n      used {\n        entries {\n          resourceType\n          quantity\n        }\n      }\n    }\n  }\n  images {\n    edges {\n      node {\n        id\n        identity {\n          canonicalName\n          namespace\n        }\n      }\n    }\n  }\n  user {\n    id\n    basicInfo {\n      email\n    }\n  }\n}\n\nfragment TerminateSessionModalForProjectAdminFragment on SessionV2 {\n  id\n  metadata {\n    name\n  }\n  kernels {\n    edges {\n      node {\n        id\n        resource {\n          agentId\n          containerId\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ProjectAdminSessionPageQuery(\n  $projectId: UUID!\n  $filter: SessionV2Filter\n  $orderBy: [SessionV2OrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  projectSessionsV2(scope: {projectId: $projectId}, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        metadata {\n          name\n        }\n        ...BAISessionNodesV2Fragment\n        ...TerminateSessionModalForProjectAdminFragment\n      }\n    }\n  }\n}\n\nfragment BAIImageNodeSimpleTagV2Fragment on ImageV2 {\n  identity {\n    canonicalName\n    namespace\n    architecture\n  }\n  metadata {\n    tags {\n      key\n      value\n    }\n    labels {\n      key\n      value\n    }\n  }\n}\n\nfragment BAISessionClusterModeV2Fragment on SessionV2MetadataInfo {\n  clusterMode\n  clusterSize\n}\n\nfragment BAISessionNodesV2Fragment on SessionV2 {\n  id\n  project {\n    id\n    basicInfo {\n      name\n    }\n  }\n  metadata {\n    name\n    ...BAISessionTypeTagV2Fragment\n    ...BAISessionClusterModeV2Fragment\n  }\n  lifecycle {\n    status\n    createdAt\n    terminatedAt\n  }\n  resource {\n    resourceGroupName\n    allocation {\n      requested {\n        entries {\n          resourceType\n          quantity\n        }\n      }\n      used {\n        entries {\n          resourceType\n          quantity\n        }\n      }\n    }\n  }\n  images {\n    edges {\n      node {\n        id\n        ...BAIImageNodeSimpleTagV2Fragment\n      }\n    }\n  }\n  user {\n    id\n    basicInfo {\n      email\n    }\n  }\n}\n\nfragment BAISessionTypeTagV2Fragment on SessionV2MetadataInfo {\n  sessionType\n}\n\nfragment TerminateSessionModalForProjectAdminFragment on SessionV2 {\n  id\n  metadata {\n    name\n  }\n  kernels {\n    edges {\n      node {\n        id\n        resource {\n          agentId\n          containerId\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -11,7 +11,7 @@ import {
   createAnonymousBackendaiClient,
   useWebUINavigate,
 } from '../hooks';
-import { useDeviceMetaData } from '../hooks/backendai';
+import { useDeviceMetaData, useImageMetaData } from '../hooks/backendai';
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { useThemeMode } from '../hooks/useThemeMode';
 import '../index.css';
@@ -262,11 +262,18 @@ const commonAppProps: AppProps = {
   },
 };
 
-const BAIMetaDataWrapper = ({ children }: { children: ReactNode }) => {
-  const { data } = useDeviceMetaData();
+const BAIMetaDataProviderWrapper = ({ children }: { children: ReactNode }) => {
+  const { data: deviceMetaData } = useDeviceMetaData();
+  const { data: imageMetaData } = useImageMetaData();
 
   return (
-    <BAIMetaDataProvider deviceMetaData={data}>{children}</BAIMetaDataProvider>
+    <BAIMetaDataProvider
+      deviceMetaData={deviceMetaData}
+      imageMetaData={imageMetaData}
+      imagePath="resources/icons"
+    >
+      {children}
+    </BAIMetaDataProvider>
   );
 };
 
@@ -373,7 +380,7 @@ export const DefaultProvidersForReactRoot: React.FC<{
                * unchanged. See FR-2986 / packages/backend.ai-ui/src/hooks/
                * useBAIi18n.ts.
                */}
-              <BAIMetaDataWrapper>
+              <BAIMetaDataProviderWrapper>
                 <App {...commonAppProps}>
                   {/* Single app-wide notification renderer. Lives outside
                         the Suspense below so toasts work on every route and
@@ -408,7 +415,7 @@ export const DefaultProvidersForReactRoot: React.FC<{
                     </StyleProvider>
                   </CacheProvider>
                 </App>
-              </BAIMetaDataWrapper>
+              </BAIMetaDataProviderWrapper>
             </BAIConfigProvider>
           </QueryClientProvider>
         </RelayEnvironmentProvider>

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -32,7 +32,7 @@ import {
 import { filterOutEmpty, BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { ArrowLeftIcon, ShieldUserIcon } from 'lucide-react';
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { use, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
@@ -47,7 +47,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
   const { token } = theme.useToken();
   const { themeConfig } = useCustomThemeConfig();
 
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const currentSiderTheme =
     config.theme?.algorithm === theme.darkAlgorithm ? 'dark' : 'light';
 
@@ -367,7 +367,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
 
 const WebUISiderWithCustomTheme: React.FC<WebUISiderProps> = (props) => {
   const { themeConfig } = useCustomThemeConfig();
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
 
   const shouldReverse =

--- a/react/src/components/ReverseThemeProvider.tsx
+++ b/react/src/components/ReverseThemeProvider.tsx
@@ -5,7 +5,7 @@
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { theme, ConfigProvider, type ConfigProviderProps } from 'antd';
 import * as _ from 'lodash-es';
-import React, { useContext } from 'react';
+import React, { use } from 'react';
 
 interface ReverseThemeProviderProps extends ConfigProviderProps {
   className?: string;
@@ -15,7 +15,7 @@ const ReverseThemeProvider: React.FC<ReverseThemeProviderProps> = ({
 }) => {
   'use memo';
   const { themeConfig } = useCustomThemeConfig();
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
 
   return (

--- a/react/src/components/ThemeAdminProvider.tsx
+++ b/react/src/components/ThemeAdminProvider.tsx
@@ -11,12 +11,12 @@ import {
   type ThemeConfig,
 } from 'antd';
 import * as _ from 'lodash-es';
-import React, { useContext } from 'react';
+import React, { use } from 'react';
 
 const ThemeAdminProvider: React.FC<ConfigProviderProps> = ({ ...props }) => {
   'use memo';
   const { themeConfig } = useCustomThemeConfig();
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
   const primaryColors = usePrimaryColors();
 

--- a/react/src/components/ThemeSecondaryProvider.tsx
+++ b/react/src/components/ThemeSecondaryProvider.tsx
@@ -11,14 +11,14 @@ import {
   type ThemeConfig,
 } from 'antd';
 import * as _ from 'lodash-es';
-import React, { useContext } from 'react';
+import React, { use } from 'react';
 
 const ThemeSecondaryProvider: React.FC<ConfigProviderProps> = ({
   ...props
 }) => {
   'use memo';
   const { themeConfig } = useCustomThemeConfig();
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
   const primaryColors = usePrimaryColors();
 

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -11,6 +11,7 @@ import {
 } from './reactQueryAlias';
 import { useBAISettingUserState, UserSettings } from './useBAISetting';
 import {
+  ImageMetaData,
   ResourceSlotDetail,
   useUpdatableState,
   useViewer,
@@ -39,8 +40,7 @@ export type KnownAcceleratorResourceSlotName =
   (typeof knownAcceleratorResourceSlotNames)[number];
 
 export type ResourceSlotName =
-  | BaseResourceSlotName
-  | KnownAcceleratorResourceSlotName;
+  BaseResourceSlotName | KnownAcceleratorResourceSlotName;
 export interface QuotaScope {
   id: string;
   quota_scope_id: string;
@@ -80,6 +80,22 @@ export const useDeviceMetaData = (key = 'first') => {
         .then((response) => response.json())
         .then((result) => result?.deviceInfo);
     },
+    staleTime: 1000 * 60 * 60 * 24,
+  });
+};
+
+export const useImageMetaData = () => {
+  return useTanQuery<ImageMetaData>({
+    // Share the cache entry with the legacy `useBackendAIImageMetaData`
+    // (react/src/hooks/index.tsx) so `image_metadata.json` is fetched only
+    // once while both hooks coexist. Keep queryKey/retry in sync with it.
+    queryKey: ['backendai-metadata-for-suspense'],
+    queryFn: () => {
+      return fetch('resources/image_metadata.json').then((response) =>
+        response.json(),
+      );
+    },
+    retry: false,
     staleTime: 1000 * 60 * 60 * 24,
   });
 };

--- a/react/src/hooks/useThemeMode.tsx
+++ b/react/src/hooks/useThemeMode.tsx
@@ -6,7 +6,7 @@ import { useLocalStorageGlobalState } from './useLocalStorageGlobalState';
 import {
   PropsWithChildren,
   createContext,
-  useContext,
+  use,
   useEffect,
   useState,
 } from 'react';
@@ -91,7 +91,7 @@ export const ThemeModeProvider: React.FC<PropsWithChildren> = ({
 };
 
 export const useThemeMode = () => {
-  const context = useContext(ThemeModeContext);
+  const context = use(ThemeModeContext);
   if (context === undefined) {
     throw new Error(
       'useThemeModeContext must be used within a ThemeModeProvider',

--- a/react/src/pages/ProjectAdminSessionPage.tsx
+++ b/react/src/pages/ProjectAdminSessionPage.tsx
@@ -332,8 +332,11 @@ const ProjectAdminSessionContent: React.FC<ProjectAdminSessionContentProps> = ({
         }}
         tableSettings={{
           columnOverrides: columnOverrides,
-          // Match the default-visible columns of the admin session list
-          // (AdminComputeSessionListPage).
+          // BAISessionNodesV2 hides these columns by default
+          // (defaultHidden: true) to keep the shared component compact for
+          // future consumers. Intentionally override them to visible here so
+          // this page matches the default-visible columns of the v1 admin
+          // session list (AdminComputeSessionListPage).
           defaultColumnOverrides: {
             environment: { hidden: false },
             resourceGroup: { hidden: false },


### PR DESCRIPTION
Resolves #7548 (FR-2948)

## Summary

Renders the rich image environment (icon + framework name + version + architecture) in `BAISessionNodesV2`, matching the v1 admin session list (`SessionNodes` → `ImageNodeSimpleTag`), and replaces the prop-drilled v1 session tag components used by the v2 list with dedicated fragment-based v2 components.

## Changes

### Image metadata via `BAIMetaDataProvider` (mirrors the `device_metadata` pattern)
- `types.ts`: add `ImageMetaData` / `ImageMetadataInfo` / `ImageMetadataLabel` types (shape of `image_metadata.json`).
- `context.ts`: add `BAIImageMetaDataContext` and `BAIImagePathContext`.
- `BAIMetaDataProvider`: accept optional `imageMetaData` and `imagePath` props alongside `deviceMetaData`.
- `useBAIImageMetaData` hook: exposes null-safe helpers (`getImageMeta`, `getImageIcon`, `getBaseImage`, `getBaseVersion`, `tagAlias`). No `resources/...` path is hardcoded in the package.
- App side (`DefaultProviders.tsx` + `useImageMetaData`): fetch `resources/image_metadata.json` and feed it into the same `BAIMetaDataProvider`, together with `imagePath="resources/icons"`. The query shares its cache entry (`queryKey` / `retry`) with the legacy `useBackendAIImageMetaData` hook so `image_metadata.json` is fetched only once while both hooks coexist.

### Host-provided icon path (no image assets bundled in the package)
- Icon image files stay in the host app (`resources/icons/`). The package receives the base path via the new `imagePath` provider prop and joins it with the icon filename declared in `imageInfo[key].icon` (falling back to `default.png`).
- `useBAIImageMetaData`'s `getImageIcon(imageName)` returns the full icon URL (`{imagePath}/{icon}`), or `undefined` when no `imagePath` has been provided — the package never bundles or resolves app asset paths on its own, so any host (webui, Storybook, another monorepo consumer) can point it at its own static directory.
- `BAIImageMetaIcon`: renders `<img src={getImageIcon(image)}>` (1em, vertical-align middle — same rendering as the v1 `ImageMetaIcon`), and renders nothing when `imagePath` is absent.

### Rich environment column
- `BAIImageNodeSimpleTagV2` (fragment on `ImageV2`): mirrors v1 `ImageNodeSimpleTag` — icon + base name + version + architecture (+ tags when not `withoutTag`).
- `BAISessionNodesV2` environment column now renders `BAIImageNodeSimpleTagV2` (`withoutTag`, non-copyable), identical to the v1 admin session list.

### v2 fragment-based session tag components
- `BAISessionTypeTagV2` and `BAISessionClusterModeV2` consume the `SessionV2MetadataInfo` fragment directly (instead of receiving values via props). `BAISessionClusterModeV2` uses `useBAIi18n` per the FR-2986 BUI i18n convention.
- `BAISessionNodesV2` uses them via fragment spreads on `metadata`.
- Revert the prop overrides previously added to the v1 `BAISessionTypeTag` (added in #7533) back to its original fragment-only form. The v1 `BAISessionClusterMode` keeps its value props (`clusterMode` / `clusterSize`) unchanged from `main`, since `AdminDeploymentPresetNodes` (FR-3108) consumes them with plain values.

### useContext → React 19 `use` migration (repo-wide, folded into this PR)
- Replace all 10 remaining `useContext` call sites (9 files) in `react/src` and `packages/backend.ai-ui/src` with the React 19 `use` API (recommended superset of `useContext`).
- `useAnonymousBAIClient` / `useBAIDeviceMetaData`: hoist the context read out of the `try/catch` block (`use` cannot be called inside try/catch; `useContext` never throws, so behavior is unchanged).
- `useConnectedBAIClient` now uses `use` consistently for both the context read and the promise unwrap.

## Verification

`bash scripts/verify.sh`: **ALL PASS** (Relay, Lint, Format, TypeScript, Vite warmup paths).

## How to test

1. Use the test server `10.82.0.130` and log in as `user@lablup.com`.
2. Switch to the `project-admin` project, then open the project admin menu → **Sessions** (`/project-admin-session`).
3. In the session list, check the tag area of each row and verify the image icons render correctly (environment tag icon + type / cluster-mode tags). The icons should load from the host app's `resources/icons/` path (e.g. `resources/icons/python.png`), with `default.png` shown for images that have no icon in `image_metadata.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


