### PR TITLE
refactor(FR-2964): switch route and deployment scheduling history modals to render-as-you-fetch

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryNodeTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryNodeTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<561adf7e0b25fe3b06afa2208e51e9dd>>
+ * @generated SignedSource<<7826d64cc35baebfbae84de866de9d0e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 export type SchedulingResult = "EXPIRED" | "FAILURE" | "GIVE_UP" | "NEED_RETRY" | "SKIPPED" | "STALE" | "SUCCESS" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
-export type BAIRouteSchedulingHistoryNodesFragment$data = ReadonlyArray<{
+export type BAIRouteSchedulingHistoryNodeTableFragment$data = ReadonlyArray<{
   readonly attempts: number;
   readonly category: string;
   readonly createdAt: string;
@@ -28,11 +28,11 @@ export type BAIRouteSchedulingHistoryNodesFragment$data = ReadonlyArray<{
   }>;
   readonly toStatus: string | null | undefined;
   readonly updatedAt: string;
-  readonly " $fragmentType": "BAIRouteSchedulingHistoryNodesFragment";
+  readonly " $fragmentType": "BAIRouteSchedulingHistoryNodeTableFragment";
 }>;
-export type BAIRouteSchedulingHistoryNodesFragment$key = ReadonlyArray<{
-  readonly " $data"?: BAIRouteSchedulingHistoryNodesFragment$data;
-  readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryNodesFragment">;
+export type BAIRouteSchedulingHistoryNodeTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAIRouteSchedulingHistoryNodeTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryNodeTableFragment">;
 }>;
 
 const node: ReaderFragment = {
@@ -41,7 +41,7 @@ const node: ReaderFragment = {
   "metadata": {
     "plural": true
   },
-  "name": "BAIRouteSchedulingHistoryNodesFragment",
+  "name": "BAIRouteSchedulingHistoryNodeTableFragment",
   "selections": [
     {
       "alias": null,
@@ -155,6 +155,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "8aa21d0647efcd639e380be63f1c6c9a";
+(node as any).hash = "3f283b3e8ef039a11e41ade44a38092f";
 
 export default node;

--- a/packages/backend.ai-ui/src/components/BAIModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.tsx
@@ -30,7 +30,24 @@ export type MinimizedPlacement =
   | 'topRight'
   | 'topLeft';
 
-export interface BAIModalProps extends ModalProps {
+/**
+ * Footer render-function form, re-typed from antd's `ModalProps['footer']`.
+ * antd's footer union does not let TypeScript contextually type the render
+ * function's parameters (they fall back to implicit `any`), so callers are
+ * forced to annotate `(originNode, { OkBtn, CancelBtn }) => ...`. This clean
+ * named signature restores parameter inference.
+ */
+export type BAIModalFooterRender = (
+  originNode: React.ReactNode,
+  extra: { OkBtn: React.FC; CancelBtn: React.FC },
+) => React.ReactNode;
+
+export interface BAIModalProps extends Omit<ModalProps, 'footer'> {
+  /**
+   * Modal footer. Re-typed (vs antd's `ModalProps['footer']`) so the
+   * render-function form infers its parameter types without manual annotation.
+   */
+  footer?: React.ReactNode | BAIModalFooterRender;
   /** Enable dragging modal by header */
   draggable?: boolean;
   /**

--- a/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.tsx
@@ -1,5 +1,5 @@
 import type { DrawerProps, ModalProps } from 'antd';
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface BAIUnmountModalAfterCloseProps {
   children: React.ReactElement<ModalProps | DrawerProps>;
@@ -31,16 +31,24 @@ const BAIUnmountAfterClose: React.FC<BAIUnmountModalAfterCloseProps> = ({
   const childElement = React.Children.only(children);
   const isOpen = childElement.props.open;
 
-  // Manage internal rendering state
-  const [isMount, setIsMount] = useState(isOpen);
+  // Track whether the exit animation has finished. While open, the child is
+  // always mounted; once closed, it stays mounted until the close animation
+  // completes (afterClose / afterOpenChange) so the exit transition is shown.
+  // Initialize from `isOpen` so a child that mounts already-open does not start
+  // in the "closed" state (which could unmount it before its effect runs).
+  const [afterClosed, setAfterClosed] = useState(() => !isOpen);
 
-  // Update internal state when the child's open prop becomes true
-  useLayoutEffect(() => {
+  // Reset the afterClosed state to false whenever the modal is opened, so it can be unmounted after the next close.
+  useEffect(() => {
     if (isOpen) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsMount(true);
+      setAfterClosed(false);
     }
   }, [isOpen]);
+
+  // Derive synchronously so the child mounts on the same render `open` flips to
+  // true (no one-render delay), while still surviving the close animation.
+  const isMount = isOpen || !afterClosed;
 
   // Return null if the modal should not be rendered
   if (!isMount) {
@@ -56,7 +64,7 @@ const BAIUnmountAfterClose: React.FC<BAIUnmountModalAfterCloseProps> = ({
       originalAfterClose(...args);
     }
     // Set internal state to false after the exit animation completes
-    setIsMount(false);
+    setAfterClosed(true);
   };
 
   // Preserve the original afterOpenChange callback if it exists
@@ -69,7 +77,7 @@ const BAIUnmountAfterClose: React.FC<BAIUnmountModalAfterCloseProps> = ({
     }
     // Set internal state to false after the exit animation completes
     if (!open) {
-      setIsMount(false);
+      setAfterClosed(true);
     }
   };
 

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryNodeTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryNodeTable.tsx
@@ -1,7 +1,7 @@
 import {
-  BAIRouteSchedulingHistoryNodesFragment$data,
-  BAIRouteSchedulingHistoryNodesFragment$key,
-} from '../../__generated__/BAIRouteSchedulingHistoryNodesFragment.graphql';
+  BAIRouteSchedulingHistoryNodeTableFragment$data,
+  BAIRouteSchedulingHistoryNodeTableFragment$key,
+} from '../../__generated__/BAIRouteSchedulingHistoryNodeTableFragment.graphql';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
@@ -25,7 +25,7 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type RouteSchedulingHistoryNodeInList = NonNullable<
-  BAIRouteSchedulingHistoryNodesFragment$data[number]
+  BAIRouteSchedulingHistoryNodeTableFragment$data[number]
 >;
 
 const availableHistorySorterKeys = [] as const;
@@ -43,7 +43,7 @@ export interface BAIRouteSchedulingHistoryNodesProps extends Omit<
   BAITableProps<RouteSchedulingHistoryNodeInList>,
   'dataSource' | 'onChangeOrder' | 'columns'
 > {
-  schedulingHistoryFrgmt: BAIRouteSchedulingHistoryNodesFragment$key;
+  schedulingHistoryFrgmt: BAIRouteSchedulingHistoryNodeTableFragment$key;
   disableSorter?: boolean;
   customizeColumns?: (
     baseColumns: BAIColumnsType<RouteSchedulingHistoryNodeInList>,
@@ -53,7 +53,7 @@ export interface BAIRouteSchedulingHistoryNodesProps extends Omit<
   ) => void;
 }
 
-const BAIRouteSchedulingHistoryNodes = ({
+const BAIRouteSchedulingHistoryNodeTable = ({
   schedulingHistoryFrgmt,
   disableSorter,
   customizeColumns,
@@ -63,9 +63,9 @@ const BAIRouteSchedulingHistoryNodes = ({
   'use memo';
   const { t } = useTranslation();
 
-  const histories = useFragment<BAIRouteSchedulingHistoryNodesFragment$key>(
+  const histories = useFragment<BAIRouteSchedulingHistoryNodeTableFragment$key>(
     graphql`
-      fragment BAIRouteSchedulingHistoryNodesFragment on RouteHistory
+      fragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory
       @relay(plural: true) {
         id
         routeId
@@ -221,4 +221,4 @@ const BAIRouteSchedulingHistoryNodes = ({
   );
 };
 
-export default BAIRouteSchedulingHistoryNodes;
+export default BAIRouteSchedulingHistoryNodeTable;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -168,11 +168,11 @@ export type {
   BAIDeploymentSchedulingHistoryNodesProps,
   DeploymentSchedulingHistoryNodeInList,
 } from './BAIDeploymentSchedulingHistoryNodes';
-export { default as BAIRouteSchedulingHistoryNodes } from './BAIRouteSchedulingHistoryNodes';
+export { default as BAIRouteSchedulingHistoryNodeTable } from './BAIRouteSchedulingHistoryNodeTable';
 export type {
   BAIRouteSchedulingHistoryNodesProps,
   RouteSchedulingHistoryNodeInList,
-} from './BAIRouteSchedulingHistoryNodes';
+} from './BAIRouteSchedulingHistoryNodeTable';
 export { default as BAIDeploymentSelect } from './BAIDeploymentSelect';
 export type {
   BAIDeploymentSelectProps,

--- a/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b16df7a175ad48283f610c5ff36fd64a>>
+ * @generated SignedSource<<5d0ef863d0714f49059be1797b0c4c60>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -85,7 +85,7 @@ export type RouteSchedulingHistoryModalQuery$data = {
   readonly routeScopedSchedulingHistories: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryNodesFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryNodeTableFragment">;
       };
     }>;
   } | null | undefined;
@@ -187,7 +187,7 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "BAIRouteSchedulingHistoryNodesFragment"
+                    "name": "BAIRouteSchedulingHistoryNodeTableFragment"
                   }
                 ],
                 "storageKey": null
@@ -356,16 +356,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "29c038756b4243a1e47b62a67235b457",
+    "cacheID": "5db4b1d03cdc23ddcee7e24da57e934d",
     "id": null,
     "metadata": {},
     "name": "RouteSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryNodesFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodesFragment on RouteHistory {\n  id\n  routeId\n  deploymentId\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryNodeTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  routeId\n  deploymentId\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7be39a383677ce5c2d3413fe1d719830";
+(node as any).hash = "d718b55942730d51c42ce434352c4e59";
 
 export default node;

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -8,12 +8,15 @@ import type {
   DeploymentConfigurationSection_deployment$key,
 } from '../__generated__/DeploymentConfigurationSection_deployment.graphql';
 import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
+import { DeploymentSchedulingHistoryModalQuery } from '../__generated__/DeploymentSchedulingHistoryModalQuery.graphql';
 import { useWebUINavigate } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import DeploymentRevisionDetail from './DeploymentRevisionDetail';
 import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
 import DeploymentRevisionHistoryTab from './DeploymentRevisionHistoryTab';
-import DeploymentSchedulingHistoryModal from './DeploymentSchedulingHistoryModal';
+import DeploymentSchedulingHistoryModal, {
+  DeploymentSchedulingHistoryQuery,
+} from './DeploymentSchedulingHistoryModal';
 import DeploymentSettingModal from './DeploymentSettingModal';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
 import {
@@ -58,7 +61,7 @@ import type { BAIDeploymentStatus } from 'backend.ai-ui';
 import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useFragment, useMutation } from 'react-relay';
+import { graphql, useFragment, useMutation, useQueryLoader } from 'react-relay';
 import { useLocation } from 'react-router-dom';
 
 interface DeploymentConfigurationSectionProps {
@@ -81,8 +84,11 @@ const renderFallback = () => (
 
 const DeploymentOverviewContent: React.FC<{
   deployment: DeploymentSectionData;
-  onClickSchedulingHistory?: () => void;
-}> = ({ deployment, onClickSchedulingHistory }) => {
+  onClickSchedulingHistoryAction?: () => Promise<void>;
+}> = ({
+  deployment,
+  onClickSchedulingHistoryAction: onClickSchedulingHistory,
+}) => {
   'use memo';
   const { t } = useTranslation();
   const webuiNavigate = useWebUINavigate();
@@ -108,7 +114,10 @@ const DeploymentOverviewContent: React.FC<{
                 type="link"
                 size="small"
                 icon={<HistoryOutlined />}
-                onClick={onClickSchedulingHistory}
+                style={{ padding: 0 }}
+                action={async () => {
+                  await onClickSchedulingHistory();
+                }}
               >
                 {t('deployment.SchedulingHistory')}
               </BAIButton>
@@ -298,6 +307,10 @@ const DeploymentConfigurationSection: React.FC<
   const [settingModalOpen, setSettingModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [historyModalOpen, setHistoryModalOpen] = useState(false);
+  const [deploymentHistoryQueryRef, loadDeploymentHistoryQuery] =
+    useQueryLoader<DeploymentSchedulingHistoryModalQuery>(
+      DeploymentSchedulingHistoryQuery,
+    );
   const baiClient = useConnectedBAIClient();
   const supportsDeploymentSchedulingHistory =
     baiClient?.supports('deployment-scheduling-history') ?? false;
@@ -418,9 +431,25 @@ const DeploymentConfigurationSection: React.FC<
       >
         <DeploymentOverviewContent
           deployment={deployment}
-          onClickSchedulingHistory={
-            supportsDeploymentSchedulingHistory
-              ? () => setHistoryModalOpen(true)
+          onClickSchedulingHistoryAction={
+            supportsDeploymentSchedulingHistory && deployment?.id
+              ? async () => {
+                  // Render-as-you-fetch: start the request in the open event.
+                  const rawId = deployment.id;
+                  if (!rawId) {
+                    return;
+                  }
+                  loadDeploymentHistoryQuery(
+                    {
+                      scope: {
+                        deploymentId: safeDecodeUuid(rawId) ?? rawId,
+                      },
+                      orderBy: [{ field: 'UPDATED_AT', direction: 'DESC' }],
+                    },
+                    { fetchPolicy: 'store-and-network' },
+                  );
+                  setHistoryModalOpen(true);
+                }
               : undefined
           }
         />
@@ -547,12 +576,15 @@ const DeploymentConfigurationSection: React.FC<
         onOk={handleDelete}
         onCancel={() => setIsDeleteModalOpen(false)}
       />
-      {deployment?.id && (
-        <DeploymentSchedulingHistoryModal
-          open={historyModalOpen}
-          deploymentId={safeDecodeUuid(deployment.id) ?? deployment.id}
-          onCancel={() => setHistoryModalOpen(false)}
-        />
+      {deploymentHistoryQueryRef != null && (
+        <BAIUnmountAfterClose>
+          <DeploymentSchedulingHistoryModal
+            open={historyModalOpen}
+            queryRef={deploymentHistoryQueryRef}
+            onReload={loadDeploymentHistoryQuery}
+            onCancel={() => setHistoryModalOpen(false)}
+          />
+        </BAIUnmountAfterClose>
       )}
     </>
   );

--- a/react/src/components/DeploymentReplicasTab.tsx
+++ b/react/src/components/DeploymentReplicasTab.tsx
@@ -8,13 +8,16 @@ import {
 } from '../__generated__/DeploymentReplicasTabListQuery.graphql';
 import { DeploymentReplicasTab_deployment$key } from '../__generated__/DeploymentReplicasTab_deployment.graphql';
 import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
+import { RouteSchedulingHistoryModalQuery } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import BAIRadioGroup from './BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
 import QuestionIconWithTooltip from './QuestionIconWithTooltip';
 import ReplicaStatusTag, { ReplicaStatus } from './ReplicaStatusTag';
-import RouteSchedulingHistoryModal from './RouteSchedulingHistoryModal';
+import RouteSchedulingHistoryModal, {
+  RouteSchedulingHistoryQuery,
+} from './RouteSchedulingHistoryModal';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import { HistoryOutlined } from '@ant-design/icons';
 import { Tooltip, Typography } from 'antd';
@@ -44,7 +47,12 @@ import {
 } from 'nuqs';
 import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
+import {
+  graphql,
+  useFragment,
+  useLazyLoadQuery,
+  useQueryLoader,
+} from 'react-relay';
 
 type ReplicaStatusCategory = 'running' | 'terminated';
 
@@ -165,7 +173,11 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
   const supportsRouteSchedulingHistory = baiClient.supports(
     'route-scheduling-history',
   );
-  const [historyRouteId, setHistoryRouteId] = useState<string | null>(null);
+  const [isRouteHistoryOpen, setIsRouteHistoryOpen] = useState(false);
+  const [routeHistoryQueryRef, loadRouteHistoryQuery] =
+    useQueryLoader<RouteSchedulingHistoryModalQuery>(
+      RouteSchedulingHistoryQuery,
+    );
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     null,
   );
@@ -293,9 +305,20 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
                 icon={<HistoryOutlined />}
                 size="small"
                 style={{ padding: 0 }}
-                onClick={() =>
-                  setHistoryRouteId(safeDecodeUuid(record.id) ?? record.id)
-                }
+                action={async () => {
+                  const id = safeDecodeUuid(record.id) ?? record.id;
+                  // Render-as-you-fetch: start the request in the open event.
+                  loadRouteHistoryQuery(
+                    {
+                      scope: { routeId: id },
+                      orderBy: [{ field: 'UPDATED_AT', direction: 'DESC' }],
+                    },
+                    {
+                      fetchPolicy: 'store-and-network',
+                    },
+                  );
+                  setIsRouteHistoryOpen(true);
+                }}
               />
             </Tooltip>
           )}
@@ -516,11 +539,16 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
           onClose={() => setDrawerRevisionFrgmt(null)}
         />
       </BAIUnmountAfterClose>
-      <RouteSchedulingHistoryModal
-        open={!!historyRouteId}
-        routeId={historyRouteId ?? ''}
-        onCancel={() => setHistoryRouteId(null)}
-      />
+      {routeHistoryQueryRef != null && (
+        <BAIUnmountAfterClose>
+          <RouteSchedulingHistoryModal
+            open={isRouteHistoryOpen}
+            queryRef={routeHistoryQueryRef}
+            onReload={loadRouteHistoryQuery}
+            onCancel={() => setIsRouteHistoryOpen(false)}
+          />
+        </BAIUnmountAfterClose>
+      )}
     </>
   );
 };

--- a/react/src/components/DeploymentSchedulingHistoryModal.tsx
+++ b/react/src/components/DeploymentSchedulingHistoryModal.tsx
@@ -5,7 +5,6 @@ import {
 } from '../__generated__/DeploymentSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import {
-  BAIButton,
   BAIDeploymentSchedulingHistoryNodes,
   BAIFetchKeyButton,
   BAIFlex,
@@ -17,19 +16,56 @@ import {
 import * as _ from 'lodash-es';
 import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery } from 'react-relay';
+import {
+  graphql,
+  PreloadedQuery,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
+
+// Exported so the opener can `loadQuery` it in the click event (render-as-you-
+// fetch). Operation name must match the generated artifact; the const name only
+// differs to avoid clashing with the imported generated type.
+export const DeploymentSchedulingHistoryQuery = graphql`
+  query DeploymentSchedulingHistoryModalQuery(
+    $scope: DeploymentScope!
+    $filter: DeploymentHistoryFilter
+    $orderBy: [DeploymentHistoryOrderBy!]
+  ) {
+    deploymentScopedSchedulingHistories(
+      scope: $scope
+      filter: $filter
+      orderBy: $orderBy
+    ) {
+      edges {
+        node {
+          ...BAIDeploymentSchedulingHistoryNodesFragment
+        }
+      }
+    }
+  }
+`;
 
 interface DeploymentSchedulingHistoryModalProps extends Omit<
   BAIModalProps,
   'children' | 'title'
 > {
-  deploymentId: string;
+  /** Preloaded query reference produced by the opener via `useQueryLoader`. */
+  queryRef: PreloadedQuery<DeploymentSchedulingHistoryModalQuery>;
+  /**
+   * Re-run the query when filter / order / refresh changes. Same signature as
+   * `useQueryLoader`'s `loadQuery`, so the opener can pass it directly.
+   */
+  onReload: (
+    variables: DeploymentSchedulingHistoryModalQuery['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
 }
 
 const DeploymentSchedulingHistoryModal = ({
   open,
-  loading,
-  deploymentId,
+  queryRef,
+  onReload,
   onCancel,
   ...modalProps
 }: DeploymentSchedulingHistoryModalProps) => {
@@ -39,48 +75,26 @@ const DeploymentSchedulingHistoryModal = ({
   const [filter, setFilter] = useState<DeploymentHistoryFilter>();
   const [order, setOrder] = useState<string | null>('-updatedAt');
 
-  const deferredOpenValue = useDeferredValue(open);
-  const deferredFetchKey = useDeferredValue(fetchKey);
-  const deferredFilter = useDeferredValue(filter);
-  const deferredOrder = useDeferredValue(order);
-  const queryRef = useLazyLoadQuery<DeploymentSchedulingHistoryModalQuery>(
-    graphql`
-      query DeploymentSchedulingHistoryModalQuery(
-        $scope: DeploymentScope!
-        $filter: DeploymentHistoryFilter
-        $orderBy: [DeploymentHistoryOrderBy!]
-      ) {
-        deploymentScopedSchedulingHistories(
-          scope: $scope
-          filter: $filter
-          orderBy: $orderBy
-        ) {
-          edges {
-            node {
-              ...BAIDeploymentSchedulingHistoryNodesFragment
-            }
-          }
-        }
-      }
-    `,
-    {
-      scope: {
-        deploymentId: deploymentId,
-      },
-      filter: deferredFilter ?? undefined,
-      orderBy: convertToOrderBy<DeploymentHistoryOrderBy>(deferredOrder) ?? [
-        { field: 'UPDATED_AT', direction: 'DESC' },
-      ],
-    },
-    {
-      fetchKey: deferredFetchKey,
-      fetchPolicy: deferredOpenValue ? 'network-only' : 'store-only',
-    },
+  // Re-fetches happen from event handlers (filter / order / refresh), never from
+  // render or an effect. We carry the existing variables forward via
+  // `...queryRef.variables` (scope/deploymentId already live there) and override
+  // only what changed, so no separate variable builder is needed.
+
+  // Keep the previous result visible while the next one loads so re-fetches show
+  // the old data with an inline loading indicator instead of flashing the
+  // Suspense fallback. `deferredQueryRef !== queryRef` is the "additional
+  // loading in progress" signal.
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetchingInTransition = deferredQueryRef !== queryRef;
+
+  const data = usePreloadedQuery<DeploymentSchedulingHistoryModalQuery>(
+    DeploymentSchedulingHistoryQuery,
+    deferredQueryRef,
   );
+
   return (
     <BAIModal
       title={t('deployment.DeploymentSchedulingHistory')}
-      loading={loading || deferredOpenValue !== open}
       open={open}
       width={'90%'}
       style={{
@@ -91,17 +105,8 @@ const DeploymentSchedulingHistoryModal = ({
           minHeight: '80vh',
         },
       }}
-      footer={
-        <BAIButton
-          onClick={(e) =>
-            onCancel?.(
-              e as Parameters<NonNullable<BAIModalProps['onCancel']>>[0],
-            )
-          }
-        >
-          {t('button.Close')}
-        </BAIButton>
-      }
+      cancelText={t('button.Close')}
+      footer={(_originNode, { CancelBtn }) => <CancelBtn />}
       onCancel={onCancel}
       {...modalProps}
     >
@@ -109,7 +114,13 @@ const DeploymentSchedulingHistoryModal = ({
         <BAIFlex justify="between" wrap="wrap" gap="sm">
           <BAIGraphQLPropertyFilter
             value={filter}
-            onChange={setFilter}
+            onChange={(next) => {
+              setFilter(next);
+              onReload(
+                { ...queryRef.variables, filter: next },
+                { fetchPolicy: 'network-only' },
+              );
+            }}
             filterProperties={[
               {
                 key: 'id',
@@ -179,23 +190,31 @@ const DeploymentSchedulingHistoryModal = ({
           <BAIFlex>
             <BAIFetchKeyButton
               value={fetchKey}
-              onChange={updateFetchKey}
-              loading={deferredFetchKey !== fetchKey}
+              onChange={(key) => {
+                updateFetchKey(key);
+                onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+              }}
+              loading={isRefetchingInTransition}
               autoUpdateDelay={null}
             />
           </BAIFlex>
         </BAIFlex>
         <BAIDeploymentSchedulingHistoryNodes
           resizable
-          loading={
-            deferredFetchKey !== fetchKey ||
-            deferredFilter !== filter ||
-            deferredOrder !== order
-          }
+          loading={isRefetchingInTransition}
           order={order}
-          onChangeOrder={setOrder}
+          onChangeOrder={(nextOrder) => {
+            setOrder(nextOrder);
+            onReload(
+              {
+                ...queryRef.variables,
+                orderBy: convertToOrderBy<DeploymentHistoryOrderBy>(nextOrder),
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          }}
           schedulingHistoryFrgmt={_.map(
-            queryRef.deploymentScopedSchedulingHistories?.edges,
+            data.deploymentScopedSchedulingHistories?.edges,
             'node',
           )}
         />

--- a/react/src/components/RouteSchedulingHistoryModal.tsx
+++ b/react/src/components/RouteSchedulingHistoryModal.tsx
@@ -5,31 +5,67 @@ import {
 } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import {
-  BAIButton,
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIModal,
   BAIModalProps,
-  BAIRouteSchedulingHistoryNodes,
+  BAIRouteSchedulingHistoryNodeTable,
   useFetchKey,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery } from 'react-relay';
+import {
+  graphql,
+  PreloadedQuery,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
+
+// Exported so the opener can `loadQuery` it in the click event (render-as-you-
+// fetch). Operation name must match the generated artifact; the const name only
+// differs to avoid clashing with the imported generated type.
+export const RouteSchedulingHistoryQuery = graphql`
+  query RouteSchedulingHistoryModalQuery(
+    $scope: RouteScope!
+    $filter: RouteHistoryFilter
+    $orderBy: [RouteHistoryOrderBy!]
+  ) {
+    routeScopedSchedulingHistories(
+      scope: $scope
+      filter: $filter
+      orderBy: $orderBy
+    ) {
+      edges {
+        node {
+          ...BAIRouteSchedulingHistoryNodeTableFragment
+        }
+      }
+    }
+  }
+`;
 
 interface RouteSchedulingHistoryModalProps extends Omit<
   BAIModalProps,
   'children' | 'title'
 > {
-  routeId: string;
+  /** Preloaded query reference produced by the opener via `useQueryLoader`. */
+  queryRef: PreloadedQuery<RouteSchedulingHistoryModalQuery>;
+  /**
+   * Re-run the query when filter / order / refresh changes. Same signature as
+   * `useQueryLoader`'s `loadQuery`, so the opener can pass it directly.
+   */
+  onReload: (
+    variables: RouteSchedulingHistoryModalQuery['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
 }
 
 const RouteSchedulingHistoryModal = ({
   open,
-  loading,
-  routeId,
+  queryRef,
+  onReload,
   onCancel,
   ...modalProps
 }: RouteSchedulingHistoryModalProps) => {
@@ -39,48 +75,26 @@ const RouteSchedulingHistoryModal = ({
   const [filter, setFilter] = useState<RouteHistoryFilter>();
   const [order, setOrder] = useState<string | null>('-updatedAt');
 
-  const deferredOpenValue = useDeferredValue(open);
-  const deferredFetchKey = useDeferredValue(fetchKey);
-  const deferredFilter = useDeferredValue(filter);
-  const deferredOrder = useDeferredValue(order);
-  const queryRef = useLazyLoadQuery<RouteSchedulingHistoryModalQuery>(
-    graphql`
-      query RouteSchedulingHistoryModalQuery(
-        $scope: RouteScope!
-        $filter: RouteHistoryFilter
-        $orderBy: [RouteHistoryOrderBy!]
-      ) {
-        routeScopedSchedulingHistories(
-          scope: $scope
-          filter: $filter
-          orderBy: $orderBy
-        ) {
-          edges {
-            node {
-              ...BAIRouteSchedulingHistoryNodesFragment
-            }
-          }
-        }
-      }
-    `,
-    {
-      scope: {
-        routeId: routeId,
-      },
-      filter: deferredFilter ?? undefined,
-      orderBy: convertToOrderBy<RouteHistoryOrderBy>(deferredOrder) ?? [
-        { field: 'UPDATED_AT', direction: 'DESC' },
-      ],
-    },
-    {
-      fetchKey: deferredFetchKey,
-      fetchPolicy: deferredOpenValue ? 'network-only' : 'store-only',
-    },
+  // Re-fetches happen from event handlers (filter / order / refresh), never from
+  // render or an effect. We carry the existing variables forward via
+  // `...queryRef.variables` (scope/routeId already live there) and override only
+  // what changed, so no separate variable builder is needed.
+
+  // Keep the previous result visible while the next one loads so re-fetches show
+  // the old data with an inline loading indicator instead of flashing the
+  // Suspense fallback. `deferredQueryRef !== queryRef` is the "additional
+  // loading in progress" signal.
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetchingInTransition = deferredQueryRef !== queryRef;
+
+  const data = usePreloadedQuery<RouteSchedulingHistoryModalQuery>(
+    RouteSchedulingHistoryQuery,
+    deferredQueryRef,
   );
+
   return (
     <BAIModal
       title={t('route.RouteSchedulingHistory')}
-      loading={loading || deferredOpenValue !== open}
       open={open}
       width={'90%'}
       style={{
@@ -91,17 +105,8 @@ const RouteSchedulingHistoryModal = ({
           minHeight: '80vh',
         },
       }}
-      footer={
-        <BAIButton
-          onClick={(e) =>
-            onCancel?.(
-              e as Parameters<NonNullable<BAIModalProps['onCancel']>>[0],
-            )
-          }
-        >
-          {t('button.Close')}
-        </BAIButton>
-      }
+      cancelText={t('button.Close')}
+      footer={(_originNode, { CancelBtn }) => <CancelBtn />}
       onCancel={onCancel}
       {...modalProps}
     >
@@ -109,7 +114,13 @@ const RouteSchedulingHistoryModal = ({
         <BAIFlex justify="between" wrap="wrap" gap="sm">
           <BAIGraphQLPropertyFilter
             value={filter}
-            onChange={setFilter}
+            onChange={(next) => {
+              setFilter(next);
+              onReload(
+                { ...queryRef.variables, filter: next },
+                { fetchPolicy: 'network-only' },
+              );
+            }}
             filterProperties={[
               {
                 key: 'id',
@@ -179,23 +190,31 @@ const RouteSchedulingHistoryModal = ({
           <BAIFlex>
             <BAIFetchKeyButton
               value={fetchKey}
-              onChange={updateFetchKey}
-              loading={deferredFetchKey !== fetchKey}
+              onChange={(key) => {
+                updateFetchKey(key);
+                onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+              }}
+              loading={isRefetchingInTransition}
               autoUpdateDelay={null}
             />
           </BAIFlex>
         </BAIFlex>
-        <BAIRouteSchedulingHistoryNodes
+        <BAIRouteSchedulingHistoryNodeTable
           resizable
-          loading={
-            deferredFetchKey !== fetchKey ||
-            deferredFilter !== filter ||
-            deferredOrder !== order
-          }
+          loading={isRefetchingInTransition}
           order={order}
-          onChangeOrder={setOrder}
+          onChangeOrder={(nextOrder) => {
+            setOrder(nextOrder);
+            onReload(
+              {
+                ...queryRef.variables,
+                orderBy: convertToOrderBy<RouteHistoryOrderBy>(nextOrder),
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          }}
           schedulingHistoryFrgmt={_.map(
-            queryRef.routeScopedSchedulingHistories?.edges,
+            data.routeScopedSchedulingHistories?.edges,
             'node',
           )}
         />
@@ -203,5 +222,4 @@ const RouteSchedulingHistoryModal = ({
     </BAIModal>
   );
 };
-
 export default RouteSchedulingHistoryModal;

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -33,7 +33,6 @@ import {
 import {
   BAIButton,
   BAICard,
-  BAIDeploymentStatusTag,
   BAIDeploymentStatus,
   BAIFlex,
   BAIUnmountAfterClose,
@@ -276,7 +275,6 @@ const DeploymentDetailPage: React.FC = () => {
         <Typography.Title level={3} style={{ margin: 0 }}>
           {deploymentName}
         </Typography.Title>
-        <BAIDeploymentStatusTag status={deploymentStatus} />
       </BAIFlex>
       <DeploymentConfigurationSection
         deploymentFrgmt={deployment}

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   RouteTrafficStatus,
 } from '../__generated__/EndpointDetailPageQuery.graphql';
 import { InferenceSessionErrorModalFragment$key } from '../__generated__/InferenceSessionErrorModalFragment.graphql';
+import { RouteSchedulingHistoryModalQuery } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import AutoScalingRuleEditorModalLegacy, {
   COMPARATOR_LABELS,
 } from '../components/AutoScalingRuleEditorModalLegacy';
@@ -29,7 +30,9 @@ import EndpointTokenGenerationModal from '../components/EndpointTokenGenerationM
 import { useFolderExplorerOpener } from '../components/FolderExplorerOpener';
 import ImageNodeSimpleTag from '../components/ImageNodeSimpleTag';
 import InferenceSessionErrorModal from '../components/InferenceSessionErrorModal';
-import RouteSchedulingHistoryModal from '../components/RouteSchedulingHistoryModal';
+import RouteSchedulingHistoryModal, {
+  RouteSchedulingHistoryQuery,
+} from '../components/RouteSchedulingHistoryModal';
 import SessionDetailDrawer from '../components/SessionDetailDrawer';
 import SourceCodeView from '../components/SourceCodeView';
 import SwitchToProjectButton from '../components/SwitchToProjectButton';
@@ -97,13 +100,19 @@ import {
   CircleArrowUpIcon,
 } from 'lucide-react';
 import React, {
+  startTransition,
   Suspense,
   useDeferredValue,
   useState,
   useTransition,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  useLazyLoadQuery,
+  useMutation,
+  useQueryLoader,
+} from 'react-relay';
 import { useParams } from 'react-router-dom';
 import { PayloadError } from 'relay-runtime';
 
@@ -200,7 +209,11 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
   const supportsRouteSchedulingHistory = baiClient.supports(
     'route-scheduling-history',
   );
-  const [historyRouteId, setHistoryRouteId] = useState<string | null>(null);
+  const [isRouteHistoryOpen, setIsRouteHistoryOpen] = useState(false);
+  const [routeHistoryQueryRef, loadRouteHistoryQuery] =
+    useQueryLoader<RouteSchedulingHistoryModalQuery>(
+      RouteSchedulingHistoryQuery,
+    );
   const [errorDataForJSONModal, setErrorDataForJSONModal] = useState<string>();
   const {
     endpoint,
@@ -1463,7 +1476,24 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               }
               onClickSchedulingHistory={
                 supportsRouteSchedulingHistory
-                  ? (routeId) => setHistoryRouteId(routeId)
+                  ? (routeId) => {
+                      // Open as a transition so a first-open suspend does not
+                      // flash the page-level Suspense fallback (the row icon
+                      // fires this as an urgent onClick).
+                      startTransition(() => {
+                        // Render-as-you-fetch: start the request in the open event.
+                        loadRouteHistoryQuery(
+                          {
+                            scope: { routeId },
+                            orderBy: [
+                              { field: 'UPDATED_AT', direction: 'DESC' },
+                            ],
+                          },
+                          { fetchPolicy: 'network-only' },
+                        );
+                        setIsRouteHistoryOpen(true);
+                      });
+                    }
                   : undefined
               }
               pagination={{
@@ -1621,11 +1651,16 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           setErrorDataForJSONModal(undefined);
         }}
       />
-      <RouteSchedulingHistoryModal
-        open={!!historyRouteId}
-        routeId={historyRouteId ?? ''}
-        onCancel={() => setHistoryRouteId(null)}
-      />
+      {routeHistoryQueryRef != null && (
+        <BAIUnmountAfterClose>
+          <RouteSchedulingHistoryModal
+            open={isRouteHistoryOpen}
+            queryRef={routeHistoryQueryRef}
+            onReload={loadRouteHistoryQuery}
+            onCancel={() => setIsRouteHistoryOpen(false)}
+          />
+        </BAIUnmountAfterClose>
+      )}
     </BAIFlex>
   );
 };


### PR DESCRIPTION
Resolves #7574 (FR-2964)

## Summary

Refactor both scheduling-history modals (route and deployment) from lazy fetching (`useLazyLoadQuery`) to **render-as-you-fetch**:

- The opener (`DeploymentReplicasTab`, `EndpointDetailPage`, `DeploymentConfigurationSection`) starts the request in the trigger button's `action` via `useQueryLoader`'s `loadQuery` (`store-and-network`), and the modal reads it with `usePreloadedQuery`. Starting the fetch outside render avoids the React 19 / StrictMode re-render→refetch behavior that `useLazyLoadQuery` exhibits, and the button's `action` loading state covers the open transition.
- Refetches (filter / order / refresh) carry the existing variables forward (`...queryRef.variables`) and use a **deferred query reference**, so previous rows stay visible with an inline loading indicator. `onReload` matches `loadQuery`'s signature, so the opener passes its loader directly (no wrapper, no separate variable builder).
- Fix `BAIModal` `footer` typing: re-type `footer` via a named `BAIModalFooterRender` union so the render-function form (`(node, { CancelBtn }) => …`) infers its parameter types without manual annotation. (antd's `ModalProps['footer']` resolves to `any` in this project, which dropped contextual inference.)
- Refactor `BAIUnmountAfterClose` to derive mount state synchronously — mounts on open without a one-render delay, unmounts after the close animation so internal modal state resets.
- Rename `BAIRouteSchedulingHistoryNodes` → `BAIRouteSchedulingHistoryNodeTable`.

## Notes

- Stacked on #7553 (FR-2950).
- The repo has pre-existing, environment-wide TypeScript baseline noise (unbuilt workspace types); the changed files add no new type errors and Relay compiles cleanly.

## Test plan

- [ ] Route modal: open from the endpoint route table and the deployment replicas table; filter / order / refresh keep rows visible with an inline loading indicator; clearing the sort removes ordering; close/reopen resets state.
- [ ] Deployment modal: open from the deployment overview "Scheduling History" button; same filter / order / refresh / close behavior.