### PR TITLE
feat(FR-3087): add required field support to RuntimeVariantPreset

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -4179,6 +4179,9 @@ input CreateRuntimeVariantPresetInput
   For 'env' target, the environment variable name; for 'args' target, the CLI flag name.
   """
   key: String!
+
+  """Whether this preset option is required when creating a deployment."""
+  required: Boolean! = false
 }
 
 """Added in 26.4.2. Create preset payload."""
@@ -17044,6 +17047,9 @@ type RuntimeVariantPreset implements Node
 
   """Timestamp of the last modification to this preset."""
   updatedAt: DateTime
+
+  """Whether this preset option must be filled in before submitting a deployment."""
+  required: Boolean!
 }
 
 """Added in 26.4.2. Paginated list of runtime variant presets."""
@@ -19445,6 +19451,9 @@ input UpdateRuntimeVariantPresetInput
 
   """New key."""
   key: String = null
+
+  """Set to true/false to update required; null means no change."""
+  required: Boolean = null
 }
 
 """Added in 26.4.2. Update preset payload."""

--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -924,6 +924,11 @@ export class Client {
       // for the same staging-manager reason as above.
       this._features['keypair-resource-policy-user-filter'] = true;
     }
+    // TODO(FR-3087): simplify to '26.4.4' once rc builds are out of use.
+    // BA-6326 / backend PR #12000 — RuntimeVariantPreset.required: Boolean!
+    if (this.isManagerVersionCompatibleWith('26.4.4rc7')) {
+      this._features['runtime-variant-preset-required'] = true;
+    }
   }
 
   /**

--- a/react/src/__generated__/useRuntimeParameterSchemaPresetsQuery.graphql.ts
+++ b/react/src/__generated__/useRuntimeParameterSchemaPresetsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ef887233f31a4b824af5a87f0f88a4c4>>
+ * @generated SignedSource<<1e86816b3320f3a6fd3dfbc3ec5dfc2c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -62,6 +62,7 @@ export type useRuntimeParameterSchemaPresetsQuery$data = {
         readonly displayName: string | null | undefined;
         readonly name: string;
         readonly rank: number;
+        readonly required: boolean;
         readonly targetSpec: {
           readonly defaultValue: string | null | undefined;
           readonly key: string;
@@ -166,6 +167,13 @@ v6 = {
 v7 = {
   "alias": null,
   "args": null,
+  "kind": "ScalarField",
+  "name": "required",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
   "concreteType": "PresetTargetSpec",
   "kind": "LinkedField",
   "name": "targetSpec",
@@ -202,21 +210,21 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "min",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "max",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "UIOption",
@@ -239,8 +247,8 @@ v10 = {
       "name": "slider",
       "plural": false,
       "selections": [
-        (v8/*: any*/),
         (v9/*: any*/),
+        (v10/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -259,8 +267,8 @@ v10 = {
       "name": "number",
       "plural": false,
       "selections": [
-        (v8/*: any*/),
-        (v9/*: any*/)
+        (v9/*: any*/),
+        (v10/*: any*/)
       ],
       "storageKey": null
     },
@@ -360,7 +368,8 @@ return {
                     (v5/*: any*/),
                     (v6/*: any*/),
                     (v7/*: any*/),
-                    (v10/*: any*/)
+                    (v8/*: any*/),
+                    (v11/*: any*/)
                   ],
                   "storageKey": null
                 }
@@ -412,7 +421,8 @@ return {
                   (v5/*: any*/),
                   (v6/*: any*/),
                   (v7/*: any*/),
-                  (v10/*: any*/),
+                  (v8/*: any*/),
+                  (v11/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -432,16 +442,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9ec67e7389f1f7cec0f197e6ff23ec91",
+    "cacheID": "3b1462d68628516e8328b7a3def4c27f",
     "id": null,
     "metadata": {},
     "name": "useRuntimeParameterSchemaPresetsQuery",
     "operationKind": "query",
-    "text": "query useRuntimeParameterSchemaPresetsQuery(\n  $filter: RuntimeVariantPresetFilter\n  $orderBy: [RuntimeVariantPresetOrderBy!]\n) {\n  runtimeVariantPresetsResult: runtimeVariantPresets(filter: $filter, orderBy: $orderBy, first: 100) {\n    edges {\n      node {\n        name\n        description\n        rank\n        category\n        displayName\n        targetSpec {\n          presetTarget\n          valueType\n          defaultValue\n          key\n        }\n        uiOption {\n          uiType\n          slider {\n            min\n            max\n            step\n          }\n          number {\n            min\n            max\n          }\n          choices {\n            items {\n              value\n              label\n            }\n          }\n          text {\n            placeholder\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query useRuntimeParameterSchemaPresetsQuery(\n  $filter: RuntimeVariantPresetFilter\n  $orderBy: [RuntimeVariantPresetOrderBy!]\n) {\n  runtimeVariantPresetsResult: runtimeVariantPresets(filter: $filter, orderBy: $orderBy, first: 100) {\n    edges {\n      node {\n        name\n        description\n        rank\n        category\n        displayName\n        required @since(version: \"26.4.4rc7\")\n        targetSpec {\n          presetTarget\n          valueType\n          defaultValue\n          key\n        }\n        uiOption {\n          uiType\n          slider {\n            min\n            max\n            step\n          }\n          number {\n            min\n            max\n          }\n          choices {\n            items {\n              value\n              label\n            }\n          }\n          text {\n            placeholder\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ca5ee1b8f0a7378db0a58b62f8709a68";
+(node as any).hash = "b6be7e3447225bf2a010b745ba3b4af2";
 
 export default node;

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -127,6 +127,8 @@ export type FormValues = ImageEnvironmentFormInput &
     commandInterval?: number;
     commandMaxWaitTime?: number;
     environ: EnvVarFormListValue[];
+    /** Runtime-variant preset values, registered by RuntimeParameterFormSection. */
+    runtimeParams?: RuntimeParameterValues;
   };
 
 export type PresetFormValues = {
@@ -395,9 +397,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
     Record<string, string>
   >({});
 
-  // Runtime parameter refs — kept outside form state so slider/input changes
-  // don't re-render the modal. Read at submit time via serializeRuntimeParamsToEnviron.
-  const runtimeParamValuesRef = useRef<RuntimeParameterValues>({});
+  // Runtime parameter values live in `customForm` under the `runtimeParams`
+  // namespace (registered by RuntimeParameterFormSection), so required presets
+  // participate in normal form validation. Touched keys and groups are kept in
+  // refs since changing them must not re-render the modal — both are only read
+  // at submit time via serializeRuntimeParamsToEnviron.
   const runtimeParamTouchedKeysRef = useRef<Set<string>>(new Set());
   const runtimeParamGroupsRef = useRef<RuntimeParameterGroup[] | null>(null);
 
@@ -951,14 +955,16 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
     setMode('custom');
   };
 
-  // Serialize runtime parameter UI values (from RuntimeParameterFormSection)
-  // into an environ map — mirrors ServiceLauncherPageContent logic.
+  // Serialize runtime parameter form values (registered by
+  // RuntimeParameterFormSection under `runtimeParams`) into an environ map —
+  // mirrors ServiceLauncherPageContent logic.
   const serializeRuntimeParamsToEnviron = (
     environ: Record<string, string>,
     runtimeVariant: string,
+    runtimeParams: RuntimeParameterValues | undefined,
   ) => {
     const groups = runtimeParamGroupsRef.current;
-    if (!groups || Object.keys(runtimeParamValuesRef.current).length === 0)
+    if (!groups || !runtimeParams || Object.keys(runtimeParams).length === 0)
       return;
 
     const extraArgsEnvVar = getExtraArgsEnvVarName(runtimeVariant);
@@ -966,9 +972,13 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
       if (envName !== extraArgsEnvVar) delete environ[envName];
     }
 
+    // Form values are native-typed (number/boolean/string); downstream
+    // merge/compare logic works on the API's string encoding.
     const touchedValues: Record<string, string> = {};
-    for (const [key, val] of Object.entries(runtimeParamValuesRef.current)) {
-      if (runtimeParamTouchedKeysRef.current.has(key)) touchedValues[key] = val;
+    for (const [key, val] of Object.entries(runtimeParams)) {
+      if (!runtimeParamTouchedKeysRef.current.has(key)) continue;
+      if (val === undefined || val === null || val === '') continue;
+      touchedValues[key] = String(val);
     }
 
     const presets = flattenPresets(groups);
@@ -1093,7 +1103,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
       if (variable) environRecord[variable] = value;
     }
     if (!isCustom) {
-      serializeRuntimeParamsToEnviron(environRecord, variantName);
+      serializeRuntimeParamsToEnviron(
+        environRecord,
+        variantName,
+        values.runtimeParams,
+      );
     }
     const environEntries = Object.entries(environRecord).map(
       ([name, value]) => ({ name, value }),
@@ -1609,12 +1623,6 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                   <Suspense fallback={null}>
                     <RuntimeParameterFormSection
                       runtimeVariant={variantName}
-                      onChange={(values) => {
-                        runtimeParamValuesRef.current = {
-                          ...runtimeParamValuesRef.current,
-                          ...values,
-                        };
-                      }}
                       onTouchedKeysChange={(keys) => {
                         runtimeParamTouchedKeysRef.current = keys;
                       }}

--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -3,13 +3,14 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { reverseMapExtraArgs } from '../helper/runtimeExtraArgsParser';
+import { useSuspendedBackendaiClient } from '../hooks';
 import {
   RuntimeVariantPresetDef,
   RuntimeParameterGroup,
   useRuntimeParameterSchema,
-  buildDefaultsMap,
   buildArgsSchemaKeySet,
   buildEnvPresetKeySet,
+  flattenPresets,
 } from '../hooks/useRuntimeParameterSchema';
 import InputNumberWithSlider from './InputNumberWithSlider';
 import { UndoOutlined } from '@ant-design/icons';
@@ -26,7 +27,7 @@ import {
   Tabs,
 } from 'antd';
 import { BAIButton, BAIFlex } from 'backend.ai-ui';
-import React, { useCallback, useEffect, useEffectEvent, useState } from 'react';
+import React, { useEffect, useEffectEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 /** Convert category slug to a display-friendly label. */
@@ -38,13 +39,47 @@ function formatCategoryLabel(category: string): string {
     .join(' ');
 }
 
+/** Native value type stored in antd form state for a runtime parameter. */
+export type RuntimeParameterFormValue = string | number | boolean | undefined;
+
+/**
+ * Runtime parameter values keyed by the preset key (e.g. '--dtype', 'HF_TOKEN').
+ * Lives in the enclosing antd form under the `runtimeParams` namespace.
+ */
 export interface RuntimeParameterValues {
-  [key: string]: string;
+  [key: string]: RuntimeParameterFormValue;
+}
+
+/** antd form name path for the runtime parameter namespace. */
+export const RUNTIME_PARAMS_NAMESPACE = 'runtimeParams';
+
+/**
+ * Convert the API's string-encoded value into the native type stored in
+ * form state (numbers for INT/FLOAT, booleans for BOOL/FLAG).
+ */
+function toNativeValue(
+  param: RuntimeVariantPresetDef,
+  raw: string,
+): RuntimeParameterFormValue {
+  switch (param.valueType) {
+    case 'INT': {
+      const n = parseInt(raw, 10);
+      return Number.isNaN(n) ? undefined : n;
+    }
+    case 'FLOAT': {
+      const n = parseFloat(raw);
+      return Number.isNaN(n) ? undefined : n;
+    }
+    case 'BOOL':
+    case 'FLAG':
+      return raw === 'true';
+    default:
+      return raw;
+  }
 }
 
 interface RuntimeParameterFormSectionProps {
   runtimeVariant: string;
-  onChange?: (values: RuntimeParameterValues) => void;
   /** Called when the set of touched parameter keys changes */
   onTouchedKeysChange?: (touchedKeys: Set<string>) => void;
   /** Called when preset groups are loaded from the API */
@@ -57,13 +92,15 @@ interface RuntimeParameterFormSectionProps {
 
 /**
  * Dynamic form section for runtime parameters.
- * Renders slider/input/select/checkbox controls based on API-provided preset schema.
+ * Renders slider/input/select/checkbox controls based on API-provided preset
+ * schema. Values are registered as fields of the **enclosing antd form** under
+ * the `runtimeParams` namespace, so required presets participate in normal
+ * form validation (`validateFields` / `onFinish`).
  */
 const RuntimeParameterFormSection: React.FC<
   RuntimeParameterFormSectionProps
 > = ({
   runtimeVariant,
-  onChange,
   onTouchedKeysChange,
   onGroupsLoaded,
   initialExtraArgs,
@@ -72,6 +109,11 @@ const RuntimeParameterFormSection: React.FC<
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
+  const form = Form.useFormInstance();
+  const baiClient = useSuspendedBackendaiClient();
+  const supportsRequiredField = baiClient.supports(
+    'runtime-variant-preset-required',
+  );
   const groups = useRuntimeParameterSchema(runtimeVariant);
 
   // Notify parent when groups change (for serialization at submit time)
@@ -90,30 +132,20 @@ const RuntimeParameterFormSection: React.FC<
     };
   }, [groups]);
 
-  const [internalValues, setInternalValues] = useState<RuntimeParameterValues>(
-    {},
-  );
-  const values = internalValues;
-
   // Track which parameter keys the user has explicitly interacted with.
   // In edit mode, keys already present in the endpoint's env vars are pre-marked.
   const [touchedKeys, setTouchedKeys] = useState<Set<string>>(new Set());
 
   const [activeTab, setActiveTab] = useState<string>('');
 
-  const setValues = useCallback(
-    (newValues: RuntimeParameterValues) => {
-      setInternalValues(newValues);
-      onChange?.(newValues);
-    },
-    [onChange],
-  );
-
-  // Initialize from defaults or reverse-map from existing extra args / env vars
+  // Initialize form values. Defaults are deliberately NOT seeded — they are
+  // surfaced as control placeholders instead, so untouched fields stay empty
+  // (the runtime applies its own defaults) and required presets fail
+  // validation until the user supplies an explicit value. In edit mode,
+  // values reverse-mapped from the existing extra args / env vars are seeded.
   const initializeValues = useEffectEvent(() => {
     if (!groups) return;
 
-    const defaults = buildDefaultsMap(groups);
     const hasInitialData = !!initialExtraArgs || !!initialEnvVars;
 
     if (hasInitialData) {
@@ -140,14 +172,25 @@ const RuntimeParameterFormSection: React.FC<
         }
       }
 
-      const allMapped = { ...mappedFromArgs, ...mappedFromEnv };
-      setValues({ ...defaults, ...allMapped });
+      const presetMap = new Map(flattenPresets(groups).map((p) => [p.key, p]));
+      const nativeMapped: RuntimeParameterValues = {};
+      for (const [key, raw] of Object.entries({
+        ...mappedFromArgs,
+        ...mappedFromEnv,
+      })) {
+        const preset = presetMap.get(key);
+        if (preset) nativeMapped[key] = toNativeValue(preset, raw);
+      }
+
+      // Replace the whole namespace so values from a previously selected
+      // variant don't leak into this one.
+      form.setFieldValue(RUNTIME_PARAMS_NAMESPACE, nativeMapped);
       // Pre-mark keys from existing env vars as touched
-      const initialTouched = new Set(Object.keys(allMapped));
+      const initialTouched = new Set(Object.keys(nativeMapped));
       setTouchedKeys(initialTouched);
       onTouchedKeysChange?.(initialTouched);
     } else {
-      setValues(defaults);
+      form.setFieldValue(RUNTIME_PARAMS_NAMESPACE, {});
       setTouchedKeys(new Set());
       onTouchedKeysChange?.(new Set());
     }
@@ -160,33 +203,25 @@ const RuntimeParameterFormSection: React.FC<
     initializeValues();
   }, [runtimeVariant, groups]);
 
-  const handleParamChange = useCallback(
-    (key: string, newValue: string) => {
-      setInternalValues((prev) => {
-        const updated = { ...prev, [key]: newValue };
-        // Notify parent outside updater to keep it pure
-        queueMicrotask(() => onChange?.(updated));
-        return updated;
-      });
-      setTouchedKeys((prev) => {
-        if (prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.add(key);
-        // Notify parent outside updater to keep it pure
-        queueMicrotask(() => onTouchedKeysChange?.(next));
-        return next;
-      });
-    },
-    [onChange, onTouchedKeysChange],
-  );
+  const markTouched = (key: string) => {
+    setTouchedKeys((prev) => {
+      if (prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.add(key);
+      // Notify parent outside updater to keep it pure
+      queueMicrotask(() => onTouchedKeysChange?.(next));
+      return next;
+    });
+  };
 
-  const handleReset = useCallback(() => {
+  const handleReset = () => {
     if (!groups) return;
-    const defaults = buildDefaultsMap(groups);
-    setValues(defaults);
+    // Empty form = every parameter falls back to the runtime's own default
+    // (untouched/empty keys are excluded from serialization).
+    form.setFieldValue(RUNTIME_PARAMS_NAMESPACE, {});
     setTouchedKeys(new Set());
     onTouchedKeysChange?.(new Set());
-  }, [groups, setValues, onTouchedKeysChange]);
+  };
 
   if (!groups) return null;
 
@@ -213,9 +248,11 @@ const RuntimeParameterFormSection: React.FC<
             <BAIFlex justify="between" align="center" style={{ flex: 1 }}>
               <span>
                 {t('modelService.RuntimeParamTitle')}{' '}
-                <span style={{ color: token.colorTextSecondary }}>
-                  ({t('general.Optional')})
-                </span>
+                {!supportsRequiredField && (
+                  <span style={{ color: token.colorTextSecondary }}>
+                    ({t('general.Optional')})
+                  </span>
+                )}
               </span>
               <Tooltip title={t('button.Reset')}>
                 <BAIButton
@@ -249,12 +286,15 @@ const RuntimeParameterFormSection: React.FC<
                   return {
                     key: tab.key,
                     label: tab.label,
+                    // Mount every pane up front so required rules of fields in
+                    // unvisited tabs are registered with the form — otherwise
+                    // `validateFields()` silently skips them.
+                    forceRender: true,
                     children: group ? (
                       <ParameterGroupContent
                         group={group}
-                        values={values}
                         touchedKeys={touchedKeys}
-                        onParamChange={handleParamChange}
+                        onParamTouch={markTouched}
                       />
                     ) : null,
                   };
@@ -270,16 +310,14 @@ const RuntimeParameterFormSection: React.FC<
 
 interface ParameterGroupContentProps {
   group: RuntimeParameterGroup;
-  values: RuntimeParameterValues;
   touchedKeys: Set<string>;
-  onParamChange: (key: string, value: string) => void;
+  onParamTouch: (key: string) => void;
 }
 
 const ParameterGroupContent: React.FC<ParameterGroupContentProps> = ({
   group,
-  values,
   touchedKeys,
-  onParamChange,
+  onParamTouch,
 }) => {
   'use memo';
   return (
@@ -288,9 +326,8 @@ const ParameterGroupContent: React.FC<ParameterGroupContentProps> = ({
         <ParameterControl
           key={param.key}
           param={param}
-          value={values[param.key] ?? param.defaultValue ?? ''}
           touched={touchedKeys.has(param.key)}
-          onChange={(val) => onParamChange(param.key, val)}
+          onTouch={() => onParamTouch(param.key)}
         />
       ))}
     </BAIFlex>
@@ -299,20 +336,22 @@ const ParameterGroupContent: React.FC<ParameterGroupContentProps> = ({
 
 interface ParameterControlProps {
   param: RuntimeVariantPresetDef;
-  value: string;
   touched: boolean;
-  onChange: (value: string) => void;
+  onTouch: () => void;
 }
 
 const ParameterControl: React.FC<ParameterControlProps> = ({
   param,
-  value,
   touched,
-  onChange,
+  onTouch,
 }) => {
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
+  const baiClient = useSuspendedBackendaiClient();
+  const supportsRequired = baiClient.supports(
+    'runtime-variant-preset-required',
+  );
 
   const label = param.displayName ?? param.name;
   const tooltip = param.description ?? undefined;
@@ -321,6 +360,14 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
   };
   const controlOpacity = touched ? undefined : 0.45;
   const controlTransition = 'opacity 0.2s';
+
+  // Defaults are shown as placeholders (not seeded into form state), so a
+  // required preset always demands an explicit user value before submit.
+  const isRequired = supportsRequired && param.required;
+  const requiredRules = isRequired
+    ? [{ required: true, message: t('general.ValueRequired', { name: label }) }]
+    : undefined;
+  const defaultPlaceholder = param.defaultValue ?? undefined;
 
   const uiType = param.uiType;
 
@@ -331,18 +378,20 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
       const step = param.slider?.step ?? 1;
       return (
         <Form.Item
+          name={[RUNTIME_PARAMS_NAMESPACE, param.key]}
           label={label}
           tooltip={tooltip}
           style={formItemStyle}
-          required
+          required={isRequired}
+          rules={requiredRules}
         >
           <InputNumberWithSlider
             min={min}
             max={max}
             step={step}
-            value={value ? parseFloat(value) : min}
-            onChange={(v) => onChange(String(v))}
+            onChange={onTouch}
             inputContainerMinWidth={190}
+            inputNumberProps={{ placeholder: defaultPlaceholder }}
             style={{ opacity: controlOpacity, transition: controlTransition }}
             sliderProps={{
               marks: {
@@ -364,25 +413,19 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
       const isInt = param.valueType === 'INT';
       return (
         <Form.Item
+          name={[RUNTIME_PARAMS_NAMESPACE, param.key]}
           label={label}
           tooltip={tooltip}
           style={formItemStyle}
-          required
+          required={isRequired}
+          rules={requiredRules}
         >
           <InputNumber
             min={min}
             max={max}
             step={isInt ? 1 : 0.1}
-            value={
-              value
-                ? isInt
-                  ? parseInt(value, 10)
-                  : parseFloat(value)
-                : undefined
-            }
-            onChange={(v) => {
-              if (v !== null) onChange(String(v));
-            }}
+            onChange={onTouch}
+            placeholder={defaultPlaceholder}
             style={{
               width: '100%',
               opacity: controlOpacity,
@@ -396,15 +439,21 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
     case 'select':
       return (
         <Form.Item
+          name={[RUNTIME_PARAMS_NAMESPACE, param.key]}
           label={label}
           tooltip={tooltip}
           style={formItemStyle}
-          required
+          required={isRequired}
+          rules={requiredRules}
         >
           <Select
-            value={value || undefined}
             allowClear
-            onChange={(val) => onChange(val ?? '')}
+            onChange={onTouch}
+            placeholder={
+              param.choices?.items.find(
+                (opt) => opt.value === param.defaultValue,
+              )?.label ?? defaultPlaceholder
+            }
             style={{ opacity: controlOpacity, transition: controlTransition }}
             options={param.choices?.items.map((opt) => ({
               value: opt.value,
@@ -417,14 +466,16 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
     case 'checkbox':
       return (
         <Form.Item
+          name={[RUNTIME_PARAMS_NAMESPACE, param.key]}
+          valuePropName="checked"
           label={label}
           tooltip={tooltip}
           style={formItemStyle}
-          required
+          required={isRequired}
+          rules={requiredRules}
         >
           <Checkbox
-            checked={value === 'true'}
-            onChange={(e) => onChange(e.target.checked ? 'true' : 'false')}
+            onChange={onTouch}
             aria-label={label}
             style={{ opacity: controlOpacity, transition: controlTransition }}
           >
@@ -437,18 +488,17 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
     default:
       return (
         <Form.Item
+          name={[RUNTIME_PARAMS_NAMESPACE, param.key]}
           label={label}
           tooltip={tooltip}
           style={formItemStyle}
-          required
+          required={isRequired}
+          rules={requiredRules}
         >
           <Input
-            value={touched ? value : ''}
-            onChange={(e) => onChange(e.target.value)}
+            onChange={onTouch}
             placeholder={
-              !touched
-                ? value || (param.text?.placeholder ?? undefined)
-                : (param.text?.placeholder ?? undefined)
+              defaultPlaceholder ?? param.text?.placeholder ?? undefined
             }
             style={{ opacity: controlOpacity, transition: controlTransition }}
           />

--- a/react/src/hooks/useRuntimeParameterSchema.ts
+++ b/react/src/hooks/useRuntimeParameterSchema.ts
@@ -57,6 +57,8 @@ export interface RuntimeVariantPresetDef {
   choices: { items: ReadonlyArray<SelectOption> } | null;
   /** Text input placeholder. */
   text: { placeholder: string | null } | null;
+  /** Whether this parameter must be filled in before submitting a deployment. */
+  required: boolean;
 }
 
 /** Group of presets within the same category. */
@@ -129,6 +131,10 @@ export function useRuntimeParameterSchema(
               rank
               category
               displayName
+              # Version-gated: stripped from the request on managers older than
+              # the capability cutoff (runtime-variant-preset-required in
+              # client.ts) so the presets query stays valid on legacy backends.
+              required @since(version: "26.4.4rc7")
               targetSpec {
                 presetTarget
                 valueType
@@ -191,6 +197,9 @@ export function useRuntimeParameterSchema(
         rank: node.rank,
         category: node.category ?? null,
         displayName: node.displayName ?? null,
+        // `required` is absent when the field is version-gated out (see the
+        // `@since` directive in the query) — default to false on legacy backends.
+        required: node.required ?? false,
         presetTarget: node.targetSpec.presetTarget as PresetTarget,
         valueType: node.targetSpec.valueType as PresetValueType,
         defaultValue: node.targetSpec.defaultValue ?? null,


### PR DESCRIPTION
Resolves #7814 (FR-3087)

## Summary

Adds frontend support for the `required: Boolean!` field introduced in `RuntimeVariantPreset` by backend PR [#12000](https://github.com/lablup/backend.ai/pull/12000) (BA-6326).

### Changes

- **Schema** (`data/schema.graphql`): Add `required: Boolean!` to `RuntimeVariantPreset`, `required: Boolean! = false` to `CreateRuntimeVariantPresetInput`, `required: Boolean = null` to `UpdateRuntimeVariantPresetInput`
- **Capability gate** (`client.ts`): `runtime-variant-preset-required` feature flag for manager >= 26.4.4rc7
- **Hook** (`useRuntimeParameterSchema.ts`): Fetch `required` with `@since(version: "26.4.4rc7")` so the presets query stays valid on legacy managers (the field is stripped client-side); default to `false` when absent
- **Form section** (`RuntimeParameterFormSection.tsx`): Register each parameter control as a real antd form field under the `runtimeParams` namespace (`name={['runtimeParams', key]}`) so `required` rules participate in `validateFields()`. Values are native-typed (number/boolean/string) in form state. Defaults are surfaced as control placeholders (not seeded into form state), so untouched fields stay empty and required presets demand an explicit user value before submit. All category tab panes are force-rendered so rules of fields in unvisited tabs register with the form.
- **Modal** (`DeploymentAddRevisionModal.tsx`): Serialize runtime params from `values.runtimeParams` (form state) instead of a side-channel ref; required presets now block submission with a field-level error when left empty

### Out of scope

- Admin CRUD UI for `RuntimeVariantPreset` (create/edit with `required` toggle) — no admin management page exists in the current frontend. Tasks 2 & 4 from the issue require a dedicated admin page which is tracked separately.
- A section-header "Contains required fields" indicator — dropped after review; the per-field asterisk is sufficient.

## Test plan

- [x] `scripts/verify.sh` — Relay / Lint / Format / TypeScript pass
- [ ] Deployment form shows red asterisk only on `required: true` runtime parameters
- [ ] Submitting with an empty required parameter is blocked with a field-level error (including params in unvisited tabs)
- [ ] On managers < 26.4.4rc7 the presets query succeeds and the UI behaves as before (`(optional)` label, no asterisks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

