### PR TITLE
feat(FR-3033): add ScopedAuditLog preloaded audit-log view (filter + refresh)

### DIFF
--- a/react/src/__generated__/ScopedAuditLogQuery.graphql.ts
+++ b/react/src/__generated__/ScopedAuditLogQuery.graphql.ts
@@ -1,0 +1,384 @@
+/**
+ * @generated SignedSource<<fbea6f237e6dc12f6f2686754b5eb0c5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type AuditLogOrderField = "CREATED_AT" | "ENTITY_TYPE" | "OPERATION" | "STATUS" | "%future added value";
+export type AuditLogStatus = "ERROR" | "RUNNING" | "SUCCESS" | "UNKNOWN" | "%future added value";
+export type OrderDirection = "ASC" | "DESC" | "%future added value";
+export type RBACElementType = "AGENT" | "APP_CONFIG" | "ARTIFACT" | "ARTIFACT_REGISTRY" | "ARTIFACT_REVISION" | "AUDIT_LOG" | "CONTAINER_REGISTRY" | "DEPLOYMENT_POLICY" | "DEPLOYMENT_REVISION" | "DEPLOYMENT_TOKEN" | "DOMAIN" | "DOMAIN_ADMIN_PAGE" | "EVENT_LOG" | "IMAGE" | "IMAGE_ALIAS" | "KERNEL" | "KEYPAIR" | "KEYPAIR_RESOURCE_POLICY" | "MODEL_CARD" | "MODEL_DEPLOYMENT" | "NETWORK" | "NOTIFICATION_CHANNEL" | "NOTIFICATION_RULE" | "PROJECT" | "PROJECT_ADMIN_PAGE" | "PROJECT_RESOURCE_POLICY" | "RESOURCE_GROUP" | "RESOURCE_PRESET" | "ROLE" | "ROLE_ASSIGNMENT" | "ROUTING" | "SESSION" | "SESSION_APP_SERVICE" | "SESSION_TEMPLATE" | "STORAGE_HOST" | "USER" | "USER_EMAIL" | "USER_RESOURCE_POLICY" | "VFOLDER" | "VFOLDER_DATA" | "%future added value";
+export type AuditLogScope = {
+  entity?: ReadonlyArray<EntityTypeScope> | null | undefined;
+  triggeredUser?: ReadonlyArray<UUIDScope> | null | undefined;
+};
+export type EntityTypeScope = {
+  entityId: string;
+  entityType: RBACElementType;
+};
+export type UUIDScope = {
+  value: string;
+};
+export type AuditLogFilter = {
+  AND?: ReadonlyArray<AuditLogFilter> | null | undefined;
+  NOT?: ReadonlyArray<AuditLogFilter> | null | undefined;
+  OR?: ReadonlyArray<AuditLogFilter> | null | undefined;
+  createdAt?: DateTimeFilter | null | undefined;
+  entityId?: StringFilter | null | undefined;
+  entityType?: StringFilter | null | undefined;
+  operation?: StringFilter | null | undefined;
+  status?: AuditLogStatusFilter | null | undefined;
+  triggeredBy?: StringFilter | null | undefined;
+};
+export type StringFilter = {
+  contains?: string | null | undefined;
+  endsWith?: string | null | undefined;
+  equals?: string | null | undefined;
+  iContains?: string | null | undefined;
+  iEndsWith?: string | null | undefined;
+  iEquals?: string | null | undefined;
+  iIn?: ReadonlyArray<string> | null | undefined;
+  iNotContains?: string | null | undefined;
+  iNotEndsWith?: string | null | undefined;
+  iNotEquals?: string | null | undefined;
+  iNotIn?: ReadonlyArray<string> | null | undefined;
+  iNotStartsWith?: string | null | undefined;
+  iStartsWith?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notContains?: string | null | undefined;
+  notEndsWith?: string | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
+  notStartsWith?: string | null | undefined;
+  startsWith?: string | null | undefined;
+};
+export type AuditLogStatusFilter = {
+  equals?: AuditLogStatus | null | undefined;
+  in?: ReadonlyArray<AuditLogStatus> | null | undefined;
+  notEquals?: AuditLogStatus | null | undefined;
+  notIn?: ReadonlyArray<AuditLogStatus> | null | undefined;
+};
+export type DateTimeFilter = {
+  after?: string | null | undefined;
+  before?: string | null | undefined;
+  equals?: string | null | undefined;
+  notEquals?: string | null | undefined;
+};
+export type AuditLogOrderBy = {
+  direction?: OrderDirection;
+  field: AuditLogOrderField;
+};
+export type ScopedAuditLogQuery$variables = {
+  filter?: AuditLogFilter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  orderBy?: ReadonlyArray<AuditLogOrderBy> | null | undefined;
+  scope: AuditLogScope;
+};
+export type ScopedAuditLogQuery$data = {
+  readonly scopedAuditLogsV2: {
+    readonly count: number;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly " $fragmentSpreads": FragmentRefs<"BAIAuditLogNodesFragment">;
+      };
+    }>;
+  } | null | undefined;
+};
+export type ScopedAuditLogQuery = {
+  response: ScopedAuditLogQuery$data;
+  variables: ScopedAuditLogQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "limit"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "scope"
+},
+v5 = [
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Variable",
+    "name": "offset",
+    "variableName": "offset"
+  },
+  {
+    "kind": "Variable",
+    "name": "orderBy",
+    "variableName": "orderBy"
+  },
+  {
+    "kind": "Variable",
+    "name": "scope",
+    "variableName": "scope"
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ScopedAuditLogQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v5/*: any*/),
+        "concreteType": "AuditLogV2Connection",
+        "kind": "LinkedField",
+        "name": "scopedAuditLogsV2",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AuditLogV2Edge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AuditLogV2",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "BAIAuditLogNodesFragment"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v4/*: any*/),
+      (v0/*: any*/),
+      (v3/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ScopedAuditLogQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v5/*: any*/),
+        "concreteType": "AuditLogV2Connection",
+        "kind": "LinkedField",
+        "name": "scopedAuditLogsV2",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AuditLogV2Edge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AuditLogV2",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v7/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "operation",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "status",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "description",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "duration",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "requestId",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "actionId",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "entityType",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "entityId",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "triggeredBy",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "UserV2",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "UserV2BasicInfo",
+                        "kind": "LinkedField",
+                        "name": "basicInfo",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "email",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2dcf9c0b20e5a73b15d792b27a74e854",
+    "id": null,
+    "metadata": {},
+    "name": "ScopedAuditLogQuery",
+    "operationKind": "query",
+    "text": "query ScopedAuditLogQuery(\n  $scope: AuditLogScope!\n  $filter: AuditLogFilter\n  $orderBy: [AuditLogOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  scopedAuditLogsV2(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAIAuditLogNodesFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIAuditLogNodesFragment on AuditLogV2 {\n  id\n  createdAt\n  operation\n  status\n  description\n  duration\n  requestId\n  actionId\n  entityType\n  entityId\n  triggeredBy\n  user {\n    id\n    basicInfo {\n      email\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "aed480d1dcdb66e1eb7a47b53892072d";
+
+export default node;

