### PR TITLE
feat(FR-3163): show image architecture in deployment preset image select

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIAdminImageSelectPaginatedQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminImageSelectPaginatedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ad6a539a202d3009cb10a3f5282124df>>
+ * @generated SignedSource<<8d2264399408b5cde4b337f60bfe297e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -77,6 +77,7 @@ export type BAIAdminImageSelectPaginatedQuery$data = {
       readonly node: {
         readonly id: string;
         readonly identity: {
+          readonly architecture: string;
           readonly canonicalName: string;
         };
       };
@@ -183,6 +184,13 @@ v3 = [
                     "kind": "ScalarField",
                     "name": "canonicalName",
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "architecture",
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -223,16 +231,16 @@ return {
     "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "3605d3829fb95096dc3f8daee65f73fa",
+    "cacheID": "3607855c4e9666c6ebd350ba0a2c510c",
     "id": null,
     "metadata": {},
     "name": "BAIAdminImageSelectPaginatedQuery",
     "operationKind": "query",
-    "text": "query BAIAdminImageSelectPaginatedQuery(\n  $offset: Int!\n  $limit: Int!\n  $filter: ImageV2Filter\n) {\n  adminImagesV2(offset: $offset, limit: $limit, filter: $filter, orderBy: [{field: NAME, direction: ASC}]) {\n    count\n    edges {\n      node {\n        id\n        identity {\n          canonicalName\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query BAIAdminImageSelectPaginatedQuery(\n  $offset: Int!\n  $limit: Int!\n  $filter: ImageV2Filter\n) {\n  adminImagesV2(offset: $offset, limit: $limit, filter: $filter, orderBy: [{field: NAME, direction: ASC}]) {\n    count\n    edges {\n      node {\n        id\n        identity {\n          canonicalName\n          architecture\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9d58814c6c642167f778476211c7c450";
+(node as any).hash = "f54610edee78e3778fe21cf9882fcff3";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAIAdminImageSelectValueQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminImageSelectValueQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a34cf1eabd5a75ee2c9655ba5631ce81>>
+ * @generated SignedSource<<4a138ae76fc64218c4e6ceb47768aa4d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,7 @@ export type BAIAdminImageSelectValueQuery$data = {
       readonly node: {
         readonly id: string;
         readonly identity: {
+          readonly architecture: string;
           readonly canonicalName: string;
         };
       };
@@ -117,6 +118,13 @@ v1 = [
                         "kind": "ScalarField",
                         "name": "canonicalName",
                         "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "architecture",
+                        "storageKey": null
                       }
                     ],
                     "storageKey": null
@@ -151,16 +159,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "bdf4f10fcbd263a6bd1d728d9ff5792a",
+    "cacheID": "47f080415673e9662ff4de04aa724726",
     "id": null,
     "metadata": {},
     "name": "BAIAdminImageSelectValueQuery",
     "operationKind": "query",
-    "text": "query BAIAdminImageSelectValueQuery(\n  $ids: [UUID!]\n  $skipSelected: Boolean!\n) {\n  adminImagesV2(filter: {id: {in: $ids}}, limit: 100) @skip(if: $skipSelected) {\n    edges {\n      node {\n        id\n        identity {\n          canonicalName\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query BAIAdminImageSelectValueQuery(\n  $ids: [UUID!]\n  $skipSelected: Boolean!\n) {\n  adminImagesV2(filter: {id: {in: $ids}}, limit: 100) @skip(if: $skipSelected) {\n    edges {\n      node {\n        id\n        identity {\n          canonicalName\n          architecture\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "3394b693b9cf130b5afe941b098a010b";
+(node as any).hash = "32cc3f7dc9c87d1eea7fef694d9cc899";
 
 export default node;

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminImageSelect.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminImageSelect.stories.tsx
@@ -7,28 +7,37 @@ import { createMockEnvironment } from 'relay-test-utils';
 // Relay global ID format: btoa('TypeName:localId')
 const makeImageId = (localId: string) => btoa(`ImageV2Node:${localId}`);
 
-type ImageMockItem = { id: string; canonicalName: string };
+type ImageMockItem = {
+  id: string;
+  canonicalName: string;
+  architecture: string;
+};
 
 const sampleImages: ImageMockItem[] = [
   {
     id: makeImageId('aaaa1111-1111-1111-1111-111111111111'),
     canonicalName: 'cr.backend.ai/stable/python:3.11-cuda12.1',
+    architecture: 'x86_64',
   },
   {
     id: makeImageId('bbbb2222-2222-2222-2222-222222222222'),
     canonicalName: 'cr.backend.ai/stable/pytorch:2.1-cuda12.1',
+    architecture: 'aarch64',
   },
   {
     id: makeImageId('cccc3333-3333-3333-3333-333333333333'),
     canonicalName: 'cr.backend.ai/stable/tensorflow:2.14-cuda12.1',
+    architecture: 'x86_64',
   },
   {
     id: makeImageId('dddd4444-4444-4444-4444-444444444444'),
     canonicalName: 'cr.backend.ai/stable/python:3.10-cpu',
+    architecture: 'aarch64',
   },
   {
     id: makeImageId('eeee5555-5555-5555-5555-555555555555'),
     canonicalName: 'cr.backend.ai/stable/jupyter:7.1-cuda12.1',
+    architecture: 'x86_64',
   },
 ];
 
@@ -39,11 +48,16 @@ const sampleManyImages: ImageMockItem[] = Array.from(
       `image-${String(i + 1).padStart(4, '0')}-0000-0000-0000-000000000000`,
     ),
     canonicalName: `cr.backend.ai/stable/image-${i + 1}:latest`,
+    architecture: i % 2 === 0 ? 'x86_64' : 'aarch64',
   }),
 );
 
