### PR TITLE
feat(FR-3147): add opt-in auto-refresh interval dropdown to BAIFetchKeyButton

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.stories.tsx
@@ -23,10 +23,12 @@ A refresh button that manages fetch keys for data refetching with auto-update ca
 | \`loading\` | \`boolean\` | \`false\` | Loading state of the data fetch |
 | \`lastLoadTime\` | \`Date\` | \`undefined\` | Timestamp of the last successful load |
 | \`showLastLoadTime\` | \`boolean\` | \`false\` | Shows "Last updated: X ago" in tooltip |
-| \`autoUpdateDelay\` | \`number \\| null\` | \`null\` | Auto-refresh interval in milliseconds |
+| \`autoUpdateDelay\` | \`number \\| null\` | \`null\` | Auto-refresh interval in ms (controllable); \`null\` = Off |
 | \`onChange\` | \`(fetchKey: string) => void\` | - | Callback fired when fetch key updates |
 | \`hidden\` | \`boolean\` | \`false\` | Hides the button completely |
 | \`pauseWhenHidden\` | \`boolean\` | \`true\` | Pauses auto-update when button is hidden |
+| \`onChangeAutoUpdateDelay\` | \`(delayMs: number \\| null) => void\` | - | Fired when the user picks an interval; **providing it shows the dropdown** |
+| \`autoUpdateDelayOptions\` | \`number[]\` | \`[5000, 10000, 15000, 30000, 60000]\` | Interval presets (ms); "Off" is auto-prepended |
 
 For all other props, refer to [Ant Design Button](https://ant.design/components/button).
         `,
@@ -67,7 +69,8 @@ For all other props, refer to [Ant Design Button](https://ant.design/components/
     },
     autoUpdateDelay: {
       control: { type: 'number' },
-      description: 'Auto-refresh interval in milliseconds, null to disable',
+      description:
+        'Auto-refresh interval in ms (controllable); null disables (Off)',
       table: {
         type: { summary: 'number | null' },
         defaultValue: { summary: 'null' },
@@ -94,6 +97,23 @@ For all other props, refer to [Ant Design Button](https://ant.design/components/
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'true' },
+      },
+    },
+    onChangeAutoUpdateDelay: {
+      action: 'onChangeAutoUpdateDelay',
+      description:
+        'Fired when the user selects an interval or "Off"; providing it shows the dropdown',
+      table: {
+        type: { summary: '(delayMs: number | null) => void' },
+      },
+    },
+    autoUpdateDelayOptions: {
+      control: { type: 'object' },
+      description:
+        'Interval presets in ms; "Off" is auto-prepended by the component',
+      table: {
+        type: { summary: 'number[]' },
+        defaultValue: { summary: '[5000, 10000, 15000, 30000, 60000]' },
       },
     },
   },
