### PR TITLE
feat(FR-3216): add login history tab to user settings

### DIFF
--- a/react/src/__generated__/LoginHistoryQuery.graphql.ts
+++ b/react/src/__generated__/LoginHistoryQuery.graphql.ts
@@ -1,0 +1,283 @@
+/**
+ * @generated SignedSource<<a3055ee85da450ac405c1543624dc841>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type LoginAttemptResult = "EVICTED" | "EXPIRED" | "FAILED_BLOCKED" | "FAILED_INVALID_CREDENTIALS" | "FAILED_PASSWORD_EXPIRED" | "FAILED_REJECTED_BY_HOOK" | "FAILED_SESSION_ALREADY_EXISTS" | "FAILED_USER_INACTIVE" | "LOGOUT" | "REVOKED_BY_ADMIN" | "REVOKED_BY_USER" | "SUCCESS" | "%future added value";
+export type LoginHistoryOrderField = "CREATED_AT" | "DOMAIN_NAME" | "RESULT" | "%future added value";
+export type OrderDirection = "ASC" | "DESC" | "%future added value";
+export type LoginHistoryFilter = {
+  AND?: ReadonlyArray<LoginHistoryFilter> | null | undefined;
+  NOT?: ReadonlyArray<LoginHistoryFilter> | null | undefined;
+  OR?: ReadonlyArray<LoginHistoryFilter> | null | undefined;
+  createdAt?: DateTimeFilter | null | undefined;
+  domainName?: StringFilter | null | undefined;
+  result?: LoginHistoryResultFilter | null | undefined;
+};
+export type StringFilter = {
+  contains?: string | null | undefined;
+  endsWith?: string | null | undefined;
+  equals?: string | null | undefined;
+  iContains?: string | null | undefined;
+  iEndsWith?: string | null | undefined;
+  iEquals?: string | null | undefined;
+  iIn?: ReadonlyArray<string> | null | undefined;
+  iNotContains?: string | null | undefined;
+  iNotEndsWith?: string | null | undefined;
+  iNotEquals?: string | null | undefined;
+  iNotIn?: ReadonlyArray<string> | null | undefined;
+  iNotStartsWith?: string | null | undefined;
+  iStartsWith?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notContains?: string | null | undefined;
+  notEndsWith?: string | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
+  notStartsWith?: string | null | undefined;
+  startsWith?: string | null | undefined;
+};
+export type LoginHistoryResultFilter = {
+  equals?: LoginAttemptResult | null | undefined;
+  in?: ReadonlyArray<LoginAttemptResult> | null | undefined;
+  notEquals?: LoginAttemptResult | null | undefined;
+  notIn?: ReadonlyArray<LoginAttemptResult> | null | undefined;
+};
+export type DateTimeFilter = {
+  after?: string | null | undefined;
+  before?: string | null | undefined;
+  equals?: string | null | undefined;
+  notEquals?: string | null | undefined;
+};
+export type LoginHistoryOrderBy = {
+  direction?: OrderDirection;
+  field: LoginHistoryOrderField;
+};
+export type LoginHistoryQuery$variables = {
+  filter?: LoginHistoryFilter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+  orderBy?: ReadonlyArray<LoginHistoryOrderBy> | null | undefined;
+};
+export type LoginHistoryQuery$data = {
+  readonly myLoginHistoryV2: {
+    readonly count: number;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly " $fragmentSpreads": FragmentRefs<"LoginHistoryTableFragment">;
+      };
+    }>;
+  } | null | undefined;
+};
+export type LoginHistoryQuery = {
+  response: LoginHistoryQuery$data;
+  variables: LoginHistoryQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "limit"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Variable",
+    "name": "offset",
+    "variableName": "offset"
+  },
+  {
+    "kind": "Variable",
+    "name": "orderBy",
+    "variableName": "orderBy"
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "LoginHistoryQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "LoginHistoryV2Connection",
+        "kind": "LinkedField",
+        "name": "myLoginHistoryV2",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "LoginHistoryV2Edge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LoginHistoryV2",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "LoginHistoryTableFragment"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v3/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "LoginHistoryQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "LoginHistoryV2Connection",
+        "kind": "LinkedField",
+        "name": "myLoginHistoryV2",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "LoginHistoryV2Edge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LoginHistoryV2",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "result",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "domainName",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "failReason",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "87a2e20e056f29b101fd53083de25d21",
+    "id": null,
+    "metadata": {},
+    "name": "LoginHistoryQuery",
+    "operationKind": "query",
+    "text": "query LoginHistoryQuery(\n  $filter: LoginHistoryFilter\n  $orderBy: [LoginHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  myLoginHistoryV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...LoginHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment LoginHistoryTableFragment on LoginHistoryV2 {\n  id\n  result\n  domainName\n  failReason\n  createdAt\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "97281b824d5d55f0864367353b2cac86";
+
+export default node;

--- a/react/src/__generated__/LoginHistoryTableFragment.graphql.ts
+++ b/react/src/__generated__/LoginHistoryTableFragment.graphql.ts
@@ -1,0 +1,77 @@
+/**
+ * @generated SignedSource<<ae9d24b12118cc4abcd9da38a807d7eb>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type LoginAttemptResult = "EVICTED" | "EXPIRED" | "FAILED_BLOCKED" | "FAILED_INVALID_CREDENTIALS" | "FAILED_PASSWORD_EXPIRED" | "FAILED_REJECTED_BY_HOOK" | "FAILED_SESSION_ALREADY_EXISTS" | "FAILED_USER_INACTIVE" | "LOGOUT" | "REVOKED_BY_ADMIN" | "REVOKED_BY_USER" | "SUCCESS" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type LoginHistoryTableFragment$data = ReadonlyArray<{
+  readonly createdAt: string;
+  readonly domainName: string;
+  readonly failReason: string | null | undefined;
+  readonly id: string;
+  readonly result: LoginAttemptResult;
+  readonly " $fragmentType": "LoginHistoryTableFragment";
+}>;
+export type LoginHistoryTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: LoginHistoryTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"LoginHistoryTableFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "LoginHistoryTableFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "result",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "domainName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "failReason",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    }
+  ],
+  "type": "LoginHistoryV2",
+  "abstractKey": null
+};
+
+(node as any).hash = "4dfc2f6ccb6413b8af45b3902aa77534";
+
+export default node;

--- a/react/src/components/LoginHistory.tsx
+++ b/react/src/components/LoginHistory.tsx
@@ -1,0 +1,187 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type {
+  LoginHistoryOrderBy,
+  LoginHistoryQuery as LoginHistoryQueryType,
+} from '../__generated__/LoginHistoryQuery.graphql';
+import { convertToOrderBy } from '../helper';
+import LoginHistoryTable, {
+  loginResultFilterOptions,
+  type LoginHistoryTableProps,
+} from './LoginHistoryTable';
+import {
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIGraphQLPropertyFilter,
+  filterOutNullAndUndefined,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { useDeferredValue } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  graphql,
+  PreloadedQuery,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
+
+export const LoginHistoryQuery = graphql`
+  query LoginHistoryQuery(
+    $filter: LoginHistoryFilter
+    $orderBy: [LoginHistoryOrderBy!]
+    $limit: Int
+    $offset: Int
+  ) {
+    myLoginHistoryV2(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          ...LoginHistoryTableFragment
+        }
+      }
+    }
+  }
+`;
+
+export interface LoginHistoryProps extends Omit<
+  LoginHistoryTableProps,
+  | 'loginHistoryFrgmt'
+  | 'loading'
+  | 'order'
+  | 'onChangeOrder'
+  | 'dataSource'
+  | 'pagination'
+  | 'customizeColumns'
+> {
+  queryRef: PreloadedQuery<LoginHistoryQueryType>;
+  onReload: (
+    variables: LoginHistoryQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
+
+/**
+ * LoginHistory - Reads a preloaded `myLoginHistoryV2` query and renders it as a
+ * `LoginHistoryTable` with a filter bar and a refresh button. The consumer owns
+ * `useQueryLoader` / `loadQuery`; this view reads the `queryRef` via
+ * `usePreloadedQuery` and re-runs filter / sort / refresh / paging through
+ * `onReload`. Reading the *deferred* `queryRef` keeps the previous rows visible
+ * while the next result loads (inline loading, no Suspense-fallback flash).
+ * Login history is read-only, so unlike `LoginSession` there is no row action or
+ * mutation here — only filtering, sorting, and offset pagination. Render inside a
+ * `Suspense` (+ `BAIErrorBoundary`) boundary.
+ */
+const LoginHistory = ({
+  queryRef,
+  onReload,
+  ...tableProps
+}: LoginHistoryProps) => {
+  'use memo';
+  const { t } = useTranslation();
+
+  const filter = queryRef.variables.filter ?? undefined;
+  const orderBy = queryRef.variables.orderBy?.[0];
+  const order = orderBy
+    ? `${orderBy.direction === 'DESC' ? '-' : ''}${_.camelCase(orderBy.field)}`
+    : null;
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
+
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
+
+  const data = usePreloadedQuery<LoginHistoryQueryType>(
+    LoginHistoryQuery,
+    deferredQueryRef,
+  );
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="sm">
+      <BAIFlex justify="between" wrap="wrap" gap="sm">
+        <BAIGraphQLPropertyFilter
+          value={filter}
+          onChange={(next) => {
+            onReload(
+              { ...queryRef.variables, filter: next, offset: 0 },
+              { fetchPolicy: 'network-only' },
+            );
+          }}
+          filterProperties={[
+            {
+              key: 'result',
+              propertyLabel: t('loginHistory.Result'),
+              type: 'enum',
+              fixedOperator: 'equals',
+              strictSelection: true,
+              options: loginResultFilterOptions,
+            },
+            {
+              key: 'domainName',
+              propertyLabel: t('loginHistory.Domain'),
+              type: 'string',
+              fixedOperator: 'contains',
+            },
+            {
+              key: 'createdAt',
+              propertyLabel: t('loginHistory.LoginTime'),
+              type: 'datetime',
+              defaultOperator: 'after',
+            },
+          ]}
+        />
+        <BAIFetchKeyButton
+          value=""
+          onChange={() => {
+            onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+          }}
+          loading={isRefetching}
+          autoUpdateDelay={7_000}
+        />
+      </BAIFlex>
+      <LoginHistoryTable
+        resizable
+        loading={isRefetching}
+        order={order}
+        onChangeOrder={(nextOrder) => {
+          onReload(
+            {
+              ...queryRef.variables,
+              orderBy: convertToOrderBy<LoginHistoryOrderBy>(nextOrder),
+              offset: 0,
+            },
+            { fetchPolicy: 'network-only' },
+          );
+        }}
+        pagination={{
+          pageSize,
+          current,
+          total: data.myLoginHistoryV2?.count ?? 0,
+          onChange: (nextCurrent, nextPageSize) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                limit: nextPageSize,
+                offset: nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          },
+        }}
+        loginHistoryFrgmt={filterOutNullAndUndefined(
+          _.map(data.myLoginHistoryV2?.edges, 'node'),
+        )}
+        {...tableProps}
+      />
+    </BAIFlex>
+  );
+};
+
+export default LoginHistory;

