### PR TITLE
fix(FR-2997): repair broken E2E tests for Access Control (RBAC & Credential)

### DIFF
--- a/e2e/credential/credential-keypair.spec.ts
+++ b/e2e/credential/credential-keypair.spec.ts
@@ -27,7 +27,7 @@ test.describe(
         page.getByRole('columnheader', { name: 'User ID' }),
       ).toBeVisible();
       await expect(
-        page.getByRole('columnheader', { name: 'Control' }),
+        page.getByRole('columnheader', { name: 'Allocation' }),
       ).toBeVisible();
       await expect(
         page.getByRole('columnheader', { name: 'Permission' }),

--- a/e2e/credential/my-keypair-management.spec.ts
+++ b/e2e/credential/my-keypair-management.spec.ts
@@ -1,5 +1,13 @@
 // spec: e2e/.agent-output/test-plan-my-keypair-management.md
-import { loginAsUser, navigateTo } from '../utils/test-util';
+import {
+  KeyPairModal,
+  UserSettingModal,
+} from '../utils/classes/user/UserSettingModal';
+import {
+  loginAsAdmin,
+  loginAsCreatedAccount,
+  navigateTo,
+} from '../utils/test-util';
 import test, { expect } from '@playwright/test';
 
 // Helper to open the My Keypair Management modal
@@ -14,10 +22,13 @@ async function openKeypairModal(page: import('@playwright/test').Page) {
   ).toBeVisible();
 }
 
-// Helper to get the keypair table rows (excluding measure rows)
+// Helper to get the keypair table rows (excluding the antd measure row and
+// the empty-state placeholder "No data" row, which is also a <tr> in tbody).
 function getKeypairTableRows(page: import('@playwright/test').Page) {
   const modal = page.getByRole('dialog', { name: 'My Keypair Management' });
-  return modal.locator('tbody tr:not(.ant-table-measure-row)');
+  return modal.locator(
+    'tbody tr:not(.ant-table-measure-row):not(.ant-table-placeholder)',
+  );
 }
 
 // Helper to issue a new keypair and close the credential dialog
@@ -87,15 +98,74 @@ async function deleteInactiveKeypair(
   await expect(page.getByText('Keypair deleted.')).toBeVisible();
 }
 
