### PR TITLE
refactor(FR-3077): replace direct <style> elements with nonce-safe styling

### DIFF
--- a/react/eslint.config.js
+++ b/react/eslint.config.js
@@ -1,8 +1,8 @@
-import { base, react } from "eslint-config-bai";
-import relayPlugin from "eslint-plugin-relay";
-import jsonSchemaValidator from "eslint-plugin-json-schema-validator";
-import jsoncParser from "jsonc-eslint-parser";
-import globals from "globals";
+import { base, react } from 'eslint-config-bai';
+import jsonSchemaValidator from 'eslint-plugin-json-schema-validator';
+import relayPlugin from 'eslint-plugin-relay';
+import globals from 'globals';
+import jsoncParser from 'jsonc-eslint-parser';
 
 export default [
   ...base,
@@ -10,8 +10,8 @@ export default [
 
   {
     languageOptions: {
-      ecmaVersion: "latest",
-      sourceType: "module",
+      ecmaVersion: 'latest',
+      sourceType: 'module',
       globals: {
         ...globals.browser,
         ...globals.es2016,
@@ -24,50 +24,63 @@ export default [
       relay: relayPlugin,
     },
     rules: {
-      "relay/graphql-syntax": "off",
-      "relay/unused-fields": "off",
-      "relay/must-colocate-fragment-spreads": "off",
+      'relay/graphql-syntax': 'off',
+      'relay/unused-fields': 'off',
+      'relay/must-colocate-fragment-spreads': 'off',
     },
   },
 
   {
-    files: ["**/*.ts", "**/*.tsx"],
+    files: ['**/*.ts', '**/*.tsx'],
     rules: {
-      "no-restricted-imports": [
-        "error",
+      'no-restricted-imports': [
+        'error',
         {
           patterns: [
-            "backend.ai-ui/*",
-            "!backend.ai-ui/dist",
-            "@lobehub/fluent-emoji",
+            'backend.ai-ui/*',
+            '!backend.ai-ui/dist',
+            '@lobehub/fluent-emoji',
           ],
           paths: [
             {
-              name: "antd-style",
-              importNames: ["useThemeMode"],
+              name: 'antd-style',
+              importNames: ['useThemeMode'],
               message: "Use 'src/hooks/useThemeMode' instead.",
             },
             {
-              name: "react-router-dom",
-              importNames: ["useNavigate", "Navigate"],
+              name: 'react-router-dom',
+              importNames: ['useNavigate', 'Navigate'],
               message:
                 "Use 'useWebUINavigate' from 'src/hooks' or '<WebUINavigate>' from 'src/components/WebUINavigate' instead.",
             },
           ],
         },
       ],
+      // CSP: a raw <style> element carries no nonce and is dropped by a strict
+      // `style-src 'nonce-...'` policy. Use createGlobalStyle / createStyles
+      // from 'antd-style' (nonce'd via the <StyleProvider> in DefaultProviders)
+      // for dynamic/global CSS, or import an external .css file (covered by
+      // `style-src 'self'`) for static CSS.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "JSXOpeningElement[name.name='style']",
+          message:
+            "Direct <style> elements are forbidden (CSP nonce safety). Use createGlobalStyle/createStyles from 'antd-style', or import an external .css file.",
+        },
+      ],
     },
   },
 
   {
-    files: ["**/*.test.*"],
+    files: ['**/*.test.*'],
     rules: {
-      "no-console": "off",
+      'no-console': 'off',
     },
   },
 
   {
-    files: ["**/*.test.*", "**/__tests__/**"],
+    files: ['**/*.test.*', '**/__tests__/**'],
     languageOptions: {
       globals: {
         ...globals.jest,
@@ -76,12 +89,12 @@ export default [
   },
 
   {
-    files: ["**/*.json"],
+    files: ['**/*.json'],
     languageOptions: {
       parser: jsoncParser,
     },
     plugins: {
-      "json-schema-validator": jsonSchemaValidator,
+      'json-schema-validator': jsonSchemaValidator,
     },
     rules: {
       ...jsonSchemaValidator.configs.recommended.rules,
@@ -89,6 +102,6 @@ export default [
   },
 
   {
-    ignores: ["**/__generated__/**", "build/**", "**/*.tsx_", "**/*.ts_"],
+    ignores: ['**/__generated__/**', 'build/**', '**/*.tsx_', '**/*.ts_'],
   },
 ];

--- a/react/src/ambient.d.ts
+++ b/react/src/ambient.d.ts
@@ -46,6 +46,11 @@ declare module globalThis {
   var packageValidUntil: string;
   // eslint-disable-next-line no-var
   var buildNumber: string;
+  // Per-request CSP nonce, substituted into index.html by the web server
+  // (`{{nonce}}`); empty string in local dev. Threaded into antd's
+  // ConfigProvider `csp` and antd-style's `<StyleProvider nonce>`.
+  // eslint-disable-next-line no-var
+  var baiNonce: string;
   // eslint-disable-next-line no-var
   var appLauncher: {
     showLauncher?: (sessionId: {

--- a/react/src/components/BAIContentWithDrawerArea.tsx
+++ b/react/src/components/BAIContentWithDrawerArea.tsx
@@ -3,7 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { isOpenDrawerState } from './BAINotificationButton';
-import { Grid, Layout, theme } from 'antd';
+import { Grid, Layout } from 'antd';
+import { createGlobalStyle } from 'antd-style';
 import { BasicProps } from 'antd/lib/layout/layout';
 import { useAtomValue } from 'jotai';
 import React from 'react';
@@ -11,35 +12,52 @@ import React from 'react';
 interface Props extends BasicProps {
   drawerWidth?: number;
 }
+
+type DrawerStyle = 'margin-style' | 'overlay-style';
+
+// Global rules that depend on the drawer's open/width state. createGlobalStyle
+// injects a nonce'd emotion <style> (via the <StyleProvider nonce> in
+// DefaultProviders), so it survives a strict CSP style-src policy — unlike a
+// raw <style> element. The non-theme values (drawerWidth, drawerStyle) are
+// forwarded as props; `theme` is antd-style's theme.
+const DrawerAreaGlobalStyle = createGlobalStyle((props) => {
+  const { drawerWidth, drawerStyle, theme } = props as unknown as {
+    drawerWidth: number;
+    drawerStyle: DrawerStyle;
+    theme: { colorBorder: string };
+  };
+  return `
+    .main-layout-main-content {
+      transition: margin-right 0.3s ease;
+    }
+    .main-layout-main-content.margin-style {
+      margin-right: ${drawerWidth}px;
+    }
+    .ant-drawer-content-wrapper {
+      ${
+        drawerStyle === 'margin-style'
+          ? `box-shadow: none !important;
+          border-left: 1px solid ${theme.colorBorder};`
+          : ''
+      }
+    }
+  `;
+}) as unknown as React.FC<{ drawerWidth: number; drawerStyle: DrawerStyle }>;
+
 const BAIContentWithDrawerArea: React.FC<Props> = ({
   drawerWidth = 256,
   ...contextProps
 }) => {
   const isOpenDrawer = useAtomValue(isOpenDrawerState);
   const { xl } = Grid.useBreakpoint();
-  const { token } = theme.useToken();
-  const drawerStyle = xl && isOpenDrawer ? 'margin-style' : 'overlay-style';
-  const extraStyle = `
-    .main-layout-main-content{
-      transition: margin-right 0.3s ease;
-    }
-    .main-layout-main-content.margin-style{
-      margin-right: ${drawerWidth}px;
-    }
-    .ant-drawer-content-wrapper {
-      ${
-        drawerStyle === 'margin-style'
-          ? `
-          box-shadow: none !important;
-          border-left: 1px solid ${token.colorBorder};
-        `
-          : ''
-      }
-    }
-  `;
+  const drawerStyle: DrawerStyle =
+    xl && isOpenDrawer ? 'margin-style' : 'overlay-style';
   return (
     <>
-      <style>{extraStyle}</style>
+      <DrawerAreaGlobalStyle
+        drawerWidth={drawerWidth}
+        drawerStyle={drawerStyle}
+      />
       <Layout.Content
         {...contextProps}
         className={

--- a/react/src/components/BAISider.css
+++ b/react/src/components/BAISider.css
@@ -1,0 +1,29 @@
+/*
+ * Static global styles for <BAISider>. Extracted from an inline <style>
+ * element (forbidden under strict CSP); a same-origin stylesheet is covered
+ * by `style-src 'self'` and needs no nonce.
+ */
+.bai-sider .ant-layout-sider-children {
+  display: flex;
+  flex-direction: column;
+}
+
+.bai-sider::-webkit-scrollbar {
+  width: 0px;
+}
+
+.bai-sider::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.bai-sider::-webkit-scrollbar-thumb {
+  background: transparent;
+}
+
+.bai-sider .draggable {
+  -webkit-app-region: drag;
+}
+
+.bai-sider .non-draggable {
+  -webkit-app-region: no-drag;
+}

--- a/react/src/components/BAISider.tsx
+++ b/react/src/components/BAISider.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import './BAISider.css';
 import { ConfigProvider, Grid, type SiderProps, theme } from 'antd';
 import Sider from 'antd/es/layout/Sider';
 import { BAIFlex } from 'backend.ai-ui';
@@ -26,32 +27,6 @@ const BAISider = forwardRef<HTMLDivElement, BAISiderProps>(
 
     return (
       <>
-        <style>
-          {`
-          .bai-sider .ant-layout-sider-children {
-            display: flex;
-            flex-direction: column;
-          }
-
-          .bai-sider::-webkit-scrollbar {
-            width: 0px;
-          }
-          
-          .bai-sider::-webkit-scrollbar-track {
-            background: transparent; 
-          }
-          
-          .bai-sider::-webkit-scrollbar-thumb {
-            background: transparent;
-          }
-          .bai-sider .draggable {
-            -webkit-app-region: drag;
-          }
-          .bai-sider .non-draggable {
-            -webkit-app-region: no-drag;
-          }
-        `}
-        </style>
         <Sider
           ref={ref}
           width={SIDER_WIDTH}

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -13,11 +13,11 @@ import {
 import { useDeviceMetaData } from '../hooks/backendai';
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { useThemeMode } from '../hooks/useThemeMode';
-// @ts-ignore
-import indexCss from '../index.css?raw';
+import '../index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useUpdateEffect } from 'ahooks';
 import { App, type AppProps, theme } from 'antd';
+import { StyleProvider } from 'antd-style';
 import { BAIConfigProvider, BAIText, BAIMetaDataProvider } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import 'dayjs/locale/de';
@@ -270,7 +270,6 @@ export const DefaultProvidersForReactRoot: React.FC<{
 
   return (
     <>
-      <style>{indexCss}</style>
       {RelayEnvironment && (
         <RelayEnvironmentProvider environment={RelayEnvironment}>
           <QueryClientProvider client={queryClient}>
@@ -284,7 +283,6 @@ export const DefaultProvidersForReactRoot: React.FC<{
                   ? theme.darkAlgorithm
                   : theme.defaultAlgorithm,
               }}
-              // @ts-ignore
               csp={{ nonce: globalThis.baiNonce }}
               clientPromise={backendaiClientPromise}
               anonymousClientFactory={createAnonymousBackendaiClient}
@@ -337,14 +335,23 @@ export const DefaultProvidersForReactRoot: React.FC<{
               <BAIMetaDataWrapper>
                 <QueryParamProvider adapter={ReactRouter6Adapter}>
                   <App {...commonAppProps}>
-                    {/* <StyleProvider container={shadowRoot} cache={cache}> */}
-                    <Suspense>
-                      {/* <BrowserRouter> */}
-                      {/* <RoutingEventHandler /> */}
-                      {children}
-                      {/* </BrowserRouter> */}
-                    </Suspense>
-                    {/* </StyleProvider> */}
+                    {/*
+                     * antd-style (createStyles / createGlobalStyle) injects its
+                     * emotion <style> nodes into this StyleProvider's cache.
+                     * The nonce is required so those runtime styles survive a
+                     * strict CSP `style-src 'nonce-...'` policy — without it the
+                     * emotion sheets carry no nonce and the browser drops them.
+                     * antd's own cssinjs styles get the nonce separately via the
+                     * BAIConfigProvider `csp` prop above.
+                     */}
+                    <StyleProvider nonce={globalThis.baiNonce}>
+                      <Suspense>
+                        {/* <BrowserRouter> */}
+                        {/* <RoutingEventHandler /> */}
+                        {children}
+                        {/* </BrowserRouter> */}
+                      </Suspense>
+                    </StyleProvider>
                   </App>
                 </QueryParamProvider>
               </BAIMetaDataWrapper>

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -28,7 +28,7 @@ import WebUIBreadcrumb from '../WebUIBreadcrumb';
 import WebUIHeader from './WebUIHeader';
 import WebUISider from './WebUISider';
 import { App, ConfigProvider, Layout, type LayoutProps, theme } from 'antd';
-import { createStyles } from 'antd-style';
+import { createGlobalStyle, createStyles } from 'antd-style';
 import { BAIFlex } from 'backend.ai-ui';
 import { atom, useSetAtom } from 'jotai';
 import * as _ from 'lodash-es';
@@ -52,6 +52,33 @@ export const mainContentDivRefState = atom<React.RefObject<HTMLElement | null>>(
     current: null,
   },
 );
+
+// Global scrollbar styling. antd-style's createGlobalStyle injects a nonce'd
+// emotion <style> (via the <StyleProvider nonce> in DefaultProviders), so it
+// survives a strict CSP style-src policy — unlike a raw <style> element.
+const ScrollbarGlobalStyle = createGlobalStyle`
+  /* Scrollbar stylings */
+  /* Works on Firefox */
+  * {
+    scrollbar-width: 2px;
+    scrollbar-color: ${({ theme }) => theme.colorBorderSecondary}
+      ${({ theme }) => theme.colorBgElevated};
+  }
+
+  /* Works on Chrome, Edge, and Safari */
+  *::-webkit-scrollbar {
+    max-width: 2px;
+    background-color: ${({ theme }) => theme.colorBgElevated};
+  }
+
+  *::-webkit-scrollbar-track {
+    background: ${({ theme }) => theme.colorBgElevated};
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.colorBorderSecondary};
+  }
+`;
 
 const useStyle = createStyles(({ css, token }) => ({
   alertWrapper: css`
@@ -130,31 +157,7 @@ function MainLayout() {
   return (
     <LayoutWithPageTestId>
       <CSSTokenVariables />
-      <style>
-        {`
-          /* Scrollbar stylings */
-          /* Works on Firefox */
-          * {
-            scrollbar-width: 2px;
-            scrollbar-color: var(--token-colorBorderSecondary, ${token.colorBorderSecondary},  #464646)
-              var(--token-colorBgElevated, transparent);
-          }
-
-          /* Works on Chrome, Edge, and Safari */
-          *::-webkit-scrollbar {
-            max-width: 2px;
-            background-color: var(--token-colorBgElevated, ${token.colorBgElevated}, transparent);
-          }
-
-          *::-webkit-scrollbar-track {
-            background: var(--token-colorBgElevated, ${token.colorBgElevated}, transparent);
-          }
-
-          *::-webkit-scrollbar-thumb {
-            background-color: var(--token-colorBorderSecondary, ${token.colorBorderSecondary}, #464646);
-          }
-        `}
-      </style>
+      <ScrollbarGlobalStyle />
       <NotificationForAnonymous />
       <Suspense fallback={null}>
         <DismissSplashOnMount />
@@ -387,33 +390,47 @@ export const NotificationForAnonymous = () => {
   return null;
 };
 
-export const CSSTokenVariables = () => {
-  const { token } = theme.useToken();
-  const { isDarkMode } = useThemeMode(); // This is to make sure the theme mode is updated
+type ThemeToken = ReturnType<typeof theme.useToken>['token'];
 
-  const themeConfig = useCustomThemeConfig();
-  return (
-    <style>
-      {`
-:root {
+// `:root { --token-*: ... }` bridge so plain CSS / inline styles can read antd
+// tokens via `var(--token-...)`. Built from antd's `theme.useToken()` (the clean
+// token set) passed in as a prop, rather than antd-style's theme — whose extra
+// non-token keys (appearance, isDarkMode, setters, ...) would otherwise leak
+// into the output. createGlobalStyle injects it as a nonce'd <style>.
+const TokenCssVariables = createGlobalStyle((props) => {
+  const { token, logoUrl } = props as unknown as {
+    token: ThemeToken;
+    logoUrl: string;
+  };
+  return `:root {
 ${Object.entries(token)
   .map(([key, value]) => {
     // Skip Component specific tokens
     if (key.charAt(0) === key.charAt(0).toUpperCase()) {
       return '';
-    } else {
-      return typeof value === 'number'
-        ? `--token-${key}: ${value}px;`
-        : `--token-${key}: ${value?.toString() ?? ''};`;
     }
+    return typeof value === 'number'
+      ? `--token-${key}: ${value}px;`
+      : `--token-${key}: ${value?.toString() ?? ''};`;
   })
   .join('\n')}
 
-  --theme-logo-url: url("${
-    isDarkMode ? themeConfig?.logo.srcDark : themeConfig?.logo.src
-  }");
-      `}
-    </style>
+  --theme-logo-url: url("${logoUrl}");
+}`;
+}) as unknown as React.FC<{ token: ThemeToken; logoUrl: string }>;
+
+export const CSSTokenVariables = () => {
+  const { token } = theme.useToken();
+  const { isDarkMode } = useThemeMode(); // This is to make sure the theme mode is updated
+  const themeConfig = useCustomThemeConfig();
+
+  return (
+    <TokenCssVariables
+      token={token}
+      logoUrl={
+        (isDarkMode ? themeConfig?.logo.srcDark : themeConfig?.logo.src) ?? ''
+      }
+    />
   );
 };
 

--- a/react/src/components/WEBUINotificationDrawer.css
+++ b/react/src/components/WEBUINotificationDrawer.css
@@ -1,0 +1,9 @@
+/*
+ * Static global styles for <WEBUINotificationDrawer>. Extracted from an inline
+ * <style> element (forbidden under strict CSP); a same-origin stylesheet is
+ * covered by `style-src 'self'` and needs no nonce.
+ */
+.ant-drawer-header-title .ant-drawer-close,
+.ant-drawer-header .ant-drawer-extra {
+  -webkit-app-region: no-drag;
+}

--- a/react/src/components/WEBUINotificationDrawer.tsx
+++ b/react/src/components/WEBUINotificationDrawer.tsx
@@ -7,6 +7,7 @@ import { useBAINotificationState } from '../hooks/useBAINotification';
 import BAIGeneralNotificationItem from './BAIGeneralNotificationItem';
 import BAIMultiStepNotificationItem from './BAIMultiStepNotificationItem';
 import BAINodeNotificationItem from './BAINodeNotificationItem';
+import './WEBUINotificationDrawer.css';
 import { MoreOutlined } from '@ant-design/icons';
 import {
   Drawer,
@@ -92,14 +93,6 @@ const WEBUINotificationDrawer: React.FC<Props> = ({ ...drawerProps }) => {
       }
       {...drawerProps}
     >
-      <style>
-        {`
-          .ant-drawer-header-title .ant-drawer-close,
-          .ant-drawer-header .ant-drawer-extra{
-            -webkit-app-region: no-drag;
-          }
-        `}
-      </style>
       <List
         itemLayout="vertical"
         dataSource={

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -40,8 +40,7 @@ import { useCurrentUserRole } from '../hooks/backendai';
 import { useCurrentResourceGroupState } from '../hooks/useCurrentProject';
 import { useRecentSessionHistory } from '../hooks/useRecentSessionHistory';
 import { useStartSession } from '../hooks/useStartSession';
-// @ts-ignore
-import customCSS from './SessionLauncherPage.css?raw';
+import './SessionLauncherPage.css';
 import {
   DoubleRightOutlined,
   EllipsisOutlined,
@@ -507,7 +506,6 @@ const SessionLauncherPage = () => {
       }}
       gap={'md'}
     >
-      <style>{customCSS}</style>
       <BAIFlex direction="row" gap="md" align="start">
         <BAIFlex
           direction="column"


### PR DESCRIPTION
Resolves #7797 (FR-3077)

Direct `<style>` JSX elements carry no nonce and are dropped by the browser under a strict CSP `style-src 'nonce-...'` policy (no `'unsafe-inline'`). This makes the WebUI compatible with a hardened server that substitutes `{{nonce}}` into `index.html`.

## Changes
- **Static CSS → external `.css` imports** (covered by `style-src 'self'`): `DefaultProviders` (`index.css`), `SessionLauncherPage`, `BAISider` (new `BAISider.css`), `WEBUINotificationDrawer` (new `WEBUINotificationDrawer.css`).
- **Dynamic/token CSS → antd-style `createGlobalStyle`** (nonce'd): `MainLayout` scrollbar + the `:root` `--token-*` bridge (`CSSTokenVariables`), `BAIContentWithDrawerArea`.
- **Activate** antd-style `<StyleProvider nonce={globalThis.baiNonce}>` so emotion styles (`createStyles` / `createGlobalStyle`) carry the per-request nonce. antd's own cssinjs styles are already nonce'd via the `BAIConfigProvider` `csp` prop.
- **Lint guard**: new `no-restricted-syntax` ESLint rule forbidding raw `<style>` JSX.

## Verification
`scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript). No raw `<style>` JSX remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
