### PR TITLE
feat(FR-3121): Admin Model Card form — comma label separator + default domain

### DIFF
--- a/react/src/components/AdminModelCardSettingModal.tsx
+++ b/react/src/components/AdminModelCardSettingModal.tsx
@@ -5,6 +5,7 @@
 import type { AdminModelCardSettingModalCreateMutation } from '../__generated__/AdminModelCardSettingModalCreateMutation.graphql';
 import type { AdminModelCardSettingModalFragment$key } from '../__generated__/AdminModelCardSettingModalFragment.graphql';
 import type { AdminModelCardSettingModalUpdateMutation } from '../__generated__/AdminModelCardSettingModalUpdateMutation.graphql';
+import { useCurrentDomainValue } from '../hooks';
 import {
   useCurrentProjectValue,
   useSetCurrentProject,
@@ -83,6 +84,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
   const [isOpenCreateFolderModal, setIsOpenCreateFolderModal] = useState(false);
 
   const currentProject = useCurrentProjectValue();
+  const currentDomain = useCurrentDomainValue();
   const setCurrentProject = useSetCurrentProject();
 
   const modelCard = useFragment(
@@ -187,6 +189,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
       }
     : {
         accessLevel: 'INTERNAL',
+        domainName: currentDomain,
       };
 
   const buildMetadataInput = (values: FormInputType) => ({
@@ -462,8 +465,10 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
             label={t('adminModelCard.Framework')}
             tooltip={t('adminModelCard.FrameworkTooltip')}
           >
+            {/* FR-3121: commit a framework on comma in addition to Enter. */}
             <Select
               mode="tags"
+              tokenSeparators={[',']}
               placeholder={t('adminModelCard.AddFramework')}
               notFoundContent={null}
             />
@@ -474,8 +479,10 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
             label={t('adminModelCard.Label')}
             tooltip={t('adminModelCard.LabelTooltip')}
           >
+            {/* FR-3121: commit a label on comma in addition to Enter. */}
             <Select
               mode="tags"
+              tokenSeparators={[',']}
               placeholder={t('adminModelCard.AddLabel')}
               notFoundContent={null}
             />


### PR DESCRIPTION
> **Stacked on #7868**

Resolves #7863 (FR-3121)

## Summary

Admin Model Card create/edit form (`AdminModelCardSettingModal`) usability fixes.

## Changes

- **Label** field commits a tag on `,` (comma) in addition to Enter (`tokenSeparators`).
- **Domain** field defaults to the current domain via the Form's `initialValues` on create.

## Not in this PR — needs clarification

- **Project selector on the form**: the model card's `projectId` is a non-null `MODEL_STORE`-project id and `CreateModelCardV2Input` exposes only `modelStoreProjectId`, so there is no per-compute-project input field; switching it would also need to re-scope the VFolder selector. Kept as the current project and documented as `TODO(FR-3121)` at the call site.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript).
