### PR TITLE
chore(FR-3064): prune dead pnpm overrides (node-forge, langium)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,6 @@ catalogs:
 
 overrides:
   tar-fs@2: 2.1.4
-  node-forge: '>=1.3.2'
-  langium: ^4.2.4
   js-cookie: ^3.0.7
   mermaid: ^11.15.0
   serialize-javascript: ^7.0.5
@@ -9818,11 +9816,6 @@ packages:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
 
-  resolve@1.22.10:
-    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -13823,7 +13816,7 @@ snapshots:
       '@rushstack/ts-command-line': 5.0.1(@types/node@25.3.5)
       lodash: 4.18.1
       minimatch: 3.1.5
-      resolve: 1.22.10
+      resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
       typescript: 5.8.2
@@ -22014,12 +22007,6 @@ snapshots:
   resolve-pkg-maps@1.0.0: {}
 
   resolve.exports@2.0.3: {}
-
-  resolve@1.22.10:
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@1.22.11:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,10 +79,6 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - react@19.2.6
   - react-dom@19.2.6
-  # Required by the `langium: ^4.2.4` override below — 4.2.4 is the first
-  # release that declares its previously phantom imports as real dependencies.
-  # Remove this entry once 4.2.4 ages past 7 days.
-  - langium@4.2.4
 minimumReleaseAgeIgnoreMissingTime: false
 resolutionMode: time-based
 
@@ -99,13 +95,6 @@ allowBuilds:
 
 overrides:
   tar-fs@2: 2.1.4
-  node-forge: ">=1.3.2"
-  # langium is pulled transitively via @ant-design/x and @lobehub/ui →
-  # mermaid → @mermaid-js/parser. 4.2.1–4.2.3 import vscode-languageserver-
-  # {types,protocol}, vscode-jsonrpc and @chevrotain/regexp-to-ast without
-  # declaring them; under `enableGlobalVirtualStore` esbuild/Vite cannot
-  # resolve these phantom imports. 4.2.4 declares all four as real deps.
-  langium: ^4.2.4
   # Runtime security overrides — FR-3014. Pin transitive deps that end up in
   # the production bundle to the first Dependabot-recommended patched
   # version. Remove an entry when every upstream consumer ranges to the


### PR DESCRIPTION
Resolves #7765 (FR-3064)

Removes two dead `overrides:` entries from `pnpm-workspace.yaml` — both are no-ops (0 consumers in `pnpm-lock.yaml`) — plus the orphaned `langium` `minimumReleaseAgeExclude` twin. Net effect: **−2 overrides, none added.**

## Removed (dead)
- **`node-forge: ">=1.3.2"`** — 0 consumers in the lockfile; floor was also stale (current advisories require 1.4.0).
- **`langium: ^4.2.4`** — `@mermaid-js/parser@1.1.1` dropped its langium dependency, so nothing pulls langium anymore. Its paired `minimumReleaseAgeExclude: langium@4.2.4` entry is likewise dead and removed together.

## Kept (verified still load-bearing)
- **`serialize-javascript`** — `@rollup/plugin-terser@0.4.4` pins `^6.0.1`, a major below the 7.0.5 fix; removing it regresses to vulnerable 6.0.2.
- **`dompurify`** — `monaco-editor@0.55.1` exact-pins `3.2.7`; only the override drags it to a patched version.

(`tar-fs`, `js-cookie`, `mermaid`, `uuid@^11/^13` left untouched — out of scope for this dead-entry sweep.)

## ajv ReDoS — Dependabot #262 — dismissed, not fixed in code
Triaged as part of this sweep. The vulnerable `ajv@8.12.0`/`8.13.0` are **build-time only** and pulled solely by `@microsoft/api-extractor` — a phantom **optional peer** of `vite-plugin-dts` (`rollupTypes: false`) and `tsup` (`dts: true`, non-experimental) that our build **never invokes**; ajv never reaches the shipped Vite bundle. A no-override "bump" does not cleanly resolve it (pnpm resolves the optional peer to a *second* api-extractor copy, leaving the old ajv in place), and adding an override for a never-executed tool would only grow override debt. **Alert #262 dismissed as "vulnerable code is not actually used."**

## Notes
- `pnpm-lock.yaml` also reflects an incidental transitive `resolve` `1.22.10 → 1.22.11` patch float from re-resolution.

## Verification
`bash scripts/verify.sh` → `=== ALL PASS ===`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
