### PR TITLE
feat(FR-3222): migrate User Resource Policy page to Strawberry V2 GraphQL

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -903,6 +903,11 @@ type AppConfigAllowList implements Node
   """Scope type the entry permits writes at (public | domain | user)."""
   scopeType: AppConfigScopeType!
 
+  """
+  Added in 26.8.0. Merge rank applied to fragments under this entry (low to high; higher wins).
+  """
+  rank: Int!
+
   """Creation timestamp (UTC)."""
   createdAt: DateTime!
 
@@ -986,6 +991,7 @@ enum AppConfigAllowListOrderField
 {
   CONFIG_NAME @join__enumValue(graph: STRAWBERRY)
   SCOPE_TYPE @join__enumValue(graph: STRAWBERRY)
+  RANK @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
@@ -1652,6 +1658,9 @@ input AuditLogFilter
   status: AuditLogStatusFilter = null
   createdAt: DateTimeFilter = null
   triggeredBy: StringFilter = null
+
+  """Added in 26.8.0. Filter by acted_as (the effective/acting user UUID)."""
+  actedAs: UUIDFilter = null
   AND: [AuditLogFilter!] = null
   OR: [AuditLogFilter!] = null
   NOT: [AuditLogFilter!] = null
@@ -1805,6 +1814,11 @@ type AuditLogV2 implements Node
   """UUID string of the user who triggered the action."""
   triggeredBy: String
 
+  """
+  Added in 26.8.0. UUID of the effective (acting) user the action ran as. Differs from triggered_by only while a super admin is impersonating a target.
+  """
+  actedAs: UUID
+
   """Human-readable description of the operation."""
   description: String!
 
@@ -1818,6 +1832,11 @@ type AuditLogV2 implements Node
   The user who triggered this audit log entry, resolved from triggered_by UUID.
   """
   user: UserV2
+
+  """
+  Added in 26.8.0. The effective (acting) user the action ran as, resolved from acted_as UUID. Differs from user only while a super admin is impersonating a target.
+  """
+  actor: UserV2
 }
 
 """Added in 26.3.0. Connection type for paginated audit log results."""
@@ -2042,8 +2061,10 @@ Added in 26.4.2. Binary size with both raw bytes and human-readable format.
 type BinarySizeInfo
   @join__type(graph: STRAWBERRY)
 {
-  """Size in bytes."""
-  value: Int!
+  """
+  Exact size in bytes as a decimal string (e.g., '1073741824'); accepted as BinarySizeInput.expr.
+  """
+  expr: String!
 
   """Size in human-readable format (e.g., '1g', '512m')."""
   display: String!
@@ -2977,6 +2998,56 @@ type ComputePlugins
   entries: [ComputePluginEntry!]!
 }
 
+"""
+Added in 26.8.0. Compute a session's scheduling against a resource group without provisioning.
+"""
+input ComputeScheduleInput
+  @join__type(graph: STRAWBERRY)
+{
+  kernels: [ComputeScheduleKernelResourceInput!]!
+  clusterMode: SessionClusterMode!
+  resourceGroupId: ID!
+}
+
+"""
+Added in 26.8.0. Per-kernel resource request for a compute-schedule. The image is optional when a resource-group default supplies it downstream.
+"""
+input ComputeScheduleKernelResourceInput
+  @join__type(graph: STRAWBERRY)
+{
+  imageId: ID = null
+  resources: [ResourceSlotEntryInput!] = null
+}
+
+"""
+Added in 26.8.0. Compute-schedule outcome for a single kernel. Results correspond positionally to the requested kernels.
+"""
+type ComputeScheduleKernelResult
+  @join__type(graph: STRAWBERRY)
+{
+  """Resource slots resolved for this kernel after applying defaults."""
+  requestedSlots: [ResourceSlotEntry!]!
+
+  """Architecture resolved for this kernel."""
+  requestedArchitecture: String!
+
+  """Whether this kernel could be scheduled onto a target node."""
+  success: Boolean!
+
+  """What to change so the kernel would fit. Null when success is True."""
+  reasonHint: UnschedulableReasonHint
+}
+
+"""Added in 26.8.0. Result of a compute-schedule request."""
+type ComputeSchedulePayload
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Per-kernel compute-schedule outcomes, correlated to the request by list index.
+  """
+  results: [ComputeScheduleKernelResult!]!
+}
+
 type ComputeSession implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
   @join__type(graph: GRAPHENE)
@@ -3448,6 +3519,11 @@ input CreateAppConfigAllowListInput
 
   """Scope at which fragments may be written (public | domain | user)."""
   scopeType: AppConfigScopeType!
+
+  """
+  Added in 26.8.0. Merge rank applied to fragments under this entry (low to high; higher wins). Defaults to the scope type's default rank (public=100, domain=200, user=300).
+  """
+  rank: Int = null
 }
 
 """Added in 26.7.0. Payload for app config allow-list entry creation."""
@@ -6949,8 +7025,13 @@ input EnqueueSessionInput
   """Resource slot allocations."""
   resourceEntries: [SessionResourceSlotEntryInput!]!
 
-  """Scaling group name."""
-  resourceGroup: String = null
+  """
+  Deprecated since 26.8.0. Use resource_group_id instead. Resource group name.
+  """
+  resourceGroup: String = null @deprecated(reason: "Use resource_group_id instead.")
+
+  """Added in 26.8.0. Resource group UUID. Auto-selected if omitted."""
+  resourceGroupId: ID = null
 
   """Additional resource options."""
   resourceOpts: SessionResourceOptsInput = null
@@ -7038,6 +7119,16 @@ input EntityFilter
 {
   entityType: RBACElementTypeFilter = null
   entityId: StringFilter = null
+
+  """
+  Added in 26.8.0. Filter by the type of scope the entity is registered in.
+  """
+  scopeType: RBACElementTypeFilter = null
+
+  """
+  Added in 26.8.0. Filter by the id of scope the entity is registered in.
+  """
+  scopeId: StringFilter = null
   AND: [EntityFilter!] = null
   OR: [EntityFilter!] = null
   NOT: [EntityFilter!] = null
@@ -8435,6 +8526,11 @@ type KernelV2 implements Node
   """Added in 26.2.0. The resource group this kernel is assigned to."""
   resourceGroup: ResourceGroup
 
+  """
+  Added in 26.8.0. Resource allocation (requested / used / allocated) computed on-demand from the resource_allocations table. Unlike the deprecated eager `resource.allocation`, `allocated` here persists after the kernel is freed or terminated (for statistics and billing).
+  """
+  resourceAllocation: ResourceAllocation!
+
   """Added in 26.3.0. The session this kernel belongs to."""
   session: SessionV2
 
@@ -9825,19 +9921,15 @@ type ModelDeployment implements Node
   """
   scalingState: ScalingState!
 
-  """
-  Added in 26.4.3. The current active revision of this deployment, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The current active revision of this deployment."""
   currentRevision: ModelRevision
 
   """
-  Added in 26.4.3. The revision currently being deployed (in progress, not yet active), resolved via DataLoader.
+  Added in 26.4.3. The revision currently being deployed (in progress, not yet active).
   """
   deployingRevision: ModelRevision
 
-  """
-  Added in 26.4.3. The user who created this deployment, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The user who created this deployment."""
   creator: UserV2
 
   """Added in 25.19.0. Deployment policy configuration."""
@@ -9885,25 +9977,19 @@ Added in 25.19.0. Contains metadata information for a model deployment including
 type ModelDeploymentMetadata
   @join__type(graph: STRAWBERRY)
 {
-  """
-  Added in 26.4.4. The resource group this deployment runs in, resolved via DataLoader.
-  """
+  """Added in 26.4.4. The resource group this deployment runs in."""
   resourceGroup: ResourceGroup
 
   """The project of this entity."""
   project: GroupNode @deprecated(reason: "Use project_v2 instead.")
 
-  """
-  Added in 26.4.3. The project this deployment belongs to, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The project this deployment belongs to."""
   projectV2: ProjectV2
 
   """The domain of this entity."""
   domain: DomainNode @deprecated(reason: "Use domain_v2 instead.")
 
-  """
-  Added in 26.4.3. The domain this deployment belongs to, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The domain this deployment belongs to."""
   domainV2: DomainV2
   projectId: ID!
   domainName: String!
@@ -10166,9 +10252,7 @@ type ModelReplica implements Node
   """
   session: ComputeSessionNode @deprecated(reason: "Use session_v2 instead.")
 
-  """
-  Added in 26.4.3. The compute session running this replica, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The compute session running this replica."""
   sessionV2: SessionV2
 
   """The revision of this entity."""
@@ -10253,19 +10337,15 @@ type ModelRevision implements Node
   """The image of this entity."""
   image: ImageNode @deprecated(reason: "Use image_v2 instead.")
 
-  """
-  Added in 26.4.3. The container image used by this revision, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The container image used by this revision."""
   imageV2: ImageV2
 
   """
-  Added in 26.4.4. The deployment-level preset that produced this revision, resolved via DataLoader. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
+  Added in 26.4.4. The deployment-level preset that produced this revision. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
   """
   revisionPreset: DeploymentRevisionPreset
 
-  """
-  Added in 26.4.4. The parent deployment owning this revision, resolved via DataLoader.
-  """
+  """Added in 26.4.4. The parent deployment owning this revision."""
   deployment: ModelDeployment
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
@@ -10390,7 +10470,9 @@ type ModelServiceConfig
   """
   startCommand: [String!] @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
   shell: String
 
   """Port number for the model service."""
@@ -10419,8 +10501,10 @@ input ModelServiceConfigInput
   """
   startCommand: [String!] = null @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
-  shell: String = null
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
+  shell: String = "/bin/bash"
 
   """Port number for the model service."""
   port: Int = null
@@ -11357,6 +11441,11 @@ type Mutation
   Added in 26.7.0. Purge an app config allow-list entry by id (super admin only).
   """
   adminPurgeAppConfigAllowList(input: PurgeAppConfigAllowListInput!): PurgeAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.8.0. Update an app config allow-list entry's rank by id (super admin only).
+  """
+  adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
@@ -12660,6 +12749,9 @@ type PredefinedAtomicPermission
 type PreemptionConfig
   @join__type(graph: STRAWBERRY)
 {
+  """Whether preemption is enabled for this resource group (opt-in)."""
+  enabled: Boolean!
+
   """Sessions with priority <= this value are eligible for preemption."""
   preemptiblePriority: Int!
 
@@ -12668,12 +12760,22 @@ type PreemptionConfig
 
   """How to preempt a session when preemption is triggered."""
   mode: PreemptionMode!
+
+  """
+  Minimum session runtime in seconds before it becomes preemptible (0 = disabled).
+  """
+  preemptionMinRuntime: Float!
 }
 
 """Added in 26.3.0. Input for preemption configuration."""
 input PreemptionConfigInput
   @join__type(graph: STRAWBERRY)
 {
+  """
+  Added in 26.8.0. Whether preemption is enabled for this resource group (opt-in). Default is false.
+  """
+  enabled: Boolean! = false
+
   """Sessions with priority <= this value are preemptible. Default is 5."""
   preemptiblePriority: Int! = 5
 
@@ -12684,6 +12786,11 @@ input PreemptionConfigInput
 
   """How to preempt sessions (TERMINATE, RESCHEDULE). Default is TERMINATE."""
   mode: PreemptionMode! = TERMINATE
+
+  """
+  Added in 26.8.0. Minimum session runtime in seconds before it becomes preemptible (0 = disabled). Default is 0.
+  """
+  preemptionMinRuntime: Float! = 0
 }
 
 """
@@ -12931,8 +13038,10 @@ input PresetModelServiceConfigInput
   """
   startCommand: [String!] = null @deprecated(reason: "Use `command` instead.")
 
-  """Shell configured for the model service."""
-  shell: String! = "/bin/bash"
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping.
+  """
+  shell: String = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""
   port: Int!
@@ -13524,6 +13633,15 @@ type ProjectUsageBucket implements Node
   """
   usageCapacityRatio: ResourceSlot
 
+  """Added in 26.8.0. The project entity this usage bucket belongs to."""
+  project: ProjectV2
+
+  """Added in 26.8.0. The domain entity this usage bucket belongs to."""
+  domain: DomainV2
+
+  """Added in 26.8.0. The resource group this usage was recorded in."""
+  resourceGroup: ResourceGroup
+
   """
   Added in 26.1.0. User usage buckets belonging to this project. Returns paginated user-level usage history for all users in this project within the same scaling group.
   """
@@ -13997,6 +14115,11 @@ input PurgeVFolderOptionsInput
   If true, also delete model card record(s) referencing the vfolder. If false, the request is rejected when any model card still references it.
   """
   cascadeModelCard: Boolean! = false
+
+  """
+  Added in 26.8.0. If true, bypass the in-use guards and purge the vfolder even when it is mounted by a live session, referenced by an active model-service endpoint, or not in a purgable status. Irreversible — use with caution. If false (default), the request is rejected in those cases.
+  """
+  force: Boolean! = false
 }
 
 """
@@ -14320,7 +14443,7 @@ type Query
   """Added in 25.5.0."""
   total_resource_slot(
     """
-    `statuses` argument is an array of session statuses. Only sessions with the specified statuses will be queried to calculate the sum of total resource slots. The argument should be an array of the following valid status values: ['PENDING', 'DEPRIORITIZING', 'SCHEDULED', 'PREPARING', 'PULLING', 'PREPARED', 'CREATING', 'RUNNING', 'RESTARTING', 'RUNNING_DEGRADED', 'TERMINATING', 'TERMINATED', 'ERROR', 'CANCELLED'].
+    `statuses` argument is an array of session statuses. Only sessions with the specified statuses will be queried to calculate the sum of total resource slots. The argument should be an array of the following valid status values: ['PENDING', 'DEPRIORITIZING', 'SCHEDULED', 'PREPARING', 'PULLING', 'PREPARED', 'CREATING', 'RUNNING', 'RESTARTING', 'RUNNING_DEGRADED', 'PREEMPTED', 'TERMINATING', 'TERMINATED', 'ERROR', 'CANCELLED'].
     Default value is null.
     """
     statuses: [String] = null
@@ -14496,6 +14619,11 @@ type Query
   Added in 26.4.4. List all registered deployment scheduling handlers (superadmin only). The returned ``name`` values are valid keys for ``DeploymentOptions.handler_options.by_handler``.
   """
   schedulingHandlers: [SchedulingHandlerNode!] @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.8.0. Compute whether a session could be created on a resource group, without actually provisioning it. Checks each kernel's resource request against the group's agents and returns per-kernel admission outcomes, with hints on what to reduce for kernels that do not fit.
+  """
+  computeSchedule(input: ComputeScheduleInput!): ComputeSchedulePayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get allowed resource groups for a domain (admin only).
@@ -15697,6 +15825,11 @@ type ResourceAllocation
   The resource slots currently used. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
   """
   used: ResourceSlot
+
+  """
+  The resource slots actually allocated, computed from the resource_allocations table. Unlike `used`, this persists after the session/kernel is freed or terminated (for statistics and billing). Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
+  """
+  allocated: ResourceSlot
 }
 
 """
@@ -16633,6 +16766,7 @@ input RoleFilter
   source: RoleSourceFilter = null
   status: RoleStatusFilter = null
   assignedUser: RoleUserNestedFilter = null
+  mappedScope: RoleMappedScopeNestedFilter = null
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
   NOT: [RoleFilter!] = null
@@ -16774,6 +16908,19 @@ input RoleInvitationUserNestedFilter
   @join__type(graph: STRAWBERRY)
 {
   email: StringFilter = null
+}
+
+"""
+Added in 26.8.0. Filter roles by the scope they are mapped (registered) to.
+"""
+input RoleMappedScopeNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  scopeType: RBACElementTypeFilter = null
+  scopeId: StringFilter = null
+  AND: [RoleMappedScopeNestedFilter!] = null
+  OR: [RoleMappedScopeNestedFilter!] = null
+  NOT: [RoleMappedScopeNestedFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for roles"""
@@ -17134,9 +17281,7 @@ type Route implements Node
   """
   session: ID @deprecated(reason: "Use session_v2 instead.")
 
-  """
-  Added in 26.4.3. The compute session associated with this route, resolved via DataLoader.
-  """
+  """Added in 26.4.3. The compute session associated with this route."""
   sessionV2: SessionV2
 
   """The revision associated with the route."""
@@ -17497,6 +17642,11 @@ type RuntimeVariantPreset implements Node
 
   """Timestamp of the last modification to this preset."""
   updatedAt: DateTime
+
+  """
+  Added in 26.8.0. The runtime variant this preset belongs to. Fetch its name and other attributes in a single query alongside the preset list.
+  """
+  runtimeVariant: RuntimeVariant
 }
 
 """Added in 26.4.2. Paginated list of runtime variant presets."""
@@ -17568,9 +17718,7 @@ Added in 26.4.4. A runtime variant preset value materialised on a revision.
 type RuntimeVariantPresetValue
   @join__type(graph: STRAWBERRY)
 {
-  """
-  The runtime variant preset this value is bound to, resolved via DataLoader.
-  """
+  """The runtime variant preset this value is bound to."""
   preset: RuntimeVariantPreset
 
   """Runtime variant preset ID."""
@@ -18442,6 +18590,11 @@ type SessionV2 implements Node
   Added in 26.4.4. The model deployment replica served by this session: a single replica instance of a model deployment that runs in this compute session and serves inference requests. Null for non-inference sessions.
   """
   replica: ModelReplica
+
+  """
+  Added in 26.8.0. Resource allocation (requested / used / allocated) computed on-demand from the resource_allocations table. Unlike the deprecated eager `resource.allocation`, `allocated` here persists after the session is freed or terminated (for statistics and billing).
+  """
+  resourceAllocation: ResourceAllocation!
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""
@@ -18628,6 +18781,7 @@ enum SessionV2Status
   CREATING @join__enumValue(graph: STRAWBERRY)
   RUNNING @join__enumValue(graph: STRAWBERRY)
   DEPRIORITIZING @join__enumValue(graph: STRAWBERRY)
+  PREEMPTED @join__enumValue(graph: STRAWBERRY)
   TERMINATING @join__enumValue(graph: STRAWBERRY)
   TERMINATED @join__enumValue(graph: STRAWBERRY)
   CANCELLED @join__enumValue(graph: STRAWBERRY)
@@ -19082,6 +19236,19 @@ type UnregisterStorageNamespacePayload
   id: UUID!
 }
 
+"""
+Added in 26.8.0. What the caller could change so an unschedulable kernel would fit. Present only when the kernel could not be scheduled.
+"""
+type UnschedulableReasonHint
+  @join__type(graph: STRAWBERRY)
+{
+  """Subtract these slots to fit the best-fitting node."""
+  requiredReduction: [ResourceSlotEntry!]
+
+  """Architectures that actually exist among the scheduling targets."""
+  availableArchs: [String!]
+}
+
 type UnsetQuotaScope
   @join__type(graph: GRAPHENE)
 {
@@ -19163,6 +19330,29 @@ input UpdateAllowedResourceGroupsForProjectInput
 
   """Resource group names to disallow."""
   remove: [String!] = null
+}
+
+"""
+Added in 26.8.0. Input for updating an app config allow-list entry (rank only).
+"""
+input UpdateAppConfigAllowListInput
+  @join__type(graph: STRAWBERRY)
+{
+  """App config allow-list entry id to update."""
+  id: UUID!
+
+  """
+  New merge rank applied to fragments under this entry (low to high; higher wins). Omit to leave unchanged.
+  """
+  rank: Int = null
+}
+
+"""Added in 26.8.0. Payload for app config allow-list entry update."""
+type UpdateAppConfigAllowListPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Updated app config allow-list entry."""
+  appConfigAllowList: AppConfigAllowList!
 }
 
 """
@@ -20849,6 +21039,18 @@ type UserUsageBucket implements Node
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
   usageCapacityRatio: ResourceSlot
+
+  """Added in 26.8.0. The user entity this usage bucket belongs to."""
+  user: UserV2
+
+  """Added in 26.8.0. The project entity this usage bucket belongs to."""
+  project: ProjectV2
+
+  """Added in 26.8.0. The domain entity this usage bucket belongs to."""
+  domain: DomainV2
+
+  """Added in 26.8.0. The resource group this usage was recorded in."""
+  resourceGroup: ResourceGroup
 }
 
 """

--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -933,6 +933,19 @@ export class Client {
       // TODO(FR-3139): simplify to '26.4.4' once rc builds are out of use.
       this._features['model-runtime-variant-preset-values'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('26.7.0')) {
+      // Strawberry V2 filter inputs gained the AND/OR/NOT sub-filter
+      // combinators (schema: "Added in 26.7.0"), which
+      // `BAIGraphQLPropertyFilter` emits when conditions are combined. Older
+      // managers reject those arguments.
+      this._features['sub-filter'] = true;
+    }
+    if (this.isManagerVersionCompatibleWith('26.8.0')) {
+      // BinarySizeInfo replaced `value: Int!` with `expr: String!` (exact
+      // bytes as a decimal string, round-trippable into BinarySizeInput.expr)
+      // in the 26.8.0 supergraph. Older managers only serve `value`.
+      this._features['binary-size-expr'] = true;
+    }
   }
 
   /**

--- a/packages/backend.ai-ui/src/__generated__/BAIAdminSessionSelectPaginatedQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminSessionSelectPaginatedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9e1cc57ae669786806f212146c46b1ec>>
+ * @generated SignedSource<<4f24a6817998dfa043a1e11d8cc901bb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
+export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREEMPTED" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
 export type SessionV2Filter = {
   AND?: ReadonlyArray<SessionV2Filter> | null | undefined;
   NOT?: ReadonlyArray<SessionV2Filter> | null | undefined;

--- a/packages/backend.ai-ui/src/__generated__/BAIAdminSessionSelectValueQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminSessionSelectValueQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ddb6b8c07d1c9bf705182ad1db18040c>>
+ * @generated SignedSource<<44a5171229c6c116842ba72817612324>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
+export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREEMPTED" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
 export type SessionV2Filter = {
   AND?: ReadonlyArray<SessionV2Filter> | null | undefined;
   NOT?: ReadonlyArray<SessionV2Filter> | null | undefined;

--- a/packages/backend.ai-ui/src/__generated__/BAILoginHistoryTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAILoginHistoryTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ae9d24b12118cc4abcd9da38a807d7eb>>
+ * @generated SignedSource<<b46502ce6db2a4e97c42f8343a01d795>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,17 +11,17 @@
 import { ReaderFragment } from 'relay-runtime';
 export type LoginAttemptResult = "EVICTED" | "EXPIRED" | "FAILED_BLOCKED" | "FAILED_INVALID_CREDENTIALS" | "FAILED_PASSWORD_EXPIRED" | "FAILED_REJECTED_BY_HOOK" | "FAILED_SESSION_ALREADY_EXISTS" | "FAILED_USER_INACTIVE" | "LOGOUT" | "REVOKED_BY_ADMIN" | "REVOKED_BY_USER" | "SUCCESS" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
-export type LoginHistoryTableFragment$data = ReadonlyArray<{
+export type BAILoginHistoryTableFragment$data = ReadonlyArray<{
   readonly createdAt: string;
   readonly domainName: string;
   readonly failReason: string | null | undefined;
   readonly id: string;
   readonly result: LoginAttemptResult;
-  readonly " $fragmentType": "LoginHistoryTableFragment";
+  readonly " $fragmentType": "BAILoginHistoryTableFragment";
 }>;
-export type LoginHistoryTableFragment$key = ReadonlyArray<{
-  readonly " $data"?: LoginHistoryTableFragment$data;
-  readonly " $fragmentSpreads": FragmentRefs<"LoginHistoryTableFragment">;
+export type BAILoginHistoryTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAILoginHistoryTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAILoginHistoryTableFragment">;
 }>;
 
 const node: ReaderFragment = {
@@ -30,7 +30,7 @@ const node: ReaderFragment = {
   "metadata": {
     "plural": true
   },
-  "name": "LoginHistoryTableFragment",
+  "name": "BAILoginHistoryTableFragment",
   "selections": [
     {
       "alias": null,
@@ -72,6 +72,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "4dfc2f6ccb6413b8af45b3902aa77534";
+(node as any).hash = "7e66ffc2186bbcd9be2f6196b9467f1c";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAILoginSessionTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAILoginSessionTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1e504c0fa59eb73844de24c968db5e42>>
+ * @generated SignedSource<<3bf8c18c092c8207b75fa939ee3288e8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type LoginSessionTableFragment$data = ReadonlyArray<{
+export type BAILoginSessionTableFragment$data = ReadonlyArray<{
   readonly accessKey: string;
   readonly createdAt: string;
   readonly id: string;
@@ -21,11 +21,11 @@ export type LoginSessionTableFragment$data = ReadonlyArray<{
     };
     readonly id: string;
   } | null | undefined;
-  readonly " $fragmentType": "LoginSessionTableFragment";
+  readonly " $fragmentType": "BAILoginSessionTableFragment";
 }>;
-export type LoginSessionTableFragment$key = ReadonlyArray<{
-  readonly " $data"?: LoginSessionTableFragment$data;
-  readonly " $fragmentSpreads": FragmentRefs<"LoginSessionTableFragment">;
+export type BAILoginSessionTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAILoginSessionTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAILoginSessionTableFragment">;
 }>;
 
 const node: ReaderFragment = (function(){
@@ -42,7 +42,7 @@ return {
   "metadata": {
     "plural": true
   },
-  "name": "LoginSessionTableFragment",
+  "name": "BAILoginSessionTableFragment",
   "selections": [
     (v0/*: any*/),
     {
@@ -102,6 +102,6 @@ return {
 };
 })();
 
