### PR TITLE
fix(FR-2965): keep remaining filter tags when closing one tag

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
@@ -1,0 +1,96 @@
+import BAIGraphQLPropertyFilter, {
+  type FilterProperty,
+  type GraphQLFilter,
+} from './BAIGraphQLPropertyFilter';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+
+const filterProperties: Array<FilterProperty> = [
+  {
+    key: 'name',
+    propertyLabel: 'Name',
+    type: 'string',
+    fixedOperator: 'iContains',
+  },
+];
+
+// Controlled wrapper so closing a tag triggers a real re-render with the
+// updated filter value (mirrors how consumers pass value/onChange).
+const Controlled = ({ initial }: { initial: GraphQLFilter | undefined }) => {
+  const [value, setValue] = useState<GraphQLFilter | undefined>(initial);
+  return (
+    <BAIGraphQLPropertyFilter
+      filterProperties={filterProperties}
+      value={value}
+      onChange={setValue}
+    />
+  );
+};
+
+describe('BAIGraphQLPropertyFilter tag removal', () => {
+  const twoFilters: GraphQLFilter = {
+    AND: [{ name: { iContains: 'alpha' } }, { name: { iContains: 'beta' } }],
+  };
+
+  it('removes only the closed tag and keeps the rest visible (FR-2965)', async () => {
+    render(<Controlled initial={twoFilters} />);
+
+    // Both tags are present and visible initially.
+    const alphaTag = screen.getByText(/Name.*alpha/);
+    const betaTag = screen.getByText(/Name.*beta/);
+    expect(alphaTag).toBeVisible();
+    expect(betaTag).toBeVisible();
+
+    // Close the FIRST tag.
+    const closeIcons = document.querySelectorAll('.ant-tag-close-icon');
+    expect(closeIcons.length).toBe(2);
+    fireEvent.click(closeIcons[0]);
+
+    // The first filter is gone; the second remains VISIBLE (regression: it
+    // previously became `ant-tag-hidden` because antd Tag self-hid and the
+    // surviving condition reused that hidden instance).
+    await waitFor(() => {
+      expect(screen.queryByText(/Name.*alpha/)).not.toBeInTheDocument();
+    });
+    const remaining = screen.getByText(/Name.*beta/);
+    expect(remaining).toBeVisible();
+    expect(remaining.closest('.ant-tag')).not.toHaveClass('ant-tag-hidden');
+  });
+
+  it('emits the remaining condition via onChange when one of two tags is closed', async () => {
+    const onChange = vi.fn();
+    render(
+      <BAIGraphQLPropertyFilter
+        filterProperties={filterProperties}
+        value={twoFilters}
+        onChange={onChange}
+      />,
+    );
+
+    const closeIcons = document.querySelectorAll('.ant-tag-close-icon');
+    fireEvent.click(closeIcons[0]);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ name: { iContains: 'beta' } });
+    });
+  });
+
+  it('clears the filter when the only tag is closed', async () => {
+    const onChange = vi.fn();
+    render(
+      <BAIGraphQLPropertyFilter
+        filterProperties={filterProperties}
+        value={{ name: { iContains: 'solo' } }}
+        onChange={onChange}
+      />,
+    );
+
+    const closeIcon = document.querySelector('.ant-tag-close-icon');
+    expect(closeIcon).toBeInTheDocument();
+    fireEvent.click(closeIcon!);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(undefined);
+    });
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -477,6 +477,12 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
 
   // Reassign sequential ids: the converter generates random ids per call,
   // which would change every render and remount every Tag.
