### PR TITLE
fix: use token-based color for provisioning/warming-up replica tags

### DIFF
--- a/react/src/components/ReplicaStatusTag.tsx
+++ b/react/src/components/ReplicaStatusTag.tsx
@@ -5,7 +5,7 @@
 import { LoadingOutlined } from '@ant-design/icons';
 import { Tooltip } from 'antd';
 import type { TagProps } from 'antd';
-import { BAITag, type SemanticColor } from 'backend.ai-ui';
+import { BAITag } from 'backend.ai-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -36,13 +36,30 @@ export interface ReplicaStatusTagProps extends Omit<TagProps, 'color'> {
   showTooltip?: boolean;
 }
 
-const replicaStatusColorMap: Record<ReplicaStatus, SemanticColor> = {
+/**
+ * Antd `Tag` preset status colors. Only these five values are recognized by
+ * antd as status presets (`success | processing | error | warning | default`)
+ * and therefore resolve to theme tokens (`colorSuccess`, `colorInfo`, …) that
+ * adapt to dark mode. `'info'` is NOT an antd status preset — passing it makes
+ * antd treat the tag as a custom color and fall back to hardcoded white text,
+ * which glares in dark mode. Use `'processing'` for info-colored states: it
+ * maps to the `colorInfo` token and `BAITag` already renders its background
+ * transparent via the `colorInfoBg` override.
+ */
+type TagPresetStatusColor =
+  | 'success'
+  | 'processing'
+  | 'error'
+  | 'warning'
+  | 'default';
+
+const replicaStatusColorMap: Record<ReplicaStatus, TagPresetStatusColor> = {
   HEALTHY: 'success',
   UNHEALTHY: 'error',
   DEGRADED: 'warning',
   NOT_CHECKED: 'default',
-  PROVISIONING: 'info',
-  WARMING_UP: 'info',
+  PROVISIONING: 'processing',
+  WARMING_UP: 'processing',
   RUNNING: 'success',
   TERMINATING: 'warning',
   TERMINATED: 'default',
@@ -77,9 +94,9 @@ const ReplicaStatusTag: React.FC<ReplicaStatusTagProps> = ({
     ? t(`replicaStatus.tooltip.${i18nKey}`, { defaultValue: '' })
     : undefined;
 
-  // WARMING_UP and PROVISIONING share the `info` semantic color; render a
-  // spinner on WARMING_UP so the two states stay visually distinct in the
-  // status column.
+  // WARMING_UP and PROVISIONING share the `processing` (info) status color;
+  // render a spinner on WARMING_UP so the two states stay visually distinct in
+  // the status column.
   const icon = status === 'WARMING_UP' ? <LoadingOutlined spin /> : undefined;
 
   const tag = (


### PR DESCRIPTION
## Summary

The **Provisioning (프로비저닝 중)** replica status tag was too glaring/bright in dark mode, as reported. The root cause was a hardcoded fallback color rather than a theme token.

### Root cause

`ReplicaStatusTag` mapped `PROVISIONING` and `WARMING_UP` to the `info` semantic color and passed that string straight to antd's `Tag` via `BAITag`:

```ts
PROVISIONING: 'info',
WARMING_UP: 'info',
```

But **antd 6 only recognizes `success | processing | error | warning | default` as preset status colors** — `'info'` is **not** one of them (`components/_util/colors.ts`). When an unrecognized value is passed, antd takes its *custom-color* path: `isPreset`/`isStatus` are both `false`, the `colorInfoBg: 'transparent'` override in `BAITag` never applies, and the tag text falls back to antd's hardcoded **white (`#fff`)** (`colorTextLightSolid`). Against a dark background that white text glares.

The sibling states (`success`/`warning`/`error`) are valid antd statuses, so they correctly resolve to theme tokens with a transparent background — which is why only the provisioning/warming-up tags stood out.

### Fix

Map the info-colored states to antd's **`processing`** status, which resolves to the **`colorInfo` theme token** (dark-mode aware). `BAITag` already sets `colorInfoBg: 'transparent'`, so these tags now render a transparent background with token-colored text — visually consistent with the success/warning/error tags.

| State | Before (`color`) | After (`color`) | Result |
|---|---|---|---|
| `PROVISIONING` | `'info'` (invalid → `#fff` text) | `'processing'` (→ `colorInfo` token) | dark-mode aware |
| `WARMING_UP` | `'info'` (invalid → `#fff` text) | `'processing'` (→ `colorInfo` token) | dark-mode aware |

The `WARMING_UP` spinner (`LoadingOutlined`) is unchanged, so the two info states stay visually distinct.

## Verification

- `tsc --noEmit` — clean
- ESLint / Prettier — clean (pre-commit hooks passed)
- No GraphQL/schema changes; no generated files affected.

## Test plan

- Switch to dark mode → open a deployment's **Replicas (복제본)** tab.
- Confirm the **Provisioning** / **Warming up** tags use the muted info/blue token text on a transparent background, no longer glaring white.
- Confirm Running / Healthy (success), Degraded (warning), Failed (error), and Not checked (default) tags are unchanged.

https://claude.ai/code/session_017XHiquBAgyiBUgk2BHcRCt

---
_Generated by [Claude Code](https://claude.ai/code/session_017XHiquBAgyiBUgk2BHcRCt)_