### PR TITLE
feat(FR-3024): expose new adminUsersV2 filters in super-admin user list

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1883,6 +1883,48 @@ type BulkAddRolePermissionFailureInfo
 }
 
 """
+Added in UNRELEASED. Failure detail for a single permission entry in a bulk add operation.
+"""
+type BulkAddRolePermissionPresetFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """Entity type of the permission entry that failed."""
+  entityType: RBACElementType!
+
+  """Operation of the permission entry that failed."""
+  operation: OperationType!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Input for bulk-adding permission entries to an existing role preset.
+"""
+input BulkAddRolePermissionPresetsInput
+  @join__type(graph: STRAWBERRY)
+{
+  """ID of the role preset to add permissions to."""
+  rolePresetId: ID!
+
+  """Permission entries to insert. Duplicates are surfaced as failures."""
+  permissions: [RolePermissionPresetEntryInput!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-adding permission entries to a role preset.
+"""
+type BulkAddRolePermissionPresetsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission entries that were added."""
+  items: [RolePermissionPreset!]!
+
+  """Permission entries that failed to be added (e.g., duplicates)."""
+  failed: [BulkAddRolePermissionPresetFailureInfo!]!
+}
+
+"""
 Added in UNRELEASED. Input for bulk-inserting scoped permissions across one or more roles
 """
 input BulkAddRolePermissionsInput
@@ -1935,12 +1977,27 @@ type BulkAssignRolePayload
   failed: [BulkAssignRoleError!]!
 }
 
-"""Added in 26.2.0. Payload for bulk user creation mutation."""
+"""
+Added in 26.2.0. Payload for bulk user creation mutation. Deprecated since 26.4.4.
+"""
 type BulkCreateUsersV2Payload
   @join__type(graph: STRAWBERRY)
 {
   """List of successfully created users."""
   createdUsers: [UserV2!]!
+
+  """List of errors for users that failed to create."""
+  failed: [BulkCreateUserV2Error!]!
+}
+
+"""
+Added in UNRELEASED. Payload for bulk user creation, including each user's generated keypair.
+"""
+type BulkCreateUsersWithKeypairV2Payload
+  @join__type(graph: STRAWBERRY)
+{
+  """List of successfully created users with their generated keypairs."""
+  created: [CreateUserV2Payload!]!
 
   """List of errors for users that failed to create."""
   failed: [BulkCreateUserV2Error!]!
@@ -2008,6 +2065,27 @@ type BulkDeleteModelCardV2Error
   message: String!
 }
 
+"""Added in UNRELEASED. Input for bulk-soft-deleting role presets."""
+input BulkDeleteRolePresetsInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset UUIDs to soft-delete."""
+  rolePresetIds: [ID!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-soft-deleting role presets.
+"""
+type BulkDeleteRolePresetsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Role presets that were soft-deleted."""
+  items: [RolePreset!]!
+
+  """Role preset IDs that failed to soft-delete."""
+  failed: [BulkRolePresetFailureInfo!]!
+}
+
 """Added in 26.4.2. Input for soft-deleting multiple virtual folders."""
 input BulkDeleteVFoldersV2Input
   @join__type(graph: STRAWBERRY)
@@ -2022,6 +2100,27 @@ type BulkDeleteVFoldersV2Payload
 {
   """Number of virtual folders successfully soft-deleted."""
   deletedCount: Int!
+}
+
+"""Added in UNRELEASED. Input for bulk-hard-deleting role presets."""
+input BulkPurgeRolePresetsInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset UUIDs to purge."""
+  rolePresetIds: [ID!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-hard-deleting role presets.
+"""
+type BulkPurgeRolePresetsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Role presets that were purged."""
+  items: [RolePreset!]!
+
+  """Role preset IDs that failed to purge."""
+  failed: [BulkRolePresetFailureInfo!]!
 }
 
 """
@@ -2125,6 +2224,29 @@ type BulkRemoveRolePermissionFailureInfo
 }
 
 """
+Added in UNRELEASED. Input for bulk-removing permission entries from a role preset.
+"""
+input BulkRemoveRolePermissionPresetsInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission entry row IDs to delete."""
+  permissionPresetIds: [ID!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-removing permission entries from a role preset.
+"""
+type BulkRemoveRolePermissionPresetsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Permission entries that were removed."""
+  items: [RolePermissionPreset!]!
+
+  """Permission entry IDs that failed to delete."""
+  failed: [BulkRolePermissionPresetFailureInfo!]!
+}
+
+"""
 Added in UNRELEASED. Input for bulk-deleting permission rows by primary key
 """
 input BulkRemoveRolePermissionsInput
@@ -2142,6 +2264,29 @@ type BulkRemoveRolePermissionsPayload
 
   """Permission IDs that failed to delete"""
   failed: [BulkRemoveRolePermissionFailureInfo!]!
+}
+
+"""
+Added in UNRELEASED. Input for bulk-restoring soft-deleted role presets.
+"""
+input BulkRestoreRolePresetsInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset UUIDs to restore."""
+  rolePresetIds: [ID!]!
+}
+
+"""
+Added in UNRELEASED. Payload returned after bulk-restoring soft-deleted role presets.
+"""
+type BulkRestoreRolePresetsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Role presets that were restored."""
+  items: [RolePreset!]!
+
+  """Role preset IDs that failed to restore."""
+  failed: [BulkRolePresetFailureInfo!]!
 }
 
 """
@@ -2174,6 +2319,32 @@ type BulkRevokeRolePayload
 
   """Users that failed to be revoked"""
   failed: [BulkRevokeRoleError!]!
