### PR TITLE
fix(FR-3113): break up e2e serial cascade skips and document justified serial blocks

### DIFF
--- a/e2e/config/page-access-control.spec.ts
+++ b/e2e/config/page-access-control.spec.ts
@@ -184,10 +184,15 @@ test.describe(
   },
 );
 
-test.describe.serial(
+// Not serial: tests are independent (each logs in fresh; afterEach resets config),
+// so a failure doesn't cascade. mode: 'default' keeps them sequential on one worker
+// because config.toml is server-global state.
+test.describe(
   'Page Access Control - Permission-Based Access (401 Page)',
   { tag: ['@critical', '@config', '@functional'] },
   () => {
+    test.describe.configure({ mode: 'default' });
+
     test.afterEach(async ({ page, request }) => {
       // Reset config after each test
       await modifyConfigToml(page, request, {
@@ -285,10 +290,15 @@ test.describe.serial(
   },
 );
 
-test.describe.serial(
+// Not serial: tests are independent (each sets its own config; afterEach resets),
+// so a failure doesn't cascade. mode: 'default' keeps them sequential on one worker
+// because config.toml is server-global state.
+test.describe(
   'Page Access Control - Not Found Page (404)',
   { tag: ['@critical', '@config', '@functional'] },
   () => {
+    test.describe.configure({ mode: 'default' });
+
     test.afterEach(async ({ page, request }) => {
       // Reset config after each test
       await modifyConfigToml(page, request, {
@@ -381,10 +391,14 @@ test.describe.serial(
   },
 );
 
-test.describe.serial(
+// Not serial: single test — no ordering dependency. mode: 'default' keeps any
+// future tests sequential on one worker because config.toml is server-global state.
+test.describe(
   'Page Access Control - Root Redirect with Configuration',
   { tag: ['@critical', '@config', '@functional'] },
   () => {
+    test.describe.configure({ mode: 'default' });
+
     test.afterEach(async ({ page, request }) => {
       // Reset config after each test
       await modifyConfigToml(page, request, {
@@ -449,10 +463,15 @@ test.describe.serial(
   },
 );
 
-test.describe.serial(
+// Not serial: tests are independent (each sets its own config; afterEach resets),
+// so a failure doesn't cascade. mode: 'default' keeps them sequential on one worker
+// because config.toml is server-global state.
+test.describe(
   'Page Access Control - Combined Scenarios (blocklist + inactiveList)',
   { tag: ['@critical', '@config', '@functional'] },
   () => {
+    test.describe.configure({ mode: 'default' });
+
     test.afterEach(async ({ page, request }) => {
       // Reset config after each test
       await modifyConfigToml(page, request, {

--- a/e2e/project/project-crud.spec.ts
+++ b/e2e/project/project-crud.spec.ts
@@ -1,78 +1,84 @@
 // spec: e2e/.agent-output/test-plan-project.md
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
-import test, { expect } from '@playwright/test';
+import test, { expect, Page } from '@playwright/test';
 
 const TEST_RUN_ID = Date.now().toString(36);
 const PROJECT_NAME = `e2e-test-project-${TEST_RUN_ID}`;
 const PROJECT_DESCRIPTION = 'Test project for E2E';
 const UPDATED_DESCRIPTION = 'Updated E2E description';
 
-test.describe.serial(
-  'Project CRUD',
+// Run groups and tests in this file in order on a single worker so the
+// independent list test doesn't interleave with the CRUD chain.
+test.describe.configure({ mode: 'default' });
+
+// Cleanup function to delete the test project if it exists.
+// The project lifecycle is: Active → Deactivated (trash) → Purged (hard delete).
+// This helper handles all lifecycle states: if the project is active it
+// deactivates it first, then switches to the Inactive tab and purges it.
+async function cleanupTestProject(page: Page) {
+  // Check Active tab first
+  const activeProjectRow = page
+    .getByRole('row')
+    .filter({ hasText: PROJECT_NAME });
+  const isActiveVisible = await activeProjectRow
+    .isVisible({ timeout: 2000 })
+    .catch(() => false);
+
+  if (isActiveVisible) {
+    // Deactivate first (Popconfirm flow)
+    await activeProjectRow.hover();
+    await activeProjectRow
+      .locator('.bai-name-action-cell-actions button')
+      .nth(1)
+      .click();
+    const deactivatePopconfirm = page.locator('.ant-popconfirm');
+    await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
+    await deactivatePopconfirm
+      .getByRole('button', { name: 'Deactivate' })
+      .click();
+    await expect(activeProjectRow).toBeHidden({ timeout: 10000 });
+  }
+
+  // Switch to Inactive tab and purge
+  // Use the label wrapper (not the hidden radio input) to click the radio button
+  await page
+    .locator('label')
+    .filter({ hasText: /^Inactive$/ })
+    .click();
+  const inactiveProjectRow = page
+    .getByRole('row')
+    .filter({ hasText: PROJECT_NAME });
+  const isInactiveVisible = await inactiveProjectRow
+    .isVisible({ timeout: 5000 })
+    .catch(() => false);
+
+  if (isInactiveVisible) {
+    await inactiveProjectRow.hover();
+    // In Inactive tab: buttons are [setting(0), activate(1), purge(2)]
+    await inactiveProjectRow
+      .locator('.bai-name-action-cell-actions button')
+      .nth(2)
+      .click();
+    const purgeDialog = page.getByRole('dialog', { name: 'Purge Project' });
+    await expect(purgeDialog).toBeVisible({ timeout: 5000 });
+    await purgeDialog.locator('#confirmText').fill(PROJECT_NAME);
+    await purgeDialog.getByRole('button', { name: 'Purge' }).click();
+    await expect(inactiveProjectRow).toBeHidden({ timeout: 10000 });
+  }
+
+  // Return to Active tab for subsequent tests
+  await page
+    .locator('label')
+    .filter({ hasText: /^Active$/ })
+    .click();
+}
+
+// Independent of the CRUD chain: only reads the default project list, so a
+// chain failure must not skip it (extracted from the serial block in FR-3113).
+test.describe(
+  'Project List',
   { tag: ['@critical', '@project', '@functional'] },
   () => {
-    // Cleanup function to delete the test project if it exists.
-    // The project lifecycle is: Active → Deactivated (trash) → Purged (hard delete).
-    // This helper handles all lifecycle states: if the project is active it
-    // deactivates it first, then switches to the Inactive tab and purges it.
-    async function cleanupTestProject(page: any) {
-      // Check Active tab first
-      const activeProjectRow = page
-        .getByRole('row')
-        .filter({ hasText: PROJECT_NAME });
-      const isActiveVisible = await activeProjectRow
-        .isVisible({ timeout: 2000 })
-        .catch(() => false);
-
-      if (isActiveVisible) {
-        // Deactivate first (Popconfirm flow)
-        await activeProjectRow.hover();
-        await activeProjectRow
-          .locator('.bai-name-action-cell-actions button')
-          .nth(1)
-          .click();
-        const deactivatePopconfirm = page.locator('.ant-popconfirm');
-        await expect(deactivatePopconfirm).toBeVisible({ timeout: 5000 });
-        await deactivatePopconfirm
-          .getByRole('button', { name: 'Deactivate' })
-          .click();
-        await expect(activeProjectRow).toBeHidden({ timeout: 10000 });
-      }
-
-      // Switch to Inactive tab and purge
-      // Use the label wrapper (not the hidden radio input) to click the radio button
-      await page
-        .locator('label')
-        .filter({ hasText: /^Inactive$/ })
-        .click();
-      const inactiveProjectRow = page
-        .getByRole('row')
-        .filter({ hasText: PROJECT_NAME });
-      const isInactiveVisible = await inactiveProjectRow
-        .isVisible({ timeout: 5000 })
-        .catch(() => false);
-
-      if (isInactiveVisible) {
-        await inactiveProjectRow.hover();
-        // In Inactive tab: buttons are [setting(0), activate(1), purge(2)]
-        await inactiveProjectRow
-          .locator('.bai-name-action-cell-actions button')
-          .nth(2)
-          .click();
-        const purgeDialog = page.getByRole('dialog', { name: 'Purge Project' });
-        await expect(purgeDialog).toBeVisible({ timeout: 5000 });
-        await purgeDialog.locator('#confirmText').fill(PROJECT_NAME);
-        await purgeDialog.getByRole('button', { name: 'Purge' }).click();
-        await expect(inactiveProjectRow).toBeHidden({ timeout: 10000 });
-      }
-
-      // Return to Active tab for subsequent tests
-      await page
-        .locator('label')
-        .filter({ hasText: /^Active$/ })
-        .click();
-    }
-
     test('Admin can see project list with expected columns', async ({
       page,
       request,
@@ -117,15 +123,23 @@ test.describe.serial(
       await expect(
         defaultRow.getByRole('cell', { name: 'GENERAL' }),
       ).toBeVisible();
-
-      // 6. Cleanup any leftover test project from previous runs
-      await cleanupTestProject(page);
     });
+  },
+);
 
+// Keep serial: create → edit → filter → delete operate on the same project
+// (PROJECT_NAME).
+test.describe.serial(
+  'Project CRUD',
+  { tag: ['@critical', '@project', '@functional'] },
+  () => {
     test('Admin can create a new project', async ({ page, request }) => {
       // 1. Login as admin and navigate to project page
       await loginAsAdmin(page, request);
       await navigateTo(page, 'project');
+
+      // Cleanup any leftover test project (also handles serial-group retries)
+      await cleanupTestProject(page);
 
       // 2. Click the Create Project button
       await page.getByRole('button', { name: 'Create Project' }).click();

--- a/e2e/rbac/rbac-role-crud.spec.ts
+++ b/e2e/rbac/rbac-role-crud.spec.ts
@@ -8,6 +8,13 @@ const ROLE_NAME = `e2e-role-${TEST_RUN_ID}`;
 const ROLE_NAME_EDITED = `e2e-role-edited-${TEST_RUN_ID}`;
 const ROLE_DESCRIPTION = `E2E test role created at ${new Date().toISOString()}`;
 
+// Run all groups in this file in order on a single worker so the independent
+// system-role check below doesn't interleave with the CRUD chain (role
+// creation/purging shifts table pagination).
+test.describe.configure({ mode: 'default' });
+
+// Keep serial: lifecycle chain on a single custom role — create → edit (rename)
+// → deactivate → activate → purge all share ROLE_NAME / ROLE_NAME_EDITED state.
 test.describe.serial(
   'RBAC Role CRUD',
   { tag: ['@rbac', '@critical', '@functional'] },
@@ -288,76 +295,6 @@ test.describe.serial(
       });
     });
 
-    test('Superadmin cannot edit a system role name or description (edit button absent)', async ({
-      page,
-      request,
-    }) => {
-      // 1. Login as admin
-      await loginAsAdmin(page, request);
-
-      // 2. Navigate to RBAC page
-      await navigateTo(page, 'rbac');
-
-      // 3. Find the Source column index. Columns: Role Name(1) Description(2) Scope Type(3)
-      //    Scope ID(4) Source(5) Created At(6) Updated At(7).
-      // Locate system roles using a column-header-based approach to find
-      // a row where the Source cell value is exactly "System", excluding "monitor" (known bug).
-      // If no system row is visible on page 1, navigate to the last page where they accumulate.
-      const systemRoleRowLocator = () =>
-        page
-          .locator('tr.ant-table-row')
-          .filter({
-            has: page.locator('td:nth-child(5)', { hasText: /^System$/ }),
-          })
-          .filter({ hasNotText: /monitor/i })
-          .first();
-
-      let systemRoleRow = systemRoleRowLocator();
-      const isSystemVisible = await systemRoleRow
-        .isVisible({ timeout: 3000 })
-        .catch(() => false);
-      if (!isSystemVisible) {
-        // Navigate to last page to find system roles
-        const lastPageButton = page.locator('.ant-pagination-item').last();
-        await lastPageButton.click();
-        await expect(page.locator('.ant-table-row').first()).toBeVisible({
-          timeout: 10000,
-        });
-        systemRoleRow = systemRoleRowLocator();
-      }
-      await expect(systemRoleRow).toBeVisible({ timeout: 10000 });
-
-      // 4. Click the role name to open the detail drawer.
-      const titleElement = systemRoleRow
-        .getByRole('cell')
-        .first()
-        .locator('.ant-typography')
-        .first();
-      // Extract name for later verification (must be done before click to avoid stale ref)
-      const systemRoleName = (await titleElement.textContent())?.trim() ?? null;
-      await titleElement.click();
-
-      // 5. Verify the drawer title "RBAC Role Info" appears
-      const drawer = page.locator('.ant-drawer');
-      await expect(drawer.getByText('RBAC Role Info')).toBeVisible();
-
-      // 6. Verify the drawer heading matches the role name we clicked
-      if (systemRoleName) {
-        await expect(
-          drawer.locator('h3').filter({ hasText: systemRoleName }),
-        ).toBeVisible({
-          timeout: 5000,
-        });
-      }
-
-      // 7. Verify the Edit button is NOT present for system roles
-      // The Edit Role button would have size="large" (CSS class .ant-btn-lg) if present
-      await expect(drawer.locator('.ant-btn-lg').first()).toBeHidden();
-
-      // Close the drawer
-      await drawer.getByRole('button', { name: 'close' }).click();
-    });
-
     test('Superadmin can delete (soft-delete) an active custom role', async ({
       page,
       request,
@@ -539,6 +476,84 @@ test.describe.serial(
       await expect(
         page.getByRole('row').filter({ hasText: ROLE_NAME_EDITED }),
       ).toBeHidden({ timeout: 5000 });
+    });
+  },
+);
+
+// Independent of the CRUD chain above: only reads existing system roles, so a
+// chain failure must not skip it (extracted from the serial block in FR-3113).
+test.describe(
+  'RBAC System Role Restrictions',
+  { tag: ['@rbac', '@critical', '@functional'] },
+  () => {
+    test('Superadmin cannot edit a system role name or description (edit button absent)', async ({
+      page,
+      request,
+    }) => {
+      // 1. Login as admin
+      await loginAsAdmin(page, request);
+
+      // 2. Navigate to RBAC page
+      await navigateTo(page, 'rbac');
+
+      // 3. Find the Source column index. Columns: Role Name(1) Description(2) Scope Type(3)
+      //    Scope ID(4) Source(5) Created At(6) Updated At(7).
+      // Locate system roles using a column-header-based approach to find
+      // a row where the Source cell value is exactly "System", excluding "monitor" (known bug).
+      // If no system row is visible on page 1, navigate to the last page where they accumulate.
+      const systemRoleRowLocator = () =>
+        page
+          .locator('tr.ant-table-row')
+          .filter({
+            has: page.locator('td:nth-child(5)', { hasText: /^System$/ }),
+          })
+          .filter({ hasNotText: /monitor/i })
+          .first();
+
+      let systemRoleRow = systemRoleRowLocator();
+      const isSystemVisible = await systemRoleRow
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+      if (!isSystemVisible) {
+        // Navigate to last page to find system roles
+        const lastPageButton = page.locator('.ant-pagination-item').last();
+        await lastPageButton.click();
+        await expect(page.locator('.ant-table-row').first()).toBeVisible({
+          timeout: 10000,
+        });
+        systemRoleRow = systemRoleRowLocator();
+      }
+      await expect(systemRoleRow).toBeVisible({ timeout: 10000 });
+
+      // 4. Click the role name to open the detail drawer.
+      const titleElement = systemRoleRow
+        .getByRole('cell')
+        .first()
+        .locator('.ant-typography')
+        .first();
+      // Extract name for later verification (must be done before click to avoid stale ref)
+      const systemRoleName = (await titleElement.textContent())?.trim() ?? null;
+      await titleElement.click();
+
+      // 5. Verify the drawer title "RBAC Role Info" appears
+      const drawer = page.locator('.ant-drawer');
+      await expect(drawer.getByText('RBAC Role Info')).toBeVisible();
+
+      // 6. Verify the drawer heading matches the role name we clicked
+      if (systemRoleName) {
+        await expect(
+          drawer.locator('h3').filter({ hasText: systemRoleName }),
+        ).toBeVisible({
+          timeout: 5000,
+        });
+      }
+
+      // 7. Verify the Edit button is NOT present for system roles
+      // The Edit Role button would have size="large" (CSS class .ant-btn-lg) if present
+      await expect(drawer.locator('.ant-btn-lg').first()).toBeHidden();
+
+      // Close the drawer
+      await drawer.getByRole('button', { name: 'close' }).click();
     });
   },
 );

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -363,10 +363,15 @@ test.describe(
   },
 );
 
-test.describe.serial(
+// Not serial: each test provisions its own role (cleanupTestRole + createTestRole),
+// so a failure doesn't cascade. mode: 'default' keeps tests sequential on one worker
+// because they share the same ROLE_NAME (fullyParallel would make them race).
+test.describe(
   'RBAC Role Permissions Management',
   { tag: ['@rbac', '@critical', '@functional'] },
   () => {
+    test.describe.configure({ mode: 'default' });
+
     test('Superadmin can add a permission to a role', async ({
       page,
       request,
@@ -662,10 +667,15 @@ const ASSIGN_FIXTURE_EMAIL = `e2e-rbac-assign-${ASSIGN_FIXTURE_RUN_ID}@lablup.co
 const ASSIGN_FIXTURE_USERNAME = `e2e-rbac-assign-${ASSIGN_FIXTURE_RUN_ID}`;
 const ASSIGN_FIXTURE_PASSWORD = 'testing@123';
 
-test.describe.serial(
+// Not serial: each test provisions its own role (cleanupTestRole + createTestRole),
+// so a failure doesn't cascade. mode: 'default' keeps tests sequential on one worker
+// because they share the same ROLE_NAME (fullyParallel would make them race).
+test.describe(
   'RBAC Role Assignments Management',
   { tag: ['@rbac', '@critical', '@functional'] },
   () => {
+    test.describe.configure({ mode: 'default' });
+
     test.beforeAll(async ({ browser }) => {
       // Admin creates the disposable user via the Credential page UI.
       const adminContext = await browser.newContext();

--- a/e2e/resource-policy/resource-policy.spec.ts
+++ b/e2e/resource-policy/resource-policy.spec.ts
@@ -24,43 +24,50 @@ test.describe(
   'Resource Policy',
   { tag: ['@critical', '@resource-policy', '@functional'] },
   () => {
+    // Run groups and tests in this file in order on a single worker so the
+    // independent list tests don't interleave with the CRUD chains.
+    test.describe.configure({ mode: 'default' });
+
+    // Independent of the CRUD chain: only reads the default policy list, so a
+    // chain failure must not skip it (extracted from the serial block in FR-3113).
+    test('Admin can see Keypair policy list with expected columns', async ({
+      page,
+      request,
+    }) => {
+      await loginAsAdmin(page, request);
+      await navigateTo(page, 'resource-policy');
+
+      // Verify Keypair tab is selected by default
+      await expect(
+        page.getByRole('tab', { name: 'Keypair', selected: true }),
+      ).toBeVisible();
+
+      // Verify table columns
+      await expect(
+        page.getByRole('columnheader', { name: 'Name' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Concurrency' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Cluster Size' }),
+      ).toBeVisible();
+
+      // Verify default policy row exists
+      const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
+      await expect(defaultRow).toBeVisible();
+    });
+
+    // Keep serial: create → edit → delete operate on the same named policy.
     test.describe.serial('Keypair Resource Policy CRUD', () => {
       const KEYPAIR_POLICY_NAME = `e2e-kp-policy-${TEST_RUN_ID}`;
-
-      test('Admin can see Keypair policy list with expected columns', async ({
-        page,
-        request,
-      }) => {
-        await loginAsAdmin(page, request);
-        await navigateTo(page, 'resource-policy');
-
-        // Verify Keypair tab is selected by default
-        await expect(
-          page.getByRole('tab', { name: 'Keypair', selected: true }),
-        ).toBeVisible();
-
-        // Verify table columns
-        await expect(
-          page.getByRole('columnheader', { name: 'Name' }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('columnheader', { name: 'Concurrency' }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('columnheader', { name: 'Cluster Size' }),
-        ).toBeVisible();
-
-        // Verify default policy row exists
-        const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
-        await expect(defaultRow).toBeVisible();
-
-        // Cleanup any leftover test policy
-        await cleanupPolicy(page, KEYPAIR_POLICY_NAME);
-      });
 
       test('Admin can create a Keypair policy', async ({ page, request }) => {
         await loginAsAdmin(page, request);
         await navigateTo(page, 'resource-policy');
+
+        // Cleanup any leftover test policy (also handles serial-group retries)
+        await cleanupPolicy(page, KEYPAIR_POLICY_NAME);
 
         // Click Create button
         await page.getByRole('button', { name: 'Create' }).click();
@@ -154,34 +161,34 @@ test.describe(
       });
     });
 
+    // Independent of the CRUD chain: only reads the default policy list, so a
+    // chain failure must not skip it (extracted from the serial block in FR-3113).
+    test('Admin can see User policy list', async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+      await navigateTo(page, 'resource-policy');
+
+      // Switch to User tab
+      await page.getByRole('tab', { name: 'User' }).click();
+      await expect(
+        page.getByRole('tab', { name: 'User', selected: true }),
+      ).toBeVisible();
+
+      // Verify table columns
+      await expect(
+        page.getByRole('columnheader', { name: 'Name' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Max Folder Count' }),
+      ).toBeVisible();
+
+      // Verify default policy row exists
+      const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
+      await expect(defaultRow).toBeVisible();
+    });
+
+    // Keep serial: create → delete operate on the same named policy.
     test.describe.serial('User Resource Policy CRUD', () => {
       const USER_POLICY_NAME = `e2e-user-policy-${TEST_RUN_ID}`;
-
-      test('Admin can see User policy list', async ({ page, request }) => {
-        await loginAsAdmin(page, request);
-        await navigateTo(page, 'resource-policy');
-
-        // Switch to User tab
-        await page.getByRole('tab', { name: 'User' }).click();
-        await expect(
-          page.getByRole('tab', { name: 'User', selected: true }),
-        ).toBeVisible();
-
-        // Verify table columns
-        await expect(
-          page.getByRole('columnheader', { name: 'Name' }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('columnheader', { name: 'Max Folder Count' }),
-        ).toBeVisible();
-
-        // Verify default policy row exists
-        const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
-        await expect(defaultRow).toBeVisible();
-
-        // Cleanup
-        await cleanupPolicy(page, USER_POLICY_NAME);
-      });
 
       test('Admin can create a User policy', async ({ page, request }) => {
         await loginAsAdmin(page, request);
@@ -189,6 +196,9 @@ test.describe(
 
         // Switch to User tab
         await page.getByRole('tab', { name: 'User' }).click();
+
+        // Cleanup any leftover test policy (also handles serial-group retries)
+        await cleanupPolicy(page, USER_POLICY_NAME);
 
         // Click Create button
         await page.getByRole('button', { name: 'Create' }).click();
@@ -256,34 +266,34 @@ test.describe(
       });
     });
 
+    // Independent of the CRUD chain: only reads the default policy list, so a
+    // chain failure must not skip it (extracted from the serial block in FR-3113).
+    test('Admin can see Project policy list', async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+      await navigateTo(page, 'resource-policy');
+
+      // Switch to Project tab
+      await page.getByRole('tab', { name: 'Project' }).click();
+      await expect(
+        page.getByRole('tab', { name: 'Project', selected: true }),
+      ).toBeVisible();
+
+      // Verify table columns
+      await expect(
+        page.getByRole('columnheader', { name: 'Name' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Max Folder Count' }),
+      ).toBeVisible();
+
+      // Verify default policy row
+      const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
+      await expect(defaultRow).toBeVisible();
+    });
+
+    // Keep serial: create → delete operate on the same named policy.
     test.describe.serial('Project Resource Policy CRUD', () => {
       const PROJECT_POLICY_NAME = `e2e-proj-policy-${TEST_RUN_ID}`;
-
-      test('Admin can see Project policy list', async ({ page, request }) => {
-        await loginAsAdmin(page, request);
-        await navigateTo(page, 'resource-policy');
-
-        // Switch to Project tab
-        await page.getByRole('tab', { name: 'Project' }).click();
-        await expect(
-          page.getByRole('tab', { name: 'Project', selected: true }),
-        ).toBeVisible();
-
-        // Verify table columns
-        await expect(
-          page.getByRole('columnheader', { name: 'Name' }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('columnheader', { name: 'Max Folder Count' }),
-        ).toBeVisible();
-
-        // Verify default policy row
-        const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
-        await expect(defaultRow).toBeVisible();
-
-        // Cleanup
-        await cleanupPolicy(page, PROJECT_POLICY_NAME);
-      });
 
       test('Admin can create a Project policy', async ({ page, request }) => {
         await loginAsAdmin(page, request);
@@ -291,6 +301,9 @@ test.describe(
 
         // Switch to Project tab
         await page.getByRole('tab', { name: 'Project' }).click();
+
+        // Cleanup any leftover test policy (also handles serial-group retries)
+        await cleanupPolicy(page, PROJECT_POLICY_NAME);
 
         // Click Create button
         await page.getByRole('button', { name: 'Create' }).click();

--- a/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
+++ b/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
@@ -24,6 +24,9 @@ const EMAIL = `e2e-ip-restrict-${TEST_RUN_ID}@lablup.com`;
 const USERNAME = `e2e-ip-restrict-${TEST_RUN_ID}`;
 const PASSWORD = 'testing@123';
 
+// Keep serial: tests share the user created in the first test and the
+// currentClientIp captured in the second; later tests depend on the IP
+// allow-list state set by earlier ones, and the last test cleans up.
 test.describe.serial(
   'IP restriction enforcement during active session',
   { tag: ['@functional', '@regression', '@user-profile'] },

--- a/e2e/user/user-crud.spec.ts
+++ b/e2e/user/user-crud.spec.ts
@@ -24,6 +24,9 @@ const PASSWORD = 'testing@123';
 const NEW_PASSWORD = 'new-password@123';
 const MODIFIED_USERNAME = `modified-e2e-user-${TEST_RUN_ID}`;
 
+// Keep serial: lifecycle chain on a single user (EMAIL) — create → update
+// password → deactivate → reactivate → purge → login-denied all carry the
+// user's credentials and active/inactive state forward between tests.
 test.describe.serial(
   'User CRUD',
   { tag: ['@critical', '@user', '@functional'] },

--- a/e2e/vfolder/file-upload-dnd.spec.ts
+++ b/e2e/vfolder/file-upload-dnd.spec.ts
@@ -30,7 +30,8 @@ const openFolderExplorer = async (
   return modal;
 };
 
-test.describe.serial(
+// Not serial: single test — no ordering dependency.
+test.describe(
   'Drag-and-Drop File Upload',
   { tag: ['@critical', '@vfolder', '@functional'] },
   () => {

--- a/e2e/vfolder/file-upload-duplicate.spec.ts
+++ b/e2e/vfolder/file-upload-duplicate.spec.ts
@@ -30,6 +30,8 @@ const openFolderExplorer = async (
   return modal;
 };
 
+// Keep serial: the cancel test depends on the vfolder and the file uploaded
+// by the first test (overwrite-confirmation requires the pre-existing file).
 test.describe.serial(
   'Duplicate File Upload',
   { tag: ['@critical', '@vfolder', '@functional'] },

--- a/e2e/vfolder/file-upload-permissions.spec.ts
+++ b/e2e/vfolder/file-upload-permissions.spec.ts
@@ -23,6 +23,8 @@ const openFolderExplorer = async (
   return modal;
 };
 
+// Keep serial: the permission-change tests (currently fixme — FR-3110) reuse
+// the RW/RO folders created by the preceding creation tests in this block.
 test.describe.serial(
   'Upload Permission Controls',
   { tag: ['@critical', '@vfolder', '@functional'] },

--- a/e2e/vfolder/file-upload-subdirectory.spec.ts
+++ b/e2e/vfolder/file-upload-subdirectory.spec.ts
@@ -30,7 +30,8 @@ const openFolderExplorer = async (
   return modal;
 };
 
-test.describe.serial(
+// Not serial: single test — no ordering dependency.
+test.describe(
   'Upload to Subdirectory',
   { tag: ['@critical', '@vfolder', '@functional'] },
   () => {

--- a/e2e/vfolder/file-upload.spec.ts
+++ b/e2e/vfolder/file-upload.spec.ts
@@ -30,6 +30,9 @@ const openFolderExplorer = async (
   return modal;
 };
 
+// Keep serial: the tests chain state on one shared vfolder. testFolderName
+// (declared at describe scope) names that folder; the first (single-file)
+// test creates it and the multi-file test uploads into the same folder.
 test.describe.serial(
   'Button-Based File Upload',
   { tag: ['@critical', '@vfolder', '@functional'] },

--- a/e2e/vfolder/vfolder-consecutive-deletion.spec.ts
+++ b/e2e/vfolder/vfolder-consecutive-deletion.spec.ts
@@ -8,7 +8,8 @@ import {
 } from '../utils/test-util';
 import { test } from '@playwright/test';
 
-test.describe.serial(
+// Not serial: single test — no ordering dependency.
+test.describe(
   'VFolder Consecutive Deletion - User Operations',
   { tag: ['@regression', '@vfolder', '@functional'] },
   () => {

--- a/e2e/vfolder/vfolder-crud.spec.ts
+++ b/e2e/vfolder/vfolder-crud.spec.ts
@@ -21,9 +21,18 @@ test.describe(
       await loginAsUser(page, request);
     });
     const folderName = 'e2e-test-folder-user-creation' + new Date().getTime();
-    // Run creation tests serially since they all share the same folder name
-    test.describe.serial('vFolder Creation', () => {
+    // Not serial: each creation test uses a unique folder name generated in
+    // beforeEach and cleaned up in afterEach, so a failure doesn't cascade.
+    // mode: 'default' keeps tests sequential on one worker to limit backend load.
+    test.describe('vFolder Creation', () => {
+      test.describe.configure({ mode: 'default' });
+      let creationFolderName: string;
       test.beforeEach(async ({ page }) => {
+        creationFolderName =
+          'e2e-test-folder-user-creation-' +
+          Date.now() +
+          '-' +
+          Math.random().toString(36).slice(2, 6);
         await page.getByRole('link', { name: 'Data' }).click();
         await page
           .getByRole('button', { name: 'Create Folder' })
@@ -31,15 +40,15 @@ test.describe(
           .click();
       });
       test.afterEach(async ({ page }) => {
-        await moveToTrashAndVerify(page, folderName);
-        await deleteForeverAndVerifyFromTrash(page, folderName);
+        await moveToTrashAndVerify(page, creationFolderName);
+        await deleteForeverAndVerifyFromTrash(page, creationFolderName);
       });
       test('User can create a vFolder by selecting a specific location', async ({
         page,
       }) => {
         const folderCreationModal = new FolderCreationModal(page);
         await folderCreationModal.modalToBeVisible();
-        await folderCreationModal.fillFolderName(folderName);
+        await folderCreationModal.fillFolderName(creationFolderName);
         await folderCreationModal.fillLocationSelector('local');
         await folderCreationModal.selectLocationOptionByText('local');
         await (await folderCreationModal.getCreateButton()).click();
@@ -47,13 +56,13 @@ test.describe(
       test('User can create default vFolder', async ({ page }) => {
         const folderCreationModal = new FolderCreationModal(page);
         await folderCreationModal.modalToBeVisible();
-        await folderCreationModal.fillFolderName(folderName);
+        await folderCreationModal.fillFolderName(creationFolderName);
         await (await folderCreationModal.getCreateButton()).click();
       });
       test('User can create Model vFolder', async ({ page }) => {
         const folderCreationModal = new FolderCreationModal(page);
         await folderCreationModal.modalToBeVisible();
-        await folderCreationModal.fillFolderName(folderName);
+        await folderCreationModal.fillFolderName(creationFolderName);
         await (await folderCreationModal.getModelUsageModeRadio()).check();
         await expect(
           await folderCreationModal.getModelUsageModeRadio(),
@@ -63,7 +72,7 @@ test.describe(
       test('User can create cloneable Model vFolder', async ({ page }) => {
         const folderCreationModal = new FolderCreationModal(page);
         await folderCreationModal.modalToBeVisible();
-        await folderCreationModal.fillFolderName(folderName);
+        await folderCreationModal.fillFolderName(creationFolderName);
         await (await folderCreationModal.getModelUsageModeRadio()).check();
         await expect(
           await folderCreationModal.getModelUsageModeRadio(),
@@ -77,7 +86,7 @@ test.describe(
       test('User can create Read & Write vFolder', async ({ page }) => {
         const folderCreationModal = new FolderCreationModal(page);
         await folderCreationModal.modalToBeVisible();
-        await folderCreationModal.fillFolderName(folderName);
+        await folderCreationModal.fillFolderName(creationFolderName);
         await (await folderCreationModal.getReadWritePermissionRadio()).check();
         await expect(
           await folderCreationModal.getReadWritePermissionRadio(),
@@ -87,7 +96,7 @@ test.describe(
       test('User can create Read Only vFolder', async ({ page }) => {
         const folderCreationModal = new FolderCreationModal(page);
         await folderCreationModal.modalToBeVisible();
-        await folderCreationModal.fillFolderName(folderName);
+        await folderCreationModal.fillFolderName(creationFolderName);
         await (await folderCreationModal.getReadOnlyPermissionRadio()).check();
         await expect(
           await folderCreationModal.getReadOnlyPermissionRadio(),
@@ -95,8 +104,9 @@ test.describe(
         await (await folderCreationModal.getCreateButton()).click();
       });
     });
-    // Auto Mount uses a dedicated folder name (dot-prefixed) that is independent
-    test.describe.serial('Auto Mount vFolder Creation', () => {
+    // Auto Mount uses a dedicated folder name (dot-prefixed) that is independent.
+    // Not serial: single test — no ordering dependency.
+    test.describe('Auto Mount vFolder Creation', () => {
       const folderName = '.e2e-test-folder-auto-mount' + new Date().getTime();
       test.beforeEach(async ({ page }) => {
         await page.getByRole('link', { name: 'Data' }).click();
@@ -134,7 +144,9 @@ test.describe(
   },
 );
 
-test.describe.serial(
+// Not serial: single test — no ordering dependency; the folder is created in
+// beforeEach and cleaned up in afterEach.
+test.describe(
   'VFolder Sharing',
   { tag: ['@critical', '@vfolder', '@functional'] },
   () => {

--- a/e2e/vfolder/vfolder-explorer-modal.spec.ts
+++ b/e2e/vfolder/vfolder-explorer-modal.spec.ts
@@ -26,10 +26,17 @@ const openFolderExplorer = async (
   return modal;
 };
 
-test.describe.serial(
+// Not serial: each test provisions its own uniquely-named folder (or uses
+// none) and deletes it at the end of its body, so a failure doesn't cascade.
+// A mid-test failure can leave its folder behind, but names are unique per
+// run so later tests/runs are unaffected. mode: 'default' keeps tests
+// sequential on one worker to limit backend load.
+test.describe(
   'VFolder Explorer Modal',
   { tag: ['@critical', '@vfolder', '@functional'] },
   () => {
+    test.describe.configure({ mode: 'default' });
+
     test.beforeEach(async ({ page, request }) => {
       await loginAsUser(page, request);
       await navigateTo(page, 'data');


### PR DESCRIPTION
Resolves #7850 (FR-3113)

<!-- STACK -->
**📚 Stack (merge bottom → top), epic FR-3109:**

- #7853 — FR-3111: stale visual-regression baselines
- #7855 — FR-3113: serial cascade splits  ← **this PR**
- #7859 — FR-3110: removed/restructured-UI fixmes
- #7854 — FR-3112: runtime-skip → declarative feature gates
- #7861 — FR-3114: environment-constraint tags
<!-- /STACK -->

## Category 4: `test.describe.serial` cascade skips — inventory & decisions

A single failing test inside a `describe.serial` block marks every subsequent test in the block as "did not run". This PR audits all 23 in-scope `describe.serial` blocks and applies one of three treatments. Key context: `playwright.config.ts` sets `fullyParallel: true`, so a bare `test.describe` would let tests of one file race each other across workers (locally; CI pins `workers: 1`). Blocks whose tests are independent but share server-global state or sequencing needs are therefore converted to `test.describe` + `test.describe.configure({ mode: 'default' })` — same ordering, same single worker, **no failure cascade**.

### Decision inventory (23 blocks)

| # | File | Block | Tests | Decision | Cascade pool recovered |
|---|------|-------|-------|----------|------------------------|
| 1 | rbac/rbac-role-crud.spec.ts | RBAC Role CRUD | 6 | **Split (partial)**: extracted independent read-only "system role edit button absent" test into its own group; kept create→edit→deactivate→activate→purge chain serial (documented) | up to 3 (system-role failure no longer skips deactivate/activate/purge; chain failures no longer skip the system-role test) |
| 2 | rbac/rbac-role-detail.spec.ts | Role Permissions Management | 3 | **Split**: serial → `mode: 'default'` (each test self-provisions its role via `cleanupTestRole`+`createTestRole`) | up to 2 |
| 3 | rbac/rbac-role-detail.spec.ts | Role Assignments Management | 3 | **Split**: serial → `mode: 'default'` (same self-provisioning pattern) | up to 2 |
| 4 | resource-policy/resource-policy.spec.ts | Keypair Resource Policy CRUD | 4 | **Split (partial)**: extracted independent list test; moved leftover-cleanup into create test; kept create→edit→delete serial (documented) | up to 3 |
| 5 | resource-policy/resource-policy.spec.ts | User Resource Policy CRUD | 3 | **Split (partial)**: same treatment; kept create→delete serial | up to 2 |
| 6 | resource-policy/resource-policy.spec.ts | Project Resource Policy CRUD | 3 | **Split (partial)**: same treatment; kept create→delete serial | up to 2 |
| 7 | project/project-crud.spec.ts | Project CRUD | 5 | **Split (partial)**: extracted independent list test; moved cleanup into create test; kept create→edit→filter→delete serial (documented) | up to 4 |
| 8 | config/page-access-control.spec.ts | Permission-Based Access (401) | 2 | **Split**: serial → `mode: 'default'` (tests independent; `afterEach` resets server-global config.toml) | 1 |
| 9 | config/page-access-control.spec.ts | Not Found Page (404) | 2 | **Split**: serial → `mode: 'default'` | 1 |
| 10 | config/page-access-control.spec.ts | Root Redirect | 1 | **Split**: single test — serial removed (hygiene, no cascade possible) | 0 |
| 11 | config/page-access-control.spec.ts | Combined Scenarios | 2 | **Split**: serial → `mode: 'default'` | 1 |
| 12 | user/user-crud.spec.ts | User CRUD | 6 | **Keep serial** (documented): lifecycle chain on one user — password change and active/inactive state carry forward | — |
| 13 | user-profile/user-ip-restriction-enforcement.spec.ts | IP restriction enforcement | 4 | **Keep serial** (documented): shares created user + `currentClientIp` captured mid-chain; last test is cleanup | — |
| 14 | vfolder/vfolder-crud.spec.ts | vFolder Creation | 6 | **Split**: unique per-test folder name generated in `beforeEach` + `mode: 'default'` (also fixes latent name race with the standalone CRUD test under `fullyParallel`) | up to 5 |
| 15 | vfolder/vfolder-crud.spec.ts | Auto Mount vFolder Creation | 1 | **Split**: single test — serial removed | 0 |
| 16 | vfolder/vfolder-crud.spec.ts | VFolder Sharing | 1 | **Split**: single test — serial removed | 0 |
| 17 | vfolder/file-upload.spec.ts | Button-Based File Upload | 2 | **Keep serial** (documented): test 2 uploads into the vfolder created in test 1's body | — |
| 18 | vfolder/file-upload-dnd.spec.ts | Drag-and-Drop File Upload | 1 | **Split**: single test — serial removed | 0 |
| 19 | vfolder/file-upload-subdirectory.spec.ts | Upload to Subdirectory | 1 | **Split**: single test — serial removed | 0 |
| 20 | vfolder/file-upload-duplicate.spec.ts | Duplicate File Upload | 2 | **Keep serial** (documented): cancel test depends on the file uploaded by test 1 | — |
| 21 | vfolder/file-upload-permissions.spec.ts | Upload Permission Controls | 4 (2 fixme) | **Keep serial** (documented only — comment above block): fixme permission-change tests (FR-3110) reuse folders created by preceding tests; file deliberately not restructured | — |
| 22 | vfolder/vfolder-consecutive-deletion.spec.ts | Consecutive Deletion | 1 | **Split**: single test — serial removed | 0 |
| 23 | vfolder/vfolder-explorer-modal.spec.ts | VFolder Explorer Modal | 3 | **Split**: serial → `mode: 'default'` (each test creates/cleans its own uniquely-named folder or uses none); fixme at the other describe block untouched | up to 2 |

**Totals**: 13 split fully, 5 split partially (independent tests extracted, documented chain kept serial), 5 kept serial with justification comments, 0 mega-test conversions. Estimated coverage-signal recovery: **up to ~28 tests** no longer auto-skipped by a single upstream failure (scenario-dependent; per-block maxima above).

### Notes

- For serial chains whose first test previously performed leftover cleanup (resource-policy ×3, project-crud), the cleanup call moved into the new chain head (the create test) because serial-group retries restart from the first test of the block.
- Out of scope, untouched: the ~20 additional `test.describe.configure({ mode: 'serial' })` blocks elsewhere in the suite (different grep surface than this ticket's `describe.serial` list), the upstream failures themselves, and all `test.fixme` markers (FR-3110).
- All 78 tests across the 15 touched files parse via `npx playwright test --list`.

### Verification

```
=== TypeScript ===
--- TypeScript: PASS ---

=== Vite warmup paths ===
--- Vite warmup paths: PASS ---

=== Terminology (warn-only) ===
--- Terminology: WARN-ONLY (does not affect build status) ---

=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



> Rebased onto main after FR-2996 (#7684) / FR-2997 (#7688) merged. Conflict resolutions adopt main's repaired implementations inside the de-serialized structure: project-crud uses main's full deactivate-then-purge cleanup helper (hoisted to module scope, typed `Page`); rbac-role-crud keeps main's robust system-role test body in the extracted independent block; rbac-role-detail keeps main's disposable fixture user (`beforeAll`) inside the non-serial `mode: 'default'` block.
