### PR TITLE
fix(FR-2977): move applying-revision alert inside current revision tab

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
@@ -68,6 +68,8 @@ export interface BAINameActionCellProps {
   showActions?: 'hover' | 'always';
   /** Minimum number of action buttons to keep visible before overflow. Default: 0 */
   minVisibleActions?: number;
+  /** Disable the overflow More (…) button. Individual menu items remain visible. */
+  moreMenuDisabled?: boolean;
   /** Show a copy-to-clipboard icon on hover next to the title text */
   copyable?: boolean;
   style?: React.CSSProperties;
@@ -162,6 +164,7 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
   actions,
   showActions = 'hover',
   minVisibleActions = 0,
+  moreMenuDisabled,
   copyable,
   style,
   className,
@@ -428,6 +431,7 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
                 size="small"
                 icon={<MoreOutlined />}
                 aria-label="More actions"
+                disabled={moreMenuDisabled}
               />
             </Dropdown>
           )}

--- a/react/src/components/AutoScalingRuleList.tsx
+++ b/react/src/components/AutoScalingRuleList.tsx
@@ -32,12 +32,7 @@ import type { BAITableProps, GraphQLFilter } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import * as _ from 'lodash-es';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
-import React, {
-  useDeferredValue,
-  useImperativeHandle,
-  useState,
-  useTransition,
-} from 'react';
+import React, { useDeferredValue, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 
@@ -366,39 +361,16 @@ const AutoScalingRuleListNodes: React.FC<AutoScalingRuleListNodesProps> = ({
 
 // --- List orchestrator component ---
 
-export interface AutoScalingRuleListRef {
-  openAddModal: () => void;
-}
-
 interface AutoScalingRuleListProps {
   deploymentId: string; // Relay global ID (e.g., toGlobalId('ModelDeployment', uuid))
   isEndpointDestroying: boolean;
   isOwnedByCurrentUser: boolean;
-  fetchKey?: string;
-  /**
-   * When true, the inline "Add rules" primary button is hidden so the parent
-   * can render its own trigger (typically in a `BAICard.extra` slot). The
-   * editor modal is still managed internally; callers should use
-   * `ref.current.openAddModal()` to open it.
-   */
-  hideInlineAddButton?: boolean;
-  /**
-   * When true, the inline refresh button (`BAIFetchKeyButton`) is hidden so
-   * the parent can render refresh in a `BAICard.extra` slot. Drive the
-   * refetch externally by bumping `fetchKey`.
-   */
-  hideInlineRefreshButton?: boolean;
-  ref?: React.Ref<AutoScalingRuleListRef>;
 }
 
 const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
   deploymentId,
   isEndpointDestroying,
   isOwnedByCurrentUser,
-  fetchKey: parentFetchKey,
-  hideInlineAddButton = false,
-  hideInlineRefreshButton = false,
-  ref,
 }) => {
   'use memo';
   const { t } = useTranslation();
@@ -412,17 +384,6 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
     id: string;
     metricName: string;
   } | null>(null);
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      openAddModal: () => {
-        setEditingRuleId(null);
-        setIsOpenEditorModal(true);
-      },
-    }),
-    [],
-  );
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.AutoScalingRuleList',
@@ -501,7 +462,7 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
     deferredQueryVariables,
     {
       fetchPolicy: 'store-and-network',
-      fetchKey: parentFetchKey ? `${parentFetchKey}_${fetchKey}` : fetchKey,
+      fetchKey,
     },
   );
 
@@ -591,28 +552,24 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
               });
             }}
           />
