### PR TITLE
fix(FR-3090): robustly clean up E2E vfolders so the test server is not left dirty

### DIFF
--- a/e2e/global-cleanup.teardown.ts
+++ b/e2e/global-cleanup.teardown.ts
@@ -1,0 +1,78 @@
+/**
+ * Global cleanup teardown (FR-3090).
+ *
+ * Runs once after the whole suite — wired via the `chromium` project's
+ * `teardown: 'cleanup'` in `playwright.config.ts` — regardless of whether the
+ * tests passed or failed. Per-test `afterEach` cleanup is best-effort and can be
+ * aborted when a test exhausts its 180s budget (the cleanup then stops mid-way,
+ * leaving an `e2e-*` orphan behind). This teardown is the safety net that
+ * guarantees the shared test server is left clean.
+ *
+ * It is intentionally tolerant: every sweep is best-effort and never fails the
+ * run — a cleanup hiccup must not turn a green suite red. It sweeps as the user
+ * (personal folders on /data) and as the admin (/admin-data), because different
+ * specs create folders under different accounts:
+ *   - vfolder-crud / file-* / type-selection (user) → personal folders on /data
+ *   - type-selection project (admin) → project folders, created on /project-data
+ *     but only DELETABLE from /admin-data (VFolderNodesV2 on /project-data does
+ *     not expose trash/delete). /admin-data also lists every other admin-visible
+ *     folder, so it doubles as a catch-all.
+ *
+ * The pattern is the broad `/e2e-/i` (covering `e2e-test-*`, `e2e-mod-*`, the
+ * dot-prefixed auto-mount folder, etc.). Broad matching is safe HERE — unlike in
+ * a per-test `sweepVFolders` call — because the teardown runs after every other
+ * project has finished, so no parallel test owns a live `e2e-*` folder.
+ */
+import { sweepServices, sweepVFolders } from './utils/cleanup-util';
+import { loginAsAdmin, loginAsUser } from './utils/test-util';
+import { Page, test } from '@playwright/test';
+
+// Matches every e2e vfolder naming scheme used across the specs.
+const E2E_VFOLDER_PATTERN = /e2e-/i;
+
+/** Run a best-effort sweep, swallowing any error so teardown never fails. */
+async function safeSweep(
+  label: string,
+  fn: (page: Page) => Promise<unknown>,
+  page: Page,
+): Promise<void> {
+  try {
+    await fn(page);
+  } catch (error) {
+    console.warn(`[global-cleanup] ${label} sweep failed (ignored):`, error);
+  }
+}
+
+test.describe('Global e2e cleanup', () => {
+  // The sweep may have to trash + delete-forever several leftover folders, each
+  // a multi-step navigate/filter/confirm flow, and a stuck folder now fails its
+  // action at the 30s actionTimeout before being skipped. Give the cleanup more
+  // room than the default 180s so it can drain a backlog instead of timing out
+  // mid-sweep and leaving the rest behind.
+  test.describe.configure({ timeout: 300_000 });
+
+  test('sweep leftover e2e vfolders (user)', async ({ page, request }) => {
+    await loginAsUser(page, request);
+    await safeSweep(
+      'user /data',
+      (p) => sweepVFolders(p, E2E_VFOLDER_PATTERN, 'data'),
+      page,
+    );
+  });
+
+  test('sweep leftover e2e vfolders and services (admin)', async ({
+    page,
+    request,
+  }) => {
+    await loginAsAdmin(page, request);
+    // /admin-data (AdminVFolderNodeListPage) lists every vfolder visible to an
+    // admin — project folders (only deletable here, not on /project-data) plus
+    // any folder another sweep missed — using the same table component as /data.
+    await safeSweep(
+      'admin /admin-data',
+      (p) => sweepVFolders(p, E2E_VFOLDER_PATTERN, 'admin-data'),
+      page,
+    );
+    await safeSweep('admin services', (p) => sweepServices(p), page);
+  });
+});

--- a/e2e/utils/cleanup-util.ts
+++ b/e2e/utils/cleanup-util.ts
@@ -2,7 +2,11 @@
  * Reusable cleanup utilities for e2e tests.
  * Sweep-deletes services and vfolders matching e2e naming patterns.
  */
