### PR TITLE
feat(FR-3073): redesign loading splash with Diagonal Weave background and reuse it on the login screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@
   <link rel="stylesheet" href="resources/custom.css">
   <script src="manifest/app.js"></script>
   <title>Backend.AI</title>
-  <!-- Critical inline CSS: ensures splash is visible before external CSS loads -->
+  <!-- Critical inline CSS: paints the page/splash backdrop immediately so there
+       is no color flash before the stylesheet applies. The full splash (Diagonal
+       Weave) styling lives in resources/webui.css. -->
   <style>
     body { margin: 0; background-color: rgba(247, 247, 246, 1); }
     body.dark-theme { background-color: #191919; }
@@ -75,30 +77,39 @@
     <div id="react-root"></div>
     <div id="splash" class="splash">
       <div class="splash-drag-area"></div>
-      <div class="splash-card">
-        <div class="splash-header">
-          <div class="logo"></div>
+      <!-- Diagonal Weave background: two woven line layers, drifting slowly -->
+      <svg class="splash-bg" viewBox="0 0 1440 900" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+        <g transform="rotate(23 720 450)"><g id="splash-weaveA" class="splash-weave splash-drift"></g></g>
+        <g transform="rotate(-23 720 450)"><g id="splash-weaveB" class="splash-weave splash-driftB"></g></g>
+      </svg>
+      <div class="splash-veil"></div>
+      <!-- Centered logo + wire-cube loader -->
+      <div class="splash-center">
+        <div class="splash-logo" role="img" aria-label="Backend.AI"></div>
+        <div class="splash-loader">
+          <span class="splash-cube" aria-hidden="true">
+            <svg viewBox="0 0 40 40" width="22" height="22">
+              <line class="edge" x1="20" y1="6" x2="31.9" y2="13" style="--i:2"></line>
+              <line class="edge" x1="31.9" y1="13" x2="31.9" y2="27" style="--i:4"></line>
+              <line class="edge" x1="31.9" y1="27" x2="20" y2="34" style="--i:5"></line>
+              <line class="edge" x1="20" y1="34" x2="8.1" y2="27" style="--i:7"></line>
+              <line class="edge" x1="8.1" y1="27" x2="8.1" y2="13" style="--i:8"></line>
+              <line class="edge" x1="8.1" y1="13" x2="20" y2="6" style="--i:1"></line>
+              <line class="edge" x1="20" y1="20" x2="20" y2="34" style="--i:6"></line>
+              <line class="edge" x1="20" y1="20" x2="31.9" y2="13" style="--i:3"></line>
+              <line class="edge" x1="20" y1="20" x2="8.1" y2="13" style="--i:0"></line>
+            </svg>
+          </span>
+          <div id="loading-message" class="splash-msg">Loading components...</div>
         </div>
-        <div class="splash-information">
-          <ul>
-            <li>Backend.AI Web UI <span id="version-detail" class="detail"></span></li>
-            <li><span id="license-detail"></span></li>
-            <li><span id="mode-detail" class="detail"></span> <span id="build-detail" class="detail"></span></li>
-          </ul>
-          <ul>
-            <li>Powered by open-source software</li>
-            <li class="copyright">Copyright &copy; 2015-2026 Lablup Inc.</li>
-          </ul>
+      </div>
+      <!-- Corner metadata: version/build bottom-left, copyright bottom-right -->
+      <div class="splash-meta">
+        <div class="splash-meta-id">
+          <div class="splash-meta-main">Backend.AI Web UI <span id="version-detail" class="splash-ver"></span></div>
+          <div class="splash-meta-sub"><span id="mode-detail"></span><span id="build-detail"></span></div>
         </div>
-        <div class="splash-loading">
-          <div class="sk-folding-cube">
-            <div class="sk-cube1 sk-cube"></div>
-            <div class="sk-cube2 sk-cube"></div>
-            <div class="sk-cube3 sk-cube"></div>
-            <div class="sk-cube4 sk-cube"></div>
-          </div>
-          <div id="loading-message" class="loading-message">Loading components...</div>
-        </div>
+        <div class="splash-meta-foot">Powered by open-source software &middot; Copyright &copy; 2015-2026 Lablup Inc.<span id="license-detail"></span></div>
       </div>
     </div>
     <noscript>
@@ -107,13 +118,44 @@
     <!-- Backend.AI client classes are now initialized by React global-stores.ts -->
     <script nonce="{{nonce}}">
       document.getElementById('version-detail').innerText = globalThis.packageVersion;
-      document.getElementById('build-detail').innerText = ' Build ' + globalThis.buildNumber;
+      document.getElementById('build-detail').innerText = ' · Build ' + globalThis.buildNumber;
       document.getElementById('license-detail').innerText = '';
       if (globalThis.isElectron) {
         document.getElementById('mode-detail').innerText = 'App';
       } else {
         document.getElementById('mode-detail').innerText = 'WebServer';
       }
+
+      // Diagonal Weave splash: build the woven line layers and prime the wire-cube loader.
+      (function () {
+        var NS = 'http://www.w3.org/2000/svg';
+        var layerA = document.getElementById('splash-weaveA');
+        var layerB = document.getElementById('splash-weaveB');
+        if (layerA && layerB) {
+          var spacing = 28, x1 = -1100, x2 = 2540, k = 0;
+          for (var y = -1200; y < 1200; y += spacing) {
+            var la = document.createElementNS(NS, 'line');
+            la.setAttribute('x1', x1); la.setAttribute('y1', y);
+            la.setAttribute('x2', x2); la.setAttribute('y2', y);
+            if (k % 9 === 0) la.setAttribute('class', 'warm');
+            layerA.appendChild(la);
+            var lb = document.createElementNS(NS, 'line');
+            lb.setAttribute('x1', x1); lb.setAttribute('y1', y);
+            lb.setAttribute('x2', x2); lb.setAttribute('y2', y);
+            layerB.appendChild(lb);
+            k++;
+          }
+        }
+        // Wire-cube loader: set each edge's dash length so the spiral draw animates.
+        var edges = document.querySelectorAll('#splash .splash-cube .edge');
+        for (var i = 0; i < edges.length; i++) {
+          var L = edges[i].getTotalLength();
+          edges[i].style.setProperty('--L', L.toFixed(2));
+          edges[i].style.strokeDasharray = L.toFixed(2);
+          edges[i].style.strokeDashoffset = L.toFixed(2);
+        }
+      })();
+
       if (globalThis.isIE) {
         alert('Internet Explorer is not supported. Please visit with modern browsers.');
         document.getElementById('loading-message').innerText = 'Not supported browser.';
@@ -131,50 +173,72 @@
         }
       }
 
