### PR TITLE
fix(FR-3133): remove duplicate '#' prefix in Korean ApplyingRevision i18n string

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -995,7 +995,7 @@
     "ApplyRevision": "리비전 적용",
     "ApplySuccess": "리비전 #{{revisionNumber}} 적용이 요청되었습니다.",
     "Applying": "적용 중",
-    "ApplyingRevision": "리비전 #{{revisionNumber}}을(를) 적용 중입니다.",
+    "ApplyingRevision": "리비전 {{revisionNumber}}을(를) 적용 중입니다.",
     "ApplyingRevisionDetail": "적용 중인 리비전 상세",
     "AutoApply": "추가 후 바로 적용",
     "AutoScaling": "오토스케일링",


### PR DESCRIPTION
Resolves #7884 (FR-3133)

## Summary

The Korean translation for `deployment.ApplyingRevision` contained `#{{revisionNumber}}` while all other 20 languages use `{{revisionNumber}}` (without `#`). The call site in `DeploymentConfigurationSection.tsx` already prepends `#` to the value before passing it to the translation function, so Korean users saw `##4` instead of `#4` when a revision was being applied.

**Root cause**: `ko.json` `ApplyingRevision` key had an extra `#` that is inconsistent with all other language files.

**Fix**: Remove the extra `#` from the Korean `ApplyingRevision` string to match the behavior of all other languages.

## Changed Files

- `resources/i18n/ko.json` — remove duplicate `#` from `deployment.ApplyingRevision`

## Verification

```
- en: "Applying revision {{revisionNumber}}." + code prepends `#` → "Applying revision #4." ✅
- ko (before): "리비전 #{{revisionNumber}}을(를) 적용 중입니다." + code prepends `#` → "리비전 ##4을(를) 적용 중입니다." ❌
- ko (after):  "리비전 {{revisionNumber}}을(를) 적용 중입니다." + code prepends `#` → "리비전 #4을(를) 적용 중입니다." ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)