### PR TITLE
feat(FR-3137): clarify deployment & model selectors on Chat page

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -123,6 +123,7 @@ export interface BAISelectProps<
   atBottomThreshold?: number;
   atBottomStateChange?: (atBottom: boolean) => void;
   bottomLoading?: boolean;
+  header?: React.ReactNode;
   footer?: React.ReactNode;
   endReached?: () => void; // New prop for endReached
   searchAction?: (value: string) => Promise<void>;
@@ -138,6 +139,7 @@ function BAISelect<
   tooltip = '',
   atBottomThreshold = 30,
   atBottomStateChange,
+  header,
   footer,
   endReached, // Destructure the new prop
   searchAction,
@@ -227,7 +229,7 @@ function BAISelect<
           selectProps.onPopupScroll?.(e);
         }}
         popupRender={
-          footer
+          header || footer
             ? (menu) => {
                 // Process with custom popupRender if provided
                 // const renderedMenu = selectProps.popupRender
@@ -236,30 +238,59 @@ function BAISelect<
 
                 return (
                   <BAIFlex direction="column" align="stretch">
+                    {header ? (
+                      <>
+                        <BAIFlex
+                          align="center"
+                          style={{
+                            paddingBottom: token.paddingXXS,
+                            paddingInline: token.paddingSM,
+                          }}
+                        >
+                          {_.isString(header) ? (
+                            <Typography.Text type="secondary">
+                              {header}
+                            </Typography.Text>
+                          ) : (
+                            header
+                          )}
+                        </BAIFlex>
+                        <Divider
+                          style={{
+                            margin: 0,
+                            marginBottom: token.marginXXS,
+                          }}
+                        />
+                      </>
+                    ) : null}
                     {menu}
-                    <Divider
-                      style={{
-                        margin: 0,
-                        marginBottom: token.paddingXS,
-                      }}
-                    />
-                    <BAIFlex
-                      direction="column"
-                      align="end"
-                      gap={'xs'}
-                      style={{
-                        paddingBottom: token.paddingXXS,
-                        paddingInline: token.paddingSM,
-                      }}
-                    >
-                      {_.isString(footer) ? (
-                        <Typography.Text type="secondary">
-                          {footer}
-                        </Typography.Text>
-                      ) : (
-                        footer
-                      )}
-                    </BAIFlex>
+                    {footer ? (
+                      <>
+                        <Divider
+                          style={{
+                            margin: 0,
+                            marginBottom: token.paddingXS,
+                          }}
+                        />
+                        <BAIFlex
+                          direction="column"
+                          align="end"
+                          gap={'xs'}
+                          style={{
+                            paddingBottom: token.paddingXXS,
+                            paddingInline: token.paddingSM,
+                          }}
+                        >
+                          {_.isString(footer) ? (
+                            <Typography.Text type="secondary">
+                              {footer}
+                            </Typography.Text>
+                          ) : (
+                            footer
+                          )}
+                        </BAIFlex>
+                      </>
+                    ) : null}
                   </BAIFlex>
                 );
               }

--- a/react/src/__generated__/ChatCardQuery.graphql.ts
+++ b/react/src/__generated__/ChatCardQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c9b11cc78d999a8adae74bc3eee94da9>>
+ * @generated SignedSource<<647732c7555c81ded3a8bc56d94d23ca>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -107,6 +107,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -116,12 +123,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6e2c7cca467d32f74de4ddf840a8f08a",
+    "cacheID": "88acc886856e154b1e3691c9159266a3",
     "id": null,
     "metadata": {},
     "name": "ChatCardQuery",
     "operationKind": "query",
-    "text": "query ChatCardQuery(\n  $endpointId: UUID!\n) {\n  endpoint(endpoint_id: $endpointId) {\n    endpoint_id\n    url\n    ...ChatHeader_Endpoint\n    id\n  }\n}\n\nfragment ChatHeader_Endpoint on Endpoint {\n  endpoint_id\n}\n"
+    "text": "query ChatCardQuery(\n  $endpointId: UUID!\n) {\n  endpoint(endpoint_id: $endpointId) {\n    endpoint_id\n    url\n    ...ChatHeader_Endpoint\n    id\n  }\n}\n\nfragment ChatHeader_Endpoint on Endpoint {\n  endpoint_id\n  name\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/ChatHeader_Endpoint.graphql.ts
+++ b/react/src/__generated__/ChatHeader_Endpoint.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c53946a820e47295c1530ab5d02ed807>>
+ * @generated SignedSource<<514d5a97f361d828c0a0a20d504f6506>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ChatHeader_Endpoint$data = {
   readonly endpoint_id: string | null | undefined;
+  readonly name: string | null | undefined;
   readonly " $fragmentType": "ChatHeader_Endpoint";
 };
 export type ChatHeader_Endpoint$key = {
@@ -31,12 +32,19 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "endpoint_id",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
     }
   ],
   "type": "Endpoint",
   "abstractKey": null
 };
 
