### PR TITLE
fix(FR-3114): tag and gate e2e tests skipped by environment constraints

### DIFF
--- a/e2e/E2E-TEST-NAMING-GUIDELINES.md
+++ b/e2e/E2E-TEST-NAMING-GUIDELINES.md
@@ -298,6 +298,36 @@ UI element inside the test body and skipping when it is absent. The gate skips
 with an auditable reason on incapable backends; on capable backends a missing
 UI element fails the test instead of silently skipping.
 
+### Environment-constraint tags (FR-3114)
+
+When a spec needs a backend environment capability or pre-seeded data that
+the standard test cluster may not provide, tag it so it can be excluded on
+incapable targets (and re-included once infra provisions the capability):
+
+- `@requires-app-<service>` — the session image used by the suite must
+  expose the `<service>` service port (`ai.backend.service-ports`), e.g.
+  `@requires-app-jupyter`, `@requires-app-jupyterlab`, `@requires-app-vscode`,
+  `@requires-app-sshd`, `@requires-app-vscode-desktop`
+- `@requires-vfolder-type-group` — the cluster's etcd `volumes/_types`
+  config must include `group` (Project-type vfolders). Gate with
+  `skipUnlessAllowedVFolderType(page, 'group', ...)`
+- `@requires-seeded-data` — the target cluster must hold pre-seeded data
+  beyond a fresh install's defaults (e.g. >20 registered images for image
+  list pagination, >1 page of model store cards, an inactive keypair on the
+  e2e user account). The skip reason must state the exact data precondition.
+
+```bash
+# Run everything that works on a freshly installed, unseeded cluster
+npx playwright test --grep-invert "@requires-seeded-data"
+
+# Exclude suites that need specific session apps or Project-type vfolders
+npx playwright test --grep-invert "@requires-app-|@requires-vfolder-type-group"
+```
+
+Each `@requires-*` tagged test keeps a runtime gate (a `test.skip(condition,
+reason)` whose reason cites the constraint and the tag) so a run on an
+incapable backend reports an auditable skip instead of a false pass.
+
 ## Test Structure Best Practices
 
 ### 1. Spec Reference Comment

--- a/e2e/admin-model-card/admin-model-card-url-state.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-url-state.spec.ts
@@ -134,41 +134,46 @@ test.describe(
     });
 
     // 10.3 Pagination state is persisted in the URL query parameters
-    test('Superadmin can persist pagination state in the URL query parameters', async ({
-      page,
-    }) => {
-      const adminModelCardPage = new AdminModelCardPage(page);
-      await page.goto(
-        `${webuiEndpoint}/admin-deployments?tab=model-store-management`,
-      );
-      await adminModelCardPage.waitForTableLoad();
+    test(
+      'Superadmin can persist pagination state in the URL query parameters',
+      { tag: ['@requires-seeded-data'] },
+      async ({ page }) => {
+        const adminModelCardPage = new AdminModelCardPage(page);
+        await page.goto(
+          `${webuiEndpoint}/admin-deployments?tab=model-store-management`,
+        );
+        await adminModelCardPage.waitForTableLoad();
 
-      // Only proceed if there are multiple pages
-      const nextButton = page.getByRole('button', { name: 'right' });
-      const isNextEnabled = await nextButton.isEnabled();
-      if (!isNextEnabled) {
-        test.skip();
-        return;
-      }
+        // Environment data gate (FR-3114): this scenario needs more than one
+        // page of model store cards on the target cluster. Seeding more model
+        // cards is an infra task — until then the test skips with an auditable
+        // reason.
+        const nextButton = page.getByRole('button', { name: 'right' });
+        const isNextEnabled = await nextButton.isEnabled();
+        test.skip(
+          !isNextEnabled,
+          'Pagination scenario requires more than one page of model store cards on the target cluster (@requires-seeded-data)',
+        );
 
-      // Navigate to page 2
-      await nextButton.click();
-      // Use the URL as the source of truth for the active page
-      await expect(page).toHaveURL(/current=2/);
+        // Navigate to page 2
+        await nextButton.click();
+        // Use the URL as the source of truth for the active page
+        await expect(page).toHaveURL(/current=2/);
 
-      // Verify page 2 pagination item is active
-      await expect(
-        page.getByRole('listitem', { name: '2' }).first(),
-      ).toBeVisible();
+        // Verify page 2 pagination item is active
+        await expect(
+          page.getByRole('listitem', { name: '2' }).first(),
+        ).toBeVisible();
 
-      const page2URL = page.url();
+        const page2URL = page.url();
 
-      // Reload the page and verify it stays on page 2
-      await page.goto(page2URL);
-      await adminModelCardPage.waitForTableLoad();
+        // Reload the page and verify it stays on page 2
+        await page.goto(page2URL);
+        await adminModelCardPage.waitForTableLoad();
 
-      // Verify page 2 is still active after reload
-      await expect(page).toHaveURL(/current=2/);
-    });
+        // Verify page 2 is still active after reload
+        await expect(page).toHaveURL(/current=2/);
+      },
+    );
   },
 );

--- a/e2e/app-launcher/app-launcher-launch.spec.ts
+++ b/e2e/app-launcher/app-launcher-launch.spec.ts
@@ -237,364 +237,394 @@ test.describe(
       }
     });
 
