### PR TITLE
feat(FR-3095): expose more user fields in CSV export via exportKey

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
@@ -154,6 +154,7 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
       {
         key: 'id',
         title: t('comp:UserNodes.UserID'),
+        exportKey: 'uuid',
         render: (__, record) => (
           <BAIText copyable ellipsis monospace style={{ maxWidth: 100 }}>
             {toLocalId(record.id)}
@@ -170,12 +171,14 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
       {
         key: 'full_name',
         title: t('comp:UserNodes.FullName'),
+        exportKey: 'full_name',
         render: (__, record) => record.basicInfo?.fullName || '-',
       },
       {
         key: 'domain_name',
         title: t('comp:UserNodes.DomainName'),
         dataIndex: 'domainName',
+        exportKey: 'domain_name',
         minWidth: 100,
         sorter: isEnableSorter('domainName'),
         render: (__, record) => record.organization?.domainName || '-',
@@ -188,16 +191,19 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
       {
         key: 'system_role',
         title: t('comp:UserNodes.Role'),
+        exportKey: 'role',
         render: (__, record) => record.organization?.role || '-',
       },
       {
         key: 'resource_policy',
         title: t('comp:UserNodes.ResourcePolicy'),
+        exportKey: 'resource_policy_name',
         render: (__, record) => record.organization?.resourcePolicy || '-',
       },
       {
         key: 'main_access_key',
         title: t('comp:UserNodes.MainAccessKey'),
+        exportKey: 'main_access_key',
         render: (__, record) =>
           record.organization?.mainAccessKey ? (
             <BAIText copyable ellipsis monospace style={{ maxWidth: 120 }}>
@@ -304,6 +310,7 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
         key: 'created_at',
         title: t('comp:UserNodes.CreatedAt'),
         dataIndex: 'createdAt',
+        exportKey: 'created_at',
         sorter: isEnableSorter('createdAt'),
         defaultSortOrder: 'descend',
         render: (__, record) =>
@@ -315,6 +322,7 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
         key: 'modified_at',
         title: t('comp:UserNodes.ModifiedAt'),
         dataIndex: 'modifiedAt',
+        exportKey: 'modified_at',
         sorter: isEnableSorter('modifiedAt'),
         render: (__, record) =>
           record.timestamps?.modifiedAt


### PR DESCRIPTION
Resolves #7827 (FR-3095)

## Summary

The v2 user table (`BAIAdminUserV2Table`) exposed too few fields for CSV export. The backend report returns 20+ fields in snake_case, but the table columns use camelCase `dataIndex` (or none), so the export modal could not match them. The export modal resolves a column's export key as `exportKey > dataIndex > none`.

## Changes

- Add `exportKey` to the columns whose `dataIndex` is camelCase or absent so they map to the backend report's snake_case field names and become selectable in the export modal:
  - `id → uuid`, `full_name → full_name`, `domain_name → domain_name`, `system_role → role`, `resource_policy → resource_policy_name`, `main_access_key → main_access_key`, `created_at → created_at`, `modified_at → modified_at`.
- Columns whose `dataIndex` already matches the report field (`email`, `username`, `status`) are left unchanged. Mirrors the v1 `BAIUserNodes` table convention.

## Verification

- `bash scripts/verify.sh` → Relay / Lint / Format / TypeScript pass.
