### PR TITLE
feat(FR-3134): default Project Folder Permission domain selector to current domain

### DIFF
--- a/react/src/components/ProjectFolderPermissionPanel.tsx
+++ b/react/src/components/ProjectFolderPermissionPanel.tsx
@@ -4,6 +4,7 @@
  */
 import { ProjectFolderPermissionPanelQuery } from '../__generated__/ProjectFolderPermissionPanelQuery.graphql';
 import { ProjectFolderPermissionPanel_storageVolumeFrgmt$key } from '../__generated__/ProjectFolderPermissionPanel_storageVolumeFrgmt.graphql';
+import { useCurrentDomainValue } from '../hooks';
 import DomainStoragePermissionTable from './DomainStoragePermissionTable';
 import ProjectStoragePermissionTable from './ProjectStoragePermissionTable';
 import { CheckCircleOutlined } from '@ant-design/icons';
@@ -51,9 +52,12 @@ const ProjectFolderPermissionPanel: React.FC<
     storageVolumeFrgmt,
   );
 
+  // Default to the current domain so the tab shows its folder permissions on
+  // open; the user can still switch to or clear the selection.
+  const currentDomain = useCurrentDomainValue();
   const [selectedDomainName, setSelectedDomainName] = useState<
     string | undefined
-  >(undefined);
+  >(currentDomain);
 
   // Bump after a domain permission save so the domain row AND the project
   // union both refetch from the single panel-level query.


### PR DESCRIPTION
Resolves #7890 (FR-3134)

## Summary

On the Agent page Storages tab (`agent?tab=storages`), opening a storage host detail drawer shows a **Project Folder Permission** tab. Its domain selector (`BAIDomainSelect`) previously initialized to `undefined`, so nothing was shown until the user manually picked a domain (`skipDomain: true` was sent to the query).

This PR defaults the selector to the **current domain** via `useCurrentDomainValue()`, so the tab immediately shows the current domain's folder permissions on open. The user can still switch to another domain or clear the selection (`allowClear`).

## Changes

- `react/src/components/ProjectFolderPermissionPanel.tsx`
  - Import `useCurrentDomainValue` from `../hooks`.
  - Initialize the `selectedDomainName` state from `useCurrentDomainValue()` instead of `undefined`.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript).