### PR TITLE
fix(FR-3030): adopt SubStepResult schema rename with pre-26.4.4 backward compat

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -231,7 +231,7 @@ type AdminCreateKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The newly created keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 
   """The secret key. Only returned at creation time."""
   secretKey: String!
@@ -340,7 +340,7 @@ type AdminUpdateKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 }
 
 type Agent implements Item
@@ -3105,7 +3105,7 @@ input CreateContainerRegistryInput
 }
 
 """Added in 26.4.2. Input for creating a container registry."""
-input CreateContainerRegistryInputGQL
+input CreateContainerRegistryInputV2
   @join__type(graph: STRAWBERRY)
 {
   """URL of the container registry."""
@@ -3188,7 +3188,7 @@ type CreateContainerRegistryNodeV2
 """
 Added in 26.4.2. Payload for container registry create/update mutations.
 """
-type CreateContainerRegistryPayloadGQL
+type CreateContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created container registry."""
@@ -3299,7 +3299,7 @@ input CreateDeploymentRevisionPresetInput
 }
 
 """Added in 26.4.2. Create deployment revision preset payload."""
-type CreateDeploymentRevisionPresetPayloadGQL
+type CreateDeploymentRevisionPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """The created preset."""
@@ -3315,7 +3315,7 @@ type CreateDomain
 }
 
 """Added in 26.4.2. Input for creating a new domain."""
-input CreateDomainInputGQL
+input CreateDomainInput
   @join__type(graph: STRAWBERRY)
 {
   """Domain name. Must be unique across the system."""
@@ -3430,30 +3430,8 @@ type CreateKeyPairResourcePolicy
   resource_policy: KeyPairResourcePolicy
 }
 
-input CreateKeyPairResourcePolicyInput
-  @join__type(graph: GRAPHENE)
-{
-  default_for_unspecified: String!
-  total_resource_slots: JSONString = "{}"
-  max_session_lifetime: Int = 0
-  max_concurrent_sessions: Int!
-  max_concurrent_sftp_sessions: Int = 1
-  max_containers_per_session: Int!
-  idle_timeout: BigInt!
-  allowed_vfolder_hosts: JSONString
-  max_vfolder_count: Int @deprecated(reason: "Deprecated since 23.09.4.")
-  max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.4.")
-  max_quota_scope_size: BigInt @deprecated(reason: "Deprecated since 23.09.6.")
-
-  """Added in 24.03.4."""
-  max_pending_session_count: Int
-
-  """Added in 24.03.4."""
-  max_pending_session_resource_slots: JSONString
-}
-
 """Added in 26.4.2. Input for creating a keypair resource policy."""
-input CreateKeypairResourcePolicyInputGQL
+input CreateKeypairResourcePolicyInput
   @join__type(graph: STRAWBERRY)
 {
   """Policy name. Must be unique."""
@@ -3490,10 +3468,32 @@ input CreateKeypairResourcePolicyInputGQL
   allowedVfolderHosts: [VFolderHostPermissionEntryInput!]!
 }
 
+input CreateKeyPairResourcePolicyInput
+  @join__type(graph: GRAPHENE)
+{
+  default_for_unspecified: String!
+  total_resource_slots: JSONString = "{}"
+  max_session_lifetime: Int = 0
+  max_concurrent_sessions: Int!
+  max_concurrent_sftp_sessions: Int = 1
+  max_containers_per_session: Int!
+  idle_timeout: BigInt!
+  allowed_vfolder_hosts: JSONString
+  max_vfolder_count: Int @deprecated(reason: "Deprecated since 23.09.4.")
+  max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.4.")
+  max_quota_scope_size: BigInt @deprecated(reason: "Deprecated since 23.09.6.")
+
+  """Added in 24.03.4."""
+  max_pending_session_count: Int
+
+  """Added in 24.03.4."""
+  max_pending_session_resource_slots: JSONString
+}
+
 """
 Added in 26.4.2. Payload for keypair resource policy create/update mutations.
 """
-type CreateKeypairResourcePolicyPayloadGQL
+type CreateKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created keypair resource policy."""
@@ -3520,7 +3520,7 @@ type CreateLoginClientTypePayload
 }
 
 """Added in 26.4.2. Create model card payload."""
-type CreateModelCardPayloadGQL
+type CreateModelCardPayload
   @join__type(graph: STRAWBERRY)
 {
   """The created model card."""
@@ -3662,7 +3662,7 @@ input CreatePermissionInput
 }
 
 """Added in 26.4.2. Input for creating a new project."""
-input CreateProjectInputGQL
+input CreateProjectInput
   @join__type(graph: STRAWBERRY)
 {
   """Project name. Must be unique within the domain."""
@@ -3710,7 +3710,7 @@ input CreateProjectResourcePolicyInput
 }
 
 """Added in 26.4.2. Input for creating a project resource policy."""
-input CreateProjectResourcePolicyInputGQL
+input CreateProjectResourcePolicyInputV2
   @join__type(graph: STRAWBERRY)
 {
   """Policy name. Must be unique."""
@@ -3729,7 +3729,7 @@ input CreateProjectResourcePolicyInputGQL
 """
 Added in 26.4.2. Payload for project resource policy create/update mutations.
 """
-type CreateProjectResourcePolicyPayloadGQL
+type CreateProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created project resource policy."""
@@ -3807,7 +3807,7 @@ input CreateResourceGroupInput
 }
 
 """Added in 26.4.2. Payload for resource group creation."""
-type CreateResourceGroupPayloadGQL
+type CreateResourceGroupPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created resource group."""
@@ -3835,7 +3835,7 @@ input CreateResourcePresetInput
 }
 
 """Added in 26.4.2. Payload for resource preset creation."""
-type CreateResourcePresetPayloadGQL
+type CreateResourcePresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created resource preset."""
@@ -3924,7 +3924,7 @@ input CreateRuntimeVariantInput
 }
 
 """Added in 26.4.2. Payload for runtime variant creation."""
-type CreateRuntimeVariantPayloadGQL
+type CreateRuntimeVariantPayload
   @join__type(graph: STRAWBERRY)
 {
   """The created runtime variant."""
@@ -3964,7 +3964,7 @@ input CreateRuntimeVariantPresetInput
 }
 
 """Added in 26.4.2. Create preset payload."""
-type CreateRuntimeVariantPresetPayloadGQL
+type CreateRuntimeVariantPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """The created preset."""
@@ -4069,7 +4069,7 @@ input CreateUserResourcePolicyInput
 }
 
 """Added in 26.4.2. Input for creating a user resource policy."""
-input CreateUserResourcePolicyInputGQL
+input CreateUserResourcePolicyInputV2
   @join__type(graph: STRAWBERRY)
 {
   """Policy name. Must be unique."""
@@ -4096,7 +4096,7 @@ input CreateUserResourcePolicyInputGQL
 """
 Added in 26.4.2. Payload for user resource policy create/update mutations.
 """
-type CreateUserResourcePolicyPayloadGQL
+type CreateUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Created user resource policy."""
@@ -4500,7 +4500,7 @@ input DelegateImportArtifactsInput
   """
   Added in 26.1.0. Options controlling import behavior such as forcing re-download.
   """
-  options: ImportArtifactsOptionsGQL = null
+  options: ImportArtifactsOptions = null
 }
 
 """
@@ -4635,7 +4635,7 @@ type DeleteContainerRegistryNodeV2
 }
 
 """Added in 26.4.2. Payload for container registry deletion."""
-type DeleteContainerRegistryPayloadGQL
+type DeleteContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted container registry."""
@@ -4666,7 +4666,7 @@ type DeleteDeploymentPayload
 }
 
 """Added in 26.4.2. Delete deployment revision preset payload."""
-type DeleteDeploymentRevisionPresetPayloadGQL
+type DeleteDeploymentRevisionPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted preset."""
@@ -4699,7 +4699,7 @@ type DeleteDomainConfigPayload
 }
 
 """Added in 26.4.2. Payload for domain deletion mutation."""
-type DeleteDomainPayloadGQL
+type DeleteDomainPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the deletion was successful."""
@@ -4773,7 +4773,7 @@ type DeleteKeyPairResourcePolicy
 }
 
 """Added in 26.4.2. Payload for keypair resource policy deletion."""
-type DeleteKeypairResourcePolicyPayloadGQL
+type DeleteKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Name of the deleted keypair resource policy."""
@@ -4789,7 +4789,7 @@ type DeleteLoginClientTypePayload
 }
 
 """Added in 26.4.2. Delete model card payload."""
-type DeleteModelCardPayloadGQL
+type DeleteModelCardPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted model card."""
@@ -4875,7 +4875,7 @@ type DeletePermissionPayload
 }
 
 """Added in 26.4.2. Payload for project deletion mutation."""
