### PR TITLE
fix(FR-3061): pack Electron runtime deps into app.asar (disable global virtual store)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ dep_electron: dep_web
 			mkdir -p build/electron-app; \
 			cp -r electron-app/* build/electron-app/; \
 			cp electron-app/.npmrc build/electron-app/; \
-			pnpm i --prefix ./build/electron-app --ignore-workspace; \
+			(cd ./build/electron-app && pnpm i --ignore-workspace --config.node-linker=hoisted --config.enable-global-virtual-store=false); \
 		fi && \
 		rm -rf build/electron-app/app build/electron-app/resources build/electron-app/manifest && \
 		cp -Rp build/web build/electron-app/app && \

--- a/electron-app/.npmrc
+++ b/electron-app/.npmrc
@@ -1,2 +1,6 @@
 node-linker=hoisted
 public-hoist-pattern = *
+# Keep deps as real files inside the app dir so @electron/packager can
+# pack them into app.asar (the repo-root enableGlobalVirtualStore would
+# otherwise link them into an external global store — see dep_electron).
+enable-global-virtual-store=false


### PR DESCRIPTION
Resolves #7759 (FR-3061)

## Problem

The packaged macOS desktop app (DMG / `make mac`) crashes immediately on launch:

```
A JavaScript error occurred in the main process
Uncaught Exception:
Error: ENOENT, node_modules/.pnpm/smol-toml@1.6.1/node_modules/smol-toml
not found in /Applications/Backend.AI Desktop.app/Contents/Resources/app.asar
```

`electron-app/main.js` requires `smol-toml` (config.toml parsing) and `mime-types` (es6 protocol MIME), but those packages are not inside `app.asar`.

## Root cause

The repo-root `pnpm-workspace.yaml` sets **`enableGlobalVirtualStore: true`** (FR-2856 / #7332). When `make dep` installs the `build/electron-app` runtime deps via `pnpm i --prefix ./build/electron-app --ignore-workspace` (from the repo root), that setting still applies and stores the real dependency files in a **global pnpm store outside the app directory** — `build/electron-app/node_modules` ends up with only links pointing out of the app root.

`@electron/packager` builds `app.asar` rooted at `build/electron-app`, so it can't include those external files. At runtime `require('smol-toml')` resolves to the `.pnpm/...` path that isn't in the asar → ENOENT.

`electron-app/.npmrc`'s existing `node-linker=hoisted` (FR-666) is defeated by the global virtual store, and `--ignore-workspace` does not turn it off.

**Pre-existing & electron-version-independent** — verified by A/B test: the same `build/electron-app` crashes identically under electron 35 and 39 (this is *not* introduced by the electron 39 bump in #6381).

## Fix

Install the Electron runtime deps from inside the app dir, with the global virtual store disabled and the hoisted linker, so deps are real files local to the app:

- **Makefile** (`dep_electron`): `(cd ./build/electron-app && pnpm i --ignore-workspace --config.node-linker=hoisted --config.enable-global-virtual-store=false)`
- **electron-app/.npmrc**: add `enable-global-virtual-store=false`

## Verification

`rm -rf build/electron-app && make dep`:
- `build/electron-app/node_modules/smol-toml` → **real directory** (was a symlink to the external global store)
- resolved path is **inside** `build/electron-app` (not the global store)
- `node -e "require('smol-toml'); require('mime-types')"` → OK

→ asar (rooted at `build/electron-app`) now includes the deps.

## Test plan
- [x] `rm -rf build/electron-app && make dep` → smol-toml/mime-types are real dirs inside the app, require() works
- [ ] Reviewer (macOS): `make clean && make mac` (or DMG build) → launch the app, confirm it reaches the login screen without the ENOENT crash

> Note: `dep_electron` skips the install when `build/electron-app` already exists — run `make clean` (or `rm -rf build/electron-app`) for the fix to take effect on an existing checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)