### PR TITLE
fix(FR-3131): polish deployment preset Resources form and review display

### DIFF
--- a/react/src/components/AdminDeploymentPresetResourceFields.tsx
+++ b/react/src/components/AdminDeploymentPresetResourceFields.tsx
@@ -135,7 +135,10 @@ export const FixedResourceSlotField: React.FC<{
           required={required}
           rules={[{ required, message: '' }]}
         >
-          <BAIDynamicUnitInputNumber style={{ width: '100%' }} />
+          <BAIDynamicUnitInputNumber
+            style={{ width: '100%' }}
+            defaultUnit="g"
+          />
         </Form.Item>
       ) : (
         <Form.Item

--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -5,6 +5,7 @@
 import { useAdminImageCanonicalName } from '../hooks/hooksUsingRelay';
 import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
 import type { AdminDeploymentPresetFormValue } from './AdminDeploymentPresetFormTypes';
+import type { ResourceAllocationFormValue } from './SessionFormItems/ResourceAllocationFormItems';
 import SourceCodeView from './SourceCodeView';
 import { Button, Descriptions, Space, Tag, Typography, theme } from 'antd';
 import type { FormInstance } from 'antd';
@@ -64,6 +65,17 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
   const runtimeName =
     runtimeVariants.find((r) => toLocalId(r.id) === values.runtimeVariantId)
       ?.name ?? values.runtimeVariantId;
+
+  // Drop empty/partial slot rows (added but not filled in) so the review
+  // doesn't render an "undefined NaN" chip for a slot with no type/quantity.
+  const filledResourceSlots = (values.resourceSlots ?? []).filter(
+    (s) => s.resourceType && s.quantity,
+  );
+  const hasResources = !!(
+    values.cpu ||
+    values.mem ||
+    filledResourceSlots.length
+  );
 
   const editLink = (stepIndex: number, cardId: string) => (
     <Button
@@ -136,30 +148,44 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
       >
         <Descriptions column={1} size="small">
           <Descriptions.Item label={t('adminDeploymentPreset.ResourceSlots')}>
-            <BAIFlex direction="row" align="start" gap="sm" wrap="wrap">
-              <ResourceNumbersOfSession
-                resource={
-                  {
-                    ...(values.cpu ? { cpu: Number(values.cpu) } : {}),
-                    ...(values.mem ? { mem: values.mem } : {}),
-                    ...Object.fromEntries(
-                      (values.resourceSlots ?? []).map((s) => [
-                        s.resourceType,
-                        s.quantity,
-                      ]),
-                    ),
-                  } as any
-                }
-              />
-            </BAIFlex>
+            {hasResources ? (
+              <BAIFlex direction="row" align="start" gap="sm" wrap="wrap">
+                <ResourceNumbersOfSession
+                  resource={
+                    {
+                      ...(values.cpu ? { cpu: Number(values.cpu) } : {}),
+                      ...(values.mem ? { mem: values.mem } : {}),
+                      ...Object.fromEntries(
+                        filledResourceSlots.map((s) => [
+                          s.resourceType,
+                          s.quantity,
+                        ]),
+                      ),
+                    } as ResourceAllocationFormValue['resource']
+                  }
+                />
+              </BAIFlex>
+            ) : (
+              '-'
+            )}
           </Descriptions.Item>
           <Descriptions.Item label={t('adminDeploymentPreset.ResourceOpts')}>
             {values.resourceOpts?.some((o) => o.name?.trim()) ? (
-              <BAIFlex direction="row" align="start" gap="sm" wrap="wrap">
+              <BAIFlex
+                direction="row"
+                align="start"
+                gap="xs"
+                wrap="wrap"
+                style={{ maxWidth: '100%' }}
+              >
                 {values.resourceOpts
                   .filter((o) => o.name?.trim())
                   .map((o, i) => (
-                    <Typography.Text key={`${o.name?.trim()}-${i}`} code>
+                    <Typography.Text
+                      key={`${o.name?.trim()}-${i}`}
+                      code
+                      style={{ wordBreak: 'break-all', minWidth: 0 }}
+                    >
                       {o.name?.trim()}: {o.value?.trim() || '-'}
                     </Typography.Text>
                   ))}

--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -610,19 +610,27 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                 {(fields, { add, remove }) => (
                   <BAIFlex direction="column" gap="xs" align="stretch">
                     {fields.map(({ key, name, ...rest }) => (
-                      <BAIFlex
+                      // Grid with `minmax(0, 1fr)` tracks so a long custom key
+                      // can't expand its input and squash the value field — the
+                      // tracks stay 50/50 and long content scrolls within each.
+                      <div
                         key={key}
-                        direction="row"
-                        align="baseline"
-                        gap="xs"
+                        style={{
+                          display: 'grid',
+                          gridTemplateColumns:
+                            'minmax(0, 1fr) minmax(0, 1fr) auto',
+                          alignItems: 'baseline',
+                          gap: token.marginXS,
+                        }}
                       >
                         <Form.Item
                           {...rest}
                           name={[name, 'name']}
-                          style={{ marginBottom: 0, flex: 1 }}
+                          style={{ marginBottom: 0 }}
                           rules={[{ required: true, message: '' }]}
                         >
                           <AutoComplete
+                            style={{ width: '100%' }}
                             options={[{ value: 'shmem' }]}
                             filterOption={(input, option) =>
                               String(option?.value ?? '')
@@ -635,13 +643,13 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                         <Form.Item
                           {...rest}
                           name={[name, 'value']}
-                          style={{ marginBottom: 0, flex: 1 }}
+                          style={{ marginBottom: 0 }}
                           rules={[{ required: true, message: '' }]}
                         >
                           <Input placeholder="64m" />
                         </Form.Item>
                         <MinusCircleOutlined onClick={() => remove(name)} />
-                      </BAIFlex>
+                      </div>
                     ))}
                     <Form.Item noStyle>
                       <BAIButton


### PR DESCRIPTION
Resolves #7883 (FR-3131)

> **Stacked on** #7885 (FR-3129). Review/merge #7885 first.

## Problem

Found while working on FR-3129 (showing resource opts on the deployment preset review page). Separate UX defects/polish in the admin deployment preset **Resources** section:

- Entering a long custom Resource Option **key** expanded its input and squashed the value input to near-zero width.
- The MEM input defaulted to `m` (MiB) instead of the expected `g` (GiB).
- The review step rendered `undefined NaN` for resource slots when a slot row was added but left empty.

## Changes

- **Resource Options input** (`AdminDeploymentPresetSettingPageContent.tsx`): lay out each key/value row as a CSS grid with `minmax(0, 1fr)` tracks so a long custom key can't expand its input and squash the value field — the tracks stay 50/50 and long content scrolls within each. (`minWidth: 0` on the flex `Form.Item` alone didn't work because it doesn't cascade to antd's nested control wrappers.)
- **MEM default unit** (`AdminDeploymentPresetResourceFields.tsx`): pass `defaultUnit="g"` to `BAIDynamicUnitInputNumber` so memory defaults to GiB.
- **Review display** (`AdminDeploymentPresetReviewSummary.tsx`): filter out empty/partial resource-slot rows (show `-` instead of `undefined NaN`); render resource options as wrapping `name: value` tokens that stay inside the card; trim names/values at display.

## Screenshots

### Resource Options input — long key keeps a 50/50 split (MEM also defaults to GiB)
![resource-options-input](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7884/20260612-122541-resource-options-input-fixed.png)

### Review step — empty resource slots show `-`, long resource options wrap inside the card
![review-resources](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7884/20260612-122132-review-resources-wrap.png)

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript).

🤖 Generated with [Claude Code](https://claude.com/claude-code)