### PR TITLE
test(FR-1818): unit tests, e2e validation spec, and CSV fixtures

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -34,7 +34,7 @@
 | Configurations           | `/settings`                            |    10    |    8    | 🔶 80%  |
 | Resources                | `/agent-summary`, `/agent`             |    10    |    3    | 🔶 30%  |
 | Resource Policy          | `/resource-policy`                     |    13    |   10    | 🔶 77%  |
-| User Credentials         | `/credential`                          |    20    |   13    | 🔶 65%  |
+| User Credentials         | `/credential`                          |    21    |   14    | 🔶 67%  |
 | Maintenance              | `/maintenance`                         |    3     |    2    | 🔶 67%  |
 | User Settings            | `/usersettings`                        |    10    |    1    | 🔶 10%  |
 | Project                  | `/project`                             |    6     |    5    | 🔶 83%  |
@@ -647,7 +647,7 @@
 
 ### 17. User Credentials (`/credential`)
 
-**Test files:** [`e2e/user/user-crud.spec.ts`](user/user-crud.spec.ts), [`e2e/user/bulk-user-creation.spec.ts`](user/bulk-user-creation.spec.ts), [`e2e/credential/credential-keypair.spec.ts`](credential/credential-keypair.spec.ts), [`e2e/user-profile/user-ip-restriction-enforcement.spec.ts`](user-profile/user-ip-restriction-enforcement.spec.ts)
+**Test files:** [`e2e/user/user-crud.spec.ts`](user/user-crud.spec.ts), [`e2e/user/bulk-user-creation.spec.ts`](user/bulk-user-creation.spec.ts), [`e2e/credential/credential-keypair.spec.ts`](credential/credential-keypair.spec.ts), [`e2e/user-profile/user-ip-restriction-enforcement.spec.ts`](user-profile/user-ip-restriction-enforcement.spec.ts), [`e2e/credential/bulk-create-from-csv.spec.ts`](credential/bulk-create-from-csv.spec.ts)
 
 **Tabs:** Users | Credentials
 
@@ -665,6 +665,7 @@
 | Bulk create users → UserSettingModal                | ✅     | `Admin can bulk create multiple users`                                                                                      |
 | Bulk create single user                             | ✅     | `Admin can bulk create a single user`                                                                                       |
 | Bulk create modal open/cancel                       | ✅     | `Admin can open bulk create modal from dropdown` / `Admin can cancel bulk user creation`                                    |
+| Bulk create users from CSV (client-side validation) | ✅     | `bulk-create-from-csv.spec.ts` (preview stats + submit enable/disable)                                                      |
 | Update user → UserSettingModal                      | ✅     | `Admin can update user information`                                                                                         |
 | Deactivate user                                     | ✅     | `Admin can deactivate a user`                                                                                               |
 | Reactivate user                                     | ✅     | `Admin can reactivate an inactive user`                                                                                     |
@@ -691,7 +692,7 @@
 | Edit keypair → KeypairSettingModal             | ❌     | -                                                     |
 | SSH key management → SSHKeypairManagementModal | ❌     | -                                                     |
 
-**Coverage: 🔶 13/20 features**
+**Coverage: 🔶 14/21 features**
 
 ---
 

