### PR TITLE
fix(FR-3209): validate CSV password per-row instead of blocking on a missing column

### DIFF
--- a/e2e/credential/bulk-create-from-csv.spec.ts
+++ b/e2e/credential/bulk-create-from-csv.spec.ts
@@ -320,21 +320,59 @@ test.describe(
       await closeModal(page);
     });
 
-    test('admin sees a missing-column error for a raw export CSV with no password column', async ({
+    test('admin can load a passwordless export CSV; rows show per-row password errors and submit is disabled', async ({
       page,
     }) => {
       await openBulkCreateCSVModal(page);
       await uploadCSV(page, '18-export-no-password-column.csv');
-      // No global default password is set → password column is required.
-      await expect(page.locator('.ant-message-notice')).toBeVisible({
-        timeout: 5000,
-      });
+      // The passwordless CSV still loads — password is validated per row.
+      expect(await getStat(page, 'rows loaded')).toBe(2);
+      // Both rows lack a password → per-row errors, none ready to create.
+      expect(await getStat(page, 'with errors')).toBe(2);
+      expect(await getStat(page, 'ready to create')).toBe(0);
+      // The submit button stays disabled while any row has a password error.
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeDisabled();
+      // No blocking toast for this load.
+      await expect(page.locator('.ant-message-notice')).not.toBeVisible();
+      await closeModal(page);
+    });
+
+    test('admin filling the global default password reactively updates the preview and enables submit', async ({
+      page,
+    }) => {
+      await openBulkCreateCSVModal(page);
+      await uploadCSV(page, '18-export-no-password-column.csv');
+      // Loads with per-row password errors; submit disabled.
+      expect(await getStat(page, 'with errors')).toBe(2);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeDisabled();
+
+      // Typing a valid default password in the left "Global defaults" form fills
+      // the empty passwords reactively — the preview re-validates with no
+      // re-upload (the table is derived live from the global defaults).
       const dialog = page.getByRole('dialog', {
         name: 'Bulk Create Users from CSV',
       });
-      await expect(dialog.getByText('rows loaded')).not.toBeVisible({
-        timeout: 3000,
-      });
+      // Anchor off the visible "Password" form label rather than the password
+      // input's internal class, so the locator stays unambiguous even if another
+      // password input is added later.
+      const defaultPasswordInput = dialog
+        .locator('.ant-form-item')
+        .filter({ has: page.getByText('Password', { exact: true }) })
+        .locator('input');
+      await defaultPasswordInput.fill('Password!23');
+
+      // Preview updates live: per-row password errors clear, all rows ready,
+      // and the Create button enables. Poll both stats — the recalculation is
+      // driven by React re-render, so read after it settles.
+      await expect.poll(() => getStat(page, 'with errors')).toBe(0);
+      await expect.poll(() => getStat(page, 'ready to create')).toBe(2);
+      await expect(
+        page.getByRole('button', { name: /Create \d+ user/ }),
+      ).toBeEnabled();
       await closeModal(page);
     });
   },

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -523,11 +523,9 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
       columnAliases,
     );
 
-    // password is only required when no global default password is configured —
-    // export CSVs never include a password column, so a default unlocks them.
-    const missingColumns = findMissingRequiredColumns(columnsInFile, {
-      hasGlobalPassword: !!globalDefaults.defaultPassword.trim(),
-    });
+    // Only email/username are blocking columns; password is validated per row,
+    // so a passwordless CSV still loads (missing passwords become row errors).
+    const missingColumns = findMissingRequiredColumns(columnsInFile);
     if (missingColumns.length > 0) {
       message.error(
         t('credential.validation.CSVMissingColumns', {

--- a/react/src/helper/bulkUserCSV.test.ts
+++ b/react/src/helper/bulkUserCSV.test.ts
@@ -210,31 +210,18 @@ describe('extractRawUserRows', () => {
 describe('findMissingRequiredColumns', () => {
   it('passes a CSV that has email/username/password', () => {
     const { presentColumns } = analyze('16-export-field-keys.csv');
-    expect(
-      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: false }),
-    ).toEqual([]);
+    expect(findMissingRequiredColumns(presentColumns)).toEqual([]);
   });
 
-  it('flags a raw export (no password) when no global default password is set', () => {
+  it('does NOT flag a passwordless export (password is validated per-row, not as a column)', () => {
     const { presentColumns } = analyze('18-export-no-password-column.csv');
-    expect(
-      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: false }),
-    ).toEqual(['password']);
-  });
-
-  it('unlocks a passwordless export once a global default password is configured', () => {
-    const { presentColumns } = analyze('18-export-no-password-column.csv');
-    expect(
-      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: true }),
-    ).toEqual([]);
+    expect(findMissingRequiredColumns(presentColumns)).toEqual([]);
   });
 
   it('flags email/username when an export omits them', () => {
     // Reuse the missing-column fixture (username, password, full_name — no email).
     const { presentColumns } = analyze('12-error-missing-required-columns.csv');
-    expect(
-      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: false }),
-    ).toEqual(['email']);
+    expect(findMissingRequiredColumns(presentColumns)).toEqual(['email']);
   });
 });
 
@@ -256,9 +243,10 @@ describe('localized export headers (dynamic aliases)', () => {
     const { presentColumns } = analyze('19-export-localized-headers-ko.csv');
     // Without the server-provided localized aliases, nothing resolves.
     expect(presentColumns.size).toBe(0);
-    expect(
-      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: true }),
-    ).toEqual(['email', 'username']);
+    expect(findMissingRequiredColumns(presentColumns)).toEqual([
+      'email',
+      'username',
+    ]);
   });
 
   it('recognises Korean headers once dynamic aliases are merged in', () => {
@@ -282,13 +270,9 @@ describe('localized export headers (dynamic aliases)', () => {
         'need_password_change',
       ].sort(),
     );
-    // Localized export has no password column → needs a global default password.
-    expect(
-      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: false }),
-    ).toEqual(['password']);
-    expect(
-      findMissingRequiredColumns(presentColumns, { hasGlobalPassword: true }),
-    ).toEqual([]);
+    // Localized export has no password column, but that is not a blocking column
+    // (password is validated per-row), so email+username being present suffices.
+    expect(findMissingRequiredColumns(presentColumns)).toEqual([]);
     // Values land in the right canonical fields despite localized headers.
     expect(rows[0]).toMatchObject({
       email: 'ko1@example.com',

--- a/react/src/helper/bulkUserCSV.ts
+++ b/react/src/helper/bulkUserCSV.ts
@@ -86,18 +86,11 @@ export const EXPORT_KEY_TO_IMPORT: Record<string, CanonicalUserColumn> = {
   project_name: 'project',
 };
 
-// Required columns when no global default password is configured. The export
-// report never includes a password column, so importing an export CSV requires
-// the admin to set a default password — which relaxes the requirement below.
-const REQUIRED_COLUMNS_WITH_PASSWORD: CanonicalUserColumn[] = [
-  'email',
-  'username',
-  'password',
-];
-const REQUIRED_COLUMNS_WITHOUT_PASSWORD: CanonicalUserColumn[] = [
-  'email',
-  'username',
-];
+// The only blocking required columns. `password` is intentionally absent: a CSV
+// without a password column (e.g. an export report, which never includes one)
+// still loads, and missing/empty passwords surface as per-row validation errors
+// instead of blocking the whole file.
+const REQUIRED_COLUMNS: CanonicalUserColumn[] = ['email', 'username'];
 
 export interface RawUserRow {
   email: string;
@@ -189,17 +182,14 @@ export const mapUserCSVColumns = (
 
 /**
  * Returns the canonical columns that are required but missing from the file.
- * `password` is only required when no global default password is configured.
+ * Only `email` and `username` are blocking required columns; `password` is
+ * validated per row (missing/empty values become row errors, not a column-level
+ * block), so a passwordless CSV still loads.
  */
 export const findMissingRequiredColumns = (
   presentColumns: Set<CanonicalUserColumn>,
-  options: { hasGlobalPassword: boolean },
-): CanonicalUserColumn[] => {
-  const required = options.hasGlobalPassword
-    ? REQUIRED_COLUMNS_WITHOUT_PASSWORD
-    : REQUIRED_COLUMNS_WITH_PASSWORD;
-  return required.filter((canon) => !presentColumns.has(canon));
-};
+): CanonicalUserColumn[] =>
+  REQUIRED_COLUMNS.filter((canon) => !presentColumns.has(canon));
 
 /**
  * Projects parsed CSV records onto the importer's RawUserRow shape. Columns


### PR DESCRIPTION
Resolves #8039 (FR-3209)

## Problem

In the **Bulk Create Users from CSV** modal, `password` was treated as a hard-required **column**. When an uploaded CSV had no `password` column, `findMissingRequiredColumns` reported `password` as missing and `loadCSVText` showed a toast error and **returned early** — the CSV never loaded into the preview. This blocked the common flow of re-importing an **export-report CSV** (which never contains a password column).

## Change

Only `email` and `username` remain blocking required **columns**. `password` is now validated **per row**:

- A CSV **without** a `password` column (or with empty password cells) **loads into the preview**.
- Missing/empty passwords surface as **per-row** errors (`credential.validation.CSVPasswordRequired`).
- The **Create N users** button stays disabled while any row has a password error.
- Entering a **default password** in the left **Global defaults** form fills the empty passwords reactively — the preview is derived live from the global defaults, so the per-row errors clear and submit enables with no re-upload.

A missing `email` or `username` column still blocks with a clear message.

## Files

- `react/src/helper/bulkUserCSV.ts` — collapse `REQUIRED_COLUMNS_WITH/WITHOUT_PASSWORD` into a single `REQUIRED_COLUMNS = ['email', 'username']`; drop the `hasGlobalPassword` option from `findMissingRequiredColumns`.
- `react/src/components/BulkCreateUserFromCSVModal.tsx` — call `findMissingRequiredColumns` without the password coupling. Per-row validation and the default-password fallback are unchanged.
- `react/src/helper/bulkUserCSV.test.ts` — `password` is never reported as a missing required column.
- `e2e/credential/bulk-create-from-csv.spec.ts` — rewrite the passwordless-export test (loads with per-row errors, submit disabled, no blocking toast) and **add** a test that filling the global default password reactively updates the preview and enables submit.

## Verification

- `react` unit tests: `vitest run src/helper/bulkUserCSV.test.ts` → 23 passed.
- `scripts/verify.sh`: Relay / Lint / Format pass. The one TypeScript error is a pre-existing, unrelated issue in `AdminDeploymentPresetSettingPageContent.tsx` (untouched by this PR).
- e2e specs (`bulk-create-from-csv.spec.ts`, `-submit.spec.ts`) require a live cluster to run.

## Acceptance criteria

- [x] Uploading a CSV with no `password` column loads the preview (no blocking toast).
- [x] Rows with no password show the per-row "password required" error; submit is disabled.
- [x] Entering a default password on the left clears those errors and enables submit (preview updates live).
- [x] A missing `email` or `username` column still blocks with a clear message.
