### PR TITLE
feat(FR-3046): split Folder Explorer into resizable panels and refine audit log filter

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -130,6 +130,11 @@ export type FilterOperator =
 type BaseFilterProperty = {
   key: string;
   propertyLabel: string;
+  // Placeholder for this property's value input (AutoComplete / DatePicker)
+  // shown when the property is selected. Falls back to the component's generic
+  // default (`comp:BAIPropertyFilter.PlaceHolder`, or the datetime-specific
+  // default for `type: 'datetime'`) when omitted.
+  placeholder?: string;
   type: FilterPropertyType;
   operators?: FilterOperator[];
   options?: AutoCompleteProps['options'];
@@ -735,7 +740,10 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
             showTime
             style={{ minWidth: 200 }}
             onChange={(date) => setSelectedDate(date)}
-            placeholder={t('comp:BAIGraphQLPropertyFilter.SelectDateTime')}
+            placeholder={
+              selectedProperty?.placeholder ??
+              t('comp:BAIGraphQLPropertyFilter.SelectDateTime')
+            }
           />
         ) : (
           <Tooltip
@@ -757,7 +765,10 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
               options={effectiveOptions?.filter((option) =>
                 !search ? true : option.label?.toString().includes(search),
               )}
-              placeholder={t('comp:BAIPropertyFilter.PlaceHolder')}
+              placeholder={
+                selectedProperty?.placeholder ??
+                t('comp:BAIPropertyFilter.PlaceHolder')
+              }
               onBlur={() => setIsFocused(false)}
               onFocus={() => setIsFocused(true)}
             >

--- a/packages/backend.ai-ui/src/components/fragments/BAIAuditLogNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAuditLogNodes.tsx
@@ -116,11 +116,6 @@ const BAIAuditLogNodes = ({
         render: (__, record) => record.operation || '-',
       },
       {
-        key: 'actor',
-        title: t('comp:BAIAuditLogNodes.Actor'),
-        render: (__, record) => record.user?.basicInfo?.email || '-',
-      },
-      {
         key: 'status',
         title: t('comp:BAIAuditLogNodes.Status'),
         dataIndex: 'status',
@@ -152,8 +147,27 @@ const BAIAuditLogNodes = ({
       {
         key: 'triggeredBy',
         title: t('comp:BAIAuditLogNodes.TriggeredBy'),
-        render: (__, record) =>
-          record.triggeredBy ? <BAIId uuid={record.triggeredBy} /> : '-',
+        render: (__, record) => {
+          const fallback = record.triggeredBy ? (
+            <BAIId uuid={record.triggeredBy} />
+          ) : (
+            '-'
+          );
+          if (!record.user) {
+            return fallback;
+          }
+          // Show "email (id)" when the email is available; otherwise fall back
+          // to the user id alone so we never render an empty label before the
+          // parentheses when basicInfo.email is missing/null.
+          const email = record.user.basicInfo?.email;
+          return email ? (
+            <>
+              {email} &nbsp; (<BAIId globalId={record.user.id} />)
+            </>
+          ) : (
+            <BAIId globalId={record.user.id} />
+          );
+        },
       },
       {
         key: 'entityType',

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -17,7 +17,7 @@ import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import ScopedAuditLog, { ScopedAuditLogQuery } from './ScopedAuditLog';
 import VFolderNodeDescriptionV2 from './VFolderNodeDescriptionV2';
 import VFolderTextFileEditorModal from './VFolderTextFileEditorModal';
-import { Alert, Grid, Skeleton, Tabs, theme } from 'antd';
+import { Alert, Grid, Skeleton, Splitter, Tabs, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { RcFile } from 'antd/es/upload';
 import {
@@ -149,8 +149,8 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
     currentPath: string;
   } | null>(null);
 
-  const [activeTab, setActiveTab] = useState<'files' | 'metadata' | 'auditLog'>(
-    'files',
+  const [activeTab, setActiveTab] = useState<'metadata' | 'auditLog'>(
+    'metadata',
   );
   const [auditLogQueryRef, loadAuditLogQuery] =
     useQueryLoader<ScopedAuditLogQueryType>(ScopedAuditLogQuery);
@@ -305,8 +305,50 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
     />
   ) : null;
 
-  const vFolderDescriptionElement = vfolderNode ? (
-    <VFolderNodeDescriptionV2 vfolderNodeFrgmt={vfolderNode} />
+  const vFolderInfoPanelElement = vfolderNode ? (
+    <Tabs
+      type={xl ? 'card' : 'line'}
+      activeKey={activeTab}
+      onChange={(key) => {
+        if (key === 'auditLog' && auditLogQueryRef == null) {
+          loadAuditLog();
+        }
+        setActiveTab(key as typeof activeTab);
+      }}
+      styles={{
+        content: {
+          paddingBottom: token.paddingContentVertical,
+        },
+      }}
+      items={[
+        {
+          key: 'metadata',
+          label: t('explorer.Metadata'),
+          children: <VFolderNodeDescriptionV2 vfolderNodeFrgmt={vfolderNode} />,
+        },
+        {
+          key: 'auditLog',
+          label: t('auditLog.AuditLog'),
+          children: (
+            <BAIErrorBoundary>
+              {auditLogQueryRef ? (
+                <Suspense
+                  fallback={<Skeleton active paragraph={{ rows: 4 }} />}
+                >
+                  <ScopedAuditLog
+                    queryRef={auditLogQueryRef}
+                    onReload={reloadAuditLogQuery}
+                    tableSettings={{}}
+                  />
+                </Suspense>
+              ) : (
+                <Skeleton active paragraph={{ rows: 4 }} />
+              )}
+            </BAIErrorBoundary>
+          ),
+        },
+      ]}
+    />
   ) : null;
 
   return (
@@ -316,7 +358,7 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
       keyboard
       destroyOnHidden
       footer={null}
-      style={{ maxWidth: '1600px' }}
+      style={{ maxWidth: '1900px' }}
       styles={{
         body: {
           height: '100vh',
@@ -345,7 +387,12 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
         {deferredOpen !== modalProps.open || vfolderNode === undefined ? (
           <Skeleton active />
         ) : (
-          <BAIFlex direction="column" gap={'lg'} align="stretch">
+          <BAIFlex
+            direction="column"
+            gap={'lg'}
+            align="stretch"
+            style={{ minHeight: '100%' }}
+          >
             {vfolderNode === null ? (
               <Alert
                 title={t('explorer.FolderNotFoundOrNoAccess')}
@@ -375,50 +422,27 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
             ) : null}
 
             {vfolderNode && !hasNoPermissions ? (
-              <Tabs
-                activeKey={activeTab}
-                onChange={(key) => {
-                  if (key === 'auditLog' && auditLogQueryRef == null) {
-                    loadAuditLog();
-                  }
-                  setActiveTab(key as typeof activeTab);
-                }}
-                items={[
-                  {
-                    key: 'files',
-                    label: t('explorer.Files'),
-                    children: fileExplorerElement,
-                  },
-                  {
-                    key: 'metadata',
-                    label: t('explorer.Metadata'),
-                    children: vFolderDescriptionElement,
-                  },
-                  {
-                    key: 'auditLog',
-                    label: t('auditLog.AuditLog'),
-                    children: (
-                      <BAIErrorBoundary>
-                        {auditLogQueryRef ? (
-                          <Suspense
-                            fallback={
-                              <Skeleton active paragraph={{ rows: 4 }} />
-                            }
-                          >
-                            <ScopedAuditLog
-                              queryRef={auditLogQueryRef}
-                              onReload={reloadAuditLogQuery}
-                              tableSettings={{}}
-                            />
-                          </Suspense>
-                        ) : (
-                          <Skeleton active paragraph={{ rows: 4 }} />
-                        )}
-                      </BAIErrorBoundary>
-                    ),
-                  },
-                ]}
-              />
+              xl ? (
+                <Splitter
+                  style={{
+                    flex: 1,
+                    gap: token.size,
+                  }}
+                  orientation={'horizontal'}
+                >
+                  <Splitter.Panel resizable={true}>
+                    {fileExplorerElement}
+                  </Splitter.Panel>
+                  <Splitter.Panel defaultSize={'45%'} min={550}>
+                    {vFolderInfoPanelElement}
+                  </Splitter.Panel>
+                </Splitter>
+              ) : (
+                <BAIFlex direction="column" align="stretch" gap={'lg'}>
+                  {fileExplorerElement}
+                  {vFolderInfoPanelElement}
+                </BAIFlex>
+              )
             ) : null}
           </BAIFlex>
         )}

--- a/react/src/components/ScopedAuditLog.tsx
+++ b/react/src/components/ScopedAuditLog.tsx
@@ -137,6 +137,7 @@ const ScopedAuditLog = ({
               propertyLabel: t('auditLog.TriggeredBy'),
               type: 'string',
               fixedOperator: 'contains',
+              placeholder: t('auditLog.TriggeredByFilterPlaceholder'),
             },
             {
               key: 'createdAt',

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -311,7 +311,8 @@
     "Operation": "Vorgang",
     "Status": "Status",
     "Time": "Zeit",
-    "TriggeredBy": "Ausgelöst von"
+    "TriggeredBy": "Ausgelöst von",
+    "TriggeredByFilterPlaceholder": "Nach ID suchen"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Automatische Skalierungsregel hinzufügen",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Das Datei -Upload wurde durch Benutzeranforderung storniert.",
     "FileUploadFailed": "Es wurden einige Dateien nicht in Ordner '{{folderName}}' hochgeladen.",
     "Filename": "Dateiname",
-    "Files": "Dateien",
     "FolderNotFoundOrNoAccess": "Ordner, der nicht gefunden oder zugänglich ist verweigert",
     "InputTooShort": "EingabeTooShort",
     "Metadata": "Metadaten",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -311,7 +311,8 @@
     "Operation": "Λειτουργία",
     "Status": "Κατάσταση",
     "Time": "Ώρα",
-    "TriggeredBy": "Ενεργοποιήθηκε από"
+    "TriggeredBy": "Ενεργοποιήθηκε από",
+    "TriggeredByFilterPlaceholder": "Αναζήτηση κατά ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Προσθέστε κανόνα αυτόματης κλιμάκωσης",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Η μεταφόρτωση αρχείων ακυρώθηκε με αίτημα χρήστη.",
     "FileUploadFailed": "Απέτυχε να ανεβάσει κάποια αρχεία στο φάκελο '{{folderName}}'.",
     "Filename": "Όνομα αρχείου",
-    "Files": "Αρχεία",
     "FolderNotFoundOrNoAccess": "Ο φάκελος δεν βρέθηκε ή απορρίφθηκε η πρόσβαση",
     "InputTooShort": "InputTooShort",
     "Metadata": "Μεταδεδομένα",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -298,7 +298,8 @@
     "Operation": "Operation",
     "Status": "Status",
     "Time": "Time",
-    "TriggeredBy": "Triggered By"
+    "TriggeredBy": "Triggered By",
+    "TriggeredByFilterPlaceholder": "Search by ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Add Auto Scaling Rule",
@@ -1439,7 +1440,6 @@
     "FileUploadCancelled": "The file upload was canceled by user request.",
     "FileUploadFailed": "Failed to upload some files in folder '{{folderName}}'.",
     "Filename": "File Name",
-    "Files": "Files",
     "FolderNotFoundOrNoAccess": "Folder not found or access denied",
     "InputTooShort": "InputTooShort",
     "Metadata": "Metadata",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -311,7 +311,8 @@
     "Operation": "Operación",
     "Status": "Estado",
     "Time": "Hora",
-    "TriggeredBy": "Iniciado por"
+    "TriggeredBy": "Iniciado por",
+    "TriggeredByFilterPlaceholder": "Buscar por ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Agregar regla de escala automática",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "La carga de archivo fue cancelada por solicitud del usuario.",
     "FileUploadFailed": "No se pudo cargar algunos archivos en la carpeta '{{folderName}}'.",
     "Filename": "Nombre del archivo",
-    "Files": "Archivos",
     "FolderNotFoundOrNoAccess": "Carpeta no encontrada ni de acceso denegada",
     "InputTooShort": "InputTooShort",
     "Metadata": "Metadatos",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -311,7 +311,8 @@
     "Operation": "Toiminto",
     "Status": "Tila",
     "Time": "Aika",
-    "TriggeredBy": "Käynnistänyt"
+    "TriggeredBy": "Käynnistänyt",
+    "TriggeredByFilterPlaceholder": "Hae ID:llä"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Lisää automaattinen skaalaussääntö",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Tiedoston lataus peruutettiin käyttäjäpyynnöllä.",
     "FileUploadFailed": "Joidenkin tiedostojen lähettäminen kansioon '{{folderName}}'.",
     "Filename": "Tiedoston nimi",
-    "Files": "Tiedostot",
     "FolderNotFoundOrNoAccess": "Kansiota ei löydy tai pääsy kielletty",
     "InputTooShort": "InputTooShort",
     "Metadata": "Metatiedot",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -311,7 +311,8 @@
     "Operation": "Opération",
     "Status": "Statut",
     "Time": "Heure",
-    "TriggeredBy": "Déclenché par"
+    "TriggeredBy": "Déclenché par",
+    "TriggeredByFilterPlaceholder": "Rechercher par ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Ajouter la règle de mise à l'échelle automatique",
@@ -1453,7 +1454,6 @@
     "FileUploadCancelled": "Le téléchargement du fichier a été annulé par demande de l'utilisateur.",
     "FileUploadFailed": "Échec pour télécharger certains fichiers dans le dossier '{{folderName}}'.",
     "Filename": "Nom de fichier",
-    "Files": "Fichiers",
     "FolderNotFoundOrNoAccess": "Dossier non trouvé ou accès refusé",
     "InputTooShort": "Entrée Trop Courte",
     "Metadata": "Métadonnées",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -311,7 +311,8 @@
     "Operation": "Operasi",
     "Status": "Status",
     "Time": "Waktu",
-    "TriggeredBy": "Dipicu oleh"
+    "TriggeredBy": "Dipicu oleh",
+    "TriggeredByFilterPlaceholder": "Cari berdasarkan ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Tambahkan aturan penskalaan otomatis",
@@ -1453,7 +1454,6 @@
     "FileUploadCancelled": "Unggah file dibatalkan dengan permintaan pengguna.",
     "FileUploadFailed": "Gagal mengunggah beberapa file di folder '{{folderName}}'.",
     "Filename": "Nama File",
-    "Files": "File",
     "FolderNotFoundOrNoAccess": "Folder tidak ditemukan atau akses ditolak",
     "InputTooShort": "MasukanTerlaluPendek",
     "Metadata": "Metadata",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -311,7 +311,8 @@
     "Operation": "Operazione",
     "Status": "Stato",
     "Time": "Ora",
-    "TriggeredBy": "Attivato da"
+    "TriggeredBy": "Attivato da",
+    "TriggeredByFilterPlaceholder": "Cerca per ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Aggiungi regola di ridimensionamento automatico",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Il caricamento del file è stato cancellato dalla richiesta dell'utente.",
     "FileUploadFailed": "Impossibile caricare alcuni file nella cartella '{{folderName}}'.",
     "Filename": "Nome del file",
-    "Files": "File",
     "FolderNotFoundOrNoAccess": "Cartella non trovata o accesso negata",
     "InputTooShort": "Inputtroppo corto",
     "Metadata": "Metadati",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -311,7 +311,8 @@
     "Operation": "操作",
     "Status": "状態",
     "Time": "時間",
-    "TriggeredBy": "実行者"
+    "TriggeredBy": "実行者",
+    "TriggeredByFilterPlaceholder": "IDで検索"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "自動スケーリングルールを追加します",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "ファイルのアップロードは、ユーザーリクエストによってキャンセルされました。",
     "FileUploadFailed": "Folder '{{folderName}}'にいくつかのファイルをアップロードできませんでした。",
     "Filename": "ファイル名",
-    "Files": "ファイル",
     "FolderNotFoundOrNoAccess": "フォルダーが見つかりませんまたはアクセスが拒否されません",
     "InputTooShort": "InputTooShort",
     "Metadata": "メタデータ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -311,7 +311,8 @@
     "Operation": "작업",
     "Status": "상태",
     "Time": "시간",
-    "TriggeredBy": "실행자"
+    "TriggeredBy": "실행자",
+    "TriggeredByFilterPlaceholder": "ID로 검색"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "오토스케일링 규칙 추가",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "사용자 요청에 따라 파일 업로드가 취소되었습니다.",
     "FileUploadFailed": "'{{folderName}}' 폴더에서 일부 파일 업로드에 실패했습니다. ",
     "Filename": "파일 이름",
-    "Files": "파일",
     "FolderNotFoundOrNoAccess": "존재하지 않거나 접근할 수 없는 폴더입니다.",
     "InputTooShort": "입력값이 너무 짧습니다.",
     "Metadata": "메타데이터",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -311,7 +311,8 @@
     "Operation": "Үйлдэл",
     "Status": "Статус",
     "Time": "Цаг",
-    "TriggeredBy": "Гүйцэтгэсэн"
+    "TriggeredBy": "Гүйцэтгэсэн",
+    "TriggeredByFilterPlaceholder": "ID-ээр хайх"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Автомат масштабыг нэмэх",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Файлын байршуулалтыг хэрэглэгчийн хүсэлтээр цуцлагдсан.",
     "FileUploadFailed": "'{{folderName}}' Файлд файл байршуулж чадсангүй.",
     "Filename": "Хөдөлгөөний нэр",
-    "Files": "Файлууд",
     "FolderNotFoundOrNoAccess": "Фолдер олдсонгүй эсвэл хандалтыг үгүйсгэв",
     "InputTooShort": "Хэт богино байна",
     "Metadata": "Мета өгөгдөл",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -311,7 +311,8 @@
     "Operation": "Operasi",
     "Status": "Status",
     "Time": "Masa",
-    "TriggeredBy": "Dicetuskan oleh"
+    "TriggeredBy": "Dicetuskan oleh",
+    "TriggeredByFilterPlaceholder": "Cari mengikut ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Tambahkan peraturan penskalaan automatik",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Muat naik fail dibatalkan oleh permintaan pengguna.",
     "FileUploadFailed": "Gagal memuat naik beberapa fail dalam folder '{{folderName}}'.",
     "Filename": "Nama fail",
-    "Files": "Fail",
     "FolderNotFoundOrNoAccess": "Folder tidak dijumpai atau akses ditolak",
     "InputTooShort": "InputTooShort",
     "Metadata": "Metadata",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -311,7 +311,8 @@
     "Operation": "Operacja",
     "Status": "Status",
     "Time": "Czas",
-    "TriggeredBy": "Wywołane przez"
+    "TriggeredBy": "Wywołane przez",
+    "TriggeredByFilterPlaceholder": "Szukaj po ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Dodaj regułę automatycznego skalowania",
@@ -1453,7 +1454,6 @@
     "FileUploadCancelled": "Przesłanie pliku zostało anulowane na żądanie użytkownika.",
     "FileUploadFailed": "Nie udało się przesłać niektórych plików w folderze „{{folderName}}”.",
     "Filename": "Nazwa pliku",
-    "Files": "Pliki",
     "FolderNotFoundOrNoAccess": "Folder nie został znaleziony ani nie ma dostępu",
     "InputTooShort": "Wejście zbyt krótkie",
     "Metadata": "Metadane",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -311,7 +311,8 @@
     "Operation": "Operação",
     "Status": "Status",
     "Time": "Hora",
-    "TriggeredBy": "Acionado por"
+    "TriggeredBy": "Acionado por",
+    "TriggeredByFilterPlaceholder": "Pesquisar por ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Adicionar regra de escala automática",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "O upload do arquivo foi cancelado por solicitação do usuário.",
     "FileUploadFailed": "Falha ao fazer upload de alguns arquivos na pasta '{{folderName}}'.",
     "Filename": "Nome do arquivo",
-    "Files": "Arquivos",
     "FolderNotFoundOrNoAccess": "Pasta não encontrada ou acesso negado",
     "InputTooShort": "InputTooShort",
     "Metadata": "Metadados",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -311,7 +311,8 @@
     "Operation": "Operação",
     "Status": "Status",
     "Time": "Hora",
-    "TriggeredBy": "Acionado por"
+    "TriggeredBy": "Acionado por",
+    "TriggeredByFilterPlaceholder": "Pesquisar por ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Adicionar regra de escala automática",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "O upload do arquivo foi cancelado por solicitação do usuário.",
     "FileUploadFailed": "Falha ao fazer upload de alguns arquivos na pasta '{{folderName}}'.",
     "Filename": "Nome do arquivo",
-    "Files": "Arquivos",
     "FolderNotFoundOrNoAccess": "Pasta não encontrada ou acesso negado",
     "InputTooShort": "InputTooShort",
     "Metadata": "Metadados",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -311,7 +311,8 @@
     "Operation": "Операция",
     "Status": "Статус",
     "Time": "Время",
-    "TriggeredBy": "Инициировано"
+    "TriggeredBy": "Инициировано",
+    "TriggeredByFilterPlaceholder": "Поиск по ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Добавить правило масштабирования автоматического масштабирования",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Загрузка файла была отменена пользовательским запросом.",
     "FileUploadFailed": "Не удалось загрузить некоторые файлы в папке '{{folderName}}'.",
     "Filename": "Имя файла",
-    "Files": "Файлы",
     "FolderNotFoundOrNoAccess": "Папка не найдена или доступа отказана",
     "InputTooShort": "ВводОченьКороток",
     "Metadata": "Метаданные",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -311,7 +311,8 @@
     "Operation": "การดำเนินการ",
     "Status": "สถานะ",
     "Time": "เวลา",
-    "TriggeredBy": "เรียกใช้โดย"
+    "TriggeredBy": "เรียกใช้โดย",
+    "TriggeredByFilterPlaceholder": "ค้นหาโดย ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "เพิ่มกฎการปรับขนาดอัตโนมัติ",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "การอัปโหลดไฟล์ถูกยกเลิกโดยคำขอผู้ใช้",
     "FileUploadFailed": "ไม่สามารถอัปโหลดไฟล์บางไฟล์ในโฟลเดอร์ '{{folderName}}'",
     "Filename": "ชื่อไฟล์",
-    "Files": "ไฟล์",
     "FolderNotFoundOrNoAccess": "ไม่พบโฟลเดอร์หรือถูกปฏิเสธการเข้าถึง",
     "InputTooShort": "ข้อมูลที่ป้อนสั้นเกินไป",
     "Metadata": "ข้อมูลเมตา",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -311,7 +311,8 @@
     "Operation": "İşlem",
     "Status": "Durum",
     "Time": "Zaman",
-    "TriggeredBy": "Tetikleyen"
+    "TriggeredBy": "Tetikleyen",
+    "TriggeredByFilterPlaceholder": "ID ile ara"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Otomatik ölçeklendirme kuralı ekleyin",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Dosya yükleme kullanıcı isteği ile iptal edildi.",
     "FileUploadFailed": "Bazı dosyaları '{{{folderName}}' klasörüne yükleyemedi.",
     "Filename": "Dosya adı",
-    "Files": "Dosyalar",
     "FolderNotFoundOrNoAccess": "Klasör bulunamadı veya erişim reddedildi",
     "InputTooShort": "GirişÇok Kısa",
     "Metadata": "Meta veriler",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -311,7 +311,8 @@
     "Operation": "Thao tác",
     "Status": "Trạng thái",
     "Time": "Thời gian",
-    "TriggeredBy": "Thực hiện bởi"
+    "TriggeredBy": "Thực hiện bởi",
+    "TriggeredByFilterPlaceholder": "Tìm theo ID"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "Thêm quy tắc tỷ lệ tự động",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "Tải lên tệp đã bị hủy bởi yêu cầu người dùng.",
     "FileUploadFailed": "Không thể tải lên một số tệp trong thư mục '{{folderName}}'.",
     "Filename": "Tên tệp",
-    "Files": "Tệp",
     "FolderNotFoundOrNoAccess": "Thư mục không tìm thấy hoặc truy cập bị từ chối",
     "InputTooShort": "InputTooShort",
     "Metadata": "Siêu dữ liệu",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -311,7 +311,8 @@
     "Operation": "操作",
     "Status": "状态",
     "Time": "时间",
-    "TriggeredBy": "触发者"
+    "TriggeredBy": "触发者",
+    "TriggeredByFilterPlaceholder": "按 ID 搜索"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "添加自动缩放规则",
@@ -1452,7 +1453,6 @@
     "FileUploadCancelled": "文件上传已通过用户请求取消。",
     "FileUploadFailed": "无法将某些文件上传到文件夹'{{folderName}}'中。",
     "Filename": "文件名",
-    "Files": "文件",
     "FolderNotFoundOrNoAccess": "未找到或拒绝访问的文件夹",
     "InputTooShort": "输入太短",
     "Metadata": "元数据",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -311,7 +311,8 @@
     "Operation": "操作",
     "Status": "狀態",
     "Time": "時間",
-    "TriggeredBy": "觸發者"
+    "TriggeredBy": "觸發者",
+    "TriggeredByFilterPlaceholder": "以 ID 搜尋"
   },
   "autoScalingRule": {
     "AddAutoScalingRule": "添加自動縮放規則",
@@ -1453,7 +1454,6 @@
     "FileUploadCancelled": "文件上傳已通過用戶請求取消。",
     "FileUploadFailed": "無法將某些文件上傳到文件夾'{{folderName}}'中。",
     "Filename": "文件名",
-    "Files": "檔案",
     "FolderNotFoundOrNoAccess": "未找到或拒絕訪問的文件夾",
     "InputTooShort": "輸入太短",
     "Metadata": "元數據",


### PR DESCRIPTION
Relates to #7732 (FR-3046).

Stacked on #7735 (FR-3046).

## Summary

Follow-up to #7735 that revisits the Folder Explorer layout and refines the audit log table/filter UX.

### Folder Explorer layout (`FolderExplorerModalV2.tsx`)

#7735 replaced the side-by-side `Splitter` with a three-tab layout (Files / Metadata / Audit Log). This PR brings back a **resizable split layout** on wide screens while keeping the audit log:

- On `xl` screens, render a horizontal `Splitter`: `BAIFileExplorer` fills the left panel, and the right panel hosts a `Tabs` with **Metadata** and **Audit Log**. Below `xl`, the explorer and the info panel stack vertically.
- The splitter fills the modal body height (`minHeight: 100%` on the container, `flex: 1` on the splitter) so it spans the full modal regardless of content height.
- Modal `maxWidth` widened `1600 → 1900`.
- The standalone **Files** tab is gone (the explorer is always visible), so the `explorer.Files` i18n key is dropped.

### Audit log filter & columns

- `BAIGraphQLPropertyFilter`: add an optional per-property `placeholder`. When a `FilterProperty` sets `placeholder`, it overrides the generic input placeholder (and the datetime default); otherwise behavior is unchanged (backward compatible).
- `ScopedAuditLog`: the **Triggered By** filter now shows a dedicated placeholder (`auditLog.TriggeredByFilterPlaceholder` — "Search by ID").
- `BAIAuditLogNodes`: consolidate the separate **Actor** column into **Triggered By** — when a `user` is present, render `email (id)`; otherwise fall back to the raw `triggeredBy` id.

## Notes

- Added i18n key `auditLog.TriggeredByFilterPlaceholder` and removed `explorer.Files` across all 21 locales.
- Verification: `scripts/verify.sh` → **Relay / Lint / Format / TypeScript all PASS**. (The "Vite warmup paths" check fails only due to absent local build artifacts, unrelated to these source changes.)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
