### PR TITLE
style(FR-2977): reframe revision-source action wording and source icon

### DIFF
--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -14,7 +14,6 @@ import DeploymentAddRevisionModal from './DeploymentAddRevisionModal';
 import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
 import FolderLink from './FolderLink';
 import {
-  CopyOutlined,
   LoadingOutlined,
   MoreOutlined,
   PlayCircleOutlined,
@@ -52,6 +51,7 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
+import { CopyPlusIcon } from 'lucide-react';
 import {
   parseAsInteger,
   parseAsString,
@@ -469,7 +469,7 @@ const DeploymentRevisionHistoryTab: React.FC<
               {
                 key: 'duplicate',
                 title: t('deployment.AddNewRevisionFromThis'),
-                icon: <CopyOutlined />,
+                icon: <CopyPlusIcon size={token.fontSize} />,
                 showInMenu: 'always',
                 disabled: isDeploymentInStoppedCategory(deploymentStatus),
                 onClick: () => {
@@ -664,7 +664,7 @@ const DeploymentRevisionHistoryTab: React.FC<
                       {
                         key: 'duplicate',
                         label: t('deployment.AddNewRevisionFromThis'),
-                        icon: <CopyOutlined />,
+                        icon: <CopyPlusIcon size={token.fontSize} />,
                         disabled:
                           isDeploymentInStoppedCategory(deploymentStatus),
                         onClick: () => {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Replikate, die derzeit über App Proxy Datenverkehr empfangen.",
     "ActivenessStatus": "Aktivitätsstatus",
     "AddAccessToken": "Zugriffstoken hinzufügen",
-    "AddNewRevisionFromThis": "Aus dieser Revision hinzufügen",
+    "AddNewRevisionFromThis": "Neue Revision basierend auf dieser",
     "AddRevision": "Revision hinzufügen",
     "AdditionalMounts": "Zusätzliche Einhängepunkte",
     "AnotherDeploymentInProgress": "Ein weiteres Deployment-Update wird bereits durchgeführt. Bitte warten Sie, bis es abgeschlossen ist, bevor Sie es erneut versuchen.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Αντίγραφα που λαμβάνουν τρέχουσα κίνηση μέσω App Proxy.",
     "ActivenessStatus": "Κατάσταση ενεργότητας",
     "AddAccessToken": "Προσθήκη Token Πρόσβασης",
-    "AddNewRevisionFromThis": "Προσθήκη από αυτή τη Revision",
+    "AddNewRevisionFromThis": "Νέα Revision βάσει αυτής",
     "AddRevision": "Προσθήκη Revision",
     "AdditionalMounts": "Πρόσθετες Προσαρτήσεις",
     "AnotherDeploymentInProgress": "Μια άλλη ενημέρωση ανάπτυξης βρίσκεται ήδη σε εξέλιξη. Παρακαλούμε περιμένετε να ολοκληρωθεί πριν προσπαθήσετε ξανά.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -924,7 +924,7 @@
     "ActivePoolDescription": "Replicas currently receiving traffic through App Proxy.",
     "ActivenessStatus": "Activeness Status",
     "AddAccessToken": "Add Access Token",
-    "AddNewRevisionFromThis": "Add new revision from this",
+    "AddNewRevisionFromThis": "New revision based on this",
     "AddRevision": "Add Revision",
     "AdditionalMounts": "Additional Mounts",
     "AnotherDeploymentInProgress": "Another deployment update is already in progress. Please wait for it to complete before trying again.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Réplicas que actualmente reciben tráfico a través de App Proxy.",
     "ActivenessStatus": "Estado de actividad",
     "AddAccessToken": "Agregar Token de Acceso",
-    "AddNewRevisionFromThis": "Agregar a partir de esta Revisión",
+    "AddNewRevisionFromThis": "Nueva Revision basada en esta",
     "AddRevision": "Agregar Revisión",
     "AdditionalMounts": "Montajes adicionales",
     "AnotherDeploymentInProgress": "Ya hay otra actualización de despliegue en curso. Por favor, espere a que se complete antes de intentarlo de nuevo.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Replikat, jotka vastaanottavat liikennettä App Proxyn kautta.",
     "ActivenessStatus": "Aktiivisuustila",
     "AddAccessToken": "Lisää käyttöoikeustunnus",
-    "AddNewRevisionFromThis": "Lisää tästä Revisionista",
+    "AddNewRevisionFromThis": "Uusi Revision tämän pohjalta",
     "AddRevision": "Lisää Revision",
     "AdditionalMounts": "Lisäliitokset",
     "AnotherDeploymentInProgress": "Toinen käyttöönoton päivitys on jo käynnissä. Odota sen valmistumista ennen kuin yrität uudelleen.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Répliques recevant actuellement du trafic via App Proxy.",
     "ActivenessStatus": "État d'activité",
     "AddAccessToken": "Ajouter un Token d'Accès",
-    "AddNewRevisionFromThis": "Ajouter à partir de cette Revision",
+    "AddNewRevisionFromThis": "Nouvelle Revision basée sur celle-ci",
     "AddRevision": "Ajouter une Revision",
     "AdditionalMounts": "Montages supplémentaires",
     "AnotherDeploymentInProgress": "Une autre mise à jour de déploiement est déjà en cours. Veuillez attendre qu'elle se termine avant de réessayer.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Replika yang saat ini menerima lalu lintas melalui App Proxy.",
     "ActivenessStatus": "Status Keaktifan",
     "AddAccessToken": "Tambah Token Akses",
-    "AddNewRevisionFromThis": "Tambah dari Revision ini",
+    "AddNewRevisionFromThis": "Revision baru berdasarkan ini",
     "AddRevision": "Tambah Revision",
     "AdditionalMounts": "Pemasangan Tambahan",
     "AnotherDeploymentInProgress": "Pembaruan deployment lain sedang berlangsung. Harap tunggu hingga selesai sebelum mencoba lagi.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Repliche che ricevono attualmente traffico tramite App Proxy.",
     "ActivenessStatus": "Stato di attività",
     "AddAccessToken": "Aggiungi Token di Accesso",
-    "AddNewRevisionFromThis": "Aggiungi da questa Revision",
+    "AddNewRevisionFromThis": "Nuova Revision basata su questa",
     "AddRevision": "Aggiungi Revision",
     "AdditionalMounts": "Montaggio aggiuntivo",
     "AnotherDeploymentInProgress": "Un altro aggiornamento del deployment è già in corso. Attendere il completamento prima di riprovare.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "App Proxy を通じてトラフィックを受信中のレプリカです。",
     "ActivenessStatus": "アクティブ状態",
     "AddAccessToken": "アクセストークンを追加",
-    "AddNewRevisionFromThis": "このリビジョンとして追加",
+    "AddNewRevisionFromThis": "この Revision を基に Revision を作成",
     "AddRevision": "Revision を追加",
     "AdditionalMounts": "追加マウント",
     "AnotherDeploymentInProgress": "別のデプロイ更新が既に進行中です。再試行する前に完了するまでお待ちください。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "App Proxy를 통해 현재 트래픽을 수신 중인 레플리카입니다.",
     "ActivenessStatus": "활성 상태",
     "AddAccessToken": "액세스 토큰 추가",
-    "AddNewRevisionFromThis": "이 리비전으로 추가",
+    "AddNewRevisionFromThis": "이 리비전 기반으로 리비전 생성",
     "AddRevision": "리비전 추가",
     "AdditionalMounts": "추가 마운트",
     "AnotherDeploymentInProgress": "다른 배포 업데이트가 이미 진행 중입니다. 다시 시도하기 전에 완료될 때까지 기다려 주세요.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "App Proxy-р дамжуулан одоогоор трафик хүлээн авч буй репликүүд.",
     "ActivenessStatus": "Идэвхжилтийн төлөв",
     "AddAccessToken": "Хандалтын токен нэмэх",
-    "AddNewRevisionFromThis": "Энэ Revision-оос нэмэх",
+    "AddNewRevisionFromThis": "Энэ дээр суурилсан шинэ Revision",
     "AddRevision": "Revision нэмэх",
     "AdditionalMounts": "Нэмэлт холболтууд",
     "AnotherDeploymentInProgress": "Өөр байршуулалтын шинэчлэлт аль хэдийн явагдаж байна. Дахин оролдохоос өмнө дуусахыг хүлээнэ үү.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Replika yang sedang menerima trafik melalui App Proxy.",
     "ActivenessStatus": "Status Keaktifan",
     "AddAccessToken": "Tambah Token Akses",
-    "AddNewRevisionFromThis": "Tambah daripada Revision ini",
+    "AddNewRevisionFromThis": "Revision baharu berdasarkan ini",
     "AddRevision": "Tambah Revision",
     "AdditionalMounts": "Pemasangan Tambahan",
     "AnotherDeploymentInProgress": "Kemas kini deployment lain sedang dalam proses. Sila tunggu sehingga selesai sebelum mencuba lagi.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Repliki aktualnie odbierające ruch przez App Proxy.",
     "ActivenessStatus": "Status aktywności",
     "AddAccessToken": "Dodaj Token Dostępu",
-    "AddNewRevisionFromThis": "Dodaj z tej Revision",
+    "AddNewRevisionFromThis": "Nowa Revision na podstawie tej",
     "AddRevision": "Dodaj Revision",
     "AdditionalMounts": "Dodatkowe Montowania",
     "AnotherDeploymentInProgress": "Inna aktualizacja wdrożenia jest już w toku. Poczekaj na jej zakończenie przed ponowną próbą.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Réplicas atualmente recebendo tráfego pelo App Proxy.",
     "ActivenessStatus": "Status de atividade",
     "AddAccessToken": "Adicionar Token de Acesso",
-    "AddNewRevisionFromThis": "Adicionar a partir desta Revision",
+    "AddNewRevisionFromThis": "Nova Revision baseada nesta",
     "AddRevision": "Adicionar Revision",
     "AdditionalMounts": "Montagens adicionais",
     "AnotherDeploymentInProgress": "Outra atualização de implantação já está em andamento. Aguarde a conclusão antes de tentar novamente.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Réplicas a receber tráfego atualmente através do App Proxy.",
     "ActivenessStatus": "Estado de atividade",
     "AddAccessToken": "Adicionar Token de Acesso",
-    "AddNewRevisionFromThis": "Adicionar a partir desta Revision",
+    "AddNewRevisionFromThis": "Nova Revision baseada nesta",
     "AddRevision": "Adicionar Revision",
     "AdditionalMounts": "Montagens adicionais",
     "AnotherDeploymentInProgress": "Outra atualização de implementação já está em curso. Por favor, aguarde a sua conclusão antes de tentar novamente.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Реплики, в настоящее время получающие трафик через App Proxy.",
     "ActivenessStatus": "Статус активности",
     "AddAccessToken": "Добавить токен доступа",
-    "AddNewRevisionFromThis": "Добавить из этой Revision",
+    "AddNewRevisionFromThis": "Новая Revision на основе этой",
     "AddRevision": "Добавить Revision",
     "AdditionalMounts": "Дополнительные монтирования",
     "AnotherDeploymentInProgress": "Другое обновление развёртывания уже выполняется. Пожалуйста, дождитесь его завершения перед повторной попыткой.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "เรพลิกาที่กำลังรับทราฟฟิกผ่าน App Proxy ในขณะนี้",
     "ActivenessStatus": "สถานะความเคลื่อนไหว",
     "AddAccessToken": "เพิ่มโทเค็นการเข้าถึง",
-    "AddNewRevisionFromThis": "เพิ่มจาก Revision นี้",
+    "AddNewRevisionFromThis": "สร้าง Revision ใหม่จากนี้",
     "AddRevision": "เพิ่ม Revision",
     "AdditionalMounts": "การเมาท์เพิ่มเติม",
     "AnotherDeploymentInProgress": "การอัปเดตการปรับใช้อื่นกำลังดำเนินอยู่แล้ว โปรดรอให้เสร็จสิ้นก่อนลองอีกครั้ง",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "App Proxy aracılığıyla şu anda trafik alan replikalar.",
     "ActivenessStatus": "Etkinlik Durumu",
     "AddAccessToken": "Erişim Tokenı Ekle",
-    "AddNewRevisionFromThis": "Bu Revision'dan ekle",
+    "AddNewRevisionFromThis": "Bunu temel alan yeni Revision",
     "AddRevision": "Revision Ekle",
     "AdditionalMounts": "Ek Bağlama Noktaları",
     "AnotherDeploymentInProgress": "Başka bir dağıtım güncellemesi zaten devam ediyor. Tekrar denemeden önce tamamlanmasını bekleyin.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "Các bản sao đang nhận lưu lượng truy cập qua App Proxy.",
     "ActivenessStatus": "Trạng thái hoạt động",
     "AddAccessToken": "Thêm Token Truy Cập",
-    "AddNewRevisionFromThis": "Thêm từ Revision này",
+    "AddNewRevisionFromThis": "Revision mới dựa trên cái này",
     "AddRevision": "Thêm Revision",
     "AdditionalMounts": "Gắn Kết Bổ Sung",
     "AnotherDeploymentInProgress": "Một bản cập nhật triển khai khác đang được thực hiện. Vui lòng chờ cho đến khi hoàn thành trước khi thử lại.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -937,7 +937,7 @@
     "ActivePoolDescription": "当前通过 App Proxy 接收流量的副本。",
     "ActivenessStatus": "活跃状态",
     "AddAccessToken": "添加访问令牌",
-    "AddNewRevisionFromThis": "从此 Revision 新增",
+    "AddNewRevisionFromThis": "基于此新建 Revision",
     "AddRevision": "添加 Revision",
     "AdditionalMounts": "附加挂载",
     "AnotherDeploymentInProgress": "另一个部署更新已在进行中。请等待其完成后再重试。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -938,7 +938,7 @@
     "ActivePoolDescription": "目前透過 App Proxy 接收流量的副本。",
     "ActivenessStatus": "活躍狀態",
     "AddAccessToken": "新增存取令牌",
-    "AddNewRevisionFromThis": "從此 Revision 新增",
+    "AddNewRevisionFromThis": "基於此新增 Revision",
     "AddRevision": "新增 Revision",
     "AdditionalMounts": "附加掛載",
     "AnotherDeploymentInProgress": "另一個部署更新已在進行中。請等待完成後再重試。",


### PR DESCRIPTION
Resolves #7601 (FR-2977)

> **Stacked on #7671 (FR-2977).** That PR adds the "Add new revision from this" entry in the revision history row menu and the revision-detail drawer. This PR is a wording + icon polish on that same entry.

## Summary

The revision-source action seeds a **new linear revision** pre-filled from an existing revision's configuration — it does **not** fork or duplicate the history (see #7671 / #7561, which deliberately avoided a branching icon). The previous copy ("Add new revision from this" / KO "이 리비전으로 추가") leaned on a "duplicate" framing that misreads the actual behavior and read inconsistently next to the in-modal **"Load current revision"** alert, whose own copy already frames loading a revision's settings as the *starting point* for a new revision.

This PR aligns the entry with that "based on this / starting point" mental model:

- **Reframe the action label** (`deployment.AddNewRevisionFromThis`) across all 21 locales:
  - EN: `Add new revision from this` → **`New revision based on this`**
  - KO: `이 리비전으로 추가` → **`이 리비전 기반으로 리비전 생성`** (noun-ending menu style, matching `리비전 보기` / `배포 삭제`; makes "creates a revision" explicit)
  - The other 19 locales are updated to the same "new revision based on this" framing, keeping each locale's established term for *revision* (es de-accented to `Revision` and ja switched to Latin-script `Revision` to match each locale's existing deployment strings).
- **Switch the action icon** to lucide **`CopyPlus`** (`<CopyPlusIcon size={14} />`) in `DeploymentRevisionHistoryTab.tsx` — both entry points (the row overflow menu item and the drawer **More (⋯)** dropdown). It reads as "create a new revision from this one's settings" (copy **+** create new), distinct from the plain `Plus` used by the generic *Add Revision* button, without the fork/branch metaphor.

## Scope

- Out of scope by design: the in-modal alert keys (`deployment.LoadCurrentRevision`, `deployment.CurrentRevisionAvailableDescription`, `deployment.CurrentRevisionConfigurationLoaded`) are **unchanged** — the alert already uses the correct "Load / starting point" vocabulary, and the new action label now reads coherently alongside it.
- Pure copy + icon change. No behavioral or data-flow change.

## Test plan

- [x] Revision History row ⋯ menu shows the new label with the CopyPlus icon, opens the Add Revision modal prefilled from that revision.
- [x] Revision-detail drawer **More (⋯)** dropdown shows the same label + icon, same prefill behavior.
- [x] In-modal "Load current revision" alert copy/behavior unchanged.
- [x] `bash scripts/verify.sh` — Relay, Lint, Format, TypeScript all PASS.