@@ -204,6 +224,145 @@ export const AutoUpdate: Story = {
             showLastLoadTime={true}
           />
         </BAIFlex>
+      </BAIFlex>
+    );
+  },
+};
+
+export const IntervalDropdown: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Providing `onChangeAutoUpdateDelay` opts the button into the interval dropdown: a caret trigger next to the refresh button lets the user pick an auto-refresh interval or turn it off. Auto-refresh is off by default; once an interval is selected it shows as a label (e.g. "15s") on the dropdown trigger button.',
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+    const [delay, setDelay] = useState<number | null>(null);
+    const [counter, setCounter] = useState(0);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      setCounter((prev) => prev + 1);
+      // Simulate API call
+      setTimeout(() => {
+        setLoading(false);
+      }, 800);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>Configurable interval:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            autoUpdateDelay={delay}
+            onChangeAutoUpdateDelay={setDelay}
+            showLastLoadTime={true}
+          />
+          <span>Refresh count: {counter}</span>
+        </BAIFlex>
+        <div style={{ fontSize: '12px', color: '#666' }}>
+          Selected interval: {delay === null ? 'Off' : `${delay / 1000}s`}
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const CustomOptions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Consumers own the option list via `autoUpdateDelayOptions`. Here a longer-period set is passed (`[30s, 1m, 5m, 10m, 30m]`); the dropdown shows exactly those presets and the labels are formatted with the largest whole unit ("30s", "1m", "5m", "1h") via `dayjs.duration`, localized through the existing i18n keys.',
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+    const [delay, setDelay] = useState<number | null>(null);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      setTimeout(() => {
+        setLoading(false);
+      }, 800);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>Long-period options:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            autoUpdateDelay={delay}
+            onChangeAutoUpdateDelay={setDelay}
+            autoUpdateDelayOptions={[
+              30_000, 60_000, 300_000, 600_000, 1_800_000,
+            ]}
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+        <div style={{ fontSize: '12px', color: '#666' }}>
+          Selected interval (ms): {delay === null ? 'Off' : delay}
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const CustomInterval: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When the active `autoUpdateDelay` is not one of `autoUpdateDelayOptions` (e.g. a legacy 7s poller against the default `[5, 10, 15, 30, 60]s` presets), the component merges that value into the menu — sorted, deduped, and checked — so exactly one item is always selected and the running interval is never hidden. The merged value is sticky: once seen it stays in the list for the session, so after switching to another interval you can still pick 7s again. The consumer's option list is not mutated.",
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+    // Off-list starting value: 7s is not one of the default presets.
+    const [delay, setDelay] = useState<number | null>(7_000);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      setTimeout(() => {
+        setLoading(false);
+      }, 800);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>Off-list active value (7s):</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            autoUpdateDelay={delay}
+            onChangeAutoUpdateDelay={setDelay}
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+        <div style={{ fontSize: '12px', color: '#666' }}>
+          Selected interval (ms): {delay === null ? 'Off' : delay} — open the
+          menu: 7s appears merged between 5s and 10s, checked. Pick another
+          interval, reopen — 7s stays in the list (sticky).
+        </div>
       </BAIFlex>
     );
   },

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
@@ -1,14 +1,45 @@
 import { omitNullAndUndefinedFields } from '../helper';
 import { useBAIi18n } from '../hooks/useBAIi18n';
 import { useInterval, useIntervalValue } from '../hooks/useIntervalValue';
