### PR TITLE
feat(FR-3093): show success notification after terminating session

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
@@ -12,7 +12,7 @@ import { useCurrentUserRole } from '../../hooks/backendai';
 import { useSetBAINotification } from '../../hooks/useBAINotification';
 import { usePainKiller } from '../../hooks/usePainKiller';
 import { usePromiseTracker } from '../../usePromiseTracker';
-import { Card, Checkbox, type ModalProps, Typography } from 'antd';
+import { App, Card, Checkbox, type ModalProps, Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import { filterOutEmpty, BAIFlex, BAIModal } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -244,6 +244,7 @@ const TerminateSessionModal: React.FC<TerminateSessionModalProps> = ({
   const relayEvn = useRelayEnvironment();
   const painKiller = usePainKiller();
   const { upsertNotification } = useSetBAINotification();
+  const { message } = App.useApp();
 
   return (
     <BAIModal
@@ -252,20 +253,24 @@ const TerminateSessionModal: React.FC<TerminateSessionModalProps> = ({
       open={openTerminateModal}
       confirmLoading={pendingCount > 0}
       onOk={() => {
-        const promises = _.map(
-          filterOutEmpty(_.castArray(sessions)),
-          (session) => {
-            return terminateSession(session)
-              .catch((err) => {
-                upsertNotification({
-                  message: painKiller.relieve(err?.title),
-                  description: err?.description,
-                  open: true,
-                });
-              })
-              .finally(() => {
-                // refetch session node
-                return fetchQuery<TerminateSessionModalRefetchQuery>(
+        const targetSessions = filterOutEmpty(_.castArray(sessions));
+        const promises = _.map(targetSessions, (session) => {
+          return terminateSession(session)
+            .catch((err) => {
+              upsertNotification({
+                message: painKiller.relieve(err?.title),
+                description: err?.description,
+                open: true,
+              });
+              // Re-throw so Promise.allSettled below reports this session as
+              // rejected and the success/partial-failure message can be derived
+              // from the settled results.
+              throw err;
+            })
+            .finally(() => {
+              // refetch session node
+              return (
+                fetchQuery<TerminateSessionModalRefetchQuery>(
                   relayEvn,
                   graphql`
                     query TerminateSessionModalRefetchQuery(
@@ -282,12 +287,29 @@ const TerminateSessionModal: React.FC<TerminateSessionModalProps> = ({
                     id: session.id,
                     scope_id: `project:${session.project_id}`,
                   },
-                ).toPromise();
-              });
-          },
-        );
+                )
+                  .toPromise()
+                  // Swallow refetch errors so the summary toast reflects only the
+                  // termination outcome, not a failed post-termination refetch.
+                  .catch(() => {})
+              );
+            });
+        });
         promises.map(trackPromise);
-        Promise.allSettled(promises).then(() => {
+        Promise.allSettled(promises).then((results) => {
+          const rejectedCount = results.filter(
+            (result) => result.status === 'rejected',
+          ).length;
+          const succeededCount = targetSessions.length - rejectedCount;
+          if (rejectedCount > 0) {
+            message.warning(t('session.SomeSessionsNotTerminated'));
+          } else if (succeededCount > 0) {
+            message.success(
+              succeededCount === 1
+                ? t('session.SessionTerminated')
+                : t('session.SessionsTerminated'),
+            );
+          }
           setIsForce(false);
           onRequestClose(true);
         });

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2814,6 +2814,7 @@
     "SessionTerminated": "Sitzung beendet.",
     "SessionType": "SessionType",
     "SessionsTerminated": "Sitzungen beendet.",
+    "SomeSessionsNotTerminated": "Einige Sitzungen konnten nicht beendet werden.",
     "StartupCommand": "Startbefehl",
     "Status": "Status",
     "StatusDetail": "Einzelheiten",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2812,6 +2812,7 @@
     "SessionTerminated": "Η συνεδρία τερματίστηκε.",
     "SessionType": "SessionType",
     "SessionsTerminated": "Οι συνεδρίες τερματίστηκαν.",
+    "SomeSessionsNotTerminated": "Ορισμένες συνεδρίες απέτυχαν να τερματιστούν.",
     "StartupCommand": "Εντολή εκκίνησης",
     "Status": "Κατάσταση",
     "StatusDetail": "Λεπτομέρεια",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2802,6 +2802,7 @@
     "SessionTerminated": "Session terminated.",
     "SessionType": "SessionType",
     "SessionsTerminated": "Sessions terminated.",
+    "SomeSessionsNotTerminated": "Some sessions failed to terminate.",
     "StartupCommand": "Startup Command",
     "Status": "Status",
     "StatusDetail": "Detail",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2812,6 +2812,7 @@
     "SessionTerminated": "Sesión terminada.",
     "SessionType": "Tipo de sesión",
     "SessionsTerminated": "Sesiones terminadas.",
+    "SomeSessionsNotTerminated": "Algunas sesiones no pudieron terminarse.",
     "StartupCommand": "Comando de inicio",
     "Status": "Estado",
     "StatusDetail": "Detalle",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2812,6 +2812,7 @@
     "SessionTerminated": "Istunto päättyi.",
     "SessionType": "SessionType",
     "SessionsTerminated": "Istunnot lopetettu.",
+    "SomeSessionsNotTerminated": "Joidenkin istuntojen lopettaminen epäonnistui.",
     "StartupCommand": "Käynnistyskomento",
     "Status": "Tila",
     "StatusDetail": "Yksityiskohta",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2815,6 +2815,7 @@
     "SessionTerminated": "Session terminée.",
     "SessionType": "Type de session",
     "SessionsTerminated": "Séances terminées.",
+    "SomeSessionsNotTerminated": "Certaines sessions n'ont pas pu être terminées.",
     "StartupCommand": "Commande de démarrage",
     "Status": "Statut",
     "StatusDetail": "Détail",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2815,6 +2815,7 @@
     "SessionTerminated": "Sesi dihentikan.",
     "SessionType": "Jenis Sesi",
     "SessionsTerminated": "Sesi-sesi dihentikan.",
+    "SomeSessionsNotTerminated": "Beberapa sesi gagal dihentikan.",
     "StartupCommand": "Perintah startup",
     "Status": "Status",
     "StatusDetail": "Detail",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2812,6 +2812,7 @@
     "SessionTerminated": "Sessione terminata.",
     "SessionType": "Tipo di sessione",
     "SessionsTerminated": "Sessioni terminate.",
+    "SomeSessionsNotTerminated": "Alcune sessioni non sono state terminate.",
     "StartupCommand": "Comando di avvio",
     "Status": "Stato",
     "StatusDetail": "Dettaglio",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2814,6 +2814,7 @@
     "SessionTerminated": "セッションが終了しました。",
     "SessionType": "セッションタイプ",
     "SessionsTerminated": "セッションは終了しました。",
+    "SomeSessionsNotTerminated": "一部のセッションの終了に失敗しました。",
     "StartupCommand": "起動コマンド",
     "Status": "状態",
     "StatusDetail": "詳細情報",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2817,6 +2817,7 @@
     "SessionTerminated": "세션을 중지했습니다.",
     "SessionType": "세션 타입",
     "SessionsTerminated": "세션들을 중지했습니다.",
+    "SomeSessionsNotTerminated": "일부 세션 종료에 실패했습니다.",
     "StartupCommand": "시작 시 실행할 명령어",
     "Status": "상태",
     "StatusDetail": "상세 정보",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2813,6 +2813,7 @@
     "SessionTerminated": "Чуулган дуусав.",
     "SessionType": "SessionType",
     "SessionsTerminated": "Чуулган дуусгавар болсон.",
+    "SomeSessionsNotTerminated": "Зарим сессийг дуусгахад алдаа гарлаа.",
     "StartupCommand": "Эхлэх тушаал",
     "Status": "Статус",
     "StatusDetail": "Дэлгэрэнгүй",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2812,6 +2812,7 @@
     "SessionTerminated": "Sesi ditamatkan.",
     "SessionType": "Jenis Sesi",
     "SessionsTerminated": "Sesi ditamatkan.",
+    "SomeSessionsNotTerminated": "Sesetengah sesi gagal ditamatkan.",
     "StartupCommand": "Perintah Permulaan",
     "Status": "Status",
     "StatusDetail": "Perincian",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2815,6 +2815,7 @@
     "SessionTerminated": "Sesja zakończona.",
     "SessionType": "SessionType",
     "SessionsTerminated": "Sesje zakończone.",
+    "SomeSessionsNotTerminated": "Niektóre sesje nie zostały zakończone.",
     "StartupCommand": "Polecenie startowe",
     "Status": "Status",
     "StatusDetail": "Szczegóły",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2812,6 +2812,7 @@
     "SessionTerminated": "Sessão finalizada.",
     "SessionType": "Tipo de sessão",
     "SessionsTerminated": "Sessões encerradas.",
+    "SomeSessionsNotTerminated": "Algumas sessões falharam ao encerrar.",
     "StartupCommand": "Comando de inicialização",
     "Status": "Status",
     "StatusDetail": "Detalhes",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2814,6 +2814,7 @@
     "SessionTerminated": "Sessão finalizada.",
     "SessionType": "Tipo de sessão",
     "SessionsTerminated": "Sessões encerradas.",
+    "SomeSessionsNotTerminated": "Algumas sessões falharam ao encerrar.",
     "StartupCommand": "Comando de inicialização",
     "Status": "Status",
     "StatusDetail": "Detalhes",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2812,6 +2812,7 @@
     "SessionTerminated": "Сессия завершена.",
     "SessionType": "SessionType",
     "SessionsTerminated": "Сеансы завершены.",
+    "SomeSessionsNotTerminated": "Некоторые сеансы не удалось завершить.",
     "StartupCommand": "Команда запуска",
     "Status": "Статус",
     "StatusDetail": "Деталь",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2814,6 +2814,7 @@
     "SessionTerminated": "เซสชันถูกยุติแล้ว",
     "SessionType": "ประเภทเซสชัน",
     "SessionsTerminated": "เซสชันถูกยุติแล้ว",
+    "SomeSessionsNotTerminated": "บางเซสชันไม่สามารถยุติได้",
     "StartupCommand": "คำสั่งเริ่มต้น",
     "Status": "สถานะ",
     "StatusDetail": "รายละเอียด",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2812,6 +2812,7 @@
     "SessionTerminated": "Oturum sonlandırıldı.",
     "SessionType": "OturumTürü",
     "SessionsTerminated": "Oturumlar sonlandırıldı.",
+    "SomeSessionsNotTerminated": "Bazı oturumlar sonlandırılamadı.",
     "StartupCommand": "Başlatma Komutu",
     "Status": "Durum",
     "StatusDetail": "Detay",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2814,6 +2814,7 @@
     "SessionTerminated": "Phiên chấm dứt.",
     "SessionType": "Loại phiên",
     "SessionsTerminated": "Phiên đã kết thúc.",
+    "SomeSessionsNotTerminated": "Một số phiên không thể kết thúc.",
     "StartupCommand": "Lệnh khởi động",
     "Status": "Trạng thái",
     "StatusDetail": "Chi tiết",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2814,6 +2814,7 @@
     "SessionTerminated": "会话终止。",
     "SessionType": "会话类型",
     "SessionsTerminated": "会话终止。",
+    "SomeSessionsNotTerminated": "部分会话终止失败。",
     "StartupCommand": "启动命令",
     "Status": "地位",
     "StatusDetail": "详细信息",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2816,6 +2816,7 @@
     "SessionTerminated": "會話終止。",
     "SessionType": "会话类型",
     "SessionsTerminated": "會話終止。",
+    "SomeSessionsNotTerminated": "部分會話終止失敗。",
     "StartupCommand": "啟動指令",
     "Status": "地位",
     "StatusDetail": "详细信息",


### PR DESCRIPTION
Resolves #7825 (FR-3093)

## Summary

After terminating one or more sessions, no result notification was shown — only per-session errors surfaced (via `upsertNotification`). This PR adds a summary toast after a bulk terminate: a success message when every targeted session terminated, and a warning when one or more failed.

## Changes

- In `TerminateSessionModal.tsx`, derive the terminate outcome from `Promise.allSettled` results instead of a manual counter:
  - each per-session `.catch` now re-throws after `upsertNotification`, so a failed termination is reported as `rejected` by `allSettled`;
  - on settle, show `message.success` (`session.SessionTerminated` / `session.SessionsTerminated`) when all targeted sessions terminated, or `message.warning` (`session.SomeSessionsNotTerminated`) when one or more failed;
  - per-session errors keep surfacing via `upsertNotification`.
- Add new i18n key `session.SomeSessionsNotTerminated` across all supported language files.

## Verification

- `bash scripts/verify.sh` → Relay / Lint / Format / TypeScript pass.