-(node as any).hash = "baa41c02cf67330c6bf4313d43280faa";
+(node as any).hash = "2ea82665de3ccedca19e1f751f511d03";
 
 export default node;

--- a/react/src/components/Chat/ChatHeader.tsx
+++ b/react/src/components/Chat/ChatHeader.tsx
@@ -122,6 +122,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
     graphql`
       fragment ChatHeader_Endpoint on Endpoint {
         endpoint_id
+        name
       }
     `,
     endpointFrgmt,
@@ -225,6 +226,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
         {!isEmpty(models) && (
           <ModelSelect
             models={models}
+            endpointName={endpoint?.name}
             value={modelId}
             onChange={(modelId) => {
               startTransition(() => {

--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -19,7 +19,7 @@ import {
   Space,
   Tooltip,
 } from 'antd';
-import { BAIFlex, BAISelect } from 'backend.ai-ui';
+import { BAIEndpointsIcon, BAIFlex, BAISelect } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { InfoIcon } from 'lucide-react';
 import React, { useDeferredValue, useEffect, useRef, useState } from 'react';
@@ -196,6 +196,8 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
         <BAISelect
           ref={selectRef}
           placeholder={t('chatui.SelectEndpoint')}
+          prefix={<BAIEndpointsIcon />}
+          header={t('chatui.Deployment')}
           style={{
             minWidth: 100,
             fontWeight: 'normal',

--- a/react/src/components/Chat/ModelSelect.tsx
+++ b/react/src/components/Chat/ModelSelect.tsx
@@ -3,40 +3,41 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import type { ChatModel } from './ChatModel';
-import { Select, type SelectProps } from 'antd';
+import { BAISelect, type BAISelectProps } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 
-interface ModelSelectProps extends SelectProps {
+interface ModelSelectProps extends BAISelectProps {
   models?: Array<ChatModel>;
+  endpointName?: string | null;
 }
 
 const ModelSelect: React.FC<ModelSelectProps> = ({
   models,
+  endpointName,
   ...selectProps
 }) => {
+  'use memo';
+
   const { t } = useTranslation();
 
   return (
-    <Select
+    <BAISelect
       placeholder={t('chatui.SelectModel')}
       style={{
         fontWeight: 'normal',
       }}
       showSearch
-      options={_.map(
-        _.mapValues(_.groupBy(models, 'group'), (ms) =>
-          _.map(ms, ({ name }) => ({
-            label: name,
-            value: name,
-          })),
-        ),
-        (v, k) => ({
-          label: k === 'undefined' ? 'Others' : k,
-          options: v,
-        }),
-      )}
+      options={_.map(models, ({ name }) => ({
+        label: name,
+        value: name,
+      }))}
       popupMatchSelectWidth={false}
+      header={
+        endpointName
+          ? t('chatui.DeploymentModels', { name: endpointName })
+          : undefined
+      }
       {...selectProps}
     />
   );

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -50,6 +50,7 @@ export interface UserSettings {
   custom_theme_config?: CustomThemeConfig;
   deploymentRevisionCreationMode?: 'preset' | 'custom';
   schedulingHistoryExpandMode?: 'expand-all' | 'collapse-all' | 'errors-only';
+  chat_intro_alert_dismissed?: boolean;
 }
 
 export type SessionHistory = {

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -13,7 +13,17 @@ import {
 import { type ChatProviderData } from '../components/Chat/ChatModel';
 import WebUINavigate from '../components/WebUINavigate';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
-import { Badge, Button, Card, Drawer, theme, Tooltip, Typography } from 'antd';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Drawer,
+  theme,
+  Tooltip,
+  Typography,
+} from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIButton, BAIFlex, BAICard, BAITable } from 'backend.ai-ui';
 import dayjs from 'dayjs';
@@ -173,7 +183,10 @@ const PureChatPage = ({ id }: { id: string }) => {
   const defaultEndpointId = useDefaultEndpointId();
   const provider = useChatProviderData(defaultEndpointId);
   const { styles } = useStyles();
+  const { token } = theme.useToken();
   const [openHistory, setOpenHistory] = useState(false);
+  const [chatIntroAlertDismissed, setChatIntroAlertDismissed] =
+    useBAISettingUserState('chat_intro_alert_dismissed');
   const {
     chat,
     history,
@@ -248,49 +261,72 @@ const PureChatPage = ({ id }: { id: string }) => {
           </BAIFlex>
         }
       >
-        {id && (
-          <BAIFlex
-            direction="row"
-            align="stretch"
-            gap={'xs'}
-            style={{
-              overflow: 'hidden',
-              minHeight: 0,
-              height: '100%',
-            }}
-          >
-            <Suspense fallback={<Card loading style={{ width: '100%' }} />}>
-              {_.map(chat.chats, (chatData) => (
-                <ChatCard
-                  key={chatData.id}
-                  chat={chatData}
-                  onUpdateChat={(newChatProperties) => {
-                    updateChatData(chatData.id, newChatProperties);
-                  }}
-                  fetchOnClient
-                  onRemoveChat={() => {
-                    removeChatData(chatData.id);
-                  }}
-                  onAddChat={() => {
-                    addChatData(chatData);
-                  }}
-                  onSaveMessage={(message) => {
-                    saveChatMessage(chatData.id, message);
-                  }}
-                  onClearMessage={(chatData) => {
-                    clearChatMessage(chatData.id);
-                  }}
-                  closable={isClosable(chat.chats.length)}
-                  cloneable={isClonable(chat.chats.length)}
-                  style={{
-                    flex: 1,
-                    overflow: 'hidden',
-                  }}
-                />
-              ))}
-            </Suspense>
-          </BAIFlex>
-        )}
+        <BAIFlex
+          direction="column"
+          align="stretch"
+          style={{
+            overflow: 'hidden',
+            minHeight: 0,
+            height: '100%',
+          }}
+        >
+          {!chatIntroAlertDismissed && (
+            <Alert
+              type="info"
+              showIcon
+              closable={{
+                closeIcon: true,
+                afterClose: () => setChatIntroAlertDismissed(true),
+              }}
+              title={t('chatui.intro.Title')}
+              description={t('chatui.intro.Description')}
+              style={{ marginBottom: token.size }}
+            />
+          )}
+          {id && (
+            <BAIFlex
+              direction="row"
+              align="stretch"
+              gap={'xs'}
+              style={{
+                overflow: 'hidden',
+                minHeight: 0,
+                flex: 1,
+              }}
+            >
+              <Suspense fallback={<Card loading style={{ width: '100%' }} />}>
+                {_.map(chat.chats, (chatData) => (
+                  <ChatCard
+                    key={chatData.id}
+                    chat={chatData}
+                    onUpdateChat={(newChatProperties) => {
+                      updateChatData(chatData.id, newChatProperties);
+                    }}
+                    fetchOnClient
+                    onRemoveChat={() => {
+                      removeChatData(chatData.id);
+                    }}
+                    onAddChat={() => {
+                      addChatData(chatData);
+                    }}
+                    onSaveMessage={(message) => {
+                      saveChatMessage(chatData.id, message);
+                    }}
+                    onClearMessage={(chatData) => {
+                      clearChatMessage(chatData.id);
+                    }}
+                    closable={isClosable(chat.chats.length)}
+                    cloneable={isClonable(chat.chats.length)}
+                    style={{
+                      flex: 1,
+                      overflow: 'hidden',
+                    }}
+                  />
+                ))}
+              </Suspense>
+            </BAIFlex>
+          )}
+        </BAIFlex>
         <ChatHistoryDrawer
           selectedHistoryId={chat.id}
           open={openHistory}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Chat löschen",
     "DeleteChattingSession": "Chat löschen",
     "DeleteChattingSessionDescription": "Sie sind dabei, dieses Thema zu löschen. \nEinmal gelöscht, kann es nicht wiederhergestellt werden. \nBitte gehen Sie vorsichtig vor.",
+    "Deployment": "Bereitstellung",
+    "DeploymentModels": "Modelle von {{name}}",
     "DropFileHere": "Datei hier ablegen",
     "History": "Geschichte",
     "NewChat": "Neuer Chat",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Chatten Sie mit dem LLM-Modell, das in Ihrer Bereitstellung definiert ist, über eine OpenAI-kompatible API.",
+      "Title": "Chatten Sie mit Ihren bereitgestellten Modellen"
     }
   },
   "credential": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Καθαρή συνομιλία",
     "DeleteChattingSession": "Διαγραφή συνομιλίας",
     "DeleteChattingSessionDescription": "Πρόκειται να διαγράψετε αυτό το θέμα. \nΑφού διαγραφεί, δεν μπορεί να ανακτηθεί. \nΠαρακαλούμε προχωρήστε με προσοχή.",
+    "Deployment": "Ανάπτυξη",
+    "DeploymentModels": "Μοντέλα του {{name}}",
     "DropFileHere": "Αποθέστε το αρχείο εδώ",
     "History": "Ιστορία",
     "NewChat": "Νέα συνομιλία",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Συνομιλήστε με το μοντέλο LLM που ορίζεται στην Ανάπτυξή σας μέσω API συμβατού με OpenAI.",
+      "Title": "Συνομιλήστε με τα αναπτυγμένα μοντέλα σας"
     }
   },
   "credential": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -432,6 +432,8 @@
     "DeleteChatHistory": "Clear Chat",
     "DeleteChattingSession": "Delete Chat",
     "DeleteChattingSessionDescription": "You are about to delete this topic. Once deleted, it cannot be recovered. Please proceed with caution.",
+    "Deployment": "Deployment",
+    "DeploymentModels": "{{name}}'s Models",
     "DropFileHere": "Drop file here",
     "History": "History",
     "NewChat": "New Chat",
@@ -463,6 +465,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Chat with the LLM model defined in your deployment through an OpenAI-compatible API.",
+      "Title": "Chat with your deployed models"
     }
   },
   "credential": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Chat claro",
     "DeleteChattingSession": "Borrar chat",
     "DeleteChattingSessionDescription": "Estás a punto de eliminar este tema. \nUna vez eliminado, no se puede recuperar. \nProceda con precaución.",
+    "Deployment": "Despliegue",
+    "DeploymentModels": "Modelos de {{name}}",
     "DropFileHere": "Suelta el archivo aquí",
     "History": "Historia",
     "NewChat": "Nuevo chat",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Chatea con el modelo LLM definido en tu Despliegue a través de una API compatible con OpenAI.",
+      "Title": "Chatea con tus modelos desplegados"
     }
   },
   "credential": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Selkeä keskustelu",
     "DeleteChattingSession": "Poista keskustelu",
     "DeleteChattingSessionDescription": "Olet poistamassa tätä aihetta. \nKun se on poistettu, sitä ei voi palauttaa. \nOle hyvä ja jatka varoen.",
+    "Deployment": "Käyttöönotto",
+    "DeploymentModels": "{{name}}:n mallit",
     "DropFileHere": "Pudota tiedosto tähän",
     "History": "Historia",
     "NewChat": "Uusi keskustelu",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Keskustele Käyttöönotossasi määritellyn LLM-mallin kanssa OpenAI-yhteensopivan API:n kautta.",
+      "Title": "Keskustele käyttöönotetuilla malleillasi"
     }
   },
   "credential": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Chat clair",
     "DeleteChattingSession": "Supprimer le chat",
     "DeleteChattingSessionDescription": "Vous êtes sur le point de supprimer ce sujet. \nUne fois supprimé, il ne peut pas être récupéré. \nVeuillez procéder avec prudence.",
+    "Deployment": "Déploiement",
+    "DeploymentModels": "Modèles de {{name}}",
     "DropFileHere": "Déposez le fichier ici",
     "History": "L'histoire",
     "NewChat": "Nouvelle discussion",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Discutez avec le modèle LLM défini dans votre Déploiement via une API compatible OpenAI.",
+      "Title": "Discutez avec vos modèles déployés"
     }
   },
   "credential": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Hapus Obrolan",
     "DeleteChattingSession": "Menghapus Obrolan",
     "DeleteChattingSessionDescription": "Anda akan menghapus topik ini. \nSetelah dihapus, itu tidak dapat dipulihkan. \nSilakan lanjutkan dengan hati-hati.",
