### PR TITLE
fix(FR-3092): scope personal session list to current user

### DIFF
--- a/react/src/__generated__/ComputeSessionListPageQuery.graphql.ts
+++ b/react/src/__generated__/ComputeSessionListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d9c59c62e8b27ae93c20e5050499aecf>>
+ * @generated SignedSource<<6a3d9ad121b982aec86c736225f3af51>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,11 +11,16 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs, Result } from "relay-runtime";
 export type ComputeSessionListPageQuery$variables = {
+  allFilter?: string | null | undefined;
+  batchFilter?: string | null | undefined;
   filter?: string | null | undefined;
   first?: number | null | undefined;
+  inferenceFilter?: string | null | undefined;
+  interactiveFilter?: string | null | undefined;
   offset?: number | null | undefined;
   order?: string | null | undefined;
   scopeId?: any | null | undefined;
+  systemFilter?: string | null | undefined;
 };
 export type ComputeSessionListPageQuery$data = {
   readonly all: {
@@ -53,34 +58,59 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "filter"
+  "name": "allFilter"
 },
 v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "batchFilter"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v3 = {
   "defaultValue": 20,
   "kind": "LocalArgument",
   "name": "first"
 },
-v2 = {
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "inferenceFilter"
+},
+v5 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "interactiveFilter"
+},
+v6 = {
   "defaultValue": 0,
   "kind": "LocalArgument",
   "name": "offset"
 },
-v3 = {
+v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
   "name": "order"
 },
-v4 = {
+v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
   "name": "scopeId"
 },
-v5 = {
+v9 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "systemFilter"
+},
+v10 = {
   "kind": "Variable",
   "name": "scope_id",
   "variableName": "scopeId"
 },
-v6 = [
+v11 = [
   {
     "kind": "Variable",
     "name": "filter",
@@ -101,166 +131,166 @@ v6 = [
     "name": "order",
     "variableName": "order"
   },
-  (v5/*: any*/)
+  (v10/*: any*/)
 ],
-v7 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v9 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "count",
   "storageKey": null
 },
-v10 = {
+v15 = {
   "kind": "Literal",
   "name": "first",
   "value": 0
 },
-v11 = {
+v16 = {
   "kind": "Literal",
   "name": "offset",
   "value": 0
 },
-v12 = [
-  (v9/*: any*/)
+v17 = [
+  (v14/*: any*/)
 ],
-v13 = {
+v18 = {
   "alias": "all",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\""
+      "variableName": "allFilter"
     },
-    (v10/*: any*/),
-    (v11/*: any*/),
-    (v5/*: any*/)
+    (v15/*: any*/),
+    (v16/*: any*/),
+    (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v12/*: any*/),
+  "selections": (v17/*: any*/),
   "storageKey": null
 },
-v14 = {
+v19 = {
   "alias": "interactive",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
+      "variableName": "interactiveFilter"
     },
-    (v10/*: any*/),
-    (v11/*: any*/),
-    (v5/*: any*/)
+    (v15/*: any*/),
+    (v16/*: any*/),
+    (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v12/*: any*/),
+  "selections": (v17/*: any*/),
   "storageKey": null
 },
-v15 = {
+v20 = {
   "alias": "inference",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
+      "variableName": "inferenceFilter"
     },
-    (v10/*: any*/),
-    (v11/*: any*/),
-    (v5/*: any*/)
+    (v15/*: any*/),
+    (v16/*: any*/),
+    (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v12/*: any*/),
+  "selections": (v17/*: any*/),
   "storageKey": null
 },
-v16 = {
+v21 = {
   "alias": "batch",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
+      "variableName": "batchFilter"
     },
-    (v10/*: any*/),
-    (v11/*: any*/),
-    (v5/*: any*/)
+    (v15/*: any*/),
+    (v16/*: any*/),
+    (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v12/*: any*/),
+  "selections": (v17/*: any*/),
   "storageKey": null
 },
-v17 = {
+v22 = {
   "alias": "system",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
+      "variableName": "systemFilter"
     },
-    (v10/*: any*/),
-    (v11/*: any*/),
-    (v5/*: any*/)
+    (v15/*: any*/),
+    (v16/*: any*/),
+    (v10/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v12/*: any*/),
+  "selections": (v17/*: any*/),
   "storageKey": null
 },
-v18 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "row_id",
   "storageKey": null
 },
-v19 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status",
   "storageKey": null
 },
-v20 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status_info",
   "storageKey": null
 },
-v21 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "tag",
   "storageKey": null
 },