--- a/react/src/components/ScopedAuditLog.tsx
+++ b/react/src/components/ScopedAuditLog.tsx
@@ -1,0 +1,197 @@
+import type {
+  AuditLogOrderBy,
+  AuditLogScope,
+  ScopedAuditLogQuery as ScopedAuditLogQueryType,
+} from '../__generated__/ScopedAuditLogQuery.graphql';
+import { convertToOrderBy } from '../helper';
+import {
+  BAIAuditLogNodes,
+  type BAIAuditLogNodesProps,
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIGraphQLPropertyFilter,
+  filterOutNullAndUndefined,
+  useFetchKey,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { useDeferredValue } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  graphql,
+  PreloadedQuery,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
+
+export type { AuditLogScope };
+
+export const ScopedAuditLogQuery = graphql`
+  query ScopedAuditLogQuery(
+    $scope: AuditLogScope!
+    $filter: AuditLogFilter
+    $orderBy: [AuditLogOrderBy!]
+    $limit: Int
+    $offset: Int
+  ) {
+    scopedAuditLogsV2(
+      scope: $scope
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          ...BAIAuditLogNodesFragment
+        }
+      }
+    }
+  }
+`;
+
+export interface ScopedAuditLogProps extends Omit<
+  BAIAuditLogNodesProps,
+  | 'auditLogFrgmt'
+  | 'loading'
+  | 'order'
+  | 'onChangeOrder'
+  | 'dataSource'
+  | 'pagination'
+> {
+  queryRef: PreloadedQuery<ScopedAuditLogQueryType>;
+  onReload: (
+    variables: ScopedAuditLogQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
+
+/**
+ * ScopedAuditLog - Reads a preloaded `scopedAuditLogsV2` query and renders it as
+ * a `BAIAuditLogNodes` table with a filter bar and a refresh button. Mirrors the
+ * `DeploymentSchedulingHistoryModal` idiom: the consumer owns `useQueryLoader` /
+ * `loadQuery` (and the scope); this view reads the `queryRef` via
+ * `usePreloadedQuery` and re-runs filter / sort / refresh through `onReload`.
+ * Reading the *deferred* `queryRef` keeps the previous rows visible while the
+ * next result loads (inline loading, no Suspense-fallback flash). Render inside a
+ * `Suspense` (+ `BAIErrorBoundary`) boundary.
+ */
+const ScopedAuditLog = ({
+  queryRef,
+  onReload,
+  ...tableProps
+}: ScopedAuditLogProps) => {
+  'use memo';
+  const { t } = useTranslation();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+
+  const filter = queryRef.variables.filter ?? undefined;
+  const orderBy = queryRef.variables.orderBy?.[0];
+  const order = orderBy
+    ? `${orderBy.direction === 'DESC' ? '-' : ''}${_.camelCase(orderBy.field)}`
+    : null;
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
+
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
+
+  const data = usePreloadedQuery<ScopedAuditLogQueryType>(
+    ScopedAuditLogQuery,
+    deferredQueryRef,
+  );
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="sm">
+      <BAIFlex justify="between" wrap="wrap" gap="sm">
+        <BAIGraphQLPropertyFilter
+          value={filter}
+          onChange={(next) => {
+            onReload(
+              { ...queryRef.variables, filter: next, offset: 0 },
+              { fetchPolicy: 'network-only' },
+            );
+          }}
+          filterProperties={[
+            {
+              key: 'status',
+              propertyLabel: t('auditLog.Status'),
+              type: 'enum',
+              strictSelection: true,
+              options: [
+                { label: 'SUCCESS', value: 'SUCCESS' },
+                { label: 'ERROR', value: 'ERROR' },
+                { label: 'RUNNING', value: 'RUNNING' },
+                { label: 'UNKNOWN', value: 'UNKNOWN' },
+              ],
+            },
+            {
+              key: 'operation',
+              propertyLabel: t('auditLog.Operation'),
+              type: 'string',
+              fixedOperator: 'contains',
+            },
+            {
+              key: 'triggeredBy',
+              propertyLabel: t('auditLog.TriggeredBy'),
+              type: 'string',
+              fixedOperator: 'contains',
+            },
+            {
+              key: 'createdAt',
+              propertyLabel: t('auditLog.Time'),
+              type: 'datetime',
+              defaultOperator: 'after',
+            },
+          ]}
+        />
+        <BAIFetchKeyButton
+          value={fetchKey}
+          onChange={(key) => {
+            updateFetchKey(key);
+            onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+          }}
+          loading={isRefetching}
+          autoUpdateDelay={7_000}
+        />
+      </BAIFlex>
+      <BAIAuditLogNodes
+        resizable
+        loading={isRefetching}
+        order={order}
+        onChangeOrder={(nextOrder) => {
+          onReload(
+            {
+              ...queryRef.variables,
+              orderBy: convertToOrderBy<AuditLogOrderBy>(nextOrder),
+              offset: 0,
+            },
+            { fetchPolicy: 'network-only' },
+          );
+        }}
+        pagination={{
+          pageSize,
+          current,
+          total: data.scopedAuditLogsV2?.count ?? 0,
+          onChange: (nextCurrent, nextPageSize) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                limit: nextPageSize,
+                offset: nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          },
+        }}
+        auditLogFrgmt={filterOutNullAndUndefined(
+          _.map(data.scopedAuditLogsV2?.edges, 'node'),
+        )}
+        {...tableProps}
+      />
+    </BAIFlex>
+  );
+};
+
+export default ScopedAuditLog;

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Tool-Berechtigungsüberschreibungen",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Vorgang",
+    "Status": "Status",
+    "Time": "Zeit",
+    "TriggeredBy": "Ausgelöst von"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Automatische Skalierungsregel hinzufügen",
     "Comparator": "Vergleicher",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Παρακάμψεις δικαιωμάτων εργαλείων",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Λειτουργία",
+    "Status": "Κατάσταση",
+    "Time": "Ώρα",
+    "TriggeredBy": "Ενεργοποιήθηκε από"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Προσθέστε κανόνα αυτόματης κλιμάκωσης",
     "Comparator": "Συγκριτής",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -293,6 +293,12 @@
     "ToolConfig": "Tool Configuration",
     "ToolPermissionOverrides": "Tool Permission Overrides"
   },
