### PR TITLE
fix(FR-2973): prevent invitation panel disabled-state leak after refresh

### DIFF
--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -25,7 +25,8 @@ import '@material/mwc-icon-button';
 import '@material/mwc-select';
 import { css, CSSResultGroup, html } from 'lit';
 import { get as _text, translate as _t } from 'lit-translate';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
 
 /* FIXME:
  * This type definition is a workaround for resolving both Type error and Importing error.
@@ -83,6 +84,7 @@ export default class BackendAISummary extends BackendAIPage {
   @property({ type: Object }) notification = Object();
   @property({ type: Object }) resourcePolicy;
   @property({ type: Object }) invitations = Object();
+  @state() protected _processingInvitations: Set<string> = new Set();
   @property({ type: Object }) appDownloadMap;
   @property({ type: String }) appDownloadUrl;
   @property({ type: Boolean }) allowAppDownloadPanel = true;
@@ -386,25 +388,19 @@ export default class BackendAISummary extends BackendAIPage {
     if (!this.activeConnected) {
       return;
     }
-    const panel = e.target.closest('lablup-activity-panel');
+    this._markInvitationProcessing(invitation.id, true);
     try {
-      panel.setAttribute('disabled', 'true');
-      panel.querySelectorAll('mwc-button').forEach((btn) => {
-        btn.setAttribute('disabled', 'true');
-      });
       await globalThis.backendaiclient.vfolder.accept_invitation(invitation.id);
       this.notification.text =
         _text('summary.AcceptSharedVFolder') + `${invitation.vfolder_name}`;
       this.notification.show();
       this._refreshInvitations();
     } catch (err) {
-      panel.setAttribute('disabled', 'false');
-      panel.querySelectorAll('mwc-button').forEach((btn) => {
-        btn.setAttribute('disabled', 'false');
-      });
       this.notification.text = PainKiller.relieve(err.title);
       this.notification.detail = err.message;
       this.notification.show(true, err);
+    } finally {
+      this._markInvitationProcessing(invitation.id, false);
     }
   }
 
@@ -418,27 +414,39 @@ export default class BackendAISummary extends BackendAIPage {
     if (!this.activeConnected) {
       return;
     }
-    const panel = e.target.closest('lablup-activity-panel');
-
+    this._markInvitationProcessing(invitation.id, true);
     try {
-      panel.setAttribute('disabled', 'true');
-      panel.querySelectorAll('mwc-button').forEach((btn) => {
-        btn.setAttribute('disabled', 'true');
-      });
       await globalThis.backendaiclient.vfolder.delete_invitation(invitation.id);
       this.notification.text =
         _text('summary.DeclineSharedVFolder') + `${invitation.vfolder_name}`;
       this.notification.show();
       this._refreshInvitations();
     } catch (err) {
-      panel.setAttribute('disabled', 'false');
-      panel.querySelectorAll('mwc-button').forEach((btn) => {
-        btn.setAttribute('disabled', 'false');
-      });
       this.notification.text = PainKiller.relieve(err.title);
       this.notification.detail = err.message;
       this.notification.show(true, err);
+    } finally {
+      this._markInvitationProcessing(invitation.id, false);
     }
+  }
+
+  /**
+   * Mark an invitation as currently being processed so its panel/buttons
+   * render as disabled. Uses state-based tracking instead of imperative
+   * DOM mutation, which previously leaked across nodes when Lit reused
+   * keyless map() entries after `_refreshInvitations()` rebuilt the list.
+   *
+   * @param {string} invitationId
+   * @param {boolean} processing
+   */
+  private _markInvitationProcessing(invitationId: string, processing: boolean) {
+    const next = new Set(this._processingInvitations);
+    if (processing) {
+      next.add(invitationId);
+    } else {
+      next.delete(invitationId);
+    }
+    this._processingInvitations = next;
   }
 
   _stripHTMLTags(str) {
@@ -569,61 +577,71 @@ export default class BackendAISummary extends BackendAIPage {
             >
               <div slot="message">
                 ${this.invitations.length > 0
-                  ? this.invitations.map(
-                      (invitation, index) => html`
-                        <lablup-activity-panel
-                          class="inner-panel"
-                          noheader
-                          autowidth
-                          elevation="0"
-                          height="130"
-                        >
-                          <div slot="message">
-                            <div class="wrap layout">
-                              <h3 style="padding-top:10px;">
-                                From ${invitation.inviter}
-                              </h3>
-                              <span class="invitation_folder_name">
-                                ${_t('summary.FolderName')}:
-                                ${invitation.vfolder_name}
-                              </span>
-                              <div class="horizontal center layout">
-                                ${_t('summary.Permission')}:
-                                ${[...invitation.perm].map(
-                                  (c) => html`
-                                    <lablup-shields
-                                      app=""
-                                      color="${['green', 'blue', 'red'][
-                                        ['r', 'w', 'd'].indexOf(c)
-                                      ]}"
-                                      description="${c.toUpperCase()}"
-                                      ui="flat"
-                                    ></lablup-shields>
-                                  `,
-                                )}
-                              </div>
-                              <div
-                                style="margin:15px auto;"
-                                class="horizontal layout end-justified"
-                              >
-                                <mwc-button
-                                  outlined
-                                  label="${_t('summary.Decline')}"
-                                  @click="${(e) =>
-                                    this._deleteInvitation(e, invitation)}"
-                                ></mwc-button>
-                                <mwc-button
-                                  unelevated
-                                  label="${_t('summary.Accept')}"
-                                  @click="${(e) =>
-                                    this._acceptInvitation(e, invitation)}"
-                                ></mwc-button>
-                                <span class="flex"></span>
+                  ? repeat(
+                      this.invitations,
+                      (invitation: any) => invitation.id,
+                      (invitation: any) => {
+                        const isProcessing = this._processingInvitations.has(
+                          invitation.id,
+                        );
+                        return html`
+                          <lablup-activity-panel
+                            class="inner-panel"
+                            noheader
+                            autowidth
+                            elevation="0"
+                            height="130"
+                            ?disabled="${isProcessing}"
+                          >
+                            <div slot="message">
+                              <div class="wrap layout">
+                                <h3 style="padding-top:10px;">
+                                  From ${invitation.inviter}
+                                </h3>
+                                <span class="invitation_folder_name">
+                                  ${_t('summary.FolderName')}:
+                                  ${invitation.vfolder_name}
+                                </span>
+                                <div class="horizontal center layout">
+                                  ${_t('summary.Permission')}:
+                                  ${[...invitation.perm].map(
+                                    (c) => html`
+                                      <lablup-shields
+                                        app=""
+                                        color="${['green', 'blue', 'red'][
+                                          ['r', 'w', 'd'].indexOf(c)
+                                        ]}"
+                                        description="${c.toUpperCase()}"
+                                        ui="flat"
+                                      ></lablup-shields>
+                                    `,
+                                  )}
+                                </div>
+                                <div
+                                  style="margin:15px auto;"
+                                  class="horizontal layout end-justified"
+                                >
+                                  <mwc-button
+                                    outlined
+                                    label="${_t('summary.Decline')}"
+                                    ?disabled="${isProcessing}"
+                                    @click="${(e) =>
+                                      this._deleteInvitation(e, invitation)}"
+                                  ></mwc-button>
+                                  <mwc-button
+                                    unelevated
+                                    label="${_t('summary.Accept')}"
+                                    ?disabled="${isProcessing}"
+                                    @click="${(e) =>
+                                      this._acceptInvitation(e, invitation)}"
+                                  ></mwc-button>
+                                  <span class="flex"></span>
+                                </div>
                               </div>
                             </div>