-    test('User can launch Jupyter Notebook app in new browser tab', async ({}, testInfo) => {
-      testInfo.setTimeout(120000); // 2 minutes timeout for app initialization
-      test.skip(!sessionCreated, 'Session was not created successfully');
+    test(
+      'User can launch Jupyter Notebook app in new browser tab',
+      { tag: ['@requires-app-jupyter'] },
+      async ({}, testInfo) => {
+        testInfo.setTimeout(120000); // 2 minutes timeout for app initialization
+        test.skip(!sessionCreated, 'Session was not created successfully');
 
-      // Modal is already open, verify it's visible
-      await expect(appLauncherModal.getModal()).toBeVisible();
-
-      // Check if Jupyter Notebook app is available
-      const jupyterAppVisible = await appLauncherModal
-        .getAppButton('jupyter')
-        .isVisible()
-        .catch(() => false);
-
-      test.skip(!jupyterAppVisible, 'Jupyter Notebook app not available');
-
-      // Set up network request tracking
-      const proxyRequests: any[] = [];
-      sharedPage.on('request', (request) => {
-        const url = request.url();
-        if (url.includes('/proxy/') || url.includes('/add')) {
-          proxyRequests.push({
-            url,
-            method: request.method(),
-          });
-        }
-      });
-
-      // Track new page openings (MUST be set BEFORE clicking)
-      const newPagePromise = sharedContext.waitForEvent('page', {
-        timeout: 30000,
-      });
-
-      // 1. Click Jupyter Notebook app button
-      await appLauncherModal.clickApp('jupyter');
-
-      // 2. Wait for notification to appear
-      const notificationContainer = sharedPage
-        .locator('.ant-notification-notice')
-        .last();
-      await expect(notificationContainer).toBeVisible({ timeout: 10000 });
-
-      // 3. Wait for "Prepared" status in notification
-      const preparedNotification = sharedPage
-        .locator('.ant-notification-notice')
-        .filter({ hasText: 'Prepared' });
-      await expect(preparedNotification).toBeVisible({ timeout: 60000 });
-
-      // 4. Wait for app to open in new browser tab
-      const newPage = await newPagePromise;
-      await expect(newPage).toBeTruthy();
-
-      // TODO: Remove this error handling when proxy is stable
-      await handleProxyError(newPage);
-
-      // Verify the new tab was opened and has a URL (proxy routing may redirect to main app
-      // in some environments, which is acceptable - we verify the tab was opened)
-      await newPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
-      expect(newPage.url()).toBeTruthy();
-
-      // Close the new tab
-      await newPage.close();
-
-      // 5. Verify app launcher modal remains open
-      await expect(appLauncherModal.getModal()).toBeVisible();
-
-      // Network Verification: Verify proxy request includes app=jupyter parameter
-      const jupyterRequest = proxyRequests.find((req) =>
-        req.url.includes('app=jupyter'),
-      );
-      expect(jupyterRequest).toBeTruthy();
-    });
-
-    test('User can launch JupyterLab app in new browser tab', async ({}, testInfo) => {
-      testInfo.setTimeout(120000); // 2 minutes timeout for app initialization
-      test.skip(!sessionCreated, 'Session was not created successfully');
-
-      // Modal is already open, verify it's visible
-      await expect(appLauncherModal.getModal()).toBeVisible();
-
-      // Check if JupyterLab app is available
-      const jupyterlabAppVisible = await appLauncherModal
-        .getAppButton('jupyterlab')
-        .isVisible()
-        .catch(() => false);
-
-      test.skip(!jupyterlabAppVisible, 'JupyterLab app not available');
-
-      // Set up network request tracking
-      const proxyRequests: any[] = [];
-      sharedPage.on('request', (request) => {
-        const url = request.url();
-        if (url.includes('/proxy/') || url.includes('/add')) {
-          proxyRequests.push({
-            url,
-            method: request.method(),
-          });
-        }
-      });
-
-      // Track new page openings (MUST be set BEFORE clicking)
-      const newPagePromise = sharedContext.waitForEvent('page', {
-        timeout: 30000,
-      });
-
-      // 1. Click JupyterLab app button
-      await appLauncherModal.clickApp('jupyterlab');
-
-      // 2. Wait for notification to appear
-      const notificationContainer = sharedPage
-        .locator('.ant-notification-notice')
-        .last();
-      await expect(notificationContainer).toBeVisible({ timeout: 10000 });
-
-      // 3. Wait for "Prepared" status in notification
-      const preparedNotification = sharedPage
-        .locator('.ant-notification-notice')
-        .filter({ hasText: 'Prepared' });
-      await expect(preparedNotification).toBeVisible({ timeout: 60000 });
-
-      // 4. Wait for app to open in new browser tab
-      const newPage = await newPagePromise;
-      await expect(newPage).toBeTruthy();
-
-      // TODO: Remove this error handling when proxy is stable
-      await handleProxyError(newPage);
-
-      // Verify the new tab was opened and has a URL (proxy routing may redirect to main app
-      // in some environments, which is acceptable - we verify the tab was opened)
-      await newPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
-      expect(newPage.url()).toBeTruthy();
-
-      // Close the new tab
-      await newPage.close();
-
-      // 5. Verify app launcher modal remains open
-      await expect(appLauncherModal.getModal()).toBeVisible();
-
-      // Network Verification: Verify proxy request includes app=jupyterlab parameter
-      const jupyterlabRequest = proxyRequests.find((req) =>
-        req.url.includes('app=jupyterlab'),
-      );
-      expect(jupyterlabRequest).toBeTruthy();
-    });
-
-    test('User can launch Visual Studio Code app in new browser tab', async ({}, testInfo) => {
-      testInfo.setTimeout(120000); // 2 minutes timeout for app initialization
-      test.skip(!sessionCreated, 'Session was not created successfully');
-
-      // Modal is already open, verify it's visible
-      await expect(appLauncherModal.getModal()).toBeVisible();
-
-      // Check if VS Code app is available
-      const vscodeAppVisible = await appLauncherModal
-        .getAppButton('vscode')
-        .isVisible()
-        .catch(() => false);
-
-      if (!vscodeAppVisible) {
-        // VS Code app is not available in the current session's container image.
-        // This is an environment limitation (not a test bug) - some images do not include VS Code.
-        // The test verifies that the modal is still open and accessible.
-        console.log(
-          'Visual Studio Code app not available in this session image. Verifying modal is still accessible.',
-        );
+        // Modal is already open, verify it's visible
         await expect(appLauncherModal.getModal()).toBeVisible();
-        return;
-      }
 
-      // Set up network request tracking
-      const proxyRequests: any[] = [];
-      sharedPage.on('request', (request) => {
-        const url = request.url();
-        if (url.includes('/proxy/') || url.includes('/add')) {
-          proxyRequests.push({
-            url,
-            method: request.method(),
-          });
-        }
-      });
+        // Environment gate (FR-3114): app availability depends on the session
+        // image's `ai.backend.service-ports` label, which the test environment
+        // controls (the suite uses the default available image).
+        const jupyterAppVisible = await appLauncherModal
+          .getAppButton('jupyter')
+          .isVisible()
+          .catch(() => false);
 
-      // Track new page openings (MUST be set BEFORE clicking)
-      const newPagePromise = sharedContext.waitForEvent('page', {
-        timeout: 30000,
-      });
+        test.skip(
+          !jupyterAppVisible,
+          "Jupyter Notebook app requires a session image exposing the 'jupyter' service port (@requires-app-jupyter)",
+        );
 
-      // 1. Click VS Code app button
-      await appLauncherModal.clickApp('vscode');
+        // Set up network request tracking
+        const proxyRequests: any[] = [];
+        sharedPage.on('request', (request) => {
+          const url = request.url();
+          if (url.includes('/proxy/') || url.includes('/add')) {
+            proxyRequests.push({
+              url,
+              method: request.method(),
+            });
+          }
+        });
 
-      // 2. Wait for notification to appear
-      const notificationContainer = sharedPage
-        .locator('.ant-notification-notice')
-        .last();
-      await expect(notificationContainer).toBeVisible({ timeout: 10000 });
+        // Track new page openings (MUST be set BEFORE clicking)
+        const newPagePromise = sharedContext.waitForEvent('page', {
+          timeout: 30000,
+        });
 
-      // 3. Wait for "Prepared" status in notification
-      const preparedNotification = sharedPage
-        .locator('.ant-notification-notice')
-        .filter({ hasText: 'Prepared' });
-      await expect(preparedNotification).toBeVisible({ timeout: 60000 });
+        // 1. Click Jupyter Notebook app button
+        await appLauncherModal.clickApp('jupyter');
 
-      // 4. Wait for app to open in new browser tab
-      const newPage = await newPagePromise;
-      expect(newPage).toBeTruthy();
+        // 2. Wait for notification to appear
+        const notificationContainer = sharedPage
+          .locator('.ant-notification-notice')
+          .last();
+        await expect(notificationContainer).toBeVisible({ timeout: 10000 });
 
-      // TODO: Remove this error handling when proxy is stable
-      await handleProxyError(newPage);
+        // 3. Wait for "Prepared" status in notification
+        const preparedNotification = sharedPage
+          .locator('.ant-notification-notice')
+          .filter({ hasText: 'Prepared' });
+        await expect(preparedNotification).toBeVisible({ timeout: 60000 });
 
-      // Verify the new tab was opened and has a URL (proxy routing may redirect to main app
-      // in some environments, which is acceptable - we verify the tab was opened)
-      await newPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
-      expect(newPage.url()).toBeTruthy();
+        // 4. Wait for app to open in new browser tab
+        const newPage = await newPagePromise;
+        await expect(newPage).toBeTruthy();
 
-      // Close the new tab
-      await newPage.close();
+        // TODO: Remove this error handling when proxy is stable
+        await handleProxyError(newPage);
 
-      // 5. Verify app launcher modal remains open
-      await expect(appLauncherModal.getModal()).toBeVisible();
+        // Verify the new tab was opened and has a URL (proxy routing may redirect to main app
+        // in some environments, which is acceptable - we verify the tab was opened)
+        await newPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
+        expect(newPage.url()).toBeTruthy();
 
-      // Network Verification: Verify proxy request includes app=vscode parameter
-      const vscodeRequest = proxyRequests.find((req) =>
-        req.url.includes('app=vscode'),
-      );
-      expect(vscodeRequest).toBeTruthy();
-    });
+        // Close the new tab
+        await newPage.close();
 
-    test('User sees SFTP connection info modal after launching SSH/SFTP app', async () => {
-      test.skip(!sessionCreated, 'Session was not created successfully');
+        // 5. Verify app launcher modal remains open
+        await expect(appLauncherModal.getModal()).toBeVisible();
 
-      // Modal is already open, verify it's visible
-      await expect(appLauncherModal.getModal()).toBeVisible();
+        // Network Verification: Verify proxy request includes app=jupyter parameter
+        const jupyterRequest = proxyRequests.find((req) =>
+          req.url.includes('app=jupyter'),
+        );
+        expect(jupyterRequest).toBeTruthy();
+      },
+    );
 
-      // Check if SSH/SFTP app is available
-      const sshdAppVisible = await appLauncherModal
-        .getAppButton('sshd')
-        .isVisible()
-        .catch(() => false);
+    test(
+      'User can launch JupyterLab app in new browser tab',
+      { tag: ['@requires-app-jupyterlab'] },
+      async ({}, testInfo) => {
+        testInfo.setTimeout(120000); // 2 minutes timeout for app initialization
+        test.skip(!sessionCreated, 'Session was not created successfully');
 
-      test.skip(!sshdAppVisible, 'SSH/SFTP app not available');
+        // Modal is already open, verify it's visible
+        await expect(appLauncherModal.getModal()).toBeVisible();
 
-      // Set up network request tracking
-      const proxyRequests: any[] = [];
-      sharedPage.on('request', (request) => {
-        const url = request.url();
-        if (url.includes('/proxy/') || url.includes('/add')) {
-          proxyRequests.push({
-            url,
-            method: request.method(),
-          });
-        }
-      });
+        // Environment gate (FR-3114): see the Jupyter Notebook test above.
+        const jupyterlabAppVisible = await appLauncherModal
+          .getAppButton('jupyterlab')
+          .isVisible()
+          .catch(() => false);
 
-      // 1. Click SSH/SFTP app button
-      await appLauncherModal.clickApp('sshd');
+        test.skip(
+          !jupyterlabAppVisible,
+          "JupyterLab app requires a session image exposing the 'jupyterlab' service port (@requires-app-jupyterlab)",
+        );
 
-      // 2. Wait for SFTP connection info modal to appear.
-      //    Since allowNonAuthTCP is enabled in beforeAll, TCP apps must work correctly.
-      //    If the modal does not appear, the test should fail (not silently pass).
-      const sftpConnectionModal = sharedPage
-        .getByRole('dialog')
-        .filter({ hasText: /SSH.*SFTP.*connection|SFTP.*connection/i });
+        // Set up network request tracking
+        const proxyRequests: any[] = [];
+        sharedPage.on('request', (request) => {
+          const url = request.url();
+          if (url.includes('/proxy/') || url.includes('/add')) {
+            proxyRequests.push({
+              url,
+              method: request.method(),
+            });
+          }
+        });
 
-      await expect(sftpConnectionModal).toBeVisible({ timeout: 30000 });
+        // Track new page openings (MUST be set BEFORE clicking)
+        const newPagePromise = sharedContext.waitForEvent('page', {
+          timeout: 30000,
+        });
 
-      // Verify modal displays connection information
-      await expect(sftpConnectionModal).toContainText('Host');
-      await expect(sftpConnectionModal).toContainText('Port');
-      await expect(sftpConnectionModal).toContainText('User');
+        // 1. Click JupyterLab app button
+        await appLauncherModal.clickApp('jupyterlab');
 
-      // 3. Close the SFTP connection info modal
-      const sftpModalCloseButton = sftpConnectionModal.getByRole('button', {
-        name: 'Close',
-      });
-      await sftpModalCloseButton.click();
-      await expect(sftpConnectionModal).not.toBeVisible({ timeout: 5000 });
+        // 2. Wait for notification to appear
+        const notificationContainer = sharedPage
+          .locator('.ant-notification-notice')
+          .last();
+        await expect(notificationContainer).toBeVisible({ timeout: 10000 });
 
-      // 4. Verify app launcher modal remains open
-      await expect(appLauncherModal.getModal()).toBeVisible();
+        // 3. Wait for "Prepared" status in notification
+        const preparedNotification = sharedPage
+          .locator('.ant-notification-notice')
+          .filter({ hasText: 'Prepared' });
+        await expect(preparedNotification).toBeVisible({ timeout: 60000 });
 
-      // Network Verification: Verify proxy request includes app=sshd and protocol=tcp parameters
-      const sshdRequest = proxyRequests.find((req) =>
-        req.url.includes('app=sshd'),
-      );
-      expect(sshdRequest).toBeTruthy();
-      if (sshdRequest) {
-        expect(sshdRequest.url).toContain('protocol=tcp');
-      }
-    });
+        // 4. Wait for app to open in new browser tab
+        const newPage = await newPagePromise;
+        await expect(newPage).toBeTruthy();
 
-    test('User sees VS Code Desktop connection modal after launching VS Code Desktop app', async () => {
-      test.skip(!sessionCreated, 'Session was not created successfully');
+        // TODO: Remove this error handling when proxy is stable
+        await handleProxyError(newPage);
 
-      // Modal is already open, verify it's visible
-      await expect(appLauncherModal.getModal()).toBeVisible();
+        // Verify the new tab was opened and has a URL (proxy routing may redirect to main app
+        // in some environments, which is acceptable - we verify the tab was opened)
+        await newPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
+        expect(newPage.url()).toBeTruthy();
 
-      // Check if VS Code Desktop app is available
-      const vscodeDesktopAppVisible = await appLauncherModal
-        .getAppButton('vscode-desktop')
-        .isVisible()
-        .catch(() => false);
+        // Close the new tab
+        await newPage.close();
 
-      test.skip(!vscodeDesktopAppVisible, 'VS Code Desktop app not available');
+        // 5. Verify app launcher modal remains open
+        await expect(appLauncherModal.getModal()).toBeVisible();
 
-      // Set up network request tracking
-      const proxyRequests: any[] = [];
-      sharedPage.on('request', (request) => {
-        const url = request.url();
-        if (url.includes('/proxy/') || url.includes('/add')) {
-          proxyRequests.push({
-            url,
-            method: request.method(),
-          });
-        }
-      });
+        // Network Verification: Verify proxy request includes app=jupyterlab parameter
+        const jupyterlabRequest = proxyRequests.find((req) =>
+          req.url.includes('app=jupyterlab'),
+        );
+        expect(jupyterlabRequest).toBeTruthy();
+      },
+    );
 
-      // 1. Click VS Code Desktop app button
-      await appLauncherModal.clickApp('vscode-desktop');
+    test(
+      'User can launch Visual Studio Code app in new browser tab',
+      { tag: ['@requires-app-vscode'] },
+      async ({}, testInfo) => {
+        testInfo.setTimeout(120000); // 2 minutes timeout for app initialization
+        test.skip(!sessionCreated, 'Session was not created successfully');
 
-      // 2. Wait for VS Code Desktop (SSH) connection modal to appear.
-      //    Since allowNonAuthTCP is enabled in beforeAll, TCP apps must work correctly.
-      //    If the modal does not appear, the test should fail (not silently pass).
-      const vscodeDesktopModal = sharedPage
-        .getByRole('dialog')
-        .filter({ hasText: /SSH.*connection/i });
+        // Modal is already open, verify it's visible
+        await expect(appLauncherModal.getModal()).toBeVisible();
 
-      await expect(vscodeDesktopModal).toBeVisible({ timeout: 30000 });
+        // Environment gate (FR-3114): some images do not include VS Code.
+        // Previously this fell back to a no-op pass; report a skip instead so
+        // the missing coverage is visible in the test report.
+        const vscodeAppVisible = await appLauncherModal
+          .getAppButton('vscode')
+          .isVisible()
+          .catch(() => false);
 
-      // Verify modal displays connection information
-      await expect(vscodeDesktopModal).toContainText('Host');
-      await expect(vscodeDesktopModal).toContainText('Port');
+        test.skip(
+          !vscodeAppVisible,
+          "Visual Studio Code app requires a session image exposing the 'vscode' service port (@requires-app-vscode)",
+        );
 
-      // 3. Close the VS Code Desktop connection modal
-      const vscodeDesktopModalCloseButton = vscodeDesktopModal.getByRole(
-        'button',
-        {
+        // Set up network request tracking
+        const proxyRequests: any[] = [];
+        sharedPage.on('request', (request) => {
+          const url = request.url();
+          if (url.includes('/proxy/') || url.includes('/add')) {
+            proxyRequests.push({
+              url,
+              method: request.method(),
+            });
+          }
+        });
+
+        // Track new page openings (MUST be set BEFORE clicking)
+        const newPagePromise = sharedContext.waitForEvent('page', {
+          timeout: 30000,
+        });
+
+        // 1. Click VS Code app button
+        await appLauncherModal.clickApp('vscode');
+
+        // 2. Wait for notification to appear
+        const notificationContainer = sharedPage
+          .locator('.ant-notification-notice')
+          .last();
+        await expect(notificationContainer).toBeVisible({ timeout: 10000 });
+
+        // 3. Wait for "Prepared" status in notification
+        const preparedNotification = sharedPage
+          .locator('.ant-notification-notice')
+          .filter({ hasText: 'Prepared' });
+        await expect(preparedNotification).toBeVisible({ timeout: 60000 });
+
+        // 4. Wait for app to open in new browser tab
+        const newPage = await newPagePromise;
+        expect(newPage).toBeTruthy();
+
+        // TODO: Remove this error handling when proxy is stable
+        await handleProxyError(newPage);
+
+        // Verify the new tab was opened and has a URL (proxy routing may redirect to main app
+        // in some environments, which is acceptable - we verify the tab was opened)
+        await newPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
+        expect(newPage.url()).toBeTruthy();
+
+        // Close the new tab
+        await newPage.close();
+
+        // 5. Verify app launcher modal remains open
+        await expect(appLauncherModal.getModal()).toBeVisible();
+
+        // Network Verification: Verify proxy request includes app=vscode parameter
+        const vscodeRequest = proxyRequests.find((req) =>
+          req.url.includes('app=vscode'),
+        );
+        expect(vscodeRequest).toBeTruthy();
+      },
+    );
+
+    test(
+      'User sees SFTP connection info modal after launching SSH/SFTP app',
+      { tag: ['@requires-app-sshd'] },
+      async () => {
+        test.skip(!sessionCreated, 'Session was not created successfully');
+
+        // Modal is already open, verify it's visible
+        await expect(appLauncherModal.getModal()).toBeVisible();
+
+        // Environment gate (FR-3114): see the Jupyter Notebook test above.
+        const sshdAppVisible = await appLauncherModal
+          .getAppButton('sshd')
+          .isVisible()
+          .catch(() => false);
+
+        test.skip(
+          !sshdAppVisible,
+          "SSH/SFTP app requires a session image exposing the 'sshd' service port (@requires-app-sshd)",
+        );
+
+        // Set up network request tracking
+        const proxyRequests: any[] = [];
+        sharedPage.on('request', (request) => {
+          const url = request.url();
+          if (url.includes('/proxy/') || url.includes('/add')) {
+            proxyRequests.push({
+              url,
+              method: request.method(),
+            });
+          }
+        });
+
+        // 1. Click SSH/SFTP app button
+        await appLauncherModal.clickApp('sshd');
+
+        // 2. Wait for SFTP connection info modal to appear.
+        //    Since allowNonAuthTCP is enabled in beforeAll, TCP apps must work correctly.
+        //    If the modal does not appear, the test should fail (not silently pass).
+        const sftpConnectionModal = sharedPage
+          .getByRole('dialog')
+          .filter({ hasText: /SSH.*SFTP.*connection|SFTP.*connection/i });
+
+        await expect(sftpConnectionModal).toBeVisible({ timeout: 30000 });
+
+        // Verify modal displays connection information
+        await expect(sftpConnectionModal).toContainText('Host');
+        await expect(sftpConnectionModal).toContainText('Port');
+        await expect(sftpConnectionModal).toContainText('User');
+
+        // 3. Close the SFTP connection info modal
+        const sftpModalCloseButton = sftpConnectionModal.getByRole('button', {
           name: 'Close',
-        },
-      );
-      await vscodeDesktopModalCloseButton.click();
-      await expect(vscodeDesktopModal).not.toBeVisible({ timeout: 5000 });
+        });
+        await sftpModalCloseButton.click();
+        await expect(sftpConnectionModal).not.toBeVisible({ timeout: 5000 });
 
-      // 4. Verify app launcher modal remains open
-      await expect(appLauncherModal.getModal()).toBeVisible();
+        // 4. Verify app launcher modal remains open
+        await expect(appLauncherModal.getModal()).toBeVisible();
 
-      // Network Verification: VS Code Desktop uses sshd service internally (TCP protocol)
-      // Look for either app=sshd or app=vscode-desktop in the proxy requests
-      const vscodeDesktopProxyRequest = proxyRequests.find(
-        (req) =>
-          req.url.includes('app=sshd') ||
-          req.url.includes('app=vscode-desktop'),
-      );
-      // A proxy request should be made when the button is clicked (even if backend returns error)
-      if (vscodeDesktopProxyRequest) {
-        expect(vscodeDesktopProxyRequest.url).toContain('protocol=tcp');
-      }
-      // NOTE: If no proxy request is captured, the request may use a URL pattern not tracked by
-      // this listener (e.g., WebSocket or a different path). This is acceptable as the UI behavior
-      // (error notification or connection modal) has already been verified above.
-    });
+        // Network Verification: Verify proxy request includes app=sshd and protocol=tcp parameters
+        const sshdRequest = proxyRequests.find((req) =>
+          req.url.includes('app=sshd'),
+        );
+        expect(sshdRequest).toBeTruthy();
+        if (sshdRequest) {
+          expect(sshdRequest.url).toContain('protocol=tcp');
+        }
+      },
+    );
+
+    test(
+      'User sees VS Code Desktop connection modal after launching VS Code Desktop app',
+      { tag: ['@requires-app-vscode-desktop'] },
+      async () => {
+        test.skip(!sessionCreated, 'Session was not created successfully');
+
+        // Modal is already open, verify it's visible
+        await expect(appLauncherModal.getModal()).toBeVisible();
+
+        // Environment gate (FR-3114): see the Jupyter Notebook test above.
+        const vscodeDesktopAppVisible = await appLauncherModal
+          .getAppButton('vscode-desktop')
+          .isVisible()
+          .catch(() => false);
+
+        test.skip(
+          !vscodeDesktopAppVisible,
+          "VS Code Desktop app requires a session image exposing the 'vscode-desktop' service port (@requires-app-vscode-desktop)",
+        );
+
+        // Set up network request tracking
+        const proxyRequests: any[] = [];
+        sharedPage.on('request', (request) => {
+          const url = request.url();
+          if (url.includes('/proxy/') || url.includes('/add')) {
+            proxyRequests.push({
+              url,
+              method: request.method(),
+            });
+          }
+        });
+
+        // 1. Click VS Code Desktop app button
+        await appLauncherModal.clickApp('vscode-desktop');
+
+        // 2. Wait for VS Code Desktop (SSH) connection modal to appear.
+        //    Since allowNonAuthTCP is enabled in beforeAll, TCP apps must work correctly.
+        //    If the modal does not appear, the test should fail (not silently pass).
+        const vscodeDesktopModal = sharedPage
+          .getByRole('dialog')
+          .filter({ hasText: /SSH.*connection/i });
+
+        await expect(vscodeDesktopModal).toBeVisible({ timeout: 30000 });
+
+        // Verify modal displays connection information
+        await expect(vscodeDesktopModal).toContainText('Host');
+        await expect(vscodeDesktopModal).toContainText('Port');
+
+        // 3. Close the VS Code Desktop connection modal
+        const vscodeDesktopModalCloseButton = vscodeDesktopModal.getByRole(
+          'button',
+          {
+            name: 'Close',
+          },
+        );
+        await vscodeDesktopModalCloseButton.click();
+        await expect(vscodeDesktopModal).not.toBeVisible({ timeout: 5000 });
+
+        // 4. Verify app launcher modal remains open
+        await expect(appLauncherModal.getModal()).toBeVisible();
+
+        // Network Verification: VS Code Desktop uses sshd service internally (TCP protocol)
+        // Look for either app=sshd or app=vscode-desktop in the proxy requests
+        const vscodeDesktopProxyRequest = proxyRequests.find(
+          (req) =>
+            req.url.includes('app=sshd') ||
+            req.url.includes('app=vscode-desktop'),
+        );
+        // A proxy request should be made when the button is clicked (even if backend returns error)
+        if (vscodeDesktopProxyRequest) {
+          expect(vscodeDesktopProxyRequest.url).toContain('protocol=tcp');
+        }
+        // NOTE: If no proxy request is captured, the request may use a URL pattern not tracked by
+        // this listener (e.g., WebSocket or a different path). This is acceptable as the UI behavior
+        // (error notification or connection modal) has already been verified above.
+      },
+    );
 
     // FR-3027: When the App Proxy Coordinator cannot allocate a worker for the
     // circuit (e.g. the TCP worker's port pool is exhausted), the permit-key