-      // Splash fade-out: React-driven dismissal.
-      // React calls window.__dismissSplash() when meaningful UI is ready
-      // (sider/header for logged-in, login form for logged-out).
-      // MutationObserver serves as a fallback for independent routes
-      // (/verify-email, /change-password, etc.) that render content quickly.
+      // Splash lifecycle: loading -> (login-backdrop | removed).
+      //
+      // - window.__enterLoginBackdrop(): called by LoginView when the login
+      //   form becomes visible (logged-out). Keeps the weave + corner
+      //   metadata as the login screen background, hides only the loader.
+      // - window.__dismissSplash(): called by MainLayout when the authenticated
+      //   UI is ready (logged-in). Fades out and removes the whole splash so it
+      //   can't cover the app (it sits at z-index 10000).
+      //
+      // A MutationObserver + timers serve as fallbacks for routes that call
+      // neither (e.g. /verify-email, /change-password).
       (function () {
         var splash = document.getElementById('splash');
         if (!splash) return;
-        var dismissed = false;
+        var state = 'loading'; // 'loading' | 'backdrop' | 'removed'
         var observer = null;
         var fallbackTimer = null;
+
+        function clearFallbacks() {
+          if (observer) { observer.disconnect(); observer = null; }
+          if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
+        }
+
+        // Full removal (authenticated UI ready, or fallback).
         function dismiss() {
-          if (dismissed) return;
-          dismissed = true;
-          if (observer) observer.disconnect();
-          if (fallbackTimer) clearTimeout(fallbackTimer);
+          if (state === 'removed') return;
+          state = 'removed';
+          clearFallbacks();
           splash.classList.add('splash-hidden');
           splash.addEventListener('transitionend', function handler(e) {
             if (e.propertyName === 'opacity') {
               splash.removeEventListener('transitionend', handler);
-              splash.remove();
+              if (splash.parentNode) splash.remove();
             }
           });
           // Safety net: remove even if transitionend never fires (e.g. prefers-reduced-motion)
           setTimeout(function () { if (splash.parentNode) splash.remove(); }, 1000);
         }
-        // Primary trigger: called by React when the visible UI is ready.
-        // Cancels the MutationObserver fallback timer to prevent premature dismissal.
+
+        // Transition to the login backdrop (logged-out login screen).
+        function enterLoginBackdrop() {
+          if (state !== 'loading') return;
+          state = 'backdrop';
+          // The backdrop must persist through the whole login flow, so cancel
+          // the auto-removal fallbacks.
+          clearFallbacks();
+          splash.classList.add('splash-backdrop');
+        }
+
         window.__dismissSplash = dismiss;
-        // Fallback: MutationObserver for routes that don't explicitly call __dismissSplash
-        // (e.g. /verify-email, /change-password). Uses a longer delay to avoid racing
-        // with React-driven dismissal on normal routes.
+        window.__enterLoginBackdrop = enterLoginBackdrop;
+
+        // Fallback: MutationObserver for routes that don't explicitly signal.
         var reactRoot = document.getElementById('react-root');
         if (reactRoot) {
           observer = new MutationObserver(function () {
             if (reactRoot.childNodes.length > 0) {
               observer.disconnect();
+              observer = null;
               fallbackTimer = setTimeout(dismiss, 3000);
             }
           });
           observer.observe(reactRoot, { childList: true });
         }
-        // Ultimate safety fallback
-        setTimeout(dismiss, 10000);
+        // Ultimate safety fallback — but never tear down an active login backdrop.
+        setTimeout(function () { if (state !== 'backdrop') dismiss(); }, 10000);
       })();
     </script>
 </body>