+}
+
+"""
+Added in UNRELEASED. Failure detail for a single permission entry in a bulk operation.
+"""
+type BulkRolePermissionPresetFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """role_permission_presets row ID that the operation failed on."""
+  permissionPresetId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
+"""
+Added in UNRELEASED. Failure detail for a single role preset ID in a bulk operation.
+"""
+type BulkRolePresetFailureInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset ID that the operation failed on."""
+  rolePresetId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
 }
 
 """Added in 26.3.0. Payload for bulk user update mutation."""
@@ -3422,6 +3593,21 @@ type CreateKeyPair
   keypair: KeyPair
 }
 
+"""
+Added in UNRELEASED. A keypair returned at creation time, including its one-time secret key.
+"""
+type CreateKeypairPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The newly created keypair."""
+  keypair: KeyPairGQL!
+
+  """
+  The secret key of the generated keypair. Only returned at creation time.
+  """
+  secretKey: String!
+}
+
 type CreateKeyPairResourcePolicy
   @join__type(graph: GRAPHENE)
 {
@@ -3891,6 +4077,11 @@ input CreateRoleInput
   name: String!
   description: String = null
   source: RoleSource! = CUSTOM
+
+  """
+  Added in UNRELEASED. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean! = false
   scopes: [ScopeInput!] = null
 }
 
@@ -3908,6 +4099,33 @@ type CreateRoleInvitationPayload
 {
   """List of created role invitations."""
   items: [RoleInvitation!]!
+}
+
+"""Added in UNRELEASED. Input for creating a new role preset."""
+input CreateRolePresetInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset name."""
+  name: String!
+
+  """Scope type this preset targets (e.g., domain, project)."""
+  scopeType: RBACElementType!
+
+  """
+  Default value for the `auto_assign` flag on roles instantiated from this preset.
+  """
+  autoAssign: Boolean! = false
+
+  """Permission entries carried by the preset."""
+  permissions: [RolePermissionPresetEntryInput!]!
+}
+
+"""Added in UNRELEASED. Payload returned after creating a role preset."""
+type CreateRolePresetPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created role preset."""
+  rolePreset: RolePreset!
 }
 
 """Added in 26.4.2. Input for creating a runtime variant."""
@@ -4167,6 +4385,11 @@ type CreateUserV2Payload
 {
   """The newly created user."""
   user: UserV2!
+
+  """
+  The default keypair automatically generated for the user, including its one-time secret key.
+  """
+  keypair: CreateKeypairPayload!
 }
 
 """
@@ -7727,6 +7950,17 @@ type InferenceSessionErrorInfo
 }
 
 """
+Added in UNRELEASED. Filter for integer array fields. Supports 'contains' (column contains this single value), 'contains_any' (column contains any of these values), and 'contains_all' (column contains all of these values).
+"""
+input IntArrayFilter
+  @join__type(graph: STRAWBERRY)
+{
+  contains: Int = null
+  containsAny: [Int!] = null
+  containsAll: [Int!] = null
+}
+
+"""
 Added in 24.09.0. Filter for integer fields supporting equality and comparison operations.
 """
 input IntFilter
@@ -8246,6 +8480,9 @@ input KeypairFilter
   isAdmin: Boolean = null
   accessKey: StringFilter = null
   resourcePolicy: StringFilter = null
+
+  """Added in UNRELEASED. Filter keypairs by the UUID of their owner."""
+  userId: UUIDFilter = null
   createdAt: DateTimeFilter = null
   lastUsed: DateTimeFilter = null
   AND: [KeypairFilter!] = null
@@ -8387,6 +8624,15 @@ type KeyPairResourcePolicy
 }
 
 """
+Added in UNRELEASED. Nested filter for keypairs assigned to a keypair resource policy. Filters policies linked to at least one keypair matching all specified conditions.
+"""
+input KeypairResourcePolicyKeypairNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  userId: UUIDFilter = null
+}
+
+"""
 Added in 26.4.2. Keypair resource policy defining session and storage limits for API keypairs.
 """
 type KeypairResourcePolicyV2 implements Node
@@ -8433,6 +8679,9 @@ type KeypairResourcePolicyV2 implements Node
 
   """Allowed vfolder host permissions."""
   allowedVfolderHosts: [VFolderHostPermissionEntry!]!
+
+  """Added in UNRELEASED. Keypairs assigned to this resource policy."""
+  keypairs(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection
 }
 
 """Added in 26.4.2. Paginated connection for keypair resource policies."""
@@ -8472,6 +8721,11 @@ input KeypairResourcePolicyV2Filter
   idleTimeout: IntFilter = null
   maxConcurrentSftpSessions: IntFilter = null
   maxPendingSessionCount: IntFilter = null
+
+  """
+  Added in UNRELEASED. Filter policies by their assigned keypairs. A policy matches if at least one of its keypairs satisfies the conditions.
+  """
+  keypair: KeypairResourcePolicyKeypairNestedFilter = null
 }
 
 """Added in 26.4.2. Ordering specification for keypair resource policies."""
@@ -11229,9 +11483,14 @@ type Mutation
   adminCreateUserV2(input: CreateUserV2Input!): CreateUserV2Payload @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.2.0. Create multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual specifications
