### PR TITLE
fix(FR-3067): harden BAI property filter against prototype pollution and ReDoS

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
@@ -27,6 +27,13 @@ describe('buildNestedFilter', () => {
       expect(({} as Record<string, unknown>).polluted).toBeUndefined();
     },
   );
+
+  it.each(['a..b', '.a', 'a.', '.', ''])(
+    'rejects empty path segment in "%s"',
+    (path) => {
+      expect(() => buildNestedFilter(path, { eq: 'x' })).toThrow();
+    },
+  );
 });
 
 const filterProperties: Array<FilterProperty> = [

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
@@ -1,9 +1,33 @@
 import BAIGraphQLPropertyFilter, {
+  buildNestedFilter,
   type FilterProperty,
   type GraphQLFilter,
 } from './BAIGraphQLPropertyFilter';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
+
+describe('buildNestedFilter', () => {
+  it('builds a single-level filter', () => {
+    expect(buildNestedFilter('name', { eq: 'test' })).toEqual({
+      name: { eq: 'test' },
+    });
+  });
+
+  it('builds a nested filter from a dot-notation path', () => {
+    expect(buildNestedFilter('project.name', { eq: 'test' })).toEqual({
+      project: { name: { eq: 'test' } },
+    });
+  });
+
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects prototype-polluting key "%s"',
+    (key) => {
+      expect(() => buildNestedFilter(`${key}.polluted`, { eq: 'x' })).toThrow();
+      // Object.prototype must remain untouched.
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    },
+  );
+});
 
 const filterProperties: Array<FilterProperty> = [
   {

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -267,11 +267,12 @@ const PROTOTYPE_POLLUTING_KEYS = new Set([
 /**
  * Builds a nested object from a dot-notation path.
  * e.g., "project.name" with value { eq: "test" } -> { project: { name: { eq: "test" } } }
- * @throws if any path segment is a prototype-polluting key.
+ * @throws if any path segment is empty (e.g. "a..b", ".a", "a.") or a
+ *   prototype-polluting key.
  */
 export function buildNestedFilter(path: string, value: any): GraphQLFilter {
   const keys = path.split('.');
-  if (keys.some((key) => PROTOTYPE_POLLUTING_KEYS.has(key))) {
+  if (keys.some((key) => key === '' || PROTOTYPE_POLLUTING_KEYS.has(key))) {
     throw new Error(`Invalid filter property path: "${path}"`);
   }
   if (keys.length === 1) {

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -255,17 +255,30 @@ function generateId(): string {
   return `filter-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
 }
 
+// Object keys that would mutate the prototype chain if used as nested filter
+// keys. Guarding against them prevents prototype-pollution
+// (CodeQL js/prototype-polluting-assignment, js/prototype-pollution-utility).
+const PROTOTYPE_POLLUTING_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
 /**
  * Builds a nested object from a dot-notation path.
  * e.g., "project.name" with value { eq: "test" } -> { project: { name: { eq: "test" } } }
+ * @throws if any path segment is a prototype-polluting key.
  */
-function buildNestedFilter(path: string, value: any): GraphQLFilter {
+export function buildNestedFilter(path: string, value: any): GraphQLFilter {
   const keys = path.split('.');
+  if (keys.some((key) => PROTOTYPE_POLLUTING_KEYS.has(key))) {
+    throw new Error(`Invalid filter property path: "${path}"`);
+  }
   if (keys.length === 1) {
     return { [path]: value };
   }
 
-  let result: any = {};
+  const result: any = {};
   let current = result;
   for (let i = 0; i < keys.length - 1; i++) {
     current[keys[i]] = {};

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
@@ -73,6 +73,16 @@ describe('parseFilterValue', () => {
     });
   });
 
+  it('should treat Unicode whitespace (e.g. non-breaking space) as a separator', () => {
+    // \u00A0 is matched by \s but not by a fixed ASCII whitespace list.
+    const NBSP = '\u00A0';
+    expect(parseFilterValue(`name${NBSP}==${NBSP}"value"`)).toEqual({
+      property: 'name',
+      operator: '==',
+      value: 'value',
+    });
+  });
+
   it('should not backtrack catastrophically on long whitespace input (ReDoS guard)', () => {
     // Previously a polynomial-backtracking regex was used here; a long run of
     // tab characters would take seconds. The linear tokenizer must finish fast.

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
@@ -56,6 +56,37 @@ describe('parseFilterValue', () => {
       value: '%@example.com',
     });
   });
+
+  it('should treat tabs and mixed whitespace as separators', () => {
+    expect(parseFilterValue('name\t==\t"value"')).toEqual({
+      property: 'name',
+      operator: '==',
+      value: 'value',
+    });
+  });
+
+  it('should preserve whitespace inside quoted values', () => {
+    expect(parseFilterValue('name contains "foo bar baz"')).toEqual({
+      property: 'name',
+      operator: 'contains',
+      value: 'foo bar baz',
+    });
+  });
+
+  it('should not backtrack catastrophically on long whitespace input (ReDoS guard)', () => {
+    // Previously a polynomial-backtracking regex was used here; a long run of
+    // tab characters would take seconds. The linear tokenizer must finish fast.
+    const filter = 'name ==' + '\t'.repeat(50000) + '"value"';
+    const start = performance.now();
+    const result = parseFilterValue(filter);
+    const elapsed = performance.now() - start;
+    expect(result).toEqual({
+      property: 'name',
+      operator: '==',
+      value: 'value',
+    });
+    expect(elapsed).toBeLessThan(1000);
+  });
 });
 
 describe('mergeFilterValues', () => {

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -103,6 +103,12 @@ export function mergeFilterValues(
   return mergedFilter ? mergedFilter : undefined;
 }
 
+// Matches a single whitespace character. Applied per-character (never against
+// the full input), so it is constant-time and cannot backtrack — it preserves
+// the full `\s` semantics of the original split (including Unicode whitespace
+// such as a non-breaking space) without the ReDoS risk of a quantified regex.
+const WHITESPACE_CHAR = /\s/;
+
 /**
  * Splits a string on whitespace while preserving whitespace inside
  * double-quoted segments. Implemented as a single linear scan to avoid the
@@ -121,15 +127,7 @@ function tokenizeRespectingQuotes(input: string): string[] {
     if (char === '"') {
       inQuotes = !inQuotes;
       current += char;
-    } else if (
-      !inQuotes &&
-      (char === ' ' ||
-        char === '\t' ||
-        char === '\n' ||
-        char === '\r' ||
-        char === '\f' ||
-        char === '\v')
-    ) {
+    } else if (!inQuotes && WHITESPACE_CHAR.test(char)) {
       if (current !== '') {
         tokens.push(current);
         current = '';

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -104,23 +104,62 @@ export function mergeFilterValues(
 }
 
 /**
+ * Splits a string on whitespace while preserving whitespace inside
+ * double-quoted segments. Implemented as a single linear scan to avoid the
+ * polynomial-backtracking lookahead regex previously used here, which was
+ * flagged by CodeQL (js/polynomial-redos) as vulnerable to ReDoS on inputs
+ * with many repeated whitespace characters.
+ * @param input - The string to tokenize.
+ * @returns The whitespace-separated tokens (quoted segments kept intact).
+ */
+function tokenizeRespectingQuotes(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      current += char;
+    } else if (
+      !inQuotes &&
+      (char === ' ' ||
+        char === '\t' ||
+        char === '\n' ||
+        char === '\r' ||
+        char === '\f' ||
+        char === '\v')
+    ) {
+      if (current !== '') {
+        tokens.push(current);
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+  if (current !== '') {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+/**
  * Parses the filter value and returns an object containing the property, operator, and value.
  * @param filter - The filter string to parse.
  * @returns An object containing the parsed property, operator, and value.
  */
 export function parseFilterValue(filter: string) {
-  // Split the filter string into an array of strings using a regular expression.
-  // The regular expression splits the string at whitespace characters, but ignores whitespace within double quotes.
-  const [property, ...rest] = filter.split(/\s+(?=(?:(?:[^"]*"){2})*[^"]*$)/);
+  // Tokenize on whitespace, ignoring whitespace within double quotes.
+  // The first token is the property, the second is the operator, and the
+  // remainder (rejoined with single spaces) is the value.
+  const tokens = tokenizeRespectingQuotes(filter);
+  const property = tokens[0] ?? '';
+  const operator = tokens[1] ?? '';
 
-  // Join the remaining strings in the array and split them again using the same regular expression.
-  // This extracts the operator and the value from the filter string.
-  const [operator, ...valueParts] = rest
-    .join(' ')
-    .split(/\s+(?=(?:(?:[^"]*"){2})*[^"]*$)/);
-
-  // Join the value parts into a single string and remove any leading or trailing double quotes.
-  const value = valueParts.join(' ').replace(/^"|"$/g, '');
+  // Join the value tokens into a single string and remove any leading or
+  // trailing double quotes.
+  const value = tokens.slice(2).join(' ').replace(/^"|"$/g, '');
 
   // Return an object containing the parsed property, operator, and value.
   return { property, operator, value };


### PR DESCRIPTION
Resolves #7771 (FR-3067)

Fixes actionable GitHub CodeQL code-scanning alerts located in our own `backend.ai-ui` components.

## Alerts addressed

### Prototype pollution — `buildNestedFilter()` in `BAIGraphQLPropertyFilter.tsx` (CodeQL #99/#100/#101, MEDIUM)
- Rules: `js/prototype-polluting-assignment`, `js/prototype-pollution-utility`
- `buildNestedFilter()` builds a nested object from a dot-notation path via computed-key assignment. A path segment of `__proto__` / `constructor` / `prototype` could mutate the prototype chain.
- **Fix:** reject any path segment matching a prototype-polluting key (throws). Defense-in-depth — real paths come from developer-defined `FilterProperty` definitions.

### Polynomial ReDoS — `parseFilterValue()` in `BAIPropertyFilter.tsx` (CodeQL #71/#72, HIGH)
- Rule: `js/polynomial-redos`
- The filter string was split with a polynomial-backtracking look-ahead regex `/\s+(?=(?:(?:[^"]*"){2})*[^"]*$)/`; a long whitespace run (e.g. tabs) caused super-linear backtracking. Impact is limited to the user's own browser (client-side filter input), but the alert is flagged HIGH.
- **Fix:** replace the regex split with a single linear-scan tokenizer that preserves whitespace inside double-quoted segments.

## Behavior & tests
- All existing `parseFilterValue` tests pass unchanged.
- Added tests: tab / mixed-whitespace separators, whitespace preserved inside quotes, a ReDoS-guard timing test (50k tabs < 1s), and `buildNestedFilter` prototype-pollution rejection.

## Out of scope (separate decisions)
- Clear-text log storage in `backend.ai-client/src/client.ts` (#115/#116, HIGH) — needs a review of what goes into the logs.
- Vendored `src/lib/ansiup.js` alerts (#42/#46) — upgrade-or-dismiss, not hand-edited.

## Verification
`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript). Affected test files: 38 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)