--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -154,6 +154,9 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
       <BAIModal
         open={isOpen}
         closable={false}
+        // The login screen backdrop (weave + version/copyright metadata) is the
+        // persisted splash element behind this modal (z-index 10000). The modal
+        // mask dims that backdrop, so the metadata reads softly behind the mask.
         mask={!needToResetPassword}
         keyboard={false}
         maskClosable={false}
@@ -228,6 +231,10 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
                   aria-label={t('login.E-mailOrUsername', { postProcess: [] })}
                   maxLength={64}
                   autoComplete="username"
+                  // Focus the first field when the login form opens. When OTP is
+                  // later required, the OTP input mounts with its own autoFocus
+                  // and takes over.
+                  autoFocus={!otpRequired}
                   disabled={isLoading}
                 />
               </Form.Item>
@@ -267,6 +274,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
                   prefix={<LockOutlined />}
                   placeholder={t('login.APIKey', { postProcess: [] })}
                   maxLength={20}
+                  autoFocus
                   disabled={isLoading}
                 />
               </Form.Item>

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -318,8 +318,19 @@ const LoginView: React.FC<{
     }
     setIsLoginPanelOpen(true);
     setIsBlockPanelOpen(false);
-    // Dismiss splash when login form becomes visible (logged-out state)
-    (globalThis as any).__dismissSplash?.();
+    // Logged-out: turn the splash into the login backdrop (keep the weave +
+    // version/copyright metadata, hide the loader). The login modal renders
+    // above it. Fall back to full dismissal on older index.html shells that
+    // don't expose __enterLoginBackdrop.
+    const splashApi = globalThis as unknown as {
+      __enterLoginBackdrop?: () => void;
+      __dismissSplash?: () => void;
+    };
+    if (typeof splashApi.__enterLoginBackdrop === 'function') {
+      splashApi.__enterLoginBackdrop();
+    } else {
+      splashApi.__dismissSplash?.();
+    }
 
     const urlParams = new URLSearchParams(window.location.search);
     const tokenParam = urlParams.get('token');
