### PR TITLE
fix(FR-3110): triage e2e fixmes for removed or restructured UI

### DIFF
--- a/e2e/vfolder/vfolder-explorer-modal.spec.ts
+++ b/e2e/vfolder/vfolder-explorer-modal.spec.ts
@@ -224,7 +224,12 @@ test.describe(
       await modal.close();
     });
 
-    test.fixme('User can access File Browser from VFolder explorer modal without defaultFileBrowserImage setting', () => {});
+    // The "File Browser without defaultFileBrowserImage setting" scenario was a
+    // never-implemented empty test.fixme stub (added in FR-1714). The behavior
+    // still exists in the app (useDefaultFileBrowserImageWithFallback queries
+    // installed images when the config is unset), but testing it requires a
+    // config-controlled environment. Tracked as a proper implementation task in
+    // FR-3118 instead of an empty permanently-skipped placeholder.
 
     test('User can view VFolder details in the explorer modal', async ({
       page,


### PR DESCRIPTION
Resolves #7847 (FR-3110)

<!-- STACK -->
**📚 Stack (merge bottom → top), epic FR-3109:**

- #7853 — FR-3111: stale visual-regression baselines
- #7855 — FR-3113: serial cascade splits
- #7859 — FR-3110: removed/restructured-UI fixmes  ← **this PR**
- #7854 — FR-3112: runtime-skip → declarative feature gates
- #7861 — FR-3114: environment-constraint tags
<!-- /STACK -->

## What this PR does

Triage of **every `test.fixme(...)` in the non-VR E2E suite** (28 call sites; `e2e/visual_regression/` excluded — owned by FR-3111/#7853) against category 1 of FR-3109: "the underlying UI/route was removed or restructured".

**Headline finding: 0 of the 28 non-VR fixmes are category 1.** All removed-UI fixmes (`/import` 404, `/service/start` removal, `ServiceLauncherCreatePage` deletion) lived in `visual_regression/` and were already handled by FR-3111/#7853. Route checks against `react/src/routes.tsx` confirm every route these specs touch still exists (`/chat`, `/session/start`, `/serving/:id` and `/service/:id` redirect to `/deployments`, `/import` redirects to `/start`, `/data`).

The single code change: removal of the **empty placeholder stub** `test.fixme('User can access File Browser from VFolder explorer modal without defaultFileBrowserImage setting', () => {})` in `e2e/vfolder/vfolder-explorer-modal.spec.ts`. It had no body, no stated reason (added in FR-1714/#4687 as a never-implemented placeholder), and the underlying UI still exists (`useDefaultImagesWithFallback` queries installed filebrowser images when the config is unset). The real test is now tracked as **FR-3118** instead of a contentless permanently-skipped entry.

## Inventory (all 28 non-VR `test.fixme` sites)

| # | file:line | In-source reason (verbatim, abridged) | Category | Decision |
|---|---|---|---|---|
| 1 | `e2e/chat/chat.spec.ts:142` | "The stop button never becomes visible because the mock SSE response completes synchronously before the @ant-design/x Sender component can switch to the loading/stop state." | Not cat-1 — test-infra/mock limitation | Keep |
| 2 | `e2e/chat/chat.spec.ts:319` | "The chat history label does not auto-update to the first user message. The saveChatMessage callback in useHistory uses a stale closure…" | Not cat-1 — app bug (product defect) | Keep |
| 3 | `e2e/chat/chat.spec.ts:361` | "The chat history entry labels remain as the default \"Chat\" instead of updating to the first user message text." | Not cat-1 — app bug (same root cause as #2) | Keep |
| 4 | `e2e/chat/chat.spec.ts:483` | "The chat history entry labels remain as the default \"Chat\"… prevents reliable targeting of specific entries for deletion." | Not cat-1 — app bug (same root cause as #2) | Keep |
| 5 | `e2e/chat/chat.spec.ts:670` | "The error alert is not displayed even though ChatCardQuery returns url: null. The Relay store-or-network fetch policy appears to use cached endpoint data…" | Not cat-1 — test-infra (Relay cache vs mock) | Keep |
| 6 | `e2e/chat/chat.spec.ts:726` | "ChatCard.tsx intentionally suppresses model fetch errors on the first load… The notification only appears after a manual refresh trigger." | Not cat-1 — test asserts behavior the app intentionally does not have | Keep |
| 7 | `e2e/auto-scaling-rule-preset/preset-crud.spec.ts:501` | "The backend currently allows duplicate preset names without returning an error, so the expected error notification never appears." | Not cat-1 — needs-backend (missing server-side validation) | Keep |
| 8 | `e2e/auth/password-expiry.spec.ts:245` | "This test requires a live Backend.AI cluster at webServerEndpoint… The test is skipped until the backend is available." | Not cat-1 — environment/infra | Keep |
| 9 | `e2e/session/session-dependency.spec.ts:34` | "Requires an agent with available compute resources (sessions cannot reach RUNNING on current test server)." | Not cat-1 — environment/infra | Keep |
| 10 | `e2e/session/session-dependency.spec.ts:183` | (same message; describe-level beforeEach, covers 1 test) | Not cat-1 — environment/infra | Keep |
| 11 | `e2e/session/session-dependency.spec.ts:249` | "Requires a working session list table. Backend currently returns an error for session queries, preventing the table (and its settings button) from rendering." | Not cat-1 — environment/backend error | Keep |
| 12 | `e2e/serving/endpoint-route-table.spec.ts:321` | "TODO(needs-backend): Re-enable when the EndpointDetailPage route property filter exposes a \"Traffic Status\" option… pending backend support for per-route traffic status (FR-2591)." | Not cat-1 — needs-backend (FR-2591) | Keep |
| 13–15 | `e2e/serving/endpoint-route-table.spec.ts:343,378,415` | "TODO(needs-backend): Re-enable when the route property filter exposes a \"Traffic Status\" option (FR-2591)." | Not cat-1 — needs-backend (FR-2591) | Keep |
| 16 | `e2e/serving/endpoint-route-table.spec.ts:531` | "TODO(needs-backend): Re-enable when BAIRouteNodes exposes the Traffic Status column. INACTIVE tags render inside that column (FR-2591)." | Not cat-1 — needs-backend (column commented out in `BAIRouteNodes.tsx` pending FR-2591) | Keep |
| 17–18 | `e2e/serving/endpoint-route-table.spec.ts:549,750` | "TODO(needs-backend): Re-enable when BAIRouteNodes exposes the Traffic Ratio column. It is currently commented out in BAIRouteNodes.tsx pending backend support." | Not cat-1 — needs-backend (FR-2591) | Keep |
| 19 | `e2e/vfolder/file-upload-permissions.spec.ts:69` | "FIXME: Server returns \"Cannot read properties of null (reading 'type')\" on update-options API" | Not cat-1 — backend bug (UI exists: Mount Permission `BAISelect` in `VFolderNodeDescriptionV2.tsx` → legacy `vfolder.update_folder`) | Keep |
| 20 | `e2e/vfolder/file-upload-permissions.spec.ts:90` | (same as #19) | Not cat-1 — backend bug | Keep |
| 21 | `e2e/vfolder/vfolder-explorer-modal.spec.ts:225` | *(no reason — empty stub `() => {}` since FR-1714/#4687)* | Not cat-1 — unimplemented placeholder; UI still exists with fallback | **Delete stub** + implementation ticket **FR-3118** |
| 22 | `e2e/session/session-template-modal.spec.ts:242` | "Session history is not populated after creation: the Recent History modal shows \"No data\" instead of the created session name." | Not cat-1 — app bug (`pushSessionHistory` name propagation) | Keep |
| 23–28 | `e2e/session/session-lifecycle.spec.ts:69,125,163,198,236,281` | "Requires Backend.AI agent with available resources. Sessions stay PENDING in this environment." (conditional on `BACKEND_AI_AGENTS_AVAILABLE !== 'true'`) | Not cat-1 — environment/infra (per file header note) | Keep |

## Skip-pool tally (category 1 contribution)

- Non-VR `test.fixme` call sites: **28** (each covers exactly 1 test, including the two describe-scoped ones) → 28 tests in the skip pool.
- **Category 1 (removed/restructured UI): 0 tests.** All such cases were in `visual_regression/` (FR-3111/#7853).
- This PR removes 1 contentless placeholder → non-VR fixme skip-pool contribution drops 28 → **27**.
- Breakdown of the remaining 27: environment/infra 10, needs-backend 8 (7× FR-2591, 1× preset duplicate-name validation), app bug 5, test-infra/mock 2, backend bug 2 (update-options API).

## Follow-up tickets

- **FR-3118** — Implement e2e test: File Browser launch falls back when `defaultFileBrowserImage` is unset (replaces the deleted stub; parent FR-3109).

## Verification

`bash scripts/verify.sh` tail:

```
=== TERMINOLOGY SUMMARY ===
  blocking terminology findings: 0  (warn mode: not enforced)
  warn-only terminology findings: 1
  key-divergence findings (report): 0
--- Terminology: WARN-ONLY (does not affect build status) ---

=== ALL PASS ===
```

`npx playwright test --list` → `Total: 641 tests in 89 files` (all specs parse; the removed stub no longer appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

