### PR TITLE
fix(FR-3217): purge leaked e2e fixture users so the test server is not left dirty

### DIFF
--- a/e2e/credential/my-keypair-management.spec.ts
+++ b/e2e/credential/my-keypair-management.spec.ts
@@ -1,4 +1,5 @@
 // spec: e2e/.agent-output/test-plan-my-keypair-management.md
+import { createAdminApiContext, purgeUserViaApi } from '../utils/admin-api';
 import {
   KeyPairModal,
   UserSettingModal,
@@ -8,7 +9,7 @@ import {
   loginAsCreatedAccount,
   navigateTo,
 } from '../utils/test-util';
-import test, { expect } from '@playwright/test';
+import test, { expect, type APIRequestContext } from '@playwright/test';
 
 // Helper to open the My Keypair Management modal
 async function openKeypairModal(page: import('@playwright/test').Page) {
@@ -151,12 +152,26 @@ test.describe(
       }
     });
 
-    // No afterAll cleanup: each test run uses a unique fixture user
-    // (`e2e-mykeypair-<TEST_RUN_ID>@lablup.com`) that does not collide with
-    // any other run, so leftover users are harmless. A separate periodic
-    // job (or a follow-up cleanup test) should reap the `e2e-mykeypair-*`
-    // accounts. Avoiding cleanup here keeps the file's tear-down fast and
-    // prevents flake from the cleanup itself.
+    // Purge the disposable fixture user after the suite via the admin GraphQL
+    // API (pagination-immune, no UI flakiness). The global-cleanup teardown
+    // also sweeps any leaked `e2e-*` account as a belt-and-suspenders backstop,
+    // but reaping it here keeps the shared server clean even when the teardown
+    // is skipped (e.g. a single-file run). Never throws — a cleanup hiccup must
+    // not fail an otherwise-passing suite.
+    test.afterAll(async () => {
+      let api: APIRequestContext | undefined;
+      try {
+        api = await createAdminApiContext();
+        await purgeUserViaApi(api, FIXTURE_EMAIL);
+      } catch (error) {
+        console.warn(
+          `[my-keypair-management] failed to purge fixture user ${FIXTURE_EMAIL}:`,
+          error,
+        );
+      } finally {
+        await api?.dispose();
+      }
+    });
 
     test.beforeEach(async ({ page, request }) => {
       // Login as the disposable fixture user (NOT the shared user@lablup.com).

--- a/e2e/global-cleanup.teardown.ts
+++ b/e2e/global-cleanup.teardown.ts
@@ -23,12 +23,50 @@
  * a per-test `sweepVFolders` call — because the teardown runs after every other
  * project has finished, so no parallel test owns a live `e2e-*` folder.
  */
+import {
+  createAdminApiContext,
+  listUsersByPattern,
+  purgeUserViaApi,
+} from './utils/admin-api';
 import { sweepServices, sweepVFolders } from './utils/cleanup-util';
 import { loginAsAdmin, loginAsUser } from './utils/test-util';
 import { Page, test } from '@playwright/test';
 
 // Matches every e2e vfolder naming scheme used across the specs.
 const E2E_VFOLDER_PATTERN = /e2e-/i;
+
+// Matches the disposable fixture accounts other specs create (e.g.
+// e2e-rbac-assign-*, e2e-mykeypair-*, e2e-test-user-*, e2e-profile-*). Anchored
+// to the `e2e-` prefix so it can never match a standard test account
+// (admin@/user@/user2@/monitor@/domain-admin@lablup.com).
+const E2E_USER_PATTERN = /^e2e-[a-z0-9._-]*@lablup\.com$/i;
+
+/**
+ * Belt-and-suspenders user sweep (FR-3217). Specs that create fixture users now
+ * purge them in their own afterAll, but a hard-killed run can skip that hook and
+ * strand an `e2e-*` account on the shared server. This purges any leftover via
+ * the admin GraphQL API (pagination-immune, no credential-UI flakiness — see
+ * FR-3138). It CAN throw: admin login (createAdminApiContext), transport, and
+ * GraphQL errors propagate (purgeUserViaApi only swallows missing-user /
+ * `ok: false`). The caller wraps this in its own try/catch so a sweep failure
+ * never reds an otherwise-green run; the `finally` here disposes the API
+ * context even when a sweep step throws.
+ */
+async function sweepLeftoverE2EUsers(): Promise<void> {
+  const api = await createAdminApiContext();
+  try {
+    const leaked = await listUsersByPattern(api, E2E_USER_PATTERN);
+    let purged = 0;
+    for (const { email } of leaked) {
+      if (await purgeUserViaApi(api, email)) purged++;
+    }
+    if (purged > 0) {
+      console.log(`[global-cleanup] purged ${purged} leftover e2e-* user(s).`);
+    }
+  } finally {
+    await api.dispose();
+  }
+}
 
 /** Run a best-effort sweep, swallowing any error so teardown never fails. */
 async function safeSweep(
@@ -74,5 +112,12 @@ test.describe('Global e2e cleanup', () => {
       page,
     );
     await safeSweep('admin services', (p) => sweepServices(p), page);
+    // Purge any e2e-* fixture user a per-spec afterAll failed to reap. API-based,
+    // so it does not use `page`; guard it directly so a failure never reds the run.
+    try {
+      await sweepLeftoverE2EUsers();
+    } catch (error) {
+      console.warn('[global-cleanup] user sweep failed (ignored):', error);
+    }
   });
 });

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -1,12 +1,13 @@
 // spec: e2e/.agent-output/test-plan-rbac-management.md
 // Scenarios: 3.1 – 3.4, 4.1 – 4.4, 5.1 – 5.4, 6.2 – 6.3
 // (Role detail drawer, permissions management, user assignments, edge cases)
