### PR TITLE
fix(FR-3086): add CacheProvider so createGlobalStyle inherits CSP nonce

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,6 +751,12 @@ importers:
       '@dicebear/shapes':
         specifier: ^9.4.2
         version: 9.4.2(@dicebear/core@9.4.2)
+      '@emotion/cache':
+        specifier: ^11.11.0
+        version: 11.14.0
+      '@emotion/react':
+        specifier: ^11.11.4
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@lobehub/fluent-emoji':
         specifier: ^2.0.0
         version: 2.0.0(patch_hash=e3910174b171372f01ee0d0f41033c3aed501f7eba649e863c48e7a370886a88)(@babel/core@7.29.0)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(antd@6.3.7(date-fns@2.30.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(framer-motion@12.23.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -24009,6 +24015,8 @@ snapshots:
 
 time:
   '@cloudscape-design/board-components@3.0.176': '2026-05-04T10:46:18.491Z'
+  '@emotion/cache@11.14.0': '2024-12-09T08:43:28.087Z'
+  '@emotion/react@11.14.0': '2024-12-09T08:43:27.996Z'
   '@eslint/js@9.39.4': '2026-03-06T21:21:15.041Z'
   '@lobehub/fluent-emoji@2.0.0': '2025-04-28T05:40:46.019Z'
   ansi_up@6.0.6: '2025-05-16T20:58:13.495Z'

--- a/react/package.json
+++ b/react/package.json
@@ -10,6 +10,8 @@
     "@ant-design/cssinjs": "^2.1.2",
     "@ant-design/icons": "catalog:",
     "@ant-design/x": "^2.5.0",
+    "@emotion/cache": "^11.11.0",
+    "@emotion/react": "^11.11.4",
     "@cloudscape-design/board-components": "3.0.176",
     "@cloudscape-design/components": "^3.0.1280",
     "@dicebear/collection": "^9.4.2",

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -14,6 +14,8 @@ import { useDeviceMetaData } from '../hooks/backendai';
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { useThemeMode } from '../hooks/useThemeMode';
 import '../index.css';
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useUpdateEffect } from 'ahooks';
 import { App, type AppProps, theme } from 'antd';
@@ -72,6 +74,16 @@ dayjs.extend(relativeTime);
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(duration);
+
+// @emotion/react's Global (used by createGlobalStyle) reads the nonce from
+// @emotion/react's own CacheContext, not from antd-style's StyleProvider.
+// Creating this cache at module load time is safe because globalThis.baiNonce
+// is set by the inline <script nonce="{{nonce}}"> in index.html, which
+// executes before any ES module bundle.
+const emotionGlobalCache = createCache({
+  key: 'css',
+  nonce: globalThis.baiNonce,
+});
 
 // Create a client
 const queryClient = new QueryClient({
@@ -336,22 +348,31 @@ export const DefaultProvidersForReactRoot: React.FC<{
                 <QueryParamProvider adapter={ReactRouter6Adapter}>
                   <App {...commonAppProps}>
                     {/*
-                     * antd-style (createStyles / createGlobalStyle) injects its
-                     * emotion <style> nodes into this StyleProvider's cache.
-                     * The nonce is required so those runtime styles survive a
-                     * strict CSP `style-src 'nonce-...'` policy — without it the
-                     * emotion sheets carry no nonce and the browser drops them.
-                     * antd's own cssinjs styles get the nonce separately via the
-                     * BAIConfigProvider `csp` prop above.
+                     * Two separate emotion caches are needed for CSP nonce
+                     * coverage:
+                     *
+                     * 1. StyleProvider (antd-style's custom EmotionContext):
+                     *    covers createStyles() and the antd-style css() helper.
+                     *    The nonce is passed directly as a prop.
+                     *
+                     * 2. CacheProvider (@emotion/react's CacheContext):
+                     *    covers createGlobalStyle(), which uses @emotion/react's
+                     *    Global component internally. Global reads the nonce from
+                     *    cache.sheet.nonce — it does NOT read antd-style's custom
+                     *    EmotionContext. Without this wrapper, style tags emitted
+                     *    by createGlobalStyle (e.g. ScrollbarGlobalStyle) carry no
+                     *    nonce and are blocked by `style-src 'nonce-...'` CSP.
                      */}
-                    <StyleProvider nonce={globalThis.baiNonce}>
-                      <Suspense>
-                        {/* <BrowserRouter> */}
-                        {/* <RoutingEventHandler /> */}
-                        {children}
-                        {/* </BrowserRouter> */}
-                      </Suspense>
-                    </StyleProvider>
+                    <CacheProvider value={emotionGlobalCache}>
+                      <StyleProvider nonce={globalThis.baiNonce}>
+                        <Suspense>
+                          {/* <BrowserRouter> */}
+                          {/* <RoutingEventHandler /> */}
+                          {children}
+                          {/* </BrowserRouter> */}
+                        </Suspense>
+                      </StyleProvider>
+                    </CacheProvider>
                   </App>
                 </QueryParamProvider>
               </BAIMetaDataWrapper>


### PR DESCRIPTION
Resolves #7813 (FR-3086)

## Problem

antd-style's `createGlobalStyle` uses `@emotion/react`'s `Global` component internally. `Global` reads the nonce from **`@emotion/react`'s own `CacheContext`**, not from antd-style's custom `EmotionContext` that `StyleProvider` provides.

Since the app only wrapped with `<StyleProvider nonce={globalThis.baiNonce}>`, style tags emitted by `createGlobalStyle` (`ScrollbarGlobalStyle`, `TokenCssVariables`, `DrawerAreaGlobalStyle`) carried **no nonce** and were blocked by `style-src 'nonce-...'` CSP in production builds — breaking dark-mode scrollbar colors, CSS token variables, and the drawer-area width animation.

## Fix

Wrap `StyleProvider` with `<CacheProvider value={emotionGlobalCache}>` from `@emotion/react`, where `emotionGlobalCache` is a nonce-aware cache created at module load time:

```ts
const emotionGlobalCache = createCache({ key: 'css', nonce: globalThis.baiNonce });
```

Safe because `globalThis.baiNonce` is set by the inline `<script nonce="{{nonce}}">` in `index.html` before any ES module loads.

### Two emotion caches

| Provider | Context | Covers |
|---|---|---|
| `<CacheProvider value={emotionGlobalCache}>` | `@emotion/react`'s `CacheContext` | `createGlobalStyle()` via `@emotion/react`'s `Global` |
| `<StyleProvider nonce={baiNonce}>` | antd-style's `EmotionContext` | `createStyles()`, antd-style `css()` |

## Changes

- `react/src/components/DefaultProviders.tsx` — add `CacheProvider` wrapping `StyleProvider`
- `react/package.json` — add `@emotion/cache` and `@emotion/react` as explicit deps (already in store as antd-style transitive deps; pnpm strict mode requires direct listing)
- `pnpm-lock.yaml` — updated

## Verification

```
=== ALL PASS ===
```
(Relay ✅ · Lint ✅ · Format ✅ · TypeScript ✅)