### PR TITLE
feat(FR-3053): add text/hover overflow variant to BAITagList and adopt for table cells

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
@@ -4,6 +4,7 @@ import {
   BAIQuestionIconWithTooltip,
   BAITable,
   BAITableProps,
+  BAITagList,
   BAIText,
   BooleanTag,
   filterOutEmpty,
@@ -15,7 +16,6 @@ import type {
   BAIAdminUserV2TableFragment$key,
 } from '../__generated__/BAIAdminUserV2TableFragment.graphql';
 import { useBAIi18n } from '../hooks/useBAIi18n';
-import { Tag, Tooltip } from 'antd';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import React from 'react';
@@ -66,35 +66,6 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
 }) => {
   'use memo';
   const { t } = useBAIi18n();
-
-  // Show only the first item inline on a single line; collapse the rest into a
-  // `+N` tag whose tooltip reveals the full list (all items) on hover.
-  const renderOverflowList = (
-    items: ReadonlyArray<string | number> | null | undefined,
-  ) => {
-    if (!items || items.length === 0) return '-';
-    const [first, ...rest] = items;
-    return (
-      <BAIFlex gap="xxs" align="center">
-        <span style={{ whiteSpace: 'nowrap' }}>{first}</span>
-        {rest.length > 0 && (
-          <Tooltip
-            title={
-              <BAIFlex direction="column" align="start">
-                {items.map((item, index) => (
-                  <span key={index}>{item}</span>
-                ))}
-              </BAIFlex>
-            }
-          >
-            <Tag color="default" style={{ marginInlineEnd: 0, cursor: 'help' }}>
-              +{rest.length}
-            </Tag>
-          </Tooltip>
-        )}
-      </BAIFlex>
-    );
-  };
 
   const users = useFragment(
     graphql`
@@ -242,8 +213,13 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
       {
         key: 'allowed_client_ip',
         title: t('comp:UserNodes.AllowedClientIps'),
-        render: (__, record) =>
-          renderOverflowList(record.security?.allowedClientIp),
+        render: (__, record) => (
+          <BAITagList
+            variant="text"
+            maxInline={1}
+            items={record.security?.allowedClientIp ?? []}
+          />
+        ),
       },
       {
         key: 'status',
@@ -303,8 +279,13 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
             />
           </BAIFlex>
         ),
-        render: (__, record) =>
-          renderOverflowList(record.container?.containerGids),
+        render: (__, record) => (
+          <BAITagList
+            variant="text"
+            maxInline={1}
+            items={record.container?.containerGids ?? []}
+          />
+        ),
       },
       {
         key: 'created_at',

--- a/packages/backend.ai-ui/src/components/BAITagList.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.stories.tsx
@@ -1,0 +1,91 @@
+import BAITagList from './BAITagList';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * BAITagList renders a list of values, showing the first `maxInline` items
+ * inline and collapsing the rest into a `+N` overflow indicator.
+ *
+ * @see BAITagList.tsx — the `variant` and `trigger` prop JSDoc documents when
+ * to reach for each variant.
+ */
+const meta: Meta<typeof BAITagList> = {
+  title: 'Tag/BAITagList',
+  component: BAITagList,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Shows up to `maxInline` items inline and collapses the rest into a `+N` overflow indicator, whose popup lists only the hidden items. Use `variant="chip"` (default) for a click popover in modals, or `variant="text"` for a lightweight hover-tooltip overflow in table cells.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'radio' },
+      options: ['chip', 'text'],
+    },
+    trigger: {
+      control: { type: 'radio' },
+      options: ['click', 'hover'],
+    },
+    maxInline: {
+      control: { type: 'number', min: 0 },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BAITagList>;
+
+export const Default: Story = {
+  args: {
+    items: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'],
+  },
+};
+
+export const TextVariant: Story = {
+  name: 'Text variant (table cell)',
+  args: {
+    variant: 'text',
+    maxInline: 1,
+    items: ['10.0.0.1', '10.0.0.2', '10.0.0.3', '10.0.0.4'],
+  },
+};
+
+export const TextVariantNumbers: Story = {
+  name: 'Text variant (numbers)',
+  args: {
+    variant: 'text',
+    maxInline: 1,
+    items: [1000, 1001, 1002, 1003],
+  },
+};
+
+export const TextVariantClickTrigger: Story = {
+  name: 'Text variant (click popover)',
+  args: {
+    variant: 'text',
+    maxInline: 1,
+    trigger: 'click',
+    items: ['10.0.0.1', '10.0.0.2', '10.0.0.3', '10.0.0.4'],
+  },
+};
+
+export const SingleItem: Story = {
+  name: 'Single item (no +N)',
+  args: {
+    variant: 'text',
+    maxInline: 1,
+    items: ['10.0.0.1'],
+  },
+};
+
+export const Empty: Story = {
+  name: 'Empty (placeholder)',
+  args: {
+    items: [],
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAITagList.tsx
+++ b/packages/backend.ai-ui/src/components/BAITagList.tsx
@@ -1,88 +1,126 @@
-import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAIFlex from './BAIFlex';
-import { CheckOutlined, CopyOutlined } from '@ant-design/icons';
-import { Button, Popover, Tag, theme, Typography } from 'antd';
+import { Popover, Tag, theme, Tooltip, Typography } from 'antd';
 import * as _ from 'lodash-es';
-import React, { ReactNode, useState } from 'react';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
+import React, { ReactNode } from 'react';
+
+export type BAITagListItem = string | number;
 
 export interface BAITagListProps {
-  items: string[];
+  items: ReadonlyArray<BAITagListItem>;
   maxInline?: number;
   emptyText?: ReactNode;
-  popoverTitle?: ReactNode;
+  /**
+   * Visual style of the list.
+   * - `'chip'` (default): the first `maxInline` items render as antd `Tag`
+   *   chips and the `+N` overflow opens a `Popover`. Suited for interactive
+   *   contexts (modals).
+   * - `'text'`: the first `maxInline` items render as inline plain (nowrap)
+   *   text and the `+N` overflow is a compact `Tag`. Suited for dense table
+   *   cells.
+   *
+   * Both variants' popups list only the overflowed items — the inline items
+   * are already on screen, so repeating them adds nothing.
+   */
+  variant?: 'chip' | 'text';
+  /**
+   * How the overflow popup is triggered. Defaults to `'click'` for the `chip`
+   * variant and `'hover'` for the `text` variant.
+   */
+  trigger?: 'click' | 'hover';
 }
 
 const BAITagList: React.FC<BAITagListProps> = ({
   items,
   maxInline = 3,
   emptyText = '-',
-  popoverTitle,
+  variant = 'chip',
+  trigger,
 }) => {
-  const { t } = useBAIi18n();
+  'use memo';
   const { token } = theme.useToken();
-  const [copied, setCopied] = useState(false);
 
   const inlineItems = _.slice(items, 0, maxInline);
   const restItems = _.slice(items, maxInline);
-  const restCount = _.max([items.length - maxInline, 0]) || 0;
-
-  const handleCopy = () => {
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const restCount = restItems.length;
+  const effectiveTrigger = trigger ?? (variant === 'text' ? 'hover' : 'click');
 
   if (items.length === 0) {
     return <>{emptyText}</>;
   }
 
+  if (variant === 'text') {
+    const renderOverflow = () => {
+      const restItemsList = (
+        <BAIFlex
+          direction="column"
+          align="start"
+          style={{ maxHeight: 240, overflowY: 'auto' }}
+        >
+          {_.map(restItems, (item, index) => (
+            <span key={`${item}-${index}`}>{item}</span>
+          ))}
+        </BAIFlex>
+      );
+      const overflowTag = (
+        <Tag
+          color="default"
+          style={{
+            marginInlineEnd: 0,
+            cursor: effectiveTrigger === 'hover' ? 'help' : 'pointer',
+          }}
+        >
+          +{restCount}
+        </Tag>
+      );
+
+      return effectiveTrigger === 'hover' ? (
+        <Tooltip title={restItemsList}>{overflowTag}</Tooltip>
+      ) : (
+        <Popover trigger="click" content={restItemsList}>
+          {overflowTag}
+        </Popover>
+      );
+    };
+
+    return (
+      <BAIFlex gap="xxs" align="center" style={{ display: 'inline-flex' }}>
+        {_.map(inlineItems, (item, index) => (
+          <span key={`${item}-${index}`} style={{ whiteSpace: 'nowrap' }}>
+            {item}
+          </span>
+        ))}
+        {restCount > 0 && renderOverflow()}
+      </BAIFlex>
+    );
+  }
+
   return (
     <span>
       <BAIFlex wrap="wrap" gap="xs" style={{ display: 'inline-flex' }}>
-        {_.map(inlineItems, (item) => (
-          <Tag key={item}>{item}</Tag>
+        {_.map(inlineItems, (item, index) => (
+          <Tag key={`${item}-${index}`}>{item}</Tag>
         ))}
       </BAIFlex>
       {restCount > 0 && (
         <>
           &nbsp;
           <Popover
-            trigger="click"
-            title={
-              <BAIFlex justify="between">
-                <span>
-                  {popoverTitle} ({items.length})
-                </span>
-                <CopyToClipboard text={items.join(', ')} onCopy={handleCopy}>
-                  <Button
-                    size="small"
-                    type="text"
-                    icon={copied ? <CheckOutlined /> : <CopyOutlined />}
-                    style={{ color: token.colorLink }}
-                  >
-                    {copied
-                      ? t('general.button.Copied')
-                      : t('general.button.CopyAll')}
-                  </Button>
-                </CopyToClipboard>
-              </BAIFlex>
-            }
+            trigger={effectiveTrigger}
             content={
-              <div
+              <ul
                 style={{
+                  paddingLeft: token.padding,
+                  margin: 0,
                   maxHeight: 240,
                   overflow: 'auto',
-                  minWidth: 260,
                 }}
               >
-                <ul style={{ paddingLeft: token.padding, margin: 0 }}>
-                  {_.map(restItems, (item) => (
-                    <li key={item} style={{ listStyle: 'disc' }}>
-                      <Typography.Text>{item}</Typography.Text>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+                {_.map(restItems, (item, index) => (
+                  <li key={`${item}-${index}`} style={{ listStyle: 'disc' }}>
+                    <Typography.Text>{item}</Typography.Text>
+                  </li>
+                ))}
+              </ul>
             }
           >
             <Typography.Link>+{restCount}</Typography.Link>

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -135,7 +135,7 @@ export type { BAIUncontrolledInputProps } from './BAIUncontrolledInput';
 export { default as BAIUncontrolledInput } from './BAIUncontrolledInput';
 export { default as BAITag } from './BAITag';
 export { default as BAITagList } from './BAITagList';
-export type { BAITagListProps } from './BAITagList';
+export type { BAITagListProps, BAITagListItem } from './BAITagList';
 export {
   default as BAIDeploymentStatusTag,
   isDeploymentInStoppedCategory,

--- a/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
+++ b/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
@@ -575,7 +575,6 @@ const FairShareWeightSettingModal: React.FC<
                   domainsFairShares,
                   (domain) => domain.domain?.basicInfo?.name || '',
                 )}
-                popoverTitle={t('fairShare.Domain')}
               />
             ) : (
               <Input disabled />
@@ -596,7 +595,6 @@ const FairShareWeightSettingModal: React.FC<
                   projectFairShares,
                   (project) => project.project?.basicInfo?.name || '',
                 )}
-                popoverTitle={t('fairShare.Project')}
               />
             ) : (
               <Input disabled />
@@ -621,7 +619,6 @@ const FairShareWeightSettingModal: React.FC<
                   userFairShares,
                   (user) => user.user?.basicInfo?.email || '',
                 )}
-                popoverTitle={t('fairShare.User')}
               />
             ) : (
               <Input disabled />

--- a/react/src/components/FairShareItems/UsageBucketModal.tsx
+++ b/react/src/components/FairShareItems/UsageBucketModal.tsx
@@ -231,7 +231,6 @@ const UsageBucketModal: React.FC<UsageBucketModalProps> = ({
                       domainFairShares,
                       (d) => d.domain?.basicInfo?.name || '',
                     )}
-                    popoverTitle={t('fairShare.Domain')}
                   />
                 ),
               },
@@ -245,7 +244,6 @@ const UsageBucketModal: React.FC<UsageBucketModalProps> = ({
                       projectFairShares,
                       (p) => p?.project?.basicInfo?.name || '',
                     )}
-                    popoverTitle={t('fairShare.Project')}
                   />
                 ),
               },
@@ -259,7 +257,6 @@ const UsageBucketModal: React.FC<UsageBucketModalProps> = ({
                       userFairShares,
                       (u) => u?.user?.basicInfo?.email || '',
                     )}
-                    popoverTitle={t('fairShare.User')}
                   />
                 ),
               },


### PR DESCRIPTION
Resolves #7746 (FR-3053)

## Summary

The merged FR-3040 (#7721) added a local `renderOverflowList` helper inside `BAIAdminUserV2Table` that renders the first item of an array inline and collapses the rest into a `+N` tag with a hover tooltip (antd Select `maxTagCount`-style overflow).

Investigation found backend.ai-ui already ships a reusable overflow component — **`BAITagList`** — plus a specialized variant (`BAISessionAgentIds`). Rather than add a third near-duplicate, this PR **consolidates the pattern onto `BAITagList`** by giving it a lightweight text/hover variant, then adopts it in the table.

## Changes

### `BAITagList` — new `variant` + `trigger` props (backward compatible)

- `variant?: 'chip' | 'text'` — defaults to `'chip'`, so **all existing call sites (`FairShareWeightSettingModal`, `UsageBucketModal`) render identically**.
  - `chip` (existing): inline antd `Tag` chips; `+N` opens a click `Popover` with the remaining items and a copy-all action.
  - `text` (new): inline plain (nowrap) text for the first `maxInline` items; `+N` is a compact `Tag` whose popup lists **all** items. Suited for dense table cells.
- `trigger?: 'click' | 'hover'` — defaults to `'click'` for `chip`, `'hover'` for `text`. The `text` variant uses a `Tooltip` on hover and a `Popover` on click.
- `items` widened from `string[]` to `ReadonlyArray<string | number>` (new `BAITagListItem` export); existing string arrays remain assignable.
- Added the `'use memo'` directive (React Compiler).

### `BAIAdminUserV2Table` — adopt the shared component

- Removed the local `renderOverflowList` helper.
- Replaced both call sites (`allowedClientIp`, `containerGids`) with `<BAITagList variant="text" maxInline={1} items={... ?? []} />` — preserving the previous UX (first value inline, `+N` hover tooltip listing all values, `-` when empty).
- Dropped the now-unused antd `Tag`/`Tooltip` import.

### Storybook

- Added `BAITagList.stories.tsx` covering both variants (chip popover, text hover/click, numbers, single item, empty).

## Out of scope

- Migrating other comma-joined / multi-tag adoption candidates across the app (separate follow-up).

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript).