### PR TITLE
fix(FR-2952): surface server error message instead of "undefined" on failed GraphQL requests

### DIFF
--- a/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.test.tsx
+++ b/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.test.tsx
@@ -1,0 +1,120 @@
+import useErrorMessageResolver from './useErrorMessageResolver';
+import { renderHook } from '@testing-library/react';
+
+// Mock useTranslation so the default fallback is a stable, recognizable string.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const useGetErrorMessage = () => {
+  const { getErrorMessage } = useErrorMessageResolver();
+  return getErrorMessage;
+};
+
+describe('useErrorMessageResolver', () => {
+  it('returns the default message for nullish / non-object errors', () => {
+    const { result } = renderHook(() => useGetErrorMessage());
+    const getErrorMessage = result.current;
+
+    expect(getErrorMessage(undefined)).toBe('error.UnknownError');
+    expect(getErrorMessage(null)).toBe('error.UnknownError');
+    expect(getErrorMessage('boom')).toBe('error.UnknownError');
+    expect(getErrorMessage(undefined, 'fallback')).toBe('fallback');
+  });
+
+  it('prefers the GraphQL error detail over the generic client message', () => {
+    const { result } = renderHook(() => useGetErrorMessage());
+    const getErrorMessage = result.current;
+
+    // Shape thrown by the Backend.AI client for an HTTP 400 from /admin/gql:
+    // the top-level `message` only says "... - undefined" while the real
+    // detail lives in `response.errors`.
+    const error = {
+      isError: true,
+      statusCode: 400,
+      title: '400 Bad Request - undefined',
+      message: 'server responded failure: 400 Bad Request - undefined',
+      response: {
+        errors: [
+          {
+            message:
+              'Variable "$input" got invalid value; Field "options" of required type "PurgeVFolderOptionsInput!" was not provided.',
+          },
+        ],
+      },
+    };
+
+    expect(getErrorMessage(error)).toBe(
+      'Variable "$input" got invalid value; Field "options" of required type "PurgeVFolderOptionsInput!" was not provided.',
+    );
+  });
+
+  it('joins multiple GraphQL error messages with a newline', () => {
+    const { result } = renderHook(() => useGetErrorMessage());
+    const getErrorMessage = result.current;
+
+    const error = {
+      message: 'server responded failure: 400 Bad Request - undefined',
+      response: {
+        errors: [{ message: 'First problem.' }, { message: 'Second problem.' }],
+      },
+    };
+
+    expect(getErrorMessage(error)).toBe('First problem.\nSecond problem.');
+  });
+
+  it('falls back to msg / message / title when no GraphQL detail is present', () => {
+    const { result } = renderHook(() => useGetErrorMessage());
+    const getErrorMessage = result.current;
+
+    expect(getErrorMessage({ msg: 'a friendly message' })).toBe(
+      'a friendly message',
+    );
+    expect(getErrorMessage({ message: 'a deprecated message' })).toBe(
+      'a deprecated message',
+    );
+    expect(getErrorMessage({ title: 'a title' })).toBe('a title');
+  });
+
+  it('ignores an empty GraphQL errors array and uses the next available field', () => {
+    const { result } = renderHook(() => useGetErrorMessage());
+    const getErrorMessage = result.current;
+
+    expect(
+      getErrorMessage({
+        message: 'fallback message',
+        response: { errors: [] },
+      }),
+    ).toBe('fallback message');
+    expect(
+      getErrorMessage({
+        message: 'fallback message',
+        response: { errors: [{ message: '' }] },
+      }),
+    ).toBe('fallback message');
+  });
+
+  it('ignores a non-array errors field and falls back', () => {
+    const { result } = renderHook(() => useGetErrorMessage());
+    const getErrorMessage = result.current;
+
+    expect(
+      getErrorMessage({
+        message: 'fallback message',
+        // Malformed body where `errors` is not an array.
+        response: { errors: 'boom' } as never,
+      }),
+    ).toBe('fallback message');
+  });
+
+  it('appends the error_code when present', () => {
+    const { result } = renderHook(() => useGetErrorMessage());
+    const getErrorMessage = result.current;
+
+    expect(
+      getErrorMessage({ msg: 'something failed', error_code: 'E_FOO' }),
+    ).toBe('something failed (E_FOO)');
+  });
+});

