### PR TITLE
feat(FR-1436): limit deployment model folder selector to mountable hosts

### DIFF
--- a/react/src/__generated__/useMountableVFolderHostsQuery.graphql.ts
+++ b/react/src/__generated__/useMountableVFolderHostsQuery.graphql.ts
@@ -1,0 +1,96 @@
+/**
+ * @generated SignedSource<<43a8bbf9ea64e2e34e2406cea7067dcf>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type VFolderHostPermissionV2 = "CREATE_VFOLDER" | "DELETE_VFOLDER" | "DOWNLOAD_FILE" | "INVITE_OTHERS" | "MODIFY_VFOLDER" | "MOUNT_IN_SESSION" | "SET_USER_PERM" | "UPLOAD_FILE" | "%future added value";
+export type useMountableVFolderHostsQuery$variables = Record<PropertyKey, never>;
+export type useMountableVFolderHostsQuery$data = {
+  readonly myStorageHostPermissions: {
+    readonly items: ReadonlyArray<{
+      readonly host: string;
+      readonly permissions: ReadonlyArray<VFolderHostPermissionV2>;
+    }>;
+  } | null | undefined;
+};
+export type useMountableVFolderHostsQuery = {
+  response: useMountableVFolderHostsQuery$data;
+  variables: useMountableVFolderHostsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "MyStorageHostPermissionsPayload",
+    "kind": "LinkedField",
+    "name": "myStorageHostPermissions",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "StorageHostPermission",
+        "kind": "LinkedField",
+        "name": "items",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "host",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "permissions",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useMountableVFolderHostsQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "useMountableVFolderHostsQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "5acbee4bf4cfab612d4cf4947fb955e6",
+    "id": null,
+    "metadata": {},
+    "name": "useMountableVFolderHostsQuery",
+    "operationKind": "query",
+    "text": "query useMountableVFolderHostsQuery {\n  myStorageHostPermissions {\n    items {\n      host\n      permissions\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9316f9cb9510eea07cb926c473a2c556";
+
+export default node;

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -26,6 +26,7 @@ import {
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useMountableVFolderHosts } from '../hooks/useMountableVFolderHosts';
 import {
   buildRuntimeVariantPresetValues,
   type RuntimeParameterGroup,
@@ -204,6 +205,40 @@ const PresetDetailLoader: React.FC<{
       open
       presetFrgmt={data.deploymentRevisionPreset}
       onCancel={onCancel}
+    />
+  );
+};
+
+/**
+ * Model folder picker for the deployment revision forms.
+ *
+ * The backend defers the storage-host mount-permission check (MOUNT_IN_SESSION)
+ * to session start / replica spawn rather than deployment creation, so a
+ * deployment built from a model folder on a non-mountable host is accepted and
+ * only fails later when its replicas try to mount it. Restricting the picker to
+ * folders whose host the user may actually mount prevents that failure up front.
+ *
+ * The mountable-host query lives in this child component, rather than the modal
+ * body, so it suspends within each select's own `<Suspense>` skeleton instead of
+ * blanking the whole modal.
+ */
+const MountableModelFolderSelect: React.FC<
+  Omit<React.ComponentProps<typeof BAIVFolderSelect>, 'filter'>
+> = ({ ref, ...props }) => {
+  'use memo';
+  const mountableVFolderHosts = useMountableVFolderHosts();
+  const hostMountFilter =
+    mountableVFolderHosts.length > 0
+      ? mountableVFolderHosts
+          .map((host) => `host == ${JSON.stringify(host)}`)
+          .join(' | ')
+      : // No mountable host: match nothing rather than every folder.
+        'host == "__no_mountable_host__"';
+  return (
+    <BAIVFolderSelect
+      {...props}
+      ref={ref}
+      filter={`usage_mode == "model" & (${hostMountFilter})`}
     />
   );
 };
@@ -1465,12 +1500,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                     noStyle
                     rules={[{ required: true }]}
                   >
-                    <BAIVFolderSelect
+                    <MountableModelFolderSelect
                       ref={presetVFolderSelectRef}
                       currentProjectId={currentProjectId ?? undefined}
                       disabled={!currentProjectId}
                       excludeDeleted
-                      filter='usage_mode == "model"'
                       style={{ flex: 1 }}
                     />
                   </Form.Item>
@@ -1546,12 +1580,11 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
                   noStyle
                   rules={[{ required: true }]}
                 >
-                  <BAIVFolderSelect
+                  <MountableModelFolderSelect
                     ref={customVFolderSelectRef}
                     currentProjectId={currentProjectId ?? undefined}
                     disabled={!currentProjectId}
                     excludeDeleted
-                    filter='usage_mode == "model"'
                     style={{ flex: 1 }}
                   />
                 </Form.Item>

