### PR TITLE
feat(FR-2868): show unified-memory accelerators as "Unified" in resource displays and launcher

### DIFF
--- a/react/src/components/ResourceNumber.tsx
+++ b/react/src/components/ResourceNumber.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { convertToBinaryUnit } from '../helper';
-import { ResourceSlotName } from '../hooks/backendai';
+import { isUnifiedAcceleratorSlot, ResourceSlotName } from '../hooks/backendai';
 import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
 import ImageWithFallback from './ImageWithFallback';
 import { Tooltip, Typography, theme } from 'antd';
@@ -15,6 +15,7 @@ import {
 import * as _ from 'lodash-es';
 import { CpuIcon, MemoryStickIcon, MicrochipIcon } from 'lucide-react';
 import React, { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export type ResourceOpts = {
   shmem?: number;
@@ -36,11 +37,38 @@ const ResourceNumber: React.FC<ResourceNumberProps> = ({
   hideTooltip = false,
   max,
 }) => {
+  'use memo';
+  const { t } = useTranslation();
   const { token } = theme.useToken();
   const currentGroup = useCurrentResourceGroupValue();
   const { mergedResourceSlots } = useResourceSlotsDetails(
     currentGroup || undefined,
   );
+
+  // Unified-memory accelerator slots (e.g. `cuda.unified`) have no dedicated
+  // memory — they share the host memory pool. Rendering their numeric value
+  // alongside `mem` would double-count the same physical memory, so show a
+  // "Unified" label instead, with the explanation in a tooltip.
+  if (isUnifiedAcceleratorSlot(type)) {
+    const label = (
+      <Typography.Text type="secondary">
+        {t('session.launcher.Unified')}
+      </Typography.Text>
+    );
+    return (
+      <BAIFlex direction="row" gap="xxs">
+        <ResourceTypeIcon type={type} showTooltip={!hideTooltip} />
+        {hideTooltip ? (
+          label
+        ) : (
+          <Tooltip title={t('session.launcher.UnifiedAcceleratorMemoryNote')}>
+            {label}
+          </Tooltip>
+        )}
+        {extra}
+      </BAIFlex>
+    );
+  }
 
   const formatAmount = (amount: string) => {
     const roundLength =

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
@@ -8,7 +8,78 @@ import {
   ResourcePreset,
 } from '../../hooks/useResourceLimitAndRemaining';
 import { Image } from '../ImageEnvironmentSelectFormItems';
-import { getAllocatablePresetNames } from './ResourceAllocationFormItems';
+import {
+  getAllocatablePresetNames,
+  getUnifiedAcceleratorValueFromMem,
+  isUnifiedAcceleratorSlot,
+} from './ResourceAllocationFormItems';
+
+describe('getUnifiedAcceleratorValueFromMem', () => {
+  const slotsGiB = { 'cuda.unified': { display_unit: 'GiB' } };
+  const slotsMiB = { 'cuda.unified': { display_unit: 'MiB' } };
+  const slotsTiB = { 'cuda.unified': { display_unit: 'TiB' } };
+  const slotsNoMeta = { 'cuda.unified': {} };
+  const slotsUnknownUnit = { 'cuda.unified': { display_unit: 'foo' } };
+
+  it('returns mem converted to the slot display unit (GiB)', () => {
+    expect(
+      getUnifiedAcceleratorValueFromMem('8g', 'cuda.unified', slotsGiB),
+    ).toBe(8);
+  });
+
+  it('returns mem converted to the slot display unit (MiB)', () => {
+    expect(
+      getUnifiedAcceleratorValueFromMem('8g', 'cuda.unified', slotsMiB),
+    ).toBe(8192);
+  });
+
+  it('returns mem converted to the slot display unit (TiB)', () => {
+    expect(
+      getUnifiedAcceleratorValueFromMem('2048g', 'cuda.unified', slotsTiB),
+    ).toBe(2);
+  });
+
+  it('falls back to GiB when slot metadata has no display_unit', () => {
+    expect(
+      getUnifiedAcceleratorValueFromMem('8g', 'cuda.unified', slotsNoMeta),
+    ).toBe(8);
+  });
+
+  it('falls back to GiB when display_unit is unrecognized', () => {
+    expect(
+      getUnifiedAcceleratorValueFromMem('8g', 'cuda.unified', slotsUnknownUnit),
+    ).toBe(8);
+  });
+
+  it('returns 0 for undefined or zero mem', () => {
+    expect(
+      getUnifiedAcceleratorValueFromMem(undefined, 'cuda.unified', slotsGiB),
+    ).toBe(0);
+    expect(getUnifiedAcceleratorValueFromMem(0, 'cuda.unified', slotsGiB)).toBe(
+      0,
+    );
+  });
+});
+
+describe('isUnifiedAcceleratorSlot', () => {
+  it('returns true for slot names ending with .unified', () => {
+    expect(isUnifiedAcceleratorSlot('cuda.unified')).toBe(true);
+    expect(isUnifiedAcceleratorSlot('rocm.unified')).toBe(true);
+  });
+
+  it('returns false for discrete accelerator slot names', () => {
+    expect(isUnifiedAcceleratorSlot('cuda.shares')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('cuda.device')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('cuda.mem')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('rocm.device')).toBe(false);
+  });
+
+  it('returns false for nullish or empty input', () => {
+    expect(isUnifiedAcceleratorSlot(undefined)).toBe(false);
+    expect(isUnifiedAcceleratorSlot(null)).toBe(false);
+    expect(isUnifiedAcceleratorSlot('')).toBe(false);
+  });
+});
 
 describe('getAllocatablePresetNames', () => {
   const presets: Array<ResourcePreset> = [

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
@@ -11,7 +11,6 @@ import { Image } from '../ImageEnvironmentSelectFormItems';
 import {
   getAllocatablePresetNames,
   getUnifiedAcceleratorValueFromMem,
-  isUnifiedAcceleratorSlot,
 } from './ResourceAllocationFormItems';
 
 describe('getUnifiedAcceleratorValueFromMem', () => {
@@ -58,26 +57,6 @@ describe('getUnifiedAcceleratorValueFromMem', () => {
     expect(getUnifiedAcceleratorValueFromMem(0, 'cuda.unified', slotsGiB)).toBe(
       0,
     );
-  });
-});
-
-describe('isUnifiedAcceleratorSlot', () => {
-  it('returns true for slot names ending with .unified', () => {
-    expect(isUnifiedAcceleratorSlot('cuda.unified')).toBe(true);
-    expect(isUnifiedAcceleratorSlot('rocm.unified')).toBe(true);
-  });
-
-  it('returns false for discrete accelerator slot names', () => {
-    expect(isUnifiedAcceleratorSlot('cuda.shares')).toBe(false);
-    expect(isUnifiedAcceleratorSlot('cuda.device')).toBe(false);
-    expect(isUnifiedAcceleratorSlot('cuda.mem')).toBe(false);
-    expect(isUnifiedAcceleratorSlot('rocm.device')).toBe(false);
-  });
-
-  it('returns false for nullish or empty input', () => {
-    expect(isUnifiedAcceleratorSlot(undefined)).toBe(false);
-    expect(isUnifiedAcceleratorSlot(null)).toBe(false);
-    expect(isUnifiedAcceleratorSlot('')).toBe(false);
   });
 });
 

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -10,7 +10,10 @@ import {
   getDisplayUnitToInputSizeUnit,
 } from '../../helper';
 import { useSuspendedBackendaiClient } from '../../hooks';
-import { useResourceSlots } from '../../hooks/backendai';
+import {
+  isUnifiedAcceleratorSlot,
+  useResourceSlots,
+} from '../../hooks/backendai';
 import { useCurrentKeyPairResourcePolicyLazyLoadQuery } from '../../hooks/hooksUsingRelay';
 import { useCurrentProjectValue } from '../../hooks/useCurrentProject';
 import {
@@ -28,7 +31,7 @@ import ResourcePresetSelect from '../ResourcePresetSelect';
 import RemainingMark from './RemainingMark';
 import SharedMemoryFormItems from './SharedMemoryFormItems';
 import { QuestionCircleOutlined, ReloadOutlined } from '@ant-design/icons';
-import { Button, Card, Col, Form, Radio, Row, Tooltip, theme } from 'antd';
+import { Button, Card, Col, Form, Radio, Row, Tag, Tooltip, theme } from 'antd';
 import {
   useResourceSlotsDetails,
   BAIFlex,
@@ -64,16 +67,6 @@ export const isMinOversMaxValue = (min: number, max: number) => {
 };
 
 /**
- * Returns true when the given accelerator slot name represents a unified
- * memory architecture, where the accelerator memory and the host memory
- * share a single physical pool. Identified by a `.unified` suffix on the
- * slot name (e.g. `cuda.unified`).
- */
-export const isUnifiedAcceleratorSlot = (slotName?: string | null): boolean => {
-  return !!slotName && _.endsWith(slotName, '.unified');
-};
-
-/**
  * Returns the accelerator-field number derived from the host memory value
  * for a unified-memory slot. Reads the slot's `display_unit` from
  * `mergedResourceSlots` and converts `mem` to that unit. Falls back to
@@ -91,6 +84,27 @@ export const getUnifiedAcceleratorValueFromMem = (
     : undefined;
   const targetUnit = getDisplayUnitToInputSizeUnit(displayUnit) || 'g';
   return convertToBinaryUnit(mem || '0g', targetUnit)?.number ?? 0;
+};
+
+/**
+ * Read-only stand-in for the accelerator number input when a unified-memory
+ * slot is selected. The accelerator value is derived from host memory and
+ * managed by the form, so instead of an editable number we render a "Unified"
+ * tag alongside the accelerator-type selector (kept available so the user can
+ * still switch slot types). Accepts and ignores the `value` / `onChange`
+ * props injected by the enclosing `Form.Item`.
+ */
+const UnifiedAcceleratorInput: React.FC<{
+  addonAfter?: React.ReactNode;
+}> = ({ addonAfter }) => {
+  'use memo';
+  const { t } = useTranslation();
+  return (
+    <BAIFlex gap="xs" align="center">
+      <Tag>{t('session.launcher.Unified')}</Tag>
+      {addonAfter}
+    </BAIFlex>
+  );
 };
 
 export interface ResourceAllocationFormValue {
@@ -252,10 +266,7 @@ const ResourceAllocationFormItems: React.FC<
 
   // Get supported accelerator types in resource group by image
   const supportedAcceleratorTypesInRGByImage = useMemo(() => {
-    if (
-      _.isUndefined(acceleratorSlotsInRG) ||
-      (_.isNil(currentImage) && _.isEmpty(currentEnvironmentManual))
-    ) {
+    if (_.isUndefined(acceleratorSlotsInRG) || _.isNil(currentImage)) {
       return undefined;
     }
     return _.keys(acceleratorSlotsInRG).filter((acceleratorTypeName) => {
@@ -1050,6 +1061,93 @@ const ResourceAllocationFormItems: React.FC<
                         ) * currentAcceleratorStep
                       : undefined;
 
+                    // Accelerator type selector. Shared between the discrete
+                    // slider (rendered as the input's `addonAfter`) and the
+                    // unified-memory indicator, so switching slot types stays
+                    // available in both modes.
+                    const acceleratorTypeSelect =
+                      (supportedAcceleratorTypesInRGByImage?.length ?? 0) >
+                      0 ? (
+                        <Form.Item
+                          noStyle
+                          name={['resource', 'acceleratorType']}
+                          initialValue={_.first(_.keys(acceleratorSlotsInRG))}
+                        >
+                          <BAISelect
+                            style={{
+                              width: 75,
+                            }}
+                            autoSelectOption
+                            tabIndex={-1}
+                            // Do not delete disabled prop. It is necessary to prevent the user from changing the value.
+                            suffixIcon={
+                              _.size(acceleratorSlotsInRG) > 1
+                                ? undefined
+                                : null
+                            }
+                            popupMatchSelectWidth={false}
+                            options={_.map(
+                              acceleratorSlotsInRG,
+                              (_value, name) => {
+                                return {
+                                  value: name,
+                                  label:
+                                    mergedResourceSlots?.[name]?.display_unit ||
+                                    'UNIT',
+                                  disabled: !_.includes(
+                                    supportedAcceleratorTypesInRGByImage,
+                                    name,
+                                  ),
+                                };
+                              },
+                            )}
+                            onChange={(nextType: string) => {
+                              // Changing the slot type mutates the active
+                              // allocation; the previously selected preset no
+                              // longer matches.
+                              form.setFieldValue('allocationPreset', 'custom');
+                              // Keep the accelerator field consistent at the
+                              // moment the slot type changes, rather than
+                              // relying on a watcher effect that runs after
+                              // render.
+                              if (isUnifiedAcceleratorSlot(nextType)) {
+                                // Switching INTO a unified slot: mirror the
+                                // current `mem` value converted to the slot's
+                                // display unit. Write acceleratorType first so
+                                // the shared helper sees the new active slot
+                                // when it reads from the form.
+                                form.setFieldValue(
+                                  ['resource', 'acceleratorType'],
+                                  nextType,
+                                );
+                                syncUnifiedAcceleratorIfNeeded();
+                              } else if (
+                                isUnifiedAcceleratorSlot(currentAcceleratorType)
+                              ) {
+                                // Switching OUT of a unified slot into a
+                                // discrete one: reset to the discrete slot's
+                                // min so the stale mirrored GiB value from
+                                // unified mode does not bleed through as a
+                                // device count.
+                                //
+                                // Discrete-to-discrete switches are
+                                // intentionally NOT reset here:
+                                // ensureValidAcceleratorType clamps the
+                                // existing value if it falls outside the new
+                                // slot's range, so the user's current
+                                // allocation is preserved across discrete slot
+                                // changes.
+                                form.setFieldValue(
+                                  ['resource', 'accelerator'],
+                                  resourceLimits.accelerators[nextType]?.min ??
+                                    0,
+                                );
+                              }
+                            }}
+                          />
+                        </Form.Item>
+                      ) : undefined;
+
                     return (
                       <Form.Item
                         name={['resource', 'accelerator']}
@@ -1223,164 +1321,75 @@ const ResourceAllocationFormItems: React.FC<
                               ]
                         }
                       >
-                        <InputNumberWithSlider
-                          inputContainerMinWidth={190}
-                          sliderProps={{
-                            marks: {
-                              0: 0,
-                              // remaining mark code should be located before max mark code to prevent overlapping when it is same value
-                              ...(adjustedRemainingMarkValue &&
-                              showRemainingWarning
-                                ? {
-                                    [adjustedRemainingMarkValue]: {
-                                      label: <RemainingMark />,
-                                    },
-                                  }
-                                : {}),
-                              ...(_.isNumber(
-                                resourceLimits.accelerators[
-                                  currentAcceleratorType
-                                ]?.max,
-                              )
-                                ? {
-                                    // @ts-ignore
-                                    [resourceLimits.accelerators[
-                                      currentAcceleratorType
-                                    ]?.max]:
-                                      resourceLimits.accelerators[
-                                        currentAcceleratorType
-                                      ]?.max,
-                                  }
-                                : {}),
-                              ...(isUniqueType ? { 1: 1 } : {}),
-                            },
-                            tooltip: {
-                              formatter: (value = 0) => {
-                                return `${value} ${mergedResourceSlots?.[currentAcceleratorType]?.display_unit || ''}`;
-                              },
-                              open:
-                                supportedAcceleratorTypesInRGByImage?.length ===
-                                0
-                                  ? false
-                                  : undefined,
-                            },
-                          }}
-                          disabled={
-                            supportedAcceleratorTypesInRGByImage?.length ===
-                              0 || isUnifiedType
-                          }
-                          min={0}
-                          max={
-                            // Unique type should only allow 0 or 1
-                            isUniqueType
-                              ? 1
-                              : resourceLimits.accelerators[
-                                  currentAcceleratorType
-                                ]?.max
-                          }
-                          step={currentAcceleratorStep}
-                          onChange={() => {
-                            form.setFieldValue('allocationPreset', 'custom');
-                          }}
-                          inputNumberProps={{
-                            addonAfter:
-                              (supportedAcceleratorTypesInRGByImage?.length ??
-                                0) > 0 ? (
-                                <Form.Item
-                                  name={['resource', 'acceleratorType']}
-                                  initialValue={_.first(
-                                    _.keys(acceleratorSlotsInRG),
-                                  )}
-                                  style={{
-                                    marginBottom: 0,
-                                    maxWidth: 100,
-                                  }}
-                                >
-                                  <BAISelect
-                                    style={{
-                                      width: '100%',
-                                    }}
-                                    autoSelectOption
-                                    tabIndex={-1}
-                                    // Do not delete disabled prop. It is necessary to prevent the user from changing the value.
-                                    suffixIcon={
-                                      _.size(acceleratorSlotsInRG) > 1
-                                        ? undefined
-                                        : null
-                                    }
-                                    popupMatchSelectWidth={false}
-                                    options={_.map(
-                                      acceleratorSlotsInRG,
-                                      (_value, name) => {
-                                        return {
-                                          value: name,
-                                          label:
-                                            mergedResourceSlots?.[name]
-                                              ?.display_unit || 'UNIT',
-                                          disabled: !_.includes(
-                                            supportedAcceleratorTypesInRGByImage,
-                                            name,
-                                          ),
-                                        };
+                        {isUnifiedType ? (
+                          <UnifiedAcceleratorInput
+                            addonAfter={acceleratorTypeSelect}
+                          />
+                        ) : (
+                          <InputNumberWithSlider
+                            inputContainerMinWidth={190}
+                            sliderProps={{
+                              marks: {
+                                0: 0,
+                                // remaining mark code should be located before max mark code to prevent overlapping when it is same value
+                                ...(adjustedRemainingMarkValue &&
+                                showRemainingWarning
+                                  ? {
+                                      [adjustedRemainingMarkValue]: {
+                                        label: <RemainingMark />,
                                       },
-                                    )}
-                                    onChange={(nextType: string) => {
-                                      // Changing the slot type mutates the
-                                      // active allocation; the previously
-                                      // selected preset no longer matches.
-                                      form.setFieldValue(
-                                        'allocationPreset',
-                                        'custom',
-                                      );
-                                      // Keep the accelerator field consistent
-                                      // at the moment the slot type changes,
-                                      // rather than relying on a watcher
-                                      // effect that runs after render.
-                                      if (isUnifiedAcceleratorSlot(nextType)) {
-                                        // Switching INTO a unified slot:
-                                        // mirror the current `mem` value
-                                        // converted to the slot's display
-                                        // unit. Write acceleratorType first
-                                        // so the shared helper sees the new
-                                        // active slot when it reads from the
-                                        // form.
-                                        form.setFieldValue(
-                                          ['resource', 'acceleratorType'],
-                                          nextType,
-                                        );
-                                        syncUnifiedAcceleratorIfNeeded();
-                                      } else if (
-                                        isUnifiedAcceleratorSlot(
-                                          currentAcceleratorType,
-                                        )
-                                      ) {
-                                        // Switching OUT of a unified slot
-                                        // into a discrete one: reset to the
-                                        // discrete slot's min so the stale
-                                        // mirrored GiB value from unified
-                                        // mode does not bleed through as a
-                                        // device count.
-                                        //
-                                        // Discrete-to-discrete switches are
-                                        // intentionally NOT reset here:
-                                        // ensureValidAcceleratorType clamps
-                                        // the existing value if it falls
-                                        // outside the new slot's range, so
-                                        // the user's current allocation is
-                                        // preserved across discrete slot
-                                        // changes.
-                                        form.setFieldValue(
-                                          ['resource', 'accelerator'],
-                                          resourceLimits.accelerators[nextType]
-                                            ?.min ?? 0,
-                                        );
-                                      }
-                                    }}
-                                  />
-                                </Form.Item>
-                              ) : undefined,
-                          }}
-                        />
+                                    }
+                                  : {}),
+                                ...(_.isNumber(
+                                  resourceLimits.accelerators[
+                                    currentAcceleratorType
+                                  ]?.max,
+                                )
+                                  ? {
+                                      // @ts-ignore
+                                      [resourceLimits.accelerators[
+                                        currentAcceleratorType
+                                      ]?.max]:
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.max,
+                                    }
+                                  : {}),
+                                ...(isUniqueType ? { 1: 1 } : {}),
+                              },
+                              tooltip: {
+                                formatter: (value = 0) => {
+                                  return `${value} ${mergedResourceSlots?.[currentAcceleratorType]?.display_unit || ''}`;
+                                },
+                                open:
+                                  supportedAcceleratorTypesInRGByImage?.length ===
+                                  0
+                                    ? false
+                                    : undefined,
+                              },
+                            }}
+                            disabled={
+                              supportedAcceleratorTypesInRGByImage?.length ===
+                                0 || isUnifiedType
+                            }
+                            min={0}
+                            max={
+                              // Unique type should only allow 0 or 1
+                              isUniqueType
+                                ? 1
+                                : resourceLimits.accelerators[
+                                    currentAcceleratorType
+                                  ]?.max
+                            }
+                            step={currentAcceleratorStep}
+                            onChange={() => {
+                              form.setFieldValue('allocationPreset', 'custom');
+                            }}
+                            inputNumberProps={{
+                              addonAfter: acceleratorTypeSelect,
+                            }}
+                          />
+                        )}
                       </Form.Item>
                     );
                   }}

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -7,6 +7,7 @@ import {
   addNumberWithUnits,
   compareNumberWithUnits,
   convertToBinaryUnit,
+  getDisplayUnitToInputSizeUnit,
 } from '../../helper';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import { useResourceSlots } from '../../hooks/backendai';
@@ -60,6 +61,36 @@ export const RESOURCE_ALLOCATION_INITIAL_FORM_VALUES: DeepPartial<ResourceAlloca
 
 export const isMinOversMaxValue = (min: number, max: number) => {
   return min >= max;
+};
+
+/**
+ * Returns true when the given accelerator slot name represents a unified
+ * memory architecture, where the accelerator memory and the host memory
+ * share a single physical pool. Identified by a `.unified` suffix on the
+ * slot name (e.g. `cuda.unified`).
+ */
+export const isUnifiedAcceleratorSlot = (slotName?: string | null): boolean => {
+  return !!slotName && _.endsWith(slotName, '.unified');
+};
+
+/**
+ * Returns the accelerator-field number derived from the host memory value
+ * for a unified-memory slot. Reads the slot's `display_unit` from
+ * `mergedResourceSlots` and converts `mem` to that unit. Falls back to
+ * `'g'` (GiB) when the display unit is unavailable or unrecognized.
+ */
+export const getUnifiedAcceleratorValueFromMem = (
+  mem: string | number | undefined,
+  slotName: string | undefined,
+  mergedResourceSlots:
+    | Record<string, { display_unit?: string } | undefined>
+    | undefined,
+): number => {
+  const displayUnit = slotName
+    ? mergedResourceSlots?.[slotName]?.display_unit
+    : undefined;
+  const targetUnit = getDisplayUnitToInputSizeUnit(displayUnit) || 'g';
+  return convertToBinaryUnit(mem || '0g', targetUnit)?.number ?? 0;
 };
 
 export interface ResourceAllocationFormValue {
@@ -289,6 +320,28 @@ const ResourceAllocationFormItems: React.FC<
     }
   };
 
+  // Centralized helper that keeps the `resource.accelerator` field in sync
+  // with `resource.mem` whenever the active accelerator slot is a unified
+  // one. Call this from every code path that mutates `resource.mem` or
+  // `resource.acceleratorType` so submit-time form state is consistent.
+  const syncUnifiedAcceleratorIfNeeded = useEventNotStable(() => {
+    const activeAcceleratorType = form.getFieldValue([
+      'resource',
+      'acceleratorType',
+    ]);
+    if (!isUnifiedAcceleratorSlot(activeAcceleratorType)) {
+      return;
+    }
+    form.setFieldValue(
+      ['resource', 'accelerator'],
+      getUnifiedAcceleratorValueFromMem(
+        form.getFieldValue(['resource', 'mem']),
+        activeAcceleratorType,
+        mergedResourceSlots,
+      ),
+    );
+  });
+
   const ensureValidAcceleratorType = useEventNotStable(() => {
     const currentAcceleratorType = form.getFieldValue([
       'resource',
@@ -305,6 +358,9 @@ const ResourceAllocationFormItems: React.FC<
         acceleratorType: nextAcceleratorType || currentAcceleratorType,
       },
     });
+    // The accelerator type may have changed; mirror `mem` into the
+    // accelerator field if the resolved type is a unified slot.
+    syncUnifiedAcceleratorIfNeeded();
   });
 
   const updateResourceFieldsBasedOnImage = useEventNotStable(
@@ -410,6 +466,9 @@ const ResourceAllocationFormItems: React.FC<
       if (form.getFieldValue('enabledAutomaticShmem')) {
         runShmemAutomationRule(form.getFieldValue(['resource', 'mem']) || '0g');
       }
+      // mem and/or acceleratorType may have changed above; keep the
+      // accelerator field consistent for unified slots.
+      syncUnifiedAcceleratorIfNeeded();
       form
         .validateFields(['resource'], {
           recursive: true,
@@ -467,6 +526,9 @@ const ResourceAllocationFormItems: React.FC<
       if (!hasPresetShmem) {
         runShmemAutomationRule(mem || '0g');
       }
+      // mem and/or acceleratorType may have changed above; keep the
+      // accelerator field consistent for unified slots.
+      syncUnifiedAcceleratorIfNeeded();
 
       form
         .validateFields(['resource'], {
@@ -888,6 +950,13 @@ const ResourceAllocationFormItems: React.FC<
                                 ) {
                                   runShmemAutomationRule(M_plus_S || '0g');
                                 }
+                                // When the active accelerator slot is a
+                                // unified-memory slot, the accelerator field
+                                // shares a single pool with host memory.
+                                // Derive the accelerator value from `mem` at
+                                // the source of change so submit-time form
+                                // state is always consistent.
+                                syncUnifiedAcceleratorIfNeeded();
                               }}
                             />
                           </Form.Item>
@@ -945,6 +1014,10 @@ const ResourceAllocationFormItems: React.FC<
                         currentAcceleratorType as keyof typeof resourceSlots
                       ] === 'unique';
 
+                    const isUnifiedType = isUnifiedAcceleratorSlot(
+                      currentAcceleratorType,
+                    );
+
                     const isSingleCluster =
                       form.getFieldValue('cluster_size') < 2;
                     const hasQuantumSize = _.isNumber(
@@ -989,136 +1062,166 @@ const ResourceAllocationFormItems: React.FC<
                             />
                           ),
                         }}
+                        extra={
+                          isUnifiedType
+                            ? t('session.launcher.UnifiedAcceleratorMemoryNote')
+                            : undefined
+                        }
                         dependencies={[
                           ['resource', 'acceleratorType'],
                           'cluster_size',
+                          ['resource', 'mem'],
                         ]}
-                        rules={[
-                          {
-                            required:
-                              currentImageAcceleratorLimits &&
-                              currentImageAcceleratorLimits.length > 0,
-                          },
-                          {
-                            type: 'number',
-                            min:
-                              resourceLimits.accelerators[
-                                currentAcceleratorType
-                              ]?.min || 0,
-                            // Unique type should only allow 0 or 1
-                            max: isUniqueType
-                              ? 1
-                              : resourceLimits.accelerators[
-                                  currentAcceleratorType
-                                ]?.max,
-                          },
-                          {
-                            validator: async (_rule: any, value: number) => {
-                              if (
-                                _.endsWith(currentAcceleratorType, 'shares') &&
-                                form.getFieldValue('cluster_size') >= 2 &&
-                                value % 1 !== 0
-                              ) {
-                                return Promise.reject(
-                                  t(
-                                    'session.launcher.OnlyAllowsDiscreteNumberByClusterSize',
-                                  ),
-                                );
-                              } else {
-                                return Promise.resolve();
-                              }
-                            },
-                          },
-                          {
-                            validator: async (_rule: any, value: number) => {
-                              if (
-                                _.isNumber(currentAcceleratorStep) &&
-                                ![0, currentAcceleratorStep].includes(
-                                  _.round(value % currentAcceleratorStep, 5),
-                                )
-                              ) {
-                                return Promise.reject(
-                                  t(
-                                    'session.launcher.OnlyAllowsDiscreteNumberByQuantumSize',
-                                    {
-                                      stepSize: currentAcceleratorStep,
-                                    },
-                                  ),
-                                );
-                              } else {
-                                return Promise.resolve();
-                              }
-                            },
-                          },
-                          {
-                            warningOnly: true,
-                            validator: async (_rule: any, value: number) => {
-                              if (
-                                _.isNumber(
-                                  resourceLimits.accelerators[
-                                    currentAcceleratorType
-                                  ]?.min,
-                                ) &&
-                                _.isNumber(
-                                  resourceLimits.accelerators[
-                                    currentAcceleratorType
-                                  ]?.max,
-                                ) &&
-                                isMinOversMaxValue(
-                                  resourceLimits.accelerators[
-                                    currentAcceleratorType
-                                  ]?.min,
-                                  resourceLimits.accelerators[
-                                    currentAcceleratorType
-                                  ]?.max,
-                                )
-                              ) {
-                                return Promise.reject(
-                                  t(
-                                    'session.launcher.InsufficientAllocationOfResourcesWarning',
-                                  ),
-                                );
-                              }
-                              if (showRemainingWarning) {
-                                if (
-                                  _.isNumber(
-                                    remaining.accelerators[
+                        // Unified-memory slots mirror the host memory value
+                        // into a disabled field, so none of the discrete
+                        // accelerator constraints (required, min/max, step,
+                        // remaining/unique warnings, caller-provided rules)
+                        // apply. Skip all validation in that mode.
+                        rules={
+                          isUnifiedType
+                            ? []
+                            : [
+                                {
+                                  required:
+                                    currentImageAcceleratorLimits &&
+                                    currentImageAcceleratorLimits.length > 0,
+                                },
+                                {
+                                  type: 'number',
+                                  min:
+                                    resourceLimits.accelerators[
                                       currentAcceleratorType
-                                    ],
-                                  ) &&
-                                  value >
-                                    remaining.accelerators[
-                                      currentAcceleratorType
-                                    ]
-                                ) {
-                                  return Promise.reject(
-                                    t(
-                                      'session.launcher.EnqueueComputeSessionWarning',
-                                    ),
-                                  );
-                                }
-                              }
-                              return Promise.resolve();
-                            },
-                          },
-                          {
-                            warningOnly: true,
-                            validator: async (_rule, _value) => {
-                              if (isUniqueType) {
-                                return Promise.reject(
-                                  t(
-                                    'session.launcher.CurrentAcceleratorTypeAllowsMaxOne',
-                                    {
-                                      accelerator: currentAcceleratorType,
-                                    },
-                                  ),
-                                );
-                              }
-                              return Promise.resolve();
-                            },
-                          },
-                          ...(extraAcceleratorRules ?? []),
-                        ]}
+                                    ]?.min || 0,
+                                  // Unique type should only allow 0 or 1
+                                  max: isUniqueType
+                                    ? 1
+                                    : resourceLimits.accelerators[
+                                        currentAcceleratorType
+                                      ]?.max,
+                                },
+                                {
+                                  validator: async (
+                                    _rule: any,
+                                    value: number,
+                                  ) => {
+                                    if (
+                                      _.endsWith(
+                                        currentAcceleratorType,
+                                        'shares',
+                                      ) &&
+                                      form.getFieldValue('cluster_size') >= 2 &&
+                                      value % 1 !== 0
+                                    ) {
+                                      return Promise.reject(
+                                        t(
+                                          'session.launcher.OnlyAllowsDiscreteNumberByClusterSize',
+                                        ),
+                                      );
+                                    } else {
+                                      return Promise.resolve();
+                                    }
+                                  },
+                                },
+                                {
+                                  validator: async (
+                                    _rule: any,
+                                    value: number,
+                                  ) => {
+                                    if (
+                                      _.isNumber(currentAcceleratorStep) &&
+                                      ![0, currentAcceleratorStep].includes(
+                                        _.round(
+                                          value % currentAcceleratorStep,
+                                          5,
+                                        ),
+                                      )
+                                    ) {
+                                      return Promise.reject(
+                                        t(
+                                          'session.launcher.OnlyAllowsDiscreteNumberByQuantumSize',
+                                          {
+                                            stepSize: currentAcceleratorStep,
+                                          },
+                                        ),
+                                      );
+                                    } else {
+                                      return Promise.resolve();
+                                    }
+                                  },
+                                },
+                                {
+                                  warningOnly: true,
+                                  validator: async (
+                                    _rule: any,
+                                    value: number,
+                                  ) => {
+                                    if (
+                                      _.isNumber(
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.min,
+                                      ) &&
+                                      _.isNumber(
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.max,
+                                      ) &&
+                                      isMinOversMaxValue(
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.min,
+                                        resourceLimits.accelerators[
+                                          currentAcceleratorType
+                                        ]?.max,
+                                      )
+                                    ) {
+                                      return Promise.reject(
+                                        t(
+                                          'session.launcher.InsufficientAllocationOfResourcesWarning',
+                                        ),
+                                      );
+                                    }
+                                    if (showRemainingWarning) {
+                                      if (
+                                        _.isNumber(
+                                          remaining.accelerators[
+                                            currentAcceleratorType
+                                          ],
+                                        ) &&
+                                        value >
+                                          remaining.accelerators[
+                                            currentAcceleratorType
+                                          ]
+                                      ) {
+                                        return Promise.reject(
+                                          t(
+                                            'session.launcher.EnqueueComputeSessionWarning',
+                                          ),
+                                        );
+                                      }
+                                    }
+                                    return Promise.resolve();
+                                  },
+                                },
+                                {
+                                  warningOnly: true,
+                                  validator: async (_rule, _value) => {
+                                    if (isUniqueType) {
+                                      return Promise.reject(
+                                        t(
+                                          'session.launcher.CurrentAcceleratorTypeAllowsMaxOne',
+                                          {
+                                            accelerator: currentAcceleratorType,
+                                          },
+                                        ),
+                                      );
+                                    }
+                                    return Promise.resolve();
+                                  },
+                                },
+                                ...(extraAcceleratorRules ?? []),
+                              ]
+                        }
                       >
                         <InputNumberWithSlider
                           inputContainerMinWidth={190}
@@ -1163,7 +1266,8 @@ const ResourceAllocationFormItems: React.FC<
                             },
                           }}
                           disabled={
-                            supportedAcceleratorTypesInRGByImage?.length === 0
+                            supportedAcceleratorTypesInRGByImage?.length ===
+                              0 || isUnifiedType
                           }
                           min={0}
                           max={
@@ -1220,6 +1324,58 @@ const ResourceAllocationFormItems: React.FC<
                                         };
                                       },
                                     )}
+                                    onChange={(nextType: string) => {
+                                      // Changing the slot type mutates the
+                                      // active allocation; the previously
+                                      // selected preset no longer matches.
+                                      form.setFieldValue(
+                                        'allocationPreset',
+                                        'custom',
+                                      );
+                                      // Keep the accelerator field consistent
+                                      // at the moment the slot type changes,
+                                      // rather than relying on a watcher
+                                      // effect that runs after render.
+                                      if (isUnifiedAcceleratorSlot(nextType)) {
+                                        // Switching INTO a unified slot:
+                                        // mirror the current `mem` value
+                                        // converted to the slot's display
+                                        // unit. Write acceleratorType first
+                                        // so the shared helper sees the new
+                                        // active slot when it reads from the
+                                        // form.
+                                        form.setFieldValue(
+                                          ['resource', 'acceleratorType'],
+                                          nextType,
+                                        );
+                                        syncUnifiedAcceleratorIfNeeded();
+                                      } else if (
+                                        isUnifiedAcceleratorSlot(
+                                          currentAcceleratorType,
+                                        )
+                                      ) {
+                                        // Switching OUT of a unified slot
+                                        // into a discrete one: reset to the
+                                        // discrete slot's min so the stale
+                                        // mirrored GiB value from unified
+                                        // mode does not bleed through as a
+                                        // device count.
+                                        //
+                                        // Discrete-to-discrete switches are
+                                        // intentionally NOT reset here:
+                                        // ensureValidAcceleratorType clamps
+                                        // the existing value if it falls
+                                        // outside the new slot's range, so
+                                        // the user's current allocation is
+                                        // preserved across discrete slot
+                                        // changes.
+                                        form.setFieldValue(
+                                          ['resource', 'accelerator'],
+                                          resourceLimits.accelerators[nextType]
+                                            ?.min ?? 0,
+                                        );
+                                      }
+                                    }}
                                   />
                                 </Form.Item>
                               ) : undefined,

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -24,7 +24,33 @@ import {
   toFixedWithTypeValidation,
   addNumberWithUnits,
   subNumberWithUnits,
+  getDisplayUnitToInputSizeUnit,
 } from './index';
+
+describe('getDisplayUnitToInputSizeUnit', () => {
+  it('maps known binary display units to InputSizeUnit', () => {
+    expect(getDisplayUnitToInputSizeUnit('KiB')).toBe('k');
+    expect(getDisplayUnitToInputSizeUnit('MiB')).toBe('m');
+    expect(getDisplayUnitToInputSizeUnit('GiB')).toBe('g');
+    expect(getDisplayUnitToInputSizeUnit('TiB')).toBe('t');
+    expect(getDisplayUnitToInputSizeUnit('PiB')).toBe('p');
+    expect(getDisplayUnitToInputSizeUnit('EiB')).toBe('e');
+  });
+
+  it('accepts the short binary form and is case-insensitive', () => {
+    expect(getDisplayUnitToInputSizeUnit('gi')).toBe('g');
+    expect(getDisplayUnitToInputSizeUnit('Mi')).toBe('m');
+    expect(getDisplayUnitToInputSizeUnit('gib')).toBe('g');
+  });
+
+  it('returns an empty string for unknown or nullish values', () => {
+    expect(getDisplayUnitToInputSizeUnit('foo')).toBe('');
+    expect(getDisplayUnitToInputSizeUnit('GB')).toBe('');
+    expect(getDisplayUnitToInputSizeUnit('')).toBe('');
+    expect(getDisplayUnitToInputSizeUnit(null)).toBe('');
+    expect(getDisplayUnitToInputSizeUnit(undefined)).toBe('');
+  });
+});
 
 describe('isOutsideRange', () => {
   it('should return true if the value is less than the minimum', () => {

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -86,6 +86,26 @@ export type InputSizeUnit = '' | 'k' | 'm' | 'g' | 't' | 'p' | 'e';
 export type SizeUnit = InputSizeUnit;
 
 /**
+ * Maps a human-readable binary display unit (e.g. `GiB`, `Gi`, `MiB`) to the
+ * corresponding `InputSizeUnit` accepted by `convertToBinaryUnit`. Returns an
+ * empty string (bytes) when the display unit is missing or not a recognized
+ * binary size unit.
+ */
+export const getDisplayUnitToInputSizeUnit = (
+  displayUnit: string | undefined | null,
+): InputSizeUnit => {
+  if (!displayUnit) return '';
+  const unit = displayUnit.toLowerCase();
+  if (['kib', 'ki'].includes(unit)) return 'k';
+  if (['mib', 'mi'].includes(unit)) return 'm';
+  if (['gib', 'gi'].includes(unit)) return 'g';
+  if (['tib', 'ti'].includes(unit)) return 't';
+  if (['pib', 'pi'].includes(unit)) return 'p';
+  if (['eib', 'ei'].includes(unit)) return 'e';
+  return '';
+};
+
+/**
  * Converts a value with a unit to a different unit or automatically selects the most appropriate unit.
  *
  * @param inputValue - The input string value with or without a unit (e.g., '1024m', '2g', '500').

--- a/react/src/hooks/backendai.test.tsx
+++ b/react/src/hooks/backendai.test.tsx
@@ -9,11 +9,32 @@ import '../../__test__/matchMedia.mock.js';
 import {
   knownAcceleratorResourceSlotNames,
   baseResourceSlotNames,
+  isUnifiedAcceleratorSlot,
 } from './backendai';
 import Ajv from 'ajv';
 import * as _ from 'lodash-es';
 
 const ajv = new Ajv();
+
+describe('isUnifiedAcceleratorSlot', () => {
+  it('returns true for slot names ending with .unified', () => {
+    expect(isUnifiedAcceleratorSlot('cuda.unified')).toBe(true);
+    expect(isUnifiedAcceleratorSlot('rocm.unified')).toBe(true);
+  });
+
+  it('returns false for discrete accelerator slot names', () => {
+    expect(isUnifiedAcceleratorSlot('cuda.shares')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('cuda.device')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('cuda.mem')).toBe(false);
+    expect(isUnifiedAcceleratorSlot('rocm.device')).toBe(false);
+  });
+
+  it('returns false for nullish or empty input', () => {
+    expect(isUnifiedAcceleratorSlot(undefined)).toBe(false);
+    expect(isUnifiedAcceleratorSlot(null)).toBe(false);
+    expect(isUnifiedAcceleratorSlot('')).toBe(false);
+  });
+});
 
 describe('deviceMetadata JSON Schema Validation', () => {
   it('should include all known accelerator names and base resource names', () => {

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -41,6 +41,17 @@ export type KnownAcceleratorResourceSlotName =
 export type ResourceSlotName =
   | BaseResourceSlotName
   | KnownAcceleratorResourceSlotName;
+
+/**
+ * Returns true when the given accelerator slot name represents a unified
+ * memory architecture, where the accelerator memory and the host memory
+ * share a single physical pool (e.g. NVIDIA Jetson — no dedicated VRAM).
+ * Identified by a `.unified` suffix on the slot name (e.g. `cuda.unified`).
+ */
+export const isUnifiedAcceleratorSlot = (slotName?: string | null): boolean => {
+  return !!slotName && _.endsWith(slotName, '.unified');
+};
+
 export interface QuotaScope {
   id: string;
   quota_scope_id: string;

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard-App ist bereit.",
       "TitleSession": "Sitzung (Backend.AI)",
       "TotalAllocation": "Gesamtzuweisung",
+      "Unified": "Vereinheitlicht",
       "UnifiedAcceleratorMemoryNote": "Dieses Gerät hat keinen separaten Beschleunigerspeicher; es nutzt den Hostspeicher-Pool und kann nicht separat festgelegt werden.",
       "UserResourceLimit": "Beschränkung der Benutzerressourcen",
       "UsingBootstrapScriptInfo": "Bootstrap-Skript ist enthalten.",

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard-App ist bereit.",
       "TitleSession": "Sitzung (Backend.AI)",
       "TotalAllocation": "Gesamtzuweisung",
+      "UnifiedAcceleratorMemoryNote": "Dieses Gerät hat keinen separaten Beschleunigerspeicher; es nutzt den Hostspeicher-Pool und kann nicht separat festgelegt werden.",
       "UserResourceLimit": "Beschränkung der Benutzerressourcen",
       "UsingBootstrapScriptInfo": "Bootstrap-Skript ist enthalten.",
       "Version": "Ausführung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Η εφαρμογή TensorBoard είναι έτοιμη.",
       "TitleSession": "Συνεδρία (Backend.AI)",
       "TotalAllocation": "Συνολική κατανομή",
+      "Unified": "Ενοποιημένη",
       "UnifiedAcceleratorMemoryNote": "Αυτή η συσκευή δεν διαθέτει ξεχωριστή μνήμη επιταχυντή· χρησιμοποιεί τη δεξαμενή μνήμης του κεντρικού υπολογιστή και δεν μπορεί να οριστεί ξεχωριστά.",
       "UserResourceLimit": "Όριο πόρων χρήστη",
       "UsingBootstrapScriptInfo": "Το Bootstrap script περιλαμβάνεται.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Η εφαρμογή TensorBoard είναι έτοιμη.",
       "TitleSession": "Συνεδρία (Backend.AI)",
       "TotalAllocation": "Συνολική κατανομή",
+      "UnifiedAcceleratorMemoryNote": "Αυτή η συσκευή δεν διαθέτει ξεχωριστή μνήμη επιταχυντή· χρησιμοποιεί τη δεξαμενή μνήμης του κεντρικού υπολογιστή και δεν μπορεί να οριστεί ξεχωριστά.",
       "UserResourceLimit": "Όριο πόρων χρήστη",
       "UsingBootstrapScriptInfo": "Το Bootstrap script περιλαμβάνεται.",
       "Version": "Εκδοχή",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2977,6 +2977,7 @@
       "TensorBoardPrepared": "TensorBoard app prepared.",
       "TitleSession": "Session (Backend.AI)",
       "TotalAllocation": "Total Allocation",
+      "UnifiedAcceleratorMemoryNote": "This device has no separate accelerator memory; it uses the host memory pool and cannot be set separately.",
       "UserResourceLimit": "User Resource Limit",
       "UsingBootstrapScriptInfo": "Bootstrap script is included.",
       "Version": "Version",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2977,6 +2977,7 @@
       "TensorBoardPrepared": "TensorBoard app prepared.",
       "TitleSession": "Session (Backend.AI)",
       "TotalAllocation": "Total Allocation",
+      "Unified": "Unified",
       "UnifiedAcceleratorMemoryNote": "This device has no separate accelerator memory; it uses the host memory pool and cannot be set separately.",
       "UserResourceLimit": "User Resource Limit",
       "UsingBootstrapScriptInfo": "Bootstrap script is included.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplicación TensorBoard preparada.",
       "TitleSession": "Sesión (Backend.AI)",
       "TotalAllocation": "Asignación total",
+      "UnifiedAcceleratorMemoryNote": "Este dispositivo no tiene memoria de acelerador independiente; utiliza el grupo de memoria del host y no se puede configurar por separado.",
       "UserResourceLimit": "Límite de recursos de usuario",
       "UsingBootstrapScriptInfo": "Script de arranque incluido.",
       "Version": "Versión",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplicación TensorBoard preparada.",
       "TitleSession": "Sesión (Backend.AI)",
       "TotalAllocation": "Asignación total",
+      "Unified": "Unificada",
       "UnifiedAcceleratorMemoryNote": "Este dispositivo no tiene memoria de acelerador independiente; utiliza el grupo de memoria del host y no se puede configurar por separado.",
       "UserResourceLimit": "Límite de recursos de usuario",
       "UsingBootstrapScriptInfo": "Script de arranque incluido.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "TensorBoard-sovellus valmis.",
       "TitleSession": "Istunto (Backend.AI)",
       "TotalAllocation": "Kokonaismääräraha",
+      "UnifiedAcceleratorMemoryNote": "Tässä laitteessa ei ole erillistä kiihdyttimen muistia; se käyttää isäntämuistivarantoa, eikä sitä voi määrittää erikseen.",
       "UserResourceLimit": "Käyttäjän resurssirajoitus",
       "UsingBootstrapScriptInfo": "Bootstrap-skripti on mukana.",
       "Version": "Versio",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "TensorBoard-sovellus valmis.",
       "TitleSession": "Istunto (Backend.AI)",
       "TotalAllocation": "Kokonaismääräraha",
+      "Unified": "Yhtenäinen",
       "UnifiedAcceleratorMemoryNote": "Tässä laitteessa ei ole erillistä kiihdyttimen muistia; se käyttää isäntämuistivarantoa, eikä sitä voi määrittää erikseen.",
       "UserResourceLimit": "Käyttäjän resurssirajoitus",
       "UsingBootstrapScriptInfo": "Bootstrap-skripti on mukana.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "Application TensorBoard prête.",
       "TitleSession": "Session (Backend.AI)",
       "TotalAllocation": "Allocation totale",
+      "Unified": "Unifiée",
       "UnifiedAcceleratorMemoryNote": "Cet appareil n'a pas de mémoire d'accélérateur distincte ; il utilise le pool de mémoire de l'hôte et ne peut pas être défini séparément.",
       "UserResourceLimit": "Limite de ressources utilisateur",
       "UsingBootstrapScriptInfo": "Le script de démarrage est inclus.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "Application TensorBoard prête.",
       "TitleSession": "Session (Backend.AI)",
       "TotalAllocation": "Allocation totale",
+      "UnifiedAcceleratorMemoryNote": "Cet appareil n'a pas de mémoire d'accélérateur distincte ; il utilise le pool de mémoire de l'hôte et ne peut pas être défini séparément.",
       "UserResourceLimit": "Limite de ressources utilisateur",
       "UsingBootstrapScriptInfo": "Le script de démarrage est inclus.",
       "Version": "Version",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2994,6 +2994,7 @@
       "TensorBoardPrepared": "Aplikasi TensorBoard siap.",
       "TitleSession": "Sesi (Backend.AI)",
       "TotalAllocation": "Alokasi Total",
+      "Unified": "Terpadu",
       "UnifiedAcceleratorMemoryNote": "Perangkat ini tidak memiliki memori akselerator terpisah; perangkat menggunakan kumpulan memori host dan tidak dapat diatur secara terpisah.",
       "UserResourceLimit": "Batas Sumber Daya Pengguna",
       "UsingBootstrapScriptInfo": "Skrip bootstrap disertakan.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2994,6 +2994,7 @@
       "TensorBoardPrepared": "Aplikasi TensorBoard siap.",
       "TitleSession": "Sesi (Backend.AI)",
       "TotalAllocation": "Alokasi Total",
+      "UnifiedAcceleratorMemoryNote": "Perangkat ini tidak memiliki memori akselerator terpisah; perangkat menggunakan kumpulan memori host dan tidak dapat diatur secara terpisah.",
       "UserResourceLimit": "Batas Sumber Daya Pengguna",
       "UsingBootstrapScriptInfo": "Skrip bootstrap disertakan.",
       "Version": "Versi",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "App TensorBoard pronta.",
       "TitleSession": "Sessione (Backend.AI)",
       "TotalAllocation": "Allocazione totale",
+      "UnifiedAcceleratorMemoryNote": "Questo dispositivo non dispone di memoria dell'acceleratore separata; utilizza il pool di memoria host e non può essere impostata separatamente.",
       "UserResourceLimit": "Limite risorse utente",
       "UsingBootstrapScriptInfo": "Lo script di bootstrap è incluso.",
       "Version": "Versione",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "App TensorBoard pronta.",
       "TitleSession": "Sessione (Backend.AI)",
       "TotalAllocation": "Allocazione totale",
+      "Unified": "Unificata",
       "UnifiedAcceleratorMemoryNote": "Questo dispositivo non dispone di memoria dell'acceleratore separata; utilizza il pool di memoria host e non può essere impostata separatamente.",
       "UserResourceLimit": "Limite risorse utente",
       "UsingBootstrapScriptInfo": "Lo script di bootstrap è incluso.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard アプリの準備ができました。",
       "TitleSession": "セッション（Backend.AI）",
       "TotalAllocation": "総割り当て",
+      "Unified": "統合",
       "UnifiedAcceleratorMemoryNote": "このデバイスには専用のアクセラレータメモリがなく、ホストメモリプールを共用するため、個別に設定できません。",
       "UserResourceLimit": "ユーザーリソース制限",
       "UsingBootstrapScriptInfo": "ブートストラップスクリプトが含まれています。",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard アプリの準備ができました。",
       "TitleSession": "セッション（Backend.AI）",
       "TotalAllocation": "総割り当て",
+      "UnifiedAcceleratorMemoryNote": "このデバイスには専用のアクセラレータメモリがなく、ホストメモリプールを共用するため、個別に設定できません。",
       "UserResourceLimit": "ユーザーリソース制限",
       "UsingBootstrapScriptInfo": "ブートストラップスクリプトが含まれています。",
       "Version": "バージョン",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "TensorBoard 앱이 준비되었습니다.",
       "TitleSession": "세션 (Backend.AI)",
       "TotalAllocation": "총 자원 할당량",
+      "Unified": "통합",
       "UnifiedAcceleratorMemoryNote": "이 장치는 별도의 가속기 메모리가 없으며, 호스트 메모리 풀을 함께 사용하므로 따로 설정할 수 없습니다.",
       "UserResourceLimit": "사용자 자원 제한",
       "UsingBootstrapScriptInfo": "부트스트랩 스크립트가 포함되어 있습니다.",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "TensorBoard 앱이 준비되었습니다.",
       "TitleSession": "세션 (Backend.AI)",
       "TotalAllocation": "총 자원 할당량",
+      "UnifiedAcceleratorMemoryNote": "이 장치는 별도의 가속기 메모리가 없으며, 호스트 메모리 풀을 함께 사용하므로 따로 설정할 수 없습니다.",
       "UserResourceLimit": "사용자 자원 제한",
       "UsingBootstrapScriptInfo": "부트스트랩 스크립트가 포함되어 있습니다.",
       "Version": "버전",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard програм бэлэн боллоо.",
       "TitleSession": "Чуулган (Backend.AI)",
       "TotalAllocation": "Нийт хуваарилалт",
+      "Unified": "Нэгдсэн",
       "UnifiedAcceleratorMemoryNote": "Энэ төхөөрөмжид тусдаа хурдасгуурын санах ой байхгүй бөгөөд хостын санах ойн санг ашигладаг тул тусад нь тохируулах боломжгүй.",
       "UserResourceLimit": "Хэрэглэгчийн нөөцийн хязгаарлалт",
       "UsingBootstrapScriptInfo": "Bootstrap скрипт багтсан.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard програм бэлэн боллоо.",
       "TitleSession": "Чуулган (Backend.AI)",
       "TotalAllocation": "Нийт хуваарилалт",
+      "UnifiedAcceleratorMemoryNote": "Энэ төхөөрөмжид тусдаа хурдасгуурын санах ой байхгүй бөгөөд хостын санах ойн санг ашигладаг тул тусад нь тохируулах боломжгүй.",
       "UserResourceLimit": "Хэрэглэгчийн нөөцийн хязгаарлалт",
       "UsingBootstrapScriptInfo": "Bootstrap скрипт багтсан.",
       "Version": "Хувилбар",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplikasi TensorBoard disediakan.",
       "TitleSession": "Sesi (Backend.AI)",
       "TotalAllocation": "Jumlah Peruntukan",
+      "UnifiedAcceleratorMemoryNote": "Peranti ini tidak mempunyai memori pemecut yang berasingan; ia menggunakan kumpulan memori hos dan tidak boleh ditetapkan secara berasingan.",
       "UserResourceLimit": "Had Sumber Pengguna",
       "UsingBootstrapScriptInfo": "Skrip bootstrap disertakan.",
       "Version": "Versi",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplikasi TensorBoard disediakan.",
       "TitleSession": "Sesi (Backend.AI)",
       "TotalAllocation": "Jumlah Peruntukan",
+      "Unified": "Bersatu",
       "UnifiedAcceleratorMemoryNote": "Peranti ini tidak mempunyai memori pemecut yang berasingan; ia menggunakan kumpulan memori hos dan tidak boleh ditetapkan secara berasingan.",
       "UserResourceLimit": "Had Sumber Pengguna",
       "UsingBootstrapScriptInfo": "Skrip bootstrap disertakan.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "Aplikacja TensorBoard jest gotowa.",
       "TitleSession": "Sesja (Backend.AI)",
       "TotalAllocation": "Całkowity przydział",
+      "Unified": "Zunifikowana",
       "UnifiedAcceleratorMemoryNote": "To urządzenie nie ma osobnej pamięci akceleratora; korzysta z puli pamięci hosta i nie można jej ustawić osobno.",
       "UserResourceLimit": "Limit zasobów użytkownika",
       "UsingBootstrapScriptInfo": "Skrypt bootstrap jest dołączony.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2993,6 +2993,7 @@
       "TensorBoardPrepared": "Aplikacja TensorBoard jest gotowa.",
       "TitleSession": "Sesja (Backend.AI)",
       "TotalAllocation": "Całkowity przydział",
+      "UnifiedAcceleratorMemoryNote": "To urządzenie nie ma osobnej pamięci akceleratora; korzysta z puli pamięci hosta i nie można jej ustawić osobno.",
       "UserResourceLimit": "Limit zasobów użytkownika",
       "UsingBootstrapScriptInfo": "Skrypt bootstrap jest dołączony.",
       "Version": "Wersja",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplicativo TensorBoard preparado.",
       "TitleSession": "Sessão (Backend.AI)",
       "TotalAllocation": "Alocação Total",
+      "UnifiedAcceleratorMemoryNote": "Este dispositivo não tem memória de acelerador separada; usa o pool de memória do host e não pode ser definida separadamente.",
       "UserResourceLimit": "Limite de recursos do usuário",
       "UsingBootstrapScriptInfo": "O script de bootstrap está incluído.",
       "Version": "Versão",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Aplicativo TensorBoard preparado.",
       "TitleSession": "Sessão (Backend.AI)",
       "TotalAllocation": "Alocação Total",
+      "Unified": "Unificada",
       "UnifiedAcceleratorMemoryNote": "Este dispositivo não tem memória de acelerador separada; usa o pool de memória do host e não pode ser definida separadamente.",
       "UserResourceLimit": "Limite de recursos do usuário",
       "UsingBootstrapScriptInfo": "O script de bootstrap está incluído.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "Aplicação TensorBoard preparada.",
       "TitleSession": "Sessão (Backend.AI)",
       "TotalAllocation": "Alocação Total",
+      "Unified": "Unificada",
       "UnifiedAcceleratorMemoryNote": "Este dispositivo não tem memória de acelerador separada; usa o pool de memória do host e não pode ser definida separadamente.",
       "UserResourceLimit": "Limite de recursos do usuário",
       "UsingBootstrapScriptInfo": "Script de bootstrap incluído.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "Aplicação TensorBoard preparada.",
       "TitleSession": "Sessão (Backend.AI)",
       "TotalAllocation": "Alocação Total",
+      "UnifiedAcceleratorMemoryNote": "Este dispositivo não tem memória de acelerador separada; usa o pool de memória do host e não pode ser definida separadamente.",
       "UserResourceLimit": "Limite de recursos do usuário",
       "UsingBootstrapScriptInfo": "Script de bootstrap incluído.",
       "Version": "Versão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Приложение TensorBoard готово.",
       "TitleSession": "Сессия (Backend.AI)",
       "TotalAllocation": "Итого распределено",
+      "Unified": "Единая",
       "UnifiedAcceleratorMemoryNote": "На этом устройстве нет отдельной памяти ускорителя; оно использует пул памяти хоста, поэтому её нельзя задать отдельно.",
       "UserResourceLimit": "Лимит ресурсов пользователя",
       "UsingBootstrapScriptInfo": "Скрипт Bootstrap включён.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "Приложение TensorBoard готово.",
       "TitleSession": "Сессия (Backend.AI)",
       "TotalAllocation": "Итого распределено",
+      "UnifiedAcceleratorMemoryNote": "На этом устройстве нет отдельной памяти ускорителя; оно использует пул памяти хоста, поэтому её нельзя задать отдельно.",
       "UserResourceLimit": "Лимит ресурсов пользователя",
       "UsingBootstrapScriptInfo": "Скрипт Bootstrap включён.",
       "Version": "Версия",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "แอป TensorBoard พร้อมแล้ว.",
       "TitleSession": "เซสชัน (Backend.AI)",
       "TotalAllocation": "การจัดสรรทั้งหมด",
+      "UnifiedAcceleratorMemoryNote": "อุปกรณ์นี้ไม่มีหน่วยความจำของตัวเร่งแยกต่างหาก แต่ใช้พูลหน่วยความจำของโฮสต์ จึงไม่สามารถตั้งค่าแยกต่างหากได้",
       "UserResourceLimit": "ขีดจำกัดทรัพยากรผู้ใช้",
       "UsingBootstrapScriptInfo": "สคริปต์ Bootstrap ถูกรวมไว้",
       "Version": "เวอร์ชัน",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "แอป TensorBoard พร้อมแล้ว.",
       "TitleSession": "เซสชัน (Backend.AI)",
       "TotalAllocation": "การจัดสรรทั้งหมด",
+      "Unified": "แบบรวม",
       "UnifiedAcceleratorMemoryNote": "อุปกรณ์นี้ไม่มีหน่วยความจำของตัวเร่งแยกต่างหาก แต่ใช้พูลหน่วยความจำของโฮสต์ จึงไม่สามารถตั้งค่าแยกต่างหากได้",
       "UserResourceLimit": "ขีดจำกัดทรัพยากรผู้ใช้",
       "UsingBootstrapScriptInfo": "สคริปต์ Bootstrap ถูกรวมไว้",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "TensorBoard uygulaması hazır.",
       "TitleSession": "Oturum (Arka Uç.AI)",
       "TotalAllocation": "Toplam Tahsis",
+      "Unified": "Birleşik",
       "UnifiedAcceleratorMemoryNote": "Bu cihazda ayrı bir hızlandırıcı belleği yoktur; ana makine bellek havuzunu kullanır ve ayrı olarak ayarlanamaz.",
       "UserResourceLimit": "Kullanıcı Kaynak Sınırı",
       "UsingBootstrapScriptInfo": "Bootstrap betiği dahil edildi.",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2990,6 +2990,7 @@
       "TensorBoardPrepared": "TensorBoard uygulaması hazır.",
       "TitleSession": "Oturum (Arka Uç.AI)",
       "TotalAllocation": "Toplam Tahsis",
+      "UnifiedAcceleratorMemoryNote": "Bu cihazda ayrı bir hızlandırıcı belleği yoktur; ana makine bellek havuzunu kullanır ve ayrı olarak ayarlanamaz.",
       "UserResourceLimit": "Kullanıcı Kaynak Sınırı",
       "UsingBootstrapScriptInfo": "Bootstrap betiği dahil edildi.",
       "Version": "Sürüm",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "Ứng dụng TensorBoard đã sẵn sàng.",
       "TitleSession": "Phiên (Backend.AI)",
       "TotalAllocation": "Tổng phân bổ",
+      "UnifiedAcceleratorMemoryNote": "Thiết bị này không có bộ nhớ máy gia tốc riêng; nó sử dụng nhóm bộ nhớ máy chủ và không thể được đặt riêng.",
       "UserResourceLimit": "Giới hạn tài nguyên người dùng",
       "UsingBootstrapScriptInfo": "Đã bao gồm tập lệnh khởi tạo.",
       "Version": "Phiên bản",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "Ứng dụng TensorBoard đã sẵn sàng.",
       "TitleSession": "Phiên (Backend.AI)",
       "TotalAllocation": "Tổng phân bổ",
+      "Unified": "Hợp nhất",
       "UnifiedAcceleratorMemoryNote": "Thiết bị này không có bộ nhớ máy gia tốc riêng; nó sử dụng nhóm bộ nhớ máy chủ và không thể được đặt riêng.",
       "UserResourceLimit": "Giới hạn tài nguyên người dùng",
       "UsingBootstrapScriptInfo": "Đã bao gồm tập lệnh khởi tạo.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard 应用已准备就绪。",
       "TitleSession": "会话（后端.AI）",
       "TotalAllocation": "总分配",
+      "Unified": "统一",
       "UnifiedAcceleratorMemoryNote": "此设备没有独立的加速器内存，它使用主机内存池，因此无法单独设置。",
       "UserResourceLimit": "用户资源限制",
       "UsingBootstrapScriptInfo": "已包含引导脚本。",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2992,6 +2992,7 @@
       "TensorBoardPrepared": "TensorBoard 应用已准备就绪。",
       "TitleSession": "会话（后端.AI）",
       "TotalAllocation": "总分配",
+      "UnifiedAcceleratorMemoryNote": "此设备没有独立的加速器内存，它使用主机内存池，因此无法单独设置。",
       "UserResourceLimit": "用户资源限制",
       "UsingBootstrapScriptInfo": "已包含引导脚本。",
       "Version": "版本",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2994,6 +2994,7 @@
       "TensorBoardPrepared": "TensorBoard 應用程式已準備就緒。",
       "TitleSession": "會話（後端.AI）",
       "TotalAllocation": "總分配",
+      "UnifiedAcceleratorMemoryNote": "此裝置沒有獨立的加速器記憶體，它使用主機記憶體池，因此無法單獨設定。",
       "UserResourceLimit": "用戶資源限制",
       "UsingBootstrapScriptInfo": "已包含啟動腳本。",
       "Version": "版本",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2994,6 +2994,7 @@
       "TensorBoardPrepared": "TensorBoard 應用程式已準備就緒。",
       "TitleSession": "會話（後端.AI）",
       "TotalAllocation": "總分配",
+      "Unified": "統一",
       "UnifiedAcceleratorMemoryNote": "此裝置沒有獨立的加速器記憶體，它使用主機記憶體池，因此無法單獨設定。",
       "UserResourceLimit": "用戶資源限制",
       "UsingBootstrapScriptInfo": "已包含啟動腳本。",


### PR DESCRIPTION
Resolves #7361 (FR-2868)

Stacked on #7360.

## Summary

Follow-up to FR-2867. For unified-memory accelerator slots (`.unified`, e.g. NVIDIA Jetson where the CPU and GPU share one physical DRAM pool with no dedicated VRAM), the accelerator memory *is* the host memory — so rendering its numeric value would double-count the same physical pool. This shows a **"Unified"** label instead of a number, both in resource displays and the launcher form.

## Changes

- `ResourceNumber.tsx` — render the accelerator icon + a "Unified" label (with an explanatory tooltip) for `.unified` slots instead of a numeric value. Inherited automatically by the ~21 surfaces that use `ResourceNumber` (resource presets, session/service detail, agent select, keypair policy, fair-share tables, etc.).
- `ResourceAllocationFormItems.tsx` — the launcher form now shows a "Unified" tag instead of the disabled mirrored number. The accelerator-type selector is extracted and kept available in both modes so users can still switch slot types.
- `hooks/backendai.tsx` — moved `isUnifiedAcceleratorSlot` here (shared, lightweight) so display components don't have to import the heavy form module; updated the form and its tests, and moved the unit test to `backendai.test.tsx`.
- `resources/i18n/*.json` — new key `session.launcher.Unified` in all 21 languages.

## Verification

Relay / Lint (0 errors) / Format / Tests (133) PASS. `ResourceNumber.tsx` and `backendai.tsx` are TypeScript-clean; the form file keeps the same pre-existing repo-wide JSX/type errors (antd v6 + pnpm virtual store, FR-2925) — none introduced by this PR.

## Test plan

- [ ] Resource preset / session detail / agent list with a `.unified` slot → accelerator shows "Unified" (icon + label) with a tooltip, not a GiB number
- [ ] No double-counting illusion in summed displays (Total Allocation, My Resource)
- [ ] Launcher: selecting a `.unified` type shows a "Unified" tag + the type selector (still switchable); host memory remains editable
- [ ] Switching back to a discrete slot restores the numeric slider
- [ ] Submitting a `.unified` session still sends `accelerator` == host memory (unchanged from FR-2867)
