### PR TITLE
feat(FR-2958): make review sections collapsible and auto-expand non-success ones

### DIFF
--- a/packages/backend.ai-ui/src/components/BAICard.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAICard.stories.tsx
@@ -31,6 +31,10 @@ The component extends all standard Ant Design Card properties while adding Backe
 | extraButtonTitle | \`string \\| ReactNode\` | - | Title for the extra action button in the header |
 | showDivider | \`boolean\` | \`false\` | Show divider between header and body. Auto-enabled with tabs |
 | onClickExtraButton | \`() => void\` | - | Callback when extra button is clicked |
+| collapsible | \`boolean\` | \`false\` | Render a header chevron that collapses/expands the body |
+| collapsed | \`boolean\` | - | Controlled collapsed state (pair with onCollapsedChange) |
+| defaultCollapsed | \`boolean\` | \`false\` | Initial collapsed state for uncontrolled usage |
+| onCollapsedChange | \`(collapsed: boolean) => void\` | - | Fired with the next collapsed state on toggle |
         `,
       },
     },
@@ -100,6 +104,39 @@ The component extends all standard Ant Design Card properties while adding Backe
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'false' },
+      },
+    },
+    collapsible: {
+      control: { type: 'boolean' },
+      description:
+        'Allow the card body to be collapsed/expanded via a header chevron toggle',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    defaultCollapsed: {
+      control: { type: 'boolean' },
+      description: 'Initial collapsed state for uncontrolled collapsible cards',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    collapsed: {
+      control: { type: 'boolean' },
+      description:
+        'Controlled collapsed state for collapsible cards. Use together with onCollapsedChange',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    onCollapsedChange: {
+      action: 'collapsedChanged',
+      description:
+        'Callback fired with the next collapsed state when the header toggle is clicked',
+      table: {
+        type: { summary: '(collapsed: boolean) => void' },
       },
     },
     onClickExtraButton: {
@@ -344,6 +381,39 @@ export const WithDivider: Story = {
   args: {
     title: 'Card with Header Divider',
     showDivider: true,
+    children: sampleContent,
+  },
+};
+
+export const Collapsible: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A collapsible card. Click the header chevron to expand or collapse the body. Useful for review/validation sections where successful items can stay collapsed and only the ones needing attention are expanded.',
+      },
+    },
+  },
+  args: {
+    title: 'Collapsible Card',
+    collapsible: true,
+    children: sampleContent,
+  },
+};
+
+export const CollapsibleCollapsedByDefault: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An uncontrolled collapsible card that starts collapsed via `defaultCollapsed`. Only the header is shown until the user expands it.',
+      },
+    },
+  },
+  args: {
+    title: 'Collapsed by Default',
+    collapsible: true,
+    defaultCollapsed: true,
     children: sampleContent,
   },
 };

--- a/packages/backend.ai-ui/src/components/BAICard.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAICard.test.tsx
@@ -578,4 +578,95 @@ describe('BAICard', () => {
       expect(container.querySelector('.ant-card-small')).toBeInTheDocument();
     });
   });
+
+  describe('Collapsible', () => {
+    // A collapsible card with no `extra` renders exactly one role="button"
+    // (the header toggle); query it directly rather than by accessible name,
+    // which would otherwise fold in the chevron icon's own aria-label.
+    const getToggle = () => screen.getByRole('button');
+
+    it('should render expanded by default when collapsible', () => {
+      render(
+        <BAICard collapsible title="Section">
+          Collapsible content
+        </BAICard>,
+      );
+      expect(screen.getByText('Collapsible content')).toBeVisible();
+      expect(getToggle()).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should start collapsed when defaultCollapsed is set (uncontrolled)', () => {
+      render(
+        <BAICard collapsible defaultCollapsed title="Section">
+          Hidden content
+        </BAICard>,
+      );
+      expect(getToggle()).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should toggle collapsed state on header click (uncontrolled)', async () => {
+      const user = userEvent.setup();
+      render(
+        <BAICard collapsible title="Section">
+          Toggle content
+        </BAICard>,
+      );
+      const toggle = getToggle();
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should respect controlled collapsed prop and fire onCollapsedChange', async () => {
+      const user = userEvent.setup();
+      const onCollapsedChange = vi.fn();
+      const { rerender } = render(
+        <BAICard
+          collapsible
+          collapsed={false}
+          onCollapsedChange={onCollapsedChange}
+          title="Section"
+        >
+          Controlled content
+        </BAICard>,
+      );
+      const toggle = getToggle();
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+      // Clicking requests the next state via the callback but does not
+      // change the rendered state until the controlling prop updates.
+      await user.click(toggle);
+      expect(onCollapsedChange).toHaveBeenCalledWith(true);
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+      rerender(
+        <BAICard
+          collapsible
+          collapsed={true}
+          onCollapsedChange={onCollapsedChange}
+          title="Section"
+        >
+          Controlled content
+        </BAICard>,
+      );
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should provide an aria-label fallback when title is absent', () => {
+      render(<BAICard collapsible>Untitled collapsible content</BAICard>);
+      // No title → the toggle relies on an aria-label for its accessible name.
+      expect(getToggle()).toHaveAttribute('aria-label');
+    });
+
+    it('should not set aria-label when a title provides the accessible name', () => {
+      render(
+        <BAICard collapsible title="Section">
+          Content
+        </BAICard>,
+      );
+      expect(getToggle()).not.toHaveAttribute('aria-label');
+    });
+  });
 });

