### PR TITLE
fix(FR-3058): send empty JSON body for non-GET requests with null body

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -1680,7 +1680,11 @@ export class Client {
     let authBody: string;
     let d = new Date();
     if (body === null || body === undefined) {
-      requestBody = '';
+      // Some backends require a valid JSON body even when empty.
+      // Send '{}' for methods that carry a body; keep '' for GET/HEAD.
+      // authBody mirrors requestBody so the v<4 signature (which hashes the
+      // body) matches what is actually sent; v4+ excludes the body anyway.
+      requestBody = method !== 'GET' && method !== 'HEAD' ? '{}' : '';
       authBody = requestBody;
     } else if (
       typeof (body as { getBoundary?: () => string }).getBoundary ===

--- a/src/lib/backend.ai-client-node.ts
+++ b/src/lib/backend.ai-client-node.ts
@@ -1316,7 +1316,12 @@ class Client {
     let authBody;
     let d = new Date();
     if (body === null || body === undefined) {
-      requestBody = '';
+      // Some backends require a valid JSON body even when empty.
+      // Send '{}' for methods that carry a body; keep '' for GET/HEAD.
+      // authBody must match the actual body: on legacy (v<4) backends the
+      // signature hashes the body, so a mismatch fails verification. On v4+
+      // the body is excluded from the signature (see below), so this is safe.
+      requestBody = method !== 'GET' && method !== 'HEAD' ? '{}' : '';
       authBody = requestBody;
     } else if (
       typeof body.getBoundary === 'function' ||


### PR DESCRIPTION
**Jira**: [FR-3058](https://lablup.atlassian.net/browse/FR-3058)

## Summary

When the request `body` is `null`/`undefined`, `Client.newSignedRequest()` previously sent an empty string `''` as the HTTP body. Some backend REST endpoints now require at least a valid empty JSON body (`{}`) for methods that carry a body (e.g. `POST /vfolders/{name}/leave`), and reject `''` with a 400.

This centralizes the fix in `newSignedRequest()` so every call site that passes a `null` body is handled at once:

- Send `'{}'` for non-`GET`/`HEAD` methods when no body is provided.
- Keep `''` for `GET`/`HEAD` (query-based requests are unchanged).
- Keep `authBody` as `''` so HMAC signatures are unaffected — on API v4+ the body is already excluded from the signature, and on legacy (v<4) backends keeping `''` preserves the existing signature.

### Affected call sites (previously passing `null`)

- `VFolder.leave_invited()` — `POST /vfolders/{name}/leave` (confirmed broken without `{}`)
- `Client.restart()` — `PATCH /kernel/{id}`
- `Client.refreshSSHKeypair()` — `PATCH /auth/ssh-keypair`
- `Client.destroy()` — `DELETE /kernel/{id}`
- `Client.check_login()` — `POST /server/login-check` (SESSION mode)

Endpoints that already pass an explicit object or `{}` are unaffected. GET requests using query strings are intentionally left as-is.

> Related: FR-2978 (#7609) fixed `leave_invited()` individually; this PR generalizes the same fix and #7609 is stacked on top.

## Test plan

- [ ] Leave a shared (invited) vfolder — request succeeds (no 400).
- [ ] Restart a session — `PATCH /kernel/{id}` succeeds.
- [ ] Refresh SSH keypair — `PATCH /auth/ssh-keypair` succeeds.
- [ ] Verify GET requests still send no body (no regression in query-based APIs).

[FR-3058]: https://lablup.atlassian.net/browse/FR-3058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