### PR TITLE
feat(FR-3041): add session-scoped audit log tab to session detail view

### DIFF
--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -2,12 +2,15 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import type { ScopedAuditLogQuery as ScopedAuditLogQueryType } from '../__generated__/ScopedAuditLogQuery.graphql';
 import { SessionDetailContentFragment$key } from '../__generated__/SessionDetailContentFragment.graphql';
 import { SessionDetailContentQuery } from '../__generated__/SessionDetailContentQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
+import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
+import BAIErrorBoundary from './BAIErrorBoundary';
 import CodeHighlighterModal from './CodeHighlighterModal';
 import ConnectedKernelList from './ComputeSessionNodeItems/ConnectedKernelList';
 import EditableSessionName from './ComputeSessionNodeItems/EditableSessionName';
@@ -22,6 +25,7 @@ import IdleCheckDescriptionModal from './IdleCheckDescriptionModal';
 import ImageNodeSimpleTag from './ImageNodeSimpleTag';
 import { UNSAFELazySessionImageTag } from './ImageTags';
 import MountedVFolderLinks from './MountedVFolderLinks';
+import ScopedAuditLog, { ScopedAuditLogQuery } from './ScopedAuditLog';
 import { getUnifiedSlotNameFromTag } from './SessionFormItems/ResourceAllocationFormItems';
 import SessionSchedulingHistoryModal from './SessionSchedulingHistoryModal';
 import SessionUsageMonitor from './SessionUsageMonitor';
