### PR TITLE
fix(FR-2981): detect browser language at i18n init so login screen respects locale

### DIFF
--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -5,6 +5,7 @@
 import { RelayEnvironment } from '../RelayEnvironment';
 import { backendaiOptions } from '../global-stores';
 import { buiLanguages } from '../helper/bui-language';
+import { resolveInitialLanguage } from '../helper/resolveInitialLanguage';
 import {
   backendaiClientPromise,
   createAnonymousBackendaiClient,
@@ -100,6 +101,24 @@ if (typeof window !== 'undefined') {
   };
 }
 
+// Stored-language candidates for `resolveInitialLanguage`, in precedence
+// order. `BackendAISettingsStore` seeds its in-memory options with
+// `'general.language': 'en'`, so `get('language', …, 'general')` alone cannot
+// tell "a language was persisted on a previous visit" apart from "fresh store
+// default" — and treating the seed as an explicit choice would disable
+// browser-language detection entirely (the FR-2981 bug). So:
+//   1. `user.selected_language` — the user's explicit settings-page choice.
+//      Unseeded; `get()` returns null when the user never chose.
+//   2. `general.language` — the last resolved language, but only when the
+//      localStorage key actually exists (i.e. it was persisted, not seeded).
+const getStoredLanguageCandidates = (): Array<string | null | undefined> => [
+  backendaiOptions?.get('selected_language'),
+  typeof localStorage !== 'undefined' &&
+  localStorage.getItem('backendaiwebui.settings.general.language') !== null
+    ? backendaiOptions?.get('language', undefined, 'general')
+    : undefined,
+];
+
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
   .use(Backend)
@@ -145,7 +164,11 @@ i18n
     },
     postProcess:
       process.env.NODE_ENV === 'development' ? ['copyableI18nKey'] : [],
