### PR TITLE
fix(ci): make release docs PDF job resilient to Playwright download stalls

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,12 +1,12 @@
 # Build and release workflow for Backend.AI Desktop and WebUI bundle.
 #
-# Architecture: 4 parallel jobs (build_docs is fully independent, the others
-# share a web build step).
+# Architecture: parallel jobs. The web/desktop chain shares a web build step;
+# the docs chain (resolve_versions → build_docs) runs independently of it.
 #
 #   build_web (ubuntu) ──┬──> build_mac (macos)    → DMG x64/arm64 + local proxy
 #                        ├──> build_desktop (ubuntu) → Win/Linux ZIP x64/arm64 + local proxy
 #                        └──> upload web bundle
-#   build_docs (ubuntu, independent)               → User Guide PDFs (en/ko/ja/th)
+#   resolve_versions (ubuntu) ──> build_docs (Playwright container) → User Guide PDFs (en/ko/ja/th)
 #
 # Key optimizations over the previous single-job approach:
 #   1. Parallel jobs: macOS + win/linux + docs builds run concurrently (~10 min saved)
@@ -14,7 +14,8 @@
 #   3. Parallel local proxy compilation within each job (~3 min saved)
 #   4. Optimized ZIP compression level (-6 vs -9, marginal size diff, ~1 min saved)
 #   5. PDF generation reuses one Chromium instance and renders languages in
-#      parallel; Playwright browsers are cached across runs.
+#      parallel; the browser is pre-baked into the Playwright container, so
+#      there is no cdn.playwright.dev download at release time (FR-3225).
 
 name: Build and Release Packages
 on:
@@ -207,23 +208,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ──────────────────────────────────────────────────────────────────────
-  # Job 4: Build per-language User Guide PDFs (ubuntu, target ~5 min)
+  # Job 4a: Resolve the Playwright version (ubuntu, ~1 min)
   #
-  # Independent of the web/desktop jobs — only needs the docs sources under
-  # `packages/backend.ai-webui-docs/src/`. Runs in parallel with build_mac
-  # and build_desktop, so a healthy run does not extend the overall wall
-  # clock (mac is the current critical path at ~10 min).
-  #
-  # Failure handling is scoped to the PDF build step itself (not the whole
-  # job), so partial per-language failures degrade gracefully but a full
-  # generator failure (all languages failed → generate-pdf.ts exits non-
-  # zero) still fails the job. This prevents shipping a release with zero
-  # PDF assets going unnoticed.
+  # build_docs runs inside the official Playwright container, whose tag MUST
+  # match the `playwright` version resolved from the lockfile so the baked-in
+  # browsers are used (no cdn.playwright.dev download). A `container.image`
+  # value is fixed before any step runs, so it cannot reference a step output
+  # from its own job — but it CAN reference `needs.<job>.outputs.*`. This tiny
+  # job derives the version once and hands it to build_docs, keeping the image
+  # tag in lockstep with package.json automatically (no manual bump). FR-3225.
   # ──────────────────────────────────────────────────────────────────────
-  build_docs:
+  resolve_versions:
+    # Read-only: this job only derives a version string from the checkout.
     permissions:
-      contents: write
+      contents: read
     runs-on: ubuntu-latest
