### PR TITLE
fix(FR-3045): version-gate Model Store preset detail fields for managers without the new shape

### DIFF
--- a/react/src/__generated__/DeploymentAddRevisionModalPresetDetailQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentAddRevisionModalPresetDetailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f67eba64a6e09d35a9daa331b3081add>>
+ * @generated SignedSource<<0cad92b435272d4c17cfc220504891bf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -318,12 +318,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "218b82beeca87da0b64539597ed3fe1b",
+    "cacheID": "eebebd9df89f999c024db70d6df12629",
     "id": null,
     "metadata": {},
     "name": "DeploymentAddRevisionModalPresetDetailQuery",
     "operationKind": "query",
-    "text": "query DeploymentAddRevisionModalPresetDetailQuery(\n  $id: UUID!\n) {\n  deploymentRevisionPreset(id: $id) {\n    ...DeploymentPresetDetailModalFragment\n    id\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n"
+    "text": "query DeploymentAddRevisionModalPresetDetailQuery(\n  $id: UUID!\n) {\n  deploymentRevisionPreset(id: $id) {\n    ...DeploymentPresetDetailModalFragment\n    id\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId @since(version: \"26.4.4rc6\")\n    startupCommand\n    bootstrapScript\n    environ @since(version: \"26.4.4rc6\") {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots @since(version: \"26.4.4rc6\") {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/DeploymentPresetDetailModalFragment.graphql.ts
+++ b/react/src/__generated__/DeploymentPresetDetailModalFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aa104f63e58e1c03d1fb03d8c713a79f>>
+ * @generated SignedSource<<11dc9ef2b6463d6f48ddbcaeb7dbf151>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -306,6 +306,6 @@ return {
 };
 })();
 
-(node as any).hash = "1e222e4572f001b430fba49ecaf73cb4";
+(node as any).hash = "4f8625daea8479ae5039603774b9b973";
 
 export default node;

--- a/react/src/__generated__/ModelCardDrawerQuery.graphql.ts
+++ b/react/src/__generated__/ModelCardDrawerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6734430cdd637f2d80da16c22dbf390f>>
+ * @generated SignedSource<<0b583b4ce3d68ab06a1a6110c191e1d7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -505,12 +505,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "aaeebeb9b1c7374d0497836b194f8f96",
+    "cacheID": "45a3bcd6feb2070e79e85c08cc1029fa",
     "id": null,
     "metadata": {},
     "name": "ModelCardDrawerQuery",
     "operationKind": "query",
-    "text": "query ModelCardDrawerQuery(\n  $id: UUID!\n) {\n  modelCardV2(id: $id) {\n    ...ModelCardDrawerFragment\n    id\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n\nfragment ModelCardDeployModalFragment on ModelCardV2 {\n  id\n  availablePresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    edges {\n      node {\n        id\n        name\n        runtimeVariantId\n        ...DeploymentPresetDetailModalFragment\n      }\n    }\n  }\n}\n\nfragment ModelCardDrawerFragment on ModelCardV2 {\n  id\n  name\n  metadata {\n    title\n    author\n    description\n    task\n    category\n    architecture\n    framework\n    label\n    license\n    modelVersion\n  }\n  minResource {\n    resourceType\n    quantity\n  }\n  readme\n  createdAt\n  updatedAt\n  vfolder {\n    id\n    metadata {\n      name\n    }\n    ...VFolderNodeIdenticonV2Fragment\n  }\n  ...ModelCardDeployModalFragment\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n"
+    "text": "query ModelCardDrawerQuery(\n  $id: UUID!\n) {\n  modelCardV2(id: $id) {\n    ...ModelCardDrawerFragment\n    id\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId @since(version: \"26.4.4rc6\")\n    startupCommand\n    bootstrapScript\n    environ @since(version: \"26.4.4rc6\") {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots @since(version: \"26.4.4rc6\") {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n\nfragment ModelCardDeployModalFragment on ModelCardV2 {\n  id\n  availablePresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    edges {\n      node {\n        id\n        name\n        runtimeVariantId\n        ...DeploymentPresetDetailModalFragment\n      }\n    }\n  }\n}\n\nfragment ModelCardDrawerFragment on ModelCardV2 {\n  id\n  name\n  metadata {\n    title\n    author\n    description\n    task\n    category\n    architecture\n    framework\n    label\n    license\n    modelVersion\n  }\n  minResource {\n    resourceType\n    quantity\n  }\n  readme\n  createdAt\n  updatedAt\n  vfolder {\n    id\n    metadata {\n      name\n    }\n    ...VFolderNodeIdenticonV2Fragment\n  }\n  ...ModelCardDeployModalFragment\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/VFolderDeployModalQuery.graphql.ts
+++ b/react/src/__generated__/VFolderDeployModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a897f0a92c55c29fb23ea6d6d2c64e0d>>
+ * @generated SignedSource<<e85270480026aefd2a82e34937dac162>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -369,12 +369,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b639c5ceda298a0462f99b2c846b74d2",
+    "cacheID": "ffadb8246c1fa20e63f3ed355c3cd27a",
     "id": null,
     "metadata": {},
     "name": "VFolderDeployModalQuery",
     "operationKind": "query",
