### PR TITLE
refactor(FR-2953): migrate project-admin session terminate to scope-agnostic terminateSessionsV2

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1435,6 +1435,7 @@ input AuditLogFilter
   @join__type(graph: STRAWBERRY)
 {
   entityType: StringFilter = null
+  entityId: StringFilter = null
   operation: StringFilter = null
   status: AuditLogStatusFilter = null
   createdAt: DateTimeFilter = null
@@ -1522,6 +1523,19 @@ type AuditLogSchema
   Possible values of "AuditLogNode.status"
   """
   status_variants: [String]
+}
+
+"""
+Added in UNRELEASED. Scope for the scoped audit log query. All items are OR'd; raises an error if every field is empty.
+"""
+input AuditLogScope
+  @join__type(graph: STRAWBERRY)
+{
+  """Entity-tagged scope items."""
+  entity: [EntityTypeScope!] = null
+
+  """Actor UUIDs (matches audit_logs.triggered_by)."""
+  triggeredUser: [UUIDScope!] = null
 }
 
 """Added in 26.3.0. Status of an audit log entry."""
@@ -2070,7 +2084,7 @@ input BulkPurgeVFoldersV2Input
   """
   Added in UNRELEASED. Optional behavior flags applied to every vfolder in the batch. Defaults to all-false when omitted.
   """
-  options: PurgeVFolderOptionsInput!
+  options: PurgeVFolderOptionsInput
 }
 
 """Added in 26.4.2. Payload for bulk virtual folder purge."""
@@ -6684,6 +6698,19 @@ type EntityTimestamps
 }
 
 """
+Added in UNRELEASED. Entity reference parametrized by RBAC element type.
+"""
+input EntityTypeScope
+  @join__type(graph: STRAWBERRY)
+{
+  """RBAC element type of the entity."""
+  entityType: RBACElementType!
+
+  """ID of the entity."""
+  entityId: String!
+}
+
+"""
 Added in UNRELEASED. A single environment variable entry with key and value.
 """
 input EnvironEntryInput
@@ -9707,6 +9734,11 @@ type ModelRevision implements Node
   """
   revisionPresetId: UUID
 
+  """
+  Added in UNRELEASED. ID of the parent deployment that owns this revision. Exposed alongside the resolved ``deployment`` node so clients can navigate without re-fetching.
+  """
+  deploymentId: ID!
+
   """Timestamp when the revision was created."""
   createdAt: DateTime!
 
@@ -9723,16 +9755,13 @@ type ModelRevision implements Node
   """
   revisionPreset: DeploymentRevisionPreset
 
-  """Added in 26.4.2. Resource slot allocations for this revision."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]
-
-  """Added in UNRELEASED. ID of the parent deployment this revision belongs to."""
-  deploymentId: ID!
-
   """
-  Added in UNRELEASED. The parent deployment this revision belongs to, resolved via DataLoader.
+  Added in UNRELEASED. The parent deployment owning this revision, resolved via DataLoader.
   """
   deployment: ModelDeployment
+
+  """Added in 26.4.2. Resource slot allocations for this revision."""
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]
 }
 
 """Added in 25.19.0. Connection for model revisions."""
@@ -11528,8 +11557,10 @@ type Mutation
   """Added in 26.4.2. Enqueue a new compute session."""
   enqueueSession(input: EnqueueSessionInput!): EnqueueSessionPayload @join__field(graph: STRAWBERRY)
 
