### PR TITLE
feat(FR-3008): auto-expand non-success rows and add expand/collapse-all toggle in scheduling history

### DIFF
--- a/e2e/session/session-scheduling-history-modal.spec.ts
+++ b/e2e/session/session-scheduling-history-modal.spec.ts
@@ -165,9 +165,6 @@ test.describe(
         modal.getByRole('columnheader', { name: 'Result' }),
       ).toBeVisible();
       await expect(
-        modal.getByRole('columnheader', { name: 'Status Transition' }),
-      ).toBeVisible();
-      await expect(
         modal.getByRole('columnheader', { name: 'Attempts' }),
       ).toBeVisible();
       await expect(
@@ -177,48 +174,19 @@ test.describe(
         modal.getByRole('columnheader', { name: 'Created At' }),
       ).toBeVisible();
 
-      // 7. Verify the sub-header "From" and "To" within Status Transition
+      // 7. Verify the flat status-transition columns "From Status" and
+      // "To Status" (the grouped "Status Transition" header was removed).
       await expect(
-        modal.getByRole('columnheader', { name: 'From' }),
+        modal.getByRole('columnheader', { name: 'From Status' }),
       ).toBeVisible();
       await expect(
-        modal.getByRole('columnheader', { name: 'To' }),
+        modal.getByRole('columnheader', { name: 'To Status' }),
       ).toBeVisible();
-
-      // 8. Verify the Close button is visible in the modal footer
-      const closeButtonFooter = modal
-        .getByRole('button', { name: 'Close' })
-        .filter({ hasText: 'Close' });
-      await expect(closeButtonFooter).toBeVisible();
     });
 
     // ─────────────────────────────────────────────────────────────────────────
     // 3. Modal Dismissal
     // ─────────────────────────────────────────────────────────────────────────
