### PR TITLE
feat(FR-3145): group audit log sub-types under each scope and add entity-type filter

### DIFF
--- a/react/src/components/DeploymentConfigurationSection.tsx
+++ b/react/src/components/DeploymentConfigurationSection.tsx
@@ -84,6 +84,25 @@ type DeploymentSectionData =
   | null
   | undefined;
 
+/**
+ * RBAC entity types that belong to a single deployment's audit-log scope. The
+ * deployment row itself (`MODEL_DEPLOYMENT`) plus its sub-resources, so the
+ * scoped audit log surfaces token / policy / revision events alongside the
+ * deployment's own events instead of silently dropping them (FR-3145).
+ *
+ * TODO(needs-backend): these sub-type entries are scoped with the parent
+ * deployment's UUID. Confirm the backend keys `DEPLOYMENT_TOKEN/POLICY/REVISION`
+ * audit rows by the parent deployment id (and not the sub-resource's own id);
+ * if it keys by the sub-resource id, hierarchical scope matching is required
+ * server-side for these events to appear.
+ */
+const DEPLOYMENT_AUDIT_LOG_ENTITY_TYPES = [
+  'MODEL_DEPLOYMENT',
+  'DEPLOYMENT_TOKEN',
+  'DEPLOYMENT_POLICY',
+  'DEPLOYMENT_REVISION',
+] as const;
+
 const renderFallback = () => (
   <Typography.Text type="secondary">-</Typography.Text>
 );
@@ -340,15 +359,14 @@ const DeploymentConfigurationSection: React.FC<
       return;
     }
     const rawId = deployment.id;
