### PR TITLE
fix(FR-3138): isolate user-profile e2e on a disposable account with guaranteed API cleanup

### DIFF
--- a/e2e/user-profile/user-profile.spec.ts
+++ b/e2e/user-profile/user-profile.spec.ts
@@ -1,19 +1,94 @@
 // spec: e2e/.agent-output/test-plan-user-profile-allowed-client-ip.md
-import { loginAsAdmin } from '../utils/test-util';
+import {
+  createAdminApiContext,
+  purgeUserViaApi,
+  sweepProfileTestUsersViaApi,
+} from '../utils/admin-api';
+import { loginAsAdmin, loginAsCreatedAccount } from '../utils/test-util';
 import {
   openProfileModal,
   getCurrentClientIp,
   getAllowedClientIpFormItem,
   addIpTags,
   removeAllIpTags,
+  createDisposableUser,
 } from '../utils/user-profile-util';
 import test, { expect } from '@playwright/test';
+
+// These tests edit the logged-in account's own profile — full name, password,
+// and the **Allowed Client IP** allowlist. Running them as the shared
+// `admin@lablup.com` account is dangerous: an interrupted run can leave admin
+// IP-restricted and lock everyone out of the shared backend (FR-3138).
+//
+// Instead we create a single disposable user for the whole file, run every
+// profile test as that user, and purge it in an `afterAll` that runs even when
+// a test fails — so no shared account is ever mutated and nothing is left
+// behind.
+const TEST_RUN_ID = Date.now().toString(36);
+const EMAIL = `e2e-profile-${TEST_RUN_ID}@lablup.com`;
+const USERNAME = `e2e-profile-${TEST_RUN_ID}`;
+const PASSWORD = 'testing@123';
 
 test.describe(
   'User Profile Setting Modal',
   { tag: ['@functional', '@regression', '@user-profile'] },
   () => {
     test.describe.configure({ mode: 'serial' });
+
+    test.beforeAll(async ({ browser }) => {
+      // The UI account-creation flow drives several full page navigations
+      // against a possibly-remote backend, which can outlast the default
+      // per-test timeout. Give the hook its own generous budget.
+      test.setTimeout(300_000);
+
+      // Catch-all: purge any disposable user leaked by a previously
+      // hard-killed run (where afterAll could not fire) before creating ours.
+      // Done over the admin GraphQL API — the credential UI is paginated
+      // (100 rows/page) and silently misses off-page leftovers, which is the
+      // bug that motivated FR-3138. The API user list is pagination-immune.
+      const api = await createAdminApiContext();
+      try {
+        await sweepProfileTestUsersViaApi(api);
+      } finally {
+        await api.dispose();
+      }
+
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      try {
+        await loginAsAdmin(adminPage, adminContext.request);
+        await createDisposableUser(adminPage, EMAIL, USERNAME, PASSWORD);
+      } finally {
+        await adminContext.close();
+      }
+    });
+
+    test.afterAll(async () => {
+      // Guaranteed teardown: purge the disposable user over the admin GraphQL
+      // API, then sweep anything else matching the pattern. The API path is
+      // fast, deterministic, and pagination-immune, so the created account is
+      // always removed regardless of how the tests above ended (FR-3138).
+      //
+      // Teardown must never mask the real test result: a transient
+      // GraphQL/network error here (or in the admin login) is logged and
+      // swallowed instead of being allowed to fail an otherwise-green spec.
+      // The next run's beforeAll sweep is the safety net for anything left.
+      try {
+        const api = await createAdminApiContext();
+        try {
+          await purgeUserViaApi(api, EMAIL);
+          await sweepProfileTestUsersViaApi(api);
+        } finally {
+          await api.dispose();
+        }
+      } catch (e) {
+        console.warn(
+          `Profile-test teardown failed (non-fatal; next run's sweep will reclaim): ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+      }
+    });
 
     // =========================================================================
     // Allowed Client IP
@@ -23,7 +98,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -46,7 +121,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
@@ -74,7 +149,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
@@ -101,7 +176,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
@@ -124,7 +199,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
@@ -160,7 +235,7 @@ test.describe(
       });
 
       test('User can remove an IP tag', async ({ page, request }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
@@ -186,7 +261,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -208,7 +283,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -238,7 +313,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -271,7 +346,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -315,7 +390,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -360,7 +435,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -421,7 +496,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -436,7 +511,7 @@ test.describe(
       });
 
       test('Weak password is rejected', async ({ page, request }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -451,7 +526,7 @@ test.describe(
       });
 
       test('Mismatch passwords are rejected', async ({ page, request }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -472,7 +547,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -497,7 +572,7 @@ test.describe(
         page,
         request,
       }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');
@@ -510,7 +585,7 @@ test.describe(
       });
 
       test('Modal cancel does not save changes', async ({ page, request }) => {
-        await loginAsAdmin(page, request);
+        await loginAsCreatedAccount(page, request, EMAIL, PASSWORD);
         await openProfileModal(page);
 
         const modal = page.locator('.ant-modal');

--- a/e2e/utils/admin-api.ts
+++ b/e2e/utils/admin-api.ts
@@ -1,0 +1,161 @@
+import { userInfo, webServerEndpoint } from './test-util';
+import { request, type APIRequestContext } from '@playwright/test';
+
+/**
+ * Admin-side GraphQL helpers used by E2E scaffolding (setup/teardown).
+ *
+ * These talk to the manager directly over HTTP instead of driving the
+ * credential UI. The credential table is paginated (100 rows/page), so any
+ * UI-based "find this user and delete it" loop silently misses off-page rows
+ * and can hang. The admin GraphQL `users` query returns the *full* user list
+ * regardless of pagination, which makes cleanup deterministic and
+ * pagination-immune — a hard requirement for guaranteed teardown. See FR-3138.
+ */
+
+/**
+ * Creates an authenticated admin `APIRequestContext`.
+ *
+ * Logs in via `/server/login` (plain JSON — the browser-side AES payload
+ * encryption is optional and not required for the server session) so the
+ * returned context carries the manager session cookie for subsequent
+ * `/func/admin/gql` calls. The caller owns the context and must `dispose()` it.
+ */
+export async function createAdminApiContext(): Promise<APIRequestContext> {
+  const api = await request.newContext({ baseURL: webServerEndpoint });
+  const res = await api.post('/server/login', {
+    data: {
+      username: userInfo.admin.email,
+      password: userInfo.admin.password,
+    },
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok() || !body?.authenticated) {
+    await api.dispose();
+    // Only surface a minimal, known-safe subset of the response — never dump
+    // the full login body into CI logs (it may gain sensitive fields later).
+    throw new Error(
+      `Admin API login failed (status=${res.status()}, authenticated=${String(
+        body?.authenticated ?? false,
+      )})`,
+    );
+  }
+  return api;
+}
+
+/**
+ * Runs an admin GraphQL operation and returns its `data`. Throws on transport
+ * errors or GraphQL `errors`, so callers can decide whether to swallow them.
+ */
+async function gqlAdmin<T = any>(
+  api: APIRequestContext,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const res = await api.post('/func/admin/gql', {
+    data: { query, variables },
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok() || json?.errors) {
+    throw new Error(
+      `GraphQL error (${res.status()}): ${JSON.stringify(json?.errors ?? json).slice(0, 300)}`,
+    );
+  }
+  return json.data as T;
+}
+
+/**
+ * Lists every user whose email matches `pattern`, across all statuses
+ * (`is_active: null` returns active + inactive). Pagination-immune.
+ */
+export async function listUsersByPattern(
+  api: APIRequestContext,
+  pattern: RegExp,
+): Promise<Array<{ email: string }>> {
+  const data = await gqlAdmin<{ users: Array<{ email: string }> }>(
+    api,
+    `query { users(is_active: null) { email } }`,
+  );
+  return (data.users ?? []).filter((u) => pattern.test(u.email));
+}
+
+/**
+ * Permanently removes a single user by email: deactivate, then purge (with
+ * shared vfolders). Deactivating first keeps purge well-defined regardless of
+ * the user's current status. Defensive — a missing/already-gone user does not
+ * throw, so teardown never masks the real test result. See FR-3138.
+ *
+ * @returns `true` if the purge mutation reported `ok`, `false` if the user did
+ * not exist or the server rejected the purge (`ok: false`). A rejected purge is
+ * surfaced via `console.warn` rather than thrown, so teardown never masks the
+ * real test result while still making a silent cleanup failure visible.
+ */
+export async function purgeUserViaApi(
+  api: APIRequestContext,
+  email: string,
+): Promise<boolean> {
+  const existing = await listUsersByPattern(
+    api,
+    new RegExp(`^${email.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i'),
+  );
+  if (existing.length === 0) return false;
+
+  // Deactivate first so purge is well-defined irrespective of current status.
+  await gqlAdmin(
+    api,
+    `mutation($email: String!, $props: ModifyUserInput!) {
+      modify_user(email: $email, props: $props) { ok msg }
+    }`,
+    { email, props: { status: 'inactive' } },
+  ).catch(() => {
+    /* already inactive or transient — purge below still applies */
+  });
+
+  const result = await gqlAdmin<{
+    purge_user?: { ok?: boolean; msg?: string };
+  }>(
+    api,
+    `mutation($email: String!, $props: PurgeUserInput!) {
+      purge_user(email: $email, props: $props) { ok msg }
+    }`,
+    { email, props: { purge_shared_vfolders: true } },
+  );
+
+  // The mutation can return HTTP 200 with `ok: false` (permission/validation
+  // failure). Treat that as an unsuccessful purge instead of reporting success.
+  const ok = result?.purge_user?.ok === true;
+  if (!ok) {
+    console.warn(
+      `purge_user did not succeed for ${email}: ${
+        result?.purge_user?.msg ?? 'unknown reason'
+      }`,
+    );
+  }
+  return ok;
+}
+
+/**
+ * Sweep-purges every disposable profile-test user whose email matches
+ * `pattern`. Used both as a `beforeAll` catch-all (so a previous hard-killed
+ * run cannot leak its `e2e-profile-<id>@lablup.com` account) and as an
+ * `afterAll` belt-and-suspenders. Returns the number of accounts purged.
+ *
+ * Because the admin `users` query is not paginated, this finds *every* match
+ * on the deployment regardless of how many users exist — the UI-pagination
+ * blind spot that motivated FR-3138 cannot occur here.
+ */
+export async function sweepProfileTestUsersViaApi(
+  api: APIRequestContext,
+  pattern: RegExp = /^e2e-profile-[a-z0-9]+@lablup\.com$/i,
+): Promise<number> {
+  const matches = await listUsersByPattern(api, pattern);
+  let purged = 0;
+  for (const { email } of matches) {
+    if (await purgeUserViaApi(api, email)) purged++;
+  }
+  if (purged > 0) {
+    console.log(
+      `Swept ${purged} stale profile-test user(s) matching ${pattern}`,
+    );
+  }
+  return purged;
+}

--- a/e2e/utils/user-profile-util.ts
+++ b/e2e/utils/user-profile-util.ts
@@ -1,4 +1,9 @@
-import type { Page, Locator } from '@playwright/test';
+import {
+  KeyPairModal,
+  UserSettingModal,
+} from './classes/user/UserSettingModal';
+import { navigateTo } from './test-util';
+import { expect, type Page, type Locator } from '@playwright/test';
 
 /**
  * Map of action titles to their Ant Design / Lucide icon selectors.
@@ -112,6 +117,37 @@ export async function removeAllIpTags(container: Locator) {
   }
   // Press Tab to blur the combobox without closing the modal (Escape would close it)
   await selectInput.press('Tab');
+}
+
+/**
+ * Creates a fresh, disposable user through the admin credential UI.
+ *
+ * Used so profile-editing / allowed-client-IP tests never mutate a shared
+ * account (e.g. `admin@lablup.com`). The caller must be logged in as an admin
+ * on `adminPage` before invoking this. See FR-3138.
+ */
+export async function createDisposableUser(
+  adminPage: Page,
+  email: string,
+  username: string,
+  password: string,
+): Promise<void> {
+  await navigateTo(adminPage, 'credential');
+  await expect(adminPage.getByRole('tab', { name: 'Users' })).toBeVisible();
+
+  await adminPage.getByRole('button', { name: 'Create User' }).click();
+  const userSettingModal = UserSettingModal.forCreate(adminPage);
+  await userSettingModal.createUser(email, username, password);
+
+  // A key pair is generated on creation — acknowledge and close the modal.
+  const keyPairModal = new KeyPairModal(adminPage);
+  await keyPairModal.waitForVisible();
+  await keyPairModal.close();
+  await userSettingModal.waitForHidden();
+
+  await expect(adminPage.getByRole('cell', { name: email })).toBeVisible({
+    timeout: 10000,
+  });
 }
 
 /**


### PR DESCRIPTION
Resolves #7898 (FR-3138)

## Problem

`e2e/user-profile/user-profile.spec.ts` mutated the **shared** `admin@lablup.com`
"Allowed Client IP" allowlist and relied on an in-body revert to restore it. If a
test was interrupted (hard kill, crash, timeout) after setting a restrictive IP but
before the revert ran, the admin account could be locked out of the deployment —
a destructive side effect on a shared, production-like account.

## Fix

Isolate every profile test on a **disposable per-run account** instead of touching
the shared admin, with cleanup that is guaranteed even on hard-kill.

- **Disposable account per run.** `beforeAll` creates `e2e-profile-<runId>@lablup.com`
  (unique per run via `Date.now().toString(36)`) through the admin credential UI.
  All 18 tests log in as this account, so the shared admin allowlist is never mutated.

- **Guaranteed, pagination-immune cleanup** (`e2e/utils/admin-api.ts`, new).
  Teardown talks to the manager GraphQL directly (`/func/admin/gql`) rather than
  driving the credential UI. The UI table is paginated (100 rows/page), so a
  UI-based "find and delete this user" loop silently misses off-page rows and can
  hang. The admin `users(is_active: null)` query returns the **full** user list
  regardless of pagination, making teardown deterministic.
  - `afterAll` purges the run's account (deactivate → `purge_user` with
    `purge_shared_vfolders: true`).
  - **Belt-and-suspenders sweep**: both `beforeAll` and `afterAll` sweep every
    `e2e-profile-<id>@lablup.com` match, so a previously hard-killed run can never
    leak a leftover account — the next run cleans it up before starting.
  - Purge is defensive: a missing/already-gone user does not throw, so teardown
    never masks the real test result.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript).
- All 18 tests pass against `https://webui-nightly.lablup.ai/` (manager
  `http://10.82.1.100:8090`); zero leaked accounts confirmed after the run.

## Files

- `e2e/utils/admin-api.ts` (new) — API-based admin login + user purge/sweep helpers.
- `e2e/user-profile/user-profile.spec.ts` — disposable-account setup/teardown,
  all tests log in as the created account.
- `e2e/utils/user-profile-util.ts` — `createDisposableUser` helper; removed dead
  UI-based purge/sweep code superseded by the API helpers.
