### PR TITLE
feat(FR-3164): improve deployment preset list columns

### DIFF
--- a/react/src/__generated__/AdminDeploymentPresetListPageQuery.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f7e193f2654e85942461e8e11fa38f7>>
+ * @generated SignedSource<<b6093662a8996a5d54bbca2f21c2c1d0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -241,13 +241,6 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "rank",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
                     "name": "runtimeVariantId",
                     "storageKey": null
                   },
@@ -303,6 +296,13 @@ return {
                         "kind": "ScalarField",
                         "name": "imageId",
                         "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startupCommand",
+                        "storageKey": null
                       }
                     ],
                     "storageKey": null
@@ -328,6 +328,20 @@ return {
                         "kind": "ScalarField",
                         "name": "deploymentStrategy",
                         "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "openToPublic",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "revisionHistoryLimit",
+                        "storageKey": null
                       }
                     ],
                     "storageKey": null
@@ -337,6 +351,13 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "createdAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "updatedAt",
                     "storageKey": null
                   }
                 ],
@@ -351,12 +372,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f7c0148ae47503fd5354512471b34062",
+    "cacheID": "975590c5da745e264e60d74f79d5a3cc",
     "id": null,
     "metadata": {},
     "name": "AdminDeploymentPresetListPageQuery",
     "operationKind": "query",
-    "text": "query AdminDeploymentPresetListPageQuery(\n  $filter: DeploymentRevisionPresetFilter\n  $orderBy: [DeploymentRevisionPresetOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  deploymentRevisionPresets(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        ...AdminDeploymentPresetNodesFragment\n      }\n    }\n  }\n}\n\nfragment AdminDeploymentPresetNodesFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  rank\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n  }\n  deploymentDefaults {\n    replicaCount\n    deploymentStrategy\n  }\n  createdAt\n}\n"
+    "text": "query AdminDeploymentPresetListPageQuery(\n  $filter: DeploymentRevisionPresetFilter\n  $orderBy: [DeploymentRevisionPresetOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  deploymentRevisionPresets(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        ...AdminDeploymentPresetNodesFragment\n      }\n    }\n  }\n}\n\nfragment AdminDeploymentPresetNodesFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n  }\n  deploymentDefaults {\n    replicaCount\n    deploymentStrategy\n    openToPublic\n    revisionHistoryLimit\n  }\n  createdAt\n  updatedAt\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/AdminDeploymentPresetNodesFragment.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetNodesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<46774e41c560a173a4a5a28d03d27c4f>>
+ * @generated SignedSource<<fccecc4ed5b6d1562f24f9a79b09cc94>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,20 +19,23 @@ export type AdminDeploymentPresetNodesFragment$data = ReadonlyArray<{
   readonly createdAt: string;
   readonly deploymentDefaults: {
     readonly deploymentStrategy: DeploymentStrategyType | null | undefined;
+    readonly openToPublic: boolean | null | undefined;
     readonly replicaCount: number | null | undefined;
+    readonly revisionHistoryLimit: number | null | undefined;
   };
   readonly description: string | null | undefined;
   readonly execution: {
     readonly imageId: string | null | undefined;
+    readonly startupCommand: string | null | undefined;
   };
   readonly id: string;
   readonly name: string;
-  readonly rank: number;
   readonly runtimeVariant: {
     readonly id: string;
     readonly name: string;
   } | null | undefined;
   readonly runtimeVariantId: string;
+  readonly updatedAt: string | null | undefined;
   readonly " $fragmentType": "AdminDeploymentPresetNodesFragment";
 } | null | undefined>;
 export type AdminDeploymentPresetNodesFragment$key = ReadonlyArray<{
@@ -78,13 +81,6 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "description",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "rank",
       "storageKey": null
     },
     {
@@ -146,6 +142,13 @@ return {
           "kind": "ScalarField",
           "name": "imageId",
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "startupCommand",
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -171,6 +174,20 @@ return {
           "kind": "ScalarField",
           "name": "deploymentStrategy",
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "openToPublic",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "revisionHistoryLimit",
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -181,6 +198,13 @@ return {
       "kind": "ScalarField",
       "name": "createdAt",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "updatedAt",
+      "storageKey": null
     }
   ],
   "type": "DeploymentRevisionPreset",
@@ -188,6 +212,6 @@ return {
 };
 })();
 
-(node as any).hash = "f4bff724a137c2c01ed07c8d65af12dc";
+(node as any).hash = "8f8684f1a6df397171415c6b094c22c1";
 
 export default node;

