### PR TITLE
fix: Raise Node heap limit for the React production build

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -91,7 +91,7 @@
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "build": "pnpm run build:only && cp -r ./build/* ../build/web/",
-    "build:only": "pnpm run relay && vite build",
+    "build:only": "pnpm run relay && NODE_OPTIONS='--max-old-space-size=4096' vite build",
     "test": "vitest run",
     "relay": "relay-compiler",
     "lint": "eslint ./src --max-warnings=0 --no-warn-ignored",

--- a/react/package.json
+++ b/react/package.json
@@ -87,7 +87,7 @@
   "scripts": {
     "start": "NODE_OPTIONS='--max-old-space-size=4096' vite",
     "vite:dev": "vite",
-    "vite:build": "vite build",
+    "vite:build": "NODE_OPTIONS='--max-old-space-size=4096' vite build",
     "vitest": "vitest run",
     "vitest:watch": "vitest",
     "build": "pnpm run build:only && cp -r ./build/* ../build/web/",


### PR DESCRIPTION
Resolves lablup/backend.ai#12249

> Note: opened without a Jira/FR ticket; title prefix to be updated once a ticket is assigned.

## Problem
The React production build (`build:only` → `vite build`) runs under Node's default ~2 GB old-space heap and crashes with `JavaScript heap out of memory` (exit 134) on low-RAM machines. This surfaces during the core repo's `install-dev.sh` (lablup/backend.ai#12249, fixed there in lablup/backend.ai#12250).

The `start` script already raises the heap (`--max-old-space-size=4096`); the build script was never given the same treatment — that asymmetry is the bug.

## Change
Mirror the existing `start` script and scope the heap flag to the build:

```jsonc
"build:only": "pnpm run relay && NODE_OPTIONS='--max-old-space-size=4096' vite build"
```

Self-contained, no global env required, consistent with `start`.

## Verification
- [ ] `bash scripts/verify.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)