### PR TITLE
feat(FR-2951): default scheduling history to reverse chronological order

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
@@ -28,7 +28,7 @@ export type SchedulingHistoryNodeInList = NonNullable<
   BAISchedulingHistoryNodesFragment$data[number]
 >;
 
-const availableHistorySorterKeys = ['created_at', 'updated_at'] as const;
+const availableHistorySorterKeys = [] as const;
 
 export const availableHistorySorterValues = [
   ...availableHistorySorterKeys,

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionHistorySubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionHistorySubStepNodes.tsx
@@ -179,7 +179,7 @@ const BAISessionHistorySubStepNodes = ({
     <BAITable
       rowKey="step"
       size="small"
-      dataSource={filterOutNullAndUndefined(subSteps)}
+      dataSource={filterOutNullAndUndefined(subSteps).reverse()}
       columns={allColumns}
       scroll={{ x: 'max-content' }}
       {...tableProps}


### PR DESCRIPTION
Resolves #7554 (FR-2951)

## Summary
- Drop the sort UI on the **Updated At** and **Created At** columns of the phase-level scheduling history table (`BAISchedulingHistoryNodes`). Ordering is now controlled solely by the backend response.
- Render sub-step rows in `BAISessionHistorySubStepNodes` in reverse of the Relay fragment data, so the **latest sub-step appears at the top** of each expanded phase.

The phase-level table already arrives from the backend in newest-first order, and exposing sort handles invited toggles back to oldest-first that obscured the latest scheduling activity. Sub-steps are emitted by the scheduler in execution order; reversing them client-side surfaces the most recent step (which is often the failing one) at the top without touching the GraphQL schema.

Follow-up to FR-2326 (#6225).

## Screenshots

| Light mode | Dark mode |
|---|---|
| ![light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7555/20260521-221538-light.png) | ![dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7555/20260521-221542-dark.png) |

What to verify in the screenshots:
- Phase-level table: the **Updated At** and **Created At** column headers no longer carry sort arrows.
- Phase-level rows are newest-first (`promote-to-terminated` at the top, `enqueue` at the bottom).
- Expanded `schedule-sessions` sub-step table is reversed: `RepositoryAllocator` at the top (latest step of the phase) and `FIFOSequencer` at the bottom (earliest step).

## Test plan
- [ ] Open the Session Scheduling History modal on a finished session
- [ ] Phase-level table: confirm that the **Updated At** and **Created At** columns no longer show a sort arrow / are not click-to-sort
- [ ] Phase-level table: confirm the rows are in newest-first order (latest phase at the top, oldest at the bottom)
- [ ] Expand a phase and inspect the sub-step table: confirm the rows are in reverse of the previous order (the last sub-step of the phase appears at the top)
- [ ] Confirm other sortable columns (if any) are unaffected
