### PR TITLE
fix(FR-3072): use desired replica count for deployment list summary

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIModelDeploymentNodesFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIModelDeploymentNodesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<660395b15bde0b90d7faccf5f04d0b1e>>
+ * @generated SignedSource<<ee4281a0299b41f8945f58027fe32f8c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,9 +56,6 @@ export type BAIModelDeploymentNodesFragment$data = ReadonlyArray<{
   readonly runningReplicas: {
     readonly count: number;
   } | null | undefined;
-  readonly totalReplicas: {
-    readonly count: number;
-  } | null | undefined;
   readonly " $fragmentSpreads": FragmentRefs<"BAIDeploymentOwnerInfo_deployment">;
   readonly " $fragmentType": "BAIModelDeploymentNodesFragment";
 }>;
@@ -81,16 +78,7 @@ v1 = {
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
-},
-v2 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "count",
-    "storageKey": null
-  }
-];
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -266,16 +254,6 @@ return {
       "storageKey": null
     },
     {
-      "alias": "totalReplicas",
-      "args": null,
-      "concreteType": "ModelReplicaConnection",
-      "kind": "LinkedField",
-      "name": "replicas",
-      "plural": false,
-      "selections": (v2/*: any*/),
-      "storageKey": null
-    },
-    {
       "alias": "runningReplicas",
       "args": [
         {
@@ -292,7 +270,15 @@ return {
       "kind": "LinkedField",
       "name": "replicas",
       "plural": false,
-      "selections": (v2/*: any*/),
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        }
+      ],
       "storageKey": "replicas(filter:{\"status\":{\"equals\":\"RUNNING\"}})"
     },
     {
@@ -349,6 +335,6 @@ return {
 };
 })();
 
-(node as any).hash = "d7e2e42d651a342fde7c1a32802c0ff1";
+(node as any).hash = "195dfd4bb69f0f91b45177cea1c58c4e";
 
 export default node;

--- a/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
@@ -132,9 +132,6 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         replicaState {
           desiredReplicaCount
         }
-        totalReplicas: replicas {
-          count
-        }
         runningReplicas: replicas(filter: { status: { equals: RUNNING } }) {
           count
         }