-                          </div>
-                        </lablup-activity-panel>
-                      `,
+                          </lablup-activity-panel>
+                        `;
+                      },
                     )
                   : html`
                       <p>${_text('summary.NoInvitations')}</p>


### PR DESCRIPTION
Backports the invitation panel disabled-state leak fix to the 23.09 release branch.

Jira: [FR-2973](https://lablup.atlassian.net/browse/FR-2973)

## Root cause

In `src/components/backend-ai-summary-view.ts`, the Summary view's pending-invitation list combined two issues:

1. **Imperative DOM mutation in handlers.** `_acceptInvitation` / `_deleteInvitation` reached into the clicked node with

   ```ts
   const panel = e.target.closest('lablup-activity-panel');
   panel.setAttribute('disabled', 'true');
   panel.querySelectorAll('mwc-button').forEach((btn) =>
     btn.setAttribute('disabled', 'true'),
   );
   ```

   to lock the row while the API call was in flight.

2. **Keyless list render.** The render template used `this.invitations.map((invitation, index) => html\`…\`)` with no `repeat()` directive and no key. Lit therefore reuses list-item DOM nodes by **index** when the list changes.

### The bug

Given `[test, test4]` and clicking *Accept* on `test`:

1. DOM node #0 (currently bound to `test`) gets `disabled` set on the panel and on its inner `mwc-button`s.
2. The API succeeds and `_refreshInvitations()` rebuilds the array as `[test4]`.
3. Lit reuses index-0 DOM node — node #0 — and rebinds its content to `test4`. The stale `disabled` attributes set in step 1 stay on the reused node.
4. `test4` now renders disabled even though no action is in flight on it.

## Fix

- Replace imperative DOM mutation with a reactive state:
  ```ts
  @state() protected _processingInvitations: Set<string> = new Set();
  ```
  toggled via a small helper `_markInvitationProcessing(id, processing)` that swaps in a new `Set` so Lit picks up the change.
- Switch the list render from a keyless `.map()` to
  ```ts
  repeat(this.invitations, (invitation) => invitation.id, (invitation) => html\`…\`)
  ```
  so Lit reconciles items by identity (`invitation.id`), not by index.
- Bind `?disabled` on the inner `lablup-activity-panel` and on both `mwc-button`s to `_processingInvitations.has(invitation.id)`.
- Wrap the processing-flag clear in a `finally` block so the busy state is always released, regardless of success or failure (the previous catch-only reset path no longer applies because the state is keyed by id, not by DOM identity).

After the fix, the disabled state is bound to invitation **id**, not to a DOM node, so it cannot leak across rows when the list is rebuilt.

## Test plan

- [ ] Open the Summary view with two pending invitations (e.g. `test`, `test4`).
- [ ] Click *Accept* on `test`. The `test` row's buttons disable during the request.
- [ ] After the API resolves and the list refreshes to `[test4]`, the `test4` row's *Accept* / *Decline* buttons are **enabled** (regression check for FR-2973).
- [ ] Click *Decline* on `test4`. Buttons disable during the request, list refreshes to empty.
- [ ] Force an API failure (e.g. revoke the invitation mid-flight): the row's buttons re-enable after the error toast.

## Notes

- `_processingInvitations` is intentionally `@state()` (component-private reactive state) rather than `@property()` — it is not part of the public element API.
- Targets `23.09` because this is a maintenance backport of a customer-impacting bug on the release branch.

[FR-2973]: https://lablup.atlassian.net/browse/FR-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