-const makeEdge = ({ id, canonicalName }: ImageMockItem) => ({
-  node: { __typename: 'ImageV2Node', id, identity: { canonicalName } },
+const makeEdge = ({ id, canonicalName, architecture }: ImageMockItem) => ({
+  node: {
+    __typename: 'ImageV2Node',
+    id,
+    identity: { canonicalName, architecture },
+  },
 });
 
 /**
@@ -244,7 +258,7 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          'Basic usage showing 5 images. Each option displays the canonical name. Search functionality is enabled by default.',
+          'Basic usage showing 5 images of mixed CPU architectures. Each option displays the canonical name with its architecture in `<canonicalName>@<architecture>` format. Search functionality is enabled by default.',
       },
     },
   },

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminImageSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminImageSelect.tsx
@@ -109,6 +109,7 @@ const BAIAdminImageSelect: React.FC<BAIAdminImageSelectProps> = ({
                 id
                 identity {
                   canonicalName
+                  architecture
                 }
               }
             }
@@ -149,6 +150,7 @@ const BAIAdminImageSelect: React.FC<BAIAdminImageSelectProps> = ({
                 id
                 identity {
                   canonicalName
+                  architecture
                 }
               }
             }
@@ -188,8 +190,18 @@ const BAIAdminImageSelect: React.FC<BAIAdminImageSelectProps> = ({
     [updateFetchKey, startRefetchTransition],
   );
 
+  // Compose the option label as "<canonicalName>@<architecture>" (Backend.AI's
+  // canonical image reference format) so admins can distinguish images by CPU
+  // architecture (e.g. aarch64 vs x86_64) when nodes of mixed architectures are present.
+  // `identity` is optional because callers pass a possibly-absent node, but its
+  // `canonicalName` / `architecture` are non-nullable per the schema.
+  const getImageLabel = (identity?: {
+    canonicalName: string;
+    architecture: string;
+  }) => (identity ? `${identity.canonicalName}@${identity.architecture}` : '');
+
   const availableOptions = _.map(paginationData, (item) => ({
-    label: item?.identity?.canonicalName,
+    label: getImageLabel(item?.identity),
     value: item?.id ? toLocalId(item.id) : item?.id,
   }));
 
@@ -201,7 +213,7 @@ const BAIAdminImageSelect: React.FC<BAIAdminImageSelectProps> = ({
       const resolved = value ? selectedImageMap[value] : undefined;
       if (resolved) {
         return {
-          label: resolved.identity?.canonicalName,
+          label: getImageLabel(resolved.identity),
           value: toLocalId(resolved.id),
         };
       }

--- a/react/src/__generated__/hooksUsingRelay_AdminImageReferenceQuery.graphql.ts
+++ b/react/src/__generated__/hooksUsingRelay_AdminImageReferenceQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<061bc85889a29081260835fb878091f2>>
+ * @generated SignedSource<<fd7fb2a0ccbc22c5fa6b8653ac28062f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,23 +9,24 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type hooksUsingRelay_AdminImageCanonicalNameQuery$variables = {
+export type hooksUsingRelay_AdminImageReferenceQuery$variables = {
   id: string;
 };
-export type hooksUsingRelay_AdminImageCanonicalNameQuery$data = {
+export type hooksUsingRelay_AdminImageReferenceQuery$data = {
   readonly adminImagesV2: {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly identity: {
+          readonly architecture: string;
           readonly canonicalName: string;
         };
       };
     }>;
   } | null | undefined;
 };
-export type hooksUsingRelay_AdminImageCanonicalNameQuery = {
-  response: hooksUsingRelay_AdminImageCanonicalNameQuery$data;
-  variables: hooksUsingRelay_AdminImageCanonicalNameQuery$variables;
+export type hooksUsingRelay_AdminImageReferenceQuery = {
+  response: hooksUsingRelay_AdminImageReferenceQuery$data;
+  variables: hooksUsingRelay_AdminImageReferenceQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -74,6 +75,13 @@ v2 = {
       "kind": "ScalarField",
       "name": "canonicalName",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "architecture",
+      "storageKey": null
     }
   ],
   "storageKey": null
@@ -83,7 +91,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "hooksUsingRelay_AdminImageCanonicalNameQuery",
+    "name": "hooksUsingRelay_AdminImageReferenceQuery",
     "selections": [
       {
         "alias": null,
@@ -127,7 +135,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "hooksUsingRelay_AdminImageCanonicalNameQuery",
+    "name": "hooksUsingRelay_AdminImageReferenceQuery",
     "selections": [
       {
         "alias": null,
@@ -173,16 +181,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "aa61d8950f022a65a74a32ab014bb7b3",
+    "cacheID": "2488b1b0b7c570c4740c0826f33c1964",
     "id": null,
     "metadata": {},
-    "name": "hooksUsingRelay_AdminImageCanonicalNameQuery",
+    "name": "hooksUsingRelay_AdminImageReferenceQuery",
     "operationKind": "query",
-    "text": "query hooksUsingRelay_AdminImageCanonicalNameQuery(\n  $id: UUID!\n) {\n  adminImagesV2(filter: {id: {equals: $id}}, limit: 1) {\n    edges {\n      node {\n        identity {\n          canonicalName\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query hooksUsingRelay_AdminImageReferenceQuery(\n  $id: UUID!\n) {\n  adminImagesV2(filter: {id: {equals: $id}}, limit: 1) {\n    edges {\n      node {\n        identity {\n          canonicalName\n          architecture\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0a0243b442f62df3f28e69e6c91eb93a";
+(node as any).hash = "1268865e22264aa8fe7c775602949b70";
 
 export default node;

--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -2,7 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useAdminImageCanonicalName } from '../hooks/hooksUsingRelay';
+import { useAdminImageReference } from '../hooks/hooksUsingRelay';
 import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
 import type { AdminDeploymentPresetFormValue } from './AdminDeploymentPresetFormTypes';
 import SourceCodeView from './SourceCodeView';
@@ -54,7 +54,7 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
   // `true` includes untouched fields and arrays (e.g. modelDefinition.models)
   // that getFieldsValue() omits; its overload returns `any`, so annotate here.
   const values: AdminDeploymentPresetFormValue = form.getFieldsValue(true);
-  const imageCanonicalName = useAdminImageCanonicalName(values.imageId);
+  const imageReference = useAdminImageReference(values.imageId);
 
   const basicInfoHasError = BASIC_INFO_FIELDS.some((f) =>
     errorFieldNames.includes(f),
@@ -115,13 +115,13 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
             </Descriptions.Item>
           )}
           <Descriptions.Item label={t('adminDeploymentPreset.Image')}>
-            {imageCanonicalName ? (
+            {imageReference ? (
               <Typography.Text
                 code
                 style={{ wordBreak: 'break-all' }}
-                copyable={{ text: imageCanonicalName }}
+                copyable={{ text: imageReference }}
               >
-                {imageCanonicalName}
+                {imageReference}
               </Typography.Text>
             ) : (
               '-'

--- a/react/src/hooks/hooksUsingRelay.tsx
+++ b/react/src/hooks/hooksUsingRelay.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '.';
-import { hooksUsingRelay_AdminImageCanonicalNameQuery } from '../__generated__/hooksUsingRelay_AdminImageCanonicalNameQuery.graphql';
+import { hooksUsingRelay_AdminImageReferenceQuery } from '../__generated__/hooksUsingRelay_AdminImageReferenceQuery.graphql';
 import { hooksUsingRelay_ImageCanonicalNameQuery } from '../__generated__/hooksUsingRelay_ImageCanonicalNameQuery.graphql';
 import { hooksUsingRelay_KeyPairQuery } from '../__generated__/hooksUsingRelay_KeyPairQuery.graphql';
 import { hooksUsingRelay_KeyPairResourcePolicyQuery } from '../__generated__/hooksUsingRelay_KeyPairResourcePolicyQuery.graphql';
@@ -132,22 +132,25 @@ export const useImageCanonicalName = (
 };
 
 /**
- * Admin-scoped counterpart of `useImageCanonicalName`. Resolves an image id
- * via `adminImagesV2` for admin pages where the user-scoped `imageV2` query
- * is not available. See `useImageCanonicalName` for null-handling semantics.
+ * Admin-scoped counterpart of `useImageCanonicalName`. Resolves an image id to
+ * its full reference `<canonicalName>@<architecture>` via `adminImagesV2` for
+ * admin pages where the user-scoped `imageV2` query is not available. Falls back
+ * to the canonical name alone, then the raw id. See `useImageCanonicalName` for
+ * null-handling semantics.
  */
-export const useAdminImageCanonicalName = (
+export const useAdminImageReference = (
   imageId: string | null | undefined,
   options: FetchOptions = { fetchPolicy: 'store-or-network' },
 ): string | undefined => {
-  const data = useLazyLoadQuery<hooksUsingRelay_AdminImageCanonicalNameQuery>(
+  const data = useLazyLoadQuery<hooksUsingRelay_AdminImageReferenceQuery>(
     graphql`
-      query hooksUsingRelay_AdminImageCanonicalNameQuery($id: UUID!) {
+      query hooksUsingRelay_AdminImageReferenceQuery($id: UUID!) {
         adminImagesV2(filter: { id: { equals: $id } }, limit: 1) {
           edges {
             node {
               identity {
                 canonicalName
+                architecture
               }
             }
           }
@@ -158,7 +161,9 @@ export const useAdminImageCanonicalName = (
     options,
   );
   if (!imageId) return undefined;
-  return (
-    data.adminImagesV2?.edges?.[0]?.node?.identity?.canonicalName ?? imageId
-  );
+  const identity = data.adminImagesV2?.edges?.[0]?.node?.identity;
+  if (!identity?.canonicalName) return imageId;
+  return identity.architecture
+    ? `${identity.canonicalName}@${identity.architecture}`
+    : identity.canonicalName;
 };


### PR DESCRIPTION
Resolves #7948 (FR-3163)

Part of FR-3084 (Final Train to 26.4.8).

## Summary

aarch64 and x86_64 nodes are mixed, so admins must be able to see each image's CPU architecture when working with a deployment revision preset, to avoid selecting the wrong architecture.

This change surfaces the image architecture in the deployment-preset flow using [Backend.AI](http://Backend.AI)'s canonical `<canonicalName>@<architecture>` image reference format (e.g. `cr.backend.ai/stable/pytorch:2.1-cuda12.1@aarch64`):

- **Image select (`BAIAdminImageSelect`)** — added `identity.architecture` to both GraphQL queries (the paginated list query `BAIAdminImageSelectPaginatedQuery` and the selected-value resolver query `BAIAdminImageSelectValueQuery`). The rendered option label and the resolved selected-value label now read `<canonicalName>@<architecture>`, applied consistently via a shared `getImageLabel` helper.
- **Review step (`AdminDeploymentPresetReviewSummary`)** — the final "Review" step of the preset form previously showed the chosen image by canonical name only. It now displays `<canonicalName>@<architecture>` too, so the architecture stays visible all the way through confirmation. The admin-scoped resolver hook was extended to fetch `architecture` and renamed `useAdminImageCanonicalName` → `useAdminImageReference` (single caller) to reflect the new return value. This mirrors the existing `@<architecture>` formatting in `DeploymentRevisionDetail`.
- **Storybook** — `BAIAdminImageSelect.stories.tsx` mock data now includes mixed `x86_64` / `aarch64` architectures so the autodoc demonstrates the new label format.
- Regenerated Relay artifacts under `__generated__` and committed them.

`ImageV2IdentityInfo.architecture` already exists in the schema (non-nullable `String!`), so no schema change is needed. No new user-facing label text is introduced (architecture comes from data), so no locale changes are required.

## Screenshot

Image select dropdown showing each image's architecture in `image@arch` format (mixed x86_64 / aarch64):

![Image select showing image@architecture](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-7954/20260617-072757-image-select-arch.png)

> Captured via the `BAIAdminImageSelect` Storybook story (the live admin page could not be used because the available test backend is 26.4.4 while `main` is 26.5.0-alpha, a version skew that blocks login). The review-step display reuses the same `<canonicalName>@<architecture>` formatting.

Admin deployment preset create page

![image.png](https://app.graphite.com/user-attachments/assets/1f34f184-ca3a-4690-b2d6-392403c17e8e.png)

![image.png](https://app.graphite.com/user-attachments/assets/452d7908-ea6d-47cc-8050-9ff7d45567e4.png)

![image.png](https://app.graphite.com/user-attachments/assets/a06e6d2b-8c88-4eda-b053-783def593886.png)



## Verification

`bash scripts/verify.sh`:

- Relay: PASS (artifacts regenerated and committed)
- Lint: PASS
- Format: PASS
- TypeScript: only the known-environmental worktree false positive in `react/src/components/FluentEmojiIcon.tsx` (`cdn not assignable to aliyun | unpkg`) — unrelated to this change and not present in the touched files. All other checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)