--- a/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
+++ b/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
@@ -1,12 +1,26 @@
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 
+export type GraphQLErrorEntry = {
+  message?: string | null;
+};
+
 export type ErrorResponse = {
   type: string;
   title: string;
   msg?: string;
   error_code?: string;
   traceback?: string;
+};
+
+/**
+ * A failed GraphQL request (non-2xx response from `/admin/gql`) returns its
+ * detail in a top-level `errors` array instead of the manager's `title`/`msg`.
+ * This is a distinct body shape from {@link ErrorResponse}, so it gets its own
+ * type rather than being conflated with the problem+json shape.
+ */
+export type GraphQLErrorResponseBody = {
+  errors?: GraphQLErrorEntry[];
 };
 
 export type ESMClientErrorResponse = {
@@ -23,7 +37,9 @@ export type ESMClientErrorResponse = {
   description: string;
   error_code?: string;
   traceback?: string;
-  response?: ErrorResponse;
+  // The Backend.AI client attaches the raw response body here; it is either the
+  // manager's problem+json error or a GraphQL error body.
+  response?: ErrorResponse | GraphQLErrorResponseBody;
 };
 
 const useErrorMessageResolver = () => {
@@ -31,8 +47,30 @@ const useErrorMessageResolver = () => {
 
   const isErrorLike = (
     error: unknown,
-  ): error is Partial<ErrorResponse & Error> => {
+  ): error is Partial<ErrorResponse & ESMClientErrorResponse & Error> => {
     return typeof error === 'object' && error !== null;
+  };
+
+  /**
+   * Extracts the message from a GraphQL-style error response body.
+   *
+   * A failed GraphQL request (e.g. an HTTP 400 from `/admin/gql`) returns
+   * `{ errors: [{ message }] }`, which the Backend.AI client exposes on
+   * `error.response`. The client's top-level `message`/`title` fields cannot
+   * describe it — they render `"server responded failure: <status> - undefined"`
+   * because the manager's `title`/`msg` fields are absent — so the real detail
+   * lives only in this array.
+   */
+  const getGraphQLErrorMessage = (
+    response: ErrorResponse | GraphQLErrorResponseBody | undefined,
+  ): string | undefined => {
+    const errors =
+      response && 'errors' in response ? response.errors : undefined;
+    if (!Array.isArray(errors)) return undefined;
+    const messages = errors
+      .map((entry) => entry?.message)
+      .filter((message): message is string => !_.isEmpty(message));
+    return messages.length > 0 ? messages.join('\n') : undefined;
   };
 
   /**
@@ -45,8 +83,12 @@ const useErrorMessageResolver = () => {
     let errorMsg = defaultMessage || t('error.UnknownError');
     if (!error || !isErrorLike(error)) return errorMsg;
 
-    // Prioritize `msg` or `message`(deprecated) field if available.
-    if (error.msg || error.message) {
+    // Prefer the GraphQL error detail when the failed response carries one,
+    // since the client's `message`/`title` only say "... - undefined" for it.
+    const graphQLErrorMessage = getGraphQLErrorMessage(error.response);
+    if (graphQLErrorMessage) {
+      errorMsg = graphQLErrorMessage;
+    } else if (error.msg || error.message) {
       const integratedErrorMsg = error.msg || error.message || '';
       errorMsg = !_.includes(integratedErrorMsg, 'Traceback')
         ? integratedErrorMsg


### PR DESCRIPTION
Resolves #7556 (FR-2952)

## Problem

When permanently deleting a folder from the trash bin (e.g. **Project Data → Trash**, `project-data?statusCategory=deleted`), a server **HTTP 400** surfaced as:

```
server responded failure: 400 Bad Request - undefined
```

The trailing `undefined` happens because a failed GraphQL request (`POST /func/admin/gql`) returns its detail in a top-level `errors` array:

```json
{ "errors": [{ "message": "Variable \"$input\" got invalid value ...; Field \"options\" of required type \"PurgeVFolderOptionsInput!\" was not provided." }] }
```

The Backend.AI client builds its `message`/`title` from `body.title` / `body.msg`, which are absent for GraphQL error bodies — so they render `undefined`. The real detail was only available on `error.response` (the raw body the client attaches), which the error-message resolver never consulted.

## Fix

Enhance the existing error-message resolver (`useErrorMessageResolver` / `getErrorMessage` in `backend.ai-ui`) — the helper already used by the delete flow's `onError` — to prefer a GraphQL-style error message from `error.response.errors[*].message` when present, before falling back to the existing `msg` / `message` / `title` chain. Multiple GraphQL errors are joined with a newline. This is a root-cause fix in the shared resolver, so every call site that resolves a failed GraphQL request benefits.

No change to the 400 itself (that is a separate backend/schema concern) — only the error-message UX.

## Verification

Reproduced live against a running dev server + test cluster (Project Data → Trash → permanent delete):

- **Before:** `server responded failure: 400 Bad Request - undefined`
- **After:** `Variable "$input" got invalid value { ids: [...] }; Field "options" of required type "PurgeVFolderOptionsInput!" was not provided.`

Added unit tests for the resolver (GraphQL extraction, multi-error join, empty-array fallback, `msg`/`message`/`title` precedence, `error_code` suffix) — all pass.

`scripts/verify.sh`: Relay / Lint / Format **PASS**. (TypeScript step reports pre-existing errors unrelated to this change — the same ~835 errors are present on the untouched base commit due to a worktree-local `@types/react` resolution quirk; this change introduces **zero** new errors and none in the touched files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)