+    const entityId = safeDecodeUuid(rawId) ?? rawId;
     loadAuditLogQuery(
       {
         scope: {
-          entity: [
-            {
-              entityType: 'MODEL_DEPLOYMENT',
-              entityId: safeDecodeUuid(rawId) ?? rawId,
-            },
-          ],
+          entity: DEPLOYMENT_AUDIT_LOG_ENTITY_TYPES.map((entityType) => ({
+            entityType,
+            entityId,
+          })),
         },
         orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
         limit: baiPaginationOption.limit,
@@ -629,6 +647,7 @@ const DeploymentConfigurationSection: React.FC<
                 <ScopedAuditLog
                   queryRef={auditLogQueryRef}
                   onReload={reloadAuditLogQuery}
+                  scopeEntityTypes={DEPLOYMENT_AUDIT_LOG_ENTITY_TYPES}
                   tableSettings={{}}
                 />
               </Suspense>

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -73,6 +73,19 @@ interface FolderExplorerProps extends BAIModalProps {
   onRequestClose: () => void;
 }
 
+/**
+ * RBAC entity types that belong to a single vfolder's audit-log scope. The
+ * vfolder row itself (`VFOLDER`) plus its data events, so the scoped audit log
+ * surfaces file/data events alongside the vfolder's own events instead of
+ * silently dropping them (FR-3145).
+ *
+ * TODO(needs-backend): the `VFOLDER_DATA` entry is scoped with the parent
+ * vfolder's UUID. Confirm the backend keys vfolder-data audit rows by the
+ * parent vfolder id; if it keys by the data entry's own id, hierarchical scope
+ * matching is required server-side for these events to appear.
+ */
+const VFOLDER_AUDIT_LOG_ENTITY_TYPES = ['VFOLDER', 'VFOLDER_DATA'] as const;
+
 const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
   vfolderID,
   onRequestClose,
@@ -175,7 +188,10 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
     loadAuditLogQuery(
       {
         scope: {
-          entity: [{ entityType: 'VFOLDER', entityId: vfolderUuid }],
+          entity: VFOLDER_AUDIT_LOG_ENTITY_TYPES.map((entityType) => ({
+            entityType,
+            entityId: vfolderUuid,
+          })),
         },
         orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
         limit: baiPaginationOption.limit,
@@ -338,6 +354,7 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
                   <ScopedAuditLog
                     queryRef={auditLogQueryRef}
                     onReload={reloadAuditLogQuery}
+                    scopeEntityTypes={VFOLDER_AUDIT_LOG_ENTITY_TYPES}
                     tableSettings={{}}
                   />
                 </Suspense>

--- a/react/src/components/ScopedAuditLog.tsx
+++ b/react/src/components/ScopedAuditLog.tsx
@@ -1,6 +1,7 @@
 import type {
   AuditLogOrderBy,
   AuditLogScope,
+  RBACElementType,
   ScopedAuditLogQuery as ScopedAuditLogQueryType,
 } from '../__generated__/ScopedAuditLogQuery.graphql';
 import { convertToOrderBy } from '../helper';
@@ -64,6 +65,15 @@ export interface ScopedAuditLogProps extends Omit<
     variables: ScopedAuditLogQueryType['variables'],
     options?: UseQueryLoaderLoadQueryOptions,
   ) => void;
+  /**
+   * The RBAC entity types that make up this audit-log scope (e.g. for a
+   * deployment view: `MODEL_DEPLOYMENT`, `DEPLOYMENT_TOKEN`,
+   * `DEPLOYMENT_POLICY`, `DEPLOYMENT_REVISION`). When provided with more than
+   * one type, an `entityType` enum drill-down filter is added to the filter bar
+   * so users can narrow the (OR'd) scope to a single type. The consumer owns the
+   * query scope; this prop only drives the filter UI.
+   */
+  scopeEntityTypes?: ReadonlyArray<RBACElementType>;
 }
 
 /**
@@ -79,6 +89,7 @@ export interface ScopedAuditLogProps extends Omit<
 const ScopedAuditLog = ({
   queryRef,
   onReload,
+  scopeEntityTypes,
   ...tableProps
 }: ScopedAuditLogProps) => {
   'use memo';
@@ -114,6 +125,25 @@ const ScopedAuditLog = ({
             );
           }}
           filterProperties={[
+            // Drill-down by entity type within the scope. Only meaningful when
+            // the scope spans more than one entity type (e.g. a deployment scope
+            // OR'ing MODEL_DEPLOYMENT + DEPLOYMENT_TOKEN/POLICY/REVISION); a
+            // single-type scope has nothing to narrow.
+            ...((scopeEntityTypes?.length ?? 0) > 1
+              ? [
+                  {
+                    key: 'entityType',
+                    propertyLabel: t('auditLog.EntityType'),
+                    type: 'enum' as const,
+                    strictSelection: true,
+                    fixedOperator: 'equals' as const,
+                    options: scopeEntityTypes?.map((value) => ({
+                      label: value,
+                      value,
+                    })),
+                  },
+                ]
+              : []),
             {
               key: 'status',
               propertyLabel: t('auditLog.Status'),

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -73,6 +73,22 @@ import {
 } from 'react-relay';
 import { useLocation } from 'react-router-dom';
 
+/**
+ * RBAC entity types that belong to a single session's audit-log scope. The
+ * session row itself (`SESSION`) plus its app-service events, so the scoped
+ * audit log surfaces session-app events alongside the session's own events
+ * instead of silently dropping them (FR-3145).
+ *
+ * TODO(needs-backend): the `SESSION_APP_SERVICE` entry is scoped with the
+ * parent session's UUID. Confirm the backend keys session-app audit rows by the
+ * parent session id; if it keys by the app-service's own id, hierarchical scope
+ * matching is required server-side for these events to appear.
+ */
+const SESSION_AUDIT_LOG_ENTITY_TYPES = [
+  'SESSION',
+  'SESSION_APP_SERVICE',
+] as const;
+
 // When a session is tagged as using a unified-memory accelerator slot, its
 // quantity is auto-allocated and not meaningfully stored in `requested_slots`.
 // Surface that slot as the accelerator type so `ResourceNumbersOfSession`
@@ -550,10 +566,14 @@ const SessionDetailContent: React.FC<{
         defaultActiveKey="kernels"
         onChange={(key) => {
           if (key === 'auditLog' && session.row_id && !auditLogQueryRef) {
+            const entityId = session.row_id;
             loadAuditLogQuery(
               {
                 scope: {
-                  entity: [{ entityType: 'SESSION', entityId: session.row_id }],
+                  entity: SESSION_AUDIT_LOG_ENTITY_TYPES.map((entityType) => ({
+                    entityType,
+                    entityId,
+                  })),
                 },
                 orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
                 limit: baiPaginationOption.limit,
@@ -590,6 +610,7 @@ const SessionDetailContent: React.FC<{
                           <ScopedAuditLog
                             queryRef={auditLogQueryRef}
                             onReload={reloadAuditLogQuery}
+                            scopeEntityTypes={SESSION_AUDIT_LOG_ENTITY_TYPES}
                             tableSettings={{}}
                           />
                         </Suspense>

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -297,6 +297,7 @@
   },
   "auditLog": {
     "AuditLog": "Audit Log",
+    "EntityType": "Entity Type",
     "Operation": "Operation",
     "Status": "Status",
     "Time": "Time",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -310,6 +310,7 @@
   },
   "auditLog": {
     "AuditLog": "감사 로그",
+    "EntityType": "엔티티 유형",
     "Operation": "작업",
     "Status": "상태",
     "Time": "시간",


### PR DESCRIPTION
Resolves #7912 (FR-3145)

## Problem

The scoped audit log only matched a single primary entity type per view, so
sub-resource events were silently dropped from the audit history:

- **Deployment** scope showed only `MODEL_DEPLOYMENT`, not `DEPLOYMENT_TOKEN` /
  `DEPLOYMENT_POLICY` / `DEPLOYMENT_REVISION`.
- **Session** scope showed only `SESSION`, not `SESSION_APP_SERVICE`.
- **VFolder** scope showed only `VFOLDER`, not `VFOLDER_DATA`.

There was also no way to narrow the audit log to a specific entity type.

## Changes

- **Group related entity types into each consumer's query scope.** `AuditLogScope.entity`
  is an OR'd list, so each consumer now lists its parent type plus related
  sub-types (all keyed by the parent resource's UUID):
  - `DeploymentConfigurationSection` → `MODEL_DEPLOYMENT`, `DEPLOYMENT_TOKEN`, `DEPLOYMENT_POLICY`, `DEPLOYMENT_REVISION`
  - `SessionDetailContent` → `SESSION`, `SESSION_APP_SERVICE`
  - `FolderExplorerModalV2` → `VFOLDER`, `VFOLDER_DATA`
- **Add a `scopeEntityTypes` prop to `ScopedAuditLog`.** When the scope spans
  more than one entity type, the filter bar renders an `entityType` enum
  drill-down (`fixedOperator: 'equals'`, `strictSelection`) so users can narrow
  the OR'd scope to a single type. The prop's values populate the enum options;
  the consumer still owns the query scope.
- **i18n**: add `auditLog.EntityType` (en / ko).

No GraphQL or schema changes — the `entity` scope array and
`AuditLogFilter.entityType` (a `StringFilter`) already exist; this only changes
how the existing variables are populated and wires a new filter property.

## TODO(needs-backend)

Sub-type entries are scoped with the **parent** resource's UUID. This assumes
the backend keys sub-resource audit rows (e.g. `DEPLOYMENT_TOKEN`,
`SESSION_APP_SERVICE`, `VFOLDER_DATA`) by their parent's id. If the backend
instead keys them by the sub-resource's own id, hierarchical scope matching is
required server-side for those events to surface. Marked inline in each
consumer.

## Verification

`bash scripts/verify.sh`:

- **Lint**: PASS
- **Format**: PASS
- **TypeScript**: PASS
- **Relay**: FAIL — **pre-existing on `main`, unrelated to this PR**. The failure
  is in `react/src/hooks/useRuntimeParameterSchema.ts:137` (`RuntimeVariantPreset.required`
  field introduced by FR-3130 / commit `e3208ee58`, not yet present in the local
  `data/schema.graphql`). This PR adds no GraphQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)