-          {!hideInlineRefreshButton && (
-            <BAIFetchKeyButton
-              loading={isPendingRefetch}
-              value=""
-              onChange={() => {
-                startRefetchTransition(() => updateFetchKey());
-              }}
-            />
-          )}
-          {!hideInlineAddButton && (
-            <Button
-              type="primary"
-              icon={<PlusOutlined />}
-              disabled={isEndpointDestroying || !isOwnedByCurrentUser}
-              onClick={() => {
-                setEditingRuleId(null);
-                setIsOpenEditorModal(true);
-              }}
-            >
-              {t('modelService.AddRules')}
-            </Button>
-          )}
+          <BAIFetchKeyButton
+            loading={isPendingRefetch}
+            value=""
+            onChange={() => {
+              startRefetchTransition(() => updateFetchKey());
+            }}
+          />
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            disabled={isEndpointDestroying || !isOwnedByCurrentUser}
+            onClick={() => {
+              setEditingRuleId(null);
+              setIsOpenEditorModal(true);
+            }}
+          >
+            {t('modelService.AddRules')}
+          </Button>
         </BAIFlex>
         <AutoScalingRuleListNodes
           autoScalingRulesFrgmt={autoScalingRuleNodes}

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -341,6 +341,13 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
   // to Custom — the mode choice is always the user's, never forced by the
   // entry point.
   const [hasAppliedSourcePrefill, setHasAppliedSourcePrefill] = useState(false);
+  // True between "user clicked Load current revision while in Preset mode"
+  // and "the Custom form has mounted and we applied the prefill". setMode
+  // is async, so we can't `setFieldsValue` on the Custom form synchronously
+  // — it isn't mounted yet and antd Form drops calls made before
+  // registration. The mode-transition effect picks this flag up and applies
+  // once Custom is active.
+  const [pendingLoadCurrent, setPendingLoadCurrent] = useState(false);
 
   // One-shot carry-over consumed by the Custom body on mount. Set when the
   // user transitions Preset → Custom with a preset selected.
@@ -884,14 +891,44 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
     setHasAppliedSourcePrefill(true);
   });
 
+  // Pair with `handleLoadCurrent` below — when the user clicks "Load
+  // current revision" while in Preset mode, we flip to Custom and queue the
+  // apply via `pendingLoadCurrent`. This effect drains the queue once the
+  // Custom form has actually mounted.
+  const applyPendingLoadCurrent = useEffectEvent(() => {
+    if (!pendingLoadCurrent) return;
+    if (!currentRevision) return;
+    applyRevisionToCustomForm(currentRevision);
+    setPendingLoadCurrent(false);
+    setHasLoadedCurrent(true);
+    message.success(t('deployment.CurrentRevisionConfigurationLoaded'));
+  });
+
   useEffect(() => {
     if (effectiveMode === 'custom') {
       consumePresetTransferPrefill();
       applySourcePrefillOnce();
+      applyPendingLoadCurrent();
     } else {
       consumeCustomTransferPrefill();
     }
   }, [effectiveMode]);
+
+  // "Load current revision" entry point — visible mode-independently as the
+  // alert above the modal forms. In Custom mode we apply immediately; in
+  // Preset mode we flip to Custom first and let the mode-transition effect
+  // drain the apply queue once the Custom form has mounted.
+  const handleLoadCurrent = () => {
+    if (!currentRevision) return;
+    if (effectiveMode === 'custom') {
+      applyRevisionToCustomForm(currentRevision);
+      setHasLoadedCurrent(true);
+      message.success(t('deployment.CurrentRevisionConfigurationLoaded'));
+      return;
+    }
+    setPendingLoadCurrent(true);
+    setMode('custom');
+  };
 
   // Serialize runtime parameter UI values (from RuntimeParameterFormSection)
   // into an environ map — mirrors ServiceLauncherPageContent logic.
@@ -1277,6 +1314,27 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
       destroyOnHidden
       {...restModalProps}
     >
+      {/* "Load current revision" affordance — mode-independent, rendered
+          above both the Preset and Custom forms. Only for the plain
+          "Add revision" entry: when the modal opens with a source revision
+          (`sourceRevisionFrgmt`) the form is already prefilled, so the alert
+          would be redundant. After the user clicks Load once the alert
+          vanishes — there is nothing left to load. In Preset mode the click
+          flips to Custom first and applies once the form mounts (see
+          `handleLoadCurrent`). */}
+      {currentRevision && !sourceRevisionFrgmt && !hasLoadedCurrent ? (
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginBottom: token.marginMD }}
+          title={t('deployment.CurrentRevisionAvailableDescription')}
+          action={
+            <Button size="small" onClick={handleLoadCurrent}>
+              {t('deployment.LoadCurrentRevision')}
+            </Button>
+          }
+        />
+      ) : null}
       {effectiveMode === 'preset' ? (
         hasNoPresets ? (
           // Empty-state: per spec, when no preset is available in Preset Mode,
@@ -1421,35 +1479,6 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
             environ: [],
           })}
         >
