### PR TITLE
feat(FR-3052): terminology governance — approved verbs, unknown-term checker, precedence & rename rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,10 @@ Production build (`pnpm run build`) runs these steps sequentially:
 - **Documentation**: `docs-writing-guide` skill (fw plugin; user manual structure, terminology, multilingual rules)
 - **Relay**: `relay-patterns` skill (fragment architecture, naming conventions, query optimization)
 
+### Terminology Precedence
+
+When terms disagree, precedence is: (1) the live UI i18n label in `resources/i18n/{lang}.json`, (2) `terminology.json`, (3) `DOCUMENTATION-STYLE-GUIDE.md`. The higher-precedence source wins; fix the lower one to match (or open an FR to change the label). See `packages/backend.ai-webui-docs/TERMINOLOGY.md` for the term owner, new-term gate, and the atomic rename/deprecation checklist.
+
 ### Auto-Applied Instructions (loaded when editing matching files)
 
 - `react.instructions.md` → `react/**/*.tsx,react/**/*.ts`

--- a/packages/backend.ai-webui-docs/TERMINOLOGY.md
+++ b/packages/backend.ai-webui-docs/TERMINOLOGY.md
@@ -4,6 +4,12 @@ Standardized terminology for the Backend.AI WebUI user manual. Use these terms c
 
 > **This file is partially generated.** The term tables in the **Standardized Terms** section below and the **Terms to Avoid** table are generated from `terminology.json` (the single source of truth) by `scripts/generate-terminology.mjs`. Do **not** hand-edit anything between the `<!-- terminology:auto:... -->` markers — edit `terminology.json` and run `pnpm run build:terminology`. All prose outside the markers is human-curated and safe to edit directly.
 