--- a/packages/backend.ai-ui/src/components/BAICard.tsx
+++ b/packages/backend.ai-ui/src/components/BAICard.tsx
@@ -1,9 +1,14 @@
 import BAIFlex from './BAIFlex';
-import { CloseCircleTwoTone, WarningTwoTone } from '@ant-design/icons';
+import {
+  CloseCircleTwoTone,
+  RightOutlined,
+  WarningTwoTone,
+} from '@ant-design/icons';
 import { Button, Card, theme, type CardProps } from 'antd';
 import * as _ from 'lodash-es';
-import React, { cloneElement, isValidElement } from 'react';
+import React, { cloneElement, isValidElement, useState } from 'react';
 import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Props interface for BAICard component.
@@ -20,6 +25,17 @@ export interface BAICardProps extends Omit<CardProps, 'extra'> {
   showDivider?: boolean;
   /** Callback function triggered when the extra button is clicked */
   onClickExtraButton?: () => void;
+  /**
+   * When true, the card body can be collapsed/expanded via a chevron toggle
+   * in the header. Existing usages are unaffected unless this is set.
+   */
+  collapsible?: boolean;
+  /** Controlled collapsed state. Use together with `onCollapsedChange`. */
+  collapsed?: boolean;
+  /** Initial collapsed state for uncontrolled usage. Defaults to `false`. */
+  defaultCollapsed?: boolean;
+  /** Callback fired with the next collapsed state when the header is toggled. */
+  onCollapsedChange?: (collapsed: boolean) => void;
   /** React ref for the card container */
   ref?: React.Ref<HTMLDivElement> | undefined;
 }
