### PR TITLE
fix(FR-3094): reset deployment setting modal form on open

### DIFF
--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -408,15 +408,17 @@ const DeploymentListPageContent: React.FC = () => {
           }}
         />
       </BAIFlex>
-      <DeploymentSettingModal
-        open={isCreating || !!editingDeployment}
-        deploymentFrgmt={editingDeployment ?? null}
-        onRequestClose={(success) => {
-          closeCreate();
-          setEditingDeploymentId(null);
-          if (success) updateFetchKey();
-        }}
-      />
+      <BAIUnmountAfterClose>
+        <DeploymentSettingModal
+          open={isCreating || !!editingDeployment}
+          deploymentFrgmt={editingDeployment ?? null}
+          onRequestClose={(success) => {
+            closeCreate();
+            setEditingDeploymentId(null);
+            if (success) updateFetchKey();
+          }}
+        />
+      </BAIUnmountAfterClose>
       <BAIDeleteConfirmModal
         open={!!deletingDeployment}
         title={t('deployment.DeleteDeployment')}


### PR DESCRIPTION
Resolves #7826 (FR-3094)

## Summary

The deployment create/edit modal did not reset its form when reopened — it retained stale values from a previous open. `DeploymentSettingModal` stays mounted by the parent page and `destroyOnHidden` only clears the modal body, so Ant Design's `initialValues` (applied only on mount) were never re-applied on subsequent opens.

## Changes

- Wrap `<DeploymentSettingModal>` in `<BAIUnmountAfterClose>` in `DeploymentListPage.tsx`, mirroring the existing `DeploymentRevisionDetailDrawer` pattern in the same page. The modal now fully unmounts on close and remounts with fresh `initialValues` on every open.

No change to `DeploymentSettingModal.tsx` itself — the fix is purely structural in the parent page.

## Verification

- `bash scripts/verify.sh` → Relay / Lint / Format / TypeScript pass.