-import { ReloadOutlined } from '@ant-design/icons';
+import {
+  CaretDownOutlined,
+  CaretUpOutlined,
+  CheckOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
-import { Button, Tooltip, type ButtonProps } from 'antd';
+import {
+  Button,
+  Dropdown,
+  Space,
+  Tooltip,
+  type ButtonProps,
+  type MenuProps,
+} from 'antd';
 import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
 import * as _ from 'lodash-es';
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useEffectEvent,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
-interface BAIFetchKeyButtonProps extends Omit<
+dayjs.extend(duration);
+
+/**
+ * Default auto-refresh interval presets (in milliseconds) offered in the
+ * interval-selection dropdown. "Off" (`null`) is always prepended by the
+ * component and must NOT be included here. Consumers can override the list
+ * via the `autoUpdateDelayOptions` prop.
+ */
+export const AUTO_UPDATE_DELAY_OPTIONS = [
+  5_000, 10_000, 15_000, 30_000, 60_000,
+] as const;
+
+export interface BAIFetchKeyButtonProps extends Omit<
   ButtonProps,
   'value' | 'onChange' | 'loading'
 > {
@@ -16,11 +47,33 @@ interface BAIFetchKeyButtonProps extends Omit<
   loading?: boolean;
   lastLoadTime?: Date;
   showLastLoadTime?: boolean;
+  /**
+   * Auto-refresh interval in milliseconds; `null`/absent disables auto-refresh.
+   * Controllable — pair with `onChangeAutoUpdateDelay` to let the interval
+   * dropdown change it and let the host persist it (e.g. via `useBAISetting`).
+   * Without `onChangeAutoUpdateDelay` it is simply a fixed interval, exactly as
+   * existing consumers use it.
+   */
   autoUpdateDelay?: number | null;
   size?: ButtonProps['size'];
   onChange: (fetchKey: string) => void;
   hidden?: boolean;
   pauseWhenHidden?: boolean;
+  /**
+   * Fired when the user picks an interval (or "Off") from the dropdown.
+   * **Providing this callback opts the button into the interval-selection
+   * dropdown** (and makes `autoUpdateDelay` a controllable value). Without it,
+   * the component renders exactly as before — a single refresh button. The
+   * parent decides whether to show the dropdown simply by wiring this handler
+   * (typically to a persisted setting).
+   */
+  onChangeAutoUpdateDelay?: (delayMs: number | null) => void;
+  /**
+   * Interval presets shown in the dropdown, in milliseconds. "Off" (`null`) is
+   * always prepended by the component and must NOT be included here.
+   * Defaults to {@link AUTO_UPDATE_DELAY_OPTIONS}.
+   */
+  autoUpdateDelayOptions?: readonly number[];
 }
 
 /**
@@ -31,23 +84,32 @@ interface BAIFetchKeyButtonProps extends Omit<
  * @param loading - Loading state of the data fetch
  * @param lastLoadTime - Timestamp of the last successful load
  * @param showLastLoadTime - When true, shows "Last updated: X ago" in tooltip
- * @param autoUpdateDelay - Auto-refresh interval in milliseconds, null to disable
+ * @param autoUpdateDelay - Auto-refresh interval in milliseconds (controllable), null to disable
  * @param onChange - Callback fired when fetch key should be updated
  * @param hidden - When true, hides the button completely
  * @param pauseWhenHidden - When true, pauses auto-update when button is hidden
+ * @param onChangeAutoUpdateDelay - Callback fired when the user picks an interval (or "Off"); providing it shows the interval-selection dropdown
+ * @param autoUpdateDelayOptions - Interval presets (ms) shown in the dropdown
  */
 const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
   loading,
   onChange,
   showLastLoadTime,
-  autoUpdateDelay = null,
+  autoUpdateDelay,
   size,
   hidden,
   lastLoadTime: lastLoadTimeProp,
   pauseWhenHidden = true,
+  onChangeAutoUpdateDelay,
+  autoUpdateDelayOptions = AUTO_UPDATE_DELAY_OPTIONS,
   ...buttonProps
 }) => {
   'use memo';
+
+  // Providing `onChangeAutoUpdateDelay` opts the button into the
+  // interval-selection dropdown; without it the component renders exactly as
+  // before (a single refresh button), keeping all existing consumers unchanged.
+  const isAutoUpdateConfigurable = onChangeAutoUpdateDelay !== undefined;
 
   const { t } = useBAIi18n();
   const [lastLoadTime, setLastLoadTime] = useControllableValue(
@@ -57,6 +119,25 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
     }),
     {
       defaultValue: new Date(),
+    },
+  );
+
+  // The auto-refresh interval is a controllable value built on `autoUpdateDelay`
+  // (`null` means "Off"): when the parent passes it the value is controlled and
+  // the dropdown reports changes via `onChangeAutoUpdateDelay`; otherwise the
+  // component keeps it internally. We assemble the props by hand — rather than
+  // `omitNullAndUndefinedFields` (as used for `lastLoadTime` above) — because
+  // that helper strips `null`, which would turn a controlled "Off" into an
+  // uncontrolled value. So include `value` only when `autoUpdateDelay` is
+  // defined, which preserves an explicit `null`.
+  const selectedDelayControllableProps =
+    autoUpdateDelay !== undefined
+      ? { value: autoUpdateDelay, onChange: onChangeAutoUpdateDelay }
+      : { onChange: onChangeAutoUpdateDelay };
+  const [selectedDelay, setSelectedDelay] = useControllableValue<number | null>(
+    selectedDelayControllableProps,
+    {
+      defaultValue: null,
     },
   );
 
@@ -116,24 +197,140 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
       onChange(new Date().toISOString());
     },
     // only start auto-updating after the previous loading is false(done).
-    loading ? null : autoUpdateDelay,
+    loading ? null : selectedDelay,
     pauseWhenHidden,
   );
 
   const tooltipTitle = showLastLoadTime ? loadTimeMessage : undefined;
