### PR TITLE
fix(FR-3143): disable chat input when endpoint models fail to load

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -146,6 +146,9 @@ function useModels(
               name: model.id,
             }))
           : [],
+        // Preserve the error code so consumers (modelsError below) can detect
+        // a failed `/models` fetch; otherwise it is dropped by this select.
+        error: res.error,
       };
     },
   });
@@ -549,7 +552,7 @@ const PureChatCard: React.FC<ChatCardProps> = ({
         endTime={endTime}
       />
       <ChatInput
-        disabled={!baseURL}
+        disabled={!baseURL || !!modelsError}
         sync={chat.sync}
         input={input}
         setInput={setInput}


### PR DESCRIPTION
Resolves #7907 (FR-3143)

## Summary
- Disable the chat input area and send button when the selected Endpoint (Deployment) models fail to load.
- `ChatCard.tsx` now passes `disabled={!baseURL || !!modelsError}` to `ChatInput`, which forwards `disabled` through `ChatSender` to the `@ant-design/x` `Sender` (disables both the textarea and the send button).
- `modelsError` is set by `useModels` whenever the `/models` request returns an error (HTTP 401/404/500/503) or a network error, so the input is blocked exactly when there is no usable model.
- Existing behavior preserved: input is still disabled when there is no valid base URL, and the custom model form continues to allow recovery (base path / token retry).

## Test plan
- [ ] Open chat with an Endpoint whose `/models` fails (e.g. unauthorized token or unreachable endpoint) → input box and send button are disabled.
- [ ] Open chat with a healthy Endpoint that returns models → input box and send button are enabled and messages can be sent.
- [ ] Endpoint with no base URL → input remains disabled (unchanged).