### PR TITLE
test(FR-3165): add e2e regression test for chat attachment data URL delivery

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 300 / 448 features covered (67%)**
+**Overall (in-scope routes): 301 / 449 features covered (67%)**
 
 | Page                     | Route                                  | Features | Covered | Status  |
 | ------------------------ | -------------------------------------- | :------: | :-----: | :-----: |
@@ -44,11 +44,11 @@
 | Reservoir                | `/reservoir`, `/reservoir/:artifactId` |    18    |    0    |  ❌ 0%  |
 | Branding                 | `/branding`                            |    14    |    0    |  ❌ 0%  |
 | App Launcher             | (modal)                                |    19    |   11    | 🔶 58%  |
-| Chat                     | `/chat/:id?`                           |    6     |    6    | ✅ 100% |
+| Chat                     | `/chat/:id?`                           |    7     |    7    | ✅ 100% |
 | Plugin System            | (config-based)                         |    12    |   12    | ✅ 100% |
 | RBAC Management          | `/rbac`                                |    22    |   21    | 🔶 95%  |
 | Auto Scaling Rule Preset | `/admin-serving?tab=auto-scaling-rule` |    33    |   32    | 🔶 97%  |
-| **Total**                |                                        | **448**  | **300** | **67%** |
+| **Total**                |                                        | **449**  | **301** | **67%** |
 
 ---
 
@@ -932,20 +932,21 @@
 
 ### 27. Chat (`/chat/:id?`)
 
-**Test files:** [`e2e/chat/chat.spec.ts`](chat/chat.spec.ts), [`e2e/chat/chat-sync.spec.ts`](chat/chat-sync.spec.ts)
+**Test files:** [`e2e/chat/chat.spec.ts`](chat/chat.spec.ts), [`e2e/chat/chat-sync.spec.ts`](chat/chat-sync.spec.ts), [`e2e/chat/chat-attachment.spec.ts`](chat/chat-attachment.spec.ts)
 
 **Drawer:** `ChatHistoryDrawer`
 
-| Feature                          | Status | Test                                                                          |
-| -------------------------------- | ------ | ----------------------------------------------------------------------------- |
-| Chat card interface              | ✅     | `User can see the chat page with endpoint and model selectors`                |
-| Chat history → ChatHistoryDrawer | ✅     | `User can see chat history drawer after sending a message`                    |
-| New chat creation                | ✅     | `User can rename a chat session from the page title`                          |
-| Message sending/receiving        | ✅     | `User can send a message and receive a streaming response`                    |
-| Provider/model selection         | ✅     | `User can select different endpoints in each chat pane`                       |
-| Chat history deletion            | ✅     | `User is redirected to a new chat when deleting the currently active session` |
+| Feature                             | Status | Test                                                                          |
+| ----------------------------------- | ------ | ----------------------------------------------------------------------------- |
+| Chat card interface                 | ✅     | `User can see the chat page with endpoint and model selectors`                |
+| Chat history → ChatHistoryDrawer    | ✅     | `User can see chat history drawer after sending a message`                    |
+| New chat creation                   | ✅     | `User can rename a chat session from the page title`                          |
+| Message sending/receiving           | ✅     | `User can send a message and receive a streaming response`                    |
+| Provider/model selection            | ✅     | `User can select different endpoints in each chat pane`                       |
+| Chat history deletion               | ✅     | `User is redirected to a new chat when deleting the currently active session` |
+| File attachment delivery (data URL) | ✅     | `Attached file is sent to the model as a base64 data URL, not a blob URL`     |
 
-**Coverage: ✅ 6/6 features**
+**Coverage: ✅ 7/7 features**
 
 ---
 