+  Added in 26.2.0. Create multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual specifications. Deprecated since 26.4.4.
   """
-  adminBulkCreateUsersV2(input: BulkCreateUserV2Input!): BulkCreateUsersV2Payload @join__field(graph: STRAWBERRY)
+  adminBulkCreateUsersV2(input: BulkCreateUserV2Input!): BulkCreateUsersV2Payload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use adminBulkCreateUsersWithKeypairV2 instead, which also returns each created user's generated keypair and secret key.")
+
+  """
+  Added in UNRELEASED. Create multiple users in bulk (admin only). Requires superadmin privileges. Returns each created user together with its automatically generated keypair and secret key (the secret key is only returned at creation time).
+  """
+  adminBulkCreateUsersWithKeypairV2(input: BulkCreateUserV2Input!): BulkCreateUsersWithKeypairV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Update multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual update specifications
@@ -11339,6 +11598,35 @@ type Mutation
 
   """Added in 26.3.0. Delete a query preset category (admin only)."""
   adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Create a new role preset (admin only)."""
+  adminCreateRolePreset(input: CreateRolePresetInput!): CreateRolePresetPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Update an existing role preset's metadata (admin only).
+  """
+  adminUpdateRolePreset(input: UpdateRolePresetInput!): UpdateRolePresetPayload @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Bulk-soft-delete role presets (admin only)."""
+  adminDeleteRolePresets(input: BulkDeleteRolePresetsInput!): BulkDeleteRolePresetsPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Bulk-restore soft-deleted role presets (admin only).
+  """
+  adminRestoreRolePresets(input: BulkRestoreRolePresetsInput!): BulkRestoreRolePresetsPayload @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Bulk-hard-delete role presets (admin only)."""
+  adminPurgeRolePresets(input: BulkPurgeRolePresetsInput!): BulkPurgeRolePresetsPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Bulk-add permission entries to an existing role preset (admin only).
+  """
+  adminBulkAddRolePresetPermissions(input: BulkAddRolePermissionPresetsInput!): BulkAddRolePermissionPresetsPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Bulk-remove permission entries from a role preset (admin only).
+  """
+  adminBulkRemoveRolePresetPermissions(input: BulkRemoveRolePermissionPresetsInput!): BulkRemoveRolePermissionPresetsPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Create a new role (admin only)."""
   adminCreateRole(input: CreateRoleInput!): Role @join__field(graph: STRAWBERRY)
@@ -13951,6 +14239,14 @@ type Query
   """
   prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!] @join__field(graph: STRAWBERRY)
 
+  """Added in UNRELEASED. Get a single role preset by ID (admin only)."""
+  adminRolePreset(id: ID!): RolePreset @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. List role presets with filtering and pagination (admin only).
+  """
+  adminRolePresets(filter: RolePresetFilter = null, orderBy: [RolePresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RolePresetConnection @join__field(graph: STRAWBERRY)
+
   """Added in 26.3.0. Get a single role by ID (admin only)."""
   adminRole(id: UUID!): Role @join__field(graph: STRAWBERRY)
 
@@ -15754,6 +16050,11 @@ type Role implements Node
   updatedAt: DateTime!
   deletedAt: DateTime
 
+  """
+  Added in UNRELEASED. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean!
+
   """Added in 26.3.0. Permissions associated with this role."""
   permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection
 
