### PR TITLE
fix(FR-3117): provision shared vfolder in beforeAll for file-upload e2e

### DIFF
--- a/e2e/vfolder/file-upload-duplicate.spec.ts
+++ b/e2e/vfolder/file-upload-duplicate.spec.ts
@@ -30,18 +30,22 @@ const openFolderExplorer = async (
   return modal;
 };
 
-// Keep serial: the cancel test depends on the vfolder and the file uploaded
-// by the first test (overwrite-confirmation requires the pre-existing file).
-test.describe.serial(
+// Not serial: the shared vfolder AND its baseline file are provisioned once in
+// beforeAll (fresh context). Both overwrite-confirmation tests then act on that
+// pre-existing duplicate independently — neither removes the baseline file
+// (one overwrites it, the other cancels), so they are order-independent and a
+// failure in one does not cascade-skip the other. mode: 'default' keeps them
+// sequential on one worker to limit backend load. See FR-3117.
+test.describe(
   'Duplicate File Upload',
   { tag: ['@critical', '@vfolder', '@functional'] },
   () => {
-    test.describe.configure({ timeout: 90_000 });
+    test.describe.configure({ mode: 'default', timeout: 90_000 });
     const testFolderName = 'e2e-test-dup-upload-' + Date.now();
     let tmpDir: string;
     let testFilePath: string;
 
-    test.beforeAll(async () => {
+    test.beforeAll(async ({ browser, request }) => {
       // Create temporary directory and test file
       tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-dup-upload-'));
 
@@ -50,6 +54,38 @@ test.describe.serial(
         testFilePath,
         'This is test file for e2e duplicate upload testing',
       );
+
+      // Provision the shared vfolder and upload the baseline file once, in a
+      // fresh context, so each overwrite test has a pre-existing duplicate to
+      // act on without depending on the other test's body. try/finally
+      // guarantees the context is closed even if any provisioning/upload step
+      // throws, so a failed setup can't leak the context.
+      const context = await browser.newContext();
+      try {
+        const page = await context.newPage();
+        await loginAsUser(page, request);
+        await createVFolderAndVerify(
+          page,
+          testFolderName,
+          'general',
+          'user',
+          'rw',
+        );
+
+        // openFolderExplorer already calls verifyFileExplorerLoaded().
+        const modal = await openFolderExplorer(page, testFolderName);
+        const uploadButton = await modal.getUploadButton();
+        await uploadButton.click();
+        const [fileChooser] = await Promise.all([
+          page.waitForEvent('filechooser'),
+          page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+        ]);
+        await fileChooser.setFiles([testFilePath]);
+        await modal.verifyFileVisible(path.basename(testFilePath));
+        await modal.close();
+      } finally {
+        await context.close();
+      }
     });
 
     test.beforeEach(async ({ page, request }) => {
@@ -87,22 +123,15 @@ test.describe.serial(
     test('User sees duplicate confirmation when uploading existing file', async ({
       page,
     }) => {
-      // 1. Create a VFolder with Read & Write permissions
-      await createVFolderAndVerify(
-        page,
-        testFolderName,
-        'general',
-        'user',
-        'rw',
-      );
+      const fileName = path.basename(testFilePath);
 
-      // 2. Open the VFolder in FolderExplorerModal
-      let modal = await openFolderExplorer(page, testFolderName);
+      // 1. Open the shared VFolder (the baseline file was uploaded in beforeAll)
+      const modal = await openFolderExplorer(page, testFolderName);
 
-      // 3. Verify file explorer loaded
-      await modal.verifyFileExplorerLoaded();
+      // 2. Verify the pre-existing baseline file is present
+      await modal.verifyFileVisible(fileName);
 
-      // 4. Upload a test file via Upload button (first upload - establish baseline)
+      // 3. Upload the SAME file again to trigger the overwrite confirmation
       const uploadButton = await modal.getUploadButton();
       await uploadButton.click();
 
@@ -113,29 +142,7 @@ test.describe.serial(
 
       await fileChooser.setFiles([testFilePath]);
 
-      // 5. Verify the file appears in the file table
-      const fileName = path.basename(testFilePath);
-      await modal.verifyFileVisible(fileName);
-
-      // 6. Close the modal
-      await modal.close();
-
-      // 7. Re-open the VFolder in FolderExplorerModal
-      modal = await openFolderExplorer(page, testFolderName);
-
-      // 8. Click "Upload" button again
-      const uploadButton2 = await modal.getUploadButton();
-      await uploadButton2.click();
-
-      // 9. Upload the SAME file again
-      const [fileChooser2] = await Promise.all([
-        page.waitForEvent('filechooser'),
-        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
-      ]);
-
-      await fileChooser2.setFiles([testFilePath]);
-
-      // 10. Verify a confirmation modal appears with title "Overwrite Confirmation"
+      // 4. Verify a confirmation modal appears with the overwrite prompt
       const confirmModal = page.getByRole('dialog').last();
       await expect(confirmModal).toBeVisible();
       await expect(
@@ -144,10 +151,10 @@ test.describe.serial(
         ),
       ).toBeVisible();
 
-      // 11. Click "OK" to confirm overwrite
+      // 5. Click "OK" to confirm overwrite
       await page.getByRole('button', { name: 'OK' }).click();
 
-      // 12. Verify the file still exists in the file table (overwritten)
+      // 6. Verify the file still exists in the file table (overwritten)
       await modal.verifyFileVisible(fileName);
 
       // Close modal
@@ -155,10 +162,10 @@ test.describe.serial(
     });
 
     test('User can cancel duplicate file upload', async ({ page }) => {
-      // 1. Open the same VFolder in FolderExplorerModal
+      // 1. Open the shared VFolder in FolderExplorerModal
       const modal = await openFolderExplorer(page, testFolderName);
 
-      // 2. Verify the file from previous test exists in the table
+      // 2. Verify the baseline file (uploaded in beforeAll) exists in the table
       const fileName = path.basename(testFilePath);
       await modal.verifyFileVisible(fileName);
 

--- a/e2e/vfolder/file-upload.spec.ts
+++ b/e2e/vfolder/file-upload.spec.ts
@@ -30,21 +30,23 @@ const openFolderExplorer = async (
   return modal;
 };
 
-// Keep serial: the tests chain state on one shared vfolder. testFolderName
-// (declared at describe scope) names that folder; the first (single-file)
-// test creates it and the multi-file test uploads into the same folder.
-test.describe.serial(
+// Not serial: the shared vfolder is provisioned once in beforeAll (fresh
+// context, mirroring vfolder-explorer-modal.spec.ts), and each test uploads
+// its own distinct files into it, so the tests are order-independent and a
+// failure in one does not cascade-skip the others. mode: 'default' keeps them
+// sequential on one worker to limit backend load. See FR-3117.
+test.describe(
   'Button-Based File Upload',
   { tag: ['@critical', '@vfolder', '@functional'] },
   () => {
-    test.describe.configure({ timeout: 90_000 });
+    test.describe.configure({ mode: 'default', timeout: 90_000 });
     const testFolderName = 'e2e-test-upload-' + Date.now();
     let tmpDir: string;
     let testFile1Path: string;
     let testFile2Path: string;
     let testFile3Path: string;
 
-    test.beforeAll(async () => {
+    test.beforeAll(async ({ browser, request }) => {
       // Create temporary directory and test files
       tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-upload-'));
 
@@ -65,6 +67,25 @@ test.describe.serial(
         testFile3Path,
         'This is test file 3 for e2e upload testing',
       );
+
+      // Provision the shared vfolder once, in a fresh context, so neither test
+      // owns creation as an asserted step and the suite no longer needs to be
+      // serial. try/finally guarantees the context is closed even if login or
+      // folder creation throws, so a failed provisioning can't leak it.
+      const context = await browser.newContext();
+      try {
+        const page = await context.newPage();
+        await loginAsUser(page, request);
+        await createVFolderAndVerify(
+          page,
+          testFolderName,
+          'general',
+          'user',
+          'rw',
+        );
+      } finally {
+        await context.close();
+      }
     });
 
     test.beforeEach(async ({ page, request }) => {
@@ -102,39 +123,30 @@ test.describe.serial(
     test('User can upload a single file via Upload button', async ({
       page,
     }) => {
-      // 1. Create a VFolder with Read & Write permissions
-      await createVFolderAndVerify(
-        page,
-        testFolderName,
-        'general',
-        'user',
-        'rw',
-      );
-
-      // 2. Open the VFolder in FolderExplorerModal
+      // 1. Open the shared VFolder (provisioned in beforeAll) in FolderExplorerModal
       const modal = await openFolderExplorer(page, testFolderName);
 
-      // 3. Verify file explorer loaded
+      // 2. Verify file explorer loaded
       await modal.verifyFileExplorerLoaded();
 
-      // 4. Click the "Upload" button
+      // 3. Click the "Upload" button
       const uploadButton = await modal.getUploadButton();
       await uploadButton.click();
 
-      // 5. In the dropdown, click "Upload Files" button and handle file chooser
+      // 4. In the dropdown, click "Upload Files" button and handle file chooser
       const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
         page.getByRole('button', { name: 'file-add Upload Files' }).click(),
       ]);
 
-      // 6. Upload a single test file
+      // 5. Upload a single test file
       await fileChooser.setFiles([testFile1Path]);
 
-      // 7. Verify the uploaded file appears in the file table
+      // 6. Verify the uploaded file appears in the file table
       const fileName = path.basename(testFile1Path);
       await modal.verifyFileVisible(fileName);
 
-      // 8. Close modal
+      // 7. Close modal
       await modal.close();
     });
 


### PR DESCRIPTION
Resolves #7857 (FR-3117)

## Summary

Follow-up to FR-3113, part of the FR-3109 epic (reduce E2E skip ratio). `e2e/vfolder/file-upload.spec.ts` and `e2e/vfolder/file-upload-duplicate.spec.ts` were `describe.serial` because their second test depended on state created inside the first test's body (the vfolder, and for the duplicate suite the baseline uploaded file). A failure in the first test cascade-skipped the rest.

## Changes

- **Move provisioning into `test.beforeAll` (fresh browser context)**, mirroring the `vfolder-explorer-modal.spec.ts` pattern:
  - `file-upload.spec.ts`: the shared vfolder is created in `beforeAll`; each test uploads its own distinct files into it.
  - `file-upload-duplicate.spec.ts`: the shared vfolder **and** the baseline duplicate file are uploaded in `beforeAll`; both overwrite tests act on that pre-existing duplicate. Neither removes it (one overwrites, one cancels), so order doesn't matter.
- **Drop `describe.serial` → `test.describe.configure({ mode: 'default' })`** so a failure in one test no longer cascade-skips the others; `mode: 'default'` keeps them sequential on one worker to limit backend load.
- Creation is no longer an asserted step of the first test (the reason FR-3113 deferred this) — it is now pure setup.

Recovers up to 2–3 tests from the cascade skip pool.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript)
- `npx playwright test --list` parses both files (4 tests, 2 files)
- e2e-scoped ESLint passes (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