-v22 = [
+v27 = [
   {
     "alias": null,
     "args": null,
@@ -276,7 +306,7 @@ v22 = [
     "storageKey": null
   }
 ],
-v23 = [
+v28 = [
   {
     "alias": null,
     "args": null,
@@ -293,17 +323,17 @@ v23 = [
         "name": "node",
         "plural": false,
         "selections": [
-          (v7/*: any*/),
-          (v18/*: any*/),
-          (v8/*: any*/),
-          (v19/*: any*/)
+          (v12/*: any*/),
+          (v23/*: any*/),
+          (v13/*: any*/),
+          (v24/*: any*/)
         ],
         "storageKey": null
       }
     ],
     "storageKey": null
   },
-  (v9/*: any*/)
+  (v14/*: any*/)
 ];
 return {
   "fragment": {
@@ -312,7 +342,12 @@ return {
       (v1/*: any*/),
       (v2/*: any*/),
       (v3/*: any*/),
-      (v4/*: any*/)
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/),
+      (v9/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -322,7 +357,7 @@ return {
         "kind": "CatchField",
         "field": {
           "alias": "computeSessionNodeResult",
-          "args": (v6/*: any*/),
+          "args": (v11/*: any*/),
           "concreteType": "ComputeSessionConnection",
           "kind": "LinkedField",
           "name": "compute_session_nodes",
@@ -350,12 +385,12 @@ return {
                       "selections": [
                         {
                           "kind": "RequiredField",
-                          "field": (v7/*: any*/),
+                          "field": (v12/*: any*/),
                           "action": "THROW"
                         },
                         {
                           "kind": "RequiredField",
-                          "field": (v8/*: any*/),
+                          "field": (v13/*: any*/),
                           "action": "THROW"
                         },
                         {
@@ -378,17 +413,17 @@ return {
               },
               "action": "THROW"
             },
-            (v9/*: any*/)
+            (v14/*: any*/)
           ],
           "storageKey": null
         },
         "to": "RESULT"
       },
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v15/*: any*/),
-      (v16/*: any*/),
-      (v17/*: any*/)
+      (v18/*: any*/),
+      (v19/*: any*/),
+      (v20/*: any*/),
+      (v21/*: any*/),
+      (v22/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -396,18 +431,23 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
+      (v8/*: any*/),
+      (v3/*: any*/),
+      (v6/*: any*/),
+      (v2/*: any*/),
+      (v7/*: any*/),
+      (v0/*: any*/),
+      (v5/*: any*/),
       (v4/*: any*/),
       (v1/*: any*/),
-      (v2/*: any*/),
-      (v0/*: any*/),
-      (v3/*: any*/)
+      (v9/*: any*/)
     ],
     "kind": "Operation",
     "name": "ComputeSessionListPageQuery",
     "selections": [
       {
         "alias": "computeSessionNodeResult",
-        "args": (v6/*: any*/),
+        "args": (v11/*: any*/),
         "concreteType": "ComputeSessionConnection",
         "kind": "LinkedField",
         "name": "compute_session_nodes",
@@ -429,10 +469,10 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v7/*: any*/),
-                  (v8/*: any*/),
-                  (v18/*: any*/),
-                  (v19/*: any*/),
+                  (v12/*: any*/),
+                  (v13/*: any*/),
+                  (v23/*: any*/),
+                  (v24/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -461,7 +501,7 @@ return {
                     "name": "agent_ids",
                     "storageKey": null
                   },
-                  (v20/*: any*/),
+                  (v25/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -511,7 +551,7 @@ return {
                     "name": "requested_slots",
                     "storageKey": null
                   },
-                  (v21/*: any*/),
+                  (v26/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -550,7 +590,7 @@ return {
                                 "name": "cluster_role",
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -580,7 +620,7 @@ return {
                                     "name": "architecture",
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -588,7 +628,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "tags",
                                     "plural": true,
-                                    "selections": (v22/*: any*/),
+                                    "selections": (v27/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -598,7 +638,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "labels",
                                     "plural": true,
-                                    "selections": (v22/*: any*/),
+                                    "selections": (v27/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -615,12 +655,12 @@ return {
                                     "name": "namespace",
                                     "storageKey": null
                                   },
-                                  (v21/*: any*/),
-                                  (v7/*: any*/)
+                                  (v26/*: any*/),
+                                  (v12/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v18/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -635,8 +675,8 @@ return {
                                 "name": "cluster_idx",
                                 "storageKey": null
                               },
-                              (v19/*: any*/),
-                              (v20/*: any*/),
+                              (v24/*: any*/),
+                              (v25/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -682,7 +722,7 @@ return {
                         "name": "email",
                         "storageKey": null
                       },
-                      (v7/*: any*/)
+                      (v12/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -724,16 +764,16 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v18/*: any*/),
-                              (v8/*: any*/),
-                              (v7/*: any*/)
+                              (v23/*: any*/),
+                              (v13/*: any*/),
+                              (v12/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v9/*: any*/)
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -765,7 +805,7 @@ return {
                     "kind": "LinkedField",
                     "name": "dependees",
                     "plural": false,
-                    "selections": (v23/*: any*/),
+                    "selections": (v28/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -775,7 +815,7 @@ return {
                     "kind": "LinkedField",
                     "name": "dependents",
                     "plural": false,
-                    "selections": (v23/*: any*/),
+                    "selections": (v28/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -819,28 +859,28 @@ return {
             ],
             "storageKey": null
           },
-          (v9/*: any*/)
+          (v14/*: any*/)
         ],
         "storageKey": null
       },
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v15/*: any*/),
-      (v16/*: any*/),
-      (v17/*: any*/)
+      (v18/*: any*/),
+      (v19/*: any*/),
+      (v20/*: any*/),
+      (v21/*: any*/),
+      (v22/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "52b03d78a18b9f5c4a40ec0a64afe255",
+    "cacheID": "e8f01a48c50089d358dd76cd537687bf",
     "id": null,
     "metadata": {},
     "name": "ComputeSessionListPageQuery",
     "operationKind": "query",
-    "text": "query ComputeSessionListPageQuery(\n  $scopeId: ScopeField\n  $first: Int = 20\n  $offset: Int = 0\n  $filter: String\n  $order: String\n) {\n  computeSessionNodeResult: compute_session_nodes(scope_id: $scopeId, first: $first, offset: $offset, filter: $filter, order: $order) {\n    edges {\n      node {\n        id\n        name\n        ...SessionNodesFragment\n        ...TerminateSessionModalFragment\n      }\n    }\n    count\n  }\n  all: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\"\") {\n    count\n  }\n  interactive: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"interactive\\\"\") {\n    count\n  }\n  inference: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"inference\\\"\") {\n    count\n  }\n  batch: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"batch\\\"\") {\n    count\n  }\n  system: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"system\\\"\") {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks @since(version: \"24.12.0\")\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query ComputeSessionListPageQuery(\n  $scopeId: ScopeField\n  $first: Int = 20\n  $offset: Int = 0\n  $filter: String\n  $order: String\n  $allFilter: String\n  $interactiveFilter: String\n  $inferenceFilter: String\n  $batchFilter: String\n  $systemFilter: String\n) {\n  computeSessionNodeResult: compute_session_nodes(scope_id: $scopeId, first: $first, offset: $offset, filter: $filter, order: $order) {\n    edges {\n      node {\n        id\n        name\n        ...SessionNodesFragment\n        ...TerminateSessionModalFragment\n      }\n    }\n    count\n  }\n  all: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $allFilter) {\n    count\n  }\n  interactive: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $interactiveFilter) {\n    count\n  }\n  inference: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $inferenceFilter) {\n    count\n  }\n  batch: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $batchFilter) {\n    count\n  }\n  system: compute_session_nodes(scope_id: $scopeId, first: 0, offset: 0, filter: $systemFilter) {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks @since(version: \"24.12.0\")\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cf0d212d3d216caf37acec3e08f64825";
+(node as any).hash = "fd1971a2bd6b899a56cda390c054ddd3";
 
 export default node;

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -18,7 +18,7 @@ import SessionNodes, {
 import { handleRowSelectionChange } from '../helper';
 import { ExtractResultValue } from '../helper/resultTypes';
 import { useWebUINavigate } from '../hooks';
-import { useCurrentUserRole } from '../hooks/backendai';
+import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCSVExport } from '../hooks/useCSVExport';
@@ -44,7 +44,6 @@ import {
   BAIPropertyFilter,
   BAISelectionLabel,
   BAISessionsIcon,
-  filterOutEmpty,
   filterOutNullAndUndefined,
   INITIAL_FETCH_KEY,
   mergeFilterValues,
@@ -78,11 +77,15 @@ type SessionNode = NonNullableNodeOnEdges<ComputeSessionNodesData>;
 
 const CARD_MIN_HEIGHT = 200;
 
+const NOT_FINISHED_STATUS_FILTER =
+  'status != "TERMINATED" & status != "CANCELLED"';
+
 const ComputeSessionListPage = () => {
   'use memo';
   const currentProject = useCurrentProjectValue();
 
   const userRole = useCurrentUserRole();
+  const [currentUser] = useCurrentUserInfo();
 
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -146,7 +149,7 @@ const ComputeSessionListPage = () => {
   const statusFilter =
     queryParams.statusCategory === 'running' ||
     queryParams.statusCategory === undefined
-      ? 'status != "TERMINATED" & status != "CANCELLED"'
+      ? NOT_FINISHED_STATUS_FILTER
       : 'status == "TERMINATED" | status == "CANCELLED"';
 
   const isNotRunningCategory = (status?: string | null) => {
@@ -155,12 +158,45 @@ const ComputeSessionListPage = () => {
 
   const [fetchKey, updateFetchKey] = useFetchKey();
 
+  // This page is strictly personal: even admins/monitors (who hold read
+  // permission on all project sessions) should only see their own sessions.
+  const currentUserFilter = `user_id == "${currentUser.uuid}"`;
+
   const queryVariables: ComputeSessionListPageQuery$variables = {
     scopeId: `project:${currentProject.id}`,
     offset: baiPaginationOption.offset,
     first: baiPaginationOption.first,
-    filter: mergeFilterValues([statusFilter, queryParams.filter, typeFilter]),
+    filter: mergeFilterValues([
+      statusFilter,
+      queryParams.filter,
+      typeFilter,
+      currentUserFilter,
+    ]),
     order: queryParams.order || '-created_at',
+    allFilter: mergeFilterValues([
+      NOT_FINISHED_STATUS_FILTER,
+      currentUserFilter,
+    ]),
+    interactiveFilter: mergeFilterValues([
+      NOT_FINISHED_STATUS_FILTER,
+      'type == "interactive"',
+      currentUserFilter,
+    ]),
+    inferenceFilter: mergeFilterValues([
+      NOT_FINISHED_STATUS_FILTER,
+      'type == "inference"',
+      currentUserFilter,
+    ]),
+    batchFilter: mergeFilterValues([
+      NOT_FINISHED_STATUS_FILTER,
+      'type == "batch"',
+      currentUserFilter,
+    ]),
+    systemFilter: mergeFilterValues([
+      NOT_FINISHED_STATUS_FILTER,
+      'type == "system"',
+      currentUserFilter,
+    ]),
   };
 
   const deferredQueryVariables = useDeferredValue(queryVariables);
@@ -168,72 +204,77 @@ const ComputeSessionListPage = () => {
 
   const queryRef = useLazyLoadQuery<ComputeSessionListPageQuery>(
     graphql`
-        query ComputeSessionListPageQuery(
-          $scopeId: ScopeField
-          $first: Int = 20
-          $offset: Int = 0
-          $filter: String
-          $order: String
-        ) {
-          computeSessionNodeResult: compute_session_nodes(
-            scope_id: $scopeId
-            first: $first
-            offset: $offset
-            filter: $filter
-            order: $order
-          ) @catch(to: RESULT) {
-            edges @required(action: THROW) {
-              node @required(action: THROW) {
-                id @required(action: THROW)
-                name @required(action: THROW)
-                ...SessionNodesFragment
-                ...TerminateSessionModalFragment
-              }
+      query ComputeSessionListPageQuery(
+        $scopeId: ScopeField
+        $first: Int = 20
+        $offset: Int = 0
+        $filter: String
+        $order: String
+        $allFilter: String
+        $interactiveFilter: String
+        $inferenceFilter: String
+        $batchFilter: String
+        $systemFilter: String
+      ) {
+        computeSessionNodeResult: compute_session_nodes(
+          scope_id: $scopeId
+          first: $first
+          offset: $offset
+          filter: $filter
+          order: $order
+        ) @catch(to: RESULT) {
+          edges @required(action: THROW) {
+            node @required(action: THROW) {
+              id @required(action: THROW)
+              name @required(action: THROW)
+              ...SessionNodesFragment
+              ...TerminateSessionModalFragment
             }
-            count
           }
-          all: compute_session_nodes(
-            scope_id: $scopeId
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\""
-          ) {
-            count
-          }
-          interactive: compute_session_nodes(
-            scope_id: $scopeId
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
-          ) {
-            count
-          }
-          inference: compute_session_nodes(
-            scope_id: $scopeId
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
-          ) {
-            count
-          }
-          batch: compute_session_nodes(
-            scope_id: $scopeId
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
-          ) {
-            count
-          }
-          system: compute_session_nodes(
-            scope_id: $scopeId
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
-          ) {
-            count
-          }
+          count
         }
-      `,
+        all: compute_session_nodes(
+          scope_id: $scopeId
+          first: 0
+          offset: 0
+          filter: $allFilter
+        ) {
+          count
+        }
+        interactive: compute_session_nodes(
+          scope_id: $scopeId
+          first: 0
+          offset: 0
+          filter: $interactiveFilter
+        ) {
+          count
+        }
+        inference: compute_session_nodes(
+          scope_id: $scopeId
+          first: 0
+          offset: 0
+          filter: $inferenceFilter
+        ) {
+          count
+        }
+        batch: compute_session_nodes(
+          scope_id: $scopeId
+          first: 0
+          offset: 0
+          filter: $batchFilter
+        ) {
+          count
+        }
+        system: compute_session_nodes(
+          scope_id: $scopeId
+          first: 0
+          offset: 0
+          filter: $systemFilter
+        ) {
+          count
+        }
+      }
+    `,
     deferredQueryVariables,
     {
       fetchPolicy:
@@ -428,7 +469,7 @@ const ComputeSessionListPage = () => {
                 ]}
               />
               <BAIPropertyFilter
-                filterProperties={filterOutEmpty([
+                filterProperties={[
                   {
                     key: 'name',
                     propertyLabel: t('session.SessionName'),
@@ -444,14 +485,7 @@ const ComputeSessionListPage = () => {
                     propertyLabel: t('session.Agent'),
                     type: 'string',
                   },
-                  (userRole === 'superadmin' ||
-                    userRole === 'admin' ||
-                    userRole === 'monitor') && {
-                    key: 'user_email',
-                    propertyLabel: t('session.launcher.OwnerEmail'),
-                    type: 'string',
-                  },
-                ])}
+                ]}
                 value={queryParams.filter || undefined}
                 onChange={(value) => {
                   setQueryParams({ filter: value || '' });


### PR DESCRIPTION
Resolves #7824 (FR-3092)

> [!NOTE]
> CSV export currently does not support email-based filtering. As a result, when an admin exports from the user session page, the list includes sessions from all users rather than just their own. This will be addressed once BA-6480 is resolved

## Problem

The User Sessions page (`/session`) showed **other users' sessions** to admins and monitors. Backend RBAC grants admins/monitors read permission on all sessions in a project, and the page queried `compute_session_nodes` with only `scope_id: project:<id>` and no user restriction — so both the table rows and the per-type tab count badges were project-wide instead of personal.

## What changed

`react/src/pages/ComputeSessionListPage.tsx`:

- Added `const [currentUser] = useCurrentUserInfo()` and built a `user_id == "<current user uuid>"` filter.
- Merged the current-user filter into the main list query filter via `mergeFilterValues([statusFilter, queryParams.filter, typeFilter, currentUserFilter])`.
- Converted the five tab-count subqueries (`all` / `interactive` / `inference` / `batch` / `system`) from literal filter strings inside the GraphQL tag to query variables (`$allFilter`, `$interactiveFilter`, `$inferenceFilter`, `$batchFilter`, `$systemFilter`) computed in JS, preserving the exact existing status/type semantics and adding the current-user clause.
- Removed the admin/monitor-only `user_email` property from the filter dropdown — on a strictly personal page every row belongs to the current user, so the filter was meaningless.
- The `project:` scope is kept, so the page still reacts to the header project selector. Regenerated Relay artifacts via `pnpm relay`.

## Verification

```
=== Relay ===
--- Relay: PASS ---
=== Lint ===
--- Lint: PASS ---
=== Format ===
--- Format: PASS ---
=== TypeScript ===
--- TypeScript: PASS ---
=== Vite warmup paths ===
--- Vite warmup paths: PASS ---
=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-ups

- `user_id` queryfilter support on `compute_session_nodes` has been verified statically (schema/queryfilter spec) only — it should be runtime-verified against a live manager before merge.
- The page's CSV export still exports unscoped (project-wide) sessions for admins; tracked as a separate Jira follow-up.