### PR TITLE
feat(FR-3154): add reusable BAIVFolderMountConfigInput component

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderMountConfigInput.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderMountConfigInput.tsx
@@ -1,0 +1,446 @@
+import { useBAIi18n } from '../../hooks/useBAIi18n';
+import BAIFlex from '../BAIFlex';
+import BAIQuestionIconWithTooltip from '../BAIQuestionIconWithTooltip';
+import BAIText from '../BAIText';
+import BAIVFolderSelect from './BAIVFolderSelect';
+import { useControllableValue } from 'ahooks';
+import { Button, Form, Input, Skeleton, Tag, Tooltip, theme } from 'antd';
+import * as _ from 'lodash-es';
+import { XIcon } from 'lucide-react';
+import React, { Suspense } from 'react';
+
+/**
+ * A single vfolder mount configuration emitted by BAIVFolderMountConfigInput.
+ *
+ * - `vfolderId` is the vfolder's **UUID** (`row_id`), so consumers can forward
+ *   it to mount mutation inputs without further conversion.
+ * - `subpath` is the mount **source**: which subfolder inside the vfolder to
+ *   mount. Empty means the vfolder root.
+ * - `mountDestination` is the **raw alias** the user typed, stored verbatim so
+ *   the input box never transforms text mid-edit: `''` mounts at the default
+ *   `${aliasBasePath}${name}`, a relative segment like `data` resolves to
+ *   `${aliasBasePath}data`, and an absolute path like `/data` is used as-is.
+ *   Resolve it to the full container path with {@link inputToMountDestination}.
+ */
+export interface VFolderMountConfigValue {
+  vfolderId: string;
+  name?: string;
+  mountDestination?: string;
+  subpath?: string;
+}
+
+export interface BAIVFolderMountConfigInputProps {
+  value?: VFolderMountConfigValue[];
+  defaultValue?: VFolderMountConfigValue[];
+  onChange?: (value: VFolderMountConfigValue[]) => void;
+  currentProjectId?: string;
+  filter?: string;
+  disabled?: boolean;
+  /** Base path prepended to a relative alias input (mirrors VFolderTable). */
+  aliasBasePath?: string;
+  /**
+   * Names of folders that are auto-mounted (dotfile folders). Their default
+   * mount paths (`${aliasBasePath}${name}`) are added to the overlap set so a
+   * user alias colliding with an auto-mounted folder is flagged — mirrors
+   * VFolderTable's `FolderAliasOverlappingToAutoMount` check. Also shown as a
+   * read-only tag list at the bottom of the component.
+   */
+  autoMountedFolderNames?: string[];
+}
+
+// Mirrors the alias validation used by the legacy VFolderTable mount UI.
+export const vFolderAliasNameRegExp = /^[a-zA-Z0-9_/.-]*$/;
+
+const DEFAULT_ALIAS_BASE_PATH = '/home/work/';
+
+/**
+ * Convert a user-entered alias input into the resolved mount destination,
+ * following the same rule as VFolderTable's `inputToAliasPath`:
+ * - empty input        -> `${basePath}${name}`
+ * - input starting `/` -> used as-is (absolute path)
+ * - otherwise          -> `${basePath}${input}` (relative to the base path)
+ */
+export const inputToMountDestination = (
+  name: string,
+  input: string | undefined,
+  basePath: string,
+) => {
+  const trimmed = input?.trim();
+  if (!trimmed) return `${basePath}${name}`;
+  if (trimmed.startsWith('/')) return trimmed;
+  return `${basePath}${trimmed}`;
+};
+
+// Subpath must be a relative path that does not escape the vfolder.
+const isSubpathInvalid = (subpath?: string) => {
+  const trimmed = subpath?.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('/')) return true;
+  return trimmed.split('/').some((segment) => segment === '..');
+};
+
+export interface VFolderMountConfigStatusOptions {
+  /** Base path prepended to a relative alias input (mirrors VFolderTable). */
+  aliasBasePath?: string;
+  /** Names of auto-mounted folders, included in the overlap check. */
+  autoMountedFolderNames?: string[];
+}
+
+export interface VFolderMountConfigEntryStatus {
+  /** The resolved absolute mount path for the entry (for display). */
+  mountDestination: string;
+  /** Alias error, if any: a bad path format or a colliding mount path. */
+  aliasError?: 'invalidFormat' | 'overlapping';
+  /** Set when the subpath is absolute or escapes the vfolder via `..`. */
+  subpathError?: boolean;
+}
+
+/**
+ * Compute, per entry, its resolved mount destination and any alias/subpath
+ * error — the single source of truth behind the component's inline feedback.
+ * Exported so a consumer can gate a form on validity (see
+ * {@link isVFolderMountConfigValid}) or translate the error kinds itself.
+ */
+export const getVFolderMountConfigStatuses = (
+  value: VFolderMountConfigValue[] | undefined,
+  options?: VFolderMountConfigStatusOptions,
+): Record<string, VFolderMountConfigEntryStatus> => {
+  const basePath = options?.aliasBasePath ?? DEFAULT_ALIAS_BASE_PATH;
+  const entries = value ?? [];
+
+  const mountDestinationByVFolderId: Record<string, string> = {};
+  entries.forEach((entry) => {
+    mountDestinationByVFolderId[entry.vfolderId] = inputToMountDestination(
+      entry.name || entry.vfolderId,
+      entry.mountDestination,
+      basePath,
+    );
+  });
+  // Auto-mounted folders occupy their default mount path; include them so a
+  // user alias colliding with an auto-mounted folder counts as an overlap.
+  const autoMountDestinations = (options?.autoMountedFolderNames ?? []).map(
+    (n) => inputToMountDestination(n, '', basePath),
+  );
+  const destinationCounts = _.countBy([
+    ...Object.values(mountDestinationByVFolderId),
+    ...autoMountDestinations,
+  ]);
+
+  const statuses: Record<string, VFolderMountConfigEntryStatus> = {};
+  entries.forEach((entry) => {
+    const mountDestination = mountDestinationByVFolderId[entry.vfolderId];
+    statuses[entry.vfolderId] = {
+      mountDestination,
+      aliasError: !vFolderAliasNameRegExp.test(entry.mountDestination ?? '')
+        ? 'invalidFormat'
+        : destinationCounts[mountDestination] > 1
+          ? 'overlapping'
+          : undefined,
+      subpathError: isSubpathInvalid(entry.subpath),
+    };
+  });
+  return statuses;
+};
+
+/** True when every entry's alias and subpath are valid. */
+export const isVFolderMountConfigValid = (
+  value: VFolderMountConfigValue[] | undefined,
+  options?: VFolderMountConfigStatusOptions,
+): boolean =>
+  Object.values(getVFolderMountConfigStatuses(value, options)).every(
+    (status) => !status.aliasError && !status.subpathError,
+  );
+
+/**
+ * Reusable, schema-agnostic input for configuring vfolder mounts.
+ *
+ * Users pick vfolders with {@link BAIVFolderSelect} (in `row_id` mode, so the
+ * value is the vfolder UUID); each selected folder appears as a row below the
+ * select where its mount destination (alias) and an optional subpath can be
+ * edited. The alias input follows VFolderTable's rule (relative inputs are
+ * prefixed with `aliasBasePath`, absolute inputs are used as-is); the emitted
+ * `mountDestination` stores that raw alias verbatim, which the consumer
+ * resolves to the full path with {@link inputToMountDestination}. The component
+ * is controlled and emits a single `VFolderMountConfigValue[]` value.
+ *
+ * The inline per-row errors are advisory UX only. To gate a form on validity,
+ * wrap the component in one named `Form.Item` and call
+ * {@link isVFolderMountConfigValid} from a `rules` validator so
+ * `form.validateFields()` rejects on invalid input:
+ *
+ * ```tsx
+ * <Form.Item
+ *   name="mounts"
+ *   rules={[
+ *     {
+ *       validator: (_rule, value) =>
+ *         isVFolderMountConfigValid(value, { aliasBasePath, autoMountedFolderNames })
+ *           ? Promise.resolve()
+ *           : Promise.reject(new Error(t('...'))),
+ *     },
+ *   ]}
+ * >
+ *   <BAIVFolderMountConfigInput autoMountedFolderNames={...} />
+ * </Form.Item>
+ * ```
+ */
+const BAIVFolderMountConfigInput: React.FC<BAIVFolderMountConfigInputProps> = ({
+  currentProjectId,
+  filter,
+  disabled,
+  aliasBasePath = DEFAULT_ALIAS_BASE_PATH,
+  autoMountedFolderNames,
+  ...props
+}) => {
+  'use memo';
+  const { t } = useBAIi18n();
+  const { token } = theme.useToken();
+  const [value, setValue] = useControllableValue<VFolderMountConfigValue[]>(
+    props,
+    { defaultValue: [] },
+  );
+  const mountConfigs = value ?? [];
+  // `vfolderId` is the vfolder UUID; BAIVFolderSelect runs in `row_id` mode so
+  // its value, options, and resolved name map are all keyed by the same UUID.
+  const selectedIds = mountConfigs.map((entry) => entry.vfolderId);
+
+  // Resolve each entry's mount destination + validity once via the same
+  // exported helper a consumer uses to gate the form, then read per row below.
+  const statusByVFolderId = getVFolderMountConfigStatuses(mountConfigs, {
+    aliasBasePath,
+    autoMountedFolderNames,
+  });
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="xs">
+      <Suspense fallback={<Skeleton.Input active block />}>
+        <BAIVFolderSelect
+          mode="multiple"
+          allowClear
+          disabled={disabled}
+          currentProjectId={currentProjectId}
+          filter={filter}
+          valuePropName="row_id"
+          value={selectedIds}
+          onResolvedNamesChange={(nameMap) => {
+            // nameMap is keyed by row_id (== vfolderId). Backfill names that
+            // resolve asynchronously after selection. `mountDestination` is the
+            // raw alias and never depends on the name, so only `name` changes
+            // here. The guard skips a redundant emit when every name is already
+            // set — this callback fires on every node-load of BAIVFolderSelect.
+            let changed = false;
+            const next = mountConfigs.map((entry) => {
+              const resolved = nameMap[entry.vfolderId];
+              if (!entry.name && resolved) {
+                changed = true;
+                return { ...entry, name: resolved };
+              }
+              return entry;
+            });
+            if (changed) setValue(next);
+          }}
+          onChange={(ids, option) => {
+            // In `row_id` mode BAIVFolderSelect emits vfolder UUIDs directly.
+            const nextIds = _.castArray(ids ?? []);
+            const nameById: Record<string, string> = {};
+            _.castArray(option ?? []).forEach(
+              (opt: { label?: unknown; value?: string }) => {
+                if (opt?.value && _.isString(opt.label)) {
+                  nameById[opt.value] = opt.label;
+                }
+              },
+            );
+            setValue(
+              nextIds.map((id) => {
+                const resolvedName = nameById[id];
+                const existing = mountConfigs.find(
+                  (entry) => entry.vfolderId === id,
+                );
+                if (existing) {
+                  return resolvedName && !existing.name
+                    ? { ...existing, name: resolvedName }
+                    : existing;
+                }
+                return {
+                  vfolderId: id,
+                  name: resolvedName,
+                  // Raw alias starts empty -> resolves to the default mount
+                  // path (`${aliasBasePath}${name}`) at display time.
+                  mountDestination: '',
+                  subpath: '',
+                };
+              }),
+            );
+          }}
+        />
+      </Suspense>
+      {mountConfigs.length > 0 && (
+        <BAIFlex direction="column" align="stretch" gap="xxs">
+          <BAIFlex gap="xxs" align="center">
+            <BAIText type="secondary" style={{ width: 150, flexShrink: 0 }}>
+              {t('comp:BAIVFolderMountConfigInput.Name')}
+            </BAIText>
+            <BAIFlex gap="xxs" align="center" style={{ flex: 1 }}>
+              <BAIText type="secondary">
+                {t('comp:BAIVFolderMountConfigInput.PathAndAlias')}
+              </BAIText>
+              <BAIQuestionIconWithTooltip
+                title={t('comp:BAIVFolderMountConfigInput.PathAndAliasTooltip')}
+              />
+            </BAIFlex>
+            <BAIFlex gap="xxs" align="center" style={{ flex: 1 }}>
+              <BAIText type="secondary">
+                {t('comp:BAIVFolderMountConfigInput.Subpath')}
+              </BAIText>
+              <BAIQuestionIconWithTooltip
+                title={t('comp:BAIVFolderMountConfigInput.SubpathTooltip')}
+              />
+            </BAIFlex>
+            {/* Spacer aligning the header with the row's remove-button column
+                (kept in sync with the ✕ icon size via token.size). */}
+            <span style={{ width: token.size, flexShrink: 0 }} />
+          </BAIFlex>
+          {mountConfigs.map((entry) => {
+            const name = entry.name || entry.vfolderId;
+            const aliasInput = entry.mountDestination ?? '';
+            const status = statusByVFolderId[entry.vfolderId];
+            const effectiveDestination = status.mountDestination;
+            const aliasInvalidFormat = status.aliasError === 'invalidFormat';
+            const aliasOverlapping = status.aliasError === 'overlapping';
+            const subpathInvalid = !!status.subpathError;
+            return (
+              <BAIFlex
+                key={entry.vfolderId}
+                direction="row"
+                align="start"
+                gap="xxs"
+              >
+                <BAIText
+                  ellipsis={{ tooltip: true }}
+                  style={{
+                    width: 150,
+                    flexShrink: 0,
+                    // Match the input control height so the name lines up with
+                    // the input row, not the helper-text-inflated row height.
+                    lineHeight: `${token.controlHeight}px`,
+                  }}
+                >
+                  {name}
+                </BAIText>
+                {/* Nameless Form.Item: a controlled feedback wrapper (no Form
+                    ancestor / no `rules`). `help` shows errors, `extra` the
+                    always-on mount-destination hint. */}
+                <Form.Item
+                  validateStatus={
+                    aliasInvalidFormat || aliasOverlapping ? 'error' : undefined
+                  }
+                  help={
+                    aliasInvalidFormat
+                      ? t('comp:BAIVFolderMountConfigInput.AliasInvalid')
+                      : aliasOverlapping
+                        ? t('comp:BAIVFolderMountConfigInput.AliasOverlapping')
+                        : undefined
+                  }
+                  extra={
+                    aliasInvalidFormat || aliasOverlapping ? undefined : (
+                      <BAIText type="secondary" ellipsis>
+                        {effectiveDestination}
+                      </BAIText>
+                    )
+                  }
+                  style={{ flex: 1, marginBottom: 0 }}
+                >
+                  <Input
+                    size="small"
+                    disabled={disabled}
+                    placeholder={t(
+                      'comp:BAIVFolderMountConfigInput.AliasPlaceholder',
+                    )}
+                    value={aliasInput}
+                    onChange={(e) =>
+                      setValue(
+                        mountConfigs.map((m) =>
+                          m.vfolderId === entry.vfolderId
+                            ? { ...m, mountDestination: e.target.value }
+                            : m,
+                        ),
+                      )
+                    }
+                  />
+                </Form.Item>
+                <Form.Item
+                  validateStatus={subpathInvalid ? 'error' : undefined}
+                  help={
+                    subpathInvalid
+                      ? t('comp:BAIVFolderMountConfigInput.SubpathInvalid')
+                      : undefined
+                  }
+                  style={{ flex: 1, marginBottom: 0 }}
+                >
+                  <Input
+                    size="small"
+                    disabled={disabled}
+                    placeholder={t(
+                      'comp:BAIVFolderMountConfigInput.SubpathPlaceholder',
+                    )}
+                    value={entry.subpath}
+                    onChange={(e) =>
+                      setValue(
+                        mountConfigs.map((m) =>
+                          m.vfolderId === entry.vfolderId
+                            ? { ...m, subpath: e.target.value }
+                            : m,
+                        ),
+                      )
+                    }
+                  />
+                </Form.Item>
+                <Tooltip
+                  title={t('comp:BAIVFolderMountConfigInput.RemoveFolder')}
+                >
+                  <Button
+                    type="text"
+                    size="small"
+                    disabled={disabled}
+                    aria-label={t(
+                      'comp:BAIVFolderMountConfigInput.RemoveFolder',
+                    )}
+                    icon={
+                      <XIcon
+                        size={token.size}
+                        color={token.colorTextQuaternary}
+                      />
+                    }
+                    // Match the input control height so the remove button
+                    // centers on the input row, not the full (helper-inclusive)
+                    // row height.
+                    style={{ flexShrink: 0, height: token.controlHeight }}
+                    onClick={() =>
+                      setValue(
+                        mountConfigs.filter(
+                          (m) => m.vfolderId !== entry.vfolderId,
+                        ),
+                      )
+                    }
+                  />
+                </Tooltip>
+              </BAIFlex>
+            );
+          })}
+        </BAIFlex>
+      )}
+      {autoMountedFolderNames && autoMountedFolderNames.length > 0 && (
+        <BAIFlex gap="xxs" align="center" wrap="wrap">
+          <BAIText type="secondary">
+            {t('comp:BAIVFolderMountConfigInput.AutoMountedFolders')}
+          </BAIText>
+          {autoMountedFolderNames.map((folderName) => (
+            <Tag key={folderName}>{folderName}</Tag>
+          ))}
+        </BAIFlex>
+      )}
+    </BAIFlex>
+  );
+};
+
+export default BAIVFolderMountConfigInput;

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
@@ -340,7 +340,11 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
       )}
       value={
         controllableValue !== deferredControllableValue
-          ? optimisticValueWithLabel
+          ? // Optimistic state lags external value removals, so filter it to the
+            // current value to avoid briefly flickering a removed item back in.
+            optimisticValueWithLabel?.filter((item) =>
+              _.castArray(controllableValue ?? []).includes(item.value),
+            )
           : controllableValueWithLabel
       }
       labelInValue

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -88,6 +88,18 @@ export type {
   VFolderNode,
   BAIVFolderSelectRef,
 } from './BAIVFolderSelect';
