### PR TITLE
feat(FR-3075): paginate scheduling-history modals

### DIFF
--- a/react/src/__generated__/DeploymentSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/DeploymentSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c587f9e1882663e663a5d0e7f2aca1f5>>
+ * @generated SignedSource<<6423974fd699af3b00e2069e111ef76a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -77,11 +77,14 @@ export type DeploymentHistoryOrderBy = {
 };
 export type DeploymentSchedulingHistoryModalQuery$variables = {
   filter?: DeploymentHistoryFilter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
   orderBy?: ReadonlyArray<DeploymentHistoryOrderBy> | null | undefined;
   scope: DeploymentScope;
 };
 export type DeploymentSchedulingHistoryModalQuery$data = {
   readonly deploymentScopedSchedulingHistories: {
+    readonly count: number;
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly " $fragmentSpreads": FragmentRefs<"BAIDeploymentSchedulingHistoryTableFragment">;
@@ -103,18 +106,38 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "orderBy"
+  "name": "limit"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "scope"
 },
-v3 = [
+v5 = [
   {
     "kind": "Variable",
     "name": "filter",
     "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Variable",
+    "name": "offset",
+    "variableName": "offset"
   },
   {
     "kind": "Variable",
@@ -127,21 +150,28 @@ v3 = [
     "variableName": "scope"
   }
 ],
-v4 = {
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "result",
   "storageKey": null
 },
-v5 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "errorCode",
   "storageKey": null
 },
-v6 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -153,7 +183,9 @@ return {
     "argumentDefinitions": [
       (v0/*: any*/),
       (v1/*: any*/),
-      (v2/*: any*/)
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -161,12 +193,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": "DeploymentHistoryConnection",
         "kind": "LinkedField",
         "name": "deploymentScopedSchedulingHistories",
         "plural": false,
         "selections": [
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -204,21 +237,24 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v2/*: any*/),
+      (v4/*: any*/),
       (v0/*: any*/),
-      (v1/*: any*/)
+      (v3/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "DeploymentSchedulingHistoryModalQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": "DeploymentHistoryConnection",
         "kind": "LinkedField",
         "name": "deploymentScopedSchedulingHistories",
         "plural": false,
         "selections": [
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -242,7 +278,7 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
+                  (v7/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -258,9 +294,9 @@ return {
                         "name": "step",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
-                      (v5/*: any*/),
-                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -306,8 +342,8 @@ return {
                     "name": "toStatus",
                     "storageKey": null
                   },
-                  (v5/*: any*/),
-                  (v6/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -341,16 +377,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d5545baf9254238711d930e4388936dd",
+    "cacheID": "b24d145b426294eb9cc72c268ccd1df2",
     "id": null,
     "metadata": {},
     "name": "DeploymentSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query DeploymentSchedulingHistoryModalQuery(\n  $scope: DeploymentScope!\n  $filter: DeploymentHistoryFilter\n  $orderBy: [DeploymentHistoryOrderBy!]\n) {\n  deploymentScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIDeploymentSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentSchedulingHistoryNodesFragment on DeploymentHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIDeploymentSchedulingHistoryTableFragment on DeploymentHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAIDeploymentSchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query DeploymentSchedulingHistoryModalQuery(\n  $scope: DeploymentScope!\n  $filter: DeploymentHistoryFilter\n  $orderBy: [DeploymentHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  deploymentScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAIDeploymentSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentSchedulingHistoryNodesFragment on DeploymentHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIDeploymentSchedulingHistoryTableFragment on DeploymentHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAIDeploymentSchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "85600df901d6fbaa9bbc3ac84ede6d06";
+(node as any).hash = "89ec50bb9b1f834e59c642072090d378";
 
 export default node;

--- a/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/RouteSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0d329743d1c924326df8fb382f88645e>>
+ * @generated SignedSource<<ded0c3aa6171af69b86f1a792cff28d3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -78,11 +78,14 @@ export type RouteHistoryOrderBy = {
 };
 export type RouteSchedulingHistoryModalQuery$variables = {
   filter?: RouteHistoryFilter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
   orderBy?: ReadonlyArray<RouteHistoryOrderBy> | null | undefined;
   scope: RouteScope;
 };
 export type RouteSchedulingHistoryModalQuery$data = {
   readonly routeScopedSchedulingHistories: {
+    readonly count: number;
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly " $fragmentSpreads": FragmentRefs<"BAIRouteSchedulingHistoryTableFragment">;
@@ -104,18 +107,38 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "orderBy"
+  "name": "limit"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "scope"
 },
-v3 = [
+v5 = [
   {
     "kind": "Variable",
     "name": "filter",
     "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Variable",
+    "name": "offset",
+    "variableName": "offset"
   },
   {
     "kind": "Variable",
@@ -128,21 +151,28 @@ v3 = [
     "variableName": "scope"
   }
 ],
-v4 = {
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "result",
   "storageKey": null
 },
-v5 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "errorCode",
   "storageKey": null
 },
-v6 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -154,7 +184,9 @@ return {
     "argumentDefinitions": [
       (v0/*: any*/),
       (v1/*: any*/),
-      (v2/*: any*/)
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -162,12 +194,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": "RouteHistoryConnection",
         "kind": "LinkedField",
         "name": "routeScopedSchedulingHistories",
         "plural": false,
         "selections": [
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -205,21 +238,24 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v2/*: any*/),
+      (v4/*: any*/),
       (v0/*: any*/),
-      (v1/*: any*/)
+      (v3/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "RouteSchedulingHistoryModalQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": "RouteHistoryConnection",
         "kind": "LinkedField",
         "name": "routeScopedSchedulingHistories",
         "plural": false,
         "selections": [
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -243,7 +279,7 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
+                  (v7/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -259,9 +295,9 @@ return {
                         "name": "step",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
-                      (v5/*: any*/),
-                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -307,8 +343,8 @@ return {
                     "name": "toStatus",
                     "storageKey": null
                   },
-                  (v5/*: any*/),
-                  (v6/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -342,16 +378,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "76285934ccc8e905542eefed19bd318d",
+    "cacheID": "e02133438de747b29f05fb0c3109339d",
     "id": null,
     "metadata": {},
     "name": "RouteSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIRouteSchedulingHistoryTableFragment on RouteHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAIRouteSchedulingHistoryNodeTableFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query RouteSchedulingHistoryModalQuery(\n  $scope: RouteScope!\n  $filter: RouteHistoryFilter\n  $orderBy: [RouteHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  routeScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAIRouteSchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAIRouteSchedulingHistoryNodeTableFragment on RouteHistory {\n  id\n  category\n  phase\n  fromStatus\n  toStatus\n  result\n  errorCode\n  message\n  attempts\n  createdAt\n  updatedAt\n}\n\nfragment BAIRouteSchedulingHistoryTableFragment on RouteHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAIRouteSchedulingHistoryNodeTableFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0dc8467432ed583ed53bcd9160cd0cb1";
+(node as any).hash = "e770c8de50ced262d1f75ecd5be88c57";
 
 export default node;

--- a/react/src/__generated__/SessionSchedulingHistoryModalQuery.graphql.ts
+++ b/react/src/__generated__/SessionSchedulingHistoryModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ff20fa825d347e35021204496628d125>>
+ * @generated SignedSource<<17fabfcf7a1dfe7561f25db712b60f65>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -77,11 +77,14 @@ export type SessionSchedulingHistoryOrderBy = {
 };
 export type SessionSchedulingHistoryModalQuery$variables = {
   filter?: SessionSchedulingHistoryFilter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
   orderBy?: ReadonlyArray<SessionSchedulingHistoryOrderBy> | null | undefined;
   scope: SessionScope;
 };
 export type SessionSchedulingHistoryModalQuery$data = {
   readonly sessionScopedSchedulingHistories: {
+    readonly count: number;
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly " $fragmentSpreads": FragmentRefs<"BAISchedulingHistoryTableFragment">;
@@ -103,18 +106,38 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "orderBy"
+  "name": "limit"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "scope"
 },
-v3 = [
+v5 = [
   {
     "kind": "Variable",
     "name": "filter",
     "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Variable",
+    "name": "offset",
+    "variableName": "offset"
   },
   {
     "kind": "Variable",
@@ -127,14 +150,21 @@ v3 = [
     "variableName": "scope"
   }
 ],
-v4 = {
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "result",
   "storageKey": null
 },
-v5 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -146,7 +176,9 @@ return {
     "argumentDefinitions": [
       (v0/*: any*/),
       (v1/*: any*/),
-      (v2/*: any*/)
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -154,12 +186,13 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": "SessionSchedulingHistoryConnection",
         "kind": "LinkedField",
         "name": "sessionScopedSchedulingHistories",
         "plural": false,
         "selections": [
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -197,21 +230,24 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v2/*: any*/),
+      (v4/*: any*/),
       (v0/*: any*/),
-      (v1/*: any*/)
+      (v3/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "SessionSchedulingHistoryModalQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v5/*: any*/),
         "concreteType": "SessionSchedulingHistoryConnection",
         "kind": "LinkedField",
         "name": "sessionScopedSchedulingHistories",
         "plural": false,
         "selections": [
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -235,7 +271,7 @@ return {
                     "name": "id",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
+                  (v7/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -251,7 +287,7 @@ return {
                         "name": "step",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -259,7 +295,7 @@ return {
                         "name": "errorCode",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -312,7 +348,7 @@ return {
                     "name": "toStatus",
                     "storageKey": null
                   },
-                  (v5/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -332,16 +368,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fd4f2a0c97f5368a8886b4ffcc9a7bdf",
+    "cacheID": "7c5c34bfae059fe7639c97b11c1a4d9e",
     "id": null,
     "metadata": {},
     "name": "SessionSchedulingHistoryModalQuery",
     "operationKind": "query",
-    "text": "query SessionSchedulingHistoryModalQuery(\n  $scope: SessionScope!\n  $filter: SessionSchedulingHistoryFilter\n  $orderBy: [SessionSchedulingHistoryOrderBy!]\n) {\n  sessionScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy) {\n    edges {\n      node {\n        ...BAISchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n}\n\nfragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAISchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
+    "text": "query SessionSchedulingHistoryModalQuery(\n  $scope: SessionScope!\n  $filter: SessionSchedulingHistoryFilter\n  $orderBy: [SessionSchedulingHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  sessionScopedSchedulingHistories(scope: $scope, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAISchedulingHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAISchedulingHistoryNodesFragment on SessionSchedulingHistory {\n  id\n  attempts\n  createdAt\n  updatedAt\n  fromStatus\n  toStatus\n  message\n  phase\n  result\n}\n\nfragment BAISchedulingHistoryTableFragment on SessionSchedulingHistory {\n  id\n  result\n  subSteps {\n    ...BAISubStepNodesFragment\n  }\n  ...BAISchedulingHistoryNodesFragment\n}\n\nfragment BAISubStepNodesFragment on SubStepResultGQL {\n  step\n  result\n  errorCode\n  message\n  startedAt\n  endedAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f5aba8ae25a148fe9089ab6f25dd0269";
+(node as any).hash = "6221439d9cf111e4683277c5e89974db";
 
 export default node;

--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -507,6 +507,8 @@ const DeploymentConfigurationSection: React.FC<
                         deploymentId: safeDecodeUuid(rawId) ?? rawId,
                       },
                       orderBy: [{ field: 'UPDATED_AT', direction: 'DESC' }],
+                      limit: 10,
+                      offset: 0,
                     },
                     { fetchPolicy: 'store-and-network' },
                   );

--- a/react/src/components/DeploymentReplicasTab.tsx
+++ b/react/src/components/DeploymentReplicasTab.tsx
@@ -321,6 +321,8 @@ const DeploymentReplicasTab: React.FC<DeploymentReplicasTabProps> = ({
                     {
                       scope: { routeId: id },
                       orderBy: [{ field: 'UPDATED_AT', direction: 'DESC' }],
+                      limit: 10,
+                      offset: 0,
                     },
                     {
                       fetchPolicy: 'store-and-network',

--- a/react/src/components/DeploymentSchedulingHistoryModal.tsx
+++ b/react/src/components/DeploymentSchedulingHistoryModal.tsx
@@ -4,6 +4,7 @@ import {
   DeploymentSchedulingHistoryModalQuery,
 } from '../__generated__/DeploymentSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
+import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   BAIDeploymentSchedulingHistoryTable,
@@ -32,12 +33,17 @@ export const DeploymentSchedulingHistoryQuery = graphql`
     $scope: DeploymentScope!
     $filter: DeploymentHistoryFilter
     $orderBy: [DeploymentHistoryOrderBy!]
+    $limit: Int
+    $offset: Int
   ) {
     deploymentScopedSchedulingHistories(
       scope: $scope
       filter: $filter
       orderBy: $orderBy
+      limit: $limit
+      offset: $offset
     ) {
+      count
       edges {
         node {
           ...BAIDeploymentSchedulingHistoryTableFragment
@@ -81,6 +87,8 @@ const DeploymentSchedulingHistoryModal = ({
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.DeploymentSchedulingHistory',
   );
+  const { tablePaginationOption, setTablePaginationOption } =
+    useBAIPaginationOptionState({ current: 1, pageSize: 10 });
 
   // Re-fetches happen from event handlers (filter / order / refresh), never from
   // render or an effect. We carry the existing variables forward via
@@ -122,8 +130,9 @@ const DeploymentSchedulingHistoryModal = ({
             value={filter}
             onChange={(next) => {
               setFilter(next);
+              setTablePaginationOption({ current: 1 });
               onReload(
-                { ...queryRef.variables, filter: next },
+                { ...queryRef.variables, filter: next, offset: 0 },
                 { fetchPolicy: 'network-only' },
               );
             }}
@@ -217,13 +226,31 @@ const DeploymentSchedulingHistoryModal = ({
           order={order}
           onChangeOrder={(nextOrder) => {
             setOrder(nextOrder);
+            setTablePaginationOption({ current: 1 });
             onReload(
               {
                 ...queryRef.variables,
                 orderBy: convertToOrderBy<DeploymentHistoryOrderBy>(nextOrder),
+                offset: 0,
               },
               { fetchPolicy: 'network-only' },
             );
+          }}
+          pagination={{
+            pageSize: tablePaginationOption.pageSize,
+            current: tablePaginationOption.current,
+            total: data.deploymentScopedSchedulingHistories?.count ?? 0,
+            onChange: (current, pageSize) => {
+              setTablePaginationOption({ current, pageSize });
+              onReload(
+                {
+                  ...queryRef.variables,
+                  limit: pageSize,
+                  offset: current > 1 ? (current - 1) * pageSize : 0,
+                },
+                { fetchPolicy: 'network-only' },
+              );
+            },
           }}
           schedulingHistoryFrgmt={_.map(
             data.deploymentScopedSchedulingHistories?.edges,

--- a/react/src/components/RouteSchedulingHistoryModal.tsx
+++ b/react/src/components/RouteSchedulingHistoryModal.tsx
@@ -4,6 +4,7 @@ import {
   RouteSchedulingHistoryModalQuery,
 } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
+import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   BAIFetchKeyButton,
@@ -32,12 +33,17 @@ export const RouteSchedulingHistoryQuery = graphql`
     $scope: RouteScope!
     $filter: RouteHistoryFilter
     $orderBy: [RouteHistoryOrderBy!]
+    $limit: Int
+    $offset: Int
   ) {
     routeScopedSchedulingHistories(
       scope: $scope
       filter: $filter
       orderBy: $orderBy
+      limit: $limit
+      offset: $offset
     ) {
+      count
       edges {
         node {
           ...BAIRouteSchedulingHistoryTableFragment
@@ -81,6 +87,8 @@ const RouteSchedulingHistoryModal = ({
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.RouteSchedulingHistory',
   );
+  const { tablePaginationOption, setTablePaginationOption } =
+    useBAIPaginationOptionState({ current: 1, pageSize: 10 });
 
   // Re-fetches happen from event handlers (filter / order / refresh), never from
   // render or an effect. We carry the existing variables forward via
@@ -122,8 +130,9 @@ const RouteSchedulingHistoryModal = ({
             value={filter}
             onChange={(next) => {
               setFilter(next);
+              setTablePaginationOption({ current: 1 });
               onReload(
-                { ...queryRef.variables, filter: next },
+                { ...queryRef.variables, filter: next, offset: 0 },
                 { fetchPolicy: 'network-only' },
               );
             }}
@@ -217,13 +226,31 @@ const RouteSchedulingHistoryModal = ({
           order={order}
           onChangeOrder={(nextOrder) => {
             setOrder(nextOrder);
+            setTablePaginationOption({ current: 1 });
             onReload(
               {
                 ...queryRef.variables,
                 orderBy: convertToOrderBy<RouteHistoryOrderBy>(nextOrder),
+                offset: 0,
               },
               { fetchPolicy: 'network-only' },
             );
+          }}
+          pagination={{
+            pageSize: tablePaginationOption.pageSize,
+            current: tablePaginationOption.current,
+            total: data.routeScopedSchedulingHistories?.count ?? 0,
+            onChange: (current, pageSize) => {
+              setTablePaginationOption({ current, pageSize });
+              onReload(
+                {
+                  ...queryRef.variables,
+                  limit: pageSize,
+                  offset: current > 1 ? (current - 1) * pageSize : 0,
+                },
+                { fetchPolicy: 'network-only' },
+              );
+            },
           }}
           schedulingHistoryFrgmt={_.map(
             data.routeScopedSchedulingHistories?.edges,

--- a/react/src/components/SessionSchedulingHistoryModal.tsx
+++ b/react/src/components/SessionSchedulingHistoryModal.tsx
@@ -4,6 +4,7 @@ import {
   SessionSchedulingHistoryOrderBy,
 } from '../__generated__/SessionSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
+import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   BAIFetchKeyButton,
@@ -44,23 +45,35 @@ const SessionSchedulingHistoryModal = ({
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.SessionSchedulingHistory',
   );
+  const {
+    baiPaginationOption,
+    tablePaginationOption,
+    setTablePaginationOption,
+  } = useBAIPaginationOptionState({ current: 1, pageSize: 10 });
 
   const deferredOpenValue = useDeferredValue(open);
   const deferredFetchKey = useDeferredValue(fetchKey);
   const deferredFilter = useDeferredValue(filter);
   const deferredOrder = useDeferredValue(order);
+  const deferredOffset = useDeferredValue(baiPaginationOption.offset);
+  const deferredLimit = useDeferredValue(baiPaginationOption.limit);
   const queryRef = useLazyLoadQuery<SessionSchedulingHistoryModalQuery>(
     graphql`
       query SessionSchedulingHistoryModalQuery(
         $scope: SessionScope!
         $filter: SessionSchedulingHistoryFilter
         $orderBy: [SessionSchedulingHistoryOrderBy!]
+        $limit: Int
+        $offset: Int
       ) {
         sessionScopedSchedulingHistories(
           scope: $scope
           filter: $filter
           orderBy: $orderBy
+          limit: $limit
+          offset: $offset
         ) {
+          count
           edges {
             node {
               ...BAISchedulingHistoryTableFragment
@@ -77,6 +90,8 @@ const SessionSchedulingHistoryModal = ({
       orderBy: convertToOrderBy<SessionSchedulingHistoryOrderBy>(
         deferredOrder,
       ) ?? [{ field: 'UPDATED_AT', direction: 'DESC' }],
+      limit: deferredLimit,
+      offset: deferredOffset,
     },
     {
       fetchKey: deferredFetchKey,
@@ -105,7 +120,10 @@ const SessionSchedulingHistoryModal = ({
         <BAIFlex justify="between" wrap="wrap" gap="sm">
           <BAIGraphQLPropertyFilter
             value={filter}
-            onChange={setFilter}
+            onChange={(next) => {
+              setFilter(next);
+              setTablePaginationOption({ current: 1 });
+            }}
             filterProperties={[
               {
                 key: 'id',
@@ -186,15 +204,28 @@ const SessionSchedulingHistoryModal = ({
           loading={
             deferredFetchKey !== fetchKey ||
             deferredFilter !== filter ||
-            deferredOrder !== order
+            deferredOrder !== order ||
+            deferredOffset !== baiPaginationOption.offset ||
+            deferredLimit !== baiPaginationOption.limit
           }
           order={order}
-          onChangeOrder={setOrder}
+          onChangeOrder={(nextOrder) => {
+            setOrder(nextOrder);
+            setTablePaginationOption({ current: 1 });
+          }}
           expandMode={expandMode ?? undefined}
           onExpandModeChange={setExpandMode}
           tableSettings={{
             columnOverrides,
             onColumnOverridesChange: setColumnOverrides,
+          }}
+          pagination={{
+            pageSize: tablePaginationOption.pageSize,
+            current: tablePaginationOption.current,
+            total: queryRef.sessionScopedSchedulingHistories?.count ?? 0,
+            onChange: (current, pageSize) => {
+              setTablePaginationOption({ current, pageSize });
+            },
           }}
           schedulingHistoryFrgmt={_.map(
             queryRef.sessionScopedSchedulingHistories?.edges,


### PR DESCRIPTION
Resolves #7793 (FR-3075)

> **Stacked on** #7650 (FR-3008). Review/merge that PR first.

## Summary

The scheduling-history modals (**session**, **deployment**, **route**) added in #7650 fetched the **entire** scheduling history in a single query with **no pagination arguments** and `fetchPolicy: 'network-only'`, eagerly loading every row's `subSteps`. For sessions/deployments/routes that went through many scheduling cycles (retries, rescheduling), this produced a large server-side aggregation and re-fetched the whole thing on every modal open — making these modals noticeably slower than the rest of the app.

This adds offset (page-number) pagination to all three modals.

## Changes

- **`SessionSchedulingHistoryModal`** (self-contained `useLazyLoadQuery`): add `$limit`/`$offset` to the query, select `count`, wire `useBAIPaginationOptionState` with deferred `limit`/`offset`, and pass the table `pagination` config.
- **`DeploymentSchedulingHistoryModal` / `RouteSchedulingHistoryModal`** (preloaded-query pattern): add `$limit`/`$offset` + `count` to the query; the modal owns page state and calls the existing `onReload` with new `limit`/`offset` on page change. Their openers (`DeploymentConfigurationSection`, `DeploymentReplicasTab`) seed the initial `loadQuery` with `limit: 10, offset: 0`.
- Changing **filter** or **order** resets to page 1 (`offset: 0`).
- Uses **`limit` + `offset`** only — the three `*ScopedSchedulingHistories` are Strawberry V2 connections that reject mixed `first`+`offset` at runtime (see `.claude/rules/graphql-pagination.md`).

## Behavior note

With pagination, the FR-3008 **"expand errors only"** default auto-expands non-success rows **on the current page only**, not across the whole history. This is the expected trade-off for paginated tables.

## Verification

`bash scripts/verify.sh` → Relay / Lint / Format / TypeScript all pass (the Relay step only flags the regenerated `__generated__` artifacts as needing commit, which are included in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
