### PR TITLE
feat(FR-3171): show loading spinner on in-progress deployment status tags

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIDeploymentStatusTag.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDeploymentStatusTag.test.tsx
@@ -1,5 +1,7 @@
 import {
+  DEPLOYMENT_IN_PROGRESS_STATUSES,
   DEPLOYMENT_STOPPED_CATEGORY_STATUSES,
+  isDeploymentInProgress,
   isDeploymentInStoppedCategory,
 } from './BAIDeploymentStatusTag';
 import { describe, expect, it } from 'vitest';
@@ -32,5 +34,37 @@ describe('isDeploymentInStoppedCategory', () => {
     expect(isDeploymentInStoppedCategory(null)).toBe(false);
     expect(isDeploymentInStoppedCategory(undefined)).toBe(false);
     expect(isDeploymentInStoppedCategory('%future added value')).toBe(false);
+  });
+});
+
+describe('isDeploymentInProgress', () => {
+  it('returns true for every in-progress status (drives the loading spinner)', () => {
+    DEPLOYMENT_IN_PROGRESS_STATUSES.forEach((status) => {
+      expect(isDeploymentInProgress(status)).toBe(true);
+    });
+  });
+
+  it('returns false for settled / queued / non-processing statuses', () => {
+    (
+      [
+        'HEALTHY',
+        'UNHEALTHY',
+        'DEGRADED',
+        'NOT_CHECKED',
+        'PENDING',
+        'STOPPED',
+        'STOPPING',
+        'TERMINATED',
+        'READY',
+      ] as const
+    ).forEach((status) => {
+      expect(isDeploymentInProgress(status)).toBe(false);
+    });
+  });
+
+  it("returns false for null, undefined, and Relay's '%future added value'", () => {
+    expect(isDeploymentInProgress(null)).toBe(false);
+    expect(isDeploymentInProgress(undefined)).toBe(false);
+    expect(isDeploymentInProgress('%future added value')).toBe(false);
   });
 });

--- a/packages/backend.ai-ui/src/components/BAIDeploymentStatusTag.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDeploymentStatusTag.tsx
@@ -1,6 +1,7 @@
 import { SemanticColor, useSemanticColorMap } from '../helper';
 import { useBAIi18n } from '../hooks/useBAIi18n';
 import BAITag from './BAITag';
+import { LoadingOutlined } from '@ant-design/icons';
 import type { TagProps } from 'antd';
 import React from 'react';
 
@@ -45,6 +46,21 @@ export const isDeploymentInStoppedCategory = (
 ): boolean =>
   status != null &&
   (DEPLOYMENT_STOPPED_CATEGORY_STATUSES as readonly string[]).includes(status);
+
+/**
+ * Statuses that show the loading spinner on the tag — the deployment is
+ * actively processing. `PENDING` (queued, not processing) is excluded.
+ */
+export const DEPLOYMENT_IN_PROGRESS_STATUSES = [
+  'DEPLOYING',
+  'SCALING',
+] as const satisfies readonly BAIDeploymentStatus[];
+
+export const isDeploymentInProgress = (
+  status: BAIDeploymentStatus | '%future added value' | null | undefined,
+): boolean =>
+  status != null &&
+  (DEPLOYMENT_IN_PROGRESS_STATUSES as readonly string[]).includes(status);
 
 const deploymentStatusSemanticMap: Record<BAIDeploymentStatus, SemanticColor> =
   {
@@ -100,6 +116,9 @@ const BAIDeploymentStatusTag: React.FC<BAIDeploymentStatusTagProps> = ({
   return (
     <BAITag
       {...tagProps}
+      icon={
+        isDeploymentInProgress(status) ? <LoadingOutlined spin /> : undefined
+      }
       color={semanticColorMap[deploymentStatusSemanticMap[status]]}
     >
       {t(deploymentStatusI18nMap[status])}

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -107,6 +107,8 @@ export {
   default as BAIDeploymentStatusTag,
   isDeploymentInStoppedCategory,
   DEPLOYMENT_STOPPED_CATEGORY_STATUSES,
+  isDeploymentInProgress,
+  DEPLOYMENT_IN_PROGRESS_STATUSES,
 } from './BAIDeploymentStatusTag';
 export type {
   BAIDeploymentStatusTagProps,


### PR DESCRIPTION
Resolves #7968 (FR-3171)

![CleanShot 2026-06-19 at 10.12.00@2x.png](https://app.graphite.com/user-attachments/assets/99697066-6463-4d16-94bf-2ddd8f5d36e4.png)

## Summary

On the deployment page, the **Deploying** status tag was static text, so users could not easily tell that a deployment was actively in progress.

This adds a spinning loading indicator to the actively-processing deployment statuses, mirroring the transitional-status spinner already used on the session status tag (`SessionStatusTag.tsx`, which renders `<LoadingOutlined spin />` via the tag's `icon` prop).

## Changes

- `packages/backend.ai-ui/src/components/BAIDeploymentStatusTag.tsx`
  - Added `DEPLOYMENT_IN_PROGRESS_STATUSES` (`DEPLOYING`, `SCALING`) and the `isDeploymentInProgress` predicate, forming a parallel pair to the existing `DEPLOYMENT_STOPPED_CATEGORY_STATUSES` / `isDeploymentInStoppedCategory`. The predicate shares the same widened `... | '%future added value' | null | undefined` signature so callers can pass raw fragment status fields.
  - Render a spinning `LoadingOutlined` icon on the tag when the status is in-progress.
- `packages/backend.ai-ui/src/components/index.ts` — export the new constant + predicate from the package barrel, mirroring the stopped-category pair.
- `packages/backend.ai-ui/src/components/BAIDeploymentStatusTag.test.tsx` — unit tests for `isDeploymentInProgress`.

**Scope note:** the spinner applies to `DEPLOYING` and `SCALING` — the actively-processing states. `PENDING` is intentionally excluded: it is a queued/waiting state, not active processing, so a perpetual spinner there would be misleading.

No new i18n keys (existing `comp:BAIDeploymentStatusTag.*` labels are reused) and no schema/Relay changes.

## Verification

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all **PASS**. Unit tests: 6/6 pass. (The Vite warmup-paths check fails only because `build/` artifacts are absent in this environment; it is unrelated to this source-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)