### PR TITLE
fix(FR-3027): surface App Proxy "Worker not available" error instead of bogus 127.0.0.1 dialog

### DIFF
--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -816,6 +816,26 @@ export const useBackendAIAppLauncher = (
       throw response;
     }
 
+    // The App Proxy Coordinator allocates a worker for the circuit at this
+    // `/v2/proxy/auth` (`proxy`) step (`add_circuit` → `pick_worker`). When no
+    // worker slot is free — e.g. the TCP worker's port pool is exhausted — it
+    // responds with HTTP 503 `WorkerNotAvailable` ("Worker not available.").
+    // `sendRequest` returns that as a `{ status, statusText, body }` object (it
+    // only throws on network errors), and the `error_code` check above only
+    // catches HTTP-200 logical errors, so without this guard the 503 falls
+    // through to the fallback request below and the launcher ends up rendering
+    // a bogus `127.0.0.1` connection dialog instead of the error. Surface the
+    // backend message instead. (FR-3027)
+    if (isSendRequestErrorResponse(response)) {
+      throw new AppLaunchError(
+        getAppProxyErrorMessage(
+          response,
+          'Failed to allocate an app proxy worker.',
+        ),
+        'connecting',
+      );
+    }
+
     // Handle successful response with redirect_url
     if (response?.redirect_url) {
       const redirectUrl = new URL(response.redirect_url);
@@ -1013,6 +1033,58 @@ class AppLaunchError extends Error {
       Error.captureStackTrace(this, AppLaunchError);
     }
   }
