### PR TITLE
fix(FR-3204): keep model project folder mount permission read-only in Folder Explorer

### DIFF
--- a/react/src/components/FolderCreateModalV2.tsx
+++ b/react/src/components/FolderCreateModalV2.tsx
@@ -649,17 +649,18 @@ const FolderCreateModalV2: React.FC<FolderCreateModalProps> = ({
             {({ getFieldValue }) => {
               const usageMode = getFieldValue('usage_mode');
               const type = getFieldValue('type');
-              const allowOnlyROForModelProjectFolder = baiClient?.supports(
-                'allow-only-ro-permission-for-model-project-folder',
-              );
+              // Model project folders are forced read-only (FR-1290). The
+              // manager used to enforce this server-side (the dropped
+              // 'allow-only-ro-permission-for-model-project-folder' capability)
+              // and no longer seems to, but we keep enforcing it on the client
+              // to preserve that contract until the project-folder behavior is
+              // reworked. Mirrored in VFolderNodeDescriptionV2.
               const shouldDisableRWPermission =
-                usageMode === 'model' &&
-                type === 'project' &&
-                allowOnlyROForModelProjectFolder;
+                usageMode === 'model' && type === 'project';
 
               return (
                 <Form.Item
-                  label={t('data.Permission')}
+                  label={t('data.folders.MountPermission')}
                   name={'permission'}
                   required
                   dependencies={['usage_mode', 'type']}

--- a/react/src/components/VFolderNodeDescriptionV2.tsx
+++ b/react/src/components/VFolderNodeDescriptionV2.tsx
@@ -21,6 +21,7 @@ import {
   App,
   Descriptions,
   theme,
+  Tooltip,
   Typography,
   type DescriptionsProps,
 } from 'antd';
@@ -128,6 +129,14 @@ const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
       ? 'rw'
       : 'ro';
 
+  // Model project folders are read-only by design (FR-1290), matching
+  // FolderCreateModalV2. The manager used to enforce `ro` server-side and no
+  // longer seems to, but we keep enforcing it on the client to preserve that
+  // contract until the project-folder behavior is reworked.
+  const shouldDisableRWPermission =
+    vfolderNode.metadata?.usageMode === 'MODEL' &&
+    vfolderNode.accessControl?.ownershipType === 'GROUP';
+
   const items: DescriptionsProps['items'] = filterOutEmpty([
     !vfolderNode?.unmanagedPath && {
       key: 'path',
@@ -198,9 +207,27 @@ const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
           defaultValue={currentSelectPermission}
           options={[
             { value: 'ro', label: t('data.ReadOnly') },
-            { value: 'rw', label: t('data.ReadWrite') },
+            {
+              value: 'rw',
+              label: shouldDisableRWPermission ? (
+                <Tooltip
+                  title={t(
+                    'data.folders.ModelProjectFolderRestrictedToReadOnly',
+                  )}
+                >
+                  {t('data.ReadWrite')}
+                </Tooltip>
+              ) : (
+                t('data.ReadWrite')
+              ),
+              disabled: shouldDisableRWPermission,
+            },
           ]}
           onChange={(value) => {
+            // Defense-in-depth: never persist 'rw' for a restricted folder.
+            if (shouldDisableRWPermission && value === 'rw') {
+              return;
+            }
             updateMutation.mutate(
               { permission: value, id: vfolderId },
               {


### PR DESCRIPTION
Resolves #8033 (FR-3204)

## Summary

![CleanShot 2026-06-24 at 14.50.51@2x.png](https://app.graphite.com/user-attachments/assets/50830b9c-a5b5-478b-aa33-0544de3c8c97.png)

![CleanShot 2026-06-24 at 14.50.31@2x.png](https://app.graphite.com/user-attachments/assets/3e591e72-9259-403a-9cea-9b9d89d3c099.png)

When a model folder is created into a project from the Model Store, the mount permission is forced to read-only (`ro`) at creation time (`FolderCreateModalV2` / FR-1290). However, the **Folder Explorer** detail panel still let users switch that permission back to read-write (`rw`), bypassing the enforcement.

## Changes

- **`VFolderNodeDescriptionV2.tsx`** — Disable the `rw` mount-permission option for model project folders (`metadata.usageMode === 'MODEL'` && `accessControl.ownershipType === 'GROUP'`). A tooltip on the disabled option explains why, reusing the existing `data.folders.ModelProjectFolderRestrictedToReadOnly` message already shown in the create modal, plus a defensive `onChange` guard.
- **`FolderCreateModalV2.tsx`** — Rename the permission field label from `data.Permission` ("권한") to `data.folders.MountPermission` ("마운트 권한") for consistency with the Folder Explorer, since both refer to the *mount* permission. Also drop the now-redundant feature-flag gate (see below).
- **Dropped the `allow-only-ro-permission-for-model-project-folder` feature-flag gate** from both screens. The restriction is enforced by all currently supported manager versions (LTS ≥ 25.18.2), so the version gate was always `true` — a dead branch. Removing it from both call sites keeps the two screens consistent.

## Verification

`bash scripts/verify.sh` → Relay / Lint / Format / TypeScript all PASS.
(The pre-existing "Vite warmup paths" check fails on `main` as well, unrelated to this change.)

## Test plan

1. Create a model folder into a project folder from the Model Store (permission forced to `ro`).
2. Open it in Folder Explorer → the mount-permission `rw` option is disabled and shows the read-only tooltip on hover; only `ro` is selectable.
3. Non-model folders are unaffected — both `ro` and `rw` remain selectable.