### PR TITLE
fix(FR-3091): stabilize chat TPS during streaming (live elapsed denominator + cancel stale token counts)

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -303,6 +303,15 @@ const PureChatCard: React.FC<ChatCardProps> = ({
             }
 
             return result.toUIMessageStreamResponse({
+              // Surface the model-reported output token count on the final
+              // message so ChatTokenCounter can use the exact usage value for
+              // TPS instead of the gpt-tokenizer estimate. Only emitted on the
+              // 'finish' event (usage is not known mid-stream).
+              messageMetadata: ({ part }) => {
+                if (part.type === 'finish') {
+                  return { outputTokens: part.totalUsage.outputTokens };
+                }
+              },
               onError: (error) => {
                 return getAIErrorMessage(error);
               },

--- a/react/src/components/Chat/ChatTokenCounter.test.tsx
+++ b/react/src/components/Chat/ChatTokenCounter.test.tsx
@@ -1,0 +1,207 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import ChatTokenCounter from './ChatTokenCounter';
+import { act, render, screen } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import React from 'react';
+
+// Mock useTokenCount as a synchronous function returning str.length (1 token per character).
+// This lets us assert on what string ChatTokenCounter actually passes down — the string's
+// length directly reflects which parts were included — without needing gpt-tokenizer.
+vi.mock('../../hooks/useTokenizer', () => ({
+  useTokenCount: (str: string = '') => str.length,
+}));
+
+vi.mock('backend.ai-ui', () => ({
+  BAIFlex: ({ children }: { children: React.ReactNode }) => (
+    <React.Fragment>{children}</React.Fragment>
+  ),
+  BAIQuestionIconWithTooltip: () => null,
+}));
+
+vi.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+const makeAssistantMessage = (
+  parts: Array<{ type: string; text: string }>,
+  metadata?: Record<string, unknown>,
+): UIMessage =>
+  ({
+    id: 'msg-1',
+    role: 'assistant',
+    content: '',
+    parts,
+    ...(metadata ? { metadata } : {}),
+  }) as unknown as UIMessage;
+
+describe('ChatTokenCounter', () => {
+  describe('reasoning part inclusion (FR-3091)', () => {
+    it('counts text-only parts', () => {
+      const messages = [
+        makeAssistantMessage([{ type: 'text', text: 'hello' }]),
+      ];
+      render(
+        <ChatTokenCounter
+          input=""
+          messages={messages}
+          startTime={null}
+          endTime={null}
+        />,
+      );
+      expect(screen.getByText('5')).toBeTruthy(); // 'hello'.length = 5
+    });
+
+    it('includes reasoning-only parts in token count', () => {
+      // Before fix: `type === 'text'` filter excluded reasoning → 0 displayed.
+      const messages = [
+        makeAssistantMessage([{ type: 'reasoning', text: 'think' }]),
+      ];
+      render(
+        <ChatTokenCounter
+          input=""
+          messages={messages}
+          startTime={null}
+          endTime={null}
+        />,
+      );
+      expect(screen.getByText('5')).toBeTruthy(); // 'think'.length = 5
+    });
+
+    it('sums text and reasoning parts', () => {
+      // Before fix: 'think' (5) was excluded → only 'answer' (6) counted → 6 displayed.
+      const messages = [
+        makeAssistantMessage([
+          { type: 'reasoning', text: 'think' },
+          { type: 'text', text: 'answer' },
+        ]),
+      ];
+      render(
+        <ChatTokenCounter
+          input=""
+          messages={messages}
+          startTime={null}
+          endTime={null}
+        />,
+      );
+      expect(screen.getByText('11')).toBeTruthy(); // 5 + 6 = 11
+    });
+
+    it('uses reasoning tokens in TPS numerator', () => {
+      // Before fix: lastAssistantTokenCount = 0 (no text parts) → TPS guard fails → 0.0.
+      // 'thinking'.length = 8 tokens over exactly 2 s → 4.0 TPS.
+      const messages = [
+        makeAssistantMessage([{ type: 'reasoning', text: 'thinking' }]),
+      ];
+      const startTime = 1_000_000;
+      const endTime = startTime + 2_000;
+      render(
+        <ChatTokenCounter
+          input=""
+          messages={messages}
+          startTime={startTime}
+          endTime={endTime}
+        />,
+      );
+      expect(screen.getByText('4.0')).toBeTruthy();
+    });
+  });
+
+  describe('model-reported usage tokens (FR-3091)', () => {
+    it('uses metadata.outputTokens for TPS instead of the tokenizer estimate', () => {
+      // Estimate would be 100 (text length) → 100/2s = 50.0. The model reported
+      // 40 output tokens → 40/2s = 20.0 must win.
+      const messages = [
+        makeAssistantMessage([{ type: 'text', text: 'x'.repeat(100) }], {
+          outputTokens: 40,
+        }),
+      ];
+      const startTime = 1_000_000;
+      render(
+        <ChatTokenCounter
+          input=""
+          messages={messages}
+          startTime={startTime}
+          endTime={startTime + 2_000}
+        />,
+      );
+      expect(screen.getByText('20.0')).toBeTruthy();
+    });
+
+    it('falls back to the estimate when usage metadata is absent', () => {
+      // No metadata → estimate (100) / 2s = 50.0.
+      const messages = [
+        makeAssistantMessage([{ type: 'text', text: 'x'.repeat(100) }]),
+      ];
+      const startTime = 1_000_000;
+      render(
+        <ChatTokenCounter
+          input=""
+          messages={messages}
+          startTime={startTime}
+          endTime={startTime + 2_000}
+        />,
+      );
+      expect(screen.getByText('50.0')).toBeTruthy();
+    });
+  });
+
+  describe('elapsed denominator sampled at token-count updates (FR-3091)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // The denominator timestamp is captured when the token count changes, not on
+    // a timer. This guards two things at once:
+    //   1. The React Compiler freeze fix: reading Date.now() in render would
+    //      memoize the denominator on startTime/endTime only and freeze it,
+    //      inflating TPS during streaming. Sampling in an effect keeps time out
+    //      of render.
+    //   2. The new semantics (replacing the 200ms tick): pure wall-clock passage
+    //      with no new tokens must NOT change the display (no cosmetic decay);
+    //      only a token-count change re-samples the clock.
+    it('updates TPS on token-count change and holds steady while only time passes', () => {
+      const startTime = 1_000_000 - 1_000; // started 1s ago
+      const { rerender } = render(
+        <ChatTokenCounter
+          input=""
+          messages={[
+            makeAssistantMessage([{ type: 'text', text: 'x'.repeat(100) }]),
+          ]}
+          startTime={startTime}
+          endTime={null}
+        />,
+      );
+      // Mount samples now = 1_000_000 → 100 tokens / 1s = 100.0.
+      expect(screen.getByText('100.0')).toBeTruthy();
+
+      // 1s of wall-clock passes with no new tokens → denominator must hold.
+      // (A ticking timer would have decayed this to 50.0.)
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(screen.getByText('100.0')).toBeTruthy();
+
+      // A larger token count arrives at clock = 1_001_000 → re-sample the wall
+      // clock: 300 tokens / 2s = 150.0.
+      rerender(
+        <ChatTokenCounter
+          input=""
+          messages={[
+            makeAssistantMessage([{ type: 'text', text: 'x'.repeat(300) }]),
+          ]}
+          startTime={startTime}
+          endTime={null}
+        />,
+      );
+      act(() => {});
+      expect(screen.getByText('150.0')).toBeTruthy();
+    });
+  });
+});

--- a/react/src/components/Chat/ChatTokenCounter.tsx
+++ b/react/src/components/Chat/ChatTokenCounter.tsx
@@ -8,7 +8,7 @@ import { Typography, Tag, Divider } from 'antd';
 import { BAIQuestionIconWithTooltip, BAIFlex } from 'backend.ai-ui';
 import { t } from 'i18next';
 import { map, last } from 'lodash-es';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface ChatTokenCounterProps {
   input: string;
@@ -29,7 +29,7 @@ const ChatTokenCounter: React.FC<ChatTokenCounterProps> = ({
   const inputTokenCount = useTokenCount(input);
   const allChatMessageString = map(messages, (message) =>
     message?.parts
-      ?.filter((part) => part.type === 'text')
+      ?.filter((part) => part.type === 'text' || part.type === 'reasoning')
       .map((part) => part.text)
       .join(''),
   ).join('');
@@ -39,16 +39,53 @@ const ChatTokenCounter: React.FC<ChatTokenCounterProps> = ({
   const lastAssistantMessageString =
     lastAssistantMessage?.role === 'assistant'
       ? lastAssistantMessage?.parts
-          ?.filter((part) => part.type === 'text')
+          ?.filter((part) => part.type === 'text' || part.type === 'reasoning')
           .map((part) => part.text)
           .join('') || ''
       : '';
 
-  const lastAssistantTokenCount = useTokenCount(lastAssistantMessageString);
+  const estimatedLastAssistantTokenCount = useTokenCount(
+    lastAssistantMessageString,
+  );
+  // Prefer the model-reported output token count (attached to the final
+  // message metadata in ChatCard) over the client-side gpt-tokenizer estimate.
+  // It is only present once streaming finishes and only on paths that report
+  // usage (client-side streamText); during streaming and on server paths that
+  // omit usage, fall back to the estimate.
+  const usageOutputTokens =
+    lastAssistantMessage?.role === 'assistant'
+      ? (
+          lastAssistantMessage?.metadata as
+            | { outputTokens?: number }
+            | undefined
+        )?.outputTokens
+      : undefined;
+  const lastAssistantTokenCount =
+    typeof usageOutputTokens === 'number' && usageOutputTokens > 0
+      ? usageOutputTokens
+      : estimatedLastAssistantTokenCount;
+
+  // The elapsed denominator needs a current timestamp, but reading `Date.now()`
+  // directly in render does not work: under the React Compiler ('use memo'),
+  // the elapsed expression is memoized on its tracked deps (startTime/endTime)
+  // only — `Date.now()` is an untracked impure call, so the denominator would
+  // freeze at ~0s from when startTime was first set, inflating TPS until
+  // streaming ends. TPS only changes when the token count changes, so rather
+  // than a ticking timer we sample the wall clock at each token-count update:
+  // numerator and denominator are then snapshots of the same instant, with no
+  // periodic re-renders in between, while time stays out of render so the
+  // compiler freeze cannot return. If the stream stalls the display holds its
+  // last value instead of decaying; the final value at endTime is unaffected.
+  const [measuredAt, setMeasuredAt] = useState<number | null>(null);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- capture the wall-clock instant the token count was observed; it cannot be derived in render without reintroducing the compiler-frozen Date.now()
+    setMeasuredAt(Date.now());
+  }, [lastAssistantTokenCount]);
+
   let tokenPerSecond = 0;
   if (lastAssistantTokenCount > 0 && startTime) {
-    // eslint-disable-next-line react-hooks/purity
-    const elapsedSec = ((endTime ?? Date.now()) - startTime) / 1000;
+    const sampledAt = endTime ?? measuredAt;
+    const elapsedSec = sampledAt !== null ? (sampledAt - startTime) / 1000 : 0;
     tokenPerSecond = elapsedSec > 0 ? lastAssistantTokenCount / elapsedSec : 0;
   }
 

--- a/react/src/hooks/useTokenizer.test.ts
+++ b/react/src/hooks/useTokenizer.test.ts
@@ -1,7 +1,18 @@
+import * as tokenizerModule from './useTokenizer';
 import { useTokenCount, encodeAsync } from './useTokenizer';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { encode } from 'gpt-tokenizer';
 import type { Mock } from 'vitest';
+
+// A manually-resolvable promise, used to drive the order in which
+// concurrent encodeAsync calls complete.
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
 
 // Mock gpt-tokenizer
 vi.mock('gpt-tokenizer', () => ({
@@ -86,6 +97,47 @@ describe('useTokenizer', () => {
       await waitFor(() => {
         expect(result.current).toBe(0);
       });
+    });
+
+    // Regression test for FR-3091: during streaming, useTokenCount fires a
+    // new async token count on every chunk. Those calls can resolve out of
+    // order. Without cancellation, a stale (earlier-input) result that
+    // resolves *after* the latest one would overwrite the displayed count,
+    // making TPS climb after streaming ends. The effect cleanup must discard
+    // any result whose input is no longer current.
+    it('discards a stale result that resolves after a newer input', async () => {
+      const firstCall = createDeferred<number>();
+      const secondCall = createDeferred<number>();
+      const spy = vi
+        .spyOn(tokenizerModule.tokenCounter, 'encodeAsync')
+        .mockReturnValueOnce(firstCall.promise)
+        .mockReturnValueOnce(secondCall.promise);
+
+      const { result, rerender } = renderHook(
+        ({ input }) => useTokenCount(input),
+        { initialProps: { input: 'short' } },
+      );
+
+      // Change the input before the first computation resolves, kicking off a
+      // second concurrent computation.
+      rerender({ input: 'a much longer streamed message' });
+
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      // The newer (second) computation resolves first with the correct count.
+      await act(async () => {
+        secondCall.resolve(30);
+      });
+      expect(result.current).toBe(30);
+
+      // The stale (first) computation resolves later with a larger value.
+      // Cancellation must prevent it from overwriting the current count.
+      await act(async () => {
+        firstCall.resolve(5);
+      });
+      expect(result.current).toBe(30);
+
+      spy.mockRestore();
     });
   });
 });

--- a/react/src/hooks/useTokenizer.ts
+++ b/react/src/hooks/useTokenizer.ts
@@ -10,17 +10,30 @@ export const encodeAsync = async (str: string) => {
   return encode(str).length;
 };
 
+// Indirection object so `useTokenCount`'s async call can be spied on in tests.
+// A direct module-local call to `encodeAsync` cannot be intercepted under ESM,
+// which makes the out-of-order cancellation behavior (FR-3091) untestable.
+export const tokenCounter = { encodeAsync };
+
 export const useTokenCount = (input: string = '') => {
+  'use memo';
   const [value, setNum] = useState(0);
 
   useEffect(() => {
+    let cancelled = false;
     startTransition(() => {
-      encodeAsync(input)
-        .then(setNum)
+      tokenCounter
+        .encodeAsync(input)
+        .then((count) => {
+          if (!cancelled) setNum(count);
+        })
         .catch(() => {
-          setNum(input.length);
+          if (!cancelled) setNum(input.length);
         });
     });
+    return () => {
+      cancelled = true;
+    };
   }, [input]);
 
   return value;


### PR DESCRIPTION
Resolves #7821 (FR-3091)

## Summary

The chat TPS indicator misbehaved in several ways. This PR fixes them and improves accuracy.

1. **TPS shot up during streaming and snapped down at the end** (the dominant, user-visible symptom: e.g. climbing past 1100 then dropping to ~115). Caused by a frozen elapsed-time denominator under the React Compiler.
2. **TPS kept creeping up *after* streaming ended.** Caused by stale, uncancelled async token-count computations resolving one by one.
3. **`think` (reasoning) content was excluded** from the token count.
4. **The numerator was only a gpt-tokenizer estimate**, not the model's actual output token count.

## Root cause & fixes

### (1) Frozen elapsed denominator — `ChatTokenCounter`

`TPS = tokenCount / elapsedSec`. `ChatTokenCounter` uses `'use memo'`, so the React Compiler memoizes the elapsed expression on its **tracked** deps (`startTime` / `endTime`) only. `Date.now()` read in render is an untracked impure call, so the denominator was computed once — right after `startTime` was set, when elapsed ≈ 0s — and reused. The growing numerator then drove the displayed TPS ever higher until `endTime` changed and the expression recomputed against real time.

**Fix:** keep `Date.now()` out of render. Since TPS only changes when the token count changes, sample the wall clock in an effect keyed on the token count (`measuredAt`), and divide by `endTime ?? measuredAt`. Numerator and denominator are then snapshots of the same instant, with no periodic re-renders. (An earlier revision used a 200 ms ticking state; replaced per review with this coherent token-count-driven sampling — see thread.)

### (2) Stale async token counts — `useTokenCount` (`useTokenizer.ts`)

`useTokenCount` launched a new async `encodeAsync()` per streaming chunk without cancelling prior ones; after `endTime` was fixed, queued results kept resolving and bumping the numerator. **Fix:** a `cancelled` flag in the `useEffect` cleanup so only the latest `input`'s result updates state. Regression-tested for out-of-order resolution.

### (3) Reasoning tokens — `ChatTokenCounter`

`<think>` output is extracted into `reasoning` parts; the counter now includes both `text` and `reasoning` parts in the TPS numerator and the total token count.

### (4) Model-reported usage tokens — `ChatCard` + `ChatTokenCounter`

On the client-side streaming path, the model's `outputTokens` (from the stream's finish event) is attached to the final message via `toUIMessageStreamResponse`'s `messageMetadata`. `ChatTokenCounter` prefers that exact count for the TPS numerator and **falls back to the gpt-tokenizer estimate** during streaming (usage unknown mid-stream) and on paths/models that omit usage — so behavior is never worse than before.

## TPS definition

Numerator = output tokens of the last assistant message (text + reasoning) — model-reported when available, else gpt-tokenizer estimate. Denominator = decode window `startTime` (first output token / status → `streaming`) to `endTime` (stream end), excluding prefill / TTFT, matching the vLLM / Ollama convention.

## Verification

- Manual, in-browser (dev server, streaming model): before → TPS climbed past 1100 then dropped to ~115; after → stable real rate throughout, frozen at the final value on completion.
- Unit tests: `ChatTokenCounter` (denominator sampled at token-count updates and holds steady while only time passes; reasoning tokens counted; usage `outputTokens` preferred with estimate fallback) and `useTokenizer` (out-of-order stale result discarded). All pass.
- Lint passes on the changed files.

### Test limitation (honest scope note)

The denominator unit test guards the **sampling semantics** (TPS holds while time passes, re-samples on token-count change) and keeps time out of render. It does **not** reproduce the React Compiler memoization freeze itself, since the compiler is not guaranteed to run identically under Vitest (jsdom) as in the production build. The compiler-specific freeze was validated **manually in the browser** (1100 → real-rate before/after), not by an automated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
