### PR TITLE
fix(FR-3080): pin awf firewall to v0.25.60 in gh-aw lock files to fix install 404

### DIFF
--- a/.github/workflows/daily-test-improver.lock.yml
+++ b/.github/workflows/daily-test-improver.lock.yml
@@ -185,8 +185,8 @@ jobs:
           copilot --version
       - name: Install awf binary
         run: |
-          echo "Installing awf via installer script (requested version: v0.7.0)"
-          curl -sSL https://raw.githubusercontent.com/githubnext/gh-aw-firewall/main/install.sh | sudo AWF_VERSION=v0.7.0 bash
+          echo "Installing awf via installer script (requested version: v0.25.60)"
+          curl -sSL https://raw.githubusercontent.com/githubnext/gh-aw-firewall/main/install.sh | sudo AWF_VERSION=v0.25.60 bash
           which awf
           awf --version
       - name: Determine automatic lockdown mode for GitHub MCP server
@@ -622,7 +622,7 @@ jobs:
               network_mode: "defaults",
               allowed_domains: [],
               firewall_enabled: true,
-              awf_version: "v0.7.0",
+              awf_version: "v0.25.60",
               steps: {
                 firewall: "squid"
               },
@@ -940,7 +940,7 @@ jobs:
         timeout-minutes: 30
         run: |
           set -o pipefail
-          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount /tmp:/tmp:rw --mount "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" --mount /usr/bin/date:/usr/bin/date:ro --mount /usr/bin/gh:/usr/bin/gh:ro --mount /usr/bin/yq:/usr/bin/yq:ro --mount /usr/local/bin/copilot:/usr/local/bin/copilot:ro --mount /home/runner/.copilot:/home/runner/.copilot:rw --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --image-tag 0.7.0 \
+          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount /tmp:/tmp:rw --mount "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" --mount /usr/bin/date:/usr/bin/date:ro --mount /usr/bin/gh:/usr/bin/gh:ro --mount /usr/bin/yq:/usr/bin/yq:ro --mount /usr/local/bin/copilot:/usr/local/bin/copilot:ro --mount /home/runner/.copilot:/home/runner/.copilot:rw --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --image-tag 0.25.60 \
             -- /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-tool github --allow-tool safeoutputs --allow-tool shell --allow-tool tavily --allow-tool 'tavily(search)' --allow-tool 'tavily(search_news)' --allow-tool web_fetch --allow-tool write --allow-all-paths --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"${GH_AW_MODEL_AGENT_COPILOT:+ --model "$GH_AW_MODEL_AGENT_COPILOT"} \
             2>&1 | tee /tmp/gh-aw/agent-stdio.log
         env:

--- a/.github/workflows/e2e-healer.lock.yml
+++ b/.github/workflows/e2e-healer.lock.yml
@@ -106,7 +106,7 @@ jobs:
         run: bash /tmp/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: "20"
+          node-version-file: ".nvmrc"
       - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
       - name: Print E2E endpoints
         run: "echo \"=== E2E Test Configuration ===\"\necho \"E2E_WEBUI_ENDPOINT: $E2E_WEBUI_ENDPOINT\"\necho \"E2E_WEBSERVER_ENDPOINT: $E2E_WEBSERVER_ENDPOINT\"\n"
@@ -183,8 +183,8 @@ jobs:
           copilot --version
       - name: Install awf binary
         run: |
-          echo "Installing awf via installer script (requested version: v0.7.0)"
-          curl -sSL https://raw.githubusercontent.com/githubnext/gh-aw-firewall/main/install.sh | sudo AWF_VERSION=v0.7.0 bash
+          echo "Installing awf via installer script (requested version: v0.25.60)"
+          curl -sSL https://raw.githubusercontent.com/githubnext/gh-aw-firewall/main/install.sh | sudo AWF_VERSION=v0.25.60 bash
           which awf
           awf --version
       - name: Determine automatic lockdown mode for GitHub MCP server
@@ -559,7 +559,7 @@ jobs:
               network_mode: "defaults",
               allowed_domains: ["node","npm","playwright"],
               firewall_enabled: true,
-              awf_version: "v0.7.0",
+              awf_version: "v0.25.60",
               steps: {
                 firewall: "squid"
               },
@@ -810,7 +810,7 @@ jobs:
         timeout-minutes: 120
         run: |
           set -o pipefail
