### PR TITLE
fix(FR-2977): open add-revision modal directly from revision history

### DIFF
--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -18,15 +18,7 @@ import {
   MoreOutlined,
   PlayCircleOutlined,
 } from '@ant-design/icons';
-import {
-  App,
-  Dropdown,
-  Modal,
-  Popconfirm,
-  Space,
-  theme,
-  Typography,
-} from 'antd';
+import { App, Dropdown, Popconfirm, Space, theme, Typography } from 'antd';
 import {
   type BAIColumnType,
   BAIButton,
@@ -750,19 +742,13 @@ const DeploymentRevisionHistoryTab: React.FC<
           },
         }}
       />
-      <Suspense
-        // Render a loading modal shell while the modal's lazy chunks resolve,
-        // so the trigger click is visually acknowledged instead of producing a
-        // momentary no-op.
-        fallback={
-          <Modal
-            open={!!sourceRevisionFrgmt}
-            loading
-            footer={null}
-            onCancel={() => setSourceRevisionFrgmt(null)}
-          />
-        }
-      >
+      {/* Local Suspense around the lazily-mounted modal so its lazy form
+          selects (preset / vfolder / runtime variant `useLazyLoadQuery`)
+          don't bubble their suspend up to the page-level boundary and blank
+          the page. `fallback={null}` so the modal simply appears once ready,
+          instead of a loading-modal shell that then swaps for the real modal.
+          Mirrors `DeploymentDetailPage` / `VFolderNodesV2`. */}
+      <Suspense fallback={null}>
         <BAIUnmountAfterClose>
           <DeploymentAddRevisionModal
             open={!!sourceRevisionFrgmt}


### PR DESCRIPTION
Resolves #7601 (FR-2977)

> **Stacked on #7724 (FR-2977).** Addresses Seungwon Lee's review feedback on the FR-2977 / FR-2957 revision stack ([devops Teams thread](https://teams.microsoft.com/l/message/19:acd1be4236b94664b814f4d4e5c84da6@thread.skype/1780626400941)).

## Problem

Opening the **Add Revision** modal from the revision-history entry points (row overflow menu / drawer **More ⋯**) showed a `<Modal loading />` shell first, then **swapped** it for the real modal once the modal's lazy chunks resolved — the modal visibly went down and a new one came up, inconsistent with the rest of the app.

## Why the boundary is load-bearing (and the fallback was the only problem)

`DeploymentAddRevisionModal` **does** suspend on mount: its preset / model-folder / runtime-variant selects (`BAIAvailablePresetSelect`, `BAIVFolderSelect`, `BAIRuntimeVariantSelect`) each run their own `useLazyLoadQuery` and are rendered directly in the form body (not behind the modal's inner `<Suspense>` sections). So the local `<Suspense>` boundary around the mount is **load-bearing** — it keeps that suspend from bubbling up to the page-level boundary and blanking the page. The boundary must stay; only its **fallback** was wrong.

## Change

`DeploymentRevisionHistoryTab` — change the modal-mount Suspense `fallback` from a `<Modal loading />` shell to **`null`**, so the modal simply appears once ready instead of a loading-modal-then-real-modal swap. This matches how the same kind of lazily-mounted modal is handled elsewhere:

- `DeploymentDetailPage` → `<Suspense fallback={null}><BAIUnmountAfterClose><DeploymentAddRevisionModal/></BAIUnmountAfterClose></Suspense>`
- `VFolderNodesV2` → identical `<Suspense fallback={null}>` wrapper around `VFolderDeployModal`

Removes the now-unused `Modal` import. One-file, behavior-only change — no data-flow, query, or schema change.

## Test plan

- [x] Revision History row **⋯ → New revision based on this** opens the real modal directly (no loading-modal-then-real-modal swap), prefilled from that revision.
- [x] Revision-detail drawer **More ⋯ → New revision based on this** — same: drawer closes and the real modal opens directly.
- [x] The modal's lazy selects still show their own field-level skeletons while loading; the page never blanks (local Suspense boundary retained).
- [x] `bash scripts/verify.sh` — Relay, Lint, Format, TypeScript all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
