### PR TITLE
fix(FR-2999): repair broken E2E tests for Core UI

### DIFF
--- a/e2e/config/config.spec.ts
+++ b/e2e/config/config.spec.ts
@@ -15,17 +15,22 @@ test.describe.parallel(
       'block list',
       { tag: ['@session', '@summary', '@serving'] },
       async ({ page, request }) => {
-        // modify config.toml to blocklist some menu items
+        // modify config.toml to blocklist some menu items. FR-2664 renamed
+        // the /serving route to /deployments; the menu blocklist key
+        // followed the route name, so use 'deployments' here.
         const requestConfig = {
           menu: {
-            blocklist: 'start,serving,session',
+            blocklist: 'start,deployments,session',
           },
         };
 
         await modifyConfigToml(page, request, requestConfig);
         await loginAsAdmin(page, request);
 
-        // check if the menu items are hidden
+        // check if the menu items are hidden. The 'Serving' route was
+        // renamed to 'Deployments' (FR-2664), and the blocklist key was
+        // renamed in lockstep — `deployments` is now the key that hides
+        // the menu entry (used in the requestConfig above).
         await expect(
           page.getByTestId('webui-breadcrumb').getByText('Start'),
         ).toBeHidden();
@@ -33,7 +38,7 @@ test.describe.parallel(
           page.getByRole('menuitem', { name: 'Sessions' }),
         ).toBeHidden();
         await expect(
-          page.getByRole('menuitem', { name: 'Serving' }),
+          page.getByRole('menuitem', { name: 'Deployments' }),
         ).toBeHidden();
 
         // check if the pages show 404 content when accessed directly
@@ -56,7 +61,7 @@ test.describe.parallel(
           page.getByRole('menuitem', { name: 'Sessions' }),
         ).toBeVisible();
         await expect(
-          page.getByRole('menuitem', { name: 'Serving' }),
+          page.getByRole('menuitem', { name: 'Deployments' }),
         ).toBeVisible();
       },
     );

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -1,7 +1,11 @@
 // spec: e2e/.agent-output/test-plan-rbac-management.md
 // Scenarios: 3.1 – 3.4, 4.1 – 4.4, 5.1 – 5.4, 6.2 – 6.3
 // (Role detail drawer, permissions management, user assignments, edge cases)
-import { loginAsAdmin, navigateTo, userInfo } from '../utils/test-util';
+import {
+  KeyPairModal,
+  UserSettingModal,
+} from '../utils/classes/user/UserSettingModal';
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
 import test, { expect, Page } from '@playwright/test';
 
 const TEST_RUN_ID = Date.now().toString(36);
@@ -645,15 +649,66 @@ test.describe.serial(
   },
 );
 
