### PR TITLE
test(FR-3027): add e2e regression test for App Proxy "Worker not available" error

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-05-27
+> **Last Updated:** 2026-06-12
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -43,7 +43,7 @@
 | Information       | `/information`                         |    2     |    2    | ✅ 100% |
 | Reservoir         | `/reservoir`, `/reservoir/:artifactId` |    18    |    0    |  ❌ 0%  |
 | Branding          | `/branding`                            |    14    |    0    |  ❌ 0%  |
-| App Launcher      | (modal)                                |    18    |   10    | 🔶 56%  |
+| App Launcher      | (modal)                                |    19    |   11    | 🔶 58%  |
 | Chat              | `/chat/:id?`                           |    6     |    6    | ✅ 100% |
 | Plugin System     | (config-based)                         |    12    |   12    | ✅ 100% |
 | RBAC Management   | `/rbac`                                |    22    |   21    | 🔶 95%  |
@@ -920,11 +920,12 @@
 | Tensorboard → TensorboardPathModal | ❌ | - |
 | NNI Board / MLflow UI → AppLaunchConfirmationModal | ❌ | - |
 | Generic TCP apps → TCPConnectionInfoModal | ❌ | - |
+| Proxy worker unavailable → error, no bogus dialog (FR-3027) | ✅ | `User sees "Worker not available." error instead of a bogus connection dialog when the proxy worker is unavailable (FR-3027)` |
 | Pre-open port apps launch | ❌ | - |
 | "Open to Public" option with client IPs | ❌ | - |
 | "Preferred Port" option | ❌ | - |
 
-**Coverage: 🔶 10/18 features**
+**Coverage: 🔶 11/19 features**
 
 ---
 

--- a/e2e/app-launcher/app-launcher-launch.spec.ts
+++ b/e2e/app-launcher/app-launcher-launch.spec.ts
@@ -595,5 +595,97 @@ test.describe(
       // this listener (e.g., WebSocket or a different path). This is acceptable as the UI behavior
       // (error notification or connection modal) has already been verified above.
     });
+
+    // FR-3027: When the App Proxy Coordinator cannot allocate a worker for the
+    // circuit (e.g. the TCP worker's port pool is exhausted), the permit-key
+    // request inside `_connectToProxyWorker` receives an HTTP 503
+    // `WorkerNotAvailable` ("Worker not available.") problem+json response.
+    // `sendRequest` resolves that to a `{ status, statusText, body }` object
+    // rather than throwing. The launcher must surface that backend message as
+    // an error notification and must NOT open a bogus 127.0.0.1 connection
+    // dialog.
+    //
+    // The live test backend routes the App Proxy through an address that is not
+    // reachable from the browser, so the real handshake never reaches the
+    // permit step. We therefore mock the proxy handshake (conf -> add) just
+    // enough to drive the launcher into `_connectToProxyWorker`, then force the
+    // permit request to 503. The production `_connectToProxyWorker` code path
+    // — the actual fix under test — runs unchanged against a real 503 response.
+    test('User sees "Worker not available." error instead of a bogus connection dialog when the proxy worker is unavailable (FR-3027)', async ({}, testInfo) => {
+      testInfo.setTimeout(120000);
+      test.skip(!sessionCreated, 'Session was not created successfully');
+
+      await expect(appLauncherModal.getModal()).toBeVisible();
+
+      const sshdAppVisible = await appLauncherModal
+        .getAppButton('sshd')
+        .isVisible()
+        .catch(() => false);
+      test.skip(!sshdAppVisible, 'SSH/SFTP app not available');
+
+      const PERMIT_MARKER = '__fr3027_worker_permit__';
+
+      // 1. Mock the V1 proxy token mint (`PUT {proxyURL}conf`).
+      await sharedPage.route('**/conf', async (route) => {
+        if (route.request().method() !== 'PUT') return route.fallback();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ token: 'fr3027-mock-token' }),
+        });
+      });
+
+      // 2. Mock the circuit `add` endpoint so the launcher proceeds to the
+      //    permit step with a worker URL we control.
+      await sharedPage.route('**/proxy/**/add**', async (route) => {
+        const origin = new URL(route.request().url()).origin;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            url: `${origin}/${PERMIT_MARKER}?token=fr3027-mock-token`,
+          }),
+        });
+      });
+
+      // 3. Force the permit-key request (inside `_connectToProxyWorker`) to the
+      //    real backend failure: HTTP 503 `WorkerNotAvailable` problem+json.
+      await sharedPage.route(`**/${PERMIT_MARKER}**`, async (route) => {
+        await route.fulfill({
+          status: 503,
+          contentType: 'application/problem+json',
+          body: JSON.stringify({
+            type: 'https://api.backend.ai/probs/appproxy/worker-not-available',
+            title: 'Worker not available.',
+          }),
+        });
+      });
+
+      try {
+        // 4. Launch the SFTP (sshd) TCP app.
+        await appLauncherModal.clickApp('sshd');
+
+        // 5. The backend error message must surface in the launch notification.
+        const errorNotification = sharedPage
+          .locator('.ant-notification-notice')
+          .filter({ hasText: 'Worker not available.' });
+        await expect(errorNotification).toBeVisible({ timeout: 30000 });
+
+        // 6. No bogus SSH/SFTP connection dialog must open.
+        const sftpConnectionModal = sharedPage
+          .getByRole('dialog')
+          .filter({ hasText: /SSH.*SFTP.*connection|SFTP.*connection/i });
+        await expect(sftpConnectionModal).toHaveCount(0);
+
+        // 7. The app launcher modal remains open.
+        await expect(appLauncherModal.getModal()).toBeVisible();
+      } finally {
+        // Cleanup: always remove route overrides so a mid-test failure cannot
+        // leak these mocks into `afterAll` cleanup or later serial tests.
+        await sharedPage.unroute('**/conf');
+        await sharedPage.unroute('**/proxy/**/add**');
+        await sharedPage.unroute(`**/${PERMIT_MARKER}**`);
+      }
+    });
   },
 );