--- a/react/src/__generated__/AdminDeploymentPresetNodesImagesQuery.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetNodesImagesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<65edfb88908aad5cb9265eeec22282e6>>
+ * @generated SignedSource<<09c354441a4d5eeafb0e24d0d57073cd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,7 @@ export type AdminDeploymentPresetNodesImagesQuery$data = {
       readonly node: {
         readonly id: string;
         readonly identity: {
+          readonly architecture: string;
           readonly canonicalName: string;
         };
       };
@@ -112,6 +113,13 @@ v1 = [
                     "kind": "ScalarField",
                     "name": "canonicalName",
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "architecture",
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -144,16 +152,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "b16c3e55edc57c5e3de2cfb8b5a26a34",
+    "cacheID": "604ff4cb5204d2b04162356cf1bc921e",
     "id": null,
     "metadata": {},
     "name": "AdminDeploymentPresetNodesImagesQuery",
     "operationKind": "query",
-    "text": "query AdminDeploymentPresetNodesImagesQuery(\n  $ids: [UUID!]!\n  $limit: Int!\n) {\n  adminImagesV2(filter: {id: {in: $ids}}, limit: $limit) {\n    edges {\n      node {\n        id\n        identity {\n          canonicalName\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query AdminDeploymentPresetNodesImagesQuery(\n  $ids: [UUID!]!\n  $limit: Int!\n) {\n  adminImagesV2(filter: {id: {in: $ids}}, limit: $limit) {\n    edges {\n      node {\n        id\n        identity {\n          canonicalName\n          architecture\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d8f2ec0224716ede95d74f0cc01629c0";
+(node as any).hash = "3d1d4122d3da2b08617c72d2defb1ad0";
 
 export default node;

--- a/react/src/components/AdminDeploymentPresetNodes.tsx
+++ b/react/src/components/AdminDeploymentPresetNodes.tsx
@@ -11,8 +11,11 @@ import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
 import {
   BAIColumnType,
   BAINameActionCell,
+  BAISessionClusterMode,
   BAITable,
   BAITableProps,
+  BAIText,
+  BooleanTag,
   filterOutEmpty,
   filterOutNullAndUndefined,
   toLocalId,
@@ -73,7 +76,6 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
         id @required(action: NONE)
         name @required(action: NONE)
         description
-        rank
         runtimeVariantId
         runtimeVariant {
           id
@@ -85,12 +87,16 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
         }
         execution {
           imageId
+          startupCommand
         }
         deploymentDefaults {
           replicaCount
           deploymentStrategy
+          openToPublic
+          revisionHistoryLimit
         }
         createdAt
+        updatedAt
       }
     `,
     presetsFrgmt,
@@ -116,6 +122,7 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
               id
               identity {
                 canonicalName
+                architecture
               }
             }
           }
@@ -128,10 +135,15 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
 
   // PresetExecutionSpec.imageId is a raw UUID, but ImageV2.id is a Relay
   // global ID — toLocalId is required to match results back to imageIds.
-  const imageNameById: Record<string, string> = {};
+  // Label is "<canonicalName>@<architecture>" so admins can tell aarch64
+  // and x86_64 images apart.
+  const imageLabelById: Record<string, string> = {};
   for (const edge of imagesData.adminImagesV2?.edges ?? []) {
-    if (edge?.node?.id && edge.node.identity?.canonicalName) {
-      imageNameById[toLocalId(edge.node.id)] = edge.node.identity.canonicalName;
+    const identity = edge?.node?.identity;
+    if (edge?.node?.id && identity?.canonicalName) {
+      imageLabelById[toLocalId(edge.node.id)] = identity.architecture
+        ? `${identity.canonicalName}@${identity.architecture}`
+        : identity.canonicalName;
     }
   }
 
@@ -183,18 +195,40 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
         render: (__, record) => {
           const imageId = record.execution?.imageId;
           if (!imageId) return '-';
-          return imageNameById[imageId] ?? imageId;
+          const label = imageLabelById[imageId] ?? imageId;
+          return (
+            <BAIText copyable style={{ wordBreak: 'break-all' }}>
+              {label}
+            </BAIText>
+          );
+        },
+      },
+      {
+        key: 'startupCommand',
+        title: t('adminDeploymentPreset.StartupCommand'),
+        defaultHidden: true,
+        onCell: () => ({ style: { maxWidth: 500 } }),
+        render: (__, record) => {
+          const startupCommand = record.execution?.startupCommand;
+          return startupCommand ? (
+            <BAIText code copyable ellipsis={{ tooltip: true }}>
+              {startupCommand}
+            </BAIText>
+          ) : (
+            '-'
+          );
         },
       },
       {
         key: 'cluster',
         title: t('adminDeploymentPreset.Cluster'),
         defaultHidden: true,
-        render: (__, record) => {
-          const { clusterMode, clusterSize } = record.cluster ?? {};
-          if (!clusterMode) return '-';
-          return `${clusterMode} × ${clusterSize}`;
-        },
+        render: (__, record) => (
+          <BAISessionClusterMode
+            clusterMode={record.cluster?.clusterMode}
+            clusterSize={record.cluster?.clusterSize}
+          />
+        ),
       },
       {
         key: 'replicaCount',
@@ -209,12 +243,38 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
           record.deploymentDefaults?.deploymentStrategy ?? '-',
       },
       {
+        key: 'openToPublic',
+        title: t('adminDeploymentPreset.OpenToPublic'),
+        defaultHidden: true,
+        render: (__, record) => (
+          <BooleanTag
+            value={record.deploymentDefaults?.openToPublic ?? false}
+            trueLabel={t('deployment.Public')}
+            falseLabel={t('deployment.Private')}
+          />
+        ),
+      },
+      {
+        key: 'revisionHistoryLimit',
+        title: t('adminDeploymentPreset.RevisionHistoryLimit'),
+        defaultHidden: true,
+        render: (__, record) =>
+          record.deploymentDefaults?.revisionHistoryLimit ?? '-',
+      },
+      {
         key: 'createdAt',
         title: t('general.CreatedAt'),
         dataIndex: 'createdAt',
         sorter: isEnableSorter('createdAt'),
         render: (createdAt: string) =>
           createdAt ? dayjs(createdAt).format('YYYY-MM-DD HH:mm') : '-',
+      },
+      {
+        key: 'updatedAt',
+        title: t('general.ModifiedAt'),
+        dataIndex: 'updatedAt',
+        render: (updatedAt: string | null | undefined) =>
+          updatedAt ? dayjs(updatedAt).format('YYYY-MM-DD HH:mm') : '-',
       },
     ]),
     (column) => {


### PR DESCRIPTION
Resolves #7949 (FR-3164)

Part of FR-3084 (Final Train to 26.4.8).

## Summary

Improves the admin **Deployment Revision Preset** list. Originally this PR added only a **Modified** column; it now rounds out the table with the remaining displayable preset fields (all default-hidden) plus display refinements, based on core-team feedback.

### Columns

- **Modified** (`updatedAt`): shown next to **Created**, `dayjs(...).format('YYYY-MM-DD HH:mm')`, `-` when null. Display-only — the backend exposes no `UPDATED_AT` in `DeploymentRevisionPresetOrderField` (not sortable) and no `updatedAt` in `DeploymentRevisionPresetFilter` (not filterable).
- **Rank** (`rank`, default-hidden): server-sortable via the `RANK` order field.
- **Open to Public** (`deploymentDefaults.openToPublic`, default-hidden): rendered with the shared `BooleanTag` (green tag when `true`, semi-transparent when `false`); a missing value is treated as `false`.
- **Revision History Limit** (`deploymentDefaults.revisionHistoryLimit`, default-hidden).
- **Startup Command** (`execution.startupCommand`, default-hidden): rendered with `BAIText code copyable ellipsis={{ tooltip: true }}` — truncates long commands with a hover tooltip showing the full text, and provides a copy button.

### Display refinements

- **Image** column shows `<canonicalName>@<architecture>` (queries `identity.architecture`) and is **copyable** via `BAIText`, so admins can distinguish aarch64 vs x86_64 images.
- **Cluster** column reuses `BAISessionClusterMode` so the cluster-mode UI matches the session list.
- Replaced `Typography.Text` (antd) with `BAIText` (backend.ai-ui) throughout — removes the `antd` `Typography` import from this file.

### Notes

- No new i18n keys — all column titles reuse existing keys (`adminDeploymentPreset.Rank/OpenToPublic/RevisionHistoryLimit/StartupCommand`, `deployment.Public/Private`, `general.*`).
- Ran `pnpm relay`; regenerated artifacts under `__generated__` are committed.

## Verification

`bash scripts/verify.sh`: Relay/Lint/Format pass. TypeScript reports only the known-environmental worktree error in `src/components/FluentEmojiIcon.tsx:17` (patched-dep mis-link, unrelated to this change). No real failures introduced by this PR.

![image.png](https://app.graphite.com/user-attachments/assets/78719c95-5295-42bf-956b-3080b340c09e.png)

