### PR TITLE
fix(FR-3128): await config.toml bootstrap in STokenLoginBoundary before token login

### DIFF
--- a/react/src/components/STokenLoginBoundary.test.tsx
+++ b/react/src/components/STokenLoginBoundary.test.tsx
@@ -27,6 +27,7 @@ import {
   tokenLogin,
 } from '../helper/loginSessionAuth';
 import * as endpointModule from '../hooks/useResolvedApiEndpoint';
+import { initializeConfigOnce } from '../hooks/useWebUIConfig';
 import {
   STokenLoginBoundary,
   type STokenLoginError,
@@ -47,10 +48,16 @@ vi.mock('./DefaultProviders', () => ({
   jotaiStore: { get: () => null, set: () => {} },
 }));
 
-vi.mock('../hooks/useWebUIConfig', () => ({
-  __esModule: true,
-  loginConfigState: { toString: () => 'loginConfigState' },
-}));
+vi.mock('../hooks/useWebUIConfig', async () => {
+  // A real (empty) atom: the component reads it through the provider store
+  // (`store.get(loginConfigState)`), so the mock must be a genuine Jotai atom.
+  const { atom } = await vi.importActual<typeof import('jotai')>('jotai');
+  return {
+    __esModule: true,
+    loginConfigState: atom(null),
+    initializeConfigOnce: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock('../hooks/useResolvedApiEndpoint', () => {
   const state: { endpoint: string } = { endpoint: 'https://api.example.com' };
@@ -279,6 +286,26 @@ describe('STokenLoginBoundary', () => {
     expect(mockedConnectViaGQL).toHaveBeenCalledTimes(1);
     expect(connectedEventCount).toBe(1);
     expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test('awaits the config.toml bootstrap before authenticating (FR-3128)', async () => {
+    renderBoundary({});
+
+    await waitFor(() => {
+      expect(screen.getByText('children-rendered')).toBeInTheDocument();
+    });
+
+    const mockedInitializeConfigOnce = initializeConfigOnce as MockedFunction<
+      typeof initializeConfigOnce
+    >;
+    // The bootstrap config load must run, and must run BEFORE the token
+    // exchange — otherwise `applyConfigToClient` inside `tokenLogin` writes
+    // `getDefaultLoginConfig()` values (e.g. `allowNonAuthTCP: false`) into
+    // `backendaiclient._config`, hiding the SSH/SFTP app after SSO login.
+    expect(mockedInitializeConfigOnce).toHaveBeenCalledTimes(1);
+    expect(mockedInitializeConfigOnce.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedTokenLogin.mock.invocationCallOrder[0],
+    );
   });
 
   test('errorFallback replaces the built-in card for every kind', async () => {

--- a/react/src/components/STokenLoginBoundary.tsx
+++ b/react/src/components/STokenLoginBoundary.tsx
@@ -18,11 +18,13 @@ import {
   tokenLogin,
 } from '../helper/loginSessionAuth';
 import { useResolvedApiEndpoint } from '../hooks/useResolvedApiEndpoint';
-import { loginConfigState } from '../hooks/useWebUIConfig';
-import { jotaiStore } from './DefaultProviders';
+import {
+  initializeConfigOnce,
+  loginConfigState,
+} from '../hooks/useWebUIConfig';
 import { App, Form, Input, Spin, Typography } from 'antd';
 import { BAIButton, BAICard, BAIFlex, useBAILogger } from 'backend.ai-ui';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useStore } from 'jotai';
 import {
   Suspense,
   useEffect,
@@ -222,6 +224,15 @@ type PendingStep = 'connecting' | 'authenticating';
  * the caller-supplied `sToken`, dispatches `backend-ai-connected` exactly
  * once on success, and only then renders `children`. See spec section
  * "컴포넌트 설계" and "내부 동작 시퀀스" for the full contract.
+ *
+ * Config semantics: the boundary awaits the same-origin `config.toml`
+ * bootstrap (`initializeConfigOnce`) before authenticating, so webserver
+ * flags like `[resources].allowNonAuthTCP` reach
+ * `backendaiclient._config` even though `LoginView` has not mounted yet
+ * (FR-3128). The cross-origin webserver config merge
+ * (`loadConfigFromWebServer`) remains excluded per spec Q2 — callers that
+ * target an API endpoint on a different origin may invoke it from
+ * `onSuccess`.
  */
 export const STokenLoginBoundary: React.FC<STokenLoginBoundaryProps> = (
   props,
@@ -246,6 +257,12 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
   'use memo';
   const { logger } = useBAILogger();
   const apiEndpoint = useResolvedApiEndpoint();
+  // The active Jotai store (the app-level `jotaiStore` in production —
+  // `index.tsx` passes it to the root `JotaiProvider`). Used for the
+  // synchronous post-bootstrap read inside `runLoginSequence` so the
+  // component honors a custom `<Provider store={...}>` (tests, Storybook)
+  // instead of hard-binding to the module-level store.
+  const store = useStore();
   const loginConfig = useAtomValue(loginConfigState);
 
   const [phase, setPhase] = useState<Phase>({ name: 'pending' });
@@ -329,14 +346,30 @@ const STokenLoginBoundaryInner: React.FC<STokenLoginBoundaryProps> = ({
       return;
     }
 
+    // Ensure the app-level config.toml bootstrap has completed before
+    // deriving the login config. On sToken entry paths `LoginView` — the
+    // usual `useInitializeConfig` caller — only mounts after this boundary
+    // succeeds, so without this await the login would always run against
+    // `getDefaultLoginConfig()` and silently drop webserver-configured
+    // flags such as `[resources].allowNonAuthTCP`, hiding the SSH/SFTP app
+    // after SSO login (FR-3128). This is the same-origin bootstrap load,
+    // not the cross-origin `loadConfigFromWebServer` merge — the latter is
+    // still intentionally NOT invoked here (spec Q2); callers may invoke it
+    // from `onSuccess` when the API endpoint lives on another origin.
+    try {
+      await initializeConfigOnce(store, logger);
+    } catch (cause) {
+      logger.warn(
+        '[STokenLoginBoundary] config.toml bootstrap failed — continuing with defaults',
+        cause,
+      );
+    }
+
     // Prefer the live atom state; fall back to the documented defaults so
     // `applyConfigToClient(cfg)` downstream of `connectViaGQL` does not write
-    // `undefined` into `backendaiclient._config`. `loadConfigFromWebServer`
-    // is intentionally NOT invoked here — see spec Q2.
+    // `undefined` into `backendaiclient._config`.
     const cfg =
-      loginConfig ??
-      jotaiStore.get(loginConfigState) ??
-      getDefaultLoginConfig();
+      store.get(loginConfigState) ?? loginConfig ?? getDefaultLoginConfig();
     const endpoints =
       ((
         globalThis as { backendaioptions?: { get: (k: string) => unknown } }

--- a/react/src/hooks/useWebUIConfig.ts
+++ b/react/src/hooks/useWebUIConfig.ts
@@ -18,8 +18,9 @@ import {
   type LoginConfigState,
 } from '../helper/loginConfig';
 import { useBAILogger } from 'backend.ai-ui';
-import { atom, useAtomValue, useSetAtom } from 'jotai';
-import { useCallback, useEffect } from 'react';
+import { atom, useAtomValue, useSetAtom, useStore } from 'jotai';
+import type { createStore } from 'jotai';
+import { useEffect } from 'react';
 import { parse as toml } from 'smol-toml';
 
 // ---------------------------------------------------------------------------
@@ -95,10 +96,19 @@ export const proxyUrlState = atom<string>('');
 export const loginPluginState = atom<string>('');
 
 /**
- * Module-level flag to ensure config.toml is fetched only once,
- * even when multiple component instances call useInitializeConfig.
+ * Module-level in-flight promise so config.toml is fetched and processed at
+ * most once per page load, even when multiple entry points race to
+ * initialize it (LoginView via `useInitializeConfig`, sToken entry paths via
+ * `initializeConfigOnce` — see FR-3128). Concurrent callers share the same
+ * promise instead of observing a half-initialized state.
  */
-let configInitialized = false;
+let configInitPromise: Promise<void> | null = null;
+
+/**
+ * Jotai store handle shape shared by the app-level `jotaiStore` and the
+ * store returned by `useStore()`.
+ */
+type JotaiStore = ReturnType<typeof createStore>;
 
 // ---------------------------------------------------------------------------
 // TOML fetching and preprocessing
@@ -236,6 +246,94 @@ function processConfig(config: RawTomlConfig): {
   };
 }
 
+/**
+ * Fetch and process config.toml exactly once per page load, writing the
+ * results into the given Jotai store (the app-level `jotaiStore` in
+ * production — `index.tsx` passes it to the root `JotaiProvider`, so
+ * `useStore()` resolves to the same instance).
+ *
+ * Historically only `LoginView` (via `useInitializeConfig`) triggered this
+ * bootstrap. Entry points that authenticate *before* the regular layout
+ * mounts — e.g. `STokenLoginBoundary` on sToken/SSO URLs — must await this
+ * themselves, otherwise the login sequence runs against
+ * `getDefaultLoginConfig()` and silently drops webserver-configured flags
+ * such as `[resources].allowNonAuthTCP` (FR-3128).
+ *
+ * Missing or unparsable config.toml is not an error: defaults are applied
+ * and the promise resolves, mirroring the previous `useInitializeConfig`
+ * behavior.
+ */
+export function initializeConfigOnce(
+  store: JotaiStore,
+  logger: Pick<Console, 'error' | 'warn'> = console,
+): Promise<void> {
+  if (!configInitPromise) {
+    configInitPromise = (async () => {
+      // Electron uses es6:// protocol which resolves from app/ directory
+      // Web uses relative path from the HTML location
+      const configPath = (globalThis as Record<string, unknown>).isElectron
+        ? 'es6://config.toml'
+        : '../../config.toml';
+
+      const result = await fetchAndParseConfig(configPath);
+
+      if (!result.config) {
+        // config.toml is missing or failed to parse — apply defaults so the
+        // app remains functional (login page renders with empty API endpoint
+        // field).
+        const defaultConfig = getDefaultLoginConfig();
+        store.set(loginConfigState, defaultConfig);
+        store.set(proxyUrlState, defaultConfig.proxy_url);
+        store.set(autoLogoutState, false);
+        store.set(configLoadedState, true);
+
+        // Ensure config-derived globals are set even when config.toml is
+        // missing, so edition-dependent logic behaves consistently with the
+        // normal path.
+        const globalScope = globalThis as Record<string, unknown>;
+        if (globalScope.packageEdition === undefined) {
+          globalScope.packageEdition = 'Open Source';
+        }
+        if (globalScope.packageValidUntil === undefined) {
+          globalScope.packageValidUntil = '';
+        }
+
+        if (result.error) {
+          store.set(configParseErrorState, result.error);
+          logger.error(
+            '[config.toml] Failed to parse — using default configuration:',
+            result.error,
+          );
+        } else {
+          logger.warn('[config.toml] Not found — using default configuration');
+        }
+        return;
+      }
+
+      store.set(rawConfigState, result.config);
+
+      const { autoLogout, proxyUrl, loginPlugin, loginConfig } = processConfig(
+        result.config,
+      );
+
+      store.set(loginConfigState, loginConfig);
+      store.set(autoLogoutState, autoLogout);
+      store.set(proxyUrlState, proxyUrl);
+      store.set(loginPluginState, loginPlugin);
+
+      store.set(configLoadedState, true);
+    })().catch((error) => {
+      // The body above is designed never to reject (fetch/parse failures
+      // resolve through the defaults path). If it somehow does, drop the
+      // cached promise so a later caller can retry instead of permanently
+      // caching the rejection.
+      configInitPromise = null;
+      throw error;
+    });
+  }
+  return configInitPromise;
+}
+
 // ---------------------------------------------------------------------------
 // Hooks
 // ---------------------------------------------------------------------------
@@ -253,88 +351,15 @@ export function useInitializeConfig(): {
   loginConfig: LoginConfigState | null;
   loadConfig: () => Promise<void>;
 } {
-  const setRawConfig = useSetAtom(rawConfigState);
-  const setLoginConfig = useSetAtom(loginConfigState);
-  const setConfigLoaded = useSetAtom(configLoadedState);
-  const setAutoLogout = useSetAtom(autoLogoutState);
-  const setProxyUrl = useSetAtom(proxyUrlState);
-  const setLoginPlugin = useSetAtom(loginPluginState);
-  const setConfigParseError = useSetAtom(configParseErrorState);
+  'use memo';
+  const store = useStore();
   const { logger } = useBAILogger();
 
   const isLoaded = useAtomValue(configLoadedState);
   const rawConfig = useAtomValue(rawConfigState);
   const currentLoginConfig = useAtomValue(loginConfigState);
 
-  const loadConfig = useCallback(async () => {
-    // Use a module-level flag to prevent multiple LoginView instances
-    // (eager + lazy) from fetching config.toml more than once.
-    // A per-instance useRef is insufficient because each component
-    // instance gets its own ref.
-    if (configInitialized) return;
-    configInitialized = true;
-
-    // Electron uses es6:// protocol which resolves from app/ directory
-    // Web uses relative path from the HTML location
-    const configPath = (globalThis as Record<string, unknown>).isElectron
-      ? 'es6://config.toml'
-      : '../../config.toml';
-
-    const result = await fetchAndParseConfig(configPath);
-
-    if (!result.config) {
-      // config.toml is missing or failed to parse — apply defaults so the app
-      // remains functional (login page renders with empty API endpoint field).
-      const defaultConfig = getDefaultLoginConfig();
-      setLoginConfig(defaultConfig);
-      setProxyUrl(defaultConfig.proxy_url);
-      setAutoLogout(false);
-      setConfigLoaded(true);
-
-      // Ensure config-derived globals are set even when config.toml is missing,
-      // so edition-dependent logic behaves consistently with the normal path.
-      const globalScope = globalThis as Record<string, unknown>;
-      if (globalScope.packageEdition === undefined) {
-        globalScope.packageEdition = 'Open Source';
-      }
-      if (globalScope.packageValidUntil === undefined) {
-        globalScope.packageValidUntil = '';
-      }
-
-      if (result.error) {
-        setConfigParseError(result.error);
-        logger.error(
-          '[config.toml] Failed to parse — using default configuration:',
-          result.error,
-        );
-      } else {
-        logger.warn('[config.toml] Not found — using default configuration');
-      }
-      return;
-    }
-
-    setRawConfig(result.config);
-
-    const { autoLogout, proxyUrl, loginPlugin, loginConfig } = processConfig(
-      result.config,
-    );
-
-    setLoginConfig(loginConfig);
-    setAutoLogout(autoLogout);
-    setProxyUrl(proxyUrl);
-    setLoginPlugin(loginPlugin);
-
-    setConfigLoaded(true);
-  }, [
-    setRawConfig,
-    setLoginConfig,
-    setConfigLoaded,
-    setAutoLogout,
-    setProxyUrl,
-    setLoginPlugin,
-    setConfigParseError,
-    logger,
-  ]);
+  const loadConfig = () => initializeConfigOnce(store, logger);
 
   return {
     isLoaded,
@@ -391,24 +416,22 @@ export function useConfigParseError(): unknown | null {
  * Returns a setter that re-processes config after updating.
  */
 export function useUpdateRawConfig(): (config: RawTomlConfig) => void {
+  'use memo';
   const setRawConfig = useSetAtom(rawConfigState);
   const setLoginConfig = useSetAtom(loginConfigState);
   const setAutoLogout = useSetAtom(autoLogoutState);
   const setProxyUrl = useSetAtom(proxyUrlState);
   const setLoginPlugin = useSetAtom(loginPluginState);
 
-  return useCallback(
-    (config: RawTomlConfig) => {
-      setRawConfig(config);
-      const { autoLogout, proxyUrl, loginPlugin, loginConfig } =
-        processConfig(config);
-      setLoginConfig(loginConfig);
-      setAutoLogout(autoLogout);
-      setProxyUrl(proxyUrl);
-      setLoginPlugin(loginPlugin);
-    },
-    [setRawConfig, setLoginConfig, setAutoLogout, setProxyUrl, setLoginPlugin],
-  );
+  return (config: RawTomlConfig) => {
+    setRawConfig(config);
+    const { autoLogout, proxyUrl, loginPlugin, loginConfig } =
+      processConfig(config);
+    setLoginConfig(loginConfig);
+    setAutoLogout(autoLogout);
+    setProxyUrl(proxyUrl);
+    setLoginPlugin(loginPlugin);
+  };
 }
 
 /**


### PR DESCRIPTION
Resolves FR-3128 (https://lablup.atlassian.net/browse/FR-3128)

> The Jira→GitHub webhook has not cloned FR-3128 yet; this line will be updated to `Resolves #N (FR-3128)` once the clone issue appears.

## Problem

After SSO (sToken) login, the SSH/SFTP app is missing from the session App dialog (`Utilities` shows only Console/ttyd), even though the backend has `sshd` registered in `kernels.service_ports` and the webserver `config.toml` sets `[resources] allowNonAuthTCP = true`. Form-login users see SSH/SFTP correctly.

## Root cause

- `useSuspendedFilteredAppTemplate.ts` filters out the `sshd` app unless `backendaiclient._config.allowNonAuthTCP` is `true`.
- On sToken entry paths (`STokenGuard` at `/`, `/edu-applauncher`, `/applauncher`), `LoginView` — the only caller of the `config.toml` bootstrap (`useInitializeConfig`) — mounts **after** `STokenLoginBoundary` succeeds. So at login time `loginConfigState` is always empty, the boundary falls back to `getDefaultLoginConfig()` (`allowNonAuthTCP: false`), and `applyConfigToClient` bakes that default into `backendaiclient._config`.
- The issue's suggested Option 1 (invoke `loadConfigFromWebServer` from `onSuccess`) would **not** fix the reported deployment: that helper is the *cross-origin* webserver config merge and is a no-op when the WebUI is served from the webserver origin (the dogbowl case). The missing piece is the *same-origin* bootstrap `config.toml` load itself.

## Fix

- `useWebUIConfig.ts`: extract the bootstrap out of `useInitializeConfig` into a module-level, promise-deduplicated `initializeConfigOnce(store, logger)`. Concurrent entry points (LoginView, sToken boundary) share one in-flight promise; the once-flag (`configInitialized`) is replaced by the cached promise. Behavior for missing/unparsable `config.toml` is unchanged (defaults applied, promise resolves).
- `STokenLoginBoundary.tsx`: await `initializeConfigOnce(jotaiStore, logger)` before deriving the login config, so webserver flags such as `[resources].allowNonAuthTCP` reach the client config on SSO paths. The config fallback chain now reads the (freshly populated) atom first.
- Spec Q2 decision is **unchanged**: `loadConfigFromWebServer` (cross-origin merge) remains excluded from the boundary, and this is now documented in the component JSDoc as the spec requested.
- While touching `useWebUIConfig.ts`, migrated its two hooks to the React Compiler convention (`'use memo'`, dropped `useCallback`) per the project memoization rule.

## Tests

- New regression test: the boundary awaits the config bootstrap **before** `token_login` (invocation-order assertion).
- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `vitest`: STokenLoginBoundary / useWebUIConfig / useLoginOrchestration suites — 127 tests pass.

## How to test

**Automated**
- New regression test in `STokenLoginBoundary.test.tsx` asserts `initializeConfigOnce` is invoked **before** `token_login` (invocation-order assertion) — the exact invariant that was broken.

**Manual (local, no real SSO IdP needed)**

The boundary's cookie-session fast-path lets you exercise the SSO entry path with a dummy token:

1. Make sure the dev server's `config.toml` has `[resources] allowNonAuthTCP = true`.
2. Log in normally via the form once (creates a session cookie).
3. Full-page reload with `?sToken=dummy` appended to the URL — `STokenGuard` routes through `STokenLoginBoundary` and `LoginView` never mounts before login (the exact bug condition).
4. After login completes, in the browser console:
   ```js
   globalThis.backendaiclient._config.allowNonAuthTCP
   ```
   Before this fix: `false` (default baked in). After: `true` (config.toml value applied).
5. The DevTools Network tab also shows the `config.toml` fetch happening **before** `token_login` / GQL bootstrap — observable even with an invalid token.

**Deployment-level**
- On an SSO-integrated deployment (e.g. dogbowl), log in via sToken with a `user`-role account and confirm the SSH/SFTP icon appears in the session App dialog (`Utilities` category). This part is only verifiable on a real SSO deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
