### PR TITLE
fix(FR-3127): send empty environ array so cleared env vars persist on preset update

### DIFF
--- a/react/src/pages/AdminDeploymentPresetSettingPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetSettingPage.tsx
@@ -234,12 +234,15 @@ const AdminDeploymentPresetSettingPage: React.FC = () => {
             clusterSize: values.clusterSize ?? null,
             startupCommand: values.startupCommand ?? null,
             bootstrapScript: values.bootstrapScript ?? null,
-            environ: values.environ?.length
-              ? values.environ.map((e) => ({
-                  key: e.variable,
-                  value: e.value,
-                }))
-              : null,
+            // Send an explicit (possibly empty) array so that clearing all
+            // env vars actually replaces them server-side. `environ` defaults
+            // to null in UpdateDeploymentRevisionPresetInput, which means
+            // "leave unchanged" — collapsing an empty list to null would
+            // silently drop the user's deletion. (FR-3127)
+            environ: (values.environ ?? []).map((e) => ({
+              key: e.variable,
+              value: e.value,
+            })),
             resourceSlots: [
               ...(values.cpu
                 ? [{ resourceType: 'cpu', quantity: values.cpu }]
@@ -249,9 +252,10 @@ const AdminDeploymentPresetSettingPage: React.FC = () => {
                 : []),
               ...(values.resourceSlots ?? []),
             ],
-            resourceOpts: values.resourceOpts?.length
-              ? values.resourceOpts
-              : null,
+            // Same "Omit to leave unchanged" semantics as `environ`: send an
+            // explicit (possibly empty) array so clearing all resource opts is
+            // honored instead of being treated as no change. (FR-3127)
+            resourceOpts: values.resourceOpts ?? [],
             modelDefinition: buildModelDefinitionInput(values.modelDefinition),
             openToPublic: values.openToPublic ?? null,
             replicaCount: values.replicaCount ?? null,


### PR DESCRIPTION
Resolves #7871 (FR-3127)

## Problem

On 26.4.4rc8, when editing a deployment revision preset and **deleting all environment variables**, the deletion is not persisted — the preset keeps its previously saved env vars after saving.

## Root cause

In the edit branch of `handleSubmit` (`AdminDeploymentPresetSettingPage.tsx`), the `environ` field was collapsed to `null` whenever the list was empty:

```ts
environ: values.environ?.length
  ? values.environ.map((e) => ({ key: e.variable, value: e.value }))
  : null,
```

Per the schema, `UpdateDeploymentRevisionPresetInput.environ` is `[EnvironEntryInput!] = null` and documented as *"Replace environment variables. **Omit to leave unchanged**."* Because the field's default is `null`, the backend cannot distinguish an explicit `null` from an omitted field and treats both as **no change**. So clearing every env var (empty array → `null`) was silently ignored.

To actually clear them, the client must send an **empty list `[]`**.

## Fix

Always send an explicit (possibly empty) array on update, so an emptied list replaces the values server-side:

```ts
environ: (values.environ ?? []).map((e) => ({
  key: e.variable,
  value: e.value,
})),
```

`resourceOpts` in the same handler had the identical bug — its schema field (`resourceOpts: [ResourceOptsEntryInput!] = null`, *"Omit to leave unchanged"*) was also collapsed to `null` when emptied, so clearing all resource opts was silently ignored too. Fixed the same way:

```ts
resourceOpts: values.resourceOpts ?? [],
```

When entries are present this is unchanged behavior; when the user clears them all, `[]` is sent and the deletion persists.

## Scope notes

- Only the **edit** (update) branch is changed. The **create** branch genuinely has nothing to clear, so its `: null` collapsing is left as-is (harmless on create).
- The form load path maps `preset.execution.environ` / `preset.resource.resourceOpts` faithfully with no filtering (`AdminDeploymentPresetSettingPageContent.tsx`), so no-op edits round-trip the full arrays without data loss. `sanitizeSensitiveEnv` is not used on this page.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript). The only warning is a pre-existing, unrelated terminology warn.
- Reviewed by lead-frontend-reviewer agent: APPROVE (the resourceOpts inclusion was its one recommendation, applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)