### PR TITLE
fix(FR-3144): guard AdminModelCardSettingModal when Model Store project is missing

### DIFF
--- a/react/src/components/AdminModelCardSettingModal.tsx
+++ b/react/src/components/AdminModelCardSettingModal.tsx
@@ -14,6 +14,7 @@ import FolderCreateModalV2 from './FolderCreateModalV2';
 import FolderLink from './FolderLink';
 import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
 import {
+  Alert,
   App,
   Form,
   type FormInstance,
@@ -283,6 +284,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
   return (
     <>
       <BAIModal
+        {...modalProps}
         title={
           isEditMode
             ? t('adminModelCard.EditModelCard')
@@ -292,254 +294,271 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
           onRequestClose?.(false);
         }}
         okText={isEditMode ? t('button.Update') : t('button.Create')}
-        okButtonProps={{
-          loading: isCreateInFlight || isUpdateInFlight,
-        }}
         onOk={handleOk}
-        {...modalProps}
+        okButtonProps={{
+          ...modalProps.okButtonProps,
+          loading: isCreateInFlight || isUpdateInFlight,
+          disabled:
+            !modelStoreProject?.id || modalProps.okButtonProps?.disabled,
+        }}
       >
-        <Form ref={formRef} layout="vertical" initialValues={initialValues}>
-          <Form.Item
-            name="name"
-            label={t('adminModelCard.Name')}
-            tooltip={t('adminModelCard.NameTooltip')}
-            rules={[
-              {
-                required: true,
-                message: t('adminModelCard.NameRequired'),
-              },
-            ]}
-          >
-            <Input />
-          </Form.Item>
-
-          {isEditMode ? (
-            <Form.Item label={t('adminModelCard.ModelStorageFolder')}>
-              <BAIFlex gap="xs" align="center">
-                {modelCard.vfolder && (
-                  <VFolderNodeIdenticonV2
-                    vfolderNodeIdenticonFrgmt={modelCard.vfolder}
-                  />
-                )}
-                <FolderLink
-                  folderId={modelCard.vfolderId}
-                  folderName={
-                    modelCard.vfolder?.metadata?.name ?? modelCard.vfolderId
-                  }
-                />
-              </BAIFlex>
-            </Form.Item>
-          ) : (
-            <Form.Item label={t('adminModelCard.ModelStorageFolder')} required>
-              <BAIFlex gap="xs" align="center">
-                <Suspense fallback={<Input disabled style={{ flex: 1 }} />}>
-                  <Form.Item
-                    name="vfolderId"
-                    noStyle
-                    rules={[
-                      {
-                        required: true,
-                        message: t('adminModelCard.VFolderRequired'),
-                      },
-                    ]}
-                  >
-                    <BAIVFolderSelect
-                      ref={vfolderSelectRef}
-                      excludeDeleted
-                      filter='ownership_type == "group"'
-                      currentProjectId={modelStoreProject?.id ?? undefined}
-                      style={{ flex: 1 }}
-                    />
-                  </Form.Item>
-                </Suspense>
-                {isModelStoreProject ? (
-                  <BAIButton
-                    icon={<PlusIcon />}
-                    onClick={() => setIsOpenCreateFolderModal(true)}
-                  />
-                ) : (
-                  <Popconfirm
-                    title={t(
-                      'importArtifactRevisionToFolderModal.ModelStoreProjectRequired',
-                    )}
-                    description={t(
-                      'importArtifactRevisionToFolderModal.ModelStoreProjectRequiredDescription',
-                    )}
-                    okText={t('button.ChangeProject')}
-                    cancelText={t('button.Cancel')}
-                    onConfirm={() => {
-                      if (modelStoreProject?.id && modelStoreProject?.name) {
-                        startTransition(() => {
-                          setCurrentProject({
-                            projectId: modelStoreProject.id!,
-                            projectName: modelStoreProject.name!,
-                          });
-                          message.success(
-                            t(
-                              'importArtifactRevisionToFolderModal.CurrentProjectChangedSuccessfully',
-                            ),
-                          );
-                          setIsOpenCreateFolderModal(true);
-                        });
-                      } else {
-                        message.error(
-                          t(
-                            'importArtifactRevisionToFolderModal.FailedToRetrieveModelStoreProject',
-                          ),
-                        );
-                      }
-                    }}
-                  >
-                    <BAIButton icon={<PlusIcon />} />
-                  </Popconfirm>
-                )}
-              </BAIFlex>
-            </Form.Item>
-          )}
-
-          {isEditMode ? (
-            <Form.Item label={t('adminModelCard.Domain')}>
-              <Typography.Text>{modelCard.domainName}</Typography.Text>
-            </Form.Item>
-          ) : (
-            <Suspense
-              fallback={
-                <Form.Item name="domainName" label={t('adminModelCard.Domain')}>
-                  <Input disabled />
-                </Form.Item>
-              }
-            >
-              <Form.Item name="domainName" label={t('adminModelCard.Domain')}>
-                <BAIDomainSelect />
-              </Form.Item>
-            </Suspense>
-          )}
-
-          <Form.Item
-            name="author"
-            label={t('adminModelCard.Author')}
-            tooltip={t('adminModelCard.AuthorTooltip')}
-          >
-            <Input />
-          </Form.Item>
-
-          <Form.Item
-            name="title"
-            label={t('adminModelCard.Title')}
-            tooltip={t('adminModelCard.TitleTooltip')}
-          >
-            <Input />
-          </Form.Item>
-
-          <Form.Item
-            name="modelVersion"
-            label={t('adminModelCard.ModelVersion')}
-            tooltip={t('adminModelCard.ModelVersionTooltip')}
-          >
-            <Input />
-          </Form.Item>
-
-          <Form.Item
-            name="description"
-            label={t('adminModelCard.Description')}
-            tooltip={t('adminModelCard.DescriptionTooltip')}
-          >
-            <Input.TextArea rows={3} />
-          </Form.Item>
-
-          <Form.Item
-            name="task"
-            label={t('adminModelCard.Task')}
-            tooltip={t('adminModelCard.TaskTooltip')}
-          >
-            <Input placeholder={t('adminModelCard.TaskPlaceholder')} />
-          </Form.Item>
-
-          <Form.Item
-            name="category"
-            label={t('adminModelCard.Category')}
-            tooltip={t('adminModelCard.CategoryTooltip')}
-          >
-            <Input placeholder={t('adminModelCard.CategoryPlaceholder')} />
-          </Form.Item>
-
-          <Form.Item
-            name="architecture"
-            label={t('adminModelCard.Architecture')}
-            tooltip={t('adminModelCard.ArchitectureTooltip')}
-          >
-            <Input />
-          </Form.Item>
-
-          <Form.Item
-            name="framework"
-            label={t('adminModelCard.Framework')}
-            tooltip={t('adminModelCard.FrameworkTooltip')}
-          >
-            {/* FR-3121: commit a framework on comma in addition to Enter. */}
-            <Select
-              mode="tags"
-              tokenSeparators={[',']}
-              placeholder={t('adminModelCard.AddFramework')}
-              notFoundContent={null}
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="label"
-            label={t('adminModelCard.Label')}
-            tooltip={t('adminModelCard.LabelTooltip')}
-          >
-            {/* FR-3121: commit a label on comma in addition to Enter. */}
-            <Select
-              mode="tags"
-              tokenSeparators={[',']}
-              placeholder={t('adminModelCard.AddLabel')}
-              notFoundContent={null}
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="license"
-            label={t('adminModelCard.License')}
-            tooltip={t('adminModelCard.LicenseTooltip')}
-          >
-            <Input />
-          </Form.Item>
-
-          <Form.Item
-            name="readme"
-            label={t('adminModelCard.Readme')}
-            tooltip={t('adminModelCard.ReadmeTooltip')}
-          >
-            <Input.TextArea rows={6} />
-          </Form.Item>
-
-          <Form.Item
-            name="accessLevel"
-            label={t('adminModelCard.AccessLevel')}
-            tooltip={t('adminModelCard.AccessLevelTooltip')}
-            rules={[
-              {
-                required: true,
-                message: t('adminModelCard.AccessLevelRequired'),
-              },
-            ]}
-          >
-            <Select
-              options={[
+        {!modelStoreProject?.id ? (
+          <Alert
+            type="error"
+            showIcon
+            title={t('modelStore.ProjectNotFound')}
+            description={t('modelStore.ProjectNotFoundDescription')}
+          />
+        ) : (
+          <Form ref={formRef} layout="vertical" initialValues={initialValues}>
+            <Form.Item
+              name="name"
+              label={t('adminModelCard.Name')}
+              tooltip={t('adminModelCard.NameTooltip')}
+              rules={[
                 {
-                  value: 'INTERNAL',
-                  label: t('adminModelCard.Private'),
-                },
-                {
-                  value: 'PUBLIC',
-                  label: t('adminModelCard.Public'),
+                  required: true,
+                  message: t('adminModelCard.NameRequired'),
                 },
               ]}
-            />
-          </Form.Item>
-        </Form>
+            >
+              <Input />
+            </Form.Item>
+
+            {isEditMode ? (
+              <Form.Item label={t('adminModelCard.ModelStorageFolder')}>
+                <BAIFlex gap="xs" align="center">
+                  {modelCard.vfolder && (
+                    <VFolderNodeIdenticonV2
+                      vfolderNodeIdenticonFrgmt={modelCard.vfolder}
+                    />
+                  )}
+                  <FolderLink
+                    folderId={modelCard.vfolderId}
+                    folderName={
+                      modelCard.vfolder?.metadata?.name ?? modelCard.vfolderId
+                    }
+                  />
+                </BAIFlex>
+              </Form.Item>
+            ) : (
+              <Form.Item
+                label={t('adminModelCard.ModelStorageFolder')}
+                required
+              >
+                <BAIFlex gap="xs" align="center">
+                  <Suspense fallback={<Input disabled style={{ flex: 1 }} />}>
+                    <Form.Item
+                      name="vfolderId"
+                      noStyle
+                      rules={[
+                        {
+                          required: true,
+                          message: t('adminModelCard.VFolderRequired'),
+                        },
+                      ]}
+                    >
+                      <BAIVFolderSelect
+                        ref={vfolderSelectRef}
+                        excludeDeleted
+                        filter='ownership_type == "group"'
+                        currentProjectId={modelStoreProject?.id ?? undefined}
+                        style={{ flex: 1 }}
+                      />
+                    </Form.Item>
+                  </Suspense>
+                  {isModelStoreProject ? (
+                    <BAIButton
+                      icon={<PlusIcon />}
+                      onClick={() => setIsOpenCreateFolderModal(true)}
+                    />
+                  ) : (
+                    <Popconfirm
+                      title={t(
+                        'importArtifactRevisionToFolderModal.ModelStoreProjectRequired',
+                      )}
+                      description={t(
+                        'importArtifactRevisionToFolderModal.ModelStoreProjectRequiredDescription',
+                      )}
+                      okText={t('button.ChangeProject')}
+                      cancelText={t('button.Cancel')}
+                      onConfirm={() => {
+                        if (modelStoreProject?.id && modelStoreProject?.name) {
+                          startTransition(() => {
+                            setCurrentProject({
+                              projectId: modelStoreProject.id!,
+                              projectName: modelStoreProject.name!,
+                            });
+                            message.success(
+                              t(
+                                'importArtifactRevisionToFolderModal.CurrentProjectChangedSuccessfully',
+                              ),
+                            );
+                            setIsOpenCreateFolderModal(true);
+                          });
+                        } else {
+                          message.error(
+                            t(
+                              'importArtifactRevisionToFolderModal.FailedToRetrieveModelStoreProject',
+                            ),
+                          );
+                        }
+                      }}
+                    >
+                      <BAIButton icon={<PlusIcon />} />
+                    </Popconfirm>
+                  )}
+                </BAIFlex>
+              </Form.Item>
+            )}
+
+            {isEditMode ? (
+              <Form.Item label={t('adminModelCard.Domain')}>
+                <Typography.Text>{modelCard.domainName}</Typography.Text>
+              </Form.Item>
+            ) : (
+              <Suspense
+                fallback={
+                  <Form.Item
+                    name="domainName"
+                    label={t('adminModelCard.Domain')}
+                  >
+                    <Input disabled />
+                  </Form.Item>
+                }
+              >
+                <Form.Item name="domainName" label={t('adminModelCard.Domain')}>
+                  <BAIDomainSelect />
+                </Form.Item>
+              </Suspense>
+            )}
+
+            <Form.Item
+              name="author"
+              label={t('adminModelCard.Author')}
+              tooltip={t('adminModelCard.AuthorTooltip')}
+            >
+              <Input />
+            </Form.Item>
+
+            <Form.Item
+              name="title"
+              label={t('adminModelCard.Title')}
+              tooltip={t('adminModelCard.TitleTooltip')}
+            >
+              <Input />
+            </Form.Item>
+
+            <Form.Item
+              name="modelVersion"
+              label={t('adminModelCard.ModelVersion')}
+              tooltip={t('adminModelCard.ModelVersionTooltip')}
+            >
+              <Input />
+            </Form.Item>
+
+            <Form.Item
+              name="description"
+              label={t('adminModelCard.Description')}
+              tooltip={t('adminModelCard.DescriptionTooltip')}
+            >
+              <Input.TextArea rows={3} />
+            </Form.Item>
+
+            <Form.Item
+              name="task"
+              label={t('adminModelCard.Task')}
+              tooltip={t('adminModelCard.TaskTooltip')}
+            >
+              <Input placeholder={t('adminModelCard.TaskPlaceholder')} />
+            </Form.Item>
+
+            <Form.Item
+              name="category"
+              label={t('adminModelCard.Category')}
+              tooltip={t('adminModelCard.CategoryTooltip')}
+            >
+              <Input placeholder={t('adminModelCard.CategoryPlaceholder')} />
+            </Form.Item>
+
+            <Form.Item
+              name="architecture"
+              label={t('adminModelCard.Architecture')}
+              tooltip={t('adminModelCard.ArchitectureTooltip')}
+            >
+              <Input />
+            </Form.Item>
+
+            <Form.Item
+              name="framework"
+              label={t('adminModelCard.Framework')}
+              tooltip={t('adminModelCard.FrameworkTooltip')}
+            >
+              {/* FR-3121: commit a framework on comma in addition to Enter. */}
+              <Select
+                mode="tags"
+                tokenSeparators={[',']}
+                placeholder={t('adminModelCard.AddFramework')}
+                notFoundContent={null}
+              />
+            </Form.Item>
+
+            <Form.Item
+              name="label"
+              label={t('adminModelCard.Label')}
+              tooltip={t('adminModelCard.LabelTooltip')}
+            >
+              {/* FR-3121: commit a label on comma in addition to Enter. */}
+              <Select
+                mode="tags"
+                tokenSeparators={[',']}
+                placeholder={t('adminModelCard.AddLabel')}
+                notFoundContent={null}
+              />
+            </Form.Item>
+
+            <Form.Item
+              name="license"
+              label={t('adminModelCard.License')}
+              tooltip={t('adminModelCard.LicenseTooltip')}
+            >
+              <Input />
+            </Form.Item>
+
+            <Form.Item
+              name="readme"
+              label={t('adminModelCard.Readme')}
+              tooltip={t('adminModelCard.ReadmeTooltip')}
+            >
+              <Input.TextArea rows={6} />
+            </Form.Item>
+
+            <Form.Item
+              name="accessLevel"
+              label={t('adminModelCard.AccessLevel')}
+              tooltip={t('adminModelCard.AccessLevelTooltip')}
+              rules={[
+                {
+                  required: true,
+                  message: t('adminModelCard.AccessLevelRequired'),
+                },
+              ]}
+            >
+              <Select
+                options={[
+                  {
+                    value: 'INTERNAL',
+                    label: t('adminModelCard.Private'),
+                  },
+                  {
+                    value: 'PUBLIC',
+                    label: t('adminModelCard.Public'),
+                  },
+                ]}
+              />
+            </Form.Item>
+          </Form>
+        )}
       </BAIModal>
       <FolderCreateModalV2
         open={isOpenCreateFolderModal}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2163,7 +2163,7 @@
     "Preset": "Voreinstellung",
     "PresetTooltip": "Ein Preset definiert die Ressourcenkonfiguration (CPU, Speicher, GPU), die zum Ausführen dieses Modells als Dienst verwendet wird.",
     "ProjectNotFound": "Modellspeicher-Projekt nicht gefunden",
-    "ProjectNotFoundDescription": "Das MODEL_STORE-Projekt konnte nicht gefunden werden. Bitte wenden Sie sich an Ihren Administrator.",
+    "ProjectNotFoundDescription": "Das Modellspeicher-Projekt konnte nicht gefunden werden. Bitte wenden Sie sich an Ihren Administrator.",
     "QuickDeployDetailed": "Konfigurieren und bereitstellen...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Ressourcengruppe",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2161,7 +2161,7 @@
     "Preset": "Προρύθμιση",
     "PresetTooltip": "Ένα preset ορίζει τη διαμόρφωση πόρων (CPU, μνήμη, GPU) που χρησιμοποιείται για την εκτέλεση αυτού του μοντέλου ως υπηρεσία.",
     "ProjectNotFound": "Το έργο Model Store δεν βρέθηκε",
-    "ProjectNotFoundDescription": "Το έργο MODEL_STORE δεν βρέθηκε. Επικοινωνήστε με τον διαχειριστή σας.",
+    "ProjectNotFoundDescription": "Το έργο Model Store δεν βρέθηκε. Επικοινωνήστε με τον διαχειριστή σας.",
     "QuickDeployDetailed": "Διαμόρφωση και ανάπτυξη...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Ομάδα πόρων",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2148,7 +2148,7 @@
     "Preset": "Preset",
     "PresetTooltip": "A preset defines the resource configuration (CPU, memory, GPU) used to run this model as a service.",
     "ProjectNotFound": "Model Store project not found",
-    "ProjectNotFoundDescription": "The MODEL_STORE project could not be found. Please contact your administrator.",
+    "ProjectNotFoundDescription": "The Model Store project could not be found. Please contact your administrator.",
     "QuickDeployDetailed": "Configure and deploy",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Resource Group",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2161,7 +2161,7 @@
     "Preset": "Preset",
     "PresetTooltip": "Un preset define la configuración de recursos (CPU, memoria, GPU) utilizada para ejecutar este modelo como servicio.",
     "ProjectNotFound": "Proyecto de Model Store no encontrado",
-    "ProjectNotFoundDescription": "No se pudo encontrar el proyecto MODEL_STORE. Contacte a su administrador.",
+    "ProjectNotFoundDescription": "No se pudo encontrar el proyecto Model Store. Contacte a su administrador.",
     "QuickDeployDetailed": "Configurar e implementar...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Grupo de recursos",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2161,7 +2161,7 @@
     "Preset": "Esiasetus",
     "PresetTooltip": "Esiasetus määrittää resurssikokoonpanon (CPU, muisti, GPU), jota käytetään tämän mallin palveluna suorittamiseen.",
     "ProjectNotFound": "Model Store -projektia ei löydy",
-    "ProjectNotFoundDescription": "MODEL_STORE-projektia ei löytynyt. Ota yhteyttä järjestelmänvalvojaan.",
+    "ProjectNotFoundDescription": "Model Store -projektia ei löytynyt. Ota yhteyttä järjestelmänvalvojaan.",
     "QuickDeployDetailed": "Määritä ja ota käyttöön...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Resurssiryhmä",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2163,7 +2163,7 @@
     "Preset": "Preset",
     "PresetTooltip": "Un preset définit la configuration des ressources (CPU, mémoire, GPU) utilisée pour exécuter ce modèle en tant que service.",
     "ProjectNotFound": "Projet Model Store introuvable",
-    "ProjectNotFoundDescription": "Le projet MODEL_STORE est introuvable. Veuillez contacter votre administrateur.",
+    "ProjectNotFoundDescription": "Le projet Model Store est introuvable. Veuillez contacter votre administrateur.",
     "QuickDeployDetailed": "Configurer et déployer...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Groupe de ressources",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2164,7 +2164,7 @@
     "Preset": "Preset",
     "PresetTooltip": "Preset menentukan konfigurasi sumber daya (CPU, memori, GPU) yang digunakan untuk menjalankan model ini sebagai layanan.",
     "ProjectNotFound": "Proyek Model Store tidak ditemukan",
-    "ProjectNotFoundDescription": "Proyek MODEL_STORE tidak dapat ditemukan. Silakan hubungi administrator Anda.",
+    "ProjectNotFoundDescription": "Proyek Model Store tidak dapat ditemukan. Silakan hubungi administrator Anda.",
     "QuickDeployDetailed": "Konfigurasi dan deploy...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Grup Sumber Daya",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2161,7 +2161,7 @@
     "Preset": "Preset",
     "PresetTooltip": "Un preset definisce la configurazione delle risorse (CPU, memoria, GPU) utilizzata per eseguire questo modello come servizio.",
     "ProjectNotFound": "Progetto Model Store non trovato",
-    "ProjectNotFoundDescription": "Impossibile trovare il progetto MODEL_STORE. Contattare l'amministratore.",
+    "ProjectNotFoundDescription": "Impossibile trovare il progetto Model Store. Contattare l'amministratore.",
     "QuickDeployDetailed": "Configura e distribuisci...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Gruppo di risorse",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2163,7 +2163,7 @@
     "Preset": "プリセット",
     "PresetTooltip": "プリセットは、このモデルをサービスとして実行するために使用されるリソース構成（CPU、メモリ、GPU）を定義します。",
     "ProjectNotFound": "モデルストアプロジェクトが見つかりません",
-    "ProjectNotFoundDescription": "MODEL_STOREプロジェクトが見つかりませんでした。管理者にお問い合わせください。",
+    "ProjectNotFoundDescription": "モデルストアプロジェクトが見つかりませんでした。管理者にお問い合わせください。",
     "QuickDeployDetailed": "詳細設定後にデプロイ...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "リソースグループ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2163,7 +2163,7 @@
     "Preset": "프리셋",
     "PresetTooltip": "프리셋은 이 모델을 서비스로 실행하는 데 사용되는 리소스 구성(CPU, 메모리, GPU)을 정의합니다.",
     "ProjectNotFound": "모델 스토어 프로젝트를 찾을 수 없습니다",
-    "ProjectNotFoundDescription": "MODEL_STORE 프로젝트를 찾을 수 없습니다. 관리자에게 문의해 주세요.",
+    "ProjectNotFoundDescription": "모델 스토어용 프로젝트를 찾을 수 없습니다. 관리자에게 문의해 주세요.",
     "QuickDeployDetailed": "세부 설정 후 배포하기",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "자원 그룹",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2162,7 +2162,7 @@
     "Preset": "Урьдчилан тохируулга",
     "PresetTooltip": "Урьдчилсан тохиргоо нь энэ загварыг үйлчилгээ болгон ажиллуулахад ашиглах нөөцийн тохиргоог (CPU, санах ой, GPU) тодорхойлдог.",
     "ProjectNotFound": "Модел дэлгүүрийн төсөл олдсонгүй",
-    "ProjectNotFoundDescription": "MODEL_STORE төсөл олдсонгүй. Админтай холбогдоно уу.",
+    "ProjectNotFoundDescription": "Модел дэлгүүрийн төсөл олдсонгүй. Админтай холбогдоно уу.",
     "QuickDeployDetailed": "Тохируулж байршуулах...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Нөөцийн бүлэг",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2161,7 +2161,7 @@
     "Preset": "Pratetap",
     "PresetTooltip": "Pratetap mentakrifkan konfigurasi sumber (CPU, memori, GPU) yang digunakan untuk menjalankan model ini sebagai perkhidmatan.",
     "ProjectNotFound": "Projek Model Store tidak ditemui",
-    "ProjectNotFoundDescription": "Projek MODEL_STORE tidak dapat ditemui. Sila hubungi pentadbir anda.",
+    "ProjectNotFoundDescription": "Projek Model Store tidak dapat ditemui. Sila hubungi pentadbir anda.",
     "QuickDeployDetailed": "Konfigur dan deploy...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Kumpulan Sumber",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2163,7 +2163,7 @@
     "Preset": "Preset",
     "PresetTooltip": "Preset definiuje konfigurację zasobów (CPU, pamięć, GPU) używaną do uruchomienia tego modelu jako usługi.",
     "ProjectNotFound": "Nie znaleziono projektu Model Store",
-    "ProjectNotFoundDescription": "Nie można znaleźć projektu MODEL_STORE. Skontaktuj się z administratorem.",
+    "ProjectNotFoundDescription": "Nie można znaleźć projektu Model Store. Skontaktuj się z administratorem.",
     "QuickDeployDetailed": "Skonfiguruj i wdróż...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Grupa zasobów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2161,7 +2161,7 @@
     "Preset": "Preset",
     "PresetTooltip": "Um preset define a configuração de recursos (CPU, memória, GPU) usada para executar este modelo como serviço.",
     "ProjectNotFound": "Projeto Model Store não encontrado",
-    "ProjectNotFoundDescription": "O projeto MODEL_STORE não foi encontrado. Entre em contato com o administrador.",
+    "ProjectNotFoundDescription": "O projeto Model Store não foi encontrado. Entre em contato com o administrador.",
     "QuickDeployDetailed": "Configurar e implantar...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Grupo de recursos",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2163,7 +2163,7 @@
     "Preset": "Preset",
     "PresetTooltip": "Um preset define a configuração de recursos (CPU, memória, GPU) usada para executar este modelo como serviço.",
     "ProjectNotFound": "Projeto Model Store não encontrado",
-    "ProjectNotFoundDescription": "O projeto MODEL_STORE não foi encontrado. Contacte o administrador.",
+    "ProjectNotFoundDescription": "O projeto Model Store não foi encontrado. Contacte o administrador.",
     "QuickDeployDetailed": "Configurar e implantar...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Grupo de recursos",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2161,7 +2161,7 @@
     "Preset": "Пресет",
     "PresetTooltip": "Пресет определяет конфигурацию ресурсов (ЦП, память, GPU), используемую для запуска этой модели в качестве сервиса.",
     "ProjectNotFound": "Проект Model Store не найден",
-    "ProjectNotFoundDescription": "Проект MODEL_STORE не найден. Обратитесь к администратору.",
+    "ProjectNotFoundDescription": "Проект Model Store не найден. Обратитесь к администратору.",
     "QuickDeployDetailed": "Настроить и развернуть...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Группа ресурсов",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2163,7 +2163,7 @@
     "Preset": "พรีเซ็ต",
     "PresetTooltip": "พรีเซ็ตกำหนดค่าการกำหนดทรัพยากร (CPU, หน่วยความจำ, GPU) ที่ใช้ในการรันโมเดลนี้เป็นบริการ",
     "ProjectNotFound": "ไม่พบโปรเจกต์ Model Store",
-    "ProjectNotFoundDescription": "ไม่พบโปรเจกต์ MODEL_STORE กรุณาติดต่อผู้ดูแลระบบ",
+    "ProjectNotFoundDescription": "ไม่พบโปรเจกต์ Model Store กรุณาติดต่อผู้ดูแลระบบ",
     "QuickDeployDetailed": "ตั้งค่าและปรับใช้...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "กลุ่มทรัพยากร",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2161,7 +2161,7 @@
     "Preset": "Ön ayar",
     "PresetTooltip": "Bir ön ayar, bu modeli hizmet olarak çalıştırmak için kullanılan kaynak yapılandırmasını (CPU, bellek, GPU) tanımlar.",
     "ProjectNotFound": "Model Store projesi bulunamadı",
-    "ProjectNotFoundDescription": "MODEL_STORE projesi bulunamadı. Lütfen yöneticinizle iletişime geçin.",
+    "ProjectNotFoundDescription": "Model Store projesi bulunamadı. Lütfen yöneticinizle iletişime geçin.",
     "QuickDeployDetailed": "Yapılandır ve dağıt...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Kaynak grubu",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2163,7 +2163,7 @@
     "Preset": "Cấu hình sẵn có",
     "PresetTooltip": "Preset xác định cấu hình tài nguyên (CPU, bộ nhớ, GPU) được sử dụng để chạy mô hình này dưới dạng dịch vụ.",
     "ProjectNotFound": "Không tìm thấy dự án Model Store",
-    "ProjectNotFoundDescription": "Không tìm thấy dự án MODEL_STORE. Vui lòng liên hệ quản trị viên.",
+    "ProjectNotFoundDescription": "Không tìm thấy dự án Model Store. Vui lòng liên hệ quản trị viên.",
     "QuickDeployDetailed": "Cấu hình và triển khai...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "Nhóm tài nguyên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2163,7 +2163,7 @@
     "Preset": "预设",
     "PresetTooltip": "预设定义了将此模型作为服务运行时使用的资源配置（CPU、内存、GPU）。",
     "ProjectNotFound": "未找到模型商店项目",
-    "ProjectNotFoundDescription": "未找到 MODEL_STORE 项目。请联系管理员。",
+    "ProjectNotFoundDescription": "未找到模型商店项目。请联系管理员。",
     "QuickDeployDetailed": "配置后部署...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "资源组",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2165,7 +2165,7 @@
     "Preset": "預設",
     "PresetTooltip": "預設定義了將此模型作為服務運行時使用的資源配置（CPU、記憶體、GPU）。",
     "ProjectNotFound": "找不到模型商店專案",
-    "ProjectNotFoundDescription": "找不到 MODEL_STORE 專案。請聯絡管理員。",
+    "ProjectNotFoundDescription": "找不到模型商店專案。請聯絡管理員。",
     "QuickDeployDetailed": "設定後部署...",
     "RelativeTime": "{{time}}",
     "ResourceGroup": "資源群組",


### PR DESCRIPTION
Resolves #7910 (FR-3144)

## Summary

When the Model Store project (`modelStoreProject?.id`) cannot be resolved, the admin Model Card create/edit modal (`AdminModelCardSettingModal`) now shows an error `Alert` **instead of the form** and disables the confirm button, so a card cannot be submitted into a missing project. Applies to **both create and edit modes** (the modal is a single shared component).

## Why

The create flow writes the model card to the MODEL_STORE project via `modelStoreProject?.id` (FR-3136). When no model-store project is resolved, the modal previously gave no feedback and still allowed submission. This makes the missing-project state explicit, consistent with how `ModelStoreListPageV2` already surfaces the same condition.

## Changes

- Render an error `Alert` (`modelStore.ProjectNotFound` / `modelStore.ProjectNotFoundDescription`) and **hide the form entirely** when `!modelStoreProject?.id`; otherwise render the form as before.
- Disable the OK button while the project is missing. To keep the guard tamper-proof, `{...modalProps}` is spread first and `okButtonProps` is merged with the guard OR-ed into `disabled` (`!modelStoreProject?.id || modalProps.okButtonProps?.disabled`) — a caller cannot override the guard off. (Addresses Copilot review feedback.)
- Default the create form's domain to the current domain.
- Reword the raw `MODEL_STORE` enum to a human-readable "Model Store" in the ProjectNotFound description across all 22 languages. This is a **shared** i18n key, also used by `ModelStoreListPageV2`.

## How to test

There is no first-class UI to clear the Model Store project, so simulate the missing-project state by breaking the lookup query:

1. In `react/src/pages/AdminModelCardListPage.tsx`, temporarily corrupt the type filter so no group is returned, e.g.:
   ```graphql
   groups(is_active: true, type: ["MODEL_STOR"]) {  # typo: was ["MODEL_STORE"]
     id
     name
   }
   ```
2. Open the admin Model Card list and click **Create** (and open an existing card to check **Edit**).
3. Verify in **both** modes: the error alert is shown, the form is **not** rendered, and the confirm button (Create / Update) is **disabled**.
4. Revert the filter to `["MODEL_STORE"]` and confirm the form renders and submission works again.

## Verification

`bash scripts/verify.sh` → Lint / Format / TypeScript PASS. The committed change touches no GraphQL, so it introduces no Relay drift.