+  "auditLog": {
+    "Operation": "Operation",
+    "Status": "Status",
+    "Time": "Time",
+    "TriggeredBy": "Triggered By"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Add Auto Scaling Rule",
     "Comparator": "Comparator",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Anulaciones de permisos de herramientas",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Operación",
+    "Status": "Estado",
+    "Time": "Hora",
+    "TriggeredBy": "Iniciado por"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Agregar regla de escala automática",
     "Comparator": "Comparador",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Työkalun oikeusohitukset",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Toiminto",
+    "Status": "Tila",
+    "Time": "Aika",
+    "TriggeredBy": "Käynnistänyt"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Lisää automaattinen skaalaussääntö",
     "Comparator": "Vertailu",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Substitutions de permissions des outils",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Opération",
+    "Status": "Statut",
+    "Time": "Heure",
+    "TriggeredBy": "Déclenché par"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Ajouter la règle de mise à l'échelle automatique",
     "Comparator": "Comparateur",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Penggantian izin alat",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Operasi",
+    "Status": "Status",
+    "Time": "Waktu",
+    "TriggeredBy": "Dipicu oleh"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Tambahkan aturan penskalaan otomatis",
     "Comparator": "Pembanding",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Sostituzioni autorizzazioni strumenti",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Operazione",
+    "Status": "Stato",
+    "Time": "Ora",
+    "TriggeredBy": "Attivato da"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Aggiungi regola di ridimensionamento automatico",
     "Comparator": "Comparatore",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "ツール権限オーバーライド",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "操作",
+    "Status": "状態",
+    "Time": "時間",
+    "TriggeredBy": "実行者"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "自動スケーリングルールを追加します",
     "Comparator": "コンパレータ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "도구 권한 재정의",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "작업",
+    "Status": "상태",
+    "Time": "시간",
+    "TriggeredBy": "실행자"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "오토스케일링 규칙 추가",
     "Comparator": "연산자",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Хэрэгслийн зөвшөөрлийн дарааллууд",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Үйлдэл",
+    "Status": "Статус",
+    "Time": "Цаг",
+    "TriggeredBy": "Гүйцэтгэсэн"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Автомат масштабыг нэмэх",
     "Comparator": "Автоматлагч",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Penggantian kebenaran alat",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Operasi",
+    "Status": "Status",
+    "Time": "Masa",
+    "TriggeredBy": "Dicetuskan oleh"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Tambahkan peraturan penskalaan automatik",
     "Comparator": "Komparator",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Zastąpienia uprawnień narzędzi",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Operacja",
+    "Status": "Status",
+    "Time": "Czas",
+    "TriggeredBy": "Wywołane przez"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Dodaj regułę automatycznego skalowania",
     "Comparator": "Komparator",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Substituições de permissões de ferramentas",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Operação",
+    "Status": "Status",
+    "Time": "Hora",
+    "TriggeredBy": "Acionado por"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Adicionar regra de escala automática",
     "Comparator": "Comparador",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Substituições de permissões de ferramentas",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Operação",
+    "Status": "Status",
+    "Time": "Hora",
+    "TriggeredBy": "Acionado por"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Adicionar regra de escala automática",
     "Comparator": "Comparador",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Переопределения разрешений инструментов",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Операция",
+    "Status": "Статус",
+    "Time": "Время",
+    "TriggeredBy": "Инициировано"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Добавить правило масштабирования автоматического масштабирования",
     "Comparator": "Компаратор",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "การแทนที่สิทธิ์เครื่องมือ",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "การดำเนินการ",
+    "Status": "สถานะ",
+    "Time": "เวลา",
+    "TriggeredBy": "เรียกใช้โดย"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "เพิ่มกฎการปรับขนาดอัตโนมัติ",
     "Comparator": "เครื่องเปรียบเทียบ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Araç izni geçersiz kılmaları",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "İşlem",
+    "Status": "Durum",
+    "Time": "Zaman",
+    "TriggeredBy": "Tetikleyen"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Otomatik ölçeklendirme kuralı ekleyin",
     "Comparator": "Karşılaştırıcı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "Ghi đè quyền công cụ",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "Thao tác",
+    "Status": "Trạng thái",
+    "Time": "Thời gian",
+    "TriggeredBy": "Thực hiện bởi"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "Thêm quy tắc tỷ lệ tự động",
     "Comparator": "Người so sánh",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "工具权限覆盖",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "操作",
+    "Status": "状态",
+    "Time": "时间",
+    "TriggeredBy": "触发者"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "添加自动缩放规则",
     "Comparator": "比较器",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -306,6 +306,12 @@
     "ToolPermissionOverrides": "工具權限覆蓋",
     "TopP": "Top P"
   },