@@ -231,13 +228,11 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         render: (__, record) => {
           const running = record.runningReplicas?.count ?? 0;
           const desired = record.replicaState?.desiredReplicaCount ?? 0;
-          const total = record.totalReplicas?.count ?? desired;
-          const denominator = desired > 0 ? desired : total;
           return (
             <Typography.Text>
               {t('comp:BAIModelDeploymentNodes.HealthySummary', {
                 healthy: running,
-                total: denominator,
+                total: desired,
               })}
             </Typography.Text>
           );

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -231,7 +231,7 @@
     "Project": "Projekt",
     "ProjectID": "Projekt-ID",
     "ReplicaSummary": "Replikate",
-    "ReplicaSummaryTooltip": "Laufende Replikate im Verhältnis zur gewünschten (oder Gesamt-)Anzahl.",
+    "ReplicaSummaryTooltip": "Laufende Replikate im Verhältnis zur gewünschten Anzahl.",
     "Replicas": "Replikate",
     "ResourceGroup": "Ressourcengruppe",
     "RevisionNumber": "Revision",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -231,7 +231,7 @@
     "Project": "Έργο",
     "ProjectID": "ID Έργου",
     "ReplicaSummary": "Αντίγραφα",
-    "ReplicaSummaryTooltip": "Εκτελούμενα αντίγραφα σε σχέση με τον επιθυμητό (ή συνολικό) αριθμό αντιγράφων.",
+    "ReplicaSummaryTooltip": "Εκτελούμενα αντίγραφα σε σχέση με τον επιθυμητό αριθμό αντιγράφων.",
     "Replicas": "Αντίγραφα",
     "ResourceGroup": "Ομάδα Πόρων",
     "RevisionNumber": "Αναθεώρηση",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -231,7 +231,7 @@
     "Project": "Project",
     "ProjectID": "Project ID",
     "ReplicaSummary": "Replicas",
-    "ReplicaSummaryTooltip": "Running replicas over the desired (or total) replica count.",
+    "ReplicaSummaryTooltip": "Running replicas over the desired replica count.",
     "Replicas": "Replicas",
     "ResourceGroup": "Resource Group",
     "RevisionNumber": "Revision",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -231,7 +231,7 @@
     "Project": "Proyecto",
     "ProjectID": "ID del proyecto",
     "ReplicaSummary": "Réplicas",
-    "ReplicaSummaryTooltip": "Réplicas en ejecución sobre el número deseado (o total) de réplicas.",
+    "ReplicaSummaryTooltip": "Réplicas en ejecución sobre el número deseado de réplicas.",
     "Replicas": "Réplicas",
     "ResourceGroup": "Grupo de Recursos",
     "RevisionNumber": "Revisión",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -231,7 +231,7 @@
     "Project": "Projekti",
     "ProjectID": "Projektin tunnus",
     "ReplicaSummary": "Kopioita",
-    "ReplicaSummaryTooltip": "Käynnissä olevat kopiot suhteessa haluttuun (tai kokonais-) kopioiden määrään.",
+    "ReplicaSummaryTooltip": "Käynnissä olevat kopiot suhteessa haluttuun kopioiden määrään.",
     "Replicas": "Kopioita",
     "ResourceGroup": "Resurssiryhmä",
     "RevisionNumber": "Revisio",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -231,7 +231,7 @@
     "Project": "Projet",
     "ProjectID": "ID du projet",
     "ReplicaSummary": "Réplicas",
-    "ReplicaSummaryTooltip": "Réplicas en cours d'exécution par rapport au nombre souhaité (ou total) de réplicas.",
+    "ReplicaSummaryTooltip": "Réplicas en cours d'exécution par rapport au nombre souhaité de réplicas.",
     "Replicas": "Réplicas",
     "ResourceGroup": "Groupe de Ressources",
     "RevisionNumber": "Révision",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -231,7 +231,7 @@
     "Project": "Proyek",
     "ProjectID": "ID Proyek",
     "ReplicaSummary": "Replika",
-    "ReplicaSummaryTooltip": "Replika yang berjalan dari jumlah replika yang diinginkan (atau total).",
+    "ReplicaSummaryTooltip": "Replika yang berjalan dari jumlah replika yang diinginkan.",
     "Replicas": "Replika",
     "ResourceGroup": "Grup Sumber Daya",
     "RevisionNumber": "Revisi",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -231,7 +231,7 @@
     "Project": "Progetto",
     "ProjectID": "ID progetto",
     "ReplicaSummary": "Repliche",
-    "ReplicaSummaryTooltip": "Repliche in esecuzione rispetto al numero desiderato (o totale) di repliche.",
+    "ReplicaSummaryTooltip": "Repliche in esecuzione rispetto al numero desiderato di repliche.",
     "Replicas": "Repliche",
     "ResourceGroup": "Gruppo di Risorse",
     "RevisionNumber": "Revisione",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -231,7 +231,7 @@
     "Project": "プロジェクト",
     "ProjectID": "プロジェクトID",
     "ReplicaSummary": "レプリカ",
-    "ReplicaSummaryTooltip": "希望する（または合計の）レプリカ数に対して実行中のレプリカ数。",
+    "ReplicaSummaryTooltip": "希望するレプリカ数に対して実行中のレプリカ数。",
     "Replicas": "レプリカ",
     "ResourceGroup": "リソースグループ",
     "RevisionNumber": "リビジョン",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -231,7 +231,7 @@
     "Project": "프로젝트",
     "ProjectID": "프로젝트 ID",
     "ReplicaSummary": "복제본 수",
-    "ReplicaSummaryTooltip": "원하는 (또는 전체) 복제본 수 대비 실행 중인 복제본 수입니다.",
+    "ReplicaSummaryTooltip": "원하는 복제본 수 대비 실행 중인 복제본 수입니다.",
     "Replicas": "복제본 수",
     "ResourceGroup": "리소스 그룹",
     "RevisionNumber": "리비전",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -231,7 +231,7 @@
     "Project": "Төсөл",
     "ProjectID": "Төслийн ID",
     "ReplicaSummary": "Хуулбар",
-    "ReplicaSummaryTooltip": "Гүйцэтгэж байгаа хуулбарын тоо хүссэн (эсвэл нийт) хуулбарын тоотой харьцуулсан.",
+    "ReplicaSummaryTooltip": "Гүйцэтгэж байгаа хуулбарын тоо хүссэн хуулбарын тоотой харьцуулсан.",
     "Replicas": "Хуулбар",
     "ResourceGroup": "Нөөцийн бүлэг",
     "RevisionNumber": "Засвар",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -231,7 +231,7 @@
     "Project": "Projek",
     "ProjectID": "ID Projek",
     "ReplicaSummary": "Replika",
-    "ReplicaSummaryTooltip": "Bilangan replika yang berjalan berbanding bilangan replika yang dikehendaki (atau jumlah).",
+    "ReplicaSummaryTooltip": "Bilangan replika yang berjalan berbanding bilangan replika yang dikehendaki.",
     "Replicas": "Replika",
     "ResourceGroup": "Kumpulan Sumber",
     "RevisionNumber": "Semakan",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -231,7 +231,7 @@
     "Project": "Projekt",
     "ProjectID": "ID projektu",
     "ReplicaSummary": "Repliki",
-    "ReplicaSummaryTooltip": "Liczba uruchomionych replik w stosunku do żądanej (lub całkowitej) liczby replik.",
+    "ReplicaSummaryTooltip": "Liczba uruchomionych replik w stosunku do żądanej liczby replik.",
     "Replicas": "Repliki",
     "ResourceGroup": "Grupa zasobów",
     "RevisionNumber": "Rewizja",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -237,7 +237,7 @@
     "Project": "Projeto",
     "ProjectID": "ID do projeto",
     "ReplicaSummary": "Réplicas",
-    "ReplicaSummaryTooltip": "Réplicas em execução em relação ao número desejado (ou total) de réplicas.",
+    "ReplicaSummaryTooltip": "Réplicas em execução em relação ao número desejado de réplicas.",
     "Replicas": "Réplicas",
     "ResourceGroup": "Grupo de Recursos",
     "RevisionNumber": "Revisão",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -231,7 +231,7 @@
     "Project": "Projeto",
     "ProjectID": "ID do projeto",
     "ReplicaSummary": "Réplicas",
-    "ReplicaSummaryTooltip": "Réplicas em execução em relação ao número desejado (ou total) de réplicas.",
+    "ReplicaSummaryTooltip": "Réplicas em execução em relação ao número desejado de réplicas.",
     "Replicas": "Réplicas",
     "ResourceGroup": "Grupo de Recursos",
     "RevisionNumber": "Revisão",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -231,7 +231,7 @@
     "Project": "Проект",
     "ProjectID": "ID проекта",
     "ReplicaSummary": "Реплики",
-    "ReplicaSummaryTooltip": "Запущенные реплики относительно желаемого (или общего) количества реплик.",
+    "ReplicaSummaryTooltip": "Запущенные реплики относительно желаемого количества реплик.",
     "Replicas": "Реплики",
     "ResourceGroup": "Группа ресурсов",
     "RevisionNumber": "Ревизия",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -231,7 +231,7 @@
     "Project": "โปรเจกต์",
     "ProjectID": "รหัสโปรเจกต์",
     "ReplicaSummary": "จำนวนสำเนา",
-    "ReplicaSummaryTooltip": "จำนวนสำเนาที่กำลังทำงานเทียบกับจำนวนสำเนาที่ต้องการ (หรือทั้งหมด)",
+    "ReplicaSummaryTooltip": "จำนวนสำเนาที่กำลังทำงานเทียบกับจำนวนสำเนาที่ต้องการ",
     "Replicas": "จำนวนสำเนา",
     "ResourceGroup": "กลุ่มทรัพยากร",
     "RevisionNumber": "ฉบับแก้ไข",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -231,7 +231,7 @@
     "Project": "Proje",
     "ProjectID": "Proje Kimliği",
     "ReplicaSummary": "Kopyalar",
-    "ReplicaSummaryTooltip": "İstenen (veya toplam) kopya sayısına karşılık çalışan kopyalar.",
+    "ReplicaSummaryTooltip": "İstenen kopya sayısına karşılık çalışan kopyalar.",
     "Replicas": "Kopyalar",
     "ResourceGroup": "Kaynak Grubu",
     "RevisionNumber": "Revizyon",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -231,7 +231,7 @@
     "Project": "Dự án",
     "ProjectID": "ID dự án",
     "ReplicaSummary": "Số bản sao",
-    "ReplicaSummaryTooltip": "Số bản sao đang chạy so với số bản sao mong muốn (hoặc tổng số).",
+    "ReplicaSummaryTooltip": "Số bản sao đang chạy so với số bản sao mong muốn.",
     "Replicas": "Số bản sao",
     "ResourceGroup": "Nhóm tài nguyên",
     "RevisionNumber": "Phiên bản",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -231,7 +231,7 @@
     "Project": "项目",
     "ProjectID": "项目ID",
     "ReplicaSummary": "副本数",
-    "ReplicaSummaryTooltip": "正在运行的副本数与所需（或总）副本数之比。",
+    "ReplicaSummaryTooltip": "正在运行的副本数与所需副本数之比。",
     "Replicas": "副本数",
     "ResourceGroup": "资源组",
     "RevisionNumber": "修订版本",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -231,7 +231,7 @@
     "Project": "專案",
     "ProjectID": "專案ID",
     "ReplicaSummary": "副本數",
-    "ReplicaSummaryTooltip": "正在執行的副本數與所需（或總）副本數之比。",
+    "ReplicaSummaryTooltip": "正在執行的副本數與所需副本數之比。",
     "Replicas": "副本數",
     "ResourceGroup": "資源群組",
     "RevisionNumber": "修訂版本",

--- a/react/src/__generated__/AdminDeploymentListPageQuery.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<afb301dfbb15c128ed9e0c79a00bdd0c>>
+ * @generated SignedSource<<3ffbdb2d607091fad647de10a1930b34>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -196,10 +196,7 @@ v10 = {
   "name": "createdAt",
   "storageKey": null
 },
-v11 = [
-  (v5/*: any*/)
-],
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "VirtualFolderNode",
@@ -219,21 +216,21 @@ v12 = {
   ],
   "storageKey": null
 },
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "vfolderId",
   "storageKey": null
 },
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mountDestination",
   "storageKey": null
 },