-          {/* The "Load current revision" affordance is for the plain
-              "Add revision" entry only — when the modal opens with a
-              source revision (`sourceRevisionFrgmt`) the form is already
-              prefilled, so the alert would be redundant. After the user
-              clicks Load once the alert vanishes too: there is nothing
-              left to load, and the prefill has already been applied. */}
-          {currentRevision && !sourceRevisionFrgmt && !hasLoadedCurrent ? (
-            <Alert
-              type="info"
-              showIcon
-              style={{ marginBottom: token.marginMD }}
-              title={t('deployment.CurrentRevisionAvailableDescription')}
-              action={
-                <Button
-                  size="small"
-                  onClick={() => {
-                    applyRevisionToCustomForm(currentRevision);
-                    setHasLoadedCurrent(true);
-                    message.success(
-                      t('deployment.CurrentRevisionConfigurationLoaded'),
-                    );
-                  }}
-                >
-                  {t('deployment.LoadCurrentRevision')}
-                </Button>
-              }
-            />
-          ) : null}
-
           <SectionHeader>{t('deployment.step.ModelAndRuntime')}</SectionHeader>
           <Form.Item
             label={t('deployment.ModelFolder')}

--- a/react/src/components/DeploymentAutoScalingTab.tsx
+++ b/react/src/components/DeploymentAutoScalingTab.tsx
@@ -4,18 +4,11 @@
  */
 import { DeploymentAutoScalingTab_deployment$key } from '../__generated__/DeploymentAutoScalingTab_deployment.graphql';
 import { useCurrentUserInfo } from '../hooks/backendai';