-    "text": "query VFolderDeployModalQuery {\n  deploymentRevisionPresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    edges {\n      node {\n        id\n        name\n        runtimeVariantId\n        ...DeploymentPresetDetailModalFragment\n      }\n    }\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n"
+    "text": "query VFolderDeployModalQuery {\n  deploymentRevisionPresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    edges {\n      node {\n        id\n        name\n        runtimeVariantId\n        ...DeploymentPresetDetailModalFragment\n      }\n    }\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId @since(version: \"26.4.4rc6\")\n    startupCommand\n    bootstrapScript\n    environ @since(version: \"26.4.4rc6\") {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots @since(version: \"26.4.4rc6\") {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n"
   }
 };
 })();

--- a/react/src/components/DeploymentPresetDetailModal.tsx
+++ b/react/src/components/DeploymentPresetDetailModal.tsx
@@ -49,10 +49,10 @@ const DeploymentPresetDetailModal: React.FC<
           clusterSize
         }
         execution {
-          imageId
+          imageId @since(version: "26.4.4rc6")
           startupCommand
           bootstrapScript
-          environ {
+          environ @since(version: "26.4.4rc6") {
             key
             value
           }
@@ -63,7 +63,7 @@ const DeploymentPresetDetailModal: React.FC<
             value
           }
         }
-        resourceSlots {
+        resourceSlots @since(version: "26.4.4rc6") {
           slotName
           quantity
         }


### PR DESCRIPTION
Resolves #7730 (FR-3045)

## Problem

Opening the Model Store preset detail (deploy) flow against Manager **26.4.3** rendered a blank drawer/modal. The `DeploymentPresetDetailModalFragment` — composed into `ModelCardDrawerQuery` (and the `VFolderDeployModal` / `DeploymentAddRevisionModal` preset queries) — requests fields whose shape changed after 26.4.3, so the whole operation failed `GRAPHQL_VALIDATION_FAILED`:

```
Cannot query field "imageId" on type "PresetExecutionSpec". Did you mean "image"?
Cannot query field "key" on type "EnvironmentVariableEntry".
Cannot query field "slotName" on type "AllocatedResourceSlotConnection".
Cannot query field "quantity" on type "AllocatedResourceSlotConnection".
```

## Fix

Version-gate the three changed field groups with the `@since` client directive so they are stripped from the query on managers `< 26.4.4rc6` (i.e. 26.4.3 and older), letting the query validate and the drawer render:

- `execution.imageId` — renamed from `image` after 26.4.3.
- `execution.environ` — entry type changed (`name` → `key`) after 26.4.3.
- `resourceSlots` — returns a plain list (`slotName`/`quantity`) after 26.4.3; on 26.4.3 it is a connection.

The bundled (new) schema no longer contains the old field names (`image`, the old `environ` entry, the `resourceSlots` connection), so Relay cannot query the 26.4.3 shapes — graceful degradation (those three items are simply omitted on 26.4.3) is the only directive-based option. The render code already tolerates the absence: image falls back to `-`, `resourceSlots ?? []`, and `environ` is not consumed.

Gate threshold `26.4.4rc6` is consistent with the rc6 staging-manager pin used elsewhere (FR-3024) and the FR-3037 fix.

## Error boundary (investigated, no change)

The blank was the raw validation failure, not a swallowing boundary. The failing query (`ModelCardDrawer`'s `useLazyLoadQuery`) has **no** drawer-level error boundary, so any future error already propagates to the page-level `BAIErrorBoundary`. The only `ErrorBoundaryWithNullFallback` in `ModelCardDrawer` wraps just the (non-critical) model-folder link and is intentionally left as-is.

## Verification

`bash scripts/verify.sh` — Relay compiles, Lint (0 errors) / Format / TypeScript **PASS**. Regenerated `__generated__` artifacts for the 4 affected operations are committed. (The pre-existing "Vite warmup paths" check fails on clean `main` too — unrelated.)

Live verification against a 26.4.3 manager was not run from this environment (test manager unreachable here).

## Screenshot — verified on Manager 26.4.3

With this fix, the Model Store model-card drawer (whose query composes `DeploymentPresetDetailModalFragment`) now renders against Manager **26.4.3** (`10.82.0.223`) instead of showing a blank panel. The Deploy modal also opens without the validation error.

![Model Store drawer rendering on Manager 26.4.3](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7731/20260605-140757-fr-3045-drawer-fixed-26-4-3.png)