-type DeleteProjectPayloadGQL
+type DeleteProjectPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the deletion was successful."""
@@ -4890,7 +4890,7 @@ type DeleteProjectResourcePolicy
 }
 
 """Added in 26.4.2. Payload for project resource policy deletion."""
-type DeleteProjectResourcePolicyPayloadGQL
+type DeleteProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Name of the deleted project resource policy."""
@@ -4921,7 +4921,7 @@ type DeleteReservoirRegistryPayload
 }
 
 """Added in 26.4.2. Payload for resource group deletion."""
-type DeleteResourceGroupPayloadGQL
+type DeleteResourceGroupPayload
   @join__type(graph: STRAWBERRY)
 {
   """Name of the deleted resource group."""
@@ -4936,7 +4936,7 @@ type DeleteResourcePreset
 }
 
 """Added in 26.4.2. Payload for resource preset deletion."""
-type DeleteResourcePresetPayloadGQL
+type DeleteResourcePresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """UUID of the deleted resource preset."""
@@ -4959,7 +4959,7 @@ type DeleteRolePayload
 }
 
 """Added in 26.4.2. Payload for runtime variant deletion."""
-type DeleteRuntimeVariantPayloadGQL
+type DeleteRuntimeVariantPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted runtime variant."""
@@ -4967,7 +4967,7 @@ type DeleteRuntimeVariantPayloadGQL
 }
 
 """Added in 26.4.2. Delete preset payload."""
-type DeleteRuntimeVariantPresetPayloadGQL
+type DeleteRuntimeVariantPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted preset."""
@@ -4983,7 +4983,7 @@ input DeleteRuntimeVariantsInput
 }
 
 """Added in 26.4.2. Payload for bulk runtime variant deletion."""
-type DeleteRuntimeVariantsPayloadGQL
+type DeleteRuntimeVariantsPayload
   @join__type(graph: STRAWBERRY)
 {
   """Number of runtime variants successfully deleted."""
@@ -5037,7 +5037,7 @@ type DeleteUserResourcePolicy
 }
 
 """Added in 26.4.2. Payload for user resource policy deletion."""
-type DeleteUserResourcePolicyPayloadGQL
+type DeleteUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Name of the deleted user resource policy."""
@@ -5130,14 +5130,14 @@ input DeploymentFilter
 }
 
 """Added in UNRELEASED. Deployment handler-options policy response."""
-type DeploymentHandlerOptionsInfoGQL
+type DeploymentHandlerOptionsInfo
   @join__type(graph: STRAWBERRY)
 {
   """Fallback per-handler policy."""
-  default: HandlerOptionsInfoGQL!
+  default: HandlerOptionsInfo!
 
   """Per-handler overrides."""
-  byHandler: [HandlerOptionsEntryInfoGQL!]!
+  byHandler: [HandlerOptionsEntryInfo!]!
 }
 
 """Added in UNRELEASED. Deployment handler-options policy input."""
@@ -5162,7 +5162,7 @@ type DeploymentHistory implements Node
   result: SchedulingResult!
   errorCode: String
   message: String
-  subSteps: [SubStepResultGQL!]!
+  subSteps: [SubStepResult!]!
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -5235,11 +5235,11 @@ enum DeploymentHistoryOrderField
 }
 
 """Added in UNRELEASED. Deployment options payload response."""
-type DeploymentOptionsInfoGQL
+type DeploymentOptionsInfo
   @join__type(graph: STRAWBERRY)
 {
   """Handler-keyed scheduler policy (timeout + retry)."""
-  handlerOptions: DeploymentHandlerOptionsInfoGQL!
+  handlerOptions: DeploymentHandlerOptionsInfo!
 }
 
 """Added in UNRELEASED. Deployment options payload input."""
@@ -5490,7 +5490,7 @@ input DeploymentStatusFilter
 """
 Added in 25.19.0. Represents the deployment strategy configuration that determines how updates are rolled out to replicas (e.g., rolling update, blue-green).
 """
-type DeploymentStrategyGQL
+type DeploymentStrategy
   @join__type(graph: STRAWBERRY)
 {
   type: DeploymentStrategyType!
@@ -5930,7 +5930,7 @@ type DomainNode implements Node
 }
 
 """Added in 26.4.2. Payload for domain mutation responses."""
-type DomainPayloadGQL
+type DomainPayload
   @join__type(graph: STRAWBERRY)
 {
   """The domain entity."""
@@ -6793,7 +6793,7 @@ input ExtraMountInput
 """
 Added in 25.19.0. An extra virtual folder mount attached to a model revision.
 """
-type ExtraVFolderMountInfoGQL
+type ExtraVFolderMountInfo
   @join__type(graph: STRAWBERRY)
 {
   """The vfolder of this entity."""
@@ -7085,7 +7085,7 @@ scalar GroupPermissionField
 """
 Added in UNRELEASED. A single (handler_name, options) entry response for deployment handler options.
 """
-type HandlerOptionsEntryInfoGQL
+type HandlerOptionsEntryInfo
   @join__type(graph: STRAWBERRY)
 {
   """Phase timeout in seconds; `null` means unbounded for this entry."""
@@ -7114,7 +7114,7 @@ input HandlerOptionsEntryInput
 """
 Added in UNRELEASED. Per-handler scheduler policy snapshot for deployment handler options.
 """
-type HandlerOptionsInfoGQL
+type HandlerOptionsInfo
   @join__type(graph: STRAWBERRY)
 {
   """Phase timeout in seconds; `null` means unbounded for this entry."""
@@ -7375,7 +7375,7 @@ type ImageV2 implements Node
   lastUsed: DateTime
 
   """Added in 26.2.0. Aliases for this image."""
-  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection
+  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection
 }
 
 """
@@ -7437,7 +7437,7 @@ input ImageV2AliasFilter
 """
 Added in 26.2.0. Specifies the field and direction for ordering image aliases in queries.
 """