--- a/react/src/components/LoginHistoryTable.tsx
+++ b/react/src/components/LoginHistoryTable.tsx
@@ -1,0 +1,203 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type {
+  LoginHistoryTableFragment$data,
+  LoginHistoryTableFragment$key,
+} from '../__generated__/LoginHistoryTableFragment.graphql';
+import {
+  BAIColumnsType,
+  BAIColumnType,
+  BAITable,
+  BAITableProps,
+  BAITag,
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+  type SemanticColor,
+} from 'backend.ai-ui';
+import dayjs from 'dayjs';
+import * as _ from 'lodash-es';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+
+export type LoginHistoryNodeInList = NonNullable<
+  LoginHistoryTableFragment$data[number]
+>;
+
+type LoginAttemptResult = LoginHistoryNodeInList['result'];
+
+// Concrete login attempt results, in display order. Excludes Relay's
+// forward-compatibility `'%future added value'` member so it can drive the
+// result filter's select options.
+const loginAttemptResults: ReadonlyArray<
+  Exclude<LoginAttemptResult, '%future added value'>
+> = [
+  'SUCCESS',
+  'FAILED_INVALID_CREDENTIALS',
+  'FAILED_USER_INACTIVE',
+  'FAILED_BLOCKED',
+  'FAILED_PASSWORD_EXPIRED',
+  'FAILED_REJECTED_BY_HOOK',
+  'FAILED_SESSION_ALREADY_EXISTS',
+  'LOGOUT',
+  'REVOKED_BY_ADMIN',
+  'REVOKED_BY_USER',
+  'EVICTED',
+  'EXPIRED',
+];
+
+// Result-filter select options. The label is the raw server enum (results are
+// not translated), so this is a static, render-invariant list.
+export const loginResultFilterOptions = loginAttemptResults.map((result) => ({
+  label: result,
+  value: result,
+}));
+
+const availableLoginHistorySorterKeys = [
+  'createdAt',
+  'result',
+  'domainName',
+] as const;
+
+export const availableLoginHistorySorterValues = [
+  ...availableLoginHistorySorterKeys,
+  ...availableLoginHistorySorterKeys.map((key) => `-${key}` as const),
+] as const;
+
+const isEnableSorter = (key: string) => {
+  return _.includes(availableLoginHistorySorterKeys, key);
+};
+
+// Semantic color per login attempt result. SUCCESS is green, every FAILED_*
+// outcome is red, and the remaining lifecycle results (logout/expiry/eviction)
+// stay neutral or amber so a failed sign-in stands out at a glance.
+const loginHistoryResultColorMap: Record<LoginAttemptResult, SemanticColor> = {
+  SUCCESS: 'success',
+  FAILED_INVALID_CREDENTIALS: 'error',
+  FAILED_USER_INACTIVE: 'error',
+  FAILED_BLOCKED: 'error',
+  FAILED_PASSWORD_EXPIRED: 'error',
+  FAILED_REJECTED_BY_HOOK: 'error',
+  FAILED_SESSION_ALREADY_EXISTS: 'error',
+  LOGOUT: 'default',
+  REVOKED_BY_ADMIN: 'warning',
+  REVOKED_BY_USER: 'default',
+  EVICTED: 'warning',
+  EXPIRED: 'default',
+  // Relay generates `'%future added value'` for forward-compatible enums.
+  '%future added value': 'default',
+};
+
+export interface LoginHistoryTableProps extends Omit<
+  BAITableProps<LoginHistoryNodeInList>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
+  loginHistoryFrgmt: LoginHistoryTableFragment$key;
+  disableSorter?: boolean;
+  customizeColumns?: (
+    baseColumns: BAIColumnsType<LoginHistoryNodeInList>,
+  ) => BAIColumnsType<LoginHistoryNodeInList>;
+  onChangeOrder?: (
+    order: (typeof availableLoginHistorySorterValues)[number] | null,
+  ) => void;
+}
+
+/**
+ * LoginHistoryTable - Presentational table over a `LoginHistoryV2` plural
+ * fragment. Renders every login-history column; filter, pagination, and query
+ * orchestration live in the consuming surface via the `customizeColumns` prop.
+ * Login history is read-only, so unlike `LoginSessionTable` it exposes no
+ * row-level actions. Mirrors the `*Nodes` idiom (`LoginSessionTable`,
+ * `SessionNodes`).
+ */
+const LoginHistoryTable = ({
+  loginHistoryFrgmt,
+  disableSorter,
+  customizeColumns,
+  onChangeOrder,
+  ...tableProps
+}: LoginHistoryTableProps) => {
+  'use memo';
+  const { t } = useTranslation();
+
+  const loginHistory = useFragment<LoginHistoryTableFragment$key>(
+    graphql`
+      fragment LoginHistoryTableFragment on LoginHistoryV2
+      @relay(plural: true) {
+        id
+        result
+        domainName
+        failReason
+        createdAt
+      }
+    `,
+    loginHistoryFrgmt,
+  );
+
+  const baseColumns = _.map(
+    filterOutEmpty<BAIColumnType<LoginHistoryNodeInList>>([
+      {
+        key: 'result',
+        title: t('loginHistory.Result'),
+        dataIndex: 'result',
+        fixed: 'left',
+        sorter: isEnableSorter('result'),
+        // Login attempt results are shown as the raw server enum value
+        // (e.g. `FAILED_INVALID_CREDENTIALS`); only the tag color is mapped.
+        render: (__, record) => (
+          <BAITag color={loginHistoryResultColorMap[record.result]}>
+            {record.result}
+          </BAITag>
+        ),
+      },
+      {
+        key: 'domainName',
+        title: t('loginHistory.Domain'),
+        dataIndex: 'domainName',
+        sorter: isEnableSorter('domainName'),
+        render: (__, record) => record.domainName || '-',
+      },
+      {
+        key: 'createdAt',
+        title: t('loginHistory.LoginTime'),
+        dataIndex: 'createdAt',
+        sorter: isEnableSorter('createdAt'),
+        render: (__, record) =>
+          record.createdAt ? dayjs(record.createdAt).format('ll LTS') : '-',
+      },
+      {
+        key: 'failReason',
+        title: t('loginHistory.FailReason'),
+        dataIndex: 'failReason',
+        render: (__, record) => record.failReason || '-',
+      },
+    ]),
+    (column) => {
+      return disableSorter ? _.omit(column, 'sorter') : column;
+    },
+  );
+
+  const allColumns = customizeColumns
+    ? customizeColumns(baseColumns)
+    : baseColumns;
+
+  return (
+    <BAITable
+      resizable
+      rowKey="id"
+      size="small"
+      dataSource={filterOutNullAndUndefined(loginHistory)}
+      columns={allColumns}
+      scroll={{ x: 'max-content' }}
+      onChangeOrder={(order) => {
+        onChangeOrder?.(
+          (order as (typeof availableLoginHistorySorterValues)[number]) || null,
+        );
+      }}
+      {...tableProps}
+    />
+  );
+};
+
+export default LoginHistoryTable;

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -2,9 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import type { LoginHistoryQuery as LoginHistoryQueryType } from '../__generated__/LoginHistoryQuery.graphql';
 import type { LoginSessionQuery as LoginSessionQueryType } from '../__generated__/LoginSessionQuery.graphql';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ErrorLogList from '../components/ErrorLogList';
