### PR TITLE
fix(FR-2994): repair broken E2E tests for Storage (VFolder)

### DIFF
--- a/e2e/utils/classes/vfolder/FolderCreationModal.ts
+++ b/e2e/utils/classes/vfolder/FolderCreationModal.ts
@@ -156,7 +156,31 @@ export class FolderCreationModal {
     });
   }
 
+  /**
+   * Close any persistent antd notifications that may overlap the modal footer
+   * buttons (e.g. the "Click to check pending invitation(s)" notification that
+   * is rendered with duration=0 and never auto-dismisses). Without dismissing
+   * these, Playwright cannot click the Create button because the notification
+   * subtree intercepts pointer events.
+   */
+  async dismissOverlappingNotifications(): Promise<void> {
+    const notifications = this.page.locator('.ant-notification-notice');
+    // Closing a notification removes it from the DOM and shifts the remaining
+    // notices up, so iterating by a snapshotted index skips entries. Always
+    // close the first remaining notice and wait for it to detach.
+    for (let safety = 0; safety < 20; safety++) {
+      const first = notifications.first();
+      const closeBtn = first.locator('.ant-notification-notice-close');
+      const isVisible = await closeBtn.isVisible().catch(() => false);
+      if (!isVisible) return;
+      await closeBtn.click().catch(() => {});
+      await first.waitFor({ state: 'detached', timeout: 2000 }).catch(() => {});
+    }
+  }
+
   async getCreateButton(): Promise<Locator> {
+    // Dismiss any persistent notifications that could block the footer buttons
+    await this.dismissOverlappingNotifications();
     const createButton = this.modal.getByTestId('create-folder-button');
     await expect(createButton).toBeVisible();
     return createButton;

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -504,7 +504,22 @@ export async function moveToTrashAndVerify(
     .locator('.ant-modal-confirm')
     .getByRole('button', { name: 'Confirm' });
   await expect(confirmButton).toBeVisible();
+  // Wait for the DELETE /folders API response before navigating away.
+  // Without this, page.goto() in verifyVFolder would cancel the in-flight
+  // request and the folder would never move to Trash.
+  const deletionResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes('/folders') &&
+      response.request().method() === 'DELETE',
+    { timeout: 30000 },
+  );
   await confirmButton.click();
+  const deletionResponse = await deletionResponsePromise;
+  if (!deletionResponse.ok()) {
+    throw new Error(
+      `DELETE /folders returned ${deletionResponse.status()}: ${await deletionResponse.text()}`,
+    );
+  }
   await removeSearchButton(page, folderName);
   await verifyVFolder(page, folderName, 'Trash', dataPath);
 }
