### PR TITLE
e2e(FR-3112): replace in-body runtime skips with declarative feature gates

### DIFF
--- a/e2e/E2E-TEST-NAMING-GUIDELINES.md
+++ b/e2e/E2E-TEST-NAMING-GUIDELINES.md
@@ -25,6 +25,7 @@ user-workflow.spec.ts
 ```
 
 **Examples:**
+
 - ✅ `vfolder-explorer-modal.spec.ts`
 - ✅ `session-creation-workflow.spec.ts`
 - ✅ `user-settings-management.spec.ts`
@@ -40,6 +41,7 @@ test.describe.serial('[Component/Feature] - [User Role/Category] Actions', () =>
 ```
 
 **Examples:**
+
 - ✅ `FolderExplorerModal - User VFolder Access`
 - ✅ `SessionLauncher - Resource Allocation Scenarios`
 - ✅ `AdminSettings - User Management`
@@ -55,6 +57,7 @@ test('[Actor] can/cannot [action] [when/with/in condition]', async ({ page }) =>
 ```
 
 **Key Components:**
+
 - **Actor**: User, Admin, Guest, Manager (based on role)
 - **Action Verb**: create, delete, upload, download, view, modify, share, access, etc.
 - **Object**: what is being acted upon (file, folder, session, etc.)
@@ -121,6 +124,7 @@ test('User sees [UI element state] when accessing VFolder with [permission level
 ```
 
 **Examples:**
+
 ```typescript
 test('User can upload files in VFolder with write permissions', async ({ page }) => {
 test('User cannot delete folders in VFolder with read-only permissions', async ({ page }) => {
@@ -135,6 +139,7 @@ test('User completes [workflow name] successfully', async ({ page }) => {
 ```
 
 **Examples:**
+
 ```typescript
 test('User can create a VFolder and then upload files to it', async ({ page }) => {
 test('User completes session creation workflow with GPU resources', async ({ page }) => {
@@ -148,6 +153,7 @@ test('User is redirected to [location] when [condition]', async ({ page }) => {
 ```
 
 **Examples:**
+
 ```typescript
 test('User sees error message when accessing non-existent VFolder', async ({ page }) => {
 test('User is redirected to login page when session expires', async ({ page }) => {
@@ -162,6 +168,7 @@ test('User sees [UI feedback] after [action]', async ({ page }) => {
 ```
 
 **Examples:**
+
 ```typescript
 test('User can click folder row to open explorer modal', async ({ page }) => {
 test('User sees success notification after uploading file', async ({ page }) => {
@@ -176,6 +183,7 @@ test('User can verify [information] is displayed correctly', async ({ page }) =>
 ```
 
 **Examples:**
+
 ```typescript
 test('User sees folder name and permissions in explorer modal header', async ({ page }) => {
 test('User can verify VFolder size and usage in details panel', async ({ page }) => {
@@ -186,22 +194,26 @@ test('User can verify VFolder size and usage in details panel', async ({ page })
 Different user roles should be explicitly mentioned:
 
 ### User (Default Role)
+
 ```typescript
 test('User can create personal VFolder', async ({ page }) => {
 ```
 
 ### Admin
+
 ```typescript
 test('Admin can view all users sessions in the dashboard', async ({ page }) => {
 test('Admin can modify resource limits for user groups', async ({ page }) => {
 ```
 
 ### Guest
+
 ```typescript
 test('Guest cannot access VFolder management page', async ({ page }) => {
 ```
 
 ### Manager
+
 ```typescript
 test('Manager can approve VFolder sharing requests', async ({ page }) => {
 ```
@@ -252,6 +264,40 @@ test('Form Validation', async ({ page }) => {
 test('Create Form', async ({ page }) => {
 ```
 
+## Tags
+
+Tests and describe blocks are tagged via the Playwright `{ tag: [...] }` option.
+
+### Suite/category tags (existing taxonomy)
+
+- `@critical`, `@functional`, `@regression`, `@visual` — test category
+- `@admin`, `@crud` — role / operation type
+- Feature-area tags matching the directory, e.g. `@session`, `@vfolder`,
+  `@dashboard`, `@start`, `@environment`, `@statistics`, `@plugin`
+
+### Feature-gate tags (FR-3112)
+
+When a spec exercises a feature that only exists from a certain WebUI or
+Backend.AI manager version onward, tag it with an explicit version
+requirement so it can be excluded on incapable targets instead of silently
+self-skipping:
+
+- `@requires-webui-vX.Y` — requires a WebUI build >= vX.Y
+  (e.g. `@requires-webui-v26.4` for the FR-2302 datetime filters)
+- `@requires-manager-vX.Y` — requires a Backend.AI manager >= X.Y
+  (e.g. `@requires-manager-v25.15` for the FR-1575 Agent Statistics widget)
+
+```bash
+# Run everything except specs that need a newer manager
+npx playwright test --grep-invert "@requires-manager-v25.15"
+```
+
+Pair the tag with a **declarative gate** from `e2e/utils/feature-gate-util.ts`
+(`skipUnlessClientFeature`, `skipUnlessClientConfig`) instead of probing for a
+UI element inside the test body and skipping when it is absent. The gate skips
+with an auditable reason on incapable backends; on capable backends a missing
+UI element fails the test instead of silently skipping.
+
 ## Test Structure Best Practices
 
 ### 1. Spec Reference Comment
@@ -267,7 +313,9 @@ Always include a reference to the test plan at the top of the file:
 Use numbered comments to describe each test step in user terms:
 
 ```typescript
-test('User can upload file to VFolder with write permissions', async ({ page }) => {
+test('User can upload file to VFolder with write permissions', async ({
+  page,
+}) => {
   // 1. Navigate to data page
   await navigateTo(page, 'data');
 
@@ -364,9 +412,13 @@ When updating existing tests to follow these guidelines:
 ### Example Migration
 
 **Before:**
+
 ```typescript
-test.describe.serial('FolderExplorerModal - VFolder Access and Permissions', () => {
-  test('Valid VFolder with Full Permissions (Read & Write)', async ({ page }) => {
+test.describe
+  .serial('FolderExplorerModal - VFolder Access and Permissions', () => {
+  test('Valid VFolder with Full Permissions (Read & Write)', async ({
+    page,
+  }) => {
     // Test body...
   });
 
@@ -377,13 +429,18 @@ test.describe.serial('FolderExplorerModal - VFolder Access and Permissions', () 
 ```
 
 **After:**
+
 ```typescript
 test.describe.serial('FolderExplorerModal - User VFolder Access', () => {
-  test('User can create folders and upload files in VFolder with write permissions', async ({ page }) => {
+  test('User can create folders and upload files in VFolder with write permissions', async ({
+    page,
+  }) => {
     // Test body...
   });
 
-  test('User can view files but cannot upload to read-only VFolder', async ({ page }) => {
+  test('User can view files but cannot upload to read-only VFolder', async ({
+    page,
+  }) => {
     // Test body...
   });
 });

--- a/e2e/dashboard/dashboard.spec.ts
+++ b/e2e/dashboard/dashboard.spec.ts
@@ -2,6 +2,7 @@
 // scenarios: 6 (Widget Rendering), 7 (Session Count Widget), 8 (My Resources Widget),
 //            9 (My Resources in Resource Group Widget), 10 (Agent Stats Widget),
 //            11 (Recently Created Sessions Widget), 12 (Board Layout)
+import { skipUnlessClientFeature } from '../utils/feature-gate-util';
 import { loginAsAdmin, loginAsUser, navigateTo } from '../utils/test-util';
 import { test, expect } from '@playwright/test';
 
@@ -299,65 +300,68 @@ test.describe(
     // -----------------------------------------------------------------------
     // 10. Agent Stats Widget (Admin Only)
     // -----------------------------------------------------------------------
-    test.describe('Agent Stats Widget', () => {
-      test.beforeEach(async ({ page, request }) => {
-        await loginAsAdmin(page, request);
-        await navigateTo(page, 'summary');
-      });
+    test.describe(
+      'Agent Stats Widget',
+      { tag: ['@requires-manager-v25.15'] },
+      () => {
+        test.beforeEach(async ({ page, request }) => {
+          await loginAsAdmin(page, request);
+          await navigateTo(page, 'summary');
 
-      test('Admin can view cluster-level resource statistics in the Agent Stats widget', async ({
-        page,
-      }) => {
-        // Agent Stats widget requires server >= 25.15.0
-        const widget = page
-          .locator('.bai_grid_item')
-          .filter({ hasText: 'Agent Statistics' });
+          // Declarative feature gate (FR-3112): the Agent Statistics widget is
+          // rendered only when the manager supports 'agent-stats'
+          // (manager >= 25.15.0; widget introduced by FR-1575).
+          await skipUnlessClientFeature(
+            page,
+            'agent-stats',
+            "Agent Statistics widget requires the 'agent-stats' capability (Backend.AI manager >= 25.15.0, FR-1575)",
+          );
+        });
 
-        // Skip test explicitly if widget is not available on this server version
-        test.skip(
-          !(await widget.isVisible({ timeout: WIDGET_TIMEOUT })),
-          'Agent Statistics widget not available (requires server >= 25.15.0)',
-        );
+        test('Admin can view cluster-level resource statistics in the Agent Stats widget', async ({
+          page,
+        }) => {
+          // 1. The backend is capable — the widget MUST be present; absence is a failure.
+          const widget = page
+            .locator('.bai_grid_item')
+            .filter({ hasText: 'Agent Statistics' });
+          await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
-        // 2. Verify a "Used" / "Free" segmented toggle is present
-        const segmentedControl = widget.locator('.ant-segmented');
-        await expect(segmentedControl).toBeVisible();
+          // 2. Verify a "Used" / "Free" segmented toggle is present
+          const segmentedControl = widget.locator('.ant-segmented');
+          await expect(segmentedControl).toBeVisible();
 
-        // 3. Click the "Free" segment and verify it becomes selected
-        await segmentedControl.getByText('Free').click();
-        await expect(
-          segmentedControl.locator('.ant-segmented-item-selected'),
-        ).toContainText('Free');
+          // 3. Click the "Free" segment and verify it becomes selected
+          await segmentedControl.getByText('Free').click();
+          await expect(
+            segmentedControl.locator('.ant-segmented-item-selected'),
+          ).toContainText('Free');
 
-        // 4. Click the "Used" segment and verify it becomes selected
-        await segmentedControl.getByText('Used').click();
-        await expect(
-          segmentedControl.locator('.ant-segmented-item-selected'),
-        ).toContainText('Used');
-      });
+          // 4. Click the "Used" segment and verify it becomes selected
+          await segmentedControl.getByText('Used').click();
+          await expect(
+            segmentedControl.locator('.ant-segmented-item-selected'),
+          ).toContainText('Used');
+        });
 
-      test('Admin can manually refresh the Agent Stats widget', async ({
-        page,
-      }) => {
-        // Agent Stats widget requires server >= 25.15.0
-        const widget = page
-          .locator('.bai_grid_item')
-          .filter({ hasText: 'Agent Statistics' });
+        test('Admin can manually refresh the Agent Stats widget', async ({
+          page,
+        }) => {
+          // 1. The backend is capable — the widget MUST be present; absence is a failure.
+          const widget = page
+            .locator('.bai_grid_item')
+            .filter({ hasText: 'Agent Statistics' });
+          await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
-        // Skip test explicitly if widget is not available on this server version
-        test.skip(
-          !(await widget.isVisible({ timeout: WIDGET_TIMEOUT })),
-          'Agent Statistics widget not available (requires server >= 25.15.0)',
-        );
+          // 2. Click the refresh button in the widget header
+          const refreshButton = widget.getByRole('button', { name: 'reload' });
+          await refreshButton.click();
 
-        // 2. Click the refresh button in the widget header
-        const refreshButton = widget.getByRole('button', { name: 'reload' });
-        await refreshButton.click();
-
-        // 3. Verify the widget still renders after refresh (no error state)
-        await expect(widget).toBeVisible();
-      });
-    });
+          // 3. Verify the widget still renders after refresh (no error state)
+          await expect(widget).toBeVisible();
+        });
+      },
+    );
 
     // -----------------------------------------------------------------------
     // 11. Recently Created Sessions Widget

--- a/e2e/session/session-scheduling-history-modal.spec.ts
+++ b/e2e/session/session-scheduling-history-modal.spec.ts
@@ -1,4 +1,5 @@
 // E2E spec: Session Scheduling History Modal
+import { skipUnlessWebUIVersion } from '../utils/feature-gate-util';
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
 import { setupGraphQLMocks } from './mocking/graphql-interceptor';
 import { schedulingHistoryMockResponse } from './mocking/scheduling-history-mock';
@@ -371,239 +372,232 @@ test.describe(
 
     // ─────────────────────────────────────────────────────────────────────────
     // 5. Datetime Filter — Created At and Updated At
-    // NOTE: Tests in this section require datetime filter support (feat/FR-2302),
-    // introduced in the main branch after v26.3.0. If the server runs an older build,
-    // "Created At" and "Updated At" options will not appear in the property filter
-    // dropdown and these tests will be skipped automatically.
+    // Declarative feature gate (FR-3112): datetime filter properties were
+    // introduced by FR-2302 (WebUI > v26.3.0, first released in v26.4). The
+    // whole group is tagged @requires-webui-v26.4 so it can be excluded
+    // explicitly on older WebUI builds, e.g.:
+    //   npx playwright test --grep-invert "@requires-webui-v26.4"
+    // On an older build the version gate in beforeEach skips each test with
+    // an auditable reason; on a capable build a missing datetime option is a
+    // real failure (no silent skip).
     // ─────────────────────────────────────────────────────────────────────────
+    test.describe(
+      'Datetime Filter (Created At / Updated At)',
+      { tag: ['@requires-webui-v26.4'] },
+      () => {
+        // Runtime half of the @requires-webui-v26.4 gate: skip declaratively
+        // on WebUI builds that predate FR-2302 (first released in v26.4),
+        // based on the explicit version source rather than UI probing.
+        test.beforeEach(async ({ page }) => {
+          await skipUnlessWebUIVersion(
+            page,
+            '26.4',
+            'Datetime filter properties require FR-2302',
+          );
+        });
 
-    /**
-     * Helper: opens the property filter, selects a datetime property, and returns
-     * whether the datetime feature is available. Skips the test if not available.
-     */
-    async function selectDatetimeProperty(
-      page: Page,
-      modal: ReturnType<Page['getByRole']>,
-      propertyName: 'Created At' | 'Updated At',
-    ): Promise<boolean> {
-      await getPropertyFilterCombobox(modal).click();
-      const option = page.getByRole('option', { name: propertyName });
-      const isAvailable = await option
-        .isVisible({ timeout: 2000 })
-        .catch(() => false);
-      if (!isAvailable) {
-        await page.keyboard.press('Escape');
-        test.skip(
-          true,
-          `Datetime filter option "${propertyName}" requires feat/FR-2302 (WebUI > v26.3.0).`,
-        );
-        return false;
-      }
-      await option.click();
-      return true;
-    }
+        /**
+         * Helper: opens the property filter and selects a datetime property.
+         * The version gate in beforeEach guarantees FR-2302 is present, so a
+         * missing option here is a real regression and fails the test.
+         */
+        async function selectDatetimeProperty(
+          page: Page,
+          modal: ReturnType<Page['getByRole']>,
+          propertyName: 'Created At' | 'Updated At',
+        ): Promise<void> {
+          await getPropertyFilterCombobox(modal).click();
+          const option = page.getByRole('option', { name: propertyName });
+          await expect(option).toBeVisible();
+          await option.click();
+        }
 
-    test('Admin sees a DatePicker instead of text input when Created At filter property is selected', async ({
-      page,
-    }) => {
-      // 1. Open the Session Detail drawer and history modal
-      await openSessionDetailDrawer(page);
-      const modal = await openSchedulingHistoryModal(page);
+        test('Admin sees a DatePicker instead of text input when Created At filter property is selected', async ({
+          page,
+        }) => {
+          // 1. Open the Session Detail drawer and history modal
+          await openSessionDetailDrawer(page);
+          const modal = await openSchedulingHistoryModal(page);
 
-      // 2. Select "Created At" from the property selector dropdown
-      const isAvailable = await selectDatetimeProperty(
-        page,
-        modal,
-        'Created At',
-      );
-      if (!isAvailable) return;
+          // 2. Select "Created At" from the property selector dropdown
+          await selectDatetimeProperty(page, modal, 'Created At');
 
-      // 3. Verify the DatePicker input is visible for datetime type
-      const datePicker = modal
-        .locator('.ant-space-compact .ant-picker')
-        .first();
-      await expect(datePicker).toBeVisible();
+          // 3. Verify the DatePicker input is visible for datetime type
+          const datePicker = modal
+            .locator('.ant-space-compact .ant-picker')
+            .first();
+          await expect(datePicker).toBeVisible();
 
-      // 4. Verify the regular text search input is NOT visible when datetime type is selected
-      const searchInput = modal.locator(
-        '[role="combobox"][placeholder="Search"]',
-      );
-      await expect(searchInput).not.toBeVisible();
-    });
+          // 4. Verify the regular text search input is NOT visible when datetime type is selected
+          const searchInput = modal.locator(
+            '[role="combobox"][placeholder="Search"]',
+          );
+          await expect(searchInput).not.toBeVisible();
+        });
 
-    test('Admin sees a DatePicker instead of text input when Updated At filter property is selected', async ({
-      page,
-    }) => {
-      // 1. Open the Session Detail drawer and history modal
-      await openSessionDetailDrawer(page);
-      const modal = await openSchedulingHistoryModal(page);
+        test('Admin sees a DatePicker instead of text input when Updated At filter property is selected', async ({
+          page,
+        }) => {
+          // 1. Open the Session Detail drawer and history modal
+          await openSessionDetailDrawer(page);
+          const modal = await openSchedulingHistoryModal(page);
 
-      // 2. Select "Updated At" from the property selector dropdown (skip if not available)
-      const isAvailable = await selectDatetimeProperty(
-        page,
-        modal,
-        'Updated At',
-      );
-      if (!isAvailable) return;
+          // 2. Select "Updated At" from the property selector dropdown
+          await selectDatetimeProperty(page, modal, 'Updated At');
 
-      // 3. Verify the DatePicker input is visible for datetime type
-      const datePicker = modal
-        .locator('.ant-space-compact .ant-picker')
-        .first();
-      await expect(datePicker).toBeVisible();
+          // 3. Verify the DatePicker input is visible for datetime type
+          const datePicker = modal
+            .locator('.ant-space-compact .ant-picker')
+            .first();
+          await expect(datePicker).toBeVisible();
 
-      // 4. Verify the regular text search input is NOT visible when datetime type is selected
-      const searchInput = modal.locator(
-        '[role="combobox"][placeholder="Search"]',
-      );
-      await expect(searchInput).not.toBeVisible();
-    });
+          // 4. Verify the regular text search input is NOT visible when datetime type is selected
+          const searchInput = modal.locator(
+            '[role="combobox"][placeholder="Search"]',
+          );
+          await expect(searchInput).not.toBeVisible();
+        });
 
-    test('Admin can see datetime operator options (after, before) for Created At filter', async ({
-      page,
-    }) => {
-      // 1. Open the Session Detail drawer and history modal
-      await openSessionDetailDrawer(page);
-      const modal = await openSchedulingHistoryModal(page);
+        test('Admin can see datetime operator options (after, before) for Created At filter', async ({
+          page,
+        }) => {
+          // 1. Open the Session Detail drawer and history modal
+          await openSessionDetailDrawer(page);
+          const modal = await openSchedulingHistoryModal(page);
 
-      // 2. Select "Created At" from the property selector dropdown (skip if not available)
-      const isAvailable = await selectDatetimeProperty(
-        page,
-        modal,
-        'Created At',
-      );
-      if (!isAvailable) return;
+          // 2. Select "Created At" from the property selector dropdown
+          await selectDatetimeProperty(page, modal, 'Created At');
 
-      // 3. Click the operator selector (second BAISelect in the compact group).
-      // For datetime type without fixedOperator, the operator selector is shown
-      // between the property selector and the DatePicker.
-      // Click the .ant-select container directly because the .ant-select-content-value
-      // overlay intercepts pointer events on the inner [role="combobox"] input.
-      const operatorSelect = modal
-        .locator('.ant-space-compact .ant-select')
-        .nth(1);
-      await operatorSelect.click();
+          // 3. Click the operator selector (second BAISelect in the compact group).
+          // For datetime type without fixedOperator, the operator selector is shown
+          // between the property selector and the DatePicker.
+          // Click the .ant-select container directly because the .ant-select-content-value
+          // overlay intercepts pointer events on the inner [role="combobox"] input.
+          const operatorSelect = modal
+            .locator('.ant-space-compact .ant-select')
+            .nth(1);
+          await operatorSelect.click();
 
-      // 4. Verify the datetime operator options are visible
-      // Labels come from i18n comp:BAIGraphQLPropertyFilter.operator.* keys
-      await expect(page.getByRole('option', { name: 'after' })).toBeVisible();
-      await expect(page.getByRole('option', { name: 'before' })).toBeVisible();
+          // 4. Verify the datetime operator options are visible
+          // Labels come from i18n comp:BAIGraphQLPropertyFilter.operator.* keys
+          await expect(
+            page.getByRole('option', { name: 'after' }),
+          ).toBeVisible();
+          await expect(
+            page.getByRole('option', { name: 'before' }),
+          ).toBeVisible();
 
-      // 5. Close the dropdown
-      await page.keyboard.press('Escape');
-    });
+          // 5. Close the dropdown
+          await page.keyboard.press('Escape');
+        });
 
-    test('Admin can apply a Created At datetime filter using the DatePicker and see the filter tag', async ({
-      page,
-    }) => {
-      // 1. Open the Session Detail drawer and history modal
-      await openSessionDetailDrawer(page);
-      const modal = await openSchedulingHistoryModal(page);
+        test('Admin can apply a Created At datetime filter using the DatePicker and see the filter tag', async ({
+          page,
+        }) => {
+          // 1. Open the Session Detail drawer and history modal
+          await openSessionDetailDrawer(page);
+          const modal = await openSchedulingHistoryModal(page);
 
-      // 2. Select "Created At" from the property selector dropdown (skip if not available)
-      const isAvailable = await selectDatetimeProperty(
-        page,
-        modal,
-        'Created At',
-      );
-      if (!isAvailable) return;
+          // 2. Select "Created At" from the property selector dropdown
+          await selectDatetimeProperty(page, modal, 'Created At');
 
-      // 3. Click the DatePicker to open the calendar
-      const datePicker = modal
-        .locator('.ant-space-compact .ant-picker')
-        .first();
-      await datePicker.click();
+          // 3. Click the DatePicker to open the calendar
+          const datePicker = modal
+            .locator('.ant-space-compact .ant-picker')
+            .first();
+          await datePicker.click();
 
-      // 4. Select the first visible day in the calendar
-      const calendarPopup = page
-        .locator('.ant-picker-dropdown:not(.ant-picker-dropdown-hidden)')
-        .first();
-      await calendarPopup.locator('.ant-picker-cell-in-view').first().click();
+          // 4. Select the first visible day in the calendar
+          const calendarPopup = page
+            .locator('.ant-picker-dropdown:not(.ant-picker-dropdown-hidden)')
+            .first();
+          await calendarPopup
+            .locator('.ant-picker-cell-in-view')
+            .first()
+            .click();
 
-      // 5. Click the "OK" button to confirm the datetime selection (required for showTime)
-      await calendarPopup.getByRole('button', { name: 'OK' }).click();
+          // 5. Click the "OK" button to confirm the datetime selection (required for showTime)
+          await calendarPopup.getByRole('button', { name: 'OK' }).click();
 
-      // 6. Verify the filter tag for "Created At" appears with the applied condition
-      // The tag format is: "{propertyLabel} {operatorSymbol} {datetime}"
-      const filterTag = modal
-        .locator('.ant-tag', { hasText: 'Created At' })
-        .first();
-      await expect(filterTag).toBeVisible();
-    });
+          // 6. Verify the filter tag for "Created At" appears with the applied condition
+          // The tag format is: "{propertyLabel} {operatorSymbol} {datetime}"
+          const filterTag = modal
+            .locator('.ant-tag', { hasText: 'Created At' })
+            .first();
+          await expect(filterTag).toBeVisible();
+        });
 
-    test('Admin can apply an Updated At datetime filter using the DatePicker and see the filter tag', async ({
-      page,
-    }) => {
-      // 1. Open the Session Detail drawer and history modal
-      await openSessionDetailDrawer(page);
-      const modal = await openSchedulingHistoryModal(page);
+        test('Admin can apply an Updated At datetime filter using the DatePicker and see the filter tag', async ({
+          page,
+        }) => {
+          // 1. Open the Session Detail drawer and history modal
+          await openSessionDetailDrawer(page);
+          const modal = await openSchedulingHistoryModal(page);
 
-      // 2. Select "Updated At" from the property selector dropdown (skip if not available)
-      const isAvailable = await selectDatetimeProperty(
-        page,
-        modal,
-        'Updated At',
-      );
-      if (!isAvailable) return;
+          // 2. Select "Updated At" from the property selector dropdown
+          await selectDatetimeProperty(page, modal, 'Updated At');
 
-      // 3. Click the DatePicker to open the calendar
-      const datePicker = modal
-        .locator('.ant-space-compact .ant-picker')
-        .first();
-      await datePicker.click();
+          // 3. Click the DatePicker to open the calendar
+          const datePicker = modal
+            .locator('.ant-space-compact .ant-picker')
+            .first();
+          await datePicker.click();
 
-      // 4. Select the first visible day in the calendar
-      const calendarPopup = page
-        .locator('.ant-picker-dropdown:not(.ant-picker-dropdown-hidden)')
-        .first();
-      await calendarPopup.locator('.ant-picker-cell-in-view').first().click();
+          // 4. Select the first visible day in the calendar
+          const calendarPopup = page
+            .locator('.ant-picker-dropdown:not(.ant-picker-dropdown-hidden)')
+            .first();
+          await calendarPopup
+            .locator('.ant-picker-cell-in-view')
+            .first()
+            .click();
 
-      // 5. Click the "OK" button to confirm the datetime selection (required for showTime)
-      await calendarPopup.getByRole('button', { name: 'OK' }).click();
+          // 5. Click the "OK" button to confirm the datetime selection (required for showTime)
+          await calendarPopup.getByRole('button', { name: 'OK' }).click();
 
-      // 6. Verify the filter tag for "Updated At" appears with the applied condition
-      const filterTag = modal
-        .locator('.ant-tag', { hasText: 'Updated At' })
-        .first();
-      await expect(filterTag).toBeVisible();
-    });
+          // 6. Verify the filter tag for "Updated At" appears with the applied condition
+          const filterTag = modal
+            .locator('.ant-tag', { hasText: 'Updated At' })
+            .first();
+          await expect(filterTag).toBeVisible();
+        });
 
-    test('Admin can remove an applied Created At datetime filter tag', async ({
-      page,
-    }) => {
-      // 1. Open the Session Detail drawer and history modal
-      await openSessionDetailDrawer(page);
-      const modal = await openSchedulingHistoryModal(page);
+        test('Admin can remove an applied Created At datetime filter tag', async ({
+          page,
+        }) => {
+          // 1. Open the Session Detail drawer and history modal
+          await openSessionDetailDrawer(page);
+          const modal = await openSchedulingHistoryModal(page);
 
-      // 2. Apply a Created At datetime filter (skip if not available)
-      const isAvailable = await selectDatetimeProperty(
-        page,
-        modal,
-        'Created At',
-      );
-      if (!isAvailable) return;
-      const datePicker = modal
-        .locator('.ant-space-compact .ant-picker')
-        .first();
-      await datePicker.click();
-      const calendarPopup = page
-        .locator('.ant-picker-dropdown:not(.ant-picker-dropdown-hidden)')
-        .first();
-      await calendarPopup.locator('.ant-picker-cell-in-view').first().click();
-      await calendarPopup.getByRole('button', { name: 'OK' }).click();
+          // 2. Apply a Created At datetime filter
+          await selectDatetimeProperty(page, modal, 'Created At');
+          const datePicker = modal
+            .locator('.ant-space-compact .ant-picker')
+            .first();
+          await datePicker.click();
+          const calendarPopup = page
+            .locator('.ant-picker-dropdown:not(.ant-picker-dropdown-hidden)')
+            .first();
+          await calendarPopup
+            .locator('.ant-picker-cell-in-view')
+            .first()
+            .click();
+          await calendarPopup.getByRole('button', { name: 'OK' }).click();
 
-      // 3. Verify the filter tag is visible
-      const filterTag = modal
-        .locator('.ant-tag', { hasText: 'Created At' })
-        .first();
-      await expect(filterTag).toBeVisible();
+          // 3. Verify the filter tag is visible
+          const filterTag = modal
+            .locator('.ant-tag', { hasText: 'Created At' })
+            .first();
+          await expect(filterTag).toBeVisible();
 
-      // 4. Click the X (close) icon on the filter tag to remove it
-      await filterTag.getByLabel('close').click();
+          // 4. Click the X (close) icon on the filter tag to remove it
+          await filterTag.getByLabel('close').click();
 
-      // 5. Verify the filter tag is no longer visible
-      await expect(filterTag).not.toBeVisible();
-    });
+          // 5. Verify the filter tag is no longer visible
+          await expect(filterTag).not.toBeVisible();
+        });
+      },
+    );
 
     // ─────────────────────────────────────────────────────────────────────────
     // 6. Refresh Functionality

--- a/e2e/start/start-page.spec.ts
+++ b/e2e/start/start-page.spec.ts
@@ -3,6 +3,7 @@
 //            4 (Start From URL Modal), 5 (Board Item Drag-and-Drop)
 import { StartPage } from '../utils/classes/common/StartPage';
 import { FolderCreationModal } from '../utils/classes/vfolder/FolderCreationModal';
+import { skipUnlessClientConfig } from '../utils/feature-gate-util';
 import {
   loginAsAdmin,
   loginAsUser,
@@ -265,14 +266,18 @@ test.describe(
       }) => {
         const startPage = new StartPage(page);
 
-        // 1. Check if the "Start Model Service" card is visible (depends on enableModelFolders config)
-        const card = startPage.getModelServiceCard();
-
-        // Skip test explicitly if the card is not available in the current configuration
-        test.skip(
-          !(await card.isVisible()),
-          'Model service card not available in current configuration',
+        // Declarative config gate (FR-3112): the "Start Model Service" card is
+        // rendered only when `enableModelFolders = true` in config.toml
+        // (StartPage.tsx reads `baiClient._config.enableModelFolders`).
+        await skipUnlessClientConfig(
+          page,
+          'enableModelFolders',
+          'Start Model Service card requires `enableModelFolders = true` in config.toml',
         );
+
+        // 1. The config enables the feature — the card MUST be present; absence is a failure.
+        const card = startPage.getModelServiceCard();
+        await expect(card).toBeVisible({ timeout: CARD_TIMEOUT });
 
         // 2. Click the "Start Service" button within the card
         await startPage.getStartServiceButton(card).click();

--- a/e2e/statistics/statistics.spec.ts
+++ b/e2e/statistics/statistics.spec.ts
@@ -1,4 +1,5 @@
 // spec: Statistics page tests
+import { skipUnlessClientFeature } from '../utils/feature-gate-util';
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
 import test, { expect } from '@playwright/test';
 
@@ -24,28 +25,35 @@ test.describe('Statistics', { tag: ['@functional', '@statistics'] }, () => {
     await expect(page.getByText('Memory').first()).toBeVisible();
   });
 
-  test('Admin can switch to User Session History tab', async ({
-    page,
-    request,
-  }) => {
-    await loginAsAdmin(page, request);
-    await navigateTo(page, 'statistics');
+  test(
+    'Admin can switch to User Session History tab',
+    { tag: ['@requires-manager-v25.6'] },
+    async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+      await navigateTo(page, 'statistics');
 
-    // User Session History tab is conditional (requires user-metrics support)
-    const userSessionTab = page.getByRole('tab', {
-      name: 'User Session History',
-    });
-    const isTabVisible = await userSessionTab
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-    test.skip(!isTabVisible, 'User Session History tab not available');
+      // Declarative feature gate (FR-3112): the User Session History tab is
+      // rendered only when the manager supports 'user-metrics'
+      // (manager >= 25.6.0; tab introduced by FR-655).
+      await skipUnlessClientFeature(
+        page,
+        'user-metrics',
+        "User Session History tab requires the 'user-metrics' capability (Backend.AI manager >= 25.6.0, FR-655)",
+      );
 
-    await userSessionTab.click();
-    await expect(
-      page.getByRole('tab', {
+      // The backend is capable — the tab MUST be present; absence is a failure.
+      const userSessionTab = page.getByRole('tab', {
         name: 'User Session History',
-        selected: true,
-      }),
-    ).toBeVisible();
-  });
+      });
+      await expect(userSessionTab).toBeVisible();
+
+      await userSessionTab.click();
+      await expect(
+        page.getByRole('tab', {
+          name: 'User Session History',
+          selected: true,
+        }),
+      ).toBeVisible();
+    },
+  );
 });

--- a/e2e/utils/feature-gate-util.ts
+++ b/e2e/utils/feature-gate-util.ts
@@ -1,0 +1,152 @@
+/**
+ * Declarative feature-gate helpers for E2E tests (FR-3112).
+ *
+ * Problem: tests used to probe for a UI element from inside the test body and
+ * silently skip when it was absent ("widget not visible → assume the feature
+ * is unavailable"). Such graceful self-skips hide coverage gaps: a green run
+ * can mean the feature was absent everywhere, and a regression that removes
+ * the element is reported as "skipped" instead of "failed".
+ *
+ * Instead, gate the test on the *actual* capability source the WebUI itself
+ * reads, and let the UI assertion fail loudly when the backend is capable:
+ *
+ * - Manager-version capabilities → `skipUnlessClientFeature(page, 'agent-stats', ...)`
+ *   (same source of truth as `baiClient.supports(...)` in components; the
+ *   version → flag mapping lives in `packages/backend.ai-client/src/client.ts`
+ *   `_updateSupportList()`)
+ * - `config.toml` toggles → `skipUnlessClientConfig(page, 'enableModelFolders', ...)`
+ *   (same source of truth as `baiClient._config.*` in components)
+ *
+ * Pair these gates with a version-requirement tag on the test or describe
+ * block (e.g. `@requires-manager-v25.15`, `@requires-webui-v26.4`) so gated
+ * specs can be excluded explicitly on incapable targets:
+ * `npx playwright test --grep-invert "@requires-manager-v25.15"`.
+ * See e2e/E2E-TEST-NAMING-GUIDELINES.md ("Feature-gate tags (FR-3112)").
+ */
+import { test, Page } from '@playwright/test';
+
+/**
+ * Waits until the global Backend.AI client is initialized and ready.
+ * The client is created during login, so callers must be logged in first
+ * (e.g. via `loginAsAdmin` / `loginAsUser` in a `beforeEach`).
+ */
+async function waitForBackendAIClient(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      typeof (globalThis as any).backendaiclient !== 'undefined' &&
+      (globalThis as any).backendaiclient !== null &&
+      (globalThis as any).backendaiclient.ready === true,
+    { timeout: 10000 },
+  );
+}
+
+/**
+ * Reads the WebUI package version injected by `index.html`
+ * (`globalThis.packageVersion`, e.g. "26.5.0-alpha.0"). Available on every
+ * page as soon as the app shell loads — no login required.
+ */
+export async function getWebUIVersion(page: Page): Promise<string> {
+  return page.evaluate(() => (globalThis as any).packageVersion as string);
+}
+
+/**
+ * Numeric, segment-wise dotted-version comparison ("26.5.0-alpha.0" vs
+ * "26.4"). Pre-release suffixes are ignored: an alpha/rc of a release line
+ * already contains the features gated on that line.
+ */
+function isVersionAtLeast(version: string, minVersion: string): boolean {
+  const parse = (v: string) =>
+    v
+      .split('-')[0]
+      .split('.')
+      .map((seg) => Number.parseInt(seg, 10) || 0);
+  const a = parse(version);
+  const b = parse(minVersion);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff > 0;
+  }
+  return true;
+}
+
+/**
+ * Declaratively skips the current test when the WebUI under test is older
+ * than `minVersion`. Use for WebUI-version capabilities that have no
+ * `baiClient.supports(...)` flag (pair with a `@requires-webui-vX.Y` tag).
+ * On a capable build the test proceeds, so a missing UI element fails
+ * loudly instead of being reported as a skip.
+ */
+export async function skipUnlessWebUIVersion(
+  page: Page,
+  minVersion: string,
+  reason: string,
+): Promise<void> {
+  const version = await getWebUIVersion(page);
+  test.skip(
+    !isVersionAtLeast(version, minVersion),
+    `${reason} (WebUI ${version} < ${minVersion})`,
+  );
+}
+
+/**
+ * Returns whether the logged-in Backend.AI client reports support for the
+ * given capability flag — the same check components perform via
+ * `baiClient.supports(feature)`.
+ */
+export async function clientSupports(
+  page: Page,
+  feature: string,
+): Promise<boolean> {
+  await waitForBackendAIClient(page);
+  return page.evaluate(
+    (f) => !!(globalThis as any).backendaiclient?.supports(f),
+    feature,
+  );
+}
+
+/**
+ * Returns a value from the logged-in Backend.AI client's parsed `config.toml`
+ * (`baiClient._config`), e.g. `enableModelFolders`.
+ */
+export async function getClientConfigValue(
+  page: Page,
+  key: string,
+): Promise<unknown> {
+  await waitForBackendAIClient(page);
+  return page.evaluate(
+    (k) => (globalThis as any).backendaiclient?._config?.[k],
+    key,
+  );
+}
+
+/**
+ * Declarative feature gate: skips the current test (with the given auditable
+ * reason) when the backend does not support the capability flag. When the
+ * backend IS capable, the test proceeds — so a missing UI element becomes a
+ * real failure instead of a silent skip.
+ *
+ * The `reason` should cite the originating feature ticket and the minimum
+ * backend version, e.g.
+ * `"Agent Statistics widget requires the 'agent-stats' capability (manager >= 25.15.0, FR-1575)"`.
+ */
+export async function skipUnlessClientFeature(
+  page: Page,
+  feature: string,
+  reason: string,
+): Promise<void> {
+  const supported = await clientSupports(page, feature);
+  test.skip(!supported, reason);
+}
+
+/**
+ * Declarative config gate: skips the current test (with the given auditable
+ * reason) when the given `config.toml` key is falsy for the logged-in client.
+ */
+export async function skipUnlessClientConfig(
+  page: Page,
+  key: string,
+  reason: string,
+): Promise<void> {
+  const value = await getClientConfigValue(page, key);
+  test.skip(!value, reason);
+}


### PR DESCRIPTION
Resolves #7849 (FR-3112)

<!-- STACK -->
**📚 Stack (merge bottom → top), epic FR-3109:**

- #7853 — FR-3111: stale visual-regression baselines
- #7855 — FR-3113: serial cascade splits
- #7859 — FR-3110: removed/restructured-UI fixmes
- #7854 — FR-3112: runtime-skip → declarative feature gates  ← **this PR**
- #7861 — FR-3114: environment-constraint tags
<!-- /STACK -->

## What this PR does

Replaces "probe a UI element inside the test body → silently skip when absent" patterns with explicit, declarative feature gates. On incapable backends the tests still skip (with an auditable reason citing the originating ticket and minimum version); on capable backends a missing UI element now **fails** instead of silently skipping.

- New helper `e2e/utils/feature-gate-util.ts`: `skipUnlessClientFeature(page, flag, reason)` gates on the same source of truth the WebUI components read (`baiClient.supports(...)`, mapped from the manager version in `packages/backend.ai-client/src/client.ts`), and `skipUnlessClientConfig(page, key, reason)` gates on `config.toml` toggles (`baiClient._config.*`).
- New feature-gate tags `@requires-manager-vX.Y` / `@requires-webui-vX.Y` (consistent with the pre-existing `@requires-session` tag), documented in `e2e/E2E-TEST-NAMING-GUIDELINES.md`, so gated groups can be excluded explicitly: `npx playwright test --grep-invert "@requires-manager-v25.15"`.

## Inventory — every in-body `test.skip(...)` under `e2e/`

### Converted to declarative gates (this PR)

| File:line (before) | Probed condition | Gated feature / origin ticket | New gate |
|---|---|---|---|
| `e2e/statistics/statistics.spec.ts:41` | User Session History tab visible? | `user-metrics` capability, manager >= 25.6.0 (FR-655) | `skipUnlessClientFeature('user-metrics')` + test tag `@requires-manager-v25.6`; tab absence on capable manager now fails |
| `e2e/dashboard/dashboard.spec.ts:317,348` | Agent Statistics widget visible? | `agent-stats` capability, manager >= 25.15.0 (FR-1575) | describe-level `beforeEach` gate + describe tag `@requires-manager-v25.15`; widget absence on capable manager now fails |
| `e2e/start/start-page.spec.ts:272` | "Start Model Service" card visible? | `enableModelFolders = true` in config.toml (`StartPage.tsx` reads `baiClient._config.enableModelFolders`) | `skipUnlessClientConfig('enableModelFolders')`; card absence with config enabled now fails |
| `e2e/session/session-scheduling-history-modal.spec.ts:426` (helper used by 6 tests) | "Created At"/"Updated At" option in property filter dropdown | datetime filter properties, FR-2302 (WebUI > v26.3.0) | 6 tests wrapped in nested describe `Datetime Filter (Created At / Updated At)` tagged `@requires-webui-v26.4`; helper simplified to a single documented gate (removed the dead `boolean` return / `if (!isAvailable) return` dance — `test.skip(true, ...)` already aborts the test) |

### Kept — setup-failure guards (not feature detection; conservative per issue scope)

| File:line | Condition | Note |
|---|---|---|
| `e2e/app-launcher/app-launcher-basic.spec.ts:123,136,150,212` | `test.skip(!sessionCreated, ...)` | `beforeAll` session creation failed (no agent available); guards serial suite, not a feature probe |
| `e2e/app-launcher/app-launcher-launch.spec.ts:173,242,314,386,466,529` | `test.skip(!sessionCreated, ...)` | same as above |

### Category 5 — deferred to FR-3114 (backend environment / data constraints, untouched)

| File:line | Condition |
|---|---|
| `e2e/app-launcher/app-launcher-launch.spec.ts:253,325,477,540` | Jupyter / JupyterLab / SSH-SFTP / VS Code Desktop app button visible — depends on which apps the session image exposes (image/environment property) |
| `e2e/environment/environment.spec.ts:645` | needs > 20 images for page-2 pagination (data volume) |
| `e2e/admin-model-card/admin-model-card-url-state.spec.ts:125` | needs multiple pages of model cards (data volume) |
| `e2e/credential/my-keypair-management.spec.ts:846` | needs >= 1 inactive keypair (data precondition) |
| `e2e/session/session-cluster-mode.spec.ts` (env probes), `e2e/vfolder/vfolder-type-selection.spec.ts:85,135` | explicitly out of scope per issue |

### Kept — not runtime probes (already declarative or unreachable)

| File:line | Classification |
|---|---|
| `e2e/vite-poc-smoke.spec.ts:13` | already a declarative env-var opt-in gate (`CI` / `VITE_POC_SMOKE`), no UI probing |
| `e2e/environment/environment.spec.ts:29` | whole-test declarative `test.skip('title', fn)` (no uninstall path in WebUI) — category 1/2 disabled test; inner skip at `:50` is unreachable |
| `e2e/session/session-creation.spec.ts:315` | whole-test declarative `test.skip('title', fn)` with `TODO: fix this test` — category 1/2 |
| `e2e/vfolder/file-create.spec.ts:200` | whole-test declarative `test.skip('title', fn)` pending permission API fix — category 1/2 |
| `e2e/session/session-dependency.spec.ts:286` | unreachable — the test is `test.fixme(true, ...)`'d at `:249` (categories 1/2, untouched per issue) |

## Counts

- Converted to declarative gate: **4 probe sites → 10 tests** now declaratively gated
- Split to tagged group: **1** (datetime filter group tagged `@requires-webui-v26.4`; nested tagged describe used instead of a separate file to preserve the suite's serial mode and shared mocks/helpers)
- Kept as setup guard: **10** (`!sessionCreated`)
- Deferred to FR-3114 (env/data constraints): **7** probe sites
- Kept as already-declarative / unreachable / disabled (cat 1/2): **6**

## Verification

```
=== ALL PASS ===
```

`bash scripts/verify.sh` passes (terminology check: 1 pre-existing warn-only finding, unrelated). `npx playwright test --list` confirms all 4 touched spec files still parse and the `@requires-*` tags resolve (11 tagged tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
