### PR TITLE
fix(FR-2954): wrap BAIAgentTable JSON-parsed cells in error boundary

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
@@ -8,7 +8,8 @@ import {
   convertUnitValue,
   toFixedFloorWithoutTrailingZeros,
 } from '../../helper';
-import { useResourceSlotsDetails } from '../../hooks';
+import { useBAILogger, useResourceSlotsDetails } from '../../hooks';
+import BAIAlertIconWithTooltip from '../BAIAlertIconWithTooltip';
 import BAIDoubleTag from '../BAIDoubleTag';
 import BAIFlex from '../BAIFlex';
 import BAIIntervalView from '../BAIIntervalView';
@@ -24,6 +25,11 @@ import { theme, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
+import { type ErrorInfo } from 'react';
+import {
+  ErrorBoundary,
+  type ErrorBoundaryPropsWithRender,
+} from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
@@ -45,6 +51,531 @@ export const availableAgentSorterValues = [
 
 const isEnableSorter = (key: string) => {
   return _.includes(availableAgentSorterKeys, key);
+};
+
+const CellErrorBoundary: React.FC<
+  Omit<ErrorBoundaryPropsWithRender, 'fallbackRender'>
+> = ({ children, ...errorBoundaryProps }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { logger } = useBAILogger();
+  return (
+    <ErrorBoundary
+      onError={(error: Error, info: ErrorInfo) =>
+        logger.error(
+          '[BAIAgentTable] Cell render failed:',
+          error,
+          info.componentStack,
+        )
+      }
+      fallbackRender={() => (
+        <BAIAlertIconWithTooltip
+          type="error"
+          title={t('comp:AgentTable.FailedToLoadCellData')}
+        />
+      )}
+      {...errorBoundaryProps}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+};
+
+const AllocationCell: React.FC<{ record: AgentNodeInList }> = ({ record }) => {
+  'use memo';
+  const { token } = theme.useToken();
+  const { mergedResourceSlots } = useResourceSlotsDetails();
+  const parsedOccupiedSlots: {
+    [key in ResourceSlotName]: string | undefined;
+  } = JSON.parse(record?.occupied_slots || '{}');
+  const parsedAvailableSlots: {
+    [key in ResourceSlotName]: string | undefined;
+  } = JSON.parse(record?.available_slots || '{}');
+  return (
+    <BAIFlex direction="column" gap="xxs">
+      {_.map(
+        parsedAvailableSlots,
+        (_value: string | number, key: ResourceSlotName) => {
+          if (key === 'cpu') {
+            const cpuPercent = _.toFinite(
+              (_.toNumber(parsedOccupiedSlots.cpu) /
+                _.toNumber(parsedAvailableSlots.cpu)) *
+                100,
+            );
+            return (
+              <BAIFlex
+                key={key}
+                justify="between"
+                style={{ width: '100%' }}
+                gap={'xs'}
+              >
+                <BAIFlex gap="xxs">
+                  <ResourceTypeIcon key={key} type={key} />
+                  <Typography.Text>
+                    {toFixedFloorWithoutTrailingZeros(
+                      parsedOccupiedSlots.cpu || 0,
+                      0,
+                    )}
+                    &nbsp;/&nbsp;
+                    {toFixedFloorWithoutTrailingZeros(
+                      parsedAvailableSlots.cpu || 0,
+                      0,
+                    )}
+                  </Typography.Text>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: token.sizeXS }}
+                  >
+                    {mergedResourceSlots?.cpu?.display_unit}
+                  </Typography.Text>
+                </BAIFlex>
+                <BAIProgressWithLabel
+                  percent={cpuPercent}
+                  strokeColor={
+                    cpuPercent > 80 ? token.colorError : token.colorSuccess
+                  }
+                  width={120}
+                  valueLabel={
+                    toFixedFloorWithoutTrailingZeros(cpuPercent, 1) + ' %'
+                  }
+                />
+              </BAIFlex>
+            );
+          } else if (key === 'mem') {
+            const memPercent = _.toFinite(
+              (_.toNumber(parsedOccupiedSlots.mem) /
+                _.toNumber(parsedAvailableSlots.mem)) *
+                100,
+            );
+            return (
+              <BAIFlex
+                key={'mem'}
+                justify="between"
+                style={{ width: '100%' }}
+                gap={'xs'}
+              >
+                <BAIFlex gap="xxs">
+                  <ResourceTypeIcon type={'mem'} />
+                  <Typography.Text>
+                    {convertToBinaryUnit(parsedOccupiedSlots.mem, 'g', 0)
+                      ?.numberFixed ?? 0}
+                    &nbsp;/&nbsp;
+                    {convertToBinaryUnit(parsedAvailableSlots.mem, 'g', 0)
+                      ?.numberFixed ?? 0}
+                  </Typography.Text>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: token.sizeXS }}
+                  >
+                    GiB
+                  </Typography.Text>
+                </BAIFlex>
+                <BAIProgressWithLabel
+                  percent={memPercent}
+                  strokeColor={
+                    memPercent > 80 ? token.colorError : token.colorSuccess
+                  }
+                  width={120}
+                  valueLabel={
+                    toFixedFloorWithoutTrailingZeros(memPercent, 1) + ' %'
+                  }
+                />
+              </BAIFlex>
+            );
+          } else if (parsedAvailableSlots[key]) {
+            const percent = _.toFinite(
+              (_.toNumber(parsedOccupiedSlots[key]) /
+                _.toNumber(parsedAvailableSlots[key])) *
+                100,
+            );
+            return (
+              <BAIFlex
+                key={key}
+                justify="between"
+                gap={'xs'}
+                style={{ width: '100%' }}
+              >
+                <BAIFlex gap="xxs">
+                  <ResourceTypeIcon key={key} type={key} />
+                  <Typography.Text>
+                    {toFixedFloorWithoutTrailingZeros(
+                      parsedOccupiedSlots[key] || 0,
+                      2,
+                    )}
+                    &nbsp;/&nbsp;
+                    {toFixedFloorWithoutTrailingZeros(
+                      parsedAvailableSlots[key],
+                      2,
+                    )}
+                  </Typography.Text>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: token.sizeXS }}
+                  >
+                    {mergedResourceSlots?.[key]?.display_unit}
+                  </Typography.Text>
+                </BAIFlex>
+                <BAIProgressWithLabel
+                  percent={percent}
+                  strokeColor={
+                    percent > 80 ? token.colorError : token.colorSuccess
+                  }
+                  width={120}
+                  valueLabel={
+                    toFixedFloorWithoutTrailingZeros(percent, 1) + ' %'
+                  }
+                />
+              </BAIFlex>
+            );
+          }
+        },
+      )}
+    </BAIFlex>
+  );
+};
+
+const UtilizationCell: React.FC<{
+  value: string | null | undefined;
+  record: AgentNodeInList;
+}> = ({ value, record }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { mergedResourceSlots } = useResourceSlotsDetails();
+  const parsedValue = JSON.parse(value || '{}');
+  const available_slots = JSON.parse(record?.available_slots || '{}');
+  if (record?.status === 'ALIVE') {
+    const liveStat = {
+      cpu_util: { capacity: 0, current: 0, ratio: 0 },
+      mem_util: { capacity: 0, current: 0, ratio: 0 },
+    };
+    if (parsedValue && parsedValue.node && parsedValue.devices) {
+      const numCores = _.keys(parsedValue.devices.cpu_util).length;
+      liveStat.cpu_util.capacity = _.toFinite(
+        parsedValue.node.cpu_util.capacity,
+      );
+      liveStat.cpu_util.current = _.toFinite(parsedValue.node.cpu_util.current);
+      liveStat.cpu_util.ratio = Math.min(
+        _.toFinite(parsedValue.node.cpu_util.pct) / 100 / (numCores || 1),
+        1,
+      );
+      liveStat.mem_util.capacity = _.toInteger(
+        available_slots.mem || parsedValue.node.mem.capacity,
+      );
+      liveStat.mem_util.current = _.toInteger(parsedValue.node.mem.current);
+      liveStat.mem_util.ratio =
+        liveStat.mem_util.current / liveStat.mem_util.capacity || 0;
+    }
+    _.forEach(_.keys(parsedValue?.node), (statKey) => {
+      if (['cpu_util', 'mem', 'disk', 'net_rx', 'net_tx'].includes(statKey))
+        return;
+      if (_.includes(statKey, '_util')) {
+        // core utilization
+        liveStat[statKey as keyof typeof liveStat] = {
+          capacity: _.toFinite(parsedValue.node[statKey].capacity) || 100,
+          current: _.toFinite(parsedValue.node[statKey].current),
+          ratio: _.toFinite(parsedValue.node[statKey].current) / 100 || 0,
+        };
+      } else if (statKey.includes('_mem')) {
+        // memory utilization
+        liveStat[statKey as keyof typeof liveStat] = {
+          capacity: _.toFinite(parsedValue.node[statKey].capacity),
+          current: _.toFinite(parsedValue.node[statKey].current),
+          ratio: _.toFinite(parsedValue.node[statKey].pct) / 100 || 0,
+        };
+      }
+    });
+    const baseUnit =
+      convertUnitValue(_.toString(liveStat.mem_util.capacity), 'auto')?.unit ||
+      'g';
+    return (
+      <BAIFlex direction="column" gap="xxs">
+        <BAIFlex
+          // CPU
+          justify="between"
+          style={{ minWidth: 200, width: '100%' }}
+          data-testid="live-stat-cpu"
+        >
+          <Typography.Text>
+            {mergedResourceSlots?.cpu?.human_readable_name}
+          </Typography.Text>
+          <BAIProgressWithLabel
+            percent={liveStat.cpu_util.ratio * 100}
+            width={120}
+            valueLabel={
+              toFixedFloorWithoutTrailingZeros(
+                _.toFinite(liveStat.cpu_util.ratio * 100),
+                1,
+              ) + ' %'
+            }
+          />
+        </BAIFlex>
+        <BAIFlex
+          // MEM
+          justify="between"
+          style={{ minWidth: 200, width: '100%' }}
+          data-testid="live-stat-mem"
+        >
+          <Typography.Text>
+            {mergedResourceSlots?.mem?.human_readable_name}
+          </Typography.Text>
+          <BAIProgressWithLabel
+            percent={liveStat.mem_util.ratio * 100}
+            width={120}
+            valueLabel={
+              convertToBinaryUnit(
+                _.toString(liveStat.mem_util.current),
+                baseUnit,
+              )?.numberFixed +
+              ' / ' +
+              convertToBinaryUnit(
+                _.toString(liveStat.mem_util.capacity),
+                baseUnit,
+              )?.displayValue
+            }
+          />
+        </BAIFlex>
+        {_.map(_.keys(parsedValue?.node), (statKey) => {
+          if (['cpu_util', 'mem', 'disk'].includes(statKey)) {
+            return;
+          }
+          if (_.includes(statKey, '_util')) {
+            const deviceName = _.split(statKey, '_')[0] + '.device';
+            return (
+              <BAIFlex
+                key={statKey}
+                justify="between"
+                style={{ minWidth: 200, width: '100%' }}
+                gap="xxs"
+                data-testid={`live-stat-${statKey}`}
+              >
+                <Typography.Text>
+                  {mergedResourceSlots?.[deviceName]?.human_readable_name}
+                  (util)
+                </Typography.Text>
+                <BAIProgressWithLabel
+                  width={120}
+                  percent={
+                    (liveStat[statKey as keyof typeof liveStat].current /
+                      liveStat[statKey as keyof typeof liveStat].capacity) *
+                      100 || 0
+                  }
+                  valueLabel={
+                    _.toFinite(
+                      toFixedFloorWithoutTrailingZeros(
+                        liveStat[statKey as keyof typeof liveStat].ratio * 100,
+                        1,
+                      ),
+                    ) + ' %'
+                  }
+                />
+              </BAIFlex>
+            );
+          }
+          if (_.includes(statKey, '_mem')) {
+            const deviceName = _.split(statKey, '_')[0] + '.device';
+            const baseUnit =
+              convertUnitValue(
+                _.toString(liveStat[statKey as keyof typeof liveStat].capacity),
+                'auto',
+              )?.unit || 'g';
+            return (
+              <BAIFlex
+                key={statKey}
+                justify="between"
+                style={{ minWidth: 200, width: '100%' }}
+                gap="xxs"
+                data-testid={`live-stat-${statKey}`}
+              >
+                <Typography.Text>
+                  {mergedResourceSlots?.[deviceName]?.human_readable_name}
+                  (mem)
+                </Typography.Text>
+                <BAIProgressWithLabel
+                  width={120}
+                  percent={
+                    (liveStat[statKey as keyof typeof liveStat].current /
+                      liveStat[statKey as keyof typeof liveStat].capacity) *
+                      100 || 0
+                  }
+                  valueLabel={
+                    convertToBinaryUnit(
+                      _.toString(
+                        liveStat[statKey as keyof typeof liveStat].current,
+                      ),
+                      baseUnit,
+                    )?.numberFixed +
+                    ' / ' +
+                    convertToBinaryUnit(
+                      _.toString(
+                        liveStat[statKey as keyof typeof liveStat].capacity,
+                      ),
+                      baseUnit,
+                    )?.displayValue
+                  }
+                />
+              </BAIFlex>
+            );
+          }
+          if (_.includes(statKey, '_power')) {
+            const deviceName =
+              _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+            const humanReadableName =
+              mergedResourceSlots?.[deviceName]?.human_readable_name;
+            return (
+              <BAIFlex
+                key={statKey}
+                justify="between"
+                style={{ minWidth: 200, width: '100%' }}
+                gap="xxs"
+                data-testid={`live-stat-${statKey}`}
+              >
+                <BAIText>{`${humanReadableName}(power)`}</BAIText>
+                <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedValue.node[statKey]?.current, 2)} ${parsedValue.node[statKey].unit_hint}`}</BAIText>
+              </BAIFlex>
+            );
+          }
+          if (_.includes(statKey, '_temperature')) {
+            const deviceName =
+              _.split(statKey, '_').slice(0, -1).join('_') + '.device';
+            const humanReadableName =
+              mergedResourceSlots?.[deviceName]?.human_readable_name;
+            return (
+              <BAIFlex
+                key={statKey}
+                justify="between"
+                style={{ minWidth: 200, width: '100%' }}
+                gap="xxs"
+                data-testid={`live-stat-${statKey}`}
+              >
+                <BAIText>{`${humanReadableName}(temp)`}</BAIText>
+                <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedValue.node[statKey]?.current, 2)} °C`}</BAIText>
+              </BAIFlex>
+            );
+          }
+          if (_.includes(['net_rx', 'net_tx'], statKey)) {
+            const convertedValue = convertToDecimalUnit(
+              parsedValue.node[statKey]?.current,
+              'auto',
+            );
+            return (
+              <BAIFlex
+                key={statKey}
+                justify="between"
+                style={{ minWidth: 200, width: '100%' }}
+                gap="xxs"
+                data-testid={`live-stat-${statKey}`}
+              >
+                <BAIText>{statKey === 'net_rx' ? 'Net Rx' : 'Net Tx'}</BAIText>
+                <BAIText>
+                  {`${convertedValue?.numberFixed ?? 0} ${convertedValue?.unit.toUpperCase() ?? ''}bps`}
+                </BAIText>
+              </BAIFlex>
+            );
+          }
+          return (
+            <BAIFlex
+              key={statKey}
+              justify="between"
+              style={{ minWidth: 200, width: '100%' }}
+              gap="xxs"
+              data-testid={`live-stat-${statKey}`}
+            >
+              <BAIText>{statKey}</BAIText>
+              <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedValue.node[statKey]?.current ?? 0, 2)}${parsedValue.node[statKey]?.unit_hint ? ` ${parsedValue.node[statKey].unit_hint}` : ''}`}</BAIText>
+            </BAIFlex>
+          );
+        })}
+      </BAIFlex>
+    );
+  } else {
+    return <>{t('comp:AgentTable.NoAvailableLiveStat')}</>;
+  }
+};
+
+const DiskPctCell: React.FC<{ record: AgentNodeInList }> = ({ record }) => {
+  'use memo';
+  const { token } = theme.useToken();
+  const parsedDisk = JSON.parse(record?.live_stat || '{}')?.node?.disk ?? {};
+  const pctValue = _.toFinite(parsedDisk.pct) || 0;
+  const pct = _.toFinite(toFixedFloorWithoutTrailingZeros(pctValue, 2));
+  const color = pct > 80 ? token.colorError : token.colorSuccess;
+  const baseUnit =
+    convertUnitValue(parsedDisk?.capacity, 'auto', { base: 1000 })?.unit || 'g';
+  return (
+    <BAIFlex direction="column" align="end">
+      <BAIProgressWithLabel
+        valueLabel={toFixedFloorWithoutTrailingZeros(pct, 1) + ' %'}
+        percent={pct}
+        strokeColor={color}
+        width={120}
+      />
+      {!_.isEmpty(parsedDisk) && (
+        <Typography.Text style={{ fontSize: token.fontSizeSM }}>
+          {convertToDecimalUnit(parsedDisk?.current, baseUnit)?.numberFixed}
+          &nbsp;/&nbsp;
+          {convertToDecimalUnit(parsedDisk?.capacity, baseUnit)?.displayValue}
+        </Typography.Text>
+      )}
+    </BAIFlex>
+  );
+};
+
+const StatusCell: React.FC<{
+  value: string | null | undefined;
+  record: AgentNodeInList;
+}> = ({ value, record }) => {
+  'use memo';
+  const parsedComputePlugins = JSON.parse(record?.compute_plugins || '{}');
+  const parsedAvailableSlots = JSON.parse(record?.available_slots || '{}');
+  return (
+    <BAIFlex direction="column" gap="xxs" align="start">
+      <BAIDoubleTag
+        values={[
+          { label: 'Agent' },
+          {
+            label: record?.version || '',
+            color:
+              value === 'ALIVE'
+                ? 'green'
+                : value === 'TERMINATED'
+                  ? 'red'
+                  : 'blue',
+          },
+        ]}
+      />
+      {parsedComputePlugins?.cuda ? (
+        <>
+          {parsedComputePlugins?.cuda?.cuda_version ? (
+            <BAIDoubleTag
+              values={[
+                { label: 'CUDA' },
+                {
+                  label: parsedComputePlugins?.cuda?.cuda_version,
+                  color: 'green',
+                },
+              ]}
+            />
+          ) : (
+            <BAITag color="green">CUDA Disabled</BAITag>
+          )}
+          <BAIDoubleTag
+            values={[
+              { label: 'CUDA Plugin' },
+              {
+                label: parsedComputePlugins?.cuda?.version,
+                color: 'blue',
+              },
+            ]}
+          />
+          {_.includes(_.keys(parsedAvailableSlots), 'cuda.shares') ? (
+            <BAITag color="blue" style={{ borderRadius: 0 }}>
+              Fractional GPU™
+            </BAITag>
+          ) : null}
+        </>
+      ) : null}
+    </BAIFlex>
+  );
 };
 
 export interface BAIAgentTableProps extends Omit<
@@ -71,8 +602,6 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const baiClient = useConnectedBAIClient();
-
-  const { mergedResourceSlots } = useResourceSlotsDetails();
 
   const agents = useFragment(
     graphql`
@@ -167,468 +696,32 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
     {
       title: t('comp:AgentTable.Allocation'),
       key: 'allocated_resources',
-      render: (_value, record) => {
-        const parsedOccupiedSlots: {
-          [key in ResourceSlotName]: string | undefined;
-        } = JSON.parse(record?.occupied_slots || '{}');
-        const parsedAvailableSlots: {
-          [key in ResourceSlotName]: string | undefined;
-        } = JSON.parse(record?.available_slots || '{}');
-        return (
-          <BAIFlex direction="column" gap="xxs">
-            {_.map(
-              parsedAvailableSlots,
-              (_value: string | number, key: ResourceSlotName) => {
-                if (key === 'cpu') {
-                  const cpuPercent = _.toFinite(
-                    (_.toNumber(parsedOccupiedSlots.cpu) /
-                      _.toNumber(parsedAvailableSlots.cpu)) *
-                      100,
-                  );
-                  return (
-                    <BAIFlex
-                      key={key}
-                      justify="between"
-                      style={{ width: '100%' }}
-                      gap={'xs'}
-                    >
-                      <BAIFlex gap="xxs">
-                        <ResourceTypeIcon key={key} type={key} />
-                        <Typography.Text>
-                          {toFixedFloorWithoutTrailingZeros(
-                            parsedOccupiedSlots.cpu || 0,
-                            0,
-                          )}
-                          &nbsp;/&nbsp;
-                          {toFixedFloorWithoutTrailingZeros(
-                            parsedAvailableSlots.cpu || 0,
-                            0,
-                          )}
-                        </Typography.Text>
-                        <Typography.Text
-                          type="secondary"
-                          style={{ fontSize: token.sizeXS }}
-                        >
-                          {mergedResourceSlots?.cpu?.display_unit}
-                        </Typography.Text>
-                      </BAIFlex>
-                      <BAIProgressWithLabel
-                        percent={cpuPercent}
-                        strokeColor={
-                          cpuPercent > 80
-                            ? token.colorError
-                            : token.colorSuccess
-                        }
-                        width={120}
-                        valueLabel={
-                          toFixedFloorWithoutTrailingZeros(cpuPercent, 1) + ' %'
-                        }
-                      />
-                    </BAIFlex>
-                  );
-                } else if (key === 'mem') {
-                  const memPercent = _.toFinite(
-                    (_.toNumber(parsedOccupiedSlots.mem) /
-                      _.toNumber(parsedAvailableSlots.mem)) *
-                      100,
-                  );
-                  return (
-                    <BAIFlex
-                      key={'mem'}
-                      justify="between"
-                      style={{ width: '100%' }}
-                      gap={'xs'}
-                    >
-                      <BAIFlex gap="xxs">
-                        <ResourceTypeIcon type={'mem'} />
-                        <Typography.Text>
-                          {convertToBinaryUnit(parsedOccupiedSlots.mem, 'g', 0)
-                            ?.numberFixed ?? 0}
-                          &nbsp;/&nbsp;
-                          {convertToBinaryUnit(parsedAvailableSlots.mem, 'g', 0)
-                            ?.numberFixed ?? 0}
-                        </Typography.Text>
-                        <Typography.Text
-                          type="secondary"
-                          style={{ fontSize: token.sizeXS }}
-                        >
-                          GiB
-                        </Typography.Text>
-                      </BAIFlex>
-                      <BAIProgressWithLabel
-                        percent={memPercent}
-                        strokeColor={
-                          memPercent > 80
-                            ? token.colorError
-                            : token.colorSuccess
-                        }
-                        width={120}
-                        valueLabel={
-                          toFixedFloorWithoutTrailingZeros(memPercent, 1) + ' %'
-                        }
-                      />
-                    </BAIFlex>
-                  );
-                } else if (parsedAvailableSlots[key]) {
-                  const percent = _.toFinite(
-                    (_.toNumber(parsedOccupiedSlots[key]) /
-                      _.toNumber(parsedAvailableSlots[key])) *
-                      100,
-                  );
-                  return (
-                    <BAIFlex
-                      key={key}
-                      justify="between"
-                      gap={'xs'}
-                      style={{ width: '100%' }}
-                    >
-                      <BAIFlex gap="xxs">
-                        <ResourceTypeIcon key={key} type={key} />
-                        <Typography.Text>
-                          {toFixedFloorWithoutTrailingZeros(
-                            parsedOccupiedSlots[key] || 0,
-                            2,
-                          )}
-                          &nbsp;/&nbsp;
-                          {toFixedFloorWithoutTrailingZeros(
-                            parsedAvailableSlots[key],
-                            2,
-                          )}
-                        </Typography.Text>
-                        <Typography.Text
-                          type="secondary"
-                          style={{ fontSize: token.sizeXS }}
-                        >
-                          {mergedResourceSlots?.[key]?.display_unit}
-                        </Typography.Text>
-                      </BAIFlex>
-                      <BAIProgressWithLabel
-                        percent={percent}
-                        strokeColor={
-                          percent > 80 ? token.colorError : token.colorSuccess
-                        }
-                        width={120}
-                        valueLabel={
-                          toFixedFloorWithoutTrailingZeros(percent, 1) + ' %'
-                        }
-                      />
-                    </BAIFlex>
-                  );
-                }
-              },
-            )}
-          </BAIFlex>
-        );
-      },
+      render: (_value, record) => (
+        <CellErrorBoundary
+          resetKeys={[record?.occupied_slots, record?.available_slots]}
+        >
+          <AllocationCell record={record} />
+        </CellErrorBoundary>
+      ),
     },
     {
       title: t('comp:AgentTable.Utilization'),
       key: 'live_stat',
       dataIndex: 'live_stat',
-      render: (value, record) => {
-        const parsedValue = JSON.parse(value || '{}');
-        const available_slots = JSON.parse(record?.available_slots || '{}');
-        if (record?.status === 'ALIVE') {
-          const liveStat = {
-            cpu_util: { capacity: 0, current: 0, ratio: 0 },
-            mem_util: { capacity: 0, current: 0, ratio: 0 },
-          };
-          if (parsedValue && parsedValue.node && parsedValue.devices) {
-            const numCores = _.keys(parsedValue.devices.cpu_util).length;
-            liveStat.cpu_util.capacity = _.toFinite(
-              parsedValue.node.cpu_util.capacity,
-            );
-            liveStat.cpu_util.current = _.toFinite(
-              parsedValue.node.cpu_util.current,
-            );
-            liveStat.cpu_util.ratio = Math.min(
-              _.toFinite(parsedValue.node.cpu_util.pct) / 100 / (numCores || 1),
-              1,
-            );
-            liveStat.mem_util.capacity = _.toInteger(
-              available_slots.mem || parsedValue.node.mem.capacity,
-            );
-            liveStat.mem_util.current = _.toInteger(
-              parsedValue.node.mem.current,
-            );
-            liveStat.mem_util.ratio =
-              liveStat.mem_util.current / liveStat.mem_util.capacity || 0;
-          }
-          _.forEach(_.keys(parsedValue?.node), (statKey) => {
-            if (
-              ['cpu_util', 'mem', 'disk', 'net_rx', 'net_tx'].includes(statKey)
-            )
-              return;
-            if (_.includes(statKey, '_util')) {
-              // core utilization
-              liveStat[statKey as keyof typeof liveStat] = {
-                capacity: _.toFinite(parsedValue.node[statKey].capacity) || 100,
-                current: _.toFinite(parsedValue.node[statKey].current),
-                ratio: _.toFinite(parsedValue.node[statKey].current) / 100 || 0,
-              };
-            } else if (statKey.includes('_mem')) {
-              // memory utilization
-              liveStat[statKey as keyof typeof liveStat] = {
-                capacity: _.toFinite(parsedValue.node[statKey].capacity),
-                current: _.toFinite(parsedValue.node[statKey].current),
-                ratio: _.toFinite(parsedValue.node[statKey].pct) / 100 || 0,
-              };
-            }
-          });
-          const baseUnit =
-            convertUnitValue(_.toString(liveStat.mem_util.capacity), 'auto')
-              ?.unit || 'g';
-          return (
-            <BAIFlex direction="column" gap="xxs">
-              <BAIFlex
-                // CPU
-                justify="between"
-                style={{ minWidth: 200, width: '100%' }}
-                data-testid="live-stat-cpu"
-              >
-                <Typography.Text>
-                  {mergedResourceSlots?.cpu?.human_readable_name}
-                </Typography.Text>
-                <BAIProgressWithLabel
-                  percent={liveStat.cpu_util.ratio * 100}
-                  width={120}
-                  valueLabel={
-                    toFixedFloorWithoutTrailingZeros(
-                      _.toFinite(liveStat.cpu_util.ratio * 100),
-                      1,
-                    ) + ' %'
-                  }
-                />
-              </BAIFlex>
-              <BAIFlex
-                // MEM
-                justify="between"
-                style={{ minWidth: 200, width: '100%' }}
-                data-testid="live-stat-mem"
-              >
-                <Typography.Text>
-                  {mergedResourceSlots?.mem?.human_readable_name}
-                </Typography.Text>
-                <BAIProgressWithLabel
-                  percent={liveStat.mem_util.ratio * 100}
-                  width={120}
-                  valueLabel={
-                    convertToBinaryUnit(
-                      _.toString(liveStat.mem_util.current),
-                      baseUnit,
-                    )?.numberFixed +
-                    ' / ' +
-                    convertToBinaryUnit(
-                      _.toString(liveStat.mem_util.capacity),
-                      baseUnit,
-                    )?.displayValue
-                  }
-                />
-              </BAIFlex>
-              {_.map(_.keys(parsedValue?.node), (statKey) => {
-                if (['cpu_util', 'mem', 'disk'].includes(statKey)) {
-                  return;
-                }
-                if (_.includes(statKey, '_util')) {
-                  const deviceName = _.split(statKey, '_')[0] + '.device';
-                  return (
-                    <BAIFlex
-                      key={statKey}
-                      justify="between"
-                      style={{ minWidth: 200, width: '100%' }}
-                      gap="xxs"
-                      data-testid={`live-stat-${statKey}`}
-                    >
-                      <Typography.Text>
-                        {mergedResourceSlots?.[deviceName]?.human_readable_name}
-                        (util)
-                      </Typography.Text>
-                      <BAIProgressWithLabel
-                        width={120}
-                        percent={
-                          (liveStat[statKey as keyof typeof liveStat].current /
-                            liveStat[statKey as keyof typeof liveStat]
-                              .capacity) *
-                            100 || 0
-                        }
-                        valueLabel={
-                          _.toFinite(
-                            toFixedFloorWithoutTrailingZeros(
-                              liveStat[statKey as keyof typeof liveStat].ratio *
-                                100,
-                              1,
-                            ),
-                          ) + ' %'
-                        }
-                      />
-                    </BAIFlex>
-                  );
-                }
-                if (_.includes(statKey, '_mem')) {
-                  const deviceName = _.split(statKey, '_')[0] + '.device';
-                  const baseUnit =
-                    convertUnitValue(
-                      _.toString(
-                        liveStat[statKey as keyof typeof liveStat].capacity,
-                      ),
-                      'auto',
-                    )?.unit || 'g';
-                  return (
-                    <BAIFlex
-                      key={statKey}
-                      justify="between"
-                      style={{ minWidth: 200, width: '100%' }}
-                      gap="xxs"
-                      data-testid={`live-stat-${statKey}`}
-                    >
-                      <Typography.Text>
-                        {mergedResourceSlots?.[deviceName]?.human_readable_name}
-                        (mem)
-                      </Typography.Text>
-                      <BAIProgressWithLabel
-                        width={120}
-                        percent={
-                          (liveStat[statKey as keyof typeof liveStat].current /
-                            liveStat[statKey as keyof typeof liveStat]
-                              .capacity) *
-                            100 || 0
-                        }
-                        valueLabel={
-                          convertToBinaryUnit(
-                            _.toString(
-                              liveStat[statKey as keyof typeof liveStat]
-                                .current,
-                            ),
-                            baseUnit,
-                          )?.numberFixed +
-                          ' / ' +
-                          convertToBinaryUnit(
-                            _.toString(
-                              liveStat[statKey as keyof typeof liveStat]
-                                .capacity,
-                            ),
-                            baseUnit,
-                          )?.displayValue
-                        }
-                      />
-                    </BAIFlex>
-                  );
-                }
-                if (_.includes(statKey, '_power')) {
-                  const deviceName =
-                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                  const humanReadableName =
-                    mergedResourceSlots?.[deviceName]?.human_readable_name;
-                  return (
-                    <BAIFlex
-                      key={statKey}
-                      justify="between"
-                      style={{ minWidth: 200, width: '100%' }}
-                      gap="xxs"
-                      data-testid={`live-stat-${statKey}`}
-                    >
-                      <BAIText>{`${humanReadableName}(power)`}</BAIText>
-                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedValue.node[statKey]?.current, 2)} ${parsedValue.node[statKey].unit_hint}`}</BAIText>
-                    </BAIFlex>
-                  );
-                }
-                if (_.includes(statKey, '_temperature')) {
-                  const deviceName =
-                    _.split(statKey, '_').slice(0, -1).join('_') + '.device';
-                  const humanReadableName =
-                    mergedResourceSlots?.[deviceName]?.human_readable_name;
-                  return (
-                    <BAIFlex
-                      key={statKey}
-                      justify="between"
-                      style={{ minWidth: 200, width: '100%' }}
-                      gap="xxs"
-                      data-testid={`live-stat-${statKey}`}
-                    >
-                      <BAIText>{`${humanReadableName}(temp)`}</BAIText>
-                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedValue.node[statKey]?.current, 2)} °C`}</BAIText>
-                    </BAIFlex>
-                  );
-                }
-                if (_.includes(['net_rx', 'net_tx'], statKey)) {
-                  const convertedValue = convertToDecimalUnit(
-                    parsedValue.node[statKey]?.current,
-                    'auto',
-                  );
-                  return (
-                    <BAIFlex
-                      key={statKey}
-                      justify="between"
-                      style={{ minWidth: 200, width: '100%' }}
-                      gap="xxs"
-                      data-testid={`live-stat-${statKey}`}
-                    >
-                      <BAIText>
-                        {statKey === 'net_rx' ? 'Net Rx' : 'Net Tx'}
-                      </BAIText>
-                      <BAIText>
-                        {`${convertedValue?.numberFixed ?? 0} ${convertedValue?.unit.toUpperCase() ?? ''}bps`}
-                      </BAIText>
-                    </BAIFlex>
-                  );
-                }
-                return (
-                  <BAIFlex
-                    key={statKey}
-                    justify="between"
-                    style={{ minWidth: 200, width: '100%' }}
-                    gap="xxs"
-                    data-testid={`live-stat-${statKey}`}
-                  >
-                    <BAIText>{statKey}</BAIText>
-                    <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedValue.node[statKey]?.current ?? 0, 2)}${parsedValue.node[statKey]?.unit_hint ? ` ${parsedValue.node[statKey].unit_hint}` : ''}`}</BAIText>
-                  </BAIFlex>
-                );
-              })}
-            </BAIFlex>
-          );
-        } else {
-          return t('comp:AgentTable.NoAvailableLiveStat');
-        }
-      },
+      render: (value, record) => (
+        <CellErrorBoundary resetKeys={[value, record?.available_slots]}>
+          <UtilizationCell value={value} record={record} />
+        </CellErrorBoundary>
+      ),
     },
     {
       title: t('comp:AgentTable.DiskPerc'),
       key: 'disk_pct',
-      render: (_value, record) => {
-        const parsedDisk =
-          JSON.parse(record?.live_stat || '{}')?.node?.disk ?? {};
-        const pctValue = _.toFinite(parsedDisk.pct) || 0;
-        const pct = _.toFinite(toFixedFloorWithoutTrailingZeros(pctValue, 2));
-        const color = pct > 80 ? token.colorError : token.colorSuccess;
-        const baseUnit =
-          convertUnitValue(parsedDisk?.capacity, 'auto', {
-            base: 1000,
-          })?.unit || 'g';
-        return (
-          <BAIFlex direction="column" align="end">
-            <BAIProgressWithLabel
-              valueLabel={toFixedFloorWithoutTrailingZeros(pct, 1) + ' %'}
-              percent={pct}
-              strokeColor={color}
-              width={120}
-            />
-            {!_.isEmpty(parsedDisk) && (
-              <Typography.Text style={{ fontSize: token.fontSizeSM }}>
-                {
-                  convertToDecimalUnit(parsedDisk?.current, baseUnit)
-                    ?.numberFixed
-                }
-                &nbsp;/&nbsp;
-                {
-                  convertToDecimalUnit(parsedDisk?.capacity, baseUnit)
-                    ?.displayValue
-                }
-              </Typography.Text>
-            )}
-          </BAIFlex>
-        );
-      },
+      render: (_value, record) => (
+        <CellErrorBoundary resetKeys={[record?.live_stat]}>
+          <DiskPctCell record={record} />
+        </CellErrorBoundary>
+      ),
     },
     {
       title: t('comp:AgentTable.ResourceGroup'),
@@ -640,63 +733,13 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
       title: t('comp:AgentTable.Status'),
       key: 'status',
       dataIndex: 'status',
-      render: (value, record) => {
-        const parsedComputePlugins = JSON.parse(
-          record?.compute_plugins || '{}',
-        );
-        const parsedAvailableSlots = JSON.parse(
-          record?.available_slots || '{}',
-        );
-        return (
-          <BAIFlex direction="column" gap="xxs" align="start">
-            <BAIDoubleTag
-              values={[
-                { label: 'Agent' },
-                {
-                  label: record?.version || '',
-                  color:
-                    value === 'ALIVE'
-                      ? 'green'
-                      : value === 'TERMINATED'
-                        ? 'red'
-                        : 'blue',
-                },
-              ]}
-            />
-            {parsedComputePlugins?.cuda ? (
-              <>
-                {parsedComputePlugins?.cuda?.cuda_version ? (
-                  <BAIDoubleTag
-                    values={[
-                      { label: 'CUDA' },
-                      {
-                        label: parsedComputePlugins?.cuda?.cuda_version,
-                        color: 'green',
-                      },
-                    ]}
-                  />
-                ) : (
-                  <BAITag color="green">CUDA Disabled</BAITag>
-                )}
-                <BAIDoubleTag
-                  values={[
-                    { label: 'CUDA Plugin' },
-                    {
-                      label: parsedComputePlugins?.cuda?.version,
-                      color: 'blue',
-                    },
-                  ]}
-                />
-                {_.includes(_.keys(parsedAvailableSlots), 'cuda.shares') ? (
-                  <BAITag color="blue" style={{ borderRadius: 0 }}>
-                    Fractional GPU™
-                  </BAITag>
-                ) : null}
-              </>
-            ) : null}
-          </BAIFlex>
-        );
-      },
+      render: (value, record) => (
+        <CellErrorBoundary
+          resetKeys={[value, record?.compute_plugins, record?.available_slots]}
+        >
+          <StatusCell value={value} record={record} />
+        </CellErrorBoundary>
+      ),
       sorter: isEnableSorter('status'),
     },
     {

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -5,6 +5,7 @@
     "Architecture": "Architektur",
     "DiskPerc": "Festplattenauslastung %",
     "Endpoint": "Endpunkt",
+    "FailedToLoadCellData": "Daten konnten nicht geladen werden.",
     "NoAvailableLiveStat": "Keine Live-Statistik verfügbar",
     "Region": "Region",
     "ResourceGroup": "Ressourcengruppe",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -5,6 +5,7 @@
     "Architecture": "Αρχιτεκτονική",
     "DiskPerc": "Χρήση δίσκου %",
     "Endpoint": "Σημείο τερματισμού",
+    "FailedToLoadCellData": "Αποτυχία φόρτωσης δεδομένων.",
     "NoAvailableLiveStat": "Καμία διαθέσιμη ζωντανή στατιστική",
     "Region": "Περιοχή",
     "ResourceGroup": "Ομάδα πόρων",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -5,6 +5,7 @@
     "Architecture": "Architecture",
     "DiskPerc": "Disk %",
     "Endpoint": "Endpoint",
+    "FailedToLoadCellData": "Failed to load data.",
     "NoAvailableLiveStat": "No available live stat",
     "Region": "Region",
     "ResourceGroup": "Resource Group",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -5,6 +5,7 @@
     "Architecture": "Arquitectura",
     "DiskPerc": "Uso de disco (%)",
     "Endpoint": "Punto de enlace",
+    "FailedToLoadCellData": "Error al cargar los datos.",
     "NoAvailableLiveStat": "No hay estadísticas en tiempo real disponibles",
     "Region": "Región",
     "ResourceGroup": "Grupo de recursos",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -5,6 +5,7 @@
     "Architecture": "Arkkitehtuuri",
     "DiskPerc": "Levy %",
     "Endpoint": "Päätepiste",
+    "FailedToLoadCellData": "Tietojen lataaminen epäonnistui.",
     "NoAvailableLiveStat": "Reaaliaikaisia tilastoja ei ole saatavilla",
     "Region": "Alue",
     "ResourceGroup": "Resurssiryhmä",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -5,6 +5,7 @@
     "Architecture": "Architecture",
     "DiskPerc": "Disque %",
     "Endpoint": "Point de terminaison",
+    "FailedToLoadCellData": "Échec du chargement des données.",
     "NoAvailableLiveStat": "Aucune statistique en direct disponible",
     "Region": "Région",
     "ResourceGroup": "Groupe de ressources",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -5,6 +5,7 @@
     "Architecture": "Arsitektur",
     "DiskPerc": "Disk %",
     "Endpoint": "Endpoint",
+    "FailedToLoadCellData": "Gagal memuat data.",
     "NoAvailableLiveStat": "Tidak ada statistik langsung yang tersedia",
     "Region": "Wilayah",
     "ResourceGroup": "Grup Sumber Daya",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -5,6 +5,7 @@
     "Architecture": "Architettura",
     "DiskPerc": "Disco %",
     "Endpoint": "Endpoint",
+    "FailedToLoadCellData": "Impossibile caricare i dati.",
     "NoAvailableLiveStat": "Nessuna statistica in tempo reale disponibile",
     "Region": "Regione",
     "ResourceGroup": "Gruppo di risorse",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -5,6 +5,7 @@
     "Architecture": "アーキテクチャ",
     "DiskPerc": "ディスク使用率",
     "Endpoint": "エンドポイント",
+    "FailedToLoadCellData": "データの読み込みに失敗しました。",
     "NoAvailableLiveStat": "ライブ統計は利用できません",
     "Region": "リージョン",
     "ResourceGroup": "リソースグループ",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -5,6 +5,7 @@
     "Architecture": "아키텍처",
     "DiskPerc": "디스크 %",
     "Endpoint": "엔드포인트",
+    "FailedToLoadCellData": "데이터를 불러오는데 실패했습니다.",
     "NoAvailableLiveStat": "표시할 사용량 없음",
     "Region": "지역",
     "ResourceGroup": "자원 그룹",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -5,6 +5,7 @@
     "Architecture": "Архитектур",
     "DiskPerc": "Диск %",
     "Endpoint": "Эцсийн цэг",
+    "FailedToLoadCellData": "Өгөгдөл ачааллахад алдаа гарлаа.",
     "NoAvailableLiveStat": "Амьд статистик байхгүй",
     "Region": "Бүс",
     "ResourceGroup": "Ресурсын бүлэг",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -5,6 +5,7 @@
     "Architecture": "Seni Bina",
     "DiskPerc": "Cakera %",
     "Endpoint": "Titik akhir",
+    "FailedToLoadCellData": "Gagal memuatkan data.",
     "NoAvailableLiveStat": "Tiada statistik langsung tersedia",
     "Region": "Wilayah",
     "ResourceGroup": "Kumpulan Sumber",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -5,6 +5,7 @@
     "Architecture": "Architektura",
     "DiskPerc": "Dysk %",
     "Endpoint": "Punkt końcowy",
+    "FailedToLoadCellData": "Nie udało się załadować danych.",
     "NoAvailableLiveStat": "Brak statystyk na żywo",
     "Region": "Region",
     "ResourceGroup": "Grupa zasobów",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -5,6 +5,7 @@
     "Architecture": "Arquitetura",
     "DiskPerc": "Disco %",
     "Endpoint": "Endpoint",
+    "FailedToLoadCellData": "Falha ao carregar os dados.",
     "NoAvailableLiveStat": "Nenhuma estatística em tempo real disponível",
     "Region": "Região",
     "ResourceGroup": "Grupo de Recursos",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -5,6 +5,7 @@
     "Architecture": "Arquitetura",
     "DiskPerc": "Disco %",
     "Endpoint": "Endpoint",
+    "FailedToLoadCellData": "Falha ao carregar os dados.",
     "NoAvailableLiveStat": "Nenhuma estatística em tempo real disponível",
     "Region": "Região",
     "ResourceGroup": "Grupo de Recursos",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -5,6 +5,7 @@
     "Architecture": "Архитектура",
     "DiskPerc": "Диск %",
     "Endpoint": "Конечная точка",
+    "FailedToLoadCellData": "Не удалось загрузить данные.",
     "NoAvailableLiveStat": "Живая статистика недоступна",
     "Region": "Регион",
     "ResourceGroup": "Группа ресурсов",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -5,6 +5,7 @@
     "Architecture": "สถาปัตยกรรม",
     "DiskPerc": "การใช้ดิสก์ %",
     "Endpoint": "เอ็นด์พอยต์",
+    "FailedToLoadCellData": "โหลดข้อมูลไม่สำเร็จ",
     "NoAvailableLiveStat": "ไม่มีสถิติเรียลไทม์ที่ใช้งานได้",
     "Region": "ภูมิภาค",
     "ResourceGroup": "กลุ่มทรัพยากร",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -5,6 +5,7 @@
     "Architecture": "Mimari",
     "DiskPerc": "Disk %",
     "Endpoint": "Uç Nokta",
+    "FailedToLoadCellData": "Veriler yüklenemedi.",
     "NoAvailableLiveStat": "Canlı istatistik yok",
     "Region": "Bölge",
     "ResourceGroup": "Kaynak Grubu",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -5,6 +5,7 @@
     "Architecture": "Kiến trúc",
     "DiskPerc": "Sử dụng đĩa (%)",
     "Endpoint": "Điểm cuối",
+    "FailedToLoadCellData": "Không thể tải dữ liệu.",
     "NoAvailableLiveStat": "Không có số liệu trực tiếp",
     "Region": "Khu vực",
     "ResourceGroup": "Nhóm tài nguyên",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -5,6 +5,7 @@
     "Architecture": "架构",
     "DiskPerc": "磁盘使用率 %",
     "Endpoint": "端点",
+    "FailedToLoadCellData": "数据加载失败。",
     "NoAvailableLiveStat": "暂无可用实时统计",
     "Region": "区域",
     "ResourceGroup": "资源组",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -5,6 +5,7 @@
     "Architecture": "架構",
     "DiskPerc": "磁碟使用率 (%)",
     "Endpoint": "端點",
+    "FailedToLoadCellData": "資料載入失敗。",
     "NoAvailableLiveStat": "沒有可用的即時統計",
     "Region": "區域",
     "ResourceGroup": "資源群組",


### PR DESCRIPTION
Resolves FR-2954

## Summary

`BAIAgentTable` crashed with `TypeError: Cannot read properties of undefined (reading 'current')` when an agent reported a sparse GPU live_stat (e.g. Jetson Orin Nano + `cuda_open` plugin where NVML returns `NOT_SUPPORTED` for `nvmlDeviceGetMemoryInfo`). Because all cell renders ran inline in the parent table render, a single bad row took down the entire `/agent` page and any other view sharing the same ErrorBoundary scope (notably the Session Launcher's environment/agent dropdown).

## Changes

- Extract the four columns that parse JSON (`occupied_slots`, `available_slots`, `live_stat`, `compute_plugins`) into module-scope sub-components: `AllocationCell`, `UtilizationCell`, `DiskPctCell`, `StatusCell`. This is required because `JSON.parse` must run inside a child component's render for an `ErrorBoundary` to catch it — running inside the parent's `render: (...) => { ... }` throws before the boundary is mounted.
- Wrap each of those four cells with a new `CellErrorBoundary` (built on `react-error-boundary`). On error the cell renders `BAIAlertIconWithTooltip` (red alert icon with a tooltip showing a localized failure message) instead of crashing.
- Add `comp:AgentTable.FailedToLoadCellData` to all 22 locale files (ko: "데이터를 불러오는데 실패했습니다.", en: "Failed to load data.", plus 20 other languages auto-translated).

## Screenshots

### Normal render (after fix, no regression)
![normal](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7566/20260522-182036-agent-table-normal-after.png)

### Error fallback — alert icons in the 4 affected cells (simulated via temporary throws)
The page no longer crashes; only the affected cells degrade. ID / Endpoint, Region, Starts, Resource Group, Schedulable continue to render normally.

![error fallback](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7566/20260522-182036-agent-table-error-fallback.png)

### Tooltip on hover — "Failed to load data."
Hovering an alert icon reveals the localized failure message.

![error tooltip](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7566/20260522-182036-agent-table-error-tooltip.png)

## How to verify

1. `pnpm dev` → log in → Admin → Resources → Agents.
2. With a cluster containing an agent that reports incomplete GPU metrics (e.g. Jetson Orin Nano on the cuda_open plugin), confirm the Agents table renders.
3. Affected cells in the misbehaving row show a red alert icon — hover to see "Failed to load data." (or the localized equivalent). Other rows and other cells in the same row continue to render normally.
4. Open the Session Launcher and confirm the environment/agent dropdown is no longer affected.

## Checklist

- [x] No backend / manager changes required
- [x] i18n keys added for all 22 supported locales
- [ ] Documentation
- [ ] Specific setting for review

> Note: The Jira → GitHub webhook had not yet cloned FR-2954 to GitHub at PR creation time. Once the clone lands, this description will be updated to `Resolves #<N> (FR-2954)`.