### PR TITLE
feat(FR-3055): encode current project and scope into the URL routing scheme

### DIFF
--- a/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
+++ b/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
@@ -3,11 +3,13 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { BAIComputeSessionNodeNotificationItemFragment$key } from '../__generated__/BAIComputeSessionNodeNotificationItemFragment.graphql';
+import { buildPath } from '../helper/pathBuilder';
 import { useWebUINavigate } from '../hooks';
 import {
   NotificationState,
   useSetBAINotification,
 } from '../hooks/useBAINotification';
+import { useActiveProjectName } from '../hooks/useRouteScope';
 import SessionActionButtons, {
   PrimaryAppOption,
 } from './ComputeSessionNodeItems/SessionActionButtons';
@@ -41,6 +43,7 @@ const BAIComputeSessionNodeNotificationItem: React.FC<
   const { t } = useTranslation();
   const navigate = useWebUINavigate();
   const { token } = theme.useToken();
+  const activeProjectName = useActiveProjectName();
   const node = useFragment(
     graphql`
       fragment BAIComputeSessionNodeNotificationItemFragment on ComputeSessionNode {
@@ -94,7 +97,7 @@ const BAIComputeSessionNodeNotificationItem: React.FC<
                 title={node.name || ''}
                 onClick={() => {
                   navigate(
-                    `/session${node.id ? `?${new URLSearchParams({ sessionDetail: toLocalId(node.id) }).toString()}` : ''}`,
+                    `${buildPath('project', 'session', activeProjectName)}${node.id ? `?${new URLSearchParams({ sessionDetail: toLocalId(node.id) }).toString()}` : ''}`,
                   );
                   closeNotification(notification.key);
                 }}

--- a/react/src/components/Chat/ChatHeader.tsx
+++ b/react/src/components/Chat/ChatHeader.tsx
@@ -6,6 +6,7 @@ import { ChatHeader_Endpoint$key } from '../../__generated__/ChatHeader_Endpoint
 import { useWebUINavigate } from '../../hooks';
 import { AIAgent, useAIAgent } from '../../hooks/useAIAgent';
 import { useBAISettingUserState } from '../../hooks/useBAISetting';
+import { useProjectPath } from '../../hooks/useRouteScope';
 import AIAgentSelect from './AIAgentSelect';
 import type { ChatModel, ChatParameters } from './ChatModel';
 import { ChatParametersSliders } from './ChatParametersSliders';
@@ -112,6 +113,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const [isPendingEndpointTransition, startEndpointTransition] =
     useTransition();
@@ -135,7 +137,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
       icon: <ScaleIcon />,
       onClick: () => {
         webuiNavigate({
-          pathname: '/serving',
+          pathname: buildProjectPath('deployments'),
           search: new URLSearchParams({
             tab: 'chatting',
             endpointId: endpoint?.endpoint_id ?? '',

--- a/react/src/components/Chat/ChatHistory.ts
+++ b/react/src/components/Chat/ChatHistory.ts
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useWebUINavigate } from '../../hooks';
+import { useProjectPath } from '../../hooks/useRouteScope';
 import {
   DEFAULT_CHAT_PARAMETERS,
   type ChatData,
@@ -92,6 +93,7 @@ export function useHistory(id: string, provider: ChatProviderData) {
   const [history, setHistory] = useState<ChatHistoryData[]>([]);
   const [chat, setChat] = useState<ChatHistoryData | undefined>(undefined);
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const removeHistory = useCallback((id: string) => {
     chatHistoryCache.delete(id);
@@ -131,13 +133,13 @@ export function useHistory(id: string, provider: ChatProviderData) {
 
       if (!getChatById(id)) {
         updateHistory({ ...chat });
-        webuiNavigate(`/chat/${chat.id}`, { replace: true });
+        webuiNavigate(buildProjectPath(`chat/${chat.id}`), { replace: true });
         return;
       }
 
       updateHistory({ ...chat });
     },
-    [chat, webuiNavigate, updateHistory, logger],
+    [chat, webuiNavigate, buildProjectPath, updateHistory, logger],
   );
 
   const removeChatData = useCallback(
@@ -183,10 +185,10 @@ export function useHistory(id: string, provider: ChatProviderData) {
         updateHistory(currentChat);
       } else {
         updateHistory({ ...chat });
-        webuiNavigate(`/chat/${chat.id}`, { replace: true });
+        webuiNavigate(buildProjectPath(`chat/${chat.id}`), { replace: true });
       }
     },
-    [chat, updateHistory, webuiNavigate, logger],
+    [chat, updateHistory, webuiNavigate, buildProjectPath, logger],
   );
 
   const saveChatMessage = useCallback(
@@ -246,10 +248,10 @@ export function useHistory(id: string, provider: ChatProviderData) {
         updateHistory(currentChat);
       } else {
         updateHistory({ ...chat });
-        webuiNavigate(`/chat/${chat.id}`, { replace: true });
+        webuiNavigate(buildProjectPath(`chat/${chat.id}`), { replace: true });
       }
     },
-    [chat, updateHistory, webuiNavigate, logger],
+    [chat, updateHistory, webuiNavigate, buildProjectPath, logger],
   );
 
   const clearChatMessage = useCallback(

--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -9,6 +9,7 @@ import {
 import { EndpointSelectValueQuery } from '../../__generated__/EndpointSelectValueQuery.graphql';
 import { useWebUINavigate } from '../../hooks';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import { useProjectPath } from '../../hooks/useRouteScope';
 import TotalFooter from '../TotalFooter';
 import { useControllableValue } from 'ahooks';
 import {
@@ -190,6 +191,7 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
   );
 
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const isValueMatched = searchStr === deferredSearchStr;
   useEffect(() => {
@@ -258,7 +260,9 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
               icon={<InfoIcon />}
               disabled={!controllableValue}
               onClick={() => {
-                webuiNavigate(`/serving/${controllableValue}`);
+                webuiNavigate(
+                  buildProjectPath(`deployments/${controllableValue}`),
+                );
               }}
             />
           </Tooltip>

--- a/react/src/components/DeploymentBasicInfoCard.tsx
+++ b/react/src/components/DeploymentBasicInfoCard.tsx
@@ -8,7 +8,9 @@ import type {
   DeploymentBasicInfoCard_deployment$key,
 } from '../__generated__/DeploymentBasicInfoCard_deployment.graphql';
 import { DeploymentSchedulingHistoryModalQuery } from '../__generated__/DeploymentSchedulingHistoryModalQuery.graphql';
+import { buildPath } from '../helper/pathBuilder';
 import { useWebUINavigate } from '../hooks';
+import { useActiveProjectName, useRouteScope } from '../hooks/useRouteScope';
 import DeploymentSchedulingHistoryModal, {
   DeploymentSchedulingHistoryQuery,
 } from './DeploymentSchedulingHistoryModal';
@@ -46,7 +48,6 @@ import { SquarePenIcon } from 'lucide-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation, useQueryLoader } from 'react-relay';
-import { useLocation } from 'react-router-dom';
 
 interface DeploymentBasicInfoCardProps {
   deploymentFrgmt: DeploymentBasicInfoCard_deployment$key | null;
@@ -81,7 +82,8 @@ const DeploymentOverviewContent: React.FC<{
   'use memo';
   const { t } = useTranslation();
   const webuiNavigate = useWebUINavigate();
-  const location = useLocation();
+  const routeScope = useRouteScope();
+  const activeProjectName = useActiveProjectName();
 
   const projectName =
     deployment?.metadata.projectV2?.basicInfo?.name ??
@@ -183,17 +185,16 @@ const DeploymentOverviewContent: React.FC<{
           metadataFrgmt={deployment?.metadata ?? null}
           onTagClick={(tag) => {
             // Stay within the same deployment-list URL space the user came
-            // from (`/admin-deployments`, `/project-admin-deployments`, or
-            // the user-facing `/deployments`) so breadcrumb / back navigation
-            // remain coherent — see FR-2847 (admin) and FR-2930 (project
-            // admin) for the per-scope detail-route precedent.
-            const targetPathname = location.pathname.startsWith(
-              '/admin-deployments',
-            )
-              ? '/admin-deployments'
-              : location.pathname.startsWith('/project-admin-deployments')
-                ? '/project-admin-deployments'
-                : '/deployments';
+            // from (admin / project-admin / user `deployments`) so breadcrumb /
+            // back navigation remain coherent — see FR-2847 (admin) and
+            // FR-2930 (project admin) for the per-scope detail-route precedent.
+            // The current scope (from the route handle) plus the active project
+            // name yield the correct scope-aware list path via `buildPath`.
+            const targetPathname = buildPath(
+              routeScope,
+              'deployments',
+              activeProjectName,
+            );
             webuiNavigate({
               pathname: targetPathname,
               search: new URLSearchParams({
@@ -232,7 +233,8 @@ const DeploymentBasicInfoCard: React.FC<DeploymentBasicInfoCardProps> = ({
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const webuiNavigate = useWebUINavigate();
-  const location = useLocation();
+  const routeScope = useRouteScope();
+  const activeProjectName = useActiveProjectName();
 
   const deployment = useFragment(
     graphql`
@@ -291,11 +293,10 @@ const DeploymentBasicInfoCard: React.FC<DeploymentBasicInfoCardProps> = ({
   // Derive the stopped-category guard locally from this component's own
   // fragment status (rather than threading a boolean prop down from the page).
   const deploymentStatus = deployment?.metadata.status;
-  const listPath = location.pathname.startsWith('/admin-deployments')
-    ? '/admin-deployments'
-    : location.pathname.startsWith('/project-admin-deployments')
-      ? '/project-admin-deployments'
-      : '/deployments';
+  // Scope-aware deployment-list path for back navigation. The current route
+  // scope (admin / projectAdmin / project, from the route handle) plus the
+  // active project name produce the correct list URL via `buildPath`.
+  const listPath = buildPath(routeScope, 'deployments', activeProjectName);
 
   const handleDelete = () => {
     if (!deployment?.id) return;

--- a/react/src/components/DeploymentSettingModal.tsx
+++ b/react/src/components/DeploymentSettingModal.tsx
@@ -7,6 +7,7 @@ import { DeploymentSettingModalUpdateMutation } from '../__generated__/Deploymen
 import { DeploymentSettingModal_deployment$key } from '../__generated__/DeploymentSettingModal_deployment.graphql';
 import { useCurrentDomainValue, useWebUINavigate } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   App,
   Button,
@@ -56,6 +57,7 @@ const DeploymentSettingModal: React.FC<DeploymentSettingModalProps> = ({
   const { token } = theme.useToken();
   const [form] = Form.useForm<FormValues>();
   const navigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const { message } = App.useApp();
   const { id: projectId, name: projectName } = useCurrentProjectValue();
   const currentDomain = useCurrentDomainValue();
@@ -182,7 +184,7 @@ const DeploymentSettingModal: React.FC<DeploymentSettingModalProps> = ({
               const newId = toLocalId(createModelDeployment.deployment.id);
               message.success(t('deployment.DeploymentCreated'));
               onRequestClose(true);
-              navigate(`/deployments/${newId}`);
+              navigate(buildProjectPath(`deployments/${newId}`));
             },
             onError: (err) => {
               message.error(

--- a/react/src/components/FileBrowserButton.tsx
+++ b/react/src/components/FileBrowserButton.tsx
@@ -11,6 +11,7 @@ import {
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDefaultFileBrowserImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
 import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   StartSessionWithDefaultValue,
   useStartSession,
@@ -45,6 +46,7 @@ const FileBrowserButton: React.FC<FileBrowserButtonProps> = ({
   const { logger } = useBAILogger();
 
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
@@ -176,7 +178,7 @@ const FileBrowserButton: React.FC<FileBrowserButtonProps> = ({
                   params.set('formValues', JSON.stringify(launcherValue));
                   params.set('step', '4');
                   webuiNavigate({
-                    pathname: '/session/start',
+                    pathname: buildProjectPath('session/start'),
                     search: params.toString(),
                   });
                 },

--- a/react/src/components/FileBrowserButtonV2.tsx
+++ b/react/src/components/FileBrowserButtonV2.tsx
@@ -11,6 +11,7 @@ import {
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDefaultFileBrowserImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
 import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   StartSessionWithDefaultValue,
   useStartSession,
@@ -45,6 +46,7 @@ const FileBrowserButtonV2: React.FC<FileBrowserButtonV2Props> = ({
   const { logger } = useBAILogger();
 
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
@@ -176,7 +178,7 @@ const FileBrowserButtonV2: React.FC<FileBrowserButtonV2Props> = ({
                   params.set('formValues', JSON.stringify(launcherValue));
                   params.set('step', '4');
                   webuiNavigate({
-                    pathname: '/session/start',
+                    pathname: buildProjectPath('session/start'),
                     search: params.toString(),
                   });
                 },

--- a/react/src/components/ImportFromHuggingFaceModal.tsx
+++ b/react/src/components/ImportFromHuggingFaceModal.tsx
@@ -7,6 +7,7 @@ import { baiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useSuspenseTanQuery, useTanMutation } from '../hooks/reactQueryAlias';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   CloudUploadOutlined,
   FilterOutlined,
@@ -108,6 +109,7 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
     throw new Error('Project ID is required for ImportFromHuggingFaceModal');
   }
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const [isImportOnly, { toggle: toggleIsImportOnly }] = useToggle(false);
   const [huggingFaceURL, setHuggingFaceURL] = useState<string | undefined>();
   const [typedURL, setTypedURL] = useState<string>('');
@@ -430,7 +432,7 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
                       }
                       onClick={() => {
                         webuiNavigate({
-                          pathname: '/data',
+                          pathname: buildProjectPath('data'),
                           search: new URLSearchParams({
                             tab: 'model',
                             folder: importResult.folder.id,

--- a/react/src/components/ImportNotebookForm.tsx
+++ b/react/src/components/ImportNotebookForm.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   StartSessionWithDefaultValue,
   useStartSession,
@@ -66,6 +67,7 @@ const ImportNotebookForm: React.FC<ImportNotebookFormProps> = ({
   const { t } = useTranslation();
   const app = App.useApp();
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const baiClient = useSuspendedBackendaiClient();
   const { startSessionWithDefault, upsertSessionNotification } =
     useStartSession();
@@ -92,7 +94,7 @@ const ImportNotebookForm: React.FC<ImportNotebookFormProps> = ({
           } as PrimaryAppOption,
         },
       ]);
-      webuiNavigate('/session');
+      webuiNavigate(buildProjectPath('session'));
     }
 
     if (results?.rejected && results.rejected.length > 0) {
@@ -171,7 +173,7 @@ const ImportNotebookForm: React.FC<ImportNotebookFormProps> = ({
                       params.set('formValues', JSON.stringify(launcherValue));
                       params.set('step', '4');
                       webuiNavigate({
-                        pathname: '/session/start',
+                        pathname: buildProjectPath('session/start'),
                         search: params.toString(),
                       });
                     })

--- a/react/src/components/MainLayout/AdminScopeLayout.tsx
+++ b/react/src/components/MainLayout/AdminScopeLayout.tsx
@@ -1,0 +1,22 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+/**
+ * Layout element for the global `/admin/*` (system / superadmin) subtree.
+ *
+ * Intentionally thin: it only renders the matched child route via `<Outlet />`.
+ * It exists as the single injection point for future "system scope = no current
+ * project" handling (see plan §3.2 / §6 — deferred). Keeping it as a dedicated
+ * component (rather than inlining `element: <Outlet/>`) means that work can land
+ * here without another route-tree change.
+ */
+const AdminScopeLayout: React.FC = () => {
+  'use memo';
+  return <Outlet />;
+};
+
+export default AdminScopeLayout;

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -8,6 +8,7 @@ import { useBAISettingUserState } from '../../hooks/useBAISetting';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import { useLogoutEventListeners } from '../../hooks/useLogout';
 import usePrimaryColors from '../../hooks/usePrimaryColors';
+import { useCurrentMenuKey, useRouteScope } from '../../hooks/useRouteScope';
 import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
 import { useSetupWebUIPluginEffect } from '../../hooks/useWebUIPluginState';
 import Page401 from '../../pages/Page401';
@@ -37,7 +38,6 @@ import React, {
   Suspense,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -369,8 +369,14 @@ const AutoAdminPrimaryColorProvider = ({
   'use memo';
 
   const primaryColors = usePrimaryColors();
-  const { isSelectedAdminCategoryMenu } = useWebUIMenuItems();
-  if (isSelectedAdminCategoryMenu) {
+  // Apply the admin primary color on any non-project scope (global `admin` and
+  // `projectAdmin`). Derived from the matched route handle via `useRouteScope`
+  // rather than the role-filtered `isSelectedAdminCategoryMenu`, so the admin
+  // theming is driven by the URL scope itself — correct under the
+  // scope-prefixed routes and independent of which admin menu items the
+  // current user's role happens to surface.
+  const isAdminScope = useRouteScope() !== 'project';
+  if (isAdminScope) {
     return (
       <ConfigProvider
         theme={{
@@ -388,13 +394,20 @@ const AutoAdminPrimaryColorProvider = ({
 };
 
 const LayoutWithPageTestId: React.FC<LayoutProps> = (props) => {
+  'use memo';
   const location = useLocation();
-  const pageTest = useMemo(() => {
-    const cleanPath = location.pathname.replace(/^\//, '').replace(/\//g, '-');
-    return cleanPath ? `page-${cleanPath}` : 'page-root';
-    // `location` is from react-router useLocation() — pathname is reactive across navigations.
-    // react-doctor-disable-next-line react-doctor/no-mutable-in-deps
-  }, [location.pathname]);
+  // Prefer the scope-aware menu key (route handle) so the page test id stays
+  // stable across the scope-prefixed URLs (e.g. `/project/<name>/session` and
+  // `/admin/session` both yield `page-session` / `page-admin-session` rather
+  // than leaking the project name into the selector). Fall back to the cleaned
+  // pathname for routes without a feature handle (login utils, error, etc.).
+  const currentMenuKey = useCurrentMenuKey();
+  const cleanPath = location.pathname.replace(/^\//, '').replace(/\//g, '-');
+  const pageTest = currentMenuKey
+    ? `page-${currentMenuKey}`
+    : cleanPath
+      ? `page-${cleanPath}`
+      : 'page-root';
   return <Layout {...props} data-testid={pageTest} />;
 };
 

--- a/react/src/components/MainLayout/ProjectScopeLayout.tsx
+++ b/react/src/components/MainLayout/ProjectScopeLayout.tsx
@@ -1,0 +1,115 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { buildPath } from '../../helper/pathBuilder';
+import { useSuspendedBackendaiClient } from '../../hooks';
+import {
+  useCurrentProjectValue,
+  useSetCurrentProject,
+} from '../../hooks/useCurrentProject';
+import WebUINavigate from '../WebUINavigate';
+import { BAIAlert, BAIFlex } from 'backend.ai-ui';
+import React, { useEffect, useEffectEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Outlet, useParams } from 'react-router-dom';
+
+interface BackendAIClientGroups {
+  groups?: string[];
+  groupIds?: Record<string, string>;
+}
+
+/**
+ * Layout element for the `/project/:projectName/*` subtree (project + project
+ * admin scopes). It keeps the URL `:projectName` and the existing
+ * `currentProjectAtom` in sync, and guards against invalid / inaccessible
+ * project names.
+ *
+ * Resolution (render-time, no setState):
+ *   - `id = baiClient.groupIds[name]` (name -> uuid)
+ *   - membership = `baiClient.groups.includes(name)`
+ *
+ * If the URL project name is invalid (not a member, or no resolvable id), the
+ * layout redirects (replace) to a guaranteed-valid fallback project's session
+ * page rather than rendering with an undefined project id:
+ *   - fallback = current atom project name if the user is still a member of it,
+ *     otherwise `groups[0]`.
+ *   - if the user has NO groups at all, we cannot synthesize a `/project//...`
+ *     path, so we render the existing "no accessible projects" guidance.
+ *
+ * Sync (effect-only, idempotent):
+ *   - `setCurrentProject({ projectName, projectId })` runs in an effect keyed on
+ *     `[projectName]`, guarded so it only fires when the atom name differs from
+ *     the URL name. The body is wrapped in `useEffectEvent` so it reads the
+ *     latest resolved id / current value without widening the dep array (repo
+ *     convention `use-effect-event.md`).
+ */
+const ProjectScopeLayout: React.FC = () => {
+  'use memo';
+  const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
+  const { projectName: rawProjectName } = useParams<{ projectName: string }>();
+  const currentProject = useCurrentProjectValue();
+  const setCurrentProject = useSetCurrentProject();
+
+  // `useParams` already decodes percent-encoding; treat a missing param as ''.
+  const projectName = rawProjectName ?? '';
+
+  const clientGroups = baiClient as unknown as BackendAIClientGroups;
+  const groups = clientGroups.groups ?? [];
+  const groupIds = clientGroups.groupIds ?? {};
+
+  const isMember = groups.includes(projectName);
+  const resolvedId = groupIds[projectName];
+  const isValid = isMember && !!resolvedId;
+
+  // Effect-event reads the latest resolved id / current value; the surrounding
+  // effect only re-synchronizes when the URL project name changes.
+  const syncProject = useEffectEvent(() => {
+    if (!isValid) {
+      return;
+    }
+    if (currentProject.name !== projectName) {
+      setCurrentProject({ projectName, projectId: resolvedId });
+    }
+  });
+
+  useEffect(() => {
+    syncProject();
+  }, [projectName]);
+
+  if (!isValid) {
+    // No groups at all: cannot build a valid `/project/<name>/...` path. Show
+    // the same "no accessible projects" guidance used by the project selector
+    // rather than redirecting into an invalid empty-name URL.
+    if (groups.length === 0) {
+      return (
+        <BAIFlex direction="column" align="stretch" style={{ width: '100%' }}>
+          <BAIAlert
+            type="warning"
+            showIcon
+            description={t('projectSelect.NoAccessibleProjects')}
+          />
+        </BAIFlex>
+      );
+    }
+
+    // Invalid / inaccessible name: redirect to a guaranteed-valid fallback.
+    // Prefer the current atom project if the user is still a member of it,
+    // otherwise the first group.
+    const currentName = currentProject.name ?? '';
+    const fallbackName =
+      currentName && groups.includes(currentName) ? currentName : groups[0];
+
+    return (
+      <WebUINavigate
+        to={buildPath('project', 'session', fallbackName)}
+        replace
+      />
+    );
+  }
+
+  return <Outlet />;
+};
+
+export default ProjectScopeLayout;

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { buildPath, MENU_KEY_TO_SCOPE_FEATURE } from '../../helper/pathBuilder';
 import {
   useCurrentDomainValue,
   useSuspendedBackendaiClient,
@@ -15,6 +16,7 @@ import {
   useCurrentUserProjectRoles,
   useEffectiveAdminRole,
 } from '../../hooks/useCurrentUserProjectRoles';
+import { useCurrentMenuKey, useRouteScope } from '../../hooks/useRouteScope';
 import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
 import BAINotificationButton from '../BAINotificationButton';
 import LoginSessionExtendButton from '../LoginSessionExtendButton';
@@ -30,6 +32,7 @@ import { BAIFlex, BAIFlexProps } from 'backend.ai-ui';
 import { MenuIcon } from 'lucide-react';
 import { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 const useStyles = createStyles(({ css }) => ({
   webuiHeader: css`
@@ -56,7 +59,10 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
   const baiClient = useSuspendedBackendaiClient();
   const gridBreakpoint = Grid.useBreakpoint();
   const webuiNavigate = useWebUINavigate();
-  const { isSelectedAdminCategoryMenu, defaultMenuPath } = useWebUIMenuItems();
+  const location = useLocation();
+  const routeScope = useRouteScope();
+  const currentMenuKey = useCurrentMenuKey();
+  const { isSelectedAdminCategoryMenu } = useWebUIMenuItems();
   const effectiveAdminRole = useEffectiveAdminRole();
   const { projectAdminIds } = useCurrentUserProjectRoles();
   // Last visited general page — shared with WebUISider's "go back" button so
@@ -87,6 +93,46 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
     projectResourcePolicy: unknown;
   }) => {
     setOptimisticProjectId(projectInfo.projectId);
+
+    // On project / project-admin scope the URL owns the current project: stay
+    // on the exact same page and swap ONLY the project name, then let
+    // `ProjectScopeLayout` converge `currentProjectAtom` to the new URL. We
+    // deliberately do NOT call `setCurrentProject` here on these scopes, to
+    // avoid the atom being set twice (once here, once by the layout sync effect).
+    if (routeScope === 'project' || routeScope === 'projectAdmin') {
+      // Replace only the `:projectName` segment, preserving everything after it
+      // (e.g. `/session/start`, a detail `:id`) and the query string, so
+      // in-progress UI state survives — matching the legacy behavior where
+      // changing the project never navigated away (the session launcher form
+      // stays mounted with its contents intact).
+      const segments = location.pathname.split('/');
+      if (segments[1] === 'project' && segments.length > 2) {
+        segments[2] = encodeURIComponent(projectInfo.projectName);
+        startProjectChangedTransition(() => {
+          webuiNavigate(segments.join('/') + location.search);
+        });
+        return;
+      }
+      // Defensive fallback: reconstruct from the current feature key when the
+      // path is not under `/project/:projectName` for some reason.
+      const scopeFeature = currentMenuKey
+        ? MENU_KEY_TO_SCOPE_FEATURE[currentMenuKey]
+        : undefined;
+      const featureKey =
+        scopeFeature && scopeFeature.scope === routeScope
+          ? scopeFeature.featureKey
+          : 'session';
+      startProjectChangedTransition(() => {
+        webuiNavigate(
+          buildPath(routeScope, featureKey, projectInfo.projectName) +
+            location.search,
+        );
+      });
+      return;
+    }
+
+    // Admin (global) scope has no project-aware layout, so preserve today's
+    // behavior: update the atom directly without navigating.
     startProjectChangedTransition(() => {
       setCurrentProject(projectInfo);
     });
@@ -177,10 +223,40 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
                   cancelText: t('button.Cancel'),
                   onOk: () => {
                     setIsConfirmingProjectSwitch(false);
-                    applyProjectChange(projectInfo);
-                    // Exit admin mode by navigating to the last-visited
-                    // general page (or the default menu path as fallback).
-                    webuiNavigate(goBackPath || defaultMenuPath);
+                    setOptimisticProjectId(projectInfo.projectId);
+                    // Leaving admin mode: switch to the target project (atom)
+                    // and navigate to the last-visited general page, but rewrite
+                    // that page's project segment to the NEW project so the
+                    // project-scope layout doesn't immediately sync the atom
+                    // back to the old project's name.
+                    startProjectChangedTransition(() => {
+                      setCurrentProject(projectInfo);
+                    });
+                    // Return to the last-visited general page, preserving its
+                    // full sub-path (e.g. /session/start) and swapping ONLY the
+                    // project segment to the NEW project, so the project-scope
+                    // layout does not sync the atom back to the old project.
+                    const fallbackFeature =
+                      currentMenuKey &&
+                      MENU_KEY_TO_SCOPE_FEATURE[currentMenuKey]?.scope ===
+                        'project'
+                        ? MENU_KEY_TO_SCOPE_FEATURE[currentMenuKey].featureKey
+                        : 'session';
+                    let target = buildPath(
+                      'project',
+                      fallbackFeature,
+                      projectInfo.projectName,
+                    );
+                    if (goBackPath) {
+                      const segments = goBackPath.split('/');
+                      if (segments[1] === 'project' && segments.length > 2) {
+                        segments[2] = encodeURIComponent(
+                          projectInfo.projectName,
+                        );
+                        target = segments.join('/');
+                      }
+                    }
+                    webuiNavigate(target);
                   },
                   onCancel: () => {
                     // Revert the optimistic selection back to the current

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -6,6 +6,11 @@ import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
 import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
 import usePrimaryColors from '../../hooks/usePrimaryColors';
 import {
+  rewriteProjectNameInPath,
+  useActiveProjectName,
+  useCurrentMenuKey,
+} from '../../hooks/useRouteScope';
+import {
   getPathFromMenuKey,
   useWebUIMenuItems,
 } from '../../hooks/useWebUIMenuItems';
@@ -53,6 +58,14 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
 
   const webuiNavigate = useWebUINavigate();
   const location = useLocation();
+  // Scope-aware current menu key (route handle), correct under the new
+  // `/project/:name/<feature>` and `/admin/<feature>` URL shapes where the
+  // first pathname segment is the scope prefix, not the feature key.
+  const currentMenuKey = useCurrentMenuKey();
+  // Active project NAME (URL `:projectName` if present, else current project
+  // atom). Used to build the scope-aware admin-settings link and to rewrite the
+  // stored `goBackPath` to the current project on read.
+  const activeProjectName = useActiveProjectName();
   const baiClient = useSuspendedBackendaiClient();
 
   const [isOpenSignoutModal, { toggle: toggleSignoutModal }] = useToggle(false);
@@ -79,7 +92,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
     hideGroupName: props.collapsed,
   });
 
-  const [goBackPath, setGoBackPath] = useSessionStorageState(
+  const [goBackPath, setGoBackPath] = useSessionStorageState<string>(
     'backendaiwebui.last_visited_general_path',
   );
 
@@ -119,7 +132,16 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
           shape="circle"
           icon={<ArrowLeftIcon />}
           onClick={() => {
-            webuiNavigate(goBackPath || defaultMenuPath);
+            // `goBackPath` stores the last visited general (project-scoped)
+            // path, e.g. `/project/<oldName>/session`. If the user switched
+            // projects while in admin mode, rewrite its `:projectName` segment
+            // to the current project so "go back" lands on the active project,
+            // not the stale one. Non-project paths pass through unchanged.
+            webuiNavigate(
+              goBackPath
+                ? rewriteProjectNameInPath(goBackPath, activeProjectName)
+                : defaultMenuPath,
+            );
           }}
           aria-label={t('webui.menu.GoBack')}
           style={{
@@ -216,10 +238,10 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
           <BAIMenu
             collapsed={props.collapsed}
             selectedKeys={[
-              location.pathname.split('/')[1] || 'start',
+              currentMenuKey || 'start',
               // TODO: After 'SessionListPage' is completed and used as the main page, remove this code
               //       and change 'job' key to 'session'
-              location.pathname.split('/')[1] === 'session' ? 'job' : '',
+              currentMenuKey === 'session' ? 'job' : '',
             ]}
             // @ts-ignore
             items={filterOutEmpty([
@@ -227,7 +249,10 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
                 // Go to first page of admin setting pages.
                 label: (
                   <WebUILink
-                    to={getPathFromMenuKey(firstAvailableAdminMenuItem.key)}
+                    to={getPathFromMenuKey(
+                      firstAvailableAdminMenuItem.key,
+                      activeProjectName,
+                    )}
                   >
                     {t('webui.menu.AdminSettings')}
                   </WebUILink>
@@ -250,7 +275,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
             {adminHeader}
             <BAIMenu
               collapsed={props.collapsed}
-              selectedKeys={[location.pathname.split('/')[1]]}
+              selectedKeys={currentMenuKey ? [currentMenuKey] : []}
               items={groupedAdminMenu as MenuProps['items']}
             />
           </ConfigProvider>

--- a/react/src/components/ModelCardDeployModal.tsx
+++ b/react/src/components/ModelCardDeployModal.tsx
@@ -6,6 +6,7 @@ import type { ModelCardDeployModalFragment$key } from '../__generated__/ModelCar
 import { ModelCardDeployModalMutation } from '../__generated__/ModelCardDeployModalMutation.graphql';
 import { useWebUINavigate } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useProjectPath } from '../hooks/useRouteScope';
 import DeploymentPresetDetailModal from './DeploymentPresetDetailModal';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Alert, App, Button, Form, Space, theme, Tooltip } from 'antd';
@@ -64,6 +65,7 @@ const ModelCardDeployModal: React.FC<ModelCardDeployModalProps> = ({
   const { message } = App.useApp();
   const { getErrorMessage } = useErrorMessageResolver();
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const { token } = theme.useToken();
   const { id: projectId, name: projectName } = useCurrentProjectValue();
 
@@ -182,7 +184,9 @@ const ModelCardDeployModal: React.FC<ModelCardDeployModalProps> = ({
           }
           message.success(t('modelStore.DeploySuccess'));
           onDeployed(payload.deploymentId);
-          webuiNavigate(`/deployments/${payload.deploymentId}`);
+          webuiNavigate(
+            buildProjectPath(`deployments/${payload.deploymentId}`),
+          );
           resolve();
         },
         onError: (error) => {
@@ -280,7 +284,7 @@ const ModelCardDeployModal: React.FC<ModelCardDeployModalProps> = ({
                   <BAILink
                     onClick={() => {
                       onClose();
-                      webuiNavigate('/deployments');
+                      webuiNavigate(buildProjectPath('deployments'));
                     }}
                   />
                 ),

--- a/react/src/components/PluginLoader.tsx
+++ b/react/src/components/PluginLoader.tsx
@@ -13,6 +13,7 @@
  * 5. Updates Jotai plugin state atoms for navigation menu integration
  * 6. Manages plugin active/inactive state based on the current route
  */
+import { useCurrentMenuKey } from '../hooks/useRouteScope';
 import { configLoadedState, rawConfigState } from '../hooks/useWebUIConfig';
 import {
   type PluginPage,
@@ -24,7 +25,6 @@ import {
 import { useBAILogger } from 'backend.ai-ui';
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
 
 interface PluginPageElement extends HTMLElement {
   active: boolean;
@@ -64,7 +64,7 @@ function PluginLoader() {
   const containerRef = useRef<HTMLDivElement>(null);
   const pluginElementsRef = useRef<Map<string, PluginPageElement>>(new Map());
   const loadingGuardRef = useRef(false);
-  const location = useLocation();
+  const currentMenuKey = useCurrentMenuKey();
 
   const loadPlugins = useCallback(
     async (configString: string) => {
@@ -220,9 +220,15 @@ function PluginLoader() {
     setPluginLoaded,
   ]);
 
-  // Activate/deactivate plugin pages based on current route
+  // Activate/deactivate plugin pages based on current route.
+  // Match against the scope-aware menu key (route handle) rather than the raw
+  // first pathname segment: under `/project/:name/<feature>` and
+  // `/admin/<feature>` the first segment is the scope prefix. Flat plugin URLs
+  // (`/<plugin-url>`, served by the catch-all) carry no handle, so
+  // `useCurrentMenuKey()` falls back to the first pathname segment for them —
+  // which is exactly the plugin element name.
   useEffect(() => {
-    const currentPage = location.pathname.split('/')[1] || '';
+    const currentPage = currentMenuKey || '';
 
     pluginElementsRef.current.forEach((element, name) => {
       if (name === currentPage) {
@@ -240,9 +246,7 @@ function PluginLoader() {
         element.style.minHeight = '';
       }
     });
-    // `location` is from react-router useLocation() — pathname is reactive across navigations.
-    // react-doctor-disable-next-line react-doctor/no-mutable-in-deps
-  }, [location.pathname]);
+  }, [currentMenuKey]);
 
   return (
     <div

--- a/react/src/components/ProjectAdminScopeAlert.tsx
+++ b/react/src/components/ProjectAdminScopeAlert.tsx
@@ -2,28 +2,24 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { PROJECT_ADMIN_PAGE_KEYS } from '../hooks/useWebUIMenuItems';
+import { useRouteScope } from '../hooks/useRouteScope';
 import { BAIAlert, BAIAlertProps } from 'backend.ai-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
 
 interface ProjectAdminScopeAlertProps extends BAIAlertProps {}
 
 const ProjectAdminScopeAlert: React.FC<ProjectAdminScopeAlertProps> = (
   props,
 ) => {
+  'use memo';
   const { t } = useTranslation();
-  const location = useLocation();
-
-  // PROJECT_ADMIN_PAGE_KEYS is the single source of truth for which
-  // routes belong to the project-admin section. Project-admin paths
-  // are mounted at `/<key>` (e.g. `/project-admin-users`), so the
-  // first pathname segment is the menu key.
-  const firstSegment = location.pathname.split('/')[1];
-  const isProjectAdminPage = (
-    PROJECT_ADMIN_PAGE_KEYS as ReadonlyArray<string>
-  ).includes(firstSegment);
+  // Project-admin pages live under `/project/:name/admin/*`; the route handle
+  // marks them with `scope: 'projectAdmin'`. Reading the scope from the matched
+  // route (rather than parsing the pathname's first segment, which is now the
+  // `project` prefix) is the single source of truth for this gate.
+  const scope = useRouteScope();
+  const isProjectAdminPage = scope === 'projectAdmin';
 
   if (!isProjectAdminPage) return null;
 

--- a/react/src/components/SFTPServerButton.tsx
+++ b/react/src/components/SFTPServerButton.tsx
@@ -14,6 +14,7 @@ import {
 } from '../hooks/useCurrentProject';
 import { useDefaultSystemSSHImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
 import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   StartSessionWithDefaultValue,
   useStartSession,
@@ -48,6 +49,7 @@ const SFTPServerButton: React.FC<SFTPServerButtonProps> = ({
   const { message, modal } = App.useApp();
 
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
@@ -195,7 +197,7 @@ const SFTPServerButton: React.FC<SFTPServerButtonProps> = ({
                   params.set('formValues', JSON.stringify(launcherValue));
                   params.set('step', '4');
                   webuiNavigate({
-                    pathname: '/session/start',
+                    pathname: buildProjectPath('session/start'),
                     search: params.toString(),
                   });
                 },

--- a/react/src/components/SFTPServerButtonV2.tsx
+++ b/react/src/components/SFTPServerButtonV2.tsx
@@ -14,6 +14,7 @@ import {
 } from '../hooks/useCurrentProject';
 import { useDefaultSystemSSHImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
 import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   StartSessionWithDefaultValue,
   useStartSession,
@@ -48,6 +49,7 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
   const { message, modal } = App.useApp();
 
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
@@ -195,7 +197,7 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
                   params.set('formValues', JSON.stringify(launcherValue));
                   params.set('step', '4');
                   webuiNavigate({
-                    pathname: '/session/start',
+                    pathname: buildProjectPath('session/start'),
                     search: params.toString(),
                   });
                 },

--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -6,6 +6,7 @@ import { VFolderDeployModalMutation } from '../__generated__/VFolderDeployModalM
 import { VFolderDeployModalQuery } from '../__generated__/VFolderDeployModalQuery.graphql';
 import { useWebUINavigate } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useProjectPath } from '../hooks/useRouteScope';
 import DeploymentPresetDetailModal from './DeploymentPresetDetailModal';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Alert, App, Button, Form, Space, theme, Tooltip } from 'antd';
@@ -61,6 +62,7 @@ const VFolderDeployModal: React.FC<VFolderDeployModalProps> = ({
   const { message } = App.useApp();
   const { getErrorMessage } = useErrorMessageResolver();
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const { token } = theme.useToken();
   const { id: projectId, name: projectName } = useCurrentProjectValue();
 
@@ -195,7 +197,9 @@ const VFolderDeployModal: React.FC<VFolderDeployModalProps> = ({
           }
           message.success(t('modelStore.DeploySuccess'));
           onDeployed?.(payload.deploymentId);
-          webuiNavigate(`/deployments/${payload.deploymentId}`);
+          webuiNavigate(
+            buildProjectPath(`deployments/${payload.deploymentId}`),
+          );
           resolve();
         },
         onError: (error) => {
@@ -294,7 +298,7 @@ const VFolderDeployModal: React.FC<VFolderDeployModalProps> = ({
                   <BAILink
                     onClick={() => {
                       onClose();
-                      webuiNavigate('/deployments');
+                      webuiNavigate(buildProjectPath('deployments'));
                     }}
                   />
                 ),

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -11,6 +11,7 @@ import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useEffectiveAdminRole } from '../hooks/useCurrentUserProjectRoles';
+import { useProjectPath } from '../hooks/useRouteScope';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
 import DeploymentSettingModal from './DeploymentSettingModal';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
@@ -279,6 +280,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
   const { upsertNotification } = useSetBAINotification();
   const { getErrorMessage } = useErrorMessageResolver();
   const navigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const [deletingVFolder, setDeletingVFolder] =
     useState<VFolderNodeInList | null>(null);
@@ -416,7 +418,10 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                                       style={{ fontWeight: 'normal' }}
                                       onClick={() => {
                                         navigate({
-                                          pathname: '/session',
+                                          pathname: buildProjectPath(
+                                            'session',
+                                            { scope: 'project' },
+                                          ),
                                           search: new URLSearchParams({
                                             sessionDetail: sessionId,
                                           }).toString(),

--- a/react/src/components/VFolderNodesV2.tsx
+++ b/react/src/components/VFolderNodesV2.tsx
@@ -12,6 +12,7 @@ import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useSuspenseTanQuery, useTanQuery } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
+import { useProjectPath } from '../hooks/useRouteScope';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
 import DeleteForeverVFolderModalV2 from './DeleteForeverVFolderModalV2';
 import DeploymentSettingModal from './DeploymentSettingModal';
@@ -439,6 +440,7 @@ const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
   const [inviteFolderId, setInviteFolderId] = useState<string | null>(null);
   const { getErrorMessage } = useErrorMessageResolver();
   const navigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const { upsertNotification } = useSetBAINotification();
 
   // Row-level hard-delete reuses the same modal as the bulk toolbar
@@ -556,7 +558,7 @@ const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
               style={{ fontWeight: 'normal' }}
               onClick={() => {
                 navigate({
-                  pathname: '/session',
+                  pathname: buildProjectPath('session', { scope: 'project' }),
                   search: new URLSearchParams({
                     sessionDetail: sessionId,
                   }).toString(),

--- a/react/src/components/WEBUIHelpButton.tsx
+++ b/react/src/components/WEBUIHelpButton.tsx
@@ -2,11 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useCurrentMenuKey } from '../hooks/useRouteScope';
 import { useCurrentLanguage } from './DefaultProviders';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, type ButtonProps } from 'antd';
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 
 // Languages the hosted user manual (https://webui.docs.backend.ai) is
 // published in. Any other WebUI locale falls back to English.
@@ -138,7 +138,10 @@ const WEBUIHelpButton: React.FC<WEBUIHelpButtonProps> = ({ ...props }) => {
     : rawVersion.split('.').slice(0, 2).filter(Boolean).join('.') || 'next';
   const manualURL = `https://webui.docs.backend.ai/${docsVersion}/${docsLang}/`;
 
-  const matchingKey = location.pathname.split('/')[1] || '';
+  // Scope-aware menu key (route handle): under the `/admin/<feature>` and
+  // `/project/:name/<feature>` URLs the first pathname segment is the scope
+  // prefix, so the help-anchor lookup uses the matched route's menu key.
+  const matchingKey = useCurrentMenuKey() || '';
   // Prefer a tab-specific manual section when the active tab (`?tab=…`) has
   // one, otherwise use the page-level mapping.
   const activeTab = new URLSearchParams(location.search).get('tab');

--- a/react/src/helper/pathBuilder.test.ts
+++ b/react/src/helper/pathBuilder.test.ts
@@ -1,0 +1,189 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Tests for the scope-aware path-building primitives.
+ *
+ * Coverage:
+ * - buildPath() produces correct URLs for each scope
+ * - buildPath() encodes project names (spaces / dots / unicode / slashes)
+ * - MENU_KEY_TO_SCOPE_FEATURE covers every VALID_MENU_KEYS entry
+ * - scopeFeatureToMenuKey() inverts the map to canonical (non-alias) keys
+ * - round-trip: menu key -> {scope, feature} -> canonical menu key
+ */
+import { VALID_MENU_KEYS } from '../hooks/useWebUIMenuItems';
+import {
+  buildPath,
+  MENU_KEY_TO_SCOPE_FEATURE,
+  scopeFeatureToMenuKey,
+} from './pathBuilder';
+
+describe('buildPath', () => {
+  it('builds admin paths without a project name', () => {
+    expect(buildPath('admin', 'session')).toBe('/admin/session');
+    expect(buildPath('admin', 'users')).toBe('/admin/users');
+    expect(buildPath('admin', 'reservoir')).toBe('/admin/reservoir');
+  });
+
+  it('ignores the project name for admin scope', () => {
+    expect(buildPath('admin', 'data', 'my-project')).toBe('/admin/data');
+  });
+
+  it('builds project paths with the project name', () => {
+    expect(buildPath('project', 'session', 'my-project')).toBe(
+      '/project/my-project/session',
+    );
+    expect(buildPath('project', 'deployments', 'alpha')).toBe(
+      '/project/alpha/deployments',
+    );
+  });
+
+  it('builds projectAdmin paths with the /admin/ segment', () => {
+    expect(buildPath('projectAdmin', 'session', 'my-project')).toBe(
+      '/project/my-project/admin/session',
+    );
+    expect(buildPath('projectAdmin', 'users', 'alpha')).toBe(
+      '/project/alpha/admin/users',
+    );
+  });
+
+  it('encodes project names with spaces, dots and unicode', () => {
+    expect(buildPath('project', 'session', 'my project')).toBe(
+      '/project/my%20project/session',
+    );
+    expect(buildPath('project', 'session', 'my.project.dots')).toBe(
+      '/project/my.project.dots/session',
+    );
+    expect(buildPath('project', 'session', '한글-프로젝트')).toBe(
+      `/project/${encodeURIComponent('한글-프로젝트')}/session`,
+    );
+  });
+
+  it('encodes slashes in project names to avoid path collisions', () => {
+    expect(buildPath('project', 'session', 'a/b')).toBe(
+      '/project/a%2Fb/session',
+    );
+  });
+
+  it('produces an empty project segment when name is missing', () => {
+    expect(buildPath('project', 'session')).toBe('/project//session');
+    expect(buildPath('projectAdmin', 'session', null)).toBe(
+      '/project//admin/session',
+    );
+  });
+});
+
+describe('MENU_KEY_TO_SCOPE_FEATURE', () => {
+  it('covers every VALID_MENU_KEYS entry', () => {
+    const missing = VALID_MENU_KEYS.filter(
+      (key) => !(key in MENU_KEY_TO_SCOPE_FEATURE),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('maps generalMenu keys to the project scope', () => {
+    expect(MENU_KEY_TO_SCOPE_FEATURE['session']).toEqual({
+      scope: 'project',
+      featureKey: 'session',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['start']).toEqual({
+      scope: 'project',
+      featureKey: 'start',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['chat']).toEqual({
+      scope: 'project',
+      featureKey: 'chat',
+    });
+  });
+
+  it('maps PROJECT_ADMIN keys to the projectAdmin scope', () => {
+    expect(MENU_KEY_TO_SCOPE_FEATURE['project-admin-session']).toEqual({
+      scope: 'projectAdmin',
+      featureKey: 'session',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['project-admin-deployments']).toEqual({
+      scope: 'projectAdmin',
+      featureKey: 'deployments',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['project-data']).toEqual({
+      scope: 'projectAdmin',
+      featureKey: 'data',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['project-admin-users']).toEqual({
+      scope: 'projectAdmin',
+      featureKey: 'users',
+    });
+  });
+
+  it('maps remaining adminMenu keys to the admin scope', () => {
+    expect(MENU_KEY_TO_SCOPE_FEATURE['admin-session']).toEqual({
+      scope: 'admin',
+      featureKey: 'session',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['credential']).toEqual({
+      scope: 'admin',
+      featureKey: 'users',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['admin-data']).toEqual({
+      scope: 'admin',
+      featureKey: 'data',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['reservoir']).toEqual({
+      scope: 'admin',
+      featureKey: 'reservoir',
+    });
+    expect(MENU_KEY_TO_SCOPE_FEATURE['project']).toEqual({
+      scope: 'admin',
+      featureKey: 'project',
+    });
+  });
+
+  it('maps aliases to the same target as their canonical key', () => {
+    expect(MENU_KEY_TO_SCOPE_FEATURE['summary']).toEqual(
+      MENU_KEY_TO_SCOPE_FEATURE['dashboard'],
+    );
+    expect(MENU_KEY_TO_SCOPE_FEATURE['job']).toEqual(
+      MENU_KEY_TO_SCOPE_FEATURE['session'],
+    );
+  });
+});
+
+describe('scopeFeatureToMenuKey', () => {
+  it('inverts the map for canonical keys', () => {
+    expect(scopeFeatureToMenuKey('project', 'session')).toBe('session');
+    expect(scopeFeatureToMenuKey('admin', 'session')).toBe('admin-session');
+    expect(scopeFeatureToMenuKey('projectAdmin', 'session')).toBe(
+      'project-admin-session',
+    );
+    expect(scopeFeatureToMenuKey('admin', 'users')).toBe('credential');
+    expect(scopeFeatureToMenuKey('projectAdmin', 'users')).toBe(
+      'project-admin-users',
+    );
+    expect(scopeFeatureToMenuKey('projectAdmin', 'data')).toBe('project-data');
+    expect(scopeFeatureToMenuKey('admin', 'data')).toBe('admin-data');
+  });
+
+  it('resolves dashboard/session to the canonical key, not the alias', () => {
+    expect(scopeFeatureToMenuKey('project', 'dashboard')).toBe('dashboard');
+    expect(scopeFeatureToMenuKey('project', 'session')).toBe('session');
+  });
+
+  it('returns undefined for unknown combinations', () => {
+    expect(scopeFeatureToMenuKey('admin', 'start')).toBeUndefined();
+    expect(scopeFeatureToMenuKey('project', 'nonexistent')).toBeUndefined();
+    expect(scopeFeatureToMenuKey('projectAdmin', 'agent')).toBeUndefined();
+  });
+
+  it('round-trips every non-alias menu key through scope/feature', () => {
+    const aliases = new Set(['summary', 'job']);
+    for (const [menuKey, { scope, featureKey }] of Object.entries(
+      MENU_KEY_TO_SCOPE_FEATURE,
+    )) {
+      if (aliases.has(menuKey)) {
+        continue;
+      }
+      expect(scopeFeatureToMenuKey(scope, featureKey)).toBe(menuKey);
+    }
+  });
+});

--- a/react/src/helper/pathBuilder.ts
+++ b/react/src/helper/pathBuilder.ts
@@ -1,0 +1,167 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Path-building primitives for the scope-aware routing scheme.
+ *
+ * The webui routes encode the "scope" (project / project-admin / system-admin)
+ * directly in the URL:
+ *
+ *   - project:      `/project/<projectName>/<featureKey>`
+ *   - projectAdmin: `/project/<projectName>/admin/<featureKey>`
+ *   - admin:        `/admin/<featureKey>`
+ *
+ * `buildPath` is the ONLY function that knows this URL structure; everything
+ * else (hooks, components, redirects) goes through it so the layout can change
+ * in one place.
+ *
+ * This module is intentionally framework-free (no React / react-router imports)
+ * so it can be unit-tested in isolation and reused from non-component code.
+ */
+
+/**
+ * The three routing scopes. `project` and `projectAdmin` live under the
+ * `/project/:projectName` subtree; `admin` is a separate global namespace.
+ */
+export type RouteScope = 'project' | 'projectAdmin' | 'admin';
+
+/**
+ * A scope-relative feature key (the feature portion of a route, e.g.
+ * 'session', 'deployments', 'data', 'users'). This is distinct from the legacy
+ * "menu key" (e.g. 'admin-session', 'project-data') which encodes the scope in
+ * its name.
+ */
+export type FeatureKey = string;
+
+/**
+ * Builds a scope-aware URL path for the given feature key.
+ *
+ * @param scope        The routing scope.
+ * @param key          The scope-relative feature key (e.g. 'session').
+ * @param projectName  The project NAME (not UUID). Required for `project` and
+ *                     `projectAdmin` scopes; ignored for `admin`.
+ *
+ * The project name is `encodeURIComponent`-encoded so names with spaces / dots
+ * / unicode round-trip safely. If a project name is required but missing, the
+ * path is built with an empty segment (callers/layout guards are responsible
+ * for never producing such a state at runtime).
+ */
+export const buildPath = (
+  scope: RouteScope,
+  key: FeatureKey,
+  projectName?: string | null,
+): string => {
+  switch (scope) {
+    case 'admin':
+      return `/admin/${key}`;
+    case 'projectAdmin':
+      return `/project/${encodeURIComponent(projectName ?? '')}/admin/${key}`;
+    case 'project':
+    default:
+      return `/project/${encodeURIComponent(projectName ?? '')}/${key}`;
+  }
+};
+
+interface ScopeFeature {
+  scope: RouteScope;
+  featureKey: FeatureKey;
+}
+
+/**
+ * Bidirectional map from the existing menu key (as defined in
+ * `VALID_MENU_KEYS` in `hooks/useWebUIMenuItems.tsx`) to its `{scope,
+ * featureKey}` pair.
+ *
+ * Covers EVERY key in `VALID_MENU_KEYS`, per the confirmed scope decisions:
+ *
+ * generalMenu  -> project scope at `/project/:name/<feature>`
+ * PROJECT_ADMIN_PAGE_KEYS -> projectAdmin at `/project/:name/admin/<feature>`
+ * all other adminMenu keys -> admin at `/admin/<feature>`
+ *
+ * Aliases (`summary`->dashboard, `job`->session) share the same target as
+ * their canonical key; the inverse lookup resolves to the canonical key.
+ */
+export const MENU_KEY_TO_SCOPE_FEATURE: Record<string, ScopeFeature> = {
+  // --- generalMenu: project scope ---
+  start: { scope: 'project', featureKey: 'start' },
+  dashboard: { scope: 'project', featureKey: 'dashboard' },
+  summary: { scope: 'project', featureKey: 'dashboard' }, // alias -> dashboard
+  session: { scope: 'project', featureKey: 'session' },
+  job: { scope: 'project', featureKey: 'session' }, // alias -> session
+  deployments: { scope: 'project', featureKey: 'deployments' },
+  'model-store': { scope: 'project', featureKey: 'model-store' },
+  'ai-agent': { scope: 'project', featureKey: 'ai-agent' },
+  chat: { scope: 'project', featureKey: 'chat' },
+  data: { scope: 'project', featureKey: 'data' },
+  'my-environment': { scope: 'project', featureKey: 'my-environment' },
+  'agent-summary': { scope: 'project', featureKey: 'agent-summary' },
+  statistics: { scope: 'project', featureKey: 'statistics' },
+  // 'pipeline' (FastTrack) is an external window.open link, NOT a route, but it
+  // belongs to the project (general) menu, so map it to project scope for
+  // completeness / round-trip coverage.
+  pipeline: { scope: 'project', featureKey: 'pipeline' },
+
+  // --- PROJECT_ADMIN_PAGE_KEYS: projectAdmin scope ---
+  'project-admin-session': { scope: 'projectAdmin', featureKey: 'session' },
+  'project-admin-deployments': {
+    scope: 'projectAdmin',
+    featureKey: 'deployments',
+  },
+  'project-data': { scope: 'projectAdmin', featureKey: 'data' },
+  'project-admin-users': { scope: 'projectAdmin', featureKey: 'users' },
+
+  // --- all other adminMenu (ALL_ADMIN_PAGE_KEYS): global admin scope ---
+  'admin-session': { scope: 'admin', featureKey: 'session' },
+  'admin-deployments': { scope: 'admin', featureKey: 'deployments' },
+  'admin-data': { scope: 'admin', featureKey: 'data' },
+  'admin-dashboard': { scope: 'admin', featureKey: 'dashboard' },
+  credential: { scope: 'admin', featureKey: 'users' },
+  environment: { scope: 'admin', featureKey: 'environment' },
+  'resource-policy': { scope: 'admin', featureKey: 'resource-policy' },
+  reservoir: { scope: 'admin', featureKey: 'reservoir' },
+  scheduler: { scope: 'admin', featureKey: 'scheduler' },
+  agent: { scope: 'admin', featureKey: 'agent' },
+  project: { scope: 'admin', featureKey: 'project' },
+  settings: { scope: 'admin', featureKey: 'settings' },
+  maintenance: { scope: 'admin', featureKey: 'maintenance' },
+  diagnostics: { scope: 'admin', featureKey: 'diagnostics' },
+  rbac: { scope: 'admin', featureKey: 'rbac' },
+  branding: { scope: 'admin', featureKey: 'branding' },
+  information: { scope: 'admin', featureKey: 'information' },
+};
+
+/**
+ * Inverse lookup table built from `MENU_KEY_TO_SCOPE_FEATURE`. Keyed by
+ * `"<scope>:<featureKey>"`. Alias menu keys (`summary`, `job`) are intentionally
+ * skipped so the inverse resolves to the canonical menu key
+ * (`dashboard`, `session`).
+ */
+const ALIAS_MENU_KEYS: ReadonlySet<string> = new Set(['summary', 'job']);
+
+const SCOPE_FEATURE_TO_MENU_KEY: Record<string, string> = (() => {
+  const table: Record<string, string> = {};
+  for (const [menuKey, { scope, featureKey }] of Object.entries(
+    MENU_KEY_TO_SCOPE_FEATURE,
+  )) {
+    if (ALIAS_MENU_KEYS.has(menuKey)) {
+      continue;
+    }
+    table[`${scope}:${featureKey}`] = menuKey;
+  }
+  return table;
+})();
+
+/**
+ * Resolves a `{scope, featureKey}` pair back to its canonical menu key, or
+ * `undefined` if the combination is not a known route.
+ *
+ * e.g. `scopeFeatureToMenuKey('admin', 'session')` -> `'admin-session'`,
+ *      `scopeFeatureToMenuKey('project', 'session')` -> `'session'`.
+ */
+export const scopeFeatureToMenuKey = (
+  scope: RouteScope,
+  featureKey: FeatureKey,
+): string | undefined => {
+  return SCOPE_FEATURE_TO_MENU_KEY[`${scope}:${featureKey}`];
+};

--- a/react/src/hooks/getPathFromMenuKey.test.ts
+++ b/react/src/hooks/getPathFromMenuKey.test.ts
@@ -1,0 +1,76 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Tests for the scope-aware `getPathFromMenuKey` helper.
+ *
+ * It delegates to `buildPath` via `MENU_KEY_TO_SCOPE_FEATURE`, producing
+ * `/project/<name>/<feature>` for general (project) keys,
+ * `/project/<name>/admin/<feature>` for project-admin keys, and
+ * `/admin/<feature>` for global admin keys (project name ignored). When a
+ * project-scoped key has no resolvable project name, it falls back to the
+ * legacy flat path (which the redirect shims resolve at runtime) instead of
+ * emitting a broken `/project//<feature>` URL.
+ */
+import { VALID_MENU_KEYS, getPathFromMenuKey } from './useWebUIMenuItems';
+
+describe('getPathFromMenuKey', () => {
+  it('builds project-scoped paths for general menu keys with a project name', () => {
+    expect(getPathFromMenuKey('session', 'alpha')).toBe(
+      '/project/alpha/session',
+    );
+    expect(getPathFromMenuKey('start', 'alpha')).toBe('/project/alpha/start');
+    expect(getPathFromMenuKey('data', 'alpha')).toBe('/project/alpha/data');
+  });
+
+  it('resolves general menu aliases to their canonical feature', () => {
+    // 'job' -> session, 'summary' -> dashboard
+    expect(getPathFromMenuKey('job', 'alpha')).toBe('/project/alpha/session');
+    expect(getPathFromMenuKey('summary', 'alpha')).toBe(
+      '/project/alpha/dashboard',
+    );
+  });
+
+  it('builds project-admin paths under the /admin/ segment', () => {
+    expect(getPathFromMenuKey('project-admin-session', 'alpha')).toBe(
+      '/project/alpha/admin/session',
+    );
+    expect(getPathFromMenuKey('project-data', 'alpha')).toBe(
+      '/project/alpha/admin/data',
+    );
+    expect(getPathFromMenuKey('project-admin-users', 'alpha')).toBe(
+      '/project/alpha/admin/users',
+    );
+  });
+
+  it('builds global admin paths and ignores the project name', () => {
+    expect(getPathFromMenuKey('admin-session', 'alpha')).toBe('/admin/session');
+    expect(getPathFromMenuKey('credential', 'alpha')).toBe('/admin/users');
+    expect(getPathFromMenuKey('admin-data')).toBe('/admin/data');
+    expect(getPathFromMenuKey('reservoir')).toBe('/admin/reservoir');
+  });
+
+  it('encodes the project name for project-scoped keys', () => {
+    expect(getPathFromMenuKey('session', 'a b')).toBe('/project/a%20b/session');
+  });
+
+  it('falls back to the legacy flat path when a project-scoped key has no project name', () => {
+    // No `/project//...` — the legacy flat path is mounted as a redirect shim.
+    expect(getPathFromMenuKey('session')).toBe('/session');
+    expect(getPathFromMenuKey('session', undefined)).toBe('/session');
+    expect(getPathFromMenuKey('session', '')).toBe('/session');
+    expect(getPathFromMenuKey('job')).toBe('/session');
+    expect(getPathFromMenuKey('summary')).toBe('/dashboard');
+    expect(getPathFromMenuKey('project-data')).toBe('/project-data');
+  });
+
+  it('never produces a path with an empty project segment', () => {
+    for (const key of VALID_MENU_KEYS) {
+      // Without a project name, project-scoped keys fall back to flat paths.
+      expect(getPathFromMenuKey(key)).not.toContain('/project//');
+      // With a project name, the segment is always populated.
+      expect(getPathFromMenuKey(key, 'alpha')).not.toContain('/project//');
+    }
+  });
+});

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -6,6 +6,7 @@ import { useSuspendedBackendaiClient, useWebUINavigate } from '.';
 import { useBackendAIAppLauncherFragment$key } from '../__generated__/useBackendAIAppLauncherFragment.graphql';
 import { requestLocalProxyToken } from '../helper/localProxyToken';
 import { useSetBAINotification } from './useBAINotification';
+import { useProjectPath } from './useRouteScope';
 import { BAILink, useBAILogger, useErrorMessageResolver } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
@@ -26,6 +27,7 @@ export const useBackendAIAppLauncher = (
   const { upsertNotification } = useSetBAINotification();
   const { getErrorMessage } = useErrorMessageResolver();
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const baiClient = useSuspendedBackendaiClient();
   const { logger } = useBAILogger();
 
@@ -768,7 +770,7 @@ export const useBackendAIAppLauncher = (
               const newSearchParams = new URLSearchParams(location.search);
               newSearchParams.set('sessionDetail', session?.row_id || '');
               webuiNavigate({
-                pathname: `/session`,
+                pathname: buildProjectPath('session'),
                 search: newSearchParams.toString(),
               });
             }}

--- a/react/src/hooks/useRouteScope.test.ts
+++ b/react/src/hooks/useRouteScope.test.ts
@@ -1,0 +1,181 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Tests for the pure pathname parser `getRouteScopeAndKey`.
+ *
+ * The React hooks in `useRouteScope.ts` (`useRouteScope`, `useCurrentMenuKey`,
+ * `useActiveProjectName`, `useProjectPath`) are covered indirectly: they all
+ * fall back to `getRouteScopeAndKey` when no route handle is present, and the
+ * pure parser is the load-bearing logic. The map round-trip is also exercised
+ * here against `buildPath` to confirm parse(build(x)) === x.
+ */
+import {
+  buildPath,
+  MENU_KEY_TO_SCOPE_FEATURE,
+  RouteScope,
+} from '../helper/pathBuilder';
+import { getRouteScopeAndKey, rewriteProjectNameInPath } from './useRouteScope';
+
+describe('getRouteScopeAndKey', () => {
+  it('parses global admin paths', () => {
+    expect(getRouteScopeAndKey('/admin/session')).toEqual({
+      scope: 'admin',
+      featureKey: 'session',
+    });
+    expect(getRouteScopeAndKey('/admin/users')).toEqual({
+      scope: 'admin',
+      featureKey: 'users',
+    });
+  });
+
+  it('parses global admin paths with trailing child segments', () => {
+    // Only the feature key (first segment after /admin) is extracted.
+    expect(getRouteScopeAndKey('/admin/deployments/abc-123')).toEqual({
+      scope: 'admin',
+      featureKey: 'deployments',
+    });
+  });
+
+  it('parses project-scope paths', () => {
+    expect(getRouteScopeAndKey('/project/my-proj/session')).toEqual({
+      scope: 'project',
+      featureKey: 'session',
+      projectName: 'my-proj',
+    });
+    expect(getRouteScopeAndKey('/project/alpha/deployments/dep-1')).toEqual({
+      scope: 'project',
+      featureKey: 'deployments',
+      projectName: 'alpha',
+    });
+  });
+
+  it('parses project-admin-scope paths', () => {
+    expect(getRouteScopeAndKey('/project/my-proj/admin/session')).toEqual({
+      scope: 'projectAdmin',
+      featureKey: 'session',
+      projectName: 'my-proj',
+    });
+    expect(getRouteScopeAndKey('/project/alpha/admin/users')).toEqual({
+      scope: 'projectAdmin',
+      featureKey: 'users',
+      projectName: 'alpha',
+    });
+  });
+
+  it('decodes encoded project names', () => {
+    expect(getRouteScopeAndKey('/project/my%20project/session')).toEqual({
+      scope: 'project',
+      featureKey: 'session',
+      projectName: 'my project',
+    });
+    expect(
+      getRouteScopeAndKey(`/project/${encodeURIComponent('한글')}/session`),
+    ).toEqual({
+      scope: 'project',
+      featureKey: 'session',
+      projectName: '한글',
+    });
+  });
+
+  it('falls back to project scope for legacy unprefixed paths', () => {
+    expect(getRouteScopeAndKey('/session')).toEqual({
+      scope: 'project',
+      featureKey: 'session',
+    });
+    expect(getRouteScopeAndKey('/data')).toEqual({
+      scope: 'project',
+      featureKey: 'data',
+    });
+  });
+
+  it('handles the root path', () => {
+    expect(getRouteScopeAndKey('/')).toEqual({
+      scope: 'project',
+      featureKey: '',
+    });
+  });
+
+  it('handles a malformed encoded project name without throwing', () => {
+    // '%' alone is not a valid escape sequence; decodeSafe should not throw.
+    expect(() => getRouteScopeAndKey('/project/%/session')).not.toThrow();
+    const result = getRouteScopeAndKey('/project/%/session');
+    expect(result.scope).toBe('project');
+    expect(result.featureKey).toBe('session');
+  });
+});
+
+describe('rewriteProjectNameInPath', () => {
+  it('replaces the project-name segment of a project path', () => {
+    expect(rewriteProjectNameInPath('/project/old/session', 'new')).toBe(
+      '/project/new/session',
+    );
+  });
+
+  it('replaces the project-name segment of a project-admin path', () => {
+    expect(rewriteProjectNameInPath('/project/old/admin/data', 'new')).toBe(
+      '/project/new/admin/data',
+    );
+  });
+
+  it('preserves search and hash after the rewritten segment', () => {
+    expect(
+      rewriteProjectNameInPath('/project/old/session?tab=1#frag', 'new'),
+    ).toBe('/project/new/session?tab=1#frag');
+  });
+
+  it('preserves trailing detail segments', () => {
+    expect(
+      rewriteProjectNameInPath('/project/old/deployments/dep-1', 'new'),
+    ).toBe('/project/new/deployments/dep-1');
+  });
+
+  it('encodes the replacement project name', () => {
+    expect(rewriteProjectNameInPath('/project/old/session', 'a b')).toBe(
+      '/project/a%20b/session',
+    );
+  });
+
+  it('leaves non-project paths unchanged', () => {
+    expect(rewriteProjectNameInPath('/admin/session', 'new')).toBe(
+      '/admin/session',
+    );
+    expect(rewriteProjectNameInPath('/usersettings', 'new')).toBe(
+      '/usersettings',
+    );
+  });
+
+  it('returns the original path when no project name is provided', () => {
+    expect(rewriteProjectNameInPath('/project/old/session', undefined)).toBe(
+      '/project/old/session',
+    );
+    expect(rewriteProjectNameInPath('/project/old/session', '')).toBe(
+      '/project/old/session',
+    );
+    expect(rewriteProjectNameInPath('/project/old/session', null)).toBe(
+      '/project/old/session',
+    );
+  });
+});
+
+describe('getRouteScopeAndKey <-> buildPath round-trip', () => {
+  it('parse(build(scope, feature, name)) recovers scope + feature', () => {
+    const projectName = 'my-proj';
+    for (const { scope, featureKey } of Object.values(
+      MENU_KEY_TO_SCOPE_FEATURE,
+    )) {
+      // 'pipeline' is an external link, not a real route, but it still
+      // round-trips structurally through buildPath/getRouteScopeAndKey.
+      const path = buildPath(scope as RouteScope, featureKey, projectName);
+      const parsed = getRouteScopeAndKey(path);
+      expect(parsed.scope).toBe(scope);
+      expect(parsed.featureKey).toBe(featureKey);
+      if (scope === 'admin') {
+        expect(parsed.projectName).toBeUndefined();
+      } else {
+        expect(parsed.projectName).toBe(projectName);
+      }
+    }
+  });
+});

--- a/react/src/hooks/useRouteScope.ts
+++ b/react/src/hooks/useRouteScope.ts
@@ -1,0 +1,227 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Scope-aware routing primitives.
+ *
+ * These hooks read the scope / feature key from the DEEPEST `useMatches()`
+ * handle (populated by the route generator as `handle.scope` /
+ * `handle.menuKey`). When no handle is present (e.g. legacy redirect shims or
+ * navigation code that runs before the new subtree is mounted), they fall back
+ * to parsing the pathname via `getRouteScopeAndKey`.
+ *
+ * The point of these primitives is to replace every `location.pathname.split('/')[1]`
+ * / `startsWith('/admin-...')` first-segment check with a single, scope-aware
+ * source of truth.
+ */
+import { buildPath, RouteScope, FeatureKey } from '../helper/pathBuilder';
+import { useCurrentProjectValue } from './useCurrentProject';
+import { useLocation, useMatches } from 'react-router-dom';
+
+/**
+ * Shape of the route `handle` attached by the route generator. Optional fields
+ * because not every match carries scope metadata (e.g. layout routes).
+ */
+interface ScopeRouteHandle {
+  scope?: RouteScope;
+  menuKey?: string;
+}
+
+export interface RouteScopeInfo {
+  scope: RouteScope;
+  featureKey: FeatureKey;
+  projectName?: string;
+}
+
+/**
+ * Parses a pathname into `{scope, featureKey, projectName?}`.
+ *
+ * Recognizes (in order of specificity):
+ *   - `/project/:name/admin/:feature`           -> projectAdmin
+ *   - `/project/:name/:feature`                 -> project
+ *   - `/admin/:feature`                         -> admin
+ *   - legacy unprefixed `/:feature` (and deeper) -> project (default scope)
+ *
+ * `projectName` is decoded with `decodeURIComponent` so it matches the stored
+ * project name exactly. The default scope is `project` (the most common case),
+ * matching the historical assumption that the first segment is a project-scoped
+ * feature key.
+ *
+ * This is a pure helper (no React) so it can be used outside of components and
+ * unit-tested directly.
+ */
+export const getRouteScopeAndKey = (pathname: string): RouteScopeInfo => {
+  // Strip leading slash and split into non-empty segments.
+  const segments = pathname.split('/').filter((s) => s.length > 0);
+
+  if (segments[0] === 'admin') {
+    return {
+      scope: 'admin',
+      featureKey: segments[1] ?? '',
+    };
+  }
+
+  if (segments[0] === 'project') {
+    const projectName = decodeSafe(segments[1] ?? '');
+    if (segments[2] === 'admin') {
+      return {
+        scope: 'projectAdmin',
+        featureKey: segments[3] ?? '',
+        projectName,
+      };
+    }
+    return {
+      scope: 'project',
+      featureKey: segments[2] ?? '',
+      projectName,
+    };
+  }
+
+  // Legacy unprefixed path: first segment is the feature key, default scope.
+  return {
+    scope: 'project',
+    featureKey: segments[0] ?? '',
+  };
+};
+
+const decodeSafe = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    // Malformed URI component — fall back to the raw value rather than throwing.
+    return value;
+  }
+};
+
+/**
+ * Rewrites the `:projectName` segment of a project-scoped path to
+ * `projectName`, preserving the rest of the path (and any query / hash).
+ *
+ * Used when reading a stored navigation target (e.g. the sider's
+ * `goBackPath`) that was captured under a possibly-different project: if the
+ * user switched projects in the meantime, going "back" should land on the
+ * CURRENT project, not the stale one baked into the stored path.
+ *
+ *   rewriteProjectNameInPath('/project/old/session', 'new')
+ *     -> '/project/new/session'
+ *   rewriteProjectNameInPath('/project/old/admin/data?x=1', 'new')
+ *     -> '/project/new/admin/data?x=1'
+ *
+ * Non-project paths (e.g. `/admin/session`, `/usersettings`) are returned
+ * unchanged. When `projectName` is falsy the original path is returned (we
+ * cannot synthesize a valid `/project//...` segment).
+ */
+export const rewriteProjectNameInPath = (
+  path: string,
+  projectName?: string | null,
+): string => {
+  if (!projectName) {
+    return path;
+  }
+  // Match a leading `/project/<segment>` and replace only `<segment>`,
+  // keeping everything after it (further path, search, hash) intact.
+  return path.replace(
+    /^\/project\/[^/?#]*/,
+    `/project/${encodeURIComponent(projectName)}`,
+  );
+};
+
+/**
+ * Returns the deepest route match handle that carries scope metadata, or
+ * `undefined`. We prefer the deepest match so detail/child routes resolve
+ * correctly even when parent layout routes also carry handles.
+ */
+const useDeepestScopeHandle = (): ScopeRouteHandle | undefined => {
+  'use memo';
+  const matches = useMatches();
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const handle = matches[i]?.handle as ScopeRouteHandle | undefined;
+    if (handle && (handle.scope || handle.menuKey)) {
+      return handle;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * The current routing scope. Reads the deepest match `handle.scope`; falls back
+ * to parsing the pathname. Defaults to `project`.
+ */
+export const useRouteScope = (): RouteScope => {
+  'use memo';
+  const handle = useDeepestScopeHandle();
+  const location = useLocation();
+  if (handle?.scope) {
+    return handle.scope;
+  }
+  return getRouteScopeAndKey(location.pathname).scope;
+};
+
+/**
+ * The current menu key (legacy hyphenated key, e.g. 'admin-session'). Reads the
+ * deepest match `handle.menuKey`; falls back to the pathname-derived feature
+ * key. May be `undefined` when nothing matches.
+ */
+export const useCurrentMenuKey = (): string | undefined => {
+  'use memo';
+  const handle = useDeepestScopeHandle();
+  const location = useLocation();
+  if (handle?.menuKey) {
+    return handle.menuKey;
+  }
+  const { featureKey } = getRouteScopeAndKey(location.pathname);
+  return featureKey || undefined;
+};
+
+/**
+ * The active project NAME for the current route. Prefers the `:projectName`
+ * param from the URL (via `useMatches`); falls back to the current project atom
+ * value. This is the key shim that lets project-dependent hooks/components keep
+ * reading the atom while still being URL-accurate on project routes (the layout
+ * effect converges the atom to the URL).
+ */
+export const useActiveProjectName = (): string | undefined => {
+  'use memo';
+  const matches = useMatches();
+  const currentProject = useCurrentProjectValue();
+
+  // Find the deepest match that carries a `projectName` param.
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const params = matches[i]?.params as
+      | Record<string, string | undefined>
+      | undefined;
+    const name = params?.projectName;
+    if (name) {
+      return decodeSafe(name);
+    }
+  }
+
+  return currentProject.name ?? undefined;
+};
+
+interface ProjectPathOptions {
+  scope?: RouteScope;
+}
+
+/**
+ * Returns a link builder bound to the current scope / active project. Pass an
+ * explicit `scope` to override (e.g. to build an `admin` link from a project
+ * page).
+ *
+ *   const buildLink = useProjectPath();
+ *   buildLink('session');                          // current scope + project
+ *   buildLink('users', { scope: 'admin' });        // /admin/users
+ */
+export const useProjectPath = (): ((
+  key: FeatureKey,
+  opts?: ProjectPathOptions,
+) => string) => {
+  'use memo';
+  const scope = useRouteScope();
+  const projectName = useActiveProjectName();
+
+  return (key: FeatureKey, opts?: ProjectPathOptions): string => {
+    return buildPath(opts?.scope ?? scope, key, projectName);
+  };
+};

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -4,11 +4,13 @@
  */
 import { useSuspendedBackendaiClient } from '.';
 import WebUILink from '../components/WebUILink';
+import { buildPath, MENU_KEY_TO_SCOPE_FEATURE } from '../helper/pathBuilder';
 import { useCurrentUserRole } from './backendai';
 import { useDiagnosticsBadgeSeverity } from './useAutoDiagnostics';
 import { useBAISettingUserState } from './useBAISetting';
 import { useEffectiveAdminRole } from './useCurrentUserProjectRoles';
 import { useCustomThemeConfig } from './useCustomThemeConfig';
+import { useActiveProjectName, useCurrentMenuKey } from './useRouteScope';
 import {
   PluginPage,
   useWebUIPluginLoadedValue,
@@ -33,7 +35,6 @@ import {
 } from '@ant-design/icons';
 import { useSessionStorageState } from 'ahooks';
 import { Badge, theme, Typography } from 'antd';
-import { GetProp } from 'antd/lib';
 import { MenuItemType } from 'antd/lib/menu/interface';
 import {
   BAIEndpointsIcon,
@@ -196,13 +197,45 @@ const SUPERADMIN_ONLY_PAGE_KEYS: ReadonlySet<string> = new Set([
   'information',
 ]);
 
-// Convert menu key to URL path
-// Most keys map directly to /${key}, with exceptions for backward compatibility
-export const getPathFromMenuKey = (key: MenuKeys): string => {
+// Legacy flat path for a menu key (the pre-scope-aware URL, e.g. `/session`,
+// `/project-data`, `/admin-session`). These flat paths are still mounted as
+// backward-compat redirect shims (`legacyRedirects.tsx`), so emitting one is a
+// safe fallback: the shim resolves it to the canonical scope-aware URL at
+// runtime. Used when a project-scoped menu key has no resolvable project name
+// (avoids producing an invalid `/project//<feature>` path).
+const getLegacyFlatPath = (key: MenuKeys): string => {
   // 'job' is an alias for '/session' (backward compatibility)
   if (key === 'job') return '/session';
   if (key === 'summary') return '/dashboard';
   return `/${key}`;
+};
+
+// Convert a menu key to its scope-aware URL path.
+//
+// Delegates to `buildPath` via `MENU_KEY_TO_SCOPE_FEATURE` so a menu key like
+// `session` (project scope) becomes `/project/<projectName>/session`,
+// `project-data` (project-admin scope) becomes
+// `/project/<projectName>/admin/data`, and `admin-session` (global admin)
+// becomes `/admin/session`.
+//
+// `projectName` is required for project / projectAdmin scopes. When it is
+// missing (e.g. the rare "no current project" edge case), we fall back to the
+// legacy flat path which the redirect shims resolve, rather than building a
+// broken `/project//...` URL. Admin-scope keys never need a project name.
+export const getPathFromMenuKey = (
+  key: MenuKeys,
+  projectName?: string | null,
+): string => {
+  const scopeFeature = MENU_KEY_TO_SCOPE_FEATURE[key];
+  if (!scopeFeature) {
+    // Unknown key (e.g. a plugin url passed through): preserve legacy behavior.
+    return getLegacyFlatPath(key);
+  }
+  const { scope, featureKey } = scopeFeature;
+  if (scope !== 'admin' && !projectName) {
+    return getLegacyFlatPath(key);
+  }
+  return buildPath(scope, featureKey, projectName);
 };
 
 type MenuItem = {
@@ -237,6 +270,18 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   const effectiveAdminRole = useEffectiveAdminRole();
 
   const location = useLocation();
+  // Scope-aware current menu key (legacy hyphenated key, e.g. 'admin-session',
+  // 'project-data', 'session'). Derived from the matched route `handle.menuKey`
+  // (with a pathname-parse fallback) so it stays correct under the new
+  // `/project/:name/<feature>` and `/admin/<feature>` URL shapes, where
+  // `location.pathname.split('/')[1]` would return the scope prefix
+  // ('project'/'admin') instead of the feature key.
+  const currentMenuKeyFromRoute = useCurrentMenuKey();
+  // Active project NAME (URL `:projectName` if present, else current project
+  // atom). Used to build scope-aware menu `to` paths via `getPathFromMenuKey` /
+  // `buildPath` so every menu link points at `/project/<name>/<feature>` (or
+  // `/admin/<feature>` for admin keys, where the name is ignored).
+  const activeProjectName = useActiveProjectName();
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
   const isHideAgents = baiClient?._config?.hideAgents ?? true;
@@ -255,52 +300,71 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
 
   const diagnosticsBadgeSeverity = useDiagnosticsBadgeSeverity();
 
-  // Helper to create menu item with labelText reused in label
+  // Helper to create a menu item. The `to` path is derived from the menu `key`
+  // via `getPathFromMenuKey` (scope-aware: `/project/<name>/<feature>` for
+  // general keys), so call sites no longer hardcode the URL — a single source
+  // of truth that stays correct under the scope-prefixed routing scheme.
   const createMenuItem = (
-    to: GetProp<typeof WebUILink, 'to'>,
     labelText: string,
     icon: React.ReactNode,
     key: MenuKeys,
     group: MenuGroupName,
   ): WebUIGeneralMenuItemType => ({
-    label: <WebUILink to={to}>{labelText}</WebUILink>,
+    label: (
+      <WebUILink to={getPathFromMenuKey(key, activeProjectName)}>
+        {labelText}
+      </WebUILink>
+    ),
     icon,
     key,
     group,
     labelText,
   });
 
+  // Admin menu item builder — same scope-aware `to` derivation, with the admin
+  // menu's info-color icons and admin group typing.
+  const createAdminMenuItem = (
+    labelText: string,
+    icon: React.ReactNode,
+    key: MenuKeys,
+    group: AdminMenuGroupName,
+  ): WebUIAdminMenuItemType => ({
+    label: (
+      <WebUILink to={getPathFromMenuKey(key, activeProjectName)}>
+        {labelText}
+      </WebUILink>
+    ),
+    icon,
+    key,
+    group,
+  });
+
   const generalMenu = filterOutEmpty<WebUIGeneralMenuItemType>([
     createMenuItem(
-      '/start',
       t('webui.menu.Start'),
       <PlayCircleOutlined style={{ color: token.colorPrimary }} />,
       'start',
       'none',
     ),
     createMenuItem(
-      '/dashboard',
       t('webui.menu.Dashboard'),
       <DashboardOutlined style={{ color: token.colorPrimary }} />,
       'dashboard',
       'none',
     ),
     createMenuItem(
-      '/session',
       t('webui.menu.Sessions'),
       <BAISessionsIcon style={{ color: token.colorPrimary }} />,
       'session',
       'workload',
     ),
     createMenuItem(
-      '/deployments',
       t('webui.menu.Deployments'),
       <BAIEndpointsIcon style={{ color: token.colorPrimary }} />,
       'deployments',
       'service',
     ),
     createMenuItem(
-      '/model-store',
       t('data.ModelStore'),
       <BAIModelStoreIcon style={{ color: token.colorPrimary }} />,
       'model-store',
@@ -308,28 +372,24 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
     ),
     experimentalAIAgents &&
       createMenuItem(
-        '/ai-agent',
         t('webui.menu.AIAgents'),
         <BotMessageSquare style={{ color: token.colorPrimary }} />,
         'ai-agent',
         'playground',
       ),
     createMenuItem(
-      '/chat',
       t('webui.menu.Chat'),
       <MessageOutlined style={{ color: token.colorPrimary }} />,
       'chat',
       'playground',
     ),
     createMenuItem(
-      '/data',
       t('webui.menu.Data'),
       <CloudUploadOutlined style={{ color: token.colorPrimary }} />,
       'data',
       'storage',
     ),
     createMenuItem(
-      '/my-environment',
       t('webui.menu.MyEnvironments'),
       <BAIMyEnvironmentsIcon style={{ color: token.colorPrimary }} />,
       'my-environment',
@@ -337,14 +397,12 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
     ),
     !isHideAgents &&
       createMenuItem(
-        '/agent-summary',
         t('webui.menu.AgentSummary'),
         <HddOutlined style={{ color: token.colorPrimary }} />,
         'agent-summary',
         'metrics',
       ),
     createMenuItem(
-      '/statistics',
       t('webui.menu.Statistics'),
       <BarChartOutlined style={{ color: token.colorPrimary }} />,
       'statistics',
@@ -364,183 +422,161 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
 
   const isSuperAdmin = currentUserRole === 'superadmin';
 
+  const diagnosticsIcon = diagnosticsBadgeSeverity ? (
+    <Badge
+      dot
+      offset={[-2, 2]}
+      color={
+        diagnosticsBadgeSeverity === 'critical'
+          ? token.colorError
+          : token.colorWarning
+      }
+    >
+      <Activity style={{ color: token.colorInfo }} />
+    </Badge>
+  ) : (
+    <Activity style={{ color: token.colorInfo }} />
+  );
+
   const fullAdminMenu: Array<WebUIAdminMenuItemType> = filterOutEmpty([
     // --- Operations group ---
-    {
-      label: <WebUILink to="/credential">{t('webui.menu.Users')}</WebUILink>,
-      icon: <UserOutlined style={{ color: token.colorInfo }} />,
-      key: 'credential' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    {
-      label: (
-        <WebUILink to="/project-admin-users">
-          {t('webui.menu.ProjectMembers')}
-        </WebUILink>
+    createAdminMenuItem(
+      t('webui.menu.Users'),
+      <UserOutlined style={{ color: token.colorInfo }} />,
+      'credential',
+      'admin-operations',
+    ),
+    createAdminMenuItem(
+      t('webui.menu.ProjectMembers'),
+      <TeamOutlined style={{ color: token.colorInfo }} />,
+      'project-admin-users',
+      'admin-operations',
+    ),
+    createAdminMenuItem(
+      t('webui.menu.Data'),
+      <CloudUploadOutlined style={{ color: token.colorInfo }} />,
+      'project-data',
+      'admin-operations',
+    ),
+    createAdminMenuItem(
+      t('webui.menu.ProjectSessions'),
+      <BAISessionsIcon style={{ color: token.colorInfo }} />,
+      'project-admin-session',
+      'admin-operations',
+    ),
+    createAdminMenuItem(
+      t('webui.menu.ProjectDeployments'),
+      <BAIEndpointsIcon style={{ color: token.colorInfo }} />,
+      'project-admin-deployments',
+      'admin-operations',
+    ),
+    isSuperAdmin &&
+      createAdminMenuItem(
+        t('webui.menu.Projects'),
+        <TeamOutlined style={{ color: token.colorInfo }} />,
+        'project',
+        'admin-operations',
       ),
-      icon: <TeamOutlined style={{ color: token.colorInfo }} />,
-      key: 'project-admin-users' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    {
-      label: <WebUILink to="/project-data">{t('webui.menu.Data')}</WebUILink>,
-      icon: <CloudUploadOutlined style={{ color: token.colorInfo }} />,
-      key: 'project-data' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    {
-      label: (
-        <WebUILink to="/project-admin-session">
-          {t('webui.menu.ProjectSessions')}
-        </WebUILink>
+    isSuperAdmin &&
+      createAdminMenuItem(
+        t('webui.menu.Data'),
+        <CloudUploadOutlined style={{ color: token.colorInfo }} />,
+        'admin-data',
+        'admin-operations',
       ),
-      icon: <BAISessionsIcon style={{ color: token.colorInfo }} />,
-      key: 'project-admin-session' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    {
-      label: (
-        <WebUILink to="/project-admin-deployments">
-          {t('webui.menu.ProjectDeployments')}
-        </WebUILink>
+    createAdminMenuItem(
+      t('webui.menu.Sessions'),
+      <BAISessionsIcon style={{ color: token.colorInfo }} />,
+      'admin-session',
+      'admin-operations',
+    ),
+    isSuperAdmin &&
+      createAdminMenuItem(
+        t('webui.menu.Deployments'),
+        <BAIEndpointsIcon style={{ color: token.colorInfo }} />,
+        'admin-deployments',
+        'admin-operations',
       ),
-      icon: <BAIEndpointsIcon style={{ color: token.colorInfo }} />,
-      key: 'project-admin-deployments' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    isSuperAdmin && {
-      label: <WebUILink to="/project">{t('webui.menu.Projects')}</WebUILink>,
-      icon: <TeamOutlined style={{ color: token.colorInfo }} />,
-      key: 'project' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    isSuperAdmin && {
-      label: <WebUILink to="/admin-data">{t('webui.menu.Data')}</WebUILink>,
-      icon: <CloudUploadOutlined style={{ color: token.colorInfo }} />,
-      key: 'admin-data' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    {
-      label: (
-        <WebUILink to="/admin-session">{t('webui.menu.Sessions')}</WebUILink>
-      ),
-      icon: <BAISessionsIcon style={{ color: token.colorInfo }} />,
-      key: 'admin-session' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    isSuperAdmin && {
-      label: (
-        <WebUILink to="/admin-deployments">
-          {t('webui.menu.Deployments')}
-        </WebUILink>
-      ),
-      icon: <BAIEndpointsIcon style={{ color: token.colorInfo }} />,
-      key: 'admin-deployments' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    {
-      label: (
-        <WebUILink to="/environment">{t('webui.menu.Environments')}</WebUILink>
-      ),
-      icon: <FileDoneOutlined style={{ color: token.colorInfo }} />,
-      key: 'environment' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
+    createAdminMenuItem(
+      t('webui.menu.Environments'),
+      <FileDoneOutlined style={{ color: token.colorInfo }} />,
+      'environment',
+      'admin-operations',
+    ),
     baiClient?.supports('reservoir') &&
-      baiClient?._config.enableReservoir && {
-        label: (
-          <WebUILink to="/reservoir">{t('webui.menu.Reservoir')}</WebUILink>
-        ),
-        icon: <PackagePlus style={{ color: token.colorInfo }} />,
-        key: 'reservoir' as MenuKeys,
-        group: 'admin-operations' as AdminMenuGroupName,
-      },
-    baiClient?.supports('fair-share-scheduling') && {
-      label: <WebUILink to="/scheduler">{t('webui.menu.Scheduler')}</WebUILink>,
-      icon: <ClipboardClock style={{ color: token.colorInfo }} />,
-      key: 'scheduler' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
-    {
-      label: (
-        <WebUILink to="/resource-policy">
-          {t('webui.menu.ResourcePolicies')}
-        </WebUILink>
+      baiClient?._config.enableReservoir &&
+      createAdminMenuItem(
+        t('webui.menu.Reservoir'),
+        <PackagePlus style={{ color: token.colorInfo }} />,
+        'reservoir',
+        'admin-operations',
       ),
-      icon: <SolutionOutlined style={{ color: token.colorInfo }} />,
-      key: 'resource-policy' as MenuKeys,
-      group: 'admin-operations' as AdminMenuGroupName,
-    },
+    baiClient?.supports('fair-share-scheduling') &&
+      createAdminMenuItem(
+        t('webui.menu.Scheduler'),
+        <ClipboardClock style={{ color: token.colorInfo }} />,
+        'scheduler',
+        'admin-operations',
+      ),
+    createAdminMenuItem(
+      t('webui.menu.ResourcePolicies'),
+      <SolutionOutlined style={{ color: token.colorInfo }} />,
+      'resource-policy',
+      'admin-operations',
+    ),
     // --- Infrastructure group (superadmin only) ---
-    isSuperAdmin && {
-      label: <WebUILink to="/agent">{t('webui.menu.Resources')}</WebUILink>,
-      icon: <HddOutlined style={{ color: token.colorInfo }} />,
-      key: 'agent' as MenuKeys,
-      group: 'admin-infrastructure' as AdminMenuGroupName,
-    },
-    isSuperAdmin && {
-      label: (
-        <WebUILink to="/settings">{t('webui.menu.Configurations')}</WebUILink>
+    isSuperAdmin &&
+      createAdminMenuItem(
+        t('webui.menu.Resources'),
+        <HddOutlined style={{ color: token.colorInfo }} />,
+        'agent',
+        'admin-infrastructure',
       ),
-      icon: <ControlOutlined style={{ color: token.colorInfo }} />,
-      key: 'settings' as MenuKeys,
-      group: 'admin-infrastructure' as AdminMenuGroupName,
-    },
-    isSuperAdmin && {
-      label: (
-        <WebUILink to="/maintenance">{t('webui.menu.Maintenance')}</WebUILink>
+    isSuperAdmin &&
+      createAdminMenuItem(
+        t('webui.menu.Configurations'),
+        <ControlOutlined style={{ color: token.colorInfo }} />,
+        'settings',
+        'admin-infrastructure',
       ),
-      icon: <ToolOutlined style={{ color: token.colorInfo }} />,
-      key: 'maintenance' as MenuKeys,
-      group: 'admin-infrastructure' as AdminMenuGroupName,
-    },
-    isSuperAdmin && {
-      label: (
-        <WebUILink to="/diagnostics">{t('webui.menu.Diagnostics')}</WebUILink>
+    isSuperAdmin &&
+      createAdminMenuItem(
+        t('webui.menu.Maintenance'),
+        <ToolOutlined style={{ color: token.colorInfo }} />,
+        'maintenance',
+        'admin-infrastructure',
       ),
-      icon: diagnosticsBadgeSeverity ? (
-        <Badge
-          dot
-          offset={[-2, 2]}
-          color={
-            diagnosticsBadgeSeverity === 'critical'
-              ? token.colorError
-              : token.colorWarning
-          }
-        >
-          <Activity style={{ color: token.colorInfo }} />
-        </Badge>
-      ) : (
-        <Activity style={{ color: token.colorInfo }} />
+    isSuperAdmin &&
+      createAdminMenuItem(
+        t('webui.menu.Diagnostics'),
+        diagnosticsIcon,
+        'diagnostics',
+        'admin-infrastructure',
       ),
-      key: 'diagnostics' as MenuKeys,
-      group: 'admin-infrastructure' as AdminMenuGroupName,
-    },
     // --- System group (superadmin only) ---
     isSuperAdmin &&
-      baiClient?.supports('rbac') && {
-        label: (
-          <WebUILink to="/rbac">{t('webui.menu.RBACManagement')}</WebUILink>
-        ),
-        icon: <SafetyCertificateOutlined style={{ color: token.colorInfo }} />,
-        key: 'rbac' as MenuKeys,
-        group: 'admin-system' as AdminMenuGroupName,
-      },
-    isSuperAdmin &&
-      !isThemePreviewMode && {
-        label: <WebUILink to="/branding">{t('webui.menu.Branding')}</WebUILink>,
-        icon: <Palette style={{ color: token.colorInfo }} />,
-        key: 'branding' as MenuKeys,
-        group: 'admin-system' as AdminMenuGroupName,
-      },
-    isSuperAdmin && {
-      label: (
-        <WebUILink to="/information">{t('webui.menu.Information')}</WebUILink>
+      baiClient?.supports('rbac') &&
+      createAdminMenuItem(
+        t('webui.menu.RBACManagement'),
+        <SafetyCertificateOutlined style={{ color: token.colorInfo }} />,
+        'rbac',
+        'admin-system',
       ),
-      icon: <InfoCircleOutlined style={{ color: token.colorInfo }} />,
-      key: 'information' as MenuKeys,
-      group: 'admin-system' as AdminMenuGroupName,
-    },
+    isSuperAdmin &&
+      !isThemePreviewMode &&
+      createAdminMenuItem(
+        t('webui.menu.Branding'),
+        <Palette style={{ color: token.colorInfo }} />,
+        'branding',
+        'admin-system',
+      ),
+    isSuperAdmin &&
+      createAdminMenuItem(
+        t('webui.menu.Information'),
+        <InfoCircleOutlined style={{ color: token.colorInfo }} />,
+        'information',
+        'admin-system',
+      ),
   ]);
 
   // 3-tier admin gating:
@@ -778,7 +814,7 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
 
   const isSelectedAdminCategoryMenu = _.some(adminMenu, (item) => {
     if (item && 'key' in item) {
-      return item.key === location.pathname.split('/')[1];
+      return item.key === currentMenuKeyFromRoute;
     }
     return false;
   });
@@ -791,10 +827,10 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   // when the user's role excludes it from the admin menu (e.g. superadmin on
   // `/project-admin-users`, or a user switched into a project where they
   // lack admin rights).
-  const currentPathFirstSegment = location.pathname.split('/')[1] || '';
+  const currentPageMenuKey = currentMenuKeyFromRoute ?? '';
   const isCurrentPathAdminCategory =
-    ALL_ADMIN_PAGE_KEYS.has(currentPathFirstSegment) ||
-    PROJECT_ADMIN_PAGE_KEY_SET.has(currentPathFirstSegment);
+    ALL_ADMIN_PAGE_KEYS.has(currentPageMenuKey) ||
+    PROJECT_ADMIN_PAGE_KEY_SET.has(currentPageMenuKey);
 
   // Get the first available menu item from groupedGeneralMenu
   // (after blocklist filtering, excluding disabled/inactive items)
@@ -825,8 +861,13 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
     return null;
   })();
 
-  // Check if current page is in blocklist
-  const currentPathKey = location.pathname.split('/')[1] || '';
+  // Check if current page is in blocklist.
+  // `currentMenuKeyFromRoute` is the scope-aware legacy menu key (from the
+  // matched route handle), so it equals the feature key for general pages and
+  // the hyphenated admin key for admin pages — exactly what `allValidPaths`,
+  // `ALL_ADMIN_PAGE_KEYS` and `PROJECT_ADMIN_PAGE_KEY_SET` are keyed on. Empty
+  // (`''`) means "root / no feature matched" and is treated as always valid.
+  const currentPathKey = currentMenuKeyFromRoute ?? '';
   const currentMenuKey = currentPathKey;
   // Root path '/' should not be blocked (it redirects to first available menu)
   const isCurrentPageBlocked =
@@ -928,12 +969,16 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   // Get theme config for custom logo href
   const { themeConfig } = useCustomThemeConfig();
 
-  // Default menu path considering theme config's logo href
-  // Priority: themeConfig.logo.href > firstAvailableMenuItem path > '/start'
+  // Default menu path considering theme config's logo href.
+  // Priority: themeConfig.logo.href > firstAvailableMenuItem path > '/start'.
+  // Project-aware: `getPathFromMenuKey` builds `/project/<name>/<feature>` for
+  // the first general menu item using the active project name. When no project
+  // is resolvable it falls back to the legacy flat path (e.g. `/start`), which
+  // the redirect shims resolve to the canonical project URL at runtime.
   const defaultMenuPath =
     themeConfig?.logo?.href ||
     (firstAvailableMenuItem?.key
-      ? getPathFromMenuKey(firstAvailableMenuItem.key)
+      ? getPathFromMenuKey(firstAvailableMenuItem.key, activeProjectName)
       : '/start');
 
   return {

--- a/react/src/legacyRedirects.tsx
+++ b/react/src/legacyRedirects.tsx
@@ -1,0 +1,119 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Backward-compatibility redirect shims for the scope-aware routing scheme.
+ *
+ * Old, project-less URLs (`/session`, `/deployments/:id`, `/admin-session`,
+ * `/project-data`, `/credential`, ...) keep working by redirecting (`replace`)
+ * to their new canonical paths. This protects deep links, bookmarks, and the
+ * external `react-navigate` event that Lit / electron shells dispatch.
+ *
+ * Two flavours:
+ *   - Class A (static): admin / system paths that do NOT need a runtime project
+ *     (e.g. `/admin-session -> /admin/session`).
+ *   - Class B (runtime project): user & project-admin paths that must inject the
+ *     current project NAME into the target (e.g. `/session ->
+ *     /project/<cur>/session`). The current project is read from the atom via
+ *     `useActiveProjectName()`. When no project is resolvable, the shim renders
+ *     a terminal "no accessible projects" guidance instead of redirecting:
+ *     redirecting to a project-scoped path (e.g. `/start`, itself a Class B shim)
+ *     would bounce back here and loop.
+ *
+ * All shims preserve `location.search`. The factories that handle detail routes
+ * read the dynamic param (`:deploymentId` / `:serviceId` / `:presetId` /
+ * `:artifactId`) and forward it.
+ */
+import WebUINavigate from './components/WebUINavigate';
+import { buildPath, RouteScope, FeatureKey } from './helper/pathBuilder';
+import { useActiveProjectName } from './hooks/useRouteScope';
+import { BAIAlert, BAIFlex } from 'backend.ai-ui';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useParams } from 'react-router-dom';
+
+/**
+ * Builds the trailing segment(s) after the feature key from the matched dynamic
+ * params, e.g. `:deploymentId` -> `/<id>`. Returns '' when no param is present.
+ */
+const useDetailSuffix = (
+  paramName?: string,
+): { suffix: string; missing: boolean } => {
+  'use memo';
+  const params = useParams();
+  if (!paramName) {
+    return { suffix: '', missing: false };
+  }
+  const value = params[paramName];
+  if (!value) {
+    return { suffix: '', missing: true };
+  }
+  return { suffix: `/${value}`, missing: false };
+};
+
+interface LegacyRedirectOptions {
+  /** Append a fixed sub-path after the feature key (e.g. 'start', 'deployment-presets/new'). */
+  subPath?: string;
+  /**
+   * Read a dynamic route param and append it after the feature key
+   * (e.g. 'deploymentId' -> `/<deploymentId>`). Mutually exclusive with
+   * `subPath`.
+   */
+  param?: string;
+}
+
+/**
+ * Class A — static admin redirect. Produces a `<WebUINavigate>` to the
+ * scope-aware admin path for `featureKey`, preserving search and any
+ * configured sub-path / dynamic param. No project is required.
+ */
+export const AdminRedirect: React.FC<{
+  featureKey: FeatureKey;
+  options?: LegacyRedirectOptions;
+}> = ({ featureKey, options }) => {
+  'use memo';
+  const location = useLocation();
+  const { suffix } = useDetailSuffix(options?.param);
+  const tail = options?.subPath ? `/${options.subPath}` : suffix;
+  const target = buildPath('admin', featureKey) + tail + location.search;
+  return <WebUINavigate to={target} replace />;
+};
+
+/**
+ * Class B — runtime project-scoped redirect. Injects the current project NAME
+ * and produces a `<WebUINavigate>` to the scope-aware (`project` /
+ * `projectAdmin`) path. Falls back to `/start` when no project is resolvable.
+ */
+export const ProjectScopedRedirect: React.FC<{
+  scope: Extract<RouteScope, 'project' | 'projectAdmin'>;
+  featureKey: FeatureKey;
+  options?: LegacyRedirectOptions;
+}> = ({ scope, featureKey, options }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const location = useLocation();
+  const projectName = useActiveProjectName();
+  const { suffix } = useDetailSuffix(options?.param);
+
+  if (!projectName) {
+    // No resolvable project (user belongs to no project). Render the same
+    // "no accessible projects" guidance as ProjectScopeLayout. Redirecting to a
+    // project-scoped path (e.g. `/start`, itself a Class B shim) would bounce
+    // back here and loop, so this branch is terminal.
+    return (
+      <BAIFlex direction="column" align="stretch" style={{ width: '100%' }}>
+        <BAIAlert
+          type="warning"
+          showIcon
+          description={t('projectSelect.NoAccessibleProjects')}
+        />
+      </BAIFlex>
+    );
+  }
+
+  const tail = options?.subPath ? `/${options.subPath}` : suffix;
+  const target =
+    buildPath(scope, featureKey, projectName) + tail + location.search;
+  return <WebUINavigate to={target} replace />;
+};

--- a/react/src/pages/AIAgentPage.tsx
+++ b/react/src/pages/AIAgentPage.tsx
@@ -6,6 +6,7 @@ import AgentEditorModal from '../components/AgentEditorModal';
 import { FluentEmojiIcon } from '../components/FluentEmojiIcon';
 import { useWebUINavigate } from '../hooks';
 import { AIAgent, useAIAgent } from '../hooks/useAIAgent';
+import { useProjectPath } from '../hooks/useRouteScope';
 import { DeleteFilled, MoreOutlined, UndoOutlined } from '@ant-design/icons';
 import {
   Button,
@@ -185,6 +186,7 @@ const AIAgentPage: React.FC = () => {
   const { agents, builtInAgents, deleteAgent, getEndpointBinding } =
     useAIAgent();
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const { styles } = useStyles();
 
   const [isEditorOpen, setIsEditorOpen] = useState(false);
@@ -248,7 +250,7 @@ const AIAgentPage: React.FC = () => {
                     searchParams.endpointId = binding.endpoint_id;
                   }
                   webuiNavigate({
-                    pathname: '/chat',
+                    pathname: buildProjectPath('chat'),
                     search: new URLSearchParams(searchParams).toString(),
                   });
                 }}

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -16,6 +16,7 @@ import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import DeploymentSettingModal from '../components/DeploymentSettingModal';
 import PrometheusPresetTab from '../components/PrometheusPresetTab';
+import { buildPath } from '../helper/pathBuilder';
 import {
   useSuspendedBackendaiClient,
   useTabQuerySnapshot,
@@ -431,7 +432,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
                         stopRowClick
                         onTagClick={(tag) => {
                           webUINavigate({
-                            pathname: '/admin-deployments',
+                            pathname: buildPath('admin', 'deployments'),
                             search: new URLSearchParams({
                               filter: JSON.stringify({
                                 tags: { iContains: tag },

--- a/react/src/pages/AdminDeploymentPresetListPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetListPage.tsx
@@ -13,6 +13,7 @@ import AdminDeploymentPresetNodes, {
   type DeploymentPresetNodeInList,
 } from '../components/AdminDeploymentPresetNodes';
 import { convertToOrderBy } from '../helper';
+import { buildPath } from '../helper/pathBuilder';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -138,12 +139,15 @@ const AdminDeploymentPresetListPage: React.FC = () => {
 
   const handleEditPreset = (preset: DeploymentPresetNodeInList) => {
     webuiNavigate(
-      `/admin-deployments/deployment-presets/${toLocalId(preset.id)}/edit`,
+      buildPath(
+        'admin',
+        `deployments/deployment-presets/${toLocalId(preset.id)}/edit`,
+      ),
     );
   };
 
   const handleOpenCreateModal = () => {
-    webuiNavigate('/admin-deployments/deployment-presets/new');
+    webuiNavigate(buildPath('admin', 'deployments/deployment-presets/new'));
   };
 
   const isSupported = baiClient.supports('deployment-preset');

--- a/react/src/pages/AdminDeploymentPresetSettingPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetSettingPage.tsx
@@ -12,6 +12,7 @@ import AdminDeploymentPresetSettingPageContent, {
   type ModelDefinitionFormValue,
 } from '../components/AdminDeploymentPresetSettingPageContent';
 import { tokenizeShellCommand } from '../helper/parseCliCommand';
+import { buildPath } from '../helper/pathBuilder';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { type RuntimeVariantPresetValueEntry } from '../hooks/useRuntimeParameterSchema';
 import { App, Form, Typography, theme } from 'antd';
@@ -266,7 +267,7 @@ const AdminDeploymentPresetSettingPage: React.FC = () => {
     const params = new URLSearchParams();
     params.set('tab', 'deployment-presets');
     webuiNavigate({
-      pathname: '/admin-deployments',
+      pathname: buildPath('admin', 'deployments'),
       search: params.toString(),
     });
   };

--- a/react/src/pages/AdminModelCardListPage.tsx
+++ b/react/src/pages/AdminModelCardListPage.tsx
@@ -14,6 +14,7 @@ import AdminModelCardSettingModal from '../components/AdminModelCardSettingModal
 import { useFolderExplorerOpener } from '../components/FolderExplorerOpener';
 import VFolderNodeIdenticonV2 from '../components/VFolderNodeIdenticonV2';
 import { convertToOrderBy, handleRowSelectionChange } from '../helper';
+import { buildPath } from '../helper/pathBuilder';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -549,7 +550,7 @@ const AdminModelCardListPage: React.FC = () => {
                       type: 'success',
                       message: t('adminModelCard.ModelCardAndFolderDeleted'),
                       to: {
-                        pathname: '/admin-data',
+                        pathname: buildPath('admin', 'data'),
                         search: folderTrashSearch,
                       },
                       toText: t('adminModelCard.GoToTrash'),
@@ -692,7 +693,7 @@ const AdminModelCardListPage: React.FC = () => {
                       { count: successes.length },
                     ),
                     to: {
-                      pathname: '/admin-data',
+                      pathname: buildPath('admin', 'data'),
                       search: new URLSearchParams({
                         statusCategory: 'deleted',
                       }).toString(),

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -14,6 +14,7 @@ import { type ChatProviderData } from '../components/Chat/ChatModel';
 import WebUINavigate from '../components/WebUINavigate';
 import { useWebUINavigate } from '../hooks';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   Alert,
   Badge,
@@ -210,6 +211,7 @@ const PureChatPage = ({ id }: { id: string }) => {
     updateHistory,
   } = useHistory(id, provider);
   const navigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   return (
     chat && (
@@ -274,7 +276,7 @@ const PureChatPage = ({ id }: { id: string }) => {
                   icon={<PlusIcon />}
                   onClick={() => {
                     setOpenHistory(false);
-                    navigate('/chat', { replace: true });
+                    navigate(buildProjectPath('chat'), { replace: true });
                   }}
                 />
               </Tooltip>
@@ -355,14 +357,14 @@ const PureChatPage = ({ id }: { id: string }) => {
 
               if (remainHistories === 0) {
                 setOpenHistory(false);
-                navigate('/chat', { replace: true });
+                navigate(buildProjectPath('chat'), { replace: true });
               } else if (historyId === chat.id) {
                 const chat = history.filter(({ id }) => id !== historyId)[0];
-                navigate(`/chat/${chat?.id}`, { replace: true });
+                navigate(buildProjectPath(`chat/${chat?.id}`), { replace: true });
               }
             }}
             onClickHistory={(historyId) => {
-              navigate(`/chat/${historyId}`, { replace: true });
+              navigate(buildProjectPath(`chat/${historyId}`), { replace: true });
             }}
           />
         </BAICard>
@@ -380,10 +382,12 @@ function isClonable(chatLength: number) {
 }
 
 const ChatPage: React.FC = () => {
+  'use memo';
   const { id } = useParams();
+  const buildProjectPath = useProjectPath();
 
   if (id && !getChatById(id)) {
-    return <WebUINavigate to="/chat" replace />;
+    return <WebUINavigate to={buildProjectPath('chat')} replace />;
   }
 
   return <PureChatPage id={id || generateChatId()} />;

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -24,6 +24,7 @@ import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginati
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCSVExport } from '../hooks/useCSVExport';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useProjectPath } from '../hooks/useRouteScope';
 import {
   Alert,
   App,
@@ -93,6 +94,7 @@ const ComputeSessionListPage = () => {
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const webUINavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const location = useLocation();
   const [selectedSessionList, setSelectedSessionList] = useState<
     Array<SessionNode>
@@ -316,7 +318,7 @@ const ComputeSessionListPage = () => {
                 buttonText={t('start.button.StartSession')}
                 icon={<BAISessionsIcon />}
                 type="simple"
-                to={'/session/start'}
+                to={buildProjectPath('session/start')}
                 style={{
                   height: '100%',
                 }}
@@ -368,7 +370,7 @@ const ComputeSessionListPage = () => {
         variant="borderless"
         title={t('webui.menu.Sessions')}
         extra={
-          <BAILink to={'/session/start'}>
+          <BAILink to={buildProjectPath('session/start')}>
             <Button type="primary">{t('start.button.StartSession')}</Button>
           </BAILink>
         }

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -22,6 +22,7 @@ import {
   useCurrentProjectValue,
   useCurrentResourceGroupValue,
 } from '../hooks/useCurrentProject';
+import { useProjectPath } from '../hooks/useRouteScope';
 import { Skeleton, theme } from 'antd';
 import {
   BAIBoardItemErrorBoundary,
@@ -44,6 +45,7 @@ const DashboardPage: React.FC = () => {
   const userRole = useCurrentUserRole();
   const baiClient = useSuspendedBackendaiClient();
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [isPendingIntervalRefetch, startIntervalRefetchTransition] =
@@ -193,7 +195,7 @@ const DashboardPage: React.FC = () => {
                 fetchKey={fetchKey}
                 onRequestBadgeClick={() => {
                   webuiNavigate({
-                    pathname: '/data',
+                    pathname: buildProjectPath('data'),
                     search: new URLSearchParams({
                       invitation: 'true',
                     }).toString(),

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -14,9 +14,11 @@ import DeploymentReplicasCard from '../components/DeploymentReplicasCard';
 import DeploymentRevisionCard from '../components/DeploymentRevisionCard';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import SwitchToProjectButton from '../components/SwitchToProjectButton';
+import { buildPath } from '../helper/pathBuilder';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useActiveProjectName } from '../hooks/useRouteScope';
 import {
   getPathFromMenuKey,
   useWebUIMenuItems,
@@ -72,6 +74,7 @@ const DeploymentDetailPage: React.FC = () => {
   const webuiNavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const currentProject = useCurrentProjectValue();
+  const activeProjectName = useActiveProjectName();
   const isChatBlocked = !!baiClient?._config?.blockList?.includes('chat');
 
   const { deploymentId: deploymentIdParam } = useParams<{
@@ -343,7 +346,7 @@ const DeploymentDetailPage: React.FC = () => {
                 icon={<BotMessageSquareIcon size={token.fontSizeLG} />}
                 onClick={() => {
                   webuiNavigate({
-                    pathname: '/chat',
+                    pathname: buildPath('project', 'chat', activeProjectName),
                     search: new URLSearchParams({
                       endpointId: deploymentId,
                     }).toString(),
@@ -494,11 +497,12 @@ const DeploymentInaccessibleResult: React.FC = () => {
   const { t } = useTranslation();
   const webuiNavigate = useWebUINavigate();
   const { firstAvailableMenuItem } = useWebUIMenuItems();
+  const activeProjectName = useActiveProjectName();
   // Mirror Page401 — route to the user's first available menu item so the
   // button takes them somewhere actionable instead of bouncing through the
   // index redirect.
   const defaultPagePath = firstAvailableMenuItem
-    ? getPathFromMenuKey(firstAvailableMenuItem.key)
+    ? getPathFromMenuKey(firstAvailableMenuItem.key, activeProjectName)
     : '/start';
   const defaultPageTitle =
     firstAvailableMenuItem?.labelText ?? t('webui.menu.FirstPageNameAlias');

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -18,6 +18,7 @@ import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useProjectPath } from '../hooks/useRouteScope';
 import { DeleteFilled } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import { App, Button, Skeleton, Typography } from 'antd';
@@ -56,6 +57,7 @@ const DeploymentListPageContent: React.FC = () => {
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const [isCreating, { setLeft: closeCreate, setRight: openCreate }] =
     useToggle(false);
 
@@ -382,7 +384,7 @@ const DeploymentListPageContent: React.FC = () => {
                         stopRowClick
                         onTagClick={(tag) => {
                           webuiNavigate({
-                            pathname: '/deployments',
+                            pathname: buildProjectPath('deployments'),
                             search: new URLSearchParams({
                               filter: JSON.stringify({
                                 tags: { iContains: tag },

--- a/react/src/pages/Page401.tsx
+++ b/react/src/pages/Page401.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useActiveProjectName } from '../hooks/useRouteScope';
 import {
   getPathFromMenuKey,
   useWebUIMenuItems,
@@ -15,10 +16,11 @@ const Page401 = () => {
   const { t } = useTranslation();
   const webuiNavigate = useWebUINavigate();
   const { firstAvailableMenuItem } = useWebUIMenuItems();
+  const activeProjectName = useActiveProjectName();
   useSuspendedBackendaiClient(); //monkey patch for flickering
 
   const defaultPagePath = firstAvailableMenuItem
-    ? getPathFromMenuKey(firstAvailableMenuItem.key)
+    ? getPathFromMenuKey(firstAvailableMenuItem.key, activeProjectName)
     : '/start';
   const defaultPageTitle =
     firstAvailableMenuItem?.labelText ?? t('webui.menu.FirstPageNameAlias');

--- a/react/src/pages/Page404.tsx
+++ b/react/src/pages/Page404.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useActiveProjectName } from '../hooks/useRouteScope';
 import {
   getPathFromMenuKey,
   useWebUIMenuItems,
@@ -15,10 +16,11 @@ const Page404 = () => {
   const { t } = useTranslation();
   const webuiNavigate = useWebUINavigate();
   const { firstAvailableMenuItem } = useWebUIMenuItems();
+  const activeProjectName = useActiveProjectName();
   useSuspendedBackendaiClient(); //monkey patch for flickering
 
   const defaultPagePath = firstAvailableMenuItem
-    ? getPathFromMenuKey(firstAvailableMenuItem.key)
+    ? getPathFromMenuKey(firstAvailableMenuItem.key, activeProjectName)
     : '/start';
   const defaultPageTitle =
     firstAvailableMenuItem?.labelText ?? t('webui.menu.FirstPageNameAlias');

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -20,6 +20,7 @@ import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useProjectPath } from '../hooks/useRouteScope';
 import { DeleteFilled } from '@ant-design/icons';
 import { App, Skeleton, Typography } from 'antd';
 import {
@@ -63,6 +64,7 @@ const ProjectAdminDeploymentsContent: React.FC<
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const webUINavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
 
   const [editingDeploymentId, setEditingDeploymentId] = useState<string | null>(
     null,
@@ -330,7 +332,9 @@ const ProjectAdminDeploymentsContent: React.FC<
                           title={record.metadata?.name ?? '-'}
                           onTitleClick={() =>
                             webUINavigate(
-                              `/project-admin-deployments/${toLocalId(record.id)}`,
+                              buildProjectPath(
+                                `deployments/${toLocalId(record.id)}`,
+                              ),
                             )
                           }
                           copyable
@@ -388,7 +392,7 @@ const ProjectAdminDeploymentsContent: React.FC<
                         stopRowClick
                         onTagClick={(tag) => {
                           webUINavigate({
-                            pathname: '/project-admin-deployments',
+                            pathname: buildProjectPath('deployments'),
                             search: new URLSearchParams({
                               filter: JSON.stringify({
                                 tags: { iContains: tag },

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -13,6 +13,7 @@ import {
 import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import ImportArtifactRevisionToFolderButton from '../components/ImportArtifactRevisionToFolderButton';
 import ImportArtifactRevisionToFolderModal from '../components/ImportArtifactRevisionToFolderModal';
+import { buildPath } from '../helper/pathBuilder';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { Button, Typography, Descriptions, theme, Tooltip } from 'antd';
@@ -655,7 +656,7 @@ const ReservoirArtifactDetailPage = () => {
                       }),
                       showIcon: true,
                       toText: t('reservoirPage.GoToArtifact'),
-                      to: `/reservoir/${task.artifact.id}`,
+                      to: buildPath('admin', `reservoir/${task.artifact.id}`),
                     };
                   },
                   rejected: (_data, _notification) => {

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -12,6 +12,7 @@ import {
 import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import ScanArtifactModelsFromHuggingFaceModal from '../components/ScanArtifactModelsFromHuggingFaceModal';
+import { buildPath } from '../helper/pathBuilder';
 import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
@@ -564,7 +565,7 @@ const ReservoirPage: React.FC = () => {
                         version: task.version,
                       }),
                       toText: t('reservoirPage.GoToArtifact'),
-                      to: `/reservoir/${task.artifact.id}`,
+                      to: buildPath('admin', `reservoir/${task.artifact.id}`),
                     };
                   },
                   rejected: (_data, _notification) => {
@@ -587,7 +588,7 @@ const ReservoirPage: React.FC = () => {
         open={deferredOpenHuggingFaceModal}
         onRequestClose={(_e, artifactId) => {
           toggleOpenHuggingFaceModal();
-          navigate(`/reservoir/${toLocalId(artifactId)}`);
+          navigate(buildPath('admin', `reservoir/${toLocalId(artifactId)}`));
         }}
         onCancel={toggleOpenHuggingFaceModal}
       />

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -11,6 +11,7 @@ import ThemeSecondaryProvider from '../components/ThemeSecondaryProvider';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useProjectPath } from '../hooks/useRouteScope';
 import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
 import { MenuKeys } from '../hooks/useWebUIMenuItems';
 import { SessionLauncherFormValue } from './SessionLauncherPage';
@@ -44,6 +45,7 @@ const StartPage: React.FC = () => {
   const enableModelFolders = baiClient?._config?.enableModelFolders ?? false;
 
   const webuiNavigate = useWebUINavigate();
+  const buildProjectPath = useProjectPath();
   const [isOpenCreateModal, setIsOpenCreateModal] = useState<boolean>(false);
   const [isOpenStartURLModal, setIsOpenStartURLModal] =
     useState<boolean>(false);
@@ -175,7 +177,7 @@ const StartPage: React.FC = () => {
             description={t('start.StartSessionDesc')}
             buttonText={t('start.button.StartSession')}
             icon={<BAIInteractiveSessionIcon />}
-            onClick={() => webuiNavigate('/session/start')}
+            onClick={() => webuiNavigate(buildProjectPath('session/start'))}
           />
         ),
       },
@@ -200,7 +202,9 @@ const StartPage: React.FC = () => {
               const params = new URLSearchParams();
               params.set('step', '0');
               params.set('formValues', JSON.stringify(launcherValue));
-              webuiNavigate(`/session/start?${params.toString()}`);
+              webuiNavigate(
+                `${buildProjectPath('session/start')}?${params.toString()}`,
+              );
             }}
           />
         ),
@@ -220,7 +224,7 @@ const StartPage: React.FC = () => {
               description={t('start.StartDeploymentDesc')}
               buttonText={t('start.button.StartDeployment')}
               icon={<AppstoreAddOutlined />}
-              onClick={() => webuiNavigate('/deployments')}
+              onClick={() => webuiNavigate(buildProjectPath('deployments'))}
             />
           </ThemeSecondaryProvider>
         ),
@@ -300,7 +304,7 @@ const StartPage: React.FC = () => {
           onRequestClose={(response) => {
             setIsOpenCreateModal(false);
             if (response) {
-              webuiNavigate('/data');
+              webuiNavigate(buildProjectPath('data'));
             }
           }}
         />

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -11,7 +11,9 @@ import ErrorBoundaryWithNullFallback from './components/ErrorBoundaryWithNullFal
 import FlexActivityIndicator from './components/FlexActivityIndicator';
 import LocationStateBreadCrumb from './components/LocationStateBreadCrumb';
 import LoginView from './components/LoginView';
+import AdminScopeLayout from './components/MainLayout/AdminScopeLayout';
 import MainLayout from './components/MainLayout/MainLayout';
+import ProjectScopeLayout from './components/MainLayout/ProjectScopeLayout';
 import { STokenLoginBoundary } from './components/STokenLoginBoundary';
 import StorageHostFetchErrorBoundary from './components/StorageHostFetchErrorBoundary';
 import WebUINavigate from './components/WebUINavigate';
@@ -26,6 +28,7 @@ import {
   populateRouterPaths,
 } from './hooks/useWebUIMenuItems';
 import { pluginApiEndpointState } from './hooks/useWebUIPluginState';
+import { AdminRedirect, ProjectScopedRedirect } from './legacyRedirects';
 // High priority to import the component
 import ComputeSessionListPage from './pages/ComputeSessionListPage';
 import Page404 from './pages/Page404';
@@ -36,7 +39,7 @@ import { useSetAtom } from 'jotai';
 import { parseAsString, useQueryStates } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { RouteObject, useLocation, useParams } from 'react-router-dom';
+import { RouteObject, useParams } from 'react-router-dom';
 
 const LoginViewLazy = React.lazy(() => import('./components/LoginView'));
 
@@ -137,6 +140,11 @@ const ModelStoreListPageV2 = React.lazy(
   () => import('./pages/ModelStoreListPageV2'),
 );
 
+const DefaultMenuRedirect: React.FC = () => {
+  const { defaultMenuPath } = useWebUIMenuItems();
+  return <WebUINavigate to={defaultMenuPath} replace />;
+};
+
 /**
  * MainLayout children routes - these are the actual page routes
  */
@@ -144,110 +152,526 @@ export const mainLayoutChildRoutes: RouteObject[] = [
   {
     // Redirect to first available menu when accessing root path
     index: true,
-    Component: () => {
-      const { defaultMenuPath } = useWebUIMenuItems();
-      return <WebUINavigate to={defaultMenuPath} replace />;
-    },
+    Component: DefaultMenuRedirect,
   },
   {
     //for electron dev mode
     path: '/build/electron-app/app/index.html',
-    Component: () => {
-      const { defaultMenuPath } = useWebUIMenuItems();
-      return <WebUINavigate to={defaultMenuPath} replace />;
-    },
+    Component: DefaultMenuRedirect,
   },
   {
     //for electron prod mode
     path: '/app/index.html',
-    Component: () => {
-      const { defaultMenuPath } = useWebUIMenuItems();
-      return <WebUINavigate to={defaultMenuPath} replace />;
-    },
+    Component: DefaultMenuRedirect,
   },
+  // --- New scope-aware subtrees ---
+  // Project scope subtree: `/project/:projectName/*` (general user menu) plus
+  // the nested `admin` segment for project-admin pages. Relative child paths +
+  // `handle.{scope,menuKey}` metadata drive the scope-aware primitives
+  // (`useRouteScope`, `useCurrentMenuKey`).
   {
-    path: '/start',
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <StartPage />
-      </Suspense>
-    ),
-    handle: { labelKey: 'webui.menu.Start' },
-  },
-  {
-    path: '/chat/:id?',
-    handle: { labelKey: 'webui.menu.Chat' },
-    Component: () => {
-      useSuspendedBackendaiClient();
-      return (
-        <Suspense fallback={<FlexActivityIndicator spinSize="large" />}>
-          <ChatPage />
-        </Suspense>
-      );
-    },
-  },
-  {
-    path: '/dashboard',
-    handle: { labelKey: 'webui.menu.Dashboard' },
-    Component: () => {
-      return (
-        <BAIErrorBoundary>
-          <Suspense fallback={<Skeleton active />}>
-            <DashboardPage />
-          </Suspense>
-        </BAIErrorBoundary>
-      );
-    },
-  },
-  {
-    // TODO: For the convenience of existing users, this path will be retained. It is scheduled for deletion in the future.
-    path: '/summary',
-    Component: () => {
-      const location = useLocation();
-      return <WebUINavigate to={'/dashboard' + location.search} replace />;
-    },
-    handle: { labelKey: 'webui.menu.Summary' },
-  },
-  {
-    // TODO: For the convenience of existing users, this path will be retained. It is scheduled for deletion in the future.
-    path: '/job',
-    handle: { labelKey: 'webui.menu.Sessions' },
-    Component: () => {
-      const location = useLocation();
-      return <WebUINavigate to={'/session' + location.search} replace />;
-    },
-  },
-  {
-    path: '/session',
-    handle: { labelKey: 'webui.menu.Sessions' },
+    path: 'project/:projectName',
+    element: <ProjectScopeLayout />,
     children: [
       {
-        path: '',
-        Component: () => {
-          useSuspendedBackendaiClient();
-
-          return (
-            <Suspense fallback={<Skeleton active />}>
-              <ComputeSessionListPage />
-              <SessionDetailAndContainerLogOpenerLegacy />
-            </Suspense>
-          );
+        path: 'start',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <StartPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'project',
+          menuKey: 'start',
+          labelKey: 'webui.menu.Start',
         },
       },
       {
-        path: '/session/start',
-        // handle: { labelKey: 'session.launcher.StartNewSession' },
+        path: 'dashboard',
         Component: () => {
-          const { token } = theme.useToken();
           return (
-            <BAIFlex
-              direction="column"
-              gap={token.paddingContentVerticalLG}
-              align="stretch"
-              style={{ paddingBottom: token.paddingContentVerticalLG }}
+            <BAIErrorBoundary>
+              <Suspense fallback={<Skeleton active />}>
+                <DashboardPage />
+              </Suspense>
+            </BAIErrorBoundary>
+          );
+        },
+        handle: {
+          scope: 'project',
+          menuKey: 'dashboard',
+          labelKey: 'webui.menu.Dashboard',
+        },
+      },
+      {
+        path: 'session',
+        handle: {
+          scope: 'project',
+          menuKey: 'session',
+          labelKey: 'webui.menu.Sessions',
+        },
+        children: [
+          {
+            index: true,
+            Component: () => {
+              useSuspendedBackendaiClient();
+              return (
+                <Suspense fallback={<Skeleton active />}>
+                  <ComputeSessionListPage />
+                  <SessionDetailAndContainerLogOpenerLegacy />
+                </Suspense>
+              );
+            },
+            handle: { scope: 'project', menuKey: 'session' },
+          },
+          {
+            path: 'start',
+            Component: () => {
+              const { token } = theme.useToken();
+              return (
+                <BAIFlex
+                  direction="column"
+                  gap={token.paddingContentVerticalLG}
+                  align="stretch"
+                  style={{ paddingBottom: token.paddingContentVerticalLG }}
+                >
+                  <LocationStateBreadCrumb />
+                  <StorageHostFetchErrorBoundary>
+                    <Suspense
+                      fallback={
+                        <BAIFlex direction="column" style={{ maxWidth: 700 }}>
+                          <Skeleton active />
+                        </BAIFlex>
+                      }
+                    >
+                      <SessionLauncherPage />
+                    </Suspense>
+                  </StorageHostFetchErrorBoundary>
+                </BAIFlex>
+              );
+            },
+            handle: {
+              scope: 'project',
+              menuKey: 'session',
+              labelKey: 'session.launcher.StartNewSession',
+            },
+          },
+        ],
+      },
+      {
+        path: 'deployments',
+        handle: {
+          scope: 'project',
+          menuKey: 'deployments',
+          labelKey: 'webui.menu.Deployments',
+        },
+        children: [
+          {
+            index: true,
+            Component: () => {
+              const { t } = useTranslation();
+              useSuspendedBackendaiClient();
+              return (
+                <Suspense
+                  fallback={
+                    <BAICard title={t('webui.menu.Deployments')} loading />
+                  }
+                >
+                  <DeploymentListPage />
+                </Suspense>
+              );
+            },
+            handle: { scope: 'project', menuKey: 'deployments' },
+          },
+          {
+            path: ':deploymentId',
+            element: (
+              <Suspense fallback={<Skeleton active />}>
+                <DeploymentDetailPage />
+              </Suspense>
+            ),
+            handle: {
+              scope: 'project',
+              menuKey: 'deployments',
+              labelKey: 'webui.menu.DeploymentDetail',
+            },
+          },
+        ],
+      },
+      {
+        path: 'model-store',
+        Component: () => (
+          <Suspense fallback={<Skeleton active />}>
+            <ModelStoreListPageV2 />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'project',
+          menuKey: 'model-store',
+          labelKey: 'data.ModelStore',
+        },
+      },
+      {
+        path: 'chat/:id?',
+        Component: () => {
+          useSuspendedBackendaiClient();
+          return (
+            <Suspense fallback={<FlexActivityIndicator spinSize="large" />}>
+              <ChatPage />
+            </Suspense>
+          );
+        },
+        handle: {
+          scope: 'project',
+          menuKey: 'chat',
+          labelKey: 'webui.menu.Chat',
+        },
+      },
+      {
+        path: 'data',
+        Component: () => {
+          return <VFolderNodeListPage />;
+        },
+        handle: {
+          scope: 'project',
+          menuKey: 'data',
+          labelKey: 'webui.menu.Data',
+        },
+      },
+      {
+        path: 'my-environment',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <MyEnvironmentPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'project',
+          menuKey: 'my-environment',
+          labelKey: 'webui.menu.MyEnvironments',
+        },
+      },
+      {
+        path: 'agent-summary',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <AgentSummaryPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'project',
+          menuKey: 'agent-summary',
+          labelKey: 'webui.menu.AgentSummary',
+        },
+      },
+      {
+        path: 'statistics',
+        Component: () => {
+          useSuspendedBackendaiClient();
+          return (
+            <Suspense
+              fallback={
+                <BAIFlex direction="column" style={{ maxWidth: 700 }}>
+                  <Skeleton active />
+                </BAIFlex>
+              }
             >
-              <LocationStateBreadCrumb />
-              <StorageHostFetchErrorBoundary>
+              <StatisticsPage />
+            </Suspense>
+          );
+        },
+        handle: {
+          scope: 'project',
+          menuKey: 'statistics',
+          labelKey: 'webui.menu.Statistics',
+        },
+      },
+      {
+        path: 'ai-agent',
+        Component: () => {
+          const [experimentalAIAgents] = useBAISettingUserState(
+            'experimental_ai_agents',
+          );
+          return experimentalAIAgents ? (
+            <Suspense fallback={<Skeleton active />}>
+              <AIAgentPage />
+            </Suspense>
+          ) : (
+            <WebUINavigate to={'/start'} replace />
+          );
+        },
+        handle: {
+          scope: 'project',
+          menuKey: 'ai-agent',
+          labelKey: 'webui.menu.AIAgents',
+        },
+      },
+      // --- project-admin scope: /project/:projectName/admin/* ---
+      {
+        path: 'admin',
+        children: [
+          {
+            path: 'session',
+            Component: () => {
+              useSuspendedBackendaiClient();
+              return (
+                <Suspense fallback={<Skeleton active />}>
+                  <ProjectAdminSessionPage />
+                </Suspense>
+              );
+            },
+            handle: {
+              scope: 'projectAdmin',
+              menuKey: 'project-admin-session',
+              labelKey: 'webui.menu.ProjectSessions',
+            },
+          },
+          {
+            path: 'deployments',
+            handle: {
+              scope: 'projectAdmin',
+              menuKey: 'project-admin-deployments',
+              labelKey: 'webui.menu.ProjectDeployments',
+            },
+            children: [
+              {
+                index: true,
+                Component: () => {
+                  useSuspendedBackendaiClient();
+                  return (
+                    <Suspense fallback={<Skeleton active />}>
+                      <ProjectAdminDeploymentsPage />
+                    </Suspense>
+                  );
+                },
+                handle: {
+                  scope: 'projectAdmin',
+                  menuKey: 'project-admin-deployments',
+                },
+              },
+              {
+                path: ':deploymentId',
+                element: (
+                  <Suspense fallback={<Skeleton active />}>
+                    <DeploymentDetailPage />
+                  </Suspense>
+                ),
+                handle: {
+                  scope: 'projectAdmin',
+                  menuKey: 'project-admin-deployments',
+                  labelKey: 'webui.menu.DeploymentDetail',
+                },
+              },
+            ],
+          },
+          {
+            path: 'data',
+            Component: () => {
+              useSuspendedBackendaiClient();
+              return (
+                <Suspense fallback={<Skeleton active />}>
+                  <ProjectAdminDataPage />
+                </Suspense>
+              );
+            },
+            handle: {
+              scope: 'projectAdmin',
+              menuKey: 'project-data',
+              labelKey: 'webui.menu.Data',
+            },
+          },
+          {
+            path: 'users',
+            Component: () => {
+              useSuspendedBackendaiClient();
+              return (
+                <Suspense fallback={<Skeleton active />}>
+                  <ProjectAdminUsersPage />
+                </Suspense>
+              );
+            },
+            handle: {
+              scope: 'projectAdmin',
+              menuKey: 'project-admin-users',
+              labelKey: 'webui.menu.ProjectMembers',
+            },
+          },
+        ],
+      },
+    ],
+  },
+  // Global admin subtree: `/admin/*`. Segment names follow the confirmed scope
+  // decisions (e.g. `credential -> users`, `admin-session -> session`,
+  // `admin-data -> data`). `handle.menuKey` preserves the legacy menu key so
+  // role gating / sider highlighting keep working unchanged.
+  {
+    path: 'admin',
+    element: <AdminScopeLayout />,
+    children: [
+      {
+        path: 'session',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <AdminSessionPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'admin-session',
+          labelKey: 'webui.menu.Sessions',
+        },
+      },
+      {
+        path: 'deployments',
+        handle: {
+          scope: 'admin',
+          menuKey: 'admin-deployments',
+          labelKey: 'webui.menu.Serving',
+        },
+        children: [
+          {
+            index: true,
+            Component: () => {
+              return (
+                <BAIErrorBoundary>
+                  <Suspense fallback={<BAICard loading />}>
+                    <AdminDeploymentListPage />
+                  </Suspense>
+                </BAIErrorBoundary>
+              );
+            },
+            handle: { scope: 'admin', menuKey: 'admin-deployments' },
+          },
+          {
+            path: 'deployment-presets/new',
+            element: (
+              <BAIErrorBoundary>
+                <Suspense fallback={<Skeleton active />}>
+                  <AdminDeploymentPresetSettingPage />
+                </Suspense>
+              </BAIErrorBoundary>
+            ),
+            handle: {
+              scope: 'admin',
+              menuKey: 'admin-deployments',
+              labelKey: 'adminDeploymentPreset.CreatePreset',
+            },
+          },
+          {
+            path: 'deployment-presets/:presetId/edit',
+            element: (
+              <BAIErrorBoundary>
+                <Suspense fallback={<Skeleton active />}>
+                  <AdminDeploymentPresetSettingPage />
+                </Suspense>
+              </BAIErrorBoundary>
+            ),
+            handle: {
+              scope: 'admin',
+              menuKey: 'admin-deployments',
+              labelKey: 'adminDeploymentPreset.EditPreset',
+            },
+          },
+          {
+            path: ':deploymentId',
+            element: (
+              <Suspense fallback={<Skeleton active />}>
+                <DeploymentDetailPage />
+              </Suspense>
+            ),
+            handle: {
+              scope: 'admin',
+              menuKey: 'admin-deployments',
+              labelKey: 'webui.menu.DeploymentDetail',
+            },
+          },
+        ],
+      },
+      {
+        path: 'data',
+        Component: () => {
+          useSuspendedBackendaiClient();
+          return (
+            <Suspense fallback={<Skeleton active />}>
+              <AdminVFolderNodeListPage />
+            </Suspense>
+          );
+        },
+        handle: {
+          scope: 'admin',
+          menuKey: 'admin-data',
+          labelKey: 'webui.menu.Data',
+        },
+      },
+      {
+        path: 'dashboard',
+        Component: () => {
+          return (
+            <BAIErrorBoundary>
+              <Suspense fallback={<Skeleton active />}>
+                <AdminDashboardPage />
+              </Suspense>
+            </BAIErrorBoundary>
+          );
+        },
+        handle: {
+          scope: 'admin',
+          menuKey: 'admin-dashboard',
+          labelKey: 'webui.menu.AdminDashboard',
+        },
+      },
+      {
+        path: 'users',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <AdminUsersPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'credential',
+          labelKey: 'webui.menu.UserCredentials&Policies',
+        },
+      },
+      {
+        path: 'environment',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <EnvironmentPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'environment',
+          labelKey: 'webui.menu.Environments',
+        },
+      },
+      {
+        path: 'resource-policy',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <ResourcePolicyPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'resource-policy',
+          labelKey: 'webui.menu.ResourcePolicies',
+        },
+      },
+      {
+        path: 'reservoir',
+        handle: {
+          scope: 'admin',
+          menuKey: 'reservoir',
+          labelKey: 'webui.menu.Reservoir',
+        },
+        children: [
+          {
+            index: true,
+            Component: () => {
+              const baiClient = useSuspendedBackendaiClient();
+              return baiClient?.supports('reservoir') ? (
                 <Suspense
                   fallback={
                     <BAIFlex direction="column" style={{ maxWidth: 700 }}>
@@ -255,74 +679,270 @@ export const mainLayoutChildRoutes: RouteObject[] = [
                     </BAIFlex>
                   }
                 >
-                  <SessionLauncherPage />
+                  <ReservoirPage />
                 </Suspense>
-              </StorageHostFetchErrorBoundary>
-            </BAIFlex>
+              ) : (
+                <WebUINavigate to={'/error'} replace />
+              );
+            },
+            handle: { scope: 'admin', menuKey: 'reservoir' },
+          },
+          {
+            path: ':artifactId',
+            Component: () => {
+              const baiClient = useSuspendedBackendaiClient();
+              return baiClient?.supports('reservoir') ? (
+                <Suspense fallback={<Skeleton active />}>
+                  <ReservoirArtifactDetailPage />
+                </Suspense>
+              ) : (
+                <WebUINavigate to={'/error'} replace />
+              );
+            },
+            handle: {
+              scope: 'admin',
+              menuKey: 'reservoir',
+              labelKey: 'webui.menu.ArtifactDetails',
+            },
+          },
+        ],
+      },
+      {
+        path: 'scheduler',
+        Component: () => {
+          const baiClient = useSuspendedBackendaiClient();
+          return baiClient?.supports('fair-share-scheduling') ? (
+            <Suspense fallback={<Skeleton active />}>
+              <SchedulerPage />
+              <SessionDetailAndContainerLogOpenerLegacy />
+            </Suspense>
+          ) : (
+            <WebUINavigate to={'/error'} replace />
           );
         },
+        handle: {
+          scope: 'admin',
+          menuKey: 'scheduler',
+          labelKey: 'webui.menu.Scheduler',
+        },
+      },
+      {
+        path: 'agent',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <ResourcesPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'agent',
+          labelKey: 'webui.menu.Resources',
+        },
+      },
+      {
+        path: 'project',
+        element: (
+          <BAIErrorBoundary>
+            <Suspense fallback={<Skeleton active />}>
+              <ProjectPage />
+            </Suspense>
+          </BAIErrorBoundary>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'project',
+          labelKey: 'webui.menu.Projects',
+        },
+      },
+      {
+        path: 'settings',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <ConfigurationsPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'settings',
+          labelKey: 'webui.menu.Configurations',
+        },
+      },
+      {
+        path: 'maintenance',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <MaintenancePage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'maintenance',
+          labelKey: 'webui.menu.Maintenance',
+        },
+      },
+      {
+        path: 'diagnostics',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <DiagnosticsPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'diagnostics',
+          labelKey: 'webui.menu.Diagnostics',
+        },
+      },
+      {
+        path: 'rbac',
+        Component: () => {
+          const baiClient = useSuspendedBackendaiClient();
+          return baiClient?.supports('rbac') ? (
+            <Suspense fallback={<Skeleton active />}>
+              <RBACManagementPage />
+            </Suspense>
+          ) : (
+            <WebUINavigate to={'/error'} replace />
+          );
+        },
+        handle: {
+          scope: 'admin',
+          menuKey: 'rbac',
+          labelKey: 'webui.menu.RBACManagement',
+        },
+      },
+      {
+        path: 'branding',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <BrandingPage />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'branding',
+          labelKey: 'webui.menu.Branding',
+        },
+      },
+      {
+        path: 'information',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <Information />
+          </Suspense>
+        ),
+        handle: {
+          scope: 'admin',
+          menuKey: 'information',
+          labelKey: 'webui.menu.Information',
+        },
+      },
+    ],
+  },
+  // --- Backward-compat redirect shims (old flat URLs -> canonical) ---
+  // Legacy flat redirect shims. Old, project-less URLs `replace`-redirect to
+  // the new canonical scope-aware paths so deep links / bookmarks / external
+  // `react-navigate` events keep working.
+  //
+  // Class A (static admin): no runtime project needed.
+  // Class B (runtime project): inject the current project NAME via
+  // `useActiveProjectName()`; fall back to `/start` when none is resolvable.
+  // --- Class B: user (project) scope ---
+  {
+    path: '/start',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="start" />
+    ),
+    handle: { labelKey: 'webui.menu.Start' },
+  },
+  {
+    path: '/dashboard',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="dashboard" />
+    ),
+    handle: { labelKey: 'webui.menu.Dashboard' },
+  },
+  {
+    // alias -> dashboard
+    path: '/summary',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="dashboard" />
+    ),
+    handle: { labelKey: 'webui.menu.Summary' },
+  },
+  {
+    path: '/session',
+    handle: { labelKey: 'webui.menu.Sessions' },
+    children: [
+      {
+        index: true,
+        Component: () => (
+          <ProjectScopedRedirect scope="project" featureKey="session" />
+        ),
+      },
+      {
+        path: '/session/start',
+        Component: () => (
+          <ProjectScopedRedirect
+            scope="project"
+            featureKey="session"
+            options={{ subPath: 'start' }}
+          />
+        ),
         handle: { labelKey: 'session.launcher.StartNewSession' },
       },
     ],
   },
   {
-    // FR-2664 — New Deployment UI routes. Replaces the legacy /serving
-    // routes (see fallback redirects below).
+    // alias -> session
+    path: '/job',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="session" />
+    ),
+    handle: { labelKey: 'webui.menu.Sessions' },
+  },
+  {
     path: '/deployments',
     handle: { labelKey: 'webui.menu.Deployments' },
     children: [
       {
-        path: '',
-        Component: () => {
-          const { t } = useTranslation();
-          useSuspendedBackendaiClient();
-          return (
-            <Suspense
-              fallback={<BAICard title={t('webui.menu.Deployments')} loading />}
-            >
-              <DeploymentListPage />
-            </Suspense>
-          );
-        },
+        index: true,
+        Component: () => (
+          <ProjectScopedRedirect scope="project" featureKey="deployments" />
+        ),
       },
       {
         path: ':deploymentId',
-        handle: { labelKey: 'webui.menu.DeploymentDetail' },
-        element: (
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentDetailPage />
-          </Suspense>
+        Component: () => (
+          <ProjectScopedRedirect
+            scope="project"
+            featureKey="deployments"
+            options={{ param: 'deploymentId' }}
+          />
         ),
       },
     ],
   },
   {
-    // FR-2664 — Legacy /serving fallback. Transient redirect; remove once
-    // all internal links + external references have been migrated.
+    // FR-2664 — Legacy /serving fallback -> project deployments.
     path: '/serving',
     handle: { labelKey: 'webui.menu.Deployments' },
     children: [
       {
-        path: '',
-        Component: () => {
-          const location = useLocation();
-          return (
-            <WebUINavigate to={'/deployments' + location.search} replace />
-          );
-        },
+        index: true,
+        Component: () => (
+          <ProjectScopedRedirect scope="project" featureKey="deployments" />
+        ),
       },
       {
         path: ':serviceId',
-        Component: () => {
-          const { serviceId } = useParams<{ serviceId: string }>();
-          const location = useLocation();
-          return (
-            <WebUINavigate
-              to={`/deployments/${serviceId}${location.search}`}
-              replace
-            />
-          );
-        },
+        Component: () => (
+          <ProjectScopedRedirect
+            scope="project"
+            featureKey="deployments"
+            options={{ param: 'serviceId' }}
+          />
+        ),
       },
     ],
   },
@@ -331,455 +951,305 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     handle: { labelKey: 'webui.menu.Serving' },
     children: [
       {
-        path: '',
-        element: <WebUINavigate to="/deployments" replace />,
+        index: true,
+        Component: () => (
+          <ProjectScopedRedirect scope="project" featureKey="deployments" />
+        ),
       },
       {
-        // FR-2664 — Legacy fallback: /service/:endpointId → /deployments/:deploymentId
         path: ':endpointId',
-        Component: () => {
-          const { endpointId } = useParams<{ endpointId: string }>();
-          const location = useLocation();
-          return (
-            <WebUINavigate
-              to={`/deployments/${endpointId}${location.search}`}
-              replace
-            />
-          );
-        },
+        Component: () => (
+          <ProjectScopedRedirect
+            scope="project"
+            featureKey="deployments"
+            options={{ param: 'endpointId' }}
+          />
+        ),
       },
     ],
   },
   {
     path: '/model-store',
-    handle: { labelKey: 'data.ModelStore' },
     Component: () => (
-      <Suspense fallback={<Skeleton active />}>
-        <ModelStoreListPageV2 />
-      </Suspense>
+      <ProjectScopedRedirect scope="project" featureKey="model-store" />
     ),
+    handle: { labelKey: 'data.ModelStore' },
   },
-  // Redirect paths for backward compatibility
   {
-    path: '/import',
+    path: '/chat/:id?',
     Component: () => {
-      const location = useLocation();
-      return <WebUINavigate to={'/start' + location.search} replace />;
+      const { id } = useParams<{ id: string }>();
+      return (
+        <ProjectScopedRedirect
+          scope="project"
+          featureKey={id ? `chat/${id}` : 'chat'}
+        />
+      );
     },
-  },
-  // Redirect paths for legacy support
-  {
-    path: '/github',
-    Component: () => {
-      const location = useLocation();
-      return <WebUINavigate to={'/start' + location.search} replace />;
-    },
+    handle: { labelKey: 'webui.menu.Chat' },
   },
   {
     path: '/data',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="data" />
+    ),
     handle: { labelKey: 'webui.menu.Data' },
-    Component: () => {
-      return <VFolderNodeListPage />;
-    },
   },
   {
     path: '/my-environment',
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <MyEnvironmentPage />
-      </Suspense>
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="my-environment" />
     ),
     handle: { labelKey: 'webui.menu.MyEnvironments' },
   },
   {
     path: '/agent-summary',
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <AgentSummaryPage />
-      </Suspense>
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="agent-summary" />
     ),
     handle: { labelKey: 'webui.menu.AgentSummary' },
   },
   {
     path: '/statistics',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="statistics" />
+    ),
     handle: { labelKey: 'webui.menu.Statistics' },
-    Component: () => {
-      useSuspendedBackendaiClient();
-      return (
-        <Suspense
-          fallback={
-            <BAIFlex direction="column" style={{ maxWidth: 700 }}>
-              <Skeleton active />
-            </BAIFlex>
-          }
-        >
-          <StatisticsPage />
-        </Suspense>
-      );
-    },
   },
   {
-    path: '/admin-session',
-    handle: { labelKey: 'webui.menu.Sessions' },
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <AdminSessionPage />
-      </Suspense>
+    path: '/ai-agent',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="ai-agent" />
+    ),
+    handle: { labelKey: 'webui.menu.AIAgents' },
+  },
+  // legacy aliases that historically pointed at /start
+  {
+    path: '/import',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="start" />
     ),
   },
   {
-    // FR-2664 — New admin deployment list route. Replaces the legacy
-    // /admin-serving route (see fallback redirect below).
-    path: '/admin-deployments',
-    handle: { labelKey: 'webui.menu.Serving' },
-    children: [
-      {
-        index: true,
-        Component: () => {
-          return (
-            <BAIErrorBoundary>
-              <Suspense fallback={<BAICard loading />}>
-                <AdminDeploymentListPage />
-              </Suspense>
-            </BAIErrorBoundary>
-          );
-        },
-      },
-      {
-        path: 'deployment-presets/new',
-        handle: { labelKey: 'adminDeploymentPreset.CreatePreset' },
-        element: (
-          <BAIErrorBoundary>
-            <Suspense fallback={<Skeleton active />}>
-              <AdminDeploymentPresetSettingPage />
-            </Suspense>
-          </BAIErrorBoundary>
-        ),
-      },
-      {
-        path: 'deployment-presets/:presetId/edit',
-        handle: { labelKey: 'adminDeploymentPreset.EditPreset' },
-        element: (
-          <BAIErrorBoundary>
-            <Suspense fallback={<Skeleton active />}>
-              <AdminDeploymentPresetSettingPage />
-            </Suspense>
-          </BAIErrorBoundary>
-        ),
-      },
-      {
-        // FR-2847 — Admin deployment detail route. Reuses the shared
-        // `DeploymentDetailPage` component but keeps admins under the
-        // `/admin-deployments/*` URL space so that breadcrumbs and back
-        // navigation preserve the admin context.
-        path: ':deploymentId',
-        handle: { labelKey: 'webui.menu.DeploymentDetail' },
-        element: (
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentDetailPage />
-          </Suspense>
-        ),
-      },
-    ],
+    path: '/github',
+    Component: () => (
+      <ProjectScopedRedirect scope="project" featureKey="start" />
+    ),
   },
+  // --- Class B: project-admin scope ---
   {
-    // FR-2664 — Legacy /admin-serving fallback. Transient redirect; remove
-    // once all internal links + external references have been migrated.
-    path: '/admin-serving',
-    handle: { labelKey: 'webui.menu.Serving' },
-    children: [
-      {
-        index: true,
-        Component: () => {
-          const location = useLocation();
-          return (
-            <WebUINavigate
-              to={'/admin-deployments' + location.search}
-              replace
-            />
-          );
-        },
-      },
-      {
-        // FR-2847 — Legacy `/admin-serving/:serviceId` redirects to the
-        // admin-scoped detail route so admins stay under
-        // `/admin-deployments/*` instead of the user-facing
-        // `/deployments/:deploymentId`.
-        path: ':serviceId',
-        Component: () => {
-          const { serviceId } = useParams<{ serviceId: string }>();
-          const location = useLocation();
-          return (
-            <WebUINavigate
-              to={`/admin-deployments/${serviceId}${location.search}`}
-              replace
-            />
-          );
-        },
-      },
-    ],
-  },
-  {
-    path: '/admin-data',
-    handle: { labelKey: 'webui.menu.Data' },
-    Component: () => {
-      useSuspendedBackendaiClient();
-      return (
-        <Suspense fallback={<Skeleton active />}>
-          <AdminVFolderNodeListPage />
-        </Suspense>
-      );
-    },
-  },
-  {
-    path: '/project-admin-users',
-    handle: { labelKey: 'webui.menu.ProjectMembers' },
-    Component: () => {
-      useSuspendedBackendaiClient();
-      return (
-        <Suspense fallback={<Skeleton active />}>
-          <ProjectAdminUsersPage />
-        </Suspense>
-      );
-    },
+    path: '/project-admin-session',
+    Component: () => (
+      <ProjectScopedRedirect scope="projectAdmin" featureKey="session" />
+    ),
+    handle: { labelKey: 'webui.menu.ProjectSessions' },
   },
   {
     path: '/project-data',
+    Component: () => (
+      <ProjectScopedRedirect scope="projectAdmin" featureKey="data" />
+    ),
     handle: { labelKey: 'webui.menu.Data' },
-    Component: () => {
-      useSuspendedBackendaiClient();
-      return (
-        <Suspense fallback={<Skeleton active />}>
-          <ProjectAdminDataPage />
-        </Suspense>
-      );
-    },
   },
   {
-    path: '/project-admin-session',
-    handle: { labelKey: 'webui.menu.ProjectSessions' },
-    Component: () => {
-      useSuspendedBackendaiClient();
-      return (
-        <Suspense fallback={<Skeleton active />}>
-          <ProjectAdminSessionPage />
-        </Suspense>
-      );
-    },
+    path: '/project-admin-users',
+    Component: () => (
+      <ProjectScopedRedirect scope="projectAdmin" featureKey="users" />
+    ),
+    handle: { labelKey: 'webui.menu.ProjectMembers' },
   },
   {
-    // FR-2930 — Project-admin deployment list + detail. The detail route
-    // intentionally lives under `/project-admin-deployments/*` (rather than
-    // reusing `/deployments/:id`) to preserve breadcrumb / back-navigation
-    // context, mirroring the admin precedent established in FR-2847.
     path: '/project-admin-deployments',
     handle: { labelKey: 'webui.menu.ProjectDeployments' },
     children: [
       {
         index: true,
+        Component: () => (
+          <ProjectScopedRedirect
+            scope="projectAdmin"
+            featureKey="deployments"
+          />
+        ),
+      },
+      {
+        path: ':deploymentId',
+        Component: () => (
+          <ProjectScopedRedirect
+            scope="projectAdmin"
+            featureKey="deployments"
+            options={{ param: 'deploymentId' }}
+          />
+        ),
+      },
+    ],
+  },
+  // --- Class A: global admin scope ---
+  {
+    path: '/admin-session',
+    Component: () => <AdminRedirect featureKey="session" />,
+    handle: { labelKey: 'webui.menu.Sessions' },
+  },
+  {
+    path: '/admin-deployments',
+    handle: { labelKey: 'webui.menu.Serving' },
+    children: [
+      {
+        index: true,
+        Component: () => <AdminRedirect featureKey="deployments" />,
+      },
+      {
+        path: 'deployment-presets/new',
+        Component: () => (
+          <AdminRedirect
+            featureKey="deployments"
+            options={{ subPath: 'deployment-presets/new' }}
+          />
+        ),
+      },
+      {
+        path: 'deployment-presets/:presetId/edit',
         Component: () => {
-          useSuspendedBackendaiClient();
+          const { presetId } = useParams<{ presetId: string }>();
           return (
-            <Suspense fallback={<Skeleton active />}>
-              <ProjectAdminDeploymentsPage />
-            </Suspense>
+            <AdminRedirect
+              featureKey="deployments"
+              options={{ subPath: `deployment-presets/${presetId}/edit` }}
+            />
           );
         },
       },
       {
         path: ':deploymentId',
-        handle: { labelKey: 'webui.menu.DeploymentDetail' },
-        element: (
-          <Suspense fallback={<Skeleton active />}>
-            <DeploymentDetailPage />
-          </Suspense>
+        Component: () => (
+          <AdminRedirect
+            featureKey="deployments"
+            options={{ param: 'deploymentId' }}
+          />
         ),
       },
     ],
   },
   {
+    // FR-2664 — Legacy /admin-serving fallback -> admin deployments.
+    path: '/admin-serving',
+    handle: { labelKey: 'webui.menu.Serving' },
+    children: [
+      {
+        index: true,
+        Component: () => <AdminRedirect featureKey="deployments" />,
+      },
+      {
+        path: ':serviceId',
+        Component: () => (
+          <AdminRedirect
+            featureKey="deployments"
+            options={{ param: 'serviceId' }}
+          />
+        ),
+      },
+    ],
+  },
+  {
+    path: '/admin-data',
+    Component: () => <AdminRedirect featureKey="data" />,
+    handle: { labelKey: 'webui.menu.Data' },
+  },
+  {
+    path: '/admin-dashboard',
+    Component: () => <AdminRedirect featureKey="dashboard" />,
+    handle: { labelKey: 'webui.menu.AdminDashboard' },
+  },
+  {
+    path: '/credential',
+    Component: () => <AdminRedirect featureKey="users" />,
+    handle: { labelKey: 'webui.menu.UserCredentials&Policies' },
+  },
+  {
     path: '/environment',
+    Component: () => <AdminRedirect featureKey="environment" />,
     handle: { labelKey: 'webui.menu.Environments' },
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <EnvironmentPage />
-      </Suspense>
-    ),
-  },
-  {
-    path: '/scheduler',
-    handle: { labelKey: 'webui.menu.Scheduler' },
-    Component: () => {
-      const baiClient = useSuspendedBackendaiClient();
-      return baiClient?.supports('fair-share-scheduling') ? (
-        <Suspense fallback={<Skeleton active />}>
-          <SchedulerPage />
-          <SessionDetailAndContainerLogOpenerLegacy />
-        </Suspense>
-      ) : (
-        <WebUINavigate to={'/error'} replace />
-      );
-    },
-  },
-  {
-    path: '/agent',
-    handle: { labelKey: 'webui.menu.Resources' },
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <ResourcesPage />
-      </Suspense>
-    ),
   },
   {
     path: '/resource-policy',
+    Component: () => <AdminRedirect featureKey="resource-policy" />,
     handle: { labelKey: 'webui.menu.ResourcePolicies' },
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <ResourcePolicyPage />
-      </Suspense>
-    ),
   },
   {
     path: '/reservoir',
     handle: { labelKey: 'webui.menu.Reservoir' },
     children: [
       {
-        path: '',
-        Component: () => {
-          const baiClient = useSuspendedBackendaiClient();
-          return baiClient?.supports('reservoir') ? (
-            <Suspense
-              fallback={
-                <BAIFlex direction="column" style={{ maxWidth: 700 }}>
-                  <Skeleton active />
-                </BAIFlex>
-              }
-            >
-              <ReservoirPage />
-            </Suspense>
-          ) : (
-            <WebUINavigate to={'/error'} replace />
-          );
-        },
+        index: true,
+        Component: () => <AdminRedirect featureKey="reservoir" />,
       },
       {
         path: '/reservoir/:artifactId',
-        Component: () => {
-          const baiClient = useSuspendedBackendaiClient();
-          return baiClient?.supports('reservoir') ? (
-            <Suspense fallback={<Skeleton active />}>
-              <ReservoirArtifactDetailPage />
-            </Suspense>
-          ) : (
-            <WebUINavigate to={'/error'} replace />
-          );
-        },
+        Component: () => (
+          <AdminRedirect
+            featureKey="reservoir"
+            options={{ param: 'artifactId' }}
+          />
+        ),
         handle: { labelKey: 'webui.menu.ArtifactDetails' },
       },
     ],
   },
   {
+    path: '/scheduler',
+    Component: () => <AdminRedirect featureKey="scheduler" />,
+    handle: { labelKey: 'webui.menu.Scheduler' },
+  },
+  {
+    path: '/agent',
+    Component: () => <AdminRedirect featureKey="agent" />,
+    handle: { labelKey: 'webui.menu.Resources' },
+  },
+  {
+    path: '/project',
+    Component: () => <AdminRedirect featureKey="project" />,
+    handle: { labelKey: 'webui.menu.Projects' },
+  },
+  {
     path: '/settings',
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <ConfigurationsPage />
-      </Suspense>
-    ),
+    Component: () => <AdminRedirect featureKey="settings" />,
     handle: { labelKey: 'webui.menu.Configurations' },
   },
   {
     path: '/maintenance',
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <MaintenancePage />
-      </Suspense>
-    ),
+    Component: () => <AdminRedirect featureKey="maintenance" />,
     handle: { labelKey: 'webui.menu.Maintenance' },
   },
   {
     path: '/diagnostics',
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <DiagnosticsPage />
-      </Suspense>
-    ),
+    Component: () => <AdminRedirect featureKey="diagnostics" />,
     handle: { labelKey: 'webui.menu.Diagnostics' },
   },
   {
     path: '/rbac',
+    Component: () => <AdminRedirect featureKey="rbac" />,
     handle: { labelKey: 'webui.menu.RBACManagement' },
-    Component: () => {
-      const baiClient = useSuspendedBackendaiClient();
-      return baiClient?.supports('rbac') ? (
-        <Suspense fallback={<Skeleton active />}>
-          <RBACManagementPage />
-        </Suspense>
-      ) : (
-        <WebUINavigate to={'/error'} replace />
-      );
-    },
   },
   {
     path: '/branding',
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <BrandingPage />
-      </Suspense>
-    ),
+    Component: () => <AdminRedirect featureKey="branding" />,
     handle: { labelKey: 'webui.menu.Branding' },
   },
   {
-    path: '/project',
-    element: (
-      <BAIErrorBoundary>
-        <Suspense fallback={<Skeleton active />}>
-          <ProjectPage />
-        </Suspense>
-      </BAIErrorBoundary>
-    ),
-    handle: { labelKey: 'webui.menu.Projects' },
+    path: '/information',
+    Component: () => <AdminRedirect featureKey="information" />,
+    handle: { labelKey: 'webui.menu.Information' },
   },
   {
     path: '/storage-settings/:hostname',
-    element: <WebUINavigate to="/agent?tab=storages" replace />,
+    element: <WebUINavigate to="/admin/agent?tab=storages" replace />,
   },
-  {
-    path: '/information',
-    handle: { labelKey: 'webui.menu.Information' },
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <Information />
-      </Suspense>
-    ),
-  },
+  // --- Global, no-prefix, unchanged ---
   {
     path: '/usersettings',
     handle: { labelKey: 'webui.menu.Settings&Logs' },
     element: (
       <Suspense fallback={<Skeleton active />}>
         <UserSettingsPage />
-      </Suspense>
-    ),
-  },
-  {
-    path: '/admin-dashboard',
-    handle: { labelKey: 'webui.menu.AdminDashboard' },
-    Component: () => {
-      return (
-        <BAIErrorBoundary>
-          <Suspense fallback={<Skeleton active />}>
-            <AdminDashboardPage />
-          </Suspense>
-        </BAIErrorBoundary>
-      );
-    },
-  },
-  {
-    path: '/credential',
-    handle: { labelKey: 'webui.menu.UserCredentials&Policies' },
-    element: (
-      <Suspense fallback={<Skeleton active />}>
-        <AdminUsersPage />
       </Suspense>
     ),
   },
@@ -799,22 +1269,6 @@ export const mainLayoutChildRoutes: RouteObject[] = [
   {
     path: '*',
     element: <></>,
-  },
-  {
-    path: '/ai-agent',
-    handle: { labelKey: 'webui.menu.AIAgents' },
-    Component: () => {
-      const [experimentalAIAgents] = useBAISettingUserState(
-        'experimental_ai_agents',
-      );
-      return experimentalAIAgents ? (
-        <Suspense fallback={<Skeleton active />}>
-          <AIAgentPage />
-        </Suspense>
-      ) : (
-        <WebUINavigate to={'/start'} replace />
-      );
-    },
   },
 ];
 
@@ -1147,7 +1601,41 @@ function extractRoutePaths(
 // Populate the shared routerPaths registry so useWebUIMenuItems can read
 // valid paths without importing routes.tsx directly (which would create a
 // circular dependency: routes → useWebUIMenuItems → routes).
-const { staticPaths, dynamicPatterns } = extractRoutePaths(
-  mainLayoutChildRoutes,
+//
+// IMPORTANT (scope-aware routing): the registry must contain the FEATURE
+// segment (e.g. `session`, `data`, `users`, `deployments/:deploymentId`), NOT
+// the scope prefix (`project`/`admin`). `useWebUIMenuItems` derives the current
+// feature/menu key via `useCurrentMenuKey()` (route handle) and validates it
+// against this registry, so feeding it the raw first segment (`project`/
+// `admin`) would break 404 detection. We therefore run `extractRoutePaths` over
+// the un-nested feature route arrays (relative paths == feature keys) plus the
+// legacy redirect shims (so old flat URLs remain "valid" during the transition).
+//
+// The feature route arrays are read back out of the inline `mainLayoutChildRoutes`
+// tree: the `project/:projectName` and `admin` scope subtrees' own `children`
+// (relative feature paths), and the legacy redirect shims that sit between the
+// `admin` subtree and the global `/usersettings` route.
+const projectScopeChildren =
+  mainLayoutChildRoutes.find((route) => route.path === 'project/:projectName')
+    ?.children ?? [];
+const adminScopeChildren =
+  mainLayoutChildRoutes.find((route) => route.path === 'admin')?.children ?? [];
+const legacyRedirectStartIndex =
+  mainLayoutChildRoutes.findIndex((route) => route.path === 'admin') + 1;
+const legacyRedirectEndIndex = mainLayoutChildRoutes.findIndex(
+  (route) => route.path === '/usersettings',
+);
+const legacyRedirectRoutes = mainLayoutChildRoutes.slice(
+  legacyRedirectStartIndex,
+  legacyRedirectEndIndex,
+);
+const staticPaths = new Set<string>();
+const dynamicPatterns: RegExp[] = [];
+[projectScopeChildren, adminScopeChildren, legacyRedirectRoutes].forEach(
+  (routeArray) => {
+    const result = extractRoutePaths(routeArray);
+    result.staticPaths.forEach((p) => staticPaths.add(p));
+    dynamicPatterns.push(...result.dynamicPatterns);
+  },
 );
 populateRouterPaths(staticPaths, dynamicPatterns);


### PR DESCRIPTION
Resolves #7750 (FR-3055)

## Summary

Encode the current project and the routing scope into the URL path, moving "current project" out of ambient global state.

- Scope-aware routes: `/project/:projectName/<feature>` (user), `/project/:projectName/admin/<feature>` (project-admin), `/admin/<feature>` (super/domain-admin)
- New primitives: `buildPath()` + menuKey↔scope map (`react/src/helper/pathBuilder.ts`); `useRouteScope` / `useCurrentMenuKey` / `useActiveProjectName` / `useProjectPath` (`react/src/hooks/useRouteScope.ts`)
- `ProjectScopeLayout` keeps the URL `:projectName` and the existing `currentProjectAtom` in sync (reuses `useCurrentProject`, no parallel store); `AdminScopeLayout` is the seam for global admin
- Replace first-path-segment assumptions (`location.pathname.split('/')[1]`, `startsWith('/admin-...')`) with route `handle.scope` / `handle.menuKey` (via `useMatches`) across menu, sider, page-access guard, help button, plugin loader, deployment config
- `react/src/legacyRedirects.tsx`: Class A (static `/admin-*` → `/admin/*`) + Class B (runtime project-scoped) redirect shims so old URLs canonicalize to the new ones — both old and new URLs resolve (regression-safe)
- Migrate ~40 imperative navigations + all menu links to `buildPath`
- Header project switch swaps only the `:projectName` segment, preserving the rest of the path so in-progress UI survives (e.g. the session launcher form stays mounted)

## Verification

- `bash scripts/verify.sh`: Lint / Format / TypeScript / Vite warmup **PASS**; Relay compiles clean with **0 `__generated__` changes** (the verify.sh Relay step only fails on a sandbox watchman-priority limitation, not on the code)
- `pnpm --prefix react test`: **924 tests pass** (44 files, incl. new `pathBuilder` / `useRouteScope` / `getPathFromMenuKey` specs)
- Dev-server smoke (Playwright): `/`, `/session`, `/project/default/session`, `/admin/session`, `/project/default/admin/users` all render with no uncaught errors

## Test plan

- [ ] Login → general-menu URLs are `/project/<name>/...`; switching project keeps the same page (session launcher form preserved)
- [ ] Old URLs (`/session`, `/admin-deployments`, `/project-admin-session`, `/credential`, `/summary`) redirect to the new canonical paths
- [ ] Project-admin (`/project/<name>/admin/*`) and super-admin (`/admin/*`) pages render with correct scope and sidebar highlight
- [ ] Deployment detail back/list path is correct in user / project-admin / admin scopes
- [ ] A user with no projects sees the "no accessible projects" guidance (no redirect loop)

## Scope / follow-ups

Lands the routing change as a single PR (the original plan was a Graphite stack). Tracked separately as follow-ups: access control (the backend `deployment(id)` resolver is unscoped), the super-admin "no current project" shared-hook concern, and E2E spec path updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
