### PR TITLE
fix(FR-2990): preserve acceleratorType form registration in session launcher

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -221,7 +221,10 @@ const ResourceAllocationFormItems: React.FC<
 
   // Get supported accelerator types in resource group by image
   const supportedAcceleratorTypesInRGByImage = useMemo(() => {
-    if (_.isUndefined(acceleratorSlotsInRG) || _.isNil(currentImage)) {
+    if (
+      _.isUndefined(acceleratorSlotsInRG) ||
+      (_.isNil(currentImage) && _.isEmpty(currentEnvironmentManual))
+    ) {
       return undefined;
     }
     return _.keys(acceleratorSlotsInRG).filter((acceleratorTypeName) => {


### PR DESCRIPTION
Resolves #7623 (FR-2990)

## Summary
- Treat a non-empty `environments.manual` value as a valid signal for `supportedAcceleratorTypesInRGByImage` so the accelerator-type `<Select>` stays mounted in manual-environment mode.
- With the selector mounted, `form.validateFields()` keeps `resource.acceleratorType` in the payload that `useStartSession` reads, so the create-session request no longer omits the accelerator slot.

## Why
The session launcher Preview reads `form.getFieldValue('resource')` (returns preserved values) while submission reads `form.validateFields()` (returns mounted-field values only). When the user entered the image manually, `currentImage` was nil → `supportedAcceleratorTypesInRGByImage` short-circuited to `undefined` → the accelerator-type `<Select>` was removed from the JSX tree. The two readers diverged: Preview showed a GPU resource that the actual create-session request omitted. CLI was not affected since it bypasses the form.

## Test plan
- [ ] On the session launcher, select a normal image with GPU support, set GPU count, launch — request includes the accelerator slot (regression check).
- [ ] On the session launcher, switch the environment to "Manual" input, enter a custom image, set GPU count, launch — the request includes `{ [acceleratorType]: count }` and the spawned container actually sees the GPU.
- [ ] Toggle between a normal image and Manual input back-to-back without reloading — `resource.acceleratorType` stays consistent between Preview and the submitted payload.