+import LoginHistory, { LoginHistoryQuery } from '../components/LoginHistory';
 import LoginSession, { LoginSessionQuery } from '../components/LoginSession';
 import MyKeypairInfoModalLegacy from '../components/MyKeypairInfoModalLegacy';
 import MyKeypairManagementModal from '../components/MyKeypairManagementModal';
@@ -27,7 +29,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useQueryLoader } from 'react-relay';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-type TabKey = 'general' | 'logs' | 'login-sessions';
+type TabKey = 'general' | 'logs' | 'login-sessions' | 'login-history';
 export type ShellScriptType = 'bootstrap' | 'userconfig' | undefined;
 
 const tabParam = withDefault(StringParam, 'general');
@@ -42,10 +44,12 @@ const UserPreferencesPage = () => {
 
   const [loginSessionQueryRef, loadLoginSessionQuery] =
     useQueryLoader<LoginSessionQueryType>(LoginSessionQuery);
-  // Lazily fetch login sessions only once the tab is active (covers both a tab
-  // click and a direct `?tab=login-sessions` URL restore), so the query never
-  // runs on the General/Logs tabs.
-  const ensureLoginSessionLoaded = useEffectEvent(() => {
+  const [loginHistoryQueryRef, loadLoginHistoryQuery] =
+    useQueryLoader<LoginHistoryQueryType>(LoginHistoryQuery);
+  // Lazily fetch a tab's data only once it becomes active (covers both a tab
+  // click and a direct `?tab=...` URL restore), so neither query runs while the
+  // General/Logs tabs are shown.
+  const ensureActiveTabQueryLoaded = useEffectEvent(() => {
     if (curTabKey === 'login-sessions' && !loginSessionQueryRef) {
       loadLoginSessionQuery(
         {
@@ -56,10 +60,20 @@ const UserPreferencesPage = () => {
         { fetchPolicy: 'store-and-network' },
       );
     }
+    if (curTabKey === 'login-history' && !loginHistoryQueryRef) {
+      loadLoginHistoryQuery(
+        {
+          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
+          limit: 10,
+          offset: 0,
+        },
+        { fetchPolicy: 'store-and-network' },
+      );
+    }
   });
   useEffect(
-    function loadLoginSessionOnTabActivation() {
-      ensureLoginSessionLoaded();
+    function loadActiveTabQueryOnActivation() {
+      ensureActiveTabQueryLoaded();
     },
     [curTabKey],
   );
@@ -409,6 +423,10 @@ const UserPreferencesPage = () => {
             key: 'login-sessions',
             label: t('userSettings.LoginSessions'),
           },
+          {
+            key: 'login-history',
+            label: t('userSettings.LoginHistory'),
+          },
         ]}
       >
         <Suspense fallback={<Skeleton active />}>
@@ -433,6 +451,18 @@ const UserPreferencesPage = () => {
                 <LoginSession
                   queryRef={loginSessionQueryRef}
                   onReload={loadLoginSessionQuery}
+                />
+              ) : (
+                <Skeleton active />
+              )}
+            </BAIErrorBoundary>
+          )}
+          {curTabKey === 'login-history' && (
+            <BAIErrorBoundary>
+              {loginHistoryQueryRef ? (
+                <LoginHistory
+                  queryRef={loginHistoryQueryRef}
+                  onReload={loadLoginHistoryQuery}
                 />
               ) : (
                 <Skeleton active />

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1868,6 +1868,12 @@
       "LoginWithSAML": "Anmeldung mit SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Domain",
+    "FailReason": "Fehlergrund",
+    "LoginTime": "Anmeldezeit",
+    "Result": "Ergebnis"
+  },
   "loginSession": {
     "AccessKey": "Zugriffsschlüssel",
     "CreatedAt": "Erstellt am",
@@ -3357,6 +3363,7 @@
     "Language": "Sprache",
     "LightMode": "Lichtmodus",
     "LightTheme": "Hellmodus",
+    "LoginHistory": "Anmeldeverlauf",
     "LoginSessions": "Anmeldesitzungen",
     "Logo": "CI-Logo",
     "Logs": "Protokolle",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1866,6 +1866,12 @@
       "LoginWithSAML": "Σύνδεση με SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Τομέας",
+    "FailReason": "Αιτία αποτυχίας",
+    "LoginTime": "Ώρα σύνδεσης",
+    "Result": "Αποτέλεσμα"
+  },
   "loginSession": {
     "AccessKey": "Κλειδί πρόσβασης",
     "CreatedAt": "Δημιουργήθηκε στο",
@@ -3355,6 +3361,7 @@
     "Language": "Γλώσσα",
     "LightMode": "Λειτουργία φωτός",
     "LightTheme": "Φωτεινή λειτουργία",
+    "LoginHistory": "Ιστορικό συνδέσεων",
     "LoginSessions": "Συνεδρίες Σύνδεσης",
     "Logo": "Λογότυπο CI",
     "Logs": "Κούτσουρα",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1856,6 +1856,12 @@
       "LoginWithSAML": "Login with SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Domain",
+    "FailReason": "Failure Reason",
+    "LoginTime": "Login Time",
+    "Result": "Result"
+  },
   "loginSession": {
     "AccessKey": "Access Key",
     "CreatedAt": "Created At",
@@ -3345,6 +3351,7 @@
     "Language": "Language",
     "LightMode": "Light mode",
     "LightTheme": "Light Mode",
+    "LoginHistory": "Login History",
     "LoginSessions": "Login Sessions",
     "Logo": "Logo CI",
     "Logs": "Logs",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1866,6 +1866,12 @@
       "LoginWithSAML": "Inicio de sesión con SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Dominio",
+    "FailReason": "Motivo del error",
+    "LoginTime": "Hora de inicio de sesión",
+    "Result": "Resultado"
+  },
   "loginSession": {
     "AccessKey": "Clave de acceso",
     "CreatedAt": "Creado en",
@@ -3355,6 +3361,7 @@
     "Language": "Idioma",
     "LightMode": "Modo de luz",
     "LightTheme": "Modo claro",
+    "LoginHistory": "Historial de inicio de sesión",
     "LoginSessions": "Sesiones de inicio de sesión",
     "Logo": "Logotipo de CI",
     "Logs": "Registros",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1866,6 +1866,12 @@
       "LoginWithSAML": "Kirjautuminen SAML:llä"
     }
   },
+  "loginHistory": {
+    "Domain": "Toimialue",
+    "FailReason": "Epäonnistumisen syy",
+    "LoginTime": "Kirjautumisaika",
+    "Result": "Tulos"
+  },
   "loginSession": {
     "AccessKey": "Pääsyavain",
     "CreatedAt": "Luotu klo",
@@ -3355,6 +3361,7 @@
     "Language": "Kieli",
     "LightMode": "Valotila",
     "LightTheme": "Vaalea tila",
+    "LoginHistory": "Kirjautumishistoria",
     "LoginSessions": "Kirjautumisistunnot",
     "Logo": "CI-logo",
     "Logs": "Lokit",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1867,6 +1867,12 @@
       "LoginWithSAML": "Se connecter avec SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Domaine",
+    "FailReason": "Raison de l'échec",
+    "LoginTime": "Heure de connexion",
+    "Result": "Résultat"
+  },
   "loginSession": {
     "AccessKey": "Clé d'accès",
     "CreatedAt": "Créé à",
@@ -3358,6 +3364,7 @@
     "Language": "Langue",
     "LightMode": "Mode lumière",
     "LightTheme": "Mode clair",
+    "LoginHistory": "Historique de connexion",
     "LoginSessions": "Sessions de connexion",
     "Logo": "Logo d'intégration continue",
     "Logs": "Journaux",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1869,6 +1869,12 @@
       "LoginWithSAML": "Masuk dengan SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Domain",
+    "FailReason": "Alasan Kegagalan",
+    "LoginTime": "Waktu Login",
+    "Result": "Hasil"
+  },
   "loginSession": {
     "AccessKey": "Kunci Akses",
     "CreatedAt": "Dibuat Pada",
@@ -3359,6 +3365,7 @@
     "Language": "Bahasa",
     "LightMode": "Modus Cahaya",
     "LightTheme": "Mode Terang",
+    "LoginHistory": "Riwayat Login",
     "LoginSessions": "Sesi Login",
     "Logo": "Logo CI",
     "Logs": "Log",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1866,6 +1866,12 @@
       "LoginWithSAML": "Accesso con SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Dominio",
+    "FailReason": "Motivo dell'errore",
+    "LoginTime": "Ora di accesso",
+    "Result": "Risultato"
+  },
   "loginSession": {
     "AccessKey": "Chiave di accesso",
     "CreatedAt": "Creato a",
@@ -3355,6 +3361,7 @@
     "Language": "linguaggio",
     "LightMode": "Modalità luce",
     "LightTheme": "Modalità chiara",
+    "LoginHistory": "Cronologia degli accessi",
     "LoginSessions": "Sessioni di accesso",
     "Logo": "Logo CI",
     "Logs": "Registri",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1871,6 +1871,12 @@
       "LoginWithSAML": "SAMLログイン"
     }
   },
+  "loginHistory": {
+    "Domain": "ドメイン",
+    "FailReason": "失敗の理由",
+    "LoginTime": "ログイン日時",
+    "Result": "結果"
+  },
   "loginSession": {
     "AccessKey": "アクセスキー",
     "CreatedAt": "作成日",
@@ -3360,6 +3366,7 @@
     "Language": "言語",
     "LightMode": "ライトモード",
     "LightTheme": "ライトモード",
+    "LoginHistory": "ログイン履歴",
     "LoginSessions": "ログインセッション",
     "Logo": "CIロゴ",
     "Logs": "ログ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1871,6 +1871,12 @@
       "LoginWithSAML": "SAML 로그인"
     }
   },
+  "loginHistory": {
+    "Domain": "도메인",
+    "FailReason": "실패 사유",
+    "LoginTime": "로그인 시각",
+    "Result": "결과"
+  },
   "loginSession": {
     "AccessKey": "액세스 키",
     "CreatedAt": "생성 시각",
@@ -3361,6 +3367,7 @@
     "Language": "언어",
     "LightMode": "라이트 모드",
     "LightTheme": "라이트 모드",
+    "LoginHistory": "로그인 기록",
     "LoginSessions": "로그인 세션",
     "Logo": "로고 CI",
     "Logs": "로그",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1867,6 +1867,12 @@
       "LoginWithSAML": "SAML-ээр нэвтэрнэ үү"
     }
   },