--- a/e2e/credential/my-keypair-management.spec.ts
+++ b/e2e/credential/my-keypair-management.spec.ts
@@ -914,46 +914,53 @@ test.describe(
       ).toBeHidden({ timeout: 10000 });
     });
 
-    test('User cannot delete a keypair without typing the exact confirmation phrase', async ({
-      page,
-    }) => {
-      await openKeypairModal(page);
+    test(
+      'User cannot delete a keypair without typing the exact confirmation phrase',
+      { tag: ['@requires-seeded-data'] },
+      async ({ page }) => {
+        await openKeypairModal(page);
 
-      const modal = page.getByRole('dialog', { name: 'My Keypair Management' });
+        const modal = page.getByRole('dialog', {
+          name: 'My Keypair Management',
+        });
 
-      // Switch to Inactive tab
-      await modal.locator('label').filter({ hasText: 'Inactive' }).click();
+        // Switch to Inactive tab
+        await modal.locator('label').filter({ hasText: 'Inactive' }).click();
 
-      const inactiveRows = getKeypairTableRows(page);
-      const count = await inactiveRows.count();
+        const inactiveRows = getKeypairTableRows(page);
+        const count = await inactiveRows.count();
 
-      if (count === 0) {
+        // Environment data gate (FR-3114): needs at least one pre-existing
+        // inactive keypair on the e2e user account. Seeding it is an infra
+        // task — until then the test skips with an auditable reason.
         test.skip(
-          true,
-          'Requires at least one inactive keypair to exercise the delete confirmation flow.',
+          count === 0,
+          'Requires at least one inactive keypair on the e2e user account to exercise the delete confirmation flow (@requires-seeded-data)',
         );
-      }
 
-      // Click Delete Keypair on first inactive row (in Controls cell)
-      await inactiveRows
-        .first()
-        .locator('td')
-        .nth(1)
-        .locator('button.ant-btn-dangerous')
-        .click();
+        // Click Delete Keypair on first inactive row (in Controls cell)
+        await inactiveRows
+          .first()
+          .locator('td')
+          .nth(1)
+          .locator('button.ant-btn-dangerous')
+          .click();
 
-      const deleteDialog = page.getByRole('dialog', { name: /Delete Keypair/ });
-      await expect(deleteDialog).toBeVisible();
+        const deleteDialog = page.getByRole('dialog', {
+          name: /Delete Keypair/,
+        });
+        await expect(deleteDialog).toBeVisible();
 
-      // Verify Delete button is disabled when input is empty
-      await expect(
-        deleteDialog.getByRole('button', { name: 'Delete' }),
-      ).toBeDisabled();
+        // Verify Delete button is disabled when input is empty
+        await expect(
+          deleteDialog.getByRole('button', { name: 'Delete' }),
+        ).toBeDisabled();
 
-      // Close the dialog without deleting
-      await deleteDialog.getByRole('button', { name: 'Close' }).click();
-      await expect(deleteDialog).toBeHidden();
-    });
+        // Close the dialog without deleting
+        await deleteDialog.getByRole('button', { name: 'Close' }).click();
+        await expect(deleteDialog).toBeHidden();
+      },
+    );
 
     test('User can cancel the delete confirmation dialog without deleting the keypair', async ({
       page,

--- a/e2e/environment/environment.spec.ts
+++ b/e2e/environment/environment.spec.ts
@@ -617,72 +617,77 @@ test.describe(
     });
 
     // Scenario 2.10 — Pagination resets to page 1 when filter applied
-    test('Admin sees pagination reset to page 1 when a filter is applied on page 2', async ({
-      page,
-    }) => {
-      // 1. Check total row count to determine if there are enough images for page 2
-      // Use the visible standalone pagination (ant-pagination-end); the built-in
-      // ant-table-pagination is hidden on this page.
-      const paginationTotal = page
-        .locator('.ant-pagination-end')
-        .locator('.ant-pagination-total-text');
-      // Ensure pagination total text is present and readable; fail if it is not.
-      await expect(paginationTotal).toBeVisible();
-      const totalText = await paginationTotal.textContent();
-      if (!totalText) {
-        throw new Error('Pagination total text is empty or null');
-      }
-      const totalMatch = totalText.match(/of\s+(\d+)/);
-      if (!totalMatch) {
-        throw new Error(
-          `Unexpected pagination total text format: "${totalText}"`,
+    test(
+      'Admin sees pagination reset to page 1 when a filter is applied on page 2',
+      { tag: ['@requires-seeded-data'] },
+      async ({ page }) => {
+        // 1. Check total row count to determine if there are enough images for page 2
+        // Use the visible standalone pagination (ant-pagination-end); the built-in
+        // ant-table-pagination is hidden on this page.
+        const paginationTotal = page
+          .locator('.ant-pagination-end')
+          .locator('.ant-pagination-total-text');
+        // Ensure pagination total text is present and readable; fail if it is not.
+        await expect(paginationTotal).toBeVisible();
+        const totalText = await paginationTotal.textContent();
+        if (!totalText) {
+          throw new Error('Pagination total text is empty or null');
+        }
+        const totalMatch = totalText.match(/of\s+(\d+)/);
+        if (!totalMatch) {
+          throw new Error(
+            `Unexpected pagination total text format: "${totalText}"`,
+          );
+        }
+        const total = parseInt(totalMatch[1], 10);
+
+        // Environment data gate (FR-3114): this scenario needs a second page of
+        // results, i.e. more than 20 images registered on the target cluster
+        // (default page size is 20). Seeding more images is an infra task —
+        // until then the test skips with an auditable reason.
+        test.skip(
+          total <= 20,
+          `Pagination scenario requires more than 20 images in the image list (found ${total}; default page size 20, @requires-seeded-data)`,
         );
-      }
-      const total = parseInt(totalMatch[1], 10);
 
-      // Skip if not enough images for page 2 (default page size is 20)
-      if (total <= 20) {
-        test.skip();
-        return;
-      }
+        // Use the standalone visible pagination (ant-pagination-end) which is the
+        // actual pagination rendered for the image list. The ant-table-pagination
+        // built into the table is hidden (display:none) on this page.
+        const visiblePagination = page.locator('.ant-pagination-end');
 
-      // Use the standalone visible pagination (ant-pagination-end) which is the
-      // actual pagination rendered for the image list. The ant-table-pagination
-      // built into the table is hidden (display:none) on this page.
-      const visiblePagination = page.locator('.ant-pagination-end');
+        // 2. Navigate to page 2 by clicking the page 2 button in pagination
+        await visiblePagination
+          .locator('.ant-pagination-item')
+          .filter({ hasText: '2' })
+          .click();
+        await page
+          .locator('.ant-spin-spinning')
+          .waitFor({ state: 'detached', timeout: 10000 })
+          .catch(() => {});
 
-      // 2. Navigate to page 2 by clicking the page 2 button in pagination
-      await visiblePagination
-        .locator('.ant-pagination-item')
-        .filter({ hasText: '2' })
-        .click();
-      await page
-        .locator('.ant-spin-spinning')
-        .waitFor({ state: 'detached', timeout: 10000 })
-        .catch(() => {});
+        // 3. Verify we are on page 2
+        await expect(
+          visiblePagination.locator('.ant-pagination-item-active'),
+        ).toHaveText('2');
 
-      // 3. Verify we are on page 2
-      await expect(
-        visiblePagination.locator('.ant-pagination-item-active'),
-      ).toHaveText('2');
+        // 4. Apply a Name filter with value "python"
+        await applyImageFilter(page, 'Name', 'python');
+        const nameTag = page
+          .locator('.ant-tag')
+          .filter({ has: page.locator('[aria-label="Close"]') })
+          .filter({ hasText: 'Name: python' });
+        await expect(nameTag).toBeVisible();
 
-      // 4. Apply a Name filter with value "python"
-      await applyImageFilter(page, 'Name', 'python');
-      const nameTag = page
-        .locator('.ant-tag')
-        .filter({ has: page.locator('[aria-label="Close"]') })
-        .filter({ hasText: 'Name: python' });
-      await expect(nameTag).toBeVisible();
+        // 5. Verify pagination has reset to page 1
+        await expect(
+          visiblePagination.locator('.ant-pagination-item-active'),
+        ).toHaveText('1');
 
-      // 5. Verify pagination has reset to page 1
-      await expect(
-        visiblePagination.locator('.ant-pagination-item-active'),
-      ).toHaveText('1');
-
-      // 6. Cleanup: remove the filter tag
-      await removeFilterTag(page, 'Name: python');
-      await expect(nameTag).not.toBeVisible();
-    });
+        // 6. Cleanup: remove the filter tag
+        await removeFilterTag(page, 'Name: python');
+        await expect(nameTag).not.toBeVisible();
+      },
+    );
 
     // Scenario 2.11 — Strict selection rejects freeform input
     test('Admin cannot add a filter for architecture with an invalid freeform value', async ({

--- a/e2e/session/session-cluster-mode.spec.ts
+++ b/e2e/session/session-cluster-mode.spec.ts
@@ -1,7 +1,8 @@
 // spec: e2e/.agent-output/test-plan-session-cluster-mode.md
 // seed: e2e/seed.spec.ts
+import { skipUnlessWebUIVersion } from '../utils/feature-gate-util';
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 /**
  * Helper: navigate to session launcher step 2 and wait for the Cluster mode section.
@@ -13,6 +14,25 @@ async function navigateToClusterModeSection(
   await navigateTo(page, 'session/start');
   await page.getByRole('button', { name: '2 Environments & Resource' }).click();
   await expect(page.getByText('Cluster mode')).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Runtime half of the @requires-webui-v26.4 gate (FR-3114): the
+ * "Multi-node with size 1 will be created as a single-node session." warning
+ * is rendered by ClusterModeFormItems (FR-2381), introduced after WebUI
+ * v26.3.0 and first released in v26.4. Gates on the explicit WebUI version
+ * source (`globalThis.packageVersion`) instead of probing the warning
+ * element, so on a capable build a missing warning is a real failure — the
+ * `expect(warningMessage).toBeVisible()` at the call site is the failure
+ * signal. Exclude these specs on older targets with:
+ *   npx playwright test --grep-invert "@requires-webui-v26.4"
+ */
+async function skipUnlessSizeOneWarningAvailable(page: Page): Promise<void> {
+  await skipUnlessWebUIVersion(
+    page,
+    '26.4',
+    'Multi-node size-1 warning requires ClusterModeFormItems (FR-2381, @requires-webui-v26.4)',
+  );
 }
 
 test.describe(
@@ -29,7 +49,7 @@ test.describe(
 
     test(
       'User sees warning when selecting Multi Node with cluster size 1',
-      { tag: ['@smoke', '@regression'] },
+      { tag: ['@smoke', '@regression', '@requires-webui-v26.4'] },
       async ({ page }) => {
         // NOTE: This test requires ClusterModeFormItems.tsx (feat/FR-2381),
         // which was introduced in the main branch after v26.3.0.
@@ -61,24 +81,10 @@ test.describe(
 
         // Verify the warning message is displayed beneath the cluster size control.
         // This warning is shown by ClusterModeFormItems (introduced in FR-2381).
-        // Skip gracefully if the feature is not available in the server's build.
         const warningMessage = page.getByText(
           'Multi-node with size 1 will be created as a single-node session.',
         );
-        // Wait up to 5 s for the async form validation to render the warning.
-        // Skip gracefully only if the feature is genuinely absent in the build.
-        const isWarningVisible = await warningMessage
-          .first()
-          .waitFor({ state: 'visible', timeout: 5000 })
-          .then(() => true)
-          .catch(() => false);
-        if (!isWarningVisible) {
-          test.skip(
-            true,
-            'Warning feature (FR-2381) not available in the server build. Requires WebUI > v26.3.0.',
-          );
-          return;
-        }
+        await skipUnlessSizeOneWarningAvailable(page);
         await expect(warningMessage).toBeVisible();
       },
     );
@@ -160,7 +166,7 @@ test.describe(
 
     test(
       'User dismisses warning by switching from Multi Node to Single Node',
-      { tag: ['@smoke', '@regression'] },
+      { tag: ['@smoke', '@regression', '@requires-webui-v26.4'] },
       async ({ page }) => {
         // NOTE: Requires ClusterModeFormItems.tsx (feat/FR-2381) — see note above.
         await navigateToClusterModeSection(page);
@@ -173,21 +179,7 @@ test.describe(
         const warningMessage = page.getByText(
           'Multi-node with size 1 will be created as a single-node session.',
         );
-
-        // Wait up to 5 s for the async form validation to render the warning.
-        // Skip gracefully only if the feature is genuinely absent in the build.
-        const isWarningVisible = await warningMessage
-          .first()
-          .waitFor({ state: 'visible', timeout: 5000 })
-          .then(() => true)
-          .catch(() => false);
-        if (!isWarningVisible) {
-          test.skip(
-            true,
-            'Warning feature (FR-2381) not available in the server build. Requires WebUI > v26.3.0.',
-          );
-          return;
-        }
+        await skipUnlessSizeOneWarningAvailable(page);
 
         // Switch to Single Node by clicking the Single Node label
         const singleNodeLabel = page
@@ -202,7 +194,7 @@ test.describe(
 
     test(
       'User sees warning again after switching back from Single Node to Multi Node with size 1',
-      { tag: ['@regression'] },
+      { tag: ['@regression', '@requires-webui-v26.4'] },
       async ({ page }) => {
         // NOTE: Requires ClusterModeFormItems.tsx (feat/FR-2381) — see note above.
         await navigateToClusterModeSection(page);
@@ -219,20 +211,7 @@ test.describe(
 
         // Select Multi Node — check if warning feature is available
         await multiNodeLabel.click();
-        // Wait up to 5 s for the async form validation to render the warning.
-        // Skip gracefully only if the feature is genuinely absent in the build.
-        const isWarningVisible = await warningMessage
-          .first()
-          .waitFor({ state: 'visible', timeout: 5000 })
-          .then(() => true)
-          .catch(() => false);
-        if (!isWarningVisible) {
-          test.skip(
-            true,
-            'Warning feature (FR-2381) not available in the server build. Requires WebUI > v26.3.0.',
-          );
-          return;
-        }
+        await skipUnlessSizeOneWarningAvailable(page);
 
         // Switch to Single Node — warning should disappear
         await singleNodeLabel.click();

--- a/e2e/utils/feature-gate-util.ts
+++ b/e2e/utils/feature-gate-util.ts
@@ -16,12 +16,18 @@
  *   `_updateSupportList()`)
  * - `config.toml` toggles → `skipUnlessClientConfig(page, 'enableModelFolders', ...)`
  *   (same source of truth as `baiClient._config.*` in components)
+ * - Client properties (FR-3114) → `getClientProperty(page, 'current_group')`
+ *   (same source of truth as `baiClient.<property>` in components)
+ * - etcd-configured vfolder types (FR-3114) →
+ *   `skipUnlessAllowedVFolderType(page, 'group', ...)` (same source of truth
+ *   as `baiClient.vfolder.list_allowed_types()`)
  *
  * Pair these gates with a version-requirement tag on the test or describe
  * block (e.g. `@requires-manager-v25.15`, `@requires-webui-v26.4`) so gated
  * specs can be excluded explicitly on incapable targets:
  * `npx playwright test --grep-invert "@requires-manager-v25.15"`.
- * See e2e/E2E-TEST-NAMING-GUIDELINES.md ("Feature-gate tags (FR-3112)").
+ * See e2e/E2E-TEST-NAMING-GUIDELINES.md ("Feature-gate tags (FR-3112)" and
+ * "Environment-constraint tags (FR-3114)").
  */
 import { test, Page } from '@playwright/test';
 
@@ -149,4 +155,47 @@ export async function skipUnlessClientConfig(
 ): Promise<void> {
   const value = await getClientConfigValue(page, key);
   test.skip(!value, reason);
+}
+
+/**
+ * Returns a top-level property of the logged-in Backend.AI client, e.g.
+ * `current_group` (the active project name) — the same source components
+ * read via `useCurrentProjectValue()` / `baiClient.current_group`.
+ */
+export async function getClientProperty(
+  page: Page,
+  key: string,
+): Promise<unknown> {
+  await waitForBackendAIClient(page);
+  return page.evaluate((k) => (globalThis as any).backendaiclient?.[k], key);
+}
+
+/**
+ * Returns the vfolder types allowed by the cluster's etcd configuration
+ * (`volumes/_types`), e.g. `['user', 'group']` — the same source
+ * `FolderCreateModal` reads via `baiClient.vfolder.list_allowed_types()`.
+ */
+export async function listAllowedVFolderTypes(page: Page): Promise<string[]> {
+  await waitForBackendAIClient(page);
+  return page.evaluate(async () => {
+    const types = await (
+      globalThis as any
+    ).backendaiclient?.vfolder?.list_allowed_types();
+    return Array.isArray(types) ? types : [];
+  });
+}
+
+/**
+ * Declarative environment gate (FR-3114): skips the current test (with the
+ * given auditable reason) when the cluster's etcd `volumes/_types` config
+ * does not allow the given vfolder type (e.g. `'group'` for Project-type
+ * vfolders). Pair with the `@requires-vfolder-type-group` tag.
+ */
+export async function skipUnlessAllowedVFolderType(
+  page: Page,
+  type: string,
+  reason: string,
+): Promise<void> {
+  const allowedTypes = await listAllowedVFolderTypes(page);
+  test.skip(!allowedTypes.includes(type), reason);
 }

--- a/e2e/vfolder/vfolder-type-selection.spec.ts
+++ b/e2e/vfolder/vfolder-type-selection.spec.ts
@@ -1,5 +1,9 @@
 import { FolderCreationModal } from '../utils/classes/vfolder/FolderCreationModal';
 import {
+  getClientProperty,
+  skipUnlessAllowedVFolderType,
+} from '../utils/feature-gate-util';
+import {
   deleteForeverAndVerifyFromTrash,
   loginAsAdmin,
   loginAsUser,
@@ -95,26 +99,35 @@ test.describe(
         }
       });
 
-      test('Admin can create a Project-type vfolder', async ({ page }) => {
-        const modal = await openCreateFolderModalAsAdmin(page);
-        await modal.fillFolderName(folderName);
+      test(
+        'Admin can create a Project-type vfolder',
+        { tag: ['@requires-vfolder-type-group'] },
+        async ({ page }) => {
+          // Declarative environment gate (FR-3114): Project-type vfolders are
+          // only offered when the cluster's etcd `volumes/_types` config
+          // includes 'group' (FolderCreateModal reads it via
+          // `baiClient.vfolder.list_allowed_types()`).
+          await skipUnlessAllowedVFolderType(
+            page,
+            'group',
+            "Project-type vfolder creation requires the 'group' vfolder type in the cluster's etcd `volumes/_types` config (@requires-vfolder-type-group)",
+          );
 
-        // Project-type radio should be visible for admin
-        const projectTypeRadio = await modal.getProjectTypeRadio();
-        await expect(projectTypeRadio).toBeVisible();
+          const modal = await openCreateFolderModalAsAdmin(page);
+          await modal.fillFolderName(folderName);
 
-        // Check if project type radio is enabled (requires 'group' type in ETCD config)
-        const isDisabled = await projectTypeRadio.isDisabled();
-        if (!isDisabled) {
+          // The environment allows 'group' — the Project-type radio MUST be
+          // present and selectable; a disabled radio here is a real failure.
+          const projectTypeRadio = await modal.getProjectTypeRadio();
+          await expect(projectTypeRadio).toBeVisible();
+          await expect(projectTypeRadio).toBeEnabled();
+
           await projectTypeRadio.check();
           await expect(projectTypeRadio).toBeChecked();
-        } else {
-          // If project type is not available, fall back to user type and skip
-          test.skip(true, 'Project type is not available in this environment');
-        }
 
-        await (await modal.getCreateButton()).click();
-      });
+          await (await modal.getCreateButton()).click();
+        },
+      );
     });
 
     test.describe('Project radio disabled states (admin)', () => {
@@ -143,6 +156,21 @@ test.describe(
       test('Project radio is disabled when usage mode is model (non-model-store project)', async ({
         page,
       }) => {
+        // Declarative environment gate (FR-3114): this disabled-state
+        // assertion only holds when the admin's active project is NOT the
+        // model-store project (`FolderCreateModal` enables the Project radio
+        // in model mode when `currentProject.name === 'model-store'`). Gate
+        // on the actual capability source (`baiClient.current_group`) instead
+        // of probing the radio's enabled state.
+        const currentProjectName = await getClientProperty(
+          page,
+          'current_group',
+        );
+        test.skip(
+          currentProjectName === 'model-store',
+          "Disabled-state assertion assumes a non-model-store project; the admin's active project is the model-store project.",
+        );
+
         const modal = new FolderCreationModal(page);
         await modal.modalToBeVisible();
         await modal.fillFolderName(folderName);
@@ -155,16 +183,6 @@ test.describe(
         // Project-type radio should be visible for admin
         const projectTypeRadio = await modal.getProjectTypeRadio();
         await expect(projectTypeRadio).toBeVisible();
-
-        // If the project radio is enabled here, we are likely in a model-store project.
-        // In that case, this test's assumption ("non-model-store project") does not hold,
-        // so skip to avoid environment-dependent failures.
-        if (await projectTypeRadio.isEnabled()) {
-          test.skip(
-            true,
-            'Current project behaves as model-store; skipping disabled-state assertion.',
-          );
-        }
 
         // Project radio should be disabled when model mode is selected
         // and current project is not model-store


### PR DESCRIPTION
Resolves #7851 (FR-3114)

<!-- STACK -->
**📚 Stack (merge bottom → top), epic FR-3109:**

- #7853 — FR-3111: stale visual-regression baselines
- #7855 — FR-3113: serial cascade splits
- #7859 — FR-3110: removed/restructured-UI fixmes
- #7854 — FR-3112: runtime-skip → declarative feature gates
- #7861 — FR-3114: environment-constraint tags  ← **this PR**
<!-- /STACK -->

## What this does

Audits every in-body `test.skip(...)` whose reason is a backend **environment constraint** the test cluster cannot satisfy, and converts each into a declarative, auditable gate paired with a `@requires-<env>` tag (extending the FR-3112 taxonomy in `e2e/E2E-TEST-NAMING-GUIDELINES.md`). Constraints the cluster *should* satisfy were collected into one infra provisioning ticket: **FR-3119**.

## Inventory

| Site | Constraint (minimum spec) | Decision |
|---|---|---|
| `session-cluster-mode.spec.ts` (3 probes, ex-L72/178/219) | FR-2381 size-1 warning UI (WebUI > v26.3.0) | Tag `@requires-webui-v26.4` + `skipUnlessSizeOneWarningAvailable()` gating on the explicit version source via `skipUnlessWebUIVersion(page, '26.4', ...)` (reads `globalThis.packageVersion`); a missing warning on a capable build fails loudly |
| `vfolder-type-selection.spec.ts` ex-L85 | etcd `volumes/_types` must include `group` | Tag `@requires-vfolder-type-group` + new `skipUnlessAllowedVFolderType()` gate on `baiClient.vfolder.list_allowed_types()`; disabled radio now fails loudly on capable backends |
| `vfolder-type-selection.spec.ts` ex-L135 | active project must not be `model-store` | Declarative gate on `baiClient.current_group` (replaces enabled-state probe); account-state, no tag |
| `app-launcher-launch.spec.ts` jupyter / jupyterlab / vscode / sshd / vscode-desktop probes | session image must expose the service port (`ai.backend.service-ports`) | Tags `@requires-app-<service>` + auditable skip reasons; the vscode probe's silent no-op pass fallback converted to a visible skip |
| `environment.spec.ts` ex-L645 | > 20 registered images (page-2 pagination) | Tag `@requires-seeded-data` + reasoned skip; provision ask in FR-3119 |
| `admin-model-card-url-state.spec.ts` ex-L125 | > 1 page of model store cards | Tag `@requires-seeded-data` + reasoned skip; provision ask in FR-3119 |
| `my-keypair-management.spec.ts` ex-L846 | ≥ 1 inactive keypair on the e2e user | Tag `@requires-seeded-data` + reasoned skip; provision ask in FR-3119 |
| `environment.spec.ts` L50, `session-dependency.spec.ts` L286 | — | Left as-is: inside an already-disabled `test.skip('title', fn)` / `test.fixme` test (owned by other categories) |
| `vite-poc-smoke.spec.ts` L13 | — | Left as-is: local opt-in env-var gate, not a backend constraint |
| `statistics.spec.ts`, `dashboard.spec.ts`, `start-page.spec.ts`, `session-scheduling-history-modal.spec.ts` | — | Already converted by parent #7854 — untouched |

## Tag taxonomy additions (documented in `E2E-TEST-NAMING-GUIDELINES.md`)

- `@requires-app-<service>` — session image must expose the `<service>` service port (jupyter, jupyterlab, vscode, sshd, vscode-desktop)
- `@requires-vfolder-type-group` — etcd `volumes/_types` includes `group`
- `@requires-seeded-data` — cluster must hold pre-seeded data beyond a fresh install's defaults
- (reused) `@requires-webui-v26.4` for the FR-2381 cluster-mode warning probes

## New gate helpers (`e2e/utils/feature-gate-util.ts`)

- `getClientProperty(page, key)` — read a top-level `backendaiclient` property (e.g. `current_group`)
- `listAllowedVFolderTypes(page)` / `skipUnlessAllowedVFolderType(page, type, reason)` — gate on etcd-allowed vfolder types

## Follow-up

- Infra provisioning ticket: **FR-3119** (multi-node capacity, >20 images, >1 page model cards, inactive keypair seed, image service ports, `group` vfolder type)

## Verification

```
=== TERMINOLOGY SUMMARY ===
  blocking terminology findings: 0  (warn mode: not enforced)
  warn-only terminology findings: 1
  key-divergence findings (report): 0
--- Terminology: WARN-ONLY (does not affect build status) ---

=== ALL PASS ===
```

`npx playwright test --list` — 642 tests in 89 files, all parse; `--grep "@requires-"` resolves 23 tagged tests (9 newly tagged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



> Post-review updates: the cluster-mode gate now uses the explicit WebUI-version source (Copilot feedback); rebased onto main after FR-2992~FR-3002 merged — conflict resolutions keep main's repaired helpers (`loginAsAdmin`, `openCreateFolderModalAsAdmin`) inside this PR's declarative gates. Listener-accumulation feedback in app-launcher is pre-existing and tracked in FR-3126.