### PR TITLE
fix(FR-3070): send shutdown-service & download params in request body

### DIFF
--- a/packages/backend.ai-client/src/client.test.ts
+++ b/packages/backend.ai-client/src/client.test.ts
@@ -1,0 +1,123 @@
+import { Client } from './client';
+import { ClientConfig } from './client-config';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// The `Client` constructor reads `localStorage` (the login session id), and the
+// request path persists a log stack to it; both are absent in vitest's default
+// `node` environment. Provide a minimal in-memory stub so the client can be
+// instantiated and exercised without jsdom, and tear it down afterwards so the
+// global override never leaks into other test files.
+beforeAll(() => {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+    clear: () => store.clear(),
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+/**
+ * Regression tests for FR-3070.
+ *
+ * The manager migrated the session REST handlers from the legacy
+ * `@check_api_params` decorator to the Handler-class pattern (BA-4723). Two
+ * handlers now use `BodyParam` with a *required* body field, so the params
+ * must be sent in the JSON request body — not as a query string with a null
+ * body, which a migrated backend rejects with `400 MalformedRequestBody`:
+ *
+ *   POST /session/{name}/shutdown-service  -> required body field `service_name`
+ *   POST /session/{name}/download          -> required body field `files`
+ *
+ * These tests inspect the request object that `newSignedRequest` produces (no
+ * fetch, no live backend) and lock in that the params land in the body and that
+ * `download` is a POST. They fail on the pre-FR-3070 code, where the params
+ * were in the URL query string and the HTTP body was null/empty.
+ */
+
+function makeSessionClient(): Client {
+  // SESSION mode mirrors how the React UI instantiates the client
+  // (globalThis.backendaiclient) and skips HMAC signing, so no crypto/fetch is
+  // touched while building the request.
+  const config = new ClientConfig(
+    'test-user@lablup.com',
+    'test-password',
+    'https://api.test',
+    'SESSION',
+  );
+  return new Client(config, 'test');
+}
+
+/**
+ * Capture the request object the method hands to `_wrapWithPromise` instead of
+ * firing it. `_wrapWithPromise` is the single seam both `shutdown_service` and
+ * `download` call after building the request.
+ */
+async function captureRequest(
+  client: Client,
+  run: (client: Client) => Promise<unknown>,
+) {
+  const spy = vi.spyOn(client, '_wrapWithPromise').mockResolvedValue(undefined);
+  await run(client);
+  expect(spy).toHaveBeenCalledOnce();
+  return spy.mock.calls[0][0] as {
+    method: string;
+    uri: string;
+    body: string | FormData;
+  };
+}
+
+describe('session REST params go in the JSON body (FR-3070)', () => {
+  it('shutdown_service: POST with service_name in the body, not the query string', async () => {
+    const client = makeSessionClient();
+    const rqst = await captureRequest(client, (c) =>
+      c.shutdown_service('sess-1', 'tensorboard'),
+    );
+
+    expect(rqst.method).toBe('POST');
+    expect(rqst.uri).toContain('/sess-1/shutdown-service');
+    // params must NOT be encoded in the URL
+    expect(rqst.uri).not.toContain('?');
+    expect(rqst.uri).not.toContain('service_name=');
+    // params MUST be in the JSON body
+    expect(JSON.parse(rqst.body as string)).toEqual({
+      service_name: 'tensorboard',
+    });
+  });
+
+  it('download: switched to POST with the files array in the body', async () => {
+    const client = makeSessionClient();
+    const rqst = await captureRequest(client, (c) =>
+      c.download('sess-1', ['a.txt', 'b.txt']),
+    );
+
+    // regression guard: the node client copy used GET against the deprecated
+    // /download stub; both copies must use the real POST handler.
+    expect(rqst.method).toBe('POST');
+    expect(rqst.uri).toContain('/sess-1/download');
+    expect(rqst.uri).not.toContain('?');
+    expect(rqst.uri).not.toContain('files=');
+    expect(JSON.parse(rqst.body as string)).toEqual({
+      files: ['a.txt', 'b.txt'],
+    });
+  });
+
+  it('download_single: deliberately unchanged — `file` stays in the query string', async () => {
+    // download_single uses QueryParam[file] on the manager, so it is the one
+    // endpoint of the three that is *not* migrated to a body param. Guard that
+    // it is not accidentally folded into the body-param change above.
+    const client = makeSessionClient();
+    const rqst = await captureRequest(client, (c) =>
+      c.download_single('sess-1', 'a.txt'),
+    );
+
+    expect(rqst.method).toBe('POST');
+    expect(rqst.uri).toContain('/sess-1/download_single?');
+    expect(rqst.uri).toContain('file=a.txt');
+    expect(rqst.body).toBe('');
+  });
+});

--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -1661,14 +1661,13 @@ export class Client {
     sessionId: string,
     service_name: string,
   ): Promise<any> {
-    let params = {
-      service_name: service_name,
-    };
-    const q = new URLSearchParams(params).toString();
+    // `service_name` goes in the request body: migrated backends read it from
+    // BodyParam[ShutdownServiceRequest] (a required field) and reject a null
+    // body; legacy backends read the body too when present. See FR-3070.
     let rqst = this.newSignedRequest(
       'POST',
-      `${this.kernelPrefix}/${sessionId}/shutdown-service?${q}`,
-      null,
+      `${this.kernelPrefix}/${sessionId}/shutdown-service`,
+      { service_name },
       null,
     );
     return this._wrapWithPromise(rqst, true);
@@ -1688,18 +1687,13 @@ export class Client {
   }
 
   async download(sessionId: string, files: string[]): Promise<any> {
-    // URLSearchParams stringifies the array to a comma-joined value
-    // (e.g. `files=a,b`). Preserve that legacy encoding rather than
-    // emitting a repeated key. Cast through the URLSearchParams init
-    // type so strict TS accepts the array value.
-    const params = { files: files };
-    const q = new URLSearchParams(
-      params as unknown as Record<string, string>,
-    ).toString();
+    // `files` goes in the request body: migrated backends read it from
+    // BodyParam[DownloadFilesRequest] (a required field) and reject a null
+    // body; legacy backends read the body too when present. See FR-3070.
     let rqst = this.newSignedRequest(
       'POST',
-      `${this.kernelPrefix}/${sessionId}/download?${q}`,
-      null,
+      `${this.kernelPrefix}/${sessionId}/download`,
+      { files },
       null,
     );
     return this._wrapWithPromise(rqst, true);


### PR DESCRIPTION
Resolves #7777 (FR-3070)

> [!NOTE]
> The blocker [BA-6341](https://lablup.atlassian.net/browse/BA-6341) is **resolved** — the manager's `shutdown-service` / `download` handlers are now migrated to the `BodyParam` pattern on core `main`, so this is ready to merge.

## Test environment

A patched build is deployed at `http://10.122.10.215:8090` (migrated manager) with a running `tensorboard-demo` session, ready for verification.

To verify the `shutdown_service` fix end-to-end:

1. Log in as `admin@lablup.com` (the session is owned by this account's keypair; logging in with a different keypair makes `shutdown-service` return `404 SessionNotFound` — a keypair-scoping quirk, unrelated to this fix).
2. Open the `tensorboard-demo` session's app launcher → **TensorBoard** → enter a log directory → **Use**.
3. `POST /session/{id}/shutdown-service` should return **204 No Content** (the `service_name` now travels in the JSON body), and TensorBoard should relaunch in a new tab.

> [!NOTE]
> **If the "Use" button hangs on a spinner, it is not this fix.** The TensorBoard relaunch flow calls `closeWsproxy()`, which sends a `delete` request to the **local** wsproxy at `http://127.0.0.1:5050` (the default when `config.toml`'s `wsproxy.proxyURL` is empty), and that fetch has no timeout. If a local process is listening on port `5050` and stalls the request, the relaunch never proceeds. **Free port `5050` (stop whatever is bound to it) and retry** — the `shutdown-service` call itself still returns `204`. This hang is a separate, pre-existing app-launcher issue, tracked independently.

## Summary

The manager migrated the session REST handlers from the legacy `@check_api_params` decorator to the Handler-class pattern (BA-4723). Two handlers now use `BodyParam` with a **required** body field, but the webui client still sends those fields as a **query string** with a `null` HTTP body:

| Endpoint | Handler (now) | Required body field | webui sent (before) |
| --- | --- | --- | --- |
| `POST /session/{name}/shutdown-service` | `BodyParam[ShutdownServiceRequest]` (`service_name: str`) | `service_name` | `?service_name=…`, null body |
| `POST /session/{name}/download` | `BodyParam[DownloadFilesRequest]` (`files: list[str]`) | `files` | `?files=…`, null body |

This is **not** broken on every backend — it depends on the manager version:

- **Un-migrated (legacy) manager** → works, because `check_api_params` reads the query string. This is why these flows worked recently.
- **Migrated manager** → fails two ways: (1) the null body is rejected with `400 MalformedRequestBody` before the handler runs, and (2) even an empty `{}` body would fail validation because the required field is not in the body. The migrated handler reads **only** `BodyParam` — there is no query-string fallback.

Same root cause as #7609 (leave) but **stricter** — `{}` is not enough; the params must move into the body.

## Change

Send the params in the JSON request body instead of the query string, in the React UI client:

- `packages/backend.ai-client/src/client.ts` — load-bearing for the React UI (`globalThis.backendaiclient`). `shutdown_service` now sends `{ service_name }`; `download` now sends `{ files }`. Both stay `POST`.

`download_single` (`file` via `QueryParam`) is unaffected and left unchanged.

### Where each change is exercised

- **`shutdown_service` → has a live UI caller.** Called from `TensorboardPathModal.tsx` when a session's TensorBoard service is shut down / restarted on a new logdir. This is the one path with an end-to-end UI flow to verify against a migrated manager.
- **`download` (multi-file) → no live UI caller; the regression test is its guard.** No component currently calls `client.download(sessionId, files)` (the multi-file session-container download is a legacy library API). The single-file path the UI actually uses, `download_single` (SFTP/SSH key download in `SFTPConnectionInfoModal` / `VSCodeDesktopConnectionModal`), is unchanged here. Storage-folder (vfolder) downloads are a **separate** Storage-Proxy token flow (`vfolder.request_download_token` → `download_with_token`) and are not affected by this PR. So the `download` fix is locked in by the unit test rather than a manual UI flow.

Adds `packages/backend.ai-client/src/client.test.ts`: regression tests that inspect the request object `newSignedRequest` produces (no fetch, no live backend) and lock in that the params land in the JSON body, that `download` stays a `POST`, and that `download_single` keeps `file` in the query string.

> [!NOTE]
> The legacy ESM client `src/lib/backend.ai-client-node.ts` (Electron wsproxy) still sends these params in the query string and is intentionally **out of scope** for this PR. It can be brought in line in a follow-up if the Electron path needs to target a migrated manager.

## Backward compatibility

Safe against legacy (un-migrated) managers: legacy `check_api_params` reads from the **body when a body is present** (only falling back to `dict(request.query)` when there is none), and `tx.MultiKey` has a plain-dict fallback that reads a JSON list for `files`. So the body form works on both legacy and migrated managers.

## Test plan

- [ ] **Manual (migrated manager):** shut down / restart a session's TensorBoard service via the TensorBoard path modal — `POST /shutdown-service` succeeds with `{ service_name }` in the body (no `400`). This is the only manual flow needed.
- [x] **Unit:** `pnpm --filter backend.ai-client test` — regression tests guard the `download` body/POST shape (no live UI caller) and `download_single` staying query-string. (3/3 passing)
- [ ] Optional: verify against a legacy manager that `shutdown-service` still works.
- [ ] CI: relay / lint / format / tsc.


[BA-6341]: https://lablup.atlassian.net/browse/BA-6341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