### PR TITLE
feat(FR-3069): show health check configuration in preset info modal

### DIFF
--- a/react/src/__generated__/DeploymentAddRevisionModalPresetDetailQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentAddRevisionModalPresetDetailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f67eba64a6e09d35a9daa331b3081add>>
+ * @generated SignedSource<<338f1f3af5637d8ae21f9aabbb305306>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -311,6 +311,100 @@ return {
               (v4/*: any*/)
             ],
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ModelDefinition",
+            "kind": "LinkedField",
+            "name": "modelDefinition",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ModelConfig",
+                "kind": "LinkedField",
+                "name": "models",
+                "plural": true,
+                "selections": [
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ModelServiceConfig",
+                    "kind": "LinkedField",
+                    "name": "service",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ModelHealthCheck",
+                        "kind": "LinkedField",
+                        "name": "healthCheck",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "enable",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "interval",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "path",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "maxRetries",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "maxWaitTime",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "expectedStatusCode",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "initialDelay",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -318,12 +412,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "218b82beeca87da0b64539597ed3fe1b",
+    "cacheID": "94c65f71636e7d7056fd7b6118114fa6",
     "id": null,
     "metadata": {},
     "name": "DeploymentAddRevisionModalPresetDetailQuery",
     "operationKind": "query",
-    "text": "query DeploymentAddRevisionModalPresetDetailQuery(\n  $id: UUID!\n) {\n  deploymentRevisionPreset(id: $id) {\n    ...DeploymentPresetDetailModalFragment\n    id\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n"
+    "text": "query DeploymentAddRevisionModalPresetDetailQuery(\n  $id: UUID!\n) {\n  deploymentRevisionPreset(id: $id) {\n    ...DeploymentPresetDetailModalFragment\n    id\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n  modelDefinition {\n    models {\n      name\n      service {\n        healthCheck {\n          enable @since(version: \"26.4.4rc7\")\n          interval\n          path\n          maxRetries\n          maxWaitTime\n          expectedStatusCode\n          initialDelay\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/DeploymentPresetDetailModalFragment.graphql.ts
+++ b/react/src/__generated__/DeploymentPresetDetailModalFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aa104f63e58e1c03d1fb03d8c713a79f>>
+ * @generated SignedSource<<88a44238871fbabe6a7fa049df098125>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,6 +33,22 @@ export type DeploymentPresetDetailModalFragment$data = {
     readonly startupCommand: string | null | undefined;
   };
   readonly id: string;
+  readonly modelDefinition: {
+    readonly models: ReadonlyArray<{
+      readonly name: string;
+      readonly service: {
+        readonly healthCheck: {
+          readonly enable: boolean;
+          readonly expectedStatusCode: number;
+          readonly initialDelay: number;
+          readonly interval: number;
+          readonly maxRetries: number;
+          readonly maxWaitTime: number;
+          readonly path: string;
+        } | null | undefined;
+      } | null | undefined;
+    }>;
+  } | null | undefined;
   readonly name: string;
   readonly presetValues: ReadonlyArray<{
     readonly presetId: string;
@@ -299,6 +315,100 @@ return {
         (v2/*: any*/)
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ModelDefinition",
+      "kind": "LinkedField",
+      "name": "modelDefinition",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ModelConfig",
+          "kind": "LinkedField",
+          "name": "models",
+          "plural": true,
+          "selections": [
+            (v1/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "ModelServiceConfig",
+              "kind": "LinkedField",
+              "name": "service",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "ModelHealthCheck",
+                  "kind": "LinkedField",
+                  "name": "healthCheck",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "enable",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "interval",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "path",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "maxRetries",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "maxWaitTime",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "expectedStatusCode",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "initialDelay",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "DeploymentRevisionPreset",
@@ -306,6 +416,6 @@ return {
 };
 })();
 
-(node as any).hash = "1e222e4572f001b430fba49ecaf73cb4";
+(node as any).hash = "b68e103a615d081fdd48b53fb46f6bc0";
 
 export default node;

--- a/react/src/__generated__/ModelCardDrawerQuery.graphql.ts
+++ b/react/src/__generated__/ModelCardDrawerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6734430cdd637f2d80da16c22dbf390f>>
+ * @generated SignedSource<<af078d1872c28b8285e0118bbdeb8901>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -489,6 +489,100 @@ return {
                           (v6/*: any*/)
                         ],
                         "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ModelDefinition",
+                        "kind": "LinkedField",
+                        "name": "modelDefinition",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ModelConfig",
+                            "kind": "LinkedField",
+                            "name": "models",
+                            "plural": true,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ModelServiceConfig",
+                                "kind": "LinkedField",
+                                "name": "service",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "ModelHealthCheck",
+                                    "kind": "LinkedField",
+                                    "name": "healthCheck",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "enable",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "interval",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "path",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "maxRetries",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "maxWaitTime",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "expectedStatusCode",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "initialDelay",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
                       }
                     ],
                     "storageKey": null
@@ -505,12 +599,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "aaeebeb9b1c7374d0497836b194f8f96",
+    "cacheID": "ca953eeb1bed8b30c67fa2eb94ab9b8a",
     "id": null,
     "metadata": {},
     "name": "ModelCardDrawerQuery",
     "operationKind": "query",
-    "text": "query ModelCardDrawerQuery(\n  $id: UUID!\n) {\n  modelCardV2(id: $id) {\n    ...ModelCardDrawerFragment\n    id\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n\nfragment ModelCardDeployModalFragment on ModelCardV2 {\n  id\n  availablePresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    edges {\n      node {\n        id\n        name\n        runtimeVariantId\n        ...DeploymentPresetDetailModalFragment\n      }\n    }\n  }\n}\n\nfragment ModelCardDrawerFragment on ModelCardV2 {\n  id\n  name\n  metadata {\n    title\n    author\n    description\n    task\n    category\n    architecture\n    framework\n    label\n    license\n    modelVersion\n  }\n  minResource {\n    resourceType\n    quantity\n  }\n  readme\n  createdAt\n  updatedAt\n  vfolder {\n    id\n    metadata {\n      name\n    }\n    ...VFolderNodeIdenticonV2Fragment\n  }\n  ...ModelCardDeployModalFragment\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n"
+    "text": "query ModelCardDrawerQuery(\n  $id: UUID!\n) {\n  modelCardV2(id: $id) {\n    ...ModelCardDrawerFragment\n    id\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n  modelDefinition {\n    models {\n      name\n      service {\n        healthCheck {\n          enable @since(version: \"26.4.4rc7\")\n          interval\n          path\n          maxRetries\n          maxWaitTime\n          expectedStatusCode\n          initialDelay\n        }\n      }\n    }\n  }\n}\n\nfragment ModelCardDeployModalFragment on ModelCardV2 {\n  id\n  availablePresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    edges {\n      node {\n        id\n        name\n        runtimeVariantId\n        ...DeploymentPresetDetailModalFragment\n      }\n    }\n  }\n}\n\nfragment ModelCardDrawerFragment on ModelCardV2 {\n  id\n  name\n  metadata {\n    title\n    author\n    description\n    task\n    category\n    architecture\n    framework\n    label\n    license\n    modelVersion\n  }\n  minResource {\n    resourceType\n    quantity\n  }\n  readme\n  createdAt\n  updatedAt\n  vfolder {\n    id\n    metadata {\n      name\n    }\n    ...VFolderNodeIdenticonV2Fragment\n  }\n  ...ModelCardDeployModalFragment\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/VFolderDeployModalQuery.graphql.ts
+++ b/react/src/__generated__/VFolderDeployModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a897f0a92c55c29fb23ea6d6d2c64e0d>>
+ * @generated SignedSource<<b8ba2ba687ad86de495b7858c4d45059>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -356,6 +356,100 @@ return {
                       (v4/*: any*/)
                     ],
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ModelDefinition",
+                    "kind": "LinkedField",
+                    "name": "modelDefinition",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ModelConfig",
+                        "kind": "LinkedField",
+                        "name": "models",
+                        "plural": true,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ModelServiceConfig",
+                            "kind": "LinkedField",
+                            "name": "service",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ModelHealthCheck",
+                                "kind": "LinkedField",
+                                "name": "healthCheck",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "enable",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "interval",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "path",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "maxRetries",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "maxWaitTime",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "expectedStatusCode",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "initialDelay",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -369,12 +463,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b639c5ceda298a0462f99b2c846b74d2",
+    "cacheID": "d0c97a7d0865516a626167dce59c72d6",
     "id": null,
     "metadata": {},
     "name": "VFolderDeployModalQuery",
     "operationKind": "query",
-    "text": "query VFolderDeployModalQuery {\n  deploymentRevisionPresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    edges {\n      node {\n        id\n        name\n        runtimeVariantId\n        ...DeploymentPresetDetailModalFragment\n      }\n    }\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n}\n"
+    "text": "query VFolderDeployModalQuery {\n  deploymentRevisionPresets(orderBy: [{field: RANK, direction: \"ASC\"}]) {\n    edges {\n      node {\n        id\n        name\n        runtimeVariantId\n        ...DeploymentPresetDetailModalFragment\n      }\n    }\n  }\n}\n\nfragment DeploymentPresetDetailModalFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n    bootstrapScript\n    environ {\n      key\n      value\n    }\n  }\n  resource {\n    resourceOpts {\n      name\n      value\n    }\n  }\n  resourceSlots {\n    slotName\n    quantity\n  }\n  deploymentDefaults {\n    openToPublic\n    replicaCount\n    revisionHistoryLimit\n    deploymentStrategy\n  }\n  presetValues {\n    presetId\n    value\n  }\n  modelDefinition {\n    models {\n      name\n      service {\n        healthCheck {\n          enable @since(version: \"26.4.4rc7\")\n          interval\n          path\n          maxRetries\n          maxWaitTime\n          expectedStatusCode\n          initialDelay\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/react/src/components/DeploymentPresetDetailModal.tsx
+++ b/react/src/components/DeploymentPresetDetailModal.tsx
@@ -77,6 +77,23 @@ const DeploymentPresetDetailModal: React.FC<
           presetId
           value
         }