--- a/e2e/credential/bulk-create-from-csv.spec.ts
+++ b/e2e/credential/bulk-create-from-csv.spec.ts
@@ -1,0 +1,341 @@
+// spec: Bulk Create Users from CSV — client-side validation tests
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import test, { expect, Page } from '@playwright/test';
+import path from 'path';
+
+const SAMPLES_DIR = path.resolve(__dirname, '../../test-fixtures/csv-samples');
+
+async function openBulkCreateCSVModal(page: Page) {
+  await navigateTo(page, 'credential?tab=users');
+  // Wait for UserManagement to fully load
+  await expect(page.getByRole('button', { name: 'Create User' })).toBeVisible({
+    timeout: 15000,
+  });
+  // Click the ellipsis dropdown button — scoped to the Space.Compact that contains
+  // "Create User", to avoid matching the antd Tabs nav "more" button.
+  const createUserBtn = page.getByRole('button', { name: 'Create User' });
+  await createUserBtn
+    .locator('xpath=ancestor::*[contains(@class,"ant-space-compact")]')
+    .getByRole('button', { name: 'ellipsis' })
+    .click();
+  await page
+    .getByRole('menuitem', { name: 'Bulk Create Users from CSV' })
+    .click();
+  await expect(
+    page.getByRole('dialog', { name: 'Bulk Create Users from CSV' }),
+  ).toBeVisible({ timeout: 5000 });
+}
+
+async function uploadCSV(page: Page, filename: string) {
+  const dialog = page.getByRole('dialog', {
+    name: 'Bulk Create Users from CSV',
+  });
+  const fileInput = dialog.locator('input[name="file"]');
+  await fileInput.setInputFiles(path.join(SAMPLES_DIR, filename));
+}
+
+/** Read stat numbers from the preview bar by label text */
+async function getStat(page: Page, label: string): Promise<number> {
+  const dialog = page.getByRole('dialog', {
+    name: 'Bulk Create Users from CSV',
+  });
+  // BAIPanelItem renders the title span first, then the numeric value span
+  // (nested inside a flex wrapper). Find the title, then read the value span.
+  const labelEl = dialog.getByText(label, { exact: true });
+  await expect(labelEl).toBeVisible({ timeout: 8000 });
+  const container = labelEl.locator('..');
+  // The label is the first span; the numeric value is the last span.
+  const numText = await container.locator('span').last().textContent();
+  const parsed = parseInt(numText ?? '', 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(
+      `Failed to parse numeric stat for label "${label}" (got "${numText ?? ''}")`,
+    );
+  }
+  return parsed;
+}
+
+async function closeModal(page: Page) {
+  await page
+    .getByRole('dialog', { name: 'Bulk Create Users from CSV' })
+    .getByRole('button', { name: 'Cancel' })
+    .click();
+  await expect(
+    page.getByRole('dialog', { name: 'Bulk Create Users from CSV' }),
+  ).not.toBeVisible({ timeout: 5000 });
+}
+
+test.describe(
+  'Bulk Create Users from CSV — validation',
+  { tag: ['@credential', '@functional', '@fr-1818'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    // ── Valid CSVs ──────────────────────────────────────────────────────────
+
+    test('admin can upload a full CSV with all fields and see 5 valid rows', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '01-valid-all-fields.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(5);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      expect(await getStat(page, 'ready to create')).toBe(5);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeEnabled();
+      await closeModal(page);
+    });
+
+    test('admin can upload a minimal CSV (required fields only) and see 3 valid rows', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '02-valid-minimal.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(3);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeEnabled();
+      await closeModal(page);
+    });
+
+    test('admin can upload a CSV with column aliases and see 2 valid rows', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '03-valid-column-aliases.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(2);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      await closeModal(page);
+    });
+
+    test('admin can upload a CSV covering all roles and see 4 valid rows', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '04-valid-all-roles.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(4);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      await closeModal(page);
+    });
+
+    test('admin can upload a CSV covering all statuses and see 4 valid rows', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '05-valid-all-statuses.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(4);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      await closeModal(page);
+    });
+
+    test('admin can upload a CSV with RFC-4180 quoted fields and see 3 valid rows', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '13-valid-quoted-fields.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(3);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      await closeModal(page);
+    });
+
+    test('admin can upload a CSV with various need_password_change values and see 5 valid rows', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '14-valid-need-password-change.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(5);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      await closeModal(page);
+    });
+
+    // ── Error CSVs ─────────────────────────────────────────────────────────
+
+    test('admin cannot submit when CSV rows have missing required fields', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '06-error-missing-required.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(4);
+      expect(await getStat(page, 'with errors')).toBeGreaterThan(0);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeDisabled();
+      await closeModal(page);
+    });
+
+    test('admin cannot submit when CSV has invalid email formats', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '07-error-invalid-email.csv');
+      expect(await getStat(page, 'with errors')).toBe(4);
+      expect(await getStat(page, 'ready to create')).toBe(1);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeDisabled();
+      await closeModal(page);
+    });
+
+    test('admin cannot submit when CSV has duplicate emails', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '08-error-duplicate-email.csv');
+      expect(await getStat(page, 'with errors')).toBe(3);
+      expect(await getStat(page, 'ready to create')).toBe(1);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeDisabled();
+      await closeModal(page);
+    });
+
+    test('admin cannot submit when CSV has invalid passwords', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '09-error-invalid-password.csv');
+      expect(await getStat(page, 'with errors')).toBe(4);
+      expect(await getStat(page, 'ready to create')).toBe(1);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeDisabled();
+      await closeModal(page);
+    });
+
+    test('admin cannot submit when CSV has invalid role or status values', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '10-error-invalid-role-status.csv');
+      expect(await getStat(page, 'with errors')).toBe(3);
+      expect(await getStat(page, 'ready to create')).toBe(1);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeDisabled();
+      await closeModal(page);
+    });
+
+    // ── Edge cases ─────────────────────────────────────────────────────────
+
+    test('admin can filter to errors-only view in a mixed CSV', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '11-mixed-valid-and-errors.csv');
+      const dialog = page.getByRole('dialog', {
+        name: 'Bulk Create Users from CSV',
+      });
+      const totalRows = await getStat(page, 'rows loaded');
+      expect(totalRows).toBeGreaterThan(0);
+      const errorCount = await getStat(page, 'with errors');
+      expect(errorCount).toBeGreaterThan(0);
+
+      // Toggle "Only show errors"
+      await dialog.getByRole('switch').click();
+      const rows = dialog.locator('table tbody tr:not(.ant-table-measure-row)');
+      await expect.poll(() => rows.count(), { timeout: 5000 }).toBe(errorCount);
+      await closeModal(page);
+    });
+
+    test('admin sees an error message when CSV is missing a required column', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '12-error-missing-required-columns.csv');
+      // Toast error — Ant Design message renders in .ant-message
+      await expect(page.locator('.ant-message-notice')).toBeVisible({
+        timeout: 5000,
+      });
+      // Preview stats should NOT appear (no file loaded into state)
+      const dialog = page.getByRole('dialog', {
+        name: 'Bulk Create Users from CSV',
+      });
+      await expect(dialog.getByText('rows loaded')).not.toBeVisible({
+        timeout: 3000,
+      });
+      await closeModal(page);
+    });
+
+    test('admin sees a warning when CSV file has only headers and no data rows', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '15-error-empty-file.csv');
+      await expect(page.locator('.ant-message-notice')).toBeVisible({
+        timeout: 5000,
+      });
+      const dialog = page.getByRole('dialog', {
+        name: 'Bulk Create Users from CSV',
+      });
+      await expect(dialog.getByText('rows loaded')).not.toBeVisible({
+        timeout: 3000,
+      });
+      await closeModal(page);
+    });
+
+    // ── Export-CSV round-trip scenarios ──────────────────────────────────────
+
+    test('admin can import an export-style CSV using field keys (status_info, project_name)', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '16-export-field-keys.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(3);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      expect(await getStat(page, 'ready to create')).toBe(3);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeEnabled();
+      await closeModal(page);
+    });
+
+    test('admin can import an export CSV with extra unsupported columns (uuid, created_at, …)', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '17-export-extra-unsupported-columns.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(2);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      // Unsupported export columns are ignored: their headers must not appear.
+      const dialog = page.getByRole('dialog', {
+        name: 'Bulk Create Users from CSV',
+      });
+      await expect(
+        dialog.locator('thead').getByText('uuid', { exact: true }),
+      ).not.toBeVisible();
+      await closeModal(page);
+    });
+
+    test('admin can import an export CSV with reordered columns and a UTF-8 BOM', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '20-export-reordered-with-bom.csv');
+      expect(await getStat(page, 'rows loaded')).toBe(2);
+      expect(await getStat(page, 'with errors')).toBe(0);
+      await closeModal(page);
+    });
+
+    test('admin sees a missing-column error for a raw export CSV with no password column', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '18-export-no-password-column.csv');
+      // No global default password is set → password column is required.
+      await expect(page.locator('.ant-message-notice')).toBeVisible({
+        timeout: 5000,
+      });
+      const dialog = page.getByRole('dialog', {
+        name: 'Bulk Create Users from CSV',
+      });
+      await expect(dialog.getByText('rows loaded')).not.toBeVisible({
+        timeout: 3000,
+      });
+      await closeModal(page);
+    });
+  },
+);

