### PR TITLE
refactor(FR-3078): use antd tokens directly, shrink the :root --token-* bridge

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.tsx
@@ -562,7 +562,7 @@ const BAIModal: React.FC<BAIModalProps> = ({
         },
         header: {
           marginBottom: 0,
-          borderBottom: `1px solid var(--token-colorBorder, ${token.colorBorder})`,
+          borderBottom: `1px solid ${token.colorBorder}`,
           borderWidth: '100%',
           justifyContent: 'space-between',
           display: 'flex',

--- a/react/src/components/BAIBoard.tsx
+++ b/react/src/components/BAIBoard.tsx
@@ -11,13 +11,13 @@ const useStyles = createStyles(({ css, token }) => {
   return {
     board: css`
       .bai_board_placeholder {
-        border-radius: var(--token-borderRadius) !important;
+        border-radius: ${token.borderRadius}px !important;
       }
       .bai_board_placeholder--active {
-        background-color: var(--token-colorSplit) !important ;
+        background-color: ${token.colorSplit} !important ;
       }
       .bai_board_placeholder--hover {
-        background-color: var(--token-colorPrimaryHover) !important ;
+        background-color: ${token.colorPrimaryHover} !important ;
         // FIXME: global token doesn't exist, so opacity fits color
         opacity: 0.3;
       }
@@ -69,8 +69,8 @@ const useStyles = createStyles(({ css, token }) => {
     `,
     boardItems: css`
       & > div:first-child {
-        border-radius: var(--token-borderRadius) !important;
-        background-color: var(--token-colorBgContainer) !important;
+        border-radius: ${token.borderRadius}px !important;
+        background-color: ${token.colorBgContainer} !important;
         border: 1px solid ${token.colorBorderSecondary} !important;
       }
 
@@ -83,8 +83,8 @@ const useStyles = createStyles(({ css, token }) => {
       }
 
       & > div:first-child > div:first-child > div:first-child {
-        margin-bottom: var(--token-margin);
-        background-color: var(--token-colorBgContainer) !important;
+        margin-bottom: ${token.margin}px;
+        background-color: ${token.colorBgContainer} !important;
         position: absolute;
         z-index: 1;
       }

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -42,7 +42,7 @@ const MODEL_STORE_PROJECT_NAME = 'model-store';
 const FOLDER_NAME_MAX_LENGTH = 64;
 const MODAL_WIDTH = 650;
 
-const useStyles = createStyles(({ css }) => ({
+const useStyles = createStyles(({ css, token }) => ({
   modal: css`
     .ant-modal-body {
       padding-top: 24px !important;
@@ -53,10 +53,10 @@ const useStyles = createStyles(({ css }) => ({
     .ant-form-item-label {
       display: flex;
       align-items: start;
-      padding-left: var(--token-paddingSM);
+      padding-left: ${token.paddingSM}px;
     }
     .ant-form-item-control {
-      padding-right: var(--token-paddingSM);
+      padding-right: ${token.paddingSM}px;
     }
     .ant-form-item-label > label::after {
       display: none !important;

--- a/react/src/components/FolderCreateModalV2.tsx
+++ b/react/src/components/FolderCreateModalV2.tsx
@@ -51,7 +51,7 @@ const MODEL_STORE_PROJECT_NAME = 'model-store';
 const FOLDER_NAME_MAX_LENGTH = 64;
 const MODAL_WIDTH = 650;
 
-const useStyles = createStyles(({ css }) => ({
+const useStyles = createStyles(({ css, token }) => ({
   modal: css`
     .ant-modal-body {
       padding: 0 !important;
@@ -61,10 +61,10 @@ const useStyles = createStyles(({ css }) => ({
     .ant-form-item-label {
       display: flex;
       align-items: start;
-      padding-left: var(--token-paddingSM);
+      padding-left: ${token.paddingSM}px;
     }
     .ant-form-item-control {
-      padding-right: var(--token-paddingSM);
+      padding-right: ${token.paddingSM}px;
     }
     .ant-form-item-label > label::after {
       display: none !important;

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -4,11 +4,9 @@
  */
 import { useWebUINavigate } from '../../hooks';
 import { useBAISettingUserState } from '../../hooks/useBAISetting';
-import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import { useLogoutEventListeners } from '../../hooks/useLogout';
 import usePrimaryColors from '../../hooks/usePrimaryColors';
-import { useThemeMode } from '../../hooks/useThemeMode';
 import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
 import { useSetupWebUIPluginEffect } from '../../hooks/useWebUIPluginState';
 import Page401 from '../../pages/Page401';
@@ -392,46 +390,26 @@ export const NotificationForAnonymous = () => {
 
 type ThemeToken = ReturnType<typeof theme.useToken>['token'];
 
-// `:root { --token-*: ... }` bridge so plain CSS / inline styles can read antd
-// tokens via `var(--token-...)`. Built from antd's `theme.useToken()` (the clean
-// token set) passed in as a prop, rather than antd-style's theme — whose extra
-// non-token keys (appearance, isDarkMode, setters, ...) would otherwise leak
-// into the output. createGlobalStyle injects it as a nonce'd <style>.
+// Minimal `:root` bridge exposing only the antd tokens that OUT-OF-TREE global
+// CSS still needs: `resources/webui.css` styles `body` (outside the React /
+// antd cssVar scope), so it reads these via `var(--token-...)`. In-tree styles
+// reference the antd token directly (createStyles / createGlobalStyle) and no
+// longer depend on this bridge. createGlobalStyle injects it as a nonce'd
+// <style>; `token` changes on theme switch, so the values stay in sync.
 const TokenCssVariables = createGlobalStyle((props) => {
-  const { token, logoUrl } = props as unknown as {
-    token: ThemeToken;
-    logoUrl: string;
-  };
+  const { token } = props as unknown as { token: ThemeToken };
   return `:root {
-${Object.entries(token)
-  .map(([key, value]) => {
-    // Skip Component specific tokens
-    if (key.charAt(0) === key.charAt(0).toUpperCase()) {
-      return '';
-    }
-    return typeof value === 'number'
-      ? `--token-${key}: ${value}px;`
-      : `--token-${key}: ${value?.toString() ?? ''};`;
-  })
-  .join('\n')}
-
-  --theme-logo-url: url("${logoUrl}");
+  --token-colorPrimary: ${token.colorPrimary};
+  --token-colorBgBase: ${token.colorBgBase};
+  --token-colorBgContainer: ${token.colorBgContainer};
+  --token-colorBorder: ${token.colorBorder};
 }`;
-}) as unknown as React.FC<{ token: ThemeToken; logoUrl: string }>;
+}) as unknown as React.FC<{ token: ThemeToken }>;
 
 export const CSSTokenVariables = () => {
   const { token } = theme.useToken();
-  const { isDarkMode } = useThemeMode(); // This is to make sure the theme mode is updated
-  const themeConfig = useCustomThemeConfig();
 
-  return (
-    <TokenCssVariables
-      token={token}
-      logoUrl={
-        (isDarkMode ? themeConfig?.logo.srcDark : themeConfig?.logo.src) ?? ''
-      }
-    />
-  );
+  return <TokenCssVariables token={token} />;
 };
 
 /**

--- a/react/src/components/SettingList.tsx
+++ b/react/src/components/SettingList.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from 'react-i18next';
 const useStyles = createStyles(({ css }) => ({
   TabStyles: css`
     .ant-tabs-tab-active {
-      font-weight: var(--token-fontWeightSuperStrong, 700);
+      font-weight: 700;
     }
     .ant-typography-secondary {
       font-weight: normal !important;


### PR DESCRIPTION
Resolves #7798 (FR-3078)

Follow-up to #7799. Migrates in-tree `var(--token-*)` consumers to the antd token directly and shrinks the `:root` CSS-variable bridge.

## Why the bridge can't just be deleted
antd v6 native cssVar (`--ant-*`) is **class-scoped, not `:root`** — in `@ant-design/cssinjs/util/css-variables.js` the selector ends in `.{cssVarKey}`, applied only inside the React tree. So out-of-tree CSS (`resources/webui.css` styles `body`) cannot read `--ant-*`. The `:root` `--token-*` bridge therefore stays — but only for the tokens that out-of-tree CSS actually needs.

## Changes
- Migrate in-tree consumers (`BAIBoard`, `FolderCreateModal`/`V2`, `SettingList`, `BAIModal`) from `var(--token-X)` → antd `token`/`theme` directly (`createStyles`/`createGlobalStyle` already expose them). _(The `MainLayout` scrollbar's invalid multi-fallback `var()` was fixed directly in the parent #7799, so it carries no `var(--token-*)` by the time this PR applies.)_
- `SettingList`'s `var(--token-fontWeightSuperStrong, 700)` referenced a non-antd token that was never set, so it always rendered `700` → inlined.
- Shrink `CSSTokenVariables` from the full-token loop to the only 4 tokens `resources/webui.css` reads (`colorPrimary`, `colorBgBase`, `colorBgContainer`, `colorBorder`); drop the dead `--theme-logo-url` (no consumer anywhere).

No in-tree `var(--token-*)` remains; behavior preserved.

## Verification
`scripts/verify.sh` → `=== ALL PASS ===`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
