### PR TITLE
fix: allow same-origin framing for Storybook deployment (ui.backend.ai)

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -84,6 +84,15 @@ applications:
             value: "camera=(), microphone=(), geolocation=(), interest-cohort=()"
 
   # Storybook (backend.ai-ui) — App root: packages/backend.ai-ui
+  #
+  # NOTE: Storybook's manager shell renders every component preview by
+  # embedding `iframe.html` in a same-origin <iframe>. The baseline
+  # `X-Frame-Options: DENY` + `frame-ancestors 'none'` used by the other
+  # apps blocks ALL framing — including same-origin — so the preview pane
+  # comes up blank for every story/doc. This app therefore relaxes the
+  # framing headers to SAMEORIGIN / `frame-ancestors 'self'`, which still
+  # blocks cross-origin clickjacking but lets the manager → preview iframe
+  # load. The remaining baseline headers are unchanged.
   - appRoot: packages/backend.ai-ui
     customHeaders:
       - pattern: "**"
@@ -91,9 +100,9 @@ applications:
           - key: "Strict-Transport-Security"
             value: "max-age=31536000; includeSubDomains"
           - key: "X-Frame-Options"
-            value: "DENY"
+            value: "SAMEORIGIN"
           - key: "Content-Security-Policy"
-            value: "frame-ancestors 'none'"
+            value: "frame-ancestors 'self'"
           - key: "X-Content-Type-Options"
             value: "nosniff"
           - key: "Referrer-Policy"


### PR DESCRIPTION
## Problem

Every component preview at **https://ui.backend.ai/** (Storybook for `packages/backend.ai-ui`) renders **blank**. The manager shell — sidebar, search, and the docs prose — shows up, but the actual component preview pane is empty for every story and `--documentation` page.

Example (blank): https://ui.backend.ai/?path=/docs/table-bainameactioncell--documentation

## Root cause

Storybook's manager shell renders each preview by embedding `iframe.html` in a **same-origin `<iframe>`**. The baseline security headers added in #7600 (FR-2976) via `customHttp.yml` apply to the Storybook app too:

```
X-Frame-Options: DENY
Content-Security-Policy: frame-ancestors 'none'
```

`DENY` / `frame-ancestors 'none'` block **all** framing, including same-origin, so the browser refuses to load the preview iframe:

```
Framing 'https://ui.backend.ai/' violates the following Content Security Policy
directive: "frame-ancestors 'none'". The request has been blocked.
net::ERR_BLOCKED_BY_RESPONSE  https://ui.backend.ai/iframe.html?...&viewMode=docs
```

Loading `iframe.html` directly (top-level, not framed) renders the component fine — confirming the build and stories are healthy and the only blocker is the framing header.

## Fix

Relax the framing headers **for the Storybook `appRoot` only**:

| Header | Before | After |
|---|---|---|
| `X-Frame-Options` | `DENY` | `SAMEORIGIN` |
| `Content-Security-Policy` | `frame-ancestors 'none'` | `frame-ancestors 'self'` |

This keeps cross-origin clickjacking protection (only the same origin may frame the page) while allowing the manager → preview iframe to load. The `react` and `backend.ai-webui-docs` apps don't frame themselves and keep the stricter `DENY` / `'none'` baseline unchanged.

## Verification

- `iframe.html` standalone → component renders ✅ (build/stories healthy)
- `/?path=...` (manager) → only failure is the CSP framing block ✅ (exactly what this change addresses)
- After merge, Amplify redeploys from `main`'s `customHttp.yml`. Confirm with:
  ```
  curl -sI https://ui.backend.ai/iframe.html | grep -iE 'frame'
  # expect: x-frame-options: SAMEORIGIN  /  content-security-policy: frame-ancestors 'self'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)