### PR TITLE
fix(FR-3181): reset automount folders when project changes in Start Session dialog

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -301,20 +301,21 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   );
 
   useEffect(() => {
-    _.isFunction(onChangeAutoMountedFolders) &&
-      onChangeAutoMountedFolders(autoMountedFolderNames);
-    // Do not need to run when `autoMountedFolderNames` changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoMountedFolderNames]);
-
-  useEffect(() => {
-    // Only reset selectedRowKeys when currentProject changes if there are no controlled selectedRowKeys
+    // Reset selected rows and auto-mounted folders when the project changes.
+    // This effect must be defined BEFORE the autoMountedFolderNames effect so
+    // that React runs it first. The autoMountedFolderNames effect fires second
+    // and re-populates the field with the new project's dot-file folders.
     if (!controlledSelectedRowKeys || controlledSelectedRowKeys.length === 0) {
       setSelectedRowKeys([]);
     }
-    // Reset selectedRowKeys when currentProject changes
+    _.isFunction(onChangeAutoMountedFolders) && onChangeAutoMountedFolders([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentProject.id]);
+
+  useEffect(() => {
+    _.isFunction(onChangeAutoMountedFolders) &&
+      onChangeAutoMountedFolders(autoMountedFolderNames);
+  }, [autoMountedFolderNames, onChangeAutoMountedFolders]);
 
   const [searchKey, setSearchKey] = useState('');
   const displayingFolders = useMemo(() => {


### PR DESCRIPTION
Resolves #7993 (FR-3181)

## Problem

When switching projects in the Start Session dialog's storage step, the previous project's dot-file VFolders (automount folders) were being added to the automount list alongside the new project's dot-file VFolders, instead of replacing them.

**Root cause**: In `VFolderTable.tsx`, two `useEffect` hooks were in the wrong order:

1. `useEffect([autoMountedFolderNames])` — syncs the `autoMountedFolderNames` form field
2. `useEffect([currentProject.id])` — resets `selectedRowKeys` on project change

When the project changed, both effects fired in the same React commit. The second (sync) effect ran last and re-populated the form field with the *new* project's dot folders — so the automount field was reset correctly when folder names changed by reference. However, if the new project had the same dot-folder names (or the effect order mattered), stale data could remain.

More critically, the project-change effect never called `onChangeAutoMountedFolders([])` to clear the form field before the new data arrived. The automount form field (`autoMountedFolderNames`) lives in the parent form and is only set via `form.setFieldValue(...)` — it doesn't clear on its own.

## Fix

Reordered the two `useEffect` hooks in `VFolderTable.tsx` so the project-change effect is defined **before** the `autoMountedFolderNames` sync effect. React fires effects in definition order within the same commit, so:

1. **Project-change effect** (now first): clears `selectedRowKeys` + calls `onChangeAutoMountedFolders([])` to empty the automount field
2. **Sync effect** (now second): re-populates the field with the new project's dot folders

This ensures the field is always cleared before being re-filled, whether the new data arrives in the same render or a later one (after a Suspense re-fetch).

## Checklist

- [x] No documentation changes needed (internal session dialog behavior)
- [ ] Minimum required manager version: N/A (frontend-only fix)
- [ ] Test: Open Start Session dialog → select a project with dot-file VFolders → switch to a different project → verify the automount folder list shows only the new project's dot folders, not the previous project's