### PR TITLE
fix(FR-3169): use session name in V1 app-launcher proxy URL

### DIFF
--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -202,8 +202,14 @@ export const useBackendAIAppLauncher = (
       );
     }
     const token = response.token;
+    // `ComputeSessionNode.name` is nullable in the schema; the V1 wsproxy
+    // resolves the session by name, so a missing name would build a
+    // `.../undefined/...` path and fail as SessionNotFound (surfaced as 503).
+    if (!session?.name) {
+      throw new AppLaunchError('Session name is not available.', 'configuring');
+    }
     return new URL(
-      `proxy/${token}/${session?.row_id}/add?${new URLSearchParams({ app }).toString()}`,
+      `proxy/${token}/${encodeURIComponent(session.name)}/add?${new URLSearchParams({ app }).toString()}`,
       proxyURL,
     ).href;
   };
@@ -282,11 +288,20 @@ export const useBackendAIAppLauncher = (
    * Used when re-launching apps like tensorboard that need to be restarted with different args.
    */
   const _close_wsproxy = async (app: string) => {
+    // V1 wsproxy keys its proxy map by session name (must match the `add`
+    // URL). `name` is nullable in the schema, so skip cleanup rather than
+    // building a `.../undefined/...` path that targets the wrong key.
+    if (!session?.name) {
+      logger.warn(
+        '[_close_wsproxy] Session name is not available; skipping close.',
+      );
+      return false;
+    }
     const token = baiClient._config.accessKey;
     const proxyURL = await getProxyURL(await getWSProxyVersion());
 
     const uri = new URL(
-      `proxy/${token}/${session?.row_id}/delete?${new URLSearchParams({ app }).toString()}`,
+      `proxy/${token}/${encodeURIComponent(session.name)}/delete?${new URLSearchParams({ app }).toString()}`,
       proxyURL,
     );
 


### PR DESCRIPTION
Resolves #7965 (FR-3169)

> **Stacked on** #7962

## Problem

In the Electron desktop app, launching a session app (ttyd, Jupyter, VSCode, etc.) over the **V1 wsproxy** path fails with a **503 "Server connection failed"** page.

The V1 app-launcher built the proxy URL with `session.row_id` (UUID):

```
proxy/{token}/{session.row_id}/add?app=ttyd
```

The bundled wsproxy forwards this identifier **unchanged** to the manager streaming endpoint:

```
ws://{manager}/stream/session/{UUID}/httpproxy?app=ttyd
```

The manager's `/stream/session/{session_name}/...` handler resolves the session by **name**, so a UUID finds no match and raises `SessionNotFound` (HTTP 404). The wsproxy then wraps any non-101 WebSocket upgrade response into a **503 "Proxy Error"** page (`src/wsproxy/lib/console-appproxy.js`), so the end user sees a 503 even though the underlying error is 404.

This is why the `/add` step succeeds and returns a redirect URL, but following the redirect (which is when the wsproxy actually opens the upstream WebSocket) fails with 503.

## Fix

In `react/src/hooks/useBackendAIAppLauncher.tsx`, send `session.name` instead of `session.row_id` for the **V1** proxy `add` and `delete` URLs (the `name` field is already selected in the fragment).

`add` and `delete` must use the same identifier because the wsproxy keys its internal proxy map by it (`add` stores `sessionId + '|' + app`; `delete` matches on the same `sessionId`).

The **V2** path (`v2/proxy/.../add`, `startService`) is intentionally left on `session.row_id` — the manager's V2 start-service action resolves by `session_id` (UUID), so changing it would regress V2.

## Scope / caveat

session `name` is only unique within an access-key scope, so this is a targeted fix for the V1 path. The robust long-term fix is for the manager streaming endpoint to also accept a session UUID — tracked in **BA-6341**.

## Verification

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all **PASS**.

## Test plan

- [ ] Build the Desktop app from this branch, start a compute session, and open a session app (ttyd / Jupyter / Terminal) over the V1 wsproxy path — it should open without the 503 page.

## Related

- BA-6280 — `resolve_session` receives a session ID in its `session_name` argument, causing `SessionNotFound` (404).
- BA-6341 — Session REST endpoints should accept session UUID as well as session name in URL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
