### PR TITLE
fix(FR-3227): harden local wsproxy against cross-origin access and token forgery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,3 +255,4 @@ clean:
 	@rm -rf ./app/backend*; rm -rf ./app/Backend*
 	@rm -rf ./build/unbundle ./build/bundle ./build/web ./build/electron-app
 	@rm -rf ./react/build
+	@rm -rf ./src/wsproxy/dist

--- a/README.md
+++ b/README.md
@@ -219,23 +219,23 @@ If your branch name contains an `FR-XXXX` issue number, the URL is `https://fr-X
 
 ### Commands Reference
 
-| Command | Description |
-|---------|-------------|
-| `pnpm run dev` | TypeScript watch + Relay watch + React dev server (concurrent) |
-| `pnpm run wsproxy` | WebSocket proxy (required for dev) |
-| `pnpm run build` | Full production build |
-| `pnpm run build:react-only` | Build only React app |
-| `pnpm run relay` | One-time Relay/GraphQL compile (project root) |
-| `pnpm run relay:watch` | Relay watch mode (uses nodemon) |
-| `pnpm run lint` | ESLint check |
-| `pnpm run lint-fix` | Auto-fix ESLint issues |
-| `pnpm run format` | Prettier format check |
-| `pnpm run format-fix` | Auto-fix formatting |
-| `bash scripts/verify.sh` | Run Relay + Lint + Format + TypeScript checks |
-| `pnpm run electron:d` | Run Electron in dev mode |
-| `pnpm run electron:d:hmr` | Run Electron in dev mode with HMR (live debug) |
-| `pnpm run test` | Jest unit tests (root: scripts/, src/) |
-| `cd react && pnpm run test` | Jest unit tests for React app |
+| Command                     | Description                                                    |
+| --------------------------- | -------------------------------------------------------------- |
+| `pnpm run dev`              | TypeScript watch + Relay watch + React dev server (concurrent) |
+| `pnpm run wsproxy`          | WebSocket proxy (required for dev)                             |
+| `pnpm run build`            | Full production build                                          |
+| `pnpm run build:react-only` | Build only React app                                           |
+| `pnpm run relay`            | One-time Relay/GraphQL compile (project root)                  |
+| `pnpm run relay:watch`      | Relay watch mode (uses nodemon)                                |
+| `pnpm run lint`             | ESLint check                                                   |
+| `pnpm run lint-fix`         | Auto-fix ESLint issues                                         |
+| `pnpm run format`           | Prettier format check                                          |
+| `pnpm run format-fix`       | Auto-fix formatting                                            |
+| `bash scripts/verify.sh`    | Run Relay + Lint + Format + TypeScript checks                  |
+| `pnpm run electron:d`       | Run Electron in dev mode                                       |
+| `pnpm run electron:d:hmr`   | Run Electron in dev mode with HMR (live debug)                 |
+| `pnpm run test`             | Jest unit tests (root: scripts/, src/)                         |
+| `cd react && pnpm run test` | Jest unit tests for React app                                  |
 
 ### Unit Testing
 
@@ -254,6 +254,7 @@ $ cp e2e/envs/.env.playwright.sample e2e/envs/.env.playwright
 ```
 
 Available environment variables:
+
 - `E2E_WEBUI_ENDPOINT` - WebUI endpoint URL (default: `http://127.0.0.1:9081`)
 - `E2E_WEBSERVER_ENDPOINT` - Backend.AI server endpoint URL (default: `http://127.0.0.1:8090`)
 - User credentials: `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`, etc.
@@ -492,6 +493,34 @@ $ set EXT_HTTP_PROXY=http://10.20.30.40:3128 (Windows)
 
 Even if you are using Electron embedded websocket proxy, you have to set the
 environment variable manually to pass through a http proxy.
+
+#### Restricting cross-origin access to the local websocket proxy
+
+The local websocket proxy only accepts cross-origin browser requests from
+**trusted origins**. The Electron renderer (loaded over `file://`, i.e. an
+`Origin` of `null` or no `Origin` header) and any **loopback** origin
+(`localhost` / `127.0.0.1` / `[::1]`, on any port) are always trusted. This
+includes `*.localhost` subdomains such as the Portless dev URL
+`https://fr-XXXX.localhost:1355` (the `.localhost` TLD always resolves to
+loopback per RFC 6761), so the Electron Desktop app and the local
+`pnpm run dev` setup need no extra configuration.
+
+If you serve the WebUI from a **non-loopback origin** (e.g. a self-hosted
+`https://webui.example.com`) and point `wsproxy.proxyURL` at this local proxy,
+add that origin to the allowlist via the `WSPROXY_CORS_ORIGINS` environment
+variable. It accepts either a comma-separated list or a JSON array:
+
+```console
+$ export WSPROXY_CORS_ORIGINS="https://webui.example.com,https://admin.example.com"
+$ export WSPROXY_CORS_ORIGINS='["https://webui.example.com"]'
+```
+
+Like the other proxy variables, this is an environment variable of the proxy
+**process** (it is _not_ part of the browser-side `config.toml`). When started
+with `pnpm run wsproxy`, the proxy also loads a `.env` file from the repository
+root (via `dotenv`), so you can put `WSPROXY_CORS_ORIGINS=...` there instead of
+exporting it. Requests from disallowed origins receive no CORS headers and a
+`PUT /conf` from a disallowed origin is rejected with `403`.
 
 ## Build web server with specific configuration
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-json-schema-validator": "catalog:",
     "eslint-plugin-prettier": "^5.5.5",
     "express": "^4.22.1",
+    "express-rate-limit": "^7.4.0",
     "globals": "catalog:",
     "husky": "^9.1.7",
     "i18next-scanner": "^4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
       express:
         specifier: ^4.22.1
         version: 4.22.1
+      express-rate-limit:
+        specifier: ^7.4.0
+        version: 7.5.1(express@4.22.1)
       globals:
         specifier: 'catalog:'
         version: 16.5.0
@@ -6849,6 +6852,12 @@ packages:
   expect@30.3.0:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -18345,6 +18354,10 @@ snapshots:
       jest-mock: 30.3.0
       jest-util: 30.3.0
 
+  express-rate-limit@7.5.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
@@ -24017,6 +24030,7 @@ time:
   ansi_up@6.0.6: '2025-05-16T20:58:13.495Z'
   dompurify@3.4.5: '2026-05-18T07:46:30.210Z'
   electron@39.8.10: '2026-05-05T20:55:08.499Z'
+  express-rate-limit@7.5.1: '2025-06-21T03:08:25.153Z'
   handlebars@4.7.9: '2026-03-26T20:46:39.280Z'
   lodash@4.18.1: '2026-04-01T21:01:20.458Z'
   react-router-dom@6.30.4: '2026-05-29T19:41:50.812Z'

