### PR TITLE
feat(FR-2967): wire BAITable column reordering and enable it on the session list

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -48,8 +48,14 @@ interface BAITablePaginationConfig extends Omit<
 export interface BAITableColumnOverrideItem {
   /** Override the default visibility of a column */
   hidden?: boolean;
+  /**
+   * Override the column display order. Lower values come first. Persisted in
+   * the same overrides record as `hidden`, so reordering needs no extra
+   * persistence plumbing. Only set when the user has reordered columns away
+   * from their natural (declaration) order; see `disableColumnReorder`.
+   */
+  order?: number;
   // Future extensibility: width?, pinned?, etc.
-  // order?: number; // Override column order
 }
 /**
  * Record type mapping column keys to their override configurations
@@ -72,6 +78,15 @@ export interface BAITableSettings {
   onColumnOverridesChange?: (
     overrides: Record<string, BAITableColumnOverrideItem>,
   ) => void;
+  /**
+   * Disable drag-to-reorder in the settings modal. Reorder is **on by default**
+   * for every table that passes `tableSettings`: users can reorder columns via
+   * drag-and-drop, and the chosen order is persisted in
+   * `columnOverrides[key].order` (riding the same record as `hidden`, so no
+   * extra persistence plumbing is needed). Set to `true` only when reorder is
+   * not appropriate — e.g. a table whose column order is semantically fixed.
+   */
+  disableColumnReorder?: boolean;
 }
 
 export interface BAIExportSettings {
@@ -267,11 +282,28 @@ const BAITable = <RecordType extends AnyObject = AnyObject>({
   );
   // Merge defaultColumnOverrides with columnOverrides so that defaults apply
   // for columns not explicitly overridden by the user.
-  const effectiveColumnOverrides = useMemo(() => {
-    const defaults = tableSettings?.defaultColumnOverrides ?? {};
-    const overrides = columnOverrides ?? {};
-    return { ...defaults, ...overrides };
-  }, [tableSettings, columnOverrides]);
+  const effectiveColumnOverrides: Record<string, BAITableColumnOverrideItem> =
+    useMemo(() => {
+      const defaults = tableSettings?.defaultColumnOverrides ?? {};
+      const overrides = columnOverrides ?? {};
+      return { ...defaults, ...overrides };
+    }, [tableSettings, columnOverrides]);
+  // Column reorder is on by default for every table that wires `tableSettings`;
+  // an opt-out flag (`disableColumnReorder`) handles the rare table whose
+  // column order is semantically fixed. Tables without `tableSettings` have no
+  // settings modal at all, so the question doesn't apply.
+  const isColumnReorderEnabled =
+    !!tableSettings && !tableSettings.disableColumnReorder;
+  // Order of column keys shown in the settings modal, reflecting any persisted
+  // reordering. Undefined when reordering is disabled so the modal keeps the
+  // natural declaration order.
+  const initialColumnOrder = isColumnReorderEnabled
+    ? _.sortBy(
+        _.compact((columns ?? []).map((column) => column.key?.toString())),
+        (columnKey) =>
+          effectiveColumnOverrides[columnKey]?.order ?? Number.MAX_SAFE_INTEGER,
+      )
+    : undefined;
   const [isColumnSettingModalOpen, setIsColumnSettingModalOpen] =
     useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
@@ -301,6 +333,21 @@ const BAITable = <RecordType extends AnyObject = AnyObject>({
         const columnKey = column.key?.toString();
         if (!columnKey) return true;
         return isColumnVisible(column, columnKey, effectiveColumnOverrides);
+      });
+    }
+
+    // Apply persisted column display order from overrides. Order indices were
+    // assigned over the full column set, so sorting the (already visibility-
+    // filtered) columns by them preserves the correct relative order. Columns
+    // without an order override (e.g. ones added in a newer version) fall back
+    // to the end while keeping their declaration order (stable sort).
+    if (isColumnReorderEnabled && processedColumns) {
+      processedColumns = _.sortBy(processedColumns, (column) => {
+        const columnKey = column.key?.toString();
+        const columnOrder = columnKey
+          ? effectiveColumnOverrides[columnKey]?.order
+          : undefined;
+        return columnOrder ?? Number.MAX_SAFE_INTEGER;
       });
     }
 
@@ -361,6 +408,7 @@ const BAITable = <RecordType extends AnyObject = AnyObject>({
     order,
     tableSettings,
     effectiveColumnOverrides,
+    isColumnReorderEnabled,
   ]);
 
   const isValidPageNumber = () => {
@@ -530,20 +578,46 @@ const BAITable = <RecordType extends AnyObject = AnyObject>({
               setIsColumnSettingModalOpen(false);
               if (formValues) {
                 const selectedKeys = formValues.selectedColumnKeys || [];
+                // The modal emits a key for every column, using '' for keyless
+                // ones. Compact it so it lines up with `naturalOrder` (which
+                // drops keyless columns) — otherwise a table with a keyless
+                // column would always look "reordered".
+                const columnOrder = _.compact(formValues.columnOrder || []);
+                // Natural (declaration) order of all column keys, used to decide
+                // whether the user actually reordered anything.
+                const naturalOrder = _.compact(
+                  (columns ?? []).map((col) => col.key?.toString()),
+                );
+                const isReordered =
+                  isColumnReorderEnabled &&
+                  !_.isEqual(columnOrder, naturalOrder);
                 const newOverrides: Record<string, BAITableColumnOverrideItem> =
                   {};
 
                 // Only store in overrides when different from default values
                 columns?.forEach((col) => {
                   const key = col.key?.toString();
-                  if (key) {
-                    const shouldBeVisible = selectedKeys.includes(key);
-                    const defaultVisible = !col.defaultHidden;
+                  if (!key) return;
 
-                    // Only store when different from default
-                    if (shouldBeVisible !== defaultVisible) {
-                      newOverrides[key] = { hidden: !shouldBeVisible };
+                  const override: BAITableColumnOverrideItem = {};
+
+                  // Visibility: only store when different from default
+                  const shouldBeVisible = selectedKeys.includes(key);
+                  const defaultVisible = !col.defaultHidden;
+                  if (shouldBeVisible !== defaultVisible) {
+                    override.hidden = !shouldBeVisible;
+                  }
+
+                  // Order: only store when the user reordered away from natural
+                  if (isReordered) {
+                    const orderIndex = columnOrder.indexOf(key);
+                    if (orderIndex !== -1) {
+                      override.order = orderIndex;
                     }
+                  }
+
+                  if (!_.isEmpty(override)) {
+                    newOverrides[key] = override;
                   }
                 });
 
@@ -552,7 +626,8 @@ const BAITable = <RecordType extends AnyObject = AnyObject>({
             }}
             columns={columns || []}
             columnOverrides={effectiveColumnOverrides}
-            disableSorter
+            disableReorder={!isColumnReorderEnabled}
+            initialColumnOrder={initialColumnOrder}
           />
         </BAIUnmountAfterClose>
       )}

--- a/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.stories.tsx
@@ -40,7 +40,7 @@ BAITableSettingModal is a modal component for configuring table column settings.
 
 ### Drag and Drop Reordering
 - Reorder columns by dragging rows
-- Can be disabled with \`disableSorter\` prop
+- Can be disabled with \`disableReorder\` prop
 - Drag handle with visual feedback
 
 ### Form Integration
@@ -60,7 +60,7 @@ BAITableSettingModal is a modal component for configuring table column settings.
       control: { type: 'boolean' },
       description: 'Whether the modal is open',
     },
-    disableSorter: {
+    disableReorder: {
       control: { type: 'boolean' },
       description: 'Disable column reordering functionality',
     },
@@ -222,7 +222,7 @@ export const WithDisabledSorter: Story = {
           onRequestClose={() => setIsOpen(false)}
           columns={sampleColumns}
           columnOverrides={{}}
-          disableSorter={true}
+          disableReorder={true}
         />
       </div>
     );

--- a/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
@@ -32,6 +32,7 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useEffectEvent,
   useContext,
   useMemo,
 } from 'react';
@@ -84,8 +85,8 @@ interface TableSettingProps extends ModalProps {
   columns: BAIColumnsType<any>;
   /** Current column override settings */
   columnOverrides: Record<string, BAITableColumnOverrideItem>;
-  /** Whether to disable the column sorting functionality */
-  disableSorter?: boolean;
+  /** Whether to hide the drag-handle column and disable drag-to-reorder. */
+  disableReorder?: boolean;
   /** Initial order of columns */
   initialColumnOrder?: string[];
 }
@@ -191,7 +192,7 @@ const Row: React.FC<RowProps> = (props) => {
  *   onRequestClose={handleClose}
  *   columns={tableColumns}
  *   columnOverrides={currentOverrides}
- *   disableSorter={false}
+ *   disableReorder={false}
  * />
  * ```
  */
@@ -200,7 +201,7 @@ const BAITableSettingModal: React.FC<TableSettingProps> = ({
   columns,
   columnOverrides,
   initialColumnOrder,
-  disableSorter,
+  disableReorder,
   ...modalProps
 }) => {
   'use memo';
@@ -262,7 +263,25 @@ const BAITableSettingModal: React.FC<TableSettingProps> = ({
 
   const [searchKeyword, setSearchKeyword] = useState<string>('');
 
-  useEffect(() => {
+  // Re-sync `dataSource` only when the *value* of the column set / order
+  // changes — not on every parent re-render. BAITable rebuilds its `columns`
+  // (and thus passes a new `initialColumnOrder` array) on each render, so
+  // depending on their identity here would reset the table and wipe the user's
+  // in-progress drag reorder or visibility edits whenever the parent re-renders
+  // (e.g. a list auto-refresh while the modal is open). The signature captures
+  // the column keys, their persisted visibility, and the persisted order. This
+  // matters especially now that reorder is on by default for every table that
+  // passes `tableSettings` (opt-out via `disableColumnReorder`).
+  const syncSignature = JSON.stringify({
+    columns: columnOptions.map((option) => ({
+      key: option.key,
+      visible: option.visible,
+      required: option.required,
+    })),
+    order: initialColumnOrder ?? null,
+  });
+
+  const resyncDataSource = useEffectEvent(() => {
     if (initialColumnOrder) {
       const orderedOptions = [...columnOptions];
       orderedOptions.sort((a, b) => {
@@ -273,12 +292,15 @@ const BAITableSettingModal: React.FC<TableSettingProps> = ({
         if (indexB === -1) return -1;
         return indexA - indexB;
       });
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDataSource(orderedOptions);
     } else {
       setDataSource(columnOptions);
     }
-  }, [columnOptions, initialColumnOrder]);
+  });
+
+  useEffect(() => {
+    resyncDataSource();
+  }, [syncSignature]);
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;
@@ -335,7 +357,7 @@ const BAITableSettingModal: React.FC<TableSettingProps> = ({
       key: 'sort',
       align: 'left',
       width: 30,
-      hidden: disableSorter,
+      hidden: disableReorder,
       render: () => <DragHandle disabled={!!searchKeyword} />,
     },
     {


### PR DESCRIPTION
Resolves #7581 (FR-2967)

## Summary

`BAITableSettingModal` already implements full drag-and-drop column reordering (DndContext / `useSortable` / `DragHandle` / `handleDragEnd`) and emits a `columnOrder` array on confirm — but it was never wired through `BAITable`, so the feature had no effect: the modal was passed `disableSorter` unconditionally (hiding the drag handle), the emitted `columnOrder` was ignored, and there was no slot to persist it. This PR completes the end-to-end wiring.

**Reorder is enabled by default** for every table that wires `tableSettings`. The opt-out flag (`disableColumnReorder`) handles the rare table whose column order is semantically fixed. No per-page boilerplate is required: existing pages that already persist `columnOverrides` automatically gain reorder (and the chosen order rides along inside the same record).

## What changed

**`packages/backend.ai-ui/src/components/Table/BAITable.tsx`**
- Added `order?: number` to `BAITableColumnOverrideItem`. The chosen order rides along inside the same `columnOverrides` record pages already persist with `useBAISettingUserState`, so **no new persistence plumbing** is needed.
- Added an opt-out `disableColumnReorder?: boolean` flag to `BAITableSettings`. Defaults to `false` — reorder is on for every table that passes `tableSettings`.
- Drop the hardcoded `disableSorter` so the drag handle shows, pass `initialColumnOrder` (derived from the persisted order), persist `columnOrder` on confirm (only when the user reordered away from the natural declaration order, so reverting clears it), and sort columns by the persisted order when rendering.
- Consolidated the gate into a single derived const (`isColumnReorderEnabled`) so the four call sites stay in lockstep.

**`packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx`**
- Fixed a re-render bug exposed by actually enabling the feature: the modal re-synced its `dataSource` from `columnOptions` / `initialColumnOrder` on every identity change. Because `BAITable` rebuilds `columns` (and thus a new `initialColumnOrder` array) on each render, any parent re-render while the modal is open — e.g. the session list auto-refresh — reset the table and **wiped the user's in-progress drag reorder / visibility edits**. The re-sync now keys off a value-based signature (column keys + persisted visibility + persisted order) via `useEffectEvent`, so identity churn from parent re-renders no longer clobbers in-progress edits.
- Renamed the modal's `disableSorter` prop to `disableReorder`. The old name semantically collided with antd's standard "sorter" (= column data sort, asc/desc) — and the `*Nodes` components in this same package legitimately use `disableSorter` for that data-sort meaning. The modal's prop actually gates the drag-to-reorder handle column, not data sorting; renaming removes the same-name-opposite-meaning collision now that this PR is the first to actually exercise the prop.

**`packages/backend.ai-ui/src/components/Table/BAITableSettingModal.stories.tsx`**
- Followed the prop rename in argTypes, docs, and the disabled-reorder story.

No per-page changes: `ComputeSessionListPage` is unchanged from `main` because reorder is now the default.

## Why default-on (opt-out)

The reorder wiring lives in the shared `BAITable`. Every page that uses `tableSettings` already has a settings modal where visibility is editable; making reorder a separate opt-in flag would be asymmetric and create an arbitrary per-page boilerplate (`allowColumnReorder: true`) that's easy to forget and produces inconsistent UX across tables. Persistence is automatic (rides the existing `columnOverrides` record). The opt-out exists for the rare table whose order is semantically fixed.

## Verification

`bash scripts/verify.sh`: Relay / Lint / Format / Vite warmup **PASS**. The TypeScript step's failures are pre-existing `@types/react` phantom errors present identically on a pristine `main` checkout in this environment (antd `Card`/`ErrorBoundary` "not a valid JSX element" + blanket implicit-any); the dev server's `tsc --watch` reports **0 errors** for this change.

**Live verification on a dev server (backend `http://10.122.10.107:8090`, admin account):**
- Table settings modal now shows a drag handle next to every column on the compute session list (previously hidden).
- Dragging a column (Memory) above another (Status) and confirming reorders the table.
- The order persists in `table_column_overrides.ComputeSessionListPage` and survives a full page reload.
- The re-render fix verified: dragging, waiting for a session-list auto-refresh, then confirming now keeps the new order (previously it reverted).
- Default-on verified on a second table: the Agent list (`Admin Settings → Resources → Agent`) shows the same drag handles in its settings modal with no per-page change.
- Prop rename verified after HMR: modal still opens, all column rows still show their drag handles.

## Out of scope (follow-up)

- UX polish for the interaction between reordering and `fixed: 'left'` / `required` columns (e.g. the `name` column). Planned fix is to keep `fixed` columns pinned to the edges during reorder at the BAITable level. Now applies to every table that has a fixed column, since reorder is default-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)