+}
+
+/**
+ * Detect the error-object shape that {@link sendRequest} resolves to for non-OK
+ * HTTP responses (`{ status, statusText, body }`). It returns this object
+ * instead of throwing so retry logic can inspect the status code; call sites
+ * that are not retrying must check for it explicitly, otherwise an error
+ * response (which carries no success payload) flows downstream as a
+ * pseudo-success. (FR-3027)
+ */
+function isSendRequestErrorResponse(
+  response: unknown,
+): response is { status: number; statusText?: string; body?: unknown } {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    typeof (response as { status?: unknown }).status === 'number' &&
+    (response as { status: number }).status >= 400
+  );
+}
+
+/**
+ * Extract a human-readable message from a {@link sendRequest} error response.
+ *
+ * App Proxy errors are Backend.AI problem+json bodies
+ * (`{ type, title, error_code, msg? }`), e.g. HTTP 503 `WorkerNotAvailable`
+ * with `title: "Worker not available."`. Prefer `msg` / `title` / `message`
+ * from the parsed body, then fall back to `statusText`, then the default.
+ */
+function getAppProxyErrorMessage(
+  response: { status: number; statusText?: string; body?: unknown },
+  fallback: string,
+): string {
+  const body = response.body;
+  if (body && typeof body === 'object') {
+    const { msg, title, message } = body as {
+      msg?: unknown;
+      title?: unknown;
+      message?: unknown;
+    };
+    const candidate = msg ?? title ?? message;
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  if (typeof body === 'string' && body.length > 0) {
+    return body;
+  }
+  if (response.statusText && response.statusText.length > 0) {
+    return response.statusText;
+  }
+  return fallback;
 }
 
 /**


### PR DESCRIPTION
Linked Jira: FR-3027 (https://lablup.atlassian.net/browse/FR-3027)

> No GitHub clone of FR-3027 exists yet (the Jira→GitHub webhook did not fire for this ticket), so this PR uses a `Linked Jira:` placeholder instead of `Resolves #N (FR-3027)`.

## Problem

When the App Proxy Coordinator cannot allocate a worker for the circuit — e.g. the TCP worker's port pool is exhausted — launching a TCP app (SSH/SFTP, VNC, XRDP, vscode-desktop) makes the Coordinator return an HTTP **503 `WorkerNotAvailable`** ("Worker not available."). The WebUI failed to surface this error and instead rendered a bogus connection dialog with `127.0.0.1` / port `0`, as if the tunnel had been created with a malformed address.

## Where the 503 comes from (verified against `lablup/backend.ai`)

The launch is a two-step call from the WebUI:

1. **Manager `POST /session/{session_id}/start-service`** — starts the service in the container and asks the Coordinator (`POST {wsproxy_addr}/v2/conf`) for a token. This only mints a token; it does **not** select a worker or allocate a port. Returns `{ token, wsproxy_addr }`. No error here.
2. **Coordinator `GET {wsproxy_addr}/v2/proxy/auth?token=…&session_id=…`** — the WebUI calls the Coordinator directly with that token. Handler: `proxy()` (`coordinator/api/proxy.py`). For interactive apps it runs `add_circuit()` → `pick_worker()` (`coordinator/models/worker.py`). For an SSH (TCP / PORT-frontend) worker whose port pool is fully occupied, `available_slots - occupied_slots <= 0` filters out every worker and `pick_worker` raises **`WorkerNotAvailable`** → HTTP 503, problem+json `title: "Worker not available."` (`common/errors/service.py`).

In the frontend, step 2 is the permit-key request inside **`_connectToProxyWorker`** (`react/src/hooks/useBackendAIAppLauncher.tsx`). `sendRequest` does **not** throw on non-OK HTTP responses — it returns an error object `{ status, statusText, body }` so retry logic can inspect the status. `_connectToProxyWorker` only re-threw on `response.error_code` (an HTTP-200 logical-error field), so the HTTP-503 error object fell through to the fallback request path and the launcher ended up with no resolvable gateway → the bogus `127.0.0.1` dialog.

## Fix (minimal, scoped to the reported scenario)

`react/src/hooks/useBackendAIAppLauncher.tsx` only — a single behavioral change:
- In **`_connectToProxyWorker`**, after the `/v2/proxy/auth` permit-key request, detect the `sendRequest` error-object shape and throw an `AppLaunchError` (stage `connecting`) carrying the backend message. The launch promise then rejects → the error is surfaced through the **existing** app-launch error path (the launch notification's `rejected` handler + the launcher's `message.error`, both via `getErrorMessage(error)`), and `onPrepared` is never called, so no bogus connection dialog opens.
- Two small module-private helpers support it:
  - `isSendRequestErrorResponse(response)` — detects `{ status, statusText, body }` with `status >= 400`.
  - `getAppProxyErrorMessage(response, fallback)` — extracts the message from the problem+json body (`msg` / `title` / `message`), then `statusText`, then a fallback. For `WorkerNotAvailable` this resolves to `title` = "Worker not available.".

No other files are touched — the launcher modal, notification handler, error class, etc. are unchanged from `main`.

## Verification

- `scripts/verify.sh`: **Lint / Format / TypeScript PASS**. The Relay step fails **locally only** due to an environment issue (no `watchman` daemon and the dev shell is niced, so `relay-compiler` refuses to start watchman); this PR changes **no** GraphQL (`graphql` tags / `__generated__` are untouched), so Relay output is unaffected and CI validates it in a clean environment.
- Manually verified end-to-end against a live backend: with the TCP worker down, the `/v2/proxy/auth` request returns 503 `WorkerNotAvailable` and the WebUI now shows "Worker not available." instead of a `127.0.0.1` connection dialog.

## Reproduction (for QA)

Simplest path — on the internal test server **`10.82.0.130`**: create a compute session, then launch the **SFTP (SSH)** app while the App Proxy TCP worker is unavailable (stop the TCP worker, or exhaust its port pool as below). The launcher then shows **"Worker not available."** instead of a `127.0.0.1` connection dialog.

Faithful port-pool-exhaustion setup: requires a backend whose `start-service` is session-id based (backend change 11884). Configure the App Proxy TCP worker (PORT frontend mode) with a 1-slot `bind_port_range`, occupy it with one TCP app, then launch another TCP app on a different session → Coordinator returns 503 `WorkerNotAvailable` at `/v2/proxy/auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)