+    "Deployment": "Deployment",
+    "DeploymentModels": "Model dari {{name}}",
     "DropFileHere": "Letakkan file di sini",
     "History": "Sejarah",
     "NewChat": "Obrolan Baru",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Ngobrol dengan model LLM yang ditentukan dalam Deployment Anda melalui API yang kompatibel dengan OpenAI.",
+      "Title": "Ngobrol dengan model yang telah Anda deploy"
     }
   },
   "credential": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Chat chiara",
     "DeleteChattingSession": "Cancellare la chat",
     "DeleteChattingSessionDescription": "Stai per eliminare questo argomento. \nUna volta eliminato, non può essere recuperato. \nSi prega di procedere con cautela.",
+    "Deployment": "Distribuzione",
+    "DeploymentModels": "Modelli di {{name}}",
     "DropFileHere": "Rilascia il file qui",
     "History": "La storia",
     "NewChat": "Nuova chiacchierata",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Chatta con il modello LLM definito nella tua Distribuzione tramite un'API compatibile con OpenAI.",
+      "Title": "Chatta con i tuoi modelli distribuiti"
     }
   },
   "credential": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "クリア・チャット",
     "DeleteChattingSession": "チャット削除",
     "DeleteChattingSessionDescription": "このトピックを削除しようとしています。\n一度削除すると復元することはできません。\n慎重に進めてください。",
