### PR TITLE
fix(FR-3211): add Fair Share option to scheduler setting

### DIFF
--- a/react/src/components/ConfigurationsSettingList.tsx
+++ b/react/src/components/ConfigurationsSettingList.tsx
@@ -12,7 +12,7 @@ import { Alert, App, Button } from 'antd';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export type SchedulerType = 'fifo' | 'lifo' | 'drf';
+export type SchedulerType = 'fifo' | 'lifo' | 'drf' | 'fair-share';
 export type ImagePullingBehavior = 'digest' | 'tag' | 'none';
 export type SchedulerOptions = {
   num_retries_to_skip: string;

--- a/react/src/components/SchedulerSettingModal.tsx
+++ b/react/src/components/SchedulerSettingModal.tsx
@@ -153,6 +153,10 @@ const SchedulerSettingModal = ({
                 label: 'DRF',
                 value: 'drf',
               },
+              {
+                label: 'Fair Share',
+                value: 'fair-share',
+              },
             ]}
           />
         </Form.Item>


### PR DESCRIPTION
Resolves FR-3211

> Note: the Jira→GitHub clone for FR-3211 was not found at PR creation time, so the issue reference is by Jira key only. If/when the cloned GitHub issue appears, update this line to `Resolves #<N> (FR-3211)` for auto-linking.

## Summary

The global per-job scheduler setting (`SchedulerSettingModal`, "Config per-job scheduler") only offered **FIFO / LIFO / DRF** and was missing the **Fair Share** scheduler, so it could not be selected. The backend exposes `SchedulerType.FAIR_SHARE` (`"fair-share"`), and the per-resource-group scheduler input (`ResourceGroupSettingModal`) already lists it — only the global setting was missing it.

## Changes

- `react/src/components/SchedulerSettingModal.tsx`: add `{ label: 'Fair Share', value: 'fair-share' }` to the scheduler `<Select>` options (after DRF).
- `react/src/components/ConfigurationsSettingList.tsx`: extend the `SchedulerType` union with `'fair-share'`.

The existing `num_retries_to_skip` guard (only FIFO permits a non-zero value) generalizes correctly — `fair-share` is not `fifo`, so it behaves like LIFO/DRF and requires `0`. No new code needed.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript).

🤖 Generated with [Claude Code](https://claude.com/claude-code)