--- a/e2e/chat/chat-attachment.spec.ts
+++ b/e2e/chat/chat-attachment.spec.ts
@@ -1,0 +1,88 @@
+// spec: e2e/.agent-output/test-plan-chat.md
+// Section: 1 (Basic Chat Flow) — file attachment regression (FR-3161)
+//
+// Regression coverage for FR-3161: a chat attachment must be forwarded to the
+// model endpoint as a base64 `data:` URL, not a `blob:` object URL. A `blob:`
+// URL is only resolvable inside the document that created it, so the model
+// endpoint can never read it; encoding the file as a data URL inlines the bytes
+// so they reach the model as-is.
+import { setupChatPage } from './mocking/chat-mock-data';
+import { test, expect, type Request } from '@playwright/test';
+
+// A minimal valid 1x1 transparent PNG, used as the attachment payload.
+const ONE_PX_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+test.describe(
+  'Chat File Attachment',
+  { tag: ['@chat', '@functional', '@regression'] },
+  () => {
+    test.beforeEach(async ({ page }) => {
+      // Clear chat history before the page loads so each test starts blank.
+      await page.addInitScript(() => {
+        localStorage.removeItem('backendaiwebui.cache.chat_history');
+      });
+    });
+
+    test('Attached file is sent to the model as a base64 data URL, not a blob URL', async ({
+      page,
+      request,
+    }) => {
+      // Setup: login, install GraphQL/models/completions mocks, navigate to /chat
+      await setupChatPage(page, request);
+
+      // Wait for the chat input to be *enabled*, not merely visible. The input
+      // stays `disabled` until the mocked model-readiness chain completes
+      // (ChatPageQuery auto-selects the endpoint → ChatCardQuery resolves the
+      // base URL → /v1/models returns without error). Gating on `toBeEnabled`
+      // is the deterministic readiness barrier — unlike the model-name text,
+      // which was flaky — and it must happen *before* the 15s waitForRequest
+      // window below, otherwise that window would include the model-load time
+      // and time out on slower machines while the input is still disabled.
+      const chatInput = page.getByPlaceholder('Type your message here...');
+      await expect(chatInput).toBeVisible({ timeout: 10000 });
+      await expect(chatInput).toBeEnabled({ timeout: 15000 });
+
+      // Attach a PNG through the (hidden) Attachments upload input. The prefix
+      // Attachments is always rendered, so the first file input is the target.
+      const fileInput = page.locator('input[type="file"]').first();
+      await fileInput.setInputFiles({
+        name: 'attachment.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from(ONE_PX_PNG_BASE64, 'base64'),
+      });
+
+      // Capture the outgoing completions request so we can inspect the payload
+      // the model endpoint actually receives.
+      const completionsRequestPromise = page.waitForRequest(
+        (req: Request) =>
+          req.url().includes('/v1/chat/completions') && req.method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      // Type a message and send (Sender submitType="enter").
+      await chatInput.click();
+      await chatInput.fill('Describe this image');
+      await chatInput.press('Enter');
+
+      // The user message appears in the thread.
+      await expect(page.getByText('Describe this image').first()).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Inspect the completions request body.
+      const completionsRequest = await completionsRequestPromise;
+      const postData = completionsRequest.postData() ?? '';
+
+      // The attachment must be inlined as a base64 data URL preserving the media
+      // type — this is the fix. A blob: URL would never be readable by the model.
+      expect(postData).toContain('data:image/png;base64,');
+      expect(postData).not.toContain('blob:');
+
+      // The assistant reply still streams back, proving the request succeeded.
+      await expect(page.getByText('Hello from mock!').first()).toBeVisible({
+        timeout: 15000,
+      });
+    });
+  },
+);

--- a/e2e/chat/mocking/chat-mock-data.ts
+++ b/e2e/chat/mocking/chat-mock-data.ts
@@ -101,6 +101,11 @@ export function chatCardQueryMockResponse(endpointId: string) {
     endpoint: {
       endpoint_id: endpointId,
       url: isB ? MOCK_ENDPOINT_URL_B : MOCK_ENDPOINT_URL,
+      // `replicas` is selected by ChatCardQuery (FR-3156, #7935). It must be
+      // present in the mock — the query wraps `endpoint` in Relay `@catch`,
+      // so a missing field makes the catch result not-ok, nulls the endpoint,
+      // and leaves the chat input disabled (no base URL → no /v1/models fetch).
+      replicas: 1,
       name: isB ? 'mock-endpoint-b' : 'mock-endpoint',
     },
   };
@@ -114,6 +119,10 @@ export function chatCardQueryNullUrlMockResponse(endpointId: string) {
     endpoint: {
       endpoint_id: endpointId,
       url: null,
+      // See chatCardQueryMockResponse: `replicas` must be present for the
+      // Relay `@catch` on `endpoint` to resolve to a value (here we are
+      // deliberately exercising the null-URL path, not a missing endpoint).
+      replicas: 1,
       name: 'mock-endpoint-no-url',
     },
   };


### PR DESCRIPTION
Resolves #7950 (FR-3165)

> Stacked on #7946 (FR-3161).

## Summary

Adds a Playwright e2e regression test guarding the FR-3161 fix: a chat attachment must reach the model endpoint as a base64 `data:` URL, never a `blob:` object URL (which is only resolvable inside the document that created it, so the model could never read it).

## What the test does

`e2e/chat/chat-attachment.spec.ts`:

1. Sets up the chat page with the existing mock infrastructure (`setupChatPage` — GraphQL + `/v1/models` + `/v1/chat/completions` mocks).
2. Attaches a 1×1 PNG through the (hidden) `@ant-design/x` `Attachments` upload input.
3. Sends a message and captures the outgoing `/v1/chat/completions` request.
4. Asserts the payload:
   - **contains** `data:image/png;base64,` (attachment inlined as a data URL, media type preserved), and
   - **does not contain** `blob:`.
5. Confirms the assistant reply still streams back.

## Verification

- `prettier --check` — pass
- `eslint --config e2e/eslint.config.mjs` — pass

Note: the full Playwright run requires a live Backend.AI cluster, so this was verified statically (lint/format + conformance to the existing `e2e/chat/chat.spec.ts` mocked patterns) rather than executed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
