### PR TITLE
feat(FR-3032): add BAIAuditLogNodes common audit-log table to BUI

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIAuditLogNodesFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAuditLogNodesFragment.graphql.ts
@@ -1,0 +1,164 @@
+/**
+ * @generated SignedSource<<ad95c6bade27aae5a1da84eea3633438>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AuditLogStatus = "ERROR" | "RUNNING" | "SUCCESS" | "UNKNOWN" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type BAIAuditLogNodesFragment$data = ReadonlyArray<{
+  readonly actionId: string;
+  readonly createdAt: string;
+  readonly description: string;
+  readonly duration: string | null | undefined;
+  readonly entityId: string | null | undefined;
+  readonly entityType: string;
+  readonly id: string;
+  readonly operation: string;
+  readonly requestId: string | null | undefined;
+  readonly status: AuditLogStatus;
+  readonly triggeredBy: string | null | undefined;
+  readonly user: {
+    readonly basicInfo: {
+      readonly email: string;
+    };
+    readonly id: string;
+  } | null | undefined;
+  readonly " $fragmentType": "BAIAuditLogNodesFragment";
+}>;
+export type BAIAuditLogNodesFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAIAuditLogNodesFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIAuditLogNodesFragment">;
+}>;
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "BAIAuditLogNodesFragment",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "operation",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "duration",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "requestId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "actionId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "entityType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "entityId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "triggeredBy",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "UserV2",
+      "kind": "LinkedField",
+      "name": "user",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "UserV2BasicInfo",
+          "kind": "LinkedField",
+          "name": "basicInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "email",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "AuditLogV2",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "f2d26f682eb8305a97c2b876d27bbdd4";
+
+export default node;

--- a/packages/backend.ai-ui/src/components/BAIAuditLogStatusTag.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAuditLogStatusTag.stories.tsx
@@ -1,0 +1,168 @@
+import BAIAuditLogStatusTag, { AuditLogStatus } from './BAIAuditLogStatusTag';
+import BAIFlex from './BAIFlex';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * BAIAuditLogStatusTag displays an audit log entry's status using a semantic
+ * color-coded badge.
+ *
+ * Key features:
+ * - Semantic color system: success (green), error (red), info (blue), outline (unknown)
+ * - `RUNNING` adds a processing (ripple) animation
+ * - Colors automatically adapt to light/dark theme via Ant Design design tokens
+ * - Simple presentational component with no Relay dependency
+ */
+const meta: Meta<typeof BAIAuditLogStatusTag> = {
+  title: 'Badge/BAIAuditLogStatusTag',
+  component: BAIAuditLogStatusTag,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIAuditLogStatusTag** displays an audit log status with a semantic color-coded badge.
+
+## Features
+- Semantic color system using Ant Design design tokens (theme-aware)
+- SUCCESS → success (green)
+- ERROR → error (red)
+- RUNNING → info (blue) with a processing ripple
+- UNKNOWN → outline-only dot (indeterminate)
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| status | \`AuditLogStatus \\| null\` | - | The audit log status to display |
+
+## Usage
+\`\`\`tsx
+<BAIAuditLogStatusTag status="SUCCESS" />
+<BAIAuditLogStatusTag status="ERROR" />
+<BAIAuditLogStatusTag status="RUNNING" />
+<BAIAuditLogStatusTag status="UNKNOWN" />
+\`\`\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    status: {
+      control: { type: 'select' },
+      options: ['SUCCESS', 'ERROR', 'RUNNING', 'UNKNOWN', null],
+      description: 'The audit log status to display',
+      table: {
+        type: {
+          summary: "'SUCCESS' | 'ERROR' | 'RUNNING' | 'UNKNOWN' | null",
+        },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIAuditLogStatusTag>;
+
+/**
+ * Default state showing a successful operation.
+ */
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Basic usage showing a successful audit log entry with a green badge.',
+      },
+    },
+  },
+  args: {
+    status: 'SUCCESS',
+  },
+};
+
+/**
+ * Error state — the operation failed, shown in red.
+ */
+export const Error: Story = {
+  name: 'ErrorState',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows a failed audit log entry with a red badge.',
+      },
+    },
+  },
+  args: {
+    status: 'ERROR',
+  },
+};
+
+/**
+ * Running state — the operation is in progress, shown in blue with a ripple.
+ */
+export const Running: Story = {
+  name: 'RunningState',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows an in-progress audit log entry with a blue (info) badge and a processing ripple animation.',
+      },
+    },
+  },
+  args: {
+    status: 'RUNNING',
+  },
+};
+
+/**
+ * Unknown state — indeterminate status, shown as an outline-only dot.
+ */
+export const Unknown: Story = {
+  name: 'UnknownState',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows an unknown audit log status as an outline-only dot, indicating an indeterminate state.',
+      },
+    },
+  },
+  args: {
+    status: 'UNKNOWN',
+  },
+};
+
+/**
+ * Display all status variants side by side for comparison.
+ */
+export const AllStatuses: Story = {
+  name: 'AllStatuses',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays all available audit log statuses for comparison. Colors are derived from Ant Design semantic tokens and adapt to the active theme.',
+      },
+    },
+  },
+  render: () => {
+    const statuses: AuditLogStatus[] = [
+      'SUCCESS',
+      'ERROR',
+      'RUNNING',
+      'UNKNOWN',
+    ];
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        {statuses.map((status) => (
+          <BAIAuditLogStatusTag key={status} status={status} />
+        ))}
+        <BAIAuditLogStatusTag status={null} />
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAIAuditLogStatusTag.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAuditLogStatusTag.tsx
@@ -1,0 +1,51 @@
+import { SemanticColor } from '../helper';
+import BAIBadge, { BAIBadgeProps } from './BAIBadge';
+import * as _ from 'lodash-es';
+
+/**
+ * Status values of an audit log entry, mirroring the backend `AuditLogStatus`
+ * enum (`SUCCESS | ERROR | UNKNOWN | RUNNING`). Defined as a hand-written union
+ * so the badge stays a presentational component with no Relay dependency.
+ */
+export type AuditLogStatus = 'SUCCESS' | 'ERROR' | 'UNKNOWN' | 'RUNNING';
+
+export interface BAIAuditLogStatusTagProps extends Omit<
+  BAIBadgeProps,
+  'text' | 'color' | 'processing'
+> {
+  status: AuditLogStatus | null;
+}
+
+const statusSemanticMap: Record<AuditLogStatus, SemanticColor | undefined> = {
+  SUCCESS: 'success',
+  ERROR: 'error',
+  RUNNING: 'info',
+  // Unknown / indeterminate — render an outline-only dot (color undefined).
+  UNKNOWN: undefined,
+} as const;
+
+/**
+ * BAIAuditLogStatusTag - Semantic color-coded status badge for audit log
+ * entries. Wraps {@link BAIBadge}, mapping each `AuditLogStatus` to a semantic
+ * color (`SUCCESS` → success, `ERROR` → error, `RUNNING` → info + processing
+ * ripple, `UNKNOWN` → outline dot). Presentational only, no Relay dependency.
+ */
+const BAIAuditLogStatusTag = ({
+  status,
+  ...badgeProps
+}: BAIAuditLogStatusTagProps) => {
+  'use memo';
+  const semanticColor = status ? _.get(statusSemanticMap, status) : undefined;
+
+  return (
+    <BAIBadge
+      {...badgeProps}
+      color={semanticColor}
+      processing={status === 'RUNNING'}
+      text={status}
+      style={{ whiteSpace: 'nowrap', ...badgeProps.style }}
+    />
+  );
+};
+
+export default BAIAuditLogStatusTag;

--- a/packages/backend.ai-ui/src/components/fragments/BAIAuditLogNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAuditLogNodes.tsx
@@ -1,0 +1,214 @@
+import {
+  BAIAuditLogNodesFragment$data,
+  BAIAuditLogNodesFragment$key,
+} from '../../__generated__/BAIAuditLogNodesFragment.graphql';
+import { filterOutEmpty, filterOutNullAndUndefined } from '../../helper';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
+import BAIAuditLogStatusTag, { AuditLogStatus } from '../BAIAuditLogStatusTag';
+import BAIId from '../BAIId';
+import BAIText from '../BAIText';
+import {
+  BAIColumnsType,
+  BAIColumnType,
+  BAITable,
+  BAITableProps,
+} from '../Table';
+import dayjs from 'dayjs';
+import * as _ from 'lodash-es';
+import { graphql, useFragment } from 'react-relay';
+
+export type AuditLogNodeInList = NonNullable<
+  BAIAuditLogNodesFragment$data[number]
+>;
+
+const availableAuditLogSorterKeys = [
+  'createdAt',
+  'operation',
+  'status',
+] as const;
+
+export const availableAuditLogSorterValues = [
+  ...availableAuditLogSorterKeys,
+  ...availableAuditLogSorterKeys.map((key) => `-${key}` as const),
+] as const;
+
+const isEnableSorter = (key: string) => {
+  return _.includes(availableAuditLogSorterKeys, key);
+};
+
+const toAuditLogStatus = (status: string): AuditLogStatus | null => {
+  return _.includes(['SUCCESS', 'ERROR', 'UNKNOWN', 'RUNNING'], status)
+    ? (status as AuditLogStatus)
+    : null;
+};
+
+export interface BAIAuditLogNodesProps extends Omit<
+  BAITableProps<AuditLogNodeInList>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
+  auditLogFrgmt: BAIAuditLogNodesFragment$key;
+  disableSorter?: boolean;
+  customizeColumns?: (
+    baseColumns: BAIColumnsType<AuditLogNodeInList>,
+  ) => BAIColumnsType<AuditLogNodeInList>;
+  onChangeOrder?: (
+    order: (typeof availableAuditLogSorterValues)[number] | null,
+  ) => void;
+}
+
+/**
+ * BAIAuditLogNodes - The common audit log table view. Presentational table over
+ * an `AuditLogV2` plural fragment, scoped to a single resource. Renders the
+ * standardized column / status UX shared across the Session, VFolder, and Model
+ * Deployment detail surfaces; filter, pagination, and query orchestration live
+ * in the consuming surface.
+ */
+const BAIAuditLogNodes = ({
+  auditLogFrgmt,
+  disableSorter,
+  customizeColumns,
+  onChangeOrder,
+  ...tableProps
+}: BAIAuditLogNodesProps) => {
+  'use memo';
+  const { t } = useBAIi18n();
+
+  const auditLogs = useFragment<BAIAuditLogNodesFragment$key>(
+    graphql`
+      fragment BAIAuditLogNodesFragment on AuditLogV2 @relay(plural: true) {
+        id
+        createdAt
+        operation
+        status
+        description
+        duration
+        requestId
+        actionId
+        entityType
+        entityId
+        triggeredBy
+        user {
+          id
+          basicInfo {
+            email
+          }
+        }
+      }
+    `,
+    auditLogFrgmt,
+  );
+
+  const baseColumns = _.map(
+    filterOutEmpty<BAIColumnType<AuditLogNodeInList>>([
+      {
+        key: 'createdAt',
+        title: t('comp:BAIAuditLogNodes.Time'),
+        dataIndex: 'createdAt',
+        sorter: isEnableSorter('createdAt'),
+        render: (__, record) =>
+          record.createdAt ? dayjs(record.createdAt).format('ll LTS') : '-',
+      },
+      {
+        key: 'operation',
+        title: t('comp:BAIAuditLogNodes.Operation'),
+        dataIndex: 'operation',
+        sorter: isEnableSorter('operation'),
+        render: (__, record) => record.operation || '-',
+      },
+      {
+        key: 'actor',
+        title: t('comp:BAIAuditLogNodes.Actor'),
+        render: (__, record) => record.user?.basicInfo?.email || '-',
+      },
+      {
+        key: 'status',
+        title: t('comp:BAIAuditLogNodes.Status'),
+        dataIndex: 'status',
+        sorter: isEnableSorter('status'),
+        render: (__, record) => (
+          <BAIAuditLogStatusTag status={toAuditLogStatus(record.status)} />
+        ),
+      },
+      {
+        key: 'description',
+        title: t('comp:BAIAuditLogNodes.Description'),
+        dataIndex: 'description',
+        onCell: () => ({ style: { maxWidth: 400 } }),
+        render: (__, record) =>
+          record.description ? (
+            <BAIText ellipsis={{ tooltip: true }} style={{ width: '100%' }}>
+              {record.description}
+            </BAIText>
+          ) : (
+            '-'
+          ),
+      },
+      {
+        key: 'duration',
+        title: t('comp:BAIAuditLogNodes.Duration'),
+        dataIndex: 'duration',
+        render: (__, record) => record.duration || '-',
+      },
+      {
+        key: 'triggeredBy',
+        title: t('comp:BAIAuditLogNodes.TriggeredBy'),
+        render: (__, record) =>
+          record.triggeredBy ? <BAIId uuid={record.triggeredBy} /> : '-',
+      },
+      {
+        key: 'entityType',
+        title: t('comp:BAIAuditLogNodes.EntityType'),
+        dataIndex: 'entityType',
+        defaultHidden: true,
+        render: (__, record) => record.entityType || '-',
+      },
+      {
+        key: 'entityId',
+        title: t('comp:BAIAuditLogNodes.EntityId'),
+        defaultHidden: true,
+        render: (__, record) =>
+          record.entityId ? <BAIId uuid={record.entityId} /> : '-',
+      },
+      {
+        key: 'requestId',
+        title: t('comp:BAIAuditLogNodes.RequestId'),
+        defaultHidden: true,
+        render: (__, record) =>
+          record.requestId ? <BAIId uuid={record.requestId} /> : '-',
+      },
+      {
+        key: 'actionId',
+        title: t('comp:BAIAuditLogNodes.ActionId'),
+        defaultHidden: true,
+        render: (__, record) =>
+          record.actionId ? <BAIId uuid={record.actionId} /> : '-',
+      },
+    ]),
+    (column) => {
+      return disableSorter ? _.omit(column, 'sorter') : column;
+    },
+  );
+
+  const allColumns = customizeColumns
+    ? customizeColumns(baseColumns)
+    : baseColumns;
+
+  return (
+    <BAITable
+      resizable
+      rowKey="id"
+      size="small"
+      dataSource={filterOutNullAndUndefined(auditLogs)}
+      columns={allColumns}
+      scroll={{ x: 'max-content' }}
+      onChangeOrder={(order) => {
+        onChangeOrder?.(
+          (order as (typeof availableAuditLogSorterValues)[number]) || null,
+        );
+      }}
+      {...tableProps}
+    />
+  );
+};
+
+export default BAIAuditLogNodes;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -169,6 +169,11 @@ export type {
   BAISchedulingHistoryNodesProps,
   SchedulingHistoryNodeInList,
 } from './BAISchedulingHistoryNodes';
+export { default as BAIAuditLogNodes } from './BAIAuditLogNodes';
+export type {
+  BAIAuditLogNodesProps,
+  AuditLogNodeInList,
+} from './BAIAuditLogNodes';
 export { default as BAIDeploymentSchedulingHistoryNodes } from './BAIDeploymentSchedulingHistoryNodes';
 export type {
   BAIDeploymentSchedulingHistoryNodesProps,

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -122,6 +122,11 @@ export type {
   BAISchedulingResultBadgeProps,
   SchedulingResult,
 } from './BAISchedulingResultBadge';
+export { default as BAIAuditLogStatusTag } from './BAIAuditLogStatusTag';
+export type {
+  BAIAuditLogStatusTagProps,
+  AuditLogStatus,
+} from './BAIAuditLogStatusTag';
 export { default as StorageUsageBadge } from './StorageUsageBadge';
 export type { StorageUsageBadgeProps } from './StorageUsageBadge';
 export { default as BAIBoardItemErrorBoundary } from './BAIBoardItemErrorBoundary';

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -67,6 +67,19 @@
     "Updated": "Aktualisiert",
     "Version": "Version"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "Aktions-ID",
+    "Actor": "Akteur",
+    "Description": "Beschreibung",
+    "Duration": "Dauer",
+    "EntityId": "Entitäts-ID",
+    "EntityType": "Entitätstyp",
+    "Operation": "Vorgang",
+    "RequestId": "Anfragen-ID",
+    "Status": "Status",
+    "Time": "Zeit",
+    "TriggeredBy": "Ausgelöst von"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Voreinstellung auswählen"
   },

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -67,6 +67,19 @@
     "Updated": "Ενημερωμένος",
     "Version": "Εκδοχή"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID ενέργειας",
+    "Actor": "Εκτελεστής",
+    "Description": "Περιγραφή",
+    "Duration": "Διάρκεια",
+    "EntityId": "ID οντότητας",
+    "EntityType": "Τύπος οντότητας",
+    "Operation": "Λειτουργία",
+    "RequestId": "ID αιτήματος",
+    "Status": "Κατάσταση",
+    "Time": "Ώρα",
+    "TriggeredBy": "Ενεργοποιήθηκε από"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Επιλέξτε προεπιλογή"
   },

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -67,6 +67,19 @@
     "Updated": "Updated",
     "Version": "Version"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "Action ID",
+    "Actor": "Actor",
+    "Description": "Description",
+    "Duration": "Duration",
+    "EntityId": "Entity ID",
+    "EntityType": "Entity Type",
+    "Operation": "Operation",
+    "RequestId": "Request ID",
+    "Status": "Status",
+    "Time": "Time",
+    "TriggeredBy": "Triggered By"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Select Preset"
   },

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -67,6 +67,19 @@
     "Updated": "Actualizado",
     "Version": "Versión"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID de acción",
+    "Actor": "Actor",
+    "Description": "Descripción",
+    "Duration": "Duración",
+    "EntityId": "ID de entidad",
+    "EntityType": "Tipo de entidad",
+    "Operation": "Operación",
+    "RequestId": "ID de solicitud",
+    "Status": "Estado",
+    "Time": "Hora",
+    "TriggeredBy": "Iniciado por"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Seleccionar preset"
   },

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -67,6 +67,19 @@
     "Updated": "Päivitetty",
     "Version": "Versio"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "Toiminnon ID",
+    "Actor": "Suorittaja",
+    "Description": "Kuvaus",
+    "Duration": "Kesto",
+    "EntityId": "Entiteetin ID",
+    "EntityType": "Entiteettityyppi",
+    "Operation": "Toiminto",
+    "RequestId": "Pyynnön ID",
+    "Status": "Tila",
+    "Time": "Aika",
+    "TriggeredBy": "Laukaisija"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Valitse esiasetus"
   },

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -67,6 +67,19 @@
     "Updated": "Mis à jour",
     "Version": "Version"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID d'action",
+    "Actor": "Acteur",
+    "Description": "Description",
+    "Duration": "Durée",
+    "EntityId": "ID d'entité",
+    "EntityType": "Type d'entité",
+    "Operation": "Opération",
+    "RequestId": "ID de requête",
+    "Status": "Statut",
+    "Time": "Heure",
+    "TriggeredBy": "Déclenché par"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Sélectionner un preset"
   },

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -67,6 +67,19 @@
     "Updated": "Diperbarui",
     "Version": "Versi"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID Tindakan",
+    "Actor": "Pelaku",
+    "Description": "Deskripsi",
+    "Duration": "Durasi",
+    "EntityId": "ID Entitas",
+    "EntityType": "Jenis Entitas",
+    "Operation": "Operasi",
+    "RequestId": "ID Permintaan",
+    "Status": "Status",
+    "Time": "Waktu",
+    "TriggeredBy": "Dipicu oleh"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Pilih Preset"
   },

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -67,6 +67,19 @@
     "Updated": "Aggiornato",
     "Version": "Versione"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID azione",
+    "Actor": "Attore",
+    "Description": "Descrizione",
+    "Duration": "Durata",
+    "EntityId": "ID entità",
+    "EntityType": "Tipo di entità",
+    "Operation": "Operazione",
+    "RequestId": "ID richiesta",
+    "Status": "Stato",
+    "Time": "Ora",
+    "TriggeredBy": "Avviato da"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Seleziona preset"
   },

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -67,6 +67,19 @@
     "Updated": "更新",
     "Version": "バージョン"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "アクション ID",
+    "Actor": "実行者",
+    "Description": "説明",
+    "Duration": "所要時間",
+    "EntityId": "エンティティ ID",
+    "EntityType": "エンティティタイプ",
+    "Operation": "操作",
+    "RequestId": "リクエスト ID",
+    "Status": "ステータス",
+    "Time": "時刻",
+    "TriggeredBy": "起動者"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "プリセットを選択"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -67,6 +67,19 @@
     "Updated": "업데이트",
     "Version": "버전"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "액션 ID",
+    "Actor": "수행자",
+    "Description": "설명",
+    "Duration": "소요 시간",
+    "EntityId": "엔티티 ID",
+    "EntityType": "엔티티 유형",
+    "Operation": "작업",
+    "RequestId": "요청 ID",
+    "Status": "상태",
+    "Time": "시간",
+    "TriggeredBy": "실행자"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "프리셋을 선택해주세요"
   },

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -67,6 +67,19 @@
     "Updated": "Шинэчилсэн цаг нь",
     "Version": "Таамаглал"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "Үйлийн ID",
+    "Actor": "Гүйцэтгэгч",
+    "Description": "Тайлбар",
+    "Duration": "Үргэлжлэх хугацаа",
+    "EntityId": "Объектын ID",
+    "EntityType": "Объектын төрөл",
+    "Operation": "Үйлдэл",
+    "RequestId": "Хүсэлтийн ID",
+    "Status": "Төлөв",
+    "Time": "Цаг",
+    "TriggeredBy": "Өдөөгч"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Урьдчилан тохиргоо сонгох"
   },

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -67,6 +67,19 @@
     "Updated": "Dikemas kini",
     "Version": "Versi"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID Tindakan",
+    "Actor": "Pelaku",
+    "Description": "Penerangan",
+    "Duration": "Tempoh",
+    "EntityId": "ID Entiti",
+    "EntityType": "Jenis Entiti",
+    "Operation": "Operasi",
+    "RequestId": "ID Permintaan",
+    "Status": "Status",
+    "Time": "Masa",
+    "TriggeredBy": "Dicetuskan oleh"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Pilih Pratetap"
   },

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -67,6 +67,19 @@
     "Updated": "Zaktualizowane",
     "Version": "Wersja"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID akcji",
+    "Actor": "Aktor",
+    "Description": "Opis",
+    "Duration": "Czas trwania",
+    "EntityId": "ID encji",
+    "EntityType": "Typ encji",
+    "Operation": "Operacja",
+    "RequestId": "ID żądania",
+    "Status": "Status",
+    "Time": "Czas",
+    "TriggeredBy": "Wywołane przez"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Wybierz preset"
   },

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -67,6 +67,19 @@
     "Updated": "Atualizado",
     "Version": "Versão"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID de ação",
+    "Actor": "Ator",
+    "Description": "Descrição",
+    "Duration": "Duração",
+    "EntityId": "ID de entidade",
+    "EntityType": "Tipo de entidade",
+    "Operation": "Operação",
+    "RequestId": "ID de solicitação",
+    "Status": "Status",
+    "Time": "Hora",
+    "TriggeredBy": "Acionado por"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Selecionar preset"
   },

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -67,6 +67,19 @@
     "Updated": "Atualizado",
     "Version": "Versão"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID de ação",
+    "Actor": "Ator",
+    "Description": "Descrição",
+    "Duration": "Duração",
+    "EntityId": "ID de entidade",
+    "EntityType": "Tipo de entidade",
+    "Operation": "Operação",
+    "RequestId": "ID de solicitação",
+    "Status": "Estado",
+    "Time": "Hora",
+    "TriggeredBy": "Acionado por"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Selecionar preset"
   },

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -67,6 +67,19 @@
     "Updated": "Обновлено",
     "Version": "Версия"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID действия",
+    "Actor": "Исполнитель",
+    "Description": "Описание",
+    "Duration": "Длительность",
+    "EntityId": "ID объекта",
+    "EntityType": "Тип объекта",
+    "Operation": "Операция",
+    "RequestId": "ID запроса",
+    "Status": "Статус",
+    "Time": "Время",
+    "TriggeredBy": "Инициатор"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Выберите пресет"
   },

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -67,6 +67,19 @@
     "Updated": "อัปเดต",
     "Version": "รุ่น"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "รหัสการดำเนินการ",
+    "Actor": "ผู้ดำเนินการ",
+    "Description": "คำอธิบาย",
+    "Duration": "ระยะเวลา",
+    "EntityId": "รหัสเอนทิตี",
+    "EntityType": "ประเภทเอนทิตี",
+    "Operation": "การดำเนินการ",
+    "RequestId": "รหัสคำขอ",
+    "Status": "สถานะ",
+    "Time": "เวลา",
+    "TriggeredBy": "ผู้กระตุ้น"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "เลือกการตั้งค่าล่วงหน้า"
   },

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -67,6 +67,19 @@
     "Updated": "Güncellenmiş",
     "Version": "Versiyon"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "Eylem ID",
+    "Actor": "Aktör",
+    "Description": "Açıklama",
+    "Duration": "Süre",
+    "EntityId": "Varlık ID",
+    "EntityType": "Varlık Tipi",
+    "Operation": "İşlem",
+    "RequestId": "İstek ID",
+    "Status": "Durum",
+    "Time": "Zaman",
+    "TriggeredBy": "Tetikleyen"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Ön ayar seçin"
   },

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -67,6 +67,19 @@
     "Updated": "Cập nhật",
     "Version": "Phiên bản"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "ID hành động",
+    "Actor": "Người thực hiện",
+    "Description": "Mô tả",
+    "Duration": "Thời lượng",
+    "EntityId": "ID thực thể",
+    "EntityType": "Loại thực thể",
+    "Operation": "Thao tác",
+    "RequestId": "ID yêu cầu",
+    "Status": "Trạng thái",
+    "Time": "Thời gian",
+    "TriggeredBy": "Kích hoạt bởi"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "Chọn cài đặt sẵn"
   },

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -67,6 +67,19 @@
     "Updated": "更新",
     "Version": "版本"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "操作 ID",
+    "Actor": "执行者",
+    "Description": "描述",
+    "Duration": "持续时间",
+    "EntityId": "实体 ID",
+    "EntityType": "实体类型",
+    "Operation": "操作",
+    "RequestId": "请求 ID",
+    "Status": "状态",
+    "Time": "时间",
+    "TriggeredBy": "触发者"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "选择预设"
   },

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -67,6 +67,19 @@
     "Updated": "更新",
     "Version": "版本"
   },
+  "comp:BAIAuditLogNodes": {
+    "ActionId": "操作 ID",
+    "Actor": "執行者",
+    "Description": "描述",
+    "Duration": "持續時間",
+    "EntityId": "實體 ID",
+    "EntityType": "實體類型",
+    "Operation": "操作",
+    "RequestId": "請求 ID",
+    "Status": "狀態",
+    "Time": "時間",
+    "TriggeredBy": "觸發者"
+  },
   "comp:BAIAvailablePresetSelect": {
     "SelectPreset": "選擇預設"
   },


### PR DESCRIPTION
Resolves #7700 (FR-3032)

> **Stacked on** #7550 (`feat(FR-2949): add AuditLogTable component spec`). Review/merge that spec PR first.
>
> Implements the spec authored in **FR-2949** (`.specs/FR-2949-audit-log-table/spec.md`), under Epic **FR-2920**.

## Scope

Implements only the **공통 뷰 (common view)** of the audit-log table as a reusable BUI component, per the spec's `공통 뷰 — 레이아웃 / 컬럼 / 정렬·페이지네이션` sections. Follows the thin `*Nodes` precedent (`BAISchedulingHistoryNodes`): a presentational table over a Relay fragment; **filters, pagination, and per-surface query orchestration stay in the consuming surface**.

## Changes (`packages/backend.ai-ui/`)

- **`BAIAuditLogNodes`** (`components/fragments/`) — table over an `AuditLogV2 @relay(plural: true)` fragment.
  - Visible columns: **Time · Operation · Actor · Status · Description · Duration**.
  - Hidden via column toggle (`defaultHidden`): **Request ID · Action ID** (copyable `BAIId`).
  - Sortable on `createdAt / operation / status` → `AuditLogOrderField` (`ENTITY_TYPE` omitted — single-resource scope).
  - Actor reads `user.basicInfo.email` directly (backend resolves from `triggered_by`; no separate lookup, no UUID fallback).
  - Description: `BAIText` ellipsis + hover tooltip. Exposes `customizeColumns` / `disableSorter` / `onChangeOrder` + table passthrough.
- **`BAIAuditLogStatusTag`** (+ story) — semantic status badge: `SUCCESS`→success, `ERROR`→error, `RUNNING`→info+ripple, `UNKNOWN`→outline dot.
- `comp:BAIAuditLogNodes` i18n keys (en/ko); component exports; generated Relay fragment.

## Not in this PR (deferred to follow-up sub-tasks under FR-2920)

Filter bar (`BAIGraphQLPropertyFilter`: date / status / operation / actor), cursor pagination (**default page size 10**, options `[10, 50, 100]`), render-as-you-fetch tab hosting, version gating, and the Session / VFolder / Deployment entry points.

## Verification

`bash scripts/verify.sh`: **Relay / Lint / Format / TypeScript PASS.** The one harness `FAIL` ("Vite warmup paths") is **pre-existing** — a greedy-awk parse bug in `react/vite.config.ts` (untouched here) that fails identically on clean `main`.

Verified at compile/type level against the schema-generated fragment. The `BAIAuditLogNodes` render path is not yet exercised (no consumer mounts it — matching the `*Nodes` no-mock-story convention); `BAIAuditLogStatusTag` is covered by its story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)