### PR TITLE
fix(FR-3099): show success notification on deployment create/edit

### DIFF
--- a/react/src/components/DeploymentSettingModal.tsx
+++ b/react/src/components/DeploymentSettingModal.tsx
@@ -131,6 +131,7 @@ const DeploymentSettingModal: React.FC<DeploymentSettingModalProps> = ({
                 );
                 return;
               }
+              message.success(t('deployment.DeploymentUpdated'));
               onRequestClose(true);
             },
             onError: (err) => {
@@ -179,6 +180,7 @@ const DeploymentSettingModal: React.FC<DeploymentSettingModalProps> = ({
                 return;
               }
               const newId = toLocalId(createModelDeployment.deployment.id);
+              message.success(t('deployment.DeploymentCreated'));
               onRequestClose(true);
               navigate(`/deployments/${newId}`);
             },


### PR DESCRIPTION
Resolves #7831 (FR-3099)

## Summary

Editing or creating a deployment via the deployment setting modal showed no success feedback — the modal closed silently, inconsistent with the project's async-action feedback convention.

## Changes

- Add `message.success(t('deployment.DeploymentUpdated'))` on the update success path and `message.success(t('deployment.DeploymentCreated'))` on the create success path in `DeploymentSettingModal.tsx`. Both i18n keys already exist in all locales, so no translation changes are needed.

## Verification

- `bash scripts/verify.sh` → Relay / Lint / Format / TypeScript pass.
