### PR TITLE
fix(FR-3091): cancel stale token counts; include reasoning parts in TPS

### DIFF
--- a/react/src/components/Chat/ChatTokenCounter.tsx
+++ b/react/src/components/Chat/ChatTokenCounter.tsx
@@ -29,7 +29,7 @@ const ChatTokenCounter: React.FC<ChatTokenCounterProps> = ({
   const inputTokenCount = useTokenCount(input);
   const allChatMessageString = map(messages, (message) =>
     message?.parts
-      ?.filter((part) => part.type === 'text')
+      ?.filter((part) => part.type === 'text' || part.type === 'reasoning')
       .map((part) => part.text)
       .join(''),
   ).join('');
@@ -39,7 +39,7 @@ const ChatTokenCounter: React.FC<ChatTokenCounterProps> = ({
   const lastAssistantMessageString =
     lastAssistantMessage?.role === 'assistant'
       ? lastAssistantMessage?.parts
-          ?.filter((part) => part.type === 'text')
+          ?.filter((part) => part.type === 'text' || part.type === 'reasoning')
           .map((part) => part.text)
           .join('') || ''
       : '';

--- a/react/src/hooks/useTokenizer.ts
+++ b/react/src/hooks/useTokenizer.ts
@@ -11,16 +11,21 @@ export const encodeAsync = async (str: string) => {
 };
 
 export const useTokenCount = (input: string = '') => {
+  'use memo';
   const [value, setNum] = useState(0);
 
   useEffect(() => {
-    startTransition(() => {
-      encodeAsync(input)
-        .then(setNum)
-        .catch(() => {
-          setNum(input.length);
-        });
-    });
+    let cancelled = false;
+    encodeAsync(input)
+      .then((count) => {
+        if (!cancelled) startTransition(() => setNum(count));
+      })
+      .catch(() => {
+        if (!cancelled) startTransition(() => setNum(input.length));
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [input]);
 
   return value;


### PR DESCRIPTION
Resolves #7820 (FR-3091)

## Problem

Two issues with the chat TPS display:

1. **Stale async counts**: TPS keeps rising after streaming ends. `useTokenCount` was firing a new async token computation on every render without cancelling the previous one. When streaming ended and `endTime` became fixed, queued computations kept resolving with progressively larger counts — a fixed denominator but rising numerator meant TPS climbed until all queued computations drained.

2. **Reasoning phase not tracked**: During the thinking/reasoning phase ("추론중"), only `type === 'text'` parts were counted. While the model is reasoning, `text` parts are empty so `lastAssistantTokenCount` was 0, making TPS show 0 throughout the entire reasoning phase.

## Fix

### `react/src/hooks/useTokenizer.ts`
- Add a `cancelled` flag and cleanup return to `useEffect` in `useTokenCount`. When `input` changes, the previous async computation is marked cancelled; its `setNum` call is discarded.
- Move `startTransition` inside the `.then`/`.catch` callbacks to wrap only the state update (not the async initiation).
- Add `'use memo'` directive per React Compiler convention.

### `react/src/components/Chat/ChatTokenCounter.tsx`
- Include `part.type === 'reasoning'` alongside `'text'` when building:
  - `lastAssistantMessageString` (TPS numerator)
  - `allChatMessageString` (total token count)
- Both `TextUIPart` and `ReasoningUIPart` expose `.text: string`, so the map is type-safe.

## Verification

- Relay: PASS
- Lint: PASS
- Format: PASS (changed files)