### PR TITLE
fix(FR-3129): show resource opts on deployment preset review step

### DIFF
--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -153,6 +153,21 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
               />
             </BAIFlex>
           </Descriptions.Item>
+          <Descriptions.Item label={t('adminDeploymentPreset.ResourceOpts')}>
+            {values.resourceOpts?.some((o) => o.name?.trim()) ? (
+              <BAIFlex direction="row" align="start" gap="sm" wrap="wrap">
+                {values.resourceOpts
+                  .filter((o) => o.name?.trim())
+                  .map((o, i) => (
+                    <Typography.Text key={`${o.name}-${i}`} code>
+                      {o.name}: {o.value || '-'}
+                    </Typography.Text>
+                  ))}
+              </BAIFlex>
+            ) : (
+              '-'
+            )}
+          </Descriptions.Item>
           <Descriptions.Item label={t('adminDeploymentPreset.ClusterMode')}>
             {values.clusterMode === 'SINGLE_NODE'
               ? t('adminDeploymentPreset.SingleNode')


### PR DESCRIPTION
Resolves #7874 (FR-3129)

## Problem

In the admin deployment preset setting wizard, the **Resources** step lets users add resource opts (e.g. `shmem`) via the `resourceOpts` form list. The final **review** step (`AdminDeploymentPresetReviewSummary`) rendered ResourceSlots, ClusterMode and ClusterSize, but never read `values.resourceOpts` — so the configured opts were missing from the review and users could not verify them before submission.

> Note: the original report named `DeploymentAddRevisionModal`, but that modal is a single-form modal with no separate review page. The flow that actually has a "final review page" is the admin deployment preset wizard (`STEP_KEYS = ['basic', 'model', 'review']`).

## Fix

Render `values.resourceOpts` as `name: value` pairs in the Resources card of the review summary, consistent with the other resource fields. Empty entries are filtered out; the item shows `-` when no opts are configured.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="826" height="211" alt="image" src="https://github.com/user-attachments/assets/efc43945-b361-4086-95f4-283c6a4c245f" />
