### PR TITLE
fix(FR-3166): add shell syntax helper text to start command inputs

### DIFF
--- a/react/src/components/AdminDeploymentPresetModelConfigItem.tsx
+++ b/react/src/components/AdminDeploymentPresetModelConfigItem.tsx
@@ -100,6 +100,8 @@ const ModelConfigItem: React.FC<{
             {...restField}
             name={[listItemName, 'service', 'startCommand']}
             label={t('adminDeploymentPreset.modelDef.StartCommand')}
+            tooltip={t('modelService.StartCommandTooltip')}
+            extra={t('modelService.StartCommandHelperShell')}
             rules={[{ required: true }]}
           >
             <Input

--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -237,9 +237,18 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
         <Descriptions column={1} size="small">
           <Descriptions.Item label={t('adminDeploymentPreset.StartupCommand')}>
             {values.startupCommand ? (
-              <Typography.Text code style={{ whiteSpace: 'pre-wrap' }}>
+              <SourceCodeView language="shell">
                 {values.startupCommand}
-              </Typography.Text>
+              </SourceCodeView>
+            ) : (
+              '-'
+            )}
+          </Descriptions.Item>
+          <Descriptions.Item label={t('adminDeploymentPreset.BootstrapScript')}>
+            {values.bootstrapScript ? (
+              <SourceCodeView language="shell">
+                {values.bootstrapScript}
+              </SourceCodeView>
             ) : (
               '-'
             )}
@@ -301,9 +310,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
                     <Descriptions.Item
                       label={t('adminDeploymentPreset.modelDef.StartCommand')}
                     >
-                      <Typography.Text code>
+                      <SourceCodeView language="shell">
                         {m.service.startCommand}
-                      </Typography.Text>
+                      </SourceCodeView>
                     </Descriptions.Item>
                   )}
                   {(m.service?.preStartActions?.length ?? 0) > 0 && (

--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -4,6 +4,7 @@
  */
 import type { AdminDeploymentPresetSettingPageContent_preset$key } from '../__generated__/AdminDeploymentPresetSettingPageContent_preset.graphql';
 import EnvVarFormList from '../components/EnvVarFormList';
+import { formatShellCommand } from '../helper/parseCliCommand';
 import {
   buildRuntimeVariantPresetValues,
   collectTouchedRuntimePresetParams,
@@ -424,7 +425,9 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                   ? {
                       port: m.service.port,
                       shell: m.service.shell,
-                      startCommand: m.service.startCommand?.join(' ') ?? '',
+                      startCommand: formatShellCommand(
+                        m.service.startCommand ?? [],
+                      ),
                       // 26.4.4rc7+: `enable` is authoritative; older managers
                       // omit it, so fall back to the object's presence.
                       enableHealthCheck:
@@ -917,6 +920,8 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
             <Form.Item
               name="startupCommand"
               label={t('adminDeploymentPreset.StartupCommand')}
+              tooltip={t('modelService.StartCommandTooltip')}
+              extra={t('modelService.StartCommandHelperShell')}
             >
               <Input.TextArea
                 rows={2}

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -1138,7 +1138,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                 modelPath: values.commandModelMount ?? '/models',
                 service: {
                   preStartActions: [],
-                  startCommand: tokenizeShellCommand(values.startCommand),
+                  startCommand: tokenizeShellCommand(values.startCommand ?? ''),
                   port: values.commandPort ?? 8000,
                   healthCheck,
                 },
@@ -1681,6 +1681,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                             name="startCommand"
                             label={t('modelService.StartCommand')}
                             tooltip={t('modelService.StartCommandTooltip')}
+                            extra={t('modelService.StartCommandHelperShell')}
                             rules={[{ required: true, whitespace: true }]}
                           >
                             <Input.TextArea

--- a/react/src/pages/AdminDeploymentPresetSettingPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetSettingPage.tsx
@@ -11,6 +11,7 @@ import AdminDeploymentPresetSettingPageContent, {
   type AdminDeploymentPresetFormValue,
   type ModelDefinitionFormValue,
 } from '../components/AdminDeploymentPresetSettingPageContent';
+import { tokenizeShellCommand } from '../helper/parseCliCommand';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { type RuntimeVariantPresetValueEntry } from '../hooks/useRuntimeParameterSchema';
 import { App, Form, Typography, theme } from 'antd';
@@ -52,9 +53,7 @@ const buildModelDefinitionInput = (
           service: {
             port: service.port,
             shell: service.shell,
-            startCommand: service.startCommand.trim()
-              ? service.startCommand.trim().split(/\s+/)
-              : [],
+            startCommand: tokenizeShellCommand(service.startCommand),
             preStartActions: (service.preStartActions ?? []).map((a) => ({
               action: a.action,
               args: (() => {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Vorab-Aktionen",
       "Shell": "Shell",
       "StartCommand": "Startbefehl",
-      "StartCommandPlaceholder": "z. B. python server.py",
+      "StartCommandPlaceholder": "z. B. vllm serve /models --tp 2",
       "Task": "Aufgabe",
       "Title": "Titel",
       "Version": "Version"
@@ -2094,7 +2094,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Befehl starten",
-    "StartCommandPlaceholder": "z. B. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Shell-Syntax: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "z. B. vllm serve /models --tp 2",
     "StartCommandTooltip": "Der CLI-Befehl zum Starten des Modell-Serving-Prozesses.",
     "StartModelService": "Dienst aus Modellordner starten",
     "StartModelServiceWithName": "Dienst aus Modellordner starten: {{name}}",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Ενέργειες πριν την εκκίνηση",
       "Shell": "Shell",
       "StartCommand": "Εντολή εκκίνησης",
-      "StartCommandPlaceholder": "π.χ., python server.py",
+      "StartCommandPlaceholder": "π.χ. vllm serve /models --tp 2",
       "Task": "Εργασία",
       "Title": "Τίτλος",
       "Version": "Έκδοση"
@@ -2092,7 +2092,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Εκκίνηση Εντολή",
-    "StartCommandPlaceholder": "π.χ., vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Σύνταξη shell: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "π.χ. vllm serve /models --tp 2",
     "StartCommandTooltip": "Η εντολή CLI για εκκίνηση της διεργασίας εξυπηρέτησης μοντέλου.",
     "StartModelService": "Εκκίνηση υπηρεσίας από τον φάκελο μοντέλου",
     "StartModelServiceWithName": "Εκκίνηση υπηρεσίας από τον φάκελο μοντέλου: {{name}}",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Pre-Start Actions",
       "Shell": "Shell",
       "StartCommand": "Start Command",
-      "StartCommandPlaceholder": "e.g., python server.py",
+      "StartCommandPlaceholder": "e.g., vllm serve /models --tp 2",
       "Task": "Task",
       "Title": "Title",
       "Version": "Version"
@@ -2082,7 +2082,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Start Command",
-    "StartCommandPlaceholder": "e.g., vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Shell syntax: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "e.g., vllm serve /models --tp 2",
     "StartCommandTooltip": "The CLI command to start the model serving process.",
     "StartModelService": "Start Service from Model Folder",
     "StartModelServiceWithName": "Start Service from Model Folder: {{name}}",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Acciones previas al inicio",
       "Shell": "Shell",
       "StartCommand": "Comando de inicio",
-      "StartCommandPlaceholder": "p. ej., python server.py",
+      "StartCommandPlaceholder": "ej. vllm serve /models --tp 2",
       "Task": "Tarea",
       "Title": "Título",
       "Version": "Versión"
@@ -2092,7 +2092,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Comando de inicio",
-    "StartCommandPlaceholder": "p. ej., vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Sintaxis shell: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "ej. vllm serve /models --tp 2",
     "StartCommandTooltip": "El comando CLI para iniciar el proceso de servicio del modelo.",
     "StartModelService": "Iniciar servicio desde la carpeta del modelo",
     "StartModelServiceWithName": "Iniciar servicio desde la carpeta del modelo: {{name}}",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Käynnistystä edeltävät toiminnot",
       "Shell": "Shell",
       "StartCommand": "Käynnistyskomento",
-      "StartCommandPlaceholder": "esim. python server.py",
+      "StartCommandPlaceholder": "esim. vllm serve /models --tp 2",
       "Task": "Tehtävä",
       "Title": "Otsikko",
       "Version": "Versio"
@@ -2092,7 +2092,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Käynnistä komento",
-    "StartCommandPlaceholder": "esim. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Shell-syntaksi: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "esim. vllm serve /models --tp 2",
     "StartCommandTooltip": "CLI-komento mallin palveluprosessin käynnistämiseksi.",
     "StartModelService": "Start Service from Model Folder",
     "StartModelServiceWithName": "Start Service from Model Folder: {{name}}",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Actions avant démarrage",
       "Shell": "Shell",
       "StartCommand": "Commande de démarrage",
-      "StartCommandPlaceholder": "ex. : python server.py",
+      "StartCommandPlaceholder": "ex. vllm serve /models --tp 2",
       "Task": "Tâche",
       "Title": "Titre",
       "Version": "Version"
@@ -2094,7 +2094,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Démarrer la commande",
-    "StartCommandPlaceholder": "ex. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Syntaxe shell : /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "ex. vllm serve /models --tp 2",
     "StartCommandTooltip": "La commande CLI pour démarrer le processus de service du modèle.",
     "StartModelService": "Démarrer le service depuis le dossier modèle",
     "StartModelServiceWithName": "Démarrer le service depuis le dossier modèle : {{name}}",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Tindakan Pra-Mulai",
       "Shell": "Shell",
       "StartCommand": "Perintah Mulai",
-      "StartCommandPlaceholder": "mis., python server.py",
+      "StartCommandPlaceholder": "mis. vllm serve /models --tp 2",
       "Task": "Tugas",
       "Title": "Judul",
       "Version": "Versi"
@@ -2095,7 +2095,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Mulai Perintah",
-    "StartCommandPlaceholder": "mis. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Sintaks shell: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "mis. vllm serve /models --tp 2",
     "StartCommandTooltip": "Perintah CLI untuk memulai proses penyajian model.",
     "StartModelService": "Mulai Layanan dari Folder Model",
     "StartModelServiceWithName": "Mulai Layanan dari Folder Model: {{name}}",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Azioni pre-avvio",
       "Shell": "Shell",
       "StartCommand": "Comando di avvio",
-      "StartCommandPlaceholder": "es., python server.py",
+      "StartCommandPlaceholder": "es. vllm serve /models --tp 2",
       "Task": "Attività",
       "Title": "Titolo",
       "Version": "Versione"
@@ -2092,7 +2092,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Avvia comando",
-    "StartCommandPlaceholder": "es. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Sintassi shell: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "es. vllm serve /models --tp 2",
     "StartCommandTooltip": "Il comando CLI per avviare il processo di servizio del modello.",
     "StartModelService": "Avvia servizio dalla cartella del modello",
     "StartModelServiceWithName": "Avvia servizio dalla cartella del modello: {{name}}",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -107,7 +107,7 @@
       "PreStartActions": "起動前アクション",
       "Shell": "シェル",
       "StartCommand": "起動コマンド",
-      "StartCommandPlaceholder": "例: python server.py",
+      "StartCommandPlaceholder": "例: vllm serve /models --tp 2",
       "Task": "タスク",
       "Title": "タイトル",
       "Version": "バージョン"
@@ -2094,7 +2094,8 @@
     "Shell": "シェル",
     "StartChat": "Start Chat",
     "StartCommand": "開始コマンド",
-    "StartCommandPlaceholder": "例: vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "シェル構文: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "例: vllm serve /models --tp 2",
     "StartCommandTooltip": "モデルサービングプロセスを開始するための CLI コマンドです。",
     "StartModelService": "モデルフォルダからサービスを開始",
     "StartModelServiceWithName": "モデルフォルダからサービスを開始: {{name}}",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -107,7 +107,7 @@
       "PreStartActions": "사전 실행 동작",
       "Shell": "셸",
       "StartCommand": "시작 명령",
-      "StartCommandPlaceholder": "예: python server.py",
+      "StartCommandPlaceholder": "예: vllm serve /models --tp 2",
       "Task": "태스크",
       "Title": "제목",
       "Version": "버전"
@@ -2097,7 +2097,8 @@
     "Shell": "셸",
     "StartChat": "Start Chat",
     "StartCommand": "시작 명령어",
-    "StartCommandPlaceholder": "예: vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "쉘 문법: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "예: vllm serve /models --tp 2",
     "StartCommandTooltip": "모델 서빙 프로세스를 시작하는 CLI 명령어입니다.",
     "StartModelService": "모델 폴더로 서비스 시작",
     "StartModelServiceWithName": "모델 폴더로 서비스 시작: {{name}}",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Эхлэхийн өмнөх үйлдлүүд",
       "Shell": "Shell",
       "StartCommand": "Эхлүүлэх тушаал",
-      "StartCommandPlaceholder": "жш.: python server.py",
+      "StartCommandPlaceholder": "жн: vllm serve /models --tp 2",
       "Task": "Даалгавар",
       "Title": "Гарчиг",
       "Version": "Хувилбар"
@@ -2093,7 +2093,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Эхлэх тушаал",
-    "StartCommandPlaceholder": "жш нь vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Shell синтакс: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "жн: vllm serve /models --tp 2",
     "StartCommandTooltip": "Загвар үйлчлэх процессыг эхлүүлэх CLI тушаал.",
     "StartModelService": "Загварын хавтаснаас үйлчилгээ эхлүүлэх",
     "StartModelServiceWithName": "Загварын хавтаснаас үйлчилгээ эхлүүлэх: {{name}}",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Tindakan Pra-Mula",
       "Shell": "Shell",
       "StartCommand": "Perintah Mula",
-      "StartCommandPlaceholder": "cth., python server.py",
+      "StartCommandPlaceholder": "cth. vllm serve /models --tp 2",
       "Task": "Tugas",
       "Title": "Tajuk",
       "Version": "Versi"
@@ -2092,7 +2092,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Mulakan Perintah",
-    "StartCommandPlaceholder": "cth. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Sintaks shell: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "cth. vllm serve /models --tp 2",
     "StartCommandTooltip": "Perintah CLI untuk memulakan proses penyajian model.",
     "StartModelService": "Mulakan Perkhidmatan dari Folder Model",
     "StartModelServiceWithName": "Mulakan Perkhidmatan dari Folder Model: {{name}}",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Akcje przed uruchomieniem",
       "Shell": "Shell",
       "StartCommand": "Polecenie uruchomienia",
-      "StartCommandPlaceholder": "np. python server.py",
+      "StartCommandPlaceholder": "np. vllm serve /models --tp 2",
       "Task": "Zadanie",
       "Title": "Tytuł",
       "Version": "Wersja"
@@ -2094,7 +2094,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Uruchom polecenie",
-    "StartCommandPlaceholder": "np. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Składnia powłoki: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "np. vllm serve /models --tp 2",
     "StartCommandTooltip": "Polecenie CLI do uruchomienia procesu obsługi modelu.",
     "StartModelService": "Uruchom usługę z folderu modelu",
     "StartModelServiceWithName": "Uruchom usługę z folderu modelu: {{name}}",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Ações de pré-inicialização",
       "Shell": "Shell",
       "StartCommand": "Comando de inicialização",
-      "StartCommandPlaceholder": "ex.: python server.py",
+      "StartCommandPlaceholder": "ex. vllm serve /models --tp 2",
       "Task": "Tarefa",
       "Title": "Título",
       "Version": "Versão"
@@ -2092,7 +2092,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Comando Iniciar",
-    "StartCommandPlaceholder": "ex. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Sintaxe shell: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "ex. vllm serve /models --tp 2",
     "StartCommandTooltip": "O comando CLI para iniciar o processo de serviço do modelo.",
     "StartModelService": "Iniciar Serviço a partir da Pasta de Modelo",
     "StartModelServiceWithName": "Iniciar Serviço a partir da Pasta de Modelo: {{name}}",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Ações antes do arranque",
       "Shell": "Shell",
       "StartCommand": "Comando de arranque",
-      "StartCommandPlaceholder": "ex.: python server.py",
+      "StartCommandPlaceholder": "ex. vllm serve /models --tp 2",
       "Task": "Tarefa",
       "Title": "Título",
       "Version": "Versão"
@@ -2094,7 +2094,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Comando Iniciar",
-    "StartCommandPlaceholder": "ex. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Sintaxe shell: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "ex. vllm serve /models --tp 2",
     "StartCommandTooltip": "O comando CLI para iniciar o processo de serviço do modelo.",
     "StartModelService": "Start Service from Model Folder",
     "StartModelServiceWithName": "Start Service from Model Folder: {{name}}",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Действия перед запуском",
       "Shell": "Shell",
       "StartCommand": "Команда запуска",
-      "StartCommandPlaceholder": "напр., python server.py",
+      "StartCommandPlaceholder": "напр. vllm serve /models --tp 2",
       "Task": "Задача",
       "Title": "Заголовок",
       "Version": "Версия"
@@ -2092,7 +2092,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Запустить команду",
-    "StartCommandPlaceholder": "напр. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Синтаксис оболочки: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "напр. vllm serve /models --tp 2",
     "StartCommandTooltip": "Команда CLI для запуска процесса обслуживания модели.",
     "StartModelService": "Запустить сервис из папки модели",
     "StartModelServiceWithName": "Запустить сервис из папки модели: {{name}}",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -107,7 +107,7 @@
       "PreStartActions": "การกระทำก่อนเริ่ม",
       "Shell": "Shell",
       "StartCommand": "คำสั่งเริ่มต้น",
-      "StartCommandPlaceholder": "เช่น python server.py",
+      "StartCommandPlaceholder": "เช่น vllm serve /models --tp 2",
       "Task": "งาน",
       "Title": "ชื่อเรื่อง",
       "Version": "เวอร์ชัน"
@@ -2094,7 +2094,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "คำสั่งเริ่มต้น",
-    "StartCommandPlaceholder": "เช่น vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "ไวยากรณ์เชลล์: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "เช่น vllm serve /models --tp 2",
     "StartCommandTooltip": "คำสั่ง CLI สำหรับเริ่มต้นกระบวนการให้บริการโมเดล",
     "StartModelService": "Start Service from Model Folder",
     "StartModelServiceWithName": "Start Service from Model Folder: {{name}}",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Başlatma Öncesi Eylemler",
       "Shell": "Shell",
       "StartCommand": "Başlatma Komutu",
-      "StartCommandPlaceholder": "örn. python server.py",
+      "StartCommandPlaceholder": "örn. vllm serve /models --tp 2",
       "Task": "Görev",
       "Title": "Başlık",
       "Version": "Sürüm"
@@ -2092,7 +2092,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Komutu Başlat",
-    "StartCommandPlaceholder": "örn. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Kabuk sözdizimi: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "örn. vllm serve /models --tp 2",
     "StartCommandTooltip": "Model servis sürecini başlatmak için CLI komutu.",
     "StartModelService": "Model Klasöründen Hizmet Başlat",
     "StartModelServiceWithName": "Model Klasöründen Hizmet Başlat: {{name}}",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -107,7 +107,7 @@
       "PreStartActions": "Hành động trước khởi động",
       "Shell": "Shell",
       "StartCommand": "Lệnh khởi động",
-      "StartCommandPlaceholder": "vd.: python server.py",
+      "StartCommandPlaceholder": "vd: vllm serve /models --tp 2",
       "Task": "Tác vụ",
       "Title": "Tiêu đề",
       "Version": "Phiên bản"
@@ -2094,7 +2094,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "Bắt đầu lệnh",
-    "StartCommandPlaceholder": "vd. vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Cú pháp shell: /bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "vd: vllm serve /models --tp 2",
     "StartCommandTooltip": "Lệnh CLI để khởi động tiến trình phục vụ mô hình.",
     "StartModelService": "Khởi động dịch vụ từ thư mục mô hình",
     "StartModelServiceWithName": "Khởi động dịch vụ từ thư mục mô hình: {{name}}",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -107,7 +107,7 @@
       "PreStartActions": "启动前操作",
       "Shell": "Shell",
       "StartCommand": "启动命令",
-      "StartCommandPlaceholder": "例如：python server.py",
+      "StartCommandPlaceholder": "例如： vllm serve /models --tp 2",
       "Task": "任务",
       "Title": "标题",
       "Version": "版本"
@@ -2094,7 +2094,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "启动命令",
-    "StartCommandPlaceholder": "例如：vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Shell 语法：/bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "例如： vllm serve /models --tp 2",
     "StartCommandTooltip": "用于启动模型服务进程的 CLI 命令。",
     "StartModelService": "从模型文件夹启动服务",
     "StartModelServiceWithName": "从模型文件夹启动服务：{{name}}",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -107,7 +107,7 @@
       "PreStartActions": "啟動前動作",
       "Shell": "Shell",
       "StartCommand": "啟動指令",
-      "StartCommandPlaceholder": "例如：python server.py",
+      "StartCommandPlaceholder": "例如： vllm serve /models --tp 2",
       "Task": "任務",
       "Title": "標題",
       "Version": "版本"
@@ -2096,7 +2096,8 @@
     "Shell": "Shell",
     "StartChat": "Start Chat",
     "StartCommand": "啟動命令",
-    "StartCommandPlaceholder": "例如：vllm serve /models/my-model --tp 2",
+    "StartCommandHelperShell": "Shell 語法：/bin/bash -c \"cmd1; cmd2\"",
+    "StartCommandPlaceholder": "例如： vllm serve /models --tp 2",
     "StartCommandTooltip": "用於啟動模型服務程序的 CLI 命令。",
     "StartModelService": "從模型資料夾啟動服務",
     "StartModelServiceWithName": "從模型資料夾啟動服務：{{name}}",


### PR DESCRIPTION
Resolves #7956 (FR-3166)

## Problem

Compound shell commands like `chmod +x /setup.sh; vllm serve /models` failed at startup because the manager executes `startCommand: [String!]` as a direct exec (no shell), so semicolons and other shell operators are not interpreted.

## Solution

The WebUI tokenizes the start command string into an argv array (e.g., `vllm serve /models --tp 2` → `["vllm", "serve", "/models", "--tp", "2"]`) and displays an inline helper text below the input field telling users how to opt into shell syntax explicitly:

> Shell syntax: `/bin/bash -c "cmd1; cmd2"`

When users need shell operators, they prefix the command with an explicit shell invocation; the manager then exec's `/bin/bash -c` and interprets the rest as a shell expression. We do not silently wrap commands.

## Changes

### Start command inputs (tokenize + helper text + tooltip)
- **`react/src/components/DeploymentAddRevisionModal.tsx`** — Tokenize via `tokenizeShellCommand` (was naive split); helper text + tooltip on the start command field.
- **`react/src/components/AdminDeploymentPresetModelConfigItem.tsx`** — Helper text + tooltip on the model-definition service start command field.
- **`react/src/components/AdminDeploymentPresetSettingPageContent.tsx`** — Helper text + tooltip on the `startupCommand` field; use `formatShellCommand` for prefill.
- **`react/src/pages/AdminDeploymentPresetSettingPage.tsx`** — Use `tokenizeShellCommand` instead of naïve split on submit.

### Helper cleanup
- **`react/src/helper/parseCliCommand.ts`** — Removed thin wrappers `buildStartCommand`/`unwrapStartCommand`; callers use `tokenizeShellCommand`/`formatShellCommand` directly.

### Review step (step 4) display
- **`react/src/components/AdminDeploymentPresetReviewSummary.tsx`** — Render `startupCommand`, model-definition `startCommand`, and `bootstrapScript` as `SourceCodeView` code blocks (consistent with the environment-variables display) instead of inline `Typography.Text code`.

### i18n
- **`resources/i18n/*.json`** (22 languages) — Added `modelService.StartCommandHelperShell` (language-specific prefix, double-quoted `"cmd1; cmd2"`); updated `StartCommandPlaceholder` examples.

## Verification

```
bash scripts/verify.sh  → ALL PASS
pnpm run test           → tests pass
```