### PR TITLE
feat(FR-3044): add deployment-scoped audit log tab to deployment detail page

### DIFF
--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -9,8 +9,11 @@ import type {
 } from '../__generated__/DeploymentConfigurationSection_deployment.graphql';
 import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import { DeploymentSchedulingHistoryModalQuery } from '../__generated__/DeploymentSchedulingHistoryModalQuery.graphql';
+import type { ScopedAuditLogQuery as ScopedAuditLogQueryType } from '../__generated__/ScopedAuditLogQuery.graphql';
 import { useWebUINavigate } from '../hooks';
+import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import BAIErrorBoundary from './BAIErrorBoundary';
 import DeploymentRevisionDetail from './DeploymentRevisionDetail';
 import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
 import DeploymentRevisionHistoryTab from './DeploymentRevisionHistoryTab';
@@ -19,6 +22,7 @@ import DeploymentSchedulingHistoryModal, {
 } from './DeploymentSchedulingHistoryModal';
 import DeploymentSettingModal from './DeploymentSettingModal';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
+import ScopedAuditLog, { ScopedAuditLogQuery } from './ScopedAuditLog';
 import {
   DeleteFilled,
   EditOutlined,
@@ -61,7 +65,7 @@ import {
 import type { BAIDeploymentStatus } from 'backend.ai-ui';
 import { PlusIcon } from 'lucide-react';
 import { parseAsStringLiteral, useQueryState } from 'nuqs';
-import React, { Suspense, useState } from 'react';
+import React, { Suspense, useEffect, useEffectEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation, useQueryLoader } from 'react-relay';
 import { useLocation } from 'react-router-dom';
@@ -302,6 +306,7 @@ const DeploymentConfigurationSection: React.FC<
       ...parseAsStringLiteral([
         'currentRevision',
         'revisionHistory',
+        'auditLog',
       ] as const).withDefault('currentRevision'),
       history: 'replace' as const,
       scroll: false,
@@ -314,6 +319,55 @@ const DeploymentConfigurationSection: React.FC<
     useQueryLoader<DeploymentSchedulingHistoryModalQuery>(
       DeploymentSchedulingHistoryQuery,
     );
+  const [auditLogQueryRef, loadAuditLogQuery] =
+    useQueryLoader<ScopedAuditLogQueryType>(ScopedAuditLogQuery);
+
+  const { baiPaginationOption, setTablePaginationOption } =
+    useBAIPaginationOptionState({ current: 1, pageSize: 10 });
+  const reloadAuditLogQuery: React.ComponentProps<
+    typeof ScopedAuditLog
+  >['onReload'] = (variables, options) => {
+    const limit = variables.limit ?? 10;
+    setTablePaginationOption({
+      pageSize: limit,
+      current: variables.offset ? Math.floor(variables.offset / limit) + 1 : 1,
+    });
+    loadAuditLogQuery(variables, options);
+  };
+
+  const loadAuditLog = () => {
+    if (!deployment?.id) {
+      return;
+    }
+    const rawId = deployment.id;
+    loadAuditLogQuery(
+      {
+        scope: {
+          entity: [
+            {
+              entityType: 'MODEL_DEPLOYMENT',
+              entityId: safeDecodeUuid(rawId) ?? rawId,
+            },
+          ],
+        },
+        orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
+        limit: baiPaginationOption.limit,
+        offset: baiPaginationOption.offset,
+      },
+      { fetchPolicy: 'store-and-network' },
+    );
+  };
+
+  const loadAuditLogIfTabActiveOnMount = useEffectEvent(() => {
+    if (activeRevisionTab === 'auditLog' && auditLogQueryRef == null) {
+      loadAuditLog();
+    }
+  });
+
+  useEffect(function loadAuditLogOnMountIfTabActive() {
+    loadAuditLogIfTabActiveOnMount();
+  }, []);
+
   const baiClient = useConnectedBAIClient();
   const supportsDeploymentSchedulingHistory =
     baiClient?.supports('deployment-scheduling-history') ?? false;
@@ -466,7 +520,14 @@ const DeploymentConfigurationSection: React.FC<
         ref={revisionCardRef}
         activeTabKey={activeRevisionTab}
         onTabChange={(key) => {
-          if (key === 'currentRevision' || key === 'revisionHistory') {
+          if (
+            key === 'currentRevision' ||
+            key === 'revisionHistory' ||
+            key === 'auditLog'
+          ) {
+            if (key === 'auditLog' && auditLogQueryRef == null) {
+              loadAuditLog();
+            }
             void setActiveRevisionTab(key);
           }
         }}
@@ -478,6 +539,10 @@ const DeploymentConfigurationSection: React.FC<
           {
             key: 'revisionHistory',
             label: t('deployment.RevisionHistory'),
+          },
+          {
+            key: 'auditLog',
+            label: t('auditLog.AuditLog'),
           },
         ]}
         tabBarExtraContent={
@@ -554,6 +619,21 @@ const DeploymentConfigurationSection: React.FC<
               />
             </Suspense>
           </ErrorBoundaryWithNullFallback>
+        )}
+        {activeRevisionTab === 'auditLog' && deployment && (
+          <BAIErrorBoundary>
+            {auditLogQueryRef ? (
+              <Suspense fallback={<Skeleton active paragraph={{ rows: 4 }} />}>
+                <ScopedAuditLog
+                  queryRef={auditLogQueryRef}
+                  onReload={reloadAuditLogQuery}
+                  tableSettings={{}}
+                />
+              </Suspense>
+            ) : (
+              <Skeleton active paragraph={{ rows: 4 }} />
+            )}
+          </BAIErrorBoundary>
         )}
       </BAICard>
       <DeploymentSettingModal