-input ImageV2AliasOrderByGQL
+input ImageV2AliasOrderBy
   @join__type(graph: STRAWBERRY)
 {
   field: ImageV2AliasOrderField!
@@ -7561,7 +7561,7 @@ type ImageV2MetadataInfo
 """
 Added in 26.2.0. Specifies the field and direction for ordering images in queries.
 """
-input ImageV2OrderByGQL
+input ImageV2OrderBy
   @join__type(graph: STRAWBERRY)
 {
   field: ImageV2OrderField!
@@ -7683,7 +7683,7 @@ input ImportArtifactsInput
   """
   Added in 26.1.0. Options controlling import behavior such as forcing re-download.
   """
-  options: ImportArtifactsOptionsGQL = null
+  options: ImportArtifactsOptions = null
 }
 
 """
@@ -7691,7 +7691,7 @@ Added in 24.09.0. Options for importing artifact revisions.
 
 Controls import behavior such as forcing re-download regardless of digest freshness.
 """
-input ImportArtifactsOptionsGQL
+input ImportArtifactsOptions
   @join__type(graph: STRAWBERRY)
 {
   """Force re-download regardless of digest freshness check."""
@@ -7727,6 +7727,17 @@ type InferenceSessionErrorInfo
 }
 
 """
+Added in UNRELEASED. Filter for integer array fields. Supports 'contains' (column contains this single value), 'contains_any' (column contains any of these values), and 'contains_all' (column contains all of these values).
+"""
+input IntArrayFilter
+  @join__type(graph: STRAWBERRY)
+{
+  contains: Int = null
+  containsAny: [Int!] = null
+  containsAll: [Int!] = null
+}
+
+"""
 Added in 24.09.0. Filter for integer fields supporting equality and comparison operations.
 """
 input IntFilter
@@ -7758,7 +7769,7 @@ type IssueMyKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The newly created keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 
   """
   The newly generated secret key. This value is only returned at creation time.
@@ -8230,7 +8241,7 @@ type KeyPairConnection
   pageInfo: PageInfo!
 
   """Contains the nodes in this connection"""
-  edges: [KeyPairGQLEdge!]!
+  edges: [KeyPairV2Edge!]!
 
   """Total number of keypair records matching the query criteria."""
   count: Int!
@@ -8251,64 +8262,6 @@ input KeypairFilter
   AND: [KeypairFilter!] = null
   OR: [KeypairFilter!] = null
   NOT: [KeypairFilter!] = null
-}
-
-"""
-Added in 26.4.2. Keypair entity representing an API access key. The access_key field serves as the unique identifier. Secret key and private SSH key are excluded for security reasons.
-"""
-type KeyPairGQL implements Node
-  @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
-  id: ID!
-
-  """The access key string."""
-  accessKey: String!
-
-  """Whether the keypair is currently active."""
-  isActive: Boolean
-
-  """Whether the keypair has admin privileges."""
-  isAdmin: Boolean
-
-  """Timestamp when the keypair was created."""
-  createdAt: DateTime
-
-  """Timestamp when the keypair was last modified."""
-  modifiedAt: DateTime
-
-  """Timestamp when the keypair was last used for an API call."""
-  lastUsed: DateTime
-
-  """API rate limit (requests per minute)."""
-  rateLimit: Int!
-
-  """Total number of API queries made with this keypair."""
-  numQueries: Int!
-
-  """Name of the resource policy assigned to this keypair."""
-  resourcePolicy: String!
-
-  """The SSH public key associated with this keypair."""
-  sshPublicKey: String
-
-  """UUID of the user who owns this keypair."""
-  userId: UUID!
-
-  """Added in 26.4.3. The user who owns this keypair."""
-  user: UserV2
-}
-
-"""An edge in a connection."""
-type KeyPairGQLEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
-  cursor: String!
-
-  """The item at the end of the edge"""
-  node: KeyPairGQL!
 }
 
 input KeyPairInput
@@ -8387,6 +8340,15 @@ type KeyPairResourcePolicy
 }
 
 """
+Added in UNRELEASED. Nested filter for keypairs assigned to a keypair resource policy. Filters policies linked to at least one keypair matching all specified conditions.
+"""
+input KeypairResourcePolicyKeypairNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  userId: UUIDFilter = null
+}
+
+"""
 Added in 26.4.2. Keypair resource policy defining session and storage limits for API keypairs.
 """
 type KeypairResourcePolicyV2 implements Node
@@ -8433,6 +8395,9 @@ type KeypairResourcePolicyV2 implements Node
 
   """Allowed vfolder host permissions."""
   allowedVfolderHosts: [VFolderHostPermissionEntry!]!
+
+  """Added in UNRELEASED. Keypairs assigned to this resource policy."""
+  keypairs(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection
 }
 
 """Added in 26.4.2. Paginated connection for keypair resource policies."""
@@ -8472,6 +8437,11 @@ input KeypairResourcePolicyV2Filter
   idleTimeout: IntFilter = null
   maxConcurrentSftpSessions: IntFilter = null
   maxPendingSessionCount: IntFilter = null
+
+  """
+  Added in UNRELEASED. Filter policies by their assigned keypairs. A policy matches if at least one of its keypairs satisfies the conditions.
+  """
+  keypair: KeypairResourcePolicyKeypairNestedFilter = null
 }
 
 """Added in 26.4.2. Ordering specification for keypair resource policies."""
@@ -8499,6 +8469,64 @@ enum KeypairResourcePolicyV2OrderField
   IDLE_TIMEOUT @join__enumValue(graph: STRAWBERRY)
   MAX_CONCURRENT_SFTP_SESSIONS @join__enumValue(graph: STRAWBERRY)
   MAX_PENDING_SESSION_COUNT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in 26.4.2. Keypair entity representing an API access key. The access_key field serves as the unique identifier. Secret key and private SSH key are excluded for security reasons.
+"""
+type KeyPairV2 implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """The access key string."""
+  accessKey: String!
+
+  """Whether the keypair is currently active."""
+  isActive: Boolean
+
+  """Whether the keypair has admin privileges."""
+  isAdmin: Boolean
+
+  """Timestamp when the keypair was created."""
+  createdAt: DateTime
+
+  """Timestamp when the keypair was last modified."""
+  modifiedAt: DateTime
+
+  """Timestamp when the keypair was last used for an API call."""
+  lastUsed: DateTime
+
+  """API rate limit (requests per minute)."""
+  rateLimit: Int!
+
+  """Total number of API queries made with this keypair."""
+  numQueries: Int!
+
+  """Name of the resource policy assigned to this keypair."""
+  resourcePolicy: String!
+
+  """The SSH public key associated with this keypair."""
+  sshPublicKey: String
+
+  """UUID of the user who owns this keypair."""
+  userId: UUID!
+
+  """Added in 26.4.3. The user who owns this keypair."""
+  user: UserV2
+}
+
+"""An edge in a connection."""
+type KeyPairV2Edge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: KeyPairV2!
 }
 
 type KVPair
@@ -9323,10 +9351,10 @@ type ModelDeployment implements Node
   networkAccess: ModelDeploymentNetworkAccess!
   currentRevisionId: ID
   deployingRevisionId: ID
-  defaultDeploymentStrategy: DeploymentStrategyGQL!
+  defaultDeploymentStrategy: DeploymentStrategy!
   replicaState: ReplicaState!
   createdUserId: ID!
-  options: DeploymentOptionsInfoGQL!
+  options: DeploymentOptionsInfo!
 
   """
   Added in UNRELEASED. Replica scaling axis, orthogonal to ``metadata.status`` (lifecycle). ``SCALING`` while the replica reconciler is adjusting replica count; ``STABLE`` once holding at the desired count.
@@ -9727,7 +9755,7 @@ type ModelRevision implements Node
   modelDefinition: ModelDefinition
 
   """Additional volume folder mounts."""
-  extraMounts: [ExtraVFolderMountInfoGQL!]!
+  extraMounts: [ExtraVFolderMountInfo!]!
 
   """
   Added in UNRELEASED. ID of the deployment-level preset that produced this revision. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
@@ -10883,13 +10911,13 @@ type Mutation
   cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new container registry (admin only)."""
-  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputGQL!): CreateContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputV2!): CreateContainerRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a container registry (admin only)."""
-  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInputGQL!): UpdateContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInput!): UpdateContainerRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a container registry (admin only)."""
-  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Create model deployment."""
   createModelDeployment(input: CreateDeploymentInput!): CreateDeploymentPayload @join__field(graph: STRAWBERRY)
@@ -11138,10 +11166,10 @@ type Mutation
   adminUpdateResourceGroup(input: UpdateResourceGroupInput!): UpdateResourceGroupPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new resource group (admin only)."""
-  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a resource group (admin only)."""
-  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update allowed resource groups for a domain (admin only).
@@ -11181,42 +11209,42 @@ type Mutation
   """
   Added in 26.4.2. Create a new domain (admin only). Requires superadmin privileges.
   """
-  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateDomainV2(input: CreateDomainInput!): DomainPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a domain (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInputGQL!): DomainPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInput!): DomainPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Soft-delete a domain (admin only). Requires superadmin privileges.
   """
-  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteDomainV2(domainName: String!): DeleteDomainPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Permanently purge a domain and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL @join__field(graph: STRAWBERRY)
+  adminPurgeDomainV2(domainName: String!): PurgeDomainPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Create a new project (admin only). Requires superadmin privileges.
   """
-  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateProjectV2(input: CreateProjectInput!): ProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a project (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInputGQL!): ProjectPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInput!): ProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Soft-delete a project (admin only). Requires superadmin privileges.
   """
-  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Permanently purge a project and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL @join__field(graph: STRAWBERRY)
+  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Unassign users from a project. RBAC validates project admin permission.
@@ -11401,46 +11429,46 @@ type Mutation
   adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
-  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInput!): CreateKeypairResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a keypair resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInputGQL!): UpdateKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInput!): UpdateKeypairResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a keypair resource policy (admin only)."""
-  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new user resource policy (admin only)."""
-  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputGQL!): CreateUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputV2!): CreateUserResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a user resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInputGQL!): UpdateUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInput!): UpdateUserResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a user resource policy (admin only)."""
-  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new project resource policy (admin only)."""
-  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputGQL!): CreateProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputV2!): CreateProjectResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a project resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInputGQL!): UpdateProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInput!): UpdateProjectResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a project resource policy (admin only)."""
-  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new resource preset (admin only)."""
-  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a resource preset (admin only)."""
-  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a resource preset (admin only)."""
-  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new login client type (super admin only)."""
   adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload @join__field(graph: STRAWBERRY)
@@ -11452,43 +11480,43 @@ type Mutation
   adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
-  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a runtime variant (superadmin only)."""
-  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a runtime variant (superadmin only)."""
-  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete multiple runtime variants (superadmin only)."""
-  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a runtime variant preset (superadmin only)."""
-  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a runtime variant preset (superadmin only)."""
-  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a runtime variant preset (superadmin only)."""
-  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a deployment revision preset (admin only)."""
-  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a deployment revision preset (admin only)."""
-  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a deployment revision preset (admin only)."""
-  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a model card (admin only)."""
-  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL @join__field(graph: STRAWBERRY)
+  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a model card (admin only)."""
-  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL @join__field(graph: STRAWBERRY)
+  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a model card (admin only)."""
-  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayloadGQL @join__field(graph: STRAWBERRY)
+  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Bulk-delete model cards (admin only) with per-card partial-failure reporting.
@@ -12620,7 +12648,7 @@ type ProjectOrganizationInfo
 }
 
 """Added in 26.4.2. Payload for project mutation responses."""
-type ProjectPayloadGQL
+type ProjectPayload
   @join__type(graph: STRAWBERRY)
 {
   """The project entity."""
@@ -13109,7 +13137,7 @@ type PurgeDomain
 }
 
 """Added in 26.4.2. Payload for domain permanent deletion mutation."""
-type PurgeDomainPayloadGQL
+type PurgeDomainPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the purge was successful."""
@@ -13176,7 +13204,7 @@ type PurgeImagesPayload
 }
 
 """Added in 26.4.2. Payload for project permanent deletion mutation."""
-type PurgeProjectPayloadGQL
+type PurgeProjectPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the purge was successful."""
@@ -13853,7 +13881,7 @@ type Query
   """
   Added in 26.2.0. Query images with optional filtering, ordering, and pagination (admin only). Returns container images available in the system. Images are container specifications that define runtime environments for compute sessions. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
-  adminImagesV2(filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
+  adminImagesV2(filter: ImageV2Filter = null, orderBy: [ImageV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query kernels with pagination and filtering. (admin only)
@@ -13919,7 +13947,7 @@ type Query
   """
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
   """
-  adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
+  adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.
@@ -13982,7 +14010,7 @@ type Query
   """
   Added in 26.4.2. Get a single keypair by access key (admin only). Requires superadmin privileges.
   """
-  adminKeypairV2(accessKey: String!): KeyPairGQL @join__field(graph: STRAWBERRY)
+  adminKeypairV2(accessKey: String!): KeyPairV2 @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List all keypairs with filtering and pagination (admin only). Requires superadmin privileges.
@@ -14065,12 +14093,12 @@ type Query
   """
   Added in 26.2.0. Query images within a specific container registry with optional filtering, ordering, and pagination. Returns container images that belong to the specified registry. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
-  containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
+  containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query image aliases within a specific image with optional filtering, ordering, and pagination. Returns image aliases that belong to the specified image. Supports both cursor-based and offset-based pagination.
   """
-  imageScopedAliases(scope: ImageV2Scope!, filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
+  imageScopedAliases(scope: ImageV2Scope!, filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.2.0. Get scheduling history for a specific session."""
   sessionScopedSchedulingHistories(scope: SessionScope!, filter: SessionSchedulingHistoryFilter = null, orderBy: [SessionSchedulingHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionSchedulingHistoryConnection @join__field(graph: STRAWBERRY)
@@ -14728,7 +14756,7 @@ type ReplaceResourceGroupDefaultDeploymentOptionsPayload
   resourceGroupName: String!
 
   """The newly persisted ``default_deployment_options`` surface."""
-  defaultDeploymentOptions: DeploymentOptionsInfoGQL!
+  defaultDeploymentOptions: DeploymentOptionsInfo!
 }
 
 """
@@ -15033,7 +15061,7 @@ type ResourceGroup implements Node
   """
   Added in UNRELEASED. Default deployment options (timeouts, etc.) snapshot-copied onto each new deployment created in this resource group.
   """
-  defaultDeploymentOptions: DeploymentOptionsInfoGQL!
+  defaultDeploymentOptions: DeploymentOptionsInfo!
 
   """
   Added in UNRELEASED. Default session options used as the fallback layer for the scheduling controller's options resolver at session enqueue time.
@@ -16237,7 +16265,7 @@ type RouteHistory implements Node
   result: SchedulingResult!
   errorCode: String
   message: String
-  subSteps: [SubStepResultGQL!]!
+  subSteps: [SubStepResult!]!
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -17240,7 +17268,7 @@ type SessionSchedulingHistory implements Node
   result: SchedulingResult!
   errorCode: String
   message: String
-  subSteps: [SubStepResultGQL!]!
+  subSteps: [SubStepResult!]!
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -17824,7 +17852,7 @@ type Subscription
 }
 
 """Added in 26.3.0. Sub-step result in scheduling history."""
-type SubStepResultGQL
+type SubStepResult
   @join__type(graph: STRAWBERRY)
 {
   step: String!
@@ -18152,7 +18180,7 @@ type UpdateAutoScalingRulePayload
 """
 Added in 26.4.2. Input for updating a container registry. All fields optional except id.
 """
-input UpdateContainerRegistryInputGQL
+input UpdateContainerRegistryInput
   @join__type(graph: STRAWBERRY)
 {
   """ID of the registry to update."""
@@ -18187,7 +18215,7 @@ input UpdateContainerRegistryInputGQL
 }
 
 """Added in 26.4.2. Payload for container registry update mutation."""
-type UpdateContainerRegistryPayloadGQL
+type UpdateContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated container registry."""
@@ -18331,7 +18359,7 @@ input UpdateDeploymentRevisionPresetInput
 }
 
 """Added in 26.4.2. Update deployment revision preset payload."""
-type UpdateDeploymentRevisionPresetPayloadGQL
+type UpdateDeploymentRevisionPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated preset."""
@@ -18341,7 +18369,7 @@ type UpdateDeploymentRevisionPresetPayloadGQL
 """
 Added in 26.4.2. Input for updating domain information. All fields optional.
 """
-input UpdateDomainInputGQL
+input UpdateDomainInput
   @join__type(graph: STRAWBERRY)
 {
   """New domain name."""
@@ -18381,7 +18409,7 @@ type UpdateHuggingFaceRegistryPayload
 """
 Added in 26.4.2. Input for updating a keypair resource policy. All fields optional.
 """
-input UpdateKeypairResourcePolicyInputGQL
+input UpdateKeypairResourcePolicyInput
   @join__type(graph: STRAWBERRY)
 {
   """Updated default for unspecified."""
@@ -18416,7 +18444,7 @@ input UpdateKeypairResourcePolicyInputGQL
 }
 
 """Added in 26.4.2. Payload for keypair resource policy update mutation."""
-type UpdateKeypairResourcePolicyPayloadGQL
+type UpdateKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated keypair resource policy."""
@@ -18445,7 +18473,7 @@ type UpdateLoginClientTypePayload
 }
 
 """Added in 26.4.2. Update model card payload."""
-type UpdateModelCardPayloadGQL
+type UpdateModelCardPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated model card."""
@@ -18546,7 +18574,7 @@ type UpdateMyKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated keypair."""
-  keypair: KeyPairGQL!
+  keypair: KeyPairV2!
 }
 
 """Added in 24.09.0. Input for updating a notification channel"""
@@ -18622,7 +18650,7 @@ input UpdatePermissionInput
 """
 Added in 26.4.2. Input for updating project information. All fields optional.
 """
-input UpdateProjectInputGQL
+input UpdateProjectInput
   @join__type(graph: STRAWBERRY)
 {
   """New project name."""
@@ -18644,7 +18672,7 @@ input UpdateProjectInputGQL
 """
 Added in 26.4.2. Input for updating a project resource policy. All fields optional.
 """
-input UpdateProjectResourcePolicyInputGQL
+input UpdateProjectResourcePolicyInput
   @join__type(graph: STRAWBERRY)
 {
   """Updated max vfolder count."""
@@ -18658,7 +18686,7 @@ input UpdateProjectResourcePolicyInputGQL
 }
 
 """Added in 26.4.2. Payload for project resource policy update mutation."""
-type UpdateProjectResourcePolicyPayloadGQL
+type UpdateProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated project resource policy."""
@@ -18777,7 +18805,7 @@ type UpdateResourceGroupPayload
 }
 
 """Added in 26.4.2. Payload for resource preset update."""
-type UpdateResourcePresetPayloadGQL
+type UpdateResourcePresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated resource preset."""
@@ -18850,7 +18878,7 @@ input UpdateRuntimeVariantInput
 }
 
 """Added in 26.4.2. Payload for runtime variant update."""
-type UpdateRuntimeVariantPayloadGQL
+type UpdateRuntimeVariantPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated runtime variant."""
@@ -18887,7 +18915,7 @@ input UpdateRuntimeVariantPresetInput
 }
 
 """Added in 26.4.2. Update preset payload."""
