### PR TITLE
fix(FR-3152): build complete service input for preset model definition

### DIFF
--- a/react/src/components/AdminDeploymentPresetFormTypes.ts
+++ b/react/src/components/AdminDeploymentPresetFormTypes.ts
@@ -21,9 +21,13 @@ export type PreStartActionFormValue = {
 };
 
 export type ModelServiceFormValue = {
-  port?: number;
-  shell?: string;
-  startCommand?: string;
+  // `service` itself is optional on a model, but when present these three are
+  // always provided: the form marks them `required` (see
+  // AdminDeploymentPresetModelConfigItem) and the create path's
+  // PresetModelServiceConfigInput requires `port` / `startCommand` non-null.
+  port: number;
+  shell: string;
+  startCommand: string;
   preStartActions?: PreStartActionFormValue[];
   enableHealthCheck?: boolean;
   healthCheck?: ModelHealthCheckFormValue;

--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -300,9 +300,8 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                 service: m.service
                   ? {
                       port: m.service.port,
-                      shell: m.service.shell ?? undefined,
-                      startCommand:
-                        m.service.startCommand?.join(' ') ?? undefined,
+                      shell: m.service.shell,
+                      startCommand: m.service.startCommand?.join(' ') ?? '',
                       // 26.4.4rc7+: `enable` is authoritative; older managers
                       // omit it, so fall back to the object's presence.
                       enableHealthCheck:

--- a/react/src/pages/AdminDeploymentPresetSettingPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetSettingPage.tsx
@@ -28,72 +28,89 @@ const buildModelDefinitionInput = (
   // The model definition is optional: the card's switch (`enabled`) gates it,
   // so when off we omit it entirely (`modelDefinition: null`).
   if (!value?.enabled || !value.models?.length) return null;
+  // A model is only emitted when it carries a service, so if no model has one
+  // the definition is effectively empty — omit it (`modelDefinition: null`)
+  // instead of sending `{ models: [] }`, which violates the create path's
+  // "at least one model" requirement.
+  if (!value.models.some((m) => m.service)) return null;
   return {
-    models: value.models.map((m) => ({
-      name: m.name,
-      modelPath: m.modelPath,
-      // `port` is required by the preset's strict ModelDefinition validation
-      // (no backend default), so the form guarantees it is present here.
-      service: {
-        port: m.service?.port ?? null,
-        shell: m.service?.shell,
-        startCommand: m.service?.startCommand?.trim()
-          ? m.service.startCommand.trim().split(/\s+/)
-          : null,
-        preStartActions: (m.service?.preStartActions ?? []).map((a) => ({
-          action: a.action,
-          args: (() => {
-            try {
-              return JSON.parse(a.args || '{}');
-            } catch {
-              return {};
-            }
-          })(),
-        })),
-        healthCheck: (() => {
-          const hc = m.service?.healthCheck;
-          const checked = !!m.service?.enableHealthCheck;
-          // Disabled → send health_check: null. The preset's strict validation
-          // checks every inner field whenever the object is present, and GraphQL
-          // injects null for omitted fields (which pydantic rejects), so
-          // `{ enable: false }` alone still fails — null is the only way to disable.
-          if (!checked) return null;
-          // Enabled → the form requires all HC fields, so they are present here.
-          const fields = {
-            path: hc?.path,
-            interval: hc?.interval,
-            maxRetries: hc?.maxRetries,
-            maxWaitTime: hc?.maxWaitTime,
-            expectedStatusCode: hc?.expectedStatusCode,
-            initialDelay: hc?.initialDelay,
-          };
-          // Managers < 26.4.4rc7 strip the `enable` flag; on 26.4.4rc7+ it is
-          // sent explicitly to mark the check enabled.
-          return supportsHealthCheckEnable
-            ? { enable: true, ...fields }
-            : fields;
-        })(),
-      },
-      metadata: m.metadata
-        ? {
-            author: m.metadata.author || null,
-            title: m.metadata.title || null,
-            version: m.metadata.version || null,
-            created: null,
-            lastModified: null,
-            description: m.metadata.description || null,
-            task: m.metadata.task || null,
-            category: m.metadata.category || null,
-            architecture: m.metadata.architecture || null,
-            framework: m.metadata.framework?.length
-              ? m.metadata.framework
-              : null,
-            label: m.metadata.label?.length ? m.metadata.label : null,
-            license: m.metadata.license || null,
-            minResource: null,
-          }
-        : null,
-    })),
+    models: value.models.flatMap((m) => {
+      const service = m.service;
+      // `service` is optional on a model, but the create path's
+      // PresetModelServiceConfigInput is required (the update path's is
+      // nullable), so a model without a service can't be submitted — skip it.
+      // When present, ModelServiceFormValue guarantees port/shell/startCommand,
+      // so no field-level guards or non-null assertions are needed here.
+      if (!service) {
+        return [];
+      }
+      return [
+        {
+          name: m.name,
+          modelPath: m.modelPath,
+          service: {
+            port: service.port,
+            shell: service.shell,
+            startCommand: service.startCommand.trim()
+              ? service.startCommand.trim().split(/\s+/)
+              : [],
+            preStartActions: (service.preStartActions ?? []).map((a) => ({
+              action: a.action,
+              args: (() => {
+                try {
+                  return JSON.parse(a.args || '{}');
+                } catch {
+                  return {};
+                }
+              })(),
+            })),
+            healthCheck: (() => {
+              const hc = service.healthCheck;
+              const checked = !!service.enableHealthCheck;
+              // Disabled → send health_check: null. The preset's strict
+              // validation checks every inner field whenever the object is
+              // present, and GraphQL injects null for omitted fields (which
+              // pydantic rejects), so `{ enable: false }` alone still fails —
+              // null is the only way to disable.
+              if (!checked) return null;
+              // Enabled → the form requires all HC fields, so they are present.
+              const fields = {
+                path: hc?.path,
+                interval: hc?.interval,
+                maxRetries: hc?.maxRetries,
+                maxWaitTime: hc?.maxWaitTime,
+                expectedStatusCode: hc?.expectedStatusCode,
+                initialDelay: hc?.initialDelay,
+              };
+              // Managers < 26.4.4rc7 strip the `enable` flag; on 26.4.4rc7+ it
+              // is sent explicitly to mark the check enabled.
+              return supportsHealthCheckEnable
+                ? { enable: true, ...fields }
+                : fields;
+            })(),
+          },
+          metadata: m.metadata
+            ? {
+                author: m.metadata.author || null,
+                title: m.metadata.title || null,
+                version: m.metadata.version || null,
+                created: null,
+                lastModified: null,
+                description: m.metadata.description || null,
+                task: m.metadata.task || null,
+                category: m.metadata.category || null,
+                architecture: m.metadata.architecture || null,
+                framework: m.metadata.framework?.length
+                  ? m.metadata.framework
+                  : null,
+                label: m.metadata.label?.length ? m.metadata.label : null,
+                license: m.metadata.license || null,
+                minResource: null,
+              }
+            : null,
+        },
+      ];
+    }),
   };
 };
 


### PR DESCRIPTION
Resolves #7929 (FR-3152)

## Problem

`tsc` failed at the `adminCreateDeploymentRevisionPreset` call site in `AdminDeploymentPresetSettingPage.tsx`:

```
Type 'number | null' is not assignable to type 'number'.
  The types of 'service.port' are incompatible between these types.
```

`buildModelDefinitionInput` builds a **single** model-definition shape reused by both preset mutations, but the two take **different** input types:

| Mutation | modelDefinition input | `service` | `port` / `startCommand` |
|---|---|---|---|
| `adminUpdateDeploymentRevisionPreset` | `ModelDefinitionInput` → `ModelServiceConfigInput` | nullable | nullable |
| `adminCreateDeploymentRevisionPreset` | `PresetModelDefinitionInput` → `PresetModelServiceConfigInput!` | **required** | **non-null** (`Int!`, `[String!]!`) |

The helper emitted a partially-nullable service (`port: … ?? null`, `startCommand: … : null`), which satisfied the loose **update** path but violated the strict **create** path — so the error surfaced only at the create call site.

## Fix

Encode the invariant in the form type instead of guarding at runtime. `service` is optional on a model, but **when present** its `port` / `shell` / `startCommand` are always provided (the form marks them `required` in `AdminDeploymentPresetModelConfigItem`). So `ModelServiceFormValue` now declares those three as required:

```ts
export type ModelServiceFormValue = {
  port: number;        // was port?: number
  shell: string;       // was shell?: string
  startCommand: string; // was startCommand?: string
  preStartActions?: PreStartActionFormValue[];
  enableHealthCheck?: boolean;
  healthCheck?: ModelHealthCheckFormValue;
};
```

With that, `buildModelDefinitionInput` only needs to branch on whether the service exists (`if (!service) return []`) — a model without a service can't be submitted to the create path, so it is skipped. The required fields are then read directly, with **no per-field guards and no non-null (`!`) assertions**. The resulting complete service type-checks against the strict create input and stays assignable to the loose update input.

The only follow-on change is the edit-mode loader (`AdminDeploymentPresetSettingPageContent.tsx`), where the nullable read-side `startCommand` now falls back to `''` instead of `undefined` to match the required form type.

## Files

- `AdminDeploymentPresetFormTypes.ts` — `port` / `shell` / `startCommand` made required.
- `AdminDeploymentPresetSettingPageContent.tsx` — loader `startCommand ?? ''`.
- `AdminDeploymentPresetSettingPage.tsx` — `buildModelDefinitionInput` reads required fields directly; drops service-less models.

## Verification

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all **PASS**.