### PR TITLE
fix(FR-3057): scope-aware 404, help-doc anchors, and invalid-project fallback

### DIFF
--- a/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
+++ b/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
@@ -3,13 +3,12 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { BAIComputeSessionNodeNotificationItemFragment$key } from '../__generated__/BAIComputeSessionNodeNotificationItemFragment.graphql';
-import { buildPath } from '../helper/pathBuilder';
 import { useWebUINavigate } from '../hooks';
 import {
   NotificationState,
   useSetBAINotification,
 } from '../hooks/useBAINotification';
-import { useActiveProjectName } from '../hooks/useRouteScope';
+import { useProjectPath } from '../hooks/useRouteScope';
 import SessionActionButtons, {
   PrimaryAppOption,
 } from './ComputeSessionNodeItems/SessionActionButtons';
@@ -43,7 +42,7 @@ const BAIComputeSessionNodeNotificationItem: React.FC<
   const { t } = useTranslation();
   const navigate = useWebUINavigate();
   const { token } = theme.useToken();
-  const activeProjectName = useActiveProjectName();
+  const buildProjectPath = useProjectPath();
   const node = useFragment(
     graphql`
       fragment BAIComputeSessionNodeNotificationItemFragment on ComputeSessionNode {
@@ -97,7 +96,7 @@ const BAIComputeSessionNodeNotificationItem: React.FC<
                 title={node.name || ''}
                 onClick={() => {
                   navigate(
-                    `${buildPath('project', 'session', activeProjectName)}${node.id ? `?${new URLSearchParams({ sessionDetail: toLocalId(node.id) }).toString()}` : ''}`,
+                    `${buildProjectPath('session', { scope: 'project' })}${node.id ? `?${new URLSearchParams({ sessionDetail: toLocalId(node.id) }).toString()}` : ''}`,
                   );
                   closeNotification(notification.key);
                 }}

--- a/react/src/components/DeploymentBasicInfoCard.tsx
+++ b/react/src/components/DeploymentBasicInfoCard.tsx
@@ -8,9 +8,8 @@ import type {
   DeploymentBasicInfoCard_deployment$key,
 } from '../__generated__/DeploymentBasicInfoCard_deployment.graphql';
 import { DeploymentSchedulingHistoryModalQuery } from '../__generated__/DeploymentSchedulingHistoryModalQuery.graphql';
-import { buildPath } from '../helper/pathBuilder';
 import { useWebUINavigate } from '../hooks';
-import { useActiveProjectName, useRouteScope } from '../hooks/useRouteScope';
+import { useProjectPath } from '../hooks/useRouteScope';
 import DeploymentSchedulingHistoryModal, {
   DeploymentSchedulingHistoryQuery,
 } from './DeploymentSchedulingHistoryModal';
@@ -82,8 +81,7 @@ const DeploymentOverviewContent: React.FC<{
   'use memo';
   const { t } = useTranslation();
   const webuiNavigate = useWebUINavigate();
-  const routeScope = useRouteScope();
-  const activeProjectName = useActiveProjectName();
+  const buildProjectPath = useProjectPath();
 
   const projectName =
     deployment?.metadata.projectV2?.basicInfo?.name ??
@@ -189,12 +187,8 @@ const DeploymentOverviewContent: React.FC<{
             // back navigation remain coherent — see FR-2847 (admin) and
             // FR-2930 (project admin) for the per-scope detail-route precedent.
             // The current scope (from the route handle) plus the active project
-            // name yield the correct scope-aware list path via `buildPath`.
-            const targetPathname = buildPath(
-              routeScope,
-              'deployments',
-              activeProjectName,
-            );
+            // name yield the correct scope-aware list path via `useProjectPath`.
+            const targetPathname = buildProjectPath('deployments');
             webuiNavigate({
               pathname: targetPathname,
               search: new URLSearchParams({
@@ -233,8 +227,7 @@ const DeploymentBasicInfoCard: React.FC<DeploymentBasicInfoCardProps> = ({
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const webuiNavigate = useWebUINavigate();
-  const routeScope = useRouteScope();
-  const activeProjectName = useActiveProjectName();
+  const buildProjectPath = useProjectPath();
 
   const deployment = useFragment(
     graphql`
@@ -295,8 +288,8 @@ const DeploymentBasicInfoCard: React.FC<DeploymentBasicInfoCardProps> = ({
   const deploymentStatus = deployment?.metadata.status;
   // Scope-aware deployment-list path for back navigation. The current route
   // scope (admin / projectAdmin / project, from the route handle) plus the
-  // active project name produce the correct list URL via `buildPath`.
-  const listPath = buildPath(routeScope, 'deployments', activeProjectName);
+  // active project name produce the correct list URL via `useProjectPath`.
+  const listPath = buildProjectPath('deployments');
 
   const handleDelete = () => {
     if (!deployment?.id) return;

--- a/react/src/components/MainLayout/ProjectScopeErrorState.tsx
+++ b/react/src/components/MainLayout/ProjectScopeErrorState.tsx
@@ -6,33 +6,32 @@ import { useThemeMode } from '../../hooks/useThemeMode';
 import { Typography, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIFlex } from 'backend.ai-ui';
-import { ArrowUpIcon } from 'lucide-react';
-import React from 'react';
+import { ArrowUpLeftIcon } from 'lucide-react';
+import React, { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 
 /**
- * Scope-aware error state for the `/project/:projectName/*` subtree, designed
- * as the calm sibling of the Diagonal Weave loading curtain (FR-3073):
+ * Scope-aware error state for the `/project/:projectName/*` subtree — the
+ * "dissolving session cube" hero, designed as the showcase sibling of the
+ * Diagonal Weave loading curtain (FR-3073):
  *
- *  - a quiet fragment of the curtain's ±23° weave (28px pitch, sparse warm
- *    orange accent lines) drifts imperceptibly behind the content. Instead of
- *    a background-colored veil, the weave itself is radially MASKED so the
- *    center stays void — this keeps the treatment independent of the layout
- *    background color.
- *  - the brand wire-frame session cube renders "unmaterialized": six edges
- *    draw once on mount, the three edges around the top-right vertex stay
- *    dashed ghosts, and the missing vertex is cued with a dashed accent
- *    circle and a small "?".
- *  - a monospace path-chip row (`/project/` + the invalid name in a warm
- *    dashed chip + the ghosted feature segment) shows WHERE the URL broke.
- *    It is derived from route data — not from translated copy — so the
- *    invalid name stays instantly findable without touching i18n strings.
+ *  - a giant gradient `404` watermark and a soft radial wash give the scene
+ *    depth; a quiet fragment of the curtain's ±23° weave stays at the
+ *    corners (radially MASKED, so the treatment is independent of the
+ *    layout background color).
+ *  - the brand wire-frame session cube renders large, gently floating over
+ *    a soft ground shadow. The top-right corner is "dissolving": its edges
+ *    are dashed ghosts, the missing vertex is ringed in accent, and small
+ *    fragments drift off and fade.
+ *  - a glass path pill (`/project / <broken name> / <feature>`) shows WHERE
+ *    the URL broke. It is derived from route data — not translated copy —
+ *    so the invalid name stays instantly findable without touching i18n.
  *  - title / subtitle / CTA reuse the existing `projectSelect.*` i18n keys.
  *
- * All decorative elements (weave, cube, chip row) are `aria-hidden`; the
- * heading carries the semantics. Mount animations keep their final state in
- * the base styles (hidden states exist only inside keyframes), so
- * `prefers-reduced-motion` collapses everything to the resting layout.
+ * All decorative elements (watermark, weave, cube, pill) are `aria-hidden`;
+ * the heading carries the semantics. Motion keeps its final/resting state in
+ * base styles (hidden states exist only inside keyframes), so
+ * `prefers-reduced-motion` collapses everything to a calm static layout.
  */
 
 const WEAVE_PITCH = 28;
@@ -53,17 +52,17 @@ const useStyles = createStyles(({ css }) => ({
     height: 100%;
     pointer-events: none;
     /* Radial mask instead of a painted veil: the weave fades out under the
-       center lockup and stays strongest toward the corners, regardless of the
-       surrounding layout background color. */
+       center composition and stays strongest toward the corners, regardless
+       of the surrounding layout background color. */
     mask-image: radial-gradient(
-      ellipse 62% 58% at 50% 46%,
-      transparent 34%,
-      #000 78%
+      ellipse 65% 60% at 50% 44%,
+      transparent 42%,
+      #000 88%
     );
     -webkit-mask-image: radial-gradient(
-      ellipse 62% 58% at 50% 46%,
-      transparent 34%,
-      #000 78%
+      ellipse 65% 60% at 50% 44%,
+      transparent 42%,
+      #000 88%
     );
   `,
   driftA: css`
@@ -88,43 +87,47 @@ const useStyles = createStyles(({ css }) => ({
       animation: none;
     }
   `,
-  cube: css`
-    overflow: visible;
-    line {
-      stroke-linecap: round;
-    }
-    .draw {
-      /* Base state = fully drawn; the hidden state lives only inside the
-         keyframes, so reduced-motion lands on the finished cube. */
-      stroke-dasharray: 40;
-      stroke-dashoffset: 0;
-      animation: project-scope-cube-draw 0.5s ease-out both;
-    }
-    .fade {
-      opacity: 1;
-      animation: project-scope-cube-fade 0.45s ease-out both;
-      animation-delay: 0.55s;
-    }
-    @keyframes project-scope-cube-draw {
-      from {
-        stroke-dashoffset: 40;
+  hero: css`
+    position: relative;
+    width: 196px;
+    height: 196px;
+    animation: project-scope-float 6s ease-in-out infinite;
+    @keyframes project-scope-float {
+      0%,
+      100% {
+        transform: translateY(0);
       }
-      to {
-        stroke-dashoffset: 0;
+      50% {
+        transform: translateY(-7px);
       }
     }
-    @keyframes project-scope-cube-fade {
-      from {
-        opacity: 0;
-      }
-      to {
-        opacity: 1;
-      }
+    svg {
+      overflow: visible;
     }
     @media (prefers-reduced-motion: reduce) {
-      .draw,
-      .fade {
+      animation: none;
+      .project-scope-bit {
         animation: none;
+        opacity: 0;
+      }
+    }
+  `,
+  bit: css`
+    position: absolute;
+    /* Resting state is invisible; the fragments exist only mid-flight. */
+    opacity: 0;
+    animation: project-scope-bit-drift 3.6s ease-out infinite;
+    @keyframes project-scope-bit-drift {
+      0% {
+        opacity: 0;
+        translate: 0 0;
+      }
+      12% {
+        opacity: 0.95;
+      }
+      100% {
+        opacity: 0;
+        translate: 34px -46px;
       }
     }
   `,
@@ -137,7 +140,7 @@ interface ProjectScopeErrorStateProps {
   /** The invalid project name from the URL (not-found variant). */
   projectName?: string;
   /** The feature segment after the project name (e.g. 'session'), ghosted in
-   *  the chip row. */
+   *  the path pill. */
   featureKey?: string;
   /** Action area under the copy (e.g. the "Go to {{project}}" button). */
   extra?: React.ReactNode;
@@ -153,7 +156,8 @@ const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
-  const { styles } = useStyles();
+  const { styles, cx } = useStyles();
+  const gradientId = useId();
 
   // Curtain palette (resources/webui.css `.splash` custom props). The dark
   // accent is the splash's brighter #E88A28 — tuned for dark surfaces —
@@ -165,20 +169,16 @@ const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
     ? 'rgba(232,138,40,0.18)'
     : 'rgba(255,122,0,0.16)';
   const accent = isDarkMode ? '#E88A28' : '#FF7A00';
-  // Chip TEXT ink: the invalid name is small bold mono, so light mode uses a
-  // darker orange (~4.8:1 on the near-white chip) instead of the raw accent
-  // (~2.6:1). The dashed border / "?" stay on the decorative splash accent.
-  const chipInk = isDarkMode ? '#E88A28' : '#B25400';
+  const amber = isDarkMode ? '#F2B56B' : '#FFB25E';
+  // Pill TEXT ink for the broken name: small bold mono, so light mode uses a
+  // darker orange (~4.8:1 on the pill bg) instead of the raw accent.
+  const pillInk = isDarkMode ? '#F2A045' : '#B25400';
+  const glow = isDarkMode ? 'rgba(232,138,40,0.17)' : 'rgba(255,122,0,0.10)';
+  const watermarkInk = isDarkMode
+    ? 'rgba(232,138,40,0.16)'
+    : 'rgba(255,122,0,0.11)';
 
   const isNotFound = variant === 'not-found';
-
-  const chipBase: React.CSSProperties = {
-    fontFamily: token.fontFamilyCode,
-    fontSize: token.fontSizeSM,
-    lineHeight: 1.6,
-    padding: `${token.paddingXXS}px ${token.paddingXS}px`,
-    borderRadius: token.borderRadiusSM,
-  };
 
   const weaveLines = (warmEvery?: number) =>
     WEAVE_YS.map((y, i) => (
@@ -193,6 +193,10 @@ const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
       />
     ));
 
+  const pillSeparator = (
+    <span style={{ color: token.colorTextQuaternary, opacity: 0.7 }}>/</span>
+  );
+
   return (
     <BAIFlex
       direction="column"
@@ -205,7 +209,7 @@ const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
         overflow: 'hidden',
       }}
     >
-      {/* Diagonal Weave fragment (decorative) */}
+      {/* Diagonal Weave fragment at the corners (decorative) */}
       <svg
         className={styles.weave}
         viewBox="0 0 1440 900"
@@ -220,130 +224,254 @@ const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
         </g>
       </svg>
 
+      {/* Soft radial wash behind the hero (decorative) */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: '38%',
+          width: 740,
+          height: 540,
+          transform: 'translate(-50%, -50%)',
+          background: `radial-gradient(ellipse 50% 44% at 50% 50%, ${glow}, transparent 68%)`,
+          filter: 'blur(8px)',
+          pointerEvents: 'none',
+        }}
+      />
+
       <BAIFlex
         direction="column"
         align="center"
-        gap="md"
         style={{
           position: 'relative',
-          maxWidth: 560,
+          maxWidth: 640,
           padding: token.paddingLG,
         }}
       >
-        {/* The session cube that failed to materialize (decorative) */}
-        <svg
-          className={styles.cube}
-          viewBox="0 0 40 40"
-          width={104}
-          height={104}
-          aria-hidden="true"
-        >
-          {/* solid edges, drawn once on mount */}
-          {(
-            [
-              [8.1, 13, 20, 6],
-              [8.1, 13, 8.1, 27],
-              [8.1, 27, 20, 34],
-              [31.9, 27, 20, 34],
-              [20, 20, 20, 34],
-              [20, 20, 8.1, 13],
-            ] as const
-          ).map(([x1, y1, x2, y2], i) => (
-            <line
-              key={i}
-              className="draw"
-              x1={x1}
-              y1={y1}
-              x2={x2}
-              y2={y2}
-              stroke={token.colorTextSecondary}
-              strokeWidth={1.5}
-              style={{ animationDelay: `${i * 0.07}s` }}
-            />
-          ))}
-          {/* edges that failed to materialize */}
-          {(
-            [
-              [20, 6, 31.9, 13],
-              [31.9, 13, 31.9, 27],
-              [20, 20, 31.9, 13],
-            ] as const
-          ).map(([x1, y1, x2, y2], i) => (
-            <line
-              key={i}
-              className="fade"
-              x1={x1}
-              y1={y1}
-              x2={x2}
-              y2={y2}
-              stroke={token.colorTextQuaternary}
-              strokeWidth={1.2}
-              strokeDasharray="2.4 3"
-            />
-          ))}
-          {/* missing-vertex cue */}
-          <circle
-            className="fade"
-            cx={31.9}
-            cy={13}
-            r={2.6}
-            fill="none"
-            stroke={accent}
-            strokeWidth={1.1}
-            strokeDasharray="1.8 2"
-          />
-          <text
-            className="fade"
-            x={35.6}
-            y={10}
-            fill={accent}
-            fontSize={7}
-            fontWeight={700}
-          >
-            ?
-          </text>
-        </svg>
-
-        {/* Path chip row — derived from route data, not from i18n copy
-            (decorative; the heading below carries the semantics). */}
-        <BAIFlex
-          align="center"
-          gap="xxs"
-          aria-hidden="true"
-          wrap="wrap"
-          justify="center"
-        >
-          <span
-            style={{
-              ...chipBase,
-              color: token.colorTextTertiary,
-              backgroundColor: token.colorFillTertiary,
-            }}
-          >
-            /project/
-          </span>
-          <span
-            style={{
-              ...chipBase,
-              color: chipInk,
-              fontWeight: 600,
-              border: `1px dashed ${accent}`,
-              backgroundColor: isDarkMode
-                ? 'rgba(232,138,40,0.10)'
-                : 'rgba(255,122,0,0.07)',
-              transform: 'rotate(-1.5deg)',
-            }}
-          >
-            {isNotFound ? projectName : '—'}
-          </span>
-          {isNotFound && featureKey ? (
-            <span style={{ ...chipBase, color: token.colorTextQuaternary }}>
-              /{featureKey}
-            </span>
+        {/* Hero: giant watermark + the dissolving session cube (decorative) */}
+        <div style={{ position: 'relative' }} aria-hidden="true">
+          {isNotFound ? (
+            <div
+              style={{
+                position: 'absolute',
+                top: -58,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                fontSize: 'min(232px, 26vh)',
+                fontWeight: 800,
+                letterSpacing: '-0.04em',
+                lineHeight: 1,
+                userSelect: 'none',
+                backgroundImage: `linear-gradient(180deg, ${watermarkInk} 0%, transparent 78%)`,
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                color: 'transparent',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              404
+            </div>
           ) : null}
-        </BAIFlex>
+          <div className={styles.hero}>
+            <svg viewBox="0 0 120 120" width={196} height={196}>
+              <defs>
+                <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="1">
+                  <stop offset="0" stopColor={accent} />
+                  <stop offset="1" stopColor={amber} />
+                </linearGradient>
+              </defs>
+              {isNotFound ? (
+                <>
+                  {/* materialized edges */}
+                  <path
+                    d="M60 14 L24 35 L24 77 L60 98 L95.6 77"
+                    fill="none"
+                    stroke={token.colorText}
+                    strokeWidth={2.3}
+                    strokeLinecap="round"
+                    opacity={0.82}
+                  />
+                  <path
+                    d="M60 56 L60 98 M60 56 L24 35"
+                    fill="none"
+                    stroke={`url(#${gradientId})`}
+                    strokeWidth={2.3}
+                    strokeLinecap="round"
+                  />
+                  {/* the dissolving corner */}
+                  <path
+                    d="M60 14 L95.6 35 L95.6 68 M60 56 L86 41"
+                    fill="none"
+                    stroke={token.colorTextQuaternary}
+                    strokeWidth={1.7}
+                    strokeLinecap="round"
+                    strokeDasharray="3.5 5"
+                    opacity={0.75}
+                  />
+                  <circle
+                    cx={95.6}
+                    cy={35}
+                    r={7}
+                    fill="none"
+                    stroke={accent}
+                    strokeWidth={1.6}
+                    strokeDasharray="2.6 3"
+                  />
+                </>
+              ) : (
+                <>
+                  {/* no projects at all: the whole cube is a ghost */}
+                  <path
+                    d="M60 14 L24 35 L24 77 L60 98 L95.6 77 L95.6 35 Z M60 56 L60 98 M60 56 L24 35 M60 56 L95.6 35"
+                    fill="none"
+                    stroke={token.colorTextQuaternary}
+                    strokeWidth={1.9}
+                    strokeLinecap="round"
+                    strokeDasharray="3.5 5"
+                  />
+                  <text
+                    x={60}
+                    y={64}
+                    textAnchor="middle"
+                    fill={accent}
+                    fontSize={17}
+                    fontWeight={700}
+                  >
+                    ?
+                  </text>
+                </>
+              )}
+            </svg>
+            {isNotFound ? (
+              <>
+                {/* fragments drifting off the missing corner */}
+                <span
+                  className={cx(styles.bit, 'project-scope-bit')}
+                  style={{
+                    left: '76%',
+                    top: '12%',
+                    width: 9,
+                    height: 9,
+                    borderRadius: 2,
+                    border: `1.6px solid ${accent}`,
+                    animationDelay: '0.2s',
+                  }}
+                />
+                <span
+                  className={cx(styles.bit, 'project-scope-bit')}
+                  style={{
+                    left: '88%',
+                    top: '24%',
+                    width: 8,
+                    height: 8,
+                    borderRadius: 2,
+                    border: `1.6px solid ${accent}`,
+                    rotate: '45deg',
+                    animationDelay: '1.4s',
+                  }}
+                />
+                <span
+                  className={cx(styles.bit, 'project-scope-bit')}
+                  style={{
+                    left: '82%',
+                    top: '6%',
+                    width: 5,
+                    height: 5,
+                    borderRadius: '50%',
+                    backgroundColor: amber,
+                    animationDelay: '2.5s',
+                  }}
+                />
+              </>
+            ) : null}
+            {/* soft ground shadow */}
+            <div
+              style={{
+                position: 'absolute',
+                left: '50%',
+                bottom: -18,
+                width: 150,
+                height: 26,
+                transform: 'translateX(-50%)',
+                background: `radial-gradient(ellipse 50% 50% at 50% 50%, ${
+                  isDarkMode ? 'rgba(0,0,0,0.5)' : 'rgba(30,20,10,0.16)'
+                }, transparent 70%)`,
+                filter: 'blur(6px)',
+              }}
+            />
+          </div>
+        </div>
 
-        <Typography.Title level={4} style={{ margin: 0, textAlign: 'center' }}>
+        {/* Glass path pill — derived from route data, not from i18n copy
+            (decorative; the heading below carries the semantics). */}
+        {isNotFound ? (
+          <BAIFlex
+            align="center"
+            gap={4}
+            aria-hidden="true"
+            style={{
+              marginTop: token.marginLG,
+              marginBottom: token.marginXS,
+              padding: '9px 18px',
+              borderRadius: 999,
+              backgroundColor: isDarkMode
+                ? 'rgba(255,255,255,0.045)'
+                : 'rgba(255,255,255,0.78)',
+              border: `1px solid ${
+                isDarkMode ? 'rgba(255,255,255,0.09)' : 'rgba(20,20,20,0.09)'
+              }`,
+              backdropFilter: 'blur(10px)',
+              boxShadow: '0 4px 18px rgba(0,0,0,0.06)',
+              fontFamily: token.fontFamilyCode,
+              fontSize: token.fontSize,
+            }}
+          >
+            <span style={{ color: token.colorTextQuaternary }}>/project</span>
+            {pillSeparator}
+            <span
+              style={{
+                color: pillInk,
+                fontWeight: 700,
+                backgroundColor: isDarkMode
+                  ? 'rgba(232,138,40,0.13)'
+                  : 'rgba(255,122,0,0.10)',
+                padding: '3px 9px',
+                borderRadius: 999,
+                textDecorationLine: 'underline',
+                textDecorationStyle: 'wavy',
+                textDecorationColor: accent,
+                textDecorationThickness: 1.2,
+                textUnderlineOffset: 4,
+              }}
+            >
+              {projectName}
+            </span>
+            {featureKey ? (
+              <>
+                {pillSeparator}
+                <span
+                  style={{ color: token.colorTextQuaternary, opacity: 0.75 }}
+                >
+                  {featureKey}
+                </span>
+              </>
+            ) : null}
+          </BAIFlex>
+        ) : null}
+
+        <Typography.Title
+          level={4}
+          style={{
+            margin: 0,
+            marginTop: isNotFound ? token.marginSM : token.marginLG,
+            textAlign: 'center',
+            fontSize: token.fontSizeHeading3,
+            letterSpacing: '-0.015em',
+            lineHeight: 1.32,
+            maxWidth: 560,
+          }}
+        >
           {isNotFound
             ? t('projectSelect.ProjectNotFoundOrNoAccess', {
                 project: projectName,
@@ -351,12 +479,15 @@ const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
             : t('projectSelect.NoAccessibleProjects')}
         </Typography.Title>
 
-        <Typography.Text type="secondary" style={{ textAlign: 'center' }}>
+        <Typography.Text
+          type="secondary"
+          style={{ marginTop: token.marginSM, textAlign: 'center' }}
+        >
           {isNotFound ? (
             <>
-              <ArrowUpIcon
-                size="0.9em"
-                style={{ verticalAlign: '-0.1em', marginRight: 4 }}
+              <ArrowUpLeftIcon
+                size="0.95em"
+                style={{ verticalAlign: '-0.12em', marginRight: 5 }}
                 aria-hidden="true"
               />
               {t('projectSelect.SwitchToAccessibleProject')}
@@ -367,7 +498,17 @@ const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
         </Typography.Text>
 
         {extra ? (
-          <div style={{ marginTop: token.marginXS }}>{extra}</div>
+          <div
+            style={{
+              marginTop: token.marginXL,
+              // Soft accent glow under the CTA without touching its styles.
+              filter: `drop-shadow(0 10px 18px ${
+                isDarkMode ? 'rgba(232,138,40,0.35)' : 'rgba(255,122,0,0.30)'
+              })`,
+            }}
+          >
+            {extra}
+          </div>
         ) : null}
       </BAIFlex>
     </BAIFlex>

--- a/react/src/components/MainLayout/ProjectScopeErrorState.tsx
+++ b/react/src/components/MainLayout/ProjectScopeErrorState.tsx
@@ -1,0 +1,377 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useThemeMode } from '../../hooks/useThemeMode';
+import { Typography, theme } from 'antd';
+import { createStyles } from 'antd-style';
+import { BAIFlex } from 'backend.ai-ui';
+import { ArrowUpIcon } from 'lucide-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Scope-aware error state for the `/project/:projectName/*` subtree, designed
+ * as the calm sibling of the Diagonal Weave loading curtain (FR-3073):
+ *
+ *  - a quiet fragment of the curtain's ±23° weave (28px pitch, sparse warm
+ *    orange accent lines) drifts imperceptibly behind the content. Instead of
+ *    a background-colored veil, the weave itself is radially MASKED so the
+ *    center stays void — this keeps the treatment independent of the layout
+ *    background color.
+ *  - the brand wire-frame session cube renders "unmaterialized": six edges
+ *    draw once on mount, the three edges around the top-right vertex stay
+ *    dashed ghosts, and the missing vertex is cued with a dashed accent
+ *    circle and a small "?".
+ *  - a monospace path-chip row (`/project/` + the invalid name in a warm
+ *    dashed chip + the ghosted feature segment) shows WHERE the URL broke.
+ *    It is derived from route data — not from translated copy — so the
+ *    invalid name stays instantly findable without touching i18n strings.
+ *  - title / subtitle / CTA reuse the existing `projectSelect.*` i18n keys.
+ *
+ * All decorative elements (weave, cube, chip row) are `aria-hidden`; the
+ * heading carries the semantics. Mount animations keep their final state in
+ * the base styles (hidden states exist only inside keyframes), so
+ * `prefers-reduced-motion` collapses everything to the resting layout.
+ */
+
+const WEAVE_PITCH = 28;
+// Seamless drift loop: each layer translates by the warm-line period
+// (9 lines = 252px), so the line range is over-extended by a full period on
+// BOTH ends — coverage never runs out at any point of the cycle.
+const WEAVE_PERIOD = WEAVE_PITCH * 9;
+const WEAVE_YS = Array.from(
+  { length: Math.ceil((2400 + 2 * WEAVE_PERIOD) / WEAVE_PITCH) },
+  (_, i) => -1200 - WEAVE_PERIOD + i * WEAVE_PITCH,
+);
+
+const useStyles = createStyles(({ css }) => ({
+  weave: css`
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    /* Radial mask instead of a painted veil: the weave fades out under the
+       center lockup and stays strongest toward the corners, regardless of the
+       surrounding layout background color. */
+    mask-image: radial-gradient(
+      ellipse 62% 58% at 50% 46%,
+      transparent 34%,
+      #000 78%
+    );
+    -webkit-mask-image: radial-gradient(
+      ellipse 62% 58% at 50% 46%,
+      transparent 34%,
+      #000 78%
+    );
+  `,
+  driftA: css`
+    animation: project-scope-drift-a 110s linear infinite;
+    @keyframes project-scope-drift-a {
+      to {
+        transform: translateY(${WEAVE_PERIOD}px);
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  `,
+  driftB: css`
+    animation: project-scope-drift-b 150s linear infinite;
+    @keyframes project-scope-drift-b {
+      to {
+        transform: translateY(-${WEAVE_PERIOD}px);
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  `,
+  cube: css`
+    overflow: visible;
+    line {
+      stroke-linecap: round;
+    }
+    .draw {
+      /* Base state = fully drawn; the hidden state lives only inside the
+         keyframes, so reduced-motion lands on the finished cube. */
+      stroke-dasharray: 40;
+      stroke-dashoffset: 0;
+      animation: project-scope-cube-draw 0.5s ease-out both;
+    }
+    .fade {
+      opacity: 1;
+      animation: project-scope-cube-fade 0.45s ease-out both;
+      animation-delay: 0.55s;
+    }
+    @keyframes project-scope-cube-draw {
+      from {
+        stroke-dashoffset: 40;
+      }
+      to {
+        stroke-dashoffset: 0;
+      }
+    }
+    @keyframes project-scope-cube-fade {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .draw,
+      .fade {
+        animation: none;
+      }
+    }
+  `,
+}));
+
+interface ProjectScopeErrorStateProps {
+  /** 'not-found' = invalid/inaccessible project name; 'no-projects' = the
+   *  user belongs to no project at all. */
+  variant: 'not-found' | 'no-projects';
+  /** The invalid project name from the URL (not-found variant). */
+  projectName?: string;
+  /** The feature segment after the project name (e.g. 'session'), ghosted in
+   *  the chip row. */
+  featureKey?: string;
+  /** Action area under the copy (e.g. the "Go to {{project}}" button). */
+  extra?: React.ReactNode;
+}
+
+const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
+  variant,
+  projectName,
+  featureKey,
+  extra,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { isDarkMode } = useThemeMode();
+  const { styles } = useStyles();
+
+  // Curtain palette (resources/webui.css `.splash` custom props). The dark
+  // accent is the splash's brighter #E88A28 — tuned for dark surfaces —
+  // rather than the primary token, matching the loading curtain exactly.
+  const weaveLine = isDarkMode
+    ? 'rgba(255,255,255,0.05)'
+    : 'rgba(20,20,20,0.055)';
+  const weaveWarm = isDarkMode
+    ? 'rgba(232,138,40,0.18)'
+    : 'rgba(255,122,0,0.16)';
+  const accent = isDarkMode ? '#E88A28' : '#FF7A00';
+  // Chip TEXT ink: the invalid name is small bold mono, so light mode uses a
+  // darker orange (~4.8:1 on the near-white chip) instead of the raw accent
+  // (~2.6:1). The dashed border / "?" stay on the decorative splash accent.
+  const chipInk = isDarkMode ? '#E88A28' : '#B25400';
+
+  const isNotFound = variant === 'not-found';
+
+  const chipBase: React.CSSProperties = {
+    fontFamily: token.fontFamilyCode,
+    fontSize: token.fontSizeSM,
+    lineHeight: 1.6,
+    padding: `${token.paddingXXS}px ${token.paddingXS}px`,
+    borderRadius: token.borderRadiusSM,
+  };
+
+  const weaveLines = (warmEvery?: number) =>
+    WEAVE_YS.map((y, i) => (
+      <line
+        key={y}
+        x1={-1100}
+        y1={y}
+        x2={2540}
+        y2={y}
+        stroke={warmEvery && i % warmEvery === 0 ? weaveWarm : weaveLine}
+        strokeWidth={1}
+      />
+    ));
+
+  return (
+    <BAIFlex
+      direction="column"
+      align="center"
+      justify="center"
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Diagonal Weave fragment (decorative) */}
+      <svg
+        className={styles.weave}
+        viewBox="0 0 1440 900"
+        preserveAspectRatio="xMidYMid slice"
+        aria-hidden="true"
+      >
+        <g transform="rotate(23 720 450)">
+          <g className={styles.driftA}>{weaveLines(9)}</g>
+        </g>
+        <g transform="rotate(-23 720 450)">
+          <g className={styles.driftB}>{weaveLines()}</g>
+        </g>
+      </svg>
+
+      <BAIFlex
+        direction="column"
+        align="center"
+        gap="md"
+        style={{
+          position: 'relative',
+          maxWidth: 560,
+          padding: token.paddingLG,
+        }}
+      >
+        {/* The session cube that failed to materialize (decorative) */}
+        <svg
+          className={styles.cube}
+          viewBox="0 0 40 40"
+          width={104}
+          height={104}
+          aria-hidden="true"
+        >
+          {/* solid edges, drawn once on mount */}
+          {(
+            [
+              [8.1, 13, 20, 6],
+              [8.1, 13, 8.1, 27],
+              [8.1, 27, 20, 34],
+              [31.9, 27, 20, 34],
+              [20, 20, 20, 34],
+              [20, 20, 8.1, 13],
+            ] as const
+          ).map(([x1, y1, x2, y2], i) => (
+            <line
+              key={i}
+              className="draw"
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke={token.colorTextSecondary}
+              strokeWidth={1.5}
+              style={{ animationDelay: `${i * 0.07}s` }}
+            />
+          ))}
+          {/* edges that failed to materialize */}
+          {(
+            [
+              [20, 6, 31.9, 13],
+              [31.9, 13, 31.9, 27],
+              [20, 20, 31.9, 13],
+            ] as const
+          ).map(([x1, y1, x2, y2], i) => (
+            <line
+              key={i}
+              className="fade"
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke={token.colorTextQuaternary}
+              strokeWidth={1.2}
+              strokeDasharray="2.4 3"
+            />
+          ))}
+          {/* missing-vertex cue */}
+          <circle
+            className="fade"
+            cx={31.9}
+            cy={13}
+            r={2.6}
+            fill="none"
+            stroke={accent}
+            strokeWidth={1.1}
+            strokeDasharray="1.8 2"
+          />
+          <text
+            className="fade"
+            x={35.6}
+            y={10}
+            fill={accent}
+            fontSize={7}
+            fontWeight={700}
+          >
+            ?
+          </text>
+        </svg>
+
+        {/* Path chip row — derived from route data, not from i18n copy
+            (decorative; the heading below carries the semantics). */}
+        <BAIFlex
+          align="center"
+          gap="xxs"
+          aria-hidden="true"
+          wrap="wrap"
+          justify="center"
+        >
+          <span
+            style={{
+              ...chipBase,
+              color: token.colorTextTertiary,
+              backgroundColor: token.colorFillTertiary,
+            }}
+          >
+            /project/
+          </span>
+          <span
+            style={{
+              ...chipBase,
+              color: chipInk,
+              fontWeight: 600,
+              border: `1px dashed ${accent}`,
+              backgroundColor: isDarkMode
+                ? 'rgba(232,138,40,0.10)'
+                : 'rgba(255,122,0,0.07)',
+              transform: 'rotate(-1.5deg)',
+            }}
+          >
+            {isNotFound ? projectName : '—'}
+          </span>
+          {isNotFound && featureKey ? (
+            <span style={{ ...chipBase, color: token.colorTextQuaternary }}>
+              /{featureKey}
+            </span>
+          ) : null}
+        </BAIFlex>
+
+        <Typography.Title level={4} style={{ margin: 0, textAlign: 'center' }}>
+          {isNotFound
+            ? t('projectSelect.ProjectNotFoundOrNoAccess', {
+                project: projectName,
+              })
+            : t('projectSelect.NoAccessibleProjects')}
+        </Typography.Title>
+
+        <Typography.Text type="secondary" style={{ textAlign: 'center' }}>
+          {isNotFound ? (
+            <>
+              <ArrowUpIcon
+                size="0.9em"
+                style={{ verticalAlign: '-0.1em', marginRight: 4 }}
+                aria-hidden="true"
+              />
+              {t('projectSelect.SwitchToAccessibleProject')}
+            </>
+          ) : (
+            t('projectSelect.AskAdminForProjectAccess')
+          )}
+        </Typography.Text>
+
+        {extra ? (
+          <div style={{ marginTop: token.marginXS }}>{extra}</div>
+        ) : null}
+      </BAIFlex>
+    </BAIFlex>
+  );
+};
+
+export default ProjectScopeErrorState;

--- a/react/src/components/MainLayout/ProjectScopeErrorState.tsx
+++ b/react/src/components/MainLayout/ProjectScopeErrorState.tsx
@@ -2,145 +2,28 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useThemeMode } from '../../hooks/useThemeMode';
-import { Typography, theme } from 'antd';
-import { createStyles } from 'antd-style';
-import { BAIFlex } from 'backend.ai-ui';
+import RouteErrorContent, { RouteErrorSegment } from '../RouteErrorContent';
 import { ArrowUpLeftIcon } from 'lucide-react';
-import React, { useId } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 /**
- * Scope-aware error state for the `/project/:projectName/*` subtree — the
- * "dissolving session cube" hero, designed as the showcase sibling of the
- * Diagonal Weave loading curtain (FR-3073):
+ * Error states for the `/project/:projectName/*` subtree, rendered in the
+ * shared minimal route-error language (see `RouteErrorContent`):
  *
- *  - a giant gradient `404` watermark and a soft radial wash give the scene
- *    depth; a quiet fragment of the curtain's ±23° weave stays at the
- *    corners (radially MASKED, so the treatment is independent of the
- *    layout background color).
- *  - the brand wire-frame session cube renders large, gently floating over
- *    a soft ground shadow. The top-right corner is "dissolving": its edges
- *    are dashed ghosts, the missing vertex is ringed in accent, and small
- *    fragments drift off and fade.
- *  - a glass path pill (`/project / <broken name> / <feature>`) shows WHERE
- *    the URL broke. It is derived from route data — not translated copy —
- *    so the invalid name stays instantly findable without touching i18n.
- *  - title / subtitle / CTA reuse the existing `projectSelect.*` i18n keys.
- *
- * All decorative elements (watermark, weave, cube, pill) are `aria-hidden`;
- * the heading carries the semantics. Motion keeps its final/resting state in
- * base styles (hidden states exist only inside keyframes), so
- * `prefers-reduced-motion` collapses everything to a calm static layout.
+ *  - 'not-found': the URL names a project that does not exist or is not
+ *    accessible. The pill shows WHERE the URL broke (the project segment),
+ *    derived from route data — not translated copy — so the invalid name is
+ *    instantly findable without touching i18n strings.
+ *  - 'no-projects': the user belongs to no project at all; a terminal notice
+ *    with an administrator hint.
  */
 
-const WEAVE_PITCH = 28;
-// Seamless drift loop: each layer translates by the warm-line period
-// (9 lines = 252px), so the line range is over-extended by a full period on
-// BOTH ends — coverage never runs out at any point of the cycle.
-const WEAVE_PERIOD = WEAVE_PITCH * 9;
-const WEAVE_YS = Array.from(
-  { length: Math.ceil((2400 + 2 * WEAVE_PERIOD) / WEAVE_PITCH) },
-  (_, i) => -1200 - WEAVE_PERIOD + i * WEAVE_PITCH,
-);
-
-const useStyles = createStyles(({ css }) => ({
-  weave: css`
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    /* Radial mask instead of a painted veil: the weave fades out under the
-       center composition and stays strongest toward the corners, regardless
-       of the surrounding layout background color. */
-    mask-image: radial-gradient(
-      ellipse 65% 60% at 50% 44%,
-      transparent 42%,
-      #000 88%
-    );
-    -webkit-mask-image: radial-gradient(
-      ellipse 65% 60% at 50% 44%,
-      transparent 42%,
-      #000 88%
-    );
-  `,
-  driftA: css`
-    animation: project-scope-drift-a 110s linear infinite;
-    @keyframes project-scope-drift-a {
-      to {
-        transform: translateY(${WEAVE_PERIOD}px);
-      }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
-    }
-  `,
-  driftB: css`
-    animation: project-scope-drift-b 150s linear infinite;
-    @keyframes project-scope-drift-b {
-      to {
-        transform: translateY(-${WEAVE_PERIOD}px);
-      }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
-    }
-  `,
-  hero: css`
-    position: relative;
-    width: 196px;
-    height: 196px;
-    animation: project-scope-float 6s ease-in-out infinite;
-    @keyframes project-scope-float {
-      0%,
-      100% {
-        transform: translateY(0);
-      }
-      50% {
-        transform: translateY(-7px);
-      }
-    }
-    svg {
-      overflow: visible;
-    }
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
-      .project-scope-bit {
-        animation: none;
-        opacity: 0;
-      }
-    }
-  `,
-  bit: css`
-    position: absolute;
-    /* Resting state is invisible; the fragments exist only mid-flight. */
-    opacity: 0;
-    animation: project-scope-bit-drift 3.6s ease-out infinite;
-    @keyframes project-scope-bit-drift {
-      0% {
-        opacity: 0;
-        translate: 0 0;
-      }
-      12% {
-        opacity: 0.95;
-      }
-      100% {
-        opacity: 0;
-        translate: 34px -46px;
-      }
-    }
-  `,
-}));
-
 interface ProjectScopeErrorStateProps {
-  /** 'not-found' = invalid/inaccessible project name; 'no-projects' = the
-   *  user belongs to no project at all. */
   variant: 'not-found' | 'no-projects';
   /** The invalid project name from the URL (not-found variant). */
   projectName?: string;
-  /** The feature segment after the project name (e.g. 'session'), ghosted in
-   *  the path pill. */
+  /** The feature segment after the project name (e.g. 'session'). */
   featureKey?: string;
   /** Action area under the copy (e.g. the "Go to {{project}}" button). */
   extra?: React.ReactNode;
@@ -154,364 +37,40 @@ const ProjectScopeErrorState: React.FC<ProjectScopeErrorStateProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
-  const { isDarkMode } = useThemeMode();
-  const { styles, cx } = useStyles();
-  const gradientId = useId();
 
-  // Curtain palette (resources/webui.css `.splash` custom props). The dark
-  // accent is the splash's brighter #E88A28 — tuned for dark surfaces —
-  // rather than the primary token, matching the loading curtain exactly.
-  const weaveLine = isDarkMode
-    ? 'rgba(255,255,255,0.05)'
-    : 'rgba(20,20,20,0.055)';
-  const weaveWarm = isDarkMode
-    ? 'rgba(232,138,40,0.18)'
-    : 'rgba(255,122,0,0.16)';
-  const accent = isDarkMode ? '#E88A28' : '#FF7A00';
-  const amber = isDarkMode ? '#F2B56B' : '#FFB25E';
-  // Pill TEXT ink for the broken name: small bold mono, so light mode uses a
-  // darker orange (~4.8:1 on the pill bg) instead of the raw accent.
-  const pillInk = isDarkMode ? '#F2A045' : '#B25400';
-  const glow = isDarkMode ? 'rgba(232,138,40,0.17)' : 'rgba(255,122,0,0.10)';
-  const watermarkInk = isDarkMode
-    ? 'rgba(232,138,40,0.16)'
-    : 'rgba(255,122,0,0.11)';
-
-  const isNotFound = variant === 'not-found';
-
-  const weaveLines = (warmEvery?: number) =>
-    WEAVE_YS.map((y, i) => (
-      <line
-        key={y}
-        x1={-1100}
-        y1={y}
-        x2={2540}
-        y2={y}
-        stroke={warmEvery && i % warmEvery === 0 ? weaveWarm : weaveLine}
-        strokeWidth={1}
+  if (variant === 'no-projects') {
+    return (
+      <RouteErrorContent
+        title={t('projectSelect.NoAccessibleProjects')}
+        description={t('projectSelect.AskAdminForProjectAccess')}
       />
-    ));
+    );
+  }
 
-  const pillSeparator = (
-    <span style={{ color: token.colorTextQuaternary, opacity: 0.7 }}>/</span>
-  );
+  const segments: RouteErrorSegment[] = [
+    { text: 'project' },
+    { text: projectName ?? '', broken: true },
+    ...(featureKey ? [{ text: featureKey }] : []),
+  ];
 
   return (
-    <BAIFlex
-      direction="column"
-      align="center"
-      justify="center"
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-        overflow: 'hidden',
-      }}
-    >
-      {/* Diagonal Weave fragment at the corners (decorative) */}
-      <svg
-        className={styles.weave}
-        viewBox="0 0 1440 900"
-        preserveAspectRatio="xMidYMid slice"
-        aria-hidden="true"
-      >
-        <g transform="rotate(23 720 450)">
-          <g className={styles.driftA}>{weaveLines(9)}</g>
-        </g>
-        <g transform="rotate(-23 720 450)">
-          <g className={styles.driftB}>{weaveLines()}</g>
-        </g>
-      </svg>
-
-      {/* Soft radial wash behind the hero (decorative) */}
-      <div
-        aria-hidden="true"
-        style={{
-          position: 'absolute',
-          left: '50%',
-          top: '38%',
-          width: 740,
-          height: 540,
-          transform: 'translate(-50%, -50%)',
-          background: `radial-gradient(ellipse 50% 44% at 50% 50%, ${glow}, transparent 68%)`,
-          filter: 'blur(8px)',
-          pointerEvents: 'none',
-        }}
-      />
-
-      <BAIFlex
-        direction="column"
-        align="center"
-        style={{
-          position: 'relative',
-          maxWidth: 640,
-          padding: token.paddingLG,
-        }}
-      >
-        {/* Hero: giant watermark + the dissolving session cube (decorative) */}
-        <div style={{ position: 'relative' }} aria-hidden="true">
-          {isNotFound ? (
-            <div
-              style={{
-                position: 'absolute',
-                top: -58,
-                left: '50%',
-                transform: 'translateX(-50%)',
-                fontSize: 'min(232px, 26vh)',
-                fontWeight: 800,
-                letterSpacing: '-0.04em',
-                lineHeight: 1,
-                userSelect: 'none',
-                backgroundImage: `linear-gradient(180deg, ${watermarkInk} 0%, transparent 78%)`,
-                WebkitBackgroundClip: 'text',
-                backgroundClip: 'text',
-                color: 'transparent',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              404
-            </div>
-          ) : null}
-          <div className={styles.hero}>
-            <svg viewBox="0 0 120 120" width={196} height={196}>
-              <defs>
-                <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="1">
-                  <stop offset="0" stopColor={accent} />
-                  <stop offset="1" stopColor={amber} />
-                </linearGradient>
-              </defs>
-              {isNotFound ? (
-                <>
-                  {/* materialized edges */}
-                  <path
-                    d="M60 14 L24 35 L24 77 L60 98 L95.6 77"
-                    fill="none"
-                    stroke={token.colorText}
-                    strokeWidth={2.3}
-                    strokeLinecap="round"
-                    opacity={0.82}
-                  />
-                  <path
-                    d="M60 56 L60 98 M60 56 L24 35"
-                    fill="none"
-                    stroke={`url(#${gradientId})`}
-                    strokeWidth={2.3}
-                    strokeLinecap="round"
-                  />
-                  {/* the dissolving corner */}
-                  <path
-                    d="M60 14 L95.6 35 L95.6 68 M60 56 L86 41"
-                    fill="none"
-                    stroke={token.colorTextQuaternary}
-                    strokeWidth={1.7}
-                    strokeLinecap="round"
-                    strokeDasharray="3.5 5"
-                    opacity={0.75}
-                  />
-                  <circle
-                    cx={95.6}
-                    cy={35}
-                    r={7}
-                    fill="none"
-                    stroke={accent}
-                    strokeWidth={1.6}
-                    strokeDasharray="2.6 3"
-                  />
-                </>
-              ) : (
-                <>
-                  {/* no projects at all: the whole cube is a ghost */}
-                  <path
-                    d="M60 14 L24 35 L24 77 L60 98 L95.6 77 L95.6 35 Z M60 56 L60 98 M60 56 L24 35 M60 56 L95.6 35"
-                    fill="none"
-                    stroke={token.colorTextQuaternary}
-                    strokeWidth={1.9}
-                    strokeLinecap="round"
-                    strokeDasharray="3.5 5"
-                  />
-                  <text
-                    x={60}
-                    y={64}
-                    textAnchor="middle"
-                    fill={accent}
-                    fontSize={17}
-                    fontWeight={700}
-                  >
-                    ?
-                  </text>
-                </>
-              )}
-            </svg>
-            {isNotFound ? (
-              <>
-                {/* fragments drifting off the missing corner */}
-                <span
-                  className={cx(styles.bit, 'project-scope-bit')}
-                  style={{
-                    left: '76%',
-                    top: '12%',
-                    width: 9,
-                    height: 9,
-                    borderRadius: 2,
-                    border: `1.6px solid ${accent}`,
-                    animationDelay: '0.2s',
-                  }}
-                />
-                <span
-                  className={cx(styles.bit, 'project-scope-bit')}
-                  style={{
-                    left: '88%',
-                    top: '24%',
-                    width: 8,
-                    height: 8,
-                    borderRadius: 2,
-                    border: `1.6px solid ${accent}`,
-                    rotate: '45deg',
-                    animationDelay: '1.4s',
-                  }}
-                />
-                <span
-                  className={cx(styles.bit, 'project-scope-bit')}
-                  style={{
-                    left: '82%',
-                    top: '6%',
-                    width: 5,
-                    height: 5,
-                    borderRadius: '50%',
-                    backgroundColor: amber,
-                    animationDelay: '2.5s',
-                  }}
-                />
-              </>
-            ) : null}
-            {/* soft ground shadow */}
-            <div
-              style={{
-                position: 'absolute',
-                left: '50%',
-                bottom: -18,
-                width: 150,
-                height: 26,
-                transform: 'translateX(-50%)',
-                background: `radial-gradient(ellipse 50% 50% at 50% 50%, ${
-                  isDarkMode ? 'rgba(0,0,0,0.5)' : 'rgba(30,20,10,0.16)'
-                }, transparent 70%)`,
-                filter: 'blur(6px)',
-              }}
-            />
-          </div>
-        </div>
-
-        {/* Glass path pill — derived from route data, not from i18n copy
-            (decorative; the heading below carries the semantics). */}
-        {isNotFound ? (
-          <BAIFlex
-            align="center"
-            gap={4}
+    <RouteErrorContent
+      segments={segments}
+      title={t('projectSelect.ProjectNotFoundOrNoAccess', {
+        project: projectName,
+      })}
+      description={
+        <>
+          <ArrowUpLeftIcon
+            size="0.95em"
+            style={{ verticalAlign: '-0.12em', marginRight: 5 }}
             aria-hidden="true"
-            style={{
-              marginTop: token.marginLG,
-              marginBottom: token.marginXS,
-              padding: '9px 18px',
-              borderRadius: 999,
-              backgroundColor: isDarkMode
-                ? 'rgba(255,255,255,0.045)'
-                : 'rgba(255,255,255,0.78)',
-              border: `1px solid ${
-                isDarkMode ? 'rgba(255,255,255,0.09)' : 'rgba(20,20,20,0.09)'
-              }`,
-              backdropFilter: 'blur(10px)',
-              boxShadow: '0 4px 18px rgba(0,0,0,0.06)',
-              fontFamily: token.fontFamilyCode,
-              fontSize: token.fontSize,
-            }}
-          >
-            <span style={{ color: token.colorTextQuaternary }}>/project</span>
-            {pillSeparator}
-            <span
-              style={{
-                color: pillInk,
-                fontWeight: 700,
-                backgroundColor: isDarkMode
-                  ? 'rgba(232,138,40,0.13)'
-                  : 'rgba(255,122,0,0.10)',
-                padding: '3px 9px',
-                borderRadius: 999,
-                textDecorationLine: 'underline',
-                textDecorationStyle: 'wavy',
-                textDecorationColor: accent,
-                textDecorationThickness: 1.2,
-                textUnderlineOffset: 4,
-              }}
-            >
-              {projectName}
-            </span>
-            {featureKey ? (
-              <>
-                {pillSeparator}
-                <span
-                  style={{ color: token.colorTextQuaternary, opacity: 0.75 }}
-                >
-                  {featureKey}
-                </span>
-              </>
-            ) : null}
-          </BAIFlex>
-        ) : null}
-
-        <Typography.Title
-          level={4}
-          style={{
-            margin: 0,
-            marginTop: isNotFound ? token.marginSM : token.marginLG,
-            textAlign: 'center',
-            fontSize: token.fontSizeHeading3,
-            letterSpacing: '-0.015em',
-            lineHeight: 1.32,
-            maxWidth: 560,
-          }}
-        >
-          {isNotFound
-            ? t('projectSelect.ProjectNotFoundOrNoAccess', {
-                project: projectName,
-              })
-            : t('projectSelect.NoAccessibleProjects')}
-        </Typography.Title>
-
-        <Typography.Text
-          type="secondary"
-          style={{ marginTop: token.marginSM, textAlign: 'center' }}
-        >
-          {isNotFound ? (
-            <>
-              <ArrowUpLeftIcon
-                size="0.95em"
-                style={{ verticalAlign: '-0.12em', marginRight: 5 }}
-                aria-hidden="true"
-              />
-              {t('projectSelect.SwitchToAccessibleProject')}
-            </>
-          ) : (
-            t('projectSelect.AskAdminForProjectAccess')
-          )}
-        </Typography.Text>
-
-        {extra ? (
-          <div
-            style={{
-              marginTop: token.marginXL,
-              // Soft accent glow under the CTA without touching its styles.
-              filter: `drop-shadow(0 10px 18px ${
-                isDarkMode ? 'rgba(232,138,40,0.35)' : 'rgba(255,122,0,0.30)'
-              })`,
-            }}
-          >
-            {extra}
-          </div>
-        ) : null}
-      </BAIFlex>
-    </BAIFlex>
+          />
+          {t('projectSelect.SwitchToAccessibleProject')}
+        </>
+      }
+      extra={extra}
+    />
   );
 };
 

--- a/react/src/components/MainLayout/ProjectScopeLayout.tsx
+++ b/react/src/components/MainLayout/ProjectScopeLayout.tsx
@@ -11,6 +11,7 @@ import {
 import { getRouteScopeAndKey } from '../../hooks/useRouteScope';
 import ProjectScopeErrorState from './ProjectScopeErrorState';
 import { Button } from 'antd';
+import { ArrowRightIcon } from 'lucide-react';
 import React, { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
@@ -108,6 +109,9 @@ const ProjectScopeLayout: React.FC = () => {
         extra={
           <Button
             type="primary"
+            size="large"
+            icon={<ArrowRightIcon size="1em" />}
+            iconPosition="end"
             onClick={() =>
               webuiNavigate(buildPath('project', 'session', ownProject))
             }

--- a/react/src/components/MainLayout/ProjectScopeLayout.tsx
+++ b/react/src/components/MainLayout/ProjectScopeLayout.tsx
@@ -8,11 +8,12 @@ import {
   useCurrentProjectValue,
   useSetCurrentProject,
 } from '../../hooks/useCurrentProject';
-import { Button, Result } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { getRouteScopeAndKey } from '../../hooks/useRouteScope';
+import ProjectScopeErrorState from './ProjectScopeErrorState';
+import { Button } from 'antd';
 import React, { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useLocation, useParams } from 'react-router-dom';
 
 interface BackendAIClientGroups {
   groups?: string[];
@@ -51,6 +52,7 @@ const ProjectScopeLayout: React.FC = () => {
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
   const { projectName: rawProjectName } = useParams<{ projectName: string }>();
+  const location = useLocation();
   const currentProject = useCurrentProjectValue();
   const setCurrentProject = useSetCurrentProject();
   const webuiNavigate = useWebUINavigate();
@@ -85,19 +87,7 @@ const ProjectScopeLayout: React.FC = () => {
     // No groups at all: the user belongs to no project. Render a terminal
     // "no accessible projects" status.
     if (groups.length === 0) {
-      return (
-        <BAIFlex
-          direction="column"
-          align="center"
-          justify="center"
-          style={{ width: '100%', height: '100%' }}
-        >
-          <Result
-            status="warning"
-            title={t('projectSelect.NoAccessibleProjects')}
-          />
-        </BAIFlex>
-      );
+      return <ProjectScopeErrorState variant="no-projects" />;
     }
 
     // Invalid / inaccessible project name while the user DOES have other
@@ -111,30 +101,21 @@ const ProjectScopeLayout: React.FC = () => {
         ? currentProject.name
         : groups[0];
     return (
-      <BAIFlex
-        direction="column"
-        align="center"
-        justify="center"
-        style={{ width: '100%', height: '100%' }}
-      >
-        <Result
-          status="404"
-          title={t('projectSelect.ProjectNotFoundOrNoAccess', {
-            project: projectName,
-          })}
-          subTitle={t('projectSelect.SwitchToAccessibleProject')}
-          extra={
-            <Button
-              type="primary"
-              onClick={() =>
-                webuiNavigate(buildPath('project', 'session', ownProject))
-              }
-            >
-              {t('projectSelect.GoToProject', { project: ownProject })}
-            </Button>
-          }
-        />
-      </BAIFlex>
+      <ProjectScopeErrorState
+        variant="not-found"
+        projectName={projectName}
+        featureKey={getRouteScopeAndKey(location.pathname).featureKey}
+        extra={
+          <Button
+            type="primary"
+            onClick={() =>
+              webuiNavigate(buildPath('project', 'session', ownProject))
+            }
+          >
+            {t('projectSelect.GoToProject', { project: ownProject })}
+          </Button>
+        }
+      />
     );
   }
 

--- a/react/src/components/MainLayout/ProjectScopeLayout.tsx
+++ b/react/src/components/MainLayout/ProjectScopeLayout.tsx
@@ -3,13 +3,13 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { buildPath } from '../../helper/pathBuilder';
-import { useSuspendedBackendaiClient } from '../../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
 import {
   useCurrentProjectValue,
   useSetCurrentProject,
 } from '../../hooks/useCurrentProject';
-import WebUINavigate from '../WebUINavigate';
-import { BAIAlert, BAIFlex } from 'backend.ai-ui';
+import { Button, Result } from 'antd';
+import { BAIFlex } from 'backend.ai-ui';
 import React, { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useParams } from 'react-router-dom';
@@ -30,12 +30,14 @@ interface BackendAIClientGroups {
  *   - membership = `baiClient.groups.includes(name)`
  *
  * If the URL project name is invalid (not a member, or no resolvable id), the
- * layout redirects (replace) to a guaranteed-valid fallback project's session
- * page rather than rendering with an undefined project id:
- *   - fallback = current atom project name if the user is still a member of it,
- *     otherwise `groups[0]`.
- *   - if the user has NO groups at all, we cannot synthesize a `/project//...`
- *     path, so we render the existing "no accessible projects" guidance.
+ * layout does NOT silently switch to another project — the name is just a name
+ * and may legitimately be missing or access-restricted (stale bookmark, shared
+ * link to a project the user cannot access, renamed/deleted project). Instead it
+ * renders an explicit "not found / no access" guidance:
+ *   - if the user has NO groups at all, the "no accessible projects" guidance.
+ *   - otherwise a "project not found or no access" notice, keeping the header
+ *     project selector available and offering a button that navigates to one of
+ *     the user's own projects on an explicit click.
  *
  * Sync (effect-only, idempotent):
  *   - `setCurrentProject({ projectName, projectId })` runs in an effect keyed on
@@ -51,6 +53,7 @@ const ProjectScopeLayout: React.FC = () => {
   const { projectName: rawProjectName } = useParams<{ projectName: string }>();
   const currentProject = useCurrentProjectValue();
   const setCurrentProject = useSetCurrentProject();
+  const webuiNavigate = useWebUINavigate();
 
   // `useParams` already decodes percent-encoding; treat a missing param as ''.
   const projectName = rawProjectName ?? '';
@@ -79,33 +82,59 @@ const ProjectScopeLayout: React.FC = () => {
   }, [projectName]);
 
   if (!isValid) {
-    // No groups at all: cannot build a valid `/project/<name>/...` path. Show
-    // the same "no accessible projects" guidance used by the project selector
-    // rather than redirecting into an invalid empty-name URL.
+    // No groups at all: the user belongs to no project. Render a terminal
+    // "no accessible projects" status.
     if (groups.length === 0) {
       return (
-        <BAIFlex direction="column" align="stretch" style={{ width: '100%' }}>
-          <BAIAlert
-            type="warning"
-            showIcon
-            description={t('projectSelect.NoAccessibleProjects')}
+        <BAIFlex
+          direction="column"
+          align="center"
+          justify="center"
+          style={{ width: '100%', height: '100%' }}
+        >
+          <Result
+            status="warning"
+            title={t('projectSelect.NoAccessibleProjects')}
           />
         </BAIFlex>
       );
     }
 
-    // Invalid / inaccessible name: redirect to a guaranteed-valid fallback.
-    // Prefer the current atom project if the user is still a member of it,
-    // otherwise the first group.
-    const currentName = currentProject.name ?? '';
-    const fallbackName =
-      currentName && groups.includes(currentName) ? currentName : groups[0];
-
+    // Invalid / inaccessible project name while the user DOES have other
+    // projects: do NOT silently switch to an arbitrary project (the name is
+    // just a name — it may not exist or be access-restricted). Render an
+    // explicit "not found / no access" status. The header project selector
+    // shows no selection for this invalid project, and a convenience button
+    // navigates to one of the user's own projects on an explicit click.
+    const ownProject =
+      currentProject.name && groups.includes(currentProject.name)
+        ? currentProject.name
+        : groups[0];
     return (
-      <WebUINavigate
-        to={buildPath('project', 'session', fallbackName)}
-        replace
-      />
+      <BAIFlex
+        direction="column"
+        align="center"
+        justify="center"
+        style={{ width: '100%', height: '100%' }}
+      >
+        <Result
+          status="404"
+          title={t('projectSelect.ProjectNotFoundOrNoAccess', {
+            project: projectName,
+          })}
+          subTitle={t('projectSelect.SwitchToAccessibleProject')}
+          extra={
+            <Button
+              type="primary"
+              onClick={() =>
+                webuiNavigate(buildPath('project', 'session', ownProject))
+              }
+            >
+              {t('projectSelect.GoToProject', { project: ownProject })}
+            </Button>
+          }
+        />
+      </BAIFlex>
     );
   }
 

--- a/react/src/components/MainLayout/ProjectScopeLayout.tsx
+++ b/react/src/components/MainLayout/ProjectScopeLayout.tsx
@@ -97,10 +97,9 @@ const ProjectScopeLayout: React.FC = () => {
     // explicit "not found / no access" status. The header project selector
     // shows no selection for this invalid project, and a convenience button
     // navigates to one of the user's own projects on an explicit click.
-    const ownProject =
-      currentProject.name && groups.includes(currentProject.name)
-        ? currentProject.name
-        : groups[0];
+    // Offer the alphabetically-first accessible project as the escape hatch —
+    // a stable, predictable target regardless of what the atom last held.
+    const ownProject = [...groups].sort((a, b) => a.localeCompare(b))[0];
     return (
       <ProjectScopeErrorState
         variant="not-found"

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -16,7 +16,11 @@ import {
   useCurrentUserProjectRoles,
   useEffectiveAdminRole,
 } from '../../hooks/useCurrentUserProjectRoles';
-import { useCurrentMenuKey, useRouteScope } from '../../hooks/useRouteScope';
+import {
+  useActiveProjectName,
+  useCurrentMenuKey,
+  useRouteScope,
+} from '../../hooks/useRouteScope';
 import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
 import BAINotificationButton from '../BAINotificationButton';
 import LoginSessionExtendButton from '../LoginSessionExtendButton';
@@ -62,6 +66,14 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
   const location = useLocation();
   const routeScope = useRouteScope();
   const currentMenuKey = useCurrentMenuKey();
+  // When the URL carries an invalid/inaccessible `:projectName`, the atom keeps
+  // the last valid project, which would make the header selector look like that
+  // project is selected. Detect this and show the selector unselected instead.
+  const activeProjectName = useActiveProjectName();
+  const accessibleProjectNames =
+    (baiClient as unknown as { groups?: string[] })?.groups ?? [];
+  const isUrlProjectInvalid =
+    !!activeProjectName && !accessibleProjectNames.includes(activeProjectName);
   const { isSelectedAdminCategoryMenu } = useWebUIMenuItems();
   const effectiveAdminRole = useEffectiveAdminRole();
   const { projectAdminIds } = useCurrentUserProjectRoles();
@@ -195,7 +207,13 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
             className="non-draggable"
             showSearch
             domain={currentDomainName}
-            value={isProjectChanging ? optimisticProjectId : currentProject?.id}
+            value={
+              isProjectChanging
+                ? optimisticProjectId
+                : isUrlProjectInvalid
+                  ? undefined
+                  : currentProject?.id
+            }
             onSelectProject={(projectInfo) => {
               const isTargetProjectAdmin = projectAdminIds.includes(
                 projectInfo.projectId,

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -17,6 +17,7 @@ import {
   useEffectiveAdminRole,
 } from '../../hooks/useCurrentUserProjectRoles';
 import {
+  rewriteProjectNameInPath,
   useActiveProjectName,
   useCurrentMenuKey,
   useRouteScope,
@@ -119,9 +120,13 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
       // stays mounted with its contents intact).
       const segments = location.pathname.split('/');
       if (segments[1] === 'project' && segments.length > 2) {
-        segments[2] = encodeURIComponent(projectInfo.projectName);
         startProjectChangedTransition(() => {
-          webuiNavigate(segments.join('/') + location.search);
+          webuiNavigate(
+            rewriteProjectNameInPath(
+              location.pathname,
+              projectInfo.projectName,
+            ) + location.search,
+          );
         });
         return;
       }
@@ -268,10 +273,10 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
                     if (goBackPath) {
                       const segments = goBackPath.split('/');
                       if (segments[1] === 'project' && segments.length > 2) {
-                        segments[2] = encodeURIComponent(
+                        target = rewriteProjectNameInPath(
+                          goBackPath,
                           projectInfo.projectName,
                         );
-                        target = segments.join('/');
                       }
                     }
                     webuiNavigate(target);

--- a/react/src/components/RouteErrorContent.tsx
+++ b/react/src/components/RouteErrorContent.tsx
@@ -1,0 +1,150 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useThemeMode } from '../hooks/useThemeMode';
+import { Typography, theme } from 'antd';
+import { BAIFlex } from 'backend.ai-ui';
+import React from 'react';
+
+/**
+ * Shared minimal composition for route-level error states (invalid project,
+ * unknown page). One visual language for every "this URL is wrong" screen:
+ *
+ *   [ /path / broken-segment / rest ]   <- monospace pill (route data)
+ *   Title                               <- semantic heading, i18n copy
+ *   Description                         <- secondary hint
+ *   [ CTA ]
+ *
+ * The pill is decorative (`aria-hidden`) — the heading carries the
+ * semantics. The broken segment is highlighted with a warm chip and a wavy
+ * accent underline; everything else stays quiet.
+ */
+
+export interface RouteErrorSegment {
+  text: string;
+  broken?: boolean;
+}
+
+interface RouteErrorContentProps {
+  /** Path segments for the pill; omit to hide the pill entirely. */
+  segments?: RouteErrorSegment[];
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Action area under the copy (e.g. a primary navigation button). */
+  extra?: React.ReactNode;
+}
+
+const RouteErrorContent: React.FC<RouteErrorContentProps> = ({
+  segments,
+  title,
+  description,
+  extra,
+}) => {
+  'use memo';
+  const { token } = theme.useToken();
+  const { isDarkMode } = useThemeMode();
+
+  // Splash-derived warm palette: the broken-segment ink needs ~4.5:1 on the
+  // pill background, so light mode uses a darker orange than the raw accent.
+  const accent = isDarkMode ? '#E88A28' : '#FF7A00';
+  const brokenInk = isDarkMode ? '#F2A045' : '#B25400';
+
+  const separator = (
+    <span style={{ color: token.colorTextQuaternary, opacity: 0.6 }}>/</span>
+  );
+
+  return (
+    <BAIFlex
+      direction="column"
+      align="center"
+      justify="center"
+      style={{ width: '100%', height: '100%' }}
+    >
+      <BAIFlex
+        direction="column"
+        align="center"
+        style={{ maxWidth: 640, padding: token.paddingLG }}
+      >
+        {segments?.length ? (
+          <BAIFlex
+            align="center"
+            gap={6}
+            wrap="wrap"
+            justify="center"
+            aria-hidden="true"
+            style={{
+              marginBottom: token.marginLG,
+              padding: '9px 18px',
+              borderRadius: 999,
+              backgroundColor: token.colorBgContainer,
+              border: `1px solid ${token.colorBorderSecondary}`,
+              fontFamily: token.fontFamilyCode,
+              fontSize: token.fontSize,
+            }}
+          >
+            {separator}
+            {segments.map((segment, i) => (
+              <React.Fragment key={i}>
+                {i > 0 ? separator : null}
+                {segment.broken ? (
+                  <span
+                    style={{
+                      color: brokenInk,
+                      fontWeight: 700,
+                      backgroundColor: isDarkMode
+                        ? 'rgba(232,138,40,0.13)'
+                        : 'rgba(255,122,0,0.10)',
+                      padding: '3px 9px',
+                      borderRadius: 999,
+                      textDecorationLine: 'underline',
+                      textDecorationStyle: 'wavy',
+                      textDecorationColor: accent,
+                      textDecorationThickness: 1.2,
+                      textUnderlineOffset: 4,
+                    }}
+                  >
+                    {segment.text}
+                  </span>
+                ) : (
+                  <span style={{ color: token.colorTextQuaternary }}>
+                    {segment.text}
+                  </span>
+                )}
+              </React.Fragment>
+            ))}
+          </BAIFlex>
+        ) : null}
+
+        <Typography.Title
+          level={4}
+          style={{
+            margin: 0,
+            textAlign: 'center',
+            fontSize: token.fontSizeHeading3,
+            letterSpacing: '-0.015em',
+            lineHeight: 1.32,
+            maxWidth: 560,
+          }}
+        >
+          {title}
+        </Typography.Title>
+
+        {description ? (
+          <Typography.Text
+            type="secondary"
+            style={{ marginTop: token.marginSM, textAlign: 'center' }}
+          >
+            {description}
+          </Typography.Text>
+        ) : null}
+
+        {extra ? (
+          <div style={{ marginTop: token.marginXL }}>{extra}</div>
+        ) : null}
+      </BAIFlex>
+    </BAIFlex>
+  );
+};
+
+export default RouteErrorContent;

--- a/react/src/components/WEBUIHelpButton.tsx
+++ b/react/src/components/WEBUIHelpButton.tsx
@@ -7,6 +7,7 @@ import { useCurrentLanguage } from './DefaultProviders';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, type ButtonProps } from 'antd';
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 // Languages the hosted user manual (https://webui.docs.backend.ai) is
 // published in. Any other WebUI locale falls back to English.

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -4,13 +4,21 @@
  */
 import { useSuspendedBackendaiClient } from '.';
 import WebUILink from '../components/WebUILink';
-import { buildPath, MENU_KEY_TO_SCOPE_FEATURE } from '../helper/pathBuilder';
+import {
+  buildPath,
+  MENU_KEY_TO_SCOPE_FEATURE,
+  scopeFeatureToMenuKey,
+} from '../helper/pathBuilder';
 import { useCurrentUserRole } from './backendai';
 import { useDiagnosticsBadgeSeverity } from './useAutoDiagnostics';
 import { useBAISettingUserState } from './useBAISetting';
 import { useEffectiveAdminRole } from './useCurrentUserProjectRoles';
 import { useCustomThemeConfig } from './useCustomThemeConfig';
-import { useActiveProjectName, useCurrentMenuKey } from './useRouteScope';
+import {
+  getRouteScopeAndKey,
+  useActiveProjectName,
+  useCurrentMenuKey,
+} from './useRouteScope';
 import {
   PluginPage,
   useWebUIPluginLoadedValue,
@@ -917,6 +925,28 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
 
     // If plugins haven't loaded yet, assume page is valid to prevent flickering
     if (!isPluginLoaded) return false;
+
+    // Scope-aware 404: under the `/admin/<feature>` and
+    // `/project/:name/<feature>` (incl. `/project/:name/admin/<feature>`)
+    // namespaces, a feature key that is valid in a *different* scope
+    // (e.g. `/admin/start` where `start` is a user feature, or
+    // `/project/x/agent` where `agent` is admin-only) matches no route and the
+    // scope subtree renders an empty <Outlet/>. Treat such cross-scope URLs as
+    // 404 instead of a blank page.
+    const { scope: pathScope, featureKey: pathFeatureKey } =
+      getRouteScopeAndKey(location.pathname);
+    const hasScopePrefix =
+      location.pathname.startsWith('/admin/') ||
+      location.pathname.startsWith('/project/');
+    if (
+      hasScopePrefix &&
+      pathFeatureKey &&
+      !scopeFeatureToMenuKey(pathScope, pathFeatureKey) &&
+      !matchesDynamicRoute &&
+      !plugins?.page?.some((page) => page?.url === pathFeatureKey)
+    ) {
+      return true;
+    }
 
     // Check if path is in valid paths set
     if (allValidPaths.has(currentPathKey)) return false;

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -176,7 +176,7 @@ const ALL_ADMIN_PAGE_KEYS: ReadonlySet<string> = new Set([
 // the admin category. Other admin pages remain visible only to domain admins or
 // superadmins. Kept as a plain array so it can be exported and reused (e.g. for
 // per-page route gating in follow-up PRs).
-export const PROJECT_ADMIN_PAGE_KEYS = [
+const PROJECT_ADMIN_PAGE_KEYS = [
   // 'admin-session',
   // 'admin-deployments',
   // 'admin-data',

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -14,11 +14,10 @@ import DeploymentReplicasCard from '../components/DeploymentReplicasCard';
 import DeploymentRevisionCard from '../components/DeploymentRevisionCard';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import SwitchToProjectButton from '../components/SwitchToProjectButton';
-import { buildPath } from '../helper/pathBuilder';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { useActiveProjectName } from '../hooks/useRouteScope';
+import { useActiveProjectName, useProjectPath } from '../hooks/useRouteScope';
 import {
   getPathFromMenuKey,
   useWebUIMenuItems,
@@ -74,7 +73,7 @@ const DeploymentDetailPage: React.FC = () => {
   const webuiNavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const currentProject = useCurrentProjectValue();
-  const activeProjectName = useActiveProjectName();
+  const buildProjectPath = useProjectPath();
   const isChatBlocked = !!baiClient?._config?.blockList?.includes('chat');
 
   const { deploymentId: deploymentIdParam } = useParams<{
@@ -346,7 +345,7 @@ const DeploymentDetailPage: React.FC = () => {
                 icon={<BotMessageSquareIcon size={token.fontSizeLG} />}
                 onClick={() => {
                   webuiNavigate({
-                    pathname: buildPath('project', 'chat', activeProjectName),
+                    pathname: buildProjectPath('chat', { scope: 'project' }),
                     search: new URLSearchParams({
                       endpointId: deploymentId,
                     }).toString(),

--- a/react/src/pages/Page404.tsx
+++ b/react/src/pages/Page404.tsx
@@ -2,19 +2,27 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import RouteErrorContent, {
+  RouteErrorSegment,
+} from '../components/RouteErrorContent';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useActiveProjectName } from '../hooks/useRouteScope';
 import {
   getPathFromMenuKey,
   useWebUIMenuItems,
 } from '../hooks/useWebUIMenuItems';
-import { Button, Typography } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { Button } from 'antd';
+import { ArrowRightIcon } from 'lucide-react';
 import { Trans, useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+
+const MAX_SEGMENTS = 4;
 
 const Page404 = () => {
+  'use memo';
   const { t } = useTranslation();
   const webuiNavigate = useWebUINavigate();
+  const location = useLocation();
   const { firstAvailableMenuItem } = useWebUIMenuItems();
   const activeProjectName = useActiveProjectName();
   useSuspendedBackendaiClient(); //monkey patch for flickering
@@ -25,44 +33,36 @@ const Page404 = () => {
   const defaultPageTitle =
     firstAvailableMenuItem?.labelText ?? t('webui.menu.FirstPageNameAlias');
 
+  // The pill shows the unknown path with its LAST segment marked broken —
+  // that is the part the router could not resolve. Long paths are capped
+  // with a leading ellipsis so detail-page URLs stay readable.
+  const rawSegments = location.pathname.split('/').filter(Boolean);
+  const capped =
+    rawSegments.length > MAX_SEGMENTS
+      ? ['…', ...rawSegments.slice(-(MAX_SEGMENTS - 1))]
+      : rawSegments;
+  const segments: RouteErrorSegment[] = capped.map((text, i) => ({
+    text,
+    broken: i === capped.length - 1,
+  }));
+
   return (
-    <BAIFlex
-      direction="column"
-      justify="center"
-      align="center"
-      style={{
-        height: 'calc(100vh - 150px)',
-      }}
-      wrap="wrap"
-    >
-      <BAIFlex wrap="wrap" justify="center">
-        <img
-          src="/resources/images/404_not_found.svg"
-          // style="width:500px;margin:20px;"
-          style={{
-            width: 500,
-            margin: 20,
-          }}
-          alt="404 Not Found"
-        />
-        <BAIFlex direction="column" align="start" gap={'lg'}>
-          <Typography.Title level={2} style={{ margin: 0 }}>
-            {/* t('webui.NotFound') */}
-            <Trans i18nKey={'webui.NotFound'} />
-          </Typography.Title>
-          <Typography.Text type="secondary" style={{ margin: 0 }}>
-            {t('webui.DescNotFound')}
-          </Typography.Text>
-          <Button
-            size="large"
-            type="primary"
-            onClick={() => webuiNavigate(defaultPagePath)}
-          >
-            {t('button.GoBackToStartPage', { title: defaultPageTitle })}
-          </Button>
-        </BAIFlex>
-      </BAIFlex>
-    </BAIFlex>
+    <RouteErrorContent
+      segments={segments.length ? segments : undefined}
+      title={<Trans i18nKey={'webui.NotFound'} />}
+      description={t('webui.DescNotFound')}
+      extra={
+        <Button
+          type="primary"
+          size="large"
+          icon={<ArrowRightIcon size="1em" />}
+          iconPosition="end"
+          onClick={() => webuiNavigate(defaultPagePath)}
+        >
+          {t('button.GoBackToStartPage', { title: defaultPageTitle })}
+        </Button>
+      }
+    />
   );
 };
 

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "Mitglied"
   },
   "projectSelect": {
+    "GoToProject": "Zu {{project}} wechseln",
     "NoAccessibleProjects": "Keine zugänglichen Projekte.",
-    "ProjectAdminBadge": "Projektadministrator"
+    "ProjectAdminBadge": "Projektadministrator",
+    "ProjectNotFoundOrNoAccess": "Das Projekt '{{project}}' wurde nicht gefunden oder Sie haben keinen Zugriff darauf.",
+    "SwitchToAccessibleProject": "Wählen Sie ein zugängliches Projekt aus der Projektauswahl oben auf der Seite."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Voreinstellung hinzufügen",

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "Mitglied"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Bitten Sie Ihren Administrator, Ihnen Zugriff auf ein Projekt zu gewähren.",
     "GoToProject": "Zu {{project}} wechseln",
     "NoAccessibleProjects": "Keine zugänglichen Projekte.",
     "ProjectAdminBadge": "Projektadministrator",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2112,6 +2112,7 @@
     "RoleMember": "Μέλος"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Ζητήστε από τον διαχειριστή σας να σας παραχωρήσει πρόσβαση σε ένα έργο.",
     "GoToProject": "Μετάβαση στο {{project}}",
     "NoAccessibleProjects": "Δεν υπάρχουν προσβάσιμα έργα.",
     "ProjectAdminBadge": "Διαχειριστής έργου",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2112,8 +2112,11 @@
     "RoleMember": "Μέλος"
   },
   "projectSelect": {
+    "GoToProject": "Μετάβαση στο {{project}}",
     "NoAccessibleProjects": "Δεν υπάρχουν προσβάσιμα έργα.",
-    "ProjectAdminBadge": "Διαχειριστής έργου"
+    "ProjectAdminBadge": "Διαχειριστής έργου",
+    "ProjectNotFoundOrNoAccess": "Το έργο '{{project}}' δεν βρέθηκε ή δεν έχετε πρόσβαση σε αυτό.",
+    "SwitchToAccessibleProject": "Επιλέξτε ένα προσβάσιμο έργο από τον επιλογέα έργου στο επάνω μέρος της σελίδας."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Προσθήκη προεπιλογής",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2099,6 +2099,7 @@
     "RoleMember": "Member"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Ask your administrator to grant you access to a project.",
     "GoToProject": "Go to {{project}}",
     "NoAccessibleProjects": "No accessible projects.",
     "ProjectAdminBadge": "Project Admin",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2099,8 +2099,11 @@
     "RoleMember": "Member"
   },
   "projectSelect": {
+    "GoToProject": "Go to {{project}}",
     "NoAccessibleProjects": "No accessible projects.",
-    "ProjectAdminBadge": "Project Admin"
+    "ProjectAdminBadge": "Project Admin",
+    "ProjectNotFoundOrNoAccess": "Project ‘{{project}}’ was not found or you don’t have access to it.",
+    "SwitchToAccessibleProject": "Select an accessible project from the project selector at the top of the page."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Add Preset",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2112,8 +2112,11 @@
     "RoleMember": "Miembro"
   },
   "projectSelect": {
+    "GoToProject": "Ir al proyecto {{project}}",
     "NoAccessibleProjects": "No hay proyectos accesibles.",
-    "ProjectAdminBadge": "Administrador del proyecto"
+    "ProjectAdminBadge": "Administrador del proyecto",
+    "ProjectNotFoundOrNoAccess": "El proyecto '{{project}}' no fue encontrado o no tienes acceso a él.",
+    "SwitchToAccessibleProject": "Selecciona un proyecto accesible desde el selector de proyectos en la parte superior de la página."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Agregar preset",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2112,6 +2112,7 @@
     "RoleMember": "Miembro"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Pida a su administrador que le conceda acceso a un proyecto.",
     "GoToProject": "Ir al proyecto {{project}}",
     "NoAccessibleProjects": "No hay proyectos accesibles.",
     "ProjectAdminBadge": "Administrador del proyecto",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2112,6 +2112,7 @@
     "RoleMember": "Jäsen"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Pyydä järjestelmänvalvojaa myöntämään sinulle pääsy projektiin.",
     "GoToProject": "Siirry projektiin {{project}}",
     "NoAccessibleProjects": "Ei saatavilla olevia projekteja.",
     "ProjectAdminBadge": "Projektin ylläpitäjä",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2112,8 +2112,11 @@
     "RoleMember": "Jäsen"
   },
   "projectSelect": {
+    "GoToProject": "Siirry projektiin {{project}}",
     "NoAccessibleProjects": "Ei saatavilla olevia projekteja.",
-    "ProjectAdminBadge": "Projektin ylläpitäjä"
+    "ProjectAdminBadge": "Projektin ylläpitäjä",
+    "ProjectNotFoundOrNoAccess": "Projektia '{{project}}' ei löydy tai sinulla ei ole siihen pääsyä.",
+    "SwitchToAccessibleProject": "Valitse käytettävissä oleva projekti sivun yläreunassa olevasta projektin valitsimesta."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Lisää esiasetus",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "Membre"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Demandez à votre administrateur de vous accorder l'accès à un projet.",
     "GoToProject": "Aller au projet {{project}}",
     "NoAccessibleProjects": "Aucun projet accessible.",
     "ProjectAdminBadge": "Administrateur de projet",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "Membre"
   },
   "projectSelect": {
+    "GoToProject": "Aller au projet {{project}}",
     "NoAccessibleProjects": "Aucun projet accessible.",
-    "ProjectAdminBadge": "Administrateur de projet"
+    "ProjectAdminBadge": "Administrateur de projet",
+    "ProjectNotFoundOrNoAccess": "Le projet '{{project}}' est introuvable ou vous n'y avez pas accès.",
+    "SwitchToAccessibleProject": "Sélectionnez un projet accessible depuis le sélecteur de projet en haut de la page."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Ajouter un préréglage",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2115,8 +2115,11 @@
     "RoleMember": "Anggota"
   },
   "projectSelect": {
+    "GoToProject": "Buka {{project}}",
     "NoAccessibleProjects": "Tidak ada proyek yang dapat diakses.",
-    "ProjectAdminBadge": "Admin Proyek"
+    "ProjectAdminBadge": "Admin Proyek",
+    "ProjectNotFoundOrNoAccess": "Proyek '{{project}}' tidak ditemukan atau Anda tidak memiliki akses ke proyek tersebut.",
+    "SwitchToAccessibleProject": "Pilih proyek yang dapat diakses dari pemilih proyek di bagian atas halaman."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Tambah Preset",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2115,6 +2115,7 @@
     "RoleMember": "Anggota"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Minta administrator Anda untuk memberikan akses ke sebuah proyek.",
     "GoToProject": "Buka {{project}}",
     "NoAccessibleProjects": "Tidak ada proyek yang dapat diakses.",
     "ProjectAdminBadge": "Admin Proyek",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2112,8 +2112,11 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "GoToProject": "Vai al progetto {{project}}",
     "NoAccessibleProjects": "Nessun progetto accessibile.",
-    "ProjectAdminBadge": "Amministratore del progetto"
+    "ProjectAdminBadge": "Amministratore del progetto",
+    "ProjectNotFoundOrNoAccess": "Il progetto '{{project}}' non è stato trovato o non hai accesso ad esso.",
+    "SwitchToAccessibleProject": "Seleziona un progetto accessibile dal selettore di progetto nella parte superiore della pagina."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Aggiungi preset",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2112,6 +2112,7 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Chiedi al tuo amministratore di concederti l'accesso a un progetto.",
     "GoToProject": "Vai al progetto {{project}}",
     "NoAccessibleProjects": "Nessun progetto accessibile.",
     "ProjectAdminBadge": "Amministratore del progetto",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "メンバー"
   },
   "projectSelect": {
+    "GoToProject": "{{project}} へ移動",
     "NoAccessibleProjects": "アクセス可能なプロジェクトがありません。",
-    "ProjectAdminBadge": "プロジェクト管理者"
+    "ProjectAdminBadge": "プロジェクト管理者",
+    "ProjectNotFoundOrNoAccess": "プロジェクト '{{project}}' が見つからないか、アクセス権がありません。",
+    "SwitchToAccessibleProject": "ページ上部のプロジェクトセレクターからアクセス可能なプロジェクトを選択してください。"
   },
   "prometheusQueryPreset": {
     "AddPreset": "プリセットを追加",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "メンバー"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "管理者にプロジェクトへのアクセス権を依頼してください。",
     "GoToProject": "{{project}} へ移動",
     "NoAccessibleProjects": "アクセス可能なプロジェクトがありません。",
     "ProjectAdminBadge": "プロジェクト管理者",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "구성원"
   },
   "projectSelect": {
+    "GoToProject": "{{project}}로 이동",
     "NoAccessibleProjects": "선택 가능한 프로젝트가 없습니다.",
-    "ProjectAdminBadge": "프로젝트 관리자"
+    "ProjectAdminBadge": "프로젝트 관리자",
+    "ProjectNotFoundOrNoAccess": "프로젝트 '{{project}}'를 찾을 수 없거나 접근 권한이 없습니다.",
+    "SwitchToAccessibleProject": "페이지 상단의 프로젝트 선택기에서 접근 가능한 프로젝트를 선택하세요."
   },
   "prometheusQueryPreset": {
     "AddPreset": "프리셋 추가",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "구성원"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "관리자에게 프로젝트 접근 권한을 요청하세요.",
     "GoToProject": "{{project}}로 이동",
     "NoAccessibleProjects": "선택 가능한 프로젝트가 없습니다.",
     "ProjectAdminBadge": "프로젝트 관리자",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2113,6 +2113,7 @@
     "RoleMember": "Гишүүн"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Администратораасаа төсөлд хандах эрх олгохыг хүсээрэй.",
     "GoToProject": "{{project}} руу очих",
     "NoAccessibleProjects": "Боломжтой төсөл байхгүй байна.",
     "ProjectAdminBadge": "Төслийн администратор",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2113,8 +2113,11 @@
     "RoleMember": "Гишүүн"
   },
   "projectSelect": {
+    "GoToProject": "{{project}} руу очих",
     "NoAccessibleProjects": "Боломжтой төсөл байхгүй байна.",
-    "ProjectAdminBadge": "Төслийн администратор"
+    "ProjectAdminBadge": "Төслийн администратор",
+    "ProjectNotFoundOrNoAccess": "'{{project}}' төсөл олдсонгүй эсвэл танд хандах эрх байхгүй байна.",
+    "SwitchToAccessibleProject": "Хуудасны дээд хэсэгт байрлах төсөл сонгогчоос нэвтрэх боломжтой төслийг сонгоно уу."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Урьдчилсан тохиргоо нэмэх",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2112,8 +2112,11 @@
     "RoleMember": "Ahli"
   },
   "projectSelect": {
+    "GoToProject": "Pergi ke {{project}}",
     "NoAccessibleProjects": "Tiada projek yang boleh diakses.",
-    "ProjectAdminBadge": "Pentadbir Projek"
+    "ProjectAdminBadge": "Pentadbir Projek",
+    "ProjectNotFoundOrNoAccess": "Projek '{{project}}' tidak ditemui atau anda tidak mempunyai akses kepadanya.",
+    "SwitchToAccessibleProject": "Pilih projek yang boleh diakses daripada pemilih projek di bahagian atas halaman."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Tambah Pratetap",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2112,6 +2112,7 @@
     "RoleMember": "Ahli"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Minta pentadbir anda memberikan akses kepada projek.",
     "GoToProject": "Pergi ke {{project}}",
     "NoAccessibleProjects": "Tiada projek yang boleh diakses.",
     "ProjectAdminBadge": "Pentadbir Projek",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "Członek"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Poproś administratora o przyznanie dostępu do projektu.",
     "GoToProject": "Przejdź do {{project}}",
     "NoAccessibleProjects": "Brak dostępnych projektów.",
     "ProjectAdminBadge": "Administrator projektu",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "Członek"
   },
   "projectSelect": {
+    "GoToProject": "Przejdź do {{project}}",
     "NoAccessibleProjects": "Brak dostępnych projektów.",
-    "ProjectAdminBadge": "Administrator projektu"
+    "ProjectAdminBadge": "Administrator projektu",
+    "ProjectNotFoundOrNoAccess": "Projekt '{{project}}' nie został znaleziony lub nie masz do niego dostępu.",
+    "SwitchToAccessibleProject": "Wybierz dostępny projekt z selektora projektów na górze strony."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Dodaj preset",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2112,8 +2112,11 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "GoToProject": "Ir para {{project}}",
     "NoAccessibleProjects": "Nenhum projeto acessível.",
-    "ProjectAdminBadge": "Administrador do projeto"
+    "ProjectAdminBadge": "Administrador do projeto",
+    "ProjectNotFoundOrNoAccess": "O projeto '{{project}}' não foi encontrado ou você não tem acesso a ele.",
+    "SwitchToAccessibleProject": "Selecione um projeto acessível a partir do seletor de projetos no topo da página."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Adicionar predefinição",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2112,6 +2112,7 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Peça ao seu administrador para conceder acesso a um projeto.",
     "GoToProject": "Ir para {{project}}",
     "NoAccessibleProjects": "Nenhum projeto acessível.",
     "ProjectAdminBadge": "Administrador do projeto",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "GoToProject": "Ir para {{project}}",
     "NoAccessibleProjects": "Nenhum projeto acessível.",
-    "ProjectAdminBadge": "Administrador do projeto"
+    "ProjectAdminBadge": "Administrador do projeto",
+    "ProjectNotFoundOrNoAccess": "O projeto '{{project}}' não foi encontrado ou não tem acesso a ele.",
+    "SwitchToAccessibleProject": "Selecione um projeto acessível a partir do seletor de projetos no topo da página."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Adicionar predefinição",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "Membro"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Peça ao seu administrador para lhe conceder acesso a um projeto.",
     "GoToProject": "Ir para {{project}}",
     "NoAccessibleProjects": "Nenhum projeto acessível.",
     "ProjectAdminBadge": "Administrador do projeto",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2112,6 +2112,7 @@
     "RoleMember": "Участник"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Попросите администратора предоставить вам доступ к проекту.",
     "GoToProject": "Перейти к {{project}}",
     "NoAccessibleProjects": "Нет доступных проектов.",
     "ProjectAdminBadge": "Администратор проекта",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2112,8 +2112,11 @@
     "RoleMember": "Участник"
   },
   "projectSelect": {
+    "GoToProject": "Перейти к {{project}}",
     "NoAccessibleProjects": "Нет доступных проектов.",
-    "ProjectAdminBadge": "Администратор проекта"
+    "ProjectAdminBadge": "Администратор проекта",
+    "ProjectNotFoundOrNoAccess": "Проект '{{project}}' не найден или у вас нет к нему доступа.",
+    "SwitchToAccessibleProject": "Выберите доступный проект в селекторе проектов в верхней части страницы."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Добавить пресет",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "สมาชิก"
   },
   "projectSelect": {
+    "GoToProject": "ไปยัง {{project}}",
     "NoAccessibleProjects": "ไม่มีโปรเจกต์ที่สามารถเข้าถึงได้",
-    "ProjectAdminBadge": "ผู้ดูแลโปรเจกต์"
+    "ProjectAdminBadge": "ผู้ดูแลโปรเจกต์",
+    "ProjectNotFoundOrNoAccess": "ไม่พบโปรเจกต์ '{{project}}' หรือคุณไม่มีสิทธิ์เข้าถึง",
+    "SwitchToAccessibleProject": "เลือกโปรเจกต์ที่สามารถเข้าถึงได้จากตัวเลือกโปรเจกต์ที่ด้านบนของหน้า"
   },
   "prometheusQueryPreset": {
     "AddPreset": "เพิ่มพรีเซต",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "สมาชิก"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "โปรดติดต่อผู้ดูแลระบบเพื่อขอสิทธิ์เข้าถึงโปรเจกต์",
     "GoToProject": "ไปยัง {{project}}",
     "NoAccessibleProjects": "ไม่มีโปรเจกต์ที่สามารถเข้าถึงได้",
     "ProjectAdminBadge": "ผู้ดูแลโปรเจกต์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2112,6 +2112,7 @@
     "RoleMember": "Üye"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Yöneticinizden bir projeye erişim izni vermesini isteyin.",
     "GoToProject": "{{project}} projesine git",
     "NoAccessibleProjects": "Erişilebilir proje bulunmuyor.",
     "ProjectAdminBadge": "Proje Yöneticisi",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2112,8 +2112,11 @@
     "RoleMember": "Üye"
   },
   "projectSelect": {
+    "GoToProject": "{{project}} projesine git",
     "NoAccessibleProjects": "Erişilebilir proje bulunmuyor.",
-    "ProjectAdminBadge": "Proje Yöneticisi"
+    "ProjectAdminBadge": "Proje Yöneticisi",
+    "ProjectNotFoundOrNoAccess": "'{{project}}' projesi bulunamadı veya erişim izniniz yok.",
+    "SwitchToAccessibleProject": "Sayfanın üstündeki proje seçicisinden erişilebilir bir proje seçin."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Ön ayar ekle",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "Thành viên"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "Hãy yêu cầu quản trị viên cấp cho bạn quyền truy cập vào một dự án.",
     "GoToProject": "Đi đến {{project}}",
     "NoAccessibleProjects": "Không có dự án nào có thể truy cập.",
     "ProjectAdminBadge": "Quản trị dự án",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "Thành viên"
   },
   "projectSelect": {
+    "GoToProject": "Đi đến {{project}}",
     "NoAccessibleProjects": "Không có dự án nào có thể truy cập.",
-    "ProjectAdminBadge": "Quản trị dự án"
+    "ProjectAdminBadge": "Quản trị dự án",
+    "ProjectNotFoundOrNoAccess": "Dự án '{{project}}' không được tìm thấy hoặc bạn không có quyền truy cập vào nó.",
+    "SwitchToAccessibleProject": "Chọn một dự án có thể truy cập từ bộ chọn dự án ở đầu trang."
   },
   "prometheusQueryPreset": {
     "AddPreset": "Thêm cài đặt sẵn",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2114,8 +2114,11 @@
     "RoleMember": "成员"
   },
   "projectSelect": {
+    "GoToProject": "前往 {{project}}",
     "NoAccessibleProjects": "没有可访问的项目。",
-    "ProjectAdminBadge": "项目管理员"
+    "ProjectAdminBadge": "项目管理员",
+    "ProjectNotFoundOrNoAccess": "项目 '{{project}}' 未找到或您没有访问权限。",
+    "SwitchToAccessibleProject": "请从页面顶部的项目选择器中选择一个可访问的项目。"
   },
   "prometheusQueryPreset": {
     "AddPreset": "添加预设",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2114,6 +2114,7 @@
     "RoleMember": "成员"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "请联系管理员为您授予项目访问权限。",
     "GoToProject": "前往 {{project}}",
     "NoAccessibleProjects": "没有可访问的项目。",
     "ProjectAdminBadge": "项目管理员",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2116,6 +2116,7 @@
     "RoleMember": "成員"
   },
   "projectSelect": {
+    "AskAdminForProjectAccess": "請聯絡管理員為您授予專案存取權限。",
     "GoToProject": "前往 {{project}}",
     "NoAccessibleProjects": "沒有可存取的專案。",
     "ProjectAdminBadge": "專案管理員",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2116,8 +2116,11 @@
     "RoleMember": "成員"
   },
   "projectSelect": {
+    "GoToProject": "前往 {{project}}",
     "NoAccessibleProjects": "沒有可存取的專案。",
-    "ProjectAdminBadge": "專案管理員"
+    "ProjectAdminBadge": "專案管理員",
+    "ProjectNotFoundOrNoAccess": "找不到專案 '{{project}}' 或您沒有存取權限。",
+    "SwitchToAccessibleProject": "請從頁面頂部的專案選擇器中選擇一個可存取的專案。"
   },
   "prometheusQueryPreset": {
     "AddPreset": "新增預設",


### PR DESCRIPTION
Resolves #7754 (FR-3057)

Stacked on #7751 (FR-3055).

## Summary

Follow-up fixes for navigation regressions found by browser-walking every route after the scope-aware routing change (#7751):

- **Cross-scope URLs now 404 instead of rendering blank** (`react/src/hooks/useWebUIMenuItems.tsx`): under the `/admin/<feature>` and `/project/:name/<feature>` namespaces, a feature key valid in a *different* scope (e.g. `/admin/start`, `/project/x/agent`) matched no route and rendered an empty `<Outlet/>`. `isCurrentPageNotFound` now validates the scope+feature via `scopeFeatureToMenuKey()` and returns 404. Valid routes are unaffected.
- **Help button resolves the correct docs anchor** (`react/src/components/WEBUIHelpButton.tsx`): the lookup table was keyed by pre-scope first-segments, so `deployments` and the admin/project-admin menu keys fell back to the docs homepage. Added the scope-aware menu keys mapping to the same anchors as their legacy keys.
- **Invalid / inaccessible `:projectName` shows an explicit "not found / no access" status instead of silently switching projects** (`react/src/components/MainLayout/ProjectScopeLayout.tsx`, `WebUIHeader.tsx`): per review feedback — a project name is just a name (it may not exist or be access-restricted), so redirecting to an arbitrary "current/first" project is misleading. The layout now renders an antd `<Result status="404">` ("Project '<name>' was not found or you don't have access to it") with a "Go to <your project>" action; and the header project selector shows **no selection (placeholder)** for an invalid URL project instead of misleadingly showing the last valid project. New i18n keys translated into all 21 languages.

## Verification (live browser walk against a cluster, super-admin)

- Walked the full route set (user / admin / project-admin), all 16 old-URL redirect shims, and transitions (menu clicks, project switch on list + form, back button) — all correct; valid routes render.
- After this PR (browser-verified): cross-scope typo URLs (`/admin/start` etc.) render Page404; `/project/default/deployments` help → `model_serving/model_serving.html`; `/project/<invalid>/session` renders the "project not found / no access" notice (no redirect) with a "Go to <project>" button.
- `pnpm --prefix react test`: 917 tests pass; tsc / lint / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Route-error states redesign (v3, minimal)

All route-level error states now share one minimal composition (`RouteErrorContent`): a monospace **path pill** with the broken segment highlighted (warm chip + wavy accent underline), a heading, a secondary hint, and a CTA. No decorative background/illustration.

- **Invalid project** (`/project/<bad>/...`): pill marks the project segment; hint points at the header selector; CTA goes to the **alphabetically-first accessible project**.
- **Unknown feature/path** (`/project/default/model-store2`, any 404): `Page404` renders the same language, marking the unresolved segment, keeping its existing copy.
- **No accessible projects**: title + administrator hint (new i18n key `AskAdminForProjectAccess`, 21 languages).
- Pill is `aria-hidden` (heading carries semantics); the broken-segment ink is contrast-tuned per theme (`#B25400` light / `#F2A045` dark).

| Invalid project — light | Invalid project — dark | Unknown page — light |
|---|---|---|
| ![invalid light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7755/20260707-141346-invalid-project-v3-light.png) | ![invalid dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7755/20260707-141352-invalid-project-v3-dark.png) | ![feature 404](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7755/20260707-141357-feature-404-v3-light.png) |