@@ -73,9 +89,29 @@ const BAICard: React.FC<BAICardProps> = ({
   style,
   styles,
   showDivider,
+  collapsible,
+  collapsed,
+  defaultCollapsed,
+  onCollapsedChange,
   ...cardProps
 }) => {
   const { token } = theme.useToken();
+  const { t } = useTranslation();
+
+  const [internalCollapsed, setInternalCollapsed] = useState(
+    defaultCollapsed ?? false,
+  );
+  // Controlled when `collapsed` is provided, otherwise uncontrolled.
+  const mergedCollapsed = collapsible
+    ? (collapsed ?? internalCollapsed)
+    : false;
+  const toggleCollapsed = () => {
+    const next = !mergedCollapsed;
+    if (collapsed === undefined) {
+      setInternalCollapsed(next);
+    }
+    onCollapsedChange?.(next);
+  };
 
   const extraWithoutFontWeight = isValidElement(extra)
     ? cloneElement(extra as React.ReactElement<any>, {
@@ -137,17 +173,54 @@ const BAICard: React.FC<BAICardProps> = ({
             }
           : {},
         styles,
+        // Hide the body while collapsed (kept last so it wins the merge).
+        collapsible && mergedCollapsed ? { body: { display: 'none' } } : {},
       )}
       {...cardProps}
       title={
-        cardProps.title || extra ? (
+        cardProps.title || extra || collapsible ? (
           <BAIFlex
-            justify={cardProps.title ? 'between' : 'end'}
+            justify={cardProps.title || collapsible ? 'between' : 'end'}
             align="center"
             wrap="wrap"
             gap="sm"
           >
-            {cardProps.title}
+            {collapsible ? (
+              <BAIFlex
+                align="center"
+                gap="xs"
+                style={{ cursor: 'pointer', flex: 1, minWidth: 0 }}
+                role="button"
+                tabIndex={0}
+                aria-expanded={!mergedCollapsed}
+                aria-label={
+                  cardProps.title
+                    ? undefined
+                    : mergedCollapsed
+                      ? t('general.button.Expand')
+                      : t('general.button.Collapse')
+                }
+                onClick={toggleCollapsed}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleCollapsed();
+                  }
+                }}
+              >
+                <RightOutlined
+                  rotate={mergedCollapsed ? 0 : 90}
+                  style={{
+                    fontSize: token.fontSizeSM,
+                    color: token.colorTextTertiary,
+                    transition: 'transform 0.2s',
+                  }}
+                />
+                {cardProps.title}
+              </BAIFlex>
+            ) : (
+              cardProps.title
+            )}
             <BAIFlex>{_extra}</BAIFlex>
           </BAIFlex>
         ) : null

--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -10,7 +10,7 @@ import { Button, Descriptions, Space, Tag, Typography, theme } from 'antd';
 import type { FormInstance } from 'antd';
 import { BAICard, BAIFlex, toLocalId } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React from 'react';
+import React, { useEffect, useEffectEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // ---------------------------------------------------------------------------
@@ -61,6 +61,33 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
   );
   const step2HasError = STEP2_FIELDS.some((f) => errorFieldNames.includes(f));
 
+  // Sections with validation errors are "non-success" and expanded by default
+  // so the user lands on what needs fixing.
+  const sectionErrors: Record<string, boolean> = {
+    basicInfo: basicInfoHasError,
+    resources: resourcesHasError,
+    deployment: deploymentHasError,
+    modelAndExecution: step2HasError,
+  };
+  const nonSuccessKeys = _.keys(_.pickBy(sectionErrors));
+  // Resync expansion to the non-success sections whenever the failing set
+  // changes (e.g. after validation completes on entering the review step).
+  const nonSuccessSignature = nonSuccessKeys.join('|');
+  const [expandedKeys, setExpandedKeys] = useState<string[]>(nonSuccessKeys);
+  const syncExpandedToNonSuccess = useEffectEvent(() => {
+    setExpandedKeys(_.keys(_.pickBy(sectionErrors)));
+  });
+  useEffect(() => {
+    syncExpandedToNonSuccess();
+  }, [nonSuccessSignature]);
+
+  const isExpanded = (key: string) => expandedKeys.includes(key);
+  const handleCollapsedChange = (key: string) => (collapsed: boolean) => {
+    setExpandedKeys((prev) =>
+      collapsed ? prev.filter((k) => k !== key) : _.uniq([...prev, key]),
+    );
+  };
+
   const runtimeName =
     runtimeVariants.find((r) => toLocalId(r.id) === values.runtimeVariantId)
       ?.name ?? values.runtimeVariantId;
@@ -93,6 +120,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
         }
         title={t('adminDeploymentPreset.step.BasicInfo')}
         extra={editLink(0, 'preset-form-card-basic')}
+        collapsible
+        collapsed={!isExpanded('basicInfo')}
+        onCollapsedChange={handleCollapsedChange('basicInfo')}
       >
         <Descriptions column={1} size="small">
           <Descriptions.Item label={t('adminDeploymentPreset.Name')}>
@@ -133,6 +163,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
         }
         title={t('adminDeploymentPreset.step.Resources')}
         extra={editLink(0, 'preset-form-card-resources')}
+        collapsible
+        collapsed={!isExpanded('resources')}
+        onCollapsedChange={handleCollapsedChange('resources')}
       >
         <Descriptions column={1} size="small">
           <Descriptions.Item label={t('adminDeploymentPreset.ResourceSlots')}>
@@ -175,6 +208,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
         }
         title={t('adminDeploymentPreset.step.Deployment')}
         extra={editLink(0, 'preset-form-card-deployment')}
+        collapsible
+        collapsed={!isExpanded('deployment')}
+        onCollapsedChange={handleCollapsedChange('deployment')}
       >
         <Descriptions column={2} size="small">
           <Descriptions.Item label={t('adminDeploymentPreset.Replicas')}>
@@ -202,6 +238,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
         style={step2HasError ? { borderColor: token.colorError } : undefined}
         title={t('adminDeploymentPreset.step.ModelAndExecution')}
         extra={editLink(1, 'preset-form-card-model')}
+        collapsible
+        collapsed={!isExpanded('modelAndExecution')}
+        onCollapsedChange={handleCollapsedChange('modelAndExecution')}
       >
         <Descriptions column={1} size="small">
           <Descriptions.Item label={t('adminDeploymentPreset.StartupCommand')}>

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -36,6 +36,7 @@ import {
 import { BAIAlert, BAICard, BAIDoubleTag, BAIFlex } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
+import { useEffect, useEffectEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const SessionLauncherPreview: React.FC<{
@@ -53,6 +54,61 @@ const SessionLauncherPreview: React.FC<{
   const currentProject = useCurrentProjectValue();
   const [, { getBaseVersion, getBaseImage, tagAlias }] =
     useBackendAIImageMetaData();
+
+  // Per-section validation status. A section is "non-success" when it holds a
+  // field error; those sections are expanded by default so the user lands on
+  // what needs fixing.
+  const sessionTypeHasError =
+    form.getFieldError('sessionName').length > 0 ||
+    form.getFieldError(['batch', 'command']).length > 0 ||
+    form.getFieldError(['batch', 'scheduleDate']).length > 0;
+  const ownerHasError =
+    form.getFieldError(['owner', 'email']).length > 0 ||
+    form.getFieldError(['owner', 'accesskey']).length > 0 ||
+    form.getFieldError(['owner', 'project']).length > 0 ||
+    form.getFieldError(['owner', 'resourceGroup']).length > 0;
+  const environmentsHasError = _.some(
+    form.getFieldValue('envvars') as SessionLauncherFormValue['envvars'],
+    (_v, idx) =>
+      form.getFieldError(['envvars', idx, 'variable']).length > 0 ||
+      form.getFieldError(['envvars', idx, 'value']).length > 0,
+  );
+  const resourceAllocationHasError =
+    _.some(form.getFieldValue('resource'), (_v, key) => {
+      // @ts-ignore
+      return form.getFieldError(['resource', key]).length > 0;
+    }) ||
+    form.getFieldError(['num_of_sessions']).length > 0 ||
+    form.getFieldError('resourceGroup').length > 0;
+  const dataStorageHasError = form.getFieldError('mount_id_map').length > 0;
+  const networkHasError = form.getFieldError('ports').length > 0;
+
+  const sectionErrors: Record<string, boolean> = {
+    sessionType: sessionTypeHasError,
+    owner: ownerHasError,
+    environments: environmentsHasError,
+    resourceAllocation: resourceAllocationHasError,
+    dataStorage: dataStorageHasError,
+    network: networkHasError,
+  };
+  const nonSuccessKeys = _.keys(_.pickBy(sectionErrors));
+  // Resync expansion to the non-success sections whenever the set of failing
+  // sections changes (e.g. after validation completes on entering the step).
+  const nonSuccessSignature = nonSuccessKeys.join('|');
+  const [expandedKeys, setExpandedKeys] = useState<string[]>(nonSuccessKeys);
+  const syncExpandedToNonSuccess = useEffectEvent(() => {
+    setExpandedKeys(_.keys(_.pickBy(sectionErrors)));
+  });
+  useEffect(() => {
+    syncExpandedToNonSuccess();
+  }, [nonSuccessSignature]);
+
+  const isExpanded = (key: string) => expandedKeys.includes(key);
+  const handleCollapsedChange = (key: string) => (collapsed: boolean) => {
+    setExpandedKeys((prev) =>
+      collapsed ? prev.filter((k) => k !== key) : _.uniq([...prev, key]),
+    );
+  };
 
   return (
     <>
@@ -92,13 +148,10 @@ const SessionLauncherPreview: React.FC<{
         title={t('session.launcher.SessionType')}
         showDivider
         size="small"
-        status={
-          form.getFieldError('sessionName').length > 0 ||
-          form.getFieldError(['batch', 'command']).length > 0 ||
-          form.getFieldError(['batch', 'scheduleDate']).length > 0
-            ? 'error'
-            : undefined
-        }
+        status={sessionTypeHasError ? 'error' : undefined}
+        collapsible
+        collapsed={!isExpanded('sessionType')}
+        onCollapsedChange={handleCollapsedChange('sessionType')}
         extraButtonTitle={t('button.Edit')}
         onClickExtraButton={() => {
           onClickEditStep('sessionType');
@@ -169,6 +222,9 @@ const SessionLauncherPreview: React.FC<{
         </Descriptions>
       </BAICard>
       <SessionOwnerSetterPreviewCard
+        collapsible
+        collapsed={!isExpanded('owner')}
+        onCollapsedChange={handleCollapsedChange('owner')}
         onClickExtraButton={() => {
           onClickEditStep('sessionType');
         }}
@@ -177,21 +233,10 @@ const SessionLauncherPreview: React.FC<{
         title={t('session.launcher.Environments')}
         showDivider
         size="small"
-        status={
-          _.some(
-            form.getFieldValue(
-              'envvars',
-            ) as SessionLauncherFormValue['envvars'],
-            (_v, idx) => {
-              return (
-                form.getFieldError(['envvars', idx, 'variable']).length > 0 ||
-                form.getFieldError(['envvars', idx, 'value']).length > 0
-              );
-            },
-          )
-            ? 'error'
-            : undefined
-        }
+        status={environmentsHasError ? 'error' : undefined}
+        collapsible
+        collapsed={!isExpanded('environments')}
+        onCollapsedChange={handleCollapsedChange('environments')}
         extraButtonTitle={t('button.Edit')}
         onClickExtraButton={() => {
           onClickEditStep('environment');
@@ -410,18 +455,10 @@ const SessionLauncherPreview: React.FC<{
       <BAICard
         title={t('session.launcher.ResourceAllocation')}
         showDivider
-        status={
-          _.some(form.getFieldValue('resource'), (_v, key) => {
-            return (
-              // @ts-ignore
-              form.getFieldError(['resource', key]).length > 0
-            );
-          }) ||
-          form.getFieldError(['num_of_sessions']).length > 0 ||
-          form.getFieldError('resourceGroup').length > 0
-            ? 'error'
-            : undefined
-        }
+        status={resourceAllocationHasError ? 'error' : undefined}
+        collapsible
+        collapsed={!isExpanded('resourceAllocation')}
+        onCollapsedChange={handleCollapsedChange('resourceAllocation')}
         size="small"
         extraButtonTitle={t('button.Edit')}
         onClickExtraButton={() => {
@@ -556,9 +593,10 @@ const SessionLauncherPreview: React.FC<{
         title={t('webui.menu.Data&Storage')}
         showDivider
         size="small"
-        status={
-          form.getFieldError('mount_id_map').length > 0 ? 'error' : undefined
-        }
+        status={dataStorageHasError ? 'error' : undefined}
+        collapsible
+        collapsed={!isExpanded('dataStorage')}
+        onCollapsedChange={handleCollapsedChange('dataStorage')}
         extraButtonTitle={t('button.Edit')}
         onClickExtraButton={() => {
           onClickEditStep('storage');
@@ -629,7 +667,10 @@ const SessionLauncherPreview: React.FC<{
         title="Network"
         showDivider
         size="small"
-        status={form.getFieldError('ports').length > 0 ? 'error' : undefined}
+        status={networkHasError ? 'error' : undefined}
+        collapsible
+        collapsed={!isExpanded('network')}
+        onCollapsedChange={handleCollapsedChange('network')}
         extraButtonTitle={t('button.Edit')}
         onClickExtraButton={() => {
           onClickEditStep('network');


### PR DESCRIPTION
Resolves #7562 (FR-2958)

## Summary

On the final review/validation step of the **Session Launcher** and the **Deployment Preset** setting page, the review is shown as a list of section cards. Previously every section was always fully expanded, so users had to scan the whole list to find what needed fixing.

This makes those section cards collapsible and **auto-expands only the non-success sections** (sections that hold a validation error), collapsing the successful ones so the user lands on what needs attention.

- **BAICard** (`backend.ai-ui`): add `collapsible` / `collapsed` / `defaultCollapsed` / `onCollapsedChange` props. A header chevron toggles the body and is keyboard-accessible (Enter/Space). All behavior is gated behind `collapsible`, so existing BAICard usages are unaffected. Storybook stories added.
- **SessionLauncherPreview** & **AdminDeploymentPresetReviewSummary**: lift per-section expand state, initialize it to the non-success sections, and re-sync when the failing set changes (e.g. after revalidation on entering the step).

Originated from the devops/General Teams thread (2026-05-22) — request to auto-expand non-success items in the validation steps. The session **scheduling history** is intentionally out of scope.

## Test plan

- [ ] Session Launcher → final "Confirm and Launch" step with a validation error in a section → that section is expanded, the successful ones collapsed.
- [ ] Deployment Preset setting → Review step with an error → erroring section expanded, others collapsed.
- [ ] Click / keyboard-toggle a section header expands & collapses it.
- [ ] Other BAICard usages across the app are unchanged (collapsible is opt-in).

## Verification

`bash scripts/verify.sh`: **Relay / Lint / Format pass.** The **TypeScript** step reports a *pre-existing, repo-wide baseline* failure (~835 errors): `react`'s tsconfig type-checks the unbuilt `backend.ai-client` / `backend.ai-ui` sources, and antd `Card` / `Select.Option` / `ErrorBoundary` resolve as "cannot be used as a JSX component". This is identical on untouched `main` (verified) — **this PR adds no new type errors** (the only errors in touched files sit on pre-existing antd-component lines, none on the new collapsible code).