@@ -1082,6 +1093,10 @@ const LoginView: React.FC<{
       }}
     >
       <App>
+        {/* The login screen background (Diagonal Weave + version/copyright
+            metadata) is the persisted splash element from index.html, switched
+            to backdrop mode via __enterLoginBackdrop(). It sits at z-index
+            10000, below the login panel wrapper (10001). */}
         <div
           style={{
             position: 'fixed',

--- a/react/src/pages/InteractiveLoginPage.tsx
+++ b/react/src/pages/InteractiveLoginPage.tsx
@@ -10,7 +10,7 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { Button, Card, Descriptions } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { StringParam, useQueryParam } from 'use-query-params';
@@ -28,6 +28,7 @@ const InteractiveLoginPage = () => {
 };
 
 const Children = () => {
+  'use memo';
   useSuspendedBackendaiClient();
   const [userInfo] = useCurrentUserInfo();
   const { pathname, search } = useLocation();
@@ -35,12 +36,24 @@ const Children = () => {
   const [name] = useQueryParam('name', StringParam);
   const { t } = useTranslation();
 
+  // This route has no MainLayout, so the interactive-login card is its "main
+  // UI". Put the splash into login-backdrop mode (keeps the Diagonal Weave +
+  // version/copyright as the background, hides the loader) — the same backdrop
+  // the login screen uses — and render the card above it. Without this the
+  // splash (z-index 10000) is never dismissed and covers the card, leaving the
+  // screen stuck on the loading curtain.
+  useEffect(() => {
+    (
+      globalThis as typeof globalThis & { __enterLoginBackdrop?: () => void }
+    ).__enterLoginBackdrop?.();
+  }, []);
+
   return (
     <BAIFlex
       direction="column"
       align="center"
       justify="center"
-      style={{ height: '100vh' }}
+      style={{ position: 'fixed', inset: 0, zIndex: 10001 }}
     >
       <Card title={t('interactiveLogin.InteractiveLoginWithBackendAI')}>
         <BAIFlex direction="column" gap={'sm'} align="stretch">

--- a/resources/webui.css
+++ b/resources/webui.css
@@ -16,6 +16,11 @@ body.dark-theme {
   background-color: #191919;
 }
 
+/* ── Splash / loading curtain (Diagonal Weave) ─────────────────────────────
+   A minimal backdrop (body + #splash background) is inlined in index.html so
+   the page paints its background immediately. The full splash styling lives
+   here; webui.css is a render-blocking <head> stylesheet, so these rules are in
+   effect on first paint (no flash of unstyled splash). */
 .splash {
   position: fixed;
   top: 0;
@@ -26,12 +31,36 @@ body.dark-theme {
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
   background-color: var(--token-colorBgBase, rgba(247, 247, 246, 1));
-  transition: opacity 0.2s ease-out;
+  transition: opacity 0.3s ease-out;
+  font-family:
+    "Ubuntu",
+    "Roboto",
+    "Noto Sans KR",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  /* Diagonal Weave tokens — light */
+  --splash-fg: #141414;
+  --splash-msg: #8c8c8c;
+  --splash-line: rgba(20, 20, 20, 0.055);
+  --splash-warm: rgba(255, 122, 0, 0.16);
+  --splash-accent: #ff7a00;
+  --splash-veil: rgba(247, 247, 246, 1);
+  --splash-logo: url("/manifest/backend.ai-text.svg");
 }
 
 body.dark-theme .splash {
   background-color: #191919;
+  /* Diagonal Weave tokens — dark */
+  --splash-fg: #dcdcdc;
+  --splash-line: rgba(255, 255, 255, 0.05);
+  --splash-warm: rgba(232, 138, 40, 0.18);
+  --splash-accent: #e88a28;
+  --splash-veil: #191919;
+  --splash-logo: url("/manifest/backend.ai-text-bgdark.svg");
 }
 
 .splash-drag-area {
@@ -42,6 +71,7 @@ body.dark-theme .splash {
   height: 80px;
   -webkit-app-region: drag;
   background-color: transparent;
+  z-index: 5;
 }
 
 .splash-hidden {
@@ -49,180 +79,204 @@ body.dark-theme .splash {
   pointer-events: none;
 }
 
-.splash-card {
-  position: relative;
-  width: 340px;
-  min-height: 260px;
-  border: 1px solid var(--token-colorBorder, #ccc);
-  border-radius: 10px;
-  background-color: #ffffff;
-}
-
-body.dark-theme .splash-card {
-  background-color: #191919;
-  border: 1px solid var(--token-colorBorder, #444);
-  color: #dcdcdc;
-}
-
-.splash-header {
-  width: 340px;
-  min-height: 80px;
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: left top;
-  background-color: RGB(246, 253, 247);
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
-  font-size: 28px;
-  font-weight: 400;
-  line-height: 60px;
-  overflow: hidden;
-}
-.splash-header .logo {
-  background-image: url("/manifest/backend.ai-text.svg");
-  width: 300px;
-  height: 50px;
-  margin: 15px 20px;
-  background-repeat: no-repeat;
-  background-size: contain;
-}
-
-body.dark-theme .splash-header .logo {
-  background-image: url("/manifest/backend.ai-text-bgdark.svg");
-}
-
-body.dark-theme .splash-header {
-  background-color: var(--token-colorBgContainer, #141414);
-}
-
-ul {
-  list-style-type: none;
-}
-
-.splash-information .detail {
-  font-weight: 400;
-  font-size: 13px;
-}
-
-.splash-loading {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  justify-content: center;
-  margin-top: 32px;
-}
-
-.loading-message {
-  font-size: 16px;
-}
-
-.sk-folding-cube {
-  width: 15px;
-  height: 15px;
-  flex-shrink: 0;
-  -webkit-transform: rotateZ(45deg);
-  transform: rotateZ(45deg);
-}
-
-.sk-folding-cube .sk-cube {
-  float: left;
-  width: 50%;
-  height: 50%;
-  position: relative;
-  -webkit-transform: scale(1.1);
-  -ms-transform: scale(1.1);
-  transform: scale(1.1);
-}
-
-.sk-folding-cube .sk-cube:before {
-  content: "";
+/* Woven line background (two layers rotated ±23deg, drifting slowly) */
+.splash-bg {
   position: absolute;
-  top: 0;
-  left: 0;
+  inset: 0;
   width: 100%;
   height: 100%;
-  background-color: #3e872d;
-  -webkit-animation: sk-foldCubeAngle 2.4s infinite linear both;
-  animation: sk-foldCubeAngle 2.4s infinite linear both;
-  -webkit-transform-origin: 100% 100%;
-  -ms-transform-origin: 100% 100%;
-  transform-origin: 100% 100%;
+  display: block;
 }
-
-.sk-folding-cube .sk-cube2 {
-  -webkit-transform: scale(1.1) rotateZ(90deg);
-  transform: scale(1.1) rotateZ(90deg);
+.splash-weave line {
+  stroke: var(--splash-line);
+  stroke-width: 1;
 }
-
-.sk-folding-cube .sk-cube3 {
-  -webkit-transform: scale(1.1) rotateZ(180deg);
-  transform: scale(1.1) rotateZ(180deg);
+.splash-weave line.warm {
+  stroke: var(--splash-warm);
+  stroke-width: 1.3;
 }
-
-.sk-folding-cube .sk-cube4 {
-  -webkit-transform: scale(1.1) rotateZ(270deg);
-  transform: scale(1.1) rotateZ(270deg);
+.splash-drift {
+  animation: splash-drift 16s linear infinite;
 }
-
-.sk-folding-cube .sk-cube2:before {
-  -webkit-animation-delay: 0.3s;
-  animation-delay: 0.3s;
+.splash-driftB {
+  animation: splash-driftB 22s linear infinite;
 }
-
-.sk-folding-cube .sk-cube3:before {
-  -webkit-animation-delay: 0.6s;
-  animation-delay: 0.6s;
-}
-
-.sk-folding-cube .sk-cube4:before {
-  -webkit-animation-delay: 0.9s;
-  animation-delay: 0.9s;
-}
-
-@-webkit-keyframes sk-foldCubeAngle {
-  0%,
-  10% {
-    -webkit-transform: perspective(140px) rotateX(-180deg);
-    transform: perspective(140px) rotateX(-180deg);
-    opacity: 0;
+@keyframes splash-drift {
+  from {
+    transform: translateY(0);
   }
-  25%,
-  75% {
-    -webkit-transform: perspective(140px) rotateX(0deg);
-    transform: perspective(140px) rotateX(0deg);
-    opacity: 1;
+  to {
+    transform: translateY(28px);
   }
-  90%,
+}
+@keyframes splash-driftB {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-28px);
+  }
+}
+
+/* Radial veil keeps the logo/loader area clean over the weave. The veil element
+   is centered and sized with max() floors (math functions are reliable in
+   width/height — but NOT inside a radial-gradient size, where they get dropped),
+   so the cleared area never shrinks below the logo (≤296px) + login modal
+   (400px) footprint on small screens. The gradient uses plain percentages of
+   this element. */
+.splash-veil {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: max(88%, 800px);
+  height: max(100%, 640px);
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse 50% 50% at 50% 50%,
+    var(--splash-veil) 0%,
+    var(--splash-veil) 26%,
+    transparent 60%
+  );
+}
+
+/* Logo + loader lockup (centered on screen, left-aligned internally per the
+   brand guide: the loader row aligns to the logo's left edge; the gap is kept
+   proportional to the logo height ~0.38x). */
+.splash-center {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: min(18px, 2.7vmin);
+}
+.splash-logo {
+  width: min(296px, 44vmin);
+  aspect-ratio: 720 / 118;
+  background-image: var(--splash-logo);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+.splash-loader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.splash-msg {
+  font-size: clamp(13px, 1.7vmin, 16px);
+  font-weight: 400;
+  color: var(--splash-msg);
+  letter-spacing: 0.01em;
+}
+
+/* Wire-cube loader — spiral draw of the 180deg session-icon cube */
+.splash-cube {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.splash-cube .edge {
+  fill: none;
+  stroke: var(--splash-accent);
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  animation: splash-cube-draw 1.8s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * 0.1s);
+}
+@keyframes splash-cube-draw {
+  0% {
+    stroke-dashoffset: var(--L);
+  }
+  26% {
+    stroke-dashoffset: 0;
+  }
+  72% {
+    stroke-dashoffset: 0;
+  }
   100% {
-    -webkit-transform: perspective(140px) rotateY(180deg);
-    transform: perspective(140px) rotateY(180deg);
-    opacity: 0;
+    stroke-dashoffset: calc(var(--L) * -1);
   }
 }
 
-@keyframes sk-foldCubeAngle {
-  0%,
-  10% {
-    -webkit-transform: perspective(140px) rotateX(-180deg);
-    transform: perspective(140px) rotateX(-180deg);
-    opacity: 0;
-  }
-  25%,
-  75% {
-    -webkit-transform: perspective(140px) rotateX(0deg);
-    transform: perspective(140px) rotateX(0deg);
-    opacity: 1;
-  }
-  90%,
-  100% {
-    -webkit-transform: perspective(140px) rotateY(180deg);
-    transform: perspective(140px) rotateY(180deg);
-    opacity: 0;
-  }
+/* Corner metadata — version/build bottom-left, copyright bottom-right */
+.splash-meta {
+  position: fixed;
+  left: 30px;
+  right: 30px;
+  bottom: 24px;
+  z-index: 3;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 12px;
+  color: var(--splash-msg);
+  pointer-events: none;
+}
+.splash-meta-id {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+.splash-meta-main {
+  font-size: 12.5px;
+  color: var(--splash-fg);
+  opacity: 0.72;
+}
+.splash-meta-main .splash-ver {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  opacity: 0.92;
+}
+.splash-meta-sub {
+  font-size: 11px;
+  opacity: 0.6;
+  letter-spacing: 0.01em;
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+.splash-meta-foot {
+  font-size: 11px;
+  opacity: 0.55;
+  text-align: right;
 }
 
-.copyright {
-  font-size: 12px;
+/* Login backdrop mode: keep the weave + corner metadata as the login screen
+   background, hide the loading logo/loader. The login modal (with its mask)
+   renders above this, so the metadata shows behind the mask. */
+.splash.splash-backdrop {
+  pointer-events: none;
+}
+.splash-backdrop .splash-center {
+  display: none;
+}
+
+@media (max-width: 760px) {
+  .splash-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+  .splash-meta-foot {
+    text-align: left;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .splash-drift,
+  .splash-driftB {
+    animation: none;
+  }
+  .splash-cube .edge {
+    /* !important overrides the JS-set inline stroke-dashoffset (= full path
+       length, which hides the edge), so the cube stays fully drawn and visible
+       when the draw animation is disabled. */
+    animation: none;
+    stroke-dashoffset: 0 !important;
+  }
 }
 
 /* Global Vaadin components */


### PR DESCRIPTION
Resolves #7786 (FR-3073)

## Summary

Redesigns the loading splash (loading curtain) and reuses it as the login screen background.

### Splash (loading curtain)
- Flat card + green folding-cube → animated **Diagonal Weave** background (two woven line layers drifting in opposite directions, with warm accent lines), a centered logo, a **spiral-draw wire-cube** loader (the session-icon cube), and **corner metadata** (version/build bottom-left, copyright bottom-right).
- Logo + loader form a left-aligned lockup per the brand guide (the loader row aligns to the logo's left edge; gap kept proportional to the logo height, ~0.38×).
- A radial veil keeps the logo/loader area clean over the weave; its radii are floored via `max()` so the cleared area never shrinks below the logo (≤296px) + login modal (400px) footprint on small viewports.
- Light + dark themed; honors `prefers-reduced-motion`.

### Login screen
- Reuses the same splash element as the login background ("backdrop mode"): the weave + version/copyright stay visible, the loader is hidden, and the login modal renders above it with its mask. This avoids duplicating the weave/metadata in React — single source of truth in `index.html` + `resources/webui.css`.
- Auto-focuses the first input (email/username, or API key in API mode) when the login form opens.

### Implementation
- Splash styling consolidated into `resources/webui.css` (a render-blocking `<head>` stylesheet, so there is no flash of unstyled splash); only a minimal critical backdrop stays inline in `index.html`.
- Splash lifecycle is a small state machine: `loading → login-backdrop → removed` via `window.__enterLoginBackdrop()` / `window.__dismissSplash()`.

## Files
- `index.html` — splash markup + weave/cube init + dismiss state machine; minimal inline critical CSS.
- `resources/webui.css` — full splash (Diagonal Weave) styling.
- `react/src/components/LoginView.tsx` — enter backdrop mode when the login form shows; restore the block-modal mask.
- `react/src/components/LoginFormPanel.tsx` — keep the login modal mask; autofocus the first input.

## Verification
`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript). Verified live in light + dark (splash + login) on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