--- a/react/src/helper/bulkUserCSV.test.ts
+++ b/react/src/helper/bulkUserCSV.test.ts
@@ -1,0 +1,303 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  buildDynamicColumnAliases,
+  CanonicalUserColumn,
+  extractRawUserRows,
+  findMissingRequiredColumns,
+  mapUserCSVColumns,
+  mergeColumnAliases,
+  parseBoolean,
+  ReportField,
+} from './bulkUserCSV';
+import { parseCSV } from './csv-util';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+// Fixtures live at the repo root (../test-fixtures relative to the react/
+// vitest root), shared with the Playwright e2e suite.
+const readFixture = (name: string): string =>
+  readFileSync(
+    path.resolve(process.cwd(), '../test-fixtures/csv-samples', name),
+    'utf-8',
+  );
+
+/** Convenience: parse a fixture and resolve its columns with the given aliases. */
+const analyze = (
+  fixture: string,
+  aliases = mergeColumnAliases(),
+): {
+  presentColumns: Set<CanonicalUserColumn>;
+  records: Record<string, string>[];
+  rows: ReturnType<typeof extractRawUserRows>;
+} => {
+  const records = parseCSV(readFixture(fixture));
+  const { headerMap, presentColumns } = mapUserCSVColumns(
+    Object.keys(records[0] ?? {}),
+    aliases,
+  );
+  return {
+    presentColumns,
+    records,
+    rows: extractRawUserRows(records, headerMap),
+  };
+};
+
+const sortedCols = (cols: Set<CanonicalUserColumn>) => [...cols].sort();
+
+describe('parseBoolean', () => {
+  it.each([
+    ['true', true],
+    ['TRUE', true],
+    ['1', true],
+    ['yes', true],
+    ['  Yes  ', true],
+    ['false', false],
+    ['0', false],
+    ['no', false],
+    ['', false],
+    ['anything', false],
+  ])('parses %j as %j', (input, expected) => {
+    expect(parseBoolean(input)).toBe(expected);
+  });
+});
+
+describe('mapUserCSVColumns', () => {
+  it('recognises the manual template columns', () => {
+    const { presentColumns } = analyze('01-valid-all-fields.csv');
+    expect(sortedCols(presentColumns)).toEqual(
+      [
+        'description',
+        'domain_name',
+        'email',
+        'full_name',
+        'need_password_change',
+        'password',
+        'project',
+        'resource_policy',
+        'role',
+        'status',
+        'username',
+      ].sort(),
+    );
+  });
+
+  it('recognises manual column aliases (user name, full name, domain, project_name)', () => {
+    const { presentColumns } = analyze('03-valid-column-aliases.csv');
+    expect(presentColumns.has('username')).toBe(true);
+    expect(presentColumns.has('full_name')).toBe(true);
+    expect(presentColumns.has('domain_name')).toBe(true);
+    expect(presentColumns.has('resource_policy')).toBe(true);
+    expect(presentColumns.has('need_password_change')).toBe(true);
+    // project_name → project, status stays status
+    expect(presentColumns.has('project')).toBe(true);
+  });
+
+  it('maps export field keys: status_info → status, project_name → project', () => {
+    const { presentColumns } = analyze('16-export-field-keys.csv');
+    expect(presentColumns.has('status')).toBe(true);
+    expect(presentColumns.has('project')).toBe(true);
+    // The raw export keys themselves are not treated as separate columns.
+    expect(sortedCols(presentColumns)).toEqual(
+      [
+        'email',
+        'username',
+        'password',
+        'full_name',
+        'project',
+        'role',
+        'resource_policy',
+        'description',
+        'status',
+        'need_password_change',
+      ].sort(),
+    );
+  });
+
+  it('ignores unsupported export columns (uuid, created_at, totp_activated, …)', () => {
+    const { presentColumns, records } = analyze(
+      '17-export-extra-unsupported-columns.csv',
+    );
+    // The file physically contains the extra columns…
+    expect(Object.keys(records[0])).toEqual(
+      expect.arrayContaining([
+        'uuid',
+        'created_at',
+        'totp_activated',
+        'sudo_session_enabled',
+        'modified_at',
+      ]),
+    );
+    // …but only the supported subset is recognised.
+    expect(sortedCols(presentColumns)).toEqual(
+      ['email', 'username', 'password', 'full_name', 'status'].sort(),
+    );
+  });
+
+  it('is order-independent and strips a UTF-8 BOM (Excel-saved export)', () => {
+    const { presentColumns, rows } = analyze(
+      '20-export-reordered-with-bom.csv',
+    );
+    // BOM did not corrupt the first header → email is still recognised.
+    expect(presentColumns.has('email')).toBe(true);
+    expect(sortedCols(presentColumns)).toEqual(
+      [
+        'email',
+        'username',
+        'password',
+        'full_name',
+        'role',
+        'status',
+        'description',
+        'project',
+        'resource_policy',
+        'need_password_change',
+      ].sort(),
+    );
+    expect(rows[0].email).toBe('reorder1@example.com');
+    expect(rows[0].status).toBe('active');
+    expect(rows[1].status).toBe('inactive');
+  });
+});
+
+describe('extractRawUserRows', () => {
+  it('pulls values for present columns and leaves absent ones empty', () => {
+    const { rows } = analyze('02-valid-minimal.csv');
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      email: 'minimal1@example.com',
+      username: 'minimal1',
+      password: 'Password!23',
+      // Columns absent from a minimal CSV resolve to '' (→ null/global default).
+      full_name: '',
+      role: '',
+      status: '',
+      domain_name: '',
+      description: '',
+      need_password_change: '',
+      resource_policy: '',
+      project: '',
+    });
+  });
+
+  it('reads export-key columns into the canonical fields', () => {
+    const { rows } = analyze('16-export-field-keys.csv');
+    expect(rows[0]).toMatchObject({
+      email: 'export1@example.com',
+      username: 'export1',
+      status: 'active', // from status_info
+      project: 'default', // from project_name
+      role: 'user',
+      need_password_change: 'false',
+    });
+    expect(rows[1].status).toBe('active');
+    expect(rows[1].need_password_change).toBe('true');
+    expect(rows[2].status).toBe('inactive');
+  });
+
+  it('does not pull values from unsupported columns', () => {
+    const { rows } = analyze('17-export-extra-unsupported-columns.csv');
+    expect(rows[0].email).toBe('extra1@example.com');
+    expect(rows[0].full_name).toBe('Extra One');
+    expect(rows[0].status).toBe('active');
+    // need_password_change column is absent here → empty, not the totp value.
+    expect(rows[0].need_password_change).toBe('');
+  });
+});
+
+describe('findMissingRequiredColumns', () => {
+  it('passes a CSV that has email/username/password', () => {
+    const { presentColumns } = analyze('16-export-field-keys.csv');
+    expect(
+      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: false }),
+    ).toEqual([]);
+  });
+
+  it('flags a raw export (no password) when no global default password is set', () => {
+    const { presentColumns } = analyze('18-export-no-password-column.csv');
+    expect(
+      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: false }),
+    ).toEqual(['password']);
+  });
+
+  it('unlocks a passwordless export once a global default password is configured', () => {
+    const { presentColumns } = analyze('18-export-no-password-column.csv');
+    expect(
+      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: true }),
+    ).toEqual([]);
+  });
+
+  it('flags email/username when an export omits them', () => {
+    // Reuse the missing-column fixture (username, password, full_name — no email).
+    const { presentColumns } = analyze('12-error-missing-required-columns.csv');
+    expect(
+      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: false }),
+    ).toEqual(['email']);
+  });
+});
+
+describe('localized export headers (dynamic aliases)', () => {
+  // Simulates the /export/reports/users field descriptors for a Korean UI.
+  const koReportFields: ReportField[] = [
+    { key: 'email', name: '이메일' },
+    { key: 'username', name: '사용자 이름' },
+    { key: 'full_name', name: '이름' },
+    { key: 'project_name', name: '프로젝트' },
+    { key: 'role', name: '역할' },
+    { key: 'resource_policy', name: '자원 정책' },
+    { key: 'description', name: '설명' },
+    { key: 'status_info', name: '상태' },
+    { key: 'need_password_change', name: '비밀번호 변경 필요' },
+  ];
+
+  it('does NOT recognise Korean headers with static aliases alone', () => {
+    const { presentColumns } = analyze('19-export-localized-headers-ko.csv');
+    // Without the server-provided localized aliases, nothing resolves.
+    expect(presentColumns.size).toBe(0);
+    expect(
+      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: true }),
+    ).toEqual(['email', 'username']);
+  });
+
+  it('recognises Korean headers once dynamic aliases are merged in', () => {
+    const aliases = mergeColumnAliases(
+      buildDynamicColumnAliases(koReportFields),
+    );
+    const { presentColumns, rows } = analyze(
+      '19-export-localized-headers-ko.csv',
+      aliases,
+    );
+    expect(sortedCols(presentColumns)).toEqual(
+      [
+        'email',
+        'username',
+        'full_name',
+        'project',
+        'role',
+        'resource_policy',
+        'description',
+        'status',
+        'need_password_change',
+      ].sort(),
+    );
+    // Localized export has no password column → needs a global default password.
+    expect(
+      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: false }),
+    ).toEqual(['password']);
+    expect(
+      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: true }),
+    ).toEqual([]);
+    // Values land in the right canonical fields despite localized headers.
+    expect(rows[0]).toMatchObject({
+      email: 'ko1@example.com',
+      username: 'ko1',
+      full_name: '홍길동',
+      status: 'active',
+      project: 'default',
+      role: 'user',
+    });
+    expect(rows[1].full_name).toBe('김철수');
+  });
+});

