### PR TITLE
fix(FR-3136): create model card in the MODEL_STORE project, not the current compute project

### DIFF
--- a/react/src/components/AdminModelCardSettingModal.tsx
+++ b/react/src/components/AdminModelCardSettingModal.tsx
@@ -248,7 +248,18 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
             variables: {
               input: {
                 vfolderId: toLocalId(values.vfolderId),
-                modelStoreProjectId: currentProject.id!,
+                // The model card must be created in the MODEL_STORE project — the
+                // same project that backs the VFolder selector above — not the
+                // admin's current compute project. When the admin is not currently
+                // in the model-store project, `currentProject.id` would write the
+                // card to the wrong project; `modelStoreProject.id` is the
+                // model-store-dedicated project. Falls back to the current project
+                // only if no model-store project is resolved.
+                // TODO: model cards in the model-store project are slated to
+                // become global cards. Once a query that can look up cards across
+                // projects of multiple scopes is added, this will need to change.
+                modelStoreProjectId:
+                  modelStoreProject?.id ?? currentProject.id!,
                 domainName: values.domainName || null,
                 ...metadataInput,
               },


### PR DESCRIPTION
> **Stacked on #7869**

Resolves #7894 (FR-3136)

## Summary

When creating a model card from the admin Model Card form (`AdminModelCardSettingModal`), set `modelStoreProjectId` to the MODEL_STORE-dedicated project (`modelStoreProject.id`, the same project that backs the VFolder selector) instead of the admin's current compute project (`currentProject.id`). Falls back to the current project only when no model-store project is resolved.

## Why

The create form wrote the card to `currentProject.id`. When the admin is not currently in the model-store project, the card was created in the wrong project — mismatched with its VFolder, which is already scoped to the model-store project.

## Notes

- `modelStoreProject` / `isModelStoreProject` remain props supplied by `AdminModelCardListPage` (which already fetches `group` / `groups`), keeping the modal non-suspending — `useModelStoreProject()` uses `useLazyLoadQuery` and would otherwise suspend the whole modal.
- A `TODO` is left at the call site: model cards in the model-store project are slated to become **global cards**; once a query that can look up cards across projects of multiple scopes is added, this will need to change.

## Test plan

- [ ] As an admin whose current project is a non-model-store compute project, create a model card from the admin Model Card list; verify the card's project is the model-store project (matching its VFolder), not the current compute project.
- [ ] `bash scripts/verify.sh` → ALL PASS.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript).