-type UpdateRuntimeVariantPresetPayloadGQL
+type UpdateRuntimeVariantPresetPayload
   @join__type(graph: STRAWBERRY)
 {
   """The updated preset."""
@@ -18897,7 +18925,7 @@ type UpdateRuntimeVariantPresetPayloadGQL
 """
 Added in 26.4.2. Input for updating a user resource policy. All fields optional.
 """
-input UpdateUserResourcePolicyInputGQL
+input UpdateUserResourcePolicyInput
   @join__type(graph: STRAWBERRY)
 {
   """Updated max vfolder count."""
@@ -18919,7 +18947,7 @@ input UpdateUserResourcePolicyInputGQL
 }
 
 """Added in 26.4.2. Payload for user resource policy update mutation."""
-type UpdateUserResourcePolicyPayloadGQL
+type UpdateUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
   """Updated user resource policy."""
@@ -20042,12 +20070,44 @@ input UserV2Filter
   uuid: UUIDFilter = null
   username: StringFilter = null
   email: StringFilter = null
+
+  """Added in UNRELEASED. Filter by full name."""
+  fullName: StringFilter = null
+
+  """Added in UNRELEASED. Filter by description."""
+  description: StringFilter = null
   status: UserStatusV2EnumFilter = null
+
+  """Added in UNRELEASED. Filter by status info detail."""
+  statusInfo: StringFilter = null
   domainName: StringFilter = null
 
   """Added in 26.4.2. Filter by external integration identifier."""
   integrationName: StringFilter = null
+
+  """Added in UNRELEASED. Filter by user resource policy name."""
+  resourcePolicy: StringFilter = null
   role: UserRoleV2EnumFilter = null
+
+  """Added in UNRELEASED. Filter by whether a password change is required."""
+  needPasswordChange: Boolean = null
+
+  """
+  Added in UNRELEASED. Filter by whether TOTP two-factor auth is activated.
+  """
+  totpActivated: Boolean = null
+
+  """Added in UNRELEASED. Filter by whether sudo sessions are enabled."""
+  sudoSessionEnabled: Boolean = null
+
+  """Added in UNRELEASED. Filter by container UID."""
+  containerUid: IntFilter = null
+
+  """Added in UNRELEASED. Filter by container main GID."""
+  containerMainGid: IntFilter = null
+
+  """Added in UNRELEASED. Filter by container supplementary GIDs."""
+  containerGids: IntArrayFilter = null
   createdAt: DateTimeFilter = null
   domain: UserDomainNestedFilter = null
   project: UserProjectNestedFilter = null

--- a/packages/backend.ai-ui/src/__generated__/BAIDeploymentSchedulingHistoryNodesFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIDeploymentSchedulingHistoryNodesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<99de343c87eba570df6b2b85270538f5>>
+ * @generated SignedSource<<dbdbfa33c23c20dcaa15d8eac2f1c20f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -100,7 +100,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "SubStepResultGQL",
+      "concreteType": "SubStepResult",
       "kind": "LinkedField",
       "name": "subSteps",
       "plural": true,

--- a/packages/backend.ai-ui/src/__generated__/BAIImportArtifactModalImportArtifactsMutation.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIImportArtifactModalImportArtifactsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<607b1df7379c784ecf0520b25dabf569>>
+ * @generated SignedSource<<a2ef7c9cafe03d1d7238771d49cb6bf6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,10 +12,10 @@ import { ConcreteRequest } from 'relay-runtime';
 export type ArtifactStatus = "AVAILABLE" | "FAILED" | "NEEDS_APPROVAL" | "PULLED" | "PULLING" | "REJECTED" | "SCANNED" | "VERIFYING" | "%future added value";
 export type ImportArtifactsInput = {
   artifactRevisionIds: ReadonlyArray<string>;
-  options?: ImportArtifactsOptionsGQL | null | undefined;
+  options?: ImportArtifactsOptions | null | undefined;
   vfolderId?: string | null | undefined;
 };
-export type ImportArtifactsOptionsGQL = {
+export type ImportArtifactsOptions = {
   force?: boolean;
 };
 export type BAIImportArtifactModalImportArtifactsMutation$variables = {

--- a/packages/backend.ai-ui/src/__generated__/BAIModelDeploymentNodesFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIModelDeploymentNodesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a63b256662ceb6f614675154340d2d4c>>
+ * @generated SignedSource<<660395b15bde0b90d7faccf5f04d0b1e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -232,7 +232,7 @@ return {
     {
       "alias": null,
       "args": null,
-      "concreteType": "DeploymentStrategyGQL",
+      "concreteType": "DeploymentStrategy",
       "kind": "LinkedField",
       "name": "defaultDeploymentStrategy",
       "plural": false,

--- a/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryNodeTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIRouteSchedulingHistoryNodeTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7826d64cc35baebfbae84de866de9d0e>>
+ * @generated SignedSource<<fdc09b9321574823527bae6839736570>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -116,7 +116,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "SubStepResultGQL",
+      "concreteType": "SubStepResult",
       "kind": "LinkedField",
       "name": "subSteps",
       "plural": true,

--- a/packages/backend.ai-ui/src/__generated__/BAISchedulingHistoryNodesFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISchedulingHistoryNodesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ce6f00b122f73ac787c18a8f27b6222b>>
+ * @generated SignedSource<<2db155e1aa3b90aa585caf6781d06980>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -113,7 +113,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "SubStepResultGQL",
+      "concreteType": "SubStepResult",
       "kind": "LinkedField",
       "name": "subSteps",
       "plural": true,

--- a/packages/backend.ai-ui/src/__generated__/BAISubStepNodesFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISubStepNodesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8cf1e784b5e08d460a2ad081f8f9682d>>
+ * @generated SignedSource<<3863c621690587a7cacb0a84ac57a711>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -76,10 +76,10 @@ const node: ReaderFragment = {
       "storageKey": null
     }
   ],
-  "type": "SubStepResultGQL",
+  "type": "SubStepResult",
   "abstractKey": null
 };
 
-(node as any).hash = "b293ef89b3c67ebb0a3733e1c22f6df9";
+(node as any).hash = "d08345bcb1a939d04f09280993b0f1ce";
 
 export default node;

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -65,8 +65,7 @@ const BAISubStepNodes = ({
 
   const subSteps = useFragment<BAISubStepNodesFragment$key>(
     graphql`
-      fragment BAISubStepNodesFragment on SubStepResultGQL
-      @relay(plural: true) {
+      fragment BAISubStepNodesFragment on SubStepResult @relay(plural: true) {
         step
         result
         errorCode

--- a/react/src/__generated__/AdminDeploymentListPageQuery.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<617e182bc5acc21705d187b66da1dd1d>>
+ * @generated SignedSource<<1ae8ed5e090d59a52f46d5f71750af74>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -477,7 +477,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "DeploymentStrategyGQL",
+                    "concreteType": "DeploymentStrategy",
                     "kind": "LinkedField",
                     "name": "defaultDeploymentStrategy",
                     "plural": false,
@@ -679,7 +679,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ExtraVFolderMountInfoGQL",
+                        "concreteType": "ExtraVFolderMountInfo",
                         "kind": "LinkedField",
                         "name": "extraMounts",
                         "plural": true,

--- a/react/src/__generated__/AdminDeploymentPresetListPageDeleteMutation.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetListPageDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2dcc27e935b6323ce19c277b80885e50>>
+ * @generated SignedSource<<fdc19c22cd2b8cf983872f1c570e9685>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,7 +40,7 @@ v1 = [
         "variableName": "id"
       }
     ],
-    "concreteType": "DeleteDeploymentRevisionPresetPayloadGQL",
+    "concreteType": "DeleteDeploymentRevisionPresetPayload",
     "kind": "LinkedField",
     "name": "adminDeleteDeploymentRevisionPreset",
     "plural": false,

--- a/react/src/__generated__/AdminDeploymentPresetSettingPageCreateMutation.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetSettingPageCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2244d018fc3ff2500d12cfc18865d200>>
+ * @generated SignedSource<<18b8683048a850070bfaccb92d109b5d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -140,7 +140,7 @@ v1 = [
         "variableName": "input"
       }
     ],
-    "concreteType": "CreateDeploymentRevisionPresetPayloadGQL",
+    "concreteType": "CreateDeploymentRevisionPresetPayload",
     "kind": "LinkedField",
     "name": "adminCreateDeploymentRevisionPreset",
     "plural": false,

--- a/react/src/__generated__/AdminDeploymentPresetSettingPageUpdateMutation.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetSettingPageUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<94bdb6f2b70077f3f029b92965beb219>>
+ * @generated SignedSource<<8a20160ea2c39134c8238e718e034628>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -141,7 +141,7 @@ v1 = [
         "variableName": "input"
       }
     ],
-    "concreteType": "UpdateDeploymentRevisionPresetPayloadGQL",
+    "concreteType": "UpdateDeploymentRevisionPresetPayload",
     "kind": "LinkedField",
     "name": "adminUpdateDeploymentRevisionPreset",
     "plural": false,

--- a/react/src/__generated__/AdminModelCardListPageDeleteMutation.graphql.ts
+++ b/react/src/__generated__/AdminModelCardListPageDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e98842d1465b7579349880d822db291f>>
+ * @generated SignedSource<<93b75220d353e7ee0714bd0ab441e8ca>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -54,7 +54,7 @@ v1 = [
         "variableName": "options"
       }
     ],
-    "concreteType": "DeleteModelCardPayloadGQL",
+    "concreteType": "DeleteModelCardPayload",
     "kind": "LinkedField",
     "name": "adminDeleteModelCardV2",
     "plural": false,

--- a/react/src/__generated__/AdminModelCardSettingModalCreateMutation.graphql.ts
+++ b/react/src/__generated__/AdminModelCardSettingModalCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<31cfdcfd066db219a299344a4476ab4c>>
+ * @generated SignedSource<<25b08541e9f77fb5bd8d88e2d688d975>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -61,7 +61,7 @@ v1 = [
         "variableName": "input"
       }
     ],
-    "concreteType": "CreateModelCardPayloadGQL",
+    "concreteType": "CreateModelCardPayload",
     "kind": "LinkedField",
     "name": "adminCreateModelCardV2",
     "plural": false,

--- a/react/src/__generated__/AdminModelCardSettingModalUpdateMutation.graphql.ts
+++ b/react/src/__generated__/AdminModelCardSettingModalUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1efb9812636440b518114a35bab8ac8a>>
+ * @generated SignedSource<<9c53bdde3871926b4e69c7a0e7c5c35a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -74,7 +74,7 @@ v1 = [
         "variableName": "input"
       }
     ],
-    "concreteType": "UpdateModelCardPayloadGQL",
+    "concreteType": "UpdateModelCardPayload",
     "kind": "LinkedField",
     "name": "adminUpdateModelCardV2",
     "plural": false,

--- a/react/src/__generated__/AdminUserManagementQuery.graphql.ts
+++ b/react/src/__generated__/AdminUserManagementQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<06422b89b64682dd2bc7a123c2951f55>>
+ * @generated SignedSource<<8dc4f0b6c4ffe302d3fa76829308a352>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,14 +18,24 @@ export type UserV2Filter = {
   AND?: ReadonlyArray<UserV2Filter> | null | undefined;
   NOT?: ReadonlyArray<UserV2Filter> | null | undefined;
   OR?: ReadonlyArray<UserV2Filter> | null | undefined;
+  containerGids?: IntArrayFilter | null | undefined;
+  containerMainGid?: IntFilter | null | undefined;
+  containerUid?: IntFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
+  description?: StringFilter | null | undefined;
   domain?: UserDomainNestedFilter | null | undefined;
   domainName?: StringFilter | null | undefined;
   email?: StringFilter | null | undefined;
+  fullName?: StringFilter | null | undefined;
   integrationName?: StringFilter | null | undefined;
+  needPasswordChange?: boolean | null | undefined;
   project?: UserProjectNestedFilter | null | undefined;
+  resourcePolicy?: StringFilter | null | undefined;
   role?: UserRoleV2EnumFilter | null | undefined;
   status?: UserStatusV2EnumFilter | null | undefined;
+  statusInfo?: StringFilter | null | undefined;
+  sudoSessionEnabled?: boolean | null | undefined;
+  totpActivated?: boolean | null | undefined;
   username?: StringFilter | null | undefined;
   uuid?: UUIDFilter | null | undefined;
 };
@@ -68,6 +78,19 @@ export type UserRoleV2EnumFilter = {
   in?: ReadonlyArray<UserRoleV2> | null | undefined;
   notEquals?: UserRoleV2 | null | undefined;
   notIn?: ReadonlyArray<UserRoleV2> | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type IntArrayFilter = {
+  contains?: number | null | undefined;
+  containsAll?: ReadonlyArray<number> | null | undefined;
+  containsAny?: ReadonlyArray<number> | null | undefined;
 };
 export type DateTimeFilter = {
   after?: string | null | undefined;

--- a/react/src/__generated__/AssignRoleModalQuery.graphql.ts
+++ b/react/src/__generated__/AssignRoleModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ee42ed16b22be0ea3c0e9ab108f59c57>>
+ * @generated SignedSource<<de8c6a24cb28fe80252cab09ee7029d9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,14 +15,24 @@ export type UserV2Filter = {
   AND?: ReadonlyArray<UserV2Filter> | null | undefined;
   NOT?: ReadonlyArray<UserV2Filter> | null | undefined;
   OR?: ReadonlyArray<UserV2Filter> | null | undefined;
+  containerGids?: IntArrayFilter | null | undefined;
+  containerMainGid?: IntFilter | null | undefined;
+  containerUid?: IntFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
+  description?: StringFilter | null | undefined;
   domain?: UserDomainNestedFilter | null | undefined;
   domainName?: StringFilter | null | undefined;
   email?: StringFilter | null | undefined;
+  fullName?: StringFilter | null | undefined;
   integrationName?: StringFilter | null | undefined;
+  needPasswordChange?: boolean | null | undefined;
   project?: UserProjectNestedFilter | null | undefined;
+  resourcePolicy?: StringFilter | null | undefined;
   role?: UserRoleV2EnumFilter | null | undefined;
   status?: UserStatusV2EnumFilter | null | undefined;
+  statusInfo?: StringFilter | null | undefined;
+  sudoSessionEnabled?: boolean | null | undefined;
+  totpActivated?: boolean | null | undefined;
   username?: StringFilter | null | undefined;
   uuid?: UUIDFilter | null | undefined;
 };
@@ -65,6 +75,19 @@ export type UserRoleV2EnumFilter = {
   in?: ReadonlyArray<UserRoleV2> | null | undefined;
   notEquals?: UserRoleV2 | null | undefined;
   notIn?: ReadonlyArray<UserRoleV2> | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type IntArrayFilter = {
+  contains?: number | null | undefined;
+  containsAll?: ReadonlyArray<number> | null | undefined;
+  containsAny?: ReadonlyArray<number> | null | undefined;
 };
 export type DateTimeFilter = {
   after?: string | null | undefined;

--- a/react/src/__generated__/DeploymentAddRevisionModalAddMutation.graphql.ts
+++ b/react/src/__generated__/DeploymentAddRevisionModalAddMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c441ec51b572d441d2923f3c3be1fdad>>
+ * @generated SignedSource<<d60be07feb431ee301a5b466fd94a571>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -373,7 +373,7 @@ v16 = {
 v17 = {
   "alias": null,
   "args": null,
-  "concreteType": "ExtraVFolderMountInfoGQL",
+  "concreteType": "ExtraVFolderMountInfo",
   "kind": "LinkedField",
   "name": "extraMounts",
   "plural": true,

--- a/react/src/__generated__/DeploymentAddRevisionModalQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentAddRevisionModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b374ced1535380d46d6cd4e67f3a7ccd>>
+ * @generated SignedSource<<a10d76f4c9f74c9d79919a704087216e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -236,7 +236,7 @@ v9 = {
 v10 = {
   "alias": null,
   "args": null,
-  "concreteType": "ExtraVFolderMountInfoGQL",
+  "concreteType": "ExtraVFolderMountInfo",
   "kind": "LinkedField",
   "name": "extraMounts",
   "plural": true,

--- a/react/src/__generated__/DeploymentDetailPageQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentDetailPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d47bd1f9ba142397a6e8455b33bf5138>>
+ * @generated SignedSource<<8e6c0dec43dfcb5d770517ffa0d63e86>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -293,7 +293,7 @@ v12 = [
   {
     "alias": null,
     "args": null,
-    "concreteType": "ExtraVFolderMountInfoGQL",
+    "concreteType": "ExtraVFolderMountInfo",
     "kind": "LinkedField",
     "name": "extraMounts",
     "plural": true,

--- a/react/src/__generated__/DeploymentListPageQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<240785efe8e2077d1dbd54508f14e2aa>>
+ * @generated SignedSource<<f6667dc28c07ec1d1ed37e30477d844b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -477,7 +477,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "DeploymentStrategyGQL",
+                    "concreteType": "DeploymentStrategy",
                     "kind": "LinkedField",
                     "name": "defaultDeploymentStrategy",
                     "plural": false,
@@ -679,7 +679,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ExtraVFolderMountInfoGQL",
+                        "concreteType": "ExtraVFolderMountInfo",
                         "kind": "LinkedField",
                         "name": "extraMounts",
                         "plural": true,

--- a/react/src/__generated__/DeploymentReplicasTabListQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentReplicasTabListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<66d9195c765ae81e52ed528212bcd3f1>>
+ * @generated SignedSource<<a3973aeca85d33c6a34af768e82ed2f7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -541,7 +541,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ExtraVFolderMountInfoGQL",
+                            "concreteType": "ExtraVFolderMountInfo",
                             "kind": "LinkedField",
                             "name": "extraMounts",
                             "plural": true,

--- a/react/src/__generated__/DeploymentRevisionDetail_revision.graphql.ts
+++ b/react/src/__generated__/DeploymentRevisionDetail_revision.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8a70ad58e219a153266f89a428f17903>>
+ * @generated SignedSource<<94d2dceb36c41beaf8317c23c6ac8b52>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -281,7 +281,7 @@ return {
     {
       "alias": null,
       "args": null,
-      "concreteType": "ExtraVFolderMountInfoGQL",
+      "concreteType": "ExtraVFolderMountInfo",
       "kind": "LinkedField",
       "name": "extraMounts",
       "plural": true,

--- a/react/src/__generated__/DeploymentRevisionHistoryTabActivateMutation.graphql.ts
+++ b/react/src/__generated__/DeploymentRevisionHistoryTabActivateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<92ada14f191b5a44f0974d1b2115071a>>
+ * @generated SignedSource<<7c50fac8d0b2f9eaa8363631587cd70b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -284,7 +284,7 @@ v12 = [
   {
     "alias": null,
     "args": null,
-    "concreteType": "ExtraVFolderMountInfoGQL",
+    "concreteType": "ExtraVFolderMountInfo",
     "kind": "LinkedField",
     "name": "extraMounts",
     "plural": true,

--- a/react/src/__generated__/DeploymentRevisionHistoryTabListQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentRevisionHistoryTabListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8f80265394db286560df6f857d814d3c>>
+ * @generated SignedSource<<6de7c36b3fc2f4518b007ae1e67609ec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -758,7 +758,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ExtraVFolderMountInfoGQL",
+                        "concreteType": "ExtraVFolderMountInfo",
                         "kind": "LinkedField",
                         "name": "extraMounts",
                         "plural": true,

--- a/react/src/__generated__/DeploymentSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9e0263ab0ebb2358b611f0d8cc490846>>
+ * @generated SignedSource<<5bebb4b2fbb2a01edabaabd221a42f0a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -276,7 +276,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "SubStepResultGQL",
+                    "concreteType": "SubStepResult",
                     "kind": "LinkedField",
                     "name": "subSteps",
                     "plural": true,
@@ -341,12 +341,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6cc521a7daf46bd6ff23d8369e069d7c",
+    "cacheID": "b90ddaea840e125655cec48b04c792dc",
     "id": null,
     "metadata": {},
     "name": "DeploymentSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query DeploymentSchedulingHistoryModalQuery(\n  $scope: DeploymentScope!\n  $filter: DeploymentHistoryFilter\n  $orderBy: [DeploymentHistoryOrderBy!]\n) {\n  deploymentScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIDeploymentSchedulingHistoryNodesFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentSchedulingHistoryNodesFragment on DeploymentHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query DeploymentSchedulingHistoryModalQuery(\n  $scope: DeploymentScope!\n  $filter: DeploymentHistoryFilter\n  $orderBy: [DeploymentHistoryOrderBy!]\n) {\n  deploymentScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIDeploymentSchedulingHistoryNodesFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentSchedulingHistoryNodesFragment on DeploymentHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAISubStepNodesFragment on SubStepResult {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/ImportArtifactRevisionToFolderModalMutation.graphql.ts
+++ b/react/src/__generated__/ImportArtifactRevisionToFolderModalMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c0edf71865c977be540f6380db5f7118>>
+ * @generated SignedSource<<401df58ae33c7d87765e1aa79fe6408d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,10 +11,10 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type ImportArtifactsInput = {
   artifactRevisionIds: ReadonlyArray<string>;
-  options?: ImportArtifactsOptionsGQL | null | undefined;
+  options?: ImportArtifactsOptions | null | undefined;
   vfolderId?: string | null | undefined;
 };
-export type ImportArtifactsOptionsGQL = {
+export type ImportArtifactsOptions = {
   force?: boolean;
 };
 export type ImportArtifactRevisionToFolderModalMutation$variables = {

--- a/react/src/__generated__/MyKeypairManagementModalDeactivateMyKeypairMutation.graphql.ts
+++ b/react/src/__generated__/MyKeypairManagementModalDeactivateMyKeypairMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8da6286e62a423330ae819a90623e7d2>>
+ * @generated SignedSource<<146b12dd2f519882a8c91ecf66985700>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,7 +68,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "KeyPairGQL",
+            "concreteType": "KeyPairV2",
             "kind": "LinkedField",
             "name": "keypair",
             "plural": false,
@@ -101,7 +101,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "KeyPairGQL",
+            "concreteType": "KeyPairV2",
             "kind": "LinkedField",
             "name": "keypair",
             "plural": false,

--- a/react/src/__generated__/MyKeypairManagementModalIssueMyKeypairMutation.graphql.ts
+++ b/react/src/__generated__/MyKeypairManagementModalIssueMyKeypairMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<390b5f0f16c95f40af02790daa6eae96>>
+ * @generated SignedSource<<6205ddae985c9103c4cb957e280f6185>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -64,7 +64,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "KeyPairGQL",
+            "concreteType": "KeyPairV2",
             "kind": "LinkedField",
             "name": "keypair",
             "plural": false,
@@ -99,7 +99,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "KeyPairGQL",
+            "concreteType": "KeyPairV2",
             "kind": "LinkedField",
             "name": "keypair",
             "plural": false,

--- a/react/src/__generated__/MyKeypairManagementModalQuery.graphql.ts
+++ b/react/src/__generated__/MyKeypairManagementModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<32c5c26c6d032656e873cf32b75fbd20>>
+ * @generated SignedSource<<6e4c70f87305edd533fccff7f63d127c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -148,7 +148,7 @@ v5 = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "KeyPairGQLEdge",
+      "concreteType": "KeyPairV2Edge",
       "kind": "LinkedField",
       "name": "edges",
       "plural": true,
@@ -156,7 +156,7 @@ v5 = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "KeyPairGQL",
+          "concreteType": "KeyPairV2",
           "kind": "LinkedField",
           "name": "node",
           "plural": false,

--- a/react/src/__generated__/ProjectAdminDeploymentsPageQuery.graphql.ts
+++ b/react/src/__generated__/ProjectAdminDeploymentsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<43cb27f6d76e3cb692efbf9376c920fa>>
+ * @generated SignedSource<<f32f4117ed30234f79156ed7648de52c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -496,7 +496,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "DeploymentStrategyGQL",
+                    "concreteType": "DeploymentStrategy",
                     "kind": "LinkedField",
                     "name": "defaultDeploymentStrategy",
                     "plural": false,
@@ -698,7 +698,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ExtraVFolderMountInfoGQL",
+                        "concreteType": "ExtraVFolderMountInfo",
                         "kind": "LinkedField",
                         "name": "extraMounts",
                         "plural": true,

--- a/react/src/__generated__/ProjectAdminUsersPageQuery.graphql.ts
+++ b/react/src/__generated__/ProjectAdminUsersPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<84d34c384c3916c8881e17489dfaaeb7>>
+ * @generated SignedSource<<0a37ee5792e99771c7ef78576fadb8d5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,14 +18,24 @@ export type UserV2Filter = {
   AND?: ReadonlyArray<UserV2Filter> | null | undefined;
   NOT?: ReadonlyArray<UserV2Filter> | null | undefined;
   OR?: ReadonlyArray<UserV2Filter> | null | undefined;
+  containerGids?: IntArrayFilter | null | undefined;
+  containerMainGid?: IntFilter | null | undefined;
+  containerUid?: IntFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
+  description?: StringFilter | null | undefined;
   domain?: UserDomainNestedFilter | null | undefined;
   domainName?: StringFilter | null | undefined;
   email?: StringFilter | null | undefined;
+  fullName?: StringFilter | null | undefined;
   integrationName?: StringFilter | null | undefined;
+  needPasswordChange?: boolean | null | undefined;
   project?: UserProjectNestedFilter | null | undefined;
+  resourcePolicy?: StringFilter | null | undefined;
   role?: UserRoleV2EnumFilter | null | undefined;
   status?: UserStatusV2EnumFilter | null | undefined;
+  statusInfo?: StringFilter | null | undefined;
+  sudoSessionEnabled?: boolean | null | undefined;
+  totpActivated?: boolean | null | undefined;
   username?: StringFilter | null | undefined;
   uuid?: UUIDFilter | null | undefined;
 };
@@ -68,6 +78,19 @@ export type UserRoleV2EnumFilter = {
   in?: ReadonlyArray<UserRoleV2> | null | undefined;
   notEquals?: UserRoleV2 | null | undefined;
   notIn?: ReadonlyArray<UserRoleV2> | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type IntArrayFilter = {
+  contains?: number | null | undefined;
+  containsAll?: ReadonlyArray<number> | null | undefined;
+  containsAny?: ReadonlyArray<number> | null | undefined;
 };
 export type DateTimeFilter = {
   after?: string | null | undefined;

--- a/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5d0ef863d0714f49059be1797b0c4c60>>
+ * @generated SignedSource<<bacccae0c23bbd4bda36e57f0f6d9988>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -291,7 +291,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "SubStepResultGQL",
+                    "concreteType": "SubStepResult",
                     "kind": "LinkedField",
                     "name": "subSteps",
                     "plural": true,
@@ -356,12 +356,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5db4b1d03cdc23ddcee7e24da57e934d",
+    "cacheID": "c5d46a26ccd6b60909f90515a5fea5fb",
     "id": null,
     "metadata": {},
     "name": "RouteSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryNodeTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  routeId\n  deploymentId\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryNodeTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  routeId\n  deploymentId\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAISubStepNodesFragment on SubStepResult {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/SessionSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/SessionSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<723b1f0a84f6919a10784d3ce95e2a6c>>
+ * @generated SignedSource<<7a7068e9e6a754b44a337e6fa303c569>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -289,7 +289,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "SubStepResultGQL",
+                    "concreteType": "SubStepResult",
                     "kind": "LinkedField",
                     "name": "subSteps",
                     "plural": true,
@@ -339,12 +339,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5b9e35a12fc771527f808842f63b593b",
+    "cacheID": "6eeac0bafde3e3fc3e3dd00933c5e600",
     "id": null,
     "metadata": {},
     "name": "SessionSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query SessionSchedulingHistoryModalQuery(\n  $scope: SessionScope!\n  $filter: SessionSchedulingHistoryFilter\n  $orderBy: [SessionSchedulingHistoryOrderBy!]\n) {\n  sessionScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAISchedulingHistoryNodesFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  sessionId\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query SessionSchedulingHistoryModalQuery(\n  $scope: SessionScope!\n  $filter: SessionSchedulingHistoryFilter\n  $orderBy: [SessionSchedulingHistoryOrderBy!]\n) {\n  sessionScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAISchedulingHistoryNodesFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  sessionId\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n}\n\nfragment BAISubStepNodesFragment on SubStepResult {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/UsageBucketChartContentQuery.graphql.ts
+++ b/react/src/__generated__/UsageBucketChartContentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c33ca497b0e8caf9fc97b04a727ac5af>>
+ * @generated SignedSource<<c797379542c10163658f0d1fd239394b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -101,14 +101,24 @@ export type UserV2Filter = {
   AND?: ReadonlyArray<UserV2Filter> | null | undefined;
   NOT?: ReadonlyArray<UserV2Filter> | null | undefined;
   OR?: ReadonlyArray<UserV2Filter> | null | undefined;
+  containerGids?: IntArrayFilter | null | undefined;
+  containerMainGid?: IntFilter | null | undefined;
+  containerUid?: IntFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
+  description?: StringFilter | null | undefined;
   domain?: UserDomainNestedFilter | null | undefined;
   domainName?: StringFilter | null | undefined;
   email?: StringFilter | null | undefined;
+  fullName?: StringFilter | null | undefined;
   integrationName?: StringFilter | null | undefined;
+  needPasswordChange?: boolean | null | undefined;
   project?: UserProjectNestedFilter | null | undefined;
+  resourcePolicy?: StringFilter | null | undefined;
   role?: UserRoleV2EnumFilter | null | undefined;
   status?: UserStatusV2EnumFilter | null | undefined;
+  statusInfo?: StringFilter | null | undefined;
+  sudoSessionEnabled?: boolean | null | undefined;
+  totpActivated?: boolean | null | undefined;
   username?: StringFilter | null | undefined;
   uuid?: UUIDFilter | null | undefined;
 };
@@ -123,6 +133,19 @@ export type UserRoleV2EnumFilter = {
   in?: ReadonlyArray<UserRoleV2> | null | undefined;
   notEquals?: UserRoleV2 | null | undefined;
   notIn?: ReadonlyArray<UserRoleV2> | null | undefined;
+};
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
+};
+export type IntArrayFilter = {
+  contains?: number | null | undefined;
+  containsAll?: ReadonlyArray<number> | null | undefined;
+  containsAny?: ReadonlyArray<number> | null | undefined;
 };
 export type UserDomainNestedFilter = {
   isActive?: boolean | null | undefined;


### PR DESCRIPTION
Resolves #7695 (FR-3030)

Syncs the WebUI to backend.ai #11906, which strips the unintended `GQL` suffix from v2 GraphQL schema type names (e.g. `CreateDomainInputGQL` → `CreateDomainInput`, `SubStepResultGQL` → `SubStepResult`). `data/schema.graphql` reflects the connected backend; Relay is regenerated.

## Changes

- **`data/schema.graphql`** — suffix-stripped type names (synced from the backend), incl. `SubStepResultGQL` → `SubStepResult`.
- **`BAISubStepNodes.tsx`** — the only WebUI source reference to a renamed type; fragment is now `on SubStepResult`.
- **`graphql-transformer.ts`** — backward-compat version branch (see below).
- **`graphql-transformer.test.ts`** — unit tests for both branches of the rewrite.
- 33 regenerated Relay artifacts.

The 60 other renames are mutation input/payload types referenced only in generated artifacts; their **wire query text is unchanged** (the names appear solely as build-time TypeScript types), so they require no runtime handling.

## Backward compatibility (FR-3017-style version branch)

The `SubStepResult` rename lands in core **26.4.4**. Unlike FR-3017 — where the diverging value rode in a Relay variable — this is a fragment **type condition**, which is baked into the query text and cannot be parameterized. A single compiled query against the new name is rejected at **query-validation** time on cores `< 26.4.4` (`Unknown type "SubStepResult"`), and `@catch` cannot absorb a validation error.

`manipulateGraphQLQueryWithClientDirectives` already version-branches a fragment type condition (`Query` → `Queries` for cores `< 25.14.0`). The same mechanism now rewrites `SubStepResult` → `SubStepResultGQL` for cores `< 26.4.4`, so **one** compiled query validates on every supported backend, with **no `data/schema.graphql` divergence**.

> TODO(FR-3030): pin the exact `26.4.4` rc tag once #11906 merges, mirroring the `26.4.4rc4` pin in FR-3017 (PEP440 sorts `26.4.4rcN < 26.4.4`).

## Verification

`bash scripts/verify.sh` → **Relay / Lint / Format / TypeScript PASS**. New unit tests cover both the legacy-rewrite and pass-through branches (11/11 transformer tests pass). The harness's "Vite warmup paths" check also fails on a clean `main` — pre-existing, unrelated to this change.

### Manual checks (cannot be covered by verify.sh)

`verify.sh` only compiles against the latest (`SubStepResult`) schema; it cannot exercise the `< 26.4.4` path. Confirm against live backends:

- [ ] Core `>= 26.4.4`: open Session / Route / Deployment scheduling-history → sub-steps table renders; network `subSteps` fragment sends `... on SubStepResult`.
- [ ] Core `< 26.4.4`: same modals render with no `GRAPHQL_VALIDATION_FAILED`; network sends `... on SubStepResultGQL`.