+  "loginHistory": {
+    "Domain": "Домэйн",
+    "FailReason": "Амжилтгүй болсон шалтгаан",
+    "LoginTime": "Нэвтэрсэн цаг",
+    "Result": "Үр дүн"
+  },
   "loginSession": {
     "AccessKey": "Хандалтын түлхүүр",
     "CreatedAt": "Үүсгэсэн",
@@ -3357,6 +3363,7 @@
     "Language": "Хэл",
     "LightMode": "Гэрэл горим",
     "LightTheme": "Цайвар горим",
+    "LoginHistory": "Нэвтрэх түүх",
     "LoginSessions": "Нэвтрэх сессүүд",
     "Logo": "Лого (CI)",
     "Logs": "Бүртгэл",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1866,6 +1866,12 @@
       "LoginWithSAML": "Log masuk dengan SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Domain",
+    "FailReason": "Sebab Kegagalan",
+    "LoginTime": "Masa Log Masuk",
+    "Result": "Keputusan"
+  },
   "loginSession": {
     "AccessKey": "Kunci Akses",
     "CreatedAt": "Dicipta Pada",
@@ -3355,6 +3361,7 @@
     "Language": "Bahasa",
     "LightMode": "Mod Cahaya",
     "LightTheme": "Mod Terang",
+    "LoginHistory": "Sejarah Log Masuk",
     "LoginSessions": "Sesi Log Masuk",
     "Logo": "Logo CI",
     "Logs": "Log",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1867,6 +1867,12 @@
       "LoginWithSAML": "Logowanie za pomocą SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Domena",
+    "FailReason": "Przyczyna błędu",
+    "LoginTime": "Czas logowania",
+    "Result": "Wynik"
+  },
   "loginSession": {
     "AccessKey": "Klucz dostępu",
     "CreatedAt": "Utworzono o godz",
@@ -3358,6 +3364,7 @@
     "Language": "Język",
     "LightMode": "Tryb światła",
     "LightTheme": "Tryb jasny",
+    "LoginHistory": "Historia logowania",
     "LoginSessions": "Sesje logowania",
     "Logo": "Logo CI",
     "Logs": "Dzienniki",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1866,6 +1866,12 @@
       "LoginWithSAML": "Iniciar sessão com SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Domínio",
+    "FailReason": "Motivo da falha",
+    "LoginTime": "Hora do login",
+    "Result": "Resultado"
+  },
   "loginSession": {
     "AccessKey": "Chave de acesso",
     "CreatedAt": "Criado em",
@@ -3355,6 +3361,7 @@
     "Language": "Língua",
     "LightMode": "Modo claro",
     "LightTheme": "Modo claro",
+    "LoginHistory": "Histórico de login",
     "LoginSessions": "Sessões de login",
     "Logo": "Logotipo do CI",
     "Logs": "Histórico",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1868,6 +1868,12 @@
       "LoginWithSAML": "Iniciar sessão com SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Domínio",
+    "FailReason": "Motivo da falha",
+    "LoginTime": "Hora do login",
+    "Result": "Resultado"
+  },
   "loginSession": {
     "AccessKey": "Chave de acesso",
     "CreatedAt": "Criado em",
@@ -3357,6 +3363,7 @@
     "Language": "Língua",
     "LightMode": "Modo claro",
     "LightTheme": "Modo claro",
+    "LoginHistory": "Histórico de login",
     "LoginSessions": "Sessões de login",
     "Logo": "Logotipo CI",
     "Logs": "Histórico",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1866,6 +1866,12 @@
       "LoginWithSAML": "Вход в систему с помощью SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Домен",
+    "FailReason": "Причина сбоя",
+    "LoginTime": "Время входа",
+    "Result": "Результат"
+  },
   "loginSession": {
     "AccessKey": "Ключ доступа",
     "CreatedAt": "Создано в",
@@ -3355,6 +3361,7 @@
     "Language": "Язык",
     "LightMode": "Светлый режим",
     "LightTheme": "Светлый режим",
+    "LoginHistory": "История входов",
     "LoginSessions": "Сеансы входа",
     "Logo": "Логотип CI",
     "Logs": "Журналы",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1871,6 +1871,12 @@
       "LoginWithSAML": "เข้าสู่ระบบด้วย SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "โดเมน",
+    "FailReason": "สาเหตุที่ล้มเหลว",
+    "LoginTime": "เวลาเข้าสู่ระบบ",
+    "Result": "ผลลัพธ์"
+  },
   "loginSession": {
     "AccessKey": "คีย์การเข้าถึง",
     "CreatedAt": "สร้างเมื่อ",
@@ -3360,6 +3366,7 @@
     "Language": "ภาษา",
     "LightMode": "โหมดสว่าง",
     "LightTheme": "โหมดสว่าง",
+    "LoginHistory": "ประวัติการเข้าสู่ระบบ",
     "LoginSessions": "เซสชันเข้าสู่ระบบ",
     "Logo": "โลโก้ CI",
     "Logs": "บันทึก",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1866,6 +1866,12 @@
       "LoginWithSAML": "SAML ile Oturum Açma"
     }
   },