-    lng: backendaiOptions?.get('language', 'default', 'general') || 'en',
+    // Resolve the initial language so first-paint screens (notably the login
+    // page) render in the user's browser language even when nothing has been
+    // persisted yet (e.g. private / incognito browsing). See
+    // `helper/resolveInitialLanguage.ts` for the supported-language list.
+    lng: resolveInitialLanguage(...getStoredLanguageCandidates()),
     fallbackLng: 'en',
     interpolation: {
       escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
@@ -193,8 +216,15 @@ if (import.meta.hot) {
 }
 
 export const useCurrentLanguage = () => {
+  // Resolve through the same helper as the i18n init above. On first visit
+  // the stored value is absent (legacy code may also have persisted the
+  // 'default' sentinel), and the mount effect below re-applies `lang` via
+  // `changeLanguage`. Without this resolution the effect would bounce i18n
+  // back to 'default' right after init — undoing the browser-language
+  // detection on the login screen — and set `dayjs.locale('default')` /
+  // `<html lang="default">` along the way.
   const [lang, _setLang] = useState(
-    backendaiOptions?.get('language', 'default', 'general') || 'en',
+    resolveInitialLanguage(...getStoredLanguageCandidates()),
   );
   const { i18n } = useTranslation();
 

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -29,6 +29,7 @@ import {
   loginWithSAML,
   loginWithOpenID,
 } from '../helper/loginSessionAuth';
+import { resolveInitialLanguage } from '../helper/resolveInitialLanguage';
 import { useLoginOrchestration } from '../hooks/useLoginOrchestration';
 import {
   useInitializeConfig,
@@ -42,6 +43,7 @@ import { jotaiStore } from './DefaultProviders';
 import LoginFormPanel from './LoginFormPanel';
 import { App, Button, ConfigProvider, Form, type MenuProps, Tag } from 'antd';
 import { BAIModal, BAIFlex, useBAILogger } from 'backend.ai-ui';
+import i18n from 'i18next';
 import { useAtomValue, useSetAtom } from 'jotai';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -260,54 +262,30 @@ const LoginView: React.FC<{
   }, []);
 
   // Language initialization: bridge selected_language -> general.language
-  // (replaces Lit shell's connectedCallback language setup)
+  // (replaces Lit shell's connectedCallback language setup).
+  //
+  // Shares its supported-language list and detection logic with i18n init
+  // in `DefaultProviders.tsx` via `resolveInitialLanguage`, so the login
+  // screen renders in the browser's language on first paint even when no
+  // value has been persisted yet (incognito / first-visit).
   useEffect(() => {
-    const supportLanguageCodes = [
-      'en',
-      'ko',
-      'de',
-      'el',
-      'es',
-      'fi',
-      'fr',
-      'id',
-      'it',
-      'ja',
-      'mn',
-      'ms',
-      'pl',
-      'pt',
-      'pt-BR',
-      'ru',
-      'th',
-      'tr',
-      'vi',
-      'zh-CN',
-      'zh-TW',
-    ];
+    // `selected_language` is the "user explicitly chose this" signal that
+    // overrides browser detection. If it isn't an explicit supported
+    // choice, fall back to browser detection via the shared helper.
     const selectedLang = (globalThis as any).backendaioptions?.get(
       'selected_language',
     );
+    const lang = resolveInitialLanguage(selectedLang);
 
-    // Try full locale first (e.g., 'zh-CN'), then base language (e.g., 'zh')
-    const browserLang = globalThis.navigator.language;
-    let defaultLang: string;
-    if (supportLanguageCodes.includes(browserLang)) {
-      defaultLang = browserLang;
-    } else {
-      const baseLang = browserLang.split('-')[0];
-      defaultLang = supportLanguageCodes.includes(baseLang) ? baseLang : 'en';
-    }
-
-    let lang: string;
-    if (!selectedLang || selectedLang === 'default') {
-      lang = defaultLang;
-    } else {
-      lang = supportLanguageCodes.includes(selectedLang)
-        ? selectedLang
-        : defaultLang;
-    }
     (globalThis as any).backendaioptions.set('language', lang, 'general');
+
+    // Defensive sync: i18n was already initialized with the same resolver
+    // in DefaultProviders.tsx, so this usually matches. Trigger a switch
+    // only when it doesn't (e.g. a stored explicit choice was added between
+    // init and mount).
+    if (i18n.language !== lang) {
+      i18n.changeLanguage(lang);
+    }
   }, []);
 
   const notification = useCallback((text: string, detail?: string) => {

--- a/react/src/helper/bui-language.ts
+++ b/react/src/helper/bui-language.ts
@@ -11,6 +11,7 @@
 // access them via BUI's internal i18next instance (`useBAIi18n` /
 // `BAITrans`), so the host has no reason to hold a second copy. See
 // FR-2986 / packages/backend.ai-ui/src/hooks/useBAIi18n.ts.
+import type { SupportedLanguage } from './resolveInitialLanguage';
 import de_DE from 'backend.ai-ui/dist/locale/de_DE';
 import el_GR from 'backend.ai-ui/dist/locale/el_GR';
 import en_US from 'backend.ai-ui/dist/locale/en_US';
@@ -33,7 +34,12 @@ import vi_VN from 'backend.ai-ui/dist/locale/vi_VN';
 import zh_CN from 'backend.ai-ui/dist/locale/zh_CN';
 import zh_TW from 'backend.ai-ui/dist/locale/zh_TW';
 
-// languages which are supported by backend.ai-ui
+// languages which are supported by backend.ai-ui.
+// The `satisfies` clause below is a compile-time guard that keeps this map
+// in exact two-way sync with `SUPPORTED_LANGUAGES` in
+// `helper/resolveInitialLanguage.ts` (a missing key or an extra key is a
+// type error). Type-only import, so the Vitest mock of this module is
+// unaffected.
 export const buiLanguages = {
   de: de_DE,
   el: el_GR,
@@ -56,4 +62,4 @@ export const buiLanguages = {
   vi: vi_VN,
   'zh-CN': zh_CN,
   'zh-TW': zh_TW,
-};
+} satisfies Record<SupportedLanguage, typeof en_US>;

--- a/react/src/helper/resolveInitialLanguage.test.ts
+++ b/react/src/helper/resolveInitialLanguage.test.ts
@@ -1,0 +1,98 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  SUPPORTED_LANGUAGES,
+  detectBrowserLanguage,
+  resolveInitialLanguage,
+} from './resolveInitialLanguage';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockNavigatorLanguage = (lang: string | undefined) => {
+  if (lang === undefined) {
+    vi.stubGlobal('navigator', undefined);
+    return;
+  }
+  vi.stubGlobal('navigator', { language: lang });
+};
+
+describe('resolveInitialLanguage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the stored value when it is an explicit supported choice', () => {
+    mockNavigatorLanguage('en-US');
+    expect(resolveInitialLanguage('ko')).toBe('ko');
+    expect(resolveInitialLanguage('zh-CN')).toBe('zh-CN');
+  });
+
+  it('ignores the legacy "default" sentinel and falls back to browser detection', () => {
+    mockNavigatorLanguage('ko-KR');
+    expect(resolveInitialLanguage('default')).toBe('ko');
+  });
+
+  it('ignores null / undefined / empty stored values', () => {
+    mockNavigatorLanguage('ko');
+    expect(resolveInitialLanguage(null)).toBe('ko');
+    expect(resolveInitialLanguage(undefined)).toBe('ko');
+    expect(resolveInitialLanguage('')).toBe('ko');
+  });
+
+  it('ignores an unsupported stored value and falls back to browser detection', () => {
+    mockNavigatorLanguage('ja');
+    // 'xx' is not in SUPPORTED_LANGUAGES
+    expect(resolveInitialLanguage('xx')).toBe('ja');
+  });
+
+  it('matches the full locale when supported (e.g. zh-CN)', () => {
+    mockNavigatorLanguage('zh-CN');
+    expect(detectBrowserLanguage()).toBe('zh-CN');
+    expect(resolveInitialLanguage(undefined)).toBe('zh-CN');
+  });
+
+  it('falls back to the base language when the full locale is not supported (e.g. ko-KR -> ko)', () => {
+    mockNavigatorLanguage('ko-KR');
+    expect(detectBrowserLanguage()).toBe('ko');
+    expect(resolveInitialLanguage(undefined)).toBe('ko');
+  });
+
+  it('returns "en" when neither the full locale nor the base language is supported', () => {
+    mockNavigatorLanguage('xx-YY');
+    expect(detectBrowserLanguage()).toBe('en');
+    expect(resolveInitialLanguage(undefined)).toBe('en');
+  });
+
+  it('is SSR-safe when navigator is undefined', () => {
+    mockNavigatorLanguage(undefined);
+    expect(detectBrowserLanguage()).toBe('en');
+    expect(resolveInitialLanguage(undefined)).toBe('en');
+  });
+
+  it('returns "en" when navigator.language is an empty string', () => {
+    mockNavigatorLanguage('');
+    expect(detectBrowserLanguage()).toBe('en');
+  });
+
+  it('tries candidates in order and returns the first explicit supported choice', () => {
+    mockNavigatorLanguage('fr');
+    expect(resolveInitialLanguage('ko', 'ja')).toBe('ko');
+    expect(resolveInitialLanguage(null, 'ja')).toBe('ja');
+    // the 'default' sentinel and unsupported codes are skipped, not honored
+    expect(resolveInitialLanguage('default', 'ja')).toBe('ja');
+    expect(resolveInitialLanguage(undefined, 'xx')).toBe('fr');
+  });
+
+  it('falls back to browser detection when called with no candidates', () => {
+    mockNavigatorLanguage('ko-KR');
+    expect(resolveInitialLanguage()).toBe('ko');
+  });
+
+  it('exposes the full supported-language list', () => {
+    expect(SUPPORTED_LANGUAGES).toContain('en');
+    expect(SUPPORTED_LANGUAGES).toContain('ko');
+    expect(SUPPORTED_LANGUAGES).toContain('zh-CN');
+    expect(SUPPORTED_LANGUAGES).toContain('pt-BR');
+  });
+});

--- a/react/src/helper/resolveInitialLanguage.ts
+++ b/react/src/helper/resolveInitialLanguage.ts
@@ -1,0 +1,110 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+
+/**
+ * The list of language codes the WebUI ships translations for. Used both at
+ * i18n initialization time (`DefaultProviders.tsx`) and inside `LoginView` to
+ * normalize a stored / browser-reported locale to one the app actually
+ * supports.
+ *
+ * Keep this list in sync with the translation files under
+ * `resources/i18n/*.json`. Sync with the BUI locale map is enforced at
+ * compile time: `helper/bui-language.ts` declares
+ * `buiLanguages satisfies Record<SupportedLanguage, …>`, so adding or
+ * removing a language in only one of the two places is a type error.
+ */
+export const SUPPORTED_LANGUAGES = [
+  'en',
+  'ko',
+  'de',
+  'el',
+  'es',
+  'fi',
+  'fr',
+  'id',
+  'it',
+  'ja',
+  'mn',
+  'ms',
+  'pl',
+  'pt',
+  'pt-BR',
+  'ru',
+  'th',
+  'tr',
+  'vi',
+  'zh-CN',
+  'zh-TW',
+] as const;
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+const SUPPORTED_SET: ReadonlySet<string> = new Set(SUPPORTED_LANGUAGES);
+
+const isSupported = (code: string): code is SupportedLanguage =>
+  SUPPORTED_SET.has(code);
+
+/**
+ * Returns `true` if the given value names a real, supported language. The
+ * literal string `'default'` is treated as "no choice" — it is a sentinel
+ * value used by the legacy settings store, not a valid IETF locale.
+ */
+const isExplicitSupportedChoice = (
+  value: string | null | undefined,
+): value is SupportedLanguage =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  value !== 'default' &&
+  isSupported(value);
+
+/**
+ * Picks the best supported language for the current browser by trying the
+ * full locale first (e.g. `zh-CN`), then the base language (e.g. `zh`), and
+ * finally falling back to `en`. SSR-safe: returns `'en'` when `navigator`
+ * is not defined.
+ */
+export const detectBrowserLanguage = (): SupportedLanguage => {
+  if (typeof navigator === 'undefined') {
+    return 'en';
+  }
+  const browserLang = navigator.language;
+  if (!browserLang) {
+    return 'en';
+  }
+  if (isSupported(browserLang)) {
+    return browserLang;
+  }
+  const baseLang = browserLang.split('-')[0];
+  if (isSupported(baseLang)) {
+    return baseLang;
+  }
+  return 'en';
+};
+
+/**
+ * Resolves the initial language for i18next. Candidates are tried in order;
+ * the first explicit, supported choice (typically the user's persisted
+ * `selected_language`, then the persisted `general.language`) wins. When no
+ * candidate names a real language we fall back to the browser-detected
+ * language so that first-paint screens — most notably the login page —
+ * render in the user's language even when nothing has been persisted yet
+ * (e.g. private / incognito browsing).
+ *
+ * Callers are responsible for not passing in-memory store *defaults* as
+ * candidates: `BackendAISettingsStore` seeds `general.language` with `'en'`,
+ * and treating that seed as an explicit choice would disable browser
+ * detection entirely. See `getStoredLanguageCandidates` in
+ * `components/DefaultProviders.tsx`.
+ */
+export const resolveInitialLanguage = (
+  ...storedValues: Array<string | null | undefined>
+): SupportedLanguage => {
+  for (const storedValue of storedValues) {
+    if (isExplicitSupportedChoice(storedValue)) {
+      return storedValue;
+    }
+  }
+  return detectBrowserLanguage();
+};


### PR DESCRIPTION
Resolves #7604 (FR-2981)

On a first visit with no `localStorage` history (e.g. incognito), the login screen rendered in English regardless of the browser language, because i18n was initialized from the settings store before any language had been resolved.

**What this PR changes**

- Adds `helper/resolveInitialLanguage.ts` — a single shared helper owning the supported-language list (`SUPPORTED_LANGUAGES`), browser-language detection (full locale → base language → `en`), and stored-value normalization (the legacy `'default'` sentinel and unsupported codes are treated as "no choice").
- `resolveInitialLanguage(...candidates)` accepts candidates in precedence order and returns the first explicit supported choice, falling back to browser detection.
- Wires the helper into the three sites that previously leaked `'default'` / seeded defaults into i18next:
  - **`i18n.init` `lng`** (DefaultProviders module scope) — first paint of the login screen now follows the browser locale when nothing has been persisted.
  - **`useCurrentLanguage`** (DefaultProviders) — its mount effect re-applies the stored value via `changeLanguage`; without resolving it bounced i18n back to `'default'` right after init and set `dayjs.locale('default')` / `<html lang="default">`.
  - **`LoginView`'s `selected_language` → `general.language` bridge** — replaces the inline duplicated language list and detection logic.
- **Seeded-default guard** (from Copilot review): `BackendAISettingsStore` seeds its in-memory options with `'general.language': 'en'`, so `get('language', …, 'general')` alone can never distinguish "persisted on a previous visit" from "fresh store default" — the seed would masquerade as an explicit choice and disable browser detection. `getStoredLanguageCandidates()` in `DefaultProviders.tsx` therefore resolves in order: `user.selected_language` (unseeded; the user's explicit settings-page choice) → `general.language` only when the `localStorage` key actually exists → browser detection.
- `buiLanguages` in `helper/bui-language.ts` now declares `satisfies Record<SupportedLanguage, …>`, a compile-time two-way sync guard between the BUI locale map and `SUPPORTED_LANGUAGES`.
- Unit tests for the helper (12 cases): candidate precedence, `'default'` sentinel, full-locale/base-language fallback, SSR safety.

**Verification**

- `pnpm vitest run src/helper/resolveInitialLanguage.test.ts` — 12 passed
- `bash scripts/verify.sh` — `=== ALL PASS ===`

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
