### PR TITLE
docs(FR-3195): add Japanese build link to References chapter

### DIFF
--- a/packages/backend.ai-webui-docs/src/en/references/references.md
+++ b/packages/backend.ai-webui-docs/src/en/references/references.md
@@ -1,9 +1,10 @@
 # References
 
-- Online API Manual: https://docs.backend.ai
+- Backend.AI Documentation: https://docs.backend.ai
 - Online Client SDK Manual: https://docs.backend.ai/en/latest/client
 
 The latest versions of this document can be found from sites below:
 
 - https://webui.docs.backend.ai/en/latest (English)
 - https://webui.docs.backend.ai/ko/latest (Korean)
+- https://webui.docs.backend.ai/ja/latest (Japanese)

--- a/packages/backend.ai-webui-docs/src/ja/references/references.md
+++ b/packages/backend.ai-webui-docs/src/ja/references/references.md
@@ -1,9 +1,10 @@
 # 参考文献
 
-- オンラインAPIマニュアル: https://docs.backend.ai
+- Backend.AI ドキュメント: https://docs.backend.ai
 - オンラインクライアントSDKマニュアル: https://docs.backend.ai/en/latest/client
 
 このドキュメントの最新バージョンは、以下のサイトから見つけることができます。
 
 - https://webui.docs.backend.ai/en/latest (English)
 - https://webui.docs.backend.ai/ko/latest (Korean)
+- https://webui.docs.backend.ai/ja/latest (Japanese)

--- a/packages/backend.ai-webui-docs/src/ko/references/references.md
+++ b/packages/backend.ai-webui-docs/src/ko/references/references.md
@@ -1,9 +1,10 @@
 # 참고 자료
 
-- 온라인 API 매뉴얼: https://docs.backend.ai
+- Backend.AI 문서: https://docs.backend.ai
 - 온라인 클라이언트 SDK 매뉴얼: https://docs.backend.ai/en/latest/client
 
 이 문서의 최신 버전은 아래 사이트에서 볼 수 있습니다:
 
 - https://webui.docs.backend.ai/en/latest (English)
 - https://webui.docs.backend.ai/ko/latest (Korean)
+- https://webui.docs.backend.ai/ja/latest (Japanese)

--- a/packages/backend.ai-webui-docs/src/th/references/references.md
+++ b/packages/backend.ai-webui-docs/src/th/references/references.md
@@ -1,9 +1,10 @@
 # อ้างอิง
 
-- คู่มือ API ออนไลน์: https://docs.backend.ai
+- เอกสาร Backend.AI: https://docs.backend.ai
 - คู่มือ Client SDK ออนไลน์: https://docs.backend.ai/en/latest/client
 
 เอกสารฉบับล่าสุดสามารถพบได้จากเว็บไซต์ด้านล่าง:
 
 - https://webui.docs.backend.ai/en/latest (English)
 - https://webui.docs.backend.ai/ko/latest (Korean)
+- https://webui.docs.backend.ai/ja/latest (Japanese)


### PR DESCRIPTION
Resolves #8007 (FR-3195)

> **Stacked on** #8015 — part of the v26.4.x user-manual refresh stack. Review/merge bottom-up.

## Summary

Small fix for the **References** chapter (en/ko/ja/th).

- Add the Japanese build link `https://webui.docs.backend.ai/ja/latest` to the "latest versions" list (after the Korean entry).
- Relabel "Online API Manual" → "Backend.AI Documentation" to match the destination's scope.
- Thai self-link deferred — `/th/latest` currently 404s.

## Screenshots
None.

## Test plan
- [ ] Review English docs at the preview server
- [ ] KO/JA/TH parity (verified)