+  "auditLog": {
+    "Operation": "操作",
+    "Status": "狀態",
+    "Time": "時間",
+    "TriggeredBy": "觸發者"
+  },
   "autoScalingRule": {
     "AddAutoScalingRule": "添加自動縮放規則",
     "Comparator": "比較器",


### PR DESCRIPTION
Resolves #7701 (FR-3033)

> **Stacked on** #7699 (`feat(FR-3032): add BAIAuditLogNodes common audit-log table to BUI`). Review/merge that PR first — this composes `BAIAuditLogNodes` from it.
>
> Builds on the spec authored in **FR-2949** (`.specs/FR-2949-audit-log-table/spec.md`), Epic **FR-2920**. Blocked by FR-3032.

## What

`ScopedAuditLog` (`react/src/components/ScopedAuditLog.tsx`) — reads a **preloaded** `scopedAuditLogsV2` query and renders a `BAIAuditLogNodes` (FR-3032) table with a filter bar + refresh. Mirrors the **`DeploymentSchedulingHistoryModal`** idiom (inline, no modal).

- **The consumer owns `useQueryLoader` / `loadQuery`** and builds the variables — it puts the resource scope (entity type / id, triggering user UUID) into `AuditLogScope`, starts the request (render-as-you-fetch), and passes `queryRef` + `loadQuery` (as `onReload`).
- **This view** reads `queryRef` via `usePreloadedQuery` and re-runs filter / sort / refresh through `onReload({ ...queryRef.variables, filter | orderBy }, { fetchPolicy: 'network-only' })`. The resource scope is carried forward in `queryRef.variables`, so only `filter` / `orderBy` are overridden.
- **Keep previous rows**: reads the **deferred** `queryRef` (`useDeferredValue`), so a re-fetch shows the old rows with an inline loading indicator instead of a Suspense flash.

### Props

- **`queryRef: PreloadedQuery<ScopedAuditLogQuery>`** — from the consumer's `useQueryLoader`.
- **`onReload: (variables, options?) => void`** — the consumer's `loadQuery`, called on filter/sort/refresh.
- Plus `BAIAuditLogNodes` table passthrough.

### Behavior

- **Filter**: `BAIGraphQLPropertyFilter` — status (enum, strict → `{ status: { equals } }`), operation (`contains`), created-at (range). **Refresh**: `BAIFetchKeyButton`. **Sort**: `convertToOrderBy`, default time DESC.
- **i18n**: host `auditLog.*` keys (en/ko). Exports the `ScopedAuditLogQuery` node for the consumer's `useQueryLoader`. Render inside `Suspense` + `BAIErrorBoundary`.

```tsx
const [queryRef, loadQuery] = useQueryLoader(ScopedAuditLogQuery);
// on tab click: loadQuery({ scope, orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }] }, { fetchPolicy: 'store-and-network' });
<Suspense fallback={<Skeleton active />}>
  {queryRef && <ScopedAuditLog queryRef={queryRef} onReload={loadQuery} />}
</Suspense>
```

## Owned by the consuming surface (deferred, under FR-2920)

`useQueryLoader` wiring, building the `scope`, version gating, and entry points (the "Audit Log" sub-tab) live with the Session / VFolder / Deployment integration tasks.

## Verification

`bash scripts/verify.sh`: **Relay / Lint / Format / TypeScript PASS** (the lone `FAIL`, "Vite warmup paths", is the pre-existing `react/vite.config.ts` bug, failing identically on clean `main`).

Compile/type-level — the backend does not serve `scopedAuditLogsV2` yet, so the render path isn't runtime-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)