-  return hidden ? null : (
-    <Tooltip title={tooltipTitle} placement="topLeft">
-      <Button
-        title={tooltipTitle ? undefined : t('comp:BAIFetchKeyButton.Refresh')}
-        loading={displayLoading}
-        size={size}
-        icon={<ReloadOutlined />}
-        onClick={() => {
-          onChange(new Date().toISOString());
-        }}
-        {...buttonProps}
-      />
-    </Tooltip>
+  const isAutoRefreshOn = selectedDelay !== null;
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  // "Sticky" off-list intervals: when an active value outside the consumer's
+  // presets appears (e.g. a persisted legacy 7s), remember it for the lifetime
+  // of the component so it stays selectable in the menu even after the user
+  // switches to another interval — it must not vanish the way a transient
+  // injection would. The consumer's `autoUpdateDelayOptions` is never mutated.
+  const [seenOffListDelays, setSeenOffListDelays] = useState<number[]>([]);
+  const trackOffListDelay = useEffectEvent(() => {
+    if (
+      selectedDelay !== null &&
+      !autoUpdateDelayOptions.includes(selectedDelay)
+    ) {
+      setSeenOffListDelays((prev) =>
+        prev.includes(selectedDelay) ? prev : [...prev, selectedDelay],
+      );
+    }
+  });
+  useEffect(() => {
+    trackOffListDelay();
+  }, [selectedDelay]);
+
+  // Icon-only refresh button. When the interval dropdown is shown, the selected
+  // interval label ("Ns") lives on the dropdown trigger, not here.
+  const refreshButton = (
+    <Button
+      title={tooltipTitle ? undefined : t('comp:BAIFetchKeyButton.Refresh')}
+      loading={displayLoading}
+      size={size}
+      icon={<ReloadOutlined />}
+      onClick={() => {
+        onChange(new Date().toISOString());
+      }}
+      {...buttonProps}
+    />
+  );
+
+  if (hidden) {
+    return null;
+  }
+
+  // No interval handler wired (default): render exactly as before — a single
+  // tooltip-wrapped refresh button. No layout or behavior change for the
+  // existing consumers.
+  if (!isAutoUpdateConfigurable) {
+    return (
+      <Tooltip title={tooltipTitle} placement="topLeft">
+        {refreshButton}
+      </Tooltip>
+    );
+  }
+
+  // Feature enabled: a Space.Compact group of the refresh button + a caret
+  // dropdown trigger to pick the auto-refresh interval (or turn it off). The
+  // trigger shows the selected interval ("Ns") next to the caret; the active
+  // menu option carries a check mark. Inactive options render the same icon
+  // hidden so every row stays aligned without a hardcoded spacer width.
+  const checkMark = (active: boolean) => (
+    <CheckOutlined style={{ visibility: active ? 'visible' : 'hidden' }} />
+  );
+  // Render an interval (ms) as a compact label, using the largest whole unit:
+  // "30s" / "5m" / "1h". `dayjs.duration` only picks the unit; the unit text
+  // itself is localized via i18n (e.g. ko "5분", ja "5分"), consistent with the
+  // existing `time.*` translations.
+  const formatInterval = (ms: number) => {
+    const d = dayjs.duration(ms);
+    const hours = d.asHours();
+    const minutes = d.asMinutes();
+    if (Number.isInteger(hours) && hours >= 1) {
+      return t('comp:BAIFetchKeyButton.EveryHours', { count: hours });
+    }
+    if (Number.isInteger(minutes) && minutes >= 1) {
+      return t('comp:BAIFetchKeyButton.EveryMinutes', { count: minutes });
+    }
+    return t('comp:BAIFetchKeyButton.EverySeconds', { count: d.asSeconds() });
+  };
+  // Menu options = the consumer's presets, plus any off-list interval that has
+  // been active this session (sticky, so it stays selectable), plus the current
+  // value. Deduped and ascending. This guarantees exactly one item is always
+  // checked — the active value is always present — without ever mutating the
+  // consumer's option list.
+  const mergedOptions = [
+    ...new Set([
+      ...autoUpdateDelayOptions,
+      ...seenOffListDelays,
+      ...(selectedDelay !== null ? [selectedDelay] : []),
+    ]),
+  ].sort((a, b) => a - b);
+  const menuItems: MenuProps['items'] = [
+    {
+      key: 'off',
+      label: t('comp:BAIFetchKeyButton.Off'),
+      icon: checkMark(selectedDelay === null),
+      onClick: () => setSelectedDelay(null),
+    },
+    ...mergedOptions.map((ms) => ({
+      key: String(ms),
+      label: formatInterval(ms),
+      icon: checkMark(selectedDelay === ms),
+      onClick: () => setSelectedDelay(ms),
+    })),
+  ];
+
+  return (
+    <Space.Compact>
+      <Tooltip title={tooltipTitle} placement="topLeft">
+        {refreshButton}
+      </Tooltip>
+      <Dropdown
+        trigger={['click']}
+        placement="bottomRight"
+        open={isDropdownOpen}
+        onOpenChange={setIsDropdownOpen}
+        menu={{ items: menuItems }}
+      >
+        <Tooltip title={t('comp:BAIFetchKeyButton.AutoRefresh')}>
+          <Button
+            {...buttonProps}
+            size={size}
+            iconPosition="end"
+            icon={isDropdownOpen ? <CaretUpOutlined /> : <CaretDownOutlined />}
+            aria-label={t('comp:BAIFetchKeyButton.AutoRefresh')}
+          >
+            {isAutoRefreshOn ? formatInterval(selectedDelay as number) : null}
+          </Button>
+        </Tooltip>
+      </Dropdown>
+    </Space.Compact>
   );
 };
 

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Domäne auswählen"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Automatische Aktualisierung",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Zuletzt aktualisiert",
+    "Off": "Aus",
     "Refresh": "Aktualisieren"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Επιλέξτε τομέα"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Αυτόματη ανανέωση",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Τελευταία ενημέρωση",
