### PR TITLE
fix(FR-3076): remove Lit-era duplicate notification opener, unify renderer at app root

### DIFF
--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -2,10 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import {
-  useBAINotificationEffect,
-  useBAINotificationState,
-} from '../hooks/useBAINotification';
+import { useBAINotificationState } from '../hooks/useBAINotification';
 import useKeyboardShortcut from '../hooks/useKeyboardShortcut';
 import ReverseThemeProvider from './ReverseThemeProvider';
 import WEBUINotificationDrawer from './WEBUINotificationDrawer';
@@ -15,39 +12,17 @@ import { BAIText } from 'backend.ai-ui';
 import { t } from 'i18next';
 import { atom, useAtom } from 'jotai';
 import * as _ from 'lodash-es';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 export const isOpenDrawerState = atom(false);
 
+// Pure UI: badge + drawer toggle. Notification event handling and toast
+// rendering live in the app-wide <NotificationHost /> (DefaultProviders),
+// which stays mounted regardless of authentication state.
 const BAINotificationButton: React.FC<ButtonProps> = ({ ...props }) => {
-  const [notifications, { upsertNotification, clearNotification }] =
-    useBAINotificationState();
-  useBAINotificationEffect();
+  const [notifications] = useBAINotificationState();
 
   const [isOpenDrawer, setIsOpenDrawer] = useAtom(isOpenDrawerState);
-  useEffect(() => {
-    const addNotificationHandler = (e: any) => {
-      upsertNotification(e.detail);
-    };
-    const clearNotificationHandler = (e: any) => {
-      clearNotification(e.detail.key);
-    };
-    document.addEventListener('add-bai-notification', addNotificationHandler);
-    document.addEventListener(
-      'clear-bai-notification',
-      clearNotificationHandler,
-    );
-    return () => {
-      document.removeEventListener(
-        'add-bai-notification',
-        addNotificationHandler,
-      );
-      document.removeEventListener(
-        'clear-bai-notification',
-        clearNotificationHandler,
-      );
-    };
-  }, [upsertNotification, clearNotification]);
 
   useKeyboardShortcut(
     (event) => {

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -13,6 +13,7 @@ import {
 import { useDeviceMetaData } from '../hooks/backendai';
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { useThemeMode } from '../hooks/useThemeMode';
+import NotificationHost from './NotificationHost';
 import '../index.css';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
@@ -347,6 +348,12 @@ export const DefaultProvidersForReactRoot: React.FC<{
               <BAIMetaDataWrapper>
                 <QueryParamProvider adapter={ReactRouter6Adapter}>
                   <App {...commonAppProps}>
+                    {/* Single app-wide notification renderer. Lives outside
+                        the Suspense below so toasts work on every route and
+                        in both anonymous and authenticated states. Renders
+                        null, so its position relative to the emotion caches
+                        below is irrelevant. */}
+                    <NotificationHost />
                     {/*
                      * Two separate emotion caches are needed for CSP nonce
                      * coverage:

--- a/react/src/components/EduAppLauncher.test.ts
+++ b/react/src/components/EduAppLauncher.test.ts
@@ -211,7 +211,7 @@ describe('EduAppLauncher – _dispatchNotification helper', () => {
 
 // ---------------------------------------------------------------------------
 // Tests verifying that direct CustomEvent dispatch via document matches the
-// contract consumed by BAINotificationButton.
+// contract consumed by NotificationHost.
 // ---------------------------------------------------------------------------
 
 describe('add-bai-notification event contract', () => {

--- a/react/src/components/EduAppLauncher.tsx
+++ b/react/src/components/EduAppLauncher.tsx
@@ -1052,11 +1052,9 @@ const EduAppSessionRelayLoader: React.FC<{
  * can be called unconditionally per the Rules of Hooks.
  *
  * Calls `launchApp` directly (not `launchAppWithNotification`) because
- * the EduAppLauncher page renders outside `MainLayout` and therefore
- * has no `useBAINotificationEffect` subscriber attached to drive the
- * notification's `backgroundTask.promise` lifecycle. The card UI
- * already shows per-step progress, so the notification surface is not
- * needed here. The promise resolves with the work info containing the
+ * the card UI already shows per-step progress, so a toast driven by the
+ * app-wide `NotificationHost` would only duplicate that progress
+ * display. The promise resolves with the work info containing the
  * `appConnectUrl`, which is forwarded to `onLaunched`. `AppLaunchError`
  * (e.g. service port missing → stage `'configuring'`) is forwarded to
  * `onError`.

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -25,7 +25,7 @@ import { DRAWER_WIDTH } from '../WEBUINotificationDrawer';
 import WebUIBreadcrumb from '../WebUIBreadcrumb';
 import WebUIHeader from './WebUIHeader';
 import WebUISider from './WebUISider';
-import { App, ConfigProvider, Layout, type LayoutProps, theme } from 'antd';
+import { ConfigProvider, Layout, type LayoutProps, theme } from 'antd';
 import { createGlobalStyle, createStyles } from 'antd-style';
 import { BAIFlex } from 'backend.ai-ui';
 import { atom, useSetAtom } from 'jotai';
@@ -156,7 +156,6 @@ function MainLayout() {
     <LayoutWithPageTestId>
       <CSSTokenVariables />
       <ScrollbarGlobalStyle />
-      <NotificationForAnonymous />
       <Suspense fallback={null}>
         <DismissSplashOnMount />
         <WebUISider
@@ -368,24 +367,6 @@ const LayoutWithPageTestId: React.FC<LayoutProps> = (props) => {
     // react-doctor-disable-next-line react-doctor/no-mutable-in-deps
   }, [location.pathname]);
   return <Layout {...props} data-testid={pageTest} />;
-};
-
-export const NotificationForAnonymous = () => {
-  const app = App.useApp();
-  useEffect(() => {
-    const handler = (e: any) => {
-      app.notification.open({
-        ...e.detail,
-        closeIcon: false,
-        placement: 'bottomRight',
-      });
-    };
-    document.addEventListener('add-bai-notification', handler);
-    return () => {
-      document.removeEventListener('add-bai-notification', handler);
-    };
-  }, [app.notification]);
-  return null;
 };
 
 type ThemeToken = ReturnType<typeof theme.useToken>['token'];

--- a/react/src/components/NotificationHost.tsx
+++ b/react/src/components/NotificationHost.tsx
@@ -1,0 +1,68 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  useBAINotificationEffect,
+  useSetBAINotification,
+} from '../hooks/useBAINotification';
+import React, { useEffect, useEffectEvent } from 'react';
+
+/**
+ * Single, always-mounted notification host for the whole app.
+ *
+ * Mounted once inside antd's `<App>` in `DefaultProvidersForReactRoot`, so it
+ * is alive on every route (login screen, interactive-login, edu-applauncher,
+ * authenticated main layout, ...) regardless of authentication state. It is
+ * the ONLY place that subscribes to the `add-bai-notification` DOM event and
+ * (via `useBAINotificationEffect`) the only driver of antd toast open/close.
+ *
+ * History: notifications used to be driven from two places — the
+ * authenticated header's BAINotificationButton (suspended until login) and a
+ * `NotificationForAnonymous` fallback that mirrored the same DOM event for
+ * pre-login screens, a bridge left over from the Lit shell era. Both being
+ * mounted in the authenticated state opened duplicate toasts for keyless
+ * events such as the logout "Clean up now…" message (FR-3076). Consolidating
+ * to this single host removes that bug class entirely.
+ */
+const NotificationHost: React.FC = () => {
+  'use memo';
+
+  const { upsertNotification, clearNotification } = useSetBAINotification();
+  useBAINotificationEffect();
+
+  const handleAddNotification = useEffectEvent((e: Event) => {
+    upsertNotification((e as CustomEvent).detail);
+  });
+  // No in-repo code dispatches `clear-bai-notification` anymore, but the
+  // event pair is part of the runtime plugin surface (compiled Lit-template
+  // plugins were built against a shell that consumed both events), so keep
+  // the listener for compatibility.
+  const handleClearNotification = useEffectEvent((e: Event) => {
+    clearNotification((e as CustomEvent).detail?.key);
+  });
+
+  // Register once on mount; the handlers are stable `useEffectEvent` refs that
+  // always read the latest upsert/clear, so no deps are needed.
+  useEffect(() => {
+    document.addEventListener('add-bai-notification', handleAddNotification);
+    document.addEventListener(
+      'clear-bai-notification',
+      handleClearNotification,
+    );
+    return () => {
+      document.removeEventListener(
+        'add-bai-notification',
+        handleAddNotification,
+      );
+      document.removeEventListener(
+        'clear-bai-notification',
+        handleClearNotification,
+      );
+    };
+  }, []);
+
+  return null;
+};
+
+export default NotificationHost;

--- a/react/src/global-stores.ts
+++ b/react/src/global-stores.ts
@@ -230,6 +230,14 @@ class BackendAIMetadataStore {
 // ---------------------------------------------------------------------------
 // BackendAITasker
 // Manages background task state and dispatches notification events.
+//
+// NOTE: `globalThis.tasker` is part of the runtime PLUGIN surface, not just
+// internal legacy. Compiled Lit-template plugins assign
+// `this.tasker = globalThis.tasker` in their shared BackendAIPage base class
+// (see e2e/plugin/*.js fixtures) and may call `tasker.add(...)` for
+// background-task notifications. No in-repo code calls it anymore, but do not
+// remove it without auditing the plugin ecosystem. Its `add()` dispatches
+// `add-bai-notification`, which is consumed by the app-wide NotificationHost.
 // ---------------------------------------------------------------------------
 
 class BackendAITasker {

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -320,7 +320,13 @@ export const useBAINotificationEffect = () => {
           listeningTaskIdsRef.current,
           notification.backgroundTask?.taskId,
         ) &&
-        notification.backgroundTask.status === 'pending'
+        notification.backgroundTask.status === 'pending' &&
+        // The host is always mounted (even before login / during logout).
+        // listenToBackgroundTask needs an initialized client to build the SSE
+        // request, so skip attaching until one exists; the effect re-runs on
+        // the next notification change and attaches then.
+        typeof globalThis.backendaiclient !== 'undefined' &&
+        globalThis.backendaiclient !== null
       ) {
         listeningTaskIdsRef.current.push(notification.backgroundTask?.taskId);
         const SSEEventHandler: SSEEventHandlerTypes<BackgroundTaskEvent> = {

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -949,11 +949,10 @@ export const useBackendAIAppLauncher = (
     launchAppWithNotification,
     /**
      * Lower-level launch API that returns the resolved work info via promise
-     * without going through the notification lifecycle. Use this from contexts
-     * where the BAI notification drawer is not mounted (e.g. anonymous pages
-     * outside `MainLayout`), since `launchAppWithNotification`'s `onPrepared`
-     * callback only fires when `useBAINotificationEffect` is subscribed to the
-     * background task promise.
+     * without going through the notification lifecycle. Use this where a
+     * progress toast would be redundant — e.g. the EduAppLauncher page, whose
+     * card UI already shows per-step progress, so driving a toast through the
+     * app-wide `NotificationHost` would only duplicate that display.
      *
      * Throws `AppLaunchError` for known failure stages (e.g. service port
      * missing → stage `'configuring'`).

--- a/react/src/pages/ChangePasswordPage.tsx
+++ b/react/src/pages/ChangePasswordPage.tsx
@@ -2,10 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import {
-  CSSTokenVariables,
-  NotificationForAnonymous,
-} from '../components/MainLayout/MainLayout';
+import { CSSTokenVariables } from '../components/MainLayout/MainLayout';
 import { useApiEndpoint } from '../hooks/useApiEndpoint';
 import React, { Suspense } from 'react';
 
@@ -22,7 +19,6 @@ const ChangePasswordPage: React.FC = () => {
   return (
     <>
       <CSSTokenVariables />
-      <NotificationForAnonymous />
       <Suspense fallback={null}>
         <ChangePasswordPageContent />
       </Suspense>

--- a/react/src/pages/EmailVerificationPage.tsx
+++ b/react/src/pages/EmailVerificationPage.tsx
@@ -2,10 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import {
-  CSSTokenVariables,
-  NotificationForAnonymous,
-} from '../components/MainLayout/MainLayout';
+import { CSSTokenVariables } from '../components/MainLayout/MainLayout';
 import { useApiEndpoint } from '../hooks/useApiEndpoint';
 import React, { Suspense } from 'react';
 
@@ -22,7 +19,6 @@ const EmailVerificationPage: React.FC = () => {
   return (
     <>
       <CSSTokenVariables />
-      <NotificationForAnonymous />
       <Suspense fallback={null}>
         <EmailVerificationPageContent />
       </Suspense>

--- a/react/src/pages/InteractiveLoginPage.tsx
+++ b/react/src/pages/InteractiveLoginPage.tsx
@@ -2,10 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import {
-  CSSTokenVariables,
-  NotificationForAnonymous,
-} from '../components/MainLayout/MainLayout';
+import { CSSTokenVariables } from '../components/MainLayout/MainLayout';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { Button, Card, Descriptions } from 'antd';
@@ -19,7 +16,6 @@ const InteractiveLoginPage = () => {
   return (
     <>
       <CSSTokenVariables />
-      <NotificationForAnonymous />
       <Suspense>
         <Children />
       </Suspense>


### PR DESCRIPTION
Resolves #7795 (FR-3076)

## Symptom

On logout, the **"Clean up now…"** toast notification appears **twice**.

## Root cause

The `add-bai-notification` DOM event dispatched during logout (`useLogout.ts` → `performLogoutCleanup`) was handled by **two independent toast openers**, both mounted in the authenticated state:

1. **Primary renderer** — `BAINotificationButton` → `useBAINotificationEffect`, inside `WebUIHeader`, which is suspended (`useSuspendedBackendaiClient()`) until login.
2. **`NotificationForAnonymous`** — a Lit-shell-era fallback opener (introduced with the first React root, #2121) for pre-login screens, which **stayed mounted after login** too.

Keyed notifications happened to dedupe via antd's same-key in-place update, so only keyless ones — the logout cleanup message, and the error dispatches in `ContainerRegistryList` / `ImageInstallModal` — visibly duplicated.

## Fix — one always-mounted renderer instead of coordinating two

- **New `NotificationHost`**, mounted once inside antd `<App>` in `DefaultProvidersForReactRoot`. It is now the **only** listener for the `add-bai-notification` / `clear-bai-notification` event pair and the only `app.notification.open()` driver, alive on every route (login, interactive-login, email-verification, change-password, edu-applauncher, main layout) in both anonymous and authenticated states.
- **Deleted `NotificationForAnonymous`** (MainLayout + the three standalone anonymous pages that mounted it). No pre-login dispatcher exists anymore; the root host covers any future one.
- **`BAINotificationButton` becomes pure UI** (badge + drawer toggle); its event listeners and `useBAINotificationEffect` call moved to the host.
- **SSE guard**: background-task listener attachment now waits for an initialized `backendaiclient`, since the host is mounted before login.
- Side benefit: lifts the documented limitation that pages outside `MainLayout` (e.g. EduAppLauncher, see its comment) had **no notification surface at all**.

## Plugin-surface compatibility (explicitly preserved)

`globalThis.tasker` (`BackendAITasker`) and the `add-bai-notification` / `clear-bai-notification` event pair are part of the **runtime plugin surface**: compiled Lit-template plugins assign `this.tasker = globalThis.tasker` in their shared `BackendAIPage` base class (see the `e2e/plugin/*.js` fixtures) and were built against a shell that consumed both events. They are **kept intact** — `tasker.add()` keeps dispatching `add-bai-notification`, which now lands in `NotificationHost`. A NOTE comment in `global-stores.ts` documents this so a future "dead code" cleanup doesn't break plugins.

The dispatch API is unchanged, so all existing dispatch sites and any external/plugin dispatchers keep working.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript)
- Full react unit suite: **41 files, 878 tests pass**
- Live dev-server check against a test cluster:
  - logout → **exactly one** "Clean up now…" toast (max simultaneous toasts sampled every 30ms during the logout window)
  - synthetic keyless `add-bai-notification` dispatch → exactly one toast
  - anonymous login screen renders and login/logout round-trip works

🤖 Generated with [Claude Code](https://claude.com/claude-code)