### PR TITLE
chore(FR-3028): add ESLint rule forbidding fragment $key type at its spread site

### DIFF
--- a/packages/eslint-config-bai/bai-plugin.js
+++ b/packages/eslint-config-bai/bai-plugin.js
@@ -1,0 +1,200 @@
+/**
+ * Custom ESLint rules for Backend.AI WebUI (Relay conventions).
+ *
+ * Exposed as a flat-config plugin object so both the `react/` app and the
+ * `packages/backend.ai-ui/` component library — which share this config via
+ * `eslint-config-bai` — pick the rules up.
+ */
+
+const KEY_SUFFIX = "$key";
+
+const isKeyTypeName = (name) =>
+  typeof name === "string" && name.endsWith(KEY_SUFFIX);
+
+const baseFragmentName = (keyTypeName) =>
+  keyTypeName.slice(0, -KEY_SUFFIX.length);
+
+/**
+ * Collect GraphQL fragment definitions and named fragment spreads from the
+ * cooked text of a graphql`` tagged template literal.
+ *
+ * Relay literals in this codebase contain no `${}` interpolation (fragments
+ * are referenced as the textual `...Name`), so the concatenated quasi text is
+ * the complete document and a textual scan is sufficient. Working off the
+ * graphql literal text — rather than the whole source — is what keeps JS
+ * spread operators and doc strings from being mistaken for fragment spreads.
+ */
+const scanGraphqlText = (text, defined, spread) => {
+  const defRe = /\bfragment\s+([A-Za-z_]\w*)\s+on\s/g;
+  let m;
+  while ((m = defRe.exec(text)) !== null) {
+    defined.add(m[1]);
+  }
+  const spreadRe = /\.\.\.\s*([A-Za-z_]\w*)/g;
+  while ((m = spreadRe.exec(text)) !== null) {
+    // `... on Type` is an inline fragment, not a named fragment spread.
+    if (m[1] !== "on") {
+      spread.add(m[1]);
+    }
+  }
+};
+
+/**
+ * Recursively collect TSTypeReference nodes whose name ends with `$key`,
+ * walking only structural type positions (unions, arrays, generic args,
+ * wrappers). Function-type parameters are intentionally NOT walked: a
+ * `$key` in a parameter position is a fragment-component prop/callback
+ * contract, which is the correct place to use the generated `$key` type.
+ */
+const collectKeyTypeRefs = (typeNode, out) => {
+  if (!typeNode || typeof typeNode !== "object") {
+    return;
+  }
+  if (
+    typeNode.type === "TSTypeReference" &&
+    typeNode.typeName?.type === "Identifier" &&
+    isKeyTypeName(typeNode.typeName.name)
+  ) {
+    out.push(typeNode);
+  }
+  if (Array.isArray(typeNode.types)) {
+    typeNode.types.forEach((c) => collectKeyTypeRefs(c, out));
+  }
+  if (typeNode.elementType) {
+    collectKeyTypeRefs(typeNode.elementType, out);
+  }
+  if (typeNode.typeAnnotation) {
+    collectKeyTypeRefs(typeNode.typeAnnotation, out);
+  }
+  const typeArgs = typeNode.typeArguments || typeNode.typeParameters;
+  if (typeArgs && Array.isArray(typeArgs.params)) {
+    typeArgs.params.forEach((c) => collectKeyTypeRefs(c, out));
+  }
+};
+
+/**
+ * Disallow typing a *local value* (a `useState` cell or a plain variable)
+ * with a fragment's generated `$key` type at a site that already spreads that
+ * fragment in a graphql literal.
+ *
+ * When a component spreads `...Foo` in its own query/fragment, the
+ * `useFragment` / query response already yields a value whose type carries
+ * `$fragmentSpreads` and is directly assignable to `Foo$key`. So the spreading
+ * site never needs to import `Foo$key` — it should derive the type from its
+ * own query node type instead. Importing the child fragment's `$key` here only
+ * adds type coupling to the child.
+ *
+ * Exemptions (NOT reported):
+ *  - the fragment-owning file, which DEFINES `fragment Foo on ...` (it
+ *    legitimately uses `Foo$key` for its prop and/or `useFragment<Foo$key>`);
+ *  - prop / callback-parameter positions (a fragment ref typed `Foo$key` that
+ *    is received from a parent, the standard fragment-component pattern);
+ *  - files that do not spread `...Foo` at all (the ref is sourced elsewhere).
+ *
+ * This is a project convention, not a Relay-mandated rule.
+ */
+const noFragmentKeyAtSpreadSite = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow typing a local value with a fragment's generated $key type at a site that already spreads that fragment; derive the type from the local query node instead.",
+    },
+    schema: [],
+    messages: {
+      deriveLocally:
+        "This file spreads `...{{fragment}}` in a graphql literal, so the query/fragment response already yields a value assignable to `{{name}}`. Type this {{position}} with your own query's node type instead of the child fragment's `{{name}}` (and drop the import if nothing else uses it).",
+    },
+  },
+  create(context) {
+    const definedFragments = new Set();
+    const spreadFragments = new Set();
+    const candidates = [];
+
+    const getTypeArguments = (node) =>
+      node.typeArguments || node.typeParameters || null;
+
+    return {
+      TaggedTemplateExpression(node) {
+        if (node.tag.type !== "Identifier" || node.tag.name !== "graphql") {
+          return;
+        }
+        const text = node.quasi.quasis
+          .map((q) => (q.value && (q.value.cooked ?? q.value.raw)) || "")
+          .join("\n");
+        scanGraphqlText(text, definedFragments, spreadFragments);
+      },
+
+      // useState<...$key>() / useState<...$key | null>()
+      CallExpression(node) {
+        if (
+          node.callee.type !== "Identifier" ||
+          node.callee.name !== "useState"
+        ) {
+          return;
+        }
+        const typeArgs = getTypeArguments(node);
+        if (!typeArgs || !typeArgs.params || typeArgs.params.length === 0) {
+          return;
+        }
+        const refs = [];
+        collectKeyTypeRefs(typeArgs.params[0], refs);
+        refs.forEach((ref) =>
+          candidates.push({
+            node: ref,
+            name: ref.typeName.name,
+            position: "state",
+          }),
+        );
+      },
+
+      // const x: ...$key = ...   (plain local variable annotation)
+      VariableDeclarator(node) {
+        if (
+          node.id?.type !== "Identifier" ||
+          !node.id.typeAnnotation?.typeAnnotation
+        ) {
+          return;
+        }
+        const refs = [];
+        collectKeyTypeRefs(node.id.typeAnnotation.typeAnnotation, refs);
+        refs.forEach((ref) =>
+          candidates.push({
+            node: ref,
+            name: ref.typeName.name,
+            position: "variable",
+          }),
+        );
+      },
+
+      "Program:exit"() {
+        for (const candidate of candidates) {
+          const base = baseFragmentName(candidate.name);
+          // The file owns the fragment — `$key` for its own prop is correct.
+          if (definedFragments.has(base)) {
+            continue;
+          }
+          // The ref is not produced by a local spread — sourced from a prop.
+          if (!spreadFragments.has(base)) {
+            continue;
+          }
+          context.report({
+            node: candidate.node,
+            messageId: "deriveLocally",
+            data: {
+              fragment: base,
+              name: candidate.name,
+              position: candidate.position,
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    "no-fragment-key-at-spread-site": noFragmentKeyAtSpreadSite,
+  },
+};

--- a/packages/eslint-config-bai/react.js
+++ b/packages/eslint-config-bai/react.js
@@ -1,6 +1,7 @@
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import importPlugin from "eslint-plugin-import";
+import baiPlugin from "./bai-plugin.js";
 
 export const react = [
   reactPlugin.configs.flat.recommended,
@@ -55,6 +56,16 @@ export const react = [
     rules: {
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
+    },
+  },
+
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    plugins: {
+      bai: baiPlugin,
+    },
+    rules: {
+      "bai/no-fragment-key-at-spread-site": "error",
     },
   },
 ];

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -9,7 +9,6 @@ import {
   AdminUserCredentialListQuery$data,
   AdminUserCredentialListQuery$variables,
 } from '../__generated__/AdminUserCredentialListQuery.graphql';
-import { KeypairSettingModalFragment$key } from '../__generated__/KeypairSettingModalFragment.graphql';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import BAIRadioGroup from './BAIRadioGroup';
 import KeypairInfoModal from './KeypairInfoModal';
@@ -69,7 +68,7 @@ const AdminUserCredentialList: React.FC = () => {
   });
 
   const [keypairSettingModalFrgmt, setKeypairSettingModalFrgmt] =
-    useState<KeypairSettingModalFragment$key | null>(null);
+    useState<Keypair | null>(null);
   const [openUserKeypairSettingModal, setOpenUserKeypairSettingModal] =
     useState(false);
   const [keypairInfoModalFrgmt, setKeypairInfoModalFrgmt] = useState<any>(null);

--- a/react/src/components/DeploymentReplicasTab.tsx
+++ b/react/src/components/DeploymentReplicasTab.tsx
@@ -7,7 +7,6 @@ import {
   ReplicaOrderBy,
 } from '../__generated__/DeploymentReplicasTabListQuery.graphql';
 import { DeploymentReplicasTab_deployment$key } from '../__generated__/DeploymentReplicasTab_deployment.graphql';
-import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import { RouteSchedulingHistoryModalQuery } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -56,6 +55,18 @@ import {
 } from 'react-relay';
 
 type ReplicaStatusCategory = 'running' | 'terminated';
+
+type RevisionNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<
+        NonNullable<
+          DeploymentReplicasTabListQuery['response']['deployment']
+        >['replicas']
+      >['edges'][number]
+    >['node']
+  >['revision']
+>;
 
 const TERMINATED_STATUSES = ['TERMINATED', 'FAILED_TO_START'] as const;
 
@@ -183,7 +194,7 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
     null,
   );
   const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
-    useState<DeploymentRevisionDetail_revision$key | null>(null);
+    useState<RevisionNode | null>(null);
 
   const { deployment: listData } =
     useLazyLoadQuery<DeploymentReplicasTabListQuery>(
@@ -413,13 +424,7 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
         }
         return (
           <>
-            <Typography.Link
-              onClick={() =>
-                setDrawerRevisionFrgmt(
-                  revision as DeploymentRevisionDetail_revision$key,
-                )
-              }
-            >
+            <Typography.Link onClick={() => setDrawerRevisionFrgmt(revision)}>
               {revision.revisionNumber != null
                 ? `#${revision.revisionNumber}`
                 : '-'}

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -2,13 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { KeypairResourcePolicyInfoModalFragment$key } from '../__generated__/KeypairResourcePolicyInfoModalFragment.graphql';
 import { KeypairResourcePolicyListMutation } from '../__generated__/KeypairResourcePolicyListMutation.graphql';
 import {
   KeypairResourcePolicyListQuery,
   KeypairResourcePolicyListQuery$data,
 } from '../__generated__/KeypairResourcePolicyListQuery.graphql';
-import { KeypairResourcePolicySettingModalFragment$key } from '../__generated__/KeypairResourcePolicySettingModalFragment.graphql';
 import { localeCompare, numberSorterWithInfinityValue } from '../helper';
 import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
 import { exportCSVWithFormattingRules } from '../helper/csv-util';
@@ -57,9 +55,9 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
   const [isRefetchPending, startRefetchTransition] = useTransition();
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
   const [editingKeypairResourcePolicy, setEditingKeypairResourcePolicy] =
-    useState<KeypairResourcePolicySettingModalFragment$key | null>();
+    useState<KeypairResourcePolicies | null>();
   const [currentResourcePolicy, setCurrentResourcePolicy] =
-    useState<KeypairResourcePolicyInfoModalFragment$key | null>(null);
+    useState<KeypairResourcePolicies | null>(null);
   const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
     null,
   );

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -7,7 +7,6 @@ import {
   ProjectResourcePolicyListQuery,
   ProjectResourcePolicyListQuery$data,
 } from '../__generated__/ProjectResourcePolicyListQuery.graphql';
-import { ProjectResourcePolicySettingModalFragment$key } from '../__generated__/ProjectResourcePolicySettingModalFragment.graphql';
 import {
   bytesToGB,
   localeCompare,
@@ -58,7 +57,7 @@ const ProjectResourcePolicyList: React.FC<
     useUpdatableState('initial-fetch');
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
   const [editingProjectResourcePolicy, setEditingProjectResourcePolicy] =
-    useState<ProjectResourcePolicySettingModalFragment$key | null>();
+    useState<ProjectResourcePolicies | null>();
   const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
     null,
   );

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -7,7 +7,6 @@ import {
   ResourcePresetListQuery,
   ResourcePresetListQuery$data,
 } from '../__generated__/ResourcePresetListQuery.graphql';
-import { ResourcePresetSettingModalFragment$key } from '../__generated__/ResourcePresetSettingModalFragment.graphql';
 import { localeCompare } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import ResourcePresetSettingModal from './ResourcePresetSettingModal';
@@ -47,7 +46,7 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
   const [resourcePresetsFetchKey, updateResourcePresetsFetchKey] =
     useUpdatableState('initial-fetch');
   const [editingResourcePreset, setEditingResourcePreset] =
-    useState<ResourcePresetSettingModalFragment$key | null>(null);
+    useState<ResourcePreset | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [deletingPresetName, setDeletingPresetName] = useState<string | null>(
     null,

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -7,7 +7,6 @@ import {
   UserResourcePolicyListQuery,
   UserResourcePolicyListQuery$data,
 } from '../__generated__/UserResourcePolicyListQuery.graphql';
-import { UserResourcePolicySettingModalFragment$key } from '../__generated__/UserResourcePolicySettingModalFragment.graphql';
 import {
   bytesToGB,
   localeCompare,
@@ -56,7 +55,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
     useUpdatableState('initial-fetch');
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
   const [editingUserResourcePolicy, setEditingUserResourcePolicy] =
-    useState<UserResourcePolicySettingModalFragment$key | null>();
+    useState<UserResourcePolicies | null>();
   const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
     null,
   );

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { GeneratedKeypairListModalFragment$key } from '../__generated__/GeneratedKeypairListModalFragment.graphql';
 import {
   UserSettingModalBulkCreateMutation,
   UserRoleV2,
@@ -54,6 +53,12 @@ import * as _ from 'lodash-es';
 import React, { Suspense, useDeferredValue, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation, useLazyLoadQuery } from 'react-relay';
+
+type CreatedKeypair = NonNullable<
+  NonNullable<
+    UserSettingModalCreateMutation['response']['create_user']
+  >['keypair']
+>;
 
 type UserRole = {
   [key: string]: string[];
@@ -160,7 +165,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
   const deferredOpen = useDeferredValue(baiModalProps.open);
 
   const [createdKeypairs, setCreatedKeypairs] =
-    useState<GeneratedKeypairListModalFragment$key | null>();
+    useState<ReadonlyArray<CreatedKeypair> | null>();
 
   const { user } = useLazyLoadQuery<UserSettingModalQuery>(
     graphql`

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -10,7 +10,6 @@ import type {
   DeploymentStatus,
   OrderDirection,
 } from '../__generated__/AdminDeploymentListPageQuery.graphql';
-import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
@@ -57,6 +56,16 @@ import { useSearchParams } from 'react-router-dom';
 
 type DeploymentStatusCategory = 'running' | 'finished';
 
+type RevisionNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<
+        AdminDeploymentListPageQuery['response']['adminDeployments']
+      >['edges'][number]
+    >['node']
+  >['currentRevision']
+>;
+
 const AdminDeploymentListPageContent: React.FC = () => {
   'use memo';
   const { t } = useTranslation();
@@ -72,7 +81,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
     string | null
   >(null);
   const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
-    useState<DeploymentRevisionDetail_revision$key | null>(null);
+    useState<RevisionNode | null>(null);
 
   const supportsExtendedFilter = baiClient.supports(
     'model-deployment-extended-filter',

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -9,7 +9,6 @@ import {
   DeploymentOrderBy,
   DeploymentStatus,
 } from '../__generated__/DeploymentListPageQuery.graphql';
-import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import DeploymentSettingModal from '../components/DeploymentSettingModal';
@@ -50,6 +49,16 @@ import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
 type DeploymentStatusCategory = 'running' | 'finished';
 
+type RevisionNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<
+        DeploymentListPageQuery['response']['myDeployments']
+      >['edges'][number]
+    >['node']
+  >['currentRevision']
+>;
+
 const DeploymentListPageContent: React.FC = () => {
   'use memo';
   const { t } = useTranslation();
@@ -66,7 +75,7 @@ const DeploymentListPageContent: React.FC = () => {
     string | null
   >(null);
   const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
-    useState<DeploymentRevisionDetail_revision$key | null>(null);
+    useState<RevisionNode | null>(null);
 
   const {
     baiPaginationOption,

--- a/react/src/pages/LegacyModelStoreListPage.tsx
+++ b/react/src/pages/LegacyModelStoreListPage.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { LegacyModelCardModalFragment$key } from '../__generated__/LegacyModelCardModalFragment.graphql';
 import { LegacyModelStoreListPageQuery } from '../__generated__/LegacyModelStoreListPageQuery.graphql';
 import LegacyModelCardModal from '../components/LegacyModelCardModal';
 import ModelBrandIcon from '../components/ModelBrandIcon';
@@ -60,8 +59,7 @@ const LegacyModelStoreListPage: React.FC = () => {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedTasks, setSelectedTasks] = useState<string[]>([]);
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
-  const [currentModelInfo, setCurrentModelInfo] =
-    useState<LegacyModelCardModalFragment$key | null>();
+  const [currentModelInfo, setCurrentModelInfo] = useState<ModelCard | null>();
 
   const [isPendingRefetching, startRefetchingTransition] = useTransition();
 

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import type { ProjectAdminDeploymentsPageDeleteMutation } from '../__generated__/ProjectAdminDeploymentsPageDeleteMutation.graphql';
 import type {
   DeploymentFilter,
@@ -51,6 +50,16 @@ import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
 type DeploymentStatusCategory = 'running' | 'finished';
 
+type RevisionNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<
+        ProjectAdminDeploymentsPageQuery['response']['projectDeployments']
+      >['edges'][number]
+    >['node']
+  >['currentRevision']
+>;
+
 interface ProjectAdminDeploymentsContentProps {
   projectId: string;
 }
@@ -71,7 +80,7 @@ const ProjectAdminDeploymentsContent: React.FC<
     string | null
   >(null);
   const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
-    useState<DeploymentRevisionDetail_revision$key | null>(null);
+    useState<RevisionNode | null>(null);
 
   const {
     baiPaginationOption,

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key } from '../__generated__/ImportArtifactRevisionToFolderModalArtifactRevisionFragment.graphql';
 import {
   ArtifactStatus,
   ReservoirArtifactDetailPageQuery,
@@ -73,10 +72,9 @@ const ReservoirArtifactDetailPage = () => {
     useState<BAIDeleteArtifactRevisionsModalArtifactRevisionFragmentKey>([]);
   const [selectedRevisions, setSelectedRevisions] =
     useState<BAIImportArtifactModalArtifactRevisionFragmentKey>([]);
-  const [selectedImportRevisions, setSelectedImportRevisions] =
-    useState<ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key>(
-      [],
-    );
+  const [selectedImportRevisions, setSelectedImportRevisions] = useState<
+    ReadonlyArray<RevisionNode>
+  >([]);
   const [queryParams, setQuery] = useQueryParams({
     filter: withDefault(JsonParam, {}),
   });


### PR DESCRIPTION
Resolves #7691 (FR-3028)

## Summary

Add a custom `bai/no-fragment-key-at-spread-site` ESLint rule to `eslint-config-bai`, applied to **both** `react/` and `packages/backend.ai-ui/` through the shared `react` config.

The rule flags typing a **local value** (a `useState` cell or a plain variable) with a fragment's generated `$key` type at a site that already **spreads** that fragment in a `graphql` literal. When a component spreads `...Foo` in its own query/fragment, the response already yields a value whose type carries `$fragmentSpreads` and is assignable to `Foo$key` — so the type should be derived from the local query node instead of importing the child fragment's `$key` (which only adds type coupling to the child).

### Exemptions (intentionally not flagged)
- **fragment-owning files** that define `fragment Foo on ...` — they legitimately use `Foo$key` for their prop type and/or `useFragment<Foo$key>` (e.g. `DeploymentAddRevisionModal`).
- **prop / callback-parameter positions** — the standard fragment-component prop contract.
- files that don't spread `...Foo` at all (ref sourced from a prop elsewhere).

### Implementation
- `packages/eslint-config-bai/bai-plugin.js` — new flat-config plugin exposing the rule.
- `packages/eslint-config-bai/react.js` — registers `bai/no-fragment-key-at-spread-site: "error"` for `**/*.{ts,tsx}`.
- Scans `graphql` literal text for fragment definitions/spreads. Relay literals carry no `${}` interpolation, so a textual scan is sufficient and avoids mistaking JS spread operators or doc strings for fragment spreads.

### Fixed violations (12 files)
Replaced `useState<X$key>` with the local query node type and dropped the now-unused `$key` import:
- `react/src/components/`: `AdminUserCredentialList`, `DeploymentReplicasTab`, `KeypairResourcePolicyList`, `ProjectResourcePolicyList`, `ResourcePresetList`, `UserResourcePolicyList`, `UserSettingModal`
- `react/src/pages/`: `AdminDeploymentListPage`, `DeploymentListPage`, `LegacyModelStoreListPage`, `ProjectAdminDeploymentsPage`, `ReservoirArtifactDetailPage`

Plural fragments (`UserSettingModal`, `ReservoirArtifactDetailPage`) use `ReadonlyArray<Node>`. No runtime behavior changes — only TS type annotations and imports.

> Note: this is a nice-to-have lint convention, not a Relay-mandated pattern.

## Verification

`bash scripts/verify.sh` → **Relay / Lint / Format / TypeScript all PASS**. The rule reports **0** remaining `bai/no-fragment-key-at-spread-site` violations across `react/src`. (The unrelated "Vite warmup paths" check fails only because a fresh worktree has no build artifacts; it parses `react/vite.config.ts`, which this PR does not touch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)