### PR TITLE
fix(FR-3000): repair broken E2E tests for Plugin & Infrastructure

### DIFF
--- a/e2e/plugin/plugin-system.spec.ts
+++ b/e2e/plugin/plugin-system.spec.ts
@@ -3,6 +3,7 @@ import {
   loginAsAdmin,
   loginAsUser,
   modifyConfigToml,
+  navigateTo,
 } from '../utils/test-util';
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
@@ -104,8 +105,12 @@ test.describe.parallel(
         // 3. Login as admin after setting up routes
         await loginAsAdmin(page, request);
 
-        // 4. Click "Admin Settings" menu item in sidebar
-        await page.getByRole('menuitem', { name: 'Admin Settings' }).click();
+        // 4. Navigate to a stable admin page to enter admin mode.
+        //    The admin-test-plugin itself immediately calls window.history.back()
+        //    when its component mounts, so clicking "Admin Settings" (which points
+        //    to the plugin URL) would navigate away before the admin sidebar renders.
+        //    Using /credential as a stable admin page triggers the admin sidebar view.
+        await navigateTo(page, 'credential');
 
         // 5. Verify Admin Settings panel has "Admin Tool" menuitem
         await expect(


### PR DESCRIPTION
Resolves #7635 (FR-3000)

**Stacked on**: #7706 (FR-2999) → ... → #7652 (FR-2992)

Part of FR-2059 (Fix Broken E2E Tests Cases). Repairs the Plugin & Infrastructure sub-category — 1 originally failing test in `plugin-system.spec.ts`. Final state across `e2e/plugin/`: **14 pass / 0 fail / 0 skip** (login-plugin.spec.ts + plugin-system.spec.ts).

## Root cause

### `plugin/plugin-system.spec.ts` — `Admin can see admin-permission plugin in Admin Settings panel`

The test clicked the sidebar's `Admin Settings` menuitem to enter admin mode, then asserted that the panel's `Admin Tool` menuitem (provided by the `admin-test-plugin` fixture) became visible.

In the current build, `Admin Settings` resolves to the first available admin page — which, when `admin-test-plugin` is configured via `plugin.page`, is the plugin route itself. The plugin's `updated()` lifecycle hook immediately calls `window.history.back()` (it is a `redirect`-style plugin used to verify the plugin loader, not a real page). The browser navigates away from the admin context before the admin sidebar ever renders, and the `Admin Tool` assertion times out.

**Fix**: replace the sidebar click with `navigateTo(page, 'credential')`, routing directly to a stable admin page (`/credential`) that enters admin-sidebar mode without invoking the plugin's navigation-back side effect.

```diff
-import { loginAsAdmin, loginAsUser, modifyConfigToml } from '../utils/test-util';
+import {
+  loginAsAdmin,
+  loginAsUser,
+  modifyConfigToml,
+  navigateTo,
+} from '../utils/test-util';

-await page.getByRole('menuitem', { name: 'Admin Settings' }).click();
+await navigateTo(page, 'credential');
```

All other tests (both `login-plugin.spec.ts` tests; the other 5 describe blocks of `plugin-system.spec.ts`) passed on the first run — no changes needed.

## Files changed

- `e2e/plugin/plugin-system.spec.ts` — added `navigateTo` import; swapped the `Admin Settings` click for `navigateTo(page, 'credential')` in the admin-plugin sidebar visibility test.

The plugin fixture payloads (`test-plugin.js`, `admin-test-plugin.js`, `plugin-a.js`, `plugin-b.js`, `backend-ai-homepage-link.js`) are unchanged.

## Test plan

- [x] `pnpm exec playwright test e2e/plugin/ --workers=1` — 14 pass / 0 fail / 0 skip
- [x] `pnpm exec playwright test e2e/plugin/login-plugin.spec.ts` — pass
- [x] `pnpm exec playwright test e2e/plugin/plugin-system.spec.ts` — pass
