### PR TITLE
fix(FR-2980): allow target replica count of 0 when editing existing deployment

### DIFF
--- a/react/src/components/DeploymentSettingModal.tsx
+++ b/react/src/components/DeploymentSettingModal.tsx
@@ -283,7 +283,7 @@ const DeploymentSettingModal: React.FC<DeploymentSettingModalProps> = ({
               },
             ]}
           >
-            <InputNumber min={1} style={{ width: '100%' }} />
+            <InputNumber min={deployment ? 0 : 1} style={{ width: '100%' }} />
           </Form.Item>
           <Form.Item
             name="tags"


### PR DESCRIPTION
Resolves #7603 (FR-2980)

## Summary

Allows the target replica count to be set to `0` in **Edit Deployment**, so an operator can scale an existing deployment down to zero active replicas. The minimum at **Create** time stays at `1` — creating a deployment that never runs would be confusing — so the constraint is:

```tsx
<InputNumber min={deployment ? 0 : 1} ... />
```

`deployment` is the existing mode discriminator in `DeploymentSettingModal` (truthy in edit mode, falsy in create mode), so no new flag is introduced.

## Why edit-only

Edit-only matches the literal request in FR-2980 and the typical use case (scale-to-zero on an already-running deployment). A future reader who notices the asymmetry should know it is deliberate, not an oversight.

## Side checks

- AntD `required: true` treats `0` as present (only rejects `undefined`/`null`/`''`), so the existing required rule still passes when the user enters `0`.
- `initialValues.replicaCount = deployment.replicaState?.desiredReplicaCount ?? 1` uses `??`, which preserves a backend `0` correctly when re-opening the modal.
- Tooltip copy (`deployment.DesiredReplicasTooltip`) is generic ("Number of replicas to keep running… The system scales the active pool toward this target") and already accommodates a target of 0 — no i18n drift.
- `UpdateDeploymentInput.replicaCount` is typed `number | null | undefined`, so the GraphQL schema accepts `0`. **Backend resolver acceptance of `0` should be verified against a real backend before merging.**

## Verification

`bash scripts/verify.sh` (in the worktree):

```
=== Relay ===           PASS
=== Lint ===            PASS
=== Format ===          PASS
=== TypeScript ===      FAIL (218 errors — identical baseline to main; no new errors in DeploymentSettingModal.tsx)
=== Vite warmup paths === FAIL (pre-existing baseline)
```

The TypeScript baseline on `main` is **218 errors** and this PR also reports **218 errors** — net change 0.

## Test plan

- [ ] Open an existing deployment, click **Edit**, change Desired Replicas to `0`, **Save** → request succeeds, deployment scales to zero.
- [ ] Open **Create Deployment** → Desired Replicas still rejects values below `1`.
- [ ] Re-open a deployment that was scaled to `0` → the form shows `0`, not `1`.