### PR TITLE
fix(FR-3015): gate app-launch session-not-found message to managers below 26.4.4

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -830,6 +830,9 @@ export class Client {
     if (this.isManagerVersionCompatibleWith('26.4.3')) {
       this._features['model-deployment-extended-filter'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('26.4.4')) {
+      this._features['session-app-by-user-uuid'] = true;
+    }
   }
 
   /**

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -255,12 +255,20 @@ export const useBackendAIAppLauncher = (
       if (err instanceof AppLaunchError) {
         throw err;
       }
-      // Detect "session not accessible" on session lookup. The manager
-      // scopes session lookups by the *current* access key; if the
-      // session was created under a different AK (or was terminated
+      // Detect "session not accessible" on session lookup. Before manager
+      // 26.4.4, session lookups are scoped by the *current* access key; if
+      // the session was created under a different AK (or was terminated
       // between page render and click), the lookup returns 404 /
       // "session not found", which is misleading to end users (FR-2586).
-      if (isSessionNotFoundError(err)) {
+      // From 26.4.4 on (`session-app-by-user-uuid`), the manager scopes
+      // lookups by the owner's user id instead, so a user's sessions are
+      // reachable across all of their keypairs and this AK-mismatch case no
+      // longer occurs — hence we only force the friendly message when the
+      // manager lacks that capability.
+      if (
+        isSessionNotFoundError(err) &&
+        !baiClient.supports('session-app-by-user-uuid')
+      ) {
         throw new AppLaunchError(
           t('session.appLauncher.SessionNotAccessible'),
           'configuring',


### PR DESCRIPTION
Resolves #7662 (FR-3015)

## Summary

Follow-up to #7409 (FR-2586). That PR added a friendly "session not accessible" message when an app launch fails with a 404 / "session not found" — the common cause being an access-key (AK) mismatch, where the session was created under a different keypair than the one currently in use.

From manager **26.4.4** on, streaming session lookups are scoped by the owner's **user id** instead of the **access key**. A user's sessions are therefore reachable across all of their keypairs, so the AK-mismatch case the FR-2586 workaround targets no longer occurs on those managers. This PR version-gates the workaround so it only applies to managers **below 26.4.4**.

## Implementation

- `packages/backend.ai-client/src/client.ts`: register a new capability flag `session-app-by-user-uuid`, enabled for managers `>= 26.4.4` in `_updateSupportList()`.
- `react/src/hooks/useBackendAIAppLauncher.tsx`: gate the FR-2586 friendly `AppLaunchError` behind both conditions — the error is a session-not-found error **and** the manager lacks `session-app-by-user-uuid`:

  ```ts
  if (
    isSessionNotFoundError(err) &&
    !baiClient.supports('session-app-by-user-uuid')
  ) {
    // friendly "SessionNotAccessible" message (pre-26.4.4 only)
  }
  ```

  On 26.4.4+ the workaround is disabled and the original manager error surfaces unchanged.

## Behavior matrix

| Manager | Error | Before this PR | After this PR |
|---|---|---|---|
| < 26.4.4 | 404 session-not-found (AK mismatch) | friendly message | friendly message |
| < 26.4.4 | non-404 (proxy down, timeout) | raw error | raw error |
| 26.4.4+ | 404 session-not-found (genuinely gone) | friendly message | raw error |
| 26.4.4+ | non-404 | raw error | raw error |

## Test Plan

- [ ] Pre-26.4.4 manager: launch an app on a session created under a different AK → friendly "SessionNotAccessible" message appears.
- [ ] Pre-26.4.4 manager: trigger a non-404 launch failure (e.g. proxy down) → original error message, not the AK-mismatch message.
- [ ] 26.4.4+ manager: a session is reachable across the user's keypairs; if a launch 404s for an unrelated reason, the raw manager error surfaces (no AK-mismatch message).
- [ ] Normal session launch on any manager → no behavior change.

## Verification

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all PASS. (The "Vite warmup paths" check fails on a clean checkout too because it resolves production-build artifacts that are absent without `pnpm build`; unrelated to this change.)

## Related

- #7409 (FR-2586) — the original workaround this PR version-gates.