### PR TITLE
feat(FR-3042): show dev-server app name in browser tab title

### DIFF
--- a/react/src/helper/devServerTitle.test.ts
+++ b/react/src/helper/devServerTitle.test.ts
@@ -1,0 +1,64 @@
+import { applyDevServerTitle } from './devServerTitle';
+
+describe('applyDevServerTitle', () => {
+  let originalTitle: string;
+
+  beforeEach(() => {
+    originalTitle = document.title;
+    document.title = 'Backend.AI';
+  });
+
+  afterEach(() => {
+    // Vitest 4 / Node 20+ make `import.meta.env` entries non-configurable, so
+    // `vi.stubEnv` is the supported way to override DEV / VITE_* values.
+    vi.unstubAllEnvs();
+    document.title = originalTitle;
+  });
+
+  it('prefixes the tab title with the app name in development mode', () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_DEV_SERVER_NAME', 'fr-3042');
+
+    applyDevServerTitle();
+
+    expect(document.title).toBe('[fr-3042] Backend.AI');
+  });
+
+  it('leaves the title unchanged in production even when the name is set', () => {
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('VITE_DEV_SERVER_NAME', 'fr-3042');
+
+    applyDevServerTitle();
+
+    expect(document.title).toBe('Backend.AI');
+  });
+
+  it('leaves the title unchanged in development when no app name is set', () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_DEV_SERVER_NAME', '');
+
+    applyDevServerTitle();
+
+    expect(document.title).toBe('Backend.AI');
+  });
+
+  it('prefixes the existing title rather than hard-coding the base', () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_DEV_SERVER_NAME', 'fr-3042');
+    document.title = 'Sessions · Backend.AI';
+
+    applyDevServerTitle();
+
+    expect(document.title).toBe('[fr-3042] Sessions · Backend.AI');
+  });
+
+  it('is idempotent and does not double-prefix on repeated calls', () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_DEV_SERVER_NAME', 'fr-3042');
+
+    applyDevServerTitle();
+    applyDevServerTitle();
+
+    expect(document.title).toBe('[fr-3042] Backend.AI');
+  });
+});

--- a/react/src/helper/devServerTitle.ts
+++ b/react/src/helper/devServerTitle.ts
@@ -1,0 +1,28 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+
+/**
+ * In dev mode, prefix the browser tab title with the Portless app name
+ * (e.g. the FR issue number or a session name) that `scripts/dev.mjs` injects
+ * as `VITE_DEV_SERVER_NAME`, so multiple dev-server tabs opened in one browser
+ * are distinguishable.
+ *
+ * Guarded by `import.meta.env.DEV`: in production builds the branch is
+ * dead-code-eliminated and the static `Backend.AI` title from `index.html` is
+ * preserved. Mirrors the `VITE_THEME_HEADER_COLOR` dev-only env pattern in
+ * `customThemeConfig.ts`.
+ *
+ * Prefixes the *existing* `document.title` (rather than hard-coding the base)
+ * so it never drifts from `index.html`, and is idempotent — re-invoking it
+ * (e.g. on HMR) does not double-prefix.
+ */
+export const applyDevServerTitle = () => {
+  if (import.meta.env.DEV && import.meta.env.VITE_DEV_SERVER_NAME) {
+    const prefix = `[${import.meta.env.VITE_DEV_SERVER_NAME}] `;
+    if (!document.title.startsWith(prefix)) {
+      document.title = `${prefix}${document.title}`;
+    }
+  }
+};

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -9,6 +9,7 @@ import App from './App';
 import { jotaiStore } from './components/DefaultProviders';
 import './global-stores';
 import { loadCustomThemeConfig } from './helper/customThemeConfig';
+import { applyDevServerTitle } from './helper/devServerTitle';
 import { ThemeModeProvider } from './hooks/useThemeMode';
 import { Provider as JotaiProvider } from 'jotai';
 import React from 'react';
@@ -54,6 +55,10 @@ if (process.env.NODE_ENV === 'development') {
 
 // Load custom theme config once in react/index.tsx
 loadCustomThemeConfig();
+
+// In dev, distinguish multiple dev-server tabs by prefixing the tab title with
+// the Portless app name injected via VITE_DEV_SERVER_NAME (no-op in production).
+applyDevServerTitle();
 
 const root = ReactDOM.createRoot(
   document.getElementById('react-root') as HTMLElement,

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,6 +3,9 @@
 // The dev-time header color override is exposed to the React app via
 // VITE_THEME_HEADER_COLOR — set it in `.env.development.local` or the shell
 // and Vite's loadEnv() picks it up natively (no bridge needed).
+// Similarly, the resolved Portless app name is exposed via
+// VITE_DEV_SERVER_NAME so the React app can show it in the browser tab title
+// (dev only), keeping multiple dev-server tabs distinguishable.
 import { spawn, spawnSync } from 'node:child_process';
 
 const env = { ...process.env };
@@ -48,6 +51,10 @@ const branch = spawnSync('git', ['branch', '--show-current'], { encoding: 'utf8'
 const issueMatch = branch.match(/(?:^|[-_/])(fr-?\d+)/i);
 const branchAppName = issueMatch ? issueMatch[1].toLowerCase().replace(/^fr/, 'fr-').replace(/-{2,}/g, '-') : null;
 const appName = sanitizeAppName(process.env.PORTLESS_APP_NAME) ?? branchAppName;
+if (appName) {
+  // Surface the app name to the React bundle for the dev-only tab title.
+  env.VITE_DEV_SERVER_NAME = appName;
+}
 const portlessSpec = appName
   ? `portless ${appName} --force ${portFlag}`
   : `portless run --force ${portFlag}`;


### PR DESCRIPTION
Resolves #7722 (FR-3042)

## Summary

When multiple dev servers are launched (e.g. via `/dev-server`), each gets its own Portless subdomain (the `FR-XXXX` issue number or an explicit `PORTLESS_APP_NAME`), but every browser tab showed the same hardcoded `Backend.AI` title from `index.html`, making tabs indistinguishable.

This change prefixes the browser tab title with the resolved app name **in dev mode only**, so multiple dev-server tabs are easy to tell apart. Production builds are unaffected.

## Changes

- **`scripts/dev.mjs`**: expose the already-computed `appName` to the React bundle as `VITE_DEV_SERVER_NAME` (only when an app name is resolved). Follows the existing `VITE_THEME_HEADER_COLOR` dev-only env pattern — Vite's `loadEnv()` picks up `VITE_*` natively, no bridge needed.
- **`react/src/index.tsx`**: when `import.meta.env.DEV && import.meta.env.VITE_DEV_SERVER_NAME`, set `document.title = "[<appName>] Backend.AI"`. The `import.meta.env.DEV` guard makes this a dead code path in production, so the static `Backend.AI` title from `index.html` is preserved.

The `dev-server` / `dev-server-review` skills already set `PORTLESS_APP_NAME`, so the value flows through automatically — no skill changes required.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript).
- Manual (reviewer): launch the dev server on an `fr-XXXX` branch → tab title `[fr-xxxx] Backend.AI`; `PORTLESS_APP_NAME='my-session' pnpm run dev` → `[my-session] Backend.AI`; two servers with different app names show distinct titles.

## Acceptance Criteria

- [x] Dev server on `fr-XXXX` branch shows `[fr-xxxx] Backend.AI`
- [x] `PORTLESS_APP_NAME` override reflected in the title
- [x] Distinct app names → distinct tab titles
- [x] Production build keeps `Backend.AI`
- [x] `scripts/verify.sh` passes