### PR DESCRIPTION
Linked Jira: FR-3027 (https://lablup.atlassian.net/browse/FR-3027)

> No GitHub clone of FR-3027 exists yet (the Jira→GitHub webhook did not fire for this ticket), so this PR uses a `Linked Jira:` placeholder instead of `Resolves #N (FR-3027)`.

**Stacked on #7781.**

## What

Adds an end-to-end regression test for the FR-3027 fix in #7781, which makes the App Proxy launcher surface a `WorkerNotAvailable` ("Worker not available.") error instead of rendering a bogus `127.0.0.1` connection dialog when the Coordinator cannot allocate a worker for the circuit.

The test lives alongside the existing App Launcher e2e suite (`e2e/app-launcher/app-launcher-launch.spec.ts`) and reuses its `beforeAll` setup (login, session creation, `allowNonAuthTCP`, launcher modal).

## How it exercises the fix

The live test backend routes the App Proxy through an address that is not reachable from the browser, so the real handshake never reaches the permit step. The test therefore mocks the proxy handshake just enough to drive the launcher into `_connectToProxyWorker` (the function the fix touches), then forces the permit-key request to fail the way the real backend does:

1. Mock the V1 token mint (`PUT {proxyURL}conf`) → returns a token.
2. Mock the circuit `add` endpoint → returns a permit URL the test controls.
3. Force that permit request to **HTTP 503 `WorkerNotAvailable`** with the real problem+json body (`title: "Worker not available."`, matching the backend's `error_title`).

The production `_connectToProxyWorker` code path — the actual fix under test — runs unchanged against a real 503 response.

## Assertions

- The launch notification shows the backend message **"Worker not available."**.
- **No** SSH/SFTP connection dialog opens (`toHaveCount(0)`) — i.e. the bogus `127.0.0.1` dialog is gone.
- The app launcher modal stays open.

## Verification

Run against a live backend with the fix (#7781) checked out:

- **With the fix**: ✅ pass — error notification shown, no connection dialog.
- **With the fix disabled** (sanity check that the test actually catches the regression): ❌ fail — the bogus SFTP connection dialog opens and no error notification appears.

The route overrides are torn down with `unroute` at the end so the shared serial session is unaffected by later tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