+    "Off": "Απενεργοποίηση",
     "Refresh": "Ανανέωση"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Select Domain"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Auto Refresh",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Last Updated",
+    "Off": "Off",
     "Refresh": "Refresh"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Seleccionar dominio"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Actualización automática",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Última actualización",
+    "Off": "Desactivado",
     "Refresh": "Actualizar"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Valitse toimialue"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Automaattinen päivitys",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Viimeksi päivitetty",
+    "Off": "Pois",
     "Refresh": "Päivitä"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Sélectionner un domaine"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Actualisation automatique",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Dernière mise à jour",
+    "Off": "Désactivé",
     "Refresh": "Rafraîchir"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Pilih Domain"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Penyegaran otomatis",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Terakhir diperbarui",
+    "Off": "Mati",
     "Refresh": "Segarkan"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Seleziona dominio"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Aggiornamento automatico",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Ultimo aggiornamento",
+    "Off": "Disattivato",
     "Refresh": "Aggiorna"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -154,7 +154,12 @@
     "SelectDomain": "ドメインを選択"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "自動更新",
+    "EveryHours": "{{count}}時間",
+    "EveryMinutes": "{{count}}分",
+    "EverySeconds": "{{count}}秒",
     "LastUpdated": "最終更新",
+    "Off": "オフ",
     "Refresh": "更新"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -154,7 +154,12 @@
     "SelectDomain": "도메인 선택"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "자동 새로고침",
+    "EveryHours": "{{count}}시간",
+    "EveryMinutes": "{{count}}분",
+    "EverySeconds": "{{count}}초",
     "LastUpdated": "마지막 업데이트",
+    "Off": "끄기",
     "Refresh": "새로고침"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Домен сонгох"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Автоматаар сэргээх",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Сүүлд шинэчлэгдсэн",
+    "Off": "Унтраах",
     "Refresh": "Шинэчлэх"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Pilih Domain"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Segar semula automatik",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Dikemaskini terakhir",
+    "Off": "Mati",
     "Refresh": "Segarkan"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Wybierz domenę"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Automatyczne odświeżanie",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Ostatnia aktualizacja",
+    "Off": "Wyłączone",
     "Refresh": "Odśwież"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Selecionar Domínio"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Atualização automática",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Última atualização",
+    "Off": "Desligado",
     "Refresh": "Atualizar"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Selecionar domínio"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Atualização automática",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Última atualização",
+    "Off": "Desligado",
     "Refresh": "Atualizar"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Выберите домен"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Автообновление",
+    "EveryHours": "{{count}}ч",
+    "EveryMinutes": "{{count}}м",
+    "EverySeconds": "{{count}}с",
     "LastUpdated": "Обновлено",
+    "Off": "Выкл.",
     "Refresh": "Обновить"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -154,7 +154,12 @@
     "SelectDomain": "เลือกโดเมน"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "รีเฟรชอัตโนมัติ",
+    "EveryHours": "{{count}}ชม.",
+    "EveryMinutes": "{{count}}น.",
+    "EverySeconds": "{{count}}วิ",
     "LastUpdated": "อัปเดตล่าสุด",
+    "Off": "ปิด",
     "Refresh": "รีเฟรช"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Etki Alanı Seçin"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Otomatik yenileme",
+    "EveryHours": "{{count}}sa",
+    "EveryMinutes": "{{count}}dk",
+    "EverySeconds": "{{count}}sn",
     "LastUpdated": "Son güncelleme",
+    "Off": "Kapalı",
     "Refresh": "Yenile"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -154,7 +154,12 @@
     "SelectDomain": "Chọn miền"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "Tự động làm mới",
+    "EveryHours": "{{count}}h",
+    "EveryMinutes": "{{count}}m",
+    "EverySeconds": "{{count}}s",
     "LastUpdated": "Cập nhật lần cuối",
+    "Off": "Tắt",
     "Refresh": "Làm mới"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -154,7 +154,12 @@
     "SelectDomain": "选择域"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "自动刷新",
+    "EveryHours": "{{count}}小时",
+    "EveryMinutes": "{{count}}分",
+    "EverySeconds": "{{count}}秒",
     "LastUpdated": "最后更新",
+    "Off": "关闭",
     "Refresh": "刷新"
   },
   "comp:BAIGraphQLPropertyFilter": {

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -154,7 +154,12 @@
     "SelectDomain": "選擇網域"
   },
   "comp:BAIFetchKeyButton": {
+    "AutoRefresh": "自動重新整理",
+    "EveryHours": "{{count}}小時",
+    "EveryMinutes": "{{count}}分",
+    "EverySeconds": "{{count}}秒",
     "LastUpdated": "最後更新",
+    "Off": "關閉",
     "Refresh": "重新整理"
   },
   "comp:BAIGraphQLPropertyFilter": {


### PR DESCRIPTION
Resolves #7920 (FR-3147)

## Summary

Adds an **opt-in auto-refresh interval dropdown** to the shared `BAIFetchKeyButton` (BUI package). The feature is **off by default** and only runs auto-refresh once the user explicitly selects an interval — matching the issue's requirement.

The component stays **presentational/controllable**: BUI cannot import the host's `useBAISetting` (it lives in `react/src`), so the interval is exposed as a controllable value. A follow-up stacked PR wires `useBAISetting` persistence into the consumers that actually poll.

## What changed

- **The parent opts in simply by wiring `onChangeAutoUpdateDelay`** — there is **no separate boolean flag**. Providing that handler shows the ellipsis dropdown and makes `autoUpdateDelay` a controllable value; omitting it renders **exactly as before** (a single tooltip-wrapped refresh button), so all ~55 existing call sites are unchanged. (A dropdown is only meaningful when changes can be handled, so the handler's presence is the natural gate — and unlike "is `autoUpdateDelay` set", it doesn't wrongly trigger for consumers passing `autoUpdateDelay={null}`.)
- **`autoUpdateDelay?: number | null`** is the single auto-refresh interval value (ms; `null` = Off) — controllable via `onChangeAutoUpdateDelay`. No separate "value" prop.
- **`autoUpdateDelayOptions?: number[]`** — overridable preset list (default `AUTO_UPDATE_DELAY_OPTIONS` = `[5s, 10s, 15s, 30s, 60s]`).
- **UI (per the request):** a `Space.Compact` of the refresh `Button` + an ellipsis `Dropdown`. **Off** → only the refresh arrow (current look). **On** → the button shows `N초` / `Ns` and the dropdown lists the presets plus an **Off** entry, with a check mark on the active one.
- **i18n:** added `comp:BAIFetchKeyButton` keys `AutoRefresh`, `EverySeconds` (`{{count}}` placeholder), `Off` to **all 21 BUI locale files**. Host `resources/i18n` untouched (comp:* keys live only in the BUI instance).
- **Story:** added an `Interval Dropdown` story + prop docs/argTypes.

## Note on UI

The reference image mentioned in the request didn't come through, so the exact placement follows the textual spec (off → arrow only; on → `N초` label; `Space.Compact` + ellipsis `Dropdown`). Happy to adjust placement/labels if the mockup differs.

## Screenshots

From the Storybook `Interval Dropdown` story. Off by default (just the refresh arrow + caret); once an interval is picked the dropdown trigger shows the `N초` label next to the caret, and the active option is check-marked. The caret flips up while the menu is open. (Storybook uses the English BUI i18n instance — Korean renders `끄기` / `15초`.)

| Off (default) | Menu open | Interval selected (15s) |
|---|---|---|
| ![off](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7927/20260616-071900-caret-default-off.png) | ![menu](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7927/20260616-071905-caret-menu-open.png) | ![selected 15s](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7927/20260616-071911-caret-selected-15s.png) |

Reopening the menu shows the check mark on the active interval (caret pointing up):

![menu with 15s checked](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7927/20260616-071916-caret-menu-15s.png)

## Verification

`bash scripts/verify.sh` — for this change: **Relay / Format / `backend.ai-ui` Lint — PASS · `backend.ai-ui` & `react` `tsc` — 0 errors.** (The aggregate harness occasionally flags two phantom `tsc` errors in untouched files — `FluentEmojiIcon.tsx`, `AdminDeploymentPresetSettingPage.tsx` — which don't reproduce on a clean run or on `main`; a fresh-worktree incremental-cache artifact, not part of this change.)

## Stack

Bottom of a 2-PR stack:
1. **(this PR)** `BAIFetchKeyButton` gains the opt-in interval dropdown.
2. **(#7928)** Wire `useBAISetting` persistence and enable the dropdown only on the components that currently poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