+## Precedence
+
+When sources disagree on a term, precedence is: (1) the live UI i18n label in `resources/i18n/{lang}.json`, (2) `terminology.json`, (3) `DOCUMENTATION-STYLE-GUIDE.md`.
+
+The higher-precedence source wins because the i18n label is what users actually see (ground truth); `terminology.json` is the curated decision; the style guide is the fallback for what neither covers. When they disagree, fix the lower-precedence source to match — or, if the *label itself* is wrong, open an FR to change it. A half-applied rename (label changed but termbase not, or vice versa) silently reverts intent under this rule, so always complete a rename atomically (see [Rename / Deprecation Checklist](#rename--deprecation-checklist)).
+
 ## Standardized Terms
 
 The tables below list the approved term for each concept, per language, grouped by category. `EN`/`KO`/`JA`/`TH` are the preferred terms; `—` means the source does not define that language explicitly (fall back to the English term or the contextual prose under the matching section heading). The prose sections that follow each category (usage notes, "Do NOT use" callouts, spelling rules) provide the human guidance that the table cannot capture.
@@ -182,3 +188,63 @@ Each row lists one forbidden term, its canonical replacement, and the reason. Pa
 | 자동 스케일링 (auto scaling rule) | 오토스케일링 | Match the UI label; the autoScalingRule i18n keys use "오토스케일링" |
 
 <!-- terminology:auto:avoid END -->
+
+## Approved Verbs
+
+This table pins **one approved action verb per intent** so docs and UI use the same word for the same operation. Verb choice is **context-dependent**: "remove from a list" is not "delete permanently", and "deactivate an account" is not "purge it". Each row therefore states the **context** in which its approved verb is canonical, plus the near-synonyms to avoid in that context.
+
+The table below is generated from the `verbs` array in `terminology.json`. Edit `terminology.json` and run `pnpm run build:terminology`; do not hand-edit between the markers.
+
+:::warning[Lexical, not behavioral — keep the two axes orthogonal]
+This list governs only **which word** labels an action. It does **not** decide the confirmation UX. Whether an action needs a typed-confirmation modal (`BAIConfirmModalWithInput`) or a one-click `Popconfirm` is decided **per call site** by [`.claude/rules/destructive-confirmation.md`](../../.claude/rules/destructive-confirmation.md), keyed off the action's **reversibility** — never derived from the verb. "Delete" can be reversible (soft-delete with a reachable restore path) or irreversible; the same word can map to either confirmation pattern. The optional **Reversible** column below is documentation only — read the rule, not this column, when choosing the confirmation component.
+:::
+
+<!-- terminology:auto:verbs START -->
+
+| Intent | Approved Verb (EN) | Avoid | Context | Reversible | Deciding FR | Description |
+|---|---|---|---|---|---|---|
+| cancel | Cancel | Abort, Discard | Stop an in-flight or not-yet-committed operation (request, draft, running deployment rollout). | reversible | FR-3052 | Use "Cancel" for stopping an action that has not yet had a permanent effect (a pending request, a model-service request, an unsaved form). Does not destroy persisted data. Maps to i18n `button.Cancel` / `modelService.Cancel`. |
+| delete | Delete | Destroy, Erase, Wipe | Permanently remove a standalone resource the user owns (storage folder, image, token, resource preset). | irreversible | FR-3052 | Use "Delete" for permanent removal of a resource that exists on its own. Maps to i18n `button.Delete`, `data.folders.Delete`, `environment.Delete`. NOTE: lexical only — whether a given Delete needs a typed-confirm modal is decided by destructive-confirmation.md from the action's reversibility, NOT from this word. |
+| hide | Hide | Remove, Delete, Dismiss | Make an item invisible in the UI without deleting it (hide a column, hide a notice, hide a list entry). | reversible | FR-3052 | Use "Hide" for purely cosmetic visibility changes that keep the underlying data intact and can be reversed by un-hiding. Never use "Hide" when data is actually removed. |
+| inactivate | Deactivate | Inactivate, Disable, Suspend | Disable an account/credential/project/role so it can no longer be used, while keeping its data for later reactivation. | reversible | FR-3052 | Approved verb is "Deactivate" (not "Inactivate"): the UI uses "Deactivate" 13x vs "Inactivate" 1x. Maps to i18n `credential.Deactivate`, `project.Deactivate`, `rbac.Deactivate`, `resourceGroup.Deactivate`. The single `usersettings.InactivateTheFollowingUsers` value is the drift this entry pins. Reversible: pair with Activate. |
+| purge | Purge | Delete, Wipe, Destroy | Permanently and irrecoverably erase an already-deactivated account/project/role and all its records. | irreversible | FR-3052 | Use "Purge" for the final, irreversible erase that follows "Deactivate". Distinct from "Delete": Purge implies the entity was first deactivated and now has its records expunged. Maps to i18n `project.Purge`, `project.PurgeProject`, `rbac.PurgeRole`. |
+| remove | Remove | Delete, Unlink | Detach an item from a collection / relationship without destroying the item itself (permission from a role, version from a list, member from a project). | reversible | FR-3052 | Use "Remove" for taking an item out of a list or breaking an association — the underlying entity survives elsewhere. "Remove from list" is NOT "Delete permanently". Maps to i18n `rbac.RemovePermission`, `model.RemoveSelectedVersions`. Reserve "Delete" for destroying the standalone resource. |
+| stop | Stop | Pause, Halt, Terminate | Halt a process that can later be resumed or restarted (a service replica, a pausable job). | reversible | FR-3052 | Use "Stop" only when the workload can be started again afterward. If the resources are released and the session ends, use "Terminate" instead. |
+| terminate | Terminate | Kill, Destroy, End | End a running compute session (interactive / batch / inference) or model-service endpoint. | irreversible | FR-3052 | Use "Terminate" for ending a running session/endpoint and releasing its resources. Maps to i18n `session.Terminate`, `session.TerminateSession`, `session.ForceTerminate`. Do not use "Stop" for this; "Stop" is reserved for pausable workloads. |
+
+<!-- terminology:auto:verbs END -->
+
+### Verb usage notes
+
+- **delete vs remove** — Use **Delete** to destroy a standalone resource the user owns (a storage folder, an image, a token). Use **Remove** to take an item out of a collection or break an association (a permission from a role, a version from a list, a member from a project) where the underlying entity survives elsewhere. When in doubt, ask: *does the entity still exist after the action?* If yes → Remove; if no → Delete.
+- **terminate vs stop** — Use **Terminate** to end a running compute session/endpoint and release its resources (irreversible). Use **Stop** only for a workload that can be started again afterward. Backend.AI sessions are terminated, not stopped.
+- **inactivate → Deactivate** — The approved English verb for the *inactivate* intent is **Deactivate** (the UI uses "Deactivate" overwhelmingly; "Inactivate" appears once and is treated as drift to be fixed). Deactivation is reversible (pair with Activate); the irreversible follow-up is **Purge**.
+- **purge vs delete** — Use **Purge** for the final, irreversible erase of an already-**deactivated** account/project/role and all its records. It is distinct from **Delete** (which targets standalone resources without a prior deactivate step).
+- **cancel** — Use **Cancel** to stop an in-flight or not-yet-committed operation (a pending request, an unsaved form, a running rollout) that has not yet had a permanent effect.
+- **hide** — Use **Hide** only for cosmetic visibility changes (hide a column, a notice, a list entry) that keep the underlying data intact and can be reversed by un-hiding. Never use "Hide" when data is actually removed.
+
+Per-locale approved verb forms are **out of scope for v1**: the destructive-confirmation UX is language-agnostic, so one approved English verb plus normal translation is sufficient. Add other-language `preferred` keys to a `verbs[]` entry only if a specific locale needs a pinned form.
+
+## Governance
+
+### Term Owner of Record
+
+The **docs-lead** flow (`.claude/skills/docs-lead/SKILL.md`) is the term owner of record. Every `terminology.json` mutation — adding a concept, repointing a `preferred` term, adding an `avoid[]` row, deprecating a concept — flows through docs-lead, which assigns the `decidingFR` and runs the rename checklist below. "Owner" here means *editorial accountability*, not a merge gate: a human reviewer still has to approve the change.
+
+### New-Term Gate
+
+A new user-facing noun or verb requires a `terminology.json` entry — carrying a non-null `decidingFR` — **before it ships**. A label cannot appear in `resources/i18n/{lang}.json` as a user-facing term without a corresponding curated decision in the termbase.
+
+Enforcement is **best-effort, not a substitute for review.** `scripts/check-terminology-i18n.mjs` (wired into `scripts/verify.sh` and `pnpm run lint:terminology`) can WARN when an i18n value uses a term that is *forbidden* (an `avoid[]` row) or *unknown* (no matching `concepts[].preferred`), but the checker is heuristic and warn-only — it never blocks a merge and it cannot judge whether a new term is the *right* term. The gate is satisfied by the docs-lead review that lands the `terminology.json` entry, not by a green checker. Treat a checker warning as a prompt to add (or allowlist) the entry, never as the approval itself.
+
+## Rename / Deprecation Checklist
+
+Renaming or deprecating an established term is **atomic**: the termbase, all UI locales, and all doc languages change together, in one Graphite stack. A partial rename leaves the live label and the termbase disagreeing — and because [Precedence](#precedence) says the label wins, a half-done rename silently reverts the decision. Run every step below before submitting.
+
+1. **Deprecate in `terminology.json`.** Set the old concept's `status` to `deprecated`, point `preferred` at the new term (or add the new concept), and add an `avoid[]` row (`avoid` = old term, `useInstead` = new term, plus `reason`, `lang`, and `conceptId`). Set `decidingFR` on the changed concept(s) — the new-term gate requires it.
+2. **Retranslate the UI locales.** Update all 21 files in `resources/i18n/*.json` **and** all 21 in `packages/backend.ai-ui/src/locale/*.json`. Edit `en.json` by hand, then propagate the other 20 with the `fw` i18n-translator (`/fw:i18n`).
+3. **Update the 4 doc languages.** Replace prose occurrences of the old term under `src/{en,ko,ja,th}/`.
+4. **Regenerate the term tables.** Run `pnpm run build:terminology` to refresh the `<!-- terminology:auto:* -->` regions of this file, then `pnpm run check:terminology-md` (confirms the tables match `terminology.json`) and `pnpm run lint:terminology` (confirms no live label still uses the deprecated term).
+5. **Ship as one stack.** With `scripts/verify.sh` clean, submit the whole change as a single Graphite stack (`gt submit --stack`). Do not let any step land in a separate PR ahead of the others — the atomicity is the point.
+
+The App Proxy rename (FR-2841) is the cautionary precedent for skipping this: it landed partly in prose and partly in `avoid[]`, which is exactly the split-state this checklist exists to prevent.

--- a/packages/backend.ai-webui-docs/scripts/generate-terminology.mjs
+++ b/packages/backend.ai-webui-docs/scripts/generate-terminology.mjs
@@ -11,6 +11,11 @@
  * Markers:
  *   <!-- terminology:auto:concepts START --> ... <!-- terminology:auto:concepts END -->
  *   <!-- terminology:auto:avoid START -->    ... <!-- terminology:auto:avoid END -->
+ *   <!-- terminology:auto:verbs START -->    ... <!-- terminology:auto:verbs END -->
+ *     (optional: rendered only when the verbs markers are present — absent
+ *      markers are a no-op so older TERMINOLOGY.md files keep regenerating
+ *      cleanly. One row per `verbs[]` entry; an empty `verbs` array yields a
+ *      header-only table.)
  *
  * Usage:
  *   node scripts/generate-terminology.mjs           # write TERMINOLOGY.md in place
@@ -52,6 +57,10 @@ const MARKERS = {
   avoid: {
     start: "<!-- terminology:auto:avoid START -->",
     end: "<!-- terminology:auto:avoid END -->",
+  },
+  verbs: {
+    start: "<!-- terminology:auto:verbs START -->",
+    end: "<!-- terminology:auto:verbs END -->",
   },
 };
 
@@ -197,6 +206,75 @@ function renderAvoid(data) {
 }
 
 /**
+ * Render the "Approved Verbs" table from data.verbs.
+ *
+ * A PURE LEXICON: one approved verb per intent, in a stated context, with the
+ * rejected near-synonyms. The table deliberately does NOT carry a "confirmation"
+ * column — whether an action needs a typed-confirm modal is owned by
+ * .claude/rules/destructive-confirmation.md (keyed off reversibility, per call
+ * site), and conflating the two axes is exactly what this artifact avoids. The
+ * optional "Reversible" column is documentation only.
+ * @param {any} data parsed terminology.json
+ * @returns {string}
+ */
+function renderVerbs(data) {
+  const verbs = Array.isArray(data.verbs) ? data.verbs : [];
+  // Deterministic order: by intent, then id.
+  const rows = [...verbs].sort(
+    (a, b) =>
+      byString(String(a.intent ?? ""), String(b.intent ?? "")) ||
+      byString(String(a.id ?? ""), String(b.id ?? "")),
+  );
+
+  const hasReversible = rows.some(
+    (v) => typeof v.reversible === "string" && v.reversible.length > 0,
+  );
+  const hasDecidingFR = rows.some(
+    (v) => typeof v.decidingFR === "string" && v.decidingFR.length > 0,
+  );
+  const hasDescription = rows.some(
+    (v) => typeof v.description === "string" && v.description.length > 0,
+  );
+
+  const headers = ["Intent", "Approved Verb (EN)", "Avoid", "Context"];
+  if (hasReversible) headers.push("Reversible");
+  if (hasDecidingFR) headers.push("Deciding FR");
+  if (hasDescription) headers.push("Description");
+
+  const lines = [];
+  lines.push(`| ${headers.join(" | ")} |`);
+  lines.push(`|${headers.map(() => "---").join("|")}|`);
+
+  for (const v of rows) {
+    const avoidList = Array.isArray(v.avoid) ? v.avoid.join(", ") : "";
+    const row = [
+      cell(v.intent),
+      cell(v.preferred ? v.preferred.en : undefined),
+      cell(avoidList),
+      cell(v.context),
+    ];
+    if (hasReversible) row.push(cell(v.reversible));
+    if (hasDecidingFR) row.push(cell(v.decidingFR));
+    if (hasDescription) row.push(cell(v.description));
+    lines.push(`| ${row.join(" | ")} |`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Does the markdown contain both markers of a pair? Used to make the verbs
+ * region optional: when the markers are absent we skip it entirely so older
+ * TERMINOLOGY.md files (pre-verbs) keep regenerating without error.
+ * @param {string} md
+ * @param {{start: string, end: string}} marker
+ * @returns {boolean}
+ */
+function hasMarkers(md, marker) {
+  return md.includes(marker.start) && md.includes(marker.end);
+}
+
+/**
  * Replace the content between a START/END marker pair, preserving the markers
  * and everything outside them. Throws if either marker is missing.
  * @param {string} md
@@ -236,6 +314,12 @@ function generate(md, data) {
   let out = md;
   out = replaceRegion(out, MARKERS.concepts, renderConcepts(data));
   out = replaceRegion(out, MARKERS.avoid, renderAvoid(data));
+  // Verbs region is OPTIONAL: render only when the markers exist. This keeps
+  // the generator backward-compatible with any TERMINOLOGY.md that predates the
+  // verbs table, and lets a doc opt out of the verbs table by omitting markers.
+  if (hasMarkers(out, MARKERS.verbs)) {
+    out = replaceRegion(out, MARKERS.verbs, renderVerbs(data));
+  }
   return out;
 }
 

--- a/packages/backend.ai-webui-docs/terminology.json
+++ b/packages/backend.ai-webui-docs/terminology.json
@@ -1,11 +1,6 @@
 {
   "version": 1,
-  "languages": [
-    "en",
-    "ko",
-    "ja",
-    "th"
-  ],
+  "languages": ["en", "ko", "ja", "th"],
   "concepts": [
     {
       "id": "compute-session",
@@ -632,6 +627,88 @@
       "lang": "ko",
       "context": null,
       "conceptId": "role-superadmin"
+    }
+  ],
+  "verbs": [
+    {
+      "id": "verb-cancel",
+      "intent": "cancel",
+      "context": "Stop an in-flight or not-yet-committed operation (request, draft, running deployment rollout).",
+      "preferred": { "en": "Cancel" },
+      "avoid": ["Abort", "Discard"],
+      "reversible": "reversible",
+      "decidingFR": "FR-3052",
+      "description": "Use \"Cancel\" for stopping an action that has not yet had a permanent effect (a pending request, a model-service request, an unsaved form). Does not destroy persisted data. Maps to i18n `button.Cancel` / `modelService.Cancel`."
+    },
+    {
+      "id": "verb-delete",
+      "intent": "delete",
+      "context": "Permanently remove a standalone resource the user owns (storage folder, image, token, resource preset).",
+      "preferred": { "en": "Delete" },
+      "avoid": ["Destroy", "Erase", "Wipe"],
+      "reversible": "irreversible",
+      "decidingFR": "FR-3052",
+      "description": "Use \"Delete\" for permanent removal of a resource that exists on its own. Maps to i18n `button.Delete`, `data.folders.Delete`, `environment.Delete`. NOTE: lexical only — whether a given Delete needs a typed-confirm modal is decided by destructive-confirmation.md from the action's reversibility, NOT from this word."
+    },
+    {
+      "id": "verb-remove",
+      "intent": "remove",
+      "context": "Detach an item from a collection / relationship without destroying the item itself (permission from a role, version from a list, member from a project).",
+      "preferred": { "en": "Remove" },
+      "avoid": ["Delete", "Unlink"],
+      "reversible": "reversible",
+      "decidingFR": "FR-3052",
+      "description": "Use \"Remove\" for taking an item out of a list or breaking an association — the underlying entity survives elsewhere. \"Remove from list\" is NOT \"Delete permanently\". Maps to i18n `rbac.RemovePermission`, `model.RemoveSelectedVersions`. Reserve \"Delete\" for destroying the standalone resource."
+    },
+    {
+      "id": "verb-terminate",
+      "intent": "terminate",
+      "context": "End a running compute session (interactive / batch / inference) or model-service endpoint.",
+      "preferred": { "en": "Terminate" },
+      "avoid": ["Kill", "Destroy", "End"],
+      "reversible": "irreversible",
+      "decidingFR": "FR-3052",
+      "description": "Use \"Terminate\" for ending a running session/endpoint and releasing its resources. Maps to i18n `session.Terminate`, `session.TerminateSession`, `session.ForceTerminate`. Do not use \"Stop\" for this; \"Stop\" is reserved for pausable workloads."
+    },
+    {
+      "id": "verb-stop",
+      "intent": "stop",
+      "context": "Halt a process that can later be resumed or restarted (a service replica, a pausable job).",
+      "preferred": { "en": "Stop" },
+      "avoid": ["Pause", "Halt", "Terminate"],
+      "reversible": "reversible",
+      "decidingFR": "FR-3052",
+      "description": "Use \"Stop\" only when the workload can be started again afterward. If the resources are released and the session ends, use \"Terminate\" instead."
+    },
+    {
+      "id": "verb-inactivate",
+      "intent": "inactivate",
+      "context": "Disable an account/credential/project/role so it can no longer be used, while keeping its data for later reactivation.",
+      "preferred": { "en": "Deactivate" },
+      "avoid": ["Inactivate", "Disable", "Suspend"],
+      "reversible": "reversible",
+      "decidingFR": "FR-3052",
+      "description": "Approved verb is \"Deactivate\" (not \"Inactivate\"): the UI uses \"Deactivate\" 13x vs \"Inactivate\" 1x. Maps to i18n `credential.Deactivate`, `project.Deactivate`, `rbac.Deactivate`, `resourceGroup.Deactivate`. The single `usersettings.InactivateTheFollowingUsers` value is the drift this entry pins. Reversible: pair with Activate."
+    },
+    {
+      "id": "verb-purge",
+      "intent": "purge",
+      "context": "Permanently and irrecoverably erase an already-deactivated account/project/role and all its records.",
+      "preferred": { "en": "Purge" },
+      "avoid": ["Delete", "Wipe", "Destroy"],
+      "reversible": "irreversible",
+      "decidingFR": "FR-3052",
+      "description": "Use \"Purge\" for the final, irreversible erase that follows \"Deactivate\". Distinct from \"Delete\": Purge implies the entity was first deactivated and now has its records expunged. Maps to i18n `project.Purge`, `project.PurgeProject`, `rbac.PurgeRole`."
+    },
+    {
+      "id": "verb-hide",
+      "intent": "hide",
+      "context": "Make an item invisible in the UI without deleting it (hide a column, hide a notice, hide a list entry).",
+      "preferred": { "en": "Hide" },
+      "avoid": ["Remove", "Delete", "Dismiss"],
+      "reversible": "reversible",
+      "decidingFR": "FR-3052",
+      "description": "Use \"Hide\" for purely cosmetic visibility changes that keep the underlying data intact and can be reversed by un-hiding. Never use \"Hide\" when data is actually removed."
     }
   ]
 }

--- a/packages/backend.ai-webui-docs/terminology.schema.json
+++ b/packages/backend.ai-webui-docs/terminology.schema.json
@@ -29,8 +29,13 @@
     },
     "avoid": {
       "type": "array",
-      "description": "Every row of the TERMINOLOGY.md \"Terms to Avoid\" table, one entry per forbidden term.",
+      "description": "Every row of the TERMINOLOGY.md \"Terms to Avoid\" table, one entry per forbidden NOUN/phrase. This is the ONLY list the i18n checker (scripts/check-terminology-i18n.mjs CHECK 1) scans against — verb lexicon avoidances live in verbs[].avoid and are intentionally NOT scanned here, to keep the verb axis orthogonal to the noun drift checker.",
       "items": { "$ref": "#/definitions/avoidEntry" }
+    },
+    "verbs": {
+      "type": "array",
+      "description": "Approved ACTION VERBS, one entry per user-facing intent (cancel / delete / remove / terminate / stop / inactivate / purge / hide). A pure lexicon: each entry pins exactly one approved English verb for an intent, in a stated context, with the rejected near-synonyms. ORTHOGONALITY CONTRACT: this list governs only WHICH WORD labels an action; it does NOT encode confirmation-UX behavior. Whether an action needs a typed-confirm modal (BAIConfirmModalWithInput) vs a Popconfirm is decided by .claude/rules/destructive-confirmation.md from the action's REVERSIBILITY, never derived from the verb. The optional per-entry `reversible` field is documentation only and must not be read as the confirmation rule. The i18n noun-checker (CHECK 1) does NOT read this array.",
+      "items": { "$ref": "#/definitions/verbEntry" }
     }
   },
   "definitions": {
@@ -131,6 +136,62 @@
           "description": "Optional link to concepts[].id that the canonical replacement maps to, or null.",
           "type": ["string", "null"],
           "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+        }
+      }
+    },
+    "verbEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "intent", "context", "preferred", "decidingFR"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable kebab-case verb id (e.g. \"verb-delete\").",
+          "pattern": "^verb-[a-z0-9]+(-[a-z0-9]+)*$"
+        },
+        "intent": {
+          "type": "string",
+          "description": "The user intent this verb labels: cancel / delete / remove / terminate / stop / inactivate / purge / hide.",
+          "enum": [
+            "cancel",
+            "delete",
+            "remove",
+            "terminate",
+            "stop",
+            "inactivate",
+            "purge",
+            "hide"
+          ]
+        },
+        "context": {
+          "type": "string",
+          "description": "The situation in which this intent applies. Verb choice is context-dependent (\"remove from list\" != \"delete permanently\"), so the approved verb is only canonical within this stated context.",
+          "minLength": 1
+        },
+        "preferred": {
+          "$ref": "#/definitions/preferred",
+          "description": "Approved verb per language. English-only is sufficient for v1 (the destructive-confirmation UX is language-agnostic); other locales translate normally."
+        },
+        "avoid": {
+          "type": "array",
+          "description": "Rejected near-synonyms for this intent. Documentation/review guidance ONLY — intentionally NOT consumed by the i18n CHECK 1 drift scanner (which reads only the top-level avoid[] noun list). Keeps the verb axis orthogonal to the noun checker.",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "reversible": {
+          "type": "string",
+          "description": "Documentation-only hint about whether the action can typically be undone. MUST NOT be read as the confirmation-UX rule: the typed-confirm-vs-Popconfirm decision is owned by .claude/rules/destructive-confirmation.md, per-call-site, from the action's actual reversibility — not from this verb entry.",
+          "enum": ["reversible", "irreversible"]
+        },
+        "decidingFR": {
+          "description": "FR-XXXX issue that decided this verb, or null when the source cites none.",
+          "type": ["string", "null"],
+          "pattern": "^FR-[0-9]+$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional one-line gloss: when to use the verb, which i18n keys it maps to, and how it differs from the rejected synonyms.",
+          "minLength": 1
         }
       }
     }

--- a/scripts/check-terminology-i18n.mjs
+++ b/scripts/check-terminology-i18n.mjs
@@ -8,7 +8,7 @@
  * writes, reorders, or reformats any JSON. It is meant to run AFTER prettier /
  * prettier-plugin-sort-json and the i18n merge driver, so it must not fight them.
  *
- * Two independent checks:
+ * Three independent checks:
  *
  *   CHECK 1 (terminology drift, needs the termbase):
  *     Flags i18n VALUES (never keys) that contain a forbidden term from
@@ -27,18 +27,40 @@
  *     check (e.g. near-duplicate values only, or termbase-linked segments) is a
  *     tracked follow-up.
  *
+ *   CHECK 3 (unknown capitalized user-facing noun, needs the termbase) — OFF by
+ *   default; opt in with --check3:
+ *     Surfaces a candidate NEW user-facing term that should probably be
+ *     registered in the termbase. For each ENGLISH i18n VALUE that reads like
+ *     prose (a sentence, not a short label), it mines embedded Title-Case
+ *     multiword phrases ("Resource Preset") and PascalCase product-like tokens
+ *     ("TensorBoard"), then WARNs when the phrase has no matching
+ *     terminology.json concept (preferred.en) or avoid[] term and is not in the
+ *     allowlist. This is inherently heuristic, so it is deliberately CONSERVATIVE:
+ *     it scans ONLY prose values (short UI labels / button microcopy are skipped),
+ *     peels leading imperative verbs and sentence-lead words, reuses
+ *     isInsideCodeContext() to skip identifiers / URLs / interpolation, and is
+ *     compared against the full preferred[] + avoid[] + approved-compound set
+ *     (case-insensitive). It is ALWAYS report-only ("warn"): it NEVER affects the
+ *     exit code, even under --strict, and stays OFF in verify.sh. Tune false
+ *     positives via the allowlist `ignoreNouns` array. The output is a manageable
+ *     short list, not a wall of label noise; broadening it (e.g. scanning the BUI
+ *     locale store too, or non-prose labels) is a tracked follow-up.
+ *
  * Modes:
  *   (default)  WARN  — report findings, exit 0.
  *   --warn           — same as default (explicit).
  *   --strict         — exit non-zero when there are blocking (error-severity)
- *                      CHECK 1 findings. CHECK 2 is always report-only and never
- *                      affects the exit code. Non-English and context-qualified
- *                      terminology findings are WARN-severity (never block),
- *                      because they need human judgement.
+ *                      CHECK 1 findings. CHECK 2 and CHECK 3 are always
+ *                      report-only and never affect the exit code. Non-English
+ *                      and context-qualified terminology findings are
+ *                      WARN-severity (never block), because they need human
+ *                      judgement.
  *
  * Other flags:
  *   --json           Emit machine-readable JSON instead of the text report.
  *   --check2         Enable CHECK 2 (OFF by default — see CHECK 2 note above).
+ *   --check3         Enable CHECK 3 (OFF by default — see CHECK 3 note above).
+ *                    Always report-only; never affects the exit code.
  *   --no-check1      Skip CHECK 1 (terminology drift).
  *   --help           Print usage.
  *
@@ -49,13 +71,17 @@
  *        {
  *          "ignoreValues":   ["exact string value to never flag", ...],
  *          "ignoreKeys":     ["dotted.leaf.key.path", "comp:Foo^Bar", ...],
- *          "ignoreSegments": ["Description", "Tooltip", ...]   // CHECK 2 only
+ *          "ignoreSegments": ["Description", "Tooltip", ...],  // CHECK 2 only
+ *          "ignoreNouns":    ["GitHub", "TensorBoard", ...]    // CHECK 3 only
  *        }
- *      Missing file => empty allowlist (no effect).
+ *      Missing file => empty allowlist (no effect). `ignoreNouns` entries are
+ *      matched case-insensitively against CHECK 3 candidate phrases (whole phrase
+ *      or as a contained multiword sub-phrase); seed it with known proper nouns
+ *      / product names that are not termbase concepts.
  *   2. An inline marker inside a VALUE: appending the literal token
  *      `[[i18n-term-ok]]` anywhere in a string value tells CHECK 1 to skip that
- *      value. (Used only when the canonical termbase genuinely cannot model the
- *      exception — prefer the allowlist file.)
+ *      value. (CHECK 3 honors the same marker.) Used only when the canonical
+ *      termbase genuinely cannot model the exception — prefer the allowlist file.
  *
  * Dependency-free: native Node ESM only. No npm package is imported. The output
  * JSON files (terminology.json, allowlist) are read with fs + JSON.parse — no
@@ -543,6 +569,258 @@ function runCheck2(stores, allow) {
 }
 
 // ---------------------------------------------------------------------------
+// CHECK 3 — unknown capitalized user-facing noun (candidate new term)
+//
+// Heuristic, report-only. For each ENGLISH prose VALUE, mine embedded Title-Case
+// multiword phrases and PascalCase product tokens that are NOT already a termbase
+// concept (preferred.en), NOT an avoid[] term, NOT an approved compound, and NOT
+// allowlisted (ignoreNouns). Emit a WARN suggesting the term be registered.
+//
+// Conservative by construction (see the header CHECK 3 note):
+//   - English only (store.lang === 'en'); the termbase preferred.en is English.
+//   - Prose only: a value must read like a sentence (>= 5 words, >= 3 lowercase
+//     words). Short labels / button microcopy ("Created At", "Start Service")
+//     are NOT mined — they are UI text, not candidate concepts.
+//   - Leading imperative verbs / sentence-lead words are peeled so an
+//     instruction like "Press Enter to confirm" does not surface "Press Enter".
+//   - isInsideCodeContext() skips identifiers / URLs / interpolation / backticks.
+// ---------------------------------------------------------------------------
+
+// Imperative / function verbs that lead UI labels and instructions — when one of
+// these starts a candidate phrase it is an action, not a noun concept.
+const CHECK3_LABEL_VERBS = new Set(
+  (
+    "add edit delete remove create update save cancel close open select choose " +
+    "set get start stop run view show hide upload download import export copy " +
+    "move rename clear reset apply submit confirm press click manage refresh " +
+    "reload restart launch connect disconnect install login logout register " +
+    "sign use change modify configure assign revoke grant deny allow check " +
+    "uncheck skip retry continue finish complete send receive request approve " +
+    "reject accept decline mount unmount attach detach pull push build deploy " +
+    "scale terminate purge restore archive duplicate generate validate verify " +
+    "enable disable provide requires require shutdown imported invalid"
+  ).split(/\s+/),
+);
+
+// Sentence-lead / function words that, capitalized at a sentence start, are not
+// the head of a term (peeled before evaluating a sentence-initial phrase).
+const CHECK3_SENTENCE_LEAD = new Set(
+  (
+    "the a an this that these those there here it you your we our please if when " +
+    "while after before once now then also and or but so to for of in on at by " +
+    "with from into as is are be can will would should could may might must not " +
+    "no yes all none some any each every other another same more less most least new"
+  ).split(/\s+/),
+);
+
+/**
+ * Does the value read like prose (a sentence) rather than a short label? Only
+ * prose values are mined for embedded candidate terms.
+ * @param {string} v
+ */
+function check3LooksLikeProse(v) {
+  const words = v.match(/[A-Za-z][A-Za-z'-]*/g) || [];
+  if (words.length < 5) return false;
+  const lower = words.filter((w) => /^[a-z]/.test(w)).length;
+  return lower >= 3;
+}
+
+/**
+ * Extract candidate phrases from a value:
+ *   - PascalCase single tokens with >= 2 humps (TensorBoard, FastTrack).
+ *   - Runs of >= 2 adjacent Title-Case words ("Resource Preset"), where adjacency
+ *     means separated by exactly one space (so a comma/period breaks the run).
+ * Each candidate carries whether it begins a sentence (so leading verbs / lead
+ * words can be peeled). Matches inside code context are dropped here.
+ * @param {string} value
+ */
+function check3FindCandidates(value) {
+  /** @type {Array<{text:string,start:number,end:number,kind:string,words?:string[],sentenceInitial?:boolean}>} */
+  const cands = [];
+
+  const pascalRe = /\b(?:[A-Z][a-z0-9]+){2,}\b/g;
+  let m;
+  while ((m = pascalRe.exec(value)) !== null) {
+    if (m[0].length === 0) {
+      pascalRe.lastIndex++;
+      continue;
+    }
+    const start = m.index;
+    const end = start + m[0].length;
+    if (isInsideCodeContext(value, start, end)) continue;
+    cands.push({ text: m[0], start, end, kind: "pascal" });
+  }
+
+  const wordRe = /[A-Za-z][A-Za-z'’-]*/g;
+  /** @type {Array<{text:string,start:number,end:number}>} */
+  const words = [];
+  let w;
+  while ((w = wordRe.exec(value)) !== null) {
+    words.push({ text: w[0], start: w.index, end: w.index + w[0].length });
+  }
+  let i = 0;
+  while (i < words.length) {
+    if (/^[A-Z][a-z]/.test(words[i].text)) {
+      let j = i;
+      while (
+        j + 1 < words.length &&
+        /^[A-Z][a-z]/.test(words[j + 1].text) &&
+        words[j + 1].start === words[j].end + 1 // exactly one space between
+      ) {
+        j++;
+      }
+      if (j > i) {
+        const start = words[i].start;
+        const end = words[j].end;
+        if (!isInsideCodeContext(value, start, end)) {
+          const prevChar =
+            start > 0 ? value.slice(0, start).trimEnd().slice(-1) : "";
+          const sentenceInitial = start === 0 || /[.!?:]/.test(prevChar);
+          cands.push({
+            text: value.slice(start, end),
+            start,
+            end,
+            kind: "phrase",
+            words: words.slice(i, j + 1).map((x) => x.text),
+            sentenceInitial,
+          });
+        }
+      }
+      i = j + 1;
+    } else {
+      i++;
+    }
+  }
+  return cands;
+}
+
+/**
+ * Build the set of phrases CHECK 3 treats as "already known" (lowercased): every
+ * termbase preferred.* value and avoid/useInstead term (split on , and /), plus
+ * the approved compounds, plus the allowlist ignoreNouns. A candidate is known
+ * if it equals a known phrase, or if a multiword known phrase contains it / it
+ * contains a multiword known phrase (so "Resource Preset Settings" is covered by
+ * a known "resource preset").
+ * @param {any} termbase
+ * @param {Set<string>} approvedCompounds
+ * @param {Set<string>} ignoreNouns lowercased allowlist nouns
+ */
+function buildCheck3Known(termbase, approvedCompounds, ignoreNouns) {
+  const known = new Set();
+  const add = (s) => {
+    if (typeof s !== "string") return;
+    for (const part of s.split(/[,/]/)) {
+      const norm = part.trim().toLowerCase().replace(/\s+/g, " ");
+      if (norm) known.add(norm);
+    }
+  };
+  if (termbase && Array.isArray(termbase.concepts)) {
+    for (const concept of termbase.concepts) {
+      if (concept && concept.preferred) {
+        for (const v of Object.values(concept.preferred)) add(v);
+      }
+    }
+  }
+  if (termbase && Array.isArray(termbase.avoid)) {
+    for (const row of termbase.avoid) {
+      add(row && row.avoid);
+      add(row && row.useInstead);
+    }
+  }
+  for (const p of approvedCompounds) known.add(p);
+  for (const n of ignoreNouns) known.add(n);
+  return known;
+}
+
+/**
+ * @param {string} phrase
+ * @param {Set<string>} known lowercased known phrases
+ */
+function check3IsKnown(phrase, known) {
+  const low = phrase.toLowerCase();
+  if (known.has(low)) return true;
+  for (const k of known) {
+    if (!k.includes(" ")) continue; // single tokens compared by exact match only
+    if (low.includes(k)) return true;
+    if (k.includes(low) && low.includes(" ")) return true;
+  }
+  return false;
+}
+
+/**
+ * @param {Array<{file:string,label:string,lang:string,leaves:Array<{key:string,segment:string,value:string}>}>} stores
+ * @param {Set<string>} known lowercased known phrases (preferred + avoid + compounds + ignoreNouns)
+ */
+function runCheck3(stores, known) {
+  /** phrase(lowercased) -> finding */
+  /** @type {Map<string, any>} */
+  const byPhrase = new Map();
+
+  for (const store of stores) {
+    // English only: the termbase preferred.en is the comparison key.
+    if (store.lang !== "en") continue;
+    for (const leaf of store.leaves) {
+      const value = leaf.value;
+      if (value.includes(INLINE_OK_MARKER)) continue;
+      if (!check3LooksLikeProse(value)) continue;
+
+      for (const cand of check3FindCandidates(value)) {
+        let text = cand.text;
+        if (cand.kind === "phrase") {
+          const phraseWords = cand.words.slice();
+          if (cand.sentenceInitial) {
+            // Peel leading sentence-lead / imperative words at a sentence start.
+            while (
+              phraseWords.length > 1 &&
+              (CHECK3_SENTENCE_LEAD.has(phraseWords[0].toLowerCase()) ||
+                CHECK3_LABEL_VERBS.has(phraseWords[0].toLowerCase()))
+            ) {
+              phraseWords.shift();
+            }
+          }
+          // An imperative verb still leading the phrase => it is an action label.
+          if (
+            phraseWords.length >= 1 &&
+            CHECK3_LABEL_VERBS.has(phraseWords[0].toLowerCase())
+          ) {
+            continue;
+          }
+          if (phraseWords.length < 2) continue; // need a multiword phrase
+          text = phraseWords.join(" ");
+        }
+        if (check3IsKnown(text, known)) continue;
+
+        const lowKey = text.toLowerCase();
+        let finding = byPhrase.get(lowKey);
+        if (!finding) {
+          finding = {
+            check: "unknown-noun",
+            severity: "report", // always report-only; never affects exit code
+            kind: cand.kind,
+            term: text,
+            occurrences: 0,
+            file: store.file,
+            fileLabel: store.label,
+            lang: store.lang,
+            sampleKey: leaf.key,
+            sampleValue: value,
+          };
+          byPhrase.set(lowKey, finding);
+        }
+        finding.occurrences++;
+      }
+    }
+  }
+
+  const findings = [...byPhrase.values()];
+  // Highest-signal first: most occurrences, then alphabetical for determinism.
+  findings.sort(
+    (a, b) => b.occurrences - a.occurrences || a.term.localeCompare(b.term),
+  );
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
 // Reporting
 // ---------------------------------------------------------------------------
 
@@ -551,7 +829,7 @@ function shorten(s, n = 120) {
   return s.slice(0, n - 1) + "…";
 }
 
-function printTextReport(check1, check2, opts) {
+function printTextReport(check1, check2, check3, opts) {
   const errorCount = check1.filter((f) => f.severity === "error").length;
   const warnCount = check1.filter((f) => f.severity === "warn").length;
 
@@ -638,6 +916,36 @@ function printTextReport(check1, check2, opts) {
     console.log("");
   }
 
+  if (opts.runCheck3) {
+    console.log(
+      c.bold(
+        "CHECK 3 — unknown capitalized user-facing noun (report-only, candidate terms)",
+      ),
+    );
+    if (check3.length === 0) {
+      console.log(c.dim("  no unregistered capitalized nouns found in prose."));
+    } else {
+      for (const f of check3) {
+        const occ = f.occurrences > 1 ? c.dim(` (×${f.occurrences})`) : "";
+        console.log(
+          `  ${c.yellow("warn ")} [${f.fileLabel}/${f.lang}] ${c.cyan(
+            f.term,
+          )}${occ} — no terminology.json entry; add one (with decidingFR) or allowlist it (ignoreNouns)`,
+        );
+        console.log(
+          `        e.g. ${f.sampleKey}: ${shorten(f.sampleValue, 100)}`,
+        );
+      }
+    }
+    console.log("");
+    console.log(
+      c.dim(
+        `  CHECK 3 summary: ${check3.length} candidate noun(s) (report-only; never blocks).`,
+      ),
+    );
+    console.log("");
+  }
+
   console.log(c.bold("=== TERMINOLOGY SUMMARY ==="));
   console.log(
     `  blocking terminology findings: ${errorCount}` +
@@ -645,6 +953,7 @@ function printTextReport(check1, check2, opts) {
   );
   console.log(`  warn-only terminology findings: ${warnCount}`);
   console.log(`  key-divergence findings (report): ${check2.length}`);
+  console.log(`  unknown-noun findings (report): ${check3.length}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -661,6 +970,10 @@ function parseArgs(argv) {
     // e.g. ModifiedAt -> "Modificado en" / "Modificado el"). Opt in with
     // --check2. Refining it into a high-signal check is tracked as a follow-up.
     runCheck2: false,
+    // CHECK 3 (unknown capitalized user-facing noun) is OFF by default: it is a
+    // heuristic candidate-term suggester. Opt in with --check3. It is always
+    // report-only and never affects the exit code (mirrors CHECK 2's gating).
+    runCheck3: false,
     help: false,
     // 0 = unlimited. --summary sets a sane default cap on CHECK 2 output so the
     // verify.sh harness stays readable; the full list is always available via
@@ -704,6 +1017,12 @@ function parseArgs(argv) {
       case "--no-check2":
         opts.runCheck2 = false;
         break;
+      case "--check3":
+        opts.runCheck3 = true;
+        break;
+      case "--no-check3":
+        opts.runCheck3 = false;
+        break;
       case "--no-check1":
         opts.runCheck1 = false;
         break;
@@ -723,12 +1042,13 @@ const USAGE = `check-terminology-i18n.mjs — deterministic i18n terminology che
 Usage:
   node scripts/check-terminology-i18n.mjs [--warn|--strict] [--json] [--summary]
                                           [--limit-check2=N] [--lang=en,ko]
-                                          [--no-check1] [--check2]
+                                          [--no-check1] [--check2] [--check3]
 
 Modes:
   (default) / --warn   Report findings, always exit 0.
   --strict             Exit non-zero when there are blocking (error-severity)
-                       CHECK 1 findings. CHECK 2 is always report-only.
+                       CHECK 1 findings. CHECK 2 and CHECK 3 are always
+                       report-only and never affect the exit code.
 
 Options:
   --summary            Cap CHECK 2 output at the top 20 highest-signal findings
@@ -737,14 +1057,22 @@ Options:
   --lang=en,ko         Restrict scanning to these locale files only.
   --json               Machine-readable output (always full, never capped).
   --check2             Enable CHECK 2 (OFF by default — broad/noisy today).
+  --check3             Enable CHECK 3 (OFF by default — heuristic candidate-term
+                       suggester; English prose only; always report-only).
   --no-check1          Skip CHECK 1 (terminology drift).
 
 CHECK 1  Terminology drift: i18n VALUES (never keys) vs terminology.json avoid[].
 CHECK 2  Key -> two-values divergence within each file (no termbase needed).
          OFF by default; enable with --check2. Currently low signal-to-noise.
+CHECK 3  Unknown capitalized user-facing noun: a Title-Case multiword phrase or
+         PascalCase product token in an English prose i18n VALUE with no matching
+         terminology.json concept / avoid term — a candidate to register in the
+         termbase. OFF by default; enable with --check3. WARN/report-only.
 
 Allowlist: scripts/terminology-i18n.allowlist.json (optional)
-Inline marker: append ${INLINE_OK_MARKER} to a value to skip it in CHECK 1.
+  ignoreNouns: phrases CHECK 3 must never flag (proper nouns, product names).
+Inline marker: append ${INLINE_OK_MARKER} to a value to skip it in CHECK 1
+  (CHECK 3 honors the same marker).
 `;
 
 function main() {
@@ -783,6 +1111,13 @@ function main() {
     ignoreSegments: new Set(
       Array.isArray(allowRaw.ignoreSegments) ? allowRaw.ignoreSegments : [],
     ),
+    // CHECK 3 only: lowercased phrases never flagged as candidate nouns.
+    ignoreNouns: new Set(
+      (Array.isArray(allowRaw.ignoreNouns) ? allowRaw.ignoreNouns : [])
+        .filter((s) => typeof s === "string")
+        .map((s) => s.trim().toLowerCase().replace(/\s+/g, " "))
+        .filter(Boolean),
+    ),
   };
 
   // Build the flat list of stores (one per locale file), collecting leaves.
@@ -811,6 +1146,15 @@ function main() {
     ? runCheck1(stores, avoidRows, allow, approvedCompounds)
     : [];
   const check2 = opts.runCheck2 ? runCheck2(stores, allow) : [];
+  // CHECK 3 needs the termbase (preferred.en) to know what is already "known".
+  // If the termbase failed to load, skip CHECK 3 rather than flag everything.
+  const check3 =
+    opts.runCheck3 && termbase
+      ? runCheck3(
+          stores,
+          buildCheck3Known(termbase, approvedCompounds, allow.ignoreNouns),
+        )
+      : [];
 
   if (opts.json) {
     const errorCount = check1.filter((f) => f.severity === "error").length;
@@ -823,20 +1167,22 @@ function main() {
             blocking: errorCount,
             warn: warnCount,
             keyDivergence: check2.length,
+            unknownNoun: check3.length,
           },
           check1,
           check2,
+          check3,
         },
         null,
         2,
       ) + "\n",
     );
   } else {
-    printTextReport(check1, check2, opts);
+    printTextReport(check1, check2, check3, opts);
   }
 
   const blocking = check1.filter((f) => f.severity === "error").length;
-  // CHECK 2 is always report-only and NEVER affects the exit code.
+  // CHECK 2 and CHECK 3 are always report-only and NEVER affect the exit code.
   if (opts.strict && blocking > 0) return 1;
   return 0;
 }

--- a/scripts/terminology-i18n.allowlist.json
+++ b/scripts/terminology-i18n.allowlist.json
@@ -1,6 +1,26 @@
 {
-  "$comment": "Allowlist for scripts/check-terminology-i18n.mjs. Read-only checker; this file only suppresses known-legitimate findings so a false positive never hard-blocks a valid PR. ignoreValues: exact VALUE strings never flagged by CHECK 1. ignoreKeys: leaf key paths (dotted for resources/i18n, '^'-joined for backend.ai-ui, e.g. 'comp:Foo^Bar') never flagged by CHECK 1. ignoreSegments: final key segments excluded from CHECK 2 divergence reporting. Prefer fixing the string or the termbase over adding entries here.",
+  "$comment": "Allowlist for scripts/check-terminology-i18n.mjs. Read-only checker; this file only suppresses known-legitimate findings so a false positive never hard-blocks a valid PR. ignoreValues: exact VALUE strings never flagged by CHECK 1. ignoreKeys: leaf key paths (dotted for resources/i18n, '^'-joined for backend.ai-ui, e.g. 'comp:Foo^Bar') never flagged by CHECK 1. ignoreSegments: final key segments excluded from CHECK 2 divergence reporting. ignoreNouns: capitalized phrases / PascalCase tokens (proper nouns, product names, third-party tools) that CHECK 3 must never surface as candidate new terms — matched case-insensitively as the whole phrase or a contained multiword sub-phrase. Prefer registering a real term in terminology.json, or fixing the string, over adding entries here.",
   "ignoreValues": [],
   "ignoreKeys": ["information.DescLicensee"],
-  "ignoreSegments": []
+  "ignoreSegments": [],
+  "ignoreNouns": [
+    "Backend.AI",
+    "About Backend",
+    "GitHub",
+    "GitLab",
+    "Hugging Face",
+    "TensorBoard",
+    "TensorFlow",
+    "PyTorch",
+    "Visual Studio Code",
+    "WebSocket",
+    "Ant Design",
+    "Google Cloud",
+    "FastTrack",
+    "Central Processing Unit",
+    "Remote Desktop",
+    "File Explorer",
+    "Internal Server Error",
+    "Service Unavailable"
+  ]
 }


### PR DESCRIPTION
Resolves #7740 (FR-3052)

Builds on **FR-3048** (#7737, merged) — the machine-readable `terminology.json` single source of truth + i18n terminology checker.

## What

Extends the FR-3048 termbase from *nouns only* to a full **terminology-governance** layer covering verbs, candidate-term detection, and the human process around both. Three tightly-coupled deliverables shipped as one PR (the governance prose references the verb-list rename flow and the new checker capability, so splitting them would create dangling references).

### 1. Approved verbs (`verbs[]`)
- New top-level `verbs[]` array in `terminology.json` (8 entries: cancel, delete, remove, terminate, stop, inactivate→Deactivate, purge, hide), each context-qualified: `id`, `intent` (enum, all 8 covered exactly once), `context`, `preferred.en`, per-entry `avoid[]` of rejected synonyms, doc-only `reversible`, and `decidingFR`.
- Chosen as a **new array** — not `avoid[]` rows (CHECK 1 whole-word-matches every i18n value and would fire on every Delete/Remove/Stop label) and not a sibling `verbs.json` (would double the schema/generator/drift surface).
- `terminology.schema.json` gains a `verbs` property + `verbEntry` definition (`verbs` intentionally **not** in root `required` → backward-compatible).
- `generate-terminology.mjs` renders an `## Approved Verbs` table into `TERMINOLOGY.md`, gated on `terminology:auto:verbs` markers. Round-trips idempotently (`--check` green).

### 2. Unknown-term checker (CHECK 3)
- `check-terminology-i18n.mjs` gains **CHECK 3** — flags capitalized user-facing nouns in i18n values not yet in the termbase (candidate new terms).
- **OFF by default**, opt-in via `--check3` (mirrors `--check2`). **Always report-only** — every finding carries `severity:"report"` and provably cannot reach the `--strict` exit gate (which derives `blocking` from CHECK 1 error-severity only). `--strict --check3` exits 0.
- `verify.sh` and `pnpm run lint:terminology` do **not** pass `--check3` → the CI harness stays clean.
- New `ignoreNouns` allowlist in `terminology-i18n.allowlist.json` for known proper nouns / product names.

### 3. Governance docs (lexical, not behavioral)
- `TERMINOLOGY.md`: `## Precedence` (live UI label > `terminology.json` > style guide), `## Governance` (Term Owner of Record = docs-lead, New-Term Gate built on CHECK 3's unknown-term report), and `## Rename / Deprecation Checklist` (atomic rename flow the verb list assumes). All prose lives **outside** the `terminology:auto:*` markers → generator `--check` stays green.
- `AGENTS.md`: new `### Terminology Precedence` subsection. (`CLAUDE.md` is a symlink to `AGENTS.md`, so only `AGENTS.md` is edited.)

## Scope guards
- **No new dependency** — no `package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml` changes; both scripts import only `node:` builtins.
- **Lexical, not behavioral** — the approved-verb list governs *wording*, not destructive-confirmation UX (encoded in the schema descriptions, a `:::warning[Lexical, not behavioral]` admonition, and per-entry descriptions).
- **Per-locale verb forms out of scope for v1** (the destructive-confirmation UX is language-agnostic).

## Verification
- `node packages/backend.ai-webui-docs/scripts/generate-terminology.mjs --check` → in sync (exit 0).
- `node scripts/check-terminology-i18n.mjs --warn` → unknown-noun **0** (CHECK 3 off by default); `--check3` → **25** report-only candidates; `--strict --check3` exits 0.
- `bash scripts/verify.sh` → **`=== ALL PASS ===`** (terminology step warn-only: 1 pre-existing CHECK 1 warn).

## Follow-ups (not in this PR)
- Triage the ~13 genuine CHECK 3 candidates (Fair Share Scheduler, Rate Limit, Resource Policy, Model Store, …) into `terminology.json` `concepts`, then promote CHECK 3 toward a default warn — tracked separately.
- FR-3050 (CHECK 2 redesign), FR-3051 (ko/ja/th drift), FR-3049 (flip gate to blocking) build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