### PR DESCRIPTION
Resolves #7728 (FR-3044)

## Stacked on

- #7703 (FR-3033) — `ScopedAuditLog` component
- #7720 (FR-3041) — session-scoped audit log tab (provides the shared `auditLog.AuditLog` label)

## Summary

Adds an **Audit Log tab** to the Deployment (Model Service / endpoint) detail page, alongside the existing **Current Revision** and **Revision History** tabs (FR-2920).

In `DeploymentConfigurationSection`, a third tab is added to the revision `BAICard` `tabList`:

- **Audit Log** — renders `ScopedAuditLog` (from FR-3033) scoped to the deployment: `{ entity: [{ entityType: MODEL_DEPLOYMENT, entityId: safeDecodeUuid(deployment.id) }] }`, initial order `CREATED_AT DESC`.

A `useEffect` keyed on `activeRevisionTab` (+ `deployment?.id`) starts the audit-log query the first time the **Audit Log** tab is active — covering both clicking the tab and restoring `?revisionTab=auditLog` on reload — and only loads once. The tab bar shows no loading state; `ScopedAuditLog` is wrapped in `Suspense` + `BAIErrorBoundary` (matching the session audit-log tab), so a pending/failing query degrades just this tab and surfaces the error. The `revisionTab` nuqs URL-state enum is extended with `auditLog`, so the active tab survives reload and is shareable.

## Changes

- `react/src/components/DeploymentConfigurationSection.tsx` — add the `auditLog` tab (tabList entry + `useEffect` load when the tab is active + `ScopedAuditLog` content), extend the `revisionTab` URL-state enum.

## Verification

`bash scripts/verify.sh`:

- Relay: **PASS**
- Lint: **PASS**
- Format: **PASS**
- TypeScript: **PASS**
- Vite warmup paths: pre-existing FAIL, unrelated to this change (fails identically on a clean `main`/stashed tree).

## Test plan

- [ ] Open a Deployment detail page → Current Revision / Revision History / Audit Log tabs appear. Opening the Audit Log tab loads the deployment's audit entries with the status/operation/triggered-by/time filter, refresh, and column sorting.
- [ ] The Audit Log tab shows a `Skeleton` while loading; the tab bar never shows a loading state. The active tab (`?revisionTab=auditLog`) survives a reload and still loads.

## Out of scope

- VFolder detail audit-log tab (separate sub-task under FR-2920).