-  """Added in 26.4.2. Terminate sessions within a project scope."""
-  terminateProjectSessionsV2(scope: ProjectSessionV2Scope!, sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
+  """
+  terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload @join__field(graph: STRAWBERRY)
 }
 
 """
@@ -13835,6 +13866,11 @@ type Query
   adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection @join__field(graph: STRAWBERRY)
 
   """
+  Added in UNRELEASED. Query audit logs within a scope (non-admin accessible, subject to RBAC). All scope items are OR'd; raises an error if every field is empty.
+  """
+  scopedAuditLogsV2(scope: AuditLogScope!, filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection @join__field(graph: STRAWBERRY)
+
+  """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).
   """
   adminContainerRegistriesV2(filter: ContainerRegistryV2Filter = null, orderBy: [ContainerRegistryV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ContainerRegistryV2Connection @join__field(graph: STRAWBERRY)
@@ -15854,6 +15890,7 @@ input RoleFilter
   name: StringFilter = null
   source: RoleSourceFilter = null
   status: RoleStatusFilter = null
+  assignedUser: RoleUserNestedFilter = null
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
   NOT: [RoleFilter!] = null
@@ -16067,6 +16104,16 @@ input RoleStatusFilter
 
   """Excludes roles whose status is in this list."""
   notIn: [RoleStatus!] = null
+}
+
+"""Added in UNRELEASED. Filter roles by their user assignments."""
+input RoleUserNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  userId: UUIDFilter = null
+  AND: [RoleUserNestedFilter!] = null
+  OR: [RoleUserNestedFilter!] = null
+  NOT: [RoleUserNestedFilter!] = null
 }
 
 """
@@ -18798,8 +18845,8 @@ input UpdateRuntimeVariantInput
   """New name."""
   name: String = null
 
-  """New description."""
-  description: String = null
+  """New description. Set to null to clear."""
+  description: String
 }
 
 """Added in 26.4.2. Payload for runtime variant update."""
@@ -20143,6 +20190,14 @@ Verifies that the key is a UUID (represented as a string) and the value is a flo
 """
 scalar UUIDFloatMap
   @join__type(graph: GRAPHENE)
+
+"""Added in UNRELEASED. Single-UUID scope item wrapper."""
+input UUIDScope
+  @join__type(graph: STRAWBERRY)
+{
+  """UUID value."""
+  value: UUID!
+}
 
 """Added in 24.09.0. Input for validate notification channel mutation"""
 input ValidateNotificationChannelInput

--- a/react/src/__generated__/DeleteForeverVFolderModalV2Mutation.graphql.ts
+++ b/react/src/__generated__/DeleteForeverVFolderModalV2Mutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<07109957e77c46c76f33d3676b1f6117>>
+ * @generated SignedSource<<d39ed56195bf60b52197ce2e391ea950>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type BulkPurgeVFoldersV2Input = {
   ids: ReadonlyArray<string>;
-  options: PurgeVFolderOptionsInput;
+  options?: PurgeVFolderOptionsInput | null | undefined;
 };
 export type PurgeVFolderOptionsInput = {
   cascadeModelCard?: boolean;

--- a/react/src/__generated__/RBACManagementPageQuery.graphql.ts
+++ b/react/src/__generated__/RBACManagementPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<95663cc889046dd04f566eadfc3006dd>>
+ * @generated SignedSource<<afccb43679c638477b961c247400ff78>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type RoleFilter = {
   AND?: ReadonlyArray<RoleFilter> | null | undefined;
   NOT?: ReadonlyArray<RoleFilter> | null | undefined;
   OR?: ReadonlyArray<RoleFilter> | null | undefined;
+  assignedUser?: RoleUserNestedFilter | null | undefined;
   name?: StringFilter | null | undefined;
   source?: RoleSourceFilter | null | undefined;
   status?: RoleStatusFilter | null | undefined;
@@ -55,6 +56,18 @@ export type RoleStatusFilter = {
   in?: ReadonlyArray<RoleStatus> | null | undefined;
   notEquals?: RoleStatus | null | undefined;
   notIn?: ReadonlyArray<RoleStatus> | null | undefined;
+};
+export type RoleUserNestedFilter = {
+  AND?: ReadonlyArray<RoleUserNestedFilter> | null | undefined;
+  NOT?: ReadonlyArray<RoleUserNestedFilter> | null | undefined;
+  OR?: ReadonlyArray<RoleUserNestedFilter> | null | undefined;
+  userId?: UUIDFilter | null | undefined;
+};
+export type UUIDFilter = {
+  equals?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
 };
 export type RoleOrderBy = {
   direction?: OrderDirection;

--- a/react/src/__generated__/TerminateSessionModalForProjectAdminMutation.graphql.ts
+++ b/react/src/__generated__/TerminateSessionModalForProjectAdminMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<58d81875435cd7d6cc98fe54328a4272>>
+ * @generated SignedSource<<bc1c2a7db82d47e4f5977b1c56768d7e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,16 +9,12 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type ProjectSessionV2Scope = {
-  projectId: string;
-};
 export type TerminateSessionModalForProjectAdminMutation$variables = {
   forced: boolean;
-  scope: ProjectSessionV2Scope;
   sessionIds: ReadonlyArray<string>;
 };
 export type TerminateSessionModalForProjectAdminMutation$data = {
-  readonly terminateProjectSessionsV2: {
+  readonly terminateSessionsV2: {
     readonly cancelled: ReadonlyArray<string>;
     readonly forceTerminated: ReadonlyArray<string>;
     readonly skipped: ReadonlyArray<string>;
@@ -39,14 +35,9 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "scope"
-},
-v2 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
   "name": "sessionIds"
 },
-v3 = [
+v2 = [
   {
     "alias": null,
     "args": [
@@ -57,18 +48,13 @@ v3 = [
       },
       {
         "kind": "Variable",
-        "name": "scope",
-        "variableName": "scope"
-      },
-      {
-        "kind": "Variable",
         "name": "sessionIds",
         "variableName": "sessionIds"
       }
     ],
     "concreteType": "TerminateSessionsPayload",
     "kind": "LinkedField",
-    "name": "terminateProjectSessionsV2",
+    "name": "terminateSessionsV2",
     "plural": false,
     "selections": [
       {
@@ -107,13 +93,12 @@ return {
   "fragment": {
     "argumentDefinitions": [
       (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/)
+      (v1/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
     "name": "TerminateSessionModalForProjectAdminMutation",
-    "selections": (v3/*: any*/),
+    "selections": (v2/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -121,24 +106,23 @@ return {
   "operation": {
     "argumentDefinitions": [
       (v1/*: any*/),
-      (v2/*: any*/),
       (v0/*: any*/)
     ],
     "kind": "Operation",
     "name": "TerminateSessionModalForProjectAdminMutation",
-    "selections": (v3/*: any*/)
+    "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "20ae557c865eca31dacebcdefd924a82",
+    "cacheID": "be4736b37ff54351dd17b8f5d312c2bd",
     "id": null,
     "metadata": {},
     "name": "TerminateSessionModalForProjectAdminMutation",
     "operationKind": "mutation",
-    "text": "mutation TerminateSessionModalForProjectAdminMutation(\n  $scope: ProjectSessionV2Scope!\n  $sessionIds: [ID!]!\n  $forced: Boolean!\n) {\n  terminateProjectSessionsV2(scope: $scope, sessionIds: $sessionIds, forced: $forced) {\n    cancelled\n    terminating\n    forceTerminated\n    skipped\n  }\n}\n"
+    "text": "mutation TerminateSessionModalForProjectAdminMutation(\n  $sessionIds: [ID!]!\n  $forced: Boolean!\n) {\n  terminateSessionsV2(sessionIds: $sessionIds, forced: $forced) {\n    cancelled\n    terminating\n    forceTerminated\n    skipped\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0205d9842816de89483e8953cccceec1";
+(node as any).hash = "8c1ab011f362b60cae0d0e3b7c59bf7e";
 
 export default node;

--- a/react/src/components/TerminateSessionModalForProjectAdmin.tsx
+++ b/react/src/components/TerminateSessionModalForProjectAdmin.tsx
@@ -34,7 +34,6 @@ export interface TerminateSessionModalForProjectAdminProps extends Omit<
   ModalProps,
   'onOk' | 'onCancel'
 > {
-  projectId: string;
   /** Sessions to terminate. A single-element list terminates one session;
    *  multiple elements perform a bulk terminate via the same mutation. */
   sessionsFrgmt?: TerminateSessionModalForProjectAdminFragment$key;
@@ -44,13 +43,14 @@ export interface TerminateSessionModalForProjectAdminProps extends Omit<
 /**
  * Terminate confirmation modal for the project-admin session list. Mirrors the
  * v1 `TerminateSessionModal` UI (message + highlighted name(s) + force-terminate
- * checkbox + per-agent container cleanup list), but drives the v2
- * `terminateProjectSessionsV2` mutation, which accepts an id array — so the same
- * modal handles single and bulk terminate.
+ * checkbox + per-agent container cleanup list), but drives the scope-agnostic
+ * `terminateSessionsV2` mutation, which accepts an id array — so the same modal
+ * handles single and bulk terminate. Per-session RBAC permission is enforced by
+ * the backend bulk validator; any denial fails the whole request.
  */
 const TerminateSessionModalForProjectAdmin: React.FC<
   TerminateSessionModalForProjectAdminProps
-> = ({ projectId, sessionsFrgmt, onRequestClose, ...modalProps }) => {
+> = ({ sessionsFrgmt, onRequestClose, ...modalProps }) => {
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -88,15 +88,10 @@ const TerminateSessionModalForProjectAdmin: React.FC<
   const [commitTerminate, isInFlight] =
     useMutation<TerminateSessionModalForProjectAdminMutation>(graphql`
       mutation TerminateSessionModalForProjectAdminMutation(
-        $scope: ProjectSessionV2Scope!
         $sessionIds: [ID!]!
         $forced: Boolean!
       ) {
-        terminateProjectSessionsV2(
-          scope: $scope
-          sessionIds: $sessionIds
-          forced: $forced
-        ) {
+        terminateSessionsV2(sessionIds: $sessionIds, forced: $forced) {
           cancelled
           terminating
           forceTerminated
@@ -136,7 +131,6 @@ const TerminateSessionModalForProjectAdmin: React.FC<
         }
         commitTerminate({
           variables: {
-            scope: { projectId },
             sessionIds: sessions.map((session) => toLocalId(session.id)),
             forced: isForce,
           },

--- a/react/src/pages/ProjectAdminSessionPage.tsx
+++ b/react/src/pages/ProjectAdminSessionPage.tsx
@@ -345,7 +345,6 @@ const ProjectAdminSessionContent: React.FC<ProjectAdminSessionContentProps> = ({
       />
       <TerminateSessionModalForProjectAdmin
         open={isTerminateOpen}
-        projectId={projectId}
         sessionsFrgmt={terminateTargets}
         onRequestClose={(success) => {
           setIsTerminateOpen(false);


### PR DESCRIPTION
Resolves #7558 (FR-2953)

Adapts the WebUI to backend PR [lablup/backend.ai#11748](https://app.graphite.com/github/pr/lablup/backend.ai/11748) (BA-6146), which redesigns the project-scoped session terminate mutation into a **scope-agnostic** bulk mutation with per-session RBAC enforcement.

## Backend change

| | |
|---|---|
| Before | `terminateProjectSessionsV2(scope: ProjectSessionV2Scope!, sessionIds: [ID!]!, forced: Boolean! = false)` |
| After | `terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false)` |

The `scope` argument (and the `ProjectSessionV2Scope` input) is removed. Per-session RBAC permission is now enforced by the backend bulk validator; any denial fails the whole request.

## Changes

- **`TerminateSessionModalForProjectAdmin.tsx`**
  - Mutation `terminateProjectSessionsV2` → `terminateSessionsV2`; dropped the `$scope` variable and `scope` argument.
  - Removed the now-unused `projectId` prop (it only fed `scope: { projectId }`).
  - Updated the doc comment.
- **`ProjectAdminSessionPage.tsx`**
  - Removed the `projectId` prop passed to the modal. The page keeps its own `projectId` — still used by the `projectSessionsV2` list query.
- **`data/schema.graphql`** — synced from backend. Incidental Relay artifact regeneration for `DeleteForeverVFolderModalV2Mutation` (`BulkPurgeVFoldersV2Input.options` became optional) and `RBACManagementPageQuery` (`RoleFilter.assignedUser` added) follows from the schema sync.
- Recompiled Relay artifacts.

## Verification

- `bash scripts/verify.sh`: Lint PASS, Format PASS. Relay/TypeScript "FAIL" in the harness are **pre-existing and unrelated** — the working tree has 836 pre-existing antd/JSX type errors on `main`; this branch has 835 (one fewer, none new). No errors reference the touched files. The Relay drift flag clears once artifacts are committed (done here).
- No remaining references to `terminateProjectSessionsV2` / `ProjectSessionV2Scope` in WebUI source.

## Test server

`10.122.10.107`

🤖 Generated with [Claude Code](https://claude.com/claude-code)