@@ -38,6 +42,7 @@ import {
   Grid,
   Select,
   Skeleton,
+  Tabs,
   Tag,
   theme,
   Tooltip,
@@ -60,7 +65,12 @@ import {
 import * as _ from 'lodash-es';
 import { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
+import {
+  graphql,
+  useFragment,
+  useLazyLoadQuery,
+  useQueryLoader,
+} from 'react-relay';
 import { useLocation } from 'react-router-dom';
 
 // When a session is tagged as using a unified-memory accelerator slot, its
@@ -113,6 +123,21 @@ const SessionDetailContent: React.FC<{
     openSessionSchedulingHistoryModal,
     { toggle: toggleOpenSessionSchedulingHistoryModal },
   ] = useToggle(false);
+  const [auditLogQueryRef, loadAuditLogQuery] =
+    useQueryLoader<ScopedAuditLogQueryType>(ScopedAuditLogQuery);
+
+  const { baiPaginationOption, setTablePaginationOption } =
+    useBAIPaginationOptionState({ current: 1, pageSize: 10 });
+  const reloadAuditLogQuery: React.ComponentProps<
+    typeof ScopedAuditLog
+  >['onReload'] = (variables, options) => {
+    const limit = variables.limit ?? 10;
+    setTablePaginationOption({
+      pageSize: limit,
+      current: variables.offset ? Math.floor(variables.offset / limit) + 1 : 1,
+    });
+    loadAuditLogQuery(variables, options);
+  };
 
   // TODO: Remove useLazyLoadQuery and use useRefetchableFragment instead of useFragment to fetch session data when deprecatedProjectId is removed.
   const { internalLoadedSession } = useLazyLoadQuery<SessionDetailContentQuery>(
@@ -521,19 +546,63 @@ const SessionDetailContent: React.FC<{
           )}
         </Descriptions>
       </BAIFlex>
-      <Suspense fallback={<Skeleton active />}>
-        <BAIFlex direction="column" gap={'sm'} align="stretch">
-          <Typography.Title level={4} style={{ margin: 0 }}>
-            {t('kernel.Kernels')}
-          </Typography.Title>
-          <ConnectedKernelList
-            kernelsFrgmt={filterOutNullAndUndefined(
-              session.kernel_nodes?.edges.map((e) => e?.node),
-            )}
-            sessionFrgmtForLogModal={session}
-          />
-        </BAIFlex>
-      </Suspense>
+      <Tabs
+        defaultActiveKey="kernels"
+        onChange={(key) => {
+          if (key === 'auditLog' && session.row_id && !auditLogQueryRef) {
+            loadAuditLogQuery(
+              {
+                scope: {
+                  entity: [{ entityType: 'SESSION', entityId: session.row_id }],
+                },
+                orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
+                limit: baiPaginationOption.limit,
+                offset: baiPaginationOption.offset,
+              },
+              { fetchPolicy: 'store-and-network' },
+            );
+          }
+        }}
+        items={[
+          {
+            key: 'kernels',
+            label: t('kernel.Kernels'),
+            children: (
+              <Suspense fallback={<Skeleton active />}>
+                <ConnectedKernelList
+                  kernelsFrgmt={filterOutNullAndUndefined(
+                    session.kernel_nodes?.edges.map((e) => e?.node),
+                  )}
+                  sessionFrgmtForLogModal={session}
+                />
+              </Suspense>
+            ),
+          },
+          ...(session.row_id
+            ? [
+                {
+                  key: 'auditLog',
+                  label: t('auditLog.AuditLog'),
+                  children: (
+                    <BAIErrorBoundary>
+                      {auditLogQueryRef ? (
+                        <Suspense fallback={<Skeleton active />}>
+                          <ScopedAuditLog
+                            queryRef={auditLogQueryRef}
+                            onReload={reloadAuditLogQuery}
+                            tableSettings={{}}
+                          />
+                        </Suspense>
+                      ) : (
+                        <Skeleton active />
+                      )}
+                    </BAIErrorBoundary>
+                  ),
+                },
+              ]
+            : []),
+        ]}
+      />
       <IdleCheckDescriptionModal
         open={openIdleCheckDescriptionModal}
         onCancel={() => setOpenIdleCheckDescriptionModal(false)}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Auditprotokoll",
     "Operation": "Vorgang",
     "Status": "Status",
     "Time": "Zeit",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Αρχείο ελέγχου",
     "Operation": "Λειτουργία",
     "Status": "Κατάσταση",
     "Time": "Ώρα",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -294,6 +294,7 @@
     "ToolPermissionOverrides": "Tool Permission Overrides"
   },
   "auditLog": {
+    "AuditLog": "Audit Log",
     "Operation": "Operation",
     "Status": "Status",
     "Time": "Time",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Registro de auditoría",
     "Operation": "Operación",
     "Status": "Estado",
     "Time": "Hora",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Tarkastusloki",
     "Operation": "Toiminto",
     "Status": "Tila",
     "Time": "Aika",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Journal d'audit",
     "Operation": "Opération",
     "Status": "Statut",
     "Time": "Heure",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Log Audit",
     "Operation": "Operasi",
     "Status": "Status",
     "Time": "Waktu",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Log di audit",
     "Operation": "Operazione",
     "Status": "Stato",
     "Time": "Ora",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "監査ログ",
     "Operation": "操作",
     "Status": "状態",
     "Time": "時間",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "감사 로그",
     "Operation": "작업",
     "Status": "상태",
     "Time": "시간",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Аудит лог",
     "Operation": "Үйлдэл",
     "Status": "Статус",
     "Time": "Цаг",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Log Audit",
     "Operation": "Operasi",
     "Status": "Status",
     "Time": "Masa",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Dziennik audytu",
     "Operation": "Operacja",
     "Status": "Status",
     "Time": "Czas",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Log de auditoria",
     "Operation": "Operação",
     "Status": "Status",
     "Time": "Hora",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Registo de auditoria",
     "Operation": "Operação",
     "Status": "Status",
     "Time": "Hora",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Журнал аудита",
     "Operation": "Операция",
     "Status": "Статус",
     "Time": "Время",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "บันทึกการตรวจสอบ",
     "Operation": "การดำเนินการ",
     "Status": "สถานะ",
     "Time": "เวลา",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Denetim Günlüğü",
     "Operation": "İşlem",
     "Status": "Durum",
     "Time": "Zaman",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "Nhật ký kiểm tra",
     "Operation": "Thao tác",
     "Status": "Trạng thái",
     "Time": "Thời gian",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "审计日志",
     "Operation": "操作",
     "Status": "状态",
     "Time": "时间",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -307,6 +307,7 @@
     "TopP": "Top P"
   },
   "auditLog": {
+    "AuditLog": "稽核記錄",
     "Operation": "操作",
     "Status": "狀態",
     "Time": "時間",


### PR DESCRIPTION
Resolves #7719 (FR-3041)

## Stacked on

- #7703 (FR-3033) — `ScopedAuditLog` component

## Summary

Adds a **session-scoped Audit Log tab** to the Session detail view (FR-2920).

The bottom Kernels section of the Session detail view is now a tabbed container (`BAITabs`):

- **Kernels** tab — the existing `ConnectedKernelList` (keeps its own `Suspense` boundary).
- **Audit Log** tab — renders `ScopedAuditLog` (from FR-3033) scoped to the session: `{ entity: [{ entityType: SESSION, entityId: session.row_id }] }`, initial order `CREATED_AT DESC`.

`SessionDetailContent` owns the `useQueryLoader` lifecycle and starts the audit-log query lazily on tab open (render-as-you-fetch) — `onChange` fires `loadQuery` the first time the **Audit Log** tab is selected, so the request isn't made unless the tab is opened, and re-selecting the tab keeps the user's filter/sort state. The tab bar itself has **no loading state**; only `ScopedAuditLog` is wrapped in `<Suspense fallback={<Skeleton active />}>` (+ `BAIErrorBoundary`), so the loading skeleton — and any query failure — is contained to the Audit Log tab's content.

The tab is shown to all users viewing the session (guarded only on the session's `row_id` being present).

## Changes

- `react/src/components/SessionDetailContent.tsx` — convert the Kernels section into `BAITabs`; lazily `loadQuery` the session-scoped audit log on tab open and render `ScopedAuditLog` inside a Suspense + `BAIErrorBoundary` boundary.
- `resources/i18n/*.json` — add the `auditLog.AuditLog` tab label (all 22 languages).

## Verification

`bash scripts/verify.sh`:

- Relay: **PASS**
- Lint: **PASS**
- Format: **PASS**
- TypeScript: **PASS**
- Vite warmup paths: pre-existing FAIL, unrelated to this change (fails identically on a clean `main`/stashed tree).

## Test plan

- [ ] Open a Session detail page → Kernels + Audit Log tabs appear. Opening the Audit Log tab loads the session's audit entries with the status/operation/time filter, refresh, and column sorting.
- [ ] The Audit Log tab content shows a `Skeleton` while loading; the tab bar never shows a loading state. Re-selecting the tab preserves the applied filter/sort.

## Notes

- FR-2920's epic text framed Phase 1 as superadmin-only with a Phase 2 backend permission relaxation. Per the reporter, the audit log is intended to be viewable by users on their own sessions, so the tab is not superadmin-gated. This assumes the `scopedAuditLogsV2` permission allows non-superadmins to read audit entries for sessions they can see.

## Out of scope

- VFolder / Deployment detail audit-log tabs (tracked as separate sub-tasks under FR-2920).