### PR TITLE
refactor(FR-2986): use explicit i18n instance binding in useBAIi18n

### DIFF
--- a/packages/backend.ai-ui/eslint.config.js
+++ b/packages/backend.ai-ui/eslint.config.js
@@ -28,6 +28,55 @@ export default [
     },
   },
 
+  // Enforce that BUI components access translations through the internal
+  // `useBAIi18n` hook only. Direct imports of i18n primitives from
+  // `react-i18next` would re-introduce React-Context-based lookup, which
+  // (under pnpm dedup) shadows the host app's i18n and surfaces raw keys
+  // on screen — the exact class of bug FR-2986 eliminates.
+  //
+  // All three banned bindings (`useTranslation` hook, `withTranslation` HOC,
+  // `<Translation>` render-prop) are different injection mechanisms for the
+  // same thing — a Context-derived `t`. The project is fully function-
+  // component / hook-based (`'use memo'` directive), so `useBAIi18n()` is
+  // the single replacement for all three; we do not maintain a separate
+  // BUI-instance-bound HOC or render-prop component.
+  //
+  // `useBAIi18n.ts` and `BAITrans.tsx` are exempted because they are the
+  // two places that are *allowed* to call into `react-i18next` directly
+  // (with explicit `{ i18n }` binding). Every other BUI source file routes
+  // i18n access through them.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: [
+      "src/hooks/useBAIi18n.ts",
+      "src/components/BAITrans.tsx",
+      "**/*.test.*",
+      "**/*.stories.*",
+      "**/__test__/**",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "react-i18next",
+              importNames: [
+                "useTranslation",
+                "withTranslation",
+                "Translation",
+                "Trans",
+                "I18nextProvider",
+              ],
+              message:
+                "Use `useBAIi18n` from `<relative path>/hooks/useBAIi18n` (replaces useTranslation / withTranslation / Translation) or `BAITrans` from `<relative path>/components/BAITrans` (replaces <Trans>) instead. BUI components must bind explicitly to BUI's i18n instance — see FR-2986 / packages/backend.ai-ui/src/hooks/useBAIi18n.ts.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   {
     files: ["**/*.test.*", "**/*.stories.*", "**/__test__/**"],
     languageOptions: {

--- a/packages/backend.ai-ui/src/components/BAIBoardItemErrorBoundary.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBoardItemErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIAlertIconWithTooltip from './BAIAlertIconWithTooltip';
 import BAIBoardItemTitle, {
   type BAIBoardItemTitleProps,
@@ -5,7 +6,6 @@ import BAIBoardItemTitle, {
 import { theme } from 'antd';
 import React, { type PropsWithChildren } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { useTranslation } from 'react-i18next';
 
 interface BAIBoardItemErrorBoundaryProps extends PropsWithChildren {
   title?: BAIBoardItemTitleProps['title'];
@@ -19,7 +19,7 @@ const BAIBoardItemErrorBoundary: React.FC<BAIBoardItemErrorBoundaryProps> = ({
   children,
   style,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   return (
     <ErrorBoundary

--- a/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.test.tsx
@@ -4,19 +4,27 @@ import userEvent from '@testing-library/user-event';
 import { Form, FormInstance, Select } from 'antd';
 import React, { useEffect } from 'react';
 
-// Mock react-i18next
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      const translations: Record<string, string> = {
-        'comp:BAIBulkEditFormItem.KeepAsIs': 'Keep as is',
-        'comp:BAIBulkEditFormItem.Clear': 'Clear',
-        'comp:BAIBulkEditFormItem.UndoChanges': 'Undo changes',
-      };
-      return translations[key] || key;
-    },
-  }),
-}));
+// Partial mock: preserve every real export from `react-i18next` (notably
+// `initReactI18next`, which BUI's `locale/index.ts` consumes at import
+// time) and only override `useTranslation` for predictable label strings.
+// See useErrorMessageResolver.test.tsx for the rationale (FR-2986).
+vi.mock('react-i18next', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => {
+        const translations: Record<string, string> = {
+          'comp:BAIBulkEditFormItem.KeepAsIs': 'Keep as is',
+          'comp:BAIBulkEditFormItem.Clear': 'Clear',
+          'comp:BAIBulkEditFormItem.UndoChanges': 'Undo changes',
+        };
+        return translations[key] || key;
+      },
+    }),
+  };
+});
 
 // Helper component wrapper with Form context
 const FormWrapper: React.FC<{

--- a/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import { DownOutlined } from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
@@ -11,7 +12,6 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 
 /**
  * Represents the different edit modes for bulk editing.
@@ -91,7 +91,7 @@ const BAIBulkEditFormItem: React.FC<BAIBulkEditFormItemProps> = ({
 }) => {
   'use memo';
 
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const form = Form.useFormInstance();
   const [mode, setMode] = useState<BulkEditMode>('keep');
 

--- a/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.tsx
@@ -1,10 +1,11 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import BAIModal, { type BAIModalProps } from './BAIModal';
 import BAIText from './BAIText';
+import { BAITrans } from './BAITrans';
 import { ExclamationCircleFilled } from '@ant-design/icons';
 import { Form, Input, theme, Typography, type InputProps } from 'antd';
 import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
 
 const { Text } = Typography;
 
@@ -94,7 +95,7 @@ const BAIDeleteConfirmModal: React.FC<BAIDeleteConfirmModalProps> = ({
 }) => {
   'use memo';
 
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const [form] = Form.useForm();
   const typedText = Form.useWatch('confirmText', form) ?? '';
@@ -126,7 +127,7 @@ const BAIDeleteConfirmModal: React.FC<BAIDeleteConfirmModalProps> = ({
   const resolvedOkText = okText ?? t('general.button.Delete');
 
   const resolvedInputLabel = inputLabel ?? (
-    <Trans
+    <BAITrans
       i18nKey="comp:BAIDeleteConfirmModal.TypeToConfirm"
       values={{ confirmText: resolvedConfirmText }}
       components={{ code: <BAIText code /> }}

--- a/packages/backend.ai-ui/src/components/BAIDeploymentStatusTag.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDeploymentStatusTag.tsx
@@ -1,8 +1,8 @@
 import { SemanticColor, useSemanticColorMap } from '../helper';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAITag from './BAITag';
 import type { TagProps } from 'antd';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export type BAIDeploymentStatus =
   | 'HEALTHY'
@@ -94,7 +94,7 @@ const BAIDeploymentStatusTag: React.FC<BAIDeploymentStatusTagProps> = ({
   ...tagProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const semanticColorMap = useSemanticColorMap();
 
   return (

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
@@ -1,4 +1,5 @@
 import { omitNullAndUndefinedFields } from '../helper';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import { useInterval, useIntervalValue } from '../hooks/useIntervalValue';
 import { ReloadOutlined } from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
@@ -6,7 +7,6 @@ import { Button, Tooltip, type ButtonProps } from 'antd';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import React, { useEffect, useLayoutEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 interface BAIFetchKeyButtonProps extends Omit<
   ButtonProps,
@@ -49,7 +49,7 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
 }) => {
   'use memo';
 
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const [lastLoadTime, setLastLoadTime] = useControllableValue(
     // To use the default value when lastLoadTimeProp is undefined, we need to omit the value field
     omitNullAndUndefinedFields({

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import BAISelect from './BAISelect';
 import { CloseCircleOutlined } from '@ant-design/icons';
@@ -23,7 +24,6 @@ import React, {
   useState,
 } from 'react';
 import type { ComponentProps } from 'react';
-import { useTranslation } from 'react-i18next';
 
 // GraphQL Filter Types (matching schema.graphql)
 export type StringFilter = {
@@ -456,7 +456,7 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
   'use memo';
 
   const { token } = theme.useToken();
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   t('comp:BAIGraphQLPropertyFilter.operator.IContains');
 

--- a/packages/backend.ai-ui/src/components/BAIModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.tsx
@@ -1,4 +1,5 @@
 // @ts-ignore
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import {
   BlockOutlined,
@@ -18,7 +19,6 @@ import Draggable, {
   type DraggableData,
   type DraggableEvent,
 } from 'react-draggable';
-import { useTranslation } from 'react-i18next';
 
 export const DEFAULT_BAI_MODAL_Z_INDEX = 1001;
 
@@ -295,7 +295,7 @@ const BAIModal: React.FC<BAIModalProps> = ({
   ...modalProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const [windowState, setWindowState] = useState<WindowState>('default');
 

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -1,4 +1,5 @@
 import { filterOutEmpty } from '../helper';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import { CloseCircleOutlined } from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
@@ -22,7 +23,6 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 
 //github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/models/minilang/queryfilter.py
 export type FilterProperty = {
@@ -251,7 +251,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
     });
   }, [value, filterProperties]);
 
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const options = _.map(filterProperties, (filterProperty) => ({
     label: filterProperty.propertyLabel,
     value: filterProperty.key,

--- a/packages/backend.ai-ui/src/components/BAISelectionLabel.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelectionLabel.tsx
@@ -1,7 +1,7 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import { theme, Tooltip, Typography } from 'antd';
 import { CircleXIcon } from 'lucide-react';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface BAISelectionLabelProps {
   count: number;
@@ -14,7 +14,7 @@ const BAISelectionLabel: React.FC<BAISelectionLabelProps> = ({
 }) => {
   'use memo';
 
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
   if (count <= 0) return null;

--- a/packages/backend.ai-ui/src/components/BAISessionNodesV2.tsx
+++ b/packages/backend.ai-ui/src/components/BAISessionNodesV2.tsx
@@ -21,11 +21,11 @@ import type {
   SessionV2Status,
 } from '../__generated__/BAISessionNodesV2Fragment.graphql';
 import { convertToBinaryUnit } from '../helper';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import * as _ from 'lodash-es';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 dayjs.extend(duration);
@@ -145,7 +145,7 @@ const BAISessionNodesV2: React.FC<BAISessionNodesV2Props> = ({
   ...tableProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const sessions = useFragment(
     graphql`

--- a/packages/backend.ai-ui/src/components/BAIStatistic.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIStatistic.test.tsx
@@ -1,17 +1,25 @@
 import BAIStatistic from './BAIStatistic';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-// Mock useTranslation
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      const translations: { [key: string]: string } = {
-        'comp:BAIStatistic.Unlimited': 'Unlimited',
-      };
-      return translations[key] || key;
-    },
-  }),
-}));
+// Partial mock: preserve every real export from `react-i18next` (notably
+// `initReactI18next`, which BUI's `locale/index.ts` consumes at import
+// time) and only override `useTranslation`. See
+// useErrorMessageResolver.test.tsx for the rationale (FR-2986).
+vi.mock('react-i18next', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => {
+        const translations: { [key: string]: string } = {
+          'comp:BAIStatistic.Unlimited': 'Unlimited',
+        };
+        return translations[key] || key;
+      },
+    }),
+  };
+});
 
 describe('BAIStatistic', () => {
   describe('Basic Rendering', () => {

--- a/packages/backend.ai-ui/src/components/BAIStatistic.tsx
+++ b/packages/backend.ai-ui/src/components/BAIStatistic.tsx
@@ -1,8 +1,8 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import { theme, Typography, Tooltip, Progress } from 'antd';
 import * as _ from 'lodash-es';
 import React, { type ReactNode } from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface BAIStatisticProps {
   title: ReactNode;
@@ -28,7 +28,7 @@ const BAIStatistic: React.FC<BAIStatisticProps> = ({
   style,
 }) => {
   const { token } = theme.useToken();
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const showProgress = progressMode !== 'hidden';
 
   // Format number with precision

--- a/packages/backend.ai-ui/src/components/BAITagList.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.tsx
@@ -1,10 +1,10 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import { CheckOutlined, CopyOutlined } from '@ant-design/icons';
 import { Button, Popover, Tag, theme, Typography } from 'antd';
 import * as _ from 'lodash-es';
 import React, { ReactNode, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { useTranslation } from 'react-i18next';
 
 export interface BAITagListProps {
   items: string[];
@@ -19,7 +19,7 @@ const BAITagList: React.FC<BAITagListProps> = ({
   emptyText = '-',
   popoverTitle,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const [copied, setCopied] = useState(false);
 

--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -1,10 +1,10 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import { theme, Tooltip, Typography } from 'antd';
 import type { TooltipProps } from 'antd/es/tooltip';
 import type { EllipsisConfig } from 'antd/es/typography/Base';
 import type { TextProps as AntdTextProps } from 'antd/es/typography/Text';
 import React, { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface BAITextProps extends Omit<AntdTextProps, 'ellipsis'> {
   monospace?: boolean;
@@ -47,7 +47,7 @@ const BAIText: React.FC<BAITextProps> = ({
   ...restProps
 }) => {
   const { token } = theme.useToken();
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const textRef = useRef<HTMLSpanElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);

--- a/packages/backend.ai-ui/src/components/BAITrans.tsx
+++ b/packages/backend.ai-ui/src/components/BAITrans.tsx
@@ -1,0 +1,29 @@
+// This file is the *only* BUI source location allowed to import `<Trans>`
+// directly from `react-i18next`. Every other BUI file uses the `BAITrans`
+// re-export below. The exception is wired via the `ignores` entry in
+// `eslint.config.js`'s `no-restricted-imports` rule (FR-2986).
+import { i18n as buiI18n } from '../locale';
+import React from 'react';
+import { Trans } from 'react-i18next';
+
+type BAITransProps = Omit<React.ComponentProps<typeof Trans>, 'i18n'>;
+
+/**
+ * Wrapper around react-i18next's `<Trans>` that always binds the BUI
+ * i18next instance via the `i18n` prop. BUI components must use this
+ * instead of importing `<Trans>` directly so that translation lookups
+ * never fall back to React Context (which would otherwise resolve
+ * against the host's i18n and surface raw keys — see FR-2986 and
+ * the `useBAIi18n` hook).
+ *
+ * The `i18n` prop is intentionally `Omit`ted from the public surface:
+ * callers cannot override the bound instance, which makes the lookup
+ * path provably consistent across every `<BAITrans>` usage.
+ */
+export const BAITrans = (props: BAITransProps) => {
+  'use memo';
+  // Forward all standard Trans props (children, components, count, defaults,
+  // i18nKey, ns, parent, t, tOptions, values, shouldUnescape, …) while
+  // forcing the i18n binding to BUI's instance.
+  return <Trans {...props} i18n={buiI18n} />;
+};

--- a/packages/backend.ai-ui/src/components/BAIUserNodes.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUserNodes.tsx
@@ -12,9 +12,9 @@ import {
   BAIUserNodesFragment$data,
   BAIUserNodesFragment$key,
 } from '../__generated__/BAIUserNodesFragment.graphql';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -66,7 +66,7 @@ const BAIUserNodes: React.FC<BAIUserNodesProps> = ({
   ...tableProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const users = useFragment(
     graphql`

--- a/packages/backend.ai-ui/src/components/BAIUserV2Nodes.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUserV2Nodes.tsx
@@ -12,10 +12,10 @@ import type {
   BAIUserV2NodesFragment$data,
   BAIUserV2NodesFragment$key,
 } from '../__generated__/BAIUserV2NodesFragment.graphql';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type UserV2InList = NonNullable<BAIUserV2NodesFragment$data[number]>;
@@ -60,7 +60,7 @@ const BAIUserV2Nodes: React.FC<BAIUserV2NodesProps> = ({
   ...tableProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const users = useFragment(
     graphql`

--- a/packages/backend.ai-ui/src/components/ResourceStatistics.tsx
+++ b/packages/backend.ai-ui/src/components/ResourceStatistics.tsx
@@ -1,10 +1,10 @@
 import { convertToBinaryUnit, getDisplayUnitToInputSizeUnit } from '../helper';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import BAIRowWrapWithDividers from './BAIRowWrapWithDividers';
 import BAIStatistic, { BAIStatisticProps } from './BAIStatistic';
 import { Empty, theme } from 'antd';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 interface ResourceData {
   cpu: {
@@ -59,7 +59,7 @@ const ResourceStatistics: React.FC<ResourceStatisticsProps> = ({
   progressSteps,
   precision = 2,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
   const hasResources =

--- a/packages/backend.ai-ui/src/components/Table/BAIPaginationInfoText.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAIPaginationInfoText.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 
 export interface PaginationInfoTextProps {
   start: number;
@@ -11,7 +11,7 @@ const BAIPaginationInfoText = ({
   end,
   total,
 }: PaginationInfoTextProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   return t('comp:PaginationInfoText.Total', {
     start,

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -1,4 +1,5 @@
 import { transformSorterToOrderString } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIButton from '../BAIButton';
 import BAIFlex from '../BAIFlex';
 import BAIText from '../BAIText';
@@ -26,7 +27,6 @@ import type { ColumnType, ColumnsType } from 'antd/es/table';
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { useTranslation } from 'react-i18next';
 import { Resizable, type ResizeCallbackData } from 'react-resizable';
 
 /**
@@ -266,7 +266,7 @@ const BAITable = <RecordType extends AnyObject = AnyObject>({
   ...tableProps
 }: BAITableProps<RecordType>): React.ReactElement => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { styles } = useStyles();
   const [resizedColumnWidths, setResizedColumnWidths] = useState<
     Record<string, number>

--- a/packages/backend.ai-ui/src/components/Table/BAITableColumnCSVExportModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableColumnCSVExportModal.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIButton from '../BAIButton';
 import BAIModal, { BAIModalProps } from '../BAIModal';
 import { BAIColumnsType } from './BAITable';
@@ -6,7 +7,6 @@ import { Input, theme, Form, Table, Checkbox, Typography } from 'antd';
 import type { TableColumnsType } from 'antd';
 import * as _ from 'lodash-es';
 import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 interface BAITableColumnCSVExportModalProps<T = unknown> extends BAIModalProps {
   onRequestClose?: (success: boolean) => void;
@@ -24,7 +24,7 @@ const BAITableColumnCSVExportModal = <T,>({
 }: BAITableColumnCSVExportModalProps<T>): React.JSX.Element => {
   'use memo';
 
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
   const extractTitleString = (element: React.ReactElement): string => {

--- a/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import {
   BAIColumnsType,
   isColumnVisible,
@@ -36,7 +37,6 @@ import React, {
   useContext,
   useMemo,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 
 /**
  * Form values interface for the table setting modal
@@ -207,7 +207,7 @@ const BAITableSettingModal: React.FC<TableSettingProps> = ({
   'use memo';
 
   const formRef = useRef<FormInstance>(null);
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
   const onChangeTitleToString: any = (element: any) => {

--- a/packages/backend.ai-ui/src/components/TotalFooter.tsx
+++ b/packages/backend.ai-ui/src/components/TotalFooter.tsx
@@ -1,14 +1,14 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
 import { LoadingOutlined } from '@ant-design/icons';
 import { theme, Typography } from 'antd';
-import { useTranslation } from 'react-i18next';
 
 const TotalFooter: React.FC<{
   loading?: boolean;
   total?: number;
 }> = ({ loading, total }) => {
   const { token } = theme.useToken();
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   return (
     <BAIFlex justify="end" gap={'xs'}>
       {loading ? (

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -3,6 +3,7 @@ import {
   filterOutEmpty,
   localeCompare,
 } from '../../../helper';
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIFetchKeyButton from '../../BAIFetchKeyButton';
 import BAIFlex from '../../BAIFlex';
 import BAILink from '../../BAILink';
@@ -31,7 +32,6 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 
 export const FolderInfoContext = createContext<{
   targetVFolderId: string;
@@ -96,7 +96,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
 }) => {
   'use memo';
 
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
   const [isDragMode, setIsDragMode] = useState(false);

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
 import { FolderInfoContext } from './BAIFileExplorer';
 import { useMutation } from '@tanstack/react-query';
@@ -10,7 +11,6 @@ import {
   type ModalProps,
 } from 'antd';
 import React, { use, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
 
 // FIXME: After migrate BAIModal into backend.ai-ui, should be use BAIModal instead of Antd's Modal
 interface CreateDirectoryModalProps extends ModalProps {
@@ -21,7 +21,7 @@ const CreateDirectoryModal: React.FC<CreateDirectoryModalProps> = ({
   onRequestClose,
   ...modalProps
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { message } = App.useApp();
   const { targetVFolderId, currentPath } = use(FolderInfoContext);
   const baiClient = useConnectedBAIClient();

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateFileModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateFileModal.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIModal, { type BAIModalProps } from '../../BAIModal';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
 import { FolderInfoContext } from './BAIFileExplorer';
@@ -5,7 +6,6 @@ import { useMutation } from '@tanstack/react-query';
 import { App, Form, Input, type FormInstance } from 'antd';
 import * as _ from 'lodash-es';
 import React, { use, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
 
 interface CreateFileModalProps extends BAIModalProps {
   onRequestClose: (success: boolean) => void;
@@ -16,7 +16,7 @@ const CreateFileModal: React.FC<CreateFileModalProps> = ({
   ...modalProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { message, modal } = App.useApp();
   const { targetVFolderId, currentPath } = use(FolderInfoContext);
   const baiClient = useConnectedBAIClient();

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DeleteSelectedItemsModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DeleteSelectedItemsModal.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIDeleteConfirmModal from '../../BAIDeleteConfirmModal';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
 import { VFolderFile } from '../../provider/BAIClientProvider/types';
@@ -6,7 +7,6 @@ import { useMutation } from '@tanstack/react-query';
 import { App, type ModalProps } from 'antd';
 import * as _ from 'lodash-es';
 import { use } from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface DeleteSelectedItemsModalProps extends ModalProps {
   onRequestClose: (success: boolean, deletingFilePaths?: Array<string>) => void;
@@ -24,7 +24,7 @@ const DeleteSelectedItemsModal: React.FC<DeleteSelectedItemsModalProps> = ({
   selectedFiles,
   ...modalProps
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { message } = App.useApp();
   const { currentPath, targetVFolderId } = use(FolderInfoContext);
   const baiClient = useConnectedBAIClient();

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DragAndDrop.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DragAndDrop.tsx
@@ -1,10 +1,10 @@
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import { useUploadVFolderFiles } from './hooks';
 import { InboxOutlined } from '@ant-design/icons';
 import { theme, Typography, Upload } from 'antd';
 import type { RcFile } from 'antd/es/upload';
 import { useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { useTranslation } from 'react-i18next';
 
 interface DragAndDropProps {
   onUpload: (files: Array<RcFile>, currentPath: string) => void;
@@ -16,7 +16,7 @@ const DragAndDrop: React.FC<DragAndDropProps> = ({
   onUpload,
   portalContainer,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const { uploadFiles } = useUploadVFolderFiles();
   const lastFileListRef = useRef<Array<RcFile>>([]);

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.tsx
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIFlex from '../../BAIFlex';
 import BAILink from '../../BAILink';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
@@ -10,7 +11,6 @@ import { createStyles } from 'antd-style';
 import * as _ from 'lodash-es';
 import { CornerDownLeftIcon } from 'lucide-react';
 import { use, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 interface ServerError extends Error {
   title?: string;
@@ -63,7 +63,7 @@ const EditableFileName: React.FC<EditableNameProps> = ({
   ...props
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const { modal, message } = App.useApp();
   const { styles } = useStyles();

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -1,5 +1,6 @@
 import { initiateDownload } from '../../../helper';
 import { useTanMutation } from '../../../helper/reactQueryAlias';
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIButton from '../../BAIButton';
 import BAIFlex from '../../BAIFlex';
 import BAISelectionLabel from '../../BAISelectionLabel';
@@ -24,7 +25,6 @@ import { createStyles } from 'antd-style';
 import type { RcFile } from 'antd/es/upload';
 import { DownloadIcon } from 'lucide-react';
 import { use, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
 
 const useStyles = createStyles(({ css }) => ({
   upload: css`
@@ -74,7 +74,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
   enableUpload = enableWrite,
   extra,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { lg } = Grid.useBreakpoint();
   const { token } = theme.useToken();
   const { styles } = useStyles();

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
@@ -1,5 +1,6 @@
 import { convertToBinaryUnit, initiateDownload } from '../../../helper';
 import { useTanMutation } from '../../../helper/reactQueryAlias';
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIButton, { BAIButtonProps } from '../../BAIButton';
 import BAIFlex from '../../BAIFlex';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
@@ -9,7 +10,6 @@ import { DeleteFilled, MoreOutlined } from '@ant-design/icons';
 import { App, theme, Dropdown, Tooltip } from 'antd';
 import { DownloadIcon, EditIcon } from 'lucide-react';
 import { use, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 const MAX_EDITABLE_FILE_SIZE = 1024 * 1024; // 1 MB
 
@@ -36,7 +36,7 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
 }) => {
   'use memo';
 
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const { message } = App.useApp();
   const { targetVFolderId, currentPath } = use(FolderInfoContext);

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/hooks.ts
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/hooks.ts
@@ -1,3 +1,4 @@
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
 import { VFolderFile } from '../../provider/BAIClientProvider/types';
 import { FolderInfoContext } from './BAIFileExplorer';
@@ -6,7 +7,6 @@ import { App } from 'antd';
 import { RcFile } from 'antd/es/upload';
 import * as _ from 'lodash-es';
 import { use, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 export const useSearchVFolderFiles = (vfolder: string, fetchKey?: string) => {
   const baiClient = useConnectedBAIClient();
@@ -67,7 +67,7 @@ export const useSearchVFolderFiles = (vfolder: string, fetchKey?: string) => {
 };
 
 export const useUploadVFolderFiles = () => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { modal } = App.useApp();
   const { targetVFolderId, currentPath } = use(FolderInfoContext);
   const baiClient = useConnectedBAIClient();

--- a/packages/backend.ai-ui/src/components/fragments/BAIActivateArtifactsModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIActivateArtifactsModal.tsx
@@ -1,9 +1,9 @@
 import { BAIActivateArtifactsModalArtifactsFragment$key } from '../../__generated__/BAIActivateArtifactsModalArtifactsFragment.graphql';
 import { BAIActivateArtifactsModalArtifactsFragmentRestoreArtifactsMutation } from '../../__generated__/BAIActivateArtifactsModalArtifactsFragmentRestoreArtifactsMutation.graphql';
 import { toLocalId } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
 import { App, Modal, Typography, type ModalProps } from 'antd';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
 export type BAIActivateArtifactsModalArtifactsFragmentKey =
@@ -19,7 +19,7 @@ const BAIActivateArtifactsModal = ({
   onCancel,
   ...props
 }: BAIActivateArtifactsModalProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { message } = App.useApp();
 
   const selectedArtifacts =

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminContainerRegistrySelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminContainerRegistrySelect.tsx
@@ -3,6 +3,7 @@ import { BAIAdminContainerRegistrySelectValueQuery } from '../../__generated__/B
 import { toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import { mergeFilterValues } from '../BAIPropertyFilter';
 import BAISelect, { BAISelectProps } from '../BAISelect';
@@ -18,7 +19,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type ContainerRegistryNode = NonNullable<
@@ -45,7 +45,7 @@ const BAIAdminContainerRegistrySelect: React.FC<
   BAIAdminContainerRegistrySelectProps
 > = ({ loading, filter, valuePropName = 'id', ref, ...selectProps }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminImageSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminImageSelect.tsx
@@ -6,6 +6,7 @@ import { BAIAdminImageSelectValueQuery } from '../../__generated__/BAIAdminImage
 import { toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import TotalFooter from '../TotalFooter';
@@ -20,7 +21,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type ImageV2Node = NonNullable<
@@ -54,7 +54,7 @@ const BAIAdminImageSelect: React.FC<BAIAdminImageSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
 
   const [controllableValue, setControllableValue] = useControllableValue<

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminModelServiceSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminModelServiceSelect.tsx
@@ -3,6 +3,7 @@ import { BAIAdminModelServiceSelectValueQuery } from '../../__generated__/BAIAdm
 import { toGlobalId, toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import TotalFooter from '../TotalFooter';
@@ -17,7 +18,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type ModelServiceNode = NonNullable<
@@ -43,7 +43,7 @@ const BAIAdminModelServiceSelect: React.FC<BAIAdminModelServiceSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminProjectSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminProjectSelect.tsx
@@ -3,6 +3,7 @@ import { BAIAdminProjectSelectValueQuery } from '../../__generated__/BAIAdminPro
 import { toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import TotalFooter from '../TotalFooter';
@@ -17,7 +18,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type AdminProjectNode = NonNullable<
@@ -47,7 +47,7 @@ const BAIAdminProjectSelect: React.FC<BAIAdminProjectSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
@@ -1,12 +1,12 @@
 import { BAIAdminResourceGroupSelectPaginationQuery } from '../../__generated__/BAIAdminResourceGroupSelectPaginationQuery.graphql';
 import { BAIAdminResourceGroupSelect_resourceGroupsFragment$key } from '../../__generated__/BAIAdminResourceGroupSelect_resourceGroupsFragment.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import TotalFooter from '../TotalFooter';
 import { Skeleton } from 'antd';
 import { GetRef } from 'antd/lib';
 import * as _ from 'lodash-es';
 import { useRef } from 'react';
-import { useTranslation } from 'react-i18next';
 import { usePaginationFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -22,7 +22,7 @@ const BAIAdminResourceGroupSelect = ({
   loading,
   ...selectPropsWithoutLoading
 }: BAIAdminResourceGroupSelectProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
 
   const { data, loadNext, isLoadingNext, refetch, hasNext } =

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminSessionSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminSessionSelect.tsx
@@ -3,6 +3,7 @@ import { BAIAdminSessionSelectValueQuery } from '../../__generated__/BAIAdminSes
 import { toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import TotalFooter from '../TotalFooter';
@@ -17,7 +18,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type SessionNode = NonNullable<
@@ -44,7 +44,7 @@ const BAIAdminSessionSelect: React.FC<BAIAdminSessionSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
@@ -9,6 +9,7 @@ import {
   toFixedFloorWithoutTrailingZeros,
 } from '../../helper';
 import { useBAILogger, useResourceSlotsDetails } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIAlertIconWithTooltip from '../BAIAlertIconWithTooltip';
 import BAIDoubleTag from '../BAIDoubleTag';
 import BAIFlex from '../BAIFlex';
@@ -30,7 +31,6 @@ import {
   ErrorBoundary,
   type ErrorBoundaryPropsWithRender,
 } from 'react-error-boundary';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type AgentNodeInList = NonNullable<
@@ -57,7 +57,7 @@ const CellErrorBoundary: React.FC<
   Omit<ErrorBoundaryPropsWithRender, 'fallbackRender'>
 > = ({ children, ...errorBoundaryProps }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { logger } = useBAILogger();
   return (
     <ErrorBoundary
@@ -239,7 +239,7 @@ const UtilizationCell: React.FC<{
   record: AgentNodeInList;
 }> = ({ value, record }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { mergedResourceSlots } = useResourceSlotsDetails();
   const parsedValue = JSON.parse(value || '{}');
   const available_slots = JSON.parse(record?.available_slots || '{}');
@@ -599,7 +599,7 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
   customizeColumns,
   ...tableProps
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const baiClient = useConnectedBAIClient();
 

--- a/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
@@ -2,6 +2,7 @@ import { BAIAllowedVfolderHostsWithPermissionFromGroupFragment$key } from '../..
 import { BAIAllowedVfolderHostsWithPermissionFromKeyPairResourcePolicyFragment$key } from '../../__generated__/BAIAllowedVfolderHostsWithPermissionFromKeyPairResourcePolicyFragment.graphql';
 import { BAIAllowedVfolderHostsWithPermissionQuery } from '../../__generated__/BAIAllowedVfolderHostsWithPermissionQuery.graphql';
 import { SemanticColor } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIFlex from '../BAIFlex';
 import BAILink from '../BAILink';
 import BAIModal from '../BAIModal';
@@ -11,7 +12,6 @@ import { theme } from 'antd';
 import * as _ from 'lodash-es';
 import { LockIcon, LockOpenIcon } from 'lucide-react';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 
 export type BAIAllowedVfolderHostsWithPermissionProps =
@@ -30,7 +30,7 @@ const BAIAllowedVfolderHostsWithPermission: React.FC<
   allowedHostPermissionFrgmtFromKeyPair,
   allowedHostPermissionFrgmtFromGroup,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const [storageHost, setStorageHost] = React.useState<string | null>();
 

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactDescriptions.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactDescriptions.tsx
@@ -1,10 +1,10 @@
 import { BAIArtifactDescriptionsFragment$key } from '../../__generated__/BAIArtifactDescriptionsFragment.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAILink from '../BAILink';
 import BAIArtifactTypeTag from './BAIArtifactTypeTag';
 import { Descriptions, Typography, type DescriptionsProps } from 'antd';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export interface BAIArtifactDescriptionsProps {
@@ -16,7 +16,7 @@ dayjs.extend(relativeTime);
 const BAIArtifactDescriptions = ({
   artifactFrgmt,
 }: BAIArtifactDescriptionsProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const artifact = useFragment<BAIArtifactDescriptionsFragment$key>(
     graphql`
       fragment BAIArtifactDescriptionsFragment on Artifact {

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionTable.tsx
@@ -4,6 +4,7 @@ import {
 } from '../../__generated__/BAIArtifactRevisionTableArtifactRevisionFragment.graphql';
 import { BAIArtifactRevisionTableLatestRevisionFragment$key } from '../../__generated__/BAIArtifactRevisionTableLatestRevisionFragment.graphql';
 import { convertToDecimalUnit, filterOutEmpty } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIFlex from '../BAIFlex';
 import BAITag from '../BAITag';
 import BAIText from '../BAIText';
@@ -13,7 +14,6 @@ import { Tag } from 'antd';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 dayjs.extend(relativeTime);
@@ -42,7 +42,7 @@ const BAIArtifactRevisionTable = ({
   customizeColumns,
   ...tableProps
 }: BAIArtifactRevisionTableProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const artifactRevision =
     useFragment<BAIArtifactRevisionTableArtifactRevisionFragment$key>(

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactTable.tsx
@@ -8,6 +8,7 @@ import {
   filterOutNullAndUndefined,
   toLocalId,
 } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIFlex from '../BAIFlex';
 import BAILink from '../BAILink';
 import BAIText from '../BAIText';
@@ -21,7 +22,6 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import * as _ from 'lodash-es';
 import { Package, Container, Brain, BanIcon, UndoIcon } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 dayjs.extend(relativeTime);
@@ -91,7 +91,7 @@ const BAIArtifactTable = ({
   ...tableProps
 }: BAIArtifactTableProps) => {
   const { token } = theme.useToken();
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const artifact = useFragment<BAIArtifactTableArtifactFragment$key>(
     graphql`

--- a/packages/backend.ai-ui/src/components/fragments/BAIAvailablePresetSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAvailablePresetSelect.tsx
@@ -3,6 +3,7 @@ import { BAIAvailablePresetSelectValueQuery } from '../../__generated__/BAIAvail
 import { convertToUUID, toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAIFlex from '../BAIFlex';
 import BAISelect, { BAISelectProps } from '../BAISelect';
@@ -19,7 +20,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type DeploymentRevisionPresetNode = NonNullable<
@@ -49,7 +49,7 @@ const BAIAvailablePresetSelect: React.FC<BAIAvailablePresetSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeactivateArtifactsModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeactivateArtifactsModal.tsx
@@ -1,9 +1,9 @@
 import { BAIDeactivateArtifactsModalArtifactsFragment$key } from '../../__generated__/BAIDeactivateArtifactsModalArtifactsFragment.graphql';
 import { BAIDeactivateArtifactsModalDeleteArtifactsMutation } from '../../__generated__/BAIDeactivateArtifactsModalDeleteArtifactsMutation.graphql';
 import { toLocalId } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
 import { App, Modal, Typography, type ModalProps } from 'antd';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
 export type BAIDeactivateArtifactsModalArtifactsFragmentKey =
@@ -19,7 +19,7 @@ const BAIDeactivateArtifactsModal = ({
   onCancel,
   ...modalProps
 }: BAIDeactivateArtifactsModalProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { message } = App.useApp();
   const selectedArtifacts =
     useFragment<BAIDeactivateArtifactsModalArtifactsFragment$key>(

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
@@ -10,6 +10,7 @@ import {
   filterOutNullAndUndefined,
   toLocalId,
 } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIFlex from '../BAIFlex';
 import BAIText from '../BAIText';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
@@ -18,7 +19,6 @@ import BAIArtifactDescriptions from './BAIArtifactDescriptions';
 import { QuestionCircleFilled } from '@ant-design/icons';
 import { Alert, message, Modal, theme, Tooltip, type ModalProps } from 'antd';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
 type ArtifactRevision =
@@ -47,7 +47,7 @@ const BAIDeleteArtifactRevisionsModal = ({
   onCancel,
   ...modalProps
 }: BAIDeleteArtifactRevisionsModalProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
   const [cleanupVersion, isInflightCleanupVersion] =

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentOwnerInfo.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentOwnerInfo.tsx
@@ -1,7 +1,7 @@
 import { BAIDeploymentOwnerInfo_deployment$key } from '../../__generated__/BAIDeploymentOwnerInfo_deployment.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { Tooltip, Typography } from 'antd';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export interface BAIDeploymentOwnerInfoProps {
@@ -16,7 +16,7 @@ const BAIDeploymentOwnerInfo: React.FC<BAIDeploymentOwnerInfoProps> = ({
   deploymentFrgmt,
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const deployment = useFragment(
     graphql`

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryNodes.tsx
@@ -7,6 +7,7 @@ import {
   filterOutNullAndUndefined,
   newLineToBrElement,
 } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAISchedulingResultBadge, {
   SchedulingResult,
 } from '../BAISchedulingResultBadge';
@@ -21,7 +22,6 @@ import { BAIColumnGroupType } from '../Table/BAITable';
 import BAISubStepNodes from './BAISubStepNodes';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type DeploymentSchedulingHistoryNodeInList = NonNullable<
@@ -61,7 +61,7 @@ const BAIDeploymentSchedulingHistoryNodes = ({
   ...tableProps
 }: BAIDeploymentSchedulingHistoryNodesProps) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const histories =
     useFragment<BAIDeploymentSchedulingHistoryNodesFragment$key>(

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSelect.tsx
@@ -2,6 +2,7 @@ import { BAIDeploymentSelectPaginatedQuery } from '../../__generated__/BAIDeploy
 import { BAIDeploymentSelectValueQuery } from '../../__generated__/BAIDeploymentSelectValueQuery.graphql';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import TotalFooter from '../TotalFooter';
@@ -16,7 +17,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type DeploymentNode = NonNullable<
@@ -42,7 +42,7 @@ const BAIDeploymentSelect: React.FC<BAIDeploymentSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIDomainSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDomainSelect.tsx
@@ -1,9 +1,9 @@
 import { BAIDomainSelectQuery } from '../../__generated__/BAIDomainSelectQuery.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useControllableValue } from 'ahooks';
 import { Select, type SelectProps } from 'antd';
 import * as _ from 'lodash-es';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 interface Props extends SelectProps {
@@ -13,7 +13,7 @@ const BAIDomainSelect: React.FC<Props> = ({
   activeOnly = true,
   ...selectProps
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const [value, setValue] = useControllableValue(selectProps);
 
   const { domains } = useLazyLoadQuery<BAIDomainSelectQuery>(

--- a/packages/backend.ai-ui/src/components/fragments/BAIHuggingFaceRegistrySettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIHuggingFaceRegistrySettingModal.tsx
@@ -1,10 +1,10 @@
 import { BAIHuggingFaceRegistrySettingModalFragment$key } from '../../__generated__/BAIHuggingFaceRegistrySettingModalFragment.graphql';
 import { BAIHuggingFaceRegistrySettingModalMutation } from '../../__generated__/BAIHuggingFaceRegistrySettingModalMutation.graphql';
 import { toLocalId } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIModal, { BAIModalProps } from '../BAIModal';
 import { App, Form, Input, FormInstance } from 'antd';
 import { useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
 export type BAIHuggingFaceRegistrySettingModalFragmentKey =
@@ -22,7 +22,7 @@ const BAIHuggingFaceRegistrySettingModal: React.FC<
   BAIHuggingFaceRegistrySettingModalProps
 > = ({ huggingFaceRegistryFrgmt = null, onOk, ...modalProps }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { message } = App.useApp();
   const formRef = useRef<FormInstance<FormValues>>(null);
   const [isEditing, setIsEditing] = useState(false);

--- a/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
@@ -10,6 +10,7 @@ import {
   filterOutNullAndUndefined,
   toLocalId,
 } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIFlex from '../BAIFlex';
 import BAIText from '../BAIText';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
@@ -18,7 +19,6 @@ import BAIArtifactDescriptions from './BAIArtifactDescriptions';
 import { QuestionCircleFilled } from '@ant-design/icons';
 import { Alert, App, Modal, theme, Tooltip, type ModalProps } from 'antd';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
 type ArtifactRevision =
@@ -58,7 +58,7 @@ const BAIImportArtifactModal = ({
   connectionIds,
   ...modalProps
 }: BAIImportArtifactModalProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { message } = App.useApp();
   const { token } = theme.useToken();
   const selectedArtifact =

--- a/packages/backend.ai-ui/src/components/fragments/BAIKeypairSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIKeypairSelect.tsx
@@ -2,6 +2,7 @@ import { BAIKeypairSelectPaginatedQuery } from '../../__generated__/BAIKeypairSe
 import { BAIKeypairSelectValueQuery } from '../../__generated__/BAIKeypairSelectValueQuery.graphql';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import { mergeFilterValues } from '../BAIPropertyFilter';
 import BAISelect, { BAISelectProps } from '../BAISelect';
@@ -18,7 +19,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type KeypairNode = NonNullable<
@@ -47,7 +47,7 @@ const BAIKeypairSelect: React.FC<BAIKeypairSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
@@ -3,6 +3,7 @@ import {
   BAIModelDeploymentNodesFragment$key,
 } from '../../__generated__/BAIModelDeploymentNodesFragment.graphql';
 import { filterOutEmpty, filterOutNullAndUndefined } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIDeploymentStatusTag, {
   BAIDeploymentStatus,
 } from '../BAIDeploymentStatusTag';
@@ -24,7 +25,6 @@ import { theme, Tooltip, Typography } from 'antd';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type ModelDeploymentNodeInList = NonNullable<
@@ -95,7 +95,7 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
   ...tableProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
   const deployments = useFragment<BAIModelDeploymentNodesFragment$key>(

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectBulkEditModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectBulkEditModal.tsx
@@ -1,6 +1,7 @@
 import { BAIProjectBulkEditModalFragment$key } from '../../__generated__/BAIProjectBulkEditModalFragment.graphql';
 import { BAIProjectBulkEditModalProjectMutation } from '../../__generated__/BAIProjectBulkEditModalProjectMutation.graphql';
 import { useMutationWithPromise } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIAlert from '../BAIAlert';
 import BAIFlex from '../BAIFlex';
 import BAIModal, { BAIModalProps } from '../BAIModal';
@@ -9,7 +10,6 @@ import BAIProjectResourcePolicySelect from './BAIProjectResourcePolicySelect';
 import { Form, theme } from 'antd';
 import * as _ from 'lodash-es';
 import { Suspense, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export interface BAIProjectBulkEditModalProps extends BAIModalProps {
@@ -20,7 +20,7 @@ const BAIProjectBulkEditModal = ({
   selectedProjectFragments,
   ...tableProps
 }: BAIProjectBulkEditModalProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const [form] = Form.useForm();
   const [isSaving, setIsSaving] = useState(false);

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectSelect.tsx
@@ -3,6 +3,7 @@ import { BAIProjectSelectValueQuery } from '../../__generated__/BAIProjectSelect
 import { toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import { mergeFilterValues } from '../BAIPropertyFilter';
 import BAISelect, { BAISelectProps } from '../BAISelect';
@@ -18,7 +19,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type ProjectNode = NonNullable<
@@ -46,7 +46,7 @@ const BAIProjectSelect: React.FC<BAIProjectSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectSettingModal.tsx
@@ -15,6 +15,7 @@ import { BAIProjectSettingModalModifyMutation } from '../../__generated__/BAIPro
 import { BAIProjectSettingModalQuery } from '../../__generated__/BAIProjectSettingModalQuery.graphql';
 import { convertToBinaryUnit } from '../../helper';
 import { useErrorMessageResolver, useResourceSlotsDetails } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIModal, { BAIModalProps } from '../BAIModal';
 import {
   App,
@@ -27,7 +28,6 @@ import {
 } from 'antd';
 import * as _ from 'lodash-es';
 import { useDeferredValue, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
 import {
   graphql,
   useFragment,
@@ -67,7 +67,7 @@ const BAIProjectSettingModal = ({
   ...modalProps
 }: BAIProjectSettingModalProps) => {
   const { token } = theme.useToken();
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const deferredOpen = useDeferredValue(modalProps.open);
   const { resourceSlotsInRG, deviceMetaData } = useResourceSlotsDetails();
   const form = useRef<FormInstance<FormValues>>(null);

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx
@@ -3,6 +3,7 @@ import {
   BAIProjectTableFragment$key,
 } from '../../__generated__/BAIProjectTableFragment.graphql';
 import { toLocalId } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIResourceNumberWithIcon from '../BAIResourceNumberWithIcon';
 import BAIText from '../BAIText';
 import { BAIColumnsType, BAITable, BAITableProps } from '../Table';
@@ -10,7 +11,6 @@ import AllowedVfolderHostsWithPermission from './BAIAllowedVfolderHostsWithPermi
 import { Tag } from 'antd';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export const availableProjectSorterKeys = [
@@ -63,7 +63,7 @@ const BAIProjectTable = ({
   ...tableProps
 }: BAIProjectTableProps) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const projects = useFragment<BAIProjectTableFragment$key>(
     graphql`

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectVfolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectVfolderSelect.tsx
@@ -3,6 +3,7 @@ import { BAIProjectVfolderSelectValueQuery } from '../../__generated__/BAIProjec
 import { convertToUUID, toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAILink from '../BAILink';
 import BAISelect, { BAISelectProps } from '../BAISelect';
@@ -19,7 +20,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type ProjectVfolderNode = NonNullable<
@@ -64,7 +64,7 @@ const BAIProjectVfolderSelect: React.FC<BAIProjectVfolderSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIPullingArtifactRevisionAlert.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIPullingArtifactRevisionAlert.tsx
@@ -1,10 +1,10 @@
 import { BAIPullingArtifactRevisionAlertCancelMutation } from '../../__generated__/BAIPullingArtifactRevisionAlertCancelMutation.graphql';
 import { BAIPullingArtifactRevisionAlertFragment$key } from '../../__generated__/BAIPullingArtifactRevisionAlertFragment.graphql';
 import { toLocalId } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIFlex from '../BAIFlex';
 import BAIText from '../BAIText';
 import { Alert, App, Button } from 'antd';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
 export interface BAIPullingArtifactRevisionAlertProps {
@@ -16,7 +16,7 @@ const BAIPullingArtifactRevisionAlert = ({
   pullingArtifactRevisionFrgmt,
   onOk,
 }: BAIPullingArtifactRevisionAlertProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { modal, message } = App.useApp();
 
   const pullingArtifactRevision =

--- a/packages/backend.ai-ui/src/components/fragments/BAIResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIResourceGroupSelect.tsx
@@ -1,7 +1,7 @@
 import { BAIResourceGroupSelectQuery } from '../../__generated__/BAIResourceGroupSelectQuery.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export interface BAIResourceGroupSelectProps extends Omit<
@@ -12,7 +12,7 @@ export interface BAIResourceGroupSelectProps extends Omit<
 const BAIResourceGroupSelect = ({
   ...selectProps
 }: BAIResourceGroupSelectProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   // TODO: change it to use ScalingGroupNode
   const { scaling_groups } = useLazyLoadQuery<BAIResourceGroupSelectQuery>(
     graphql`

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
@@ -10,6 +10,7 @@ import {
   toLocalId,
   useSemanticColorMap,
 } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIButton from '../BAIButton';
 import BAIFlex from '../BAIFlex';
 import BAILink from '../BAILink';
@@ -26,7 +27,6 @@ import { ExclamationCircleOutlined, HistoryOutlined } from '@ant-design/icons';
 import { Tooltip, theme } from 'antd';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type RouteNodeInList = NonNullable<BAIRouteNodesFragment$data[number]>;
@@ -93,7 +93,7 @@ const BAIRouteNodes = ({
   ...tableProps
 }: BAIRouteNodesProps) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const semanticColorMap = useSemanticColorMap();
   const baiClient = useConnectedBAIClient();

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryNodeTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryNodeTable.tsx
@@ -7,6 +7,7 @@ import {
   filterOutNullAndUndefined,
   newLineToBrElement,
 } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAISchedulingResultBadge, {
   SchedulingResult,
 } from '../BAISchedulingResultBadge';
@@ -21,7 +22,6 @@ import { BAIColumnGroupType } from '../Table/BAITable';
 import BAISubStepNodes from './BAISubStepNodes';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type RouteSchedulingHistoryNodeInList = NonNullable<
@@ -61,7 +61,7 @@ const BAIRouteSchedulingHistoryNodeTable = ({
   ...tableProps
 }: BAIRouteSchedulingHistoryNodesProps) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const histories = useFragment<BAIRouteSchedulingHistoryNodeTableFragment$key>(
     graphql`

--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantSelect.tsx
@@ -3,6 +3,7 @@ import { BAIRuntimeVariantSelectValueQuery } from '../../__generated__/BAIRuntim
 import { convertToUUID, toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import TotalFooter from '../TotalFooter';
@@ -19,7 +20,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type RuntimeVariantNode = NonNullable<
@@ -54,7 +54,7 @@ const BAIRuntimeVariantSelect: React.FC<BAIRuntimeVariantSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
@@ -7,6 +7,7 @@ import {
   filterOutNullAndUndefined,
   newLineToBrElement,
 } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAISchedulingResultBadge, {
   SchedulingResult,
 } from '../BAISchedulingResultBadge';
@@ -21,7 +22,6 @@ import { BAIColumnGroupType } from '../Table/BAITable';
 import BAISubStepNodes from './BAISubStepNodes';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type SchedulingHistoryNodeInList = NonNullable<
@@ -61,7 +61,7 @@ const BAISchedulingHistoryNodes = ({
   ...tableProps
 }: BAISchedulingHistoryNodesProps) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const histories = useFragment<BAISchedulingHistoryNodesFragment$key>(
     graphql`

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
@@ -1,11 +1,11 @@
 import { BAISessionAgentIdsFragment$key } from '../../__generated__/BAISessionAgentIdsFragment.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIFlex from '../BAIFlex';
 import { CopyOutlined } from '@ant-design/icons';
 import { Popover, Typography, Button, theme } from 'antd';
 import * as _ from 'lodash-es';
 import React, { useMemo } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 interface BAISessionAgentIdsProps {
@@ -18,7 +18,7 @@ const BAISessionAgentIds: React.FC<BAISessionAgentIdsProps> = ({
   maxInline = 3,
   emptyText = '-',
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const session = useFragment(
     graphql`

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionClusterMode.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionClusterMode.tsx
@@ -1,8 +1,8 @@
 import { BAISessionClusterModeFragment$key } from '../../__generated__/BAISessionClusterModeFragment.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { Tag, theme, Typography } from 'antd';
 import * as _ from 'lodash-es';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useFragment, graphql } from 'react-relay';
 
 export interface BAISessionClusterModeProps {
@@ -26,7 +26,7 @@ const BAISessionClusterMode: React.FC<BAISessionClusterModeProps> = ({
   showSize = true,
   mode = 'text',
 }) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
   const session = useFragment(
     graphql`

--- a/packages/backend.ai-ui/src/components/fragments/BAIStorageHostSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIStorageHostSelect.tsx
@@ -2,6 +2,7 @@ import { BAIStorageHostSelectPaginatedQuery } from '../../__generated__/BAIStora
 import { BAIStorageHostSelectValueQuery } from '../../__generated__/BAIStorageHostSelectValueQuery.graphql';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import { mergeFilterValues } from '../BAIPropertyFilter';
 import BAISelect, { BAISelectProps } from '../BAISelect';
@@ -18,7 +19,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type StorageHostNode = NonNullable<
@@ -47,7 +47,7 @@ const BAIStorageHostSelect: React.FC<BAIStorageHostSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -7,6 +7,7 @@ import {
   filterOutNullAndUndefined,
   newLineToBrElement,
 } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAISchedulingResultBadge, {
   SchedulingResult,
 } from '../BAISchedulingResultBadge';
@@ -21,7 +22,6 @@ import { theme } from 'antd';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 dayjs.extend(duration);
@@ -60,7 +60,7 @@ const BAISubStepNodes = ({
   ...tableProps
 }: BAISubStepNodesProps) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
   const subSteps = useFragment<BAISubStepNodesFragment$key>(

--- a/packages/backend.ai-ui/src/components/fragments/BAIUserSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIUserSelect.tsx
@@ -3,6 +3,7 @@ import { BAIUserSelectValueQuery } from '../../__generated__/BAIUserSelectValueQ
 import { toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import { mergeFilterValues } from '../BAIPropertyFilter';
 import BAISelect, { BAISelectProps } from '../BAISelect';
@@ -18,7 +19,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type UserNode = NonNullable<
@@ -54,7 +54,7 @@ const BAIUserSelect: React.FC<BAIUserSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
@@ -3,6 +3,7 @@ import { BAIVFolderSelectValueQuery } from '../../__generated__/BAIVFolderSelect
 import { toLocalId } from '../../helper';
 import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
 import { useFetchKey } from '../../hooks';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAILink from '../BAILink';
 import { mergeFilterValues } from '../BAIPropertyFilter';
@@ -21,7 +22,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type VFolderNode = NonNullable<
@@ -63,7 +63,7 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/packages/backend.ai-ui/src/components/provider/BAIConfigProvider/BAIConfigProvider.tsx
+++ b/packages/backend.ai-ui/src/components/provider/BAIConfigProvider/BAIConfigProvider.tsx
@@ -31,7 +31,6 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import weekday from 'dayjs/plugin/weekday';
 import { useEffect } from 'react';
-import { I18nextProvider } from 'react-i18next';
 
 dayjs.extend(weekday);
 dayjs.extend(localeData);
@@ -41,8 +40,10 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(duration);
 
-export interface BAIConfigProviderBaseProps
-  extends Omit<ConfigProviderProps, 'locale'> {
+export interface BAIConfigProviderBaseProps extends Omit<
+  ConfigProviderProps,
+  'locale'
+> {
   locale?: BAILocale;
 }
 
@@ -74,6 +75,13 @@ const BAIConfigProvider = ({
   anonymousClientFactory,
   ...props
 }: BAIConfigProviderProps) => {
+  // Sync BUI's i18n + dayjs locale to the prop. BUI components access
+  // `buiI18n` *explicitly* via `useBAIi18n()` (which calls
+  // `useTranslation(undefined, { i18n: buiI18n })`), so we do NOT wrap
+  // children with `<I18nextProvider i18n={buiI18n}>` — that would shadow
+  // the host's i18n React Context and break host components' translations
+  // (FR-2987). Explicit instance binding is enough to keep BUI translations
+  // working without leaking into the host's Context.
   useEffect(() => {
     if (locale?.lang) {
       i18n.changeLanguage(locale.lang);
@@ -82,22 +90,20 @@ const BAIConfigProvider = ({
   }, [locale?.lang]);
 
   return (
-    <I18nextProvider i18n={i18n}>
-      <QueryClientProvider client={queryClient}>
-        <ConfigProvider locale={locale?.antdLocale} {...props}>
-          {clientPromise && anonymousClientFactory ? (
-            <BAIClientProvider
-              clientPromise={clientPromise}
-              anonymousClientFactory={anonymousClientFactory}
-            >
-              {children}
-            </BAIClientProvider>
-          ) : (
-            children
-          )}
-        </ConfigProvider>
-      </QueryClientProvider>
-    </I18nextProvider>
+    <QueryClientProvider client={queryClient}>
+      <ConfigProvider locale={locale?.antdLocale} {...props}>
+        {clientPromise && anonymousClientFactory ? (
+          <BAIClientProvider
+            clientPromise={clientPromise}
+            anonymousClientFactory={anonymousClientFactory}
+          >
+            {children}
+          </BAIClientProvider>
+        ) : (
+          children
+        )}
+      </ConfigProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -166,6 +166,13 @@ export {
 } from './useBAILogger';
 export type { LoggerPlugin, LogContext, BAILogger } from './useBAILogger';
 export { useEventNotStable } from './useEventNotStable';
+// `useBAIi18n` is intentionally NOT re-exported from the package's public
+// surface — it is an internal implementation detail of how BUI components
+// bind to BUI's own i18next instance (see ../hooks/useBAIi18n.ts and the
+// ESLint rule in eslint.config.js that forbids `useTranslation` imports
+// from 'react-i18next' inside packages/backend.ai-ui/src/**). Consumers
+// of the package use their own host i18n; they have no use for BUI's
+// instance binding.
 export {
   useProjectResourceGroups,
   StorageHostFetchError,

--- a/packages/backend.ai-ui/src/hooks/useBAIi18n.ts
+++ b/packages/backend.ai-ui/src/hooks/useBAIi18n.ts
@@ -1,0 +1,32 @@
+import { i18n as buiI18n } from '../locale';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Translation hook for BUI components — binds explicitly to BUI's own
+ * i18next instance.
+ *
+ * By passing `{ i18n: buiI18n }` to `useTranslation`, react-i18next
+ * bypasses its React Context lookup entirely and uses the supplied
+ * instance directly. This means BUI components always resolve keys
+ * against BUI's bundles, regardless of what i18n provider the host
+ * app has (or whether the host uses react-i18next at all).
+ *
+ * Compared to the namespace-sharing approach (Option B), this keeps
+ * BUI fully self-contained:
+ *   - The host's `i18n.init({...})` does not need `ns: ['backend.ai-ui']`,
+ *     `nsSeparator: '^'`, or any `registerBAIResources` call.
+ *   - BUI can be consumed by an app that uses an entirely different
+ *     i18n stack (FormatJS, LinguiJS, none at all).
+ *
+ * Trade-off: host and BUI run two physical i18n instances, so language
+ * changes must be synchronised — `BAIConfigProvider` already does this
+ * by calling `buiI18n.changeLanguage(...)` whenever the `locale` prop
+ * changes.
+ *
+ * Return shape matches `useTranslation()` — `{ t, i18n, ready }` — so
+ * call sites only need to swap the hook name.
+ */
+export const useBAIi18n = () => {
+  'use memo';
+  return useTranslation(undefined, { i18n: buiI18n });
+};

--- a/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.test.tsx
+++ b/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.test.tsx
@@ -1,12 +1,23 @@
 import useErrorMessageResolver from './useErrorMessageResolver';
 import { renderHook } from '@testing-library/react';
 
-// Mock useTranslation so the default fallback is a stable, recognizable string.
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+// Partial mock: keep every real export from `react-i18next` (notably
+// `initReactI18next`, which BUI's `locale/index.ts` consumes at import
+// time) and only override `useTranslation` so the default fallback is a
+// stable, recognizable string. A wholesale `vi.mock` factory would erase
+// the other exports and break any module that transitively pulls them in
+// (FR-2986: `useBAIi18n` imports `locale` which calls
+// `i18n.use(initReactI18next)`).
+vi.mock('react-i18next', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
 
 const useGetErrorMessage = () => {
   const { getErrorMessage } = useErrorMessageResolver();

--- a/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
+++ b/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
@@ -1,5 +1,5 @@
+import { useBAIi18n } from './useBAIi18n';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 
 export type GraphQLErrorEntry = {
   message?: string | null;
@@ -43,7 +43,7 @@ export type ESMClientErrorResponse = {
 };
 
 const useErrorMessageResolver = () => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const isErrorLike = (
     error: unknown,

--- a/packages/backend.ai-ui/src/tests/BAITestButton.tsx
+++ b/packages/backend.ai-ui/src/tests/BAITestButton.tsx
@@ -1,8 +1,8 @@
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 const BAITestButton = () => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const [count, setCount] = useState(0);
   return (

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -4,7 +4,7 @@
  */
 import { RelayEnvironment } from '../RelayEnvironment';
 import { backendaiOptions } from '../global-stores';
-import { buiLanguages, buiTranslations } from '../helper/bui-language';
+import { buiLanguages } from '../helper/bui-language';
 import {
   backendaiClientPromise,
   createAnonymousBackendaiClient,
@@ -58,11 +58,7 @@ import React, {
   useLayoutEffect,
   useState,
 } from 'react';
-import {
-  I18nextProvider,
-  useTranslation,
-  initReactI18next,
-} from 'react-i18next';
+import { useTranslation, initReactI18next } from 'react-i18next';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
 import { useLocation } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
@@ -140,21 +136,6 @@ i18n
       process.env.NODE_ENV === 'development' ? ['copyableI18nKey'] : [],
     lng: backendaiOptions?.get('language', 'default', 'general') || 'en',
     fallbackLng: 'en',
-    // BUI components are rendered inside the host React tree and (since
-    // react-i18next is physically deduped by pnpm) read the host i18n
-    // instance via the shared React Context. Routing missing keys to the
-    // `backend.ai-ui` namespace lets BUI's `useTranslation()` calls
-    // resolve their keys without changing every BUI call site.
-    fallbackNS: 'backend.ai-ui',
-    // BUI uses ':' literally inside its keys (top-level entries are
-    // prefixed with "comp" + colon) and configures its own i18next
-    // instance with nsSeparator '^' so the colon is NOT parsed as a
-    // namespace boundary. The host has to mirror that separator —
-    // otherwise i18next splits BUI keys on the colon, treats the prefix
-    // as a namespace, and never reaches the bundle we register under
-    // the `backend.ai-ui` namespace via the fallback path.
-    // Verified safe: host's own translation keys contain no colon.
-    nsSeparator: '^',
     interpolation: {
       escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
     },
@@ -163,14 +144,6 @@ i18n
       transKeepBasicHtmlNodesFor: ['br', 'strong', 'span', 'code', 'p'],
     },
   });
-
-// Populate the `backend.ai-ui` namespace on the host i18n instance with
-// BUI's static locale bundles. Pairs with the `fallbackNS` above so BUI
-// components calling `useTranslation()` resolve their keys via fallback
-// against the host's (single, deduped) react-i18next Context.
-Object.entries(buiTranslations).forEach(([lng, bundle]) => {
-  i18n.addResourceBundle(lng, 'backend.ai-ui', bundle, true, true);
-});
 
 // Dev-only: react to host i18n JSON edits without a full page reload.
 // `vite.config.ts:devAssetsReloadPlugin` watches `resources/i18n/*.json` and
@@ -352,35 +325,28 @@ export const DefaultProvidersForReactRoot: React.FC<{
               }}
             >
               {/*
-               * Re-assert the host i18n React Context. BAIConfigProvider
-               * internally wraps its children with
-               * <I18nextProvider i18n={buiI18n}>; because pnpm dedupes
-               * react-i18next into a single physical copy (= a single
-               * React Context) across host and BUI, that BUI Provider
-               * would otherwise shadow the host i18n for every child and
-               * host keys would surface as raw strings.
-               *
-               * Convention: BAIConfigProvider is mounted only here, at
-               * the application root. Other call sites (e.g. the login
-               * screen) use antd's plain ConfigProvider so this shadow
-               * never enters the tree in the first place.
+               * No <I18nextProvider> wrap needed here. BUI components
+               * resolve their translations via `useBAIi18n()` which calls
+               * `useTranslation(undefined, { i18n: buiI18n })` — explicit
+               * instance binding bypasses React Context entirely, so the
+               * host's i18n Context flows through to host components
+               * unchanged. See FR-2986 / packages/backend.ai-ui/src/hooks/
+               * useBAIi18n.ts.
                */}
-              <I18nextProvider i18n={i18n}>
-                <BAIMetaDataWrapper>
-                  <QueryParamProvider adapter={ReactRouter6Adapter}>
-                    <App {...commonAppProps}>
-                      {/* <StyleProvider container={shadowRoot} cache={cache}> */}
-                      <Suspense>
-                        {/* <BrowserRouter> */}
-                        {/* <RoutingEventHandler /> */}
-                        {children}
-                        {/* </BrowserRouter> */}
-                      </Suspense>
-                      {/* </StyleProvider> */}
-                    </App>
-                  </QueryParamProvider>
-                </BAIMetaDataWrapper>
-              </I18nextProvider>
+              <BAIMetaDataWrapper>
+                <QueryParamProvider adapter={ReactRouter6Adapter}>
+                  <App {...commonAppProps}>
+                    {/* <StyleProvider container={shadowRoot} cache={cache}> */}
+                    <Suspense>
+                      {/* <BrowserRouter> */}
+                      {/* <RoutingEventHandler /> */}
+                      {children}
+                      {/* </BrowserRouter> */}
+                    </Suspense>
+                    {/* </StyleProvider> */}
+                  </App>
+                </QueryParamProvider>
+              </BAIMetaDataWrapper>
             </BAIConfigProvider>
           </QueryClientProvider>
         </RelayEnvironmentProvider>

--- a/react/src/helper/bui-language.ts
+++ b/react/src/helper/bui-language.ts
@@ -2,49 +2,34 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-// BUI translation JSON bundles. The Vite alias in `react/vite.config.ts`
-// rewrites `backend.ai-ui/dist/...` to `packages/backend.ai-ui/src/...`,
-// so these resolve to the source JSON files in the BUI package.
-import deTrans from 'backend.ai-ui/dist/locale/de.json';
+// antd / dayjs locale wrappers from the BUI package, keyed by language code.
+// `BAIConfigProvider` (and the host's antd `ConfigProvider`) consume these
+// via the `locale` prop to localise antd's built-in strings (e.g. table
+// pagination labels, date picker month names).
+//
+// BUI's own translation JSONs are NOT re-exported here. BUI components
+// access them via BUI's internal i18next instance (`useBAIi18n` /
+// `BAITrans`), so the host has no reason to hold a second copy. See
+// FR-2986 / packages/backend.ai-ui/src/hooks/useBAIi18n.ts.
 import de_DE from 'backend.ai-ui/dist/locale/de_DE';
-import elTrans from 'backend.ai-ui/dist/locale/el.json';
 import el_GR from 'backend.ai-ui/dist/locale/el_GR';
-import enTrans from 'backend.ai-ui/dist/locale/en.json';
 import en_US from 'backend.ai-ui/dist/locale/en_US';
-import esTrans from 'backend.ai-ui/dist/locale/es.json';
 import es_ES from 'backend.ai-ui/dist/locale/es_ES';
-import fiTrans from 'backend.ai-ui/dist/locale/fi.json';
 import fi_FI from 'backend.ai-ui/dist/locale/fi_FI';
-import frTrans from 'backend.ai-ui/dist/locale/fr.json';
 import fr_FR from 'backend.ai-ui/dist/locale/fr_FR';
-import idTrans from 'backend.ai-ui/dist/locale/id.json';
 import id_ID from 'backend.ai-ui/dist/locale/id_ID';
-import itTrans from 'backend.ai-ui/dist/locale/it.json';
 import it_IT from 'backend.ai-ui/dist/locale/it_IT';
-import jaTrans from 'backend.ai-ui/dist/locale/ja.json';
 import ja_JP from 'backend.ai-ui/dist/locale/ja_JP';
-import koTrans from 'backend.ai-ui/dist/locale/ko.json';
 import ko_KR from 'backend.ai-ui/dist/locale/ko_KR';
-import mnTrans from 'backend.ai-ui/dist/locale/mn.json';
 import mn_MN from 'backend.ai-ui/dist/locale/mn_MN';
-import msTrans from 'backend.ai-ui/dist/locale/ms.json';
 import ms_MY from 'backend.ai-ui/dist/locale/ms_MY';
-import plTrans from 'backend.ai-ui/dist/locale/pl.json';
 import pl_PL from 'backend.ai-ui/dist/locale/pl_PL';
-import ptBRTrans from 'backend.ai-ui/dist/locale/pt-BR.json';
-import ptTrans from 'backend.ai-ui/dist/locale/pt.json';
 import pt_BR from 'backend.ai-ui/dist/locale/pt_BR';
 import pt_PT from 'backend.ai-ui/dist/locale/pt_PT';
-import ruTrans from 'backend.ai-ui/dist/locale/ru.json';
 import ru_RU from 'backend.ai-ui/dist/locale/ru_RU';
-import thTrans from 'backend.ai-ui/dist/locale/th.json';
 import th_TH from 'backend.ai-ui/dist/locale/th_TH';
-import trTrans from 'backend.ai-ui/dist/locale/tr.json';
 import tr_TR from 'backend.ai-ui/dist/locale/tr_TR';
-import viTrans from 'backend.ai-ui/dist/locale/vi.json';
 import vi_VN from 'backend.ai-ui/dist/locale/vi_VN';
-import zhCNTrans from 'backend.ai-ui/dist/locale/zh-CN.json';
-import zhTWTrans from 'backend.ai-ui/dist/locale/zh-TW.json';
 import zh_CN from 'backend.ai-ui/dist/locale/zh_CN';
 import zh_TW from 'backend.ai-ui/dist/locale/zh_TW';
 
@@ -71,33 +56,4 @@ export const buiLanguages = {
   vi: vi_VN,
   'zh-CN': zh_CN,
   'zh-TW': zh_TW,
-};
-
-// BUI translation bundles keyed by language code, to be registered on the
-// host i18n instance under the `backend.ai-ui` namespace. Pair with
-// `fallbackNS: 'backend.ai-ui'` (and `nsSeparator: '^'`) on the host i18n
-// config so BUI components calling `useTranslation()` resolve their keys
-// via fallback against the shared (deduped) react-i18next Context.
-export const buiTranslations: Record<string, Record<string, unknown>> = {
-  de: deTrans,
-  el: elTrans,
-  en: enTrans,
-  es: esTrans,
-  fi: fiTrans,
-  fr: frTrans,
-  id: idTrans,
-  it: itTrans,
-  ja: jaTrans,
-  ko: koTrans,
-  mn: mnTrans,
-  ms: msTrans,
-  pl: plTrans,
-  'pt-BR': ptBRTrans,
-  pt: ptTrans,
-  ru: ruTrans,
-  th: thTrans,
-  tr: trTrans,
-  vi: viTrans,
-  'zh-CN': zhCNTrans,
-  'zh-TW': zhTWTrans,
 };

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -464,17 +464,19 @@ export default defineConfig(({ command, mode }) => {
     resolve: {
       // Force a single instance of shared singletons across the monorepo.
       //
-      // BUI intentionally maintains its OWN i18n instance (see the note in
-      // packages/backend.ai-ui/vite.config.ts). Do NOT add `i18next` or
-      // `react-i18next` here — the design relies on each side having its
-      // own default singleton. React, Relay, Jotai must still be deduped
-      // so hooks/state sharing works across the monorepo.
+      // Under Option C, BUI still has its own i18n instance, but accesses
+      // it via explicit binding (useBAIi18n → useTranslation({ i18n })) so
+      // dedup'ing react-i18next to one physical copy is now safe: there is
+      // no React-Context-based discovery path that could leak between BUI
+      // and host.
       dedupe: [
         'react',
         'react-dom',
         'react-relay',
         'relay-runtime',
         'jotai',
+        'i18next',
+        'react-i18next',
       ],
       // Array form lets us mix regex aliases (for `src/` baseUrl imports) with
       // the workspace-package aliases. `find` is matched against the import
@@ -588,24 +590,12 @@ export default defineConfig(({ command, mode }) => {
         // packages/backend.ai-client/src trigger HMR instead of requiring
         // a tsup rebuild + full reload.
         'backend.ai-client',
-        // BUI is designed to have its OWN i18n singleton separate from the
-        // host app (see packages/backend.ai-ui/src/locale/index.ts +
-        // BAIConfigProvider wraps children with <I18nextProvider i18n={buiI18n}>).
-        //
-        // Under CRA this worked because pnpm's per-package i18next/react-i18next
-        // copies (split by typescript peer version) meant both `react-i18next`
-        // copies had DIFFERENT React Context objects. BUI's Provider published
-        // to its own Context; host's useTranslation read host's Context.
-        //
-        // Under Vite's dep optimizer the two copies collapse into one bundled
-        // module = one Context object. BAIConfigProvider's Provider then
-        // leaks into host components and they resolve host keys against BUI's
-        // resource set (which only has BUI keys) → raw keys render.
-        //
-        // Excluding from optimization preserves natural pnpm-per-package
-        // resolution and keeps the two Context objects distinct.
-        'i18next',
-        'react-i18next',
+        // i18next / react-i18next are NOT excluded here under Option C.
+        // BUI keeps its own i18n instance but accesses it via explicit
+        // `useTranslation(undefined, { i18n: buiI18n })` binding (the
+        // `useBAIi18n` hook). That bypasses React Context entirely, so
+        // pnpm/Vite deduping react-i18next to a single module is fine —
+        // there is no Context-leakage path between BUI and the host.
       ],
     },
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -73,7 +73,7 @@ check_relay_drift() {
 }
 
 run_check "Relay" check_relay_drift
-run_check "Lint" pnpm run lint
+run_check "Lint" pnpm -r --stream lint
 run_check "Format" pnpm run format
 run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit
 run_check "Vite warmup paths" check_warmup_paths


### PR DESCRIPTION
Resolves #7615 (FR-2986)

## Summary

BUI (`packages/backend.ai-ui`) previously exposed its translations by wrapping children with `<I18nextProvider i18n={buiI18n}>` inside `BAIConfigProvider`. That design relied on host and BUI ending up with **two physically separate copies** of `react-i18next` so each side had a distinct React Context. After FR-2925 unified TypeScript peer versions, pnpm started deduping `react-i18next` into a single physical module → only one Context object → BUI's `<I18nextProvider>` shadowed the host's, causing raw key strings (`login.Login`, `login.Endpoint`, …) on the login page (FR-2987).

PR #7595 (FR-2987, **already merged**) ships a fast workaround that re-asserts the host i18n Context inside `BAIConfigProvider`. This PR is the **structural alternative** — instead of patching around the leak, it removes the React-Context dependency entirely on BUI's side.

## Approach (Option C: explicit instance binding)

BUI components now access BUI's i18n instance **directly** via `useTranslation(undefined, { i18n: buiI18n })`, exposed as an **internal-only** `useBAIi18n()` hook. That call signature tells react-i18next to skip Context lookup and use the supplied instance — so BUI is unaffected by whatever i18n provider (or absence of one) the host has.

### Code changes

- **New internal hook** `packages/backend.ai-ui/src/hooks/useBAIi18n.ts` — explicit-instance wrapper around `useTranslation`. **Not exported from the package's public surface** (`hooks/index.ts`); it is an implementation detail of how BUI binds to its own instance.
- **ESLint enforcement** in `packages/backend.ai-ui/eslint.config.js` — `no-restricted-imports` forbids `useTranslation` / `withTranslation` / `Translation` / `I18nextProvider` imports from `react-i18next` anywhere under `packages/backend.ai-ui/src/**`. `useBAIi18n.ts` itself is exempt. This prevents the original anti-pattern from reappearing in future BUI code.
- **`BAIConfigProvider`** — drops `<I18nextProvider i18n={buiI18n}>` wrap and the matching `react-i18next` import. Keeps the `useEffect` that mirrors `locale.lang` onto `buiI18n.changeLanguage(...)` and `dayjs.locale(...)` (this is the language-sync mechanism for the explicit-instance design).
- **72 BUI source files** migrated `useTranslation()` → `useBAIi18n()` with depth-aware relative import paths (including `src/tests/BAITestButton.tsx`).
- **`BAIDeleteConfirmModal`** — the single `<Trans>` usage now passes `t={t}` so it inherits the BUI-bound translation function (otherwise Trans would re-enter the Context path).
- **`react/vite.config.ts`** — drops `i18next` / `react-i18next` from `optimizeDeps.exclude`, adds them to `resolve.dedupe`. The two-physical-copies workaround is no longer required.
- **`react/src/components/DefaultProviders.tsx`** — removes the inline `<I18nextProvider i18n={i18n}>` wrap added by PR #7595, since BUI no longer leaks Context. Comment updated to point at `useBAIi18n.ts`.

## Comparison with PR #7595 (FR-2987 workaround, already merged)

| Aspect | PR #7595 (HostI18nProvider) | This PR (#7616) |
|---|---|---|
| Approach | Patch each `BAIConfigProvider` site by re-asserting host Context | Remove the leaking design at the source |
| BUI uses React Context for i18n | Yes (still) | **No** (explicit instance binding) |
| Future `BAIConfigProvider` instances | Need re-assertion added manually | Automatic — no per-site fix needed |
| `vite.config.ts` `optimizeDeps.exclude` hack | Still required | **Removed** |
| Anti-pattern recurrence prevention | Convention comment only | **ESLint rule enforced** |
| `useBAIi18n` exposed publicly | N/A | **No** — internal-only implementation detail |

## Verification

- `bash scripts/verify.sh` ends with `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Vite warmup all green).
- Dev server: `https://option-c.localhost:1356/` (worktree `option-c-explicit-instance`)
- Playwright headless check on the login page: **0 raw i18n keys** found in body text.
- ESLint guard verified: temporarily injecting `import { useTranslation } from "react-i18next"` into a BUI source file produces the expected `no-restricted-imports` error with the `useBAIi18n` migration message.

## Test plan

- [ ] Verify login page renders with no raw `*.key` strings in EN / KO / JA
- [ ] Verify language switching from user settings still propagates to BUI components (e.g. `BAITagList` Copy-All tooltip, `BAIModal` minimize tooltip)
- [ ] Verify Storybook still renders BUI components in isolation (BUI's own i18n instance + dayjs are still initialized in `locale/index.ts`)
- [ ] CI: `pnpm run -r --stream build` and `bash scripts/verify.sh` pass

## Architectural notes

- BUI is now usable from a host that does **not** use `react-i18next` at all (or uses a different version) — useful if BUI is ever distributed as an external npm package.
- Two physical i18n instances coexist (host + BUI) but they never compete because Context resolution is bypassed in BUI components. The cost is duplicated language-resource memory; given BUI bundles are small and JSON parsing is one-time, this is negligible.
- The `useBAIi18n` hook is also a step toward an Adapter-pattern future where the i18n backend behind it could be swapped without touching the 71 BUI call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)