+export { default as BAIVFolderMountConfigInput } from './BAIVFolderMountConfigInput';
+export {
+  inputToMountDestination,
+  getVFolderMountConfigStatuses,
+  isVFolderMountConfigValid,
+} from './BAIVFolderMountConfigInput';
+export type {
+  BAIVFolderMountConfigInputProps,
+  VFolderMountConfigValue,
+  VFolderMountConfigStatusOptions,
+  VFolderMountConfigEntryStatus,
+} from './BAIVFolderMountConfigInput';
 export { default as BAIProjectVfolderSelect } from './BAIProjectVfolderSelect';
 export type {
   BAIProjectVfolderSelectProps,

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Benutzer auswählen"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Ungültiges Pfadformat.",
+    "AliasOverlapping": "Der Einhängepfad überschneidet sich mit einem anderen Ordner.",
+    "AliasPlaceholder": "Einhängepfad",
+    "AutoMountedFolders": "Automatisch eingehängte Ordner",
+    "Name": "Name",
+    "PathAndAlias": "Pfad & Alias",
+    "PathAndAliasTooltip": "Der Pfad im Container, in den der Ordner eingehängt wird. Leer lassen, um den Standardpfad zu verwenden.",
+    "RemoveFolder": "Entfernen",
+    "Subpath": "Unterpfad",
+    "SubpathInvalid": "Der Unterpfad muss ein relativer Pfad sein und darf '..' nicht enthalten.",
+    "SubpathPlaceholder": "z. B. dataset/train (optional)",
+    "SubpathTooltip": "Hängt einen Unterordner innerhalb des Ordners als Quelle ein, anstatt dessen Wurzel. Leer lassen, um die Wurzel einzuhängen."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Ordner auswählen"
   },

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Επιλογή χρήστη"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Μη έγκυρη μορφή διαδρομής.",
+    "AliasOverlapping": "Η διαδρομή προσάρτησης επικαλύπτεται με άλλο φάκελο.",
+    "AliasPlaceholder": "Διαδρομή προσάρτησης",
+    "AutoMountedFolders": "Φάκελοι αυτόματης προσάρτησης",
+    "Name": "Όνομα",
+    "PathAndAlias": "Διαδρομή & Ψευδώνυμο",
+    "PathAndAliasTooltip": "Η διαδρομή εντός του container όπου θα προσαρτηθεί ο φάκελος. Αφήστε κενό για να χρησιμοποιηθεί η προεπιλεγμένη διαδρομή.",
+    "RemoveFolder": "Αφαίρεση",
+    "Subpath": "Υποδιαδρομή",
+    "SubpathInvalid": "Η υποδιαδρομή πρέπει να είναι σχετική και να μην περιέχει '..'.",
+    "SubpathPlaceholder": "π.χ. dataset/train (προαιρετικό)",
+    "SubpathTooltip": "Προσαρτά έναν υποφάκελο εντός του φακέλου ως πηγή αντί της ρίζας του. Αφήστε κενό για προσάρτηση της ρίζας."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Επιλογή φακέλου"
   },

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Select User"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Invalid path format.",
+    "AliasOverlapping": "Mount path overlaps with another folder.",
+    "AliasPlaceholder": "Mount path",
+    "AutoMountedFolders": "Automount Folders",
+    "Name": "Name",
+    "PathAndAlias": "Path & Alias",
+    "PathAndAliasTooltip": "The path inside the container where the folder will be mounted. Leave empty to use the default path.",
+    "RemoveFolder": "Remove",
+    "Subpath": "Subpath",
+    "SubpathInvalid": "Subpath must be a relative path and must not contain '..'.",
+    "SubpathPlaceholder": "e.g. dataset/train (optional)",
+    "SubpathTooltip": "Mount a subfolder inside the folder as the source instead of its root. Leave empty to mount the root."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Select Folder"
   },

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Seleccionar usuario"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Formato de ruta inválido.",
+    "AliasOverlapping": "La ruta de montaje se superpone con otra carpeta.",
+    "AliasPlaceholder": "Ruta de montaje",
+    "AutoMountedFolders": "Carpetas de montaje automático",
+    "Name": "Nombre",
+    "PathAndAlias": "Ruta & Alias",
+    "PathAndAliasTooltip": "La ruta dentro del contenedor donde se montará la carpeta. Déjelo vacío para usar la ruta predeterminada.",
+    "RemoveFolder": "Eliminar",
+    "Subpath": "Subruta",
+    "SubpathInvalid": "La subruta debe ser una ruta relativa y no debe contener '..'.",
+    "SubpathPlaceholder": "p. ej. dataset/train (opcional)",
+    "SubpathTooltip": "Monta una subcarpeta dentro de la carpeta como origen en lugar de su raíz. Déjelo vacío para montar la raíz."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Seleccionar carpeta"
   },

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Valitse käyttäjä"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Virheellinen polkumuoto.",
+    "AliasOverlapping": "Liitospolku on päällekkäinen toisen kansion kanssa.",
+    "AliasPlaceholder": "Liitospolku",
+    "AutoMountedFolders": "Automaattisesti liitetyt kansiot",
+    "Name": "Nimi",
+    "PathAndAlias": "Polku & Alias",
+    "PathAndAliasTooltip": "Polku säilön sisällä, johon kansio liitetään. Jätä tyhjäksi käyttääksesi oletuspolkua.",
+    "RemoveFolder": "Poista",
+    "Subpath": "Alihakemisto",
+    "SubpathInvalid": "Alihakemiston on oltava suhteellinen polku eikä se saa sisältää '..'.",
+    "SubpathPlaceholder": "esim. dataset/train (valinnainen)",
+    "SubpathTooltip": "Liittää kansion sisällä olevan alikansion lähteeksi juuren sijaan. Jätä tyhjäksi liittääksesi juuren."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Valitse kansio"
   },

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Sélectionner un utilisateur"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Format de chemin invalide.",
+    "AliasOverlapping": "Le chemin de montage chevauche un autre dossier.",
+    "AliasPlaceholder": "Chemin de montage",
+    "AutoMountedFolders": "Dossiers montés automatiquement",
+    "Name": "Nom",
+    "PathAndAlias": "Chemin & Alias",
+    "PathAndAliasTooltip": "Le chemin à l'intérieur du conteneur où le dossier sera monté. Laissez vide pour utiliser le chemin par défaut.",
+    "RemoveFolder": "Supprimer",
+    "Subpath": "Sous-chemin",
+    "SubpathInvalid": "Le sous-chemin doit être un chemin relatif et ne doit pas contenir '..'.",
+    "SubpathPlaceholder": "ex. dataset/train (facultatif)",
+    "SubpathTooltip": "Monte un sous-dossier à l'intérieur du dossier comme source au lieu de sa racine. Laissez vide pour monter la racine."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Sélectionner un dossier"
   },

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Pilih Pengguna"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Format jalur tidak valid.",
+    "AliasOverlapping": "Jalur mount bertumpang tindih dengan folder lain.",
+    "AliasPlaceholder": "Jalur mount",
+    "AutoMountedFolders": "Folder mount otomatis",
+    "Name": "Nama",
+    "PathAndAlias": "Jalur & Alias",
+    "PathAndAliasTooltip": "Jalur di dalam container tempat folder akan di-mount. Kosongkan untuk menggunakan jalur default.",
+    "RemoveFolder": "Hapus",
+    "Subpath": "Subjal",
+    "SubpathInvalid": "Subjalur harus berupa jalur relatif dan tidak boleh mengandung '..'.",
+    "SubpathPlaceholder": "mis. dataset/train (opsional)",
+    "SubpathTooltip": "Mount subfolder di dalam folder sebagai sumber, bukan dari direktori root-nya. Kosongkan untuk mount dari root."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Pilih Folder"
   },

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Seleziona utente"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Formato del percorso non valido.",
+    "AliasOverlapping": "Il percorso di montaggio si sovrappone a un'altra cartella.",
+    "AliasPlaceholder": "Percorso di montaggio",
+    "AutoMountedFolders": "Cartelle montate automaticamente",
+    "Name": "Nome",
+    "PathAndAlias": "Percorso & Alias",
+    "PathAndAliasTooltip": "Il percorso all'interno del container dove verrà montata la cartella. Lasciare vuoto per usare il percorso predefinito.",
+    "RemoveFolder": "Rimuovi",
+    "Subpath": "Sottopercorso",
+    "SubpathInvalid": "Il sottopercorso deve essere un percorso relativo e non deve contenere '..'.",
+    "SubpathPlaceholder": "es. dataset/train (facoltativo)",
+    "SubpathTooltip": "Monta una sottocartella all'interno della cartella come sorgente invece della sua radice. Lasciare vuoto per montare la radice."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Seleziona cartella"
   },

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "ユーザーを選択"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "パスの形式が無効です。",
+    "AliasOverlapping": "マウントパスが別のフォルダと重複しています。",
+    "AliasPlaceholder": "マウントパス",
+    "AutoMountedFolders": "自動マウントフォルダ",
+    "Name": "名前",
+    "PathAndAlias": "パス & エイリアス",
+    "PathAndAliasTooltip": "コンテナ内でフォルダがマウントされるパスです。デフォルトのパスを使用する場合は空欄にしてください。",
+    "RemoveFolder": "削除",
+    "Subpath": "サブパス",
+    "SubpathInvalid": "サブパスは相対パスである必要があり、'..' を含めることはできません。",
+    "SubpathPlaceholder": "例: dataset/train (省略可)",
+    "SubpathTooltip": "フォルダのルートではなく、フォルダ内のサブフォルダをマウントソースとして使用します。ルートをマウントするには空欄にしてください。"
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "フォルダを選択"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "사용자를 선택해주세요"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "경로 형식이 올바르지 않습니다.",
+    "AliasOverlapping": "다른 폴더와 마운트 경로가 중복됩니다.",
+    "AliasPlaceholder": "마운트 경로",
+    "AutoMountedFolders": "자동 마운트 폴더",
+    "Name": "이름",
+    "PathAndAlias": "경로 & 대체이름",
+    "PathAndAliasTooltip": "폴더가 컨테이너 내부에 마운트될 경로입니다. 비워두면 기본 경로가 사용됩니다.",
+    "RemoveFolder": "제거",
+    "Subpath": "하위 경로",
+    "SubpathInvalid": "하위 경로는 상대 경로여야 하며 '..'을 포함할 수 없습니다.",
+    "SubpathPlaceholder": "예: dataset/train (선택)",
+    "SubpathTooltip": "폴더 루트 대신 폴더 내부의 하위 경로를 마운트 소스로 사용합니다. 비워두면 루트가 마운트됩니다."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "폴더를 선택해주세요"
   },

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Хэрэглэгч сонгох"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Замын формат буруу байна.",
+    "AliasOverlapping": "Маунтын зам өөр хавтастай давхцаж байна.",
+    "AliasPlaceholder": "Маунтын зам",
+    "AutoMountedFolders": "Автоматаар маунт хийсэн хавтаснууд",
+    "Name": "Нэр",
+    "PathAndAlias": "Зам & Alias",
+    "PathAndAliasTooltip": "Хавтасыг контейнер дотор маунт хийх зам. Анхдагч замыг ашиглахын тулд хоосон үлдээнэ үү.",
+    "RemoveFolder": "Хасах",
+    "Subpath": "Дэд зам",
+    "SubpathInvalid": "Дэд зам нь харьцангуй зам байх ёстой бөгөөд '..' агуулж болохгүй.",
+    "SubpathPlaceholder": "жш нь dataset/train (заавал биш)",
+    "SubpathTooltip": "Хавтасны үндсийн оронд хавтас дотрах дэд хавтасыг эх сурвалж болгон маунт хийнэ. Үндсийг маунт хийхийн тулд хоосон үлдээнэ үү."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Хавтас сонгох"
   },

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Pilih Pengguna"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Format laluan tidak sah.",
+    "AliasOverlapping": "Laluan mount bertindih dengan folder lain.",
+    "AliasPlaceholder": "Laluan mount",
+    "AutoMountedFolders": "Folder mount automatik",
+    "Name": "Nama",
+    "PathAndAlias": "Laluan & Alias",
+    "PathAndAliasTooltip": "Laluan di dalam container tempat folder akan di-mount. Biarkan kosong untuk menggunakan laluan lalai.",
+    "RemoveFolder": "Buang",
+    "Subpath": "Sublaluan",
+    "SubpathInvalid": "Sublaluan mestilah laluan relatif dan tidak boleh mengandungi '..'.",
+    "SubpathPlaceholder": "cth. dataset/train (pilihan)",
+    "SubpathTooltip": "Mount subfolder di dalam folder sebagai sumber dan bukannya root-nya. Biarkan kosong untuk mount root."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Pilih Folder"
   },

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Wybierz użytkownika"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Nieprawidłowy format ścieżki.",
+    "AliasOverlapping": "Ścieżka montowania pokrywa się z innym folderem.",
+    "AliasPlaceholder": "Ścieżka montowania",
+    "AutoMountedFolders": "Automatycznie montowane foldery",
+    "Name": "Nazwa",
+    "PathAndAlias": "Ścieżka & Alias",
+    "PathAndAliasTooltip": "Ścieżka wewnątrz kontenera, w której zostanie zamontowany folder. Pozostaw puste, aby użyć domyślnej ścieżki.",
+    "RemoveFolder": "Usuń",
+    "Subpath": "Podścieżka",
+    "SubpathInvalid": "Podścieżka musi być ścieżką względną i nie może zawierać '..'.",
+    "SubpathPlaceholder": "np. dataset/train (opcjonalne)",
+    "SubpathTooltip": "Montuje podfolder wewnątrz folderu jako źródło zamiast jego katalogu głównego. Pozostaw puste, aby zamontować katalog główny."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Wybierz folder"
   },

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -392,6 +392,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Selecionar usuário"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Formato de caminho inválido.",
+    "AliasOverlapping": "O caminho de montagem se sobrepõe a outra pasta.",
+    "AliasPlaceholder": "Caminho de montagem",
+    "AutoMountedFolders": "Pastas de montagem automática",
+    "Name": "Nome",
+    "PathAndAlias": "Caminho & Alias",
+    "PathAndAliasTooltip": "O caminho dentro do container onde a pasta será montada. Deixe em branco para usar o caminho padrão.",
+    "RemoveFolder": "Remover",
+    "Subpath": "Subcaminho",
+    "SubpathInvalid": "O subcaminho deve ser um caminho relativo e não deve conter '..'.",
+    "SubpathPlaceholder": "ex. dataset/train (opcional)",
+    "SubpathTooltip": "Monta uma subpasta dentro da pasta como origem em vez da raiz. Deixe em branco para montar a raiz."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Selecionar pasta"
   },

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Selecionar usuário"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Formato de caminho inválido.",
+    "AliasOverlapping": "O caminho de montagem sobrepõe-se a outra pasta.",
+    "AliasPlaceholder": "Caminho de montagem",
+    "AutoMountedFolders": "Pastas de montagem automática",
+    "Name": "Nome",
+    "PathAndAlias": "Caminho & Alias",
+    "PathAndAliasTooltip": "O caminho dentro do contentor onde a pasta será montada. Deixe em branco para usar o caminho predefinido.",
+    "RemoveFolder": "Remover",
+    "Subpath": "Subcaminho",
+    "SubpathInvalid": "O subcaminho deve ser um caminho relativo e não deve conter '..'.",
+    "SubpathPlaceholder": "ex. dataset/train (opcional)",
+    "SubpathTooltip": "Monta uma subpasta dentro da pasta como origem em vez da sua raiz. Deixe em branco para montar a raiz."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Selecionar pasta"
   },

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Выберите пользователя"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Неверный формат пути.",
+    "AliasOverlapping": "Путь монтирования перекрывается с другой папкой.",
+    "AliasPlaceholder": "Путь монтирования",
+    "AutoMountedFolders": "Папки с автомонтированием",
+    "Name": "Имя",
+    "PathAndAlias": "Путь & Псевдоним",
+    "PathAndAliasTooltip": "Путь внутри контейнера, в который будет смонтирована папка. Оставьте пустым для использования пути по умолчанию.",
+    "RemoveFolder": "Удалить",
+    "Subpath": "Подпуть",
+    "SubpathInvalid": "Подпуть должен быть относительным путём и не должен содержать '..'.",
+    "SubpathPlaceholder": "напр. dataset/train (необязательно)",
+    "SubpathTooltip": "Монтирует подпапку внутри папки как источник вместо её корня. Оставьте пустым для монтирования корня."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Выбрать папку"
   },

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "เลือกผู้ใช้"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "รูปแบบพาธไม่ถูกต้อง",
+    "AliasOverlapping": "พาธ mount ซ้ำซ้อนกับโฟลเดอร์อื่น",
+    "AliasPlaceholder": "พาธ mount",
+    "AutoMountedFolders": "โฟลเดอร์ที่ mount อัตโนมัติ",
+    "Name": "ชื่อ",
+    "PathAndAlias": "พาธ & Alias",
+    "PathAndAliasTooltip": "พาธภายใน container ที่โฟลเดอร์จะถูก mount ปล่อยว่างเพื่อใช้พาธเริ่มต้น",
+    "RemoveFolder": "ลบ",
+    "Subpath": "Subpath",
+    "SubpathInvalid": "Subpath ต้องเป็น relative path และต้องไม่มี '..'",
+    "SubpathPlaceholder": "เช่น dataset/train (ไม่บังคับ)",
+    "SubpathTooltip": "mount โฟลเดอร์ย่อยภายในโฟลเดอร์เป็นแหล่งข้อมูลแทน root ปล่อยว่างเพื่อ mount จาก root"
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "เลือกโฟลเดอร์"
   },

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Kullanıcıyı Seç"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Geçersiz yol biçimi.",
+    "AliasOverlapping": "Bağlama yolu başka bir klasörle çakışıyor.",
+    "AliasPlaceholder": "Bağlama yolu",
+    "AutoMountedFolders": "Otomatik bağlanan klasörler",
+    "Name": "Ad",
+    "PathAndAlias": "Yol & Takma Ad",
+    "PathAndAliasTooltip": "Klasörün bağlanacağı container içindeki yol. Varsayılan yolu kullanmak için boş bırakın.",
+    "RemoveFolder": "Kaldır",
+    "Subpath": "Alt yol",
+    "SubpathInvalid": "Alt yol göreli bir yol olmalı ve '..' içermemelidir.",
+    "SubpathPlaceholder": "örn. dataset/train (isteğe bağlı)",
+    "SubpathTooltip": "Kök yerine klasörün içindeki bir alt klasörü kaynak olarak bağlar. Kökü bağlamak için boş bırakın."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Klasör Seç"
   },

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "Chọn người dùng"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "Định dạng đường dẫn không hợp lệ.",
+    "AliasOverlapping": "Đường dẫn mount trùng lặp với thư mục khác.",
+    "AliasPlaceholder": "Đường dẫn mount",
+    "AutoMountedFolders": "Thư mục tự động mount",
+    "Name": "Tên",
+    "PathAndAlias": "Đường dẫn & Bí danh",
+    "PathAndAliasTooltip": "Đường dẫn bên trong container nơi thư mục sẽ được mount. Để trống để sử dụng đường dẫn mặc định.",
+    "RemoveFolder": "Xóa",
+    "Subpath": "Đường dẫn con",
+    "SubpathInvalid": "Đường dẫn con phải là đường dẫn tương đối và không được chứa '..'.",
+    "SubpathPlaceholder": "vd. dataset/train (tùy chọn)",
+    "SubpathTooltip": "Mount một thư mục con bên trong thư mục làm nguồn thay vì thư mục gốc. Để trống để mount từ thư mục gốc."
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "Chọn thư mục"
   },

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "选择用户"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "路径格式无效。",
+    "AliasOverlapping": "挂载路径与另一个文件夹重叠。",
+    "AliasPlaceholder": "挂载路径",
+    "AutoMountedFolders": "自动挂载文件夹",
+    "Name": "名称",
+    "PathAndAlias": "路径 & 别名",
+    "PathAndAliasTooltip": "文件夹在容器内的挂载路径。留空则使用默认路径。",
+    "RemoveFolder": "移除",
+    "Subpath": "子路径",
+    "SubpathInvalid": "子路径必须是相对路径，且不能包含 '..'。",
+    "SubpathPlaceholder": "例如 dataset/train（可选）",
+    "SubpathTooltip": "将文件夹内的子文件夹作为挂载源，而非文件夹根目录。留空则挂载根目录。"
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "选择文件夹"
   },

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -386,6 +386,20 @@
   "comp:BAIUserSelect": {
     "SelectUser": "選擇使用者"
   },