-          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount /tmp:/tmp:rw --mount "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" --mount /usr/bin/date:/usr/bin/date:ro --mount /usr/bin/gh:/usr/bin/gh:ro --mount /usr/bin/yq:/usr/bin/yq:ro --mount /usr/local/bin/copilot:/usr/local/bin/copilot:ro --mount /home/runner/.copilot:/home/runner/.copilot:rw --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,bun.sh,cdn.playwright.dev,deb.nodesource.com,deno.land,get.pnpm.io,github.com,host.docker.internal,nodejs.org,npm,npm.pkg.github.com,npmjs.com,npmjs.org,playwright.download.prss.microsoft.com,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,skimdb.npmjs.com,www.npmjs.com,www.npmjs.org,yarnpkg.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --image-tag 0.7.0 \
+          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount /tmp:/tmp:rw --mount "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" --mount /usr/bin/date:/usr/bin/date:ro --mount /usr/bin/gh:/usr/bin/gh:ro --mount /usr/bin/yq:/usr/bin/yq:ro --mount /usr/local/bin/copilot:/usr/local/bin/copilot:ro --mount /home/runner/.copilot:/home/runner/.copilot:rw --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,bun.sh,cdn.playwright.dev,deb.nodesource.com,deno.land,get.pnpm.io,github.com,host.docker.internal,nodejs.org,npm,npm.pkg.github.com,npmjs.com,npmjs.org,playwright.download.prss.microsoft.com,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,skimdb.npmjs.com,www.npmjs.com,www.npmjs.org,yarnpkg.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --image-tag 0.25.60 \
             -- /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-tool github --allow-tool safeoutputs --allow-tool 'shell(cat)' --allow-tool 'shell(cat*)' --allow-tool 'shell(date)' --allow-tool 'shell(echo)' --allow-tool 'shell(git add:*)' --allow-tool 'shell(git branch:*)' --allow-tool 'shell(git checkout:*)' --allow-tool 'shell(git commit:*)' --allow-tool 'shell(git merge:*)' --allow-tool 'shell(git rm:*)' --allow-tool 'shell(git status)' --allow-tool 'shell(git status*)' --allow-tool 'shell(git switch:*)' --allow-tool 'shell(grep)' --allow-tool 'shell(head)' --allow-tool 'shell(ls)' --allow-tool 'shell(ls*)' --allow-tool 'shell(pwd)' --allow-tool 'shell(sort)' --allow-tool 'shell(tail)' --allow-tool 'shell(uniq)' --allow-tool 'shell(wc)' --allow-tool 'shell(yq)' --allow-tool write --allow-all-paths --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"${GH_AW_MODEL_AGENT_COPILOT:+ --model "$GH_AW_MODEL_AGENT_COPILOT"} \
             2>&1 | tee /tmp/gh-aw/agent-stdio.log
         env:

--- a/.github/workflows/e2e-healer.md
+++ b/.github/workflows/e2e-healer.md
@@ -57,7 +57,7 @@ safe-outputs:
 steps:
   - uses: actions/setup-node@v4
     with:
-      node-version: '20'
+      node-version-file: '.nvmrc'
   - uses: pnpm/action-setup@v5
     with:
       version: 11

--- a/.github/workflows/e2e-watchdog.lock.yml
+++ b/.github/workflows/e2e-watchdog.lock.yml
@@ -99,7 +99,7 @@ jobs:
         run: bash /tmp/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: "20"
+          node-version-file: ".nvmrc"
       - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288
       - name: Print E2E endpoints
         run: "echo \"=== E2E Test Configuration ===\"\necho \"E2E_WEBUI_ENDPOINT: $E2E_WEBUI_ENDPOINT\"\necho \"E2E_WEBSERVER_ENDPOINT: $E2E_WEBSERVER_ENDPOINT\"\n"
@@ -176,8 +176,8 @@ jobs:
           copilot --version
       - name: Install awf binary
         run: |
-          echo "Installing awf via installer script (requested version: v0.7.0)"
-          curl -sSL https://raw.githubusercontent.com/githubnext/gh-aw-firewall/main/install.sh | sudo AWF_VERSION=v0.7.0 bash
+          echo "Installing awf via installer script (requested version: v0.25.60)"
+          curl -sSL https://raw.githubusercontent.com/githubnext/gh-aw-firewall/main/install.sh | sudo AWF_VERSION=v0.25.60 bash
           which awf
           awf --version
       - name: Determine automatic lockdown mode for GitHub MCP server
