### PR TITLE
fix(FR-3022): use toLocalId instead of convertToUUID on new VFolder result.id

### DIFF
--- a/react/src/components/AdminModelCardSettingModal.tsx
+++ b/react/src/components/AdminModelCardSettingModal.tsx
@@ -30,7 +30,6 @@ import {
   BAIModal,
   BAIVFolderSelect,
   BAIVFolderSelectRef,
-  convertToUUID,
   toGlobalId,
   toLocalId,
   useBAILogger,
@@ -533,10 +532,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
           setIsOpenCreateFolderModal(false);
           if (result) {
             formRef.current?.setFieldsValue({
-              vfolderId: toGlobalId(
-                'VirtualFolderNode',
-                convertToUUID(result.id),
-              ),
+              vfolderId: toGlobalId('VirtualFolderNode', toLocalId(result.id)),
             });
             vfolderSelectRef.current?.refetch();
           }


### PR DESCRIPTION
Resolves #7680 (FR-3022)

## Summary

When an admin creates a new VFolder inline via the `+` button in `AdminModelCardSettingModal` (which opens `FolderCreateModalV2`), the `onRequestClose` callback receives a `result` whose `result.id` is a Relay **Globally Unique ID** (base64-encoded `VFolder:uuid`).

The previous code passed it through `convertToUUID`, which only normalizes a 32-char hex sequence into dash-separated UUID format — it does **not** decode base64. On a base64 GlobalID it fails the regex and returns the GlobalID untouched, which then gets re-wrapped by `toGlobalId`, producing a doubly-encoded value the backend rejects.

This swaps `convertToUUID` for `toLocalId` (`atob(globalId).split(':')?.[1]`), which correctly decodes the GlobalID — matching the convention already used elsewhere in the same file (`toLocalId(modelCard.id)`, `toLocalId(values.vfolderId)`).

## Changes

- `react/src/components/AdminModelCardSettingModal.tsx`: `convertToUUID(result.id)` → `toLocalId(result.id)`; dropped the now-unused `convertToUUID` import.

## Impact

Only affects the admin inline-create-VFolder path (open Model Card Setting modal → create new VFolder via `+` → submit). The dropdown-select path was unaffected. Discovered while healing `e2e/admin-model-card/` tests for FR-2995; once this lands, the `createNewFolderViaPlus` POM workaround in #7679 can be removed.

## Verification

`scripts/verify.sh` — Relay, Lint, Format, TypeScript all PASS. (The "Vite warmup paths" check fails identically on a clean `main` checkout — a pre-existing environmental issue unrelated to this change.)