@@ -16047,6 +16348,235 @@ enum RoleOrderField
   @join__type(graph: STRAWBERRY)
 {
   NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in UNRELEASED. A stored permission entry under a role preset."""
+type RolePermissionPreset implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """UUID of the parent role preset."""
+  rolePresetId: UUID!
+
+  """Entity type the permission applies to."""
+  entityType: RBACElementType!
+
+  """Operation granted by the permission."""
+  operation: OperationType!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+}
+
+"""
+Added in UNRELEASED. Paginated connection for role permission preset entries.
+"""
+type RolePermissionPresetConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RolePermissionPresetEdge!]!
+
+  """Total number of permission entries matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RolePermissionPresetEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RolePermissionPreset!
+}
+
+"""
+Added in UNRELEASED. A single (entity_type, operation) pair carried by a role preset.
+"""
+input RolePermissionPresetEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Entity type the permission applies to."""
+  entityType: RBACElementType!
+
+  """Operation granted by the permission."""
+  operation: OperationType!
+}
+
+"""
+Added in UNRELEASED. Filter input for role permission preset entries. Also used as the input for the `permission_presets` field resolver on a role preset (the resolver injects `role_preset_id` from its parent).
+"""
+input RolePermissionPresetFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by parent role preset ID."""
+  rolePresetId: UUIDFilter = null
+
+  """Filter by entity type the permission applies to."""
+  entityType: RBACElementTypeFilter = null
+
+  """Filter by granted operation."""
+  operation: OperationTypeFilter = null
+
+  """Filter by creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Combine multiple filters with AND logic. All conditions must match."""
+  AND: [RolePermissionPresetFilter!] = null
+
+  """
+  Combine multiple filters with OR logic. At least one condition must match.
+  """
+  OR: [RolePermissionPresetFilter!] = null
+
+  """Negate the specified filters. Matching records are excluded."""
+  NOT: [RolePermissionPresetFilter!] = null
+}
+
+"""
+Added in UNRELEASED. Specifies ordering for role permission preset entries.
+"""
+input RolePermissionPresetOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: RolePermissionPresetOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in UNRELEASED. Fields available for ordering role permission preset entries.
+"""
+enum RolePermissionPresetOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  ENTITY_TYPE @join__enumValue(graph: STRAWBERRY)
+  OPERATION @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in UNRELEASED. Role preset entity implementing the Relay Node pattern.
+"""
+type RolePreset implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Role preset name."""
+  name: String!
+
+  """Scope type this preset targets (e.g., domain, project)."""
+  scopeType: RBACElementType!
+
+  """
+  Default value for the `auto_assign` flag copied onto roles instantiated from this preset.
+  """
+  autoAssign: Boolean!
+
+  """
+  Soft-delete flag. Set by the delete mutation and cleared by the restore mutation; archived rows are excluded from default searches.
+  """
+  deleted: Boolean!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last modification timestamp."""
+  updatedAt: DateTime!
+
+  """Added in UNRELEASED. Permission entries carried by this role preset."""
+  permissionPresets(filter: RolePermissionPresetFilter = null, orderBy: [RolePermissionPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RolePermissionPresetConnection
+}
+
+"""Added in UNRELEASED. Paginated connection for role preset records."""
+type RolePresetConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RolePresetEdge!]!
+
+  """Total number of role preset records matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RolePresetEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RolePreset!
+}
+
+"""Added in UNRELEASED. Filter input for querying role presets."""
+input RolePresetFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by name."""
+  name: StringFilter = null
+
+  """Filter by scope type."""
+  scopeType: RBACElementTypeFilter = null
+
+  """Filter by auto-assign flag."""
+  autoAssign: Boolean = null
+
+  """
+  Filter by soft-delete flag. Searches exclude soft-deleted rows by default; set this explicitly to `true` to inspect archived presets.
+  """
+  deleted: Boolean = null
+
+  """Combine multiple filters with AND logic. All conditions must match."""
+  AND: [RolePresetFilter!] = null
+
+  """
+  Combine multiple filters with OR logic. At least one condition must match.
+  """
+  OR: [RolePresetFilter!] = null
+
+  """Negate the specified filters. Matching records are excluded."""
+  NOT: [RolePresetFilter!] = null
+}
+
+"""Added in UNRELEASED. Specifies ordering for role preset results."""
+input RolePresetOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: RolePresetOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""
+Added in UNRELEASED. Fields available for ordering role preset results.
+"""
+enum RolePresetOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  NAME @join__enumValue(graph: STRAWBERRY)
+  SCOPE_TYPE @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
@@ -18814,6 +19344,37 @@ input UpdateRoleInput
   name: String
   description: String
   status: RoleStatus
+
+  """
+  Added in UNRELEASED. Updated value for the `auto_assign` flag. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
+  """
+  autoAssign: Boolean
+}
+
+"""
+Added in UNRELEASED. Input for updating a role preset's metadata. Permission entries are managed via the dedicated add/remove mutations; the `deleted` flag via delete/restore mutations.
+"""
+input UpdateRolePresetInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Role preset UUID to update."""
+  rolePresetId: ID!
+
+  """Updated name."""
+  name: String
+
+  """
+  Updated default value for the `auto_assign` flag of instantiated roles.
+  """
+  autoAssign: Boolean
+}
+
+"""Added in UNRELEASED. Payload returned after updating a role preset."""
+type UpdateRolePresetPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Updated role preset."""
+  rolePreset: RolePreset!
 }
 
 """Added in 25.19.0. Input for updating route traffic status."""
@@ -20042,12 +20603,44 @@ input UserV2Filter
   uuid: UUIDFilter = null
   username: StringFilter = null
   email: StringFilter = null
+
+  """Added in UNRELEASED. Filter by full name."""
+  fullName: StringFilter = null
+
+  """Added in UNRELEASED. Filter by description."""
+  description: StringFilter = null
   status: UserStatusV2EnumFilter = null
+
+  """Added in UNRELEASED. Filter by status info detail."""
+  statusInfo: StringFilter = null
   domainName: StringFilter = null
 
   """Added in 26.4.2. Filter by external integration identifier."""
   integrationName: StringFilter = null
+
+  """Added in UNRELEASED. Filter by user resource policy name."""
+  resourcePolicy: StringFilter = null
   role: UserRoleV2EnumFilter = null
+
+  """Added in UNRELEASED. Filter by whether a password change is required."""
+  needPasswordChange: Boolean = null
+
+  """
+  Added in UNRELEASED. Filter by whether TOTP two-factor auth is activated.
+  """
+  totpActivated: Boolean = null
+
+  """Added in UNRELEASED. Filter by whether sudo sessions are enabled."""
+  sudoSessionEnabled: Boolean = null
+
+  """Added in UNRELEASED. Filter by container UID."""
+  containerUid: IntFilter = null
+
+  """Added in UNRELEASED. Filter by container main GID."""
+  containerMainGid: IntFilter = null
+
+  """Added in UNRELEASED. Filter by container supplementary GIDs."""
+  containerGids: IntArrayFilter = null
   createdAt: DateTimeFilter = null
   domain: UserDomainNestedFilter = null
   project: UserProjectNestedFilter = null

--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -834,6 +834,13 @@ export class Client {
     if (this.isManagerVersionCompatibleWith('26.4.4rc4')) {
       this._features['rbac-element-type-filter'] = true;
     }
+    // BA-6247 / BA-6249 user filters merged after 26.4.4rc6, so they ship in
+    // 26.4.4 (final). Pinned to the rc6 tag so the flag also activates against
+    // the rc6 staging manager (a post-rc6 snapshot reporting the rc6 version).
+    // TODO(FR-3024): simplify to '26.4.4' once rc builds are out of use.
+    if (this.isManagerVersionCompatibleWith('26.4.4rc6')) {
+      this._features['user-v2-extended-filter'] = true;
+    }
   }
 
   /**

--- a/packages/backend.ai-ui/src/__generated__/BAIAdminKeypairResourcePolicySelectPaginatedQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminKeypairResourcePolicySelectPaginatedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c1d99479c7d3f40764d07dfa47070567>>
+ * @generated SignedSource<<b7102066f31a29e34c374442f165e11d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 export type KeypairResourcePolicyV2Filter = {
   createdAt?: DateTimeFilter | null | undefined;
   idleTimeout?: IntFilter | null | undefined;
+  keypair?: KeypairResourcePolicyKeypairNestedFilter | null | undefined;
   maxConcurrentSessions?: IntFilter | null | undefined;
   maxConcurrentSftpSessions?: IntFilter | null | undefined;
   maxContainersPerSession?: IntFilter | null | undefined;
@@ -54,6 +55,15 @@ export type IntFilter = {
   lessThan?: number | null | undefined;
   lessThanOrEqual?: number | null | undefined;
   notEquals?: number | null | undefined;
+};
+export type KeypairResourcePolicyKeypairNestedFilter = {
+  userId?: UUIDFilter | null | undefined;
+};
+export type UUIDFilter = {
+  equals?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
 };
 export type BAIAdminKeypairResourcePolicySelectPaginatedQuery$variables = {
   filter?: KeypairResourcePolicyV2Filter | null | undefined;

--- a/react/src/__generated__/AdminUserManagementQuery.graphql.ts
+++ b/react/src/__generated__/AdminUserManagementQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<06422b89b64682dd2bc7a123c2951f55>>
+ * @generated SignedSource<<8dc4f0b6c4ffe302d3fa76829308a352>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,14 +18,24 @@ export type UserV2Filter = {
   AND?: ReadonlyArray<UserV2Filter> | null | undefined;
   NOT?: ReadonlyArray<UserV2Filter> | null | undefined;
   OR?: ReadonlyArray<UserV2Filter> | null | undefined;
+  containerGids?: IntArrayFilter | null | undefined;
+  containerMainGid?: IntFilter | null | undefined;
+  containerUid?: IntFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
+  description?: StringFilter | null | undefined;
   domain?: UserDomainNestedFilter | null | undefined;
   domainName?: StringFilter | null | undefined;
   email?: StringFilter | null | undefined;
+  fullName?: StringFilter | null | undefined;
   integrationName?: StringFilter | null | undefined;
+  needPasswordChange?: boolean | null | undefined;
   project?: UserProjectNestedFilter | null | undefined;
+  resourcePolicy?: StringFilter | null | undefined;
   role?: UserRoleV2EnumFilter | null | undefined;
   status?: UserStatusV2EnumFilter | null | undefined;
+  statusInfo?: StringFilter | null | undefined;
+  sudoSessionEnabled?: boolean | null | undefined;
+  totpActivated?: boolean | null | undefined;
   username?: StringFilter | null | undefined;
   uuid?: UUIDFilter | null | undefined;
 };
@@ -68,6 +78,19 @@ export type UserRoleV2EnumFilter = {
   in?: ReadonlyArray<UserRoleV2> | null | undefined;
   notEquals?: UserRoleV2 | null | undefined;
   notIn?: ReadonlyArray<UserRoleV2> | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type IntArrayFilter = {
+  contains?: number | null | undefined;
+  containsAll?: ReadonlyArray<number> | null | undefined;
+  containsAny?: ReadonlyArray<number> | null | undefined;
 };
 export type DateTimeFilter = {
   after?: string | null | undefined;

--- a/react/src/__generated__/AssignRoleModalQuery.graphql.ts
+++ b/react/src/__generated__/AssignRoleModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ee42ed16b22be0ea3c0e9ab108f59c57>>
+ * @generated SignedSource<<de8c6a24cb28fe80252cab09ee7029d9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,14 +15,24 @@ export type UserV2Filter = {
   AND?: ReadonlyArray<UserV2Filter> | null | undefined;
   NOT?: ReadonlyArray<UserV2Filter> | null | undefined;
   OR?: ReadonlyArray<UserV2Filter> | null | undefined;
+  containerGids?: IntArrayFilter | null | undefined;
+  containerMainGid?: IntFilter | null | undefined;
+  containerUid?: IntFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
+  description?: StringFilter | null | undefined;
   domain?: UserDomainNestedFilter | null | undefined;
   domainName?: StringFilter | null | undefined;
   email?: StringFilter | null | undefined;
+  fullName?: StringFilter | null | undefined;
   integrationName?: StringFilter | null | undefined;
+  needPasswordChange?: boolean | null | undefined;
   project?: UserProjectNestedFilter | null | undefined;
+  resourcePolicy?: StringFilter | null | undefined;
   role?: UserRoleV2EnumFilter | null | undefined;
   status?: UserStatusV2EnumFilter | null | undefined;
+  statusInfo?: StringFilter | null | undefined;
+  sudoSessionEnabled?: boolean | null | undefined;
+  totpActivated?: boolean | null | undefined;
   username?: StringFilter | null | undefined;
   uuid?: UUIDFilter | null | undefined;
 };
@@ -65,6 +75,19 @@ export type UserRoleV2EnumFilter = {
   in?: ReadonlyArray<UserRoleV2> | null | undefined;
   notEquals?: UserRoleV2 | null | undefined;
   notIn?: ReadonlyArray<UserRoleV2> | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type IntArrayFilter = {
+  contains?: number | null | undefined;
+  containsAll?: ReadonlyArray<number> | null | undefined;
+  containsAny?: ReadonlyArray<number> | null | undefined;
 };
 export type DateTimeFilter = {
   after?: string | null | undefined;

--- a/react/src/__generated__/MyKeypairManagementModalQuery.graphql.ts
+++ b/react/src/__generated__/MyKeypairManagementModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<32c5c26c6d032656e873cf32b75fbd20>>
+ * @generated SignedSource<<d4c3a9b36eb1200ab652d0210ec5532d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,6 +21,7 @@ export type KeypairFilter = {
   isAdmin?: boolean | null | undefined;
   lastUsed?: DateTimeFilter | null | undefined;
   resourcePolicy?: StringFilter | null | undefined;
+  userId?: UUIDFilter | null | undefined;
 };
 export type StringFilter = {
   contains?: string | null | undefined;
@@ -43,6 +44,12 @@ export type StringFilter = {
   notIn?: ReadonlyArray<string> | null | undefined;
   notStartsWith?: string | null | undefined;
   startsWith?: string | null | undefined;
+};
+export type UUIDFilter = {
+  equals?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
 };
 export type DateTimeFilter = {
   after?: string | null | undefined;

--- a/react/src/__generated__/ProjectAdminUsersPageQuery.graphql.ts
+++ b/react/src/__generated__/ProjectAdminUsersPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<84d34c384c3916c8881e17489dfaaeb7>>
+ * @generated SignedSource<<0a37ee5792e99771c7ef78576fadb8d5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,14 +18,24 @@ export type UserV2Filter = {
   AND?: ReadonlyArray<UserV2Filter> | null | undefined;
   NOT?: ReadonlyArray<UserV2Filter> | null | undefined;
   OR?: ReadonlyArray<UserV2Filter> | null | undefined;
+  containerGids?: IntArrayFilter | null | undefined;
+  containerMainGid?: IntFilter | null | undefined;
+  containerUid?: IntFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
+  description?: StringFilter | null | undefined;
   domain?: UserDomainNestedFilter | null | undefined;
   domainName?: StringFilter | null | undefined;
   email?: StringFilter | null | undefined;
+  fullName?: StringFilter | null | undefined;
   integrationName?: StringFilter | null | undefined;
+  needPasswordChange?: boolean | null | undefined;
   project?: UserProjectNestedFilter | null | undefined;
+  resourcePolicy?: StringFilter | null | undefined;
   role?: UserRoleV2EnumFilter | null | undefined;
   status?: UserStatusV2EnumFilter | null | undefined;
+  statusInfo?: StringFilter | null | undefined;
+  sudoSessionEnabled?: boolean | null | undefined;
+  totpActivated?: boolean | null | undefined;
   username?: StringFilter | null | undefined;
   uuid?: UUIDFilter | null | undefined;
 };
@@ -68,6 +78,19 @@ export type UserRoleV2EnumFilter = {
   in?: ReadonlyArray<UserRoleV2> | null | undefined;
   notEquals?: UserRoleV2 | null | undefined;
   notIn?: ReadonlyArray<UserRoleV2> | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type IntArrayFilter = {
+  contains?: number | null | undefined;
+  containsAll?: ReadonlyArray<number> | null | undefined;
+  containsAny?: ReadonlyArray<number> | null | undefined;
 };
 export type DateTimeFilter = {
   after?: string | null | undefined;

--- a/react/src/__generated__/RBACManagementPageActivateRoleMutation.graphql.ts
+++ b/react/src/__generated__/RBACManagementPageActivateRoleMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ca12e88a08e6d732f90c025c1761940a>>
+ * @generated SignedSource<<5adad86985e5ec5dad7fc295fbd9879d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type RoleStatus = "ACTIVE" | "DELETED" | "INACTIVE" | "%future added value";
 export type UpdateRoleInput = {
+  autoAssign?: boolean | null | undefined;
   description?: string | null | undefined;
   id: string;
   name?: string | null | undefined;

--- a/react/src/__generated__/RoleFormModalCreateMutation.graphql.ts
+++ b/react/src/__generated__/RoleFormModalCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cc3f68018f58cdd87e80128e95dc4cfa>>
+ * @generated SignedSource<<c28862710cfecfb6d08fd1461200a9cb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ export type RBACElementType = "AGENT" | "APP_CONFIG" | "ARTIFACT" | "ARTIFACT_RE
 export type RoleSource = "CUSTOM" | "SYSTEM" | "%future added value";
 export type RoleStatus = "ACTIVE" | "DELETED" | "INACTIVE" | "%future added value";
 export type CreateRoleInput = {
+  autoAssign?: boolean;
   description?: string | null | undefined;
   name: string;
   scopes?: ReadonlyArray<ScopeInput> | null | undefined;

--- a/react/src/__generated__/RoleFormModalUpdateMutation.graphql.ts
+++ b/react/src/__generated__/RoleFormModalUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<325cfa51c470fac7b2232bf56f2fddce>>
+ * @generated SignedSource<<7895a665f0e2282efda82d736b223d8a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type RoleStatus = "ACTIVE" | "DELETED" | "INACTIVE" | "%future added value";
 export type UpdateRoleInput = {
+  autoAssign?: boolean | null | undefined;
   description?: string | null | undefined;
   id: string;
   name?: string | null | undefined;

--- a/react/src/__generated__/UsageBucketChartContentQuery.graphql.ts
+++ b/react/src/__generated__/UsageBucketChartContentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c33ca497b0e8caf9fc97b04a727ac5af>>
+ * @generated SignedSource<<c797379542c10163658f0d1fd239394b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -101,14 +101,24 @@ export type UserV2Filter = {
   AND?: ReadonlyArray<UserV2Filter> | null | undefined;
   NOT?: ReadonlyArray<UserV2Filter> | null | undefined;
   OR?: ReadonlyArray<UserV2Filter> | null | undefined;
+  containerGids?: IntArrayFilter | null | undefined;
+  containerMainGid?: IntFilter | null | undefined;
+  containerUid?: IntFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
+  description?: StringFilter | null | undefined;
   domain?: UserDomainNestedFilter | null | undefined;
   domainName?: StringFilter | null | undefined;
   email?: StringFilter | null | undefined;
+  fullName?: StringFilter | null | undefined;
   integrationName?: StringFilter | null | undefined;
+  needPasswordChange?: boolean | null | undefined;
   project?: UserProjectNestedFilter | null | undefined;
+  resourcePolicy?: StringFilter | null | undefined;
   role?: UserRoleV2EnumFilter | null | undefined;
   status?: UserStatusV2EnumFilter | null | undefined;
+  statusInfo?: StringFilter | null | undefined;
+  sudoSessionEnabled?: boolean | null | undefined;
+  totpActivated?: boolean | null | undefined;
   username?: StringFilter | null | undefined;
   uuid?: UUIDFilter | null | undefined;
 };
@@ -123,6 +133,19 @@ export type UserRoleV2EnumFilter = {
   in?: ReadonlyArray<UserRoleV2> | null | undefined;
   notEquals?: UserRoleV2 | null | undefined;
   notIn?: ReadonlyArray<UserRoleV2> | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type IntArrayFilter = {
+  contains?: number | null | undefined;
+  containsAll?: ReadonlyArray<number> | null | undefined;
+  containsAny?: ReadonlyArray<number> | null | undefined;
 };
 export type UserDomainNestedFilter = {
   isActive?: boolean | null | undefined;

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -30,6 +30,7 @@ import {
   filterOutEmpty,
   filterOutNullAndUndefined,
   BAIFlex,
+  BAIGraphQLFilterProperty,
   BAIGraphQLPropertyFilter,
   GraphQLFilter,
   useBAILogger,
@@ -302,6 +303,119 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
     );
   };
 
+  // Container UID/GID filters map to a raw GraphQL Int; reject non-integer
+  // input before BAIGraphQLPropertyFilter coerces it via Number(...), which
+  // would otherwise produce NaN / invalid Int variables.
+  const integerRule = {
+    message: t('error.OnlyIntegersAreAllowed'),
+    validate: (value: string) => /^-?\d+$/.test(String(value).trim()),
+  };
+
+  // Filters only supported by the v2 user search API from 26.4.4 (backend
+  // BA-6247 / BA-6249). Included only when the connected manager advertises
+  // the capability, so the UI never offers filters it cannot evaluate.
+  const extendedFilterProperties: Array<BAIGraphQLFilterProperty> = [
+    {
+      key: 'fullName',
+      propertyLabel: t('credential.FullName'),
+      type: 'string',
+    },
+    {
+      key: 'resourcePolicy',
+      propertyLabel: t('credential.ResourcePolicy'),
+      type: 'string',
+    },
+    {
+      key: 'description',
+      propertyLabel: t('credential.Description'),
+      type: 'string',
+    },
+    {
+      key: 'statusInfo',
+      propertyLabel: t('credential.StatusInfo'),
+      type: 'string',
+    },
+    {
+      key: 'needPasswordChange',
+      propertyLabel: t('credential.DescRequirePasswordChange'),
+      type: 'boolean',
+    },
+    {
+      key: 'totpActivated',
+      propertyLabel: t('credential.2FAEnabled'),
+      type: 'boolean',
+    },
+    {
+      key: 'sudoSessionEnabled',
+      propertyLabel: t('credential.EnableSudoSession'),
+      type: 'boolean',
+    },
+    {
+      key: 'containerUid',
+      propertyLabel: t('credential.ContainerUID'),
+      type: 'number',
+      rule: integerRule,
+    },
+    {
+      key: 'containerMainGid',
+      propertyLabel: t('credential.ContainerGID'),
+      type: 'number',
+      rule: integerRule,
+    },
+    {
+      // IntArrayFilter: only single-GID membership (`contains`) is exposed
+      // since BAIGraphQLPropertyFilter has no array-operator input for
+      // `containsAny` / `containsAll`.
+      key: 'containerGids',
+      propertyLabel: t('credential.ContainerSupplementaryGIDs'),
+      type: 'number',
+      fixedOperator: 'contains',
+      rule: integerRule,
+    },
+  ];
+
+  const filterProperties: Array<BAIGraphQLFilterProperty> = filterOutEmpty([
+    {
+      key: 'email',
+      propertyLabel: t('general.E-Mail'),
+      type: 'string',
+    },
+    {
+      key: 'uuid',
+      propertyLabel: 'ID',
+      type: 'uuid',
+    },
+    {
+      key: 'username',
+      propertyLabel: t('credential.Name'),
+      type: 'string',
+    },
+    {
+      key: 'project.name',
+      propertyLabel: t('general.Project'),
+      type: 'string',
+    },
+    {
+      key: 'role',
+      propertyLabel: t('credential.Role'),
+      type: 'enum',
+      strictSelection: true,
+      options: [
+        {
+          label: 'superadmin',
+          value: 'SUPERADMIN',
+        },
+        {
+          label: 'user',
+          value: 'USER',
+        },
+      ],
+    },
+    ...(bailClient.supports('user-v2-extended-filter')
+      ? extendedFilterProperties
+      : []),
+  ]);
+
   return (
     <BAIFlex direction="column" align="stretch" gap="sm">
       <BAIFlex justify="between" align="start" gap="xs" wrap="wrap">
@@ -328,44 +442,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
             ]}
           />
           <BAIGraphQLPropertyFilter
-            filterProperties={[
-              {
-                key: 'email',
-                propertyLabel: t('general.E-Mail'),
-                type: 'string',
-              },
-              {
-                key: 'uuid',
-                propertyLabel: 'ID',
-                type: 'uuid',
-              },
-              {
-                key: 'username',
-                propertyLabel: t('credential.Name'),
-                type: 'string',
-              },
-              {
-                key: 'project.name',
-                propertyLabel: t('general.Project'),
-                type: 'string',
-              },
-              {
-                key: 'role',
-                propertyLabel: t('credential.Role'),
-                type: 'enum',
-                strictSelection: true,
-                options: [
-                  {
-                    label: 'superadmin',
-                    value: 'SUPERADMIN',
-                  },
-                  {
-                    label: 'user',
-                    value: 'USER',
-                  },
-                ],
-              },
-            ]}
+            filterProperties={filterProperties}
             value={queryParams.filter ?? undefined}
             onChange={(value) => {
               setQueryParams({ filter: value ?? null });

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1558,7 +1558,7 @@
     "Optional": "optional",
     "Password": "Password",
     "Permission": "Permission",
-    "Project": "Proejct",
+    "Project": "Project",
     "RemainingLoginSessionTime": "Time until auto logout",
     "ResourceGroup": "Resource Group",
     "Role": "Role",


### PR DESCRIPTION
Resolves #7683 (FR-3024)

## Summary

Expose the newly added `adminUsersV2` (`UserV2Filter`) filters in the super-admin user list's `BAIGraphQLPropertyFilter`. The list migrated to `adminUsersV2` in #7666 (merged) but only exposed 5 filters (email / ID / username / project / role). Backend BA-6247 (lablup/backend.ai#11878) and BA-6249 (lablup/backend.ai#11879) added 10 more filter fields to the v2 schema.

These v2 filters are gated behind a capability flag — older managers keep showing just the 5 base filters.

### Added filters (gated, shown only when supported)

| Type | Fields |
| --- | --- |
| String | `fullName`, `description`, `statusInfo`, `resourcePolicy` |
| Boolean | `needPasswordChange`, `totpActivated`, `sudoSessionEnabled` |
| Integer | `containerUid`, `containerMainGid` |
| Integer array | `containerGids` (single-GID membership via `contains`) |

### Version gating

- Registers a new capability flag `user-v2-extended-filter` in `packages/backend.ai-client/src/client.ts`, mirroring the existing `model-deployment-extended-filter` / `rbac-element-type-filter` (rc-pinned) pattern.
- **Gated at `26.4.4rc6`.** BA-6247 / BA-6249 merged *after* the `26.4.4rc6` tag, so they ship in **26.4.4 (final)**. The flag is pinned to the `rc6` tag so it also activates against the rc6 staging manager (a post-rc6 snapshot reporting `26.4.4rc6`). A `TODO(FR-3024)` notes simplifying to `26.4.4` once rc builds are out of use.
- The 10 extended filters live in a single `extendedFilterProperties` array and are conditionally spread into `filterProperties` via `bailClient.supports('user-v2-extended-filter')` — the 5 base filters are always present.

### Schema sync

- Syncs `data/schema.graphql` to backend.ai `main`'s composed supergraph (`docs/manager/graphql-reference/supergraph.graphql`) so `UserV2Filter` now defines the new fields. This is a **full schema bump** (+596 lines) and also pulls in other already-merged backend types (RBAC role presets, keypair filters, etc.).
- `pnpm relay` regenerated the affected artifacts (`AdminUserManagementQuery` now models the new filter fields; 7 other `__generated__` queries/mutations updated incidentally by the bump).
- Note: #7672 (FR-3020) also edits `data/schema.graphql` (surgical, IntArrayFilter + keypair nested filter). Whichever merges second will need a trivial `data/schema.graphql` restack against the other.

### Notes / out of scope

- `containerGids` is an `IntArrayFilter` (`contains` / `containsAny` / `containsAll`). `BAIGraphQLPropertyFilter` has no array-operator input, so only the single-GID `contains` operator is exposed via `fixedOperator: 'contains'`.
- The three integer filters (`containerUid` / `containerMainGid` / `containerGids`) carry an `integerRule` so non-integer input is rejected before `Number(...)` coercion (avoids `NaN` / invalid `Int` variables).
- All labels reuse existing `credential.*` i18n keys (same keys the legacy v1 user list uses) — no new i18n keys, no hardcoded strings.

## Testing

- Test against the **`10.82.0.130`** test server (reports `26.4.4rc6`).
- With the gate pinned at `26.4.4rc6`, the `user-v2-extended-filter` flag activates directly on this server — **no manual version edit needed**. All 15 filters appear in the super-admin **User Management** list; on a manager older than `26.4.4rc6`, only the 5 base filters.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript).

## Test plan

- [ ] On `10.82.0.130` (26.4.4rc6), all 15 filters are offered and each produces a valid `UserV2Filter` query.
- [ ] On a manager older than 26.4.4rc6, only the 5 base filters are offered.
- [ ] Boolean filters emit scalar `true` / `false`; `containerUid` / `containerMainGid` emit `{ equals: N }`; `containerGids` emits `{ contains: N }`.
- [ ] Non-integer input in `containerUid` / `containerMainGid` / `containerGids` is rejected with an inline error.