@@ -547,6 +562,17 @@ export async function deleteForeverAndVerifyFromTrash(
   await confirmInput.fill(folderName);
   await page.getByRole('button', { name: 'Delete forever' }).click();
 
+  // Wait for the deletion success notification to appear.
+  // This confirms the backend accepted the delete request.
+  // i18n key: data.folders.FolderDeletedForever → "Permanently deleted the ... folder."
+  // antd 6 message.success() renders a plain <div> (no ARIA role="alert"),
+  // so we use a text-based locator scoped to the antd message container.
+  const deletionNotification = page
+    .locator('.ant-message-notice')
+    .filter({ hasText: /permanently deleted/i });
+  await expect(deletionNotification).toBeVisible({ timeout: 15000 });
+  await expect(deletionNotification).toBeHidden({ timeout: 15000 });
+
   // After the "Delete forever" button is clicked, wait for the folder to
   // disappear from the Trash tab. The success toast is too transient to assert
   // reliably; the row-gone check is the authoritative signal that the deletion
@@ -584,7 +610,24 @@ export async function shareVFolderAndVerify(
   const shareModal = page.locator('.ant-modal');
   await expect(shareModal).toBeVisible();
   await shareModal.getByRole('textbox').fill(invitedUser);
+
+  // Set up the response promise before clicking Add to avoid a race condition
+  // where the response fires before we start listening.
+  // URL pattern: POST /folders/{id}/invite → 200 or 201
+  const inviteResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes('/invite') &&
+      response.request().method() === 'POST',
+    { timeout: 15000 },
+  );
   await shareModal.getByRole('button', { name: 'Add' }).click();
+  const inviteResponse = await inviteResponsePromise;
+  if (!inviteResponse.ok()) {
+    throw new Error(
+      `POST /folders/.../invite returned ${inviteResponse.status()}: ${await inviteResponse.text()}`,
+    );
+  }
+
   await shareModal.getByRole('button', { name: 'close' }).click();
 
   await removeSearchButton(page, folderName);
@@ -666,28 +709,61 @@ export async function acceptAllInvitationAndVerifySpecificFolder(
     const visible = await acceptButton
       .isVisible({ timeout: 1000 })
       .catch(() => false);
-    if (!visible) break;
-    await acceptButton.click({ force: true }).catch(() => {});
-    await page.waitForTimeout(800);
+
+    if (!isItemVisible) {
+      // Invitation not yet in the list; retry immediately. The
+      // `waitFor({ timeout: 8000 })` above already covers propagation delay.
+      continue;
+    }
+
+    // Click the Accept button inside this specific invitation item.
+    // Scoping to the item avoids accidentally accepting a stale invitation
+    // for a different folder (e.g., leftovers from previous failed test runs).
+    const acceptBtn = invitationItem.getByRole('button', { name: /^Accept$/i });
+    await expect(acceptBtn).toBeVisible({ timeout: 5000 });
+
+    const acceptResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/invitations/accept') &&
+        response.request().method() === 'POST',
+      { timeout: 10000 },
+    );
+    await acceptBtn.click();
+    const acceptResponse = await acceptResponsePromise.catch(() => null);
+    if (acceptResponse && !acceptResponse.ok()) {
+      const body = await acceptResponse.text().catch(() => '<unreadable>');
+      throw new Error(
+        `POST /invitations/accept returned HTTP ${acceptResponse.status()} — ` +
+          `folder "${folderName}" invitation acceptance failed.\nResponse body: ${body}`,
+      );
+    }
+
+    // Wait for the invitation item to be removed from the modal list (success).
+    // If it stays visible (error case), we'll still proceed and verify.
+    await invitationItem
+      .waitFor({ state: 'detached', timeout: 8000 })
+      .catch(() => {});
+
+    folderInvitationAccepted = true;
+    break;
   }
 
-  // Close the modal if still open
+  if (!folderInvitationAccepted) {
+    throw new Error(
+      `Invitation for folder "${folderName}" not found in modal after 5 attempts.`,
+    );
+  }
+
+  // Close the modal if still open.
   await page
     .locator('.ant-modal')
-    .getByRole('button', { name: /close|Cancel/i })
+    .getByRole('button', { name: /close/i })
     .first()
-    .click({ timeout: 2000 })
+    .click()
     .catch(() => {});
 
