### PR TITLE
fix(FR-2998): repair broken E2E tests for Admin & Operations

### DIFF
--- a/e2e/environment/registry.spec.ts
+++ b/e2e/environment/registry.spec.ts
@@ -89,9 +89,6 @@ test.describe(
       await expect(
         table.getByRole('columnheader', { name: 'Enabled' }),
       ).toBeVisible();
-      await expect(
-        table.getByRole('columnheader', { name: 'Control' }),
-      ).toBeVisible();
     });
 
     // 1.2
@@ -719,7 +716,9 @@ test.describe(
       // When there is only one filter property, it is auto-selected and displayed
       // as the current value in the property selector
       await expect(
-        page.locator('.ant-select-content-value', { hasText: 'Registry Name' }),
+        page
+          .locator('.ant-select-content')
+          .filter({ hasText: 'Registry Name' }),
       ).toBeVisible();
     });
   },

--- a/e2e/information/information.spec.ts
+++ b/e2e/information/information.spec.ts
@@ -22,7 +22,7 @@ test.describe('Information', { tag: ['@functional', '@information'] }, () => {
     await expect(page.getByText('Security', { exact: true })).toBeVisible();
 
     // Verify Component section
-    await expect(page.getByText('Component')).toBeVisible();
+    await expect(page.getByText('Component', { exact: true })).toBeVisible();
     await expect(
       page.getByText('Docker version', { exact: true }),
     ).toBeVisible();

--- a/e2e/project/project-crud.spec.ts
+++ b/e2e/project/project-crud.spec.ts
@@ -11,21 +11,66 @@ test.describe.serial(
   'Project CRUD',
   { tag: ['@critical', '@project', '@functional'] },
   () => {
-    // Cleanup function to delete the test project if it exists
+    // Cleanup function to delete the test project if it exists.
+    // The project lifecycle is: Active → Deactivated (trash) → Purged (hard delete).
+    // This helper handles all lifecycle states: if the project is active it
+    // deactivates it first, then switches to the Inactive tab and purges it.
     async function cleanupTestProject(page: any) {
-      const projectRow = page
+      // Check Active tab first
+      const activeProjectRow = page
         .getByRole('row')
         .filter({ hasText: PROJECT_NAME });
-      const isVisible = await projectRow
+      const isActiveVisible = await activeProjectRow
         .isVisible({ timeout: 2000 })
         .catch(() => false);
 
-      if (isVisible) {
-        await projectRow.getByRole('button', { name: 'delete' }).click();
-        const purgeDialog = page.getByRole('dialog', { name: 'Purge Project' });
-        await purgeDialog.getByRole('button', { name: 'Purge' }).click();
-        await expect(projectRow).toBeHidden({ timeout: 10000 });
+      if (isActiveVisible) {
+        // Deactivate first (Popconfirm flow)
+        await activeProjectRow.hover();
+        await activeProjectRow
+          .locator('.bai-name-action-cell-actions button')
+          .nth(1)
+          .click();
+        const deactivatePopconfirm = page.locator('.ant-popconfirm');
+        await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
+        await deactivatePopconfirm
+          .getByRole('button', { name: 'Deactivate' })
+          .click();
+        await expect(activeProjectRow).toBeHidden({ timeout: 10000 });
       }
+
+      // Switch to Inactive tab and purge
+      // Use the label wrapper (not the hidden radio input) to click the radio button
+      await page
+        .locator('label')
+        .filter({ hasText: /^Inactive$/ })
+        .click();
+      const inactiveProjectRow = page
+        .getByRole('row')
+        .filter({ hasText: PROJECT_NAME });
+      const isInactiveVisible = await inactiveProjectRow
+        .isVisible({ timeout: 5000 })
+        .catch(() => false);
+
+      if (isInactiveVisible) {
+        await inactiveProjectRow.hover();
+        // In Inactive tab: buttons are [setting(0), activate(1), purge(2)]
+        await inactiveProjectRow
+          .locator('.bai-name-action-cell-actions button')
+          .nth(2)
+          .click();
+        const purgeDialog = page.getByRole('dialog', { name: 'Purge Project' });
+        await expect(purgeDialog).toBeVisible({ timeout: 5000 });
+        await purgeDialog.locator('#confirmText').fill(PROJECT_NAME);
+        await purgeDialog.getByRole('button', { name: 'Purge' }).click();
+        await expect(inactiveProjectRow).toBeHidden({ timeout: 10000 });
+      }
+
+      // Return to Active tab for subsequent tests
+      await page
+        .locator('label')
+        .filter({ hasText: /^Active$/ })
+        .click();
     }
 
     test('Admin can see project list with expected columns', async ({
@@ -46,13 +91,10 @@ test.describe.serial(
         page.getByRole('columnheader', { name: 'Name' }),
       ).toBeVisible();
       await expect(
-        page.getByRole('columnheader', { name: 'Controls' }),
-      ).toBeVisible();
-      await expect(
         page.getByRole('columnheader', { name: 'Domain' }),
       ).toBeVisible();
       await expect(
-        page.getByRole('columnheader', { name: 'Active' }),
+        page.getByRole('columnheader', { name: 'Description' }),
       ).toBeVisible();
       await expect(
         page.getByRole('columnheader', { name: 'Type' }),
@@ -65,9 +107,12 @@ test.describe.serial(
         .first();
       await expect(defaultRow).toBeVisible();
 
-      // 5. Verify default row has Active = true and Type = GENERAL
+      // 5. Verify the Active radio button is selected and the default row has Type = GENERAL
+      // (Active is a filter tab, not a table column; the default project is active by default)
       await expect(
-        defaultRow.getByRole('cell', { name: 'true' }),
+        page.locator('.ant-radio-button-wrapper-checked', {
+          hasText: 'Active',
+        }),
       ).toBeVisible();
       await expect(
         defaultRow.getByRole('cell', { name: 'GENERAL' }),
@@ -112,9 +157,12 @@ test.describe.serial(
       // 7. Verify modal closes
       await expect(modal).toBeHidden({ timeout: 10000 });
 
-      // 8. Verify the new project appears in the table
+      // 8. Verify the new project appears in the table.
+      // The name column now renders via BAINameActionCell so the cell's
+      // accessible name also includes hover-only action labels; match by
+      // filter({ hasText }) instead of exact name.
       await expect(
-        page.getByRole('cell', { name: PROJECT_NAME, exact: true }),
+        page.getByRole('row').filter({ hasText: PROJECT_NAME }),
       ).toBeVisible({ timeout: 10000 });
     });
 
@@ -123,11 +171,13 @@ test.describe.serial(
       await loginAsAdmin(page, request);
       await navigateTo(page, 'project');
 
-      // 2. Find the test project row and click the setting button
+      // 2. Find the test project row, hover to reveal BAINameActionCell
+      // action buttons, then click the setting (edit) button.
       const projectRow = page
         .getByRole('row')
         .filter({ hasText: PROJECT_NAME });
       await expect(projectRow).toBeVisible();
+      await projectRow.hover();
       await projectRow.getByRole('button', { name: 'setting' }).click();
 
       // 3. Verify Update Project dialog appears
@@ -171,9 +221,11 @@ test.describe.serial(
       // 3. Click the search button
       await page.getByRole('button', { name: 'search' }).click();
 
-      // 4. Verify table shows only the matching project
+      // 4. Verify table shows only the matching project. The Name cell
+      // renders BAINameActionCell, so its accessible name also includes
+      // hover-only action labels; match the row by hasText instead.
       await expect(
-        page.getByRole('cell', { name: PROJECT_NAME, exact: true }),
+        page.getByRole('row').filter({ hasText: PROJECT_NAME }),
       ).toBeVisible({ timeout: 10000 });
 
       // 5. Verify only one data row is visible (excluding header rows)
@@ -197,29 +249,64 @@ test.describe.serial(
       await loginAsAdmin(page, request);
       await navigateTo(page, 'project');
 
-      // 2. Find the test project row
+      // 2. Find the test project row (Active tab is the default view)
       const projectRow = page
         .getByRole('row')
         .filter({ hasText: PROJECT_NAME });
       await expect(projectRow).toBeVisible();
 
-      // 3. Click the delete button
-      await projectRow.getByRole('button', { name: 'delete' }).click();
+      // 3. The project lifecycle is Active → Deactivated → Purged.
+      //    Step 1: Deactivate — hover the row to reveal the BAINameActionCell
+      //    action buttons, then click the deactivate button (index 1 in the
+      //    Active tab; index 0 is the setting/edit button).
+      await projectRow.hover();
+      await projectRow
+        .locator('.bai-name-action-cell-actions button')
+        .nth(1)
+        .click();
 
-      // 4. Verify Purge Project confirmation dialog appears
+      // 4. Confirm the antd Popconfirm for deactivation
+      const deactivatePopconfirm = page.locator('.ant-popconfirm');
+      await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
+      await deactivatePopconfirm
+        .getByRole('button', { name: 'Deactivate' })
+        .click();
+
+      // 5. Verify the project disappears from the Active list
+      await expect(projectRow).toBeHidden({ timeout: 10000 });
+
+      // 6. Switch to the Inactive tab to find the deactivated project
+      await page
+        .locator('label')
+        .filter({ hasText: /^Inactive$/ })
+        .click();
+
+      // 7. Find the deactivated project row in the Inactive tab
+      const inactiveProjectRow = page
+        .getByRole('row')
+        .filter({ hasText: PROJECT_NAME });
+      await expect(inactiveProjectRow).toBeVisible({ timeout: 10000 });
+
+      // 8. Hover the row and click the Purge button (index 2 in the
+      //    Inactive tab: setting(0), activate(1), purge(2))
+      await inactiveProjectRow.hover();
+      await inactiveProjectRow
+        .locator('.bai-name-action-cell-actions button')
+        .nth(2)
+        .click();
+
+      // 9. Verify the Purge Project confirmation dialog appears
       const purgeDialog = page.getByRole('dialog', { name: 'Purge Project' });
-      await expect(purgeDialog).toBeVisible();
-      await expect(
-        purgeDialog.getByText('Are you sure to purge'),
-      ).toBeVisible();
+      await expect(purgeDialog).toBeVisible({ timeout: 5000 });
 
-      // 5. Confirm deletion by clicking Purge
+      // 10. Type the project name into the confirmation input to enable the Purge button
+      await purgeDialog.locator('#confirmText').fill(PROJECT_NAME);
+
+      // 11. Click the Purge button to permanently delete the project
       await purgeDialog.getByRole('button', { name: 'Purge' }).click();
 
-      // 6. Verify the test project is removed from the table
-      await expect(
-        page.getByRole('row').filter({ hasText: PROJECT_NAME }),
-      ).toBeHidden({ timeout: 10000 });
+      // 12. Verify the project is removed from the Inactive table
+      await expect(inactiveProjectRow).toBeHidden({ timeout: 10000 });
     });
   },
 );


### PR DESCRIPTION
Resolves #7633 (FR-2998)

**Stacked on**: #7688 (FR-2997) → #7684 (FR-2996) → #7679 (FR-2995) → #7676 (FR-2994) → #7653 (FR-2993) → #7652 (FR-2992)

Part of FR-2059 (Fix Broken E2E Tests Cases). Repairs the Admin & Operations sub-category — 4 originally failing tests + cascading rewrites to project-crud after exposing the new lifecycle UX. Final state: **45 pass / 0 fail / 2 skip** across `e2e/environment/`, `e2e/my-environment/`, `e2e/project/`, `e2e/maintenance/`, `e2e/information/`, `e2e/statistics/`.

## Root causes

- **`environment/registry.spec.ts:63`** (registry list columns): the `Control` column was removed when `ContainerRegistryListNodes` migrated to `BAINameActionCell` (actions embedded in the Registry Name cell). Removed the obsolete columnheader assertion; the 7 real columns are still validated.

- **`environment/registry.spec.ts:716`** (filter property): the test used the CSS class `.ant-select-content-value` which does not exist in this antd version. Actual class is `.ant-select-content` (with optional `.ant-select-content-has-value`). Switched to `page.locator('.ant-select-content').filter({ hasText: 'Registry Name' })`.

- **`information/information.spec.ts:6`** (page server details): strict-mode hit. `getByText('Component')` matched both the `ant-descriptions-title` and the `'Loading components...'` loader. Added `{ exact: true }`.

- **`project/project-crud.spec.ts:31`** (project list columns): the `Controls` column was removed when the project list migrated to `BAIProjectTable` + `BAINameActionCell`. The `Active` column was also removed; active vs inactive is now a filter radio group. The test now asserts the 4 real columns (`Name`, `Domain`, `Description`, `Type`) and verifies the Active radio is selected via `.ant-radio-button-wrapper-checked`.

### Cascading rewrites in `project/project-crud.spec.ts` (uncovered by the column fix)

- **`:78` (create), `:122` (edit)** — the Name cell now renders via `BAINameActionCell`. Replaced the exact `getByRole('cell', { name: PROJECT_NAME, exact: true })` assertion with `getByRole('row').filter({ hasText: PROJECT_NAME })` since the cell's accessible name includes hover-only action labels. The Edit test now hovers the row before clicking the (hover-only) `setting` action button.

- **`:200` (delete)** — the project lifecycle changed from a one-shot Purge dialog to a two-step flow: **Active → Deactivated (Popconfirm) → Purged (`BAIDeleteConfirmModal` with `requireConfirmInput`)**. Rewrote the test and shared `cleanupTestProject` helper to:
  1. Hover the row, click deactivate (action button `nth(1)`).
  2. Confirm the antd Popconfirm.
  3. Switch to the Inactive tab via the label wrapper (the radio input itself is hidden).
  4. Hover the deactivated row, click purge (action button `nth(2)`).
  5. Type the project name into `#confirmText`, click Purge.
  6. Verify the row is gone, then return to the Active tab.

  Mirrors the user / role / vfolder destructive-action conventions already standardized in FR-2992 through FR-2997.

## Files changed

- `e2e/environment/registry.spec.ts` — removed obsolete `Control` columnheader; corrected filter-property selector class
- `e2e/information/information.spec.ts` — `{ exact: true }` on `Component`
- `e2e/project/project-crud.spec.ts` — column-set update, hover-then-click for `setting`, two-step deactivate→purge for delete, shared `cleanupTestProject` helper

## Test plan

- [x] `pnpm exec playwright test e2e/environment/ e2e/my-environment/ e2e/project/ e2e/maintenance/ e2e/information/ e2e/statistics/ --workers=2` — 45 pass / 0 fail / 2 skip
- [x] `pnpm exec playwright test e2e/project/project-crud.spec.ts` (full file in serial mode) — all 5 tests pass
- [x] Individual retries of the parallel-only flake (`environment.spec.ts:188 user can manage apps`) pass cleanly (17s) — backend-state-dependent test, not a regression
