### PR TITLE
feat(FR-3230): add agent watcher start/stop/restart actions to AgentDetailDrawer

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -1282,6 +1282,51 @@ export class Client {
   }
 
   /**
+   * Start the agent's watcher daemon. (superadmin only)
+   *
+   * @param {string} agentId - the agent id (row id) to control
+   */
+  async start_watcher_agent(agentId: string): Promise<any> {
+    const rqst = this.newSignedRequest(
+      'POST',
+      '/resource/watcher/agent/start',
+      { agent_id: agentId },
+      null,
+    );
+    return this._wrapWithPromise(rqst);
+  }
+
+  /**
+   * Stop the agent's watcher daemon. (superadmin only)
+   *
+   * @param {string} agentId - the agent id (row id) to control
+   */
+  async stop_watcher_agent(agentId: string): Promise<any> {
+    const rqst = this.newSignedRequest(
+      'POST',
+      '/resource/watcher/agent/stop',
+      { agent_id: agentId },
+      null,
+    );
+    return this._wrapWithPromise(rqst);
+  }
+
+  /**
+   * Restart the agent's watcher daemon. (superadmin only)
+   *
+   * @param {string} agentId - the agent id (row id) to control
+   */
+  async restart_watcher_agent(agentId: string): Promise<any> {
+    const rqst = this.newSignedRequest(
+      'POST',
+      '/resource/watcher/agent/restart',
+      { agent_id: agentId },
+      null,
+    );
+    return this._wrapWithPromise(rqst);
+  }
+
+  /**
    * Create a `compute session` if the session for the given sessionId does not exist.
    * It returns the information for the existing session otherwise, without error.
    *

--- a/react/src/__generated__/AgentActionButtonsFragment.graphql.ts
+++ b/react/src/__generated__/AgentActionButtonsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6330ce33fc5811401cfdb391eba62950>>
+ * @generated SignedSource<<c64121d94df0d2feb62183843a8ea2c1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,8 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type AgentActionButtonsFragment$data = {
-  readonly " $fragmentSpreads": FragmentRefs<"AgentSettingModalFragment">;
+  readonly status: string | null | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"AgentLifeCycleControlModalFragment" | "AgentSettingModalFragment">;
   readonly " $fragmentType": "AgentActionButtonsFragment";
 };
 export type AgentActionButtonsFragment$key = {
@@ -26,15 +27,27 @@ const node: ReaderFragment = {
   "name": "AgentActionButtonsFragment",
   "selections": [
     {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "AgentSettingModalFragment"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "AgentLifeCycleControlModalFragment"
     }
   ],
   "type": "AgentNode",
   "abstractKey": null
 };
 
-(node as any).hash = "4d1cf046e347690661f3066dc0343f87";
+(node as any).hash = "91839e2c961d0267044baf054740c45c";
 
 export default node;

--- a/react/src/__generated__/AgentDetailDrawerRefetchQuery.graphql.ts
+++ b/react/src/__generated__/AgentDetailDrawerRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3b1e224d42467e8d8937dc1857240d20>>
+ * @generated SignedSource<<d12fd86d58ff30624ff8c6f76da3beff>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -208,12 +208,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b71f3bee430adc46930be26f8a584fd2",
+    "cacheID": "c92fdf309bc05395cc32eba29156c120",
     "id": null,
     "metadata": {},
     "name": "AgentDetailDrawerRefetchQuery",
     "operationKind": "query",
-    "text": "query AgentDetailDrawerRefetchQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AgentDetailDrawerFragment\n    id\n  }\n}\n\nfragment AgentActionButtonsFragment on AgentNode {\n  ...AgentSettingModalFragment\n}\n\nfragment AgentComputePluginsFragment on AgentNode {\n  compute_plugins\n  available_slots\n}\n\nfragment AgentDetailDrawerContentFragment on AgentNode {\n  id\n  row_id\n  addr\n  status\n  status_changed\n  schedulable\n  first_contact\n  region\n  scaling_group\n  ...AgentStatusTagFragment\n  ...AgentComputePluginsFragment\n  ...AgentResourcesFragment\n  ...AgentActionButtonsFragment\n}\n\nfragment AgentDetailDrawerFragment on Node {\n  __isNode: __typename\n  ... on AgentNode {\n    id\n    ...AgentDetailDrawerContentFragment\n  }\n  id\n}\n\nfragment AgentDetailModalFragment on AgentNode {\n  id\n  live_stat\n  available_slots\n  occupied_slots\n}\n\nfragment AgentResourcesFragment on AgentNode {\n  occupied_slots\n  available_slots\n  live_stat\n  gpu_alloc_map\n  ...AgentDetailModalFragment\n}\n\nfragment AgentSettingModalFragment on AgentNode {\n  id\n  scaling_group\n  schedulable\n}\n\nfragment AgentStatusTagFragment on AgentNode {\n  status\n  status_changed\n  version\n}\n"
+    "text": "query AgentDetailDrawerRefetchQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AgentDetailDrawerFragment\n    id\n  }\n}\n\nfragment AgentActionButtonsFragment on AgentNode {\n  status\n  ...AgentSettingModalFragment\n  ...AgentLifeCycleControlModalFragment\n}\n\nfragment AgentComputePluginsFragment on AgentNode {\n  compute_plugins\n  available_slots\n}\n\nfragment AgentDetailDrawerContentFragment on AgentNode {\n  id\n  row_id\n  addr\n  status\n  status_changed\n  schedulable\n  first_contact\n  region\n  scaling_group\n  ...AgentStatusTagFragment\n  ...AgentComputePluginsFragment\n  ...AgentResourcesFragment\n  ...AgentActionButtonsFragment\n}\n\nfragment AgentDetailDrawerFragment on Node {\n  __isNode: __typename\n  ... on AgentNode {\n    id\n    ...AgentDetailDrawerContentFragment\n  }\n  id\n}\n\nfragment AgentDetailModalFragment on AgentNode {\n  id\n  live_stat\n  available_slots\n  occupied_slots\n}\n\nfragment AgentLifeCycleControlModalFragment on AgentNode {\n  id\n  status\n  status_changed\n}\n\nfragment AgentResourcesFragment on AgentNode {\n  occupied_slots\n  available_slots\n  live_stat\n  gpu_alloc_map\n  ...AgentDetailModalFragment\n}\n\nfragment AgentSettingModalFragment on AgentNode {\n  id\n  scaling_group\n  schedulable\n}\n\nfragment AgentStatusTagFragment on AgentNode {\n  status\n  status_changed\n  version\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/AgentLifeCycleControlModalFragment.graphql.ts
+++ b/react/src/__generated__/AgentLifeCycleControlModalFragment.graphql.ts
@@ -1,0 +1,72 @@
+/**
+ * @generated SignedSource<<4fd220dd7f3ca14e289b79513de4891a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type AgentLifeCycleControlModalFragment$data = {
+  readonly id: string;
+  readonly status: string | null | undefined;
+  readonly status_changed: string | null | undefined;
+  readonly " $fragmentType": "AgentLifeCycleControlModalFragment";
+};
+export type AgentLifeCycleControlModalFragment$key = {
+  readonly " $data"?: AgentLifeCycleControlModalFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"AgentLifeCycleControlModalFragment">;
+};
+
+import AgentLifeCycleControlModalRefetchQuery_graphql from './AgentLifeCycleControlModalRefetchQuery.graphql';
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": AgentLifeCycleControlModalRefetchQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "AgentLifeCycleControlModalFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status_changed",
+      "storageKey": null
+    }
+  ],
+  "type": "AgentNode",
+  "abstractKey": null
+};
+
+(node as any).hash = "99c5cc9e353444a7bb4d222088b2c063";
+
+export default node;

--- a/react/src/__generated__/AgentLifeCycleControlModalRefetchQuery.graphql.ts
+++ b/react/src/__generated__/AgentLifeCycleControlModalRefetchQuery.graphql.ts
@@ -1,0 +1,135 @@
+/**
+ * @generated SignedSource<<a0a09e582b7cb8449a54043993bf7e47>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type AgentLifeCycleControlModalRefetchQuery$variables = {
+  id: string;
+};
+export type AgentLifeCycleControlModalRefetchQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"AgentLifeCycleControlModalFragment">;
+  } | null | undefined;
+};
+export type AgentLifeCycleControlModalRefetchQuery = {
+  response: AgentLifeCycleControlModalRefetchQuery$data;
+  variables: AgentLifeCycleControlModalRefetchQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AgentLifeCycleControlModalRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "AgentLifeCycleControlModalFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AgentLifeCycleControlModalRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "status",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "status_changed",
+                "storageKey": null
+              }
+            ],
+            "type": "AgentNode",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "a4136cc2ccf00b394f52adec7530dbd1",
+    "id": null,
+    "metadata": {},
+    "name": "AgentLifeCycleControlModalRefetchQuery",
+    "operationKind": "query",
+    "text": "query AgentLifeCycleControlModalRefetchQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AgentLifeCycleControlModalFragment\n    id\n  }\n}\n\nfragment AgentLifeCycleControlModalFragment on AgentNode {\n  id\n  status\n  status_changed\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "99c5cc9e353444a7bb4d222088b2c063";
+
+export default node;

--- a/react/src/__generated__/AgentListQuery.graphql.ts
+++ b/react/src/__generated__/AgentListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<89e22c0d31ccfd7989c3205b7c7134b0>>
+ * @generated SignedSource<<cc374ecfb8ce75e2375f58b9af2d9d61>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -362,12 +362,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3531fa5c9a729b2e4ea1f6e2aea42039",
+    "cacheID": "270315af555a2a571b3752e262844b0f",
     "id": null,
     "metadata": {},
     "name": "AgentListQuery",
     "operationKind": "query",
-    "text": "query AgentListQuery(\n  $filter: String\n  $order: String\n  $offset: Int\n  $first: Int\n  $before: String\n  $after: String\n  $last: Int\n) {\n  agent_nodes(filter: $filter, order: $order, offset: $offset, first: $first, after: $after, before: $before, last: $last) {\n    edges {\n      node {\n        id\n        ...BAIAgentTableFragment\n        ...AgentDetailModalFragment\n        ...AgentDetailDrawerFragment\n      }\n    }\n    count\n  }\n}\n\nfragment AgentActionButtonsFragment on AgentNode {\n  ...AgentSettingModalFragment\n}\n\nfragment AgentComputePluginsFragment on AgentNode {\n  compute_plugins\n  available_slots\n}\n\nfragment AgentDetailDrawerContentFragment on AgentNode {\n  id\n  row_id\n  addr\n  status\n  status_changed\n  schedulable\n  first_contact\n  region\n  scaling_group\n  ...AgentStatusTagFragment\n  ...AgentComputePluginsFragment\n  ...AgentResourcesFragment\n  ...AgentActionButtonsFragment\n}\n\nfragment AgentDetailDrawerFragment on Node {\n  __isNode: __typename\n  ... on AgentNode {\n    id\n    ...AgentDetailDrawerContentFragment\n  }\n  id\n}\n\nfragment AgentDetailModalFragment on AgentNode {\n  id\n  live_stat\n  available_slots\n  occupied_slots\n}\n\nfragment AgentResourcesFragment on AgentNode {\n  occupied_slots\n  available_slots\n  live_stat\n  gpu_alloc_map\n  ...AgentDetailModalFragment\n}\n\nfragment AgentSettingModalFragment on AgentNode {\n  id\n  scaling_group\n  schedulable\n}\n\nfragment AgentStatusTagFragment on AgentNode {\n  status\n  status_changed\n  version\n}\n\nfragment BAIAgentTableFragment on AgentNode {\n  id\n  row_id\n  addr\n  region\n  architecture\n  first_contact\n  occupied_slots\n  available_slots\n  live_stat\n  status\n  scaling_group\n  compute_plugins\n  version\n  schedulable\n}\n"
+    "text": "query AgentListQuery(\n  $filter: String\n  $order: String\n  $offset: Int\n  $first: Int\n  $before: String\n  $after: String\n  $last: Int\n) {\n  agent_nodes(filter: $filter, order: $order, offset: $offset, first: $first, after: $after, before: $before, last: $last) {\n    edges {\n      node {\n        id\n        ...BAIAgentTableFragment\n        ...AgentDetailModalFragment\n        ...AgentDetailDrawerFragment\n      }\n    }\n    count\n  }\n}\n\nfragment AgentActionButtonsFragment on AgentNode {\n  status\n  ...AgentSettingModalFragment\n  ...AgentLifeCycleControlModalFragment\n}\n\nfragment AgentComputePluginsFragment on AgentNode {\n  compute_plugins\n  available_slots\n}\n\nfragment AgentDetailDrawerContentFragment on AgentNode {\n  id\n  row_id\n  addr\n  status\n  status_changed\n  schedulable\n  first_contact\n  region\n  scaling_group\n  ...AgentStatusTagFragment\n  ...AgentComputePluginsFragment\n  ...AgentResourcesFragment\n  ...AgentActionButtonsFragment\n}\n\nfragment AgentDetailDrawerFragment on Node {\n  __isNode: __typename\n  ... on AgentNode {\n    id\n    ...AgentDetailDrawerContentFragment\n  }\n  id\n}\n\nfragment AgentDetailModalFragment on AgentNode {\n  id\n  live_stat\n  available_slots\n  occupied_slots\n}\n\nfragment AgentLifeCycleControlModalFragment on AgentNode {\n  id\n  status\n  status_changed\n}\n\nfragment AgentResourcesFragment on AgentNode {\n  occupied_slots\n  available_slots\n  live_stat\n  gpu_alloc_map\n  ...AgentDetailModalFragment\n}\n\nfragment AgentSettingModalFragment on AgentNode {\n  id\n  scaling_group\n  schedulable\n}\n\nfragment AgentStatusTagFragment on AgentNode {\n  status\n  status_changed\n  version\n}\n\nfragment BAIAgentTableFragment on AgentNode {\n  id\n  row_id\n  addr\n  region\n  architecture\n  first_contact\n  occupied_slots\n  available_slots\n  live_stat\n  status\n  scaling_group\n  compute_plugins\n  version\n  schedulable\n}\n"
   }
 };
 })();

--- a/react/src/components/AgentDetailDrawerContent.tsx
+++ b/react/src/components/AgentDetailDrawerContent.tsx
@@ -8,6 +8,7 @@ import AgentActionButtons from './AgentNodeItems/AgentActionButtons';
 import AgentComputePlugins from './AgentNodeItems/AgentComputePlugins';
 import AgentResources from './AgentNodeItems/AgentResources';
 import AgentStatusTag from './AgentNodeItems/AgentStatusTag';
+import BAIErrorBoundary from './BAIErrorBoundary';
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { Descriptions, Grid, Tabs, theme, Typography } from 'antd';
 import {
@@ -150,7 +151,11 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
           {
             key: 'resources',
             label: t('agent.Resources'),
-            children: <AgentResources agentNodeFrgmt={agent} />,
+            children: (
+              <BAIErrorBoundary>
+                <AgentResources agentNodeFrgmt={agent} />
+              </BAIErrorBoundary>
+            ),
           },
         ]}
       />

--- a/react/src/components/AgentLifeCycleControlModal.tsx
+++ b/react/src/components/AgentLifeCycleControlModal.tsx
@@ -1,0 +1,166 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { AgentLifeCycleControlModalFragment$key } from '../__generated__/AgentLifeCycleControlModalFragment.graphql';
+import { AgentLifeCycleControlModalRefetchQuery } from '../__generated__/AgentLifeCycleControlModalRefetchQuery.graphql';
+import { useSuspendedBackendaiClient } from '../hooks';
+import { useTanMutation } from '../hooks/reactQueryAlias';
+import { App, theme, Typography } from 'antd';
+import {
+  BAIFlex,
+  BAIModal,
+  BAIModalProps,
+  toLocalId,
+  useBAILogger,
+  useErrorMessageResolver,
+} from 'backend.ai-ui';
+import { useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useRefetchableFragment } from 'react-relay';
+
+export type AgentLifeCycleType = 'start' | 'stop' | 'restart';
+
+interface AgentLifeCycleControlModalProps extends BAIModalProps {
+  lifeCycleType: AgentLifeCycleType | null;
+  agentNodeFrgmt?: AgentLifeCycleControlModalFragment$key | null;
+  onRequestClose: () => void;
+}
+
+const LABEL_KEY: Record<AgentLifeCycleType, string> = {
+  start: 'agent.WatcherStart',
+  stop: 'agent.WatcherStop',
+  restart: 'agent.WatcherRestart',
+};
+
+const SUCCESS_KEY: Record<AgentLifeCycleType, string> = {
+  start: 'agent.WatcherStartRequested',
+  stop: 'agent.WatcherStopRequested',
+  restart: 'agent.WatcherRestartRequested',
+};
+
+const AgentLifeCycleControlModal: React.FC<AgentLifeCycleControlModalProps> = ({
+  lifeCycleType,
+  agentNodeFrgmt,
+  onRequestClose,
+  ...modalProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+  const { logger } = useBAILogger();
+  const { getErrorMessage } = useErrorMessageResolver();
+  const baiClient = useSuspendedBackendaiClient();
+  // Refetch inside a transition so the suspend triggered by `refetchAgent`
+  // keeps the current UI instead of collapsing the drawer's Suspense
+  // boundary to its skeleton fallback.
+  const [, startRefetchTransition] = useTransition();
+
+  const [agent, refetchAgent] = useRefetchableFragment<
+    AgentLifeCycleControlModalRefetchQuery,
+    AgentLifeCycleControlModalFragment$key
+  >(
+    graphql`
+      fragment AgentLifeCycleControlModalFragment on AgentNode
+      @refetchable(queryName: "AgentLifeCycleControlModalRefetchQuery") {
+        id
+        status
+        status_changed
+      }
+    `,
+    agentNodeFrgmt ?? null,
+  );
+
+  const startWatcherMutation = useTanMutation({
+    mutationFn: (agentId: string) => baiClient.start_watcher_agent(agentId),
+  });
+  const stopWatcherMutation = useTanMutation({
+    mutationFn: (agentId: string) => baiClient.stop_watcher_agent(agentId),
+  });
+  const restartWatcherMutation = useTanMutation({
+    mutationFn: (agentId: string) => baiClient.restart_watcher_agent(agentId),
+  });
+
+  const watcherMutations: Record<
+    AgentLifeCycleType,
+    typeof startWatcherMutation
+  > = {
+    start: startWatcherMutation,
+    stop: stopWatcherMutation,
+    restart: restartWatcherMutation,
+  };
+
+  // The watcher endpoints (superadmin-only) are proxied by the manager to
+  // the agent's watcher daemon. A 200 response can still represent a
+  // failure (e.g. the agent is not loaded with systemctl), so the body is
+  // inspected for `result === 'ok'`; anything else is surfaced as a
+  // warning. Structured/raw errors (invalid params, watcher unreachable,
+  // etc.) are resolved through getErrorMessage. The client hands back a
+  // plain string for text/* responses, so both shapes are handled.
+  const handleOk = () => {
+    if (!lifeCycleType || !agent?.id) {
+      message.error(t('agent.WatcherActionFailed'));
+      onRequestClose();
+      return;
+    }
+    return watcherMutations[lifeCycleType]
+      .mutateAsync(toLocalId(agent.id))
+      .then((res: { result?: string; message?: string } | string | null) => {
+        if (res && typeof res === 'object' && res.result === 'ok') {
+          message.success(t(SUCCESS_KEY[lifeCycleType]));
+          startRefetchTransition(() => {
+            refetchAgent({}, { fetchPolicy: 'network-only' });
+          });
+        } else {
+          const detail = typeof res === 'string' ? res : res?.message;
+          message.warning(detail || t('agent.WatcherActionFailed'));
+        }
+      })
+      .catch((err: unknown) => {
+        message.error(getErrorMessage(err) || t('agent.WatcherActionFailed'));
+        logger.error('Watcher agent action failed', err);
+      })
+      .finally(() => {
+        onRequestClose();
+      });
+  };
+
+  return (
+    <BAIModal
+      {...modalProps}
+      title={lifeCycleType ? t(LABEL_KEY[lifeCycleType]) : ''}
+      okText={t('button.Confirm')}
+      okButtonProps={{
+        danger: lifeCycleType === 'stop' || lifeCycleType === 'restart',
+      }}
+      confirmLoading={
+        startWatcherMutation.isPending ||
+        stopWatcherMutation.isPending ||
+        restartWatcherMutation.isPending
+      }
+      onOk={handleOk}
+      onCancel={() => onRequestClose()}
+      destroyOnHidden
+      width={400}
+    >
+      <BAIFlex direction="column" align="stretch" gap="xs">
+        <Typography.Text>{t('agent.WatcherActionWarning')}</Typography.Text>
+        <div
+          role="list"
+          style={{
+            backgroundColor: token.colorFillQuaternary,
+            border: `1px solid ${token.colorBorderSecondary}`,
+            borderRadius: token.borderRadiusSM,
+            padding: token.paddingXS,
+            paddingInline: token.padding,
+          }}
+        >
+          <div role="listitem">{agent?.id && toLocalId(agent.id)}</div>
+        </div>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default AgentLifeCycleControlModal;

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -12,10 +12,10 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useThemeMode } from '../hooks/useThemeMode';
 import AgentDetailDrawer from './AgentDetailDrawer';
 import BAIRadioGroup from './BAIRadioGroup';
-import { ReloadOutlined } from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
-import { Button, type TableProps, Tag, theme, Tooltip } from 'antd';
+import { type TableProps, Tag, theme } from 'antd';
 import {
+  BAIFetchKeyButton,
   BAIFlex,
   BAIPropertyFilter,
   BAIFlexProps,
@@ -262,13 +262,17 @@ const AgentList: React.FC<AgentListProps> = ({
           />
         </BAIFlex>
         <BAIFlex gap="xs">
-          <Tooltip title={t('button.Refresh')}>
-            <Button
-              loading={deferredFetchKey !== fetchKey}
-              onClick={() => updateFetchKey()}
-              icon={<ReloadOutlined />}
-            ></Button>
-          </Tooltip>
+          <BAIFetchKeyButton
+            loading={
+              deferredFetchKey !== fetchKey ||
+              deferredQueryVariables !== queryVariables
+            }
+            autoUpdateDelay={15_000}
+            value={fetchKey}
+            onChange={() => {
+              updateFetchKey();
+            }}
+          />
         </BAIFlex>
       </BAIFlex>
       <BAIAgentTable

--- a/react/src/components/AgentNodeItems/AgentActionButtons.tsx
+++ b/react/src/components/AgentNodeItems/AgentActionButtons.tsx
@@ -3,10 +3,14 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { AgentActionButtonsFragment$key } from '../../__generated__/AgentActionButtonsFragment.graphql';
+import AgentLifeCycleControlModal, {
+  AgentLifeCycleType,
+} from '../AgentLifeCycleControlModal';
 import AgentSettingModal from '../AgentSettingModal';
-import { SettingOutlined } from '@ant-design/icons';
-import { Space, Tooltip } from 'antd';
-import { BAIButton, BAIButtonProps } from 'backend.ai-ui';
+import { PlayCircleOutlined, SettingOutlined } from '@ant-design/icons';
+import { Space, Tooltip, theme } from 'antd';
+import { BAIButton, BAIButtonProps, BAITerminateIcon } from 'backend.ai-ui';
+import { RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -22,13 +26,19 @@ const AgentActionButtons: React.FC<AgentActionButtonsProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
+  const { token } = theme.useToken();
 
   const [openSettingModal, setOpenSettingModal] = useState(false);
+  const [lifeCycleType, setLifeCycleType] = useState<AgentLifeCycleType | null>(
+    null,
+  );
 
   const agent = useFragment(
     graphql`
       fragment AgentActionButtonsFragment on AgentNode {
+        status
         ...AgentSettingModalFragment
+        ...AgentLifeCycleControlModalFragment
       }
     `,
     agentNodeFrgmt,
@@ -44,6 +54,36 @@ const AgentActionButtons: React.FC<AgentActionButtonsProps> = ({
             onClick={() => setOpenSettingModal(true)}
           />
         </Tooltip>
+        <Tooltip title={t('agent.WatcherRestart')}>
+          <BAIButton
+            icon={<RefreshCw />}
+            size={size}
+            onClick={() => setLifeCycleType('restart')}
+          />
+        </Tooltip>
+        <Tooltip title={t('agent.WatcherStart')}>
+          <BAIButton
+            icon={<PlayCircleOutlined />}
+            size={size}
+            disabled={agent?.status === 'ALIVE'}
+            onClick={() => setLifeCycleType('start')}
+          />
+        </Tooltip>
+        <Tooltip title={t('agent.WatcherStop')}>
+          <BAIButton
+            icon={
+              <BAITerminateIcon
+                style={{
+                  color:
+                    agent?.status === 'ALIVE' ? token.colorError : undefined,
+                }}
+              />
+            }
+            size={size}
+            disabled={agent?.status !== 'ALIVE'}
+            onClick={() => setLifeCycleType('stop')}
+          />
+        </Tooltip>
       </Space.Compact>
 
       <AgentSettingModal
@@ -52,6 +92,12 @@ const AgentActionButtons: React.FC<AgentActionButtonsProps> = ({
         onRequestClose={() => {
           setOpenSettingModal(false);
         }}
+      />
+      <AgentLifeCycleControlModal
+        open={!!lifeCycleType}
+        lifeCycleType={lifeCycleType}
+        agentNodeFrgmt={agent}
+        onRequestClose={() => setLifeCycleType(null)}
       />
     </>
   );

--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -215,187 +215,192 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
             </BAIFlex>
           }
         >
-          <Row gutter={[16, 16]}>
-            <Col xs={24} sm={12} key={'cpu_util'}>
-              <SimpleProgressWithLabel
-                key={'cpu_util'}
-                size="default"
-                title={mergedResourceSlots?.cpu?.human_readable_name}
-                percent={(
-                  Math.min(
-                    _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
-                      100 /
-                      (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
-                    1,
-                  ) * 100
-                ).toString()}
-                description={`${toFixedFloorWithoutTrailingZeros(
-                  Math.min(
-                    _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
-                      100 /
-                      (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
-                    1,
-                  ) * 100,
-                  2,
-                )}%`}
-              />
-            </Col>
-            <Col xs={24} sm={12} key={'mem'}>
-              <SimpleProgressWithLabel
-                key={'mem'}
-                size="default"
-                title={mergedResourceSlots?.mem?.human_readable_name}
-                percent={toFixedFloorWithoutTrailingZeros(
-                  (parsedLiveStat?.node?.mem?.current /
-                    (parsedAvailableSlots?.mem ||
-                      parsedLiveStat?.node?.mem?.capacity)) *
-                    100 || 0,
-                  2,
-                )}
-                description={`${toFixedFloorWithoutTrailingZeros(
-                  convertToBinaryUnit(
-                    parsedLiveStat?.node?.mem?.current || '0',
-                    convertUnitValue(
-                      _.toString(parsedLiveStat?.node?.mem.capacity),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.number || 0,
-                  2,
-                )} / ${toFixedFloorWithoutTrailingZeros(
-                  convertToBinaryUnit(
-                    parsedAvailableSlots?.mem ||
-                      parsedLiveStat?.node?.mem?.capacity ||
-                      '0',
-                    convertUnitValue(
-                      _.toString(
-                        parsedAvailableSlots?.mem ||
-                          parsedLiveStat?.node?.mem.capacity,
-                      ),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.number || 0,
-                  2,
-                )}${
-                  convertToBinaryUnit(
-                    parsedLiveStat?.node?.mem?.capacity || '0',
-                    convertUnitValue(
-                      _.toString(parsedLiveStat?.node?.mem.capacity),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.displayUnit
-                }  (${toFixedFloorWithoutTrailingZeros(
-                  parsedLiveStat?.node?.mem?.pct || 0,
-                  2,
-                )}%)`}
-              />
-            </Col>
-            {_.map(_.keys(parsedLiveStat?.node), (statKey) => {
-              if (['cpu_util', 'mem', 'disk'].includes(statKey)) {
-                return null;
-              }
-              if (_.includes(statKey, '_util')) {
-                const deviceName =
-                  _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                const current = _.toFinite(
-                  parsedLiveStat?.node?.[statKey]?.current,
-                );
-                const capacity =
-                  _.toFinite(parsedLiveStat?.node?.[statKey]?.capacity) || 100;
-                const percent = (current / capacity) * 100 || 0;
-                return (
-                  <Col xs={24} sm={12} key={statKey}>
-                    <SimpleProgressWithLabel
-                      size="default"
-                      title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(util)`}
-                      percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
-                      description={`${toFixedFloorWithoutTrailingZeros(percent, 1)}%`}
-                    />
-                  </Col>
-                );
-              }
-              if (_.includes(statKey, '_mem')) {
-                const deviceName =
-                  _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                const current = _.toFinite(
-                  parsedLiveStat?.node?.[statKey]?.current,
-                );
-                const capacity = _.toFinite(
-                  parsedLiveStat?.node?.[statKey]?.capacity,
-                );
-                const baseUnit =
-                  convertUnitValue(_.toString(capacity), 'auto')?.unit || 'g';
-                const percent = (current / capacity) * 100 || 0;
-                return (
-                  <Col xs={24} sm={12} key={statKey}>
-                    <SimpleProgressWithLabel
-                      size="default"
-                      title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(mem)`}
-                      percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
-                      description={`${
-                        convertToBinaryUnit(_.toString(current), baseUnit)
-                          ?.numberFixed
-                      } / ${
-                        convertToBinaryUnit(_.toString(capacity), baseUnit)
-                          ?.displayValue
-                      }`}
-                    />
-                  </Col>
-                );
-              }
-              if (_.includes(statKey, '_power')) {
-                const deviceName =
-                  _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                const humanReadableName =
-                  mergedResourceSlots?.[deviceName]?.human_readable_name;
+          {_.isEmpty(parsedLiveStat?.node) ? (
+            <BAIText type="secondary">-</BAIText>
+          ) : (
+            <Row gutter={[16, 16]}>
+              <Col xs={24} sm={12} key={'cpu_util'}>
+                <SimpleProgressWithLabel
+                  key={'cpu_util'}
+                  size="default"
+                  title={mergedResourceSlots?.cpu?.human_readable_name}
+                  percent={(
+                    Math.min(
+                      _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
+                        100 /
+                        (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
+                      1,
+                    ) * 100
+                  ).toString()}
+                  description={`${toFixedFloorWithoutTrailingZeros(
+                    Math.min(
+                      _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
+                        100 /
+                        (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
+                      1,
+                    ) * 100,
+                    2,
+                  )}%`}
+                />
+              </Col>
+              <Col xs={24} sm={12} key={'mem'}>
+                <SimpleProgressWithLabel
+                  key={'mem'}
+                  size="default"
+                  title={mergedResourceSlots?.mem?.human_readable_name}
+                  percent={toFixedFloorWithoutTrailingZeros(
+                    (parsedLiveStat?.node?.mem?.current /
+                      (parsedAvailableSlots?.mem ||
+                        parsedLiveStat?.node?.mem?.capacity)) *
+                      100 || 0,
+                    2,
+                  )}
+                  description={`${toFixedFloorWithoutTrailingZeros(
+                    convertToBinaryUnit(
+                      parsedLiveStat?.node?.mem?.current || '0',
+                      convertUnitValue(
+                        _.toString(parsedLiveStat?.node?.mem?.capacity),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.number || 0,
+                    2,
+                  )} / ${toFixedFloorWithoutTrailingZeros(
+                    convertToBinaryUnit(
+                      parsedAvailableSlots?.mem ||
+                        parsedLiveStat?.node?.mem?.capacity ||
+                        '0',
+                      convertUnitValue(
+                        _.toString(
+                          parsedAvailableSlots?.mem ||
+                            parsedLiveStat?.node?.mem?.capacity,
+                        ),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.number || 0,
+                    2,
+                  )}${
+                    convertToBinaryUnit(
+                      parsedLiveStat?.node?.mem?.capacity || '0',
+                      convertUnitValue(
+                        _.toString(parsedLiveStat?.node?.mem?.capacity),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.displayUnit
+                  }  (${toFixedFloorWithoutTrailingZeros(
+                    parsedLiveStat?.node?.mem?.pct || 0,
+                    2,
+                  )}%)`}
+                />
+              </Col>
+              {_.map(_.keys(parsedLiveStat?.node), (statKey) => {
+                if (['cpu_util', 'mem', 'disk'].includes(statKey)) {
+                  return null;
+                }
+                if (_.includes(statKey, '_util')) {
+                  const deviceName =
+                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                  const current = _.toFinite(
+                    parsedLiveStat?.node?.[statKey]?.current,
+                  );
+                  const capacity =
+                    _.toFinite(parsedLiveStat?.node?.[statKey]?.capacity) ||
+                    100;
+                  const percent = (current / capacity) * 100 || 0;
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <SimpleProgressWithLabel
+                        size="default"
+                        title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(util)`}
+                        percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
+                        description={`${toFixedFloorWithoutTrailingZeros(percent, 1)}%`}
+                      />
+                    </Col>
+                  );
+                }
+                if (_.includes(statKey, '_mem')) {
+                  const deviceName =
+                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                  const current = _.toFinite(
+                    parsedLiveStat?.node?.[statKey]?.current,
+                  );
+                  const capacity = _.toFinite(
+                    parsedLiveStat?.node?.[statKey]?.capacity,
+                  );
+                  const baseUnit =
+                    convertUnitValue(_.toString(capacity), 'auto')?.unit || 'g';
+                  const percent = (current / capacity) * 100 || 0;
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <SimpleProgressWithLabel
+                        size="default"
+                        title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(mem)`}
+                        percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
+                        description={`${
+                          convertToBinaryUnit(_.toString(current), baseUnit)
+                            ?.numberFixed
+                        } / ${
+                          convertToBinaryUnit(_.toString(capacity), baseUnit)
+                            ?.displayValue
+                        }`}
+                      />
+                    </Col>
+                  );
+                }
+                if (_.includes(statKey, '_power')) {
+                  const deviceName =
+                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                  const humanReadableName =
+                    mergedResourceSlots?.[deviceName]?.human_readable_name;
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <BAIFlex justify="between" gap="xxs">
+                        <BAIText>{`${humanReadableName}(power)`}</BAIText>
+                        <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} ${parsedLiveStat?.node?.[statKey]?.unit_hint ?? ''}`}</BAIText>
+                      </BAIFlex>
+                    </Col>
+                  );
+                }
+                if (_.includes(statKey, '_temperature')) {
+                  const deviceName =
+                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                  const humanReadableName =
+                    mergedResourceSlots?.[deviceName]?.human_readable_name;
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <BAIFlex justify="between" gap="xxs">
+                        <BAIText>{`${humanReadableName}(temp)`}</BAIText>
+                        <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} °C`}</BAIText>
+                      </BAIFlex>
+                    </Col>
+                  );
+                }
+                if (['net_rx', 'net_tx'].includes(statKey)) {
+                  const convertedValue = convertToDecimalUnit(
+                    parsedLiveStat?.node?.[statKey]?.current,
+                    'auto',
+                  );
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <BAIFlex justify="between" gap="xxs">
+                        <BAIText>
+                          {statKey === 'net_rx' ? 'Net Rx' : 'Net Tx'}
+                        </BAIText>
+                        <BAIText>{`${convertedValue?.numberFixed ?? 0} ${convertedValue?.unit.toUpperCase() ?? ''}bps`}</BAIText>
+                      </BAIFlex>
+                    </Col>
+                  );
+                }
                 return (
                   <Col xs={24} sm={12} key={statKey}>
                     <BAIFlex justify="between" gap="xxs">
-                      <BAIText>{`${humanReadableName}(power)`}</BAIText>
-                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} ${parsedLiveStat?.node?.[statKey]?.unit_hint ?? ''}`}</BAIText>
+                      <BAIText>{statKey}</BAIText>
+                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current ?? 0, 2)}${parsedLiveStat?.node?.[statKey]?.unit_hint ? ` ${parsedLiveStat?.node?.[statKey]?.unit_hint}` : ''}`}</BAIText>
                     </BAIFlex>
                   </Col>
                 );
-              }
-              if (_.includes(statKey, '_temperature')) {
-                const deviceName =
-                  _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                const humanReadableName =
-                  mergedResourceSlots?.[deviceName]?.human_readable_name;
-                return (
-                  <Col xs={24} sm={12} key={statKey}>
-                    <BAIFlex justify="between" gap="xxs">
-                      <BAIText>{`${humanReadableName}(temp)`}</BAIText>
-                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} °C`}</BAIText>
-                    </BAIFlex>
-                  </Col>
-                );
-              }
-              if (['net_rx', 'net_tx'].includes(statKey)) {
-                const convertedValue = convertToDecimalUnit(
-                  parsedLiveStat?.node?.[statKey]?.current,
-                  'auto',
-                );
-                return (
-                  <Col xs={24} sm={12} key={statKey}>
-                    <BAIFlex justify="between" gap="xxs">
-                      <BAIText>
-                        {statKey === 'net_rx' ? 'Net Rx' : 'Net Tx'}
-                      </BAIText>
-                      <BAIText>{`${convertedValue?.numberFixed ?? 0} ${convertedValue?.unit.toUpperCase() ?? ''}bps`}</BAIText>
-                    </BAIFlex>
-                  </Col>
-                );
-              }
-              return (
-                <Col xs={24} sm={12} key={statKey}>
-                  <BAIFlex justify="between" gap="xxs">
-                    <BAIText>{statKey}</BAIText>
-                    <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current ?? 0, 2)}${parsedLiveStat?.node?.[statKey]?.unit_hint ? ` ${parsedLiveStat?.node?.[statKey]?.unit_hint}` : ''}`}</BAIText>
-                  </BAIFlex>
-                </Col>
-              );
-            })}
-          </Row>
+              })}
+            </Row>
+          )}
         </Descriptions.Item>
       </Descriptions>
       <AgentDetailModal

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -220,6 +220,9 @@ export type BackendAIClient = {
     delete: (key: string, prefix: boolean) => Promise<any>;
   };
   get_resource_slots: () => Promise<any>;
+  start_watcher_agent: (agentId: string) => Promise<any>;
+  stop_watcher_agent: (agentId: string) => Promise<any>;
+  restart_watcher_agent: (agentId: string) => Promise<any>;
   current_group_id: () => string;
   current_group: string;
   user_uuid: string;

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -233,7 +233,15 @@
     "Status": "Status",
     "StatusChanged": "Geändert",
     "Terminated": "Beendet",
-    "Utilization": "Inanspruchnahme"
+    "Utilization": "Inanspruchnahme",
+    "WatcherActionFailed": "Agent konnte nicht gesteuert werden.",
+    "WatcherActionWarning": "Laufende Sitzungen auf diesem Agenten können betroffen sein.",
+    "WatcherRestart": "Agent neu starten",
+    "WatcherRestartRequested": "Neustart des Agenten wurde angefordert.",
+    "WatcherStart": "Agent starten",
+    "WatcherStartRequested": "Start des Agenten wurde angefordert.",
+    "WatcherStop": "Agent stoppen",
+    "WatcherStopRequested": "Stopp des Agenten wurde angefordert."
   },
   "agentStats": {
     "AgentStats": "Agentenstatistik",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -233,7 +233,15 @@
     "Status": "Κατάσταση",
     "StatusChanged": "Τροποποιήθηκε",
     "Terminated": "Τερματίστηκε",
-    "Utilization": "Χρήση"
+    "Utilization": "Χρήση",
+    "WatcherActionFailed": "Αποτυχία ελέγχου του πράκτορα.",
+    "WatcherActionWarning": "Οι τρέχουσες συνεδρίες σε αυτόν τον πράκτορα ενδέχεται να επηρεαστούν.",
+    "WatcherRestart": "Επανεκκίνηση Πράκτορα",
+    "WatcherRestartRequested": "Η επανεκκίνηση του πράκτορα έχει ζητηθεί.",
+    "WatcherStart": "Εκκίνηση Πράκτορα",
+    "WatcherStartRequested": "Η εκκίνηση του πράκτορα έχει ζητηθεί.",
+    "WatcherStop": "Διακοπή Πράκτορα",
+    "WatcherStopRequested": "Η διακοπή του πράκτορα έχει ζητηθεί."
   },
   "agentStats": {
     "AgentStats": "Στατιστικά Agent",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -233,7 +233,15 @@
     "Status": "Status",
     "StatusChanged": "Changed",
     "Terminated": "Terminated",
-    "Utilization": "Utilization"
+    "Utilization": "Utilization",
+    "WatcherActionFailed": "Failed to control the agent.",
+    "WatcherActionWarning": "Running sessions on this agent may be affected.",
+    "WatcherRestart": "Restart Agent",
+    "WatcherRestartRequested": "Agent restart has been requested.",
+    "WatcherStart": "Start Agent",
+    "WatcherStartRequested": "Agent start has been requested.",
+    "WatcherStop": "Stop Agent",
+    "WatcherStopRequested": "Agent stop has been requested."
   },
   "agentStats": {
     "AgentStats": "Agent Statistics",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -233,7 +233,15 @@
     "Status": "Estado",
     "StatusChanged": "Modificado",
     "Terminated": "Terminado",
-    "Utilization": "Utilización"
+    "Utilization": "Utilización",
+    "WatcherActionFailed": "Error al controlar el agente.",
+    "WatcherActionWarning": "Las sesiones en ejecución en este agente pueden verse afectadas.",
+    "WatcherRestart": "Reiniciar Agente",
+    "WatcherRestartRequested": "Se ha solicitado el reinicio del agente.",
+    "WatcherStart": "Iniciar Agente",
+    "WatcherStartRequested": "Se ha solicitado el inicio del agente.",
+    "WatcherStop": "Detener Agente",
+    "WatcherStopRequested": "Se ha solicitado la detención del agente."
   },
   "agentStats": {
     "AgentStats": "Estadísticas del agente",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -233,7 +233,15 @@
     "Status": "Tila",
     "StatusChanged": "Muutettu",
     "Terminated": "Lopetettu",
-    "Utilization": "Käyttö"
+    "Utilization": "Käyttö",
+    "WatcherActionFailed": "Agentin hallinta epäonnistui.",
+    "WatcherActionWarning": "Tässä agentissa käynnissä oleviin istuntoihin voi vaikuttaa.",
+    "WatcherRestart": "Käynnistä agentti uudelleen",
+    "WatcherRestartRequested": "Agentin uudelleenkäynnistys on pyydetty.",
+    "WatcherStart": "Käynnistä agentti",
+    "WatcherStartRequested": "Agentin käynnistys on pyydetty.",
+    "WatcherStop": "Pysäytä agentti",
+    "WatcherStopRequested": "Agentin pysäytys on pyydetty."
   },
   "agentStats": {
     "AgentStats": "Agenttitilastot",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -233,7 +233,15 @@
     "Status": "Statut",
     "StatusChanged": "Modifié",
     "Terminated": "Terminé",
-    "Utilization": "Utilisation"
+    "Utilization": "Utilisation",
+    "WatcherActionFailed": "Échec du contrôle de l'agent.",
+    "WatcherActionWarning": "Les sessions en cours sur cet agent peuvent être affectées.",
+    "WatcherRestart": "Redémarrer l'agent",
+    "WatcherRestartRequested": "Le redémarrage de l'agent a été demandé.",
+    "WatcherStart": "Démarrer l'agent",
+    "WatcherStartRequested": "Le démarrage de l'agent a été demandé.",
+    "WatcherStop": "Arrêter l'agent",
+    "WatcherStopRequested": "L'arrêt de l'agent a été demandé."
   },
   "agentStats": {
     "AgentStats": "Statistiques des agents",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -233,7 +233,15 @@
     "Status": "Status",
     "StatusChanged": "Diubah",
     "Terminated": "Dihentikan",
-    "Utilization": "Pemanfaatan"
+    "Utilization": "Pemanfaatan",
+    "WatcherActionFailed": "Gagal mengontrol agen.",
+    "WatcherActionWarning": "Sesi yang berjalan pada agen ini mungkin terpengaruh.",
+    "WatcherRestart": "Mulai Ulang Agen",
+    "WatcherRestartRequested": "Permintaan mulai ulang agen telah dikirim.",
+    "WatcherStart": "Mulai Agen",
+    "WatcherStartRequested": "Permintaan mulai agen telah dikirim.",
+    "WatcherStop": "Hentikan Agen",
+    "WatcherStopRequested": "Permintaan hentikan agen telah dikirim."
   },
   "agentStats": {
     "AgentStats": "Statistik Agen",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -233,7 +233,15 @@
     "Status": "Stato",
     "StatusChanged": "Modificato",
     "Terminated": "Terminato",
-    "Utilization": "Utilizzo"
+    "Utilization": "Utilizzo",
+    "WatcherActionFailed": "Impossibile controllare l'agente.",
+    "WatcherActionWarning": "Le sessioni in esecuzione su questo agente potrebbero essere interessate.",
+    "WatcherRestart": "Riavvia Agente",
+    "WatcherRestartRequested": "Il riavvio dell'agente è stato richiesto.",
+    "WatcherStart": "Avvia Agente",
+    "WatcherStartRequested": "L'avvio dell'agente è stato richiesto.",
+    "WatcherStop": "Ferma Agente",
+    "WatcherStopRequested": "L'arresto dell'agente è stato richiesto."
   },
   "agentStats": {
     "AgentStats": "Statistiche dell'agente",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -233,7 +233,15 @@
     "Status": "状態",
     "StatusChanged": "変更済み",
     "Terminated": "終了しました",
-    "Utilization": "使用量"
+    "Utilization": "使用量",
+    "WatcherActionFailed": "エージェントの制御に失敗しました。",
+    "WatcherActionWarning": "このエージェントで実行中のセッションに影響する場合があります。",
+    "WatcherRestart": "エージェントを再起動",
+    "WatcherRestartRequested": "エージェントの再起動がリクエストされました。",
+    "WatcherStart": "エージェントを起動",
+    "WatcherStartRequested": "エージェントの起動がリクエストされました。",
+    "WatcherStop": "エージェントを停止",
+    "WatcherStopRequested": "エージェントの停止がリクエストされました。"
   },
   "agentStats": {
     "AgentStats": "エージェントの統計",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -233,7 +233,15 @@
     "Status": "상태",
     "StatusChanged": "변경일",
     "Terminated": "종료됨",
-    "Utilization": "사용량"
+    "Utilization": "사용량",
+    "WatcherActionFailed": "에이전트 제어에 실패했습니다.",
+    "WatcherActionWarning": "이 에이전트에서 실행 중인 세션이 영향을 받을 수 있습니다.",
+    "WatcherRestart": "에이전트 재시작",
+    "WatcherRestartRequested": "에이전트 재시작을 요청했습니다.",
+    "WatcherStart": "에이전트 시작",
+    "WatcherStartRequested": "에이전트 시작을 요청했습니다.",
+    "WatcherStop": "에이전트 중지",
+    "WatcherStopRequested": "에이전트 중지를 요청했습니다."
   },
   "agentStats": {
     "AgentStats": "에이전트 통계",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -233,7 +233,15 @@
     "Status": "Статус",
     "StatusChanged": "Өөрчлөгдсөн",
     "Terminated": "Цуцлагдсан",
-    "Utilization": "Ашиглалт"
+    "Utilization": "Ашиглалт",
+    "WatcherActionFailed": "Агентыг удирдахад алдаа гарлаа.",
+    "WatcherActionWarning": "Энэ агент дээр ажиллаж буй сессүүд нөлөөлөлд өртөж болзошгүй.",
+    "WatcherRestart": "Агентыг дахин эхлүүлэх",
+    "WatcherRestartRequested": "Агентыг дахин эхлүүлэх хүсэлт илгээгдлээ.",
+    "WatcherStart": "Агентыг эхлүүлэх",
+    "WatcherStartRequested": "Агентыг эхлүүлэх хүсэлт илгээгдлээ.",
+    "WatcherStop": "Агентыг зогсоох",
+    "WatcherStopRequested": "Агентыг зогсоох хүсэлт илгээгдлээ."
   },
   "agentStats": {
     "AgentStats": "Ашиг олгогчийн статистик",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -233,7 +233,15 @@
     "Status": "Status",
     "StatusChanged": "Diubah",
     "Terminated": "Ditamatkan",
-    "Utilization": "Penggunaan"
+    "Utilization": "Penggunaan",
+    "WatcherActionFailed": "Gagal mengawal ejen.",
+    "WatcherActionWarning": "Sesi yang sedang berjalan pada ejen ini mungkin terjejas.",
+    "WatcherRestart": "Mulakan Semula Ejen",
+    "WatcherRestartRequested": "Permintaan mulakan semula ejen telah dihantar.",
+    "WatcherStart": "Mulakan Ejen",
+    "WatcherStartRequested": "Permintaan mulakan ejen telah dihantar.",
+    "WatcherStop": "Hentikan Ejen",
+    "WatcherStopRequested": "Permintaan hentikan ejen telah dihantar."
   },
   "agentStats": {
     "AgentStats": "Statistik Ejen",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -233,7 +233,15 @@
     "Status": "Status",
     "StatusChanged": "Zmieniono",
     "Terminated": "Zakończony",
-    "Utilization": "Wykorzystanie"
+    "Utilization": "Wykorzystanie",
+    "WatcherActionFailed": "Nie udało się sterować agentem.",
+    "WatcherActionWarning": "Sesje uruchomione na tym agencie mogą zostać zakłócone.",
+    "WatcherRestart": "Uruchom ponownie agenta",
+    "WatcherRestartRequested": "Zażądano ponownego uruchomienia agenta.",
+    "WatcherStart": "Uruchom agenta",
+    "WatcherStartRequested": "Zażądano uruchomienia agenta.",
+    "WatcherStop": "Zatrzymaj agenta",
+    "WatcherStopRequested": "Zażądano zatrzymania agenta."
   },
   "agentStats": {
     "AgentStats": "Statystyki agentów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -233,7 +233,15 @@
     "Status": "Status",
     "StatusChanged": "Alterado",
     "Terminated": "Rescindido",
-    "Utilization": "Utilização"
+    "Utilization": "Utilização",
+    "WatcherActionFailed": "Falha ao controlar o agente.",
+    "WatcherActionWarning": "As sessões em execução neste agente podem ser afetadas.",
+    "WatcherRestart": "Reiniciar Agente",
+    "WatcherRestartRequested": "O reinício do agente foi solicitado.",
+    "WatcherStart": "Iniciar Agente",
+    "WatcherStartRequested": "O início do agente foi solicitado.",
+    "WatcherStop": "Parar Agente",
+    "WatcherStopRequested": "A parada do agente foi solicitada."
   },
   "agentStats": {
     "AgentStats": "Estatísticas do Agente",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -233,7 +233,15 @@
     "Status": "Status",
     "StatusChanged": "Alterado",
     "Terminated": "Rescindido",
-    "Utilization": "Utilização"
+    "Utilization": "Utilização",
+    "WatcherActionFailed": "Falha ao controlar o agente.",
+    "WatcherActionWarning": "As sessões em execução neste agente podem ser afetadas.",
+    "WatcherRestart": "Reiniciar Agente",
+    "WatcherRestartRequested": "O reinício do agente foi solicitado.",
+    "WatcherStart": "Iniciar Agente",
+    "WatcherStartRequested": "O início do agente foi solicitado.",
+    "WatcherStop": "Parar Agente",
+    "WatcherStopRequested": "A paragem do agente foi solicitada."
   },
   "agentStats": {
     "AgentStats": "Estatísticas do Agente",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -233,7 +233,15 @@
     "Status": "Статус",
     "StatusChanged": "Изменено",
     "Terminated": "Прекращено",
-    "Utilization": "Утилизация"
+    "Utilization": "Утилизация",
+    "WatcherActionFailed": "Не удалось управлять агентом.",
+    "WatcherActionWarning": "Запущенные сеансы на этом агенте могут быть затронуты.",
+    "WatcherRestart": "Перезапустить агент",
+    "WatcherRestartRequested": "Запрос на перезапуск агента отправлен.",
+    "WatcherStart": "Запустить агент",
+    "WatcherStartRequested": "Запрос на запуск агента отправлен.",
+    "WatcherStop": "Остановить агент",
+    "WatcherStopRequested": "Запрос на остановку агента отправлен."
   },
   "agentStats": {
     "AgentStats": "Статистика агента",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -233,7 +233,15 @@
     "Status": "สถานะ",
     "StatusChanged": "เปลี่ยนแปลงแล้ว",
     "Terminated": "ยุติแล้ว",
-    "Utilization": "การใช้งาน"
+    "Utilization": "การใช้งาน",
+    "WatcherActionFailed": "ไม่สามารถควบคุมตัวแทนได้",
+    "WatcherActionWarning": "เซสชันที่กำลังทำงานบนตัวแทนนี้อาจได้รับผลกระทบ",
+    "WatcherRestart": "รีสตาร์ทตัวแทน",
+    "WatcherRestartRequested": "ส่งคำขอรีสตาร์ทตัวแทนแล้ว",
+    "WatcherStart": "เริ่มตัวแทน",
+    "WatcherStartRequested": "ส่งคำขอเริ่มตัวแทนแล้ว",
+    "WatcherStop": "หยุดตัวแทน",
+    "WatcherStopRequested": "ส่งคำขอหยุดตัวแทนแล้ว"
   },
   "agentStats": {
     "AgentStats": "สถิติตัวแทน",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -233,7 +233,15 @@
     "Status": "Durum",
     "StatusChanged": "Değiştirildi",
     "Terminated": "Sonlandırılmış",
-    "Utilization": "Kullanım"
+    "Utilization": "Kullanım",
+    "WatcherActionFailed": "Ajan kontrol edilemedi.",
+    "WatcherActionWarning": "Bu ajanda çalışan oturumlar etkilenebilir.",
+    "WatcherRestart": "Ajanı Yeniden Başlat",
+    "WatcherRestartRequested": "Ajan yeniden başlatma isteği gönderildi.",
+    "WatcherStart": "Ajanı Başlat",
+    "WatcherStartRequested": "Ajan başlatma isteği gönderildi.",
+    "WatcherStop": "Ajanı Durdur",
+    "WatcherStopRequested": "Ajan durdurma isteği gönderildi."
   },
   "agentStats": {
     "AgentStats": "Temsilci İstatistikleri",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -233,7 +233,15 @@
     "Status": "Trạng thái",
     "StatusChanged": "Đã thay đổi",
     "Terminated": "Đã chấm dứt",
-    "Utilization": "Sử dụng"
+    "Utilization": "Sử dụng",
+    "WatcherActionFailed": "Không thể điều khiển đại lý.",
+    "WatcherActionWarning": "Các phiên đang chạy trên đại lý này có thể bị ảnh hưởng.",
+    "WatcherRestart": "Khởi động lại Đại lý",
+    "WatcherRestartRequested": "Yêu cầu khởi động lại đại lý đã được gửi.",
+    "WatcherStart": "Khởi động Đại lý",
+    "WatcherStartRequested": "Yêu cầu khởi động đại lý đã được gửi.",
+    "WatcherStop": "Dừng Đại lý",
+    "WatcherStopRequested": "Yêu cầu dừng đại lý đã được gửi."
   },
   "agentStats": {
     "AgentStats": "Thống kê đại lý",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -233,7 +233,15 @@
     "Status": "地位",
     "StatusChanged": "已更改",
     "Terminated": "已终止",
-    "Utilization": "利用率"
+    "Utilization": "利用率",
+    "WatcherActionFailed": "控制代理失败。",
+    "WatcherActionWarning": "此代理上正在运行的会话可能会受到影响。",
+    "WatcherRestart": "重启代理",
+    "WatcherRestartRequested": "已发送代理重启请求。",
+    "WatcherStart": "启动代理",
+    "WatcherStartRequested": "已发送代理启动请求。",
+    "WatcherStop": "停止代理",
+    "WatcherStopRequested": "已发送代理停止请求。"
   },
   "agentStats": {
     "AgentStats": "代理统计",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -233,7 +233,15 @@
     "Status": "地位",
     "StatusChanged": "已變更",
     "Terminated": "已終止",
-    "Utilization": "利用率"
+    "Utilization": "利用率",
+    "WatcherActionFailed": "控制代理失敗。",
+    "WatcherActionWarning": "此代理上正在執行的工作階段可能會受到影響。",
+    "WatcherRestart": "重新啟動代理",
+    "WatcherRestartRequested": "已發送代理重新啟動請求。",
+    "WatcherStart": "啟動代理",
+    "WatcherStartRequested": "已發送代理啟動請求。",
+    "WatcherStop": "停止代理",
+    "WatcherStopRequested": "已發送代理停止請求。"
   },
   "agentStats": {
     "AgentStats": "代理統計",


### PR DESCRIPTION
Resolves #8085 (FR-3230)

## Summary

Migrates the agent node lifecycle controls (start / stop / restart) from the Control Panel into the WebUI. Superadmins can now start, stop, and restart an agent node directly from the **Agent detail drawer**, next to the existing Settings action.

## Test server

A superadmin login is required for both.

- **Normal flow** (start / stop / restart on a healthy watcher): use the `10.82.0.130` test server (manager API on `:8090`).
- **Error handling** (watcher down, agent not loaded with systemctl, etc.): use the `10.82.0.151` test server (manager API on `:8090`).

## Changes

- **`AgentLifeCycleControlModal.tsx`** (new): a single modal that owns the start / stop / restart confirmation and request. It takes `open` + a `lifeCycleType` (`'start' | 'stop' | 'restart'`) and branches the title / success message internally; the body shows a shared warning plus the target agent's name in a surface box (borrowed from `BAIDeleteConfirmModal`). The three watcher calls run through `useTanMutation`.
- **`AgentActionButtons.tsx`**: renders Settings + Restart / Start / Stop trigger buttons in the agent detail drawer. Each watcher button sets a single `lifeCycleType` state that drives the modal (`open={!!lifeCycleType}`). Status-aware disabling: Start disabled when the agent is `ALIVE`, Stop disabled otherwise; Restart always available. Icons/colors follow `SessionActionButtons` — Stop uses `BAITerminateIcon` + `colorError`, Restart uses the `RefreshCw` (lucide) icon.
- **`backend.ai-client` (`client.ts`)**: added `start_watcher_agent` / `stop_watcher_agent` / `restart_watcher_agent` SDK methods (with matching `BackendAIClient` type signatures) so the watcher REST calls are encapsulated and reusable.
- **`AgentResources.tsx`** (drawer crash guard): a stopped agent's `live_stat` no longer contains `node.mem`, and three call sites accessed `parsedLiveStat?.node?.mem.capacity` without optional chaining after `mem`, throwing a `TypeError` that crashed the whole drawer. Added the missing `?.` at all three sites, and the **Utilization** section now renders `-` when `live_stat.node` is empty instead of misleading 0% / NaN values.
- **`AgentDetailDrawerContent.tsx`**: wrapped `<AgentResources>` with `ErrorBoundaryWithNullFallback` so a stat-parsing failure can never take down the entire drawer again.
- **i18n**: added `agent.Watcher*` keys (button labels, success toasts, a single action warning) across all 21 locales.

## API

Uses the manager REST watcher endpoints via the new client SDK methods. These were chosen over the legacy `/api/agents/watcher_agent_*` paths (removed on current backend.ai `main`):

- `POST /resource/watcher/agent/start`
- `POST /resource/watcher/agent/stop`
- `POST /resource/watcher/agent/restart`

Body: `{ agent_id }` (the agent's `row_id`).

## Error handling

The manager proxies these to the agent's watcher daemon, so several non-trivial outcomes are handled explicitly in the modal:

- **200 + `{ result: "ok" }`** → success toast.
- **200 + a body message** (e.g. `"Agent is not loaded with systemctl."`) → surfaced as a warning. HTTP 200 does **not** guarantee success here. The client also hands back a plain string for `text/*` responses, which is handled too.
- **403 (non-superadmin)** → the component is only rendered on superadmin-only pages and the endpoints are superadmin-only on the manager.
- **400 (invalid params) / 403 (watcher token mismatch) / 500 (agent not found, watcher unreachable, timeout, etc.)** → error toast resolved through `getErrorMessage`, logged via `useBAILogger`. A missing `row_id` short-circuits before the request.

## Post-action data refresh

- `AgentLifeCycleControlModalFragment` is now `@refetchable` (`id`, `status`, `status_changed`). After a successful watcher request the modal refetches it with `network-only`, so every component reading the same `AgentNode` record (table row, detail drawer) picks up the new status automatically via the normalized store.
- The refetch runs inside `startTransition` — without it the suspend during refetch collapsed the drawer's Suspense boundary to its skeleton fallback.
- `AgentList`'s manual reload button is replaced with `BAIFetchKeyButton` (`autoUpdateDelay` 15s, matching `StorageProxyList`). Node-level refetch cannot change connection membership/count (e.g. a stopped agent leaving the ALIVE tab), and the watcher actions are async on the backend, so the periodic list refresh is what makes the list itself converge.

## Verification

`bash scripts/verify.sh` → **Relay / Lint / Format / TypeScript all PASS**. (The single terminology warning is a pre-existing key, `error.UserHasNoGroup`, unrelated to this change.)

## Screenshots

_TODO: capture from the `10.82.0.130` test server with a superadmin login._