-  // Verify the shared folder appears in the user's data page
-  await navigateTo(page, 'data');
-  await page.getByRole('tab', { name: 'Active' }).click();
-  await selectPropertyFilter(page, 'Name', folderName);
-  // Shared folders appear as a row in the table - look for the folder name in any table cell
-  await expect(
-    page.locator('tbody tr').filter({ hasText: folderName }),
-  ).toBeVisible({ timeout: 15000 });
-  await removeSearchButton(page, folderName);
+  // Verify the shared folder now appears in the user's Active data page.
+  await verifyVFolder(page, folderName, 'Active');
 }
 
 export async function restoreVFolderAndVerify(page: Page, folderName: string) {

--- a/e2e/vfolder/file-upload-subdirectory.spec.ts
+++ b/e2e/vfolder/file-upload-subdirectory.spec.ts
@@ -117,13 +117,27 @@ test.describe.serial(
       // Verify the subfolder appears in the file table (this implicitly waits for folder creation)
       await modal.verifyFileVisible(subfolderName);
 
-      // 5. Navigate into the newly created folder (click folder name)
-      await page.getByRole('cell', { name: subfolderName }).first().click();
+      // 5. Navigate into the newly created folder by clicking the folder name link
+      // inside the Name cell. Clicking the cell itself only triggers row selection
+      // (onRow handler); the actual navigation is on the Typography.Text element
+      // wrapping the folder icon + name (BAIFileExplorer's onClick handler).
+      const folderNameCell = page
+        .getByRole('dialog')
+        .first()
+        .getByRole('cell')
+        .filter({ hasText: subfolderName })
+        .first();
+      await expect(folderNameCell).toBeVisible({ timeout: 10000 });
+      await folderNameCell.getByText(subfolderName).click();
 
       // 6. Verify breadcrumb shows the subdirectory path (waits for navigation)
       await expect(
-        page.locator('.ant-breadcrumb').getByText(subfolderName),
-      ).toBeVisible();
+        page
+          .getByRole('dialog')
+          .first()
+          .locator('.ant-breadcrumb')
+          .getByText(subfolderName),
+      ).toBeVisible({ timeout: 10000 });
 
       // 7. Upload a file via Upload button
       const uploadButton = await modal.getUploadButton();
@@ -141,8 +155,12 @@ test.describe.serial(
       await modal.verifyFileVisible(fileName);
 
       // 9. Navigate back to root (click home in breadcrumb)
-      // The breadcrumb has a home icon at the beginning
-      const breadcrumb = page.locator('.ant-breadcrumb');
+      // The breadcrumb has a home icon at the beginning; scope to the dialog
+      // to avoid matching the page-level breadcrumb.
+      const breadcrumb = page
+        .getByRole('dialog')
+        .first()
+        .locator('.ant-breadcrumb');
       await breadcrumb.locator('a').first().click();
 
       // 10. Verify navigation back to root by checking subfolder is visible again

--- a/e2e/vfolder/vfolder-type-selection.spec.ts
+++ b/e2e/vfolder/vfolder-type-selection.spec.ts
@@ -4,15 +4,38 @@ import {
   loginAsAdmin,
   loginAsUser,
   moveToTrashAndVerify,
+  navigateTo,
 } from '../utils/test-util';
 import { test, expect, Page } from '@playwright/test';
 
 /**
- * Navigate to the Data page and open the Create Folder modal.
+ * Navigate to the regular Data page and open the Create Folder modal.
+ * Used by user-role tests where only the User-type radio should be visible.
  */
 async function openCreateFolderModal(page: Page): Promise<FolderCreationModal> {
   await page.getByRole('link', { name: 'Data' }).click();
-  await page.getByRole('button', { name: 'Create Folder' }).nth(1).click();
+  await page.getByRole('button', { name: 'Create Folder' }).first().click();
+  const modal = new FolderCreationModal(page);
+  await modal.modalToBeVisible();
+  return modal;
+}
+
+/**
+ * Navigate to the Project Admin Data page (/project-data) and open the Create
+ * Folder modal. This page uses folderType="project" which renders both the User
+ * and Project type radios, making it the correct page for admin Project-type
+ * vfolder tests.
+ *
+ * Note: On the /data page (VFolderNodeListPage), allowCreateProjectFolder is
+ * false (default), so the Project radio never renders — even for admin users.
+ * The /project-data page (ProjectAdminDataPage) uses folderType="project" which
+ * satisfies the rendering condition in FolderCreateModalV2.
+ */
+async function openCreateFolderModalAsAdmin(
+  page: Page,
+): Promise<FolderCreationModal> {
+  await navigateTo(page, 'project-data');
+  await page.getByRole('button', { name: 'Create Folder' }).first().click();
   const modal = new FolderCreationModal(page);
   await modal.modalToBeVisible();
   return modal;
@@ -60,15 +83,20 @@ test.describe(
 
       test.afterEach(async ({ page }) => {
         try {
-          await moveToTrashAndVerify(page, folderName);
-          await deleteForeverAndVerifyFromTrash(page, folderName);
+          // Project-type folders are only visible on /project-data, not on /data.
+          await moveToTrashAndVerify(page, folderName, 'project-data');
+          await deleteForeverAndVerifyFromTrash(
+            page,
+            folderName,
+            'project-data',
+          );
         } catch {
           // Folder may not exist if test was skipped or creation failed
         }
       });
 
       test('Admin can create a Project-type vfolder', async ({ page }) => {
-        const modal = await openCreateFolderModal(page);
+        const modal = await openCreateFolderModalAsAdmin(page);
         await modal.fillFolderName(folderName);
 
         // Project-type radio should be visible for admin
@@ -95,7 +123,7 @@ test.describe(
       test.beforeEach(async ({ page, request }, testInfo) => {
         folderName = `e2e-test-disabled-project-type-${Date.now()}-${testInfo.workerIndex}`;
         await loginAsAdmin(page, request);
-        await openCreateFolderModal(page);
+        await openCreateFolderModalAsAdmin(page);
       });
 
       test.afterEach(async ({ page }) => {
@@ -157,6 +185,19 @@ test.describe(
       test('Project radio is disabled when usage mode is automount', async ({
         page,
       }) => {
+        // The Project-type radio is only exposed via the /project-data page
+        // (ProjectAdminDataPage with folderType="project"). On that page the
+        // Auto Mount usage-mode radio is itself disabled (folderType="project"
+        // disables it in FolderCreateModalV2), so we cannot drive the UI into
+        // the automount state to verify this interaction. There is no other
+        // page in the current app where both the Project radio is visible and
+        // the automount radio is selectable.
+        test.fixme(
+          true,
+          'Automount radio is disabled on /project-data (folderType="project"), ' +
+            'preventing selection needed to assert project-radio disabled state.',
+        );
+
         const modal = new FolderCreationModal(page);
         await modal.modalToBeVisible();
         await modal.fillFolderName(folderName);
@@ -225,7 +266,7 @@ test.describe(
         request,
       }) => {
         await loginAsAdmin(page, request);
-        const modal = await openCreateFolderModal(page);
+        const modal = await openCreateFolderModalAsAdmin(page);
 
         // Both type radios should be visible for admin
         const userTypeRadio = await modal.getUserTypeRadio();


### PR DESCRIPTION
Resolves #7629 (FR-2994)

**Stacked on**: #7653 (FR-2993 — Compute & Sessions) → #7652 (FR-2992 — Auth & Identity)

Part of FR-2059 (Fix Broken E2E Tests Cases). Repairs the Storage (VFolder) sub-category — 22 failing tests across 10 spec files now pass (35 / 0 / 5 — 5 skipped are intentional `test.skip` / `test.fixme` for structurally-impossible scenarios).

## Summary

Initial baseline → final: **0 pass / 22 fail / 14 did-not-run / 4 skip** → **35 pass / 0 fail / 0 did-not-run / 5 skip**

The work was iterative — each fix layer revealed the next root cause. Progress milestones:

| Milestone | Passed |
|---|---|
| Initial run | 0 |
| Shared `Create Folder` helper fix | 1 |
| Backend project assignment | 16 |
| Notification locator (antd 6 `.ant-message-notice`) | 28 |
| Project-radio test navigation helper | 32 |
| Popconfirm + sharing helper | 32 (+ 1 fixme) |
| Pending-invitation overlay + sharing backend backfill | **35** |

## Root causes addressed (test-side)

- **`.nth(1)` Create Folder selector is stale** — `VFolderNodeListPage` was refactored to expose exactly one "Create Folder" button. Switched to `.first()` in `test-util.ts:444` and the local helpers in `vfolder-type-selection.spec.ts:15` and `vfolder-crud.spec.ts:29, 104`.

- **`moveToTrashAndVerify` race condition** — Added `waitForResponse('**/folders', DELETE)` + status check before continuing, so a follow-up `page.goto` cannot cancel the in-flight delete request and orphan the folder. Throws with the response body on non-2xx for clearer diagnostics.

- **antd 6 `message.success` notification locator** — `@rc-component/notification` no longer emits `role="alert"`. Switched from `getByRole('alert')` to `.locator('.ant-message-notice')`. Also updated the regex to match the new i18n string `data.folders.FolderDeletedForever = "Permanently deleted the ... folder."`.

- **Project-type radio gating** — In `FolderCreateModalV2`, the Project radio only renders when the page passes `folderType="project"` (or `model_project`) AND the user has admin role AND `'group'` is in `allowedTypes`. The 5 admin Project-radio tests navigated to `/data` (regular page, no `folderType` prop) instead of `/project-data`. Added `openCreateFolderModalAsAdmin()` helper that navigates to `/project-data`. One structurally impossible test (Project radio + Auto Mount simultaneously) is `test.fixme()`'d — the only page exposing the Project radio also force-disables Auto Mount in the modal.

- **Popconfirm in `restoreVFolderAndVerify`** — The restore action goes through an antd `Popconfirm` that must be explicitly confirmed; restore was being triggered without confirmation. Added the Confirm click + `waitForResponse` for `POST /restore` + success-notification wait.

- **Pending-invitation notification blocks Create button** — `StartPage` upserts a persistent notification (`"Click to check pending N invitation(s)"`) with `duration: 0` whenever the user has open vfolder invitations. The notification subtree in the bottom-right overlapped the Create modal's footer Create button, making Playwright's click retry until test timeout. Added `dismissOverlappingNotifications()` in `FolderCreationModal` and call it inside `getCreateButton()` so all callers benefit automatically.

- **Subdirectory navigation in file explorer** — `BAIFileExplorer` has two click handlers on each row (row-select via `onRow`, navigate-down via the `EditableFileName` onClick which calls `stopPropagation`). Clicking the generic cell triggered only the row-select handler. Switched the navigation click in `file-upload-subdirectory` to target the folder name text element specifically, and scoped the breadcrumb assertions to the dialog to avoid matching the page-level breadcrumb.

## Root causes addressed (backend side — fixed by reviewer separately)

These were not test bugs and required backend/data changes. They are listed here because surfacing them through these tests was load-bearing.

- **Admin / regular user had no project assignment on the test backend** — this caused `SessionLauncherPage` to crash with `BAIErrorBoundary` (see FR-2993 PR description for full mechanism). Indirectly affected vfolder tests via project-context queries.

- **New RBAC system requires explicit `soft-delete` permission per VFolder** — without it, the folder owner cannot move their own folder to Trash (`DELETE /folders` → 403). Backend granted the permission so the test user can soft-delete owned folders.

- **`user2@lablup.com` was missing a `user_roles` row** — caused `POST /folders/invitations/accept` to return 404 `"No such user system role. (009fb1a4-...)"`. Backend backfilled the user2 role mapping so invitation acceptance works.

## Files changed

- `e2e/utils/test-util.ts` — `.first()` for Create Folder, `waitForResponse` for DELETE/restore, `.ant-message-notice` notification locator, response-body in 4xx error messages
- `e2e/utils/classes/vfolder/FolderCreationModal.ts` — `dismissOverlappingNotifications()` in `getCreateButton()`
- `e2e/vfolder/vfolder-type-selection.spec.ts` — `openCreateFolderModalAsAdmin()` helper, navigation to `/project-data`, `test.fixme` for the structurally-impossible scenario
- `e2e/vfolder/vfolder-crud.spec.ts` — `.first()` for Create Folder (×2 beforeEach blocks); restore Popconfirm fix lives in `test-util.ts`
- `e2e/vfolder/file-upload-subdirectory.spec.ts` — click `getByText(subfolderName)` instead of generic cell; scope breadcrumb to dialog

## Test plan

- [x] `pnpm exec playwright test e2e/vfolder/ --workers=2` — 35 pass / 0 fail / 5 skip
- [x] All 10 spec files run cleanly individually and in the full suite
- [x] No `networkidle` waits or fallback logic introduced
- [x] Skipped tests have explicit `test.skip(...)` / `test.fixme(...)` annotations with reason comments


## Test Recordings

### `e2e/vfolder/file-upload-subdirectory.spec.ts`

| Test | Recording |
|------|-----------|
| User can upload a file to a subdirectory | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092506-file-upload-subdir-user-can-upload-to-subdirectory.webm" controls width="960"></video> |

### `e2e/vfolder/vfolder-crud.spec.ts`

| Test | Recording |
|------|-----------|
| User can create a vFolder by selecting a specific location | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092517-vfolder-crud-create-specific-location.webm" controls width="960"></video> |
| User can create default vFolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092527-vfolder-crud-create-default.webm" controls width="960"></video> |
| User can create Model vFolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092536-vfolder-crud-create-model.webm" controls width="960"></video> |
| User can create cloneable Model vFolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092547-vfolder-crud-create-cloneable-model.webm" controls width="960"></video> |
| User can create Read & Write vFolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092558-vfolder-crud-create-read-write.webm" controls width="960"></video> |
| User can create Read Only vFolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092609-vfolder-crud-create-read-only.webm" controls width="960"></video> |
| User can create Auto Mount vFolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092620-vfolder-crud-create-auto-mount.webm" controls width="960"></video> |
| User can create, delete (move to trash), restore, delete forever vFolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092631-vfolder-crud-trash-restore-delete-forever.webm" controls width="960"></video> |
| User can share vFolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092642-vfolder-crud-sharing.webm" controls width="960"></video> |

### `e2e/vfolder/vfolder-type-selection.spec.ts`

| Test | Recording |
|------|-----------|
| User can create a User-type vfolder with default selection | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092653-vfolder-type-user-default-selection.webm" controls width="960"></video> |
| Admin can create a Project-type vfolder | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092704-vfolder-type-admin-create-project.webm" controls width="960"></video> |
| Project radio is disabled when usage mode is model (non-model-store project) | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092714-vfolder-type-project-radio-disabled-non-model-store.webm" controls width="960"></video> |
| Project radio is enabled when usage mode is general | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092724-vfolder-type-project-radio-enabled-general.webm" controls width="960"></video> |
| Regular user sees only User-type radio (no Project radio) | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092734-vfolder-type-regular-user-no-project-radio.webm" controls width="960"></video> |
| Admin sees both User-type and Project-type radios | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7676/20260605-092743-vfolder-type-admin-sees-both-radios.webm" controls width="960"></video> |
