### PR TITLE
fix(FR-3098): prepend UTF-8 BOM to CSV exports via central downloadCSV helper

### DIFF
--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -12,6 +12,7 @@ import {
 import { MyKeypairManagementModalRevokeMyKeypairMutation } from '../__generated__/MyKeypairManagementModalRevokeMyKeypairMutation.graphql';
 import { MyKeypairManagementModalSwitchMainKeyMutation } from '../__generated__/MyKeypairManagementModalSwitchMainKeyMutation.graphql';
 import { convertToOrderBy } from '../helper';
+import { downloadCSV } from '../helper/csv-util';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import BAIRadioGroup from './BAIRadioGroup';
@@ -74,6 +75,8 @@ type KeypairSorterValue =
   | '-createdAt'
   | '-lastUsed';
 
+// Keypair credentials are assembled client-side; switch to the useCSVExport
+// hook once server-side CSV export supports them.
 const downloadCredentialCSV = (credential: KeypairCredential) => {
   const header = 'access_key,secret_key,ssh_public_key';
   const row = [
@@ -85,13 +88,7 @@ const downloadCredentialCSV = (credential: KeypairCredential) => {
     .join(',');
 
   const csvContent = `${header}\n${row}\n`;
-  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = `keypair_${credential.accessKey}.csv`;
-  link.click();
-  URL.revokeObjectURL(url);
+  downloadCSV(csvContent, `keypair_${credential.accessKey}.csv`);
 };
 
 const MyKeypairManagementModal: React.FC<MyKeypairManagementModalProps> = ({

--- a/react/src/helper/csv-util.test.ts
+++ b/react/src/helper/csv-util.test.ts
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 // csv-util.test.ts
-import { JSONToCSVBody } from './csv-util';
+import { downloadCSV, JSONToCSVBody, UTF8_BOM } from './csv-util';
 
 describe('JSONToCSVBody', () => {
   it('should convert JSON data to CSV format without formatting rules', () => {
@@ -73,5 +73,115 @@ describe('JSONToCSVBody', () => {
     const expected = '"name","age"\n"John ""Doe""",30\n"Jane, the Great",25';
 
     expect(result).toBe(expected);
+  });
+});
+
+describe('downloadCSV', () => {
+  // jsdom does not implement createObjectURL/revokeObjectURL; save whatever
+  // is there so the mocks below never leak into other test suites.
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  let capturedBlob: Blob | undefined;
+  let capturedAnchor: HTMLAnchorElement | undefined;
+
+  beforeEach(() => {
+    capturedBlob = undefined;
+    capturedAnchor = undefined;
+    vi.useFakeTimers();
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      capturedBlob = blob;
+      return 'blob:mock-url';
+    }) as typeof URL.createObjectURL;
+    URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL;
+
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation(
+      (tagName: string) => {
+        const element = originalCreateElement(tagName);
+        if (tagName === 'a') {
+          capturedAnchor = element as HTMLAnchorElement;
+          vi.spyOn(element as HTMLAnchorElement, 'click').mockImplementation(
+            () => {},
+          );
+        }
+        return element;
+      },
+    );
+  });
+
+  afterEach(() => {
+    // Flush downloadBlob's delayed URL.revokeObjectURL while the mock is
+    // still installed, then restore the real timers and URL methods.
+    vi.runAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  // Blob.text() strips a leading BOM while decoding, so assert on the raw
+  // bytes instead. The decoder below keeps the BOM visible via ignoreBOM.
+  const decodeKeepingBOM = async (blob: Blob) =>
+    new TextDecoder('utf-8', { ignoreBOM: true }).decode(
+      await blob.arrayBuffer(),
+    );
+
+  it('should prepend the UTF-8 BOM exactly once', async () => {
+    const csvContent = '이름,설명\n홍길동,"한글, 내용"';
+
+    downloadCSV(csvContent, 'report.csv');
+
+    const text = await decodeKeepingBOM(capturedBlob!);
+    expect(text).toBe(UTF8_BOM + csvContent);
+    expect(text.startsWith(UTF8_BOM + UTF8_BOM)).toBe(false);
+  });
+
+  it('should not duplicate a pre-existing BOM', async () => {
+    const csvContent = `${UTF8_BOM}name,value\nfoo,1`;
+
+    downloadCSV(csvContent, 'report.csv');
+
+    const text = await decodeKeepingBOM(capturedBlob!);
+    expect(text).toBe(csvContent);
+    expect(text.startsWith(UTF8_BOM + UTF8_BOM)).toBe(false);
+  });
+
+  it('should append the .csv extension when missing', () => {
+    downloadCSV('a,b\n1,2', 'report');
+
+    expect(capturedAnchor?.download).toBe('report.csv');
+  });
+
+  it('should not double the .csv extension when already present', () => {
+    downloadCSV('a,b\n1,2', 'report.csv');
+
+    expect(capturedAnchor?.download).toBe('report.csv');
+  });
+
+  it('should recognize the extension case-insensitively', () => {
+    downloadCSV('a,b\n1,2', 'report.CSV');
+
+    expect(capturedAnchor?.download).toBe('report.CSV');
+  });
+
+  it('should remove the anchor from the document after clicking', () => {
+    downloadCSV('a,b\n1,2', 'report');
+
+    expect(capturedAnchor?.click).toHaveBeenCalledTimes(1);
+    expect(capturedAnchor?.isConnected).toBe(false);
+  });
+
+  it('should revoke the object URL after a delay', () => {
+    downloadCSV('a,b\n1,2', 'report');
+
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('should set the UTF-8 CSV MIME type on the blob', () => {
+    downloadCSV('a,b\n1,2', 'report');
+
+    expect(capturedBlob?.type).toBe('text/csv;charset=utf-8;');
   });
 });

--- a/react/src/helper/csv-util.ts
+++ b/react/src/helper/csv-util.ts
@@ -64,6 +64,12 @@ export const JSONToCSVBody = <T>(
 
 /**
  * Download a file from the given blob.
+ *
+ * The anchor is appended to the document before clicking and the object URL
+ * revocation is delayed, so the download also works on Safari and older
+ * engines that ignore clicks on detached anchors or cancel downloads whose
+ * URL is revoked synchronously.
+ *
  * @param {Blob} blob - The file content.
  * @param {string} filename - The name of the file.
  */
@@ -73,8 +79,39 @@ export const downloadBlob = (blob: Blob, filename: string) => {
   const a = document.createElement('a');
   a.href = url;
   a.download = filename;
+  document.body.appendChild(a);
   a.click();
-  URL.revokeObjectURL(url);
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
+};
+
+export const UTF8_BOM = '\uFEFF';
+
+/**
+ * Download a CSV string as a file with a UTF-8 BOM prepended.
+ *
+ * The BOM makes Excel decode the file as UTF-8 instead of the system ANSI
+ * codepage (e.g. CP949 on Korean Windows), which would otherwise garble
+ * multibyte characters in localized content.
+ *
+ * This helper is for CSV content that must be assembled client-side because
+ * the backend's server-side CSV export (`POST /export/{nodeKey}/csv`) does not
+ * cover the data yet. Once server-side export supports the data you are
+ * exporting, use the `useCSVExport` hook instead of building CSV in the
+ * client.
+ *
+ * @param csvContent - The CSV content. A pre-existing BOM is not duplicated.
+ * @param filename - The download filename. `.csv` is appended if missing.
+ */
+export const downloadCSV = (csvContent: string, filename: string) => {
+  const content = csvContent.startsWith(UTF8_BOM)
+    ? csvContent
+    : UTF8_BOM + csvContent;
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  downloadBlob(
+    blob,
+    filename.toLowerCase().endsWith('.csv') ? filename : `${filename}.csv`,
+  );
 };
 
 export const exportCSVWithFormattingRules = <T>(
@@ -85,8 +122,7 @@ export const exportCSVWithFormattingRules = <T>(
   },
 ) => {
   const bodyStr = JSONToCSVBody(data, format_rules);
-  const blob = new Blob([bodyStr], { type: 'text/csv' });
-  downloadBlob(blob, `${filename}.csv`);
+  downloadCSV(bodyStr, filename);
 };
 
 /**

--- a/react/src/hooks/useCSVExport.ts
+++ b/react/src/hooks/useCSVExport.ts
@@ -1,4 +1,5 @@
 import { useSuspendedBackendaiClient } from '.';
+import { downloadCSV } from '../helper/csv-util';
 import { useCurrentUserRole } from './backendai';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import {
@@ -69,27 +70,13 @@ export const useCSVExport = (nodeKey: SupportedNodeKeys) => {
       },
     })
       .then((res: string) => {
-        const blob = new Blob([res], { type: 'text/csv;charset=utf-8;' });
-        const link = document.createElement('a');
-        const url = URL.createObjectURL(blob);
-
         const timestamp = new Date()
           .toISOString()
           .replace(/[:.]/g, '-')
           .slice(0, -5);
         const filename = `${nodeKey}_export_${timestamp}.csv`;
 
-        link.setAttribute('href', url);
-        link.setAttribute('download', filename);
-        link.style.visibility = 'hidden';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-
-        // Revoke the object URL after a short delay to ensure the download has started
-        setTimeout(() => {
-          URL.revokeObjectURL(url);
-        }, 100);
+        downloadCSV(res, filename);
         return Promise.resolve();
       })
       .catch((err: ErrorResponse) => {

--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -7,7 +7,7 @@ import EndpointDiagnosticsSection from '../components/EndpointDiagnosticsSection
 import ErrorBoundaryWithNullFallback from '../components/ErrorBoundaryWithNullFallback';
 import StorageProxyDiagnosticsSection from '../components/StorageProxyDiagnosticsSection';
 import WebServerConfigDiagnosticsSection from '../components/WebServerConfigDiagnosticsSection';
-import { downloadBlob } from '../helper/csv-util';
+import { downloadCSV } from '../helper/csv-util';
 import { DiagnosticResult } from '../types/diagnostics';
 import {
   DownloadOutlined,
@@ -137,11 +137,10 @@ const DiagnosticsPage = () => {
       .map((row) => row.map(escCsv).join(','))
       .join('\n');
 
-    const blob = new Blob([csvContent], {
-      type: 'text/csv;charset=utf-8;',
-    });
     const today = new Date().toISOString().slice(0, 10);
-    downloadBlob(blob, `diagnostics-${today}.csv`);
+    // Diagnostics reports are assembled client-side; switch to the
+    // useCSVExport hook once server-side CSV export supports them.
+    downloadCSV(csvContent, `diagnostics-${today}.csv`);
   };
 
   const allItems = [


### PR DESCRIPTION
Resolves #7830 (FR-3098)

## Problem

Exported CSV files (Diagnostics page report, admin CSV exports, keypair credential download) display garbled text when opened in Excel on systems with a non-UTF-8 ANSI codepage (e.g. CP949 on Korean Windows). CSV content includes localized `t()` strings and user-provided names, so any non-ASCII text was affected.

## Root cause

CSV download Blobs were created without a UTF-8 BOM. Without the BOM, Excel ignores the `charset=utf-8` MIME hint and decodes the file with the system ANSI codepage, garbling multibyte UTF-8 sequences.

## Fix

Added a central `downloadCSV(csvContent, filename)` helper in `react/src/helper/csv-util.ts` that:

- prepends the UTF-8 BOM (`﻿`) exactly once (guards against a pre-existing BOM, e.g. if the backend ever starts sending one),
- appends the `.csv` extension only when missing,
- creates the Blob with `text/csv;charset=utf-8;` and delegates to the generic `downloadBlob` (kept generic since it also serves non-CSV downloads).

Routed all four BOM-less CSV call sites through it:

1. `react/src/pages/DiagnosticsPage.tsx` — diagnostics report export (the reported bug; rows are built from localized `t()` strings).
2. `react/src/hooks/useCSVExport.ts` — backend `POST /export/{nodeKey}/csv` exports (sessions / users / projects / audit-logs); replaced the inline Blob + anchor boilerplate while preserving the exact `${nodeKey}_export_${timestamp}.csv` filename.
3. `react/src/helper/csv-util.ts` `exportCSVWithFormattingRules` — previously had no BOM and no charset in the Blob type.
4. `react/src/components/MyKeypairManagementModal.tsx` `downloadCredentialCSV` — ASCII-only today, unified for consistency; filename `keypair_${accessKey}.csv` preserved.

## Tests

Extended `react/src/helper/csv-util.test.ts` with a `downloadCSV` suite (8 cases): BOM prepended exactly once, pre-existing BOM not duplicated, `.csv` appended when missing, `.csv` not doubled (case-insensitively), Blob MIME type, anchor appended/removed around `click()`, and delayed `URL.revokeObjectURL`. Note: assertions decode `blob.arrayBuffer()` with `TextDecoder(..., { ignoreBOM: true })` because `Blob.text()` silently strips a leading BOM.

## Verification

```
=== Relay === PASS
=== Lint === PASS
=== Format === PASS
=== TypeScript === PASS
=== Vite warmup paths === PASS
=== ALL PASS ===
```

`pnpm vitest run src/helper/csv-util.test.ts`: 13 tests passed.

## Review follow-ups

- `useCSVExport`'s previous body-append + 100ms-delayed `URL.revokeObjectURL` behavior is now preserved centrally in `downloadBlob`, so all callers (CSV and non-CSV) get the Safari/older-engine-safe download path.
- `exportCSVWithFormattingRules` also gained the previously-missing `charset=utf-8` MIME parameter.
- CSV formula-injection neutralization (`=`, `+`, `-`, `@` prefixes) is a pre-existing gap, tracked as a separate Jira follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