+        modelDefinition {
+          models {
+            name
+            service {
+              healthCheck {
+                # TODO: change to "26.4.4" once the 26.4.4 release is out
+                enable @since(version: "26.4.4rc7")
+                interval
+                path
+                maxRetries
+                maxWaitTime
+                expectedStatusCode
+                initialDelay
+              }
+            }
+          }
+        }
       }
     `,
     presetFrgmt ?? null,
@@ -88,12 +105,21 @@ const DeploymentPresetDetailModal: React.FC<
     (opt) => opt.name === 'shmem',
   )?.value;
 
+  const healthCheck = preset?.modelDefinition?.models?.find(
+    (m) => m.service?.healthCheck,
+  )?.service?.healthCheck;
+  // On 26.4.4rc7+ `enable` is authoritative; on older managers `enable` is
+  // stripped (undefined), so fall back to presence of the object.
+  const isHealthCheckEnabled = healthCheck?.enable ?? !!healthCheck;
+  const hasServiceConfig = (preset?.modelDefinition?.models?.length ?? 0) > 0;
+
   return (
     <BAIModal
       centered
       title={t('modelService.DeploymentPresetDetail')}
       destroyOnHidden
       footer={null}
+      width={720}
       {...modalProps}
     >
       {!preset ? (
@@ -236,6 +262,68 @@ const DeploymentPresetDetailModal: React.FC<
               ]}
             />
           </BAICard>
+          {hasServiceConfig && (
+            <BAICard
+              size="small"
+              title={t('adminDeploymentPreset.SectionHealthCheck')}
+              styles={{ body: { paddingTop: 0 } }}
+            >
+              <Descriptions
+                size="small"
+                column={isHealthCheckEnabled ? 2 : 1}
+                items={[
+                  {
+                    label: t(
+                      'adminDeploymentPreset.modelDef.EnableHealthCheck',
+                    ),
+                    children: isHealthCheckEnabled
+                      ? t('general.Enabled')
+                      : t('general.Disabled'),
+                  },
+                  ...(isHealthCheckEnabled
+                    ? [
+                        {
+                          label: t(
+                            'adminDeploymentPreset.modelDef.HealthCheckPath',
+                          ),
+                          children: healthCheck?.path ?? '-',
+                        },
+                        {
+                          label: t(
+                            'adminDeploymentPreset.modelDef.HealthCheckInterval',
+                          ),
+                          children: healthCheck?.interval ?? '-',
+                        },
+                        {
+                          label: t(
+                            'adminDeploymentPreset.modelDef.HealthCheckMaxRetries',
+                          ),
+                          children: healthCheck?.maxRetries ?? '-',
+                        },
+                        {
+                          label: t(
+                            'adminDeploymentPreset.modelDef.HealthCheckMaxWaitTime',
+                          ),
+                          children: healthCheck?.maxWaitTime ?? '-',
+                        },
+                        {
+                          label: t(
+                            'adminDeploymentPreset.modelDef.HealthCheckExpectedStatus',
+                          ),
+                          children: healthCheck?.expectedStatusCode ?? '-',
+                        },
+                        {
+                          label: t(
+                            'adminDeploymentPreset.modelDef.HealthCheckInitialDelay',
+                          ),
+                          children: healthCheck?.initialDelay ?? '-',
+                        },
+                      ]
+                    : []),
+                ]}
+              />
+            </BAICard>
+          )}
         </BAIFlex>
       )}
     </BAIModal>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Cluster",
     "SectionDeploymentDefaults": "Bereitstellungsstandards",
     "SectionExecution": "Ausführung",
+    "SectionHealthCheck": "Health-Check",
     "SectionImage": "Image",
     "SectionResources": "Ressourcen",
     "SelectClusterMode": "Cluster-Modus auswählen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Σύμπλεγμα",
     "SectionDeploymentDefaults": "Προεπιλογές Ανάπτυξης",
     "SectionExecution": "Εκτέλεση",
+    "SectionHealthCheck": "Έλεγχος υγείας",
     "SectionImage": "Εικόνα",
     "SectionResources": "Πόροι",
     "SelectClusterMode": "Επιλέξτε λειτουργία συμπλέγματος",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Cluster",
     "SectionDeploymentDefaults": "Deployment Defaults",
     "SectionExecution": "Execution",
+    "SectionHealthCheck": "Health Check",
     "SectionImage": "Image",
     "SectionResources": "Resources",
     "SelectClusterMode": "Select cluster mode",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Clúster",
     "SectionDeploymentDefaults": "Valores Predeterminados de Implementación",
     "SectionExecution": "Ejecución",
+    "SectionHealthCheck": "Verificación de salud",
     "SectionImage": "Imagen",
     "SectionResources": "Recursos",
     "SelectClusterMode": "Seleccionar modo de clúster",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Klusteri",
     "SectionDeploymentDefaults": "Käyttöönottooletukset",
     "SectionExecution": "Suoritus",
+    "SectionHealthCheck": "Terveystarkistus",
     "SectionImage": "Kuva",
     "SectionResources": "Resurssit",
     "SelectClusterMode": "Valitse klusteritila",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Cluster",
     "SectionDeploymentDefaults": "Valeurs par Défaut du Déploiement",
     "SectionExecution": "Exécution",
+    "SectionHealthCheck": "Contrôle de santé",
     "SectionImage": "Image",
     "SectionResources": "Ressources",
     "SelectClusterMode": "Sélectionner le mode cluster",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Kluster",
     "SectionDeploymentDefaults": "Default Deployment",
     "SectionExecution": "Eksekusi",
+    "SectionHealthCheck": "Pemeriksaan Kesehatan",
     "SectionImage": "Image",
     "SectionResources": "Sumber Daya",
     "SelectClusterMode": "Pilih mode kluster",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Cluster",
     "SectionDeploymentDefaults": "Impostazioni Predefinite di Distribuzione",
     "SectionExecution": "Esecuzione",
+    "SectionHealthCheck": "Controllo di salute",
     "SectionImage": "Immagine",
     "SectionResources": "Risorse",
     "SelectClusterMode": "Seleziona modalità cluster",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -59,6 +59,7 @@
     "SectionCluster": "クラスター",
     "SectionDeploymentDefaults": "デプロイメントデフォルト",
     "SectionExecution": "実行",
+    "SectionHealthCheck": "ヘルスチェック",
     "SectionImage": "イメージ",
     "SectionResources": "リソース",
     "SelectClusterMode": "クラスターモードを選択",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -59,6 +59,7 @@
     "SectionCluster": "클러스터",
     "SectionDeploymentDefaults": "배포 기본값",
     "SectionExecution": "실행",
+    "SectionHealthCheck": "헬스 체크",
     "SectionImage": "이미지",
     "SectionResources": "리소스",
     "SelectClusterMode": "클러스터 모드 선택",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Кластер",
     "SectionDeploymentDefaults": "Байршуулалтын өгөгдмөл утгууд",
     "SectionExecution": "Гүйцэтгэл",
+    "SectionHealthCheck": "Эрүүл мэндийн шалгалт",
     "SectionImage": "Дүрс",
     "SectionResources": "Нөөц",
     "SelectClusterMode": "Кластерийн горим сонгох",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Kluster",
     "SectionDeploymentDefaults": "Lalai Penggunaan",
     "SectionExecution": "Pelaksanaan",
+    "SectionHealthCheck": "Semakan Kesihatan",
     "SectionImage": "Imej",
     "SectionResources": "Sumber",
     "SelectClusterMode": "Pilih mod kluster",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Klaster",
     "SectionDeploymentDefaults": "Domyślne ustawienia wdrożenia",
     "SectionExecution": "Wykonanie",
+    "SectionHealthCheck": "Sprawdzanie kondycji",
     "SectionImage": "Obraz",
     "SectionResources": "Zasoby",
     "SelectClusterMode": "Wybierz tryb klastra",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Cluster",
     "SectionDeploymentDefaults": "Padrões de Implantação",
     "SectionExecution": "Execução",
+    "SectionHealthCheck": "Verificação de integridade",
     "SectionImage": "Imagem",
     "SectionResources": "Recursos",
     "SelectClusterMode": "Selecionar modo de cluster",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Cluster",
     "SectionDeploymentDefaults": "Predefinições de Implementação",
     "SectionExecution": "Execução",
+    "SectionHealthCheck": "Verificação de integridade",
     "SectionImage": "Imagem",
     "SectionResources": "Recursos",
     "SelectClusterMode": "Selecionar modo de cluster",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Кластер",
     "SectionDeploymentDefaults": "Настройки по умолчанию",
     "SectionExecution": "Выполнение",
+    "SectionHealthCheck": "Проверка работоспособности",
     "SectionImage": "Образ",
     "SectionResources": "Ресурсы",
     "SelectClusterMode": "Выбрать режим кластера",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -59,6 +59,7 @@
     "SectionCluster": "คลัสเตอร์",
     "SectionDeploymentDefaults": "ค่าเริ่มต้นการปรับใช้",
     "SectionExecution": "การดำเนินการ",
+    "SectionHealthCheck": "การตรวจสอบสุขภาพ",
     "SectionImage": "อิมเมจ",
     "SectionResources": "ทรัพยากร",
     "SelectClusterMode": "เลือกโหมดคลัสเตอร์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Küme",
     "SectionDeploymentDefaults": "Dağıtım Varsayılanları",
     "SectionExecution": "Yürütme",
+    "SectionHealthCheck": "Sağlık Denetimi",
     "SectionImage": "İmaj",
     "SectionResources": "Kaynaklar",
     "SelectClusterMode": "Küme modunu seçin",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -59,6 +59,7 @@
     "SectionCluster": "Cụm",
     "SectionDeploymentDefaults": "Mặc định triển khai",
     "SectionExecution": "Thực thi",
+    "SectionHealthCheck": "Kiểm tra sức khỏe",
     "SectionImage": "Image",
     "SectionResources": "Tài nguyên",
     "SelectClusterMode": "Chọn chế độ cụm",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -59,6 +59,7 @@
     "SectionCluster": "集群",
     "SectionDeploymentDefaults": "部署默认值",
     "SectionExecution": "执行",
+    "SectionHealthCheck": "健康检查",
     "SectionImage": "镜像",
     "SectionResources": "资源",
     "SelectClusterMode": "选择集群模式",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -59,6 +59,7 @@
     "SectionCluster": "叢集",
     "SectionDeploymentDefaults": "部署預設值",
     "SectionExecution": "執行",
+    "SectionHealthCheck": "健康檢查",
     "SectionImage": "映像檔",
     "SectionResources": "資源",
     "SelectClusterMode": "選擇叢集模式",


### PR DESCRIPTION
Resolves #7774 (FR-3069)

> Stacked on #7775 (FR-3068) → #7753 (FR-3056).

## Summary

Follow-up to FR-3056. When a Deployment Revision Preset is configured with a health check, the saved settings were not surfaced anywhere the preset is viewed. `DeploymentPresetDetailModal` (the preset _i_\-button modal, also reused by the add-revision preset preview, model card drawer, and vfolder deploy modal) now shows the health-check configuration.

- The fragment `DeploymentPresetDetailModalFragment` selects `modelDefinition.models.service.healthCheck` (`enable @since 26.4.4rc7`, plus `path`, `interval`, `maxRetries`, `maxWaitTime`, `expectedStatusCode`, `initialDelay`).
- A new **Health Check** card renders the **Enabled / Disabled** state and, when enabled, the configured fields (each falling back to `-` when unset, where the server seeds a default). When disabled, the card uses a single-column layout to avoid an empty right column.
- Added `adminDeploymentPreset.SectionHealthCheck` i18n key across all 22 languages.

![image.png](https://app.graphite.com/user-attachments/assets/c74537d3-e3cc-4f2f-aadb-cd2d23fe4ea1.png)

![image.png](https://app.graphite.com/user-attachments/assets/0cb9d2e9-9f0d-4eac-8c17-279ade072ae2.png)



## Test plan

- [x] `pnpm relay` + `bash scripts/verify.sh` → Relay / Lint / Format / TypeScript all pass.
- [ ] On a 26.4.4rc7+ manager: open a preset with health check enabled → modal shows Enabled + fields; with it disabled → shows Disabled (single-column layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)