@@ -484,7 +484,7 @@ jobs:
               network_mode: "defaults",
               allowed_domains: ["node","npm","playwright"],
               firewall_enabled: true,
-              awf_version: "v0.7.0",
+              awf_version: "v0.25.60",
               steps: {
                 firewall: "squid"
               },
@@ -714,7 +714,7 @@ jobs:
         timeout-minutes: 120
         run: |
           set -o pipefail
-          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount /tmp:/tmp:rw --mount "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" --mount /usr/bin/date:/usr/bin/date:ro --mount /usr/bin/gh:/usr/bin/gh:ro --mount /usr/bin/yq:/usr/bin/yq:ro --mount /usr/local/bin/copilot:/usr/local/bin/copilot:ro --mount /home/runner/.copilot:/home/runner/.copilot:rw --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,bun.sh,cdn.playwright.dev,deb.nodesource.com,deno.land,get.pnpm.io,github.com,host.docker.internal,nodejs.org,npm,npm.pkg.github.com,npmjs.com,npmjs.org,playwright.download.prss.microsoft.com,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,skimdb.npmjs.com,www.npmjs.com,www.npmjs.org,yarnpkg.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --image-tag 0.7.0 \
+          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount /tmp:/tmp:rw --mount "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" --mount /usr/bin/date:/usr/bin/date:ro --mount /usr/bin/gh:/usr/bin/gh:ro --mount /usr/bin/yq:/usr/bin/yq:ro --mount /usr/local/bin/copilot:/usr/local/bin/copilot:ro --mount /home/runner/.copilot:/home/runner/.copilot:rw --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,bun.sh,cdn.playwright.dev,deb.nodesource.com,deno.land,get.pnpm.io,github.com,host.docker.internal,nodejs.org,npm,npm.pkg.github.com,npmjs.com,npmjs.org,playwright.download.prss.microsoft.com,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,skimdb.npmjs.com,www.npmjs.com,www.npmjs.org,yarnpkg.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --image-tag 0.25.60 \
             -- /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-tool github --allow-tool safeoutputs --allow-tool 'shell(cat)' --allow-tool 'shell(cat*)' --allow-tool 'shell(date)' --allow-tool 'shell(echo)' --allow-tool 'shell(git status*)' --allow-tool 'shell(grep)' --allow-tool 'shell(head)' --allow-tool 'shell(ls)' --allow-tool 'shell(ls*)' --allow-tool 'shell(pwd)' --allow-tool 'shell(sort)' --allow-tool 'shell(tail)' --allow-tool 'shell(uniq)' --allow-tool 'shell(wc)' --allow-tool 'shell(yq)' --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"${GH_AW_MODEL_AGENT_COPILOT:+ --model "$GH_AW_MODEL_AGENT_COPILOT"} \
             2>&1 | tee /tmp/gh-aw/agent-stdio.log
         env:

--- a/.github/workflows/e2e-watchdog.md
+++ b/.github/workflows/e2e-watchdog.md
@@ -48,7 +48,7 @@ safe-outputs:
 steps:
   - uses: actions/setup-node@v4
     with:
-      node-version: '20'
+      node-version-file: '.nvmrc'
   - uses: pnpm/action-setup@v5
     with:
       version: 11

--- a/.github/workflows/weekly-team-status.lock.yml
+++ b/.github/workflows/weekly-team-status.lock.yml
@@ -148,8 +148,8 @@ jobs:
           copilot --version
       - name: Install awf binary
         run: |
-          echo "Installing awf via installer script (requested version: v0.7.0)"
-          curl -sSL https://raw.githubusercontent.com/githubnext/gh-aw-firewall/main/install.sh | sudo AWF_VERSION=v0.7.0 bash
+          echo "Installing awf via installer script (requested version: v0.25.60)"
+          curl -sSL https://raw.githubusercontent.com/githubnext/gh-aw-firewall/main/install.sh | sudo AWF_VERSION=v0.25.60 bash
           which awf
           awf --version
       - name: Determine automatic lockdown mode for GitHub MCP server
