### PR TITLE
fix(FR-3212): add timeout to Chat /v1/models fetch so unresponsive endpoints don't hang on skeleton

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -141,10 +141,18 @@ function useModels(
 
         const url = createModelsURL(baseURL);
         const authToken = effectiveApiKey ?? provider.apiKey;
+        // FR-3212: An unresponsive endpoint (TCP connects but never returns an
+        // HTTP response) would otherwise hang this fetch forever, leaving the
+        // Suspense boundary spinning indefinitely. Abort after 30s so the
+        // request rejects and falls into the catch below (error: -1), driving
+        // the established CustomModelForm recovery UX. 30s is generous enough
+        // for a slow-but-healthy endpoint (cold start, app-proxy/TLS latency)
+        // while still bounding a dead connection to a recoverable failure.
         const response = await fetch(url, {
           headers: {
             Authorization: authToken ? `Bearer ${authToken}` : '',
           },
+          signal: AbortSignal.timeout(30000),
         });
 
         if (!response.ok) {


### PR DESCRIPTION
Resolves #8044 (FR-3212)

## Problem

In the chat (LLM playground), the inner chat card stayed on a loading **skeleton indefinitely** when the selected endpoint's model URL accepted a TCP connection but never returned an HTTP response (a hanging/unresponsive endpoint — e.g. a loopback app-proxy port with no live tunnel behind it).

`ChatCard`'s `useModels()` → `useSuspenseTanQuery` fetched `{endpoint.url}/v1/models` with **no timeout and no `AbortSignal`**. The `queryFn` handled only two terminal outcomes (`!response.ok` → `error: status`; thrown → `catch` → `error: -1`), but a connection that connects and then hangs makes the `fetch` promise never settle. Because `useSuspenseTanQuery` suspends until the query settles, the surrounding `<Suspense fallback={<Card loading />}>` was stuck on the skeleton forever — no error, no recovery path.

<img width="1008" height="668" alt="image" src="https://github.com/user-attachments/assets/3eebccd9-5639-4be4-a32c-713b4df702cb" />


## Fix

Pass `signal: AbortSignal.timeout(30000)` to the `/v1/models` `fetch`. On timeout the fetch rejects with a `TimeoutError`, which the **existing** `catch` converts to `{ data: [], error: -1 }` — routing into the already-established error UX (disabled chat input + `CustomModelForm` recovery) instead of hanging. No downstream behaviour changes.

### Why 30s

- Generous enough for a **slow-but-healthy** endpoint (cold start, app-proxy/TLS latency) so a legitimately slow `/v1/models` is not falsely aborted.
- Still bounds a **dead** connection to a recoverable failure: the chat card already has a refresh button (`updateFetchKey`), and the global `QueryClient` sets `retry: false` while the `queryFn` resolves (never rejects) on timeout, so there is no re-fetch amplification.
- This timeout governs **only** the model-list discovery fetch in `useModels`; the chat streaming request in `useChat` is a separate fetch with its own abort wiring and is unaffected.

## Relation

Distinct from **FR-3143** ("disable chat input when endpoint models fail to load"): that covers `/models` *resolving with an error* (401/404/500/503/network). This issue is the case where the request **never settles**, so FR-3143's error state was never reached.

## Verification

- `react/` TypeScript: `tsc --noEmit` → 0 errors (the `FluentEmojiIcon.tsx` failure in `scripts/verify.sh` is a known worktree patched-dependency mis-link, unrelated to this change).
- Prettier: clean on `ChatCard.tsx`.
- ESLint: clean on `ChatCard.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
