### PR TITLE
fix(FR-3175): gate admin-only Prometheus query preview behind super-admin check

### DIFF
--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -11,6 +11,7 @@ import { AutoScalingRuleEditorModalPresetsQuery } from '../__generated__/AutoSca
 import { AutoScalingRuleEditorModalUpdateMutation } from '../__generated__/AutoScalingRuleEditorModalUpdateMutation.graphql';
 import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentUserRole } from '../hooks/backendai';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
 import PrometheusQueryTemplatePreview from './PrometheusQueryTemplatePreview';
 import {
@@ -111,6 +112,7 @@ const AutoScalingRuleEditorModalContent: React.FC<{
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const baiClient = useSuspendedBackendaiClient();
+  const currentUserRole = useCurrentUserRole();
   const isSupportPrometheusAutoScalingRule = baiClient.supports(
     'prometheus-auto-scaling-rule',
   );
@@ -342,7 +344,7 @@ const AutoScalingRuleEditorModalContent: React.FC<{
               },
             ]}
             extra={
-              selectedPreset ? (
+              currentUserRole === 'superadmin' && selectedPreset ? (
                 <PrometheusQueryTemplatePreview
                   key={selectedPreset.id}
                   queryTemplate={selectedPreset.queryTemplate}

--- a/react/src/components/PrometheusQueryPresetEditorModal.tsx
+++ b/react/src/components/PrometheusQueryPresetEditorModal.tsx
@@ -9,6 +9,7 @@ import {
   PrometheusQueryPresetEditorModalFragment$key,
 } from '../__generated__/PrometheusQueryPresetEditorModalFragment.graphql';
 import { PrometheusQueryPresetEditorModalUpdateMutation } from '../__generated__/PrometheusQueryPresetEditorModalUpdateMutation.graphql';
+import { useCurrentUserRole } from '../hooks/backendai';
 import PrometheusQueryTemplatePreview from './PrometheusQueryTemplatePreview';
 import { App, Form, Input } from 'antd';
 import {
@@ -87,6 +88,7 @@ const PrometheusQueryPresetEditorModal: React.FC<
   const { t } = useTranslation();
   const { message } = App.useApp();
   const { logger } = useBAILogger();
+  const currentUserRole = useCurrentUserRole();
   const deferredOpen = useDeferredValue(baiModalProps.open);
 
   const preset = useFragment(
@@ -392,16 +394,18 @@ const PrometheusQueryPresetEditorModal: React.FC<
             },
           ]}
           extra={
-            <PrometheusQueryTemplatePreview
-              queryTemplate={
-                // `Form.useWatch` returns `undefined` on the very first render
-                // before `initialValues` are applied. In edit mode that would
-                // hide the preview for a tick and then trigger the 800ms
-                // debounce; falling back to the fragment value lets the
-                // preview start fetching the existing template immediately.
-                watchedQueryTemplate ?? preset?.queryTemplate ?? ''
-              }
-            />
+            currentUserRole === 'superadmin' ? (
+              <PrometheusQueryTemplatePreview
+                queryTemplate={
+                  // `Form.useWatch` returns `undefined` on the very first render
+                  // before `initialValues` are applied. In edit mode that would
+                  // hide the preview for a tick and then trigger the 800ms
+                  // debounce; falling back to the fragment value lets the
+                  // preview start fetching the existing template immediately.
+                  watchedQueryTemplate ?? preset?.queryTemplate ?? ''
+                }
+              />
+            ) : undefined
           }
         >
           <TextArea autoSize={{ minRows: 4, maxRows: 12 }} />


### PR DESCRIPTION
Resolves #7983 (FR-3175)

## Summary

![CleanShot 2026-06-19 at 11.30.14@2x.png](https://app.graphite.com/user-attachments/assets/446df1f9-3368-4ae0-b78f-135218444d9b.png)


On the autoscaling rule page, the Prometheus query template preview (`PrometheusQueryTemplatePreview.tsx`) uses the **super-admin-only** API `adminPreviewPrometheusQueryPreset`, but the preview was rendered for non-super-admin users as well, firing a request they have no permission for.

This gates the preview at its **call sites**: each parent reads `useCurrentUserRole()` and only mounts `PrometheusQueryTemplatePreview` when the current user is a `superadmin`. The query never mounts for anyone else.

## Changes

- `react/src/components/AutoScalingRuleEditorModal.tsx` — only render the preview when `currentUserRole === 'superadmin' && selectedPreset`.
- `react/src/components/PrometheusQueryPresetEditorModal.tsx` — only render the preview when `currentUserRole === 'superadmin'`.
- `react/src/components/PrometheusQueryTemplatePreview.tsx` — no role logic inside the component; its docblock now states that callers must gate it behind a super-admin check.

## Verification

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all PASS. (The only failing check is the pre-existing local Vite warmup-paths check, which depends on build artifacts and is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)