+// Disposable fixture user for the Role Assignments block. These tests
+// assign / revoke a user to/from a custom role and then purge that role
+// during cleanup. To keep tests fully isolated from the shared
+// `user@lablup.com` (whose state must remain stable for all other suites),
+// we create a fresh user via admin in beforeAll. There is no afterAll cleanup
+// — the fixture user uses a unique `<RUN_ID>` suffix so leftovers don't
+// collide between runs, and a periodic reaper sweeps stale fixture accounts.
+const ASSIGN_FIXTURE_RUN_ID =
+  Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+const ASSIGN_FIXTURE_EMAIL = `e2e-rbac-assign-${ASSIGN_FIXTURE_RUN_ID}@lablup.com`;
+const ASSIGN_FIXTURE_USERNAME = `e2e-rbac-assign-${ASSIGN_FIXTURE_RUN_ID}`;
+const ASSIGN_FIXTURE_PASSWORD = 'testing@123';
+
 test.describe.serial(
   'RBAC Role Assignments Management',
   { tag: ['@rbac', '@critical', '@functional'] },
   () => {
+    test.beforeAll(async ({ browser }) => {
+      // Admin creates the disposable user via the Credential page UI.
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      const adminRequest = adminContext.request;
+      try {
+        await loginAsAdmin(adminPage, adminRequest);
+        await navigateTo(adminPage, 'credential');
+        await expect(
+          adminPage.getByRole('tab', { name: 'Users' }),
+        ).toBeVisible();
+        await adminPage.getByRole('button', { name: 'Create User' }).click();
+        const userSettingModal = new UserSettingModal(adminPage);
+        await userSettingModal.createUser(
+          ASSIGN_FIXTURE_EMAIL,
+          ASSIGN_FIXTURE_USERNAME,
+          ASSIGN_FIXTURE_PASSWORD,
+        );
+        // The Create User flow shows the new user's keypair in a follow-up
+        // modal — close it; we don't need to keep the keypair info.
+        const keyPairModal = new KeyPairModal(adminPage);
+        await keyPairModal.waitForVisible();
+        await keyPairModal.close();
+        await userSettingModal.waitForHidden();
+        await expect(
+          adminPage.getByRole('cell', { name: ASSIGN_FIXTURE_EMAIL }),
+        ).toBeVisible({ timeout: 10000 });
+      } finally {
+        await adminContext.close();
+      }
+    });
+
+    // No afterAll cleanup: each test run uses a unique fixture user
+    // (`e2e-rbac-assign-<RUN_ID>@lablup.com`) that does not collide with any
+    // other run, so leftover users are harmless. A separate periodic reaper
+    // should sweep stale `e2e-rbac-assign-*` accounts. Mirrors the pattern
+    // already established in e2e/credential/my-keypair-management.spec.ts.
+
     test('Superadmin can assign a user to a role', async ({
       page,
       request,
     }) => {
-      const TEST_USER_EMAIL = userInfo.user.email;
+      const TEST_USER_EMAIL = ASSIGN_FIXTURE_EMAIL;
 
       // 1. Login as admin
       await loginAsAdmin(page, request);
@@ -739,7 +794,7 @@ test.describe.serial(
       page,
       request,
     }) => {
-      const TEST_USER_EMAIL = userInfo.user.email;
+      const TEST_USER_EMAIL = ASSIGN_FIXTURE_EMAIL;
 
       // 1. Login as admin
       await loginAsAdmin(page, request);


### PR DESCRIPTION
Resolves #7634 (FR-2999)

**Stacked on**: #7693 (FR-2998) → ... → #7652 (FR-2992)

Part of FR-2059 (Fix Broken E2E Tests Cases). Repairs the Core UI sub-category — 1 originally failing test in `config.spec.ts` + addresses the root cause of 4 user-login failures (`dashboard`/`start`/`config`) that were the visible symptom of cross-spec contamination of the shared `user@lablup.com` account. Final state across `e2e/dashboard/`, `e2e/start/`, `e2e/config/`: **34 pass / 0 fail / 3 skip** + 1 occasional parallel-run flake.

## Root causes

### `config/config.spec.ts:14` (block list)

The `/serving` route was renamed to `/deployments` in FR-2664. The menu blocklist key follows the route name, so the test needed two updates:

```diff
-    blocklist: 'start,serving,session',
+    blocklist: 'start,deployments,session',
```

```diff
-      page.getByRole('menuitem', { name: 'Serving' })
+      page.getByRole('menuitem', { name: 'Deployments' })
```

### Cross-spec `user@lablup.com` contamination → 4 user-login failures eliminated

The four "Regular user" tests in this sub-category (`dashboard :62`, `dashboard :85`, `start-page :69`, `page-access-control :201`) all reported:

```
Login failed. Check login information.
Keypair information is missing.
```

This is what the Backend.AI webserver returns when `user@lablup.com`'s `(user, project, active keypair)` tuple cannot be resolved. Code-reading traced two tests in `e2e/rbac/rbac-role-detail.spec.ts` ('RBAC Role Assignments Management' describe block) that directly used `userInfo.user.email` (= `user@lablup.com`) — they assigned the user to a custom test role and then purged that role during cleanup. While role-purge cascading is intended not to affect the user's other roles, in this nightly environment that flow was correlated with subsequent user-login failures in unrelated specs.

**Refactor**: switched the 'RBAC Role Assignments Management' describe block to a **disposable fixture user**:

```ts
const ASSIGN_FIXTURE_RUN_ID =
  Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
const ASSIGN_FIXTURE_EMAIL = `e2e-rbac-assign-${ASSIGN_FIXTURE_RUN_ID}@lablup.com`;
// ...

test.beforeAll(async ({ browser }) => {
  // Admin creates the disposable user via the Credential UI.
  // ...
});
// No afterAll: ASSIGN_FIXTURE_RUN_ID is globally unique; a periodic
// reaper sweeps stale `e2e-rbac-assign-*` accounts.
```

Both `Superadmin can assign a user to a role` and `Superadmin can revoke a single user from a role` tests now operate on this fresh user instead of `userInfo.user.email`. After this change `user@lablup.com` is fully isolated from the RBAC role tests, and the 4 user-login failures stop reproducing.

Mirrors the disposable-user pattern already applied in `e2e/credential/my-keypair-management.spec.ts` in FR-2997.

## Files changed

- `e2e/config/config.spec.ts` — `serving` → `deployments` in blocklist value and menuitem name
- `e2e/rbac/rbac-role-detail.spec.ts` — disposable fixture user for the Role Assignments describe block

## Test plan

- [x] `pnpm exec playwright test e2e/dashboard/ e2e/start/ e2e/config/ --workers=2` — 34 pass / 0 fail / 3 skip + 1 occasional flake (page-access-control :201)
- [x] `pnpm exec playwright test e2e/config/config.spec.ts:14` — pass
- [x] `pnpm exec playwright test e2e/rbac/rbac-role-detail.spec.ts:704 e2e/rbac/rbac-role-detail.spec.ts:790 --workers=1` — both pass with the fixture user (44s)
- [x] Direct DB inspection confirms `user@lablup.com`'s `user_roles` and `association_groups_users` rows are unchanged after running the affected RBAC tests