+  "loginHistory": {
+    "Domain": "Alan Adı",
+    "FailReason": "Hata Nedeni",
+    "LoginTime": "Oturum Açma Zamanı",
+    "Result": "Sonuç"
+  },
   "loginSession": {
     "AccessKey": "Erişim Anahtarı",
     "CreatedAt": "Oluşturulma Tarihi",
@@ -3355,6 +3361,7 @@
     "Language": "Dil",
     "LightMode": "Işık Modu",
     "LightTheme": "Açık Mod",
+    "LoginHistory": "Giriş Geçmişi",
     "LoginSessions": "Oturum Açma Oturumları",
     "Logo": "Logo CI",
     "Logs": "Kütükler",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1868,6 +1868,12 @@
       "LoginWithSAML": "Đăng nhập bằng SAML"
     }
   },
+  "loginHistory": {
+    "Domain": "Miền",
+    "FailReason": "Lý do thất bại",
+    "LoginTime": "Thời gian đăng nhập",
+    "Result": "Kết quả"
+  },
   "loginSession": {
     "AccessKey": "Khóa truy cập",
     "CreatedAt": "Được tạo tại",
@@ -3357,6 +3363,7 @@
     "Language": "Ngôn ngữ",
     "LightMode": "Chế độ sáng",
     "LightTheme": "Chế độ sáng",
+    "LoginHistory": "Lịch sử đăng nhập",
     "LoginSessions": "Phiên đăng nhập",
     "Logo": "Biểu tượng CI",
     "Logs": "Nhật ký",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1868,6 +1868,12 @@
       "LoginWithSAML": "使用 SAML 登录"
     }
   },