--- a/react/src/helper/csv-util.test.ts
+++ b/react/src/helper/csv-util.test.ts
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 // csv-util.test.ts
-import { downloadCSV, JSONToCSVBody, UTF8_BOM } from './csv-util';
+import { downloadCSV, JSONToCSVBody, parseCSV, UTF8_BOM } from './csv-util';
 
 describe('JSONToCSVBody', () => {
   it('should convert JSON data to CSV format without formatting rules', () => {
@@ -183,5 +183,58 @@ describe('downloadCSV', () => {
     downloadCSV('a,b\n1,2', 'report');
 
     expect(capturedBlob?.type).toBe('text/csv;charset=utf-8;');
+  });
+});
+
+describe('parseCSV', () => {
+  it('parses a simple CSV into keyed records', () => {
+    const csv = 'email,username\nalice@example.com,alice\nbob@example.com,bob';
+    expect(parseCSV(csv)).toEqual([
+      { email: 'alice@example.com', username: 'alice' },
+      { email: 'bob@example.com', username: 'bob' },
+    ]);
+  });
+
+  it('handles quoted fields containing commas and newlines', () => {
+    const csv = 'name,note\n"Doe, John","line1\nline2"';
+    expect(parseCSV(csv)).toEqual([
+      { name: 'Doe, John', note: 'line1\nline2' },
+    ]);
+  });
+
+  it('unescapes doubled quotes inside quoted fields', () => {
+    const csv = 'name,quote\n"John","He said ""hi"""';
+    expect(parseCSV(csv)).toEqual([{ name: 'John', quote: 'He said "hi"' }]);
+  });
+
+  it('treats CRLF line endings the same as LF', () => {
+    const csv = 'email,username\r\nalice@example.com,alice\r\n';
+    expect(parseCSV(csv)).toEqual([
+      { email: 'alice@example.com', username: 'alice' },
+    ]);
+  });
+
+  it('strips a leading UTF-8 BOM from the header', () => {
+    const csv = '\uFEFFemail,username\nalice@example.com,alice';
+    expect(parseCSV(csv)).toEqual([
+      { email: 'alice@example.com', username: 'alice' },
+    ]);
+  });
+
+  it('trims header and cell whitespace', () => {
+    const csv = ' email , username \n  alice@example.com ,  alice ';
+    expect(parseCSV(csv)).toEqual([
+      { email: 'alice@example.com', username: 'alice' },
+    ]);
+  });
+
+  it('returns an empty array when there are no data rows', () => {
+    expect(parseCSV('email,username')).toEqual([]);
+    expect(parseCSV('')).toEqual([]);
+  });
+
+  it('throws on an unterminated quoted field', () => {
+    const csv = 'email,username\n"alice@example.com,alice';
+    expect(() => parseCSV(csv)).toThrow('Unterminated quoted field in CSV');
   });
 });

--- a/test-fixtures/csv-samples/01-valid-all-fields.csv
+++ b/test-fixtures/csv-samples/01-valid-all-fields.csv
@@ -1,0 +1,6 @@
+email,username,password,full_name,domain_name,resource_policy,description,role,status,need_password_change,project
+alice@example.com,alice,Password!23,Alice Kim,default,default,ML engineer,user,active,false,
+bob@example.com,bob,Secure#456,Bob Lee,default,default,Data scientist,admin,active,true,
+carol@example.com,carol,Hello@789,Carol Park,default,default,DevOps lead,superadmin,active,false,
+dave@example.com,dave,Monitor!01,Dave Choi,default,default,Observer account,monitor,active,false,
+eve@example.com,eve,Inactive!23,Eve Song,default,default,Suspended account,user,inactive,false,

--- a/test-fixtures/csv-samples/02-valid-minimal.csv
+++ b/test-fixtures/csv-samples/02-valid-minimal.csv
@@ -1,0 +1,4 @@
+email,username,password
+minimal1@example.com,minimal1,Password!23
+minimal2@example.com,minimal2,Password!23
+minimal3@example.com,minimal3,Password!23

--- a/test-fixtures/csv-samples/03-valid-column-aliases.csv
+++ b/test-fixtures/csv-samples/03-valid-column-aliases.csv
@@ -1,0 +1,3 @@
+email,user name,password,full name,domain,resourcepolicy,description,role,status,needpasswordchange,project_name
+alias1@example.com,alias1,Password!23,Alias One,default,default,Uses column aliases,user,active,false,
+alias2@example.com,alias2,Password!23,Alias Two,default,default,All alias headers,user,active,true,

--- a/test-fixtures/csv-samples/04-valid-all-roles.csv
+++ b/test-fixtures/csv-samples/04-valid-all-roles.csv
@@ -1,0 +1,5 @@
+email,username,password,role,status
+role-user@example.com,role-user,Password!23,user,active
+role-admin@example.com,role-admin,Password!23,admin,active
+role-superadmin@example.com,role-superadmin,Password!23,superadmin,active
+role-monitor@example.com,role-monitor,Password!23,monitor,active

--- a/test-fixtures/csv-samples/05-valid-all-statuses.csv
+++ b/test-fixtures/csv-samples/05-valid-all-statuses.csv
@@ -1,0 +1,5 @@
+email,username,password,role,status
+status-active@example.com,status-active,Password!23,user,active
+status-inactive@example.com,status-inactive,Password!23,user,inactive
+status-before-ver@example.com,status-before-ver,Password!23,user,before-verification
+status-deleted@example.com,status-deleted,Password!23,user,deleted

--- a/test-fixtures/csv-samples/06-error-missing-required.csv
+++ b/test-fixtures/csv-samples/06-error-missing-required.csv
@@ -1,0 +1,5 @@
+email,username,password
+,missing-email,Password!23
+missing-username@example.com,,Password!23
+missing-password@example.com,missing-password,
+,missing-all,

--- a/test-fixtures/csv-samples/07-error-invalid-email.csv
+++ b/test-fixtures/csv-samples/07-error-invalid-email.csv
@@ -1,0 +1,6 @@
+email,username,password
+not-an-email,bad-email-1,Password!23
+@missinglocal.com,bad-email-2,Password!23
+nodomain@,bad-email-3,Password!23
+spaces in@email.com,bad-email-4,Password!23
+valid@example.com,good-email,Password!23

--- a/test-fixtures/csv-samples/08-error-duplicate-email.csv
+++ b/test-fixtures/csv-samples/08-error-duplicate-email.csv
@@ -1,0 +1,5 @@
+email,username,password
+dup@example.com,dup-user-1,Password!23
+dup@example.com,dup-user-2,Password!23
+dup@example.com,dup-user-3,Password!23
+unique@example.com,unique-user,Password!23

--- a/test-fixtures/csv-samples/09-error-invalid-password.csv
+++ b/test-fixtures/csv-samples/09-error-invalid-password.csv
@@ -1,0 +1,6 @@
+email,username,password
+short@example.com,short-pw,Ab!1
+no-special@example.com,no-special,Password123
+no-number@example.com,no-number,Password!abc
+no-letter@example.com,no-letter,12345678!@
+valid-pw@example.com,valid-pw,Password!23

--- a/test-fixtures/csv-samples/10-error-invalid-role-status.csv
+++ b/test-fixtures/csv-samples/10-error-invalid-role-status.csv
@@ -1,0 +1,5 @@
+email,username,password,role,status
+bad-role@example.com,bad-role,Password!23,superuser,active
+bad-status@example.com,bad-status,Password!23,user,disabled
+both-bad@example.com,both-bad,Password!23,manager,suspended
+valid@example.com,valid-row,Password!23,user,active

--- a/test-fixtures/csv-samples/11-mixed-valid-and-errors.csv
+++ b/test-fixtures/csv-samples/11-mixed-valid-and-errors.csv
@@ -1,0 +1,9 @@
+email,username,password,full_name,role,status
+valid1@example.com,valid1,Password!23,Valid User One,user,active
+,missing-email-user,Password!23,Missing Email,user,active
+dup@example.com,dup-a,Password!23,Duplicate A,user,active
+dup@example.com,dup-b,Password!23,Duplicate B,user,active
+bad-email-format,bad-fmt,Password!23,Bad Format,user,active
+valid2@example.com,valid2,Password!23,Valid User Two,admin,active
+valid2-again@example.com,valid3,shortpw,Valid User Three,user,active
+valid4@example.com,valid4,Password!23,Valid User Four,user,inactive

--- a/test-fixtures/csv-samples/12-error-missing-required-columns.csv
+++ b/test-fixtures/csv-samples/12-error-missing-required-columns.csv
@@ -1,0 +1,3 @@
+username,password,full_name
+no-email-col,Password!23,No Email Column User
+another-user,Password!23,Another User

--- a/test-fixtures/csv-samples/13-valid-quoted-fields.csv
+++ b/test-fixtures/csv-samples/13-valid-quoted-fields.csv
@@ -1,0 +1,4 @@
+email,username,password,full_name,description
+quoted1@example.com,quoted1,Password!23,"Kim, Jinhee","Works on ""AI"" projects"
+quoted2@example.com,quoted2,Password!23,"Lee, Minji","Description with, comma inside"
+quoted3@example.com,quoted3,Password!23,Park Jisoo,Plain description

--- a/test-fixtures/csv-samples/14-valid-need-password-change.csv
+++ b/test-fixtures/csv-samples/14-valid-need-password-change.csv
@@ -1,0 +1,6 @@
+email,username,password,need_password_change
+npchange-true@example.com,npchange-true,Password!23,true
+npchange-false@example.com,npchange-false,Password!23,false
+npchange-1@example.com,npchange-1,Password!23,1
+npchange-0@example.com,npchange-0,Password!23,0
+npchange-yes@example.com,npchange-yes,Password!23,yes

--- a/test-fixtures/csv-samples/15-error-empty-file.csv
+++ b/test-fixtures/csv-samples/15-error-empty-file.csv
@@ -1,0 +1,1 @@
+email,username,password

--- a/test-fixtures/csv-samples/16-export-field-keys.csv
+++ b/test-fixtures/csv-samples/16-export-field-keys.csv
@@ -1,0 +1,4 @@
+email,username,password,full_name,project_name,role,resource_policy,description,status_info,need_password_change
+export1@example.com,export1,Password!23,Export One,default,user,default,Exported user,active,false
+export2@example.com,export2,Password!23,Export Two,default,admin,default,Exported admin,active,true
+export3@example.com,export3,Password!23,Export Three,default,user,default,Inactive exported,inactive,false

--- a/test-fixtures/csv-samples/17-export-extra-unsupported-columns.csv
+++ b/test-fixtures/csv-samples/17-export-extra-unsupported-columns.csv
@@ -1,0 +1,3 @@
+uuid,email,created_at,username,password,totp_activated,full_name,sudo_session_enabled,status_info,modified_at
+11111111-1111-1111-1111-111111111111,extra1@example.com,2026-01-01T00:00:00Z,extra1,Password!23,true,Extra One,false,active,2026-01-02T00:00:00Z
+22222222-2222-2222-2222-222222222222,extra2@example.com,2026-01-01T00:00:00Z,extra2,Password!23,false,Extra Two,true,active,2026-01-02T00:00:00Z

--- a/test-fixtures/csv-samples/18-export-no-password-column.csv
+++ b/test-fixtures/csv-samples/18-export-no-password-column.csv
@@ -1,0 +1,3 @@
+email,username,full_name,project_name,role,resource_policy,description,status_info,need_password_change
+nopw1@example.com,nopw1,No Password One,default,user,default,Exported,active,false
+nopw2@example.com,nopw2,No Password Two,default,user,default,Exported,active,false

--- a/test-fixtures/csv-samples/19-export-localized-headers-ko.csv
+++ b/test-fixtures/csv-samples/19-export-localized-headers-ko.csv
@@ -1,0 +1,3 @@
+이메일,사용자 이름,이름,프로젝트,역할,자원 정책,설명,상태,비밀번호 변경 필요
+ko1@example.com,ko1,홍길동,default,user,default,내보낸 사용자,active,false
+ko2@example.com,ko2,김철수,default,admin,default,내보낸 관리자,active,true

--- a/test-fixtures/csv-samples/20-export-reordered-with-bom.csv
+++ b/test-fixtures/csv-samples/20-export-reordered-with-bom.csv
@@ -1,0 +1,3 @@
+﻿status_info,role,email,need_password_change,username,full_name,password,description,project_name,resource_policy
+active,user,reorder1@example.com,false,reorder1,Reorder One,Password!23,First,default,default
+inactive,admin,reorder2@example.com,true,reorder2,Reorder Two,Password!23,Second,default,default


### PR DESCRIPTION
**Stacked on #7667** (FR-1818 implementation). Merge #7667 first.

## What

Test coverage for the *Bulk Create Users from CSV* feature, separated from the implementation PR so review scopes stay distinct.

### Unit tests (`react/src/helper/`)
- **`bulkUserCSV.test.ts`** — header mapping, column aliases, row extraction, localized export round-trip, required-column detection, `parseBoolean`
- **`csv-util.test.ts`** — BOM stripping, unterminated-quote recovery, CRLF, RFC-4180 quoting (tests for `csv-util.ts` changes in the parent PR)

### E2E validation spec (`e2e/credential/`)
- **`bulk-create-from-csv.spec.ts`** — uploads each fixture CSV, asserts preview stats (`rows parsed` / `with errors` / `ready to create`) and submit-button enabled/disabled state; never submits (no backend required)

### CSV fixtures (`test-fixtures/csv-samples/`, 20 files)
Cover: valid rows (all-fields, minimal, column-aliases, roles, statuses, quoted, need-password-change), error rows (missing-required, invalid-email, duplicate-email, invalid-password, invalid-role-status, mixed), export round-trips (field-keys, extra-unsupported-columns, no-password-column, reordered+BOM, localized-headers-ko), and edge cases (empty-file, missing-required-columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)