-
-    test('Admin can close the Session Scheduling History modal using the footer Close button', async ({
-      page,
-    }) => {
-      // 1. Open the Session Detail drawer and history modal
-      await openSessionDetailDrawer(page);
-      const modal = await openSchedulingHistoryModal(page);
-
-      // 2. Verify the modal is visible
-      await expect(modal).toBeVisible();
-
-      // 3. Click the footer "Close" button
-      await modal
-        .getByRole('button', { name: 'Close' })
-        .filter({ hasText: 'Close' })
-        .click();
-
-      // 4. Verify the modal is no longer visible
-      await expect(modal).not.toBeVisible();
-
-      // 5. Verify the Session Detail drawer is still open
-      const drawer = page.getByRole('dialog', { name: 'Session Info' });
-      await expect(drawer).toBeVisible();
-    });
 
     test('Admin can close the Session Scheduling History modal using the X button in the header', async ({
       page,
@@ -231,9 +199,8 @@ test.describe(
       await expect(modal).toBeVisible();
 
       // 3. Click the X (close) button in the modal header.
-      // The Ant Design modal header X button has aria-label="Close" and appears first in DOM order.
-      // The footer "Close" button has visible text "Close" (use hasText to distinguish them).
-      // The header X button is the first button named "Close" in the modal.
+      // The Ant Design modal header X button has aria-label="Close"; the modal
+      // is footerless, so it is the only "Close" button in the modal.
       const headerCloseButton = modal
         .getByRole('button', { name: 'Close' })
         .first();
@@ -732,7 +699,15 @@ test.describe(
       await openSessionDetailDrawer(page);
       const modal = await openSchedulingHistoryModal(page);
 
-      // 2. Identify a row with an expand icon (the schedule-sessions row has sub-steps).
+      // 2. Switch to "Collapse all" via the header kebab (⋮) menu first. The
+      // default "expand errors only" mode filters SUCCESS sub-steps out of the
+      // nested table, so expanding the all-SUCCESS schedule-sessions row would
+      // show an empty sub-step table. "Collapse all" disables that filter while
+      // leaving every row collapsed, so the row can still be manually expanded.
+      await modal.locator('thead button').first().click();
+      await page.getByRole('menuitem', { name: 'Collapse all' }).click();
+
+      // 3. Identify a row with an expand icon (the schedule-sessions row has sub-steps).
       // NOTE: antd renders a "spaced" (invisible) expand button on ALL rows, even non-expandable
       // ones. Playwright's accessible-name computation for <tr> uses text content only (not
       // nested button aria-labels), so the pattern /Expand row schedule-sessions/ does not match
@@ -743,7 +718,7 @@ test.describe(
         .filter({ hasText: 'schedule-sessions' });
       await expect(expandableRow).toBeVisible();
 
-      // 3. Click the expand icon/arrow on that row
+      // 4. Click the expand icon/arrow on that row
       await expandableRow.getByLabel('Expand row').click();
 
       // 4. Verify the sub-steps table columns are visible
@@ -783,7 +758,13 @@ test.describe(
       await openSessionDetailDrawer(page);
       const modal = await openSchedulingHistoryModal(page);
 
-      // 2. Expand the schedule-sessions row.
+      // 2. Switch to "Collapse all" so the nested sub-step table is not filtered
+      // to errors-only (the default mode hides the SUCCESS sub-step asserted
+      // below). Rows start collapsed, so the row can still be manually expanded.
+      await modal.locator('thead button').first().click();
+      await page.getByRole('menuitem', { name: 'Collapse all' }).click();
+
+      // 3. Expand the schedule-sessions row.
       // Use filter by text content — see test #8 comment for why the name pattern
       // /Expand row schedule-sessions/ does not work with Playwright's row accname.
       // Narrow to the first match to avoid strict-mode violations if multiple
@@ -926,7 +907,13 @@ test.describe(
         .filter({ hasText: 'schedule-sessions' });
       await expect(scheduleRow).toBeVisible();
 
-      // 5. Expand the schedule-sessions row to view sub-step details
+      // 5. Switch to "Collapse all" so the nested sub-step table is not filtered
+      // to errors-only (the default mode hides the SUCCESS sub-step asserted in
+      // step 7). Rows stay collapsed, so the row is still manually expandable.
+      await modal.locator('thead button').first().click();
+      await page.getByRole('menuitem', { name: 'Collapse all' }).click();
+
+      // 6. Expand the schedule-sessions row to view sub-step details
       await scheduleRow.getByLabel('Expand row').click();
 
       // 6. Verify the sub-steps table appears with correct column headers
@@ -956,11 +943,8 @@ test.describe(
         modal.getByRole('columnheader', { name: 'Phase' }),
       ).toBeVisible();
 
-      // 10. Click the footer "Close" button to close the modal
-      await modal
-        .getByRole('button', { name: 'Close' })
-        .filter({ hasText: 'Close' })
-        .click();
+      // 10. Click the header X (close) button to close the modal
+      await modal.getByRole('button', { name: 'Close' }).first().click();
 
       // 11. Verify the modal is closed
       await expect(modal).not.toBeVisible();

--- a/packages/backend.ai-ui/src/__generated__/BAIDeploymentSchedulingHistoryNodesFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIDeploymentSchedulingHistoryNodesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<99de343c87eba570df6b2b85270538f5>>
+ * @generated SignedSource<<71095bfdeccbadb23853c6e22f7d6864>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,9 +21,6 @@ export type BAIDeploymentSchedulingHistoryNodesFragment$data = ReadonlyArray<{
   readonly message: string | null | undefined;
   readonly phase: string;
   readonly result: SchedulingResult;
-  readonly subSteps: ReadonlyArray<{
-    readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
-  }>;
   readonly toStatus: string | null | undefined;
   readonly updatedAt: string;
   readonly " $fragmentType": "BAIDeploymentSchedulingHistoryNodesFragment";
@@ -100,22 +97,6 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "SubStepResultGQL",
-      "kind": "LinkedField",
-      "name": "subSteps",
-      "plural": true,
-      "selections": [
-        {
-          "args": null,
-          "kind": "FragmentSpread",
-          "name": "BAISubStepNodesFragment"
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
       "kind": "ScalarField",
       "name": "attempts",
       "storageKey": null
@@ -139,6 +120,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "993394664d6af0ea9ee225d992cff972";
+(node as any).hash = "eb0787126d34e31d6d0aa79127c25d2f";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIDeploymentSchedulingHistoryTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIDeploymentSchedulingHistoryTableFragment.graphql.ts
@@ -1,0 +1,78 @@
+/**
+ * @generated SignedSource<<f04a8d6c2c26a9be4969f98eb55bd6f7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type SchedulingResult = "EXPIRED" | "FAILURE" | "GIVE_UP" | "NEED_RETRY" | "SKIPPED" | "STALE" | "SUCCESS" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type BAIDeploymentSchedulingHistoryTableFragment$data = ReadonlyArray<{
+  readonly id: string;
+  readonly result: SchedulingResult;
+  readonly subSteps: ReadonlyArray<{
+    readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
+  }>;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIDeploymentSchedulingHistoryNodesFragment">;
+  readonly " $fragmentType": "BAIDeploymentSchedulingHistoryTableFragment";
+}>;
+export type BAIDeploymentSchedulingHistoryTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAIDeploymentSchedulingHistoryTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIDeploymentSchedulingHistoryTableFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "BAIDeploymentSchedulingHistoryTableFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "result",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SubStepResultGQL",
+      "kind": "LinkedField",
+      "name": "subSteps",
+      "plural": true,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "BAISubStepNodesFragment"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "BAIDeploymentSchedulingHistoryNodesFragment"
+    }
+  ],
+  "type": "DeploymentHistory",
+  "abstractKey": null
+};
+
+(node as any).hash = "72a9b8118e4f52a97c2ab8996996098d";
+
+export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryNodeTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryNodeTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7826d64cc35baebfbae84de866de9d0e>>
+ * @generated SignedSource<<a5551f78ac6c3a7a81da42ebe1585381>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,17 +15,12 @@ export type BAIRouteSchedulingHistoryNodeTableFragment$data = ReadonlyArray<{
   readonly attempts: number;
   readonly category: string;
   readonly createdAt: string;
-  readonly deploymentId: string;
   readonly errorCode: string | null | undefined;
   readonly fromStatus: string | null | undefined;
   readonly id: string;
   readonly message: string | null | undefined;
   readonly phase: string;
   readonly result: SchedulingResult;
-  readonly routeId: string;
-  readonly subSteps: ReadonlyArray<{
-    readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
-  }>;
   readonly toStatus: string | null | undefined;
   readonly updatedAt: string;
   readonly " $fragmentType": "BAIRouteSchedulingHistoryNodeTableFragment";
@@ -48,20 +43,6 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "id",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "routeId",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "deploymentId",
       "storageKey": null
     },
     {
@@ -116,22 +97,6 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "SubStepResultGQL",
-      "kind": "LinkedField",
-      "name": "subSteps",
-      "plural": true,
-      "selections": [
-        {
-          "args": null,
-          "kind": "FragmentSpread",
-          "name": "BAISubStepNodesFragment"
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
       "kind": "ScalarField",
       "name": "attempts",
       "storageKey": null
@@ -155,6 +120,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "3f283b3e8ef039a11e41ade44a38092f";
+(node as any).hash = "bd0c64d2e599015d8b9db0afbcb05c7c";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryTableFragment.graphql.ts
@@ -1,0 +1,78 @@
+/**
+ * @generated SignedSource<<62e9f5ee291e0755eee6a0c3ad8898e4>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type SchedulingResult = "EXPIRED" | "FAILURE" | "GIVE_UP" | "NEED_RETRY" | "SKIPPED" | "STALE" | "SUCCESS" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type BAIRouteSchedulingHistoryTableFragment$data = ReadonlyArray<{
+  readonly id: string;
+  readonly result: SchedulingResult;
+  readonly subSteps: ReadonlyArray<{
+    readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
+  }>;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryNodeTableFragment">;
+  readonly " $fragmentType": "BAIRouteSchedulingHistoryTableFragment";
+}>;
+export type BAIRouteSchedulingHistoryTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAIRouteSchedulingHistoryTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryTableFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "BAIRouteSchedulingHistoryTableFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "result",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SubStepResultGQL",
+      "kind": "LinkedField",
+      "name": "subSteps",
+      "plural": true,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "BAISubStepNodesFragment"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "BAIRouteSchedulingHistoryNodeTableFragment"
+    }
+  ],
+  "type": "RouteHistory",
+  "abstractKey": null
+};
+
+(node as any).hash = "7f5f32e6a4ea10ddfc54ff01c8b260b2";
+
+export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAISchedulingHistoryNodesFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISchedulingHistoryNodesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ce6f00b122f73ac787c18a8f27b6222b>>
+ * @generated SignedSource<<bad7936a21ca79c32758a84f123d5aeb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,10 +19,6 @@ export type BAISchedulingHistoryNodesFragment$data = ReadonlyArray<{
   readonly message: string | null | undefined;
   readonly phase: string;
   readonly result: SchedulingResult;
-  readonly sessionId: string;
-  readonly subSteps: ReadonlyArray<{
-    readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
-  }>;
   readonly toStatus: string | null | undefined;
   readonly updatedAt: string;
   readonly " $fragmentType": "BAISchedulingHistoryNodesFragment";
@@ -45,13 +41,6 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "id",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "sessionId",
       "storageKey": null
     },
     {
@@ -109,28 +98,12 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "result",
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "SubStepResultGQL",
-      "kind": "LinkedField",
-      "name": "subSteps",
-      "plural": true,
-      "selections": [
-        {
-          "args": null,
-          "kind": "FragmentSpread",
-          "name": "BAISubStepNodesFragment"
-        }
-      ],
-      "storageKey": null
     }
   ],
   "type": "SessionSchedulingHistory",
   "abstractKey": null
 };
 
-(node as any).hash = "d9ace8d5059e208cc256c1f0c236d273";
+(node as any).hash = "a52af4f53e01beb70d74f67b151aa5e0";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAISchedulingHistoryTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISchedulingHistoryTableFragment.graphql.ts
@@ -1,0 +1,78 @@
+/**
+ * @generated SignedSource<<78437bb97e2f6f7f9ff2eadc98f408cd>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type SchedulingResult = "EXPIRED" | "FAILURE" | "GIVE_UP" | "NEED_RETRY" | "SKIPPED" | "STALE" | "SUCCESS" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type BAISchedulingHistoryTableFragment$data = ReadonlyArray<{
+  readonly id: string;
+  readonly result: SchedulingResult;
+  readonly subSteps: ReadonlyArray<{
+    readonly " $fragmentSpreads": FragmentRefs<"BAISubStepNodesFragment">;
+  }>;
+  readonly " $fragmentSpreads": FragmentRefs<"BAISchedulingHistoryNodesFragment">;
+  readonly " $fragmentType": "BAISchedulingHistoryTableFragment";
+}>;
+export type BAISchedulingHistoryTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAISchedulingHistoryTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAISchedulingHistoryTableFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "BAISchedulingHistoryTableFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "result",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SubStepResultGQL",
+      "kind": "LinkedField",
+      "name": "subSteps",
+      "plural": true,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "BAISubStepNodesFragment"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "BAISchedulingHistoryNodesFragment"
+    }
+  ],
+  "type": "SessionSchedulingHistory",
+  "abstractKey": null
+};
+
+(node as any).hash = "cc812aab73e7155ba3bc061806f997dd";
+
+export default node;

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -672,9 +672,9 @@ const useStyles = createStyles(({ token, css }) => ({
       font-weight: 500;
       color: ${token.colorTextTertiary};
     }
-    body:not(.dark-theme) & .ant-table-expanded-row > .ant-table-cell,
-    body:not(.dark-theme) & .ant-table-expanded-row:hover > .ant-table-cell {
-      background: #e3e3e3;
+    & .ant-table-expanded-row > .ant-table-cell,
+    & .ant-table-expanded-row:hover > .ant-table-cell {
+      background: ${token.colorFillSecondary};
     }
   `,
   zeroWithSelectionColumn: css`

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryNodes.tsx
@@ -18,8 +18,6 @@ import {
   BAITable,
   BAITableProps,
 } from '../Table';
-import { BAIColumnGroupType } from '../Table/BAITable';
-import BAISubStepNodes from './BAISubStepNodes';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { graphql, useFragment } from 'react-relay';
@@ -76,9 +74,6 @@ const BAIDeploymentSchedulingHistoryNodes = ({
           result
           errorCode
           message
-          subSteps {
-            ...BAISubStepNodesFragment
-          }
           attempts
           createdAt
           updatedAt
@@ -88,10 +83,7 @@ const BAIDeploymentSchedulingHistoryNodes = ({
     );
 
   const baseColumns = _.map(
-    filterOutEmpty<
-      | BAIColumnType<DeploymentSchedulingHistoryNodeInList>
-      | BAIColumnGroupType<DeploymentSchedulingHistoryNodeInList>
-    >([
+    filterOutEmpty<BAIColumnType<DeploymentSchedulingHistoryNodeInList>>([
       {
         dataIndex: 'updatedAt',
         title: t('comp:BAIDeploymentSchedulingHistoryNodes.UpdatedAt'),
@@ -132,22 +124,16 @@ const BAIDeploymentSchedulingHistoryNodes = ({
         sorter: isEnableSorter('category'),
       },
       {
-        title: t('comp:BAIDeploymentSchedulingHistoryNodes.StatusTransition'),
-        key: 'statusTransition',
-        children: [
-          {
-            key: 'fromStatus',
-            title: t('comp:BAIDeploymentSchedulingHistoryNodes.From'),
-            dataIndex: 'fromStatus',
-            sorter: isEnableSorter('from_status'),
-          },
-          {
-            key: 'toStatus',
-            title: t('comp:BAIDeploymentSchedulingHistoryNodes.To'),
-            dataIndex: 'toStatus',
-            sorter: isEnableSorter('to_status'),
-          },
-        ],
+        key: 'fromStatus',
+        title: t('comp:BAIDeploymentSchedulingHistoryNodes.From'),
+        dataIndex: 'fromStatus',
+        sorter: isEnableSorter('from_status'),
+      },
+      {
+        key: 'toStatus',
+        title: t('comp:BAIDeploymentSchedulingHistoryNodes.To'),
+        dataIndex: 'toStatus',
+        sorter: isEnableSorter('to_status'),
       },
       {
         dataIndex: 'attempts',
@@ -203,18 +189,6 @@ const BAIDeploymentSchedulingHistoryNodes = ({
           (order as (typeof availableDeploymentHistorySorterValues)[number]) ||
             null,
         );
-      }}
-      expandable={{
-        rowExpandable: (record) => !_.isEmpty(record.subSteps),
-        expandedRowRender: (record) => {
-          return (
-            <BAISubStepNodes
-              resizable
-              subStepsFrgmt={record.subSteps}
-              pagination={false}
-            />
-          );
-        },
       }}
       {...tableProps}
     />

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryTable.tsx
@@ -1,0 +1,85 @@
+import { BAIDeploymentSchedulingHistoryTableFragment$key } from '../../__generated__/BAIDeploymentSchedulingHistoryTableFragment.graphql';
+import { filterOutNullAndUndefined } from '../../helper';
+import {
+  type SchedulingHistoryExpandMode,
+  useSchedulingHistoryExpandable,
+} from '../../hooks/useSchedulingHistoryExpandable';
+import BAIDeploymentSchedulingHistoryNodes, {
+  BAIDeploymentSchedulingHistoryNodesProps,
+  DeploymentSchedulingHistoryNodeInList,
+} from './BAIDeploymentSchedulingHistoryNodes';
+import BAISubStepNodes from './BAISubStepNodes';
+import * as _ from 'lodash-es';
+import { graphql, useFragment } from 'react-relay';
+
+export interface BAIDeploymentSchedulingHistoryTableProps extends Omit<
+  BAIDeploymentSchedulingHistoryNodesProps,
+  'schedulingHistoryFrgmt' | 'expandable'
+> {
+  schedulingHistoryFrgmt: BAIDeploymentSchedulingHistoryTableFragment$key;
+  expandMode?: SchedulingHistoryExpandMode;
+  onExpandModeChange?: (mode: SchedulingHistoryExpandMode) => void;
+}
+
+/**
+ * Thin wrapper around the pure `BAIDeploymentSchedulingHistoryNodes` fragment
+ * table that adds the optional expand/collapse-all sub-step feature. It owns
+ * its own fragment (selecting the fields the expandable hook needs) and feeds
+ * the resolved rows straight through to the nodes component as the nodes
+ * fragment ref — valid because this fragment spreads the nodes fragment.
+ */
+const BAIDeploymentSchedulingHistoryTable = ({
+  schedulingHistoryFrgmt,
+  expandMode,
+  onExpandModeChange,
+  ...rest
+}: BAIDeploymentSchedulingHistoryTableProps) => {
+  'use memo';
+  const histories = useFragment(
+    graphql`
+      fragment BAIDeploymentSchedulingHistoryTableFragment on DeploymentHistory
+      @relay(plural: true) {
+        id
+        result
+        subSteps {
+          ...BAISubStepNodesFragment
+        }
+        ...BAIDeploymentSchedulingHistoryNodesFragment
+      }
+    `,
+    schedulingHistoryFrgmt,
+  );
+
+  const dataSource = filterOutNullAndUndefined(histories);
+  const { mode, expandedRowKeys, onExpandedRowsChange, expandColumnTitle } =
+    useSchedulingHistoryExpandable(dataSource, {
+      mode: expandMode,
+      onModeChange: onExpandModeChange,
+    });
+
+  return (
+    <BAIDeploymentSchedulingHistoryNodes
+      schedulingHistoryFrgmt={histories}
+      expandable={{
+        columnTitle: expandColumnTitle,
+        expandedRowKeys,
+        onExpandedRowsChange,
+        rowExpandable: (record: DeploymentSchedulingHistoryNodeInList) =>
+          !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
+        expandedRowRender: (record: DeploymentSchedulingHistoryNodeInList) => (
+          <BAISubStepNodes
+            resizable
+            subStepsFrgmt={
+              dataSource.find((h) => h.id === record.id)?.subSteps ?? []
+            }
+            pagination={false}
+            errorsOnly={mode === 'errors-only'}
+          />
+        ),
+      }}
+      {...rest}
+    />
+  );
+};
+
+export default BAIDeploymentSchedulingHistoryTable;

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryNodeTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryNodeTable.tsx
@@ -18,8 +18,6 @@ import {
   BAITable,
   BAITableProps,
 } from '../Table';
-import { BAIColumnGroupType } from '../Table/BAITable';
-import BAISubStepNodes from './BAISubStepNodes';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { graphql, useFragment } from 'react-relay';
@@ -68,8 +66,6 @@ const BAIRouteSchedulingHistoryNodeTable = ({
       fragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory
       @relay(plural: true) {
         id
-        routeId
-        deploymentId
         category
         phase
         fromStatus
@@ -77,9 +73,6 @@ const BAIRouteSchedulingHistoryNodeTable = ({
         result
         errorCode
         message
-        subSteps {
-          ...BAISubStepNodesFragment
-        }
         attempts
         createdAt
         updatedAt
@@ -89,10 +82,7 @@ const BAIRouteSchedulingHistoryNodeTable = ({
   );
 
   const baseColumns = _.map(
-    filterOutEmpty<
-      | BAIColumnType<RouteSchedulingHistoryNodeInList>
-      | BAIColumnGroupType<RouteSchedulingHistoryNodeInList>
-    >([
+    filterOutEmpty<BAIColumnType<RouteSchedulingHistoryNodeInList>>([
       {
         dataIndex: 'updatedAt',
         title: t('comp:BAIRouteSchedulingHistoryNodes.UpdatedAt'),
@@ -133,22 +123,16 @@ const BAIRouteSchedulingHistoryNodeTable = ({
         sorter: isEnableSorter('category'),
       },
       {
-        title: t('comp:BAIRouteSchedulingHistoryNodes.StatusTransition'),
-        key: 'statusTransition',
-        children: [
-          {
-            key: 'fromStatus',
-            title: t('comp:BAIRouteSchedulingHistoryNodes.From'),
-            dataIndex: 'fromStatus',
-            sorter: isEnableSorter('from_status'),
-          },
-          {
-            key: 'toStatus',
-            title: t('comp:BAIRouteSchedulingHistoryNodes.To'),
-            dataIndex: 'toStatus',
-            sorter: isEnableSorter('to_status'),
-          },
-        ],
+        key: 'fromStatus',
+        title: t('comp:BAIRouteSchedulingHistoryNodes.From'),
+        dataIndex: 'fromStatus',
+        sorter: isEnableSorter('from_status'),
+      },
+      {
+        key: 'toStatus',
+        title: t('comp:BAIRouteSchedulingHistoryNodes.To'),
+        dataIndex: 'toStatus',
+        sorter: isEnableSorter('to_status'),
       },
       {
         dataIndex: 'attempts',
@@ -203,18 +187,6 @@ const BAIRouteSchedulingHistoryNodeTable = ({
         onChangeOrder?.(
           (order as (typeof availableRouteHistorySorterValues)[number]) || null,
         );
-      }}
-      expandable={{
-        rowExpandable: (record) => !_.isEmpty(record.subSteps),
-        expandedRowRender: (record) => {
-          return (
-            <BAISubStepNodes
-              resizable
-              subStepsFrgmt={record.subSteps}
-              pagination={false}
-            />
-          );
-        },
       }}
       {...tableProps}
     />

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryTable.tsx
@@ -1,0 +1,85 @@
+import { BAIRouteSchedulingHistoryTableFragment$key } from '../../__generated__/BAIRouteSchedulingHistoryTableFragment.graphql';
+import { filterOutNullAndUndefined } from '../../helper';
+import {
+  type SchedulingHistoryExpandMode,
+  useSchedulingHistoryExpandable,
+} from '../../hooks/useSchedulingHistoryExpandable';
+import BAIRouteSchedulingHistoryNodeTable, {
+  BAIRouteSchedulingHistoryNodesProps,
+  RouteSchedulingHistoryNodeInList,
+} from './BAIRouteSchedulingHistoryNodeTable';
+import BAISubStepNodes from './BAISubStepNodes';
+import * as _ from 'lodash-es';
+import { graphql, useFragment } from 'react-relay';
+
+export interface BAIRouteSchedulingHistoryTableProps extends Omit<
+  BAIRouteSchedulingHistoryNodesProps,
+  'schedulingHistoryFrgmt' | 'expandable'
+> {
+  schedulingHistoryFrgmt: BAIRouteSchedulingHistoryTableFragment$key;
+  expandMode?: SchedulingHistoryExpandMode;
+  onExpandModeChange?: (mode: SchedulingHistoryExpandMode) => void;
+}
+
+/**
+ * Thin wrapper around the pure `BAIRouteSchedulingHistoryNodeTable` fragment
+ * table that adds the optional expand/collapse-all sub-step feature. It owns
+ * its own fragment (selecting the fields the expandable hook needs) and feeds
+ * the resolved rows straight through to the nodes component as the nodes
+ * fragment ref — valid because this fragment spreads the nodes fragment.
+ */
+const BAIRouteSchedulingHistoryTable = ({
+  schedulingHistoryFrgmt,
+  expandMode,
+  onExpandModeChange,
+  ...rest
+}: BAIRouteSchedulingHistoryTableProps) => {
+  'use memo';
+  const histories = useFragment(
+    graphql`
+      fragment BAIRouteSchedulingHistoryTableFragment on RouteHistory
+      @relay(plural: true) {
+        id
+        result
+        subSteps {
+          ...BAISubStepNodesFragment
+        }
+        ...BAIRouteSchedulingHistoryNodeTableFragment
+      }
+    `,
+    schedulingHistoryFrgmt,
+  );
+
+  const dataSource = filterOutNullAndUndefined(histories);
+  const { mode, expandedRowKeys, onExpandedRowsChange, expandColumnTitle } =
+    useSchedulingHistoryExpandable(dataSource, {
+      mode: expandMode,
+      onModeChange: onExpandModeChange,
+    });
+
+  return (
+    <BAIRouteSchedulingHistoryNodeTable
+      schedulingHistoryFrgmt={histories}
+      expandable={{
+        columnTitle: expandColumnTitle,
+        expandedRowKeys,
+        onExpandedRowsChange,
+        rowExpandable: (record: RouteSchedulingHistoryNodeInList) =>
+          !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
+        expandedRowRender: (record: RouteSchedulingHistoryNodeInList) => (
+          <BAISubStepNodes
+            resizable
+            subStepsFrgmt={
+              dataSource.find((h) => h.id === record.id)?.subSteps ?? []
+            }
+            pagination={false}
+            errorsOnly={mode === 'errors-only'}
+          />
+        ),
+      }}
+      {...rest}
+    />
+  );
+};
+
+export default BAIRouteSchedulingHistoryTable;

--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
@@ -18,8 +18,6 @@ import {
   BAITable,
   BAITableProps,
 } from '../Table';
-import { BAIColumnGroupType } from '../Table/BAITable';
-import BAISubStepNodes from './BAISubStepNodes';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { graphql, useFragment } from 'react-relay';
@@ -68,7 +66,6 @@ const BAISchedulingHistoryNodes = ({
       fragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory
       @relay(plural: true) {
         id
-        sessionId
         attempts
         createdAt
         updatedAt
@@ -77,19 +74,13 @@ const BAISchedulingHistoryNodes = ({
         message
         phase
         result
-        subSteps {
-          ...BAISubStepNodesFragment
-        }
       }
     `,
     schedulingHistoryFrgmt,
   );
 
   const baseColumns = _.map(
-    filterOutEmpty<
-      | BAIColumnType<SchedulingHistoryNodeInList>
-      | BAIColumnGroupType<SchedulingHistoryNodeInList>
-    >([
+    filterOutEmpty<BAIColumnType<SchedulingHistoryNodeInList>>([
       {
         dataIndex: 'updatedAt',
         title: t('comp:BAISchedulingHistoryNodes.UpdatedAt'),
@@ -124,22 +115,16 @@ const BAISchedulingHistoryNodes = ({
         sorter: isEnableSorter('result'),
       },
       {
-        title: t('comp:BAISchedulingHistoryNodes.StatusTransition'),
-        key: 'statusTransition',
-        children: [
-          {
-            key: 'fromStatus',
-            title: t('comp:BAISchedulingHistoryNodes.From'),
-            dataIndex: 'fromStatus',
-            sorter: isEnableSorter('from_status'),
-          },
-          {
-            key: 'toStatus',
-            title: t('comp:BAISchedulingHistoryNodes.To'),
-            dataIndex: 'toStatus',
-            sorter: isEnableSorter('to_status'),
-          },
-        ],
+        key: 'fromStatus',
+        title: t('comp:BAISchedulingHistoryNodes.From'),
+        dataIndex: 'fromStatus',
+        sorter: isEnableSorter('from_status'),
+      },
+      {
+        key: 'toStatus',
+        title: t('comp:BAISchedulingHistoryNodes.To'),
+        dataIndex: 'toStatus',
+        sorter: isEnableSorter('to_status'),
       },
       {
         dataIndex: 'attempts',
@@ -171,6 +156,7 @@ const BAISchedulingHistoryNodes = ({
   const allColumns = customizeColumns
     ? customizeColumns(baseColumns)
     : baseColumns;
+
   return (
     <BAITable
       rowKey={'id'}
@@ -181,18 +167,6 @@ const BAISchedulingHistoryNodes = ({
         onChangeOrder?.(
           (order as (typeof availableHistorySorterValues)[number]) || null,
         );
-      }}
-      expandable={{
-        rowExpandable: (record) => !_.isEmpty(record.subSteps),
-        expandedRowRender: (record) => {
-          return (
-            <BAISubStepNodes
-              resizable
-              subStepsFrgmt={record.subSteps}
-              pagination={false}
-            />
-          );
-        },
       }}
       {...tableProps}
     ></BAITable>

--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryTable.tsx
@@ -1,0 +1,85 @@
+import { BAISchedulingHistoryTableFragment$key } from '../../__generated__/BAISchedulingHistoryTableFragment.graphql';
+import { filterOutNullAndUndefined } from '../../helper';
+import {
+  SchedulingHistoryExpandMode,
+  useSchedulingHistoryExpandable,
+} from '../../hooks/useSchedulingHistoryExpandable';
+import BAISchedulingHistoryNodes, {
+  BAISchedulingHistoryNodesProps,
+  SchedulingHistoryNodeInList,
+} from './BAISchedulingHistoryNodes';
+import BAISubStepNodes from './BAISubStepNodes';
+import * as _ from 'lodash-es';
+import { graphql, useFragment } from 'react-relay';
+
+export interface BAISchedulingHistoryTableProps extends Omit<
+  BAISchedulingHistoryNodesProps,
+  'schedulingHistoryFrgmt' | 'expandable'
+> {
+  schedulingHistoryFrgmt: BAISchedulingHistoryTableFragment$key;
+  expandMode?: SchedulingHistoryExpandMode;
+  onExpandModeChange?: (mode: SchedulingHistoryExpandMode) => void;
+}
+
+/**
+ * Thin wrapper around the pure `BAISchedulingHistoryNodes` fragment table that
+ * adds the optional expand/collapse-all sub-step feature. It owns its own
+ * fragment (selecting the fields the expandable hook needs) and feeds the
+ * resolved rows straight through to the nodes component as the nodes fragment
+ * ref — valid because this fragment spreads the nodes fragment.
+ */
+const BAISchedulingHistoryTable = ({
+  schedulingHistoryFrgmt,
+  expandMode,
+  onExpandModeChange,
+  ...rest
+}: BAISchedulingHistoryTableProps) => {
+  'use memo';
+  const histories = useFragment(
+    graphql`
+      fragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory
+      @relay(plural: true) {
+        id
+        result
+        subSteps {
+          ...BAISubStepNodesFragment
+        }
+        ...BAISchedulingHistoryNodesFragment
+      }
+    `,
+    schedulingHistoryFrgmt,
+  );
+
+  const dataSource = filterOutNullAndUndefined(histories);
+  const { mode, expandedRowKeys, onExpandedRowsChange, expandColumnTitle } =
+    useSchedulingHistoryExpandable(dataSource, {
+      mode: expandMode,
+      onModeChange: onExpandModeChange,
+    });
+
+  return (
+    <BAISchedulingHistoryNodes
+      schedulingHistoryFrgmt={histories}
+      expandable={{
+        columnTitle: expandColumnTitle,
+        expandedRowKeys,
+        onExpandedRowsChange,
+        rowExpandable: (record: SchedulingHistoryNodeInList) =>
+          !_.isEmpty(dataSource.find((h) => h.id === record.id)?.subSteps),
+        expandedRowRender: (record: SchedulingHistoryNodeInList) => (
+          <BAISubStepNodes
+            resizable
+            subStepsFrgmt={
+              dataSource.find((h) => h.id === record.id)?.subSteps ?? []
+            }
+            pagination={false}
+            errorsOnly={mode === 'errors-only'}
+          />
+        ),
+      }}
+      {...rest}
+    />
+  );
+};
+
+export default BAISchedulingHistoryTable;

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -51,12 +51,19 @@ export interface BAISubStepNodesProps extends Omit<
     baseColumns: BAIColumnsType<SubStepInList>,
   ) => BAIColumnsType<SubStepInList>;
   disableSorter?: boolean;
+  /**
+   * When true, only non-success sub-steps are shown (mirrors the parent table's
+   * "errors-only" mode), so an expanded row surfaces just the failing / retried
+   * steps.
+   */
+  errorsOnly?: boolean;
 }
 
 const BAISubStepNodes = ({
   subStepsFrgmt,
   customizeColumns,
   disableSorter,
+  errorsOnly,
   ...tableProps
 }: BAISubStepNodesProps) => {
   'use memo';
@@ -122,6 +129,18 @@ const BAISubStepNodes = ({
         sorter: isEnableSorter('result'),
       },
       {
+        key: 'errorCode',
+        title: t('comp:BAISubStepNodes.ErrorCode'),
+        dataIndex: 'errorCode',
+        render: (__, record) =>
+          record.errorCode ? (
+            <BAIText monospace>{record.errorCode}</BAIText>
+          ) : (
+            '-'
+          ),
+        sorter: isEnableSorter('errorCode'),
+      },
+      {
         key: 'message',
         title: t('comp:BAISubStepNodes.Message'),
         dataIndex: 'message',
@@ -135,18 +154,6 @@ const BAISubStepNodes = ({
             '-'
           ),
         sorter: isEnableSorter('message'),
-      },
-      {
-        key: 'errorCode',
-        title: t('comp:BAISubStepNodes.ErrorCode'),
-        dataIndex: 'errorCode',
-        render: (__, record) =>
-          record.errorCode ? (
-            <BAIText monospace>{record.errorCode}</BAIText>
-          ) : (
-            '-'
-          ),
-        sorter: isEnableSorter('errorCode'),
       },
       {
         key: 'startedAt',
@@ -174,11 +181,15 @@ const BAISubStepNodes = ({
     ? customizeColumns(baseColumns)
     : baseColumns;
 
+  const dataSource = filterOutNullAndUndefined(subSteps)
+    .filter((subStep) => !errorsOnly || subStep.result !== 'SUCCESS')
+    .reverse();
+
   return (
     <BAITable
       rowKey="step"
       size="small"
-      dataSource={filterOutNullAndUndefined(subSteps).reverse()}
+      dataSource={dataSource}
       columns={allColumns}
       scroll={{ x: 'max-content' }}
       {...tableProps}

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -184,6 +184,12 @@ export type {
   BAIRouteSchedulingHistoryNodesProps,
   RouteSchedulingHistoryNodeInList,
 } from './BAIRouteSchedulingHistoryNodeTable';
+export { default as BAISchedulingHistoryTable } from './BAISchedulingHistoryTable';
+export type { BAISchedulingHistoryTableProps } from './BAISchedulingHistoryTable';
+export { default as BAIDeploymentSchedulingHistoryTable } from './BAIDeploymentSchedulingHistoryTable';
+export type { BAIDeploymentSchedulingHistoryTableProps } from './BAIDeploymentSchedulingHistoryTable';
+export { default as BAIRouteSchedulingHistoryTable } from './BAIRouteSchedulingHistoryTable';
+export type { BAIRouteSchedulingHistoryTableProps } from './BAIRouteSchedulingHistoryTable';
 export { default as BAIDeploymentSelect } from './BAIDeploymentSelect';
 export type {
   BAIDeploymentSelectProps,

--- a/packages/backend.ai-ui/src/hooks/useSchedulingHistoryExpandable.tsx
+++ b/packages/backend.ai-ui/src/hooks/useSchedulingHistoryExpandable.tsx
@@ -1,0 +1,207 @@
+import BAIFlex from '../components/BAIFlex';
+import { SchedulingResult } from '../components/BAISchedulingResultBadge';
+import { useBAIi18n } from './useBAIi18n';
+import { Dropdown, theme, Tooltip } from 'antd';
+import * as _ from 'lodash-es';
+import { EllipsisVerticalIcon } from 'lucide-react';
+import * as React from 'react';
+import { useEffect, useEffectEvent, useState } from 'react';
+
+/**
+ * Minimal shape shared by every scheduling-history row type
+ * (session / deployment / route). A row is expandable when it has sub-steps,
+ * and it is expanded by default unless its result is a success.
+ */
+export interface SchedulingHistoryExpandableRow {
+  readonly id: string;
+  readonly result?: SchedulingResult | '%future added value' | null;
+  readonly subSteps?: ReadonlyArray<unknown> | null;
+}
+
+/**
+ * The three master modes for the expand-icon column. The mode is controlled by
+ * the caller (so it can be persisted across reloads / navigations).
+ */
+export type SchedulingHistoryExpandMode =
+  | 'expand-all'
+  | 'collapse-all'
+  | 'errors-only';
+
+export const DEFAULT_SCHEDULING_HISTORY_EXPAND_MODE: SchedulingHistoryExpandMode =
+  'errors-only';
+
+const isRowExpandable = (record: SchedulingHistoryExpandableRow) =>
+  !_.isEmpty(record.subSteps);
+
+// "Collapse success only": every non-success row stays open by default so
+// failures / retries / expirations are visible at a glance.
+const shouldExpandByDefault = (record: SchedulingHistoryExpandableRow) =>
+  isRowExpandable(record) && record.result !== 'SUCCESS';
+
+const computeExpandedRowKeysForMode = (
+  dataSource: ReadonlyArray<SchedulingHistoryExpandableRow>,
+  mode: SchedulingHistoryExpandMode,
+): React.Key[] =>
+  mode === 'expand-all'
+    ? dataSource.filter(isRowExpandable).map((record) => record.id)
+    : mode === 'collapse-all'
+      ? []
+      : dataSource.filter(shouldExpandByDefault).map((record) => record.id);
+
+export interface UseSchedulingHistoryExpandableResult {
+  /**
+   * The effective master mode (the controlled `mode`, or the default
+   * "errors-only" when uncontrolled). Callers use this to filter the nested
+   * sub-step table to non-success rows when the mode is `errors-only`.
+   */
+  mode: SchedulingHistoryExpandMode;
+  expandedRowKeys: React.Key[];
+  onExpandedRowsChange: (expandedKeys: readonly React.Key[]) => void;
+  /**
+   * Header content for the expand-icon column: a kebab (vertical ellipsis)
+   * hover menu offering the three view actions (expand all / collapse all /
+   * expand errors only). It reads as an action menu, not a stateful toggle, so
+   * there is no "active" indication. `null` when no row in the current data set
+   * is expandable. Per-row rows keep Ant Design's default +/- expand icon.
+   */
+  expandColumnTitle: React.ReactNode;
+}
+
+/**
+ * Controls expand/collapse state for a scheduling-history table.
+ *
+ * - Initial state derives from `mode` (default "errors-only"): rows with
+ *   sub-steps whose result is not `SUCCESS` are expanded; success rows stay
+ *   collapsed.
+ * - `expandColumnTitle` renders a hover dropdown in the expand-column header
+ *   that switches between the three modes (expand-all / collapse-all /
+ *   errors-only).
+ * - Individual rows remain manually expandable via `onExpandedRowsChange`.
+ * - When the underlying data meaningfully changes (e.g. a refetch), the
+ *   current mode is re-applied — so a refresh always returns to the selected
+ *   mode even after the user toggled individual rows.
+ */
+export const useSchedulingHistoryExpandable = <
+  T extends SchedulingHistoryExpandableRow,
+>(
+  dataSource: ReadonlyArray<T>,
+  options?: {
+    mode?: SchedulingHistoryExpandMode;
+    onModeChange?: (mode: SchedulingHistoryExpandMode) => void;
+  },
+): UseSchedulingHistoryExpandableResult => {
+  'use memo';
+  const { t } = useBAIi18n();
+  const { token } = theme.useToken();
+
+  const mode = options?.mode ?? DEFAULT_SCHEDULING_HISTORY_EXPAND_MODE;
+
+  const [expandedRowKeys, setExpandedRowKeys] = useState<React.Key[]>(() =>
+    computeExpandedRowKeysForMode(dataSource, mode),
+  );
+
+  // The signature changes only on real data changes — not on the new array
+  // identity that `filterOutNullAndUndefined(...)` produces every render — so
+  // manual per-row toggles persist until the data actually reloads.
+  const dataSignature = dataSource
+    .map(
+      (record) =>
+        `${record.id}:${record.result ?? ''}:${isRowExpandable(record) ? 1 : 0}`,
+    )
+    .join('|');
+
+  const resetToDefault = useEffectEvent(() => {
+    setExpandedRowKeys(computeExpandedRowKeysForMode(dataSource, mode));
+  });
+
+  useEffect(() => {
+    resetToDefault();
+  }, [dataSignature]);
+
+  // Re-apply the master mode whenever the controlled mode prop changes so
+  // selecting a menu item immediately re-expands / collapses. `dataSource` is
+  // read fresh via the effect event without being a reactive dependency.
+  const applyMode = useEffectEvent(() => {
+    setExpandedRowKeys(computeExpandedRowKeysForMode(dataSource, mode));
+  });
+
+  useEffect(() => {
+    applyMode();
+  }, [mode]);
+
+  const expandableRowKeys = dataSource
+    .filter(isRowExpandable)
+    .map((record) => record.id);
+
+  const onExpandedRowsChange = (expandedKeys: readonly React.Key[]) => {
+    setExpandedRowKeys([...expandedKeys]);
+  };
+
+  const modeLabel: Record<SchedulingHistoryExpandMode, string> = {
+    'expand-all': t('comp:BAITable.ExpandAll'),
+    'collapse-all': t('comp:BAITable.CollapseAll'),
+    'errors-only': t('comp:BAITable.ExpandErrorsOnly'),
+  };
+
+  const menuItems = (
+    ['expand-all', 'collapse-all', 'errors-only'] as const
+  ).map((m) => ({ key: m, label: modeLabel[m] }));
+
+  const onMenuClick = ({ key }: { key: string }) => {
+    const next = key as SchedulingHistoryExpandMode;
+    // Apply eagerly so the uncontrolled case (no onModeChange) still reacts. In
+    // the controlled case onModeChange updates `mode`, and the `[mode]` effect
+    // re-applies the same (idempotent) keys — a harmless redundant set.
+    setExpandedRowKeys(computeExpandedRowKeysForMode(dataSource, next));
+    options?.onModeChange?.(next);
+  };
+
+  const expandColumnTitle =
+    expandableRowKeys.length > 0 ? (
+      // Center the trigger in the header cell so it lines up with the
+      // per-row expand icons, which Ant Design centers in their column.
+      <BAIFlex justify="center">
+        <Dropdown
+          // Click (not hover) so the menu is operable by keyboard (Enter/Space
+          // on the focused trigger) and by touch, not mouse-only.
+          trigger={['click']}
+          // A kebab (vertical ellipsis) action menu — no `selectedKeys`, so no
+          // item is shown as "active". The three modes read as actions you
+          // trigger, not a stateful toggle.
+          menu={{
+            items: menuItems,
+            onClick: onMenuClick,
+          }}
+        >
+          {/* Tooltip (not aria-label) surfaces the affordance on hover for
+              sighted users; screen-reader support is out of scope for this
+              feature. Keeps `comp:BAITable.ExpandOptions` (+ its locale
+              entries) in use. */}
+          <Tooltip title={t('comp:BAITable.ExpandOptions')}>
+            <button
+              type="button"
+              style={{
+                cursor: 'pointer',
+                border: 'none',
+                background: 'transparent',
+                padding: 0,
+                display: 'inline-flex',
+                color: token.colorTextSecondary,
+              }}
+            >
+              <EllipsisVerticalIcon size={token.fontSizeLG} />
+            </button>
+          </Tooltip>
+        </Dropdown>
+      </BAIFlex>
+    ) : null;
+
+  return {
+    mode,
+    expandedRowKeys,
+    onExpandedRowsChange,
+    expandColumnTitle,
+  };
+};
+
+export default useSchedulingHistoryExpandable;

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -127,12 +127,11 @@
     "Category": "Kategorie",
     "CreatedAt": "Erstellt am",
     "ErrorCode": "Fehlercode",
-    "From": "Von",
+    "From": "Ausgangsstatus",
     "Message": "Nachricht",
     "Phase": "Phase",
     "Result": "Ergebnis",
-    "StatusTransition": "Statuswechsel",
-    "To": "An",
+    "To": "Zielstatus",
     "UpdatedAt": "Aktualisiert am"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Kategorie",
     "CreatedAt": "Erstellt am",
     "ErrorCode": "Fehlercode",
-    "From": "Von",
+    "From": "Ausgangsstatus",
     "Message": "Nachricht",
     "Phase": "Phase",
     "Result": "Ergebnis",
-    "StatusTransition": "Statuswechsel",
-    "To": "An",
+    "To": "Zielstatus",
     "UpdatedAt": "Aktualisiert am"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Kategorie",
     "CreatedAt": "Erstellt am",
     "ErrorCode": "Fehlercode",
-    "From": "Von",
+    "From": "Ausgangsstatus",
     "Message": "Nachricht",
     "Phase": "Phase",
     "Result": "Ergebnis",
-    "StatusTransition": "Statuswechsel",
-    "To": "An",
+    "To": "Zielstatus",
     "UpdatedAt": "Aktualisiert am"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Schritt"
   },
   "comp:BAITable": {
+    "CollapseAll": "Alle einklappen",
+    "ExpandAll": "Alle ausklappen",
+    "ExpandErrorsOnly": "Nur Fehler ausklappen",
+    "ExpandOptions": "Ausklappoptionen",
     "Export": "Exportieren",
     "ExportCSV": "Als CSV exportieren",
     "GoToFirstPage": "Zur ersten Seite",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -127,12 +127,11 @@
     "Category": "Κατηγορία",
     "CreatedAt": "Δημιουργήθηκε στις",
     "ErrorCode": "Κωδικός σφάλματος",
-    "From": "Από",
+    "From": "Κατάσταση προέλευσης",
     "Message": "Μήνυμα",
     "Phase": "Φάση",
     "Result": "Αποτέλεσμα",
-    "StatusTransition": "Αλλαγή κατάστασης",
-    "To": "Έως",
+    "To": "Κατάσταση προορισμού",
     "UpdatedAt": "Ενημερώθηκε στις"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Κατηγορία",
     "CreatedAt": "Δημιουργήθηκε στις",
     "ErrorCode": "Κωδικός σφάλματος",
-    "From": "Από",
+    "From": "Κατάσταση προέλευσης",
     "Message": "Μήνυμα",
     "Phase": "Φάση",
     "Result": "Αποτέλεσμα",
-    "StatusTransition": "Αλλαγή κατάστασης",
-    "To": "Έως",
+    "To": "Κατάσταση προορισμού",
     "UpdatedAt": "Ενημερώθηκε στις"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Κατηγορία",
     "CreatedAt": "Δημιουργήθηκε στις",
     "ErrorCode": "Κωδικός σφάλματος",
-    "From": "Από",
+    "From": "Κατάσταση προέλευσης",
     "Message": "Μήνυμα",
     "Phase": "Φάση",
     "Result": "Αποτέλεσμα",
-    "StatusTransition": "Αλλαγή κατάστασης",
-    "To": "Έως",
+    "To": "Κατάσταση προορισμού",
     "UpdatedAt": "Ενημερώθηκε στις"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Βήμα"
   },
   "comp:BAITable": {
+    "CollapseAll": "Σύμπτυξη όλων",
+    "ExpandAll": "Ανάπτυξη όλων",
+    "ExpandErrorsOnly": "Ανάπτυξη μόνο σφαλμάτων",
+    "ExpandOptions": "Επιλογές ανάπτυξης",
     "Export": "Εξαγωγή",
     "ExportCSV": "Εξαγωγή CSV",
     "GoToFirstPage": "Μετάβαση στην πρώτη σελίδα",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -127,12 +127,11 @@
     "Category": "Category",
     "CreatedAt": "Created At",
     "ErrorCode": "Error Code",
-    "From": "From",
+    "From": "From Status",
     "Message": "Message",
     "Phase": "Phase",
     "Result": "Result",
-    "StatusTransition": "Status Transition",
-    "To": "To",
+    "To": "To Status",
     "UpdatedAt": "Updated At"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Category",
     "CreatedAt": "Created At",
     "ErrorCode": "Error Code",
-    "From": "From",
+    "From": "From Status",
     "Message": "Message",
     "Phase": "Phase",
     "Result": "Result",
-    "StatusTransition": "Status Transition",
-    "To": "To",
+    "To": "To Status",
     "UpdatedAt": "Updated At"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Category",
     "CreatedAt": "Created At",
     "ErrorCode": "Error Code",
-    "From": "From",
+    "From": "From Status",
     "Message": "Message",
     "Phase": "Phase",
     "Result": "Result",
-    "StatusTransition": "Status Transition",
-    "To": "To",
+    "To": "To Status",
     "UpdatedAt": "Updated At"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Step"
   },
   "comp:BAITable": {
+    "CollapseAll": "Collapse all",
+    "ExpandAll": "Expand all",
+    "ExpandErrorsOnly": "Expand errors only",
+    "ExpandOptions": "Expand options",
     "Export": "Export",
     "ExportCSV": "Export CSV",
     "GoToFirstPage": "Go to first page",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -127,12 +127,11 @@
     "Category": "Categoría",
     "CreatedAt": "Creado el",
     "ErrorCode": "Código de error",
-    "From": "De",
+    "From": "Estado de origen",
     "Message": "Mensaje",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transición de estado",
-    "To": "Para",
+    "To": "Estado de destino",
     "UpdatedAt": "Actualizado el"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Categoría",
     "CreatedAt": "Creado el",
     "ErrorCode": "Código de error",
-    "From": "De",
+    "From": "Estado de origen",
     "Message": "Mensaje",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transición de estado",
-    "To": "Para",
+    "To": "Estado de destino",
     "UpdatedAt": "Actualizado el"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Categoría",
     "CreatedAt": "Creado el",
     "ErrorCode": "Código de error",
-    "From": "De",
+    "From": "Estado de origen",
     "Message": "Mensaje",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transición de estado",
-    "To": "Para",
+    "To": "Estado de destino",
     "UpdatedAt": "Actualizado el"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Paso"
   },
   "comp:BAITable": {
+    "CollapseAll": "Contraer todo",
+    "ExpandAll": "Expandir todo",
+    "ExpandErrorsOnly": "Expandir solo errores",
+    "ExpandOptions": "Opciones de expansión",
     "Export": "Exportar",
     "ExportCSV": "Exportar CSV",
     "GoToFirstPage": "Ir a la primera página",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -127,12 +127,11 @@
     "Category": "Luokka",
     "CreatedAt": "Luotu",
     "ErrorCode": "Virhekoodi",
-    "From": "Alkaen",
+    "From": "Lähtötila",
     "Message": "Viesti",
     "Phase": "Vaihe",
     "Result": "Tulos",
-    "StatusTransition": "Tilan siirtymä",
-    "To": "Saakka",
+    "To": "Kohdetila",
     "UpdatedAt": "Päivitetty"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Luokka",
     "CreatedAt": "Luotu",
     "ErrorCode": "Virhekoodi",
-    "From": "Alkaen",
+    "From": "Lähtötila",
     "Message": "Viesti",
     "Phase": "Vaihe",
     "Result": "Tulos",
-    "StatusTransition": "Tilan siirtymä",
-    "To": "Saakka",
+    "To": "Kohdetila",
     "UpdatedAt": "Päivitetty"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Luokka",
     "CreatedAt": "Luotu",
     "ErrorCode": "Virhekoodi",
-    "From": "Alkaen",
+    "From": "Lähtötila",
     "Message": "Viesti",
     "Phase": "Vaihe",
     "Result": "Tulos",
-    "StatusTransition": "Tilan siirtymä",
-    "To": "Saakka",
+    "To": "Kohdetila",
     "UpdatedAt": "Päivitetty"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Vaihe"
   },
   "comp:BAITable": {
+    "CollapseAll": "Tiivistä kaikki",
+    "ExpandAll": "Laajenna kaikki",
+    "ExpandErrorsOnly": "Laajenna vain virheet",
+    "ExpandOptions": "Laajenemisvaihtoehdot",
     "Export": "Vie",
     "ExportCSV": "Vie CSV",
     "GoToFirstPage": "Siirry ensimmäiselle sivulle",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -127,12 +127,11 @@
     "Category": "Catégorie",
     "CreatedAt": "Créé le",
     "ErrorCode": "Code d'erreur",
-    "From": "De",
+    "From": "Statut d'origine",
     "Message": "Message",
     "Phase": "Phase",
     "Result": "Résultat",
-    "StatusTransition": "Transition d'état",
-    "To": "À",
+    "To": "Statut de destination",
     "UpdatedAt": "Mis à jour le"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Catégorie",
     "CreatedAt": "Créé le",
     "ErrorCode": "Code d'erreur",
-    "From": "De",
+    "From": "Statut d'origine",
     "Message": "Message",
     "Phase": "Phase",
     "Result": "Résultat",
-    "StatusTransition": "Transition d'état",
-    "To": "À",
+    "To": "Statut de destination",
     "UpdatedAt": "Mis à jour le"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Catégorie",
     "CreatedAt": "Créé le",
     "ErrorCode": "Code d'erreur",
-    "From": "De",
+    "From": "Statut d'origine",
     "Message": "Message",
     "Phase": "Phase",
     "Result": "Résultat",
-    "StatusTransition": "Transition d'état",
-    "To": "À",
+    "To": "Statut de destination",
     "UpdatedAt": "Mis à jour le"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Étape"
   },
   "comp:BAITable": {
+    "CollapseAll": "Tout réduire",
+    "ExpandAll": "Tout développer",
+    "ExpandErrorsOnly": "Développer les erreurs uniquement",
+    "ExpandOptions": "Options de développement",
     "Export": "Exporter",
     "ExportCSV": "Exporter en CSV",
     "GoToFirstPage": "Aller à la première page",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -127,12 +127,11 @@
     "Category": "Kategori",
     "CreatedAt": "Dibuat pada",
     "ErrorCode": "Kode Kesalahan",
-    "From": "Dari",
+    "From": "Status asal",
     "Message": "Pesan",
     "Phase": "Tahap",
     "Result": "Hasil",
-    "StatusTransition": "Transisi Status",
-    "To": "sampai",
+    "To": "Status tujuan",
     "UpdatedAt": "Diperbarui pada"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Kategori",
     "CreatedAt": "Dibuat pada",
     "ErrorCode": "Kode Kesalahan",
-    "From": "Dari",
+    "From": "Status asal",
     "Message": "Pesan",
     "Phase": "Tahap",
     "Result": "Hasil",
-    "StatusTransition": "Transisi Status",
-    "To": "sampai",
+    "To": "Status tujuan",
     "UpdatedAt": "Diperbarui pada"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Kategori",
     "CreatedAt": "Dibuat pada",
     "ErrorCode": "Kode Kesalahan",
-    "From": "Dari",
+    "From": "Status asal",
     "Message": "Pesan",
     "Phase": "Tahap",
     "Result": "Hasil",
-    "StatusTransition": "Transisi Status",
-    "To": "sampai",
+    "To": "Status tujuan",
     "UpdatedAt": "Diperbarui pada"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Langkah"
   },
   "comp:BAITable": {
+    "CollapseAll": "Ciutkan semua",
+    "ExpandAll": "Perluas semua",
+    "ExpandErrorsOnly": "Perluas hanya kesalahan",
+    "ExpandOptions": "Opsi perluasan",
     "Export": "Ekspor",
     "ExportCSV": "Ekspor CSV",
     "GoToFirstPage": "Ke halaman pertama",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -127,12 +127,11 @@
     "Category": "Categoria",
     "CreatedAt": "Creato il",
     "ErrorCode": "Codice errore",
-    "From": "Da",
+    "From": "Stato di origine",
     "Message": "Messaggio",
     "Phase": "Fase",
     "Result": "Risultato",
-    "StatusTransition": "Transizione di stato",
-    "To": "A",
+    "To": "Stato di destinazione",
     "UpdatedAt": "Aggiornato il"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Categoria",
     "CreatedAt": "Creato il",
     "ErrorCode": "Codice errore",
-    "From": "Da",
+    "From": "Stato di origine",
     "Message": "Messaggio",
     "Phase": "Fase",
     "Result": "Risultato",
-    "StatusTransition": "Transizione di stato",
-    "To": "A",
+    "To": "Stato di destinazione",
     "UpdatedAt": "Aggiornato il"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Categoria",
     "CreatedAt": "Creato il",
     "ErrorCode": "Codice errore",
-    "From": "Da",
+    "From": "Stato di origine",
     "Message": "Messaggio",
     "Phase": "Fase",
     "Result": "Risultato",
-    "StatusTransition": "Transizione di stato",
-    "To": "A",
+    "To": "Stato di destinazione",
     "UpdatedAt": "Aggiornato il"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Passo"
   },
   "comp:BAITable": {
+    "CollapseAll": "Comprimi tutto",
+    "ExpandAll": "Espandi tutto",
+    "ExpandErrorsOnly": "Espandi solo errori",
+    "ExpandOptions": "Opzioni di espansione",
     "Export": "Esporta",
     "ExportCSV": "Esporta CSV",
     "GoToFirstPage": "Vai alla prima pagina",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -127,12 +127,11 @@
     "Category": "カテゴリ",
     "CreatedAt": "作成日時",
     "ErrorCode": "エラーコード",
-    "From": "送信元",
+    "From": "遷移元ステータス",
     "Message": "メッセージ",
     "Phase": "フェーズ",
     "Result": "結果",
-    "StatusTransition": "ステータス遷移",
-    "To": "宛先",
+    "To": "遷移先ステータス",
     "UpdatedAt": "更新日時"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "カテゴリ",
     "CreatedAt": "作成日時",
     "ErrorCode": "エラーコード",
-    "From": "送信元",
+    "From": "遷移元ステータス",
     "Message": "メッセージ",
     "Phase": "フェーズ",
     "Result": "結果",
-    "StatusTransition": "ステータス遷移",
-    "To": "宛先",
+    "To": "遷移先ステータス",
     "UpdatedAt": "更新日時"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "カテゴリ",
     "CreatedAt": "作成日時",
     "ErrorCode": "エラーコード",
-    "From": "送信元",
+    "From": "遷移元ステータス",
     "Message": "メッセージ",
     "Phase": "フェーズ",
     "Result": "結果",
-    "StatusTransition": "ステータス遷移",
-    "To": "宛先",
+    "To": "遷移先ステータス",
     "UpdatedAt": "更新日時"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "ステップ"
   },
   "comp:BAITable": {
+    "CollapseAll": "すべて折りたたむ",
+    "ExpandAll": "すべて展開",
+    "ExpandErrorsOnly": "エラーのみ展開",
+    "ExpandOptions": "展開オプション",
     "Export": "エクスポート",
     "ExportCSV": "CSV をエクスポート",
     "GoToFirstPage": "最初のページへ",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -127,12 +127,11 @@
     "Category": "카테고리",
     "CreatedAt": "생성일",
     "ErrorCode": "오류 코드",
-    "From": "이전",
+    "From": "이전 상태",
     "Message": "메시지",
     "Phase": "단계",
     "Result": "결과",
-    "StatusTransition": "상태 전환",
-    "To": "이후",
+    "To": "이후 상태",
     "UpdatedAt": "수정일"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "카테고리",
     "CreatedAt": "생성일",
     "ErrorCode": "오류 코드",
-    "From": "이전",
+    "From": "이전 상태",
     "Message": "메시지",
     "Phase": "단계",
     "Result": "결과",
-    "StatusTransition": "상태 전환",
-    "To": "이후",
+    "To": "이후 상태",
     "UpdatedAt": "수정일"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "카테고리",
     "CreatedAt": "생성일",
     "ErrorCode": "오류 코드",
-    "From": "이전",
+    "From": "이전 상태",
     "Message": "메시지",
     "Phase": "단계",
     "Result": "결과",
-    "StatusTransition": "상태 전환",
-    "To": "이후",
+    "To": "이후 상태",
     "UpdatedAt": "수정일"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "세부단계"
   },
   "comp:BAITable": {
+    "CollapseAll": "모두 닫기",
+    "ExpandAll": "모두 열기",
+    "ExpandErrorsOnly": "오류만 펼치기",
+    "ExpandOptions": "펼치기 옵션",
     "Export": "내보내기",
     "ExportCSV": "CSV로 내보내기",
     "GoToFirstPage": "첫 페이지로 이동하기",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -127,12 +127,11 @@
     "Category": "Ангилал",
     "CreatedAt": "Үүссэн огноо",
     "ErrorCode": "Алдааны код",
-    "From": "Эхлэх",
+    "From": "Эх төлөв",
     "Message": "Зурвас",
     "Phase": "Шат",
     "Result": "Үр дүн",
-    "StatusTransition": "Статусын шилжилт",
-    "To": "Хүртэл",
+    "To": "Зорилтот төлөв",
     "UpdatedAt": "Шинэчлэгдсэн огноо"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Ангилал",
     "CreatedAt": "Үүссэн огноо",
     "ErrorCode": "Алдааны код",
-    "From": "Эхлэх",
+    "From": "Эх төлөв",
     "Message": "Зурвас",
     "Phase": "Шат",
     "Result": "Үр дүн",
-    "StatusTransition": "Статусын шилжилт",
-    "To": "Хүртэл",
+    "To": "Зорилтот төлөв",
     "UpdatedAt": "Шинэчлэгдсэн огноо"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Ангилал",
     "CreatedAt": "Үүссэн огноо",
     "ErrorCode": "Алдааны код",
-    "From": "Эхлэх",
+    "From": "Эх төлөв",
     "Message": "Зурвас",
     "Phase": "Шат",
     "Result": "Үр дүн",
-    "StatusTransition": "Статусын шилжилт",
-    "To": "Хүртэл",
+    "To": "Зорилтот төлөв",
     "UpdatedAt": "Шинэчлэгдсэн огноо"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Алхам"
   },
   "comp:BAITable": {
+    "CollapseAll": "Бүгдийг хураах",
+    "ExpandAll": "Бүгдийг дэлгэх",
+    "ExpandErrorsOnly": "Зөвхөн алдааг дэлгэх",
+    "ExpandOptions": "Дэлгэх сонголтууд",
     "Export": "Экспорт",
     "ExportCSV": "CSV экспортлах",
     "GoToFirstPage": "Эх хуудас руу шилжих",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -127,12 +127,11 @@
     "Category": "Kategori",
     "CreatedAt": "Dicipta pada",
     "ErrorCode": "Kod Ralat",
-    "From": "Dari",
+    "From": "Status asal",
     "Message": "Mesej",
     "Phase": "Fasa",
     "Result": "Hasil",
-    "StatusTransition": "Peralihan Status",
-    "To": "Kepada",
+    "To": "Status sasaran",
     "UpdatedAt": "Dikemas kini pada"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Kategori",
     "CreatedAt": "Dicipta pada",
     "ErrorCode": "Kod Ralat",
-    "From": "Dari",
+    "From": "Status asal",
     "Message": "Mesej",
     "Phase": "Fasa",
     "Result": "Hasil",
-    "StatusTransition": "Peralihan Status",
-    "To": "Kepada",
+    "To": "Status sasaran",
     "UpdatedAt": "Dikemas kini pada"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Kategori",
     "CreatedAt": "Dicipta pada",
     "ErrorCode": "Kod Ralat",
-    "From": "Dari",
+    "From": "Status asal",
     "Message": "Mesej",
     "Phase": "Fasa",
     "Result": "Hasil",
-    "StatusTransition": "Peralihan Status",
-    "To": "Kepada",
+    "To": "Status sasaran",
     "UpdatedAt": "Dikemas kini pada"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Langkah"
   },
   "comp:BAITable": {
+    "CollapseAll": "Runtuhkan semua",
+    "ExpandAll": "Kembangkan semua",
+    "ExpandErrorsOnly": "Kembangkan ralat sahaja",
+    "ExpandOptions": "Pilihan pengembangan",
     "Export": "Eksport",
     "ExportCSV": "Eksport CSV",
     "GoToFirstPage": "Pergi ke halaman pertama",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -127,12 +127,11 @@
     "Category": "Kategoria",
     "CreatedAt": "Utworzono",
     "ErrorCode": "Kod błędu",
-    "From": "Od",
+    "From": "Status początkowy",
     "Message": "Wiadomość",
     "Phase": "Faza",
     "Result": "Wynik",
-    "StatusTransition": "Zmiana statusu",
-    "To": "Do",
+    "To": "Status docelowy",
     "UpdatedAt": "Zaktualizowano"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Kategoria",
     "CreatedAt": "Utworzono",
     "ErrorCode": "Kod błędu",
-    "From": "Od",
+    "From": "Status początkowy",
     "Message": "Wiadomość",
     "Phase": "Faza",
     "Result": "Wynik",
-    "StatusTransition": "Zmiana statusu",
-    "To": "Do",
+    "To": "Status docelowy",
     "UpdatedAt": "Zaktualizowano"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Kategoria",
     "CreatedAt": "Utworzono",
     "ErrorCode": "Kod błędu",
-    "From": "Od",
+    "From": "Status początkowy",
     "Message": "Wiadomość",
     "Phase": "Faza",
     "Result": "Wynik",
-    "StatusTransition": "Zmiana statusu",
-    "To": "Do",
+    "To": "Status docelowy",
     "UpdatedAt": "Zaktualizowano"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Krok"
   },
   "comp:BAITable": {
+    "CollapseAll": "Zwiń wszystko",
+    "ExpandAll": "Rozwiń wszystko",
+    "ExpandErrorsOnly": "Rozwiń tylko błędy",
+    "ExpandOptions": "Opcje rozwijania",
     "Export": "Eksportuj",
     "ExportCSV": "Eksportuj do CSV",
     "GoToFirstPage": "Przejdź do pierwszej strony",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -127,12 +127,11 @@
     "Category": "Categoria",
     "CreatedAt": "Criado em",
     "ErrorCode": "Código de erro",
-    "From": "De",
+    "From": "Status de origem",
     "Message": "Mensagem",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transição de status",
-    "To": "Até",
+    "To": "Status de destino",
     "UpdatedAt": "Atualizado em"
   },
   "comp:BAIDeploymentSelect": {
@@ -331,12 +330,11 @@
     "Category": "Categoria",
     "CreatedAt": "Criado em",
     "ErrorCode": "Código de erro",
-    "From": "De",
+    "From": "Status de origem",
     "Message": "Mensagem",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transição de status",
-    "To": "Até",
+    "To": "Status de destino",
     "UpdatedAt": "Atualizado em"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -347,12 +345,11 @@
     "Category": "Categoria",
     "CreatedAt": "Criado em",
     "ErrorCode": "Código de erro",
-    "From": "De",
+    "From": "Status de origem",
     "Message": "Mensagem",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transição de status",
-    "To": "Até",
+    "To": "Status de destino",
     "UpdatedAt": "Atualizado em"
   },
   "comp:BAISessionAgentIds": {
@@ -377,6 +374,10 @@
     "Step": "Etapa"
   },
   "comp:BAITable": {
+    "CollapseAll": "Recolher tudo",
+    "ExpandAll": "Expandir tudo",
+    "ExpandErrorsOnly": "Expandir somente erros",
+    "ExpandOptions": "Opções de expansão",
     "Export": "Exportar",
     "ExportCSV": "Exportar CSV",
     "GoToFirstPage": "Ir para a primeira página",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -127,12 +127,11 @@
     "Category": "Categoria",
     "CreatedAt": "Criado em",
     "ErrorCode": "Código de erro",
-    "From": "De",
+    "From": "Estado de origem",
     "Message": "Mensagem",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transição de status",
-    "To": "Para",
+    "To": "Estado de destino",
     "UpdatedAt": "Atualizado em"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Categoria",
     "CreatedAt": "Criado em",
     "ErrorCode": "Código de erro",
-    "From": "De",
+    "From": "Estado de origem",
     "Message": "Mensagem",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transição de status",
-    "To": "Para",
+    "To": "Estado de destino",
     "UpdatedAt": "Atualizado em"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Categoria",
     "CreatedAt": "Criado em",
     "ErrorCode": "Código de erro",
-    "From": "De",
+    "From": "Estado de origem",
     "Message": "Mensagem",
     "Phase": "Fase",
     "Result": "Resultado",
-    "StatusTransition": "Transição de status",
-    "To": "Para",
+    "To": "Estado de destino",
     "UpdatedAt": "Atualizado em"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Etapa"
   },
   "comp:BAITable": {
+    "CollapseAll": "Recolher tudo",
+    "ExpandAll": "Expandir tudo",
+    "ExpandErrorsOnly": "Expandir apenas erros",
+    "ExpandOptions": "Opções de expansão",
     "Export": "Exportar",
     "ExportCSV": "Exportar CSV",
     "GoToFirstPage": "Ir para a primeira página",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -127,12 +127,11 @@
     "Category": "Категория",
     "CreatedAt": "Дата создания",
     "ErrorCode": "Код ошибки",
-    "From": "От",
+    "From": "Исходный статус",
     "Message": "Сообщение",
     "Phase": "Этап",
     "Result": "Результат",
-    "StatusTransition": "Смена статуса",
-    "To": "До",
+    "To": "Целевой статус",
     "UpdatedAt": "Обновлено"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Категория",
     "CreatedAt": "Дата создания",
     "ErrorCode": "Код ошибки",
-    "From": "От",
+    "From": "Исходный статус",
     "Message": "Сообщение",
     "Phase": "Этап",
     "Result": "Результат",
-    "StatusTransition": "Смена статуса",
-    "To": "До",
+    "To": "Целевой статус",
     "UpdatedAt": "Обновлено"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Категория",
     "CreatedAt": "Дата создания",
     "ErrorCode": "Код ошибки",
-    "From": "От",
+    "From": "Исходный статус",
     "Message": "Сообщение",
     "Phase": "Этап",
     "Result": "Результат",
-    "StatusTransition": "Смена статуса",
-    "To": "До",
+    "To": "Целевой статус",
     "UpdatedAt": "Обновлено"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Шаг"
   },
   "comp:BAITable": {
+    "CollapseAll": "Свернуть все",
+    "ExpandAll": "Развернуть все",
+    "ExpandErrorsOnly": "Развернуть только ошибки",
+    "ExpandOptions": "Параметры разворачивания",
     "Export": "Экспорт",
     "ExportCSV": "Экспорт в CSV",
     "GoToFirstPage": "Перейти на первую страницу",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -127,12 +127,11 @@
     "Category": "หมวดหมู่",
     "CreatedAt": "สร้างเมื่อ",
     "ErrorCode": "รหัสข้อผิดพลาด",
-    "From": "จาก",
+    "From": "สถานะต้นทาง",
     "Message": "ข้อความ",
     "Phase": "ระยะ",
     "Result": "ผลลัพธ์",
-    "StatusTransition": "การเปลี่ยนสถานะ",
-    "To": "ถึง",
+    "To": "สถานะปลายทาง",
     "UpdatedAt": "อัปเดตเมื่อ"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "หมวดหมู่",
     "CreatedAt": "สร้างเมื่อ",
     "ErrorCode": "รหัสข้อผิดพลาด",
-    "From": "จาก",
+    "From": "สถานะต้นทาง",
     "Message": "ข้อความ",
     "Phase": "ระยะ",
     "Result": "ผลลัพธ์",
-    "StatusTransition": "การเปลี่ยนสถานะ",
-    "To": "ถึง",
+    "To": "สถานะปลายทาง",
     "UpdatedAt": "อัปเดตเมื่อ"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "หมวดหมู่",
     "CreatedAt": "สร้างเมื่อ",
     "ErrorCode": "รหัสข้อผิดพลาด",
-    "From": "จาก",
+    "From": "สถานะต้นทาง",
     "Message": "ข้อความ",
     "Phase": "ระยะ",
     "Result": "ผลลัพธ์",
-    "StatusTransition": "การเปลี่ยนสถานะ",
-    "To": "ถึง",
+    "To": "สถานะปลายทาง",
     "UpdatedAt": "อัปเดตเมื่อ"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "ขั้นตอน"
   },
   "comp:BAITable": {
+    "CollapseAll": "ยุบทั้งหมด",
+    "ExpandAll": "ขยายทั้งหมด",
+    "ExpandErrorsOnly": "ขยายเฉพาะข้อผิดพลาด",
+    "ExpandOptions": "ตัวเลือกการขยาย",
     "Export": "ส่งออก",
     "ExportCSV": "ส่งออก CSV",
     "GoToFirstPage": "ไปยังหน้าแรก",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -127,12 +127,11 @@
     "Category": "Kategori",
     "CreatedAt": "Oluşturulma Tarihi",
     "ErrorCode": "Hata Kodu",
-    "From": "Kaynak",
+    "From": "Başlangıç durumu",
     "Message": "Mesaj",
     "Phase": "Aşama",
     "Result": "Sonuç",
-    "StatusTransition": "Durum Geçişi",
-    "To": "Bitiş",
+    "To": "Hedef durum",
     "UpdatedAt": "Güncelleme Tarihi"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Kategori",
     "CreatedAt": "Oluşturulma Tarihi",
     "ErrorCode": "Hata Kodu",
-    "From": "Kaynak",
+    "From": "Başlangıç durumu",
     "Message": "Mesaj",
     "Phase": "Aşama",
     "Result": "Sonuç",
-    "StatusTransition": "Durum Geçişi",
-    "To": "Bitiş",
+    "To": "Hedef durum",
     "UpdatedAt": "Güncelleme Tarihi"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Kategori",
     "CreatedAt": "Oluşturulma Tarihi",
     "ErrorCode": "Hata Kodu",
-    "From": "Kaynak",
+    "From": "Başlangıç durumu",
     "Message": "Mesaj",
     "Phase": "Aşama",
     "Result": "Sonuç",
-    "StatusTransition": "Durum Geçişi",
-    "To": "Bitiş",
+    "To": "Hedef durum",
     "UpdatedAt": "Güncelleme Tarihi"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Adım"
   },
   "comp:BAITable": {
+    "CollapseAll": "Tümünü daralt",
+    "ExpandAll": "Tümünü genişlet",
+    "ExpandErrorsOnly": "Yalnızca hataları genişlet",
+    "ExpandOptions": "Genişletme seçenekleri",
     "Export": "Dışa aktar",
     "ExportCSV": "CSV Dışa Aktar",
     "GoToFirstPage": "İlk sayfaya git",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -127,12 +127,11 @@
     "Category": "Danh mục",
     "CreatedAt": "Ngày tạo",
     "ErrorCode": "Mã lỗi",
-    "From": "Từ",
+    "From": "Trạng thái nguồn",
     "Message": "Tin nhắn",
     "Phase": "Giai đoạn",
     "Result": "Kết quả",
-    "StatusTransition": "Chuyển đổi trạng thái",
-    "To": "Đến",
+    "To": "Trạng thái đích",
     "UpdatedAt": "Cập nhật lúc"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "Danh mục",
     "CreatedAt": "Ngày tạo",
     "ErrorCode": "Mã lỗi",
-    "From": "Từ",
+    "From": "Trạng thái nguồn",
     "Message": "Tin nhắn",
     "Phase": "Giai đoạn",
     "Result": "Kết quả",
-    "StatusTransition": "Chuyển đổi trạng thái",
-    "To": "Đến",
+    "To": "Trạng thái đích",
     "UpdatedAt": "Cập nhật lúc"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "Danh mục",
     "CreatedAt": "Ngày tạo",
     "ErrorCode": "Mã lỗi",
-    "From": "Từ",
+    "From": "Trạng thái nguồn",
     "Message": "Tin nhắn",
     "Phase": "Giai đoạn",
     "Result": "Kết quả",
-    "StatusTransition": "Chuyển đổi trạng thái",
-    "To": "Đến",
+    "To": "Trạng thái đích",
     "UpdatedAt": "Cập nhật lúc"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "Bước"
   },
   "comp:BAITable": {
+    "CollapseAll": "Thu gọn tất cả",
+    "ExpandAll": "Mở rộng tất cả",
+    "ExpandErrorsOnly": "Chỉ mở rộng lỗi",
+    "ExpandOptions": "Tùy chọn mở rộng",
     "Export": "Xuất",
     "ExportCSV": "Xuất CSV",
     "GoToFirstPage": "Đến trang đầu",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -127,12 +127,11 @@
     "Category": "类别",
     "CreatedAt": "创建时间",
     "ErrorCode": "错误代码",
-    "From": "从",
+    "From": "起始状态",
     "Message": "消息",
     "Phase": "阶段",
     "Result": "结果",
-    "StatusTransition": "状态转换",
-    "To": "到",
+    "To": "目标状态",
     "UpdatedAt": "更新时间"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "类别",
     "CreatedAt": "创建时间",
     "ErrorCode": "错误代码",
-    "From": "从",
+    "From": "起始状态",
     "Message": "消息",
     "Phase": "阶段",
     "Result": "结果",
-    "StatusTransition": "状态转换",
-    "To": "到",
+    "To": "目标状态",
     "UpdatedAt": "更新时间"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "类别",
     "CreatedAt": "创建时间",
     "ErrorCode": "错误代码",
-    "From": "从",
+    "From": "起始状态",
     "Message": "消息",
     "Phase": "阶段",
     "Result": "结果",
-    "StatusTransition": "状态转换",
-    "To": "到",
+    "To": "目标状态",
     "UpdatedAt": "更新时间"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "步骤"
   },
   "comp:BAITable": {
+    "CollapseAll": "收起全部",
+    "ExpandAll": "展开全部",
+    "ExpandErrorsOnly": "仅展开错误",
+    "ExpandOptions": "展开选项",
     "Export": "导出",
     "ExportCSV": "导出 CSV",
     "GoToFirstPage": "转到第一页",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -127,12 +127,11 @@
     "Category": "類別",
     "CreatedAt": "建立時間",
     "ErrorCode": "錯誤代碼",
-    "From": "從",
+    "From": "起始狀態",
     "Message": "訊息",
     "Phase": "階段",
     "Result": "結果",
-    "StatusTransition": "狀態轉換",
-    "To": "至",
+    "To": "目標狀態",
     "UpdatedAt": "更新時間"
   },
   "comp:BAIDeploymentSelect": {
@@ -325,12 +324,11 @@
     "Category": "類別",
     "CreatedAt": "建立時間",
     "ErrorCode": "錯誤代碼",
-    "From": "從",
+    "From": "起始狀態",
     "Message": "訊息",
     "Phase": "階段",
     "Result": "結果",
-    "StatusTransition": "狀態轉換",
-    "To": "至",
+    "To": "目標狀態",
     "UpdatedAt": "更新時間"
   },
   "comp:BAIRuntimeVariantSelect": {
@@ -341,12 +339,11 @@
     "Category": "類別",
     "CreatedAt": "建立時間",
     "ErrorCode": "錯誤代碼",
-    "From": "從",
+    "From": "起始狀態",
     "Message": "訊息",
     "Phase": "階段",
     "Result": "結果",
-    "StatusTransition": "狀態轉換",
-    "To": "至",
+    "To": "目標狀態",
     "UpdatedAt": "更新時間"
   },
   "comp:BAISessionAgentIds": {
@@ -371,6 +368,10 @@
     "Step": "步驟"
   },
   "comp:BAITable": {
+    "CollapseAll": "收合全部",
+    "ExpandAll": "展開全部",
+    "ExpandErrorsOnly": "僅展開錯誤",
+    "ExpandOptions": "展開選項",
     "Export": "匯出",
     "ExportCSV": "匯出 CSV",
     "GoToFirstPage": "跳到第一頁",

--- a/react/src/__generated__/DeploymentSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9e0263ab0ebb2358b611f0d8cc490846>>
+ * @generated SignedSource<<c587f9e1882663e663a5d0e7f2aca1f5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -84,7 +84,7 @@ export type DeploymentSchedulingHistoryModalQuery$data = {
   readonly deploymentScopedSchedulingHistories: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly " $fragmentSpreads": FragmentRefs<"BAIDeploymentSchedulingHistoryNodesFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"BAIDeploymentSchedulingHistoryTableFragment">;
       };
     }>;
   } | null | undefined;
@@ -186,7 +186,7 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "BAIDeploymentSchedulingHistoryNodesFragment"
+                    "name": "BAIDeploymentSchedulingHistoryTableFragment"
                   }
                 ],
                 "storageKey": null
@@ -242,37 +242,7 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "category",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "phase",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "fromStatus",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "toStatus",
-                    "storageKey": null
-                  },
                   (v4/*: any*/),
-                  (v5/*: any*/),
-                  (v6/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -312,6 +282,36 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "category",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "phase",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "fromStatus",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "toStatus",
+                    "storageKey": null
+                  },
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "attempts",
                     "storageKey": null
                   },
@@ -341,16 +341,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6cc521a7daf46bd6ff23d8369e069d7c",
+    "cacheID": "d5545baf9254238711d930e4388936dd",
     "id": null,
     "metadata": {},
     "name": "DeploymentSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query DeploymentSchedulingHistoryModalQuery(\n  $scope: DeploymentScope!\n  $filter: DeploymentHistoryFilter\n  $orderBy: [DeploymentHistoryOrderBy!]\n) {\n  deploymentScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIDeploymentSchedulingHistoryNodesFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentSchedulingHistoryNodesFragment on DeploymentHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query DeploymentSchedulingHistoryModalQuery(\n  $scope: DeploymentScope!\n  $filter: DeploymentHistoryFilter\n  $orderBy: [DeploymentHistoryOrderBy!]\n) {\n  deploymentScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIDeploymentSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentSchedulingHistoryNodesFragment on DeploymentHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIDeploymentSchedulingHistoryTableFragment on DeploymentHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAIDeploymentSchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4386ab0845d3e5ba13c6f60075522b52";
+(node as any).hash = "85600df901d6fbaa9bbc3ac84ede6d06";
 
 export default node;

--- a/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5d0ef863d0714f49059be1797b0c4c60>>
+ * @generated SignedSource<<0d329743d1c924326df8fb382f88645e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -85,7 +85,7 @@ export type RouteSchedulingHistoryModalQuery$data = {
   readonly routeScopedSchedulingHistories: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryNodeTableFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryTableFragment">;
       };
     }>;
   } | null | undefined;
@@ -187,7 +187,7 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "BAIRouteSchedulingHistoryNodeTableFragment"
+                    "name": "BAIRouteSchedulingHistoryTableFragment"
                   }
                 ],
                 "storageKey": null
@@ -243,51 +243,7 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "routeId",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "deploymentId",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "category",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "phase",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "fromStatus",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "toStatus",
-                    "storageKey": null
-                  },
                   (v4/*: any*/),
-                  (v5/*: any*/),
-                  (v6/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -327,6 +283,36 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "category",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "phase",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "fromStatus",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "toStatus",
+                    "storageKey": null
+                  },
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "attempts",
                     "storageKey": null
                   },
@@ -356,16 +342,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5db4b1d03cdc23ddcee7e24da57e934d",
+    "cacheID": "76285934ccc8e905542eefed19bd318d",
     "id": null,
     "metadata": {},
     "name": "RouteSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryNodeTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  routeId\n  deploymentId\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIRouteSchedulingHistoryTableFragment on RouteHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAIRouteSchedulingHistoryNodeTableFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d718b55942730d51c42ce434352c4e59";
+(node as any).hash = "0dc8467432ed583ed53bcd9160cd0cb1";
 
 export default node;

--- a/react/src/__generated__/SessionSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/SessionSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<723b1f0a84f6919a10784d3ce95e2a6c>>
+ * @generated SignedSource<<ff20fa825d347e35021204496628d125>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -84,7 +84,7 @@ export type SessionSchedulingHistoryModalQuery$data = {
   readonly sessionScopedSchedulingHistories: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly " $fragmentSpreads": FragmentRefs<"BAISchedulingHistoryNodesFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"BAISchedulingHistoryTableFragment">;
       };
     }>;
   } | null | undefined;
@@ -131,14 +131,14 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "message",
+  "name": "result",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "result",
+  "name": "message",
   "storageKey": null
 };
 return {
@@ -179,7 +179,7 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "BAISchedulingHistoryNodesFragment"
+                    "name": "BAISchedulingHistoryTableFragment"
                   }
                 ],
                 "storageKey": null
@@ -235,11 +235,46 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
+                  (v4/*: any*/),
                   {
                     "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "sessionId",
+                    "concreteType": "SubStepResultGQL",
+                    "kind": "LinkedField",
+                    "name": "subSteps",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "step",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "errorCode",
+                        "storageKey": null
+                      },
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startedAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endedAt",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   },
                   {
@@ -277,54 +312,12 @@ return {
                     "name": "toStatus",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
                     "name": "phase",
-                    "storageKey": null
-                  },
-                  (v5/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "SubStepResultGQL",
-                    "kind": "LinkedField",
-                    "name": "subSteps",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "step",
-                        "storageKey": null
-                      },
-                      (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "errorCode",
-                        "storageKey": null
-                      },
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "startedAt",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "endedAt",
-                        "storageKey": null
-                      }
-                    ],
                     "storageKey": null
                   }
                 ],
@@ -339,16 +332,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5b9e35a12fc771527f808842f63b593b",
+    "cacheID": "fd4f2a0c97f5368a8886b4ffcc9a7bdf",
     "id": null,
     "metadata": {},
     "name": "SessionSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query SessionSchedulingHistoryModalQuery(\n  $scope: SessionScope!\n  $filter: SessionSchedulingHistoryFilter\n  $orderBy: [SessionSchedulingHistoryOrderBy!]\n) {\n  sessionScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAISchedulingHistoryNodesFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  sessionId\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query SessionSchedulingHistoryModalQuery(\n  $scope: SessionScope!\n  $filter: SessionSchedulingHistoryFilter\n  $orderBy: [SessionSchedulingHistoryOrderBy!]\n) {\n  sessionScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAISchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n}\n\nfragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAISchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "abbb837538ecf66fee1c3fb466b6c147";
+(node as any).hash = "f5aba8ae25a148fe9089ab6f25dd0269";
 
 export default node;

--- a/react/src/components/DeploymentSchedulingHistoryModal.tsx
+++ b/react/src/components/DeploymentSchedulingHistoryModal.tsx
@@ -4,8 +4,9 @@ import {
   DeploymentSchedulingHistoryModalQuery,
 } from '../__generated__/DeploymentSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
-  BAIDeploymentSchedulingHistoryNodes,
+  BAIDeploymentSchedulingHistoryTable,
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
@@ -39,7 +40,7 @@ export const DeploymentSchedulingHistoryQuery = graphql`
     ) {
       edges {
         node {
-          ...BAIDeploymentSchedulingHistoryNodesFragment
+          ...BAIDeploymentSchedulingHistoryTableFragment
         }
       }
     }
@@ -74,6 +75,12 @@ const DeploymentSchedulingHistoryModal = ({
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [filter, setFilter] = useState<DeploymentHistoryFilter>();
   const [order, setOrder] = useState<string | null>('-updatedAt');
+  const [expandMode, setExpandMode] = useBAISettingUserState(
+    'schedulingHistoryExpandMode',
+  );
+  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
+    'table_column_overrides.DeploymentSchedulingHistory',
+  );
 
   // Re-fetches happen from event handlers (filter / order / refresh), never from
   // render or an effect. We carry the existing variables forward via
@@ -105,8 +112,7 @@ const DeploymentSchedulingHistoryModal = ({
           minHeight: '80vh',
         },
       }}
-      cancelText={t('button.Close')}
-      footer={(_originNode, { CancelBtn }) => <CancelBtn />}
+      footer={null}
       onCancel={onCancel}
       {...modalProps}
     >
@@ -199,9 +205,15 @@ const DeploymentSchedulingHistoryModal = ({
             />
           </BAIFlex>
         </BAIFlex>
-        <BAIDeploymentSchedulingHistoryNodes
+        <BAIDeploymentSchedulingHistoryTable
           resizable
           loading={isRefetchingInTransition}
+          expandMode={expandMode ?? undefined}
+          onExpandModeChange={setExpandMode}
+          tableSettings={{
+            columnOverrides,
+            onColumnOverridesChange: setColumnOverrides,
+          }}
           order={order}
           onChangeOrder={(nextOrder) => {
             setOrder(nextOrder);

--- a/react/src/components/RouteSchedulingHistoryModal.tsx
+++ b/react/src/components/RouteSchedulingHistoryModal.tsx
@@ -4,13 +4,14 @@ import {
   RouteSchedulingHistoryModalQuery,
 } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIModal,
   BAIModalProps,
-  BAIRouteSchedulingHistoryNodeTable,
+  BAIRouteSchedulingHistoryTable,
   useFetchKey,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -39,7 +40,7 @@ export const RouteSchedulingHistoryQuery = graphql`
     ) {
       edges {
         node {
-          ...BAIRouteSchedulingHistoryNodeTableFragment
+          ...BAIRouteSchedulingHistoryTableFragment
         }
       }
     }
@@ -74,6 +75,12 @@ const RouteSchedulingHistoryModal = ({
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [filter, setFilter] = useState<RouteHistoryFilter>();
   const [order, setOrder] = useState<string | null>('-updatedAt');
+  const [expandMode, setExpandMode] = useBAISettingUserState(
+    'schedulingHistoryExpandMode',
+  );
+  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
+    'table_column_overrides.RouteSchedulingHistory',
+  );
 
   // Re-fetches happen from event handlers (filter / order / refresh), never from
   // render or an effect. We carry the existing variables forward via
@@ -105,8 +112,7 @@ const RouteSchedulingHistoryModal = ({
           minHeight: '80vh',
         },
       }}
-      cancelText={t('button.Close')}
-      footer={(_originNode, { CancelBtn }) => <CancelBtn />}
+      footer={null}
       onCancel={onCancel}
       {...modalProps}
     >
@@ -199,9 +205,15 @@ const RouteSchedulingHistoryModal = ({
             />
           </BAIFlex>
         </BAIFlex>
-        <BAIRouteSchedulingHistoryNodeTable
+        <BAIRouteSchedulingHistoryTable
           resizable
           loading={isRefetchingInTransition}
+          expandMode={expandMode ?? undefined}
+          onExpandModeChange={setExpandMode}
+          tableSettings={{
+            columnOverrides,
+            onColumnOverridesChange: setColumnOverrides,
+          }}
           order={order}
           onChangeOrder={(nextOrder) => {
             setOrder(nextOrder);

--- a/react/src/components/SessionSchedulingHistoryModal.tsx
+++ b/react/src/components/SessionSchedulingHistoryModal.tsx
@@ -4,14 +4,14 @@ import {
   SessionSchedulingHistoryOrderBy,
 } from '../__generated__/SessionSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
-  BAIButton,
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIModal,
   BAIModalProps,
-  BAISchedulingHistoryNodes,
+  BAISchedulingHistoryTable,
   useFetchKey,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -33,10 +33,17 @@ const SessionSchedulingHistoryModal = ({
   onCancel,
   ...modalProps
 }: SessionSchedulingHistoryModalProps) => {
+  'use memo';
   const { t } = useTranslation();
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [filter, setFilter] = useState<SessionSchedulingHistoryFilter>();
   const [order, setOrder] = useState<string | null>('-updatedAt');
+  const [expandMode, setExpandMode] = useBAISettingUserState(
+    'schedulingHistoryExpandMode',
+  );
+  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
+    'table_column_overrides.SessionSchedulingHistory',
+  );
 
   const deferredOpenValue = useDeferredValue(open);
   const deferredFetchKey = useDeferredValue(fetchKey);
@@ -56,7 +63,7 @@ const SessionSchedulingHistoryModal = ({
         ) {
           edges {
             node {
-              ...BAISchedulingHistoryNodesFragment
+              ...BAISchedulingHistoryTableFragment
             }
           }
         }
@@ -90,17 +97,7 @@ const SessionSchedulingHistoryModal = ({
           minHeight: '80vh',
         },
       }}
-      footer={
-        <BAIButton
-          onClick={(e) =>
-            onCancel?.(
-              e as Parameters<NonNullable<BAIModalProps['onCancel']>>[0],
-            )
-          }
-        >
-          {t('button.Close')}
-        </BAIButton>
-      }
+      footer={null}
       onCancel={onCancel}
       {...modalProps}
     >
@@ -184,7 +181,7 @@ const SessionSchedulingHistoryModal = ({
             />
           </BAIFlex>
         </BAIFlex>
-        <BAISchedulingHistoryNodes
+        <BAISchedulingHistoryTable
           resizable
           loading={
             deferredFetchKey !== fetchKey ||
@@ -193,6 +190,12 @@ const SessionSchedulingHistoryModal = ({
           }
           order={order}
           onChangeOrder={setOrder}
+          expandMode={expandMode ?? undefined}
+          onExpandModeChange={setExpandMode}
+          tableSettings={{
+            columnOverrides,
+            onColumnOverridesChange: setColumnOverrides,
+          }}
           schedulingHistoryFrgmt={_.map(
             queryRef.sessionScopedSchedulingHistories?.edges,
             'node',

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -49,6 +49,7 @@ export interface UserSettings {
   container_log_auto_refresh_interval?: number;
   custom_theme_config?: CustomThemeConfig;
   deploymentRevisionCreationMode?: 'preset' | 'custom';
+  schedulingHistoryExpandMode?: 'expand-all' | 'collapse-all' | 'errors-only';
 }
 
 export type SessionHistory = {


### PR DESCRIPTION
Resolves #7649 (FR-3008)

## Summary

Scheduling-history tables — **session**, **deployment**, and **route** — make scheduling problems easy to scan. A kebab (⋮) menu in the expand-column header offers three view actions — **expand all / collapse all / expand errors only** — with the chosen mode persisted per user (default **expand errors only**). In errors-only mode, non-success rows auto-expand and their nested sub-step table is filtered to just the failing / retried steps.

Originates from a Teams thread in devops/Frontend (auto-expand non-success scheduling entries). Supersedes FR-2958 / FR-2959, which were closed as *Not Planned* because they targeted the wrong surface (validation / check-result views).

## Behavior

- **Header kebab menu (⋮):** a vertical-ellipsis hover menu in the expand-column header with three actions — **Expand all**, **Collapse all**, **Expand errors only**. It reads as an action menu, not a stateful toggle: no per-item icons and no "active" highlight.
- **Persisted mode:** the selected mode is stored per user via `useBAISettingUserState('schedulingHistoryExpandMode')` and reused as the default on subsequent opens. Initial default is **expand errors only**.
- **Expand errors only:** rows whose `result !== 'SUCCESS'` are expanded; `SUCCESS` rows stay collapsed. The expanded row's **nested sub-step table hides `SUCCESS` sub-steps**, surfacing only the failing / retried steps.
- **Per-row expand icons** use Ant Design's default `+` / `−` (full expand / collapse). Individual rows remain manually expandable.
- **Result column** shows the result badge only (the previous hover info-icon/tooltip was removed).
- **On refetch:** the current mode is re-applied.

## Table presentation

- History tables use BAITable's default muted header style, which renders correctly in **both light and dark mode** (token-based, dark-mode aware). The status transition is shown as two **flat** columns — **From Status** / **To Status** — reusing the same labels as the property filter for those fields (no grouped two-level header, no cell borders).
- **Resizable** columns, **drag-to-reorder**, and **column show/hide** via `tableSettings`, with the per-column overrides persisted per user (`table_column_overrides.*`).
- **Nested sub-step table:** `Error Code` column now precedes `Message`.

## Implementation

- `useSchedulingHistoryExpandable(dataSource, { mode, onModeChange })` owns `expandedRowKeys` / `onExpandedRowsChange`, exposes the effective `mode`, and renders the kebab header menu. Reused across all three tables.
- Feature lives in dedicated wrappers — `BAISchedulingHistoryTable`, `BAIDeploymentSchedulingHistoryTable`, `BAIRouteSchedulingHistoryTable` — each owning a fragment that spreads the corresponding `*NodesFragment`, runs the hook, and supplies the `expandable` config; the base `*Nodes` components stay pure fragment tables.
- `BAISubStepNodes` gains an `errorsOnly` prop that filters out `SUCCESS` sub-steps.
- The three host modals (`SessionSchedulingHistoryModal`, `DeploymentSchedulingHistoryModal`, `RouteSchedulingHistoryModal`) wire the persisted expand-mode and column-override settings.
- The expanded-row background in `BAITable` is token-based (`colorFillSecondary`, dark-mode aware).
- i18n: `comp:BAITable.ExpandAll` / `CollapseAll` / `ExpandErrorsOnly` / `ExpandOptions` across all languages.

## Verification

`bash scripts/verify.sh` → **ALL PASS** (Relay, Lint, Format, TypeScript).

## Screenshots

Captured (light mode) against mock scheduling-history data — a `NEED_RETRY` and a `FAILURE` row, each with sub-steps mixing `SUCCESS` / `FAILURE` / `NEED_RETRY`, plus `SUCCESS` rows.

### Default — "expand errors only"
Non-success rows (`NEED_RETRY`, `FAILURE`) auto-expanded, `SUCCESS` rows collapsed. The nested sub-step tables show only non-success steps (the `FIFOSequencer` / `PrepareContainer` `SUCCESS` sub-steps are filtered out). Flat **From Status** / **To Status** columns, default muted header, no cell borders, `Error Code` before `Message`, result badge only, kebab (⋮) in the header.

![default — expand errors only](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7650/20260612-073706-errors-only-light.png)

### Header kebab menu
The ⋮ hover menu with the three plain-text actions — no icons, no active highlight.

![kebab menu](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7650/20260612-073712-kebab-menu-light.png)

### Expand all
![expand all](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7650/20260612-073719-expand-all-light.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
