### PR TITLE
fix(FR-2978): send empty JSON body in vfolder leave_invited to avoid 400

### DIFF
--- a/packages/backend.ai-client/src/resources/vfolder.ts
+++ b/packages/backend.ai-client/src/resources/vfolder.ts
@@ -232,15 +232,21 @@ export class VFolder {
    * Leave an invited Virtual folder.
    *
    * @param {string} name - Virtual folder name. If no name is given, use name on this VFolder object.
+   * @param {string} sharedUserUuid - Optional shared user UUID (admin leaving on behalf of another user).
    */
-  async leave_invited(name = null): Promise<any> {
+  async leave_invited(
+    name = null,
+    sharedUserUuid: string | null = null,
+  ): Promise<any> {
     if (name == null) {
       name = this.name;
     }
+    const body =
+      sharedUserUuid != null ? { shared_user_uuid: sharedUserUuid } : {};
     let rqst = this.client.newSignedRequest(
       'POST',
       `${this.urlPrefix}/${name}/leave`,
-      null,
+      body,
     );
     return this.client._wrapWithPromise(rqst);
   }

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -149,7 +149,10 @@ export type BackendAIClient = {
       user: string;
       vfolder: string;
     }): Promise<any>;
-    leave_invited(name: string | null): Promise<any>;
+    leave_invited(
+      name: string | null,
+      sharedUserUuid?: string | null,
+    ): Promise<any>;
     info: (name: string) => Promise<any>;
     mkdir: (
       path: string,

--- a/src/lib/backend.ai-client-node.ts
+++ b/src/lib/backend.ai-client-node.ts
@@ -1900,15 +1900,18 @@ class VFolder {
    * Leave an invited Virtual folder.
    *
    * @param {string} name - Virtual folder name. If no name is given, use name on this VFolder object.
+   * @param {string} sharedUserUuid - Optional shared user UUID (admin leaving on behalf of another user).
    */
-  async leave_invited(name = null) {
+  async leave_invited(name = null, sharedUserUuid: string | null = null) {
     if (name == null) {
       name = this.name;
     }
+    const body =
+      sharedUserUuid != null ? { shared_user_uuid: sharedUserUuid } : {};
     let rqst = this.client.newSignedRequest(
       'POST',
       `${this.urlPrefix}/${name}/leave`,
-      null,
+      body,
     );
     return this.client._wrapWithPromise(rqst);
   }


### PR DESCRIPTION
**Jira**: [FR-2978](https://lablup.atlassian.net/browse/FR-2978)

> Targets `main` directly. The previously-stacked generalized fix (#7651, which made `newSignedRequest` send `{}` for *every* null-body non-GET request) was dropped: on legacy backends `@check_api_params` only falls back to `dict(request.query)` when the body is empty, so a blanket `{}` body would suppress that fallback and silently drop query-string params on `destroy`/`restart` (e.g. `forced`, `owner_access_key`). This PR keeps the fix targeted to `leave_invited`, the one endpoint whose handler (`BodyParam[LeaveVFolderReq]`) actually rejects a null body. It also extends the client signature with the optional `sharedUserUuid` parameter (admin-on-behalf-of).


## Summary

Fixes a 400 error when a user tries to leave a shared folder via the **Shared Folder Permission** modal (both V1 `SharedFolderPermissionInfoModal` and V2 `SharedFolderPermissionInfoModalV2`).

## Root cause

The Backend.AI manager's `POST /folders/{name}/leave` REST route parses its body via `BodyParam[LeaveVFolderReq]`. All fields on `LeaveVFolderReq` are optional, but the body itself must still be valid JSON.

The frontend client's `VFolder.leave_invited` was passing `null` as the body. `newSignedRequest` serializes `null` to an empty string `''` and sends it with `Content-Type: application/json`. An empty string is not valid JSON, so the manager rejects the request with 400 before the handler runs.

Both `SharedFolderPermissionInfoModal.tsx` (V1) and `SharedFolderPermissionInfoModalV2.tsx` (V2) call the same `leave_invited` client method, so the bug reproduces in both flows.

## Change

The fix is applied in **both** copies of the API client to keep them consistent:

- `packages/backend.ai-client/src/resources/vfolder.ts` — **load-bearing for the React UI**. `react/src/global-stores.ts` registers `globalThis.BackendAIClient = ai.backend.Client` from this workspace package. This is what runs in the browser.
- `src/lib/backend.ai-client-node.ts` — legacy ESM client; only consumed by `src/wsproxy/` (Electron desktop's websocket proxy). Kept in sync to avoid a divergent regression if the Electron side ever calls the leave flow.
- `react/src/hooks/index.tsx` — extends the `BackendAIClient.vfolder.leave_invited` TypeScript signature with the new optional `sharedUserUuid` parameter (matches `LeaveVFolderReq.shared_user_uuid` for future admin-on-behalf-of flows).

Both methods now send `{}` as the JSON body by default. When `sharedUserUuid` is provided, they send `{ shared_user_uuid: sharedUserUuid }`. No existing call site needs to change for the immediate fix — both modals continue calling `leave_invited(folderId)` with a single argument.

## Test plan

- [ ] As a regular user with an accepted folder invitation, open the data page → click on the shared folder → permission modal → leave button → confirm. Expect a success toast and the folder to disappear from the list (no 400).
- [ ] Repeat for both V1 modal (regular page) and V2 modal (project admin data page).
- [ ] CI: lint / format / relay drift / TypeScript pass.

## Verification

`bash scripts/verify.sh` was run locally. Relay, Lint, Format pass. The TypeScript step reports pre-existing environmental errors (duplicate `@types/react` between `react/` and `packages/backend.ai-ui/`) that affect files unrelated to this change — CI's clean install is authoritative.

[FR-2978]: https://lablup.atlassian.net/browse/FR-2978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
