### PR TITLE
feat(FR-3120): Model Store list — hide domain filter from the user-facing filter

### DIFF
--- a/react/src/pages/ModelStoreListPageV2.tsx
+++ b/react/src/pages/ModelStoreListPageV2.tsx
@@ -410,11 +410,11 @@ const ModelStoreListPageV2: React.FC = () => {
                 propertyLabel: t('modelStore.ModelName'),
                 type: 'string',
               },
-              {
-                key: 'domainName',
-                propertyLabel: t('adminModelCard.Domain'),
-                type: 'string',
-              },
+              // NOTE(FR-3120): the domain filter is intentionally NOT exposed to
+              // end users on the Model Store list. The list is already scoped to
+              // the current domain's MODEL_STORE project via `scope.projectId`,
+              // so it only ever shows cards available in that project — a
+              // user-facing domain (or project) filter is redundant here.
               {
                 key: 'storageHost',
                 propertyLabel: t('import.StorageHost'),


### PR DESCRIPTION
Resolves #7862 (FR-3120)

## Summary

Hide the domain field from the user-facing Model Store list filter (`ModelStoreListPageV2`).

## Changes

- **Remove the `domainName` filter property** from the property filter. Regular users no longer filter Model Store cards by domain.
- `name` and `storageHost` filters are unchanged.

## Why no project-OR-domain visibility condition

The issue also asked to show cards via a `projectId == currentProject OR (domainName == currentDomain AND projectId IS NULL)` condition. This is **not implementable** and **not needed**:

- `ModelCardV2Filter.projectId` is a `UUIDFilter`, which has **no `isNull` operator**, and `ModelCardV2.projectId` is a non-null `MODEL_STORE`-project id — there are no "empty projectId = domain-wide" cards to surface.
- The list is already scoped to the current domain's `MODEL_STORE` project via `scope.projectId`, so it only ever shows the cards available in that project. No extra internal condition (and no user-facing project/domain filter) is required.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript).