--- a/react/src/hooks/useMountableVFolderHosts.ts
+++ b/react/src/hooks/useMountableVFolderHosts.ts
@@ -1,0 +1,43 @@
+import { useMountableVFolderHostsQuery } from '../__generated__/useMountableVFolderHostsQuery.graphql';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * Returns the storage hosts the current user is allowed to mount in a session.
+ *
+ * Backed by the `myStorageHostPermissions` GraphQL field (Strawberry V2), which
+ * resolves — server-side — the union of `allowed_vfolder_hosts` inherited from
+ * the domain, the user's projects, and the keypair resource policy, already
+ * intersected with the volumes currently registered on the storage manager.
+ *
+ * This avoids the legacy client-side merge (domain + group + keypair
+ * `allowed_vfolder_hosts`), which first had to resolve the keypair's
+ * resource-policy name and therefore incurred a request waterfall.
+ *
+ * Note: the host set is scoped to the user (the union across all of the user's
+ * projects), not to a single active project, so it is a slight superset of the
+ * hosts mountable in one specific project.
+ *
+ * @returns the list of host names on which the user holds the
+ *   `MOUNT_IN_SESSION` permission.
+ */
+export const useMountableVFolderHosts = (): Array<string> => {
+  'use memo';
+  const { myStorageHostPermissions } =
+    useLazyLoadQuery<useMountableVFolderHostsQuery>(
+      graphql`
+        query useMountableVFolderHostsQuery {
+          myStorageHostPermissions {
+            items {
+              host
+              permissions
+            }
+          }
+        }
+      `,
+      {},
+    );
+
+  return (myStorageHostPermissions?.items ?? [])
+    .filter((item) => item.permissions.includes('MOUNT_IN_SESSION'))
+    .map((item) => item.host);
+};


### PR DESCRIPTION
Resolves #4234 (FR-1436)

## Problem

The model folder picker on the deployment "add revision" modal (`DeploymentAddRevisionModal`, both the preset and custom forms) listed **every** `usage_mode == "model"` vfolder, regardless of whether the folder's storage host is mountable by the user. Picking a non-mountable-host folder (e.g. a left-over model-store project folder) reproduces the customer report: the request fails.

In the deployment flow this is actually **worse** than the legacy model-service flow. The backend **defers** the storage-host mount-permission check (`MOUNT_IN_SESSION`) to **session start / replica spawn**, not deployment creation:

> `repositories/deployment/db_source/db_source.py` — *"Intentionally minimal: only the `permission` column is read, without RBAC / host-permission / cross-project checks — those apply at session creation (`prepare_vfolder_mounts`), not at revision write."*

So a deployment built from a non-mountable-host model folder is **accepted**, looks created, and then its replicas silently fail to spawn with `InsufficientStoragePermission` (HTTP 400). Front-end filtering is the right place to prevent this up front.

## Change

Filter both model-folder selectors to folders whose host the current user may actually mount:

- New hook **`useMountableVFolderHosts`** reads the `myStorageHostPermissions` GraphQL field (Strawberry V2) and returns the host names carrying `MOUNT_IN_SESSION`.
- The host names are composed into the existing GraphQL `filter` string as `usage_mode == "model" & (host == "h1" | host == "h2" | …)`. `host` is server-side filterable on `vfolder_nodes`, so this keeps the selector's pagination/count intact. When the user has **no** mountable host, the filter matches nothing (rather than every folder).

### Why `myStorageHostPermissions` (no waterfall)

The legacy client-side pattern (`VFolderTable`, `useMergedAllowedStorageHostPermission`) first resolves the keypair's resource-policy **name**, then issues a second query for domain/group/keypair `allowed_vfolder_hosts`, then merges three JSON blobs client-side — a request **waterfall**. `myStorageHostPermissions` returns the **union of domain + the user's projects + keypair** permissions in a **single** query, already intersected with the registered volumes, server-side. No keypair lookup, no client merge.

No `@since` gate is needed: this modal is already gated to managers ≥ 26.4.3, and `myStorageHostPermissions` was added in 26.4.2.

## Scope notes

- **Host filter only.** Group/project (`ownership_type == "group"`) folders are intentionally **not** excluded here. The backend explicitly accepts group-owned `MODEL` folders at deployment creation, so excluding them would contradict backend intent; the customer-reported folders are correctly handled by the host filter (their host is simply not mountable). (The original FR-1435 group-exclusion lives in the now-refactored `ServiceLauncherPageContent`; whether to reinstate it under the new modal is tracked separately.)
- **Known nuance.** `myStorageHostPermissions` is scoped to the *user* (the union across all of the user's projects), so it is a slight **superset** of the hosts mountable in one specific project. This is strictly better than today (no filter) and acceptable; strict per-project scoping is out of scope here.
- **Follow-up (separate stack).** Migrating the existing waterfall consumers (`VFolderTable`, `useMergedAllowedStorageHostPermission` + its file-browser / SFTP / folder-explorer consumers) onto `myStorageHostPermissions` is tracked as a separate Jira issue and will be stacked on top of this PR.

## Verification

`bash scripts/verify.sh` → Relay / Lint / Format / TypeScript **PASS**.

## Test plan

- [ ] As a user whose project has a model folder on a **non-mountable** host, open the deployment "add revision" modal → that folder is **not** offered in the model folder selector (preset and custom forms).
- [ ] A model folder on a **mountable** host is still offered and a deployment created from it spawns replicas successfully.
- [ ] A user with no mountable hosts sees an empty model folder selector (not the full list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
