### PR TITLE
fix: Disable container log auto-refresh interval input when auto-refresh is off

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -234,6 +234,7 @@ const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
             </AutoRefreshSwitch>
             <InputNumber
               min={3}
+              disabled={!autoRefreshEnabled}
               value={(autoRefreshIntervalValue ?? 1000) / 1000}
               onChange={(value) => {
                 if (typeof value === 'number') {


### PR DESCRIPTION
Follow-up to #4640 (FR-1679).

## Problem

In `ContainerLogModal`, the auto-refresh interval `InputNumber` stayed editable even when the `AutoRefreshSwitch` was turned off. Editing the interval while auto-refresh is disabled has no effect, which is misleading.

## Change

Disable the interval `InputNumber` (`disabled={!autoRefreshEnabled}`) whenever auto-refresh is off, so the interval can only be edited while auto-refresh is active.

```diff
 <InputNumber
   min={3}
+  disabled={!autoRefreshEnabled}
   value={(autoRefreshIntervalValue ?? 1000) / 1000}
```

## Notes

- Single-line, type-safe prop addition (`InputNumber` already accepts `disabled`).
- `scripts/verify.sh` could not be run in this environment because `pnpm install` / the local dependency state is out of sync (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)