### PR TITLE
docs(FR-3009): align i18n skills/instructions with useBAIi18n convention

### DIFF
--- a/.claude/rules/react-compiler-memoization.md
+++ b/.claude/rules/react-compiler-memoization.md
@@ -31,6 +31,10 @@ This project runs **React 19.2** with **`babel-plugin-react-compiler` in annotat
 ```tsx
 const UserProfile: React.FC<Props> = ({ user, onSelect }) => {
   'use memo';
+  // Host component (`react/src/**`) — use `useTranslation` from
+  // `react-i18next`. Inside `packages/backend.ai-ui/src/**`, swap this
+  // for `useBAIi18n` from BUI's internal hook (see
+  // `.github/instructions/i18n.instructions.md` and FR-2986).
   const { t } = useTranslation();
 
   const fullName = `${user.firstName} ${user.lastName}`;

--- a/.claude/skills/create-relay-nodes-component/SKILL.md
+++ b/.claude/skills/create-relay-nodes-component/SKILL.md
@@ -176,12 +176,31 @@ Create complete TypeScript file with this structure:
 
 5. **Use `'use memo'` directive** at the top of the component body for React Compiler optimization.
 
+> **Pick the i18n hook path that matches the destination.** BUI source
+> MUST use `useBAIi18n` (direct `react-i18next` i18n imports are blocked
+> by ESLint inside BUI — FR-2986). The relative path differs by depth:
+>
+> | Destination | i18n import line |
+> |---|---|
+> | `packages/backend.ai-ui/src/components/` (the `*Nodes` default) | `import { useBAIi18n } from '../hooks/useBAIi18n';` |
+> | `packages/backend.ai-ui/src/components/fragments/` (the other-type default; matches the rest of the template paths below) | `import { useBAIi18n } from '../../hooks/useBAIi18n';` |
+> | `react/src/**` (host app) | `import { useTranslation } from 'react-i18next';` |
+>
+> When generating, also adjust the other relative imports in the
+> template (`../../__generated__/…`, `../../helper`, `../Table`, …) to
+> match the chosen depth — the template shape below is sized for the
+> `fragments/` destination.
+
 ```typescript
 import {
   {ComponentName}Fragment$data,
   {ComponentName}Fragment$key,
 } from '../../__generated__/{ComponentName}Fragment.graphql';
 import { filterOutEmpty, filterOutNullAndUndefined } from '../../helper';
+// BUI fragments/ destination (depth 2). For BUI components/ (the *Nodes
+// default — depth 1) drop one `../`: `'../hooks/useBAIi18n'`. For host
+// destination, swap to: `import { useTranslation } from 'react-i18next';`
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import {
   BAIColumnsType,
   BAIColumnType,
@@ -189,7 +208,6 @@ import {
   BAITableProps,
 } from '../Table';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 // =============================================================================
@@ -245,7 +263,8 @@ const {ComponentName} = ({
   ...tableProps
 }: {ComponentName}Props) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n(); // BUI destination
+  // Host destination: const { t } = useTranslation();
 
   // TODO: Customize fragment fields based on your GraphQL schema
   const data = useFragment<{ComponentName}Fragment$key>(

--- a/.claude/skills/react-component-basics/SKILL.md
+++ b/.claude/skills/react-component-basics/SKILL.md
@@ -40,6 +40,28 @@ guidance see the sibling skills: `react-form`, `react-modal-drawer`, `react-layo
 
 Every component file follows this shape. Deviating is a red flag in review.
 
+The example below is a **host** component (`react/src/**`). For a **BUI**
+component (`packages/backend.ai-ui/src/**`), swap the i18n hook:
+
+- Replace `import { useTranslation } from 'react-i18next'` with
+  `import { useBAIi18n } from '<relative-path>/hooks/useBAIi18n'`.
+- Replace `const { t } = useTranslation()` with `const { t } = useBAIi18n()`.
+- For rich-text interpolation, use `<BAITrans>` (not `<Trans>` from
+  `react-i18next`). Import path is also relative to where the new file
+  lives.
+
+The relative paths depend on file depth. From the most common destinations:
+
+| File lives in | `useBAIi18n` import | `BAITrans` import |
+|---|---|---|
+| `packages/backend.ai-ui/src/components/*.tsx` | `'../hooks/useBAIi18n'` | `'./BAITrans'` |
+| `packages/backend.ai-ui/src/components/fragments/*.tsx` | `'../../hooks/useBAIi18n'` | `'../BAITrans'` |
+| `packages/backend.ai-ui/src/components/Table/*.tsx` | `'../../hooks/useBAIi18n'` | `'../BAITrans'` |
+| `packages/backend.ai-ui/src/components/provider/<Provider>/*.tsx` | `'../../../hooks/useBAIi18n'` | `'../../BAITrans'` |
+
+ESLint inside BUI rejects direct `react-i18next` i18n primitives (see
+`.github/instructions/i18n.instructions.md` and FR-2986).
+
 ```tsx
 /**
  @license

--- a/.claude/skills/react-hooks-extraction/SKILL.md
+++ b/.claude/skills/react-hooks-extraction/SKILL.md
@@ -30,7 +30,7 @@ custom hooks, and `use-effect-event.md` rule.
 - **Hooks returning JSX are still named `use*`**, not `render*`. If a hook would return a full `<Component/>`, reconsider — it probably wants to be a component.
 - **`useEffectEvent` is effect-internal** — calling it outside `useEffect` / `useLayoutEffect` / `useInsertionEffect` has undefined behavior (React docs). Don't pass to JSX `onClick`.
 - **`useSuspendedBackendaiClient()` suspends the caller.** Wrap the caller in `<Suspense>` or accept that the first render shows fallback.
-- **i18n inside the hook** — call `useTranslation()` internally. Don't make callers pass `t` (project convention from lead coding style).
+- **i18n inside the hook** — call `useTranslation()` internally (or `useBAIi18n()` if the hook lives in `packages/backend.ai-ui/src/**` — see FR-2986 / `.github/instructions/i18n.instructions.md`). Don't make callers pass `t` (project convention from lead coding style).
 - **Parametrize per-call inputs on the returned function**, not on the hook argument. `const { startSession } = useStartSession(); startSession(values)` — not `useStartSession(values)`.
 - **New `useMemoizedFn` usage from ahooks is forbidden** (`.claude/rules/use-effect-event.md`). Remove existing occurrences when you touch nearby code.
 
@@ -46,8 +46,9 @@ custom hooks, and `use-effect-event.md` rule.
 
 - No React hooks involved (pure transformation)
 - I18n: prefer the function NOT taking `t` as an argument — instead make it a
-  hook so it can call `useTranslation()` internally (a consistent repo
-  convention, stated in the lead coding style)
+  hook so it can call `useTranslation()` (or `useBAIi18n()` in BUI source —
+  see FR-2986) internally (a consistent repo convention, stated in the lead
+  coding style)
 
 ### 1.3 Don't extract (yet) when
 
@@ -251,7 +252,7 @@ to be a component, not a hook.
 - [ ] Hook uses at least one React hook internally (else it's a helper function).
 - [ ] Named `use*` matching what it returns/does.
 - [ ] `'use memo'` at the start of the hook body when it contains non-trivial work.
-- [ ] Collects its own context (`useTranslation`, clients, atoms) — caller doesn't have to pass `t`.
+- [ ] Collects its own context (`useTranslation` in host / `useBAIi18n` in BUI, clients, atoms) — caller doesn't have to pass `t`.
 - [ ] Returns a named object (not a tuple, unless mimicking `useState`).
 - [ ] Effect dependencies are only values the effect truly syncs on; callbacks closed over via `useEffectEvent`.
 - [ ] No `// eslint-disable-next-line react-hooks/exhaustive-deps`.

--- a/.claude/skills/react-relay-table/SKILL.md
+++ b/.claude/skills/react-relay-table/SKILL.md
@@ -92,11 +92,15 @@ interface BAIUserNodesProps extends Omit<
     void;
 }
 
+// `BAIUserNodes` lives in `packages/backend.ai-ui/src/components/`, so it
+// imports `useBAIi18n` from BUI's internal hook rather than `useTranslation`
+// from `react-i18next` (FR-2986). A host-side relay table would use
+// `useTranslation` instead — see the orchestrator example below.
 const BAIUserNodes: React.FC<BAIUserNodesProps> = ({
   usersFrgmt, customizeColumns, disableSorter, onChangeOrder, ...tableProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
   const users = useFragment(graphql`
     fragment BAIUserNodesFragment on UserNode @relay(plural: true) {

--- a/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIAdminResourceGroupSelect.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIAdminResourceGroupSelect.md
@@ -32,7 +32,7 @@ import { Skeleton } from 'antd';
 import { GetRef } from 'antd/lib';
 import * as _ from 'lodash-es';
 import { useOptimistic, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { usePaginationFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -46,7 +46,7 @@ const BAIAdminResourceGroupSelect = ({
   loading,
   ...selectPropsWithoutLoading
 }: BAIAdminResourceGroupSelectProps) => {
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [searchStr, setSearchStr] = useState<string>();
   const [optimisticSearchStr, setOptimisticSearchStr] =

--- a/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIUserSelect.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIUserSelect.md
@@ -109,7 +109,7 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type UserNode = NonNullable<
@@ -143,7 +143,7 @@ const BAIUserSelect: React.FC<BAIUserSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIVFolderSelect.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIVFolderSelect.md
@@ -47,7 +47,7 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 export type VFolderNode = NonNullable<
@@ -85,7 +85,7 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
   ...selectProps
 }) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
     string | string[] | undefined

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@ When reviewing code:
 - All UI code is in `/react` (React) and `/packages/backend.ai-ui/` (shared components)
 - `/src` contains utilities and the websocket proxy
 - Check that GraphQL queries use Relay conventions in React components
-- Verify proper i18n usage with `useTranslation()` hook from `react-i18next`
+- Verify proper i18n usage: host components (`react/src/**`) use `useTranslation()` / `<Trans>` from `react-i18next`; BUI components (`packages/backend.ai-ui/src/**`) use `useBAIi18n()` / `<BAITrans>` from BUI's internal hook/wrapper (FR-2986). Direct imports of `useTranslation` / `Trans` / `withTranslation` / `Translation` / `I18nextProvider` from `react-i18next` inside BUI are blocked by ESLint.
 
 ### Build and Development
 

--- a/.github/instructions/i18n.instructions.md
+++ b/.github/instructions/i18n.instructions.md
@@ -26,13 +26,27 @@ These instructions ensure proper internationalization practices across the Backe
 
 ## Translation Functions
 
-### React Components
-Use React i18n hooks and functions:
+The project runs **two physically separate i18next instances** — one owned
+by the host app (`react/`), one owned by the BUI package
+(`packages/backend.ai-ui/`). Which hook a component uses depends on which
+package it lives in. **Do not import `useTranslation` / `Trans` from
+`react-i18next` directly inside `packages/backend.ai-ui/src/**`** — ESLint
+will reject it (see FR-2986).
+
+| Where the component lives | Translation hook | Rich-text component |
+|---|---|---|
+| `react/src/**` (host app) | `useTranslation()` from `react-i18next` | `<Trans>` from `react-i18next` |
+| `packages/backend.ai-ui/src/**` (BUI) | `useBAIi18n()` from `'../hooks/useBAIi18n'` (relative) | `<BAITrans>` from `'../components/BAITrans'` (relative) |
+
+### Host components (`react/src/**`)
+
+Use react-i18next directly. The hook binds to the host's i18n via React Context.
 
 ```typescript
 import { useTranslation } from 'react-i18next';
 
 const MyComponent = () => {
+  'use memo';
   const { t } = useTranslation();
 
   return (
@@ -43,6 +57,61 @@ const MyComponent = () => {
   );
 };
 ```
+
+### BUI components (`packages/backend.ai-ui/src/**`)
+
+Use the internal `useBAIi18n` hook (and `BAITrans` for rich text). They
+bind explicitly to BUI's own i18next instance via
+`useTranslation(undefined, { i18n: buiI18n })` so the lookup never falls
+back to React Context. The import path is relative — depth depends on the
+file location.
+
+```typescript
+// File: packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+import { useBAIi18n } from '../hooks/useBAIi18n';
+
+const BAIPropertyFilter = () => {
+  'use memo';
+  const { t } = useBAIi18n();
+
+  return (
+    <>
+      <Input placeholder={t('comp:BAIPropertyFilter.PlaceHolder')} />
+      <Button>{t('comp:BAIPropertyFilter.ResetFilter')}</Button>
+    </>
+  );
+};
+```
+
+For `<Trans>` (rich-text interpolation with React component children) use
+`BAITrans` instead — it wraps `<Trans i18n={buiI18n}>` so callers cannot
+forget to bind the instance.
+
+```typescript
+// File: packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.tsx
+import { BAITrans } from './BAITrans';
+
+<BAITrans
+  i18nKey="comp:BAIDeleteConfirmModal.TypeToConfirm"
+  values={{ confirmText }}
+  components={{ code: <BAIText code /> }}
+/>
+```
+
+### Why two instances?
+
+React-i18next discovers the i18n instance through React Context. When
+host and BUI share one physical react-i18next module (which they do
+under pnpm + Vite dedup), one `<I18nextProvider>` from either side
+shadows the other for the entire tree. Binding BUI calls to the
+buiI18n instance explicitly via the `useBAIi18n` hook bypasses Context
+discovery, so the two sides cannot leak into each other.
+
+The ESLint rule in `packages/backend.ai-ui/eslint.config.js` blocks
+direct imports of `useTranslation`, `withTranslation`, `Translation`,
+`Trans`, and `I18nextProvider` from `react-i18next` inside BUI source
+(only `useBAIi18n.ts` and `BAITrans.tsx` are exempt). This guarantees
+the convention is enforced, not just documented.
 
 ## Translation Key Structures
 
@@ -86,19 +155,9 @@ Use component-scoped naming with `comp:` prefix:
 
 #### Usage in Components
 
-```typescript
-// Component: BAIPropertyFilter.tsx
-import { useTranslation } from 'react-i18next';
-
-const BAIPropertyFilter = () => {
-  const { t } = useTranslation();
-
-  return (
-    <Input placeholder={t('comp:BAIPropertyFilter.PlaceHolder')} />
-    <Button>{t('comp:BAIPropertyFilter.ResetFilter')}</Button>
-  );
-};
-```
+See the "BUI components" example in the [Translation Functions](#translation-functions)
+section above. BUI components use the `useBAIi18n` hook (internal to the
+package), never `useTranslation` directly from `react-i18next`.
 
 ## Translation Guidelines
 
@@ -261,6 +320,7 @@ When reviewing code for i18n, check for:
 - [ ] Translations are concise and UI-appropriate
 - [ ] No concatenated translated strings (use placeholders instead)
 - [ ] Component-specific translations use `comp:` prefix in backend.ai-ui package
+- [ ] BUI components (`packages/backend.ai-ui/src/**`) use `useBAIi18n` / `BAITrans` — **not** `useTranslation` / `Trans` from `react-i18next` directly (ESLint enforces this; see FR-2986)
 
 ## Common Mistakes to Avoid
 
@@ -282,6 +342,26 @@ t("BAIModal.ConfirmTitle");
 
 // ✅ Good: Use comp: prefix
 t("comp:BAIModal.ConfirmTitle");
+```
+
+### Wrong i18n hook inside BUI
+
+```typescript
+// ❌ Bad: Importing useTranslation directly inside packages/backend.ai-ui/src/**
+// (ESLint error — `'useTranslation' import from 'react-i18next' is restricted`)
+import { useTranslation } from 'react-i18next';
+const MyBuiComponent = () => {
+  const { t } = useTranslation();
+  ...
+};
+
+// ✅ Good: Use BUI's internal hook
+import { useBAIi18n } from '../hooks/useBAIi18n'; // path depth varies
+const MyBuiComponent = () => {
+  'use memo';
+  const { t } = useBAIi18n();
+  ...
+};
 ```
 
 ### Conditional Text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,8 @@ Production build (`pnpm run build`) runs these steps sequentially:
 ### Internationalization
 
 - JSON translation files in `resources/i18n/` (22 languages supported)
-- React components use `useTranslation()` hook from `react-i18next`
+- **Host** components (`react/src/**`) use `useTranslation()` / `<Trans>` from `react-i18next`
+- **BUI** components (`packages/backend.ai-ui/src/**`) use `useBAIi18n()` / `<BAITrans>` — they bind explicitly to BUI's own i18next instance, bypassing React Context lookup. Direct imports of `useTranslation` / `Trans` / `withTranslation` / `Translation` / `I18nextProvider` from `react-i18next` inside BUI are blocked by ESLint (FR-2986).
 - Backend.AI UI package has own locale files in `packages/backend.ai-ui/src/locale/`
 - Run `make i18n` to extract translation strings
 


### PR DESCRIPTION
Resolves #7654 (FR-3009)

## Summary

[FR-2986](https://github.com/lablup/backend.ai-webui/pull/7616) established a new project-wide convention: BUI components (`packages/backend.ai-ui/src/**`) MUST use the internal `useBAIi18n` hook and `BAITrans` wrapper instead of importing `useTranslation` / `Trans` / `withTranslation` / `Translation` / `I18nextProvider` directly from `react-i18next`. ESLint blocks the direct imports inside BUI source.

The agent-facing documentation in this repo still taught the **old** pattern (`useTranslation` everywhere). Any code-generation skill that emitted a BUI component would produce ESLint-failing code on first commit, and reviewers/agents would keep re-deriving the convention from scratch.

This PR is **documentation-only** — no `.ts` / `.tsx` changes, no runtime impact.

## Changes

| File | What changed |
|---|---|
| `.github/instructions/i18n.instructions.md` | Rewrote "Translation Functions" section with explicit host vs BUI table; added a "Wrong i18n hook inside BUI" example; added a checklist item. |
| `AGENTS.md` (symlinked from `CLAUDE.md`) | Split the i18n bullets into host vs BUI variants. |
| `.github/copilot-instructions.md` | Review-verification line now spells out the BUI distinction. |
| `.claude/rules/react-compiler-memoization.md` | Annotated the example to point at `useBAIi18n` for BUI. |
| `.claude/skills/react-component-basics/SKILL.md` | Callout before "File Skeleton" tells the agent to swap to `useBAIi18n` / `BAITrans` for BUI destination. |
| `.claude/skills/react-hooks-extraction/SKILL.md` | i18n-inside-the-hook rule and verification checklist mention the BUI variant. |
| `.claude/skills/create-relay-nodes-component/SKILL.md` | The template now uses `useBAIi18n` (BUI default destination) with the host alternative shown inline. |
| `.claude/skills/react-relay-table/SKILL.md` | `BAIUserNodes` example now uses `useBAIi18n`, matching the live BUI source. |
| `.claude/skills/relay-infinite-scroll-select/references/patterns/BAIVFolderSelect.md` | Pattern doc mirrors the live BUI source (`useBAIi18n` + relative import path). |
| `.claude/skills/relay-infinite-scroll-select/references/patterns/BAIUserSelect.md` | Same. |
| `.claude/skills/relay-infinite-scroll-select/references/patterns/BAIAdminResourceGroupSelect.md` | Same. |

## Test plan

- [ ] Skim each updated file to confirm the BUI exception is stated where an agent would actually look (skill entry → file skeleton → example).
- [ ] Verify the i18n.instructions.md host vs BUI table matches what is enforced in `packages/backend.ai-ui/eslint.config.js`.
- [ ] Spot-check the three `relay-infinite-scroll-select/references/patterns/*.md` files against the live `packages/backend.ai-ui/src/components/fragments/BAIUserSelect.tsx`, `BAIVFolderSelect.tsx`, `BAIAdminResourceGroupSelect.tsx` to make sure the documented import paths and call signatures are exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2986]: https://lablup.atlassian.net/browse/FR-2986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