+    "Deployment": "デプロイ",
+    "DeploymentModels": "{{name}}のモデル",
     "DropFileHere": "ここにファイルをドロップします",
     "History": "歴史",
     "NewChat": "新しいチャット",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "デプロイに定義されたLLMモデルと、OpenAI互換APIを通じてチャットできます。",
+      "Title": "デプロイしたモデルとチャットする"
     }
   },
   "credential": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -445,6 +445,8 @@
     "DeleteChatHistory": "채팅 지우기",
     "DeleteChattingSession": "채팅 삭제",
     "DeleteChattingSessionDescription": "이 주제를 삭제하려고 합니다. \n삭제한 후에는 복구할 수 없습니다. \n주의해서 진행하시기 바랍니다.",
+    "Deployment": "배포",
+    "DeploymentModels": "{{name}}의 모델",
     "DropFileHere": "파일을 여기에 놓아주세요.",
     "History": "히스토리",
     "NewChat": "새 채팅",
@@ -476,6 +478,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "배포에 정의된 LLM 모델과 OpenAI 호환 API로 대화할 수 있습니다.",
+      "Title": "배포한 모델과 대화하기"
     }
   },
   "credential": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Цэвэр яриа",
     "DeleteChattingSession": "Унцыг устгана уу",
     "DeleteChattingSessionDescription": "Та энэ сэдвийг устгах гэж байна. \nУстгасны дараа сэргээх боломжгүй. \nБолгоомжтой үргэлжлүүлнэ үү.",
