### PR TITLE
fix(FR-3162): auto-refresh deployment preset list after create/update

### DIFF
--- a/react/src/pages/AdminDeploymentPresetListPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetListPage.tsx
@@ -33,9 +33,15 @@ import {
 import * as _ from 'lodash-es';
 import { PlusIcon } from 'lucide-react';
 import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
-import React, { useDeferredValue, useState } from 'react';
+import React, {
+  useDeferredValue,
+  useEffect,
+  useEffectEvent,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import { useLocation } from 'react-router-dom';
 
 const AdminDeploymentPresetListPage: React.FC = () => {
   'use memo';
@@ -74,6 +80,31 @@ const AdminDeploymentPresetListPage: React.FC = () => {
   );
 
   const [fetchKey, updateFetchKey] = useFetchKey();
+
+  // After a successful create/update, the setting page navigates back here with
+  // `state.refreshDeploymentPresets`. Force a network refetch (the same effect
+  // the refresh button and the DELETE flow trigger via `updateFetchKey()`),
+  // then clear the flag so a manual reload doesn't refetch again.
+  const location = useLocation();
+  const refreshFlag = (
+    location.state as { refreshDeploymentPresets?: boolean } | null
+  )?.refreshDeploymentPresets;
+  // `updateFetchKey` / `webuiNavigate` / `location.*` are side-effect helpers,
+  // not synchronization keys — read their latest values via useEffectEvent so
+  // the effect only re-runs on the derived `refreshFlag` (no
+  // exhaustive-deps suppression needed).
+  const clearRefreshFlag = useEffectEvent(() => {
+    updateFetchKey();
+    webuiNavigate(location.pathname + location.search, {
+      replace: true,
+      state: null,
+    });
+  });
+  useEffect(() => {
+    if (refreshFlag) {
+      clearRefreshFlag();
+    }
+  }, [refreshFlag]);
 
   const queryVariables = {
     filter: (queryParams.filter ?? undefined) as

--- a/react/src/pages/AdminDeploymentPresetSettingPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetSettingPage.tsx
@@ -258,13 +258,19 @@ const AdminDeploymentPresetSettingPage: React.FC = () => {
       `,
     );
 
-  const navigateToList = () => {
+  const navigateToList = (refresh = false) => {
     const params = new URLSearchParams();
     params.set('tab', 'deployment-presets');
-    webuiNavigate({
-      pathname: '/admin-deployments',
-      search: params.toString(),
-    });
+    webuiNavigate(
+      {
+        pathname: '/admin-deployments',
+        search: params.toString(),
+      },
+      // After a successful create/update, signal the list to force a network
+      // refetch on arrival (mirrors how DELETE calls `updateFetchKey()`); a
+      // plain navigation otherwise serves the stale store-cached list.
+      refresh ? { state: { refreshDeploymentPresets: true } } : undefined,
+    );
   };
 
   const handleSubmit = async () => {
@@ -325,7 +331,7 @@ const AdminDeploymentPresetSettingPage: React.FC = () => {
           },
         });
         message.success(t('adminDeploymentPreset.PresetUpdated'));
-        navigateToList();
+        navigateToList(true);
       } else {
         await commitCreate({
           input: {
@@ -368,7 +374,7 @@ const AdminDeploymentPresetSettingPage: React.FC = () => {
           },
         });
         message.success(t('adminDeploymentPreset.PresetCreated'));
-        navigateToList();
+        navigateToList(true);
       }
     } catch (error: unknown) {
       logger.error(error);


### PR DESCRIPTION
Resolves #7947 (FR-3162)

Part of FR-3084 (Final Train to 26.4.8).

## Summary

On the admin-only Deployment Revision Preset page (Deployment Presets tab), creating or updating a preset did not refresh the list — the user had to click the refresh button manually. The DELETE flow already auto-refreshes by calling `updateFetchKey()`, but create/update live on a separate route (`AdminDeploymentPresetSettingPage`) and only navigated back without signaling a refetch; the list then served the stale store-cached data.

This wires the same refresh effect across the route boundary:

- `AdminDeploymentPresetSettingPage.tsx`: on successful create or update, `navigateToList({ refresh: true })` now passes a navigation `state` flag (`refreshDeploymentPresets`). Cancel navigates without the flag.
- `AdminDeploymentPresetListPage.tsx`: an effect reads `location.state.refreshDeploymentPresets` on arrival and calls `updateFetchKey()` to force a `network-only` refetch (mirroring DELETE and the refresh button), then clears the flag via a `replace` navigation so a manual reload does not refetch again.

Scope is limited to the two files; no GraphQL/fragment changes, so no Relay recompile.

## Verification

`bash scripts/verify.sh`: Relay PASS, Lint PASS, Format PASS. TypeScript reports only the known-environmental worktree mis-link error in `src/components/FluentEmojiIcon.tsx` (unrelated to this change, present on `origin/main` in any worktree); `tsc` on the touched files is clean. Terminology is warn-only and pre-existing.