### PR TITLE
fix(FR-3161): send chat attachments as data URLs instead of blob URLs

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -77,6 +77,28 @@ const useStyles = createStyles(({ token, css }) => ({
   `,
 }));
 
+function readFileAsDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      // `FileReader.result` is typed `string | ArrayBuffer | null`; only a
+      // string is a valid data URL. Reject instead of casting so a malformed
+      // read can never produce an invalid `url` downstream.
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+      } else {
+        reject(new Error('FileReader did not return a data URL string.'));
+      }
+    };
+    reader.onerror = () =>
+      reject(reader.error ?? new Error('Failed to read the file.'));
+    // Without an abort handler the Promise would hang forever if the read is
+    // aborted (e.g. the file becomes unavailable mid-read).
+    reader.onabort = () => reject(new Error('File reading was aborted.'));
+    reader.readAsDataURL(file);
+  });
+}
+
 function createModelsURL(baseURL: string) {
   const { origin, pathname: path } = new URL(baseURL.trim());
   const normalizedPath = path === '/' ? '/models' : `${path}/models`;
@@ -291,9 +313,22 @@ const PureChatCard: React.FC<ChatCardProps> = ({
               abortSignal: init?.signal || undefined,
               model: wrapLanguageModel({
                 model: provider.chatModel(modelId),
-                middleware: extractReasoningMiddleware({
-                  tagName: 'think',
-                }),
+                middleware: [
+                  extractReasoningMiddleware({
+                    tagName: 'think',
+                  }),
+                  // The openai-compatible provider does not advertise any
+                  // `supportedUrls`, so the AI SDK treats a `data:` image
+                  // attachment as a remote asset and tries to *download* it,
+                  // failing with "Failed to download data:image/...". Advertise
+                  // that the model accepts image URLs inline so the SDK passes
+                  // the data URL straight through as an `image_url` part.
+                  {
+                    overrideSupportedUrls: () => ({
+                      'image/*': [/^data:/, /^https?:\/\//],
+                    }),
+                  },
+                ],
               }),
               messages: convertToModelMessages(body?.messages),
               system: agent?.systemPrompt || undefined,
@@ -374,17 +409,32 @@ const PureChatCard: React.FC<ChatCardProps> = ({
       parts.push({ type: 'text', text: textContent });
     }
 
-    // Add files if present
+    // Add files if present.
+    // Encode each file as a base64 data URL rather than an object URL: a
+    // `blob:` URL is only resolvable inside the document that created it, so it
+    // cannot be read once the attachment is forwarded to the model endpoint
+    // through the openai-compatible provider. A data URL inlines the bytes and
+    // is delivered to the model as-is.
     if (files && files.length > 0) {
-      files.forEach((file) => {
-        const url = URL.createObjectURL(file);
-        parts.push({
-          type: 'file',
-          url: url,
-          mediaType: file.type || 'application/octet-stream',
-          filename: file.name,
-        });
-      });
+      // `onSendMessage` is fired from ChatInput without awaiting, so a
+      // rejection here would surface as an unhandled promise rejection.
+      // Catch the read failure, surface it to the user, and abort the send
+      // rather than forwarding a half-built message to the model.
+      try {
+        const fileParts = await Promise.all(
+          files.map(async (file) => ({
+            type: 'file' as const,
+            url: await readFileAsDataURL(file),
+            mediaType: file.type || 'application/octet-stream',
+            filename: file.name,
+          })),
+        );
+        parts.push(...fileParts);
+      } catch (error) {
+        logger.error('Failed to read attached file(s) as data URL:', error);
+        appMessage.error(t('theme.FailedToReadFile'));
+        return;
+      }
     }
 
     // Send with parts array if we have content


### PR DESCRIPTION
Resolves #7945 (FR-3161)

> Test: dogbowl `/chat/9747e6c3-8b45-435a-a129-d86f62c0fac9`

## Problem

Uploading a file/image in the **Chat** page (LLM playground / model-serving chat) fails with an error after the model is loaded. Reproduced on 26.4.3 and on the latest rc release on the QA site. The endpoint's own file upload works when the request is sent with the correct format via cURL, so the problem is on the WebUI chat side.

## Root cause

`handleSendMessage` in `react/src/components/Chat/ChatCard.tsx` encoded each attachment with `URL.createObjectURL(file)`, producing a `blob:` URL. A `blob:` URL is only resolvable inside the browser document context that created it. Once the attachment part is handed to the `@ai-sdk/openai-compatible` provider (`convertToModelMessages` / `streamText`) and forwarded to the model endpoint, the bytes cannot be read, so the upload/image request fails. The object URL was also never revoked (minor leak).

This code was introduced in the AI SDK v5 upgrade (FR-1463, #4697), which matches the reported regression timeline (image support added, then SDK upgraded).

## Fix

Encode each attachment as a base64 **data URL** (`data:<mime>;base64,...`) via `FileReader.readAsDataURL` so the content is inlined and delivered to the model as-is. No more leaked object URLs.

## Verification

`bash scripts/verify.sh`: Relay / Lint / Format **PASS**. The single TypeScript failure is the pre-existing `FluentEmojiIcon.tsx` CDN type error from a worktree patched-dependency mis-link (environmental, unrelated to this change).

## Follow-up

- [ ] Add an e2e test covering chat file upload/download (requested in the originating Teams thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)