+    "Deployment": "Байршуулалт",
+    "DeploymentModels": "{{name}}-ын загварууд",
     "DropFileHere": "Файлыг энд буулгана уу",
     "History": "Түүх",
     "NewChat": "Шинэ чат",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Байршуулалтдаа тодорхойлсон LLM загвартай OpenAI-тай нийцтэй API-аар дамжуулан чатлаарай.",
+      "Title": "Байршуулсан загваруудтайгаа чатлах"
     }
   },
   "credential": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Sembang jelas",
     "DeleteChattingSession": "Padam sembang",
     "DeleteChattingSessionDescription": "Anda akan memadamkan topik ini. \nSetelah dipadam, ia tidak boleh dipulihkan. \nSila teruskan dengan berhati-hati.",
+    "Deployment": "Penggunaan",
+    "DeploymentModels": "Model {{name}}",
     "DropFileHere": "Lepaskan fail di sini",
     "History": "Sejarah",
     "NewChat": "Sembang Baharu",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Berbual dengan model LLM yang ditakrifkan dalam Penggunaan anda melalui API yang serasi dengan OpenAI.",
+      "Title": "Berbual dengan model yang telah anda gunakan"
     }
   },
   "credential": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Przejrzysty czat",
     "DeleteChattingSession": "Usuń czat",
     "DeleteChattingSessionDescription": "Zamierzasz usunąć ten temat. \nRaz usuniętego nie można odzyskać. \nProszę postępować ostrożnie.",
