### PR TITLE
fix(FR-3026): move applying-revision alert inside current-revision tab

### DIFF
--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -38,6 +38,7 @@ import {
   Skeleton,
   Space,
   Typography,
+  theme,
 } from 'antd';
 import {
   BAIButton,
@@ -241,6 +242,7 @@ const DeploymentConfigurationSection: React.FC<
   'use memo';
 
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const webuiNavigate = useWebUINavigate();
@@ -460,32 +462,6 @@ const DeploymentConfigurationSection: React.FC<
           }
         />
       </BAICard>
-      {isDeployingDifferentRevision && (
-        <Alert
-          type="info"
-          icon={<LoadingOutlined spin />}
-          showIcon
-          title={t('deployment.ApplyingRevision', {
-            revisionNumber:
-              deployingRevision.revisionNumber != null
-                ? `#${deployingRevision.revisionNumber}`
-                : (toLocalId(deployingRevision.id) ?? ''),
-          })}
-          action={
-            <Button
-              onClick={() =>
-                handleShowRevisionDrawer(
-                  deployingRevision,
-                  'deploying',
-                  t('deployment.ApplyingRevisionDetail'),
-                )
-              }
-            >
-              {t('deployment.ViewRevision')}
-            </Button>
-          }
-        />
-      )}
       <BAICard
         ref={revisionCardRef}
         activeTabKey={activeRevisionTab}
@@ -529,6 +505,33 @@ const DeploymentConfigurationSection: React.FC<
       >
         {activeRevisionTab === 'currentRevision' && (
           <>
+            {isDeployingDifferentRevision && (
+              <Alert
+                type="info"
+                icon={<LoadingOutlined spin />}
+                showIcon
+                style={{ marginBottom: token.marginMD }}
+                title={t('deployment.ApplyingRevision', {
+                  revisionNumber:
+                    deployingRevision.revisionNumber != null
+                      ? `#${deployingRevision.revisionNumber}`
+                      : (toLocalId(deployingRevision.id) ?? ''),
+                })}
+                action={
+                  <Button
+                    onClick={() =>
+                      handleShowRevisionDrawer(
+                        deployingRevision,
+                        'deploying',
+                        t('deployment.ApplyingRevisionDetail'),
+                      )
+                    }
+                  >
+                    {t('deployment.ViewRevision')}
+                  </Button>
+                }
+              />
+            )}
             {currentRevision ? (
               <DeploymentRevisionDetail
                 revisionFrgmt={currentRevision}


### PR DESCRIPTION
Part of #7702 (FR-3026)

## Summary

- Fixes a regression introduced by the FR-3026 stack where the `deployment.ApplyingRevision` alert was rendered between the overview `BAICard` and the revision tabs `BAICard`, instead of inside the **Current Revision** tab content
- The fix (#7671) that moved the alert inside the tab was merged to `main`, but the FR-3026 stack had diverged from that point and the alert reverted to between the cards
- Moves the alert back inside the `currentRevision` tab block, with `marginBottom: token.marginMD` spacing, matching the `main` branch behavior

## Test plan

- [ ] On a deployment where a different revision is being applied, verify the `ApplyingRevision` alert appears inside the **Current Revision** tab (not above the tab card)
- [ ] Verify the alert is absent when on the **Revision History** tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)