### PR TITLE
fix(FR-2962): use distinct URL keys for deployment revision history pagination

### DIFF
--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -125,8 +125,12 @@ const DeploymentRevisionHistoryTab: React.FC<
     {
       history: 'replace',
       urlKeys: {
-        current: 'rCurrent',
-        pageSize: 'rPageSize',
+        // Use an `rv*` prefix distinct from the replica tab's `r*` keys
+        // (rCurrent/rPageSize). Both tabs live on the same deployment
+        // detail URL, so sharing pagination keys made switching tabs carry
+        // over an out-of-range page index and render an empty table.
+        current: 'rvCurrent',
+        pageSize: 'rvPageSize',
         order: 'rvOrder',
         rvFilter: 'rvFilter',
       },


### PR DESCRIPTION
Resolves #7571 (FR-2962)

## Summary

On the Deployment detail page, the **Replica list** tab and the **Revision History** tab both bound their pagination to the *same* URL query keys (`rCurrent` / `rPageSize`). Because the two tabs share the deployment detail URL, navigating to a page that exists in one tab but not the other — e.g. going to the last replica page and then opening Revision History — left the second tab requesting an out-of-range page and rendering an empty table.

This change gives the Revision History tab its own `rvCurrent` / `rvPageSize` keys (it already used the `rv*` prefix for `rvOrder` / `rvFilter`), so the two tabs keep fully independent, URL-shareable pagination state. The Replica tab's `r*` keys are unchanged.

- `react/src/components/DeploymentRevisionHistoryTab.tsx`: `urlKeys.current` `rCurrent → rvCurrent`, `urlKeys.pageSize` `rPageSize → rvPageSize`.

> **Note (intended):** Previously-bookmarked Revision History URLs that carried `rCurrent`/`rPageSize` will no longer apply to that tab — those keys now belong solely to the Replica tab, and Revision History falls back to its defaults (page 1, size 10). This is the correct behavior since the shared keys were the source of the bug. `rvOrder`/`rvFilter` bookmarks are unaffected.

## Test plan

- [ ] Open a deployment whose replica list has more pages than its revision history.
- [ ] Go to the last replica page (URL gets `rCurrent=N`), then switch to the **Revision History** tab — it now starts on page 1 (`rvCurrent`) instead of an empty out-of-range page.
- [ ] Paginate within Revision History; the replica tab's page is preserved when switching back.
- [ ] Confirm both tabs' pagination survives a page reload (URL keys `rCurrent`/`rPageSize` vs `rvCurrent`/`rvPageSize` are independent).

## Verification

`scripts/verify.sh` (run in worktree):
- Relay: **PASS**
- Lint: **PASS**
- Format: **PASS**
- TypeScript: pre-existing/environmental worktree failures only (project-wide `backend.ai-ui` type-resolution noise affecting ~all files, incl. the package's own source). No errors introduced by this change; the edited `urlKeys` strings are type-safe by construction.

Frontend review (lead-frontend-reviewer): **Approve** — correct, complete, minimal, convention-adherent. No Must-fix/Should-fix findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This is result of https://fr-2962.localhost:1336/deployments/64e0de16-7cd6-44c9-b33b-bdfd542c094b?rStatusCategory=terminated&rvOrder=revisionNumber&rCurrent=5&revisionTab=revisionHistory
<img width="1902" height="971" alt="image" src="https://github.com/user-attachments/assets/f495fe79-bd05-4b1b-87a5-5f8b903f7bd3" />