--- a/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
@@ -7,6 +7,7 @@ import {
   TerminateSessionModalFragment$key,
 } from '../../__generated__/TerminateSessionModalFragment.graphql';
 import { TerminateSessionModalRefetchQuery } from '../../__generated__/TerminateSessionModalRefetchQuery.graphql';
+import { requestLocalProxyToken } from '../../helper/localProxyToken';
 import { BackendAIClient, useSuspendedBackendaiClient } from '../../hooks';
 import { useCurrentUserRole } from '../../hooks/backendai';
 import { useSetBAINotification } from '../../hooks/useBAINotification';
@@ -111,6 +112,7 @@ const getProxyURL = async (
   resourceGroupIdOfSession: string,
   projectId: string,
   baiClient: BackendAIClient,
+  wsproxyVersion?: string,
 ) => {
   let url = 'http://127.0.0.1:5050/';
   if (
@@ -125,13 +127,11 @@ const getProxyURL = async (
     url = baiClient._config.proxyURL;
   }
   if (resourceGroupIdOfSession !== undefined && projectId !== undefined) {
-    const wsproxyVersion = await getWSProxyVersion(
-      resourceGroupIdOfSession,
-      projectId,
-      baiClient,
-    );
-    if (wsproxyVersion !== 'v1') {
-      url = new URL(`${wsproxyVersion}/`, url).href;
+    const version =
+      wsproxyVersion ??
+      (await getWSProxyVersion(resourceGroupIdOfSession, projectId, baiClient));
+    if (version !== 'v1') {
+      url = new URL(`${version}/`, url).href;
     }
   }
   return url;
@@ -143,19 +143,40 @@ const terminateApp = async (
   currentProjectId: string,
   baiClient: BackendAIClient,
 ) => {
-  const proxyURL = await getProxyURL(
+  const wsproxyVersion = await getWSProxyVersion(
     session.scaling_group,
     currentProjectId,
     baiClient,
   );
+  const proxyURL = await getProxyURL(
+    session.scaling_group,
+    currentProjectId,
+    baiClient,
+    wsproxyVersion,
+  );
+  // The local v1 proxy now requires the per-instance secret token returned by
+  // /conf for the check and /delete routes (FR-3227). The v2 remote App Proxy
+  // keeps using the access key. If the token cannot be obtained (e.g. /conf is
+  // rejected), skip the wsproxy cleanup entirely — the session must still be
+  // terminable (mirrors the "even if wsproxy address is invalid, session must
+  // be deleted" invariant in terminateSession).
+  let token: string;
+  try {
+    token =
+      wsproxyVersion === 'v1'
+        ? await requestLocalProxyToken(baiClient, proxyURL)
+        : accessKey;
+  } catch {
+    return true;
+  }
 
   const rqst = {
     method: 'GET',
-    uri: new URL(`proxy/${accessKey}/${session.row_id}`, proxyURL).href,
+    uri: new URL(`proxy/${token}/${session.row_id}`, proxyURL).href,
   };
 
   return sendRequest(rqst).then((response) => {
-    let uri = new URL(`proxy/${accessKey}/${session.row_id}/delete`, proxyURL);
+    let uri = new URL(`proxy/${token}/${session.row_id}/delete`, proxyURL);
     if (localStorage.getItem('backendaiwebui.appproxy-permit-key')) {
       uri.searchParams.set(
         'permit_key',

--- a/react/src/helper/localProxyToken.test.ts
+++ b/react/src/helper/localProxyToken.test.ts
@@ -1,0 +1,103 @@
+import { requestLocalProxyToken } from './localProxyToken';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unit tests for the local (v1) wsproxy token handshake (FR-3227).
+ *
+ * Covers the defensive error handling: the helper must throw a clear error
+ * when `/conf` is rejected or returns no token, instead of returning
+ * `undefined` and producing `/proxy/undefined/...` URLs downstream.
+ */
+type AnyClient = Parameters<typeof requestLocalProxyToken>[0];
+
+const sessionClient = {
+  _config: {
+    endpoint: 'http://host',
+    connectionMode: 'SESSION',
+    _session_id: 'cookie-session',
+  },
+  _loginSessionId: 'login-session',
+  APIMajorVersion: 6,
+} as unknown as AnyClient;
+
+const apiClient = {
+  _config: {
+    endpoint: 'http://host',
+    connectionMode: 'API',
+    accessKey: 'AK',
+    secretKey: 'SK',
+  },
+  APIMajorVersion: 6,
+} as unknown as AnyClient;
+
+const PROXY_URL = 'http://127.0.0.1:5050/';
+
+const mockFetch = (response: {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}) => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status,
+    json: async () => response.body,
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+describe('requestLocalProxyToken (FR-3227)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the token from a successful /conf response', async () => {
+    const fetchMock = mockFetch({
+      ok: true,
+      status: 200,
+      body: { token: 'secret-token' },
+    });
+
+    const token = await requestLocalProxyToken(sessionClient, PROXY_URL);
+
+    expect(token).toBe('secret-token');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:5050/conf');
+    expect(init.method).toBe('PUT');
+    const body = JSON.parse(init.body);
+    expect(body.mode).toBe('SESSION');
+    expect(body.auth_mode).toBe('header');
+    expect(body.session).toBe('login-session');
+  });
+
+  it('sends API-mode credentials when connectionMode is API', async () => {
+    const fetchMock = mockFetch({
+      ok: true,
+      status: 200,
+      body: { token: 't' },
+    });
+
+    await requestLocalProxyToken(apiClient, PROXY_URL);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.mode).toBe('API');
+    expect(body.access_key).toBe('AK');
+    expect(body.secret_key).toBe('SK');
+  });
+
+  it('throws when /conf is rejected (non-ok response)', async () => {
+    mockFetch({ ok: false, status: 403, body: { code: 403 } });
+
+    await expect(
+      requestLocalProxyToken(sessionClient, PROXY_URL),
+    ).rejects.toThrow(/403/);
+  });
+
+  it('throws when the /conf response contains no token', async () => {
+    mockFetch({ ok: true, status: 200, body: {} });
+
+    await expect(
+      requestLocalProxyToken(sessionClient, PROXY_URL),
+    ).rejects.toThrow(/did not contain a token/);
+  });
+});

--- a/react/src/helper/localProxyToken.ts
+++ b/react/src/helper/localProxyToken.ts
@@ -1,0 +1,77 @@
+import { type BackendAIClient } from '../hooks';
+
+/**
+ * Request the local (v1) wsproxy's per-instance secret token (FR-3227).
+ *
+ * The Backend.AI Desktop / local wsproxy (`src/wsproxy/manager.js`) used to
+ * return a fixed token `"local"` from `PUT /conf` and never validated the token
+ * on the `/proxy/:token/...` routes. It now returns a random per-instance
+ * secret and rejects any other token, so every v1 proxy call — the launch
+ * (`/add`), the existence check, and the cleanup (`/delete`) routes — must
+ * present the token returned by `/conf`.
+ *
+ * This performs that `PUT /conf` handshake (idempotent — it only stores the
+ * caller's config and echoes the secret) and returns the token. It applies
+ * ONLY to the v1 (local) proxy; the v2 remote App Proxy uses a different token
+ * scheme and must not call this.
+ *
+ * @param baiClient - the active Backend.AI client (source of endpoint/auth)
+ * @param proxyURL - the v1 proxy base URL, with a trailing slash
+ * @returns the per-instance proxy token
+ */
+export async function requestLocalProxyToken(
+  baiClient: BackendAIClient,
+  proxyURL: string,
+): Promise<string> {
+  const param: {
+    endpoint: string;
+    mode?: string;
+    auth_mode?: string;
+    session?: string;
+    access_key?: string;
+    secret_key?: string;
+    api_version?: string;
+  } = {
+    endpoint: baiClient._config.endpoint,
+  };
+  if (baiClient._config.connectionMode === 'SESSION') {
+    param.mode = 'SESSION';
+    if (baiClient._loginSessionId) {
+      param.auth_mode = 'header';
+      param.session = baiClient._loginSessionId;
+    } else {
+      param.auth_mode = 'cookie';
+      param.session = baiClient._config._session_id;
+    }
+  } else {
+    param.mode = 'API';
+    param.access_key = baiClient._config.accessKey;
+    param.secret_key = baiClient._config.secretKey;
+  }
+  param.api_version = baiClient.APIMajorVersion;
+
+  const response = await fetch(new URL('conf', proxyURL).href, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(param),
+  });
+  // Fail loudly instead of returning `undefined` (which would build
+  // `/proxy/undefined/...` URLs). /conf can legitimately reject the request —
+  // e.g. 403 from the origin allowlist on a self-hosted WebUI.
+  if (!response.ok) {
+    throw new Error(
+      `Failed to obtain local proxy token: /conf responded with status ${response.status}.`,
+    );
+  }
+  const data = await response.json().catch(() => undefined);
+  if (typeof data?.token !== 'string' || data.token.length === 0) {
+    throw new Error(
+      'Failed to obtain local proxy token: /conf response did not contain a token.',
+    );
+  }
+  return data.token;
+}

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -4,6 +4,7 @@
  */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '.';
 import { useBackendAIAppLauncherFragment$key } from '../__generated__/useBackendAIAppLauncherFragment.graphql';
+import { requestLocalProxyToken } from '../helper/localProxyToken';
 import { useSetBAINotification } from './useBAINotification';
 import { BAILink, useBAILogger, useErrorMessageResolver } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -282,8 +283,26 @@ export const useBackendAIAppLauncher = (
    * Used when re-launching apps like tensorboard that need to be restarted with different args.
    */
   const _close_wsproxy = async (app: string) => {
-    const token = baiClient._config.accessKey;
-    const proxyURL = await getProxyURL(await getWSProxyVersion());
+    const wsproxyVersion = await getWSProxyVersion();
+    const proxyURL = await getProxyURL(wsproxyVersion);
+    // The local v1 proxy now requires the per-instance secret token returned
+    // by /conf for the /delete route (FR-3227). The v2 remote App Proxy keeps
+    // using the access key. If the token cannot be obtained (e.g. /conf is
+    // rejected), fail the cleanup gracefully rather than hitting
+    // `/proxy/undefined/...`.
+    let token: string;
+    try {
+      token =
+        wsproxyVersion === 'v1'
+          ? await requestLocalProxyToken(baiClient, proxyURL)
+          : baiClient._config.accessKey;
+    } catch (err) {
+      logger.error(
+        '[wsproxy] failed to obtain local proxy token for cleanup',
+        err,
+      );
+      return false;
+    }
 
     const uri = new URL(
       `proxy/${token}/${session?.row_id}/delete?${new URLSearchParams({ app }).toString()}`,
@@ -1087,6 +1106,13 @@ function getAppProxyErrorMessage(
   return fallback;
 }
 
+// A stale or dead local wsproxy gateway (see `manager.js`'s `/add` route)
+// can hand back a port whose redirect target never responds — without a
+// timeout, `fetch()` hangs indefinitely and the launcher's progress UI is
+// stuck on "Adding kernel to socket queue..." forever. Bound every proxy
+// request so a dead target fails visibly instead.
+const PROXY_REQUEST_TIMEOUT_MS = 30000;
+
 /**
  * Send a request and return the response body.
  * For error status codes, returns an object with status information for retry logic.
@@ -1104,7 +1130,10 @@ async function sendRequest(request: SendRequestConfig) {
       request.body = undefined;
     }
 
-    const resp = await fetch(request.uri, request);
+    const resp = await fetch(request.uri, {
+      ...request,
+      signal: request.signal ?? AbortSignal.timeout(PROXY_REQUEST_TIMEOUT_MS),
+    });
     const contentType = resp.headers.get('Content-Type');
 
     let body;
@@ -1132,6 +1161,11 @@ async function sendRequest(request: SendRequestConfig) {
 
     return body;
   } catch (e) {
+    if (e instanceof DOMException && e.name === 'TimeoutError') {
+      throw new Error(
+        `Request timed out after ${PROXY_REQUEST_TIMEOUT_MS}ms: ${request.uri}`,
+      );
+    }
     // Network errors or other exceptions
     throw new Error(
       `Request failed: ${e instanceof Error ? e.message : 'Unknown error'}`,

--- a/src/wsproxy/gateway/consoleproxy.js
+++ b/src/wsproxy/gateway/consoleproxy.js
@@ -17,4 +17,11 @@ module.exports = proxy = class Proxy {
   getPort() {
     return this.c.port;
   }
+  // Whether the underlying TCP listener is still bound. A gateway can outlive
+  // its usefulness (e.g. the user closed the app tab without the manager
+  // ever seeing a /delete call) while staying in `Manager.proxies` — reusing
+  // it then would hand back a port nothing is listening on.
+  isAlive() {
+    return !!this.c && !!this.c.tcpServer && this.c.tcpServer.listening;
+  }
 };

--- a/src/wsproxy/gateway/tcpwsproxy.js
+++ b/src/wsproxy/gateway/tcpwsproxy.js
@@ -16,4 +16,11 @@ module.exports = proxy = class Proxy {
   getPort() {
     return this.c.port;
   }
+  // Whether the underlying TCP listener is still bound. A gateway can outlive
+  // its usefulness (e.g. the user closed the app tab without the manager
+  // ever seeing a /delete call) while staying in `Manager.proxies` — reusing
+  // it then would hand back a port nothing is listening on.
+  isAlive() {
+    return !!this.c && !!this.c.tcpServer && this.c.tcpServer.listening;
+  }
 };

--- a/src/wsproxy/manager.js
+++ b/src/wsproxy/manager.js
@@ -8,11 +8,14 @@ Backend.AI Webapp proxy for Web UI
 const express = require('express'),
   EventEmitter = require('events'),
   cors = require('cors');
+const { rateLimit } = require('express-rate-limit');
 const logger = require('./lib/logger')(__filename);
 
-const ai = require('../lib/backend.ai-client-node'),
-  Gateway = require('./gateway/tcpwsproxy'),
-  SGateway = require('./gateway/consoleproxy');
+// The Backend.AI client and the proxy gateways are required lazily (inside the
+// handlers that use them) rather than at module load. They — and their
+// transitive deps such as backend.ai-ws-appproxy — are build artifacts that do
+// not exist in a source-only checkout, so eager requires would make the module
+// impossible to import without a full build (e.g. from the unit test).
 const htmldeco = require('./lib/htmldeco');
 const { escapeHtml } = require('./lib/htmldeco');
 const crypto = require('crypto');
@@ -32,6 +35,69 @@ function isValidRedirectPath(path) {
   // Reject paths starting with // (protocol-relative URLs)
   if (path.startsWith('//')) return false;
   return true;
+}
+
+// A cached gateway is only safe to reuse if its underlying TCP listener is
+// still bound. Nothing notifies this manager when a user merely closes an
+// app tab (only explicit session termination hits /delete), so a previous
+// gateway can linger in `Manager.proxies` long after its listener has died.
+// Reusing it would hand back a port whose client-side redirect fetch hangs
+// forever with no error, no timeout, and no way to recover.
+function isGatewayAlive(gateway) {
+  return typeof gateway.isAlive === 'function' ? gateway.isAlive() : true;
+}
+
+// Parse additional trusted browser origins from the WSPROXY_CORS_ORIGINS
+// environment variable. Accepts either a comma-separated list
+// ("https://a.example,https://b.example") or a JSON array
+// (["https://a.example","https://b.example"]). Used by self-hosted WebUI
+// deployments that serve the page from a non-loopback origin.
+function parseConfiguredOrigins() {
+  const env = process.env.WSPROXY_CORS_ORIGINS;
+  if (!env) return [];
+  let list;
+  try {
+    const parsed = JSON.parse(env);
+    list = Array.isArray(parsed) ? parsed : String(env).split(',');
+  } catch {
+    list = env.split(',');
+  }
+  return list.map((o) => String(o).trim()).filter(Boolean);
+}
+
+const configuredOrigins = parseConfiguredOrigins();
+
+// A loopback page (the WebUI dev server, the proxy itself, or any localhost
+// origin) is considered trusted: the proxy only binds to 127.0.0.1, so a
+// loopback origin is already inside the trust boundary. `*.localhost`
+// subdomains are included because RFC 6761 reserves the `.localhost` TLD to
+// always resolve to loopback (browsers force it to 127.0.0.1), so a page served
+// from e.g. the Portless dev URL `fr-3227.localhost` is genuinely local — a
+// remote attacker cannot host a page on a `.localhost` name.
+function isLoopbackOrigin(origin) {
+  try {
+    const { hostname } = new URL(origin);
+    return (
+      hostname === 'localhost' ||
+      hostname.endsWith('.localhost') ||
+      hostname === '127.0.0.1' ||
+      hostname === '[::1]' ||
+      hostname === '::1'
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Decide whether a browser request from `origin` may read the proxy response.
+// `undefined` (no Origin header → non-browser or same-origin request) and
+// `'null'` (the Electron file:// renderer) are always allowed. Every other
+// cross-origin request must be loopback or explicitly configured. This
+// replaces the previous `cors()` default of reflecting any origin as `*`.
+function isAllowedOrigin(origin) {
+  if (!origin || origin === 'null') return true;
+  if (isLoopbackOrigin(origin)) return true;
+  return configuredOrigins.includes(origin);
 }
 
 // extHttpProxy is an endpoint of a http proxy server in a network.
@@ -66,6 +132,10 @@ class Manager extends EventEmitter {
     this.proxies = {};
     this.ports = [];
     this.baseURL = undefined;
+    // Per-instance secret returned by PUT /conf and required by every
+    // /proxy/* route. Regenerated on each proxy start, never logged. 32 random
+    // bytes → a 43-char URL-safe base64url string that can sit in the URL path.
+    this.secretToken = crypto.randomBytes(32).toString('base64url');
     this.init();
   }
 
@@ -76,11 +146,80 @@ class Manager extends EventEmitter {
     }
   }
 
+  // Drop `this.proxies[p]` if it's no longer alive, so the caller always
+  // finds either a live cached gateway or nothing. Nothing notifies this
+  // manager when a user merely closes an app tab (only explicit session
+  // termination hits /delete), so a previous gateway can linger here long
+  // after its listener has died — reusing it would hand back a port whose
+  // client-side redirect fetch hangs forever with no error, no timeout, and
+  // no way to recover.
+  _evictStaleGateway(p) {
+    if (this.proxies.hasOwnProperty(p) && !isGatewayAlive(this.proxies[p])) {
+      logger.info(`Stale proxy entry for ${p}, recreating`);
+      try {
+        this.proxies[p].stop_proxy();
+      } catch (err) {
+        logger.warn(`Failed to stop stale proxy for ${p}: ${err.message}`);
+      }
+      delete this.proxies[p];
+    }
+  }
+
+  // Constant-time comparison of a caller-supplied proxy token against the
+  // per-instance secret. `crypto.timingSafeEqual` throws when the buffers
+  // differ in length, so guard the length first — an unequal length is already
+  // a definitive non-match and leaks nothing beyond what the URL length does.
+  _isAuthorizedToken(provided) {
+    if (typeof provided !== 'string' || provided.length === 0) return false;
+    const a = Buffer.from(provided, 'utf8');
+    const b = Buffer.from(this.secretToken, 'utf8');
+    if (a.length !== b.length) return false;
+    try {
+      return crypto.timingSafeEqual(a, b);
+    } catch {
+      return false;
+    }
+  }
+
   init() {
     this.app.use(express.json());
-    this.app.use(cors());
+    // Restrict cross-origin access to trusted origins. Reflecting the specific
+    // request origin (instead of `*`) is also required for the credentialed
+    // requests the WebUI sends (fetch with `credentials: 'include'`), which a
+    // wildcard ACAO would reject.
+    this.app.use(
+      cors({
+        origin: (origin, callback) => {
+          callback(null, isAllowedOrigin(origin));
+        },
+        credentials: true,
+        methods: ['GET', 'PUT', 'OPTIONS'],
+        allowedHeaders: ['Content-Type', 'Accept', 'Authorization'],
+        maxAge: 86400,
+      }),
+    );
+
+    // Rate-limit the token-authorized /proxy/* routes as defense in depth:
+    // even though the per-instance token is 256-bit (brute force is
+    // infeasible), this bounds how fast a malicious page could spam proxy
+    // add/delete to disrupt the user's app proxies. Generous limit — a single
+    // desktop user issues only a handful of proxy operations per minute.
+    const proxyRateLimiter = rateLimit({
+      windowMs: 60 * 1000,
+      limit: 600,
+      standardHeaders: true,
+      legacyHeaders: false,
+    });
 
     this.app.put('/conf', (req, res) => {
+      // CSRF / origin defense in depth: the CORS preflight already blocks
+      // disallowed browser origins from issuing this PUT, but reject them
+      // server-side too so the token secrecy does not rely solely on the
+      // browser honoring CORS.
+      if (!isAllowedOrigin(req.headers['origin'])) {
+        res.status(403).send({ code: 403 });
+        return;
+      }
       let cf = {
         created: Date.now(),
         endpoint: req.body.endpoint,
@@ -101,6 +240,7 @@ class Manager extends EventEmitter {
         cf['mode'] = 'API';
         cf['access_key'] = req.body.access_key;
         cf['secret_key'] = req.body.secret_key;
+        const ai = require('../lib/backend.ai-client-node');
         let config = new ai.backend.ClientConfig(
           req.body.access_key,
           req.body.secret_key,
@@ -111,7 +251,7 @@ class Manager extends EventEmitter {
       }
       this._config = cf;
 
-      res.send({ token: 'local' });
+      res.send({ token: this.secretToken });
     });
 
     this.app.get('/', (req, res) => {
@@ -126,7 +266,11 @@ class Manager extends EventEmitter {
       res.send({ api_version: 'v1' });
     });
 
-    this.app.get('/proxy/:token/:sessionId', (req, res) => {
+    this.app.get('/proxy/:token/:sessionId', proxyRateLimiter, (req, res) => {
+      if (!this._isAuthorizedToken(req.params['token'])) {
+        res.status(403).send({ code: 403 });
+        return;
+      }
       let sessionId = req.params['sessionId'];
       if (!this._config) {
         res.send({ code: 401 });
@@ -141,143 +285,164 @@ class Manager extends EventEmitter {
       res.send({ code: 404 });
     });
 
-    this.app.get('/proxy/:token/:sessionId/add', async (req, res) => {
-      if (!this._config) {
-        res.send({ code: 401 });
-        return;
-      }
-      let sessionId = req.params['sessionId'];
-      let app = req.query.app || 'jupyter';
-      let port = parseInt(req.query.port) || undefined;
-      let p = sessionId + '|' + app;
-      let args = req.query.args ? JSON.parse(decodeURI(req.query.args)) : {};
-      let envs = req.query.envs ? JSON.parse(decodeURI(req.query.envs)) : {};
-      const protocol = req.query.protocol || 'http';
-      let gateway;
-      let ip = this.listen_ip;
-      //let port = undefined;
-      if (this.proxies.hasOwnProperty(p)) {
-        gateway = this.proxies[p];
-        port = gateway.getPort();
-      } else {
-        if (this._config.mode == 'SESSION') {
-          gateway = new SGateway(this._config);
-        } else {
-          gateway = new Gateway(this.aiclient._config);
-        }
-        this.proxies[p] = gateway;
-
-        let assigned = false;
-        let maxtry = 5;
-        for (let i = 0; i < maxtry; i++) {
-          try {
-            await gateway.start_proxy(sessionId, app, ip, port, envs, args);
-            port = gateway.getPort();
-            assigned = true;
-            break;
-          } catch (err) {
-            if ('PortInUse' === err.message) {
-              // try next number or fallback to random port for the last resort
-              port = i < maxtry - 1 ? port + 1 : undefined;
-              if (port) {
-                logger.warn('trying next port: ' + port);
-              } else {
-                logger.warn('trying random port');
-              }
-            } else {
-              logger.warn(err.message);
-            }
-          }
-        }
-        logger.debug(`proxies: ${p}`);
-        logger.info(`Total connections: ${Object.keys(this.proxies).length}`);
-        if (!assigned) {
-          res.send({ code: 500 });
+    this.app.get(
+      '/proxy/:token/:sessionId/add',
+      proxyRateLimiter,
+      async (req, res) => {
+        if (!this._isAuthorizedToken(req.params['token'])) {
+          res.status(403).send({ code: 403 });
           return;
         }
-      }
+        if (!this._config) {
+          res.send({ code: 401 });
+          return;
+        }
+        let sessionId = req.params['sessionId'];
+        let app = req.query.app || 'jupyter';
+        let port = parseInt(req.query.port) || undefined;
+        let p = sessionId + '|' + app;
+        let args = req.query.args ? JSON.parse(decodeURI(req.query.args)) : {};
+        let envs = req.query.envs ? JSON.parse(decodeURI(req.query.envs)) : {};
+        const protocol = req.query.protocol || 'http';
+        let gateway;
+        let ip = this.listen_ip;
+        //let port = undefined;
+        this._evictStaleGateway(p);
+        if (this.proxies.hasOwnProperty(p)) {
+          gateway = this.proxies[p];
+          port = gateway.getPort();
+        } else {
+          if (this._config.mode == 'SESSION') {
+            const SGateway = require('./gateway/consoleproxy');
+            gateway = new SGateway(this._config);
+          } else {
+            const Gateway = require('./gateway/tcpwsproxy');
+            gateway = new Gateway(this.aiclient._config);
+          }
+          this.proxies[p] = gateway;
 
-      let proxy_target = 'http://' + this.proxyBaseHost + ':' + port;
-      if (app == 'sftp') {
-        logger.debug('proxy target: ' + proxy_target);
-        res.send({
-          code: 200,
-          proxy: proxy_target,
-          url: this.baseURL + '/sftp?port=' + port + '&dummy=1',
-        });
-      } else if (app == 'sshd') {
-        logger.debug('proxy target: ' + proxy_target);
-        res.send({
-          code: 200,
-          proxy: proxy_target,
-          port: port,
-          url: this.baseURL + '/sshd?port=' + port + '&dummy=1',
-        });
-      } else if (app == 'vnc') {
-        logger.debug('proxy target: ' + proxy_target);
-        res.send({
-          code: 200,
-          proxy: proxy_target,
-          port: port,
-          url: this.baseURL + '/vnc?port=' + port + '&dummy=1',
-        });
-      } else if (app == 'xrdp') {
-        logger.debug('proxy target: ' + proxy_target);
-        res.send({
-          code: 200,
-          proxy: proxy_target,
-          port: port,
-          url: this.baseURL + '/xrdp?port=' + port + '&dummy=1',
-        });
-      } else {
-        res.send({
-          code: 200,
-          proxy: proxy_target,
-          url: this.baseURL + '/redirect?port=' + port,
-        });
-      }
-    });
-
-    this.app.get('/proxy/:token/:sessionId/delete', (req, res) => {
-      //find all and kill
-      if (!this._config) {
-        res.send({ code: 401 });
-        return;
-      }
-
-      let sessionId = req.params['sessionId'];
-      let app = req.query.app || null;
-
-      if (app === null) {
-        let stopped = false;
-        for (const key in this.proxies) {
-          logger.debug(key.split('|', 1));
-          if (key.split('|', 1)[0] === sessionId) {
-            logger.info(`Found app to terminate in ${sessionId}`);
-            this.proxies[key].stop_proxy();
-            delete this.proxies[key];
-            stopped = true;
+          let assigned = false;
+          let maxtry = 5;
+          for (let i = 0; i < maxtry; i++) {
+            try {
+              await gateway.start_proxy(sessionId, app, ip, port, envs, args);
+              port = gateway.getPort();
+              assigned = true;
+              break;
+            } catch (err) {
+              if ('PortInUse' === err.message) {
+                // try next number or fallback to random port for the last resort
+                port = i < maxtry - 1 ? port + 1 : undefined;
+                if (port) {
+                  logger.warn('trying next port: ' + port);
+                } else {
+                  logger.warn('trying random port');
+                }
+              } else {
+                logger.warn(err.message);
+              }
+            }
+          }
+          logger.debug(`proxies: ${p}`);
+          logger.info(`Total connections: ${Object.keys(this.proxies).length}`);
+          if (!assigned) {
+            res.send({ code: 500 });
+            return;
           }
         }
-        logger.info(`Total connections: ${Object.keys(this.proxies).length}`);
-        if (stopped) {
-          res.send({ code: 200 });
+
+        let proxy_target = 'http://' + this.proxyBaseHost + ':' + port;
+        if (app == 'sftp') {
+          logger.debug('proxy target: ' + proxy_target);
+          res.send({
+            code: 200,
+            proxy: proxy_target,
+            url: this.baseURL + '/sftp?port=' + port + '&dummy=1',
+          });
+        } else if (app == 'sshd') {
+          logger.debug('proxy target: ' + proxy_target);
+          res.send({
+            code: 200,
+            proxy: proxy_target,
+            port: port,
+            url: this.baseURL + '/sshd?port=' + port + '&dummy=1',
+          });
+        } else if (app == 'vnc') {
+          logger.debug('proxy target: ' + proxy_target);
+          res.send({
+            code: 200,
+            proxy: proxy_target,
+            port: port,
+            url: this.baseURL + '/vnc?port=' + port + '&dummy=1',
+          });
+        } else if (app == 'xrdp') {
+          logger.debug('proxy target: ' + proxy_target);
+          res.send({
+            code: 200,
+            proxy: proxy_target,
+            port: port,
+            url: this.baseURL + '/xrdp?port=' + port + '&dummy=1',
+          });
         } else {
-          res.send({ code: 404 });
+          res.send({
+            code: 200,
+            proxy: proxy_target,
+            url: this.baseURL + '/redirect?port=' + port,
+          });
         }
-      } else {
-        let p = sessionId + '|' + app;
-        if (p in this.proxies && app !== null) {
-          logger.debug(`Found ${app} to terminate in ${sessionId}`);
-          this.proxies[p].stop_proxy();
+      },
+    );
+
+    this.app.get(
+      '/proxy/:token/:sessionId/delete',
+      proxyRateLimiter,
+      (req, res) => {
+        if (!this._isAuthorizedToken(req.params['token'])) {
+          res.status(403).send({ code: 403 });
+          return;
+        }
+        //find all and kill
+        if (!this._config) {
+          res.send({ code: 401 });
+          return;
+        }
+
+        let sessionId = req.params['sessionId'];
+        let app = req.query.app || null;
+
+        if (app === null) {
+          let stopped = false;
+          for (const key in this.proxies) {
+            logger.debug(key.split('|', 1));
+            if (key.split('|', 1)[0] === sessionId) {
+              logger.info(`Found app to terminate in ${sessionId}`);
+              this.proxies[key].stop_proxy();
+              delete this.proxies[key];
+              stopped = true;
+            }
+          }
           logger.info(`Total connections: ${Object.keys(this.proxies).length}`);
-          res.send({ code: 200 });
-          delete this.proxies[p];
+          if (stopped) {
+            res.send({ code: 200 });
+          } else {
+            res.send({ code: 404 });
+          }
         } else {
-          res.send({ code: 404 });
+          let p = sessionId + '|' + app;
+          if (p in this.proxies && app !== null) {
+            logger.debug(`Found ${app} to terminate in ${sessionId}`);
+            this.proxies[p].stop_proxy();
+            logger.info(
+              `Total connections: ${Object.keys(this.proxies).length}`,
+            );
+            res.send({ code: 200 });
+            delete this.proxies[p];
+          } else {
+            res.send({ code: 404 });
+          }
         }
-      }
-    });
+      },
+    );
 
     this.app.get('/sftp', (req, res) => {
       let port = req.query.port;
@@ -436,5 +601,10 @@ class Manager extends EventEmitter {
     });
   }
 }
+
+// Exposed for regression tests, which seed `Manager.proxies` with fake
+// gateways directly to avoid constructing real gateways (a build artifact
+// unavailable in a source-only checkout).
+Manager.isGatewayAlive = isGatewayAlive;
 
 module.exports = Manager;

--- a/src/wsproxy/manager.test.ts
+++ b/src/wsproxy/manager.test.ts
@@ -1,0 +1,270 @@
+import Manager from './manager.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * Regression tests for the local wsproxy hardening (FR-3227).
+ *
+ * The local wsproxy previously (a) enabled `cors()` for every origin, (b)
+ * returned a fixed token `"local"` from `PUT /conf`, and (c) never validated
+ * the `:token` path param on the `/proxy/*` routes. These tests pin the fixed
+ * behavior: a random per-instance token, constant-time token validation, and
+ * an origin allowlist.
+ *
+ * The tests drive `/conf` in SESSION mode, which never constructs the
+ * Backend.AI client, and never trigger a real gateway — so `manager.js`'s
+ * lazily-required build artifacts are not needed (the suite runs from a
+ * source-only checkout, e.g. CI).
+ */
+
+describe('wsproxy Manager security (FR-3227)', () => {
+  let manager: any;
+  let baseURL: string;
+
+  const json = async (res: Response) => {
+    const text = await res.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  };
+
+  // Drive `/conf` so `this._config` is set, and capture the per-instance token.
+  // SESSION mode keeps the Backend.AI client (a build artifact) out of the path.
+  const configure = async () => {
+    const res = await fetch(`${baseURL}/conf`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        endpoint: 'http://localhost:8081',
+        mode: 'SESSION',
+        auth_mode: 'header',
+        session: 'test-session',
+      }),
+    });
+    return (await json(res)).token as string;
+  };
+
+  beforeEach(async () => {
+    manager = new Manager('127.0.0.1', '127.0.0.1', 0);
+    const port = await manager.start();
+    baseURL = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) =>
+      manager.listener.close(() => resolve()),
+    );
+  });
+
+  describe('PUT /conf token', () => {
+    it('returns a random per-instance token, not the legacy "local"', async () => {
+      const token = await configure();
+      expect(token).toBeTypeOf('string');
+      expect(token).not.toBe('local');
+      // 32 random bytes encoded as base64url → 43 chars.
+      expect(token.length).toBe(43);
+    });
+
+    it('returns a distinct token per Manager instance', async () => {
+      const tokenA = await configure();
+      const other = new Manager('127.0.0.1', '127.0.0.1', 0);
+      const port = await other.start();
+      const res = await fetch(`http://127.0.0.1:${port}/conf`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          endpoint: 'http://localhost:8081',
+          mode: 'SESSION',
+          auth_mode: 'header',
+          session: 'test-session',
+        }),
+      });
+      const tokenB = (await json(res)).token;
+      await new Promise<void>((resolve) =>
+        other.listener.close(() => resolve()),
+      );
+      expect(tokenA).not.toBe(tokenB);
+    });
+
+    it('rejects a disallowed cross-origin caller with 403', async () => {
+      const res = await fetch(`${baseURL}/conf`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://evil.example',
+        },
+        body: JSON.stringify({ endpoint: 'http://localhost:8081' }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('/proxy/:token token validation', () => {
+    it('rejects /add with a wrong token (was previously accepted)', async () => {
+      await configure();
+      const res = await fetch(
+        `${baseURL}/proxy/attacker-controlled-wrong-token/victim-session/add?app=jupyter`,
+      );
+      expect(res.status).toBe(403);
+      expect((await json(res)).code).toBe(403);
+    });
+
+    it('rejects /delete with a wrong token (was previously accepted)', async () => {
+      await configure();
+      const res = await fetch(
+        `${baseURL}/proxy/attacker-controlled-wrong-token/victim-session/delete`,
+      );
+      expect(res.status).toBe(403);
+      expect((await json(res)).code).toBe(403);
+    });
+
+    it('rejects the existence-check route with a wrong token', async () => {
+      await configure();
+      const res = await fetch(
+        `${baseURL}/proxy/attacker-controlled-wrong-token/victim-session`,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects an empty token segment', async () => {
+      await configure();
+      // `//` collapses; use a single space-only token to exercise the guard.
+      const res = await fetch(`${baseURL}/proxy/%20/victim-session/delete`);
+      expect(res.status).toBe(403);
+    });
+
+    it('accepts the correct token (passes the guard, then hits normal logic)', async () => {
+      const token = await configure();
+      const res = await fetch(
+        `${baseURL}/proxy/${encodeURIComponent(token)}/no-such-session/delete`,
+      );
+      // The token check passed: we reach the normal handler, which returns 404
+      // (no such proxy) rather than 403 (rejected token).
+      expect(res.status).toBe(200);
+      expect((await json(res)).code).toBe(404);
+    });
+
+    it('rejects the correct-length-but-wrong token (constant-time path)', async () => {
+      const token = await configure();
+      // Same length as the real token but different content.
+      const forged = 'A'.repeat(token.length);
+      const res = await fetch(
+        `${baseURL}/proxy/${forged}/victim-session/delete`,
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('CORS allowlist', () => {
+    it('does not reflect a disallowed origin (no wildcard, no echo)', async () => {
+      const res = await fetch(`${baseURL}/status`, {
+        headers: { Origin: 'https://evil.example' },
+      });
+      const acao = res.headers.get('access-control-allow-origin');
+      expect(acao).not.toBe('*');
+      expect(acao).not.toBe('https://evil.example');
+    });
+
+    it('reflects a trusted loopback origin', async () => {
+      const res = await fetch(`${baseURL}/status`, {
+        headers: { Origin: 'http://localhost:5173' },
+      });
+      expect(res.headers.get('access-control-allow-origin')).toBe(
+        'http://localhost:5173',
+      );
+    });
+
+    it('reflects a *.localhost subdomain origin (e.g. the Portless dev URL)', async () => {
+      const res = await fetch(`${baseURL}/status`, {
+        headers: { Origin: 'https://fr-3227.localhost:1355' },
+      });
+      expect(res.headers.get('access-control-allow-origin')).toBe(
+        'https://fr-3227.localhost:1355',
+      );
+    });
+  });
+
+  /**
+   * Regression tests for the second-launch hang: closing an app tab never
+   * calls /delete, so a dead gateway can linger in `Manager.proxies`.
+   * Reusing it without a liveness check hands back a port nothing is
+   * listening on, and the client's redirect fetch hangs forever.
+   *
+   * These tests seed `manager.proxies` directly with fake gateway objects
+   * instead of driving `/add` end-to-end for a fresh gateway, since real
+   * gateway construction requires build artifacts unavailable in a
+   * source-only checkout (see the top-of-file comment on this suite).
+   */
+  describe('/proxy/:token/:sessionId/add stale gateway reuse', () => {
+    it('isGatewayAlive treats a gateway with no isAlive() as alive (legacy shape)', () => {
+      expect(Manager.isGatewayAlive({})).toBe(true);
+    });
+
+    it('isGatewayAlive defers to the gateway isAlive() method', () => {
+      expect(Manager.isGatewayAlive({ isAlive: () => true })).toBe(true);
+      expect(Manager.isGatewayAlive({ isAlive: () => false })).toBe(false);
+    });
+
+    it('reuses a cached gateway whose listener is still alive', async () => {
+      const token = await configure();
+      const fakeGateway = {
+        isAlive: () => true,
+        getPort: () => 55555,
+        stop_proxy: () => {
+          throw new Error('stop_proxy should not be called on a live gateway');
+        },
+      };
+      manager.proxies['sess-1|jupyter'] = fakeGateway;
+
+      const res = await fetch(
+        `${baseURL}/proxy/${encodeURIComponent(token)}/sess-1/add?app=jupyter`,
+      );
+      const body = await json(res);
+
+      expect(body.code).toBe(200);
+      expect(body.url).toContain('port=55555');
+      // Same instance — not replaced.
+      expect(manager.proxies['sess-1|jupyter']).toBe(fakeGateway);
+    });
+
+    it('evicts a stale (dead) cached gateway instead of reusing its port', () => {
+      // Exercises `_evictStaleGateway` directly rather than driving `/add`
+      // end-to-end: past eviction, the route falls through to constructing a
+      // real gateway, which requires build artifacts unavailable in a
+      // source-only checkout (see the top-of-file comment on this suite).
+      let stopped = false;
+      const deadGateway = {
+        isAlive: () => false,
+        getPort: () => 55555,
+        stop_proxy: () => {
+          stopped = true;
+        },
+      };
+      manager.proxies['sess-2|jupyter'] = deadGateway;
+
+      manager._evictStaleGateway('sess-2|jupyter');
+
+      expect(stopped).toBe(true);
+      expect(manager.proxies.hasOwnProperty('sess-2|jupyter')).toBe(false);
+    });
+
+    it('is a no-op when there is nothing cached for the key', () => {
+      expect(() => manager._evictStaleGateway('no-such-key')).not.toThrow();
+    });
+
+    it('swallows a stop_proxy() failure and still evicts the entry', () => {
+      const deadGateway = {
+        isAlive: () => false,
+        getPort: () => 55555,
+        stop_proxy: () => {
+          throw new Error('boom');
+        },
+      };
+      manager.proxies['sess-3|jupyter'] = deadGateway;
+
+      expect(() => manager._evictStaleGateway('sess-3|jupyter')).not.toThrow();
+      expect(manager.proxies.hasOwnProperty('sess-3|jupyter')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Resolves FR-3227

> Note: no cloned GitHub issue exists for FR-3227 yet (the Jira→GitHub webhook has not mirrored it). Linking the Jira key directly; update to `Resolves #<n> (FR-3227)` once the GitHub issue appears.

## Problem

The Backend.AI **Desktop** local wsproxy (`src/wsproxy/manager.js`) binds an HTTP server on `127.0.0.1` and:

1. `this.app.use(cors())` — allows **every** origin and answers with `Access-Control-Allow-Origin: *`.
2. `PUT /conf` returns a **fixed** token `{ token: "local" }`.
3. `/proxy/:token/:sessionId`, `/add`, `/delete` parse `:token` but **never validate** it.

A malicious web page open in the victim's browser (while Desktop is running) can therefore send cross-origin requests to the localhost wsproxy, **read the responses**, and reach the proxy add/delete routes with **any** token value (e.g. `attacker-controlled-wrong-token`) — exposing local proxy state and letting the page create/delete app proxies.

## Fix (`src/wsproxy/manager.js`)

- **Random per-instance secret token.** Generate `crypto.randomBytes(32).toString('base64url')` once per `Manager` instance and return it from `PUT /conf` instead of `"local"`. Never logged.
- **Constant-time token validation** on all three `/proxy/*` routes via `crypto.timingSafeEqual`, guarding the length-mismatch throw first. Wrong/forged tokens → `403`.
- **Origin allowlist instead of `cors()`.** Trusted: the Electron `file://` renderer (`Origin: null`/absent) and any loopback origin (including `*.localhost` subdomains like the Portless dev URL, per RFC 6761); extra origins via the `WSPROXY_CORS_ORIGINS` env var (comma-separated or JSON array). The specific origin is reflected (never `*`), which is also required for the WebUI's credentialed (`credentials: 'include'`) requests.
- **`PUT /conf` origin guard** (CSRF defense in depth) so token secrecy does not rely solely on the browser honoring CORS.
- **Rate limiting** on the token-authorized `/proxy/*` routes (`express-rate-limit`, 600/min) — defense in depth bounding proxy add/delete spam and token probing. Adds the `express-rate-limit` dependency (alongside the existing `express`/`cors`).

## Consumer impact

The app-launch path (`useBackendAIAppLauncher._resolveV1ProxyUri`) already uses the token returned by `/conf` — no change needed. The **v2** remote App Proxy is a different server and is **untouched**.

Two **v1 cleanup paths** previously passed `baiClient._config.accessKey` as the proxy token, which would now be rejected (silent proxy-gateway leak on app close / terminate). Both now fetch the real per-instance token via `/conf` through a shared helper (`react/src/helper/localProxyToken.ts`), gated to `v1` only:

- `react/src/hooks/useBackendAIAppLauncher.tsx` — `_close_wsproxy`
- `react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx` — `terminateApp`

## Follow-up fix: second app launch hangs on "Adding kernel to socket queue"

Testing this branch surfaced a separate bug: opening a session app works the first time, but closing it and opening an app on the same session again hangs the launcher forever at "Adding kernel to socket queue...". DevTools shows `redirect?port=<N>` (302) followed by a `127.0.0.1` request stuck `pending` indefinitely.

**Root cause**: `manager.js`'s `/proxy/:token/:sessionId/add` route caches gateways in `Manager.proxies` keyed by `sessionId|app`. The first launch awaits `gateway.start_proxy()` so it only responds once the TCP listener is actually bound. A second launch for the same key hit the reuse branch, which read `gateway.getPort()` and replied `200` **without checking whether that gateway was still alive**. Nothing in the app-launch flow notifies the manager when a user simply closes an app tab (only explicit session termination hits `/delete`), so a dead gateway could linger in the cache and get handed back on the next launch — the client's fetch into its port then hangs with no response, no error, and no timeout to recover from.

- `src/wsproxy/manager.js` — added `Manager._evictStaleGateway(p)`, called before the reuse check in `/add`: if the cached gateway's `isAlive()` reports false, `stop_proxy()` it and drop it from the cache instead of reusing it.
- `src/wsproxy/gateway/tcpwsproxy.js`, `src/wsproxy/gateway/consoleproxy.js` — added `isAlive()`, backed by the underlying `tcpServer.listening`.
- `react/src/hooks/useBackendAIAppLauncher.tsx` — `sendRequest()` now bounds every proxy request with a 30s `AbortSignal.timeout`, so a target that still doesn't respond fails visibly instead of hanging the launcher UI forever (safety net independent of the root cause above).

## Tests & CI

`src/wsproxy/manager.test.ts` (vitest, node env):

- `PUT /conf` returns a random 43-char token, distinct per instance, and `403`s a disallowed cross-origin caller.
- Wrong / forged-but-correct-length / empty token on `/add`, `/delete`, and the check route → `403`; the correct token passes the guard.
- CORS does not reflect a disallowed origin (no `*`, no echo) and does reflect a trusted loopback origin.
- `Manager.isGatewayAlive` / `_evictStaleGateway`: reuses a live cached gateway as-is; evicts and `stop_proxy()`s a dead one instead of reusing its port; stays safe when `stop_proxy()` itself throws or there's nothing cached for the key.

`manager.js` previously required the Backend.AI client and the proxy gateways at module load. Those are **build artifacts absent in a source-only checkout** (`src/lib/backend.ai-client-node.js` is gitignored; `backend.ai-ws-appproxy` is not tracked at all), so importing `manager.js` in the `root-vitest` CI job failed with `MODULE_NOT_FOUND`. They are now **required lazily** inside the handlers that use them, and the tests drive `/conf` in SESSION mode and seed `Manager.proxies` with fake gateway objects directly (never constructing a real one) — verified to pass with all build artifacts removed.

## Verification

`bash scripts/verify.sh` → Relay / Lint / Format / TypeScript all PASS (the unrelated "Vite warmup paths" check fails on this branch both before and after this change — it requires a production `build/` dir that isn't present in this checkout). `npx vitest run src/wsproxy/manager.test.ts` → 18 passed, no unhandled rejections.