+  "loginHistory": {
+    "Domain": "域",
+    "FailReason": "失败原因",
+    "LoginTime": "登录时间",
+    "Result": "结果"
+  },
   "loginSession": {
     "AccessKey": "访问密钥",
     "CreatedAt": "创建于",
@@ -3357,6 +3363,7 @@
     "Language": "语",
     "LightMode": "灯光模式",
     "LightTheme": "浅色模式",
+    "LoginHistory": "登录历史",
     "LoginSessions": "登录会话",
     "Logo": "徽标（CI）",
     "Logs": "日志",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1869,6 +1869,12 @@
       "LoginWithSAML": "使用 SAML 登录"
     }
   },
+  "loginHistory": {
+    "Domain": "網域",
+    "FailReason": "失敗原因",
+    "LoginTime": "登入時間",
+    "Result": "結果"
+  },
   "loginSession": {
     "AccessKey": "存取密鑰",
     "CreatedAt": "創建於",
@@ -3359,6 +3365,7 @@
     "Language": "語",
     "LightMode": "燈光模式",
     "LightTheme": "淺色模式",
+    "LoginHistory": "登入記錄",
     "LoginSessions": "登入工作階段",
     "Logo": "標誌（CI）",
     "Logs": "日誌",


### PR DESCRIPTION
Resolves #8049 (FR-3216)

> **Stacked on** #8054 (FR-3215 — add login sessions tab to user settings)

## Summary

Adds a **Login History** tab to the User Settings page, letting the current user review their own login attempt history. This mirrors the Login Sessions tab introduced in FR-3215 (#8054); the legacy view lived in the old Control Panel.

Login history is **read-only**, so unlike Login Sessions there is no mutation / row action here — the focus is filtering, sorting, and pagination over the `myLoginHistoryV2` connection.

## Changes

- **`LoginHistoryTable`** (presentational) — `BAITable` over a `LoginHistoryV2` plural fragment. Columns: Result, Domain, Login Time, Failure Reason. Sortable on Result / Domain / Login Time. The result is shown as the **raw server enum value** (e.g. `SUCCESS`, `FAILED_INVALID_CREDENTIALS`) wrapped in a color-coded `BAITag` (green = success, red = failure, neutral/amber = lifecycle events).
- **`LoginHistory`** (query orchestrator) — reads a preloaded `myLoginHistoryV2` query via `usePreloadedQuery`, with a `BAIGraphQLPropertyFilter` (result enum, domain name, created-at) and a refresh button. Uses the deferred-queryRef pattern for inline loading, same as `LoginSession`.
- **`UserSettingsPage`** — new `login-history` tab, lazily loaded on tab activation (covers `?tab=login-history` URL restore). The login-sessions and login-history lazy-loads now share a single `useEffectEvent` + `useEffect` keyed on the active tab.
- **Pagination** — offset/limit only (`limit` + `offset`), per the V2-connection single-mode rule. No cursor args mixed in.
- **i18n** — new `loginHistory.*` column labels (Result / Domain / Login Time / Failure Reason) and `userSettings.LoginHistory`, translated across all 22 languages. The login-result **value** itself is intentionally not translated — it is shown as the raw server enum.

## Screenshots

### Login History tab (raw result enum + offset pagination — 253 entries)
![login history table](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8057/20260626-193125-lh-table-final.png)

### Filterable properties (result / domain / login time)
![login history filter](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8057/20260626-193127-lh-filter-final.png)

## Notes

- The Jira ticket originally described an **admin** view of all users' login history (migrated from Control Panel). Per discussion with the requester, this PR was scoped to the **user's own** login history tab in User Settings, mirroring the FR-3215 login-sessions tab (`myLoginHistoryV2` rather than `adminLoginHistoryV2`). The admin-facing requirement is preserved as a follow-up: **FR-3220**.
- The `LoginHistoryV2` schema has no source-IP / client field, so that column from the ticket's wishlist is omitted.

## Verification

`bash scripts/verify.sh` — Lint / Format / TypeScript **PASS**. Relay artifacts compiled and committed. Manually verified end-to-end against a live backend: tab loads, raw result tags render, sorting works, and offset pagination pages through 253 entries (see screenshots).