### PR TITLE
fix(FR-3135): override yauzl ^3.3.1 to fix silent desktop packaging on Node >=24.16.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,7 @@ catalogs:
 
 overrides:
   tar-fs@2: 2.1.4
+  yauzl: ^3.3.1
   js-cookie: ^3.0.7
   mermaid: ^11.15.0
   serialize-javascript: ^7.0.5
@@ -6926,9 +6927,6 @@ packages:
   fbjs@3.0.5:
     resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
 
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -11398,8 +11396,9 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.3.1:
+    resolution: {integrity: sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -18403,7 +18402,7 @@ snapshots:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       get-stream: 5.2.0
-      yauzl: 2.10.0
+      yauzl: 3.3.1
     optionalDependencies:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
@@ -18462,10 +18461,6 @@ snapshots:
       ua-parser-js: 1.0.41
     transitivePeerDependencies:
       - encoding
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -23994,10 +23989,10 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yauzl@2.10.0:
+  yauzl@3.3.1:
     dependencies:
       buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,6 +95,16 @@ allowBuilds:
 
 overrides:
   tar-fs@2: 2.1.4
+  # Build-tooling override. `@electron/packager` and `electron`'s own
+  # install.js both extract their downloaded ZIPs via `extract-zip` → `yauzl`.
+  # yauzl 2.10.0 extracts only the first entry and then lets the process exit
+  # 0 with no error on Node >= 24.16.0 / >= 26.1.0, so desktop packaging
+  # produces no app bundle and the Makefile fails later at the misleading
+  # `mv`/`zip` step (build_mac + build_desktop, since CI's `.nvmrc: 24` floated
+  # 24.15.0 -> 24.16.0). yauzl >= 3.3.1 fixes the silent extraction failure.
+  # See electron/electron#51619 (#51623). Remove once extract-zip ranges to
+  # yauzl >= 3.3.1 on its own.
+  yauzl: ^3.3.1
   # Runtime security overrides — FR-3014. Pin transitive deps that end up in
   # the production bundle to the first Dependabot-recommended patched
   # version. Remove an entry when every upstream consumer ranges to the


### PR DESCRIPTION
Resolves #7892 (FR-3135)

## Summary

- `build_mac` and `build_desktop` release jobs silently fail starting v26.4.8-rc.8, producing no desktop artifacts.
- Root cause: `@electron/packager` and `electron`'s own `install.js` extract their downloaded ZIPs via `extract-zip` → `yauzl`. **yauzl 2.10.0 extracts only the first entry then lets the process exit 0 with no error on Node >= 24.16.0 / >= 26.1.0** (electron/electron#51619, dup #51623). `node ./app-packager.js` exits cleanly without producing the bundle, and the Makefile then fails at a misleading `mv`/`zip` "not found" step.
- Trigger was CI's `.nvmrc: 24` floating from Node 24.15.0 (rc.7 PASS) → 24.16.0 (rc.8+ FAIL), not the Electron 35→39 bump (coincidental timing).
- Fix: add `yauzl: ^3.3.1` to `overrides:` in `pnpm-workspace.yaml` (resolves to 3.3.1). yauzl is build-tooling only (`extract-zip` ← `@electron/packager` + `electron`); no production-bundle impact. Also fixes electron's own silent postinstall extraction.

## Test plan

- [x] Reproduced the silent failure locally on Node **24.16.0** + yauzl 2.10.0: `app-packager.js` prints `Packaging app for platform …` then exits 0 with no `Done.` and no output folder (matches CI).
- [x] With `yauzl ^3.3.1`: `extract-zip` returns all entries and `app-packager.js linux x64` produces `Backend.AI Desktop-linux-x64` with `[BUILD] Done.` on Node 24.16.0.
- [x] `pnpm install --frozen-lockfile` passes (CI install parity).
- [ ] Confirm `build_mac` + `build_desktop` go green on the next release run.