-import AutoScalingRuleList, {
-  type AutoScalingRuleListRef,
-} from './AutoScalingRuleList';
-import { PlusOutlined, QuestionCircleOutlined } from '@ant-design/icons';
-import { Button, Skeleton, Tooltip, theme } from 'antd';
-import {
-  BAICard,
-  BAIFetchKeyButton,
-  BAIFlex,
-  isDeploymentInStoppedCategory,
-} from 'backend.ai-ui';
-import React, { Suspense, useRef, useState, useTransition } from 'react';
+import AutoScalingRuleList from './AutoScalingRuleList';
+import { QuestionCircleOutlined } from '@ant-design/icons';
+import { Skeleton, Tooltip, theme } from 'antd';
+import { BAICard, BAIFlex, isDeploymentInStoppedCategory } from 'backend.ai-ui';
+import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
@@ -27,12 +20,10 @@ interface DeploymentAutoScalingTabProps {
  * DeploymentAutoScalingTab — section card on the Deployment detail page that
  * hosts the Auto-Scaling Rules management UI.
  *
- * The card owns the section title, the refresh button, and the primary "Add
- * rules" button — all rendered in the BAICard `extra` slot per project
- * convention. The actual rule list (`AutoScalingRuleList`) still owns the
- * editor modal; we drive it via an imperative `ref` so the trigger can live
- * in the card header while the modal stays co-located with the data it
- * mutates.
+ * The card owns the section title only. Both the refresh button
+ * (`BAIFetchKeyButton`) and the primary "Add rules" button live inside
+ * `AutoScalingRuleList`'s toolbar next to the property filter, so the table
+ * controls stay grouped together (per Jongeun's feedback).
  */
 const DeploymentAutoScalingTab: React.FC<DeploymentAutoScalingTabProps> = ({
   deploymentFrgmt,
@@ -41,10 +32,6 @@ const DeploymentAutoScalingTab: React.FC<DeploymentAutoScalingTabProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [currentUser] = useCurrentUserInfo();
-  const autoScalingRef = useRef<AutoScalingRuleListRef>(null);
-
-  const [isPendingRefetch, startRefetchTransition] = useTransition();
-  const [fetchKey, setFetchKey] = useState(0);
 
   const deployment = useFragment(
     graphql`
@@ -76,15 +63,6 @@ const DeploymentAutoScalingTab: React.FC<DeploymentAutoScalingTabProps> = ({
   const isOwnedByCurrentUser =
     !creatorEmail || creatorEmail === currentUser.email;
 
-  const isAddDisabled =
-    isDeploymentInStoppedCategory(status) || !isOwnedByCurrentUser;
-
-  const handleRefetch = () => {
-    startRefetchTransition(() => {
-      setFetchKey((k) => k + 1);
-    });
-  };
-
   return (
     <BAICard
       title={
@@ -97,34 +75,13 @@ const DeploymentAutoScalingTab: React.FC<DeploymentAutoScalingTabProps> = ({
           </Tooltip>
         </BAIFlex>
       }
-      extra={
-        <BAIFlex gap="xs" align="center">
-          <BAIFetchKeyButton
-            loading={isPendingRefetch}
-            value=""
-            onChange={handleRefetch}
-          />
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            disabled={isAddDisabled}
-            onClick={() => autoScalingRef.current?.openAddModal()}
-          >
-            {t('modelService.AddRules')}
-          </Button>
-        </BAIFlex>
-      }
       styles={{ body: { paddingTop: 0 } }}
     >
       <Suspense fallback={<Skeleton active />}>
         <AutoScalingRuleList
-          ref={autoScalingRef}
           deploymentId={deployment.id}
           isEndpointDestroying={isDeploymentInStoppedCategory(status)}
           isOwnedByCurrentUser={isOwnedByCurrentUser}
-          fetchKey={String(fetchKey)}
-          hideInlineAddButton
-          hideInlineRefreshButton
         />
       </Suspense>
     </BAICard>

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -38,6 +38,7 @@ import {
   Skeleton,
   Space,
   Typography,
+  theme,
 } from 'antd';
 import {
   BAIButton,
@@ -241,6 +242,7 @@ const DeploymentConfigurationSection: React.FC<
   'use memo';
 
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const webuiNavigate = useWebUINavigate();
@@ -460,32 +462,6 @@ const DeploymentConfigurationSection: React.FC<
           }
         />
       </BAICard>
-      {isDeployingDifferentRevision && (
-        <Alert
-          type="info"
-          icon={<LoadingOutlined spin />}
-          showIcon
-          title={t('deployment.ApplyingRevision', {
-            revisionNumber:
-              deployingRevision.revisionNumber != null
-                ? `#${deployingRevision.revisionNumber}`
-                : (toLocalId(deployingRevision.id) ?? ''),
-          })}
-          action={
-            <Button
-              onClick={() =>
-                handleShowRevisionDrawer(
-                  deployingRevision,
-                  'deploying',
-                  t('deployment.ApplyingRevisionDetail'),
-                )
-              }
-            >
-              {t('deployment.ViewRevision')}
-            </Button>
-          }
-        />
-      )}
       <BAICard
         ref={revisionCardRef}
         activeTabKey={activeRevisionTab}
@@ -528,17 +504,44 @@ const DeploymentConfigurationSection: React.FC<
       >
         {activeRevisionTab === 'currentRevision' && (
           <>
+            {isDeployingDifferentRevision && (
+              <Alert
+                type="info"
+                icon={<LoadingOutlined spin />}
+                showIcon
+                style={{ marginBottom: token.marginMD }}
+                title={t('deployment.ApplyingRevision', {
+                  revisionNumber:
+                    deployingRevision.revisionNumber != null
+                      ? `#${deployingRevision.revisionNumber}`
+                      : (toLocalId(deployingRevision.id) ?? ''),
+                })}
+                action={
+                  <Button
+                    onClick={() =>
+                      handleShowRevisionDrawer(
+                        deployingRevision,
+                        'deploying',
+                        t('deployment.ApplyingRevisionDetail'),
+                      )
+                    }
+                  >
+                    {t('deployment.ViewRevision')}
+                  </Button>
+                }
+              />
+            )}
             {currentRevision ? (
               <DeploymentRevisionDetail
                 revisionFrgmt={currentRevision}
                 status="current"
               />
-            ) : isDeployingDifferentRevision ? null : (
+            ) : !isDeployingDifferentRevision ? (
               <Empty
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
                 description={t('deployment.NoCurrentRevisionDeployed')}
               />
-            )}
+            ) : null}
           </>
         )}
         {activeRevisionTab === 'revisionHistory' && deployment && (

--- a/react/src/components/DeploymentRevisionDetail.tsx
+++ b/react/src/components/DeploymentRevisionDetail.tsx
@@ -19,7 +19,6 @@ import {
   BAIText,
   filterOutEmpty,
   filterOutNullAndUndefined,
-  toLocalId,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import React from 'react';
@@ -202,6 +201,7 @@ const DeploymentRevisionDetail: React.FC<{
       : {
           key: 'revision-number',
           label: t('deployment.RevisionNumber'),
+          span: screens.md ? 2 : 1,
           children:
             revision.revisionNumber != null ? (
               <BAIText>{`#${revision.revisionNumber}`}</BAIText>
@@ -212,9 +212,10 @@ const DeploymentRevisionDetail: React.FC<{
     !mergeRevisionInfo && {
       key: 'revision-id',
       label: t('modelService.RevisionID'),
+      span: screens.md ? 2 : 1,
       children: revision.id ? (
         <BAIFlex gap="xs" align="center">
-          <BAIText copyable>{toLocalId(revision.id)}</BAIText>
+          <BAIId globalId={revision.id} style={{ maxWidth: '100%' }} />
           {status === 'current' && (
             <BAITag color="success">{t('deployment.Current')}</BAITag>
           )}

--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -19,7 +19,15 @@ import {
   MoreOutlined,
   PlayCircleOutlined,
 } from '@ant-design/icons';
-import { App, Dropdown, Popconfirm, Space, theme, Typography } from 'antd';
+import {
+  App,
+  Dropdown,
+  Modal,
+  Popconfirm,
+  Space,
+  theme,
+  Typography,
+} from 'antd';
 import {
   type BAIColumnType,
   BAIButton,
@@ -50,7 +58,7 @@ import {
   parseAsStringLiteral,
   useQueryStates,
 } from 'nuqs';
-import React, { useState, useTransition } from 'react';
+import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   graphql,
@@ -393,7 +401,7 @@ const DeploymentRevisionHistoryTab: React.FC<
         return (
           <BAINameActionCell
             title={
-              <BAIFlex gap="xs" align="center">
+              <BAIFlex gap="xs" align="center" wrap="nowrap">
                 <Typography.Link
                   onClick={() =>
                     setDrawerRevision({
@@ -431,6 +439,11 @@ const DeploymentRevisionHistoryTab: React.FC<
               </BAIFlex>
             }
             showActions="always"
+            // TODO: "AddNewRevisionFromThis" is currently the only menu item.
+            // The entire More button is disabled when stopped rather than
+            // per-item. When more menu items are added, switch to per-item
+            // disabled and remove moreMenuDisabled.
+            moreMenuDisabled={isDeploymentInStoppedCategory(deploymentStatus)}
             actions={[
               {
                 key: 'deploy',
@@ -458,6 +471,7 @@ const DeploymentRevisionHistoryTab: React.FC<
                 title: t('deployment.AddNewRevisionFromThis'),
                 icon: <CopyOutlined />,
                 showInMenu: 'always',
+                disabled: isDeploymentInStoppedCategory(deploymentStatus),
                 onClick: () => {
                   setSourceRevisionFrgmt(record);
                 },
@@ -651,6 +665,8 @@ const DeploymentRevisionHistoryTab: React.FC<
                         key: 'duplicate',
                         label: t('deployment.AddNewRevisionFromThis'),
                         icon: <CopyOutlined />,
+                        disabled:
+                          isDeploymentInStoppedCategory(deploymentStatus),
                         onClick: () => {
                           // Capture the fragment ref before closing the
                           // drawer so the source survives the drawer unmount.
@@ -662,10 +678,14 @@ const DeploymentRevisionHistoryTab: React.FC<
                     ],
                   }}
                 >
+                  {/* TODO: "AddNewRevisionFromThis" is the only menu item.
+                      Disable the entire button when stopped. When more items
+                      are added, disable per-item instead. */}
                   <BAIButton
                     type="primary"
                     icon={<MoreOutlined />}
                     aria-label={t('button.More')}
+                    disabled={isDeploymentInStoppedCategory(deploymentStatus)}
                   />
                 </Dropdown>
               </Space.Compact>
@@ -730,17 +750,31 @@ const DeploymentRevisionHistoryTab: React.FC<
           },
         }}
       />
-      <BAIUnmountAfterClose>
-        <DeploymentAddRevisionModal
-          open={!!sourceRevisionFrgmt}
-          deploymentFrgmt={deployment}
-          sourceRevisionFrgmt={sourceRevisionFrgmt}
-          onRequestClose={(success) => {
-            setSourceRevisionFrgmt(null);
-            if (success) handleRefresh();
-          }}
-        />
-      </BAIUnmountAfterClose>
+      <Suspense
+        // Render a loading modal shell while the modal's lazy chunks resolve,
+        // so the trigger click is visually acknowledged instead of producing a
+        // momentary no-op.
+        fallback={
+          <Modal
+            open={!!sourceRevisionFrgmt}
+            loading
+            footer={null}
+            onCancel={() => setSourceRevisionFrgmt(null)}
+          />
+        }
+      >
+        <BAIUnmountAfterClose>
+          <DeploymentAddRevisionModal
+            open={!!sourceRevisionFrgmt}
+            deploymentFrgmt={deployment}
+            sourceRevisionFrgmt={sourceRevisionFrgmt}
+            onRequestClose={(success) => {
+              setSourceRevisionFrgmt(null);
+              if (success) handleRefresh();
+            }}
+          />
+        </BAIUnmountAfterClose>
+      </Suspense>
     </>
   );
 };


### PR DESCRIPTION
Resolves #7601 (FR-2977)

> **Stacked on #7561 (FR-2957).** That PR adds the "Add new revision from this" entry, which is what surfaces the revision-detail drawer changes below.

## Summary

Follow-up polish for FR-2977 after #7602 + #7561, focused on the deployment detail page's revision area.

- **Move the "Applying revision #N" alert inside the Current Revision tab** (`DeploymentConfigurationSection`). Previously the alert sat at the deployment level between Basic Information and the revision tabs, so it was visible even on the Revision History tab where it had no context. It now lives inside the `currentRevision` tab content next to the revision detail it describes, with `marginBottom: token.marginMD` for separation from `DeploymentRevisionDetail`.
- **Show the full revision UUID in `DeploymentRevisionDetail`.** The drawer/Current-Revision view rendered the 36-char revision ID inside a 2-column 183px cell, which truncated it to ~12 visible chars even with a copy button. Both `revision-number` and `revision-id` items now use `span: screens.md ? 2 : 1`, so each occupies a dedicated full-width row in the 2-column Descriptions. `BAIId` is rendered with `style={{ maxWidth: 'none' }}` so it sits at its natural width — the copy icon stays directly next to the UUID, and the `Current` / `Applying` `BAITag` follows immediately after in the same `BAIFlex`.
- **Move the "Add Rules" button inline in `DeploymentAutoScalingTab`.** It used to live in the `BAICard extra` slot; it now sits inside `AutoScalingRuleList`'s toolbar to the right of the refresh button (the inline-add path the list already exposed via `hideInlineAddButton`). The card stops owning a primary button it didn't actually need.
- **Misc.** Wrap `DeploymentAddRevisionModal` in a `<Suspense fallback={null}>` inside `DeploymentRevisionHistoryTab` so the row-level "Add new revision from this" action doesn't suspend the whole page on first open.

## Test plan

- [x] Open a deployment with a deploying revision — verify the "Applying revision #N" alert appears inside the Current Revision tab (not above the tabs), and disappears when switching to Revision History.
- [x] Open a revision via the Revision History row link — drawer shows `Revision Number` on one full-width row and `Revision ID <uuid> [copy] [Current|Applying]` on the next, full UUID visible, copy icon adjacent to the UUID.
- [x] On the Current Revision tab — same layout; `Current` tag visible next to the copy icon.
- [x] Auto-Scaling tab — "Add Rules" button sits to the right of the refresh button (inline), and is not duplicated in `BAICard extra`.
- [x] `bash scripts/verify.sh` — TypeScript, Relay, Lint, Format all pass.