+  // NOTE: these ids are positional, so closing a tag re-keys the survivors.
+  // The Tag's `onClose` therefore calls `e.preventDefault()` to stop antd's
+  // internal self-hide — otherwise the hidden instance would be reused for a
+  // surviving condition (see `renderConditionTag`). Positional (not
+  // content-based) ids are intentional: duplicate conditions are allowed, so
+  // content-based keys would collide.
   const conditions = convertGraphQLFilterToConditions(
     value,
     filterProperties,
@@ -629,7 +635,16 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
       <Tag
         key={condition.id}
         closable
-        onClose={() => removeCondition(condition.id)}
+        onClose={(e) => {
+          // antd Tag self-hides via its internal `visible` state on close
+          // unless the close event is prevented. Because tags are re-keyed
+          // positionally (`cond-${i}`), the self-hidden instance gets reused
+          // for the surviving condition after the re-render, making the wrong
+          // tag (or every tag) vanish. Prevent the default self-hide and let
+          // removal be driven purely by the conditions array.
+          e.preventDefault();
+          removeCondition(condition.id);
+        }}
         style={{ margin: 0 }}
         title={`${condition.propertyLabel} ${getOperatorLabel(condition.operator)} ${condition.value}`}
       >

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
@@ -3,6 +3,7 @@ import BAIPropertyFilter, {
   parseFilterValue,
 } from './BAIPropertyFilter';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 
 describe('parseFilterValue', () => {
   it('should correctly parse filter with binary operators', () => {
@@ -416,5 +417,75 @@ describe('BAIPropertyFilter Component', () => {
 
     // Should not call onChange for invalid value
     expect(mockOnChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('BAIPropertyFilter tag removal (FR-2965)', () => {
+  const filterProperties = [
+    {
+      key: 'name',
+      propertyLabel: 'Name',
+      type: 'string' as const,
+      defaultOperator: 'ilike',
+    },
+    {
+      key: 'description',
+      propertyLabel: 'Description',
+      type: 'string' as const,
+      defaultOperator: 'ilike',
+    },
+  ];
+
+  // Controlled wrapper so closing a tag triggers a real re-render with the
+  // updated value (mirrors how consumers pass value/onChange).
+  const Controlled = ({ initial }: { initial: string }) => {
+    const [value, setValue] = useState<string>(initial);
+    return (
+      <BAIPropertyFilter
+        filterProperties={filterProperties}
+        value={value}
+        onChange={setValue}
+      />
+    );
+  };
+
+  it('keeps the surviving tag visible when two filters share the same value', async () => {
+    // Same parsed value "%dup%" for two different properties. The positional
+    // part of the tag key would otherwise reuse the just-hidden instance.
+    render(
+      <Controlled initial={'name ilike "%dup%" & description ilike "%dup%"'} />,
+    );
+
+    expect(screen.getByText(/Name:/)).toBeVisible();
+    expect(screen.getByText(/Description:/)).toBeVisible();
+
+    const closeIcons = document.querySelectorAll('.ant-tag-close-icon');
+    expect(closeIcons.length).toBe(2);
+    fireEvent.click(closeIcons[0]); // close the "Name" tag
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Name:/)).not.toBeInTheDocument();
+    });
+    const remaining = screen.getByText(/Description:/);
+    expect(remaining).toBeVisible();
+    expect(remaining.closest('.ant-tag')).not.toHaveClass('ant-tag-hidden');
+  });
+
+  it('emits the remaining filter via onChange when one of two tags is closed', async () => {
+    const onChange = vi.fn();
+    render(
+      <BAIPropertyFilter
+        filterProperties={filterProperties}
+        value={'name ilike "%alpha%" & description ilike "%beta%"'}
+        onChange={onChange}
+      />,
+    );
+
+    const closeIcons = document.querySelectorAll('.ant-tag-close-icon');
+    fireEvent.click(closeIcons[0]);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('description ilike "%beta%"');
+    });
   });
 });

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -402,7 +402,17 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
             <Tag
               key={item.key}
               closable
-              onClose={() => remove(item.key)}
+              onClose={(e) => {
+                // antd Tag self-hides via its internal `visible` state on
+                // close unless the event is prevented. `item.key` is
+                // `index + value`, so after a removal the survivors are
+                // re-indexed; a remaining tag that shares the same value as
+                // the removed one inherits its old key and reuses the
+                // just-hidden instance, hiding the wrong tag. Prevent the
+                // default self-hide so removal is driven solely by the value.
+                e.preventDefault();
+                remove(item.key);
+              }}
               style={{ margin: 0 }}
             >
               {item.propertyLabel}:{' '}


### PR DESCRIPTION
Resolves #7576 (FR-2965)

## Summary

Closing a filter tag could make **other** filter tags disappear. Both shared filter components keep antd `Tag`'s self-hide behavior on close (antd's `Tag` toggles its own internal `visible` state unless the close event is prevented) while re-keying tags with a positional component — so after a removal the just-hidden Tag instance gets reused for a surviving condition, hiding the wrong tag.

- **`BAIGraphQLPropertyFilter`** — tags are keyed positionally (`cond-${i}`). Closing the first of several tags hid **every** remaining tag (it became `ant-tag-hidden` / `display:none`), leaving the filter unusable. Affects the deployment / route / session scheduling history modals and list-page GraphQL filters.
- **`BAIPropertyFilter`** — tags are keyed as `index + value`. The same bug surfaces when two filters share the same parsed value (e.g. filtering two different properties by the same text): closing the first reused the just-hidden instance and hid the survivor.

### Fix

- Call `e.preventDefault()` in each `Tag`'s `onClose` so antd no longer self-hides the tag; removal is driven solely by the value / conditions re-render.
- Positional keys are kept intentionally (duplicate conditions are allowed, so content-based keys would collide); a cross-reference comment documents the coupling.

## Test plan

- [x] Added regression tests for both components (`BAIGraphQLPropertyFilter.test.tsx`, `BAIPropertyFilter.test.tsx`): closing one of two tags keeps the other visible and **not** `ant-tag-hidden`, plus onChange-payload and single-tag-clear cases. Verified each new "surviving tag" test **fails without the fix** and passes with it.
- [x] `vitest run` on both files: all green (BAIPropertyFilter 27 passed, BAIGraphQLPropertyFilter 3 passed).
- [x] Verified live on the dev server (`/deployments` GraphQL filter): add two filters, close the first → only the second remains visible (before the fix both vanished — confirmed via a before/after run measuring `.ant-tag:visible`).
- [x] `scripts/verify.sh`: Relay / Lint / Format pass; tsc reports only pre-existing `@types/react` phantom errors on unrelated files in fresh worktrees (none reference the changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)