### PR TITLE
feat(FR-3011): show renderInput option labels in filter condition tags

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.test.tsx
@@ -147,15 +147,43 @@ const ownerCustomProperties: Array<FilterProperty> = [
   },
 ];
 
+// FR-3011: a `renderInput` control whose committed value is opaque (a UUID)
+// but which forwards the selected option (`{ value, label }`) as the second
+// `onChange` argument, mirroring `BAIUserSelect` with `valuePropName="id"`.
+const ownerLabeledProperties: Array<FilterProperty> = [
+  {
+    key: 'owner.id',
+    propertyLabel: 'Owner',
+    type: 'uuid',
+    fixedOperator: 'equals',
+    singleSelect: true,
+    renderInput: ({ onChange }) => (
+      <button
+        type="button"
+        onClick={() =>
+          onChange('uuid-alice', {
+            value: 'uuid-alice',
+            label: 'alice@example.com',
+          })
+        }
+      >
+        pick-alice
+      </button>
+    ),
+  },
+];
+
 const ControlledCustom = ({
   onFilterChange,
+  filterProperties: customProperties = ownerCustomProperties,
 }: {
   onFilterChange?: (value: GraphQLFilter | undefined) => void;
+  filterProperties?: Array<FilterProperty>;
 }) => {
   const [value, setValue] = useState<GraphQLFilter | undefined>();
   return (
     <BAIGraphQLPropertyFilter
-      filterProperties={ownerCustomProperties}
+      filterProperties={customProperties}
       value={value}
       onChange={(next) => {
         setValue(next);
@@ -198,5 +226,27 @@ describe('BAIGraphQLPropertyFilter custom renderInput', () => {
     // Both conditions are kept as separate tags.
     expect(screen.getByText(/Owner.*uuid-alice/)).toBeVisible();
     expect(document.querySelectorAll('.ant-tag')).toHaveLength(2);
+  });
+
+  it('displays the renderInput-supplied label in the tag while keeping the raw value in the filter', async () => {
+    const onFilterChange = vi.fn();
+    render(
+      <ControlledCustom
+        onFilterChange={onFilterChange}
+        filterProperties={ownerLabeledProperties}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('pick-alice'));
+
+    // The GraphQL filter still carries the opaque value (UUID), not the label.
+    await waitFor(() => {
+      expect(onFilterChange).toHaveBeenCalledWith({
+        owner: { id: { equals: 'uuid-alice' } },
+      });
+    });
+    // The tag shows the human-readable label, not the UUID.
+    expect(screen.getByText(/Owner.*alice@example\.com/)).toBeVisible();
+    expect(screen.queryByText(/uuid-alice/)).not.toBeInTheDocument();
   });
 });

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -127,6 +127,17 @@ export type FilterOperator =
   // Allow custom operators
   | (string & NonNullable<unknown>);
 
+// A selected option emitted by a `renderInput` control's `onChange`, mirroring
+// the `option` argument antd's Select hands to its own `onChange` so a control
+// can forward it verbatim — hence `value` may be a number and `label` may be a
+// ReactNode. The raw `value` is committed into the GraphQL filter; only a
+// string/number `label` is shown in the condition tag (which needs a plain
+// string). A ReactNode label is ignored and the tag falls back to the value.
+export type FilterInputOption = {
+  value: string | number;
+  label?: React.ReactNode;
+};
+
 type BaseFilterProperty = {
   key: string;
   propertyLabel: string;
@@ -158,11 +169,23 @@ type BaseFilterProperty = {
   // Replaces the default AutoComplete input with a controlled control (e.g.
   // `BAIStorageHostSelect`) bound to antd `value`/`onChange`. `onChange` commits
   // the value (string, or string[] for multi-select) as a condition
-  // immediately; `value` is always `null` so the control stays controlled-empty
-  // and clears after each commit.
+  // immediately; `value` is always `undefined` so the control stays
+  // controlled-empty and clears after each commit.
+  //
+  // When the committed value is opaque to the user (e.g. a UUID emitted by
+  // `BAIUserSelect` with `valuePropName="id"`), pass the selected option(s) as
+  // the optional second argument — the same `{ value, label }` shape antd's
+  // Select hands to its own `onChange`, so a control can forward it verbatim.
+  // The filter pairs each `label` with its own `value` (no positional alignment,
+  // so multi-select is safe) and shows the label in the condition tag, while the
+  // raw value still serializes into the GraphQL filter unchanged. Omit it to
+  // display the value as-is.
   renderInput?: (props: {
     value: string | string[] | undefined;
-    onChange: (value: string | string[] | undefined) => void;
+    onChange: (
+      value: string | string[] | undefined,
+      option?: FilterInputOption | FilterInputOption[],
+    ) => void;
   }) => React.ReactNode;
 };
 
@@ -519,6 +542,14 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
 
   const [search, setSearch] = useState<string>('');
   const [selectedDate, setSelectedDate] = useState<dayjs.Dayjs | null>(null);
+  // Maps a committed condition value to a human-readable label supplied by a
+  // `renderInput` control's `onChange` (e.g. user UUID -> email). Conditions are
+  // re-derived from the `value` filter on every render and only carry the raw
+  // value, so the label is kept here and looked up when rendering tags. Keyed by
+  // `${property}::${value}`.
+  const [valueLabelMap, setValueLabelMap] = useState<Record<string, string>>(
+    {},
+  );
   const [selectedProperty, setSelectedProperty] = useState<FilterProperty>(
     filterProperties[0],
   );
@@ -606,6 +637,27 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
     return false;
   }, [selectedProperty]);
 
+  // Persist the value -> label pairs emitted by a `renderInput` control so the
+  // condition tag can show each label (e.g. email) instead of the opaque
+  // committed value (e.g. UUID). Each option carries its own value/label pair,
+  // so the mapping is intrinsic — no positional alignment with the value array.
+  const rememberValueLabels = (
+    property: string,
+    option: FilterInputOption | FilterInputOption[],
+  ) => {
+    setValueLabelMap((prev) => {
+      const next = { ...prev };
+      _.castArray(option).forEach((o) => {
+        // Only string/number labels are renderable in a tag (and its string
+        // tooltip); skip ReactNode labels and let the tag fall back to value.
+        if (o?.value != null && (_.isString(o.label) || _.isNumber(o.label))) {
+          next[`${property}::${String(o.value)}`] = String(o.label);
+        }
+      });
+      return next;
+    });
+  };
+
   const addCondition = (
     value: string | string[],
     singleSelect: boolean = false,
@@ -661,12 +713,19 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
   ): React.ReactElement => {
     const operatorShortLabel =
       OPERATOR_SHORT_LABELS[condition.operator] || condition.operator;
+    // Prefer a renderInput-supplied label over the raw value so opaque values
+    // (e.g. UUIDs) display as something the user recognizes (e.g. an email).
+    const resolveLabel = (v: string) =>
+      valueLabelMap[`${condition.property}::${v}`] ?? v;
+    const mappedLabel =
+      valueLabelMap[`${condition.property}::${condition.value}`];
     const displayValue =
       condition.operator === 'in' || condition.operator === 'notIn'
-        ? `[${condition.value}]`
-        : condition.type === 'datetime' && dayjs(condition.value).isValid()
-          ? dayjs(condition.value).format('YYYY-MM-DD HH:mm')
-          : condition.value;
+        ? `[${String(condition.value).split(', ').map(resolveLabel).join(', ')}]`
+        : (mappedLabel ??
+          (condition.type === 'datetime' && dayjs(condition.value).isValid()
+            ? dayjs(condition.value).format('YYYY-MM-DD HH:mm')
+            : condition.value));
 
     return (
       <Tag
@@ -683,7 +742,7 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
           removeCondition(condition.id);
         }}
         style={{ margin: 0 }}
-        title={`${condition.propertyLabel} ${getOperatorLabel(condition.operator)} ${condition.value}`}
+        title={`${condition.propertyLabel} ${getOperatorLabel(condition.operator)} ${displayValue}`}
       >
         {condition.propertyLabel} {operatorShortLabel} {displayValue}
       </Tag>
@@ -746,7 +805,10 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
         {selectedProperty?.renderInput ? (
           selectedProperty.renderInput({
             value: undefined, // Always undefined to keep the control empty after commit
-            onChange: (value) => {
+            onChange: (value, option) => {
+              if (option !== undefined) {
+                rememberValueLabels(selectedProperty.key, option);
+              }
               addCondition(value ?? '', selectedProperty?.singleSelect);
             },
           })

--- a/react/src/components/UserFolderPermissionPanelV2.tsx
+++ b/react/src/components/UserFolderPermissionPanelV2.tsx
@@ -49,8 +49,6 @@ const UserFolderPermissionPanelV2: React.FC<
     storageVolumeFrgmt,
   );
 
-  // The user picker emits the local user id (UUID) under `keypair.userId.equals`
-  // — a valid `KeypairResourcePolicyV2Filter`.
   const [userFilter, setUserFilter] = useState<GraphQLFilter | undefined>();
   // Extract the picked user's UUID to scope the keypairs connection (Assigned
   // Keypairs column); `GraphQLFilter` is index-typed so guard down to a string.
@@ -93,9 +91,6 @@ const UserFolderPermissionPanelV2: React.FC<
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);
 
-  // Orchestrator query: owns the keypair-resource-policy connection (count +
-  // edges) and hands the page of nodes to the table via a plural fragment, so
-  // the filter, pagination, and refresh controls all live here.
   const { adminKeypairResourcePoliciesV2 } =
     useLazyLoadQuery<UserFolderPermissionPanelV2Query>(
       graphql`


### PR DESCRIPTION
Resolves #7656 (FR-3011)

Stacked on #8068.

## Summary

When a `renderInput` control commits a value that is opaque to the user — e.g. `BAIUserSelect` with `valuePropName="id"` emits the user's **UUID** — the filter condition tag previously showed that raw UUID. The tag is rebuilt on every render from the GraphQL filter (which only stores the UUID), so there was no channel to carry a human-readable label.

This extends `BAIGraphQLPropertyFilter`'s `renderInput` `onChange` contract so a control can pass the selected option(s) alongside the value:

```ts
onChange: (
  value: string | string[] | undefined,
  option?: FilterInputOption | FilterInputOption[], // { value, label }
) => void;
```

- The filter keeps a `value -> label` map keyed by `${property}::${value}` and renders the label in the condition tag (and its tooltip), while still serializing the **raw value** into the GraphQL filter unchanged — the backend query is untouched.
- The `option` shape mirrors antd Select's own `onChange(value, option)`, so a control can forward it verbatim. Because each option carries its own `value`/`label`, there is **no positional alignment** between value and label arrays — multi-select is safe.
- Backward compatible: `option` is optional. Controls that emit a plain string (e.g. `BAIStorageHostSelect`, whose value is already human-readable) keep working and the tag shows the value as before.

### `UserFolderPermissionPanelV2`

- The user picker's `renderInput` now just forwards `onChange={onChange}` (no adapter). `BAIUserSelect` emits `(value=UUID, option={ value, label: email })`, so the tag reads e.g. `User = someone@example.com` while the filter still queries by `keypair.userId.equals` (UUID).

## Verification

`bash scripts/verify.sh` → Relay / Lint / Format / TypeScript pass. Added a unit test asserting the tag shows the option label while the GraphQL filter still carries the raw UUID (16 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
