### PR TITLE
style(FR-3180): truncate kernel and container IDs in session details kernel list

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -17,6 +17,7 @@ import {
   BAITable,
   BAIUnmountAfterClose,
   BAIDoubleTag,
+  BAIId,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { ScrollTextIcon } from 'lucide-react';
@@ -144,28 +145,12 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
       title: t('kernel.KernelId'),
       fixed: 'left',
       dataIndex: 'row_id',
-      render: (row_id) => (
-        <>
-          <Typography.Text copyable ellipsis>
-            {row_id}
-          </Typography.Text>
-        </>
-      ),
+      render: (row_id) => (_.isEmpty(row_id) ? '-' : <BAIId uuid={row_id} />),
     },
     {
       title: t('kernel.ContainerId'),
       dataIndex: 'container_id',
-      onCell: () => ({
-        style: { maxWidth: 250 },
-      }),
-      render: (id) =>
-        _.isEmpty(id) ? (
-          '-'
-        ) : (
-          <Typography.Text copyable ellipsis>
-            {id}
-          </Typography.Text>
-        ),
+      render: (id) => (_.isEmpty(id) ? '-' : <BAIId uuid={id} />),
     },
   ]);
 


### PR DESCRIPTION
Resolves #7991 (FR-3180)

## Summary

The kernel ID and container ID columns in the Session Details → Kernels table rendered the full opaque IDs, inflating the table width. They now show a short 8-character prefix with an ellipsis.

- Display the first 8 characters followed by `…`.
- The full value is preserved in the copy button (`copyable={{ text }}`) and shown on hover via a tooltip.
- Removed the fixed `maxWidth: 250` cap on the container ID column — no longer needed now that the rendered content is short.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

## Screenshots

### After

The Kernel ID (`c4c78789…`) and Container ID (`3aad3a8d…`) columns are truncated to an 8-character prefix; the full value remains available via the copy button and the hover tooltip.

![Kernel/Container ID truncation](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8071/20260629-072449-kernel-id-truncation-after.png)