+    "Deployment": "Wdrożenie",
+    "DeploymentModels": "Modele użytkownika {{name}}",
     "DropFileHere": "Upuść plik tutaj",
     "History": "Historia",
     "NewChat": "Nowy czat",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Czatuj z modelem LLM zdefiniowanym w swoim Wdrożeniu przez API zgodne z OpenAI.",
+      "Title": "Czatuj z wdrożonymi modelami"
     }
   },
   "credential": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Conversa clara",
     "DeleteChattingSession": "Eliminar Chat",
     "DeleteChattingSessionDescription": "Você está prestes a excluir este tópico. \nUma vez excluído, ele não pode ser recuperado. \nPor favor, proceda com cautela.",
+    "Deployment": "Implantação",
+    "DeploymentModels": "Modelos de {{name}}",
     "DropFileHere": "Solte o arquivo aqui",
     "History": "História",
     "NewChat": "Novo chat",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Converse com o modelo LLM definido na sua Implantação por meio de uma API compatível com OpenAI.",
+      "Title": "Converse com seus modelos implantados"
     }
   },
   "credential": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Conversa clara",
     "DeleteChattingSession": "Eliminar Chat",
     "DeleteChattingSessionDescription": "Você está prestes a excluir este tópico. \nUma vez excluído, ele não pode ser recuperado. \nPor favor, proceda com cautela.",
+    "Deployment": "Implementação",
+    "DeploymentModels": "Modelos de {{name}}",
     "DropFileHere": "Solte o arquivo aqui",
     "History": "História",
     "NewChat": "Novo chat",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Converse com o modelo LLM definido na sua Implementação através de uma API compatível com OpenAI.",
+      "Title": "Converse com os seus modelos implementados"
     }
   },
   "credential": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Четкий чат",
     "DeleteChattingSession": "Удалить чат",
     "DeleteChattingSessionDescription": "Вы собираетесь удалить эту тему. \nПосле удаления его невозможно восстановить. \nПожалуйста, действуйте осторожно.",
+    "Deployment": "Развёртывание",
+    "DeploymentModels": "Модели {{name}}",
     "DropFileHere": "Перетащите файл сюда",
     "History": "История",
     "NewChat": "Новый чат",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Общайтесь с LLM-моделью, определённой в вашем Развёртывании, через API, совместимый с OpenAI.",
+      "Title": "Общайтесь с вашими развёрнутыми моделями"
     }
   },
   "credential": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "เคลียร์แชท",
     "DeleteChattingSession": "ลบแชท",
     "DeleteChattingSessionDescription": "คุณกำลังจะลบหัวข้อนี้ เมื่อลบแล้วจะไม่สามารถกู้คืนได้ กรุณาดำเนินการด้วยความระมัดระวัง",
+    "Deployment": "การปรับใช้",
+    "DeploymentModels": "โมเดลของ {{name}}",
     "DropFileHere": "วางไฟล์ที่นี่",
     "History": "ประวัติศาสตร์",
     "NewChat": "แชทใหม่",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "แชทกับโมเดล LLM ที่กำหนดไว้ในการปรับใช้ของคุณผ่าน API ที่เข้ากันได้กับ OpenAI",
+      "Title": "แชทกับโมเดลที่ปรับใช้ของคุณ"
     }
   },
   "credential": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Açık Sohbet",
     "DeleteChattingSession": "Sohbeti Sil",
     "DeleteChattingSessionDescription": "Bu konuyu silmek üzeresiniz. \nBir kere silindikten sonra geri getirilemez. \nLütfen dikkatli bir şekilde ilerleyin.",
+    "Deployment": "Dağıtım",
+    "DeploymentModels": "{{name}}'nin Modelleri",
     "DropFileHere": "Dosyayı buraya bırakın",
     "History": "Tarih",
     "NewChat": "Yeni sohbet",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Dağıtımınızda tanımlanan LLM modeliyle OpenAI uyumlu API aracılığıyla sohbet edin.",
+      "Title": "Dağıtılan modellerinizle sohbet edin"
     }
   },
   "credential": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "Trò chuyện rõ ràng",
     "DeleteChattingSession": "Xóa trò chuyện",
     "DeleteChattingSessionDescription": "Bạn sắp xóa chủ đề này. \nMột khi đã xóa, nó không thể được phục hồi. \nHãy tiến hành thận trọng.",
