### PR TITLE
fix(FR-3159): scope user Sessions CSV export to the current user

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -904,7 +904,14 @@ export class Client {
     if (this.isManagerVersionCompatibleWith('26.4.3')) {
       this._features['model-deployment-extended-filter'] = true;
     }
-    if (this.isManagerVersionCompatibleWith('26.4.4')) {
+    // ModelHealthCheck gained an `enable` flag in 26.4.4 (BA-6242): health
+    // checks are opt-in via `enable: true/false` instead of nulling the whole
+    // object. Pinned to the rc7 tag for the same staging-manager reason as above.
+    // TODO(FR-3056): simplify to '26.4.4' once the final release ships.
+    if (this.isManagerVersionCompatibleWith('26.4.4rc7')) {
+      this._features['model-health-check-enable'] = true;
+    }
+    if (this.isManagerVersionCompatibleWith('26.4.4rc9')) {
       // RBAC list filters became their *Filter wrapper shapes (#11442):
       // scope/entity type enums -> RBACElementTypeFilter, roleId UUID ->
       // UUIDFilter, etc. FR-3017 (entityType enum), FR-3031 (roleId UUID).
@@ -918,13 +925,7 @@ export class Client {
       this._features['runtime-variant-preset-required'] = true;
       // Role auto-assign (BA-6183 / BA-6184 / BA-6187). FR-3029.
       this._features['role-auto-assign'] = true;
-    }
-    // ModelHealthCheck gained an `enable` flag in 26.4.4 (BA-6242): health
-    // checks are opt-in via `enable: true/false` instead of nulling the whole
-    // object. Pinned to the rc7 tag for the same staging-manager reason as above.
-    // TODO(FR-3056): simplify to '26.4.4' once the final release ships.
-    if (this.isManagerVersionCompatibleWith('26.4.4rc7')) {
-      this._features['model-health-check-enable'] = true;
+      this._features['session-export-user-filter'] = true;
     }
   }
 

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -17,7 +17,7 @@ import SessionNodes, {
 } from '../components/SessionNodes';
 import { handleRowSelectionChange } from '../helper';
 import { ExtractResultValue } from '../helper/resultTypes';
-import { useWebUINavigate } from '../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -86,6 +86,7 @@ const ComputeSessionListPage = () => {
 
   const userRole = useCurrentUserRole();
   const [currentUser] = useCurrentUserInfo();
+  const baiClient = useSuspendedBackendaiClient();
 
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -618,6 +619,19 @@ const ComputeSessionListPage = () => {
                         }
                         if (queryParams.type && queryParams.type !== 'all') {
                           csvFilter.session_type = [queryParams.type];
+                        }
+                        // This page is strictly personal (see currentUserFilter
+                        // above), so the CSV export must be scoped to the current
+                        // user too — otherwise an admin exports every user's
+                        // sessions. Mirrors the table's user_id filter via the
+                        // session export `user.email` filter (BA-6480).
+                        if (
+                          baiClient.supports('session-export-user-filter') &&
+                          currentUser.email
+                        ) {
+                          csvFilter.user = {
+                            email: { equals: currentUser.email },
+                          };
                         }
                         await exportCSV(selectedExportKeys, csvFilter).catch(
                           (err) => {


### PR DESCRIPTION
Resolves #7942 (FR-3159)

## Problem

The personal Sessions page (`/session`) scopes its **table** to the current user — FR-3092 added `user_id == "<uuid>"` to every `compute_session_nodes` call in `ComputeSessionListPage.tsx`. But the table footer **CSV export** only carried `status` / `session_type` filters, so an admin/superadmin exporting from their *personal* page received **all users' sessions**, not just their own. This is the export-path equivalent of the FR-3092 bug.

## Change

- **`react/src/pages/ComputeSessionListPage.tsx`** — in `onExport`, when the feature is supported, scope the export to the current user's email, mirroring the table:

  ```ts
  if (baiClient.supports('session-export-user-filter') && currentUser.email) {
    csvFilter.user = { email: { equals: currentUser.email } };
  }
  ```

  This uses the nested `user` filter added to `SessionExportFilter` in backend.ai PR #12183 (BA-6480). `currentUser.email` is the raw `baiClient.email` (unaffected by `maskUserInfo`).

- **`packages/backend.ai-client/src/client.ts`** — register `session-export-user-filter` in the `26.4.4rc9` feature gate. As part of this, the existing `26.4.4` feature block (RBAC filter wrappers, user-v2 extended filter, keypair-resource-policy user filter, runtime-variant-preset required, role auto-assign) is **lowered to `26.4.4rc9`** and **reordered after the `26.4.4rc7` gate** so the version gates read in ascending order and all rc9-targeted features activate on the rc9 staging manager. `session-export-user-filter` is folded into that same `26.4.4rc9` block.

## Backend compatibility

`SessionExportFilter` (`BaseRequestModel`) ignores unknown keys, so the nested `user` filter is harmless on backends that don't yet honor it. On older backends the export behaves exactly as before — no error, no regression.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript).

## Related

- FR-3092 — table-display user scoping for the same page (merged).
- backend.ai PR #12183 / BA-6480 — adds the `user` filter to `SessionExportFilter`.