### PR TITLE
fix(FR-2975): display build number in splash and About modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
     <!-- Backend.AI client classes are now initialized by React global-stores.ts -->
     <script nonce="{{nonce}}">
       document.getElementById('version-detail').innerText = globalThis.packageVersion;
-      document.getElementById('build-detail').innerText = ' Build ' + globalThis.buildVersion;
+      document.getElementById('build-detail').innerText = ' Build ' + globalThis.buildNumber;
       document.getElementById('license-detail').innerText = '';
       if (globalThis.isElectron) {
         document.getElementById('mode-detail').innerText = 'App';

--- a/react/src/ambient.d.ts
+++ b/react/src/ambient.d.ts
@@ -45,7 +45,7 @@ declare module globalThis {
   // eslint-disable-next-line no-var
   var packageValidUntil: string;
   // eslint-disable-next-line no-var
-  var buildVersion: string;
+  var buildNumber: string;
   // eslint-disable-next-line no-var
   var appLauncher: {
     showLauncher?: (sessionId: {

--- a/react/src/components/AboutBackendAIModal.tsx
+++ b/react/src/components/AboutBackendAIModal.tsx
@@ -25,7 +25,7 @@ const AboutBackendAIModal = ({
   // @ts-ignore
   const packageEdition = globalThis.packageEdition;
   // @ts-ignore
-  const buildVersion = globalThis.buildVersion;
+  const buildNumber = globalThis.buildNumber;
   // @ts-ignore
   const isElectron = globalThis.isElectron;
 
@@ -88,7 +88,7 @@ const AboutBackendAIModal = ({
       <Typography.Paragraph>
         Backend.AI Cluster {baiClient.managerVersion}
         <br />
-        {isElectron ? 'App' : 'WebServer'} Build {buildVersion}
+        {isElectron ? 'App' : 'WebServer'} Build {buildNumber}
       </Typography.Paragraph>
       <Typography.Paragraph>
         Powered by{' '}


### PR DESCRIPTION
Resolves #7593 ([FR-2975](https://lablup.atlassian.net/browse/FR-2975))

## Summary
- Fix splash screen `Build undefined` by reading `globalThis.buildNumber` (the value the Makefile actually injects) instead of the obsolete `globalThis.buildVersion`.
- Fix the same regression in the About Backend.AI modal so it shows `WebServer Build <N>` / `App Build <N>` again.
- Update the ambient global declaration (`react/src/ambient.d.ts`) to declare `buildNumber: string` so the TypeScript type matches the runtime contract.

## Why
The Makefile's `versiontag` target writes `globalThis.buildNumber = "<rev-count>"` into `index.html`. The splash script and the About modal were still reading the long-removed `globalThis.buildVersion`, so both showed `undefined`. The sider footer already reads `buildNumber` correctly; this PR aligns the remaining two consumers.

## Test plan
- [ ] Load the app; splash screen displays `WebServer Build <number>` (no `undefined`).
- [ ] Open About Backend.AI modal; build line displays `WebServer Build <number>` / `App Build <number>`.
- [ ] Sider footer continues to show `<packageVersion>.<buildNumber>`.

[FR-2975]: https://lablup.atlassian.net/browse/FR-2975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