### PR TITLE
fix(FR-3097): surface backend errors and unstick auto-deploy retry in deploy modals

### DIFF
--- a/react/src/components/ModelCardDeployModal.tsx
+++ b/react/src/components/ModelCardDeployModal.tsx
@@ -17,6 +17,7 @@ import {
   type BAIModalProps,
   BAIProjectResourceGroupSelect,
   toLocalId,
+  useErrorMessageResolver,
   useProjectResourceGroups,
 } from 'backend.ai-ui';
 import React, {
@@ -61,6 +62,7 @@ const ModelCardDeployModal: React.FC<ModelCardDeployModalProps> = ({
 
   const { t } = useTranslation();
   const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
   const webuiNavigate = useWebUINavigate();
   const { token } = theme.useToken();
   const { id: projectId, name: projectName } = useCurrentProjectValue();
@@ -159,7 +161,18 @@ const ModelCardDeployModal: React.FC<ModelCardDeployModalProps> = ({
             desiredReplicaCount: 1,
           },
         },
-        onCompleted: (response) => {
+        onCompleted: (response, errors) => {
+          // Backend validation failures arrive as a null payload plus
+          // top-level GraphQL errors routed here (not to `onError`, which
+          // only fires for network errors). Surface the backend message.
+          if (errors && errors.length > 0) {
+            const firstError = errors[0];
+            const errorMessage =
+              firstError?.message ?? getErrorMessage(firstError);
+            message.error(errorMessage);
+            reject(new Error(errorMessage));
+            return;
+          }
           const payload = response.deployModelCardV2;
           if (!payload) {
             const error = new Error(t('modelStore.DeployFailed'));
@@ -188,7 +201,16 @@ const ModelCardDeployModal: React.FC<ModelCardDeployModalProps> = ({
   const onAutoDeployed = useEffectEvent(() => {
     if (didAutoDeployRef.current) return;
     didAutoDeployRef.current = true;
-    handleDeploy();
+    handleDeploy().catch(() => {
+      // On failure there is no modal chrome the user can close, so close
+      // imperatively: `onClose()` clears the parent state, flipping `open`
+      // to false, which fires the mirrored `afterClose` below and lets
+      // `BAIUnmountAfterClose` unmount us — the next Deploy click mounts a
+      // fresh instance. The ref reset is a safety net in case this
+      // instance survives.
+      didAutoDeployRef.current = false;
+      onClose();
+    });
   });
 
   useEffect(() => {

--- a/react/src/components/VFolderDeployModal.tsx
+++ b/react/src/components/VFolderDeployModal.tsx
@@ -17,6 +17,7 @@ import {
   type BAIModalProps,
   BAIProjectResourceGroupSelect,
   toLocalId,
+  useErrorMessageResolver,
   useProjectResourceGroups,
 } from 'backend.ai-ui';
 import React, {
@@ -58,6 +59,7 @@ const VFolderDeployModal: React.FC<VFolderDeployModalProps> = ({
 
   const { t } = useTranslation();
   const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
   const webuiNavigate = useWebUINavigate();
   const { token } = theme.useToken();
   const { id: projectId, name: projectName } = useCurrentProjectValue();
@@ -172,7 +174,18 @@ const VFolderDeployModal: React.FC<VFolderDeployModalProps> = ({
             desiredReplicaCount: 1,
           },
         },
-        onCompleted: (response) => {
+        onCompleted: (response, errors) => {
+          // Backend validation failures arrive as a null payload plus
+          // top-level GraphQL errors routed here (not to `onError`, which
+          // only fires for network errors). Surface the backend message.
+          if (errors && errors.length > 0) {
+            const firstError = errors[0];
+            const errorMessage =
+              firstError?.message ?? getErrorMessage(firstError);
+            message.error(errorMessage);
+            reject(new Error(errorMessage));
+            return;
+          }
           const payload = response.deployVfolderV2;
           if (!payload) {
             const error = new Error(t('modelStore.DeployFailed'));
@@ -201,7 +214,16 @@ const VFolderDeployModal: React.FC<VFolderDeployModalProps> = ({
   const onAutoDeployed = useEffectEvent(() => {
     if (didAutoDeployRef.current) return;
     didAutoDeployRef.current = true;
-    handleDeploy();
+    handleDeploy().catch(() => {
+      // On failure there is no modal chrome the user can close, so close
+      // imperatively: `onClose()` clears the parent state, flipping `open`
+      // to false, which fires the mirrored `afterClose` below and lets
+      // `BAIUnmountAfterClose` unmount us — the next Deploy click mounts a
+      // fresh instance. The ref reset is a safety net in case this
+      // instance survives.
+      didAutoDeployRef.current = false;
+      onClose();
+    });
   });
 
   useEffect(() => {


### PR DESCRIPTION
Resolves #7829 (FR-3097)

## Problem

When a deploy request fails backend validation, the user sees only the generic "Deploy failed" toast instead of the actionable backend error message. Worse, in the auto-deploy scenario (exactly 1 preset and 1 resource group, where the component renders no modal chrome), a failed deploy permanently bricks the Deploy button: every subsequent click is a silent no-op until the page is remounted.

Both defects exist identically in `VFolderDeployModal.tsx` and `ModelCardDeployModal.tsx` (copied code) — this PR fixes both.

## Root cause

- **(a) GraphQL errors discarded**: `deployVfolderV2` / `deployModelCardV2` return a nullable payload; backend validation failures arrive as `data: { ...: null }` plus top-level `errors`. Relay routes payload errors to `onCompleted(response, errors)` (`onError` fires only for network errors), but both modals declared `onCompleted: (response) => ...`, ignoring the `errors` argument and falling through to the static `t('modelStore.DeployFailed')` message.
- **(b) Retry dead after auto-deploy failure**: the auto-deploy effect sets `didAutoDeployRef.current = true` *before* calling `handleDeploy()` and never handles the rejection. On failure neither `onClose` nor `onDeployed` fires, so the parent keeps its open-state set, `open` never flips false, the mirrored `afterClose` effect never fires, `BAIUnmountAfterClose` never unmounts, and the ref stays `true` — making every later Deploy click a no-op.

## Changes

### (a) Surface backend errors
- `onCompleted` now accepts `(response, errors)`; if `errors?.length`, shows `firstError?.message ?? getErrorMessage(firstError)` (via `useErrorMessageResolver` from `backend.ai-ui`) and rejects — same convention as `DeleteVFolderModalV2.tsx` and `VFolderNodesV2.tsx`.
- The null-payload generic fallback is kept for the no-errors case.

### (b) Unstick auto-deploy retry
- `onAutoDeployed` now handles the rejection: `handleDeploy().catch(() => { didAutoDeployRef.current = false; onClose(); })`.
- Calling `onClose()` is load-bearing: it clears the parent state, flips `open` to false, fires the mirrored `afterClose` effect, and lets `BAIUnmountAfterClose` unmount the instance so the next Deploy click mounts fresh. The ref reset is a safety net.
- Verified both parents use the same contract: `VFolderNodesV2.tsx` (`onClose={() => setDeployFallbackVfolderId(null)}`) and `ModelCardDrawer.tsx` (`onClose={() => setDeployModalOpen(false)}`), so the identical fix applies to both modals.

No i18n key changes; backend messages are shown as-is. No GraphQL tag changes.

## Verification

```
=== Relay ===
--- Relay: PASS ---
=== Lint ===
--- Lint: PASS ---
=== Format ===
--- Format: PASS ---
=== TypeScript ===
--- TypeScript: PASS ---
=== Vite warmup paths ===
--- Vite warmup paths: PASS ---
=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