+  "comp:BAIVFolderMountConfigInput": {
+    "AliasInvalid": "路徑格式無效。",
+    "AliasOverlapping": "掛載路徑與另一個資料夾重疊。",
+    "AliasPlaceholder": "掛載路徑",
+    "AutoMountedFolders": "自動掛載資料夾",
+    "Name": "名稱",
+    "PathAndAlias": "路徑 & 別名",
+    "PathAndAliasTooltip": "資料夾在容器內的掛載路徑。留空則使用預設路徑。",
+    "RemoveFolder": "移除",
+    "Subpath": "子路徑",
+    "SubpathInvalid": "子路徑必須是相對路徑，且不能包含 '..'。",
+    "SubpathPlaceholder": "例如 dataset/train（選填）",
+    "SubpathTooltip": "將資料夾內的子資料夾作為掛載來源，而非資料夾根目錄。留空則掛載根目錄。"
+  },
   "comp:BAIVFolderSelect": {
     "SelectFolder": "選擇資料夾"
   },


### PR DESCRIPTION
Stacked on #7931 · Part of **FR-3059** (#7756) · Resolves **FR-3154**

## Summary
- Add `BAIVFolderMountConfigInput`, a reusable, **schema-agnostic** controlled input for configuring vfolder mounts (`packages/backend.ai-ui/src/components/fragments/`).
- Composes `BAIVFolderSelect` (multiple) to pick folders; each selected folder renders as a row below the select with:
  - a **mount destination (alias)** input — path inside the container (empty falls back to `/home/work/{name}`),
  - an optional **subpath** free-text input — which subfolder of the vfolder to mount as the source (empty = root),
  - a remove (✕) button.
- Emits a single `VFolderMountConfigValue[]` value via `value` / `onChange`, so it wraps in one `Form.Item` and the consumer maps it to any mount mutation input. No GraphQL/schema coupling.
- Inline validation: alias format (`^[a-zA-Z0-9_/.-]*$`), alias overlap between folders, and relative-subpath / no-`..` checks.
- Adds BUI i18n keys (`comp:BAIVFolderMountConfigInput`) for `en` and `ko`.

## Notes
- Standalone component only. Wiring it into session creation / Deployment revision pages is a follow-up (out of scope for this stack, per the spec).

## Verification (`scripts/verify.sh`)
- Relay / Lint / Format: **PASS**
- `backend.ai-ui` package `tsc --noEmit`: **0 errors**
- The single TypeScript failure reported by `verify.sh` is **pre-existing on `main`** (unrelated Relay input-type mismatch in `react/src/pages/AdminDeploymentPresetSettingPage.tsx`, `service.port: number | null` vs `number`) and is not introduced by this PR.

## Test plan
- [ ] Selecting multiple vfolders adds a row per folder with alias + subpath inputs
- [ ] Remove (✕) clears the row and its alias/subpath values
- [ ] Invalid alias format, overlapping mount paths, and invalid subpath show inline errors
- [ ] Empty mount destination shows the effective default path as helper text