+    "Deployment": "Triển khai",
+    "DeploymentModels": "Các mô hình của {{name}}",
     "DropFileHere": "Thả tập tin ở đây",
     "History": "Lịch sử",
     "NewChat": "Cuộc trò truyện mới",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "Trò chuyện với mô hình LLM được định nghĩa trong Triển khai của bạn qua API tương thích OpenAI.",
+      "Title": "Trò chuyện với các mô hình đã triển khai của bạn"
     }
   },
   "credential": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "清晰聊天",
     "DeleteChattingSession": "删除聊天",
     "DeleteChattingSessionDescription": "您即将删除该主题。\n一旦删除，就无法恢复。\n请谨慎行事。",
+    "Deployment": "部署",
+    "DeploymentModels": "{{name}}的模型",
     "DropFileHere": "将文件拖放到此处",
     "History": "历史",
     "NewChat": "新聊天",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "通过兼容 OpenAI 的 API，与您的部署中定义的 LLM 模型对话。",
+      "Title": "与您已部署的模型对话"
     }
   },
   "credential": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -443,6 +443,8 @@
     "DeleteChatHistory": "清晰聊天",
     "DeleteChattingSession": "删除聊天",
     "DeleteChattingSessionDescription": "您即將刪除該主題。\n一旦刪除，就無法恢復。\n請謹慎行事。",
+    "Deployment": "部署",
+    "DeploymentModels": "{{name}}的模型",
     "DropFileHere": "將文件拖放到此處",
     "History": "历史",
     "NewChat": "新聊天",
@@ -474,6 +476,10 @@
           "TopP": "Top P"
         }
       }
+    },
+    "intro": {
+      "Description": "透過相容 OpenAI 的 API，與您的部署中定義的 LLM 模型對話。",
+      "Title": "與您已部署的模型對話"
     }
   },
   "credential": {


### PR DESCRIPTION
Resolves #7897 (FR-3137)
please test with dogbowl.

## Summary

Multiple users reported confusion about the **deployment selector** and **model selector** on the Chat page — what each controls and how they relate. This PR makes both selectors self-explanatory and adds an intro banner describing the feature.

![CleanShot 2026-06-15 at 16.18.32@2x.png](https://app.graphite.com/user-attachments/assets/077091e1-899d-4871-b236-9306a4207265.png)

## Changes

1. **Deployment selector** (`EndpointSelect.tsx`)
   - Adds a deployment icon (`BAIEndpointsIcon`) as the select `prefix`.
   - Adds a **"Deployment"** header inside the dropdown.

2. **Model selector** (`ModelSelect.tsx` / `ChatHeader.tsx`)
   - Adds a **"{deployment name}'s Models"** header inside the dropdown, making the dependency on the selected deployment explicit. The `ChatHeader_Endpoint` fragment now also reads `name`.

3. **Intro Info Alert** (`ChatPage.tsx`)
   - A dismissible `info` Alert between the Chat title and the chat card: *"This chat loads the LLM model defined in a deployment you created on the Deployments page and lets you talk to it through an OpenAI-compatible API."*
   - Dismissal persists via `useBAISettingUserState('chat_intro_alert_dismissed')` (localStorage), so it won't reappear after being closed.

4. **Shared component** (`BAISelect.tsx`)
   - New backward-compatible optional `header` prop that renders a labeled header at the top of the dropdown (composes with the existing `footer`). No behavior change for existing call sites.

5. **i18n**
   - New keys `chatui.Deployment`, `chatui.DeploymentModels`, `chatui.intro.Title`, `chatui.intro.Description` authored in `en`/`ko` and translated across all 21 languages.

## Notes

- `closable={{ closeIcon: true, onClose }}` is required on the antd v6 `Alert` — with the object form, the close button only renders when `closeIcon` is truthy (caught during local testing; the X was missing without it).

## Verification

`bash scripts/verify.sh`: **Lint PASS, Format PASS, TypeScript PASS**, Relay artifacts in sync (regenerated for the `name` fragment field). The "Vite warmup paths" check fails on clean `main` too (pre-existing, unrelated to this change). i18n eslint + prettier pass on all touched locale files.

## Test plan

- [ ] Open the Chat page → the intro Alert is visible; close it → it stays closed after reload.
- [ ] Open the deployment selector → icon prefix shown, dropdown shows the "Deployment" header.
- [ ] Select a deployment, open the model selector → dropdown header reads "<deployment>'s Models".