-import { navigateTo } from './test-util';
+import {
+  navigateTo,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+} from './test-util';
 import { Page } from '@playwright/test';
 
 /**
@@ -76,71 +80,223 @@ export async function sweepServices(
 }
 
 /**
- * Trashes and permanently deletes all vfolders matching the given pattern.
- * Step 1: Move matching folders to Trash from the active tab.
- * Step 2: Delete them forever from the Trash tab.
+ * Returns the exact name of the first vfolder row matching `pattern` on the
+ * current tab that is actionable (not in `skip`, and — when
+ * `requireEnabledDelete` is set — whose move-to-trash button is enabled), or
+ * null when none qualifies. The name is read from the row's identicon name cell
+ * (`VFolder Identicon <name>`); the identicon is an <img> (no text), so the
+ * cell's text content is just the folder name — exactly the string the
+ * maintained trash/delete helpers and the "type to confirm" dialog need.
+ *
+ * Why the enabled check matters: the broad teardown sweep runs on /data as the
+ * regular user, where project-type folders (created by an admin) are visible
+ * but their move-to-trash button is DISABLED. Without this guard the sweep
+ * would call `moveToTrashAndVerify` on such a row and the unbounded `.click()`
+ * on a disabled button would retry until the whole 180s test budget is gone,
+ * aborting cleanup and stranding every other orphan. Un-actionable rows are
+ * added to `skip` so the caller's loop advances to the next candidate instead
+ * of re-selecting the same stuck row forever.
+ *
+ * Waits briefly so a still-loading table is not mistaken for "empty".
+ */
+async function firstActionableVFolderName(
+  page: Page,
+  pattern: RegExp,
+  skip: Set<string>,
+  requireEnabledDelete: boolean,
+): Promise<string | null> {
+  const rows = page.getByRole('row').filter({ hasText: pattern });
+  const appeared = await rows
+    .first()
+    .waitFor({ state: 'visible', timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared) return null;
+
+  const count = await rows.count();
+  for (let i = 0; i < count; i++) {
+    const row = rows.nth(i);
+    const nameCell = row
+      .getByRole('cell', { name: /VFolder Identicon/ })
+      .first();
+    const name = (await nameCell.textContent().catch(() => null))?.trim();
+    if (!name || skip.has(name)) continue;
+
+    if (requireEnabledDelete) {
+      const deleteBtn = row.getByRole('button', { name: 'delete' }).first();
+      // Read the button's enabled state directly. The move-to-trash button's
+      // disabled flag is derived from data that arrives with the row itself
+      // (`vfolder.permissions` → `delete_vfolder`), so it is correct as soon as
+      // the row is visible — no settling wait is needed. Reading instantly (vs.
+      // waiting) keeps the sweep fast even when the page lists many folders the
+      // current account cannot delete (e.g. the admin viewing every user's
+      // folders on /admin-data); a slow per-row wait there can exhaust the
+      // teardown's time budget. A genuinely un-deletable folder is skipped so
+      // the sweep still never hangs on it.
+      const enabled = await deleteBtn
+        .isEnabled({ timeout: 2000 })
+        .catch(() => false);
+      if (!enabled) {
+        skip.add(name);
+        continue;
+      }
+    }
+    return name;
+  }
+  return null;
+}
+
+/**
+ * Trashes and permanently deletes every vfolder matching `pattern` on the given
+ * data page. Choose `dataPath` to match where the folder is DELETABLE:
+ *   - `data`        — personal folders (the regular user data page);
+ *   - `admin-data`  — project folders and any folder visible to an admin
+ *                     (`AdminVFolderNodeListPage`). Project folders are created
+ *                     on `/project-data` but can only be deleted from
+ *                     `/admin-data`, which shares the same table component as
+ *                     `/data`.
+ *
+ * Phase 1: Active tab — move each match to Trash and delete it forever.
+ * Phase 2: Trash tab — delete forever any remaining orphans (folders a previous,
+ *   possibly aborted, test moved to Trash but never permanently deleted — the
+ *   lingering `DELETE-PENDING` rows).
+ *
+ * Rather than duplicate the row-action selectors (which drift — e.g. the move-to-
+ * trash confirm button is "Confirm", not "Move"), this delegates to the
+ * maintained `moveToTrashAndVerify` / `deleteForeverAndVerifyFromTrash` helpers.
+ * Each iteration re-reads the first matching name and operates by exact name, so
+ * it never hangs on a stale locator. It is best-effort: a single stuck folder
+ * stops that phase (logged) rather than failing the caller.
  */
 export async function sweepVFolders(
   page: Page,
   pattern: RegExp = /e2e-mod-/i,
+  dataPath: string = 'data',
   maxIterations = 20,
 ): Promise<number> {
-  await navigateTo(page, 'data');
-  let trashed = 0;
+  let removed = 0;
 
-  // Step 1: Move to trash
-  while (trashed < maxIterations) {
-    const modRow = page.getByRole('row').filter({ hasText: pattern }).first();
-    if ((await modRow.count()) === 0) break;
-
-    const trashBtn = modRow.getByRole('button', { name: 'trash bin' }).first();
-    if (!(await trashBtn.isVisible({ timeout: 3000 }).catch(() => false)))
-      break;
-    await trashBtn.click();
-
-    const moveBtn = page.getByRole('button', { name: 'Move' });
-    if (await moveBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await moveBtn.click();
+  // Phase 1: fully remove each Active folder (trash + delete forever). Skip
+  // rows whose move-to-trash button is disabled (e.g. project folders the
+  // current account cannot delete here) and rows that error out, so one stuck
+  // orphan never strands the rest of the sweep.
+  const activeSkip = new Set<string>();
+  for (let i = 0; i < maxIterations; i++) {
+    await navigateTo(page, dataPath);
+    await page
+      .getByRole('tab', { name: 'Active' })
+      .click()
+      .catch(() => {});
+    const name = await firstActionableVFolderName(
+      page,
+      pattern,
+      activeSkip,
+      true,
+    );
+    if (!name) break;
+    try {
+      await moveToTrashAndVerify(page, name, dataPath);
+      await deleteForeverAndVerifyFromTrash(page, name, dataPath);
+      removed++;
+    } catch (error) {
+      console.warn(
+        `[sweepVFolders:${dataPath}] could not remove active "${name}" (skipping):`,
+        error,
+      );
+      activeSkip.add(name);
     }
-    await page.waitForTimeout(2000);
-    trashed++;
   }
 
-  if (trashed === 0) return 0;
-
-  // Step 2: Delete forever from Trash
-  await navigateTo(page, 'data');
-  await page.getByRole('tab', { name: 'Trash' }).click();
-  await page.waitForTimeout(2000);
-
-  let deletedForever = 0;
-  while (deletedForever < maxIterations) {
-    const trashedRow = page
-      .getByRole('row')
-      .filter({ hasText: pattern })
-      .first();
-    if ((await trashedRow.count()) === 0) break;
-
-    // Extract folder name for the confirmation input
-    const rowText = (await trashedRow.textContent()) || '';
-    const nameMatch = rowText.match(new RegExp(pattern.source, 'i'));
-    // Try to get the full folder name (e.g. e2e-mod-a-abc123)
-    const fullMatch = rowText.match(/e2e-mod-[a-z]-[a-z0-9]+/i);
-    const folderName = fullMatch?.[0] || nameMatch?.[0];
-    if (!folderName) break;
-
-    await trashedRow.getByRole('button').nth(1).click();
-    const confirmInput = page.locator('#confirmText');
-    if (await confirmInput.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await confirmInput.fill(folderName);
-      await page.getByRole('button', { name: 'Delete forever' }).click();
-      await page.waitForTimeout(3000);
+  // Phase 2: delete forever any leftover Trash orphans. Same skip-and-continue
+  // policy; `deleteForeverAndVerifyFromTrash` already bounds its own enabled
+  // check, so a stuck trash row fails fast and is skipped.
+  const trashSkip = new Set<string>();
+  for (let i = 0; i < maxIterations; i++) {
+    await navigateTo(page, dataPath);
+    await page
+      .getByRole('tab', { name: 'Trash' })
+      .click()
+      .catch(() => {});
+    const name = await firstActionableVFolderName(
+      page,
+      pattern,
+      trashSkip,
+      false,
+    );
+    if (!name) break;
+    try {
+      await deleteForeverAndVerifyFromTrash(page, name, dataPath);
+      removed++;
+    } catch (error) {
+      console.warn(
+        `[sweepVFolders:${dataPath}] could not delete trashed "${name}" (skipping):`,
+        error,
+      );
+      trashSkip.add(name);
     }
-    deletedForever++;
   }
 
-  console.log(
-    `Swept ${trashed} vfolder(s) to trash, deleted ${deletedForever} forever`,
-  );
-  return deletedForever;
+  if (removed > 0) {
+    console.log(
+      `[sweepVFolders:${dataPath}] removed ${removed} folder(s) (pattern ${pattern}).`,
+    );
+  }
+  return removed;
+}
+
+/**
+ * Best-effort cleanup of a single test vfolder that NEVER throws (FR-3090).
+ *
+ * Cleanup hooks (`afterAll`/`afterEach`) previously wrapped the normal
+ * trash + delete-forever flow in a `try/catch` that just logged on failure,
+ * silently leaving the folder behind so `e2e-test-*` orphans accumulated on
+ * the test server. This helper keeps the "a cleanup hiccup must not fail an
+ * otherwise-passing test" property but actually removes the orphan:
+ *
+ *  1. Happy path — `moveToTrashAndVerify` + `deleteForeverAndVerifyFromTrash`.
+ *  2. Fallback A — the folder may already be in Trash (move-to-trash
+ *     succeeded but delete-forever failed), so retry the delete-forever step.
+ *  3. Fallback B — the folder may still be in Active, so sweep it out by name.
+ *
+ * Each stage is guarded; the helper resolves even if every stage fails (it
+ * only warns), so it is safe to call unguarded from a cleanup hook.
+ *
+ * Use it ONLY for cleanup hooks — never for tests that assert the delete flow
+ * itself (e.g. the consecutive-deletion / create-delete-restore tests).
+ */
+export async function cleanupVFolderSafely(
+  page: Page,
+  folderName: string,
+  dataPath: string = 'data',
+): Promise<void> {
+  try {
+    await moveToTrashAndVerify(page, folderName, dataPath);
+    await deleteForeverAndVerifyFromTrash(page, folderName, dataPath);
+    return;
+  } catch (error) {
+    console.warn(
+      `[cleanupVFolderSafely] primary cleanup of "${folderName}" failed; attempting fallbacks.`,
+      error,
+    );
+  }
+
+  // Fallback A: folder may already be in Trash (move succeeded, delete failed).
+  try {
+    await deleteForeverAndVerifyFromTrash(page, folderName, dataPath);
+    return;
+  } catch {
+    // fall through to the sweep
+  }
+
+  // Fallback B: folder may still be in Active — sweep it out by exact name on
+  // the same data page it was created on (project folders live on project-data).
+  try {
+    const escaped = folderName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    await sweepVFolders(page, new RegExp(escaped, 'i'), dataPath);
+  } catch (sweepError) {
+    console.warn(
+      `[cleanupVFolderSafely] all fallbacks for "${folderName}" failed; manual cleanup may be needed.`,
+      sweepError,
+    );
+  }
 }

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -500,7 +500,16 @@ export async function moveToTrashAndVerify(
   });
   await expect(folderRow).toBeVisible({ timeout: 10000 });
 
-  await folderRow.getByRole('button', { name: 'delete' }).click();
+  // Bound the move-to-trash button before clicking it. On pages where the
+  // current account cannot delete the folder (e.g. a project-type folder shown
+  // on the regular user's /data), the button stays disabled. The Playwright
+  // config sets no global actionTimeout, so a bare .click() on a disabled
+  // button would retry until the entire 180s test timeout, hanging the caller.
+  // The best-effort sweep relies on this assertion failing fast (a catchable
+  // error) so it can skip the un-deletable row instead of stranding cleanup.
+  const moveToTrashButton = folderRow.getByRole('button', { name: 'delete' });
+  await expect(moveToTrashButton).toBeEnabled({ timeout: 10000 });
+  await moveToTrashButton.click();
   // The "Move to trash" confirmation modal uses a standardized "Confirm"
   // button (t('button.Confirm')) instead of "Move".
   const confirmButton = page

--- a/e2e/vfolder/file-create.spec.ts
+++ b/e2e/vfolder/file-create.spec.ts
@@ -1,4 +1,5 @@
 import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   loginAsUser,
   navigateTo,
@@ -49,12 +50,7 @@ test.describe(
       const context = await browser.newContext();
       const page = await context.newPage();
       await loginAsUser(page, request);
-      try {
-        await moveToTrashAndVerify(page, testFolderName);
-        await deleteForeverAndVerifyFromTrash(page, testFolderName);
-      } catch {
-        console.log(`Could not delete ${testFolderName}, it may not exist`);
-      }
+      await cleanupVFolderSafely(page, testFolderName);
       await context.close();
     });
 

--- a/e2e/vfolder/file-upload-dnd.spec.ts
+++ b/e2e/vfolder/file-upload-dnd.spec.ts
@@ -1,11 +1,10 @@
 // spec: e2e/vfolder/file-upload.plan.md
 import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   loginAsUser,
   navigateTo,
   createVFolderAndVerify,
-  moveToTrashAndVerify,
-  deleteForeverAndVerifyFromTrash,
   selectPropertyFilter,
   clearAllFilters,
 } from '../utils/test-util';
@@ -69,12 +68,7 @@ test.describe(
 
       await loginAsUser(page, request);
 
-      try {
-        await moveToTrashAndVerify(page, testFolderName);
-        await deleteForeverAndVerifyFromTrash(page, testFolderName);
-      } catch {
-        console.log(`Could not delete ${testFolderName}, it may not exist`);
-      }
+      await cleanupVFolderSafely(page, testFolderName);
 
       await context.close();
 

--- a/e2e/vfolder/file-upload-duplicate.spec.ts
+++ b/e2e/vfolder/file-upload-duplicate.spec.ts
@@ -1,11 +1,10 @@
 // spec: Duplicate File Upload Test Plan
 import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   loginAsUser,
   navigateTo,
   createVFolderAndVerify,
-  moveToTrashAndVerify,
-  deleteForeverAndVerifyFromTrash,
   selectPropertyFilter,
   clearAllFilters,
 } from '../utils/test-util';
@@ -101,12 +100,7 @@ test.describe(
 
       await loginAsUser(page, request);
 
-      try {
-        await moveToTrashAndVerify(page, testFolderName);
-        await deleteForeverAndVerifyFromTrash(page, testFolderName);
-      } catch {
-        /* ignore cleanup errors */
-      }
+      await cleanupVFolderSafely(page, testFolderName);
 
       await context.close();
 

--- a/e2e/vfolder/file-upload-permissions.spec.ts
+++ b/e2e/vfolder/file-upload-permissions.spec.ts
@@ -1,11 +1,10 @@
 // spec: Upload Permission Controls Test Plan
 import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   loginAsUser,
   navigateTo,
   createVFolderAndVerify,
-  moveToTrashAndVerify,
-  deleteForeverAndVerifyFromTrash,
 } from '../utils/test-util';
 import { test, expect, Page } from '@playwright/test';
 
@@ -45,12 +44,7 @@ test.describe.serial(
       await loginAsUser(page, request);
 
       for (const folderName of [rwFolderName, roFolderName]) {
-        try {
-          await moveToTrashAndVerify(page, folderName);
-          await deleteForeverAndVerifyFromTrash(page, folderName);
-        } catch {
-          console.log(`Could not delete ${folderName}, it may not exist`);
-        }
+        await cleanupVFolderSafely(page, folderName);
       }
 
       await context.close();

--- a/e2e/vfolder/file-upload-subdirectory.spec.ts
+++ b/e2e/vfolder/file-upload-subdirectory.spec.ts
@@ -1,11 +1,10 @@
 // spec: Suite 5: Upload to Subdirectory
 import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   loginAsUser,
   navigateTo,
   createVFolderAndVerify,
-  moveToTrashAndVerify,
-  deleteForeverAndVerifyFromTrash,
   selectPropertyFilter,
   clearAllFilters,
 } from '../utils/test-util';
@@ -65,12 +64,7 @@ test.describe(
 
       await loginAsUser(page, request);
 
-      try {
-        await moveToTrashAndVerify(page, testFolderName);
-        await deleteForeverAndVerifyFromTrash(page, testFolderName);
-      } catch {
-        console.log(`Could not delete ${testFolderName}, it may not exist`);
-      }
+      await cleanupVFolderSafely(page, testFolderName);
 
       await context.close();
 

--- a/e2e/vfolder/file-upload.spec.ts
+++ b/e2e/vfolder/file-upload.spec.ts
@@ -1,11 +1,10 @@
 // spec: Button-Based File Upload Test Plan
 import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   loginAsUser,
   navigateTo,
   createVFolderAndVerify,
-  moveToTrashAndVerify,
-  deleteForeverAndVerifyFromTrash,
   selectPropertyFilter,
   clearAllFilters,
 } from '../utils/test-util';
@@ -101,12 +100,7 @@ test.describe(
 
       await loginAsUser(page, request);
 
-      try {
-        await moveToTrashAndVerify(page, testFolderName);
-        await deleteForeverAndVerifyFromTrash(page, testFolderName);
-      } catch {
-        console.log(`Could not delete ${testFolderName}, it may not exist`);
-      }
+      await cleanupVFolderSafely(page, testFolderName);
 
       await context.close();
 

--- a/e2e/vfolder/vfolder-crud.spec.ts
+++ b/e2e/vfolder/vfolder-crud.spec.ts
@@ -1,4 +1,5 @@
 import { FolderCreationModal } from '../utils/classes/vfolder/FolderCreationModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   acceptAllInvitationAndVerifySpecificFolder,
   createVFolderAndVerify,
@@ -40,8 +41,7 @@ test.describe(
           .click();
       });
       test.afterEach(async ({ page }) => {
-        await moveToTrashAndVerify(page, creationFolderName);
-        await deleteForeverAndVerifyFromTrash(page, creationFolderName);
+        await cleanupVFolderSafely(page, creationFolderName);
       });
       test('User can create a vFolder by selecting a specific location', async ({
         page,
@@ -116,8 +116,7 @@ test.describe(
           .click();
       });
       test.afterEach(async ({ page }) => {
-        await moveToTrashAndVerify(page, folderName);
-        await deleteForeverAndVerifyFromTrash(page, folderName);
+        await cleanupVFolderSafely(page, folderName);
       });
       test('User can create Auto Mount vFolder', async ({ page }) => {
         const folderCreationModal = new FolderCreationModal(page);
@@ -157,8 +156,7 @@ test.describe(
       await createVFolderAndVerify(page, sharingFolderName);
     });
     test.afterEach(async ({ page }) => {
-      await moveToTrashAndVerify(page, sharingFolderName);
-      await deleteForeverAndVerifyFromTrash(page, sharingFolderName);
+      await cleanupVFolderSafely(page, sharingFolderName);
     });
 
     test('User can share vFolder', async ({ page, browser, request }) => {

--- a/e2e/vfolder/vfolder-explorer-modal.spec.ts
+++ b/e2e/vfolder/vfolder-explorer-modal.spec.ts
@@ -1,5 +1,6 @@
 // spec: FolderExplorerModal-Test-Plan.md
 import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   loginAsUser,
   navigateTo,
@@ -170,12 +171,7 @@ test.describe(
       await loginAsUser(page, request);
 
       // Clean up folder created during tests
-      try {
-        await moveToTrashAndVerify(page, testFolderName);
-        await deleteForeverAndVerifyFromTrash(page, testFolderName);
-      } catch {
-        console.log(`Could not delete ${testFolderName}, it may not exist`);
-      }
+      await cleanupVFolderSafely(page, testFolderName);
 
       await context.close();
     });

--- a/e2e/vfolder/vfolder-type-selection.spec.ts
+++ b/e2e/vfolder/vfolder-type-selection.spec.ts
@@ -1,15 +1,10 @@
 import { FolderCreationModal } from '../utils/classes/vfolder/FolderCreationModal';
+import { cleanupVFolderSafely } from '../utils/cleanup-util';
 import {
   getClientProperty,
   skipUnlessAllowedVFolderType,
 } from '../utils/feature-gate-util';
-import {
-  deleteForeverAndVerifyFromTrash,
-  loginAsAdmin,
-  loginAsUser,
-  moveToTrashAndVerify,
-  navigateTo,
-} from '../utils/test-util';
+import { loginAsAdmin, loginAsUser, navigateTo } from '../utils/test-util';
 import { test, expect, Page } from '@playwright/test';
 
 /**
@@ -58,8 +53,7 @@ test.describe(
       });
 
       test.afterEach(async ({ page }) => {
-        await moveToTrashAndVerify(page, folderName);
-        await deleteForeverAndVerifyFromTrash(page, folderName);
+        await cleanupVFolderSafely(page, folderName);
       });
 
       test('User can create a User-type vfolder with default selection', async ({
@@ -86,17 +80,10 @@ test.describe(
       });
 
       test.afterEach(async ({ page }) => {
-        try {
-          // Project-type folders are only visible on /project-data, not on /data.
-          await moveToTrashAndVerify(page, folderName, 'project-data');
-          await deleteForeverAndVerifyFromTrash(
-            page,
-            folderName,
-            'project-data',
-          );
-        } catch {
-          // Folder may not exist if test was skipped or creation failed
-        }
+        // Project-type folders are created on /project-data but can only be
+        // DELETED from the admin data page (/admin-data); /project-data
+        // (VFolderNodesV2) does not expose the trash/delete actions.
+        await cleanupVFolderSafely(page, folderName, 'admin-data');
       });
 
       test(
@@ -146,8 +133,7 @@ test.describe(
             .getByRole('cell', { name: `VFolder Identicon ${folderName}` })
             .filter({ hasText: folderName });
           await folderRow.waitFor({ state: 'visible', timeout: 2000 });
-          await moveToTrashAndVerify(page, folderName);
-          await deleteForeverAndVerifyFromTrash(page, folderName);
+          await cleanupVFolderSafely(page, folderName);
         } catch {
           // Folder was not created; nothing to clean up
         }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,6 +36,18 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
     permissions: ["local-network-access"],
+    /*
+     * Bound every action (click/fill/check/hover/…) so a single stuck action
+     * cannot consume the whole 180s test budget. Without this, a transiently
+     * pointer-blocked click — e.g. an antd notification/tooltip portal briefly
+     * overlapping a tab or row button during the best-effort vfolder cleanup
+     * sweep — would retry until the test timeout, hanging the cleanup and
+     * leaving e2e-* orphans on the shared server (FR-3090). 30s is 3x the
+     * largest explicit per-action timeout in the suite (10s), so it never cuts
+     * a legitimately-slow action short; stuck actions now fail fast with a
+     * catchable error that the sweep's skip-and-continue handles.
+     */
+    actionTimeout: 30000,
   },
 
   snapshotPathTemplate: `e2e/{testFileDir}/snapshot/{arg}{ext}`,
@@ -43,6 +55,19 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      use: { ...devices["Desktop Chrome"], locale: "en-US" },
+      // The global cleanup runs as a dedicated teardown project, not as a
+      // regular test in the suite.
+      testIgnore: /global-cleanup\.teardown\.ts/,
+      teardown: "cleanup",
+    },
+
+    // Best-effort global cleanup (FR-3090): sweeps leftover e2e-* vfolders and
+    // services after the whole suite finishes, regardless of pass/fail, so the
+    // shared test server is always left clean. Runs only as chromium's teardown.
+    {
+      name: "cleanup",
+      testMatch: /global-cleanup\.teardown\.ts/,
       use: { ...devices["Desktop Chrome"], locale: "en-US" },
     },
 


### PR DESCRIPTION
Resolves #7819 (FR-3090)

## Summary

E2E vfolder tests left `e2e-test-*` / `e2e-*` orphans on the shared test server, polluting it over time. There were two root causes:

1. Cleanup hooks wrapped the delete flow in a `try/catch` that only logged on failure, so a failed deletion silently left an orphan.
2. **More importantly, cleanup could hang for the full 180s test budget.** A transiently pointer-blocked click (e.g. the Active/Trash tab briefly covered by an antd portal during cleanup) retried until the test timeout because the suite set no `actionTimeout`. When a cleanup test or `afterAll`/`afterEach` hook times out, the orphan is left behind — regardless of whether the test itself passed.

## Changes

### Robust per-test cleanup
- Add a never-throwing `cleanupVFolderSafely(page, folderName, dataPath?)` helper in `e2e/utils/cleanup-util.ts`:
  1. normal trash + delete-forever flow;
  2. on failure, retry delete-forever (the folder may already be in Trash);
  3. fall back to `sweepVFolders()` to remove an Active orphan by name.

  It only warns (never throws), so a cleanup hiccup cannot fail an otherwise-passing test, but the orphan is actually removed.
- Convert the `afterAll` / `afterEach` cleanup hooks across the vfolder specs to use it.
- **In-test delete assertions are intentionally left untouched** — `vfolder-crud` (create → trash → restore → delete-forever), `vfolder-consecutive-deletion`, and the in-test deletes in `vfolder-explorer-modal` exercise the delete flow itself.

### Global teardown safety net
- `e2e/global-cleanup.teardown.ts` (wired as chromium's `teardown`) sweeps leftover `e2e-*` vfolders as the user (`/data`) and as the admin (`/admin-data`, where project folders are deletable), plus services, once after the suite — so the server is left clean even when a per-test hook is aborted by a timeout.
- `sweepVFolders` now skips rows whose move-to-trash button is **disabled** (project folders on `/data`, folders the account doesn't own on `/admin-data`) via `firstActionableVFolderName`, and **continues past a failing folder instead of breaking**, so one stuck orphan no longer strands the rest of the sweep.
- Raise the teardown timeout to 300s so it can drain a backlog of leftover folders.

### The keystone fix — bound every action
- **`playwright.config.ts`: set a global `actionTimeout: 30000`.** Every action now fails fast with a catchable error instead of consuming the whole 180s test budget. 30s is 3× the largest explicit per-action timeout in the suite (10s), so it never cuts a legitimately slow action short. This removes the 180s hang in **both** the global teardown sweep **and** the per-spec cleanup hooks (which run regardless of how the suite is invoked).
- Guard `moveToTrashAndVerify` with a bounded `toBeEnabled` check before the click so a disabled button fails fast instead of retrying to the test timeout.

## Verification (live cluster)

- The hardened sweep drained **5 leftover orphans** from a prior dirty run; a second cleanup pass converged to `removed=0` (server clean).
- A full **`--workers=1`** vfolder run is green; the previously-"failing" specs (consecutive-deletion, explorer-modal, `file-*` uploads, permissions `RO↔RW` which are `test.fixme`) all pass / skip correctly in isolation. Failures seen at higher local parallelism are **load-induced flakiness** against the shared backend (a different random subset fails each run), not regressions.

## Running the tests

> [!IMPORTANT]
> **Run vfolder e2e with a single worker — the CI standard.** `playwright.config.ts` already forces `workers: 1` + `retries: 2` whenever `CI` is set, so pre-merge GitHub Actions runs are serial and retried automatically (and the `actionTimeout` fix means a hung action can no longer stall the whole CI run). Locally, the default parallelism (~one worker per 2 cores) against the **shared** backend causes load-induced flakiness, so run with **`--workers=1`** (matching CI). If you want it faster while staying reliable, use `--workers=2 --retries=2` — the retries recover transient load-flakes and the bounded `actionTimeout` makes each retry cheap.