-v15 = [
+v14 = [
   (v7/*: any*/),
   {
     "alias": null,
@@ -521,16 +518,6 @@ return {
                     "storageKey": null
                   },
                   {
-                    "alias": "totalReplicas",
-                    "args": null,
-                    "concreteType": "ModelReplicaConnection",
-                    "kind": "LinkedField",
-                    "name": "replicas",
-                    "plural": false,
-                    "selections": (v11/*: any*/),
-                    "storageKey": null
-                  },
-                  {
                     "alias": "runningReplicas",
                     "args": [
                       {
@@ -547,7 +534,9 @@ return {
                     "kind": "LinkedField",
                     "name": "replicas",
                     "plural": false,
-                    "selections": (v11/*: any*/),
+                    "selections": [
+                      (v5/*: any*/)
+                    ],
                     "storageKey": "replicas(filter:{\"status\":{\"equals\":\"RUNNING\"}})"
                   },
                   {
@@ -568,9 +557,9 @@ return {
                         "name": "modelMountConfig",
                         "plural": false,
                         "selections": [
+                          (v11/*: any*/),
                           (v12/*: any*/),
                           (v13/*: any*/),
-                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -655,7 +644,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "entries",
                                 "plural": true,
-                                "selections": (v15/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -707,7 +696,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "entries",
                                 "plural": true,
-                                "selections": (v15/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -724,8 +713,8 @@ return {
                         "name": "extraMounts",
                         "plural": true,
                         "selections": [
+                          (v12/*: any*/),
                           (v13/*: any*/),
-                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -733,7 +722,7 @@ return {
                             "name": "mountPerm",
                             "storageKey": null
                           },
-                          (v12/*: any*/)
+                          (v11/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -973,12 +962,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "be0ab164eccc5ff787f3ba9c977b086a",
+    "cacheID": "493bd36e2313b4bb53208e59b7f3d6f3",
     "id": null,
     "metadata": {},
     "name": "AdminDeploymentListPageQuery",
     "operationKind": "query",
-    "text": "query AdminDeploymentListPageQuery(\n  $filter: DeploymentFilter\n  $orderBy: [DeploymentOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminDeployments(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIModelDeploymentNodesFragment\n        ...DeploymentSettingModal_deployment\n        metadata {\n          name\n          status\n        }\n        currentRevision @since(version: \"26.4.3\") {\n          id\n          revisionNumber\n          ...DeploymentRevisionDetail_revision\n        }\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentOwnerInfo_deployment on ModelDeployment {\n  id\n  creator @since(version: \"26.4.3\") {\n    id\n    basicInfo {\n      email\n      username\n      fullName\n    }\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment BAIModelDeploymentNodesFragment on ModelDeployment {\n  id\n  currentRevisionId\n  metadata {\n    projectId\n    domainName\n    name\n    status\n    tags\n    createdAt\n    updatedAt\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    endpointUrl\n    preferredDomainName\n    openToPublic\n  }\n  defaultDeploymentStrategy {\n    type\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  totalReplicas: replicas {\n    count\n  }\n  runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n    count\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    modelMountConfig {\n      vfolder {\n        id\n        name\n      }\n    }\n  }\n  ...BAIDeploymentOwnerInfo_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
+    "text": "query AdminDeploymentListPageQuery(\n  $filter: DeploymentFilter\n  $orderBy: [DeploymentOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminDeployments(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIModelDeploymentNodesFragment\n        ...DeploymentSettingModal_deployment\n        metadata {\n          name\n          status\n        }\n        currentRevision @since(version: \"26.4.3\") {\n          id\n          revisionNumber\n          ...DeploymentRevisionDetail_revision\n        }\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentOwnerInfo_deployment on ModelDeployment {\n  id\n  creator @since(version: \"26.4.3\") {\n    id\n    basicInfo {\n      email\n      username\n      fullName\n    }\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment BAIModelDeploymentNodesFragment on ModelDeployment {\n  id\n  currentRevisionId\n  metadata {\n    projectId\n    domainName\n    name\n    status\n    tags\n    createdAt\n    updatedAt\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    endpointUrl\n    preferredDomainName\n    openToPublic\n  }\n  defaultDeploymentStrategy {\n    type\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n    count\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    modelMountConfig {\n      vfolder {\n        id\n        name\n      }\n    }\n  }\n  ...BAIDeploymentOwnerInfo_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/DeploymentListPageQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5f6fa8d74653c21606a6ab72256ea52d>>
+ * @generated SignedSource<<8d3bcf7afeb1de0e039fb3d30970c20c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -196,10 +196,7 @@ v10 = {
   "name": "createdAt",
   "storageKey": null
 },
-v11 = [
-  (v5/*: any*/)
-],
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "VirtualFolderNode",
@@ -219,21 +216,21 @@ v12 = {
   ],
   "storageKey": null
 },
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "vfolderId",
   "storageKey": null
 },
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mountDestination",
   "storageKey": null
 },
-v15 = [
+v14 = [
   (v7/*: any*/),
   {
     "alias": null,
@@ -521,16 +518,6 @@ return {
                     "storageKey": null
                   },
                   {
-                    "alias": "totalReplicas",
-                    "args": null,
-                    "concreteType": "ModelReplicaConnection",
-                    "kind": "LinkedField",
-                    "name": "replicas",
-                    "plural": false,
-                    "selections": (v11/*: any*/),
-                    "storageKey": null
-                  },
-                  {
                     "alias": "runningReplicas",
                     "args": [
                       {
@@ -547,7 +534,9 @@ return {
                     "kind": "LinkedField",
                     "name": "replicas",
                     "plural": false,
-                    "selections": (v11/*: any*/),
+                    "selections": [
+                      (v5/*: any*/)
+                    ],
                     "storageKey": "replicas(filter:{\"status\":{\"equals\":\"RUNNING\"}})"
                   },
                   {
@@ -568,9 +557,9 @@ return {
                         "name": "modelMountConfig",
                         "plural": false,
                         "selections": [
+                          (v11/*: any*/),
                           (v12/*: any*/),
                           (v13/*: any*/),
-                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -655,7 +644,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "entries",
                                 "plural": true,
-                                "selections": (v15/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -707,7 +696,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "entries",
                                 "plural": true,
-                                "selections": (v15/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -724,8 +713,8 @@ return {
                         "name": "extraMounts",
                         "plural": true,
                         "selections": [
+                          (v12/*: any*/),
                           (v13/*: any*/),
-                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -733,7 +722,7 @@ return {
                             "name": "mountPerm",
                             "storageKey": null
                           },
-                          (v12/*: any*/)
+                          (v11/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -973,12 +962,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b19937971336e14bb65dea4749999f89",
+    "cacheID": "c9362f4b73a6d5186bd2991d494b6584",
     "id": null,
     "metadata": {},
     "name": "DeploymentListPageQuery",
     "operationKind": "query",
-    "text": "query DeploymentListPageQuery(\n  $filter: DeploymentFilter\n  $orderBy: [DeploymentOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  myDeployments(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIModelDeploymentNodesFragment\n        ...DeploymentSettingModal_deployment\n        metadata {\n          name\n          status\n        }\n        currentRevision @since(version: \"26.4.3\") {\n          id\n          revisionNumber\n          ...DeploymentRevisionDetail_revision\n        }\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentOwnerInfo_deployment on ModelDeployment {\n  id\n  creator @since(version: \"26.4.3\") {\n    id\n    basicInfo {\n      email\n      username\n      fullName\n    }\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment BAIModelDeploymentNodesFragment on ModelDeployment {\n  id\n  currentRevisionId\n  metadata {\n    projectId\n    domainName\n    name\n    status\n    tags\n    createdAt\n    updatedAt\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    endpointUrl\n    preferredDomainName\n    openToPublic\n  }\n  defaultDeploymentStrategy {\n    type\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  totalReplicas: replicas {\n    count\n  }\n  runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n    count\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    modelMountConfig {\n      vfolder {\n        id\n        name\n      }\n    }\n  }\n  ...BAIDeploymentOwnerInfo_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
+    "text": "query DeploymentListPageQuery(\n  $filter: DeploymentFilter\n  $orderBy: [DeploymentOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  myDeployments(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIModelDeploymentNodesFragment\n        ...DeploymentSettingModal_deployment\n        metadata {\n          name\n          status\n        }\n        currentRevision @since(version: \"26.4.3\") {\n          id\n          revisionNumber\n          ...DeploymentRevisionDetail_revision\n        }\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentOwnerInfo_deployment on ModelDeployment {\n  id\n  creator @since(version: \"26.4.3\") {\n    id\n    basicInfo {\n      email\n      username\n      fullName\n    }\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment BAIModelDeploymentNodesFragment on ModelDeployment {\n  id\n  currentRevisionId\n  metadata {\n    projectId\n    domainName\n    name\n    status\n    tags\n    createdAt\n    updatedAt\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    endpointUrl\n    preferredDomainName\n    openToPublic\n  }\n  defaultDeploymentStrategy {\n    type\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n    count\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    modelMountConfig {\n      vfolder {\n        id\n        name\n      }\n    }\n  }\n  ...BAIDeploymentOwnerInfo_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/ProjectAdminDeploymentsPageQuery.graphql.ts
+++ b/react/src/__generated__/ProjectAdminDeploymentsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4fe4b8be7f5118e7f54409636cbc123e>>
+ * @generated SignedSource<<8f83ab8e7bf4dbf080da31e8da23b86e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -213,10 +213,7 @@ v11 = {
   "name": "createdAt",
   "storageKey": null
 },
-v12 = [
-  (v6/*: any*/)
-],
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "concreteType": "VirtualFolderNode",
@@ -236,21 +233,21 @@ v13 = {
   ],
   "storageKey": null
 },
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "vfolderId",
   "storageKey": null
 },
-v15 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mountDestination",
   "storageKey": null
 },
-v16 = [
+v15 = [
   (v8/*: any*/),
   {
     "alias": null,
@@ -540,16 +537,6 @@ return {
                     "storageKey": null
                   },
                   {
-                    "alias": "totalReplicas",
-                    "args": null,
-                    "concreteType": "ModelReplicaConnection",
-                    "kind": "LinkedField",
-                    "name": "replicas",
-                    "plural": false,
-                    "selections": (v12/*: any*/),
-                    "storageKey": null
-                  },
-                  {
                     "alias": "runningReplicas",
                     "args": [
                       {
@@ -566,7 +553,9 @@ return {
                     "kind": "LinkedField",
                     "name": "replicas",
                     "plural": false,
-                    "selections": (v12/*: any*/),
+                    "selections": [
+                      (v6/*: any*/)
+                    ],
                     "storageKey": "replicas(filter:{\"status\":{\"equals\":\"RUNNING\"}})"
                   },
                   {
@@ -587,9 +576,9 @@ return {
                         "name": "modelMountConfig",
                         "plural": false,
                         "selections": [
+                          (v12/*: any*/),
                           (v13/*: any*/),
                           (v14/*: any*/),
-                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -674,7 +663,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "entries",
                                 "plural": true,
-                                "selections": (v16/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -726,7 +715,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "entries",
                                 "plural": true,
-                                "selections": (v16/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -743,8 +732,8 @@ return {
                         "name": "extraMounts",
                         "plural": true,
                         "selections": [
+                          (v13/*: any*/),
                           (v14/*: any*/),
-                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -752,7 +741,7 @@ return {
                             "name": "mountPerm",
                             "storageKey": null
                           },
-                          (v13/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -992,12 +981,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "293ff73cb924b3052843cfcab0312ccd",
+    "cacheID": "18295edf5049f1b62350290ad9923277",
     "id": null,
     "metadata": {},
     "name": "ProjectAdminDeploymentsPageQuery",
     "operationKind": "query",
-    "text": "query ProjectAdminDeploymentsPageQuery(\n  $projectId: UUID!\n  $filter: DeploymentFilter\n  $orderBy: [DeploymentOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  projectDeployments(scope: {projectId: $projectId}, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIModelDeploymentNodesFragment\n        ...DeploymentSettingModal_deployment\n        metadata {\n          name\n          status\n        }\n        currentRevision @since(version: \"26.4.3\") {\n          id\n          revisionNumber\n          ...DeploymentRevisionDetail_revision\n        }\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentOwnerInfo_deployment on ModelDeployment {\n  id\n  creator @since(version: \"26.4.3\") {\n    id\n    basicInfo {\n      email\n      username\n      fullName\n    }\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment BAIModelDeploymentNodesFragment on ModelDeployment {\n  id\n  currentRevisionId\n  metadata {\n    projectId\n    domainName\n    name\n    status\n    tags\n    createdAt\n    updatedAt\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    endpointUrl\n    preferredDomainName\n    openToPublic\n  }\n  defaultDeploymentStrategy {\n    type\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  totalReplicas: replicas {\n    count\n  }\n  runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n    count\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    modelMountConfig {\n      vfolder {\n        id\n        name\n      }\n    }\n  }\n  ...BAIDeploymentOwnerInfo_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
+    "text": "query ProjectAdminDeploymentsPageQuery(\n  $projectId: UUID!\n  $filter: DeploymentFilter\n  $orderBy: [DeploymentOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  projectDeployments(scope: {projectId: $projectId}, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIModelDeploymentNodesFragment\n        ...DeploymentSettingModal_deployment\n        metadata {\n          name\n          status\n        }\n        currentRevision @since(version: \"26.4.3\") {\n          id\n          revisionNumber\n          ...DeploymentRevisionDetail_revision\n        }\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentOwnerInfo_deployment on ModelDeployment {\n  id\n  creator @since(version: \"26.4.3\") {\n    id\n    basicInfo {\n      email\n      username\n      fullName\n    }\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment BAIModelDeploymentNodesFragment on ModelDeployment {\n  id\n  currentRevisionId\n  metadata {\n    projectId\n    domainName\n    name\n    status\n    tags\n    createdAt\n    updatedAt\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    endpointUrl\n    preferredDomainName\n    openToPublic\n  }\n  defaultDeploymentStrategy {\n    type\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n    count\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    modelMountConfig {\n      vfolder {\n        id\n        name\n      }\n    }\n  }\n  ...BAIDeploymentOwnerInfo_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Resolves FR-3072

> Note: No cloned GitHub issue exists for FR-3072 yet (Jira→GitHub webhook not yet propagated). Once the clone appears, this should read `Resolves #<n> (FR-3072)`.

## Problem

The **Replicas** summary column in the deployment list (`BAIModelDeploymentNodes`) rendered `running / total`, where `total` came from an **unfiltered** `replicas { count }` alias — i.e. the count of *all* replicas ever created, **including terminated ones**. When `desiredReplicaCount` was `0`, the denominator fell back to that total, producing nonsensical values:

| Deployment | desired | total (incl. terminated) | running | Shown (before) | Correct (after) |
|---|---|---|---|---|---|
| e2e-fail | 0 | 440 | 0 | `0 / 440` ❌ | `0 / 0` |
| e2e-rb | 3 | 366 | 2 | `2 / 3` (lucky) | `2 / 3` |
| e2e-multi | 0 | 4 | 3 | `3 / 4` ❌ | `3 / 0` |
| e2e-slow | 0 | 1 | 1 | `1 / 1` ❌ | `1 / 0` |

## Fix

Show **`running / desiredReplicaCount`** directly:
- **Numerator** = actual `RUNNING` replica count (`runningReplicas.count`) — unchanged.
- **Denominator** = the intended/desired replica count (the maximum healthy target).

Concretely:
- Removed the `total` / `denominator` fallback logic in the `replicaSummary` render.
- Removed the now-unused `totalReplicas: replicas { count }` fragment alias (eliminates an over-fetch).
- Updated `ReplicaSummaryTooltip` (dropped the `(or total)` clause) across all 21 backend.ai-ui locales.

## Additional: Korean terminology standardization

Standardized the Korean UI term for "replica" from the transliteration **레플리카** to **복제본** in `resources/i18n/ko.json` (the file was internally inconsistent: 31 레플리카 vs 12 복제본; backend.ai-ui locales already use 복제본). Also fixed Korean particle agreement after the swap (복제본**을**, 복제본**이** — not 복제본를/복제본가, since 본 is consonant-final).

## Verification

`bash scripts/verify.sh` → Relay / Lint / Format / TypeScript all **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)