@@ -399,7 +399,7 @@ jobs:
               network_mode: "defaults",
               allowed_domains: [],
               firewall_enabled: true,
-              awf_version: "v0.7.0",
+              awf_version: "v0.25.60",
               steps: {
                 firewall: "squid"
               },
@@ -650,7 +650,7 @@ jobs:
         timeout-minutes: 20
         run: |
           set -o pipefail
-          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount /tmp:/tmp:rw --mount "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" --mount /usr/bin/date:/usr/bin/date:ro --mount /usr/bin/gh:/usr/bin/gh:ro --mount /usr/bin/yq:/usr/bin/yq:ro --mount /usr/local/bin/copilot:/usr/local/bin/copilot:ro --mount /home/runner/.copilot:/home/runner/.copilot:rw --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --image-tag 0.7.0 \
+          sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --mount /tmp:/tmp:rw --mount "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:rw" --mount /usr/bin/date:/usr/bin/date:ro --mount /usr/bin/gh:/usr/bin/gh:ro --mount /usr/bin/yq:/usr/bin/yq:ro --mount /usr/local/bin/copilot:/usr/local/bin/copilot:ro --mount /home/runner/.copilot:/home/runner/.copilot:rw --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --image-tag 0.25.60 \
             -- /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-tool github --allow-tool safeoutputs --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"${GH_AW_MODEL_AGENT_COPILOT:+ --model "$GH_AW_MODEL_AGENT_COPILOT"} \
             2>&1 | tee /tmp/gh-aw/agent-stdio.log
         env:


### PR DESCRIPTION
Resolves #7803 (FR-3080)

Fixes two distinct bugs that break the repo's gh-aw agentic workflows.

## Bug 1 — awf install 404 (the original FR-3080)

The installer (`gh-aw-firewall/main/install.sh`) downloads the `awf-bundle.js` asset, but `AWF_VERSION` was pinned to **v0.7.0**, a release that does **not** ship `awf-bundle.js`. Result: `curl .../releases/download/v0.7.0/awf-bundle.js` returns **404** and the job fails.

`storybook-coverage-checker` was already unblocked in #7667 (pin bumped to **v0.25.60**). The other four lock files were left on `v0.7.0`. This PR pins them to **v0.25.60** too, in the three generated spots per file (install `AWF_VERSION=` line, `awf_version` safe-outputs config, `--image-tag`):

- `e2e-healer.lock.yml`
- `e2e-watchdog.lock.yml`
- `weekly-team-status.lock.yml`
- `daily-test-improver.lock.yml`

All five gh-aw workflows now pin the same `awf` version.

## Bug 2 — Node 20 vs pnpm 11 crash (E2E workflows)

Surfaced on this PR's CI: the `E2E Watchdog & Healer` `agent` job dies at `pnpm install`, before the awf step:

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

The repo pins `packageManager: pnpm@11.1.1`, which requires Node ≥ v22.13 (it loads the `node:sqlite` builtin). But `e2e-watchdog.md` / `e2e-healer.md` hardcoded `node-version: '20'`, so pnpm crashes on load.

Every other workflow in the repo reads the Node version from `.nvmrc` (currently `24`) via `node-version-file: '.nvmrc'` instead of hardcoding. This PR aligns the two E2E workflows with that convention — in both the `.md` sources and their `.lock.yml` files:

```diff
-      node-version: '20'
+      node-version-file: '.nvmrc'
```

This also prevents the same drift from recurring whenever `.nvmrc` is bumped.

## Why hand-edit the generated `.lock.yml` files?

These `.lock.yml` files are generated artifacts ("DO NOT EDIT"), but recompiling via `gh aw compile` is currently non-viable: the local compiler (`gh aw` v0.68.1, vs. the v0.34.5 that generated these locks) fails strict-mode validation because the workflow `.md` sources declare secrets in their `env:` section — a newer rule that would require migrating each workflow's secret handling to engine-specific config. That is a separate toolchain migration, out of scope here. The hand-edit matches the existing repo precedent (#7667), and both the `.md` source (the real input) and the generated `.lock.yml` are updated so they stay consistent.

## Notes

- Non-blocking infra fix — these agentic workflows are not required PR checks.
- A follow-up issue should track the proper `gh aw` toolchain migration (secrets-in-env) so future `gh aw compile` runs work and these lock files can be regenerated rather than hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)