+    outputs:
+      playwright: ${{ steps.pw.outputs.version }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
@@ -242,52 +243,87 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      # Cache the Playwright browser binaries (~150 MB Chromium download).
-      # The lockfile hash keys the cache so a Playwright version bump
-      # naturally invalidates the cache without manual intervention.
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
+      - id: pw
+        name: Resolve Playwright version
+        run: echo "version=$(pnpm --filter backend.ai-webui-docs exec playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 4b: Build per-language User Guide PDFs (target ~5-7 min)
+  #
+  # Runs INSIDE the official Playwright container so Chromium and its OS deps
+  # are already baked into the image — there is NO cdn.playwright.dev download
+  # at release time. This is the FR-3225 fix: v26.4.10 shipped with zero PDFs
+  # because that download stalled for ~6h (a GitHub-runner ↔ Google Cloud
+  # Storage network issue, not a broken build) and rode the default job cap.
+  # The image is pulled from Microsoft Container Registry (Azure) — the same
+  # network as the runner — sidestepping the fragile GCS path entirely. The
+  # tag comes from `resolve_versions`, so it always matches the npm
+  # `playwright` version (a mismatch would silently re-trigger the download).
+  #
+  # Independent of the web/desktop jobs — only needs the docs sources under
+  # `packages/backend.ai-webui-docs/src/`.
+  #
+  # Failure handling: generate-pdf.ts degrades past per-language failures and
+  # exits non-zero only if *every* language failed, so a partial run still
+  # uploads what succeeded. The job is intentionally NOT `continue-on-error`:
+  # a total PDF failure must fail the run loudly so a zero-PDF release cannot
+  # go unnoticed again.
+  # ──────────────────────────────────────────────────────────────────────
+  build_docs:
+    needs: resolve_versions
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v${{ needs.resolve_versions.outputs.playwright }}-noble
+    # With browsers pre-baked, the job is dominated by the ~5-7 min PDF render
+    # plus the image pull, so this cap only trips on a genuine hang.
+    timeout-minutes: 30
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
         with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          run_install: false
 
-      - name: Install Playwright Chromium
-        run: pnpm --filter backend.ai-webui-docs exec playwright install --with-deps chromium
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
-      # PDF rendering uses two distinct font paths that need different fonts:
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      # PDF rendering uses two distinct font paths:
       #
-      # 1. Body text — rendered by Chromium from HTML. Resolves the CSS
-      #    font-family (see styles.ts) via fontconfig, so it understands
-      #    .ttc collections. `fonts-noto-cjk` provides "Noto Sans CJK KR/JP/TC"
-      #    which the CSS lists as the canonical CJK body font.
-      #
+      # 1. Body text — rendered by Chromium from HTML via fontconfig.
+      #    `fonts-noto-cjk` provides "Noto Sans CJK KR/JP/TC", the canonical
+      #    CJK body font referenced by the CSS (styles.ts).
       # 2. Header/footer — stamped post-render by pdf-lib, which cannot embed
-      #    .ttc collections. So we additionally install language-specific
-      #    single-face packages whose paths are listed in
-      #    DEFAULT_CJK_FONT_CANDIDATES (pdf-renderer.ts):
-      #      - fonts-nanum         → /usr/share/fonts/truetype/nanum/NanumBarunGothic.ttf  (ko)
-      #      - fonts-takao-gothic  → /usr/share/fonts/truetype/takao-gothic/TakaoGothic.ttf (ja)
-      #      - fonts-thai-tlwg     → /usr/share/fonts/opentype/tlwg/Loma.otf | Garuda.ttf  (th)
+      #    .ttc collections, so it needs language-specific single-face fonts
+      #    (paths in DEFAULT_CJK_FONT_CANDIDATES, pdf-renderer.ts):
+      #      - fonts-nanum        → NanumBarunGothic.ttf  (ko)
+      #      - fonts-takao-gothic → TakaoGothic.ttf        (ja)
+      #      - fonts-thai-tlwg    → Loma.otf | Garuda.ttf  (th)
       #
-      # Languages whose pdf-lib font is missing will be reported as a failure by
-      # generate-pdf.ts but will not abort the other language renders.
+      # The container runs as root, so no `sudo`. Best-effort: a missing
+      # pdf-lib font fails only that language's header stamp, not the others.
       - name: Install CJK + Thai fonts (best effort)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          apt-get update
+          apt-get install -y --no-install-recommends \
             fonts-noto-cjk \
             fonts-nanum fonts-takao-gothic fonts-thai-tlwg || true
           fc-cache -f || true
 
-      # generate-pdf.ts continues past per-language failures and exits
-      # non-zero only if *every* requested language failed. Combined with
-      # `continue-on-error: true` on the job, a partial PDF run still
-      # uploads the languages that succeeded.
       - name: Build PDFs (en/ko/ja/th)
         run: pnpm --filter backend.ai-webui-docs run pdf:all
 
       - name: Stage PDFs for upload
+        shell: bash
         run: |
           mkdir -p ./app
           if compgen -G "packages/backend.ai-webui-docs/dist/*.pdf" > /dev/null; then


### PR DESCRIPTION
Resolves #8073 (FR-3225)

## Problem

The `build_docs` job in `.github/workflows/package.yml` failed to attach User Guide PDFs to the **v26.4.10** release.

In the v26.4.10 run (`28147112326`), the `build_docs` log shows:

1. **Playwright cache MISS** (key was the lockfile hash, which churns constantly), forcing a fresh browser download.
2. `Install Playwright Chromium` started downloading Chrome for Testing from `cdn.playwright.dev` and **stalled indefinitely**.
3. The job had **no `timeout-minutes`**, so it ran to the GitHub default **6-hour** cap and was **auto-cancelled** — PDF steps skipped, release shipped with **zero PDF assets**, surfaced only as `cancelled` (not `failure`).

### Root cause confirmed during review

`cdn.playwright.dev` 307-redirects to `storage.googleapis.com`. The build URL itself is healthy (downloads in ~5s from a normal network), so the stall is a **GitHub-runner ↔ Google Cloud Storage** network condition, not a broken build. A dry-run on the fixed branch reproduced it: all 3 download attempts timed out and the job failed fast (~16 min) instead of hanging 6h — proving the failure mode and the need to remove the GCS download from the release path entirely.

## Fix — run `build_docs` in the official Playwright container

The release PDF build now runs inside `mcr.microsoft.com/playwright`, which ships **Chromium + its OS deps pre-baked**. There is **no `cdn.playwright.dev` / GCS download at release time**; the image is pulled from Microsoft Container Registry (Azure), the same network as the runner.

- **`resolve_versions` job** derives the `playwright` version from the lockfile and exposes it as an output. `build_docs` then uses `container.image: mcr.microsoft.com/playwright:v${{ needs.resolve_versions.outputs.playwright }}-noble`. A `container.image` can't read a step output from its own job but *can* read `needs.*.outputs.*`, so the image tag stays **automatically in lockstep with `package.json`** — no manual version coupling.
- **`build_docs`** drops the Chromium download/cache/retry entirely (moot in the container), installs the CJK/Thai header-stamp fonts via `apt-get` (container runs as root, no `sudo`), renders the PDFs, and uploads them.
- **`timeout-minutes: 30`** backstop so any genuine hang fails fast and visibly instead of riding the 6h cap.
- The job stays **non-`continue-on-error`**: a total PDF failure fails the run loudly so a zero-PDF release can't go unnoticed again (a stale comment claiming otherwise was removed).
- Both jobs declare explicit least-privilege `permissions` (`resolve_versions: contents: read`).

## Interim action

For v26.4.10, the four-language User Guide PDFs were built locally from latest `main` and uploaded to the release manually, so the release is no longer missing its PDFs.

## Verification

Validated end-to-end via a `workflow_dispatch` dry run (`dry_run=true`, no release assets touched):

- **Successful run:** https://github.com/lablup/backend.ai-webui/actions/runs/28356628299
  - [`resolve_versions` ✅](https://github.com/lablup/backend.ai-webui/actions/runs/28356628299/job/84001055045) — version resolved, container tag valid.
  - [`build_docs` ✅](https://github.com/lablup/backend.ai-webui/actions/runs/28356628299/job/84001162342) — **green in ~4 min** (vs. the prior 6h hang / 16 min download-fail). `Initialize containers` → `Build PDFs (en/ko/ja/th)` all pass with **no `cdn.playwright.dev` download**.
  - The `webui-docs-pdfs` artifact contains all four PDFs (en/ko/ja/th), including the Japanese header-stamp font path.
- For contrast, the pre-container dry run reproduced the stall and failed fast (~16 min) instead of hanging 6h: run `28354713006`.

Note: the successful run above is on commit `a00046fba`; the later `permissions` block (`6a62d5702`) is a static lint fix that does not change build behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)