### PR TITLE
feat(FR-3147): enable auto-refresh interval dropdown on polling consumers

### DIFF
--- a/react/src/components/AgentDetailDrawer.tsx
+++ b/react/src/components/AgentDetailDrawer.tsx
@@ -4,8 +4,9 @@
  */
 import { AgentDetailDrawerFragment$key } from '../__generated__/AgentDetailDrawerFragment.graphql';
 import AgentDetailDrawerContent from './AgentDetailDrawerContent';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import { Drawer, type DrawerProps, Skeleton } from 'antd';
-import { BAIFetchKeyButton, toLocalId, useBAILogger } from 'backend.ai-ui';
+import { toLocalId, useBAILogger } from 'backend.ai-ui';
 import { Suspense, useEffect, useEffectEvent, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useMutation, useRefetchableFragment } from 'react-relay';
@@ -78,8 +79,8 @@ const AgentDetailDrawer: React.FC<AgentDetailDrawerProps> = ({
       onClose={onRequestClose}
       {...drawerProps}
       extra={
-        <BAIFetchKeyButton
-          autoUpdateDelay={7_000}
+        <AutoUpdateFetchKeyButton
+          settingId="agent-detail"
           loading={isPendingRefetch}
           value=""
           onChange={() => {

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -11,11 +11,11 @@ import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginati
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useThemeMode } from '../hooks/useThemeMode';
 import AgentDetailDrawer from './AgentDetailDrawer';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import BAIRadioGroup from './BAIRadioGroup';
 import { useControllableValue } from 'ahooks';
 import { type TableProps, Tag, theme } from 'antd';
 import {
-  BAIFetchKeyButton,
   BAIFlex,
   BAIPropertyFilter,
   BAIFlexProps,
@@ -262,12 +262,15 @@ const AgentList: React.FC<AgentListProps> = ({
           />
         </BAIFlex>
         <BAIFlex gap="xs">
-          <BAIFetchKeyButton
+          <AutoUpdateFetchKeyButton
+            settingId="agent-list"
+            // Heavier cluster-wide query — keep the original ~15s as the
+            // fastest option instead of the default set's 5s/10s.
+            autoUpdateDelayOptions={[15_000, 30_000, 60_000, 300_000]}
             loading={
               deferredFetchKey !== fetchKey ||
               deferredQueryVariables !== queryVariables
             }
-            autoUpdateDelay={15_000}
             value={fetchKey}
             onChange={() => {
               updateFetchKey();

--- a/react/src/components/AutoUpdateFetchKeyButton.tsx
+++ b/react/src/components/AutoUpdateFetchKeyButton.tsx
@@ -1,0 +1,99 @@
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { BAIFetchKeyButton } from 'backend.ai-ui';
+import React, { ComponentProps } from 'react';
+
+/**
+ * Closed set of stable ids used to persist each consumer's auto-refresh
+ * interval (`fetchKeyAutoUpdateDelay.<settingId>`). Typing `settingId` against
+ * this union — instead of a bare `string` — gives every call site a single
+ * auditable registry and turns typos or unregistered ids into compile errors,
+ * mirroring `useHiddenColumnKeysSetting`'s `KnownSettingName`. (Uniqueness is
+ * not enforced by the type system — two call sites can still pick the same id;
+ * the union below is the manual guard against collisions.)
+ */
+export type FetchKeyAutoUpdateSettingId =
+  // Compute session surfaces (user / admin / project-admin)
+  | 'session-list'
+  | 'admin-session-list'
+  | 'project-admin-session'
+  | 'pending-session-list'
+  | 'session-detail'
+  // Deployment lists
+  | 'deployment-list'
+  | 'admin-deployment-list'
+  | 'project-admin-deployments'
+  // VFolder lists
+  | 'vfolder-list'
+  | 'admin-vfolder-list'
+  | 'project-admin-data'
+  // Other admin / detail surfaces
+  | 'project-admin-users'
+  | 'agent-detail'
+  | 'agent-list'
+  | 'storage-proxy-list'
+  | 'scoped-audit-log'
+  | 'login-history'
+  | 'login-session'
+  // Expensive / heavy views — default to the longer interval presets
+  | 'fair-share-list'
+  | 'user-sessions-metrics'
+  | 'prometheus-preset'
+  | 'reservoir'
+  | 'reservoir-artifact-detail';
+
+/**
+ * Longer interval presets (ms) for expensive/heavy views (Prometheus metric
+ * queries, fair-share). Pass via `autoUpdateDelayOptions` at those call sites so
+ * their dropdown offers coarser cadences instead of the default 5–60s set.
+ */
+export const LONG_AUTO_UPDATE_DELAY_OPTIONS = [
+  30_000, 60_000, 300_000, 600_000,
+] as const;
+
+type BAIFetchKeyButtonProps = ComponentProps<typeof BAIFetchKeyButton>;
+
+interface AutoUpdateFetchKeyButtonProps extends Omit<
+  BAIFetchKeyButtonProps,
+  'onChangeAutoUpdateDelay' | 'autoUpdateDelay'
+> {
+  /**
+   * Stable id used to persist the user-selected auto-refresh interval in user
+   * settings (`fetchKeyAutoUpdateDelay.<settingId>`). Each consumer keeps its
+   * own remembered interval. Must be a member of
+   * {@link FetchKeyAutoUpdateSettingId} so typos/unregistered ids are caught at
+   * compile time.
+   */
+  settingId: FetchKeyAutoUpdateSettingId;
+}
+
+/**
+ * Host wrapper around `BAIFetchKeyButton` that exposes the opt-in auto-refresh
+ * interval dropdown (FR-3147) and persists the chosen interval via
+ * `useBAISetting`, keyed per consumer by `settingId`.
+ *
+ * Auto-refresh is off by default; it only runs once the user picks an interval
+ * from the dropdown, and the choice is remembered per consumer across reloads.
+ *
+ * The dropdown shows the default presets ({@link AUTO_UPDATE_DELAY_OPTIONS} in
+ * BAIFetchKeyButton). A consumer can offer a different cadence by passing
+ * `autoUpdateDelayOptions` (e.g. {@link LONG_AUTO_UPDATE_DELAY_OPTIONS} for
+ * expensive views), which is forwarded to the underlying button.
+ */
+const AutoUpdateFetchKeyButton: React.FC<AutoUpdateFetchKeyButtonProps> = ({
+  settingId,
+  ...props
+}) => {
+  'use memo';
+  const [autoUpdateDelay, setAutoUpdateDelay] = useBAISettingUserState(
+    `fetchKeyAutoUpdateDelay.${settingId}`,
+  );
+  return (
+    <BAIFetchKeyButton
+      {...props}
+      autoUpdateDelay={autoUpdateDelay ?? null}
+      onChangeAutoUpdateDelay={setAutoUpdateDelay}
+    />
+  );
+};
+
+export default AutoUpdateFetchKeyButton;

--- a/react/src/components/FairShareItems/FairShareList.tsx
+++ b/react/src/components/FairShareItems/FairShareList.tsx
@@ -16,6 +16,9 @@ import {
 } from '../../__generated__/FairShareListQuery.graphql';
 import { convertToOrderBy, handleRowSelectionChange } from '../../helper';
 import { useBAIPaginationOptionStateOnSearchParam } from '../../hooks/reactPaginationQueryOptions';
+import AutoUpdateFetchKeyButton, {
+  LONG_AUTO_UPDATE_DELAY_OPTIONS,
+} from '../AutoUpdateFetchKeyButton';
 import DomainFairShareTable, {
   availableDomainFairShareSorterValues,
   DomainFairShare,
@@ -42,7 +45,6 @@ import {
   BAIQuestionIconWithTooltip,
   BAIBackButton,
   BAIButton,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAISelectionLabel,
@@ -652,8 +654,9 @@ const FairShareList: React.FC = () => {
                 </Tooltip>
               </>
             )}
-            <BAIFetchKeyButton
-              autoUpdateDelay={7_000}
+            <AutoUpdateFetchKeyButton
+              settingId="fair-share-list"
+              autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}
               loading={fetchKey !== deferredFetchKey}
               value=""
               onChange={() => {

--- a/react/src/components/LoginHistory.tsx
+++ b/react/src/components/LoginHistory.tsx
@@ -7,12 +7,12 @@ import type {
   LoginHistoryQuery as LoginHistoryQueryType,
 } from '../__generated__/LoginHistoryQuery.graphql';
 import { convertToOrderBy } from '../helper';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import LoginHistoryTable, {
   loginResultFilterOptions,
   type LoginHistoryTableProps,
 } from './LoginHistoryTable';
 import {
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   filterOutNullAndUndefined,
@@ -137,13 +137,13 @@ const LoginHistory = ({
             },
           ]}
         />
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="login-history"
           value=""
           onChange={() => {
             onReload(queryRef.variables, { fetchPolicy: 'network-only' });
           }}
           loading={isRefetching}
-          autoUpdateDelay={7_000}
         />
       </BAIFlex>
       <LoginHistoryTable

--- a/react/src/components/LoginSession.tsx
+++ b/react/src/components/LoginSession.tsx
@@ -8,6 +8,7 @@ import type {
 } from '../__generated__/LoginSessionQuery.graphql';
 import type { LoginSessionRevokeMutation } from '../__generated__/LoginSessionRevokeMutation.graphql';
 import { convertToOrderBy } from '../helper';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import LoginSessionTable, {
   type LoginSessionNodeInList,
   type LoginSessionTableProps,
@@ -15,7 +16,6 @@ import LoginSessionTable, {
 import { LogoutOutlined } from '@ant-design/icons';
 import { App } from 'antd';
 import {
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
@@ -165,13 +165,13 @@ const LoginSession = ({
             },
           ]}
         />
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="login-session"
           value=""
           onChange={() => {
             onReload(queryRef.variables, { fetchPolicy: 'network-only' });
           }}
           loading={isRefetching}
-          autoUpdateDelay={7_000}
         />
       </BAIFlex>
       <LoginSessionTable

--- a/react/src/components/PendingSessionNodeList.tsx
+++ b/react/src/components/PendingSessionNodeList.tsx
@@ -10,6 +10,7 @@ import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import SessionNodes from './SessionNodes';
 import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';
 import { Form } from 'antd';
@@ -17,7 +18,6 @@ import {
   BAIAlert,
   BAIFlex,
   filterOutNullAndUndefined,
-  BAIFetchKeyButton,
   useFetchKey,
   INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
@@ -117,12 +117,12 @@ const PendingSessionNodeList: React.FC = () => {
             tooltip={t('general.ResourceGroup')}
           />
         </Form.Item>
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="pending-session-list"
           loading={
             deferredQueryVariables !== queryVariables ||
             deferredFetchKey !== fetchKey
           }
-          autoUpdateDelay={7_000}
           value={fetchKey}
           onChange={(newFetchKey) => {
             updateFetchKey(newFetchKey);

--- a/react/src/components/PrometheusPresetTab.tsx
+++ b/react/src/components/PrometheusPresetTab.tsx
@@ -12,13 +12,15 @@ import { PrometheusQueryPresetEditorModalFragment$key } from '../__generated__/P
 import { convertToOrderBy } from '../helper';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import AutoUpdateFetchKeyButton, {
+  LONG_AUTO_UPDATE_DELAY_OPTIONS,
+} from './AutoUpdateFetchKeyButton';
 import PrometheusQueryPresetEditorModal from './PrometheusQueryPresetEditorModal';
 import PrometheusQueryPresetNodes from './PrometheusQueryPresetNodes';
 import { App } from 'antd';
 import {
   BAIButton,
   BAIDeleteConfirmModal,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   INITIAL_FETCH_KEY,
@@ -152,7 +154,9 @@ const PrometheusPresetTab: React.FC = () => {
           ]}
         />
         <BAIFlex gap="xs">
-          <BAIFetchKeyButton
+          <AutoUpdateFetchKeyButton
+            settingId="prometheus-preset"
+            autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}
             value={fetchKey}
             onChange={updateFetchKey}
             loading={isPending}

--- a/react/src/components/ScopedAuditLog.tsx
+++ b/react/src/components/ScopedAuditLog.tsx
@@ -4,10 +4,10 @@ import type {
   ScopedAuditLogQuery as ScopedAuditLogQueryType,
 } from '../__generated__/ScopedAuditLogQuery.graphql';
 import { convertToOrderBy } from '../helper';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import {
   BAIAuditLogNodes,
   type BAIAuditLogNodesProps,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   filterOutNullAndUndefined,
@@ -147,14 +147,14 @@ const ScopedAuditLog = ({
             },
           ]}
         />
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="scoped-audit-log"
           value={fetchKey}
           onChange={(key) => {
             updateFetchKey(key);
             onReload(queryRef.variables, { fetchPolicy: 'network-only' });
           }}
           loading={isRefetching}
-          autoUpdateDelay={7_000}
         />
       </BAIFlex>
       <BAIAuditLogNodes

--- a/react/src/components/SessionDetailDrawer.tsx
+++ b/react/src/components/SessionDetailDrawer.tsx
@@ -4,10 +4,11 @@
  */
 import { SessionDetailDrawerFragment$key } from '../__generated__/SessionDetailDrawerFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import SessionDetailContent from './SessionDetailContent';
 import { Drawer, Skeleton } from 'antd';
 import { DrawerProps } from 'antd/lib';
-import { BAIFetchKeyButton, useFetchKey } from 'backend.ai-ui';
+import { useFetchKey } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import React, { Suspense, useMemo, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -65,9 +66,9 @@ const SessionDetailDrawer: React.FC<SessionDetailDrawerProps> = ({
       title={t('session.SessionInfo')}
       size={800}
       extra={
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="session-detail"
           loading={isPendingReload}
-          autoUpdateDelay={7_000}
           value={fetchKey}
           onChange={(newFetchKey) => {
             startReloadTransition(() => {

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -9,6 +9,7 @@ import {
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import StorageHostDetailDrawer from './StorageHostDetailDrawer';
 import { type TableColumnsType, Tag, theme, Typography } from 'antd';
 import {
@@ -18,7 +19,6 @@ import {
   BAILink,
   BAIPureStorageIcon,
   BAITable,
-  BAIFetchKeyButton,
   BAIProgressWithLabel,
   BAIDoubleTag,
   BAIUnmountAfterClose,
@@ -256,12 +256,12 @@ const StorageProxyList = () => {
               },
             ]}
           /> */}
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="storage-proxy-list"
           loading={
             deferredFetchKey !== fetchKey ||
             deferredQueryVariables !== queryVariables
           }
-          autoUpdateDelay={15_000}
           value={fetchKey}
           onChange={() => {
             updateFetchKey();

--- a/react/src/components/UserSessionsMetrics.tsx
+++ b/react/src/components/UserSessionsMetrics.tsx
@@ -6,15 +6,13 @@ import { UserSessionsMetricsQuery } from '../__generated__/UserSessionsMetricsQu
 import { newLineToBrElement } from '../helper';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import AutoUpdateFetchKeyButton, {
+  LONG_AUTO_UPDATE_DELAY_OPTIONS,
+} from './AutoUpdateFetchKeyButton';
 import BAIBoard, { BAIBoardItem } from './BAIBoard';
 import SessionMetricGraph from './SessionMetricGraph';
 import { Alert, DatePicker, Empty, Skeleton, theme } from 'antd';
-import {
-  useUpdatableState,
-  BAIFetchKeyButton,
-  BAIFlex,
-  filterOutEmpty,
-} from 'backend.ai-ui';
+import { useUpdatableState, BAIFlex, filterOutEmpty } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { Suspense, useEffect, useMemo, useState, useTransition } from 'react';
@@ -244,7 +242,9 @@ const UserSessionsMetrics: React.FC<UserSessionsMetricsProps> = () => {
             },
           ]}
         />
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="user-sessions-metrics"
+          autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}
           loading={isPendingUsageTransition}
           value={usageFetchKey}
           onChange={() => {

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -43,6 +43,10 @@ export interface UserSettings {
   [key: `hiddenColumnKeys.${string}`]: Array<string>;
   [key: `table_column_overrides.${string}`]: BAITableColumnOverrideRecord;
   [key: `projectGroup.${string}`]: string;
+  // Per-consumer auto-refresh interval (ms) chosen via BAIFetchKeyButton's
+  // interval dropdown. `null` (or absent) means auto-refresh is off. Keyed by a
+  // stable consumer id (see AutoUpdateFetchKeyButton's `settingId`).
+  [key: `fetchKeyAutoUpdateDelay.${string}`]: number | null;
 
   max_concurrent_uploads?: number;
   container_log_auto_refresh_enabled?: boolean;

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -7,6 +7,7 @@ import {
   AdminComputeSessionListPageQuery$data,
   AdminComputeSessionListPageQuery$variables,
 } from '../__generated__/AdminComputeSessionListPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import BAITabs from '../components/BAITabs';
 import TerminateSessionModal from '../components/ComputeSessionNodeItems/TerminateSessionModal';
@@ -23,7 +24,6 @@ import { useCSVExport } from '../hooks/useCSVExport';
 import { Alert, App, Badge, Button, theme, Tooltip } from 'antd';
 import {
   BAIAdminProjectSelect,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIPropertyFilter,
   BAISelectionLabel,
@@ -386,12 +386,12 @@ const AdminComputeSessionListPage = () => {
                 </Tooltip>
               </>
             )}
-            <BAIFetchKeyButton
+            <AutoUpdateFetchKeyButton
+              settingId="admin-session-list"
               loading={
                 deferredQueryVariables !== queryVariables ||
                 deferredFetchKey !== fetchKey
               }
-              autoUpdateDelay={15_000}
               value={fetchKey}
               onChange={(newFetchKey) => {
                 updateFetchKey(newFetchKey);

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -11,6 +11,7 @@ import type {
   OrderDirection,
 } from '../__generated__/AdminDeploymentListPageQuery.graphql';
 import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
@@ -28,7 +29,6 @@ import {
   BAICard,
   BAIDeleteConfirmModal,
   BAIDeploymentTagChips,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLFilterProperty,
   BAIGraphQLPropertyFilter,
@@ -293,10 +293,10 @@ const AdminDeploymentListPageContent: React.FC = () => {
               }}
             />
           </BAIFlex>
-          <BAIFetchKeyButton
+          <AutoUpdateFetchKeyButton
+            settingId="admin-deployment-list"
             value={fetchKey}
             onChange={updateFetchKey}
-            autoUpdateDelay={15_000}
             loading={isLoading}
           />
         </BAIFlex>

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -7,6 +7,7 @@ import type {
   AdminVFolderNodeListPageQuery$data,
   AdminVFolderNodeListPageQuery$variables,
 } from '../__generated__/AdminVFolderNodeListPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import BAITabs from '../components/BAITabs';
 import DeleteVFolderModal from '../components/DeleteVFolderModal';
@@ -23,7 +24,6 @@ import { Badge, theme, Tooltip } from 'antd';
 import {
   BAIButton,
   BAICard,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIPropertyFilter,
   BAIRestoreIcon,
@@ -434,12 +434,12 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
                     </Tooltip>
                   </>
                 )}
-              <BAIFetchKeyButton
+              <AutoUpdateFetchKeyButton
+                settingId="admin-vfolder-list"
                 loading={
                   deferredQueryVariables !== queryVariables ||
                   deferredFetchKey !== fetchKey
                 }
-                autoUpdateDelay={15_000}
                 value={fetchKey}
                 onChange={(newFetchKey) => {
                   updateFetchKey(newFetchKey);

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -8,6 +8,7 @@ import {
   ComputeSessionListPageQuery$variables,
 } from '../__generated__/ComputeSessionListPageQuery.graphql';
 import ActionItemContent from '../components/ActionItemContent';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import BAITabs from '../components/BAITabs';
 import TerminateSessionModal from '../components/ComputeSessionNodeItems/TerminateSessionModal';
@@ -38,7 +39,6 @@ import {
 import {
   BAIAlertIconWithTooltip,
   BAICard,
-  BAIFetchKeyButton,
   BAIFlex,
   BAILink,
   BAIPropertyFilter,
@@ -515,12 +515,12 @@ const ComputeSessionListPage = () => {
                   </Tooltip>
                 </>
               )}
-              <BAIFetchKeyButton
+              <AutoUpdateFetchKeyButton
+                settingId="session-list"
                 loading={
                   deferredQueryVariables !== queryVariables ||
                   deferredFetchKey !== fetchKey
                 }
-                autoUpdateDelay={15_000}
                 // showLastLoadTime
                 value={fetchKey}
                 onChange={(newFetchKey) => {

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -10,6 +10,7 @@ import {
   DeploymentStatus,
 } from '../__generated__/DeploymentListPageQuery.graphql';
 import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import DeploymentSettingModal from '../components/DeploymentSettingModal';
@@ -24,7 +25,6 @@ import {
   BAICard,
   BAIDeleteConfirmModal,
   BAIDeploymentTagChips,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLFilterProperty,
   BAIGraphQLPropertyFilter,
@@ -251,8 +251,8 @@ const DeploymentListPageContent: React.FC = () => {
             />
           </BAIFlex>
           <BAIFlex gap="xs" align="center">
-            <BAIFetchKeyButton
-              autoUpdateDelay={15_000}
+            <AutoUpdateFetchKeyButton
+              settingId="deployment-list"
               value={fetchKey}
               onChange={updateFetchKey}
               loading={isPending}

--- a/react/src/pages/ProjectAdminDataPage.tsx
+++ b/react/src/pages/ProjectAdminDataPage.tsx
@@ -8,6 +8,7 @@ import type {
   VFolderFilter,
   VFolderOrderBy,
 } from '../__generated__/ProjectAdminDataPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import BAITabs from '../components/BAITabs';
@@ -30,7 +31,6 @@ import { Badge, Skeleton, theme, Tooltip } from 'antd';
 import {
   BAIButton,
   BAICard,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIPurgeIcon,
@@ -408,12 +408,12 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
                   </Tooltip>
                 </>
               )}
-            <BAIFetchKeyButton
+            <AutoUpdateFetchKeyButton
+              settingId="project-admin-data"
               loading={
                 deferredQueryVariables !== queryVariables ||
                 deferredFetchKey !== fetchKey
               }
-              autoUpdateDelay={15_000}
               value={fetchKey}
               onChange={(newFetchKey) => {
                 updateFetchKey(newFetchKey);

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -11,6 +11,7 @@ import type {
   OrderDirection,
   ProjectAdminDeploymentsPageQuery,
 } from '../__generated__/ProjectAdminDeploymentsPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
@@ -25,7 +26,6 @@ import {
   BAICard,
   BAIDeleteConfirmModal,
   BAIDeploymentTagChips,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLFilterProperty,
   BAIGraphQLPropertyFilter,
@@ -256,11 +256,11 @@ const ProjectAdminDeploymentsContent: React.FC<
               }}
             />
           </BAIFlex>
-          <BAIFetchKeyButton
+          <AutoUpdateFetchKeyButton
+            settingId="project-admin-deployments"
             loading={isLoading}
             value={fetchKey}
             onChange={(next) => updateFetchKey(next)}
-            autoUpdateDelay={15_000}
           />
         </BAIFlex>
         <BAIModelDeploymentNodes

--- a/react/src/pages/ProjectAdminSessionPage.tsx
+++ b/react/src/pages/ProjectAdminSessionPage.tsx
@@ -9,6 +9,7 @@ import type {
   SessionV2OrderBy,
   SessionV2Status,
 } from '../__generated__/ProjectAdminSessionPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import TerminateSessionModalForProjectAdmin from '../components/TerminateSessionModalForProjectAdmin';
@@ -19,7 +20,6 @@ import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { Button, Skeleton, Tooltip, theme } from 'antd';
 import {
   BAICard,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
@@ -244,11 +244,11 @@ const ProjectAdminSessionContent: React.FC<ProjectAdminSessionContentProps> = ({
               </Tooltip>
             </>
           )}
-          <BAIFetchKeyButton
+          <AutoUpdateFetchKeyButton
+            settingId="project-admin-session"
             loading={isLoading}
             value={fetchKey}
             onChange={(next) => updateFetchKey(next)}
-            autoUpdateDelay={15_000}
           />
         </BAIFlex>
       </BAIFlex>

--- a/react/src/pages/ProjectAdminUsersPage.tsx
+++ b/react/src/pages/ProjectAdminUsersPage.tsx
@@ -7,6 +7,7 @@ import type {
   UserV2Filter,
   UserV2OrderBy,
 } from '../__generated__/ProjectAdminUsersPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import { convertToOrderBy } from '../helper';
@@ -17,7 +18,6 @@ import { Skeleton } from 'antd';
 import {
   availableUserV2SorterValues,
   BAICard,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIAdminUserV2Table,
@@ -183,11 +183,11 @@ const ProjectAdminUsersContent: React.FC<ProjectAdminUsersContentProps> = ({
             }}
           />
         </BAIFlex>
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="project-admin-users"
           loading={isLoading}
           value={fetchKey}
           onChange={(next) => updateFetchKey(next)}
-          autoUpdateDelay={15_000}
         />
       </BAIFlex>
       <BAIAdminUserV2Table

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -9,6 +9,7 @@ import {
   ReservoirArtifactDetailPageQuery$data,
   ReservoirArtifactDetailPageQuery$variables,
 } from '../__generated__/ReservoirArtifactDetailPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import ImportArtifactRevisionToFolderButton from '../components/ImportArtifactRevisionToFolderButton';
 import ImportArtifactRevisionToFolderModal from '../components/ImportArtifactRevisionToFolderModal';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
@@ -23,7 +24,6 @@ import {
   BAIColumnType,
   BAIDeleteArtifactRevisionsModal,
   BAIDeleteArtifactRevisionsModalArtifactRevisionFragmentKey,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIImportArtifactModal,
@@ -298,9 +298,9 @@ const ReservoirArtifactDetailPage = () => {
           </Title>
           {artifact && <BAIArtifactTypeTag artifactTypeFrgmt={artifact} />}
         </BAIFlex>
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="reservoir-artifact-detail"
           value={fetchKey}
-          autoUpdateDelay={15_000}
           loading={deferredFetchKey !== fetchKey}
           onChange={() => {
             updateFetchKey();

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -8,6 +8,7 @@ import {
   ReservoirPageQuery$variables,
   ArtifactType,
 } from '../__generated__/ReservoirPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import ScanArtifactModelsFromHuggingFaceModal from '../components/ScanArtifactModelsFromHuggingFaceModal';
 import { useWebUINavigate } from '../hooks';
@@ -23,7 +24,6 @@ import {
   BAICard,
   BAIDeactivateArtifactsModal,
   BAIDeactivateArtifactsModalArtifactsFragmentKey,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIHuggingFaceIcon,
@@ -388,9 +388,9 @@ const ReservoirPage: React.FC = () => {
                   </Tooltip>
                 </BAIFlex>
               )}
-              <BAIFetchKeyButton
+              <AutoUpdateFetchKeyButton
+                settingId="reservoir"
                 value={fetchKey}
-                autoUpdateDelay={15_000}
                 loading={deferredFetchKey !== fetchKey}
                 onChange={() => {
                   updateFetchKey();

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -7,6 +7,7 @@ import {
   VFolderNodeListPageQuery$data,
   VFolderNodeListPageQuery$variables,
 } from '../__generated__/VFolderNodeListPageQuery.graphql';
+import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import BAITabs from '../components/BAITabs';
 import DeleteVFolderModal from '../components/DeleteVFolderModal';
@@ -24,7 +25,6 @@ import { Badge, theme, Tooltip } from 'antd';
 import {
   BAIButton,
   BAICard,
-  BAIFetchKeyButton,
   BAIFlex,
   BAILink,
   BAIPropertyFilter,
@@ -511,12 +511,12 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                     </Tooltip>
                   </>
                 )}
-              <BAIFetchKeyButton
+              <AutoUpdateFetchKeyButton
+                settingId="vfolder-list"
                 loading={
                   deferredQueryVariables !== queryVariables ||
                   deferredFetchKey !== fetchKey
                 }
-                autoUpdateDelay={15_000}
                 value={fetchKey}
                 onChange={(newFetchKey) => {
                   updateFetchKey(newFetchKey);


### PR DESCRIPTION
Resolves #7920 (FR-3147)

> **Stacked on** #7927 — review/merge that one first.

## Summary

Second PR of the FR-3147 stack. PR #7927 added the opt-in interval dropdown to the shared `BAIFetchKeyButton`; this PR wires it into the polling consumers via a host wrapper and persists the chosen interval **per consumer**.

## What changed

- **Host wrapper `AutoUpdateFetchKeyButton`** (`react/src/components/`): renders `BAIFetchKeyButton` with the interval dropdown, reading/writing the selected interval through `useBAISetting` keyed by a stable `settingId` (`fetchKeyAutoUpdateDelay.<settingId>`). `settingId` is typed against a closed `FetchKeyAutoUpdateSettingId` union so typos / unregistered ids fail at compile time.
- **Per-consumer persisted key** `fetchKeyAutoUpdateDelay.<settingId>` (`number | null`) in `useBAISetting.tsx`.
- **Migrated the fixed-timer polling consumers** to `<AutoUpdateFetchKeyButton settingId="…" />`: session/agent detail drawers, `AgentList`, `LoginHistory`, `LoginSession`, `StorageProxyList`, `ScopedAuditLog`, `FairShareList`, `PendingSessionNodeList`, and the `*ListPage` / project-admin / reservoir pages.
- **Expensive/heavy views use the longer presets** via `autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}` (30s / 1m / 5m / 10m instead of the default 5–60s):
  - `FairShareList`
  - Prometheus-side views **newly given an (opt-in) auto-refresh**: `UserSessionsMetrics`, `PrometheusPresetTab`.
- Left unchanged: components that passed `autoUpdateDelay={null}` (scheduling-history modals, `ProjectPage`); the deployment revision rollout poll (`DeploymentBasicInfoCard` / `DeploymentDetailPage`, a purpose-driven conditional poll); and the container-log viewer (it keeps its own `AutoRefreshSwitch` toggle + free-form interval).

## Behavior (per FR-3147)

Auto-refresh is **off by default**; it only runs once the user picks an interval from the dropdown, and the choice is remembered **per consumer** across reloads. Cheap views offer the default 5–60s presets; expensive views (fair-share, Prometheus metrics) offer the longer 30s–10m presets. A call site can override the presets via `autoUpdateDelayOptions`.

## Verification

`bash scripts/verify.sh`: **Relay / Lint / Format — PASS.** The aggregate harness flags one phantom `tsc` error in untouched `FluentEmojiIcon.tsx` — a known fresh-worktree patched-dep artifact, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)