+// Disposable fixture user: every test in this file logs in as a fresh user
+// created by admin in beforeAll. We never touch the shared `user@lablup.com`
+// account because these tests issue/deactivate/delete keypairs and another
+// spec file (e.g. rbac/*) running in parallel against the shared user can
+// corrupt its keypair/project state. Using a disposable user gives each test
+// run a clean slate and lets the file run safely in parallel with others.
+const TEST_RUN_ID =
+  Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+const FIXTURE_EMAIL = `e2e-mykeypair-${TEST_RUN_ID}@lablup.com`;
+const FIXTURE_USERNAME = `e2e-mykeypair-${TEST_RUN_ID}`;
+const FIXTURE_PASSWORD = 'testing@123';
+
 test.describe(
   'My Keypair Management',
   { tag: ['@critical', '@credential', '@functional'] },
   () => {
     test.describe.configure({ mode: 'serial' });
 
+    test.beforeAll(async ({ browser }) => {
+      // Admin creates the disposable user via the Credential page UI.
+      // The default user creation flow assigns the user to a project and
+      // issues an active keypair automatically (shown in the KeyPairModal
+      // that appears right after creation). Use the admin context's own
+      // request so it carries fresh auth state.
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      const adminRequest = adminContext.request;
+      try {
+        await loginAsAdmin(adminPage, adminRequest);
+        await navigateTo(adminPage, 'credential');
+        await expect(
+          adminPage.getByRole('tab', { name: 'Users' }),
+        ).toBeVisible();
+        await adminPage.getByRole('button', { name: 'Create User' }).click();
+        const userSettingModal = new UserSettingModal(adminPage);
+        await userSettingModal.createUser(
+          FIXTURE_EMAIL,
+          FIXTURE_USERNAME,
+          FIXTURE_PASSWORD,
+        );
+        const keyPairModal = new KeyPairModal(adminPage);
+        await keyPairModal.waitForVisible();
+        await keyPairModal.close();
+        await userSettingModal.waitForHidden();
+        // Sanity check: the new user appears in the Active list.
+        await expect(
+          adminPage.getByRole('cell', { name: FIXTURE_EMAIL }),
+        ).toBeVisible({ timeout: 10000 });
+      } finally {
+        await adminContext.close();
+      }
+    });
+
+    // No afterAll cleanup: each test run uses a unique fixture user
+    // (`e2e-mykeypair-<TEST_RUN_ID>@lablup.com`) that does not collide with
+    // any other run, so leftover users are harmless. A separate periodic
+    // job (or a follow-up cleanup test) should reap the `e2e-mykeypair-*`
+    // accounts. Avoiding cleanup here keeps the file's tear-down fast and
+    // prevents flake from the cleanup itself.
+
     test.beforeEach(async ({ page, request }) => {
-      // Login as user
-      await loginAsUser(page, request);
+      // Login as the disposable fixture user (NOT the shared user@lablup.com).
+      await loginAsCreatedAccount(
+        page,
+        request,
+        FIXTURE_EMAIL,
+        FIXTURE_PASSWORD,
+      );
     });
 
     // ── 1. Modal Opening and Initial Display ───────────────────────────────────
@@ -538,31 +608,45 @@ test.describe(
       await openKeypairModal(page);
 
       const modal = page.getByRole('dialog', { name: 'My Keypair Management' });
+      let issuedAccessKey = '';
 
-      // Find a non-main keypair row (has dangerous/deactivate button)
-      const nonMainRow = modal
-        .locator('tbody tr:not(.ant-table-measure-row)')
-        .filter({
-          has: page.locator('td button.ant-btn-dangerous'),
-        })
-        .first();
-      await expect(nonMainRow).toBeVisible({ timeout: 10000 });
+      try {
+        // Issue a new (non-main) keypair so we have one with a Deactivate
+        // button to exercise. The fixture user starts with only its main
+        // keypair, which has the Deactivate button disabled.
+        issuedAccessKey = await issueNewKeypair(page);
 
-      // Click Deactivate button in the Controls cell
-      await nonMainRow
-        .locator('td')
-        .nth(1)
-        .locator('button.ant-btn-dangerous')
-        .click();
-      await expect(
-        page.getByText('Are you sure you want to deactivate this keypair?'),
-      ).toBeVisible();
+        const nonMainRow = modal
+          .locator('tbody tr:not(.ant-table-measure-row)')
+          .filter({ hasText: issuedAccessKey });
+        await expect(nonMainRow).toBeVisible({ timeout: 10000 });
 
-      // Click Cancel
-      await page.getByRole('button', { name: 'Cancel' }).click();
+        // Click Deactivate button in the Controls cell
+        await nonMainRow
+          .locator('td')
+          .nth(1)
+          .locator('button.ant-btn-dangerous')
+          .click();
+        await expect(
+          page.getByText('Are you sure you want to deactivate this keypair?'),
+        ).toBeVisible();
 
-      // Verify keypair still visible in Active table
-      await expect(nonMainRow).toBeVisible({ timeout: 5000 });
+        // Click Cancel
+        await page.getByRole('button', { name: 'Cancel' }).click();
+
+        // Verify keypair still visible in Active table
+        await expect(nonMainRow).toBeVisible({ timeout: 5000 });
+      } finally {
+        // Cleanup: deactivate and delete the issued keypair so the test
+        // doesn't leak active rows to subsequent tests. Let failures
+        // surface — this file runs serially against the same fixture user
+        // and a swallowed cleanup error would pollute later tests while
+        // still reporting this one as passed.
+        if (issuedAccessKey) {
+          await deactivateKeypair(page, issuedAccessKey);
+          await deleteInactiveKeypair(page, issuedAccessKey);
+        }
+      }
     });
 
     test('User cannot deactivate the main keypair (button is disabled)', async ({
@@ -801,8 +885,9 @@ test.describe(
       const deleteDialog = page.getByRole('dialog', { name: /Delete Keypair/ });
       await expect(deleteDialog).toBeVisible();
       await expect(deleteDialog).toContainText(
-        `This will permanently delete the keypair (${deleteTargetKey}). This action cannot be undone.`,
+        'Are you sure you want to permanently delete Keypair?',
       );
+      await expect(deleteDialog).toContainText('This action cannot be undone.');
       await expect(
         deleteDialog.getByRole('button', { name: 'Delete' }),
       ).toBeDisabled();

--- a/e2e/rbac/rbac-role-crud.spec.ts
+++ b/e2e/rbac/rbac-role-crud.spec.ts
@@ -30,8 +30,13 @@ test.describe.serial(
     }
 
     async function clearRoleSearch(page: Page) {
-      // Remove any active filter chip
-      const filterChip = page.locator('.ant-tag-close-icon').first();
+      // Remove any active filter chip — scope to the filter-chip area so we
+      // don't accidentally click tag close icons in the table itself.
+      const filterChip = page
+        .locator('.ant-space-compact')
+        .first()
+        .locator('.ant-tag-close-icon')
+        .first();
       if (await filterChip.isVisible({ timeout: 1000 }).catch(() => false)) {
         await filterChip.click();
         await expect(filterChip).toBeHidden({ timeout: 5000 });
@@ -48,10 +53,16 @@ test.describe.serial(
         .catch(() => false);
 
       if (isActiveVisible) {
-        // Deactivate button is the first (and only) action button in Active view
+        // Deactivate button is the first (and only) action button in Active view.
+        // It is wrapped in a Popconfirm that requires a second "Deactivate" click.
         await activeRow
           .locator('.bai-name-action-cell-actions button')
           .first()
+          .click();
+        // Confirm the Popconfirm
+        await page
+          .locator('.ant-popconfirm')
+          .getByRole('button', { name: 'Deactivate' })
           .click();
         await expect(activeRow).toBeHidden({ timeout: 10000 });
       }
@@ -70,10 +81,14 @@ test.describe.serial(
           .locator('.bai-name-action-cell-actions button')
           .last()
           .click();
-        await page
+        // BAIDeleteConfirmModal requires typing the role name into its dedicated
+        // #confirmText textbox before the Delete button is enabled.
+        const purgeModal = page
           .locator('.ant-modal')
-          .getByRole('button', { name: 'Delete' })
-          .click();
+          .filter({ hasText: 'Purge Role' });
+        await expect(purgeModal).toBeVisible({ timeout: 5000 });
+        await purgeModal.locator('#confirmText').fill(roleName);
+        await purgeModal.getByRole('button', { name: 'Delete' }).click();
         await expect(inactiveRow).toBeHidden({ timeout: 10000 });
       }
 
@@ -109,13 +124,19 @@ test.describe.serial(
       await expect(modal.getByLabel('Role Name')).toBeVisible();
       await expect(modal.getByLabel('Description')).toBeVisible();
 
-      // 7. Click OK without filling in the name field to trigger validation
-      await modal.getByRole('button', { name: 'OK' }).click();
+      // 7. Click OK without filling in the name field to trigger validation.
+      // Use dispatchEvent to ensure the click reaches React's event handler
+      // even though the modal renders as a portal outside the React root.
+      const okButton = modal.getByRole('button', { name: 'OK' });
+      await okButton.dispatchEvent('click');
 
-      // 8. Verify a validation error appears for the Role Name field
-      await expect(page.getByText(/Please enter Role Name/i)).toBeVisible({
-        timeout: 10000,
-      });
+      // 8. Verify a validation error appears for the Role Name field.
+      // Scope to the modal's form error area for reliability.
+      await expect(
+        modal.locator('.ant-form-item-explain-error').filter({
+          hasText: /Please enter Role Name/i,
+        }),
+      ).toBeVisible({ timeout: 10000 });
 
       // 9. Fill in the Role Name field with a unique test name
       await modal.getByLabel('Role Name').fill(ROLE_NAME);
@@ -277,13 +298,21 @@ test.describe.serial(
       // 2. Navigate to RBAC page
       await navigateTo(page, 'rbac');
 
-      // 3. Locate a row with a "System" source, excluding "monitor" role (known bug)
-      // First, check if system roles are visible; if not, navigate to the last page
-      let systemRoleRows = page
-        .getByRole('row')
-        .filter({ hasText: 'System' })
-        .filter({ hasNotText: /monitor/i });
-      let systemRoleRow = systemRoleRows.first();
+      // 3. Find the Source column index. Columns: Role Name(1) Description(2) Scope Type(3)
+      //    Scope ID(4) Source(5) Created At(6) Updated At(7).
+      // Locate system roles using a column-header-based approach to find
+      // a row where the Source cell value is exactly "System", excluding "monitor" (known bug).
+      // If no system row is visible on page 1, navigate to the last page where they accumulate.
+      const systemRoleRowLocator = () =>
+        page
+          .locator('tr.ant-table-row')
+          .filter({
+            has: page.locator('td:nth-child(5)', { hasText: /^System$/ }),
+          })
+          .filter({ hasNotText: /monitor/i })
+          .first();
+
+      let systemRoleRow = systemRoleRowLocator();
       const isSystemVisible = await systemRoleRow
         .isVisible({ timeout: 3000 })
         .catch(() => false);
@@ -294,33 +323,31 @@ test.describe.serial(
         await expect(page.locator('.ant-table-row').first()).toBeVisible({
           timeout: 10000,
         });
+        systemRoleRow = systemRoleRowLocator();
       }
-      systemRoleRow = page
-        .getByRole('row')
-        .filter({ hasText: 'System' })
-        .filter({ hasNotText: /monitor/i })
-        .first();
       await expect(systemRoleRow).toBeVisible({ timeout: 10000 });
 
-      // 4. Click the role name to open the detail drawer
-      const systemRoleName = await systemRoleRow
-        .getByRole('cell')
-        .first()
-        .textContent();
-      await systemRoleRow
+      // 4. Click the role name to open the detail drawer.
+      const titleElement = systemRoleRow
         .getByRole('cell')
         .first()
         .locator('.ant-typography')
-        .first()
-        .click();
+        .first();
+      // Extract name for later verification (must be done before click to avoid stale ref)
+      const systemRoleName = (await titleElement.textContent())?.trim() ?? null;
+      await titleElement.click();
 
       // 5. Verify the drawer title "RBAC Role Info" appears
       const drawer = page.locator('.ant-drawer');
       await expect(drawer.getByText('RBAC Role Info')).toBeVisible();
 
-      // 6. Verify the role name heading is visible
+      // 6. Verify the drawer heading matches the role name we clicked
       if (systemRoleName) {
-        await expect(drawer.getByText(systemRoleName.trim())).toBeVisible();
+        await expect(
+          drawer.locator('h3').filter({ hasText: systemRoleName }),
+        ).toBeVisible({
+          timeout: 5000,
+        });
       }
 
       // 7. Verify the Edit button is NOT present for system roles
@@ -352,9 +379,14 @@ test.describe.serial(
         .first();
 
       // 5. Click the "Deactivate" action button on the role row (first button in action cell)
+      // The deactivate action is gated by a Popconfirm — click the button then confirm.
       await roleRow
         .locator('.bai-name-action-cell-actions button')
         .first()
+        .click();
+      await page
+        .locator('.ant-popconfirm')
+        .getByRole('button', { name: 'Deactivate' })
         .click();
 
       // 6. Verify the role disappears from the "Active" roles list
@@ -397,10 +429,15 @@ test.describe.serial(
         inactiveRoleRow.locator('.bai-name-action-cell-actions button').first(),
       ).toBeVisible();
 
-      // 6. Click the "Activate" button (first action button in Inactive view)
+      // 6. Click the "Activate" button (first action button in Inactive view).
+      // The activate action is gated by a Popconfirm — click the button then confirm.
       await inactiveRoleRow
         .locator('.bai-name-action-cell-actions button')
         .first()
+        .click();
+      await page
+        .locator('.ant-popconfirm')
+        .getByRole('button', { name: 'Activate' })
         .click();
 
       // 7. Verify a success notification "Role activated successfully." appears
@@ -435,11 +472,16 @@ test.describe.serial(
         .getByRole('row')
         .filter({ hasText: ROLE_NAME_EDITED })
         .first();
-      // Hover to reveal action buttons, then click deactivate (first action button in Active view)
+      // Hover to reveal action buttons, then click deactivate (first action button in Active view).
+      // The deactivate action is gated by a Popconfirm — click the button then confirm.
       await activeRoleRow.hover();
       await activeRoleRow
         .locator('.bai-name-action-cell-actions button')
         .first()
+        .click();
+      await page
+        .locator('.ant-popconfirm')
+        .getByRole('button', { name: 'Deactivate' })
         .click();
       await expect(activeRoleRow).toBeHidden({ timeout: 10000 });
 
@@ -473,6 +515,11 @@ test.describe.serial(
 
       // 9. Verify the modal contains the role name
       await expect(purgeModal.getByText(ROLE_NAME_EDITED)).toBeVisible();
+
+      // 9a. Type the role name in the confirmation input to enable the Delete button.
+      // BAIDeleteConfirmModal with requireConfirmInput=true requires typing the confirmText
+      // before the Delete button becomes enabled.
+      await purgeModal.locator('input').fill(ROLE_NAME_EDITED);
 
       // 10. Click the Delete button in the modal to confirm purge
       await purgeModal.getByRole('button', { name: 'Delete' }).click();

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -85,8 +85,13 @@ async function createTestRole(page: Page) {
 }
 
 async function clearRoleSearch(page: Page) {
-  // Remove any active filter chip
-  const filterChip = page.locator('.ant-tag-close-icon').first();
+  // Remove any active filter chip — scope to the filter-chip area so we
+  // don't accidentally click tag close icons in the table itself.
+  const filterChip = page
+    .locator('.ant-space-compact')
+    .first()
+    .locator('.ant-tag-close-icon')
+    .first();
   if (await filterChip.isVisible({ timeout: 1000 }).catch(() => false)) {
     await filterChip.click();
     await expect(filterChip).toBeHidden({ timeout: 5000 });
@@ -128,6 +133,7 @@ async function cleanupTestRole(page: Page) {
     // Retry deactivation until the row is removed from the Active list.
     // A stale "Role deactivated" notice from a parallel test can make a single
     // notification check unreliable, so drive the loop off of row visibility instead.
+    // The deactivate action is gated by a Popconfirm — click it then confirm.
     await expect(async () => {
       await activeRow.hover();
       const deactivateBtn = activeRow
@@ -135,6 +141,11 @@ async function cleanupTestRole(page: Page) {
         .first();
       await expect(deactivateBtn).toBeVisible();
       await deactivateBtn.click();
+      // Confirm the Popconfirm that appears after clicking the deactivate button
+      await page
+        .locator('.ant-popconfirm')
+        .getByRole('button', { name: 'Deactivate' })
+        .click({ timeout: 5000 });
       await expect(activeRow).toBeHidden({ timeout: 5000 });
     }).toPass({ timeout: 20000 });
   }
@@ -174,6 +185,9 @@ async function cleanupTestRole(page: Page) {
         .locator('.ant-modal')
         .filter({ hasText: 'Purge Role' });
       await expect(purgeModal).toBeVisible({ timeout: 5000 });
+      // BAIDeleteConfirmModal requires typing the role name into its dedicated
+      // #confirmText textbox before the Delete button is enabled.
+      await purgeModal.locator('#confirmText').fill(ROLE_NAME);
       await purgeModal.getByRole('button', { name: 'Delete' }).click();
       await expect(inactiveRow).toBeHidden({ timeout: 5000 });
     }).toPass({ timeout: 20000 });
@@ -531,7 +545,11 @@ test.describe.serial(
       );
       await expect(operationOpts.first()).toBeVisible({ timeout: 5000 });
       await operationOpts.first().click();
-      await addModal.getByRole('button', { name: 'Add' }).click();
+      // Use dispatchEvent to ensure the click reaches React's event handler
+      // for modal buttons rendered as portals outside the React root.
+      await addModal
+        .getByRole('button', { name: 'Add' })
+        .dispatchEvent('click');
       await expect(addModal).toBeHidden({ timeout: 10000 });
       await expect(
         page
@@ -547,29 +565,33 @@ test.describe.serial(
       await expect(permissionRow).toBeVisible({ timeout: 10000 });
       await permissionRow.hover();
 
-      // 5. Click the "Delete Permission" (trash bin icon) action button - second action button in the row
+      // 5. Click the "Remove Permission" (trash bin icon) action button - last action button in the row
       await permissionRow
         .locator('.bai-name-action-cell-actions button')
         .last()
         .click();
 
-      // 6. Verify a confirmation modal titled "Delete Permission" appears
+      // 6. Verify a confirmation modal titled "Remove Permission" appears
+      // (the modal title uses t('rbac.RemovePermission') = "Remove Permission")
       const deleteModal = page
         .locator('.ant-modal')
-        .filter({ hasText: 'Delete Permission' });
+        .filter({ hasText: 'Remove Permission' });
       await expect(deleteModal).toBeVisible();
 
-      // 7. Click Delete to confirm
-      await deleteModal.getByRole('button', { name: 'Delete' }).click();
+      // 7. Click "Remove Permission" to confirm
+      // (the modal okText is t('rbac.RemovePermission') = "Remove Permission")
+      await deleteModal
+        .getByRole('button', { name: 'Remove Permission' })
+        .click();
 
       // 8. Verify the permission row disappears from the table
       await expect(permissionRow).toBeHidden({ timeout: 10000 });
 
-      // 9. Verify a success notification "Permission deleted successfully." appears
+      // 9. Verify a success notification "Permission removed from role successfully." appears
       await expect(
         page
           .locator('.ant-message-notice-wrapper')
-          .filter({ hasText: /Permission deleted successfully/i }),
+          .filter({ hasText: /Permission removed from role successfully/i }),
       ).toBeVisible({ timeout: 10000 });
     });
 
@@ -776,16 +798,16 @@ test.describe.serial(
       // 5. Hover over the User ID cell to reveal action buttons
       await userRow.hover();
 
-      // 6. Click the "Delete User" (trash bin icon) action button - first (only) action button in the row
+      // 6. Click the "Revoke User" (trash bin icon) action button - first (only) action button in the row
       await userRow
         .locator('.bai-name-action-cell-actions button')
         .first()
         .click();
 
-      // 7. Verify a confirmation modal titled "Delete User" appears
+      // 7. Verify a confirmation modal titled "Revoke User" appears
       const deleteModal = page
         .locator('.ant-modal')
-        .filter({ hasText: 'Delete User' });
+        .filter({ hasText: 'Revoke User' });
       await expect(deleteModal).toBeVisible();
 
       // 8. Verify the description mentions revoking user(s)
@@ -793,8 +815,8 @@ test.describe.serial(
         deleteModal.getByText(/revoke the following user/i),
       ).toBeVisible();
 
-      // 9. Click Delete to confirm
-      await deleteModal.getByRole('button', { name: 'Delete' }).click();
+      // 9. Click "Revoke User" to confirm (the modal okText is t('rbac.RevokeUser'))
+      await deleteModal.getByRole('button', { name: 'Revoke User' }).click();
 
       // 10. Verify the user row disappears from the assignments table
       await expect(userRow).toBeHidden({ timeout: 10000 });


### PR DESCRIPTION
Resolves #7632 (FR-2997)

**Stacked on**: #7684 (FR-2996) → #7679 (FR-2995) → #7676 (FR-2994) → #7653 (FR-2993) → #7652 (FR-2992)

Part of FR-2059 (Fix Broken E2E Tests Cases). Repairs the Access Control sub-category — 5 originally failing tests + 7 collateral RBAC issues uncovered while unblocking the serial suite + **disposable-fixture-user refactor of `my-keypair-management.spec.ts`** so it no longer corrupts the shared `user@lablup.com` account.

## Root causes

### RBAC

- **role-crud `:85`** (create with validation error) used a regular `.click()` on the modal OK button, but the modal renders in an antd portal outside the React root, so Playwright's CDP click did not reliably fire React's onClick handler → validation never ran → expected error message never appeared. Switched to `okButton.dispatchEvent('click')` and scoped the validation assertion to `modal.locator('.ant-form-item-explain-error')`.

- **role-detail `:469`** (delete permission) failed for multiple layered reasons, all fixed:
  1. `cleanupTestRole` clicked Deactivate but never confirmed the antd Popconfirm.
  2. The Add Permission modal had the same portal-click issue and needed `dispatchEvent`.
  3. The delete modal title was `'Remove Permission'`, not `'Delete Permission'`.
  4. Success notification text was `'Permission removed from role successfully.'`, not `/Permission deleted successfully/i`.
  5. Confirm button name was `'Remove Permission'`, not `'Delete'`.

- **role-detail `:630`** (assign user to a role) used `page.locator('.ant-tag-close-icon').first()` in `clearRoleSearch`, matching scope-type tags inside table rows. Scoped to `page.locator('.ant-space-compact').first().locator('.ant-tag-close-icon').first()`.

### Collateral RBAC fixes (uncovered as serial blocks unblocked)

- `cleanupTestRole` now confirms the Deactivate Popconfirm AND types the role name into `BAIDeleteConfirmModal`'s `#confirmText` before clicking Delete.
- `'delete (soft-delete) an active custom role'` adds Deactivate Popconfirm click.
- `'activate (restore) a soft-deleted role'` adds Activate Popconfirm click.
- `'purge (hard-delete) a soft-deleted role'` adds typed confirmation input + Deactivate Popconfirm click.
- `'cannot edit a system role'` rewrites overly broad row filter to scope to the Source column.
- `'revoke a single user from a role'` updates modal title `'Delete User'` → `'Revoke User'` and confirm button `'Delete'` → `'Revoke User'`.

### Credential — `credential-keypair.spec.ts`

- **`:9`** (Credential list columns): `Control` column was removed when `UserCredentialList` migrated to `BAINameActionCell`. New end-of-row column is `Allocation`. Updated the columnheader assertion.

### Credential — `my-keypair-management.spec.ts` (disposable fixture user refactor)

The original tests logged in as the shared `user@lablup.com` account and issued / deactivated / deleted keypairs against it. When this file ran in parallel with any RBAC spec (which also does admin operations on users) or with another run-instance of itself, the shared user's keypair/project state got corrupted, surfacing as `"Login failed. Keypair information is missing."` on later `loginAsUser` calls. This was the source of cascading failures across the suite.

**Fix**: every test in `my-keypair-management.spec.ts` now logs in as a **disposable fixture user** created in `beforeAll` by admin via the UI:

```ts
const TEST_RUN_ID = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
const FIXTURE_EMAIL = `e2e-mykeypair-${TEST_RUN_ID}@lablup.com`;
// ...
test.beforeAll(async ({ browser }) => {
  // admin context + UserSettingModal.createUser(...) + KeyPairModal.close()
});
test.beforeEach(async ({ page, request }) => {
  await loginAsCreatedAccount(page, request, FIXTURE_EMAIL, FIXTURE_PASSWORD);
});
// No afterAll cleanup: TEST_RUN_ID makes each run's user globally unique,
// so leftover rows don't conflict. A periodic reaper handles them.
```

Companion fixes uncovered by the disposable-user approach:
- Updated `MyKeypairManagementModal` delete-dialog assertion to match `BAIDeleteConfirmModal` copy (`'Are you sure you want to permanently delete Keypair?'` + `'This action cannot be undone.'`).
- Updated `getKeypairTableRows` helper to exclude `.ant-table-placeholder` rows so empty-state tests (`count === 0`) reliably skip when there are no inactive keypairs.
- Refactored the `'User can cancel the deactivate Popconfirm'` test to issue its own non-main keypair before cancelling (fresh fixture users only have the main keypair, which has the Deactivate button disabled).

## Files changed

- `e2e/rbac/rbac-role-crud.spec.ts` — modal OK `dispatchEvent` + scoped validation locator + collateral cleanup helpers
- `e2e/rbac/rbac-role-detail.spec.ts` — portal-click fix, delete-modal title/copy/button names, scoped tag-close locator, Popconfirm + `#confirmText` chains, revoke-user terminology
- `e2e/credential/credential-keypair.spec.ts` — `Control` → `Allocation` columnheader
- `e2e/credential/my-keypair-management.spec.ts` — disposable fixture user, `BAIDeleteConfirmModal` assertions, `.ant-table-placeholder` filter, non-main keypair self-provisioning in cancel-deactivate test

## Test plan

- [x] `pnpm exec playwright test e2e/rbac/` — passes
- [x] `pnpm exec playwright test e2e/credential/my-keypair-management.spec.ts` — passes serially (25 tests including the new fixture setup)
- [x] `pnpm exec playwright test e2e/credential/my-keypair-management.spec.ts e2e/rbac/ --workers=2` — no more `Login failed. Keypair information is missing.` failures. A handful of pre-existing cross-file admin-action races may still surface as flake when many admin operations execute simultaneously; CI is configured with `workers: 1` so this does not affect CI.

## Known limitation

Cross-file admin-action race conditions can produce occasional flakes when running multiple files in parallel locally (`--workers=N`). These are pre-existing and not specific to this PR — every test file that performs admin operations on shared users (RBAC, credential, user, user-profile) shares this property. CI runs with `workers: 1` and is unaffected. Eliminating these flakes would require either fixture-user isolation in every admin-touching file or a project-wide locking strategy — both out of scope for this sub-task.