-(node as any).hash = "50839f84a9d0104a9f97588cd573d626";
+(node as any).hash = "694171fd979eb4444dc4d4e07bfb034e";
 
 export default node;

--- a/packages/backend.ai-ui/src/__generated__/BAISessionNodesV2Fragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAISessionNodesV2Fragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6104a8a2f7d14791c8e5216a5dedf4ef>>
+ * @generated SignedSource<<53568254ff3c580c8d2fa5096bddcec3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type ClusterMode = "MULTI_NODE" | "SINGLE_NODE" | "%future added value";
-export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
+export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREEMPTED" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
 export type SessionV2Type = "BATCH" | "INFERENCE" | "INTERACTIVE" | "SYSTEM" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type BAISessionNodesV2Fragment$data = ReadonlyArray<{

--- a/packages/backend.ai-ui/src/__generated__/BAIUserResourcePolicyV2TableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIUserResourcePolicyV2TableFragment.graphql.ts
@@ -1,0 +1,113 @@
+/**
+ * @generated SignedSource<<a9386dc4b90d386b9e3b99da60a5889a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type BAIUserResourcePolicyV2TableFragment$data = ReadonlyArray<{
+  readonly createdAt: string | null | undefined;
+  readonly id: string;
+  readonly maxConcurrentLogins: number | null | undefined;
+  readonly maxCustomizedImageCount: number;
+  readonly maxQuotaScopeSize: {
+    readonly expr: string;
+  };
+  readonly maxSessionCountPerModelSession: number;
+  readonly maxVfolderCount: number;
+  readonly name: string;
+  readonly " $fragmentType": "BAIUserResourcePolicyV2TableFragment";
+}>;
+export type BAIUserResourcePolicyV2TableFragment$key = ReadonlyArray<{
+  readonly " $data"?: BAIUserResourcePolicyV2TableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"BAIUserResourcePolicyV2TableFragment">;
+}>;
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "BAIUserResourcePolicyV2TableFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxVfolderCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxConcurrentLogins",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxSessionCountPerModelSession",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "BinarySizeInfo",
+      "kind": "LinkedField",
+      "name": "maxQuotaScopeSize",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "expr",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxCustomizedImageCount",
+      "storageKey": null
+    }
+  ],
+  "type": "UserResourcePolicyV2",
+  "abstractKey": null
+};
+
+(node as any).hash = "3bbafb80424b36776e83739641402904";
+
+export default node;

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -1,13 +1,15 @@
 import { useBAIi18n } from '../hooks/useBAIi18n';
+import BAIButton from './BAIButton';
 import BAIFlex from './BAIFlex';
 import BAISelect from './BAISelect';
-import { CloseCircleOutlined } from '@ant-design/icons';
+import { CloseCircleOutlined, SearchOutlined } from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
 import {
   AutoComplete,
   Button,
   DatePicker,
   Input,
+  InputNumber,
   Space,
   Tag,
   Tooltip,
@@ -807,6 +809,35 @@ const BAIGraphQLPropertyFilter = <
               t('comp:BAIGraphQLPropertyFilter.SelectDateTime')
             }
           />
+        ) : selectedProperty?.type === 'number' ? (
+          // `number` properties get a numeric-only input so non-numeric text
+          // can never reach `Number(value)` and surface as a `NaN` condition.
+          // Guard the displayed value too: switching from a string property
+          // can carry over non-numeric `search`, whose `Number(...)` is `NaN`,
+          // which antd `InputNumber` cannot render.
+          <>
+            <InputNumber
+              value={
+                search === '' || Number.isNaN(Number(search))
+                  ? null
+                  : Number(search)
+              }
+              onChange={(val) => {
+                setIsValid(true);
+                setSearch(_.isNil(val) ? '' : String(val));
+              }}
+              onPressEnter={() => addCondition(search)}
+              style={{ minWidth: 200 }}
+              placeholder={
+                selectedProperty?.placeholder ??
+                t('comp:BAIPropertyFilter.PlaceHolder')
+              }
+            />
+            <BAIButton
+              icon={<SearchOutlined />}
+              onClick={() => addCondition(search)}
+            />
+          </>
         ) : (
           <Tooltip
             title={isValid || !isFocused ? '' : selectedProperty.rule?.message}

--- a/packages/backend.ai-ui/src/components/BAILoginHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/BAILoginHistoryTable.tsx
@@ -1,11 +1,3 @@
-/**
- @license
- Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
- */
-import type {
-  LoginHistoryTableFragment$data,
-  LoginHistoryTableFragment$key,
-} from '../__generated__/LoginHistoryTableFragment.graphql';
 import {
   BAIColumnsType,
   BAIColumnType,
@@ -15,14 +7,18 @@ import {
   filterOutEmpty,
   filterOutNullAndUndefined,
   type SemanticColor,
-} from 'backend.ai-ui';
+} from '..';
+import type {
+  BAILoginHistoryTableFragment$data,
+  BAILoginHistoryTableFragment$key,
+} from '../__generated__/BAILoginHistoryTableFragment.graphql';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type LoginHistoryNodeInList = NonNullable<
-  LoginHistoryTableFragment$data[number]
+  BAILoginHistoryTableFragment$data[number]
 >;
 
 type LoginAttemptResult = LoginHistoryNodeInList['result'];
@@ -89,11 +85,11 @@ const loginHistoryResultColorMap: Record<LoginAttemptResult, SemanticColor> = {
   '%future added value': 'default',
 };
 
-export interface LoginHistoryTableProps extends Omit<
+export interface BAILoginHistoryTableProps extends Omit<
   BAITableProps<LoginHistoryNodeInList>,
   'dataSource' | 'columns' | 'onChangeOrder'
 > {
-  loginHistoryFrgmt: LoginHistoryTableFragment$key;
+  loginHistoryFrgmt: BAILoginHistoryTableFragment$key;
   disableSorter?: boolean;
   customizeColumns?: (
     baseColumns: BAIColumnsType<LoginHistoryNodeInList>,
@@ -104,26 +100,26 @@ export interface LoginHistoryTableProps extends Omit<
 }
 
 /**
- * LoginHistoryTable - Presentational table over a `LoginHistoryV2` plural
+ * BAILoginHistoryTable - Presentational table over a `LoginHistoryV2` plural
  * fragment. Renders every login-history column; filter, pagination, and query
  * orchestration live in the consuming surface via the `customizeColumns` prop.
- * Login history is read-only, so unlike `LoginSessionTable` it exposes no
- * row-level actions. Mirrors the `*Nodes` idiom (`LoginSessionTable`,
+ * Login history is read-only, so unlike `BAILoginSessionTable` it exposes no
+ * row-level actions. Mirrors the `*Nodes` idiom (`BAILoginSessionTable`,
  * `SessionNodes`).
  */
-const LoginHistoryTable = ({
+const BAILoginHistoryTable = ({
   loginHistoryFrgmt,
   disableSorter,
   customizeColumns,
   onChangeOrder,
   ...tableProps
-}: LoginHistoryTableProps) => {
+}: BAILoginHistoryTableProps) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
-  const loginHistory = useFragment<LoginHistoryTableFragment$key>(
+  const loginHistory = useFragment<BAILoginHistoryTableFragment$key>(
     graphql`
-      fragment LoginHistoryTableFragment on LoginHistoryV2
+      fragment BAILoginHistoryTableFragment on LoginHistoryV2
       @relay(plural: true) {
         id
         result
@@ -139,7 +135,7 @@ const LoginHistoryTable = ({
     filterOutEmpty<BAIColumnType<LoginHistoryNodeInList>>([
       {
         key: 'result',
-        title: t('loginHistory.Result'),
+        title: t('comp:BAILoginHistoryTable.Result'),
         dataIndex: 'result',
         fixed: 'left',
         sorter: isEnableSorter('result'),
@@ -153,14 +149,14 @@ const LoginHistoryTable = ({
       },
       {
         key: 'domainName',
-        title: t('loginHistory.Domain'),
+        title: t('comp:BAILoginHistoryTable.Domain'),
         dataIndex: 'domainName',
         sorter: isEnableSorter('domainName'),
         render: (__, record) => record.domainName || '-',
       },
       {
         key: 'createdAt',
-        title: t('loginHistory.LoginTime'),
+        title: t('comp:BAILoginHistoryTable.LoginTime'),
         dataIndex: 'createdAt',
         sorter: isEnableSorter('createdAt'),
         render: (__, record) =>
@@ -168,7 +164,7 @@ const LoginHistoryTable = ({
       },
       {
         key: 'failReason',
-        title: t('loginHistory.FailReason'),
+        title: t('comp:BAILoginHistoryTable.FailReason'),
         dataIndex: 'failReason',
         render: (__, record) => record.failReason || '-',
       },
@@ -200,4 +196,4 @@ const LoginHistoryTable = ({
   );
 };
 
-export default LoginHistoryTable;
+export default BAILoginHistoryTable;

--- a/packages/backend.ai-ui/src/components/BAILoginSessionTable.tsx
+++ b/packages/backend.ai-ui/src/components/BAILoginSessionTable.tsx
@@ -1,11 +1,3 @@
-/**
- @license
- Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
- */
-import type {
-  LoginSessionTableFragment$data,
-  LoginSessionTableFragment$key,
-} from '../__generated__/LoginSessionTableFragment.graphql';
 import {
   BAIColumnsType,
   BAIColumnType,
@@ -14,14 +6,18 @@ import {
   BAIText,
   filterOutEmpty,
   filterOutNullAndUndefined,
-} from 'backend.ai-ui';
+} from '..';
+import type {
+  BAILoginSessionTableFragment$data,
+  BAILoginSessionTableFragment$key,
+} from '../__generated__/BAILoginSessionTableFragment.graphql';
+import { useBAIi18n } from '../hooks/useBAIi18n';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type LoginSessionNodeInList = NonNullable<
-  LoginSessionTableFragment$data[number]
+  BAILoginSessionTableFragment$data[number]
 >;
 
 const availableLoginSessionSorterKeys = ['createdAt'] as const;
@@ -35,11 +31,11 @@ const isEnableSorter = (key: string) => {
   return _.includes(availableLoginSessionSorterKeys, key);
 };
 
-export interface LoginSessionTableProps extends Omit<
+export interface BAILoginSessionTableProps extends Omit<
   BAITableProps<LoginSessionNodeInList>,
   'dataSource' | 'columns' | 'onChangeOrder'
 > {
-  loginSessionsFrgmt: LoginSessionTableFragment$key;
+  loginSessionsFrgmt: BAILoginSessionTableFragment$key;
   disableSorter?: boolean;
   customizeColumns?: (
     baseColumns: BAIColumnsType<LoginSessionNodeInList>,
@@ -50,25 +46,25 @@ export interface LoginSessionTableProps extends Omit<
 }
 
 /**
- * LoginSessionTable - Presentational table over a `LoginSessionV2` plural
+ * BAILoginSessionTable - Presentational table over a `LoginSessionV2` plural
  * fragment. Renders every login-session column; filter, pagination, and query
  * orchestration (plus row-level actions such as revoke) live in the consuming
  * surface via the `customizeColumns` prop. Mirrors the `*Nodes` idiom
  * (`BAIAuditLogNodes`, `SessionNodes`).
  */
-const LoginSessionTable = ({
+const BAILoginSessionTable = ({
   loginSessionsFrgmt,
   disableSorter,
   customizeColumns,
   onChangeOrder,
   ...tableProps
-}: LoginSessionTableProps) => {
+}: BAILoginSessionTableProps) => {
   'use memo';
-  const { t } = useTranslation();
+  const { t } = useBAIi18n();
 
-  const loginSessions = useFragment<LoginSessionTableFragment$key>(
+  const loginSessions = useFragment<BAILoginSessionTableFragment$key>(
     graphql`
-      fragment LoginSessionTableFragment on LoginSessionV2
+      fragment BAILoginSessionTableFragment on LoginSessionV2
       @relay(plural: true) {
         id
         accessKey
@@ -91,13 +87,13 @@ const LoginSessionTable = ({
     filterOutEmpty<BAIColumnType<LoginSessionNodeInList>>([
       {
         key: 'user',
-        title: t('loginSession.User'),
+        title: t('comp:BAILoginSessionTable.User'),
         fixed: 'left',
         render: (__, record) => record.user?.basicInfo.email || '-',
       },
       {
         key: 'accessKey',
-        title: t('loginSession.AccessKey'),
+        title: t('comp:BAILoginSessionTable.AccessKey'),
         dataIndex: 'accessKey',
         render: (__, record) =>
           record.accessKey ? (
@@ -110,7 +106,7 @@ const LoginSessionTable = ({
       },
       {
         key: 'createdAt',
-        title: t('loginSession.CreatedAt'),
+        title: t('comp:BAILoginSessionTable.CreatedAt'),
         dataIndex: 'createdAt',
         sorter: isEnableSorter('createdAt'),
         render: (__, record) =>
@@ -118,7 +114,7 @@ const LoginSessionTable = ({
       },
       {
         key: 'invalidatedAt',
-        title: t('loginSession.InvalidatedAt'),
+        title: t('comp:BAILoginSessionTable.InvalidatedAt'),
         dataIndex: 'invalidatedAt',
         render: (__, record) =>
           record.invalidatedAt
@@ -153,4 +149,4 @@ const LoginSessionTable = ({
   );
 };
 
-export default LoginSessionTable;
+export default BAILoginSessionTable;

--- a/packages/backend.ai-ui/src/components/BAIUserResourcePolicyV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUserResourcePolicyV2Table.tsx
@@ -1,0 +1,170 @@
+import {
+  BAIColumnsType,
+  BAIColumnType,
+  BAITable,
+  BAITableProps,
+  convertToDecimalUnit,
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+} from '..';
+import type {
+  BAIUserResourcePolicyV2TableFragment$data,
+  BAIUserResourcePolicyV2TableFragment$key,
+} from '../__generated__/BAIUserResourcePolicyV2TableFragment.graphql';
+import { useBAIi18n } from '../hooks/useBAIi18n';
+import dayjs from 'dayjs';
+import * as _ from 'lodash-es';
+import { graphql, useFragment } from 'react-relay';
+
+export type UserResourcePolicyV2InList = NonNullable<
+  BAIUserResourcePolicyV2TableFragment$data[number]
+>;
+
+const availableUserResourcePolicySorterKeys = [
+  'name',
+  'maxVfolderCount',
+  'maxConcurrentLogins',
+  'maxSessionCountPerModelSession',
+  'maxQuotaScopeSize',
+  'maxCustomizedImageCount',
+  'createdAt',
+] as const;
+
+export const availableUserResourcePolicySorterValues = [
+  ...availableUserResourcePolicySorterKeys,
+  ...availableUserResourcePolicySorterKeys.map((key) => `-${key}` as const),
+] as const;
+
+const isEnableSorter = (key: string) => {
+  return _.includes(availableUserResourcePolicySorterKeys, key);
+};
+
+export interface BAIUserResourcePolicyV2TableProps extends Omit<
+  BAITableProps<UserResourcePolicyV2InList>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
+  userResourcePoliciesFrgmt: BAIUserResourcePolicyV2TableFragment$key;
+  disableSorter?: boolean;
+  customizeColumns?: (
+    baseColumns: BAIColumnsType<UserResourcePolicyV2InList>,
+  ) => BAIColumnsType<UserResourcePolicyV2InList>;
+  onChangeOrder?: (
+    order: (typeof availableUserResourcePolicySorterValues)[number] | null,
+  ) => void;
+}
+
+const BAIUserResourcePolicyV2Table = ({
+  userResourcePoliciesFrgmt,
+  disableSorter,
+  customizeColumns,
+  onChangeOrder,
+  ...tableProps
+}: BAIUserResourcePolicyV2TableProps) => {
+  'use memo';
+  const { t } = useBAIi18n();
+
+  const userResourcePolicies =
+    useFragment<BAIUserResourcePolicyV2TableFragment$key>(
+      graphql`
+        fragment BAIUserResourcePolicyV2TableFragment on UserResourcePolicyV2
+        @relay(plural: true) {
+          id
+          name
+          createdAt
+          maxVfolderCount
+          maxConcurrentLogins
+          maxSessionCountPerModelSession
+          maxQuotaScopeSize {
+            expr
+          }
+          maxCustomizedImageCount
+        }
+      `,
+      userResourcePoliciesFrgmt,
+    );
+
+  const baseColumns = _.map(
+    filterOutEmpty<BAIColumnType<UserResourcePolicyV2InList>>([
+      {
+        title: t('comp:BAIUserResourcePolicyV2Table.Name'),
+        dataIndex: 'name',
+        key: 'name',
+        fixed: 'left',
+        sorter: isEnableSorter('name'),
+      },
+      {
+        title: t('comp:BAIUserResourcePolicyV2Table.MaxVFolderCount'),
+        dataIndex: 'maxVfolderCount',
+        key: 'maxVfolderCount',
+        sorter: isEnableSorter('maxVfolderCount'),
+        render: (text) => (_.toNumber(text) === 0 ? '∞' : text),
+      },
+      {
+        title: t('comp:BAIUserResourcePolicyV2Table.MaxConcurrentLogins'),
+        dataIndex: 'maxConcurrentLogins',
+        key: 'maxConcurrentLogins',
+        sorter: isEnableSorter('maxConcurrentLogins'),
+        render: (text) => (_.isNil(text) ? '∞' : text),
+      },
+      {
+        title: t(
+          'comp:BAIUserResourcePolicyV2Table.MaxSessionCountPerModelSession',
+        ),
+        dataIndex: 'maxSessionCountPerModelSession',
+        key: 'maxSessionCountPerModelSession',
+        sorter: isEnableSorter('maxSessionCountPerModelSession'),
+      },
+      {
+        title: t('comp:BAIUserResourcePolicyV2Table.MaxQuotaScopeSize'),
+        dataIndex: 'maxQuotaScopeSize',
+        key: 'maxQuotaScopeSize',
+        sorter: isEnableSorter('maxQuotaScopeSize'),
+        render: (__, row) =>
+          row.maxQuotaScopeSize.expr === '-1'
+            ? '∞'
+            : (convertToDecimalUnit(row.maxQuotaScopeSize.expr, 'auto')
+                ?.displayValue ?? '-'),
+      },
+      {
+        title: t('comp:BAIUserResourcePolicyV2Table.MaxCustomizedImageCount'),
+        dataIndex: 'maxCustomizedImageCount',
+        key: 'maxCustomizedImageCount',
+        sorter: isEnableSorter('maxCustomizedImageCount'),
+      },
+      {
+        title: t('comp:BAIUserResourcePolicyV2Table.CreatedAt'),
+        dataIndex: 'createdAt',
+        key: 'createdAt',
+        sorter: isEnableSorter('createdAt'),
+        render: (text) => (text ? dayjs(text).format('lll') : '-'),
+      },
+    ]),
+    (column) => {
+      return disableSorter ? _.omit(column, 'sorter') : column;
+    },
+  );
+
+  const allColumns = customizeColumns
+    ? customizeColumns(baseColumns)
+    : baseColumns;
+
+  return (
+    <BAITable
+      resizable
+      rowKey="id"
+      showSorterTooltip={false}
+      dataSource={filterOutNullAndUndefined(userResourcePolicies)}
+      columns={allColumns}
+      scroll={{ x: 'max-content' }}
+      onChangeOrder={(order) => {
+        onChangeOrder?.(
+          (order as (typeof availableUserResourcePolicySorterValues)[number]) ||
+            null,
+        );
+      }}
+      {...tableProps}
+    />
+  );
+};
+
+export default BAIUserResourcePolicyV2Table;

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -98,10 +98,35 @@ export {
 } from './BAIAdminUserV2Table';
 export type { UserV2InList } from './BAIAdminUserV2Table';
 export {
+  default as BAILoginHistoryTable,
+  availableLoginHistorySorterValues,
+  loginResultFilterOptions,
+} from './BAILoginHistoryTable';
+export type {
+  BAILoginHistoryTableProps,
+  LoginHistoryNodeInList,
+} from './BAILoginHistoryTable';
+export {
+  default as BAILoginSessionTable,
+  availableLoginSessionSorterValues,
+} from './BAILoginSessionTable';
+export type {
+  BAILoginSessionTableProps,
+  LoginSessionNodeInList,
+} from './BAILoginSessionTable';
+export {
   default as BAISessionNodesV2,
   availableSessionV2SorterValues,
 } from './BAISessionNodesV2';
 export type { SessionV2InList } from './BAISessionNodesV2';
+export {
+  default as BAIUserResourcePolicyV2Table,
+  availableUserResourcePolicySorterValues,
+} from './BAIUserResourcePolicyV2Table';
+export type {
+  BAIUserResourcePolicyV2TableProps,
+  UserResourcePolicyV2InList,
+} from './BAIUserResourcePolicyV2Table';
 export type { BAIUncontrolledInputProps } from './BAIUncontrolledInput';
 export { default as BAIUncontrolledInput } from './BAIUncontrolledInput';
 export { default as BAITag } from './BAITag';

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Schlüsselpaar auswählen"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Domain",
+    "FailReason": "Fehlergrund",
+    "LoginTime": "Anmeldezeit",
+    "Result": "Ergebnis"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Zugriffsschlüssel",
+    "CreatedAt": "Erstellt am",
+    "InvalidatedAt": "Ungültig seit",
+    "User": "Benutzer"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "test"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Hergestellt in",
+    "MaxConcurrentLogins": "Max. gleichzeitige Anmeldungen",
+    "MaxCustomizedImageCount": "Maximale Anzahl benutzerdefinierter Bilder",
+    "MaxQuotaScopeSize": "Maximale Größe des Ordners",
+    "MaxSessionCountPerModelSession": "Maximale Sitzungsanzahl pro Modellsitzung",
+    "MaxVFolderCount": "Maximale Ordneranzahl",
+    "Name": "Name"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Benutzer auswählen"

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Επιλέξτε ζεύγος κλειδιών"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Τομέας",
+    "FailReason": "Αιτία αποτυχίας",
+    "LoginTime": "Ώρα σύνδεσης",
+    "Result": "Αποτέλεσμα"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Κλειδί πρόσβασης",
+    "CreatedAt": "Δημιουργήθηκε στο",
+    "InvalidatedAt": "Ακυρώθηκε στο",
+    "User": "Χρήστης"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "δοκιμή"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Δημιουργήθηκε στο",
+    "MaxConcurrentLogins": "Μέγιστες ταυτόχρονες συνδέσεις",
+    "MaxCustomizedImageCount": "Μέγιστος προσαρμοσμένος αριθμός εικόνων",
+    "MaxQuotaScopeSize": "Μέγιστο μέγεθος φακέλου",
+    "MaxSessionCountPerModelSession": "Μέγιστος αριθμός περιόδων σύνδεσης ανά περίοδο λειτουργίας μοντέλου",
+    "MaxVFolderCount": "Μέγιστος αριθμός φακέλων",
+    "Name": "Ονομα"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Επιλογή χρήστη"

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Select Keypair"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Domain",
+    "FailReason": "Failure Reason",
+    "LoginTime": "Login Time",
+    "Result": "Result"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Access Key",
+    "CreatedAt": "Created At",
+    "InvalidatedAt": "Invalidated At",
+    "User": "User"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "Test"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Created At",
+    "MaxConcurrentLogins": "Max Concurrent Logins",
+    "MaxCustomizedImageCount": "Max Customized Image Count",
+    "MaxQuotaScopeSize": "Max Folder Size",
+    "MaxSessionCountPerModelSession": "Max Session Count Per Model Session",
+    "MaxVFolderCount": "Max Folder Count",
+    "Name": "Name"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Select User"

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Seleccionar par de claves"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Dominio",
+    "FailReason": "Motivo del error",
+    "LoginTime": "Hora de inicio de sesión",
+    "Result": "Resultado"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Clave de acceso",
+    "CreatedAt": "Creado en",
+    "InvalidatedAt": "Invalidado en",
+    "User": "Usuario"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "prueba"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Creado en",
+    "MaxConcurrentLogins": "Máx. de inicios de sesión simultáneos",
+    "MaxCustomizedImageCount": "Número máximo de imágenes personalizadas",
+    "MaxQuotaScopeSize": "Tamaño máximo de carpeta",
+    "MaxSessionCountPerModelSession": "Recuento máximo de sesiones por sesión de modelo",
+    "MaxVFolderCount": "Número máximo de carpetas",
+    "Name": "Nombre"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Seleccionar usuario"

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Valitse avainpari"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Toimialue",
+    "FailReason": "Epäonnistumisen syy",
+    "LoginTime": "Kirjautumisaika",
+    "Result": "Tulos"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Pääsyavain",
+    "CreatedAt": "Luotu klo",
+    "InvalidatedAt": "Mitätöity klo",
+    "User": "Käyttäjä"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "testi"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Luotu klo",
+    "MaxConcurrentLogins": "Samanaikaisten kirjautumisten enimmäismäärä",
+    "MaxCustomizedImageCount": "Suurin mukautettu kuvien määrä",
+    "MaxQuotaScopeSize": "Kansioiden enimmäiskoko",
+    "MaxSessionCountPerModelSession": "Maksimi istuntojen määrä malliistuntoa kohti",
+    "MaxVFolderCount": "Kansioiden enimmäismäärä",
+    "Name": "Nimi"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Valitse käyttäjä"

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Sélectionner une paire de clés"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Domaine",
+    "FailReason": "Raison de l'échec",
+    "LoginTime": "Heure de connexion",
+    "Result": "Résultat"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Clé d'accès",
+    "CreatedAt": "Créé à",
+    "InvalidatedAt": "Invalidé à",
+    "User": "Utilisateur"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "test"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Créé à",
+    "MaxConcurrentLogins": "Connexions simultanées max.",
+    "MaxCustomizedImageCount": "Nombre maximal d'images personnalisées",
+    "MaxQuotaScopeSize": "Taille maximale du dossier",
+    "MaxSessionCountPerModelSession": "Nombre maximum de sessions par session de modèle",
+    "MaxVFolderCount": "Nombre maximum de dossiers",
+    "Name": "Nom"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Sélectionner un utilisateur"

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Pilih Keypair"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Domain",
+    "FailReason": "Alasan Kegagalan",
+    "LoginTime": "Waktu Login",
+    "Result": "Hasil"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Kunci Akses",
+    "CreatedAt": "Dibuat Pada",
+    "InvalidatedAt": "Dibatalkan Pada",
+    "User": "Pengguna"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "tes"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Dibuat di",
+    "MaxConcurrentLogins": "Login Bersamaan Maksimum",
+    "MaxCustomizedImageCount": "Jumlah Gambar Khusus Maksimum",
+    "MaxQuotaScopeSize": "Ukuran Folder Maks",
+    "MaxSessionCountPerModelSession": "Jumlah Sesi Maks Per Sesi Model",
+    "MaxVFolderCount": "Jumlah Folder Maks",
+    "Name": "Nama"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Pilih Pengguna"

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Seleziona coppia di chiavi"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Dominio",
+    "FailReason": "Motivo dell'errore",
+    "LoginTime": "Ora di accesso",
+    "Result": "Risultato"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Chiave di accesso",
+    "CreatedAt": "Creato a",
+    "InvalidatedAt": "Invalidato a",
+    "User": "Utente"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "test"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Creato a",
+    "MaxConcurrentLogins": "Accessi simultanei massimi",
+    "MaxCustomizedImageCount": "Conteggio massimo di immagini personalizzate",
+    "MaxQuotaScopeSize": "Dimensione massima della cartella",
+    "MaxSessionCountPerModelSession": "Conteggio massimo delle sessioni per sessione del modello",
+    "MaxVFolderCount": "Conteggio massimo cartelle",
+    "Name": "Nome"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Seleziona utente"

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "キーペアを選択"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "ドメイン",
+    "FailReason": "失敗の理由",
+    "LoginTime": "ログイン日時",
+    "Result": "結果"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "アクセスキー",
+    "CreatedAt": "作成日",
+    "InvalidatedAt": "無効化日",
+    "User": "ユーザー"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "全画面終了",
     "Fullscreen": "全画面",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "テスト"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "作成日",
+    "MaxConcurrentLogins": "最大同時ログイン数",
+    "MaxCustomizedImageCount": "カスタマイズされた画像の最大数",
+    "MaxQuotaScopeSize": "最大フォルダサイズ",
+    "MaxSessionCountPerModelSession": "モデルセッションごとの最大セッション数",
+    "MaxVFolderCount": "最大フォルダ数",
+    "Name": "名前"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "ユーザーを選択"

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "키페어를 선택해주세요"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "도메인",
+    "FailReason": "실패 사유",
+    "LoginTime": "로그인 시각",
+    "Result": "결과"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "액세스 키",
+    "CreatedAt": "생성 시각",
+    "InvalidatedAt": "무효화 시각",
+    "User": "사용자"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "전체 화면 종료",
     "Fullscreen": "전체 화면",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "테스트"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "생성 날짜",
+    "MaxConcurrentLogins": "최대 동시 로그인",
+    "MaxCustomizedImageCount": "최대 사용자 정의 이미지 수",
+    "MaxQuotaScopeSize": "최대 폴더 크기",
+    "MaxSessionCountPerModelSession": "모델 세션당 최대 세션 수",
+    "MaxVFolderCount": "최대 폴더 수",
+    "Name": "이름"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "사용자를 선택해주세요"

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Түлхүүрийн хос сонгох"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Домэйн",
+    "FailReason": "Амжилтгүй болсон шалтгаан",
+    "LoginTime": "Нэвтэрсэн цаг",
+    "Result": "Үр дүн"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Хандалтын түлхүүр",
+    "CreatedAt": "Үүсгэсэн",
+    "InvalidatedAt": "Хүчингүй болгосон",
+    "User": "Хэрэглэгч"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "турших"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Үүсгэсэн",
+    "MaxConcurrentLogins": "Хамгийн их зэрэгцээ нэвтрэлт",
+    "MaxCustomizedImageCount": "Хамгийн их тохируулсан зургийн тоо",
+    "MaxQuotaScopeSize": "Хавтасны хамгийн их хэмжээ",
+    "MaxSessionCountPerModelSession": "Загвар бүрийн хамгийн их сеанс тоо",
+    "MaxVFolderCount": "Хамгийн их хавтасны тоо",
+    "Name": "Нэр"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Хэрэглэгч сонгох"

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Pilih Pasangan Kunci"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Domain",
+    "FailReason": "Sebab Kegagalan",
+    "LoginTime": "Masa Log Masuk",
+    "Result": "Keputusan"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Kunci Akses",
+    "CreatedAt": "Dicipta Pada",
+    "InvalidatedAt": "Tidak Sah Pada",
+    "User": "Pengguna"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "ujian"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Dicipta Pada",
+    "MaxConcurrentLogins": "Log Masuk Serentak Maksimum",
+    "MaxCustomizedImageCount": "Kiraan Imej Tersuai Maks",
+    "MaxQuotaScopeSize": "Saiz Folder Maks",
+    "MaxSessionCountPerModelSession": "Kiraan Sesi Maks Setiap Sesi Model",
+    "MaxVFolderCount": "Kiraan Folder Maks",
+    "Name": "Nama"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Pilih Pengguna"

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Wybierz parę kluczy"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Domena",
+    "FailReason": "Przyczyna błędu",
+    "LoginTime": "Czas logowania",
+    "Result": "Wynik"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Klucz dostępu",
+    "CreatedAt": "Utworzono o godz",
+    "InvalidatedAt": "Unieważniono o godz",
+    "User": "Użytkownik"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "test"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Utworzono o godz",
+    "MaxConcurrentLogins": "Maks. liczba równoczesnych logowań",
+    "MaxCustomizedImageCount": "Maksymalna dostosowana liczba obrazów",
+    "MaxQuotaScopeSize": "Maksymalny rozmiar folderu",
+    "MaxSessionCountPerModelSession": "Maksymalna liczba sesji na sesję modelu",
+    "MaxVFolderCount": "Maksymalna liczba folderów",
+    "Name": "Nazwa"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Wybierz użytkownika"

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -213,6 +213,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Selecionar par de chaves"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Domínio",
+    "FailReason": "Motivo da falha",
+    "LoginTime": "Hora do login",
+    "Result": "Resultado"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Chave de acesso",
+    "CreatedAt": "Criado em",
+    "InvalidatedAt": "Invalidado em",
+    "User": "Usuário"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -399,6 +411,15 @@
   },
   "comp:BAITestButton": {
     "Test": "teste"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Criado em",
+    "MaxConcurrentLogins": "Máx. de logins simultâneos",
+    "MaxCustomizedImageCount": "Contagem máxima de imagens personalizadas",
+    "MaxQuotaScopeSize": "Tamanho máximo da pasta",
+    "MaxSessionCountPerModelSession": "Contagem máxima de sessões por sessão de modelo",
+    "MaxVFolderCount": "Contagem máxima de pastas",
+    "Name": "Nome"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Selecionar usuário"

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Selecionar par de chaves"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Domínio",
+    "FailReason": "Motivo da falha",
+    "LoginTime": "Hora do login",
+    "Result": "Resultado"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Chave de acesso",
+    "CreatedAt": "Criado em",
+    "InvalidatedAt": "Invalidado em",
+    "User": "Usuário"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "teste"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Criado em",
+    "MaxConcurrentLogins": "Máx. de logins simultâneos",
+    "MaxCustomizedImageCount": "Contagem máxima de imagens personalizadas",
+    "MaxQuotaScopeSize": "Tamanho máximo da pasta",
+    "MaxSessionCountPerModelSession": "Contagem máxima de sessões por sessão de modelo",
+    "MaxVFolderCount": "Contagem máxima de pastas",
+    "Name": "Nome"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Selecionar usuário"

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Выберите пару ключей"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Домен",
+    "FailReason": "Причина сбоя",
+    "LoginTime": "Время входа",
+    "Result": "Результат"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Ключ доступа",
+    "CreatedAt": "Создано в",
+    "InvalidatedAt": "Аннулировано в",
+    "User": "Пользователь"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "тест"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Создан в",
+    "MaxConcurrentLogins": "Максимум одновременных входов",
+    "MaxCustomizedImageCount": "Максимальное количество индивидуальных изображений",
+    "MaxQuotaScopeSize": "Максимальный размер папки",
+    "MaxSessionCountPerModelSession": "Максимальное количество сеансов на модельный сеанс",
+    "MaxVFolderCount": "Максимальное количество папок",
+    "Name": "Имя"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Выберите пользователя"

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "เลือกคู่คีย์"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "โดเมน",
+    "FailReason": "สาเหตุที่ล้มเหลว",
+    "LoginTime": "เวลาเข้าสู่ระบบ",
+    "Result": "ผลลัพธ์"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "คีย์การเข้าถึง",
+    "CreatedAt": "สร้างเมื่อ",
+    "InvalidatedAt": "ถูกยกเลิกเมื่อ",
+    "User": "ผู้ใช้"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "ทดสอบ"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "สร้างเมื่อ",
+    "MaxConcurrentLogins": "จำนวนการเข้าสู่ระบบพร้อมกันสูงสุด",
+    "MaxCustomizedImageCount": "จำนวนอิมเมจที่กำหนดเองสูงสุด",
+    "MaxQuotaScopeSize": "ขนาดโฟลเดอร์สูงสุด",
+    "MaxSessionCountPerModelSession": "จำนวนเซสชันสูงสุดต่อเซสชันโมเดล",
+    "MaxVFolderCount": "จำนวนโฟลเดอร์สูงสุด",
+    "Name": "ชื่อ"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "เลือกผู้ใช้"

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Anahtar Çifti Seçin"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Alan Adı",
+    "FailReason": "Hata Nedeni",
+    "LoginTime": "Oturum Açma Zamanı",
+    "Result": "Sonuç"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Erişim Anahtarı",
+    "CreatedAt": "Oluşturulma Tarihi",
+    "InvalidatedAt": "Geçersizleştirilme Tarihi",
+    "User": "Kullanıcı"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "test"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Oluşturulma Tarihi",
+    "MaxConcurrentLogins": "Maksimum eşzamanlı oturum açma",
+    "MaxCustomizedImageCount": "Maksimum Özelleştirilmiş Görüntü Sayısı",
+    "MaxQuotaScopeSize": "Maksimum Klasör Boyutu",
+    "MaxSessionCountPerModelSession": "Model Oturumu Başına Maksimum Oturum Sayısı",
+    "MaxVFolderCount": "Maksimum Klasör Sayısı",
+    "Name": "isim"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Kullanıcıyı Seç"

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Chọn cặp khóa"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "Miền",
+    "FailReason": "Lý do thất bại",
+    "LoginTime": "Thời gian đăng nhập",
+    "Result": "Kết quả"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "Khóa truy cập",
+    "CreatedAt": "Được tạo tại",
+    "InvalidatedAt": "Bị vô hiệu tại",
+    "User": "Người dùng"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "Exit fullscreen",
     "Fullscreen": "Fullscreen",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "kiểm tra"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "Được tạo tại",
+    "MaxConcurrentLogins": "Số lần đăng nhập đồng thời tối đa",
+    "MaxCustomizedImageCount": "Số lượng hình ảnh tùy chỉnh tối đa",
+    "MaxQuotaScopeSize": "Kích thước thư mục tối đa",
+    "MaxSessionCountPerModelSession": "Số phiên tối đa trên mỗi phiên mô hình",
+    "MaxVFolderCount": "Số lượng thư mục tối đa",
+    "Name": "Tên"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Chọn người dùng"

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "选择密钥对"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "域",
+    "FailReason": "失败原因",
+    "LoginTime": "登录时间",
+    "Result": "结果"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "访问密钥",
+    "CreatedAt": "创建于",
+    "InvalidatedAt": "失效于",
+    "User": "用户"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "退出全屏",
     "Fullscreen": "全屏",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "测试"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "创建于",
+    "MaxConcurrentLogins": "最大并发登录数",
+    "MaxCustomizedImageCount": "最大自定义图像数量",
+    "MaxQuotaScopeSize": "文件夹最大尺寸",
+    "MaxSessionCountPerModelSession": "每个模型会话的最大会话计数",
+    "MaxVFolderCount": "最大文件夹数",
+    "Name": "名称"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "选择用户"

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -207,6 +207,18 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "選擇金鑰對"
   },
+  "comp:BAILoginHistoryTable": {
+    "Domain": "網域",
+    "FailReason": "失敗原因",
+    "LoginTime": "登入時間",
+    "Result": "結果"
+  },
+  "comp:BAILoginSessionTable": {
+    "AccessKey": "存取密鑰",
+    "CreatedAt": "創建於",
+    "InvalidatedAt": "失效於",
+    "User": "使用者"
+  },
   "comp:BAIModal": {
     "ExitFullscreen": "退出全螢幕",
     "Fullscreen": "全螢幕",
@@ -393,6 +405,15 @@
   },
   "comp:BAITestButton": {
     "Test": "測試"
+  },
+  "comp:BAIUserResourcePolicyV2Table": {
+    "CreatedAt": "創建於",
+    "MaxConcurrentLogins": "最大並發登入數",
+    "MaxCustomizedImageCount": "最大自訂圖像數量",
+    "MaxQuotaScopeSize": "文件夹最大尺寸",
+    "MaxSessionCountPerModelSession": "每個模型會話的最大會話計數",
+    "MaxVFolderCount": "最大資料夾數",
+    "Name": "名稱"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "選擇使用者"

--- a/react/src/__generated__/AdminDeploymentPresetSettingPageCreateMutation.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetSettingPageCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<837892dcee88bb7a9639eb8158ad2d86>>
+ * @generated SignedSource<<5fd4151c93dbeed64db2bc9a56772a03>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -62,7 +62,7 @@ export type PresetModelServiceConfigInput = {
   healthCheck?: PresetModelHealthCheckInput | null | undefined;
   port: number;
   preStartActions: ReadonlyArray<PreStartActionInput>;
-  shell?: string;
+  shell?: string | null | undefined;
   startCommand?: ReadonlyArray<string> | null | undefined;
 };
 export type PreStartActionInput = {

--- a/react/src/__generated__/DeleteForeverVFolderModalV2Mutation.graphql.ts
+++ b/react/src/__generated__/DeleteForeverVFolderModalV2Mutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d39ed56195bf60b52197ce2e391ea950>>
+ * @generated SignedSource<<ecaa4617adf02ae47a598cc533cd4a46>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type BulkPurgeVFoldersV2Input = {
 };
 export type PurgeVFolderOptionsInput = {
   cascadeModelCard?: boolean;
+  force?: boolean;
 };
 export type DeleteForeverVFolderModalV2Mutation$variables = {
   input: BulkPurgeVFoldersV2Input;

--- a/react/src/__generated__/LoginSessionQuery.graphql.ts
+++ b/react/src/__generated__/LoginSessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9d3b7c031ddff78d5efed59f5c6a56d8>>
+ * @generated SignedSource<<bc76c96312e15186a8c19266351133d9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -78,7 +78,7 @@ export type LoginSessionQuery$data = {
     readonly count: number;
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly " $fragmentSpreads": FragmentRefs<"LoginSessionTableFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"BAILoginSessionTableFragment">;
       };
     }>;
   } | null | undefined;
@@ -185,7 +185,7 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "LoginSessionTableFragment"
+                    "name": "BAILoginSessionTableFragment"
                   }
                 ],
                 "storageKey": null
@@ -300,16 +300,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "686eb15e0a919f1ab37d88a35a348fbe",
+    "cacheID": "3c52e1ab1acbf8872809ee9723190991",
     "id": null,
     "metadata": {},
     "name": "LoginSessionQuery",
     "operationKind": "query",
-    "text": "query LoginSessionQuery(\n  $filter: LoginSessionFilter\n  $orderBy: [LoginSessionOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  myLoginSessionsV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...LoginSessionTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment LoginSessionTableFragment on LoginSessionV2 {\n  id\n  accessKey\n  createdAt\n  invalidatedAt\n  user {\n    id\n    basicInfo {\n      email\n    }\n  }\n}\n"
+    "text": "query LoginSessionQuery(\n  $filter: LoginSessionFilter\n  $orderBy: [LoginSessionOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  myLoginSessionsV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAILoginSessionTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAILoginSessionTableFragment on LoginSessionV2 {\n  id\n  accessKey\n  createdAt\n  invalidatedAt\n  user {\n    id\n    basicInfo {\n      email\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fa4f30598187103fd53bd68dba96d2ce";
+(node as any).hash = "8e94abd053b13ae1aec108d68c4eec30";
 
 export default node;

--- a/react/src/__generated__/ProjectAdminSessionPageQuery.graphql.ts
+++ b/react/src/__generated__/ProjectAdminSessionPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<eaf644cd3d487137ffdbc277eaec45f9>>
+ * @generated SignedSource<<56d259d066433fba3b4e12f0a61b1d17>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type OrderDirection = "ASC" | "DESC" | "%future added value";
 export type SessionV2OrderField = "CREATED_AT" | "ID" | "NAME" | "STATUS" | "TERMINATED_AT" | "%future added value";
-export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
+export type SessionV2Status = "CANCELLED" | "CREATING" | "DEPRIORITIZING" | "PENDING" | "PREEMPTED" | "PREPARED" | "PREPARING" | "RUNNING" | "SCHEDULED" | "TERMINATED" | "TERMINATING" | "%future added value";
 export type SessionV2Filter = {
   AND?: ReadonlyArray<SessionV2Filter> | null | undefined;
   NOT?: ReadonlyArray<SessionV2Filter> | null | undefined;

--- a/react/src/__generated__/RBACManagementPageQuery.graphql.ts
+++ b/react/src/__generated__/RBACManagementPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<930bf912870b3b7418fbb97db2c89854>>
+ * @generated SignedSource<<b4b31d5c8a5b29370526ba1eac42c6bb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type OrderDirection = "ASC" | "DESC" | "%future added value";
+export type RBACElementType = "AGENT" | "APP_CONFIG" | "APP_CONFIG_ALLOW_LIST" | "APP_CONFIG_DEFINITION" | "APP_CONFIG_FRAGMENT" | "ARTIFACT" | "ARTIFACT_REGISTRY" | "ARTIFACT_REVISION" | "AUDIT_LOG" | "CONTAINER_REGISTRY" | "DEPLOYMENT_POLICY" | "DEPLOYMENT_REVISION" | "DEPLOYMENT_TOKEN" | "DOMAIN" | "DOMAIN_ADMIN_PAGE" | "EVENT_LOG" | "IMAGE" | "IMAGE_ALIAS" | "KERNEL" | "KEYPAIR" | "KEYPAIR_RESOURCE_POLICY" | "MODEL_CARD" | "MODEL_DEPLOYMENT" | "NETWORK" | "NOTIFICATION_CHANNEL" | "NOTIFICATION_RULE" | "PROJECT" | "PROJECT_ADMIN_PAGE" | "PROJECT_RESOURCE_POLICY" | "RESOURCE_GROUP" | "RESOURCE_PRESET" | "ROLE" | "ROLE_ASSIGNMENT" | "ROUTING" | "SESSION" | "SESSION_APP_SERVICE" | "SESSION_TEMPLATE" | "STORAGE_HOST" | "USER" | "USER_EMAIL" | "USER_RESOURCE_POLICY" | "VFOLDER" | "VFOLDER_DATA" | "%future added value";
 export type RoleOrderField = "CREATED_AT" | "NAME" | "UPDATED_AT" | "%future added value";
 export type RoleSource = "CUSTOM" | "SYSTEM" | "%future added value";
 export type RoleStatus = "ACTIVE" | "DELETED" | "INACTIVE" | "%future added value";
@@ -19,6 +20,7 @@ export type RoleFilter = {
   NOT?: ReadonlyArray<RoleFilter> | null | undefined;
   OR?: ReadonlyArray<RoleFilter> | null | undefined;
   assignedUser?: RoleUserNestedFilter | null | undefined;
+  mappedScope?: RoleMappedScopeNestedFilter | null | undefined;
   name?: StringFilter | null | undefined;
   source?: RoleSourceFilter | null | undefined;
   status?: RoleStatusFilter | null | undefined;
@@ -68,6 +70,19 @@ export type UUIDFilter = {
   in?: ReadonlyArray<string> | null | undefined;
   notEquals?: string | null | undefined;
   notIn?: ReadonlyArray<string> | null | undefined;
+};
+export type RoleMappedScopeNestedFilter = {
+  AND?: ReadonlyArray<RoleMappedScopeNestedFilter> | null | undefined;
+  NOT?: ReadonlyArray<RoleMappedScopeNestedFilter> | null | undefined;
+  OR?: ReadonlyArray<RoleMappedScopeNestedFilter> | null | undefined;
+  scopeId?: StringFilter | null | undefined;
+  scopeType?: RBACElementTypeFilter | null | undefined;
+};
+export type RBACElementTypeFilter = {
+  equals?: RBACElementType | null | undefined;
+  in?: ReadonlyArray<RBACElementType> | null | undefined;
+  notEquals?: RBACElementType | null | undefined;
+  notIn?: ReadonlyArray<RBACElementType> | null | undefined;
 };
 export type RoleOrderBy = {
   direction?: OrderDirection;

--- a/react/src/__generated__/RoleDetailDrawerQuery.graphql.ts
+++ b/react/src/__generated__/RoleDetailDrawerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<67b7235f2f1d1a7c30db4da44ea3542e>>
+ * @generated SignedSource<<912024bcd6acb5081645b86f04c75967>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -117,6 +117,8 @@ export type EntityFilter = {
   OR?: ReadonlyArray<EntityFilter> | null | undefined;
   entityId?: StringFilter | null | undefined;
   entityType?: RBACElementTypeFilter | null | undefined;
+  scopeId?: StringFilter | null | undefined;
+  scopeType?: RBACElementTypeFilter | null | undefined;
 };
 export type EntityOrderBy = {
   direction?: OrderDirection;

--- a/react/src/__generated__/RoleScopeTabRefetchQuery.graphql.ts
+++ b/react/src/__generated__/RoleScopeTabRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d1ac80d7bfeb1c2ed44c030fb89b6d1a>>
+ * @generated SignedSource<<a93e1a6494032d03a9087faa6439351b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,8 @@ export type EntityFilter = {
   OR?: ReadonlyArray<EntityFilter> | null | undefined;
   entityId?: StringFilter | null | undefined;
   entityType?: RBACElementTypeFilter | null | undefined;
+  scopeId?: StringFilter | null | undefined;
+  scopeType?: RBACElementTypeFilter | null | undefined;
 };
 export type RBACElementTypeFilter = {
   equals?: RBACElementType | null | undefined;

--- a/react/src/__generated__/ScopedAuditLogQuery.graphql.ts
+++ b/react/src/__generated__/ScopedAuditLogQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<54032a84831af405cd4a1c2588e2214b>>
+ * @generated SignedSource<<7cf00c57a8593f157fa52843b81d7d5a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,6 +29,7 @@ export type AuditLogFilter = {
   AND?: ReadonlyArray<AuditLogFilter> | null | undefined;
   NOT?: ReadonlyArray<AuditLogFilter> | null | undefined;
   OR?: ReadonlyArray<AuditLogFilter> | null | undefined;
+  actedAs?: UUIDFilter | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
   entityId?: StringFilter | null | undefined;
   entityType?: StringFilter | null | undefined;
@@ -69,6 +70,12 @@ export type DateTimeFilter = {
   before?: string | null | undefined;
   equals?: string | null | undefined;
   notEquals?: string | null | undefined;
+};
+export type UUIDFilter = {
+  equals?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
 };
 export type AuditLogOrderBy = {
   direction?: OrderDirection;

--- a/react/src/__generated__/UserResourcePolicyV2Mutation.graphql.ts
+++ b/react/src/__generated__/UserResourcePolicyV2Mutation.graphql.ts
@@ -1,0 +1,89 @@
+/**
+ * @generated SignedSource<<55192abc177db8ed046fad148b0f9868>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UserResourcePolicyV2Mutation$variables = {
+  name: string;
+};
+export type UserResourcePolicyV2Mutation$data = {
+  readonly adminDeleteUserResourcePolicyV2: {
+    readonly name: string;
+  } | null | undefined;
+};
+export type UserResourcePolicyV2Mutation = {
+  response: UserResourcePolicyV2Mutation$data;
+  variables: UserResourcePolicyV2Mutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      }
+    ],
+    "concreteType": "DeleteUserResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminDeleteUserResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UserResourcePolicyV2Mutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "UserResourcePolicyV2Mutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "fbf8580d648b402792efee8f1dbda4d5",
+    "id": null,
+    "metadata": {},
+    "name": "UserResourcePolicyV2Mutation",
+    "operationKind": "mutation",
+    "text": "mutation UserResourcePolicyV2Mutation(\n  $name: String!\n) {\n  adminDeleteUserResourcePolicyV2(name: $name) {\n    name\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "12aba1bd23b572a97f9312abc5d145d1";
+
+export default node;

--- a/react/src/__generated__/UserResourcePolicyV2Query.graphql.ts
+++ b/react/src/__generated__/UserResourcePolicyV2Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<071a8e61632da75f29d4e2d5f4e626e6>>
+ * @generated SignedSource<<200e6326ec5656895da2dc14ce90da14>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,16 +10,19 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type LoginAttemptResult = "EVICTED" | "EXPIRED" | "FAILED_BLOCKED" | "FAILED_INVALID_CREDENTIALS" | "FAILED_PASSWORD_EXPIRED" | "FAILED_REJECTED_BY_HOOK" | "FAILED_SESSION_ALREADY_EXISTS" | "FAILED_USER_INACTIVE" | "LOGOUT" | "REVOKED_BY_ADMIN" | "REVOKED_BY_USER" | "SUCCESS" | "%future added value";
-export type LoginHistoryOrderField = "CREATED_AT" | "DOMAIN_NAME" | "RESULT" | "%future added value";
 export type OrderDirection = "ASC" | "DESC" | "%future added value";
-export type LoginHistoryFilter = {
-  AND?: ReadonlyArray<LoginHistoryFilter> | null | undefined;
-  NOT?: ReadonlyArray<LoginHistoryFilter> | null | undefined;
-  OR?: ReadonlyArray<LoginHistoryFilter> | null | undefined;
+export type UserResourcePolicyV2OrderField = "CREATED_AT" | "MAX_CONCURRENT_LOGINS" | "MAX_CUSTOMIZED_IMAGE_COUNT" | "MAX_QUOTA_SCOPE_SIZE" | "MAX_SESSION_COUNT_PER_MODEL_SESSION" | "MAX_VFOLDER_COUNT" | "NAME" | "%future added value";
+export type UserResourcePolicyV2Filter = {
+  AND?: ReadonlyArray<UserResourcePolicyV2Filter> | null | undefined;
+  NOT?: ReadonlyArray<UserResourcePolicyV2Filter> | null | undefined;
+  OR?: ReadonlyArray<UserResourcePolicyV2Filter> | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
-  domainName?: StringFilter | null | undefined;
-  result?: LoginHistoryResultFilter | null | undefined;
+  maxConcurrentLogins?: IntFilter | null | undefined;
+  maxCustomizedImageCount?: IntFilter | null | undefined;
+  maxQuotaScopeSize?: IntFilter | null | undefined;
+  maxSessionCountPerModelSession?: IntFilter | null | undefined;
+  maxVfolderCount?: IntFilter | null | undefined;
+  name?: StringFilter | null | undefined;
 };
 export type StringFilter = {
   contains?: string | null | undefined;
@@ -43,41 +46,45 @@ export type StringFilter = {
   notStartsWith?: string | null | undefined;
   startsWith?: string | null | undefined;
 };
-export type LoginHistoryResultFilter = {
-  equals?: LoginAttemptResult | null | undefined;
-  in?: ReadonlyArray<LoginAttemptResult> | null | undefined;
-  notEquals?: LoginAttemptResult | null | undefined;
-  notIn?: ReadonlyArray<LoginAttemptResult> | null | undefined;
-};
 export type DateTimeFilter = {
   after?: string | null | undefined;
   before?: string | null | undefined;
   equals?: string | null | undefined;
   notEquals?: string | null | undefined;
 };
-export type LoginHistoryOrderBy = {
-  direction?: OrderDirection;
-  field: LoginHistoryOrderField;
+export type IntFilter = {
+  equals?: number | null | undefined;
+  greaterThan?: number | null | undefined;
+  greaterThanOrEqual?: number | null | undefined;
+  lessThan?: number | null | undefined;
+  lessThanOrEqual?: number | null | undefined;
+  notEquals?: number | null | undefined;
 };
-export type LoginHistoryQuery$variables = {
-  filter?: LoginHistoryFilter | null | undefined;
+export type UserResourcePolicyV2OrderBy = {
+  direction?: OrderDirection;
+  field?: UserResourcePolicyV2OrderField;
+};
+export type UserResourcePolicyV2Query$variables = {
+  filter?: UserResourcePolicyV2Filter | null | undefined;
   limit?: number | null | undefined;
   offset?: number | null | undefined;
-  orderBy?: ReadonlyArray<LoginHistoryOrderBy> | null | undefined;
+  orderBy?: ReadonlyArray<UserResourcePolicyV2OrderBy> | null | undefined;
 };
-export type LoginHistoryQuery$data = {
-  readonly myLoginHistoryV2: {
+export type UserResourcePolicyV2Query$data = {
+  readonly adminUserResourcePoliciesV2: {
     readonly count: number;
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly " $fragmentSpreads": FragmentRefs<"BAILoginHistoryTableFragment">;
+        readonly id: string;
+        readonly name: string;
+        readonly " $fragmentSpreads": FragmentRefs<"BAIUserResourcePolicyV2TableFragment" | "UserResourcePolicyV2SettingModalFragment">;
       };
     }>;
   } | null | undefined;
 };
-export type LoginHistoryQuery = {
-  response: LoginHistoryQuery$data;
-  variables: LoginHistoryQuery$variables;
+export type UserResourcePolicyV2Query = {
+  response: UserResourcePolicyV2Query$data;
+  variables: UserResourcePolicyV2Query$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -129,6 +136,20 @@ v5 = {
   "kind": "ScalarField",
   "name": "count",
   "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -140,21 +161,21 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "LoginHistoryQuery",
+    "name": "UserResourcePolicyV2Query",
     "selections": [
       {
         "alias": null,
         "args": (v4/*: any*/),
-        "concreteType": "LoginHistoryV2Connection",
+        "concreteType": "UserResourcePolicyV2Connection",
         "kind": "LinkedField",
-        "name": "myLoginHistoryV2",
+        "name": "adminUserResourcePoliciesV2",
         "plural": false,
         "selections": [
           (v5/*: any*/),
           {
             "alias": null,
             "args": null,
-            "concreteType": "LoginHistoryV2Edge",
+            "concreteType": "UserResourcePolicyV2Edge",
             "kind": "LinkedField",
             "name": "edges",
             "plural": true,
@@ -162,15 +183,22 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "LoginHistoryV2",
+                "concreteType": "UserResourcePolicyV2",
                 "kind": "LinkedField",
                 "name": "node",
                 "plural": false,
                 "selections": [
+                  (v6/*: any*/),
+                  (v7/*: any*/),
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "BAILoginHistoryTableFragment"
+                    "name": "BAIUserResourcePolicyV2TableFragment"
+                  },
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "UserResourcePolicyV2SettingModalFragment"
                   }
                 ],
                 "storageKey": null
@@ -194,21 +222,21 @@ return {
       (v2/*: any*/)
     ],
     "kind": "Operation",
-    "name": "LoginHistoryQuery",
+    "name": "UserResourcePolicyV2Query",
     "selections": [
       {
         "alias": null,
         "args": (v4/*: any*/),
-        "concreteType": "LoginHistoryV2Connection",
+        "concreteType": "UserResourcePolicyV2Connection",
         "kind": "LinkedField",
-        "name": "myLoginHistoryV2",
+        "name": "adminUserResourcePoliciesV2",
         "plural": false,
         "selections": [
           (v5/*: any*/),
           {
             "alias": null,
             "args": null,
-            "concreteType": "LoginHistoryV2Edge",
+            "concreteType": "UserResourcePolicyV2Edge",
             "kind": "LinkedField",
             "name": "edges",
             "plural": true,
@@ -216,44 +244,64 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "LoginHistoryV2",
+                "concreteType": "UserResourcePolicyV2",
                 "kind": "LinkedField",
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "id",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "result",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "domainName",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "failReason",
-                    "storageKey": null
-                  },
+                  (v6/*: any*/),
+                  (v7/*: any*/),
                   {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
                     "name": "createdAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxVfolderCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxConcurrentLogins",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxSessionCountPerModelSession",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "BinarySizeInfo",
+                    "kind": "LinkedField",
+                    "name": "maxQuotaScopeSize",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "expr",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "maxCustomizedImageCount",
                     "storageKey": null
                   }
                 ],
@@ -268,16 +316,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d3adafeb86e63588f4380d9b4c4e9374",
+    "cacheID": "b4d6a4d0afeee1c1a05504fd9268ed2c",
     "id": null,
     "metadata": {},
-    "name": "LoginHistoryQuery",
+    "name": "UserResourcePolicyV2Query",
     "operationKind": "query",
-    "text": "query LoginHistoryQuery(\n  $filter: LoginHistoryFilter\n  $orderBy: [LoginHistoryOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  myLoginHistoryV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAILoginHistoryTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAILoginHistoryTableFragment on LoginHistoryV2 {\n  id\n  result\n  domainName\n  failReason\n  createdAt\n}\n"
+    "text": "query UserResourcePolicyV2Query(\n  $filter: UserResourcePolicyV2Filter\n  $orderBy: [UserResourcePolicyV2OrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminUserResourcePoliciesV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        ...BAIUserResourcePolicyV2TableFragment\n        ...UserResourcePolicyV2SettingModalFragment\n      }\n    }\n  }\n}\n\nfragment BAIUserResourcePolicyV2TableFragment on UserResourcePolicyV2 {\n  id\n  name\n  createdAt\n  maxVfolderCount\n  maxConcurrentLogins\n  maxSessionCountPerModelSession\n  maxQuotaScopeSize {\n    expr\n  }\n  maxCustomizedImageCount\n}\n\nfragment UserResourcePolicyV2SettingModalFragment on UserResourcePolicyV2 {\n  id\n  name\n  maxVfolderCount\n  maxConcurrentLogins\n  maxSessionCountPerModelSession\n  maxQuotaScopeSize {\n    expr\n  }\n  maxCustomizedImageCount\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e87d7bf9cea51106011c02a4e6b6a633";
+(node as any).hash = "0eca06ab39c8e6b871b0fff606e5f9a6";
 
 export default node;

--- a/react/src/__generated__/UserResourcePolicyV2SettingModalCreateMutation.graphql.ts
+++ b/react/src/__generated__/UserResourcePolicyV2SettingModalCreateMutation.graphql.ts
@@ -1,0 +1,113 @@
+/**
+ * @generated SignedSource<<e6deed280e58a57b3319a494273eb1e2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateUserResourcePolicyInputV2 = {
+  maxConcurrentLogins?: number | null | undefined;
+  maxCustomizedImageCount: number;
+  maxQuotaScopeSize: BinarySizeInput;
+  maxSessionCountPerModelSession: number;
+  maxVfolderCount: number;
+  name: string;
+};
+export type BinarySizeInput = {
+  expr: string;
+};
+export type UserResourcePolicyV2SettingModalCreateMutation$variables = {
+  input: CreateUserResourcePolicyInputV2;
+};
+export type UserResourcePolicyV2SettingModalCreateMutation$data = {
+  readonly adminCreateUserResourcePolicyV2: {
+    readonly userResourcePolicy: {
+      readonly id: string;
+    };
+  } | null | undefined;
+};
+export type UserResourcePolicyV2SettingModalCreateMutation = {
+  response: UserResourcePolicyV2SettingModalCreateMutation$data;
+  variables: UserResourcePolicyV2SettingModalCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "CreateUserResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminCreateUserResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UserResourcePolicyV2",
+        "kind": "LinkedField",
+        "name": "userResourcePolicy",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UserResourcePolicyV2SettingModalCreateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "UserResourcePolicyV2SettingModalCreateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "7e98c512569c57d484c4c0104f2e1f84",
+    "id": null,
+    "metadata": {},
+    "name": "UserResourcePolicyV2SettingModalCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation UserResourcePolicyV2SettingModalCreateMutation(\n  $input: CreateUserResourcePolicyInputV2!\n) {\n  adminCreateUserResourcePolicyV2(input: $input) {\n    userResourcePolicy {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "cfe35df6a2c4ec10fdb4984be609ca4b";
+
+export default node;

--- a/react/src/__generated__/UserResourcePolicyV2SettingModalFragment.graphql.ts
+++ b/react/src/__generated__/UserResourcePolicyV2SettingModalFragment.graphql.ts
@@ -1,0 +1,103 @@
+/**
+ * @generated SignedSource<<743c20da77f2a2fe7d2b56fbfc0391f2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type UserResourcePolicyV2SettingModalFragment$data = {
+  readonly id: string;
+  readonly maxConcurrentLogins: number | null | undefined;
+  readonly maxCustomizedImageCount: number;
+  readonly maxQuotaScopeSize: {
+    readonly expr: string;
+  };
+  readonly maxSessionCountPerModelSession: number;
+  readonly maxVfolderCount: number;
+  readonly name: string;
+  readonly " $fragmentType": "UserResourcePolicyV2SettingModalFragment";
+};
+export type UserResourcePolicyV2SettingModalFragment$key = {
+  readonly " $data"?: UserResourcePolicyV2SettingModalFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"UserResourcePolicyV2SettingModalFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "UserResourcePolicyV2SettingModalFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxVfolderCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxConcurrentLogins",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxSessionCountPerModelSession",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "BinarySizeInfo",
+      "kind": "LinkedField",
+      "name": "maxQuotaScopeSize",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "expr",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "maxCustomizedImageCount",
+      "storageKey": null
+    }
+  ],
+  "type": "UserResourcePolicyV2",
+  "abstractKey": null
+};
+
+(node as any).hash = "f9fd0c1e131b6d0eb49eb1fdd99abef6";
+
+export default node;

--- a/react/src/__generated__/UserResourcePolicyV2SettingModalModifyMutation.graphql.ts
+++ b/react/src/__generated__/UserResourcePolicyV2SettingModalModifyMutation.graphql.ts
@@ -1,0 +1,196 @@
+/**
+ * @generated SignedSource<<c54db8d5b5ac5a197f1fffe9ddd30fb8>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UpdateUserResourcePolicyInput = {
+  maxConcurrentLogins?: number | null | undefined;
+  maxCustomizedImageCount?: number | null | undefined;
+  maxQuotaScopeSize?: BinarySizeInput | null | undefined;
+  maxSessionCountPerModelSession?: number | null | undefined;
+  maxVfolderCount?: number | null | undefined;
+};
+export type BinarySizeInput = {
+  expr: string;
+};
+export type UserResourcePolicyV2SettingModalModifyMutation$variables = {
+  input: UpdateUserResourcePolicyInput;
+  name: string;
+};
+export type UserResourcePolicyV2SettingModalModifyMutation$data = {
+  readonly adminUpdateUserResourcePolicyV2: {
+    readonly userResourcePolicy: {
+      readonly createdAt: string | null | undefined;
+      readonly id: string;
+      readonly maxConcurrentLogins: number | null | undefined;
+      readonly maxCustomizedImageCount: number;
+      readonly maxQuotaScopeSize: {
+        readonly expr: string;
+      };
+      readonly maxSessionCountPerModelSession: number;
+      readonly maxVfolderCount: number;
+      readonly name: string;
+    };
+  } | null | undefined;
+};
+export type UserResourcePolicyV2SettingModalModifyMutation = {
+  response: UserResourcePolicyV2SettingModalModifyMutation$data;
+  variables: UserResourcePolicyV2SettingModalModifyMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "name"
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      },
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      }
+    ],
+    "concreteType": "UpdateUserResourcePolicyPayload",
+    "kind": "LinkedField",
+    "name": "adminUpdateUserResourcePolicyV2",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UserResourcePolicyV2",
+        "kind": "LinkedField",
+        "name": "userResourcePolicy",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxVfolderCount",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxConcurrentLogins",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxSessionCountPerModelSession",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "BinarySizeInfo",
+            "kind": "LinkedField",
+            "name": "maxQuotaScopeSize",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "expr",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "maxCustomizedImageCount",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UserResourcePolicyV2SettingModalModifyMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "UserResourcePolicyV2SettingModalModifyMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "668ead374374e2bafbf822d7f3de3a81",
+    "id": null,
+    "metadata": {},
+    "name": "UserResourcePolicyV2SettingModalModifyMutation",
+    "operationKind": "mutation",
+    "text": "mutation UserResourcePolicyV2SettingModalModifyMutation(\n  $name: String!\n  $input: UpdateUserResourcePolicyInput!\n) {\n  adminUpdateUserResourcePolicyV2(name: $name, input: $input) {\n    userResourcePolicy {\n      id\n      name\n      createdAt\n      maxVfolderCount\n      maxConcurrentLogins\n      maxSessionCountPerModelSession\n      maxQuotaScopeSize {\n        expr\n      }\n      maxCustomizedImageCount\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "748639f1ecc7608a99549d1cb7ecb1e2";
+
+export default node;

--- a/react/src/components/LoginHistory.tsx
+++ b/react/src/components/LoginHistory.tsx
@@ -8,13 +8,12 @@ import type {
 } from '../__generated__/LoginHistoryQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
-import LoginHistoryTable, {
-  loginResultFilterOptions,
-  type LoginHistoryTableProps,
-} from './LoginHistoryTable';
 import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
+  BAILoginHistoryTable,
+  type BAILoginHistoryTableProps,
+  loginResultFilterOptions,
   filterOutNullAndUndefined,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -43,7 +42,7 @@ export const LoginHistoryQuery = graphql`
       count
       edges {
         node {
-          ...LoginHistoryTableFragment
+          ...BAILoginHistoryTableFragment
         }
       }
     }
@@ -51,7 +50,7 @@ export const LoginHistoryQuery = graphql`
 `;
 
 export interface LoginHistoryProps extends Omit<
-  LoginHistoryTableProps,
+  BAILoginHistoryTableProps,
   | 'loginHistoryFrgmt'
   | 'loading'
   | 'order'
@@ -69,7 +68,7 @@ export interface LoginHistoryProps extends Omit<
 
 /**
  * LoginHistory - Reads a preloaded `myLoginHistoryV2` query and renders it as a
- * `LoginHistoryTable` with a filter bar and a refresh button. The consumer owns
+ * `BAILoginHistoryTable` with a filter bar and a refresh button. The consumer owns
  * `useQueryLoader` / `loadQuery`; this view reads the `queryRef` via
  * `usePreloadedQuery` and re-runs filter / sort / refresh / paging through
  * `onReload`. Reading the *deferred* `queryRef` keeps the previous rows visible
@@ -146,7 +145,7 @@ const LoginHistory = ({
           loading={isRefetching}
         />
       </BAIFlex>
-      <LoginHistoryTable
+      <BAILoginHistoryTable
         resizable
         loading={isRefetching}
         order={order}

--- a/react/src/components/LoginSession.tsx
+++ b/react/src/components/LoginSession.tsx
@@ -9,16 +9,15 @@ import type {
 import type { LoginSessionRevokeMutation } from '../__generated__/LoginSessionRevokeMutation.graphql';
 import { convertToOrderBy } from '../helper';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
-import LoginSessionTable, {
-  type LoginSessionNodeInList,
-  type LoginSessionTableProps,
-} from './LoginSessionTable';
 import { LogoutOutlined } from '@ant-design/icons';
 import { App } from 'antd';
 import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
+  BAILoginSessionTable,
+  type BAILoginSessionTableProps,
   BAINameActionCell,
+  type LoginSessionNodeInList,
   filterOutEmpty,
   filterOutNullAndUndefined,
   toLocalId,
@@ -50,7 +49,7 @@ export const LoginSessionQuery = graphql`
       count
       edges {
         node {
-          ...LoginSessionTableFragment
+          ...BAILoginSessionTableFragment
         }
       }
     }
@@ -58,7 +57,7 @@ export const LoginSessionQuery = graphql`
 `;
 
 export interface LoginSessionProps extends Omit<
-  LoginSessionTableProps,
+  BAILoginSessionTableProps,
   | 'loginSessionsFrgmt'
   | 'loading'
   | 'order'
@@ -76,7 +75,7 @@ export interface LoginSessionProps extends Omit<
 
 /**
  * LoginSession - Reads a preloaded `myLoginSessionsV2` query and renders it as a
- * `LoginSessionTable` with a filter bar and a refresh button. The consumer owns
+ * `BAILoginSessionTable` with a filter bar and a refresh button. The consumer owns
  * `useQueryLoader` / `loadQuery`; this view reads the `queryRef` via
  * `usePreloadedQuery` and re-runs filter / sort / refresh through `onReload`.
  * Reading the *deferred* `queryRef` keeps the previous rows visible while the
@@ -174,7 +173,7 @@ const LoginSession = ({
           loading={isRefetching}
         />
       </BAIFlex>
-      <LoginSessionTable
+      <BAILoginSessionTable
         resizable
         loading={isRefetching}
         order={order}

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -151,7 +151,7 @@ const ProjectResourcePolicyList: React.FC<
         ),
     },
     {
-      title: t('resourcePolicy.MaxQuotaScopeSize'),
+      title: t('resourcePolicy.MaxQuotaScopeSizeGB'),
       dataIndex: 'max_quota_scope_size',
       key: 'max_quota_scope_size',
       render: (text) => (text === -1 ? '∞' : bytesToGB(text)),

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -153,7 +153,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
         (b?.max_session_count_per_model_session ?? 0),
     },
     {
-      title: t('resourcePolicy.MaxQuotaScopeSize'),
+      title: t('resourcePolicy.MaxQuotaScopeSizeGB'),
       dataIndex: 'max_quota_scope_size',
       key: 'max_quota_scope_size',
       render: (text) => (text === -1 ? '∞' : bytesToGB(text)),

--- a/react/src/components/UserResourcePolicyV2.tsx
+++ b/react/src/components/UserResourcePolicyV2.tsx
@@ -1,0 +1,350 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { UserResourcePolicyV2Mutation } from '../__generated__/UserResourcePolicyV2Mutation.graphql';
+import type {
+  UserResourcePolicyV2OrderBy,
+  UserResourcePolicyV2Query as UserResourcePolicyV2QueryType,
+} from '../__generated__/UserResourcePolicyV2Query.graphql';
+import { convertToOrderBy } from '../helper';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import UserResourcePolicyV2SettingModal from './UserResourcePolicyV2SettingModal';
+import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
+import { App } from 'antd';
+import {
+  BAIButton,
+  BAIDeleteConfirmModal,
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIGraphQLPropertyFilter,
+  BAINameActionCell,
+  BAIUserResourcePolicyV2Table,
+  type BAIUserResourcePolicyV2TableProps,
+  filterOutNullAndUndefined,
+  useFetchKey,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { PlusIcon } from 'lucide-react';
+import { useDeferredValue, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  graphql,
+  PreloadedQuery,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+  useMutation,
+} from 'react-relay';
+
+export const UserResourcePolicyV2Query = graphql`
+  query UserResourcePolicyV2Query(
+    $filter: UserResourcePolicyV2Filter
+    $orderBy: [UserResourcePolicyV2OrderBy!]
+    $limit: Int
+    $offset: Int
+  ) {
+    adminUserResourcePoliciesV2(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          id
+          name
+          ...BAIUserResourcePolicyV2TableFragment
+          ...UserResourcePolicyV2SettingModalFragment
+        }
+      }
+    }
+  }
+`;
+
+type UserResourcePolicyV2Node = NonNullable<
+  NonNullable<
+    NonNullable<
+      UserResourcePolicyV2QueryType['response']['adminUserResourcePoliciesV2']
+    >['edges'][number]
+  >['node']
+>;
+
+export interface UserResourcePolicyV2Props extends Omit<
+  BAIUserResourcePolicyV2TableProps,
+  | 'userResourcePoliciesFrgmt'
+  | 'loading'
+  | 'order'
+  | 'onChangeOrder'
+  | 'dataSource'
+  | 'pagination'
+  | 'customizeColumns'
+> {
+  queryRef: PreloadedQuery<UserResourcePolicyV2QueryType>;
+  onReload: (
+    variables: UserResourcePolicyV2QueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
+
+const UserResourcePolicyV2 = ({
+  queryRef,
+  onReload,
+  ...tableProps
+}: UserResourcePolicyV2Props) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+
+  const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
+  const [editingUserResourcePolicy, setEditingUserResourcePolicy] =
+    useState<UserResourcePolicyV2Node | null>(null);
+  const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
+    null,
+  );
+
+  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
+    'table_column_overrides.UserResourcePolicyV2',
+  );
+
+  const filter = queryRef.variables.filter ?? undefined;
+  const orderBy = queryRef.variables.orderBy?.[0];
+  const order = orderBy
+    ? `${orderBy.direction === 'DESC' ? '-' : ''}${_.camelCase(orderBy.field)}`
+    : null;
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
+
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
+
+  const data = usePreloadedQuery<UserResourcePolicyV2QueryType>(
+    UserResourcePolicyV2Query,
+    deferredQueryRef,
+  );
+
+  const [commitDelete] = useMutation<UserResourcePolicyV2Mutation>(graphql`
+    mutation UserResourcePolicyV2Mutation($name: String!) {
+      adminDeleteUserResourcePolicyV2(name: $name) {
+        name
+      }
+    }
+  `);
+
+  const userResourcePolicies = filterOutNullAndUndefined(
+    (data.adminUserResourcePoliciesV2?.edges ?? []).map((edge) => edge?.node),
+  );
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="sm">
+      <BAIFlex justify={'between'} wrap="wrap" gap="sm">
+        <BAIGraphQLPropertyFilter
+          value={filter}
+          onChange={(next) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                filter: next,
+                offset: 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          }}
+          filterProperties={[
+            {
+              key: 'name',
+              propertyLabel: t('resourcePolicy.Name'),
+              type: 'string',
+              fixedOperator: 'contains',
+            },
+            {
+              key: 'createdAt',
+              propertyLabel: t('resourcePolicy.CreatedAt'),
+              type: 'datetime',
+              defaultOperator: 'after',
+            },
+            {
+              key: 'maxVfolderCount',
+              propertyLabel: t('resourcePolicy.MaxVFolderCount'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'maxConcurrentLogins',
+              propertyLabel: t('resourcePolicy.MaxConcurrentLogins'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'maxSessionCountPerModelSession',
+              propertyLabel: t('resourcePolicy.MaxSessionCountPerModelSession'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+            {
+              key: 'maxCustomizedImageCount',
+              propertyLabel: t('resourcePolicy.MaxCustomizedImageCount'),
+              type: 'number',
+              defaultOperator: 'greaterThanOrEqual',
+            },
+          ]}
+        />
+        <BAIFlex gap="xs">
+          <BAIFetchKeyButton
+            value={fetchKey}
+            onChange={(key) => {
+              updateFetchKey(key);
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+            }}
+            loading={isRefetching}
+          />
+          <BAIButton
+            type="primary"
+            icon={<PlusIcon />}
+            onClick={() => {
+              setIsCreatingPolicySetting(true);
+            }}
+          >
+            {t('button.Create')}
+          </BAIButton>
+        </BAIFlex>
+      </BAIFlex>
+      <BAIUserResourcePolicyV2Table
+        loading={isRefetching}
+        tableSettings={{
+          columnOverrides,
+          onColumnOverridesChange: setColumnOverrides,
+        }}
+        order={order}
+        onChangeOrder={(nextOrder) => {
+          onReload(
+            {
+              ...queryRef.variables,
+              orderBy: convertToOrderBy<UserResourcePolicyV2OrderBy>(nextOrder),
+              offset: 0,
+            },
+            { fetchPolicy: 'network-only' },
+          );
+        }}
+        pagination={{
+          pageSize,
+          current,
+          total: data.adminUserResourcePoliciesV2?.count ?? 0,
+          onChange: (nextCurrent, nextPageSize) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                limit: nextPageSize,
+                offset: nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
+          },
+        }}
+        customizeColumns={(columns) =>
+          _.map(columns, (column) =>
+            column.key === 'name'
+              ? {
+                  ...column,
+                  render: (name: string, record) => (
+                    <BAINameActionCell
+                      title={name}
+                      showActions="always"
+                      actions={[
+                        {
+                          key: 'settings',
+                          title: t('button.Settings'),
+                          icon: <SettingOutlined />,
+                          onClick: () => {
+                            setEditingUserResourcePolicy(
+                              _.find(userResourcePolicies, {
+                                id: record.id,
+                              }) ?? null,
+                            );
+                          },
+                        },
+                        {
+                          key: 'delete',
+                          title: t('button.Delete'),
+                          icon: <DeleteFilled />,
+                          type: 'danger',
+                          onClick: () => {
+                            setDeletingPolicyName(record.name);
+                          },
+                        },
+                      ]}
+                    />
+                  ),
+                }
+              : column,
+          )
+        }
+        userResourcePoliciesFrgmt={userResourcePolicies}
+        {...tableProps}
+      />
+      <UserResourcePolicyV2SettingModal
+        open={!!editingUserResourcePolicy || isCreatingPolicySetting}
+        userResourcePolicyFrgmt={editingUserResourcePolicy}
+        onOk={() => {
+          // A create adds a new row the offset query can't know about, so it
+          // needs a refetch. An update returns every field, so Relay merges the
+          // record by id into the store and the list reflects it without one.
+          if (isCreatingPolicySetting) {
+            onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+          }
+          setEditingUserResourcePolicy(null);
+          setIsCreatingPolicySetting(false);
+        }}
+        onCancel={() => {
+          setEditingUserResourcePolicy(null);
+          setIsCreatingPolicySetting(false);
+        }}
+      />
+      <BAIDeleteConfirmModal
+        open={!!deletingPolicyName}
+        items={
+          deletingPolicyName
+            ? [{ key: deletingPolicyName, label: deletingPolicyName }]
+            : []
+        }
+        title={t('resourcePolicy.DeletePolicy')}
+        target={t('resourcePolicy.ResourcePolicy')}
+        confirmText={deletingPolicyName ?? ''}
+        requireConfirmInput
+        onOk={() => {
+          if (deletingPolicyName) {
+            return new Promise<void>((resolve) => {
+              commitDelete({
+                variables: { name: deletingPolicyName },
+                onCompleted: (_res, errors) => {
+                  if (errors && errors.length > 0) {
+                    for (const error of errors) {
+                      message.error(error.message);
+                    }
+                  } else {
+                    onReload(queryRef.variables, {
+                      fetchPolicy: 'network-only',
+                    });
+                    message.success(t('resourcePolicy.ResourcePolicyDeleted'));
+                  }
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+                onError(err) {
+                  message.error(err?.message);
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+              });
+            });
+          }
+        }}
+        onCancel={() => setDeletingPolicyName(null)}
+      />
+    </BAIFlex>
+  );
+};
+
+export default UserResourcePolicyV2;

--- a/react/src/components/UserResourcePolicyV2SettingModal.tsx
+++ b/react/src/components/UserResourcePolicyV2SettingModal.tsx
@@ -1,0 +1,314 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  CreateUserResourcePolicyInputV2,
+  UserResourcePolicyV2SettingModalCreateMutation,
+} from '../__generated__/UserResourcePolicyV2SettingModalCreateMutation.graphql';
+import { UserResourcePolicyV2SettingModalFragment$key } from '../__generated__/UserResourcePolicyV2SettingModalFragment.graphql';
+import {
+  UpdateUserResourcePolicyInput,
+  UserResourcePolicyV2SettingModalModifyMutation,
+} from '../__generated__/UserResourcePolicyV2SettingModalModifyMutation.graphql';
+import { GBToBytes, bytesToGB } from '../helper';
+import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
+import FormItemWithUnlimited from './FormItemWithUnlimited';
+import {
+  Form,
+  Input,
+  Alert,
+  App,
+  InputNumber,
+  theme,
+  FormInstance,
+} from 'antd';
+import { BAIModal, BAIModalProps, BAIFlex } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import React, { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment, useMutation } from 'react-relay';
+
+interface UserResourcePolicyV2SettingModalProps extends Omit<
+  BAIModalProps,
+  'onOk' | 'onCancel'
+> {
+  userResourcePolicyFrgmt: UserResourcePolicyV2SettingModalFragment$key | null;
+  onOk: () => void;
+  onCancel: () => void;
+}
+
+const UserResourcePolicyV2SettingModal: React.FC<
+  UserResourcePolicyV2SettingModalProps
+> = ({ userResourcePolicyFrgmt = null, onOk, onCancel, ...baiModalProps }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+
+  const formRef = useRef<FormInstance>(null);
+
+  const userResourcePolicy = useFragment(
+    graphql`
+      fragment UserResourcePolicyV2SettingModalFragment on UserResourcePolicyV2 {
+        id
+        name
+        maxVfolderCount
+        maxConcurrentLogins
+        maxSessionCountPerModelSession
+        maxQuotaScopeSize {
+          expr
+        }
+        maxCustomizedImageCount
+      }
+    `,
+    userResourcePolicyFrgmt,
+  );
+
+  const [
+    commitCreateUserResourcePolicy,
+    isInFlightCommitCreateUserResourcePolicy,
+  ] = useMutation<UserResourcePolicyV2SettingModalCreateMutation>(graphql`
+    mutation UserResourcePolicyV2SettingModalCreateMutation(
+      $input: CreateUserResourcePolicyInputV2!
+    ) {
+      adminCreateUserResourcePolicyV2(input: $input) {
+        userResourcePolicy {
+          id
+        }
+      }
+    }
+  `);
+
+  const [
+    commitModifyUserResourcePolicy,
+    isInFlightCommitModifyUserResourcePolicy,
+  ] = useMutation<UserResourcePolicyV2SettingModalModifyMutation>(graphql`
+    mutation UserResourcePolicyV2SettingModalModifyMutation(
+      $name: String!
+      $input: UpdateUserResourcePolicyInput!
+    ) {
+      adminUpdateUserResourcePolicyV2(name: $name, input: $input) {
+        userResourcePolicy {
+          id
+          name
+          createdAt
+          maxVfolderCount
+          maxConcurrentLogins
+          maxSessionCountPerModelSession
+          maxQuotaScopeSize {
+            expr
+          }
+          maxCustomizedImageCount
+        }
+      }
+    }
+  `);
+
+  // `expr` is the exact byte count as a decimal string ('-1' = unlimited).
+  const rawMaxQuotaScopeSize = userResourcePolicy?.maxQuotaScopeSize.expr;
+  const initialMaxQuotaScopeSize =
+    _.isUndefined(rawMaxQuotaScopeSize) || rawMaxQuotaScopeSize === '-1'
+      ? -1
+      : Number(bytesToGB(Number(rawMaxQuotaScopeSize)));
+  const initialValues = {
+    name: userResourcePolicy?.name,
+    max_vfolder_count: userResourcePolicy?.maxVfolderCount ?? 0,
+    max_concurrent_logins: userResourcePolicy?.maxConcurrentLogins ?? null,
+    max_session_count_per_model_session:
+      userResourcePolicy?.maxSessionCountPerModelSession,
+    max_customized_image_count: userResourcePolicy?.maxCustomizedImageCount,
+    max_quota_scope_size: initialMaxQuotaScopeSize,
+  };
+
+  const handleOk = () => {
+    return formRef?.current
+      ?.validateFields()
+      .then((values) => {
+        const maxQuotaScopeSizeExpr =
+          values?.max_quota_scope_size === -1
+            ? '-1'
+            : String(GBToBytes(values?.max_quota_scope_size));
+        const commonInput = {
+          maxVfolderCount: values?.max_vfolder_count || 0,
+          maxConcurrentLogins: values?.max_concurrent_logins ?? null,
+          maxQuotaScopeSize: { expr: maxQuotaScopeSizeExpr },
+          maxSessionCountPerModelSession:
+            values?.max_session_count_per_model_session,
+          maxCustomizedImageCount: values?.max_customized_image_count,
+        };
+        if (userResourcePolicy === null) {
+          const input: CreateUserResourcePolicyInputV2 = {
+            name: values?.name,
+            ...commonInput,
+          };
+          commitCreateUserResourcePolicy({
+            variables: { input },
+            onCompleted(res, errors) {
+              if (!res?.adminCreateUserResourcePolicyV2 || errors) {
+                message.error(
+                  errors?.[0]?.message ||
+                    t('resourcePolicy.CannotCreateResourcePolicy'),
+                );
+                onCancel();
+              } else {
+                message.success(t('resourcePolicy.ResourcePolicyCreated'));
+                onOk();
+              }
+            },
+            onError(error) {
+              message.error(
+                error?.message ||
+                  t('resourcePolicy.CannotCreateResourcePolicy'),
+              );
+            },
+          });
+        } else {
+          const input: UpdateUserResourcePolicyInput = commonInput;
+          commitModifyUserResourcePolicy({
+            variables: { name: values?.name, input },
+            onCompleted(res, errors) {
+              if (!res?.adminUpdateUserResourcePolicyV2 || errors) {
+                message.error(
+                  errors?.[0]?.message ||
+                    t('resourcePolicy.CannotUpdateResourcePolicy'),
+                );
+                onCancel();
+              } else {
+                message.success(t('resourcePolicy.ResourcePolicyUpdated'));
+                onOk();
+              }
+            },
+            onError(error) {
+              message.error(
+                error?.message ||
+                  t('resourcePolicy.CannotUpdateResourcePolicy'),
+              );
+            },
+          });
+        }
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <BAIModal
+      title={
+        userResourcePolicy === null
+          ? t('resourcePolicy.CreateUserResourcePolicy')
+          : t('resourcePolicy.UpdateUserResourcePolicy')
+      }
+      onOk={handleOk}
+      onCancel={() => onCancel()}
+      destroyOnHidden
+      confirmLoading={
+        isInFlightCommitCreateUserResourcePolicy ||
+        isInFlightCommitModifyUserResourcePolicy
+      }
+      {...baiModalProps}
+    >
+      <Alert
+        title={t('storageHost.BeCarefulToSetUserResourcePolicy')}
+        type="warning"
+        showIcon
+        style={{ marginBottom: token.marginMD }}
+      />
+      <Form
+        ref={formRef}
+        layout="vertical"
+        initialValues={initialValues}
+        preserve={false}
+      >
+        <Form.Item
+          label={t('resourcePolicy.Name')}
+          name="name"
+          required
+          rules={[
+            {
+              required: true,
+              message: t('data.explorer.ValueRequired'),
+            },
+            {
+              max: 255,
+            },
+          ]}
+        >
+          <Input disabled={!!userResourcePolicy} />
+        </Form.Item>
+        <BAIFlex
+          direction="column"
+          align="stretch"
+          gap={'md'}
+          style={{ marginBottom: token.marginMD }}
+        >
+          <FormItemWithUnlimited
+            name={'max_vfolder_count'}
+            unlimitedValue={0}
+            label={t('resourcePolicy.MaxFolderCount')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <InputNumber
+              min={0}
+              max={SIGNED_32BIT_MAX_INT}
+              style={{ width: '100%' }}
+            />
+          </FormItemWithUnlimited>
+          <FormItemWithUnlimited
+            name={'max_quota_scope_size'}
+            unlimitedValue={-1}
+            label={t('storageHost.MaxFolderSize')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <InputNumber
+              min={0}
+              // Maximum safe integer divided by 10^9 to prevent overflow when converting GB to bytes
+              max={Math.floor(Number.MAX_SAFE_INTEGER / Math.pow(10, 9))}
+              suffix="GB"
+              style={{ width: '100%' }}
+            />
+          </FormItemWithUnlimited>
+          <FormItemWithUnlimited
+            name={'max_concurrent_logins'}
+            unlimitedValue={null}
+            label={t('resourcePolicy.MaxConcurrentLogins')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <InputNumber
+              min={0}
+              max={SIGNED_32BIT_MAX_INT}
+              style={{ width: '100%' }}
+            />
+          </FormItemWithUnlimited>
+        </BAIFlex>
+        <Form.Item
+          name={'max_session_count_per_model_session'}
+          label={t('resourcePolicy.MaxSessionCountPerModelSession')}
+          rules={[
+            { required: true, message: t('data.explorer.ValueRequired') },
+          ]}
+        >
+          <InputNumber
+            min={0}
+            max={SIGNED_32BIT_MAX_INT}
+            style={{ width: '100%' }}
+          />
+        </Form.Item>
+        <Form.Item
+          name={'max_customized_image_count'}
+          label={t('resourcePolicy.MaxCustomizedImageCount')}
+          rules={[
+            { required: true, message: t('data.explorer.ValueRequired') },
+          ]}
+        >
+          <InputNumber
+            min={0}
+            max={SIGNED_32BIT_MAX_INT}
+            style={{ width: '100%' }}
+          />
+        </Form.Item>
+      </Form>
+    </BAIModal>
+  );
+};
+
+export default UserResourcePolicyV2SettingModal;

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -2,24 +2,60 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import type { UserResourcePolicyV2Query as UserResourcePolicyV2QueryType } from '../__generated__/UserResourcePolicyV2Query.graphql';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import KeypairResourcePolicyList from '../components/KeypairResourcePolicyList';
 import ProjectResourcePolicyList from '../components/ProjectResourcePolicyList';
 import UserResourcePolicyList from '../components/UserResourcePolicyList';
-import { useWebUINavigate } from '../hooks';
+import UserResourcePolicyV2, {
+  UserResourcePolicyV2Query,
+} from '../components/UserResourcePolicyV2';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { Skeleton } from 'antd';
 import { filterOutEmpty, BAICard } from 'backend.ai-ui';
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryLoader } from 'react-relay';
 import { withDefault, StringParam, useQueryParam } from 'use-query-params';
 
 const tabParam = withDefault(StringParam, 'keypair');
 
 interface ResourcePolicyPageProps {}
 const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
+  'use memo';
   const { t } = useTranslation();
   const [curTabKey] = useQueryParam('tab', tabParam);
   const webUINavigate = useWebUINavigate();
+  const baiClient = useSuspendedBackendaiClient();
+  const supportsSubFilter = baiClient.supports('sub-filter');
+  const supportsBinarySizeExpr = baiClient.supports('binary-size-expr');
+
+  const [userResourcePolicyQueryRef, loadUserResourcePolicyQuery] =
+    useQueryLoader<UserResourcePolicyV2QueryType>(UserResourcePolicyV2Query);
+
+  const ensureUserResourcePolicyLoaded = useEffectEvent(() => {
+    if (
+      supportsSubFilter &&
+      supportsBinarySizeExpr &&
+      curTabKey === 'user' &&
+      !userResourcePolicyQueryRef
+    ) {
+      loadUserResourcePolicyQuery(
+        {
+          orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
+          limit: 10,
+          offset: 0,
+        },
+        { fetchPolicy: 'store-and-network' },
+      );
+    }
+  });
+  useEffect(
+    function loadUserResourcePolicyOnTabActivation() {
+      ensureUserResourcePolicyLoaded();
+    },
+    [curTabKey],
+  );
 
   return (
     <BAICard
@@ -55,7 +91,18 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
         )}
         {curTabKey === 'user' && (
           <BAIErrorBoundary>
-            <UserResourcePolicyList />
+            {supportsSubFilter && supportsBinarySizeExpr ? (
+              userResourcePolicyQueryRef ? (
+                <UserResourcePolicyV2
+                  queryRef={userResourcePolicyQueryRef}
+                  onReload={loadUserResourcePolicyQuery}
+                />
+              ) : (
+                <Skeleton active />
+              )
+            ) : (
+              <UserResourcePolicyList />
+            )}
           </BAIErrorBoundary>
         )}
         {curTabKey === 'project' && (

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1885,19 +1885,16 @@
   },
   "loginHistory": {
     "Domain": "Domain",
-    "FailReason": "Fehlergrund",
     "LoginTime": "Anmeldezeit",
     "Result": "Ergebnis"
   },
   "loginSession": {
     "AccessKey": "Zugriffsschlüssel",
     "CreatedAt": "Erstellt am",
-    "InvalidatedAt": "Ungültig seit",
     "RevokeFailed": "Widerruf der Anmeldesitzung fehlgeschlagen.",
     "RevokeSession": "Sitzung widerrufen",
     "RevokeSessionConfirm": "Möchten Sie diese Anmeldesitzung wirklich widerrufen?",
-    "RevokeSucceeded": "Anmeldesitzung erfolgreich widerrufen.",
-    "User": "Benutzer"
+    "RevokeSucceeded": "Anmeldesitzung erfolgreich widerrufen."
   },
   "logs": {
     "ErrorMessage": "Fehlermeldung",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "Leerlauf-Timeout (Sek.)",
     "Keypair": "Schlüsselpaar",
     "KeypairResourcePolicy": "Schlüsselpaar-Ressourcenrichtlinie",
+    "MaxConcurrentLogins": "Max. gleichzeitige Anmeldungen",
     "MaxConcurrentSFTPSessions": "Max gleichzeitige SFTP -Sitzungen",
     "MaxCustomizedImageCount": "Maximale Anzahl benutzerdefinierter Bilder",
     "MaxFolderCount": "Maximale Ordneranzahl",
     "MaxNetworkCount": "Maximale Netzwerkanzahl",
     "MaxPendingSessionCount": "Maximal ausstehende Sitzungsanzahl",
     "MaxPendingSessionResourceSlots": "Maxe ausstehende Sitzungsressourcenschlitze",
-    "MaxQuotaScopeSize": "Maximale Kontingentumfangsgröße (GB)",
+    "MaxQuotaScopeSize": "Maximale Kontingentumfangsgröße",
+    "MaxQuotaScopeSizeGB": "Maximale Kontingentumfangsgröße (GB)",
     "MaxSessionCountPerModelSession": "Maximale Sitzungsanzahl pro Modellsitzung",
     "MaxSessionLifetime": "Lebensdauer der Sitzung (Sek.)",
     "MaxVFolderCount": "Maximale Ordneranzahl",
@@ -2454,7 +2453,10 @@
     "Project": "Projekt",
     "ProjectResourcePolicy": "Projekt-Ressourcenrichtlinie",
     "ResourcePolicy": "Ressourcenrichtlinie",
+    "ResourcePolicyCreated": "Die Ressourcenrichtlinie wurde erstellt.",
+    "ResourcePolicyDeleted": "Die Ressourcenrichtlinie wurde gelöscht.",
     "ResourcePolicyNameAlreadyExists": "Der Name der Ressourcenrichtlinie ist bereits vorhanden. \nBitte ändern Sie den hinzuzufügenden Namen.",
+    "ResourcePolicyUpdated": "Die Ressourcenrichtlinie wurde aktualisiert.",
     "Resources": "Ressourcen",
     "Sessions": "Sitzungen",
     "StorageNodes": "Speicherknoten",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1883,19 +1883,16 @@
   },
   "loginHistory": {
     "Domain": "Τομέας",
-    "FailReason": "Αιτία αποτυχίας",
     "LoginTime": "Ώρα σύνδεσης",
     "Result": "Αποτέλεσμα"
   },
   "loginSession": {
     "AccessKey": "Κλειδί πρόσβασης",
     "CreatedAt": "Δημιουργήθηκε στο",
-    "InvalidatedAt": "Ακυρώθηκε στο",
     "RevokeFailed": "Αποτυχία ανάκλησης της συνεδρίας σύνδεσης.",
     "RevokeSession": "Ανάκληση συνεδρίας",
     "RevokeSessionConfirm": "Είστε βέβαιοι ότι θέλετε να ανακαλέσετε αυτή τη συνεδρία σύνδεσης;",
-    "RevokeSucceeded": "Η συνεδρία σύνδεσης ανακλήθηκε με επιτυχία.",
-    "User": "Χρήστης"
+    "RevokeSucceeded": "Η συνεδρία σύνδεσης ανακλήθηκε με επιτυχία."
   },
   "logs": {
     "ErrorMessage": "Μήνυμα λάθους",
@@ -2433,13 +2430,15 @@
     "IdleTimeoutSec": "Χρονικό όριο αδράνειας (δευτ.)",
     "Keypair": "Keypair",
     "KeypairResourcePolicy": "Πολιτική πόρων Keypair",
+    "MaxConcurrentLogins": "Μέγιστες ταυτόχρονες συνδέσεις",
     "MaxConcurrentSFTPSessions": "Max ταυτόχρονες συνεδρίες SFTP",
     "MaxCustomizedImageCount": "Μέγιστος προσαρμοσμένος αριθμός εικόνων",
     "MaxFolderCount": "Μέγιστος αριθμός φακέλων",
     "MaxNetworkCount": "Μέγιστος αριθμός δικτύου",
     "MaxPendingSessionCount": "Μέγιστο μέτρο εκκρεμούσης",
     "MaxPendingSessionResourceSlots": "Max εκκρεμείς υποδοχές πόρων συνεδρίας",
-    "MaxQuotaScopeSize": "Μέγιστο μέγεθος εύρους ορίου (GB)",
+    "MaxQuotaScopeSize": "Μέγιστο μέγεθος εύρους ορίου",
+    "MaxQuotaScopeSizeGB": "Μέγιστο μέγεθος εύρους ορίου (GB)",
     "MaxSessionCountPerModelSession": "Μέγιστος αριθμός περιόδων σύνδεσης ανά περίοδο λειτουργίας μοντέλου",
     "MaxSessionLifetime": "Διάρκεια ζωής συνόδου (sec.)",
     "MaxVFolderCount": "Μέγιστος αριθμός φακέλων",
@@ -2452,7 +2451,10 @@
     "Project": "Εργο",
     "ProjectResourcePolicy": "Πολιτική πόρων έργου",
     "ResourcePolicy": "Πολιτική πόρων",
+    "ResourcePolicyCreated": "Η πολιτική πόρων δημιουργήθηκε.",
+    "ResourcePolicyDeleted": "Η πολιτική πόρων διαγράφηκε.",
     "ResourcePolicyNameAlreadyExists": "Το όνομα της πολιτικής πόρων υπάρχει ήδη. \nΑλλάξτε το όνομα για προσθήκη.",
+    "ResourcePolicyUpdated": "Η πολιτική πόρων ενημερώθηκε.",
     "Resources": "Πόροι",
     "Sessions": "Συνεδρίες",
     "StorageNodes": "Κόμβοι αποθήκευσης",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1870,19 +1870,16 @@
   },
   "loginHistory": {
     "Domain": "Domain",
-    "FailReason": "Failure Reason",
     "LoginTime": "Login Time",
     "Result": "Result"
   },
   "loginSession": {
     "AccessKey": "Access Key",
     "CreatedAt": "Created At",
-    "InvalidatedAt": "Invalidated At",
     "RevokeFailed": "Failed to revoke login session.",
     "RevokeSession": "Revoke Session",
     "RevokeSessionConfirm": "Are you sure you want to revoke this login session?",
-    "RevokeSucceeded": "Login session revoked.",
-    "User": "User"
+    "RevokeSucceeded": "Login session revoked."
   },
   "logs": {
     "ErrorMessage": "Error Message",
@@ -2420,13 +2417,15 @@
     "IdleTimeoutSec": "Idle timeout (sec.)",
     "Keypair": "Keypair",
     "KeypairResourcePolicy": "Keypair Resource Policy",
+    "MaxConcurrentLogins": "Max Concurrent Logins",
     "MaxConcurrentSFTPSessions": "Max Concurrent SFTP Sessions",
     "MaxCustomizedImageCount": "Max Customized Image Count",
     "MaxFolderCount": "Max Folder Count",
     "MaxNetworkCount": "Max Network Count",
     "MaxPendingSessionCount": "Max Pending Session Count",
     "MaxPendingSessionResourceSlots": "Max Pending Session Resource Slots",
-    "MaxQuotaScopeSize": "Max Quota Scope Size (GB)",
+    "MaxQuotaScopeSize": "Max Quota Scope Size",
+    "MaxQuotaScopeSizeGB": "Max Quota Scope Size (GB)",
     "MaxSessionCountPerModelSession": "Max Session Count Per Model Session",
     "MaxSessionLifetime": "Session Lifetime (sec.)",
     "MaxVFolderCount": "Max Folder Count",
@@ -2439,7 +2438,10 @@
     "Project": "Project",
     "ProjectResourcePolicy": "Project Resource Policy",
     "ResourcePolicy": "Resource Policy",
+    "ResourcePolicyCreated": "Resource policy created.",
+    "ResourcePolicyDeleted": "Resource policy deleted.",
     "ResourcePolicyNameAlreadyExists": "Resource policy name already exists. Please change the name to add.",
+    "ResourcePolicyUpdated": "Resource policy updated.",
     "Resources": "Resources",
     "Sessions": "Sessions",
     "StorageNodes": "Storage Nodes",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1883,19 +1883,16 @@
   },
   "loginHistory": {
     "Domain": "Dominio",
-    "FailReason": "Motivo del error",
     "LoginTime": "Hora de inicio de sesión",
     "Result": "Resultado"
   },
   "loginSession": {
     "AccessKey": "Clave de acceso",
     "CreatedAt": "Creado en",
-    "InvalidatedAt": "Invalidado en",
     "RevokeFailed": "Error al revocar la sesión de inicio de sesión.",
     "RevokeSession": "Revocar sesión",
     "RevokeSessionConfirm": "¿Está seguro de que desea revocar esta sesión de inicio de sesión?",
-    "RevokeSucceeded": "Sesión de inicio de sesión revocada correctamente.",
-    "User": "Usuario"
+    "RevokeSucceeded": "Sesión de inicio de sesión revocada correctamente."
   },
   "logs": {
     "ErrorMessage": "Mensaje de error",
@@ -2433,13 +2430,15 @@
     "IdleTimeoutSec": "Tiempo de espera (seg.)",
     "Keypair": "Par de claves",
     "KeypairResourcePolicy": "Política de recursos de Keypair",
+    "MaxConcurrentLogins": "Máx. de inicios de sesión simultáneos",
     "MaxConcurrentSFTPSessions": "Sesiones SFTP concurrentes máximas",
     "MaxCustomizedImageCount": "Número máximo de imágenes personalizadas",
     "MaxFolderCount": "Número máximo de carpetas",
     "MaxNetworkCount": "Recuento máximo de red",
     "MaxPendingSessionCount": "Recuento de sesión pendiente máximo",
     "MaxPendingSessionResourceSlots": "MAX PENDO PENDAS DE RECURSOS DE RECURSOS DE SESIÓN",
-    "MaxQuotaScopeSize": "Tamaño máximo del alcance de la cuota (GB)",
+    "MaxQuotaScopeSize": "Tamaño máximo del alcance de la cuota",
+    "MaxQuotaScopeSizeGB": "Tamaño máximo del alcance de la cuota (GB)",
     "MaxSessionCountPerModelSession": "Recuento máximo de sesiones por sesión de modelo",
     "MaxSessionLifetime": "Duración de la sesión (seg.)",
     "MaxVFolderCount": "Número máximo de carpetas",
@@ -2452,7 +2451,10 @@
     "Project": "Proyecto",
     "ProjectResourcePolicy": "Política de recursos de proyecto",
     "ResourcePolicy": "Política de recursos",
+    "ResourcePolicyCreated": "La política de recursos ha sido creada.",
+    "ResourcePolicyDeleted": "La política de recursos ha sido eliminada.",
     "ResourcePolicyNameAlreadyExists": "El nombre de la política de recursos ya existe. \nCambie el nombre para agregarlo.",
+    "ResourcePolicyUpdated": "La política de recursos ha sido actualizada.",
     "Resources": "Recursos",
     "Sessions": "Sesiones",
     "StorageNodes": "Nodos de almacenamiento",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1883,19 +1883,16 @@
   },
   "loginHistory": {
     "Domain": "Toimialue",
-    "FailReason": "Epäonnistumisen syy",
     "LoginTime": "Kirjautumisaika",
     "Result": "Tulos"
   },
   "loginSession": {
     "AccessKey": "Pääsyavain",
     "CreatedAt": "Luotu klo",
-    "InvalidatedAt": "Mitätöity klo",
     "RevokeFailed": "Kirjautumisistunnon peruuttaminen epäonnistui.",
     "RevokeSession": "Peruuta istunto",
     "RevokeSessionConfirm": "Haluatko varmasti peruuttaa tämän kirjautumisistunnon?",
-    "RevokeSucceeded": "Kirjautumisistunto peruutettu onnistuneesti.",
-    "User": "Käyttäjä"
+    "RevokeSucceeded": "Kirjautumisistunto peruutettu onnistuneesti."
   },
   "logs": {
     "ErrorMessage": "Virheilmoitus",
@@ -2433,13 +2430,15 @@
     "IdleTimeoutSec": "Tyhjäkäynnin aikakatkaisu (sek.)",
     "Keypair": "Avainpari",
     "KeypairResourcePolicy": "Avainparin resurssikäytäntö",
+    "MaxConcurrentLogins": "Samanaikaisten kirjautumisten enimmäismäärä",
     "MaxConcurrentSFTPSessions": "Max samanaikaiset SFTP -istunnot",
     "MaxCustomizedImageCount": "Suurin mukautettu kuvien määrä",
     "MaxFolderCount": "Kansioiden enimmäismäärä",
     "MaxNetworkCount": "Verkkojen enimmäismäärä",
     "MaxPendingSessionCount": "Maxin vireillä oleva istuntomäärä",
     "MaxPendingSessionResourceSlots": "Max odottavat istunnon resurssipaikat",
-    "MaxQuotaScopeSize": "Kiintiön enimmäiskoko (GB)",
+    "MaxQuotaScopeSize": "Kiintiön enimmäiskoko",
+    "MaxQuotaScopeSizeGB": "Kiintiön enimmäiskoko (GB)",
     "MaxSessionCountPerModelSession": "Maksimi istuntojen määrä malliistuntoa kohti",
     "MaxSessionLifetime": "Istunnon kesto (sek.)",
     "MaxVFolderCount": "Kansioiden enimmäismäärä",
@@ -2452,7 +2451,10 @@
     "Project": "Projekti",
     "ProjectResourcePolicy": "Projektin resurssikäytäntö",
     "ResourcePolicy": "Resurssipolitiikka",
+    "ResourcePolicyCreated": "Resurssikäytäntö on luotu.",
+    "ResourcePolicyDeleted": "Resurssikäytäntö on poistettu.",
     "ResourcePolicyNameAlreadyExists": "Resurssikäytännön nimi on jo olemassa. \nMuuta lisättävä nimi.",
+    "ResourcePolicyUpdated": "Resurssikäytäntö on päivitetty.",
     "Resources": "Resurssit",
     "Sessions": "Istunnot",
     "StorageNodes": "Varastointisolmut",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1884,19 +1884,16 @@
   },
   "loginHistory": {
     "Domain": "Domaine",
-    "FailReason": "Raison de l'échec",
     "LoginTime": "Heure de connexion",
     "Result": "Résultat"
   },
   "loginSession": {
     "AccessKey": "Clé d'accès",
     "CreatedAt": "Créé à",
-    "InvalidatedAt": "Invalidé à",
     "RevokeFailed": "Échec de la révocation de la session de connexion.",
     "RevokeSession": "Révoquer la session",
     "RevokeSessionConfirm": "Êtes-vous sûr de vouloir révoquer cette session de connexion ?",
-    "RevokeSucceeded": "Session de connexion révoquée avec succès.",
-    "User": "Utilisateur"
+    "RevokeSucceeded": "Session de connexion révoquée avec succès."
   },
   "logs": {
     "ErrorMessage": "Message d'erreur",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "Délai d'inactivité (sec.)",
     "Keypair": "Paire de clés",
     "KeypairResourcePolicy": "Politique de ressources Keypair",
+    "MaxConcurrentLogins": "Connexions simultanées max.",
     "MaxConcurrentSFTPSessions": "Sessions SFTP max simultanées",
     "MaxCustomizedImageCount": "Nombre maximal d'images personnalisées",
     "MaxFolderCount": "Nombre maximum de dossiers",
     "MaxNetworkCount": "Nombre maximum de réseaux",
     "MaxPendingSessionCount": "Compte de session en attente maximum",
     "MaxPendingSessionResourceSlots": "Emplacements de ressources de session en attente maximale",
-    "MaxQuotaScopeSize": "Taille maximale de la portée du quota (Go)",
+    "MaxQuotaScopeSize": "Taille maximale de la portée du quota",
+    "MaxQuotaScopeSizeGB": "Taille maximale de la portée du quota (Go)",
     "MaxSessionCountPerModelSession": "Nombre maximum de sessions par session de modèle",
     "MaxSessionLifetime": "Durée de vie de la session (sec.)",
     "MaxVFolderCount": "Nombre maximum de dossiers",
@@ -2454,7 +2453,10 @@
     "Project": "Projet",
     "ProjectResourcePolicy": "Politique de ressources projet",
     "ResourcePolicy": "Politique de ressources",
+    "ResourcePolicyCreated": "La politique de ressources a été créée.",
+    "ResourcePolicyDeleted": "La politique de ressources a été supprimée.",
     "ResourcePolicyNameAlreadyExists": "Le nom de la stratégie de ressources existe déjà. \nVeuillez modifier le nom à ajouter.",
+    "ResourcePolicyUpdated": "La politique de ressources a été mise à jour.",
     "Resources": "Ressources",
     "Sessions": "Séances",
     "StorageNodes": "Nœuds de stockage",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1886,19 +1886,16 @@
   },
   "loginHistory": {
     "Domain": "Domain",
-    "FailReason": "Alasan Kegagalan",
     "LoginTime": "Waktu Login",
     "Result": "Hasil"
   },
   "loginSession": {
     "AccessKey": "Kunci Akses",
     "CreatedAt": "Dibuat Pada",
-    "InvalidatedAt": "Dibatalkan Pada",
     "RevokeFailed": "Gagal mencabut sesi login.",
     "RevokeSession": "Cabut Sesi",
     "RevokeSessionConfirm": "Apakah Anda yakin ingin mencabut sesi login ini?",
-    "RevokeSucceeded": "Sesi login berhasil dicabut.",
-    "User": "Pengguna"
+    "RevokeSucceeded": "Sesi login berhasil dicabut."
   },
   "logs": {
     "ErrorMessage": "Pesan Galat",
@@ -2436,13 +2433,15 @@
     "IdleTimeoutSec": "Waktu tunggu menganggur (dtk.)",
     "Keypair": "pasangan kunci",
     "KeypairResourcePolicy": "Kebijakan Sumber Daya Keypair",
+    "MaxConcurrentLogins": "Login Bersamaan Maksimum",
     "MaxConcurrentSFTPSessions": "Sesi SFTP Max Concurrent",
     "MaxCustomizedImageCount": "Jumlah Gambar Khusus Maksimum",
     "MaxFolderCount": "Jumlah Folder Maks",
     "MaxNetworkCount": "Jumlah Jaringan Maks",
     "MaxPendingSessionCount": "Hitungan sesi Max Tertunda",
     "MaxPendingSessionResourceSlots": "Slot sumber daya sesi maks yang tertunda",
-    "MaxQuotaScopeSize": "Ukuran Cakupan Kuota Maks (GB)",
+    "MaxQuotaScopeSize": "Ukuran Cakupan Kuota Maks",
+    "MaxQuotaScopeSizeGB": "Ukuran Cakupan Kuota Maks (GB)",
     "MaxSessionCountPerModelSession": "Jumlah Sesi Maks Per Sesi Model",
     "MaxSessionLifetime": "Sesi Seumur Hidup (detik)",
     "MaxVFolderCount": "Jumlah Folder Maks",
@@ -2455,7 +2454,10 @@
     "Project": "Proyek",
     "ProjectResourcePolicy": "Kebijakan Sumber Daya Proyek",
     "ResourcePolicy": "Kebijakan Sumber Daya",
+    "ResourcePolicyCreated": "Kebijakan sumber daya telah dibuat.",
+    "ResourcePolicyDeleted": "Kebijakan sumber daya telah dihapus.",
     "ResourcePolicyNameAlreadyExists": "Nama kebijakan sumber daya sudah ada. \nSilakan ubah nama untuk ditambahkan.",
+    "ResourcePolicyUpdated": "Kebijakan sumber daya telah diperbarui.",
     "Resources": "Sumber daya",
     "Sessions": "Sesi",
     "StorageNodes": "Node Penyimpanan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1883,19 +1883,16 @@
   },
   "loginHistory": {
     "Domain": "Dominio",
-    "FailReason": "Motivo dell'errore",
     "LoginTime": "Ora di accesso",
     "Result": "Risultato"
   },
   "loginSession": {
     "AccessKey": "Chiave di accesso",
     "CreatedAt": "Creato a",
-    "InvalidatedAt": "Invalidato a",
     "RevokeFailed": "Impossibile revocare la sessione di accesso.",
     "RevokeSession": "Revoca sessione",
     "RevokeSessionConfirm": "Sei sicuro di voler revocare questa sessione di accesso?",
-    "RevokeSucceeded": "Sessione di accesso revocata con successo.",
-    "User": "Utente"
+    "RevokeSucceeded": "Sessione di accesso revocata con successo."
   },
   "logs": {
     "ErrorMessage": "Messaggio di errore",
@@ -2433,13 +2430,15 @@
     "IdleTimeoutSec": "Timeout di inattività (sec.)",
     "Keypair": "Coppia di chiavi",
     "KeypairResourcePolicy": "Policy risorse Keypair",
+    "MaxConcurrentLogins": "Accessi simultanei massimi",
     "MaxConcurrentSFTPSessions": "Sessioni SFTP con contenitori massimi",
     "MaxCustomizedImageCount": "Conteggio massimo di immagini personalizzate",
     "MaxFolderCount": "Conteggio massimo cartelle",
     "MaxNetworkCount": "Conteggio massimo della rete",
     "MaxPendingSessionCount": "Conteggio delle sessioni massimo in sospeso",
     "MaxPendingSessionResourceSlots": "Slot di risorse sessioni massime in sospeso",
-    "MaxQuotaScopeSize": "Dimensione massima ambito quota (GB)",
+    "MaxQuotaScopeSize": "Dimensione massima ambito quota",
+    "MaxQuotaScopeSizeGB": "Dimensione massima ambito quota (GB)",
     "MaxSessionCountPerModelSession": "Conteggio massimo delle sessioni per sessione del modello",
     "MaxSessionLifetime": "Durata della sessione (sec.)",
     "MaxVFolderCount": "Conteggio massimo cartelle",
@@ -2452,7 +2451,10 @@
     "Project": "Progetto",
     "ProjectResourcePolicy": "Policy risorse progetto",
     "ResourcePolicy": "Politica delle risorse",
+    "ResourcePolicyCreated": "La politica delle risorse è stata creata.",
+    "ResourcePolicyDeleted": "La politica delle risorse è stata eliminata.",
     "ResourcePolicyNameAlreadyExists": "Il nome della policy delle risorse esiste già. \nSi prega di modificare il nome da aggiungere.",
+    "ResourcePolicyUpdated": "La politica delle risorse è stata aggiornata.",
     "Resources": "risorse",
     "Sessions": "sessioni",
     "StorageNodes": "Nodi di archiviazione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1885,19 +1885,16 @@
   },
   "loginHistory": {
     "Domain": "ドメイン",
-    "FailReason": "失敗の理由",
     "LoginTime": "ログイン日時",
     "Result": "結果"
   },
   "loginSession": {
     "AccessKey": "アクセスキー",
     "CreatedAt": "作成日",
-    "InvalidatedAt": "無効化日",
     "RevokeFailed": "ログインセッションの無効化に失敗しました。",
     "RevokeSession": "セッションを無効化",
     "RevokeSessionConfirm": "このログインセッションを無効化してもよろしいですか？",
-    "RevokeSucceeded": "ログインセッションを無効化しました。",
-    "User": "ユーザー"
+    "RevokeSucceeded": "ログインセッションを無効化しました。"
   },
   "logs": {
     "ErrorMessage": "エラーメッセージ",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "アイドルタイムアウト（秒）",
     "Keypair": "キーペア",
     "KeypairResourcePolicy": "キーペアリソースポリシー",
+    "MaxConcurrentLogins": "最大同時ログイン数",
     "MaxConcurrentSFTPSessions": "Max Concurrent SFTPセッション",
     "MaxCustomizedImageCount": "カスタマイズされた画像の最大数",
     "MaxFolderCount": "最大フォルダ数",
     "MaxNetworkCount": "最大ネットワーク数",
     "MaxPendingSessionCount": "最大保留中のセッションカウント",
     "MaxPendingSessionResourceSlots": "最大保留中のセッションリソーススロット",
-    "MaxQuotaScopeSize": "最大クォータ スコープ サイズ (GB)",
+    "MaxQuotaScopeSize": "最大クォータ スコープ サイズ",
+    "MaxQuotaScopeSizeGB": "最大クォータ スコープ サイズ (GB)",
     "MaxSessionCountPerModelSession": "モデルセッションごとの最大セッション数",
     "MaxSessionLifetime": "セッションの最大実行時間",
     "MaxVFolderCount": "最大フォルダ数",
@@ -2454,7 +2453,10 @@
     "Project": "プロジェクト",
     "ProjectResourcePolicy": "プロジェクトリソースポリシー",
     "ResourcePolicy": "リソースポリシー",
+    "ResourcePolicyCreated": "リソースポリシーが作成されました。",
+    "ResourcePolicyDeleted": "リソースポリシーが削除されました。",
     "ResourcePolicyNameAlreadyExists": "リソースポリシー名はすでに存在します。\n追加する名前を変更してください。",
+    "ResourcePolicyUpdated": "リソースポリシーが更新されました。",
     "Resources": "リソース",
     "Sessions": "セッション",
     "StorageNodes": "ストレージノード",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1885,19 +1885,16 @@
   },
   "loginHistory": {
     "Domain": "도메인",
-    "FailReason": "실패 사유",
     "LoginTime": "로그인 시각",
     "Result": "결과"
   },
   "loginSession": {
     "AccessKey": "액세스 키",
     "CreatedAt": "생성 시각",
-    "InvalidatedAt": "무효화 시각",
     "RevokeFailed": "로그인 세션 해지에 실패했습니다.",
     "RevokeSession": "세션 해지",
     "RevokeSessionConfirm": "이 로그인 세션을 해지하시겠습니까?",
-    "RevokeSucceeded": "로그인 세션을 해지했습니다.",
-    "User": "사용자"
+    "RevokeSucceeded": "로그인 세션을 해지했습니다."
   },
   "logs": {
     "ErrorMessage": "에러 메시지",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "유휴 대기 시간 (초)",
     "Keypair": "키페어",
     "KeypairResourcePolicy": "키페어 자원 정책",
+    "MaxConcurrentLogins": "최대 동시 로그인",
     "MaxConcurrentSFTPSessions": "최대 동시 SFTP 세션",
     "MaxCustomizedImageCount": "최대 사용자 정의 이미지 수",
     "MaxFolderCount": "최대 폴더 수",
     "MaxNetworkCount": "최대 네트워크 수",
     "MaxPendingSessionCount": "최대 대기 세션",
     "MaxPendingSessionResourceSlots": "최대 대기 세션 리소스 슬롯",
-    "MaxQuotaScopeSize": "최대 할당량 범위 크기(GB)",
+    "MaxQuotaScopeSize": "최대 할당량 범위 크기",
+    "MaxQuotaScopeSizeGB": "최대 할당량 범위 크기(GB)",
     "MaxSessionCountPerModelSession": "모델 세션당 최대 세션 수",
     "MaxSessionLifetime": "세션 최대 실행시간",
     "MaxVFolderCount": "최대 폴더 수",
@@ -2454,7 +2453,10 @@
     "Project": "프로젝트",
     "ProjectResourcePolicy": "프로젝트 자원 정책",
     "ResourcePolicy": "자원 정책",
+    "ResourcePolicyCreated": "자원 정책이 생성되었습니다.",
+    "ResourcePolicyDeleted": "자원 정책이 삭제되었습니다.",
     "ResourcePolicyNameAlreadyExists": "리소스 정책 이름이 이미 존재합니다. \n추가하려면 이름을 변경하세요.",
+    "ResourcePolicyUpdated": "자원 정책이 수정되었습니다.",
     "Resources": "자원",
     "Sessions": "세션",
     "StorageNodes": "저장소 노드",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1884,19 +1884,16 @@
   },
   "loginHistory": {
     "Domain": "Домэйн",
-    "FailReason": "Амжилтгүй болсон шалтгаан",
     "LoginTime": "Нэвтэрсэн цаг",
     "Result": "Үр дүн"
   },
   "loginSession": {
     "AccessKey": "Хандалтын түлхүүр",
     "CreatedAt": "Үүсгэсэн",
-    "InvalidatedAt": "Хүчингүй болгосон",
     "RevokeFailed": "Нэвтрэх сессийг цуцлахад алдаа гарлаа.",
     "RevokeSession": "Сессийг цуцлах",
     "RevokeSessionConfirm": "Энэ нэвтрэх сессийг цуцлахдаа итгэлтэй байна уу?",
-    "RevokeSucceeded": "Нэвтрэх сессийг амжилттай цуцаллаа.",
-    "User": "Хэрэглэгч"
+    "RevokeSucceeded": "Нэвтрэх сессийг амжилттай цуцаллаа."
   },
   "logs": {
     "ErrorMessage": "Алдааны зурвас",
@@ -2434,13 +2431,15 @@
     "IdleTimeoutSec": "Сул зогсолт (сек.)",
     "Keypair": "Товчлуур",
     "KeypairResourcePolicy": "Keypair нөөцийн бодлого",
+    "MaxConcurrentLogins": "Хамгийн их зэрэгцээ нэвтрэлт",
     "MaxConcurrentSFTPSessions": "Макс тохиролцсон SFTP хуралдаанууд",
     "MaxCustomizedImageCount": "Хамгийн их тохируулсан зургийн тоо",
     "MaxFolderCount": "Хамгийн их хавтасны тоо",
     "MaxNetworkCount": "Хамгийн их сүлжээний тоо",
     "MaxPendingSessionCount": "Макс хүлээгдэж буй хуралдааны тоо",
     "MaxPendingSessionResourceSlots": "Макс хүлээгдэж буй сешний нөөцийн слотууд",
-    "MaxQuotaScopeSize": "Хамгийн их квот хамрах хүрээний хэмжээ (ГБ)",
+    "MaxQuotaScopeSize": "Хамгийн их квот хамрах хүрээний хэмжээ",
+    "MaxQuotaScopeSizeGB": "Хамгийн их квот хамрах хүрээний хэмжээ (ГБ)",
     "MaxSessionCountPerModelSession": "Загвар бүрийн хамгийн их сеанс тоо",
     "MaxSessionLifetime": "Сеанс үргэлжлэх хугацаа (сек.)",
     "MaxVFolderCount": "Хамгийн их хавтасны тоо",
@@ -2453,7 +2452,10 @@
     "Project": "Төсөл",
     "ProjectResourcePolicy": "Төслийн нөөцийн бодлого",
     "ResourcePolicy": "Нөөцийн бодлого",
+    "ResourcePolicyCreated": "Нөөцийн бодлого үүсгэгдлээ.",
+    "ResourcePolicyDeleted": "Нөөцийн бодлого устгагдлаа.",
     "ResourcePolicyNameAlreadyExists": "Нөөцийн бодлогын нэр аль хэдийн байна. \nНэмэх нэрээ өөрчилнө үү.",
+    "ResourcePolicyUpdated": "Нөөцийн бодлого шинэчлэгдлээ.",
     "Resources": "Нөөц",
     "Sessions": "Чуулган",
     "StorageNodes": "Хадгалах цэгүүд",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1883,19 +1883,16 @@
   },
   "loginHistory": {
     "Domain": "Domain",
-    "FailReason": "Sebab Kegagalan",
     "LoginTime": "Masa Log Masuk",
     "Result": "Keputusan"
   },
   "loginSession": {
     "AccessKey": "Kunci Akses",
     "CreatedAt": "Dicipta Pada",
-    "InvalidatedAt": "Tidak Sah Pada",
     "RevokeFailed": "Gagal membatalkan sesi log masuk.",
     "RevokeSession": "Batalkan Sesi",
     "RevokeSessionConfirm": "Adakah anda pasti mahu membatalkan sesi log masuk ini?",
-    "RevokeSucceeded": "Sesi log masuk berjaya dibatalkan.",
-    "User": "Pengguna"
+    "RevokeSucceeded": "Sesi log masuk berjaya dibatalkan."
   },
   "logs": {
     "ErrorMessage": "Mesej Ralat",
@@ -2433,13 +2430,15 @@
     "IdleTimeoutSec": "Tamat waktu tunggu (sek.)",
     "Keypair": "Pasangan kekunci",
     "KeypairResourcePolicy": "Dasar Sumber Keypair",
+    "MaxConcurrentLogins": "Log Masuk Serentak Maksimum",
     "MaxConcurrentSFTPSessions": "Sesi SFTP bersamaan Max",
     "MaxCustomizedImageCount": "Kiraan Imej Tersuai Maks",
     "MaxFolderCount": "Kiraan Folder Maks",
     "MaxNetworkCount": "Kiraan Rangkaian Maks",
     "MaxPendingSessionCount": "Kiraan sesi maksimum yang belum selesai",
     "MaxPendingSessionResourceSlots": "Slot sumber sesi maksimum yang belum selesai",
-    "MaxQuotaScopeSize": "Saiz Skop Kuota Maks (GB)",
+    "MaxQuotaScopeSize": "Saiz Skop Kuota Maks",
+    "MaxQuotaScopeSizeGB": "Saiz Skop Kuota Maks (GB)",
     "MaxSessionCountPerModelSession": "Kiraan Sesi Maks Setiap Sesi Model",
     "MaxSessionLifetime": "Sepanjang Hayat Sesi (saat)",
     "MaxVFolderCount": "Kiraan Folder Maks",
@@ -2452,7 +2451,10 @@
     "Project": "Projek",
     "ProjectResourcePolicy": "Dasar Sumber Projek",
     "ResourcePolicy": "Dasar Sumber",
+    "ResourcePolicyCreated": "Dasar sumber telah dibuat.",
+    "ResourcePolicyDeleted": "Dasar sumber telah dipadam.",
     "ResourcePolicyNameAlreadyExists": "Nama dasar sumber sudah wujud. \nSila tukar nama untuk ditambah.",
+    "ResourcePolicyUpdated": "Dasar sumber telah dikemas kini.",
     "Resources": "Sumber",
     "Sessions": "Sesi",
     "StorageNodes": "Nod Penyimpanan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1884,19 +1884,16 @@
   },
   "loginHistory": {
     "Domain": "Domena",
-    "FailReason": "Przyczyna błędu",
     "LoginTime": "Czas logowania",
     "Result": "Wynik"
   },
   "loginSession": {
     "AccessKey": "Klucz dostępu",
     "CreatedAt": "Utworzono o godz",
-    "InvalidatedAt": "Unieważniono o godz",
     "RevokeFailed": "Nie udało się odwołać sesji logowania.",
     "RevokeSession": "Odwołaj sesję",
     "RevokeSessionConfirm": "Czy na pewno chcesz odwołać tę sesję logowania?",
-    "RevokeSucceeded": "Sesja logowania została pomyślnie odwołana.",
-    "User": "Użytkownik"
+    "RevokeSucceeded": "Sesja logowania została pomyślnie odwołana."
   },
   "logs": {
     "ErrorMessage": "Komunikat o błędzie",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "Limit czasu bezczynności (sek.)",
     "Keypair": "Para kluczy",
     "KeypairResourcePolicy": "Polityka zasobów Keypair",
+    "MaxConcurrentLogins": "Maks. liczba równoczesnych logowań",
     "MaxConcurrentSFTPSessions": "Max równoległe sesje SFTP",
     "MaxCustomizedImageCount": "Maksymalna dostosowana liczba obrazów",
     "MaxFolderCount": "Maksymalna liczba folderów",
     "MaxNetworkCount": "Maksymalna liczba sieci",
     "MaxPendingSessionCount": "Max oczekujący na liczbę sesji",
     "MaxPendingSessionResourceSlots": "Max oczekujący szczeliny zasobów sesji",
-    "MaxQuotaScopeSize": "Maksymalny rozmiar zakresu przydziału (GB)",
+    "MaxQuotaScopeSize": "Maksymalny rozmiar zakresu przydziału",
+    "MaxQuotaScopeSizeGB": "Maksymalny rozmiar zakresu przydziału (GB)",
     "MaxSessionCountPerModelSession": "Maksymalna liczba sesji na sesję modelu",
     "MaxSessionLifetime": "Czas trwania sesji (sek.)",
     "MaxVFolderCount": "Maksymalna liczba folderów",
@@ -2454,7 +2453,10 @@
     "Project": "Projekt",
     "ProjectResourcePolicy": "Polityka zasobów projektu",
     "ResourcePolicy": "Polityka zasobów",
+    "ResourcePolicyCreated": "Zasady zasobów zostały utworzone.",
+    "ResourcePolicyDeleted": "Zasady zasobów zostały usunięte.",
     "ResourcePolicyNameAlreadyExists": "Nazwa zasady zasobów już istnieje. \nAby dodać, zmień nazwę.",
+    "ResourcePolicyUpdated": "Zasady zasobów zostały zaktualizowane.",
     "Resources": "Zasoby",
     "Sessions": "Sesje",
     "StorageNodes": "Węzły magazynowania",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1883,19 +1883,16 @@
   },
   "loginHistory": {
     "Domain": "Domínio",
-    "FailReason": "Motivo da falha",
     "LoginTime": "Hora do login",
     "Result": "Resultado"
   },
   "loginSession": {
     "AccessKey": "Chave de acesso",
     "CreatedAt": "Criado em",
-    "InvalidatedAt": "Invalidado em",
     "RevokeFailed": "Falha ao revogar a sessão de login.",
     "RevokeSession": "Revogar sessão",
     "RevokeSessionConfirm": "Tem certeza de que deseja revogar esta sessão de login?",
-    "RevokeSucceeded": "Sessão de login revogada com sucesso.",
-    "User": "Usuário"
+    "RevokeSucceeded": "Sessão de login revogada com sucesso."
   },
   "logs": {
     "ErrorMessage": "Mensagem de erro",
@@ -2433,13 +2430,15 @@
     "IdleTimeoutSec": "Tempo limite ocioso (seg.)",
     "Keypair": "Par de chaves",
     "KeypairResourcePolicy": "Política de recursos de Keypair",
+    "MaxConcurrentLogins": "Máx. de logins simultâneos",
     "MaxConcurrentSFTPSessions": "Sessões SFTP simultâneas máximas",
     "MaxCustomizedImageCount": "Contagem máxima de imagens personalizadas",
     "MaxFolderCount": "Contagem máxima de pastas",
     "MaxNetworkCount": "Contagem máxima de rede",
     "MaxPendingSessionCount": "Contagem máxima de sessão pendente",
     "MaxPendingSessionResourceSlots": "Slots de recurso de sessão pendente máximo",
-    "MaxQuotaScopeSize": "Tamanho máximo do escopo da cota (GB)",
+    "MaxQuotaScopeSize": "Tamanho máximo do escopo da cota",
+    "MaxQuotaScopeSizeGB": "Tamanho máximo do escopo da cota (GB)",
     "MaxSessionCountPerModelSession": "Contagem máxima de sessões por sessão de modelo",
     "MaxSessionLifetime": "Tempo de vida da sessão (seg.)",
     "MaxVFolderCount": "Contagem máxima de pastas",
@@ -2452,7 +2451,10 @@
     "Project": "Projeto",
     "ProjectResourcePolicy": "Política de recursos de projeto",
     "ResourcePolicy": "Política de Recursos",
+    "ResourcePolicyCreated": "A política de recursos foi criada.",
+    "ResourcePolicyDeleted": "A política de recursos foi excluída.",
     "ResourcePolicyNameAlreadyExists": "O nome da política de recursos já existe. \nPor favor, altere o nome para adicionar.",
+    "ResourcePolicyUpdated": "A política de recursos foi atualizada.",
     "Resources": "Recursos",
     "Sessions": "Sessões",
     "StorageNodes": "Nós de Armazenamento",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1885,19 +1885,16 @@
   },
   "loginHistory": {
     "Domain": "Domínio",
-    "FailReason": "Motivo da falha",
     "LoginTime": "Hora do login",
     "Result": "Resultado"
   },
   "loginSession": {
     "AccessKey": "Chave de acesso",
     "CreatedAt": "Criado em",
-    "InvalidatedAt": "Invalidado em",
     "RevokeFailed": "Falha ao revogar a sessão de login.",
     "RevokeSession": "Revogar sessão",
     "RevokeSessionConfirm": "Tem certeza de que deseja revogar esta sessão de login?",
-    "RevokeSucceeded": "Sessão de login revogada com sucesso.",
-    "User": "Usuário"
+    "RevokeSucceeded": "Sessão de login revogada com sucesso."
   },
   "logs": {
     "ErrorMessage": "Mensagem de erro",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "Tempo limite ocioso (seg.)",
     "Keypair": "Par de chaves",
     "KeypairResourcePolicy": "Política de recursos de Keypair",
+    "MaxConcurrentLogins": "Máx. de logins simultâneos",
     "MaxConcurrentSFTPSessions": "Sessões SFTP simultâneas máximas",
     "MaxCustomizedImageCount": "Contagem máxima de imagens personalizadas",
     "MaxFolderCount": "Contagem máxima de pastas",
     "MaxNetworkCount": "Contagem máxima de rede",
     "MaxPendingSessionCount": "Contagem máxima de sessão pendente",
     "MaxPendingSessionResourceSlots": "Slots de recurso de sessão pendente máximo",
-    "MaxQuotaScopeSize": "Tamanho máximo do escopo da cota (GB)",
+    "MaxQuotaScopeSize": "Tamanho máximo do escopo da cota",
+    "MaxQuotaScopeSizeGB": "Tamanho máximo do escopo da cota (GB)",
     "MaxSessionCountPerModelSession": "Contagem máxima de sessões por sessão de modelo",
     "MaxSessionLifetime": "Tempo de vida da sessão (seg.)",
     "MaxVFolderCount": "Contagem máxima de pastas",
@@ -2454,7 +2453,10 @@
     "Project": "Projeto",
     "ProjectResourcePolicy": "Política de recursos de projeto",
     "ResourcePolicy": "Política de Recursos",
+    "ResourcePolicyCreated": "A política de recursos foi criada.",
+    "ResourcePolicyDeleted": "A política de recursos foi eliminada.",
     "ResourcePolicyNameAlreadyExists": "O nome da política de recursos já existe. \nPor favor, altere o nome para adicionar.",
+    "ResourcePolicyUpdated": "A política de recursos foi atualizada.",
     "Resources": "Recursos",
     "Sessions": "Sessões",
     "StorageNodes": "Nós de Armazenamento",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1883,19 +1883,16 @@
   },
   "loginHistory": {
     "Domain": "Домен",
-    "FailReason": "Причина сбоя",
     "LoginTime": "Время входа",
     "Result": "Результат"
   },
   "loginSession": {
     "AccessKey": "Ключ доступа",
     "CreatedAt": "Создано в",
-    "InvalidatedAt": "Аннулировано в",
     "RevokeFailed": "Не удалось отозвать сеанс входа.",
     "RevokeSession": "Отозвать сеанс",
     "RevokeSessionConfirm": "Вы уверены, что хотите отозвать этот сеанс входа?",
-    "RevokeSucceeded": "Сеанс входа успешно отозван.",
-    "User": "Пользователь"
+    "RevokeSucceeded": "Сеанс входа успешно отозван."
   },
   "logs": {
     "ErrorMessage": "Сообщение об ошибке",
@@ -2433,13 +2430,15 @@
     "IdleTimeoutSec": "Тайм-аут простоя (сек.)",
     "Keypair": "Ключевая пара",
     "KeypairResourcePolicy": "Политика ресурсов Keypair",
+    "MaxConcurrentLogins": "Максимум одновременных входов",
     "MaxConcurrentSFTPSessions": "Максимальные параллельные сеансы SFTP",
     "MaxCustomizedImageCount": "Максимальное количество индивидуальных изображений",
     "MaxFolderCount": "Максимальное количество папок",
     "MaxNetworkCount": "Максимальное количество сетей",
     "MaxPendingSessionCount": "Максимальный счет в ожидании сессии",
     "MaxPendingSessionResourceSlots": "Максимальный ожидающий сессионные слоты ресурсов",
-    "MaxQuotaScopeSize": "Максимальный размер квоты (ГБ)",
+    "MaxQuotaScopeSize": "Максимальный размер квоты",
+    "MaxQuotaScopeSizeGB": "Максимальный размер квоты (ГБ)",
     "MaxSessionCountPerModelSession": "Максимальное количество сеансов на модельный сеанс",
     "MaxSessionLifetime": "Время жизни сеанса (сек.)",
     "MaxVFolderCount": "Максимальное количество папок",
@@ -2452,7 +2451,10 @@
     "Project": "Проект",
     "ProjectResourcePolicy": "Политика ресурсов проекта",
     "ResourcePolicy": "Политика ресурсов",
+    "ResourcePolicyCreated": "Политика ресурсов создана.",
+    "ResourcePolicyDeleted": "Политика ресурсов удалена.",
     "ResourcePolicyNameAlreadyExists": "Название политики ресурсов уже существует. \nПожалуйста, измените имя, чтобы добавить.",
+    "ResourcePolicyUpdated": "Политика ресурсов обновлена.",
     "Resources": "Ресурсы",
     "Sessions": "Сессии",
     "StorageNodes": "Узлы хранения",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1885,19 +1885,16 @@
   },
   "loginHistory": {
     "Domain": "โดเมน",
-    "FailReason": "สาเหตุที่ล้มเหลว",
     "LoginTime": "เวลาเข้าสู่ระบบ",
     "Result": "ผลลัพธ์"
   },
   "loginSession": {
     "AccessKey": "คีย์การเข้าถึง",
     "CreatedAt": "สร้างเมื่อ",
-    "InvalidatedAt": "ถูกยกเลิกเมื่อ",
     "RevokeFailed": "ไม่สามารถเพิกถอนเซสชันเข้าสู่ระบบได้",
     "RevokeSession": "เพิกถอนเซสชัน",
     "RevokeSessionConfirm": "คุณแน่ใจหรือไม่ว่าต้องการเพิกถอนเซสชันเข้าสู่ระบบนี้?",
-    "RevokeSucceeded": "เพิกถอนเซสชันเข้าสู่ระบบสำเร็จ",
-    "User": "ผู้ใช้"
+    "RevokeSucceeded": "เพิกถอนเซสชันเข้าสู่ระบบสำเร็จ"
   },
   "logs": {
     "ErrorMessage": "ข้อความแสดงข้อผิดพลาด",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "หมดเวลาเมื่อไม่มีการใช้งาน (วินาที)",
     "Keypair": "คู่คีย์",
     "KeypairResourcePolicy": "นโยบายทรัพยากร Keypair",
+    "MaxConcurrentLogins": "จำนวนการเข้าสู่ระบบพร้อมกันสูงสุด",
     "MaxConcurrentSFTPSessions": "เซสชัน SFTP ที่เกิดขึ้นพร้อมกันสูงสุด",
     "MaxCustomizedImageCount": "จำนวนอิมเมจที่กำหนดเองสูงสุด",
     "MaxFolderCount": "จำนวนโฟลเดอร์สูงสุด",
     "MaxNetworkCount": "จำนวนเครือข่ายสูงสุด",
     "MaxPendingSessionCount": "จำนวนเซสชันที่ค้างอยู่สูงสุด",
     "MaxPendingSessionResourceSlots": "ช่องทรัพยากรเซสชันที่รออยู่สูงสุด",
-    "MaxQuotaScopeSize": "ขนาดขอบเขตโควตาสูงสุด (GB)",
+    "MaxQuotaScopeSize": "ขนาดขอบเขตโควตาสูงสุด",
+    "MaxQuotaScopeSizeGB": "ขนาดขอบเขตโควตาสูงสุด (GB)",
     "MaxSessionCountPerModelSession": "จำนวนเซสชันสูงสุดต่อเซสชันโมเดล",
     "MaxSessionLifetime": "อายุการใช้งานเซสชันสูงสุด (วินาที)",
     "MaxVFolderCount": "จำนวนโฟลเดอร์สูงสุด",
@@ -2454,7 +2453,10 @@
     "Project": "โครงการ",
     "ProjectResourcePolicy": "นโยบายทรัพยากรโครงการ",
     "ResourcePolicy": "นโยบายทรัพยากร",
+    "ResourcePolicyCreated": "นโยบายทรัพยากรถูกสร้างแล้ว",
+    "ResourcePolicyDeleted": "นโยบายทรัพยากรถูกลบแล้ว",
     "ResourcePolicyNameAlreadyExists": "มีชื่อนโยบายทรัพยากรนี้อยู่แล้ว กรุณาเปลี่ยนชื่อเพื่อเพิ่ม",
+    "ResourcePolicyUpdated": "นโยบายทรัพยากรถูกอัปเดตแล้ว",
     "Resources": "ทรัพยากร",
     "Sessions": "เซสชัน",
     "StorageNodes": "โหนดจัดเก็บ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1883,19 +1883,16 @@
   },
   "loginHistory": {
     "Domain": "Alan Adı",
-    "FailReason": "Hata Nedeni",
     "LoginTime": "Oturum Açma Zamanı",
     "Result": "Sonuç"
   },
   "loginSession": {
     "AccessKey": "Erişim Anahtarı",
     "CreatedAt": "Oluşturulma Tarihi",
-    "InvalidatedAt": "Geçersizleştirilme Tarihi",
     "RevokeFailed": "Oturum açma oturumu iptal edilemedi.",
     "RevokeSession": "Oturumu İptal Et",
     "RevokeSessionConfirm": "Bu oturum açma oturumunu iptal etmek istediğinizden emin misiniz?",
-    "RevokeSucceeded": "Oturum açma oturumu başarıyla iptal edildi.",
-    "User": "Kullanıcı"
+    "RevokeSucceeded": "Oturum açma oturumu başarıyla iptal edildi."
   },
   "logs": {
     "ErrorMessage": "Hata mesajı",
@@ -2433,13 +2430,15 @@
     "IdleTimeoutSec": "Boşta kalma zaman aşımı (sn.)",
     "Keypair": "Anahtar çifti",
     "KeypairResourcePolicy": "Keypair Kaynak Politikası",
+    "MaxConcurrentLogins": "Maksimum eşzamanlı oturum açma",
     "MaxConcurrentSFTPSessions": "Maksimum eşzamanlı SFTP oturumları",
     "MaxCustomizedImageCount": "Maksimum Özelleştirilmiş Görüntü Sayısı",
     "MaxFolderCount": "Maksimum Klasör Sayısı",
     "MaxNetworkCount": "Maksimum Ağ Sayısı",
     "MaxPendingSessionCount": "Max bekleyen oturum sayısı",
     "MaxPendingSessionResourceSlots": "Max Bekleyen Oturum Kaynak Yuvaları",
-    "MaxQuotaScopeSize": "Maksimum Kota Kapsamı Boyutu (GB)",
+    "MaxQuotaScopeSize": "Maksimum Kota Kapsamı Boyutu",
+    "MaxQuotaScopeSizeGB": "Maksimum Kota Kapsamı Boyutu (GB)",
     "MaxSessionCountPerModelSession": "Model Oturumu Başına Maksimum Oturum Sayısı",
     "MaxSessionLifetime": "Oturum Ömrü (sn.)",
     "MaxVFolderCount": "Maksimum Klasör Sayısı",
@@ -2452,7 +2451,10 @@
     "Project": "Proje",
     "ProjectResourcePolicy": "Proje Kaynak Politikası",
     "ResourcePolicy": "Kaynak Politikası",
+    "ResourcePolicyCreated": "Kaynak politikası oluşturuldu.",
+    "ResourcePolicyDeleted": "Kaynak politikası silindi.",
     "ResourcePolicyNameAlreadyExists": "Kaynak politikası adı zaten mevcut. \nLütfen eklenecek adı değiştirin.",
+    "ResourcePolicyUpdated": "Kaynak politikası güncellendi.",
     "Resources": "Kaynaklar",
     "Sessions": "Oturumlar",
     "StorageNodes": "Depolama Düğümleri",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1885,19 +1885,16 @@
   },
   "loginHistory": {
     "Domain": "Miền",
-    "FailReason": "Lý do thất bại",
     "LoginTime": "Thời gian đăng nhập",
     "Result": "Kết quả"
   },
   "loginSession": {
     "AccessKey": "Khóa truy cập",
     "CreatedAt": "Được tạo tại",
-    "InvalidatedAt": "Bị vô hiệu tại",
     "RevokeFailed": "Không thể thu hồi phiên đăng nhập.",
     "RevokeSession": "Thu hồi phiên",
     "RevokeSessionConfirm": "Bạn có chắc chắn muốn thu hồi phiên đăng nhập này không?",
-    "RevokeSucceeded": "Phiên đăng nhập đã được thu hồi thành công.",
-    "User": "Người dùng"
+    "RevokeSucceeded": "Phiên đăng nhập đã được thu hồi thành công."
   },
   "logs": {
     "ErrorMessage": "Thông báo lỗi",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "Thời gian chờ không hoạt động (giây)",
     "Keypair": "Cặp khóa",
     "KeypairResourcePolicy": "Chính sách tài nguyên Keypair",
+    "MaxConcurrentLogins": "Số lần đăng nhập đồng thời tối đa",
     "MaxConcurrentSFTPSessions": "Phiên SFTP đồng thời tối đa",
     "MaxCustomizedImageCount": "Số lượng hình ảnh tùy chỉnh tối đa",
     "MaxFolderCount": "Số lượng thư mục tối đa",
     "MaxNetworkCount": "Số lượng mạng tối đa",
     "MaxPendingSessionCount": "Số lượng phiên đang chờ xử lý tối đa",
     "MaxPendingSessionResourceSlots": "Các khe cắm tài nguyên phiên đang chờ xử lý tối đa",
-    "MaxQuotaScopeSize": "Kích thước phạm vi hạn ngạch tối đa (GB)",
+    "MaxQuotaScopeSize": "Kích thước phạm vi hạn ngạch tối đa",
+    "MaxQuotaScopeSizeGB": "Kích thước phạm vi hạn ngạch tối đa (GB)",
     "MaxSessionCountPerModelSession": "Số phiên tối đa trên mỗi phiên mô hình",
     "MaxSessionLifetime": "Thời gian tồn tại của phiên (giây)",
     "MaxVFolderCount": "Số lượng thư mục tối đa",
@@ -2454,7 +2453,10 @@
     "Project": "Dự án",
     "ProjectResourcePolicy": "Chính sách tài nguyên dự án",
     "ResourcePolicy": "Chính sách tài nguyên",
+    "ResourcePolicyCreated": "Chính sách tài nguyên đã được tạo.",
+    "ResourcePolicyDeleted": "Chính sách tài nguyên đã được xóa.",
     "ResourcePolicyNameAlreadyExists": "Tên chính sách tài nguyên đã tồn tại. \nVui lòng thay đổi tên để thêm.",
+    "ResourcePolicyUpdated": "Chính sách tài nguyên đã được cập nhật.",
     "Resources": "Tài nguyên",
     "Sessions": "Phiên",
     "StorageNodes": "Nút lưu trữ",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1885,19 +1885,16 @@
   },
   "loginHistory": {
     "Domain": "域",
-    "FailReason": "失败原因",
     "LoginTime": "登录时间",
     "Result": "结果"
   },
   "loginSession": {
     "AccessKey": "访问密钥",
     "CreatedAt": "创建于",
-    "InvalidatedAt": "失效于",
     "RevokeFailed": "撤销登录会话失败。",
     "RevokeSession": "撤销会话",
     "RevokeSessionConfirm": "您确定要撤销此登录会话吗？",
-    "RevokeSucceeded": "登录会话已成功撤销。",
-    "User": "用户"
+    "RevokeSucceeded": "登录会话已成功撤销。"
   },
   "logs": {
     "ErrorMessage": "错误信息",
@@ -2435,13 +2432,15 @@
     "IdleTimeoutSec": "空闲超时（秒）",
     "Keypair": "密钥对",
     "KeypairResourcePolicy": "密钥对资源策略",
+    "MaxConcurrentLogins": "最大并发登录数",
     "MaxConcurrentSFTPSessions": "最大并发SFTP会话",
     "MaxCustomizedImageCount": "最大自定义图像数量",
     "MaxFolderCount": "最大文件夹数",
     "MaxNetworkCount": "最大网络数",
     "MaxPendingSessionCount": "最大待定会话计数",
     "MaxPendingSessionResourceSlots": "最大待处理会话资源插槽",
-    "MaxQuotaScopeSize": "最大配额范围大小 (GB)",
+    "MaxQuotaScopeSize": "最大配额范围大小",
+    "MaxQuotaScopeSizeGB": "最大配额范围大小 (GB)",
     "MaxSessionCountPerModelSession": "每个模型会话的最大会话计数",
     "MaxSessionLifetime": "会话寿命（秒）",
     "MaxVFolderCount": "最大文件夹数",
@@ -2454,7 +2453,10 @@
     "Project": "项目",
     "ProjectResourcePolicy": "项目资源策略",
     "ResourcePolicy": "资源政策",
+    "ResourcePolicyCreated": "资源策略已创建。",
+    "ResourcePolicyDeleted": "资源策略已删除。",
     "ResourcePolicyNameAlreadyExists": "资源策略名称已存在。\n请更改名称以添加。",
+    "ResourcePolicyUpdated": "资源策略已更新。",
     "Resources": "资源",
     "Sessions": "会话",
     "StorageNodes": "存储节点",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1886,19 +1886,16 @@
   },
   "loginHistory": {
     "Domain": "網域",
-    "FailReason": "失敗原因",
     "LoginTime": "登入時間",
     "Result": "結果"
   },
   "loginSession": {
     "AccessKey": "存取密鑰",
     "CreatedAt": "創建於",
-    "InvalidatedAt": "失效於",
     "RevokeFailed": "撤銷登入工作階段失敗。",
     "RevokeSession": "撤銷工作階段",
     "RevokeSessionConfirm": "您確定要撤銷此登入工作階段嗎？",
-    "RevokeSucceeded": "登入工作階段已成功撤銷。",
-    "User": "使用者"
+    "RevokeSucceeded": "登入工作階段已成功撤銷。"
   },
   "logs": {
     "ErrorMessage": "錯誤信息",
@@ -2437,13 +2434,15 @@
     "IdleTimeoutSec": "空閒超時（秒）",
     "Keypair": "密鑰對",
     "KeypairResourcePolicy": "密鑰對資源策略",
+    "MaxConcurrentLogins": "最大並發登入數",
     "MaxConcurrentSFTPSessions": "最大並發SFTP會話",
     "MaxCustomizedImageCount": "最大自訂圖像數量",
     "MaxFolderCount": "最大資料夾數",
     "MaxNetworkCount": "最大網路數",
     "MaxPendingSessionCount": "最大待定會話計數",
     "MaxPendingSessionResourceSlots": "最大待處理會話資源插槽",
-    "MaxQuotaScopeSize": "最大配額範圍大小 (GB)",
+    "MaxQuotaScopeSize": "最大配額範圍大小",
+    "MaxQuotaScopeSizeGB": "最大配額範圍大小 (GB)",
     "MaxSessionCountPerModelSession": "每個模型會話的最大會話計數",
     "MaxSessionLifetime": "会话寿命（秒）",
     "MaxVFolderCount": "最大資料夾數",
@@ -2456,7 +2455,10 @@
     "Project": "專案",
     "ProjectResourcePolicy": "專案資源策略",
     "ResourcePolicy": "資源政策",
+    "ResourcePolicyCreated": "資源策略已建立。",
+    "ResourcePolicyDeleted": "資源策略已刪除。",
     "ResourcePolicyNameAlreadyExists": "資源策略名稱已存在。\n請更改名稱以新增。",
+    "ResourcePolicyUpdated": "資源策略已更新。",
     "Resources": "資源",
     "Sessions": "會話",
     "StorageNodes": "存儲節點",


### PR DESCRIPTION
Resolves #8061 (FR-3222)

## Summary

Migrates the **User Resource Policy** tab on the Resource Policy page from the legacy V1 `user_resource_policies` query to the Strawberry **V2** GraphQL API, as part of FR-3183 (legacy V1 `_nodes` removal / V2 migration).

New components are added alongside the legacy ones — the legacy files are **kept on disk, now unused, as a safety backup** (per request):

- **`BAIUserResourcePolicyV2Table`** (in `backend.ai-ui`) — presentational table over a `UserResourcePolicyV2` plural fragment. The name column uses `BAINameActionCell` with per-row Edit / Delete actions.
- **`UserResourcePolicyV2.tsx`** — query orchestrator reading a preloaded `adminUserResourcePoliciesV2` query; owns filter / sort / pagination (`limit`/`offset`) / refresh, the create-edit modal, and the delete flow (`adminDeleteUserResourcePolicyV2`).
- **`UserResourcePolicyV2SettingModal.tsx`** — create/edit via `adminCreateUserResourcePolicyV2` / `adminUpdateUserResourcePolicyV2`.

### Lazy load on tab activation

`ResourcePolicyPage` owns `useQueryLoader` and loads the V2 query only when the `user` tab is active (`useEffectEvent` + `useEffect([curTabKey])`), mirroring the ScopedAuditLog / FR-3215 login-sessions pattern.

**Version branching (manager-gated).** The V2 `BAIGraphQLPropertyFilter` emits the AND/OR/NOT sub-filter combinators, which `UserResourcePolicyV2Filter` only gained in **manager 26.7.0** (schema: "Added in 26.7.0"). The page therefore gates on the `sub-filter` client feature: when supported it renders `UserResourcePolicyV2`, and on older managers (< 26.7.0) it falls back to the legacy `UserResourcePolicyList` so the tab keeps working without sending arguments the manager would reject. The legacy fallback is retained for that compatibility window rather than removed outright.

## Table components moved into `backend.ai-ui`

The presentational tables are consolidated into the shared BUI package, following the `BAIAdminUserV2Table` precedent:

| Before (host) | After (BUI) |
| --- | --- |
| `UserResourcePolicyV2Table` | `BAIUserResourcePolicyV2Table` |
| `LoginSessionTable` | `BAILoginSessionTable` |
| `LoginHistoryTable` | `BAILoginHistoryTable` |

- Switched `useTranslation` → `useBAIi18n` (react-i18next direct imports are ESLint-blocked inside BUI per FR-2986); table strings moved into `comp:BAI*Table.*` namespaces in `packages/backend.ai-ui/src/locale/*.json` (all 21 languages).
- Fragments / props renamed with the `BAI` prefix (`BAI*TableFragment`, `BAI*TableProps`); components exported from the package index.
- Host orchestrators (`UserResourcePolicyV2`, `LoginSession`, `LoginHistory`) now consume them from `backend.ai-ui`. No behavior change — query orchestration (filter, pagination, sort, row actions) stays in the host.
- Host i18n keys orphaned by the move (`loginHistory.FailReason`, `loginSession.InvalidatedAt`, `loginSession.User`) removed from all locales; keys still used by the host modal / filter bars are kept.

## Schema notes

- `max_quota_scope_size` (Int) → `maxQuotaScopeSize` (`BinarySizeInfo { value, display }`); unlimited still rendered as ∞ and submitted as `BinarySizeInput { expr: '-1' }`.
- snake_case → camelCase field renames throughout.
- Pagination uses **`limit` + `offset`** only (offset mode), per the V2 connection pagination rule.

## Newly surfaced field

- `maxConcurrentLogins` is now surfaced as both a table column (rendered as ∞ when null) and a setting-modal form field. New i18n key `MaxConcurrentLogins` added across all locales.

## Units

- `maxQuotaScopeSize` is **decimal GB end-to-end**: the modal converts with `GBToBytes` (×10^9) and the list renders with `convertToDecimalUnit(value, 'auto')` — what the admin types is what the list shows.

## Out of scope

- Legacy `UserResourcePolicyList.tsx` / `UserResourcePolicySettingModal.tsx` left in place — still used as the < 26.7.0 fallback render (see "Version branching" above).

## Needs verification (backend)

- Confirm the manager accepts `BinarySizeInput { expr: "-1" }` as the "unlimited" sentinel for `maxQuotaScopeSize` on create/update (legacy passed the Int `-1`).

## Verification

`bash scripts/verify.sh`: **Relay ✅ / Lint ✅ / Format ✅ / TypeScript ✅**.

> The `Vite warmup paths` check reports FAIL, but this is **pre-existing on `main`** and unrelated to this PR — `react/vite.config.ts` is untouched. The check's awk window over-captures string literals outside the `warmup` block (e.g. `sw.js`, `buffer`, `**/*.map`), which are not real warmup entries.
