### PR TITLE
fix(FR-3037): version-gate project folder creation for managers without createVFolderInProject

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -834,16 +834,20 @@ export class Client {
     if (this.isManagerVersionCompatibleWith('26.4.4rc4')) {
       this._features['rbac-element-type-filter'] = true;
     }
-    // BA-6247 / BA-6249 user filters merged after 26.4.4rc6, so they ship in
-    // 26.4.4 (final). Pinned to the rc6 tag so the flag also activates against
-    // the rc6 staging manager (a post-rc6 snapshot reporting the rc6 version).
-    // TODO(FR-3024): simplify to '26.4.4' once rc builds are out of use.
+    // Pinned to the rc6 tag so these flags also activate against the rc6
+    // staging manager (a post-rc6 snapshot reporting the rc6 version).
+    // TODO(FR-3024, FR-3037): simplify to '26.4.4' once rc builds are out of use.
     if (this.isManagerVersionCompatibleWith('26.4.4rc6')) {
+      // BA-6247 / BA-6249 user filters merged after 26.4.4rc6 (ship in 26.4.4).
       this._features['user-v2-extended-filter'] = true;
       // adminKeypairResourcePoliciesV2 gained the `keypair.userId` nested filter
       // + the `keypairs` connection in 26.4.4 (FR-3020). Pinned to the rc6 tag
       // for the same staging-manager reason as above.
       this._features['keypair-resource-policy-user-filter'] = true;
+      // createVFolderInProject / CreateVFolderInScopeInput landed after 26.4.3;
+      // 26.4.3 and older only expose createVfolderV2, which still creates a
+      // project-owned vfolder via its `projectId` field. FR-3037.
+      this._features['vfolder-create-in-scope'] = true;
     }
   }
 

--- a/react/src/components/FolderCreateModalV2.tsx
+++ b/react/src/components/FolderCreateModalV2.tsx
@@ -286,7 +286,9 @@ const FolderCreateModalV2: React.FC<FolderCreateModalProps> = ({
 
     let vfolderResults: FolderCreationResponse | undefined;
     try {
-      if (isProjectFolder) {
+      if (isProjectFolder && baiClient.supports('vfolder-create-in-scope')) {
+        // Dedicated project-scoped mutation (createVFolderInProject /
+        // CreateVFolderInScopeInput) exists only on managers >= 26.4.4rc6.
         vfolderResults = await commitCreateInProjectMutation({
           projectId: values.group ?? '',
           input: {
@@ -297,13 +299,19 @@ const FolderCreateModalV2: React.FC<FolderCreateModalProps> = ({
           },
         }).then((res) => res?.createVFolderInProject?.vfolder);
       } else {
+        // User-scoped folders, and project folders on managers <= 26.4.3 that
+        // lack createVFolderInProject, both go through createVfolderV2.
+        // A project-owned vfolder is requested by passing `projectId`. FR-3037.
         vfolderResults = await commitCreateMutation({
           input: {
             ...baseInput,
             // `CreateVFolderV2Input` keeps the lowercase legacy strings.
             usageMode: legacyUsageMode,
             permission: values.permission,
-            projectId: null,
+            // Mirror the project-scoped path: a project folder always carries
+            // its project id (defaulted to the current project by the form);
+            // user folders pass null. Keeps both mutation paths consistent.
+            projectId: isProjectFolder ? (values.group ?? '') : null,
           },
         }).then((res) => res?.createVfolderV2?.vfolder);
       }


### PR DESCRIPTION
Resolves #7713 (FR-3037)

## Problem

On `main`, creating a **project folder** from the admin/project Data page calls the GraphQL mutation `createVFolderInProject` (input `CreateVFolderInScopeInput`). Both symbols are *Added in UNRELEASED* and do not exist in Manager **26.4.3**, so the whole operation fails `GRAPHQL_VALIDATION_FAILED` and project folder creation is fully broken on 26.4.3.

## Fix

Version-gate the project-scoped mutation and fall back to the long-standing `createVfolderV2` on older managers:

1. **`packages/backend.ai-client/src/client.ts`** — add capability flag `vfolder-create-in-scope`, gated at `isManagerVersionCompatibleWith('26.4.4rc6')`, mirroring the existing rc4/rc6 precedents (`rbac-element-type-filter`, `user-v2-extended-filter`) in the same function.
2. **`react/src/components/FolderCreateModalV2.tsx`** — `handleOk` branches:
   - `isProjectFolder && supports('vfolder-create-in-scope')` → `createVFolderInProject` (enum-typed input), unchanged behavior on new managers.
   - otherwise → `createVfolderV2` (Added in 26.4.2, present in 26.4.3) with `projectId` set for project folders. `CreateVFolderV2Input.projectId` exists since 26.4.2, so this creates a project-owned vfolder on 26.4.3.

`createVfolderV2`'s lowercase `usageMode`/`permission` strings and the new path's `GENERAL`/`READ_WRITE` enums both map the UI's options correctly. Merely declaring the `createVFolderInProject` mutation hook is safe on 26.4.3 — the operation is only sent when committed, which the branch guards.

## Notes

- **Gate threshold**: `26.4.4rc6` errs intentionally high — the fallback is functionally equivalent and valid on any manager `>= 26.4.2`, so gating slightly above the real landing version only routes a few versions through the (working) fallback. ⚠️ Before merge, confirm with the manager team that `createVFolderInProject` ships in **26.4.4 final** (same release as the rc6 user filters) so the gate can't mis-fire on a released manager lacking the symbol.

## Verification

`bash scripts/verify.sh` — Relay / Lint (0 errors) / Format / TypeScript all **PASS**. (The pre-existing "Vite warmup paths" check fails on clean `main` too — unrelated to this change.)

Live verification against a 26.4.3 manager was not run from this environment (test manager 10.82.0.223 unreachable here).