+import { createAdminApiContext, purgeUserViaApi } from '../utils/admin-api';
 import {
   KeyPairModal,
   UserSettingModal,
 } from '../utils/classes/user/UserSettingModal';
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
-import test, { expect, Page } from '@playwright/test';
+import test, { expect, Page, type APIRequestContext } from '@playwright/test';
 
 const TEST_RUN_ID = Date.now().toString(36);
 const ROLE_NAME = `e2e-detail-role-${TEST_RUN_ID}`;
@@ -658,9 +659,10 @@ test.describe(
 // assign / revoke a user to/from a custom role and then purge that role
 // during cleanup. To keep tests fully isolated from the shared
 // `user@lablup.com` (whose state must remain stable for all other suites),
-// we create a fresh user via admin in beforeAll. There is no afterAll cleanup
-// — the fixture user uses a unique `<RUN_ID>` suffix so leftovers don't
-// collide between runs, and a periodic reaper sweeps stale fixture accounts.
+// we create a fresh user via admin in beforeAll and purge it in afterAll
+// (see below) via the admin GraphQL API. The unique `<RUN_ID>` suffix keeps
+// leftovers from colliding between runs, and the global-cleanup teardown
+// sweeps any `e2e-*` account a hard-killed run failed to purge.
 const ASSIGN_FIXTURE_RUN_ID =
   Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
 const ASSIGN_FIXTURE_EMAIL = `e2e-rbac-assign-${ASSIGN_FIXTURE_RUN_ID}@lablup.com`;
@@ -708,11 +710,26 @@ test.describe(
       }
     });
 
-    // No afterAll cleanup: each test run uses a unique fixture user
-    // (`e2e-rbac-assign-<RUN_ID>@lablup.com`) that does not collide with any
-    // other run, so leftover users are harmless. A separate periodic reaper
-    // should sweep stale `e2e-rbac-assign-*` accounts. Mirrors the pattern
-    // already established in e2e/credential/my-keypair-management.spec.ts.
+    // Purge the disposable fixture user after the suite via the admin GraphQL
+    // API (pagination-immune, no UI flakiness). The global-cleanup teardown
+    // also sweeps any leaked `e2e-*` account as a belt-and-suspenders backstop,
+    // but reaping it here keeps the shared server clean even when the teardown
+    // is skipped (e.g. a single-file run). Never throws — a cleanup hiccup must
+    // not fail an otherwise-passing suite.
+    test.afterAll(async () => {
+      let api: APIRequestContext | undefined;
+      try {
+        api = await createAdminApiContext();
+        await purgeUserViaApi(api, ASSIGN_FIXTURE_EMAIL);
+      } catch (error) {
+        console.warn(
+          `[rbac-role-detail] failed to purge fixture user ${ASSIGN_FIXTURE_EMAIL}:`,
+          error,
+        );
+      } finally {
+        await api?.dispose();
+      }
+    });
 
     test('Superadmin can assign a user to a role', async ({
       page,


### PR DESCRIPTION
Resolves #8050 (FR-3217)

Follow-up to #7977 (FR-3090), which robustly cleaned up **virtual folders** in the E2E suite. FR-3090's own acceptance note asks to "use the same pattern for other entity-creating suites" — this PR starts with the highest-value, fully API-verifiable slice: the disposable fixture **users** that specs create but never delete.

## Problem

A double-check review of the rest of the E2E suite (after #7977) found the same orphan/silent-cleanup pattern for fixture users:

- `e2e/rbac/rbac-role-detail.spec.ts` and `e2e/credential/my-keypair-management.spec.ts` create a disposable fixture user (`e2e-rbac-assign-*` / `e2e-mykeypair-*`) in `beforeAll` and **never delete it** — leaking one account on *every* run (even green ones). The comments claimed "a periodic reaper sweeps stale fixture accounts", but **no such reaper exists in-repo**.

## Changes

- **`rbac-role-detail.spec.ts` / `my-keypair-management.spec.ts`**: add a never-throwing `afterAll` that purges the fixture user via the admin GraphQL API (`purgeUserViaApi`, pagination-immune, from FR-3138 `e2e/utils/admin-api.ts`). Fix the misleading "periodic reaper" comments.
- **`e2e/global-cleanup.teardown.ts`**: add a belt-and-suspenders admin sweep (`sweepLeftoverE2EUsers`) that purges any leftover `/^e2e-[a-z0-9._-]*@lablup\.com$/i` account a hard-killed run failed to reap. The pattern is anchored to the `e2e-` prefix so it can never match a standard test account (`admin@`/`user@`/`user2@`/`monitor@`/`domain-admin@lablup.com`). This also transitively backstops other user-creating specs (`bulk-user-creation`, `user-crud`).

All cleanup is best-effort and never throws — a cleanup hiccup must not fail an otherwise-passing suite.

## Out of scope (tracked in FR-3217 as follow-up)

UI-based sweeps for non-user resources — sessions, model cards, container registries, resource policies, prometheus presets — are deferred. They require live verification against the shared backend and are lower-value (per-run-unique names mean no cross-run collision). #7977's suite-wide `actionTimeout: 30000` already removes their 180s-hang leak mode.

## Verification

- `eslint --config e2e/eslint.config.mjs` on the 3 changed files — pass
- `prettier --check` — pass
- `playwright test --list` on the changed specs — parses/resolves imports, 36 tests across 3 files
- E2E not run against the shared backend (would mutate the live server); the sweep logic reuses the already-live-verified FR-3138 admin-api helpers.