### PR TITLE
fix(FR-3168): fix broken setSameSitePolicy in Electron app

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -518,12 +518,28 @@ function setSameSitePolicy() {
   session.defaultSession.webRequest.onHeadersReceived(
     filter,
     (details, callback) => {
-      const cookies = details.responseHeaders['Set-Cookie'] || [];
-      cookies.map((cookie) => cookie.replace('SameSite=Lax', 'SameSite=None')); // Override SameSite Lax option to None for App mode cookie.
-      if (cookies.length > 0 && !cookies.includes('SameSite')) {
-        // Add SameSite policy if not present.
-        details.responseHeaders['Set-Cookie'] =
-          cookies + '; SameSite=None; Secure';
+      // HTTP header names are case-insensitive and Electron may normalize the
+      // Set-Cookie key differently across platforms/versions, so find the
+      // actual key rather than assuming 'Set-Cookie'.
+      const cookieKey = Object.keys(details.responseHeaders).find(
+        (key) => key.toLowerCase() === 'set-cookie',
+      );
+      if (cookieKey) {
+        details.responseHeaders[cookieKey] = details.responseHeaders[
+          cookieKey
+        ].map((cookie) => {
+          // Normalize any SameSite value (Lax, Strict, or missing) to None so
+          // the cookie is sent on cross-site requests. Case-insensitive to
+          // match RFC 6265.
+          const withSameSite = /SameSite=/i.test(cookie)
+            ? cookie.replace(/SameSite=\w+/i, 'SameSite=None')
+            : cookie + '; SameSite=None';
+          // SameSite=None requires the Secure attribute, otherwise
+          // Chromium/Electron rejects the cookie.
+          return /;\s*Secure/i.test(withSameSite)
+            ? withSameSite
+            : withSameSite + '; Secure';
+        });
       }
       callback({ cancel: false, responseHeaders: details.responseHeaders });
     },


### PR DESCRIPTION
Resolves #7961 (FR-3168)

## Problem

When launching a session app (Jupyter, VSCode, etc.) in the Backend.AI Desktop (Electron) app, a 502 \"Server connection failed\" error appears for all apps.

The V2 app proxy \`/setup\` endpoint sets an \`appproxy_permit\` cookie with \`SameSite=Lax\`. Because the Electron webui is served from \`127.0.0.1\` and the proxy lives on a different host (e.g. \`10.x.x.x\`), this is a cross-site context. \`setSameSitePolicy()\` in \`electron-app/main.js\` was meant to patch all \`Set-Cookie\` headers to \`SameSite=None\` so the cookie survives the cross-site navigation, but bugs made it a complete no-op.

## Root Cause

**\`.map()\` result discarded** — the \`SameSite=Lax → None\` replacement was never assigned back:
```js
cookies.map((cookie) => cookie.replace('SameSite=Lax', 'SameSite=None')); // result thrown away
```

**\`Array.includes()\` used as substring search** — \`cookies.includes('SameSite')\` checks for an exact array element match (always \`false\`), so the fallback always ran. It also stringified the array (\`cookies + '; SameSite=None; Secure'\`) and appended directives to cookies that already had \`SameSite=Lax\`.

## Fix

Rewrote \`setSameSitePolicy()\` so the cookie rewrite actually applies:

- **Case-insensitive \`Set-Cookie\` key lookup** — Electron may normalize the response header key (e.g. lowercase \`set-cookie\`) across platforms/versions, so the handler finds the actual key instead of assuming \`'Set-Cookie'\` (which would silently no-op).
- **Per-cookie \`.map()\`** with the result assigned back to the located header key.
- **Normalize any \`SameSite\` value** (\`Lax\`, \`Strict\`, or missing) to \`None\` via a case-insensitive regex, per RFC 6265 — not just \`Lax\`.
- **Append \`Secure\`** when \`SameSite=None\` is set (deduplicated against an existing \`Secure\` flag), since Chromium/Electron rejects \`SameSite=None\` cookies that lack \`Secure\`.

```js
const cookieKey = Object.keys(details.responseHeaders).find(
  (key) => key.toLowerCase() === 'set-cookie',
);
if (cookieKey) {
  details.responseHeaders[cookieKey] = details.responseHeaders[cookieKey].map((cookie) => {
    const withSameSite = /SameSite=/i.test(cookie)
      ? cookie.replace(/SameSite=\w+/i, 'SameSite=None')
      : cookie + '; SameSite=None';
    return /;\s*Secure/i.test(withSameSite) ? withSameSite : withSameSite + '; Secure';
  });
}
```

## Prerequisite: app-proxy must be served over HTTPS

> **This fix is necessary but not sufficient when the app-proxy is served over plain HTTP.**

\`SameSite=None\` requires the \`Secure\` attribute, and Chromium/Electron will not store or send \`Secure\` cookies received over a plain \`http://\` (non-localhost) origin — this is intentional browser security behaviour, not a bug. As a result, even with the patched \`appproxy_permit\` cookie, subsequent requests to the app-proxy will still return 401 (E20004) on HTTP deployments because the cookie is never placed in the jar.

Observed on a plain-HTTP test endpoint (\`http://10.x.x.x\`):

| Client | \`/setup\` response | \`/\` response |
|---|---|---|
| Desktop app (Electron) | 302 + \`Set-Cookie: appproxy_permit=…; SameSite=None; Secure\` | **401** — \`Secure\` cookie not stored over HTTP |
| Regular browser (Chrome) | 302 + same \`Set-Cookie\` | **200** |

**The full resolution of FR-3168 therefore requires the app-proxy to be served over HTTPS.** This PR corrects the broken \`setSameSitePolicy()\` implementation so that the cookie patching works correctly once the HTTPS prerequisite is met. Without this fix, the cookie header is never modified even on HTTPS deployments.

## Test plan

- [ ] Verify on an **HTTPS** app-proxy deployment: build the Desktop app from this branch (\`make clean && make dep && pnpm electron:d\`), log in, start a compute session, and confirm a session app (Jupyter / VSCode / Terminal) opens without the 502 page.
- [ ] Confirm that on a plain **HTTP** app-proxy deployment, the behaviour is unchanged (401 / connection error) — this PR does not regress HTTP deployments, it simply cannot fix them without HTTPS.