### PR TITLE
fix(FR-3232): make property filter Storybook stories interactive

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.stories.tsx
@@ -1,6 +1,7 @@
 import BAIGraphQLPropertyFilter from './BAIGraphQLPropertyFilter';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Select } from 'antd';
+import { useState } from 'react';
 import { action } from 'storybook/actions';
 
 const meta: Meta<typeof BAIGraphQLPropertyFilter> = {
@@ -139,6 +140,30 @@ GraphQLFilter = {
         defaultValue: { summary: 'AND' },
       },
     },
+  },
+  // BAIGraphQLPropertyFilter is a controlled component (same as
+  // BAIPropertyFilter): it renders exactly what `value` holds and reports
+  // changes through `onChange`. Storybook args are static, so unless each
+  // change is written back into `value` the filter looks frozen — adding a
+  // condition or removing/clearing a tag has no visible effect. We hold the
+  // value in local state per story instance so every story is independently
+  // interactive. NOTE: do not use Storybook `useArgs` here — in the autodocs
+  // page only the Primary story's `updateArgs` is wired, so every other story
+  // would stay frozen. `useState` works for every instance in both the Canvas
+  // and Docs views. The per-story `onChange: action(...)` handlers still log
+  // to the Actions panel.
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return (
+      <BAIGraphQLPropertyFilter
+        {...args}
+        value={value}
+        onChange={(next) => {
+          args.onChange?.(next);
+          setValue(next);
+        }}
+      />
+    );
   },
 };
 

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
@@ -1,8 +1,7 @@
 import BAIPropertyFilter from './BAIPropertyFilter';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Select } from 'antd';
-
-// import { action } from '@storybook/addon-actions';
+import { useState } from 'react';
 
 const meta: Meta<typeof BAIPropertyFilter> = {
   title: 'Filter/BAIPropertyFilter',
@@ -63,6 +62,28 @@ The component generates filter query strings that can be used with Backend.AI's 
       },
     },
   },
+  // BAIPropertyFilter is a controlled component: it renders exactly what
+  // `value` holds and reports changes through `onChange`. Storybook args are
+  // static, so unless each change is written back into `value` the filter
+  // looks frozen — searching can't add a tag and the close/reset buttons
+  // can't remove one. We hold the value in local state per story instance so
+  // every story is independently interactive. NOTE: do not use Storybook
+  // `useArgs` here — in the autodocs page only the Primary story's
+  // `updateArgs` is wired, so every other story would stay frozen. `useState`
+  // works for every instance in both the Canvas and Docs views.
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return (
+      <BAIPropertyFilter
+        {...args}
+        value={value}
+        onChange={(next) => {
+          args.onChange?.(next);
+          setValue(next);
+        }}
+      />
+    );
+  },
 };
 
 export default meta;
@@ -98,8 +119,7 @@ export const Default: Story = {
         type: 'boolean',
       },
     ],
-    onChange: () => console.log('Filter changed'),
-    value: 'name ilike %test% & active == true',
+    value: 'name ilike "%test%" & active == true',
   },
 };
 
@@ -136,7 +156,6 @@ export const WithCustomValidation: Story = {
         strictSelection: true,
       },
     ],
-    onChange: () => console.log('Filter changed'),
   },
 };
 
@@ -175,8 +194,7 @@ export const WithAutocompleteOptions: Story = {
         strictSelection: true,
       },
     ],
-    onChange: () => console.log('Filter changed'),
-    value: 'department ilike %engineering%',
+    value: 'department ilike "%engineering%"',
   },
 };
 
@@ -201,7 +219,6 @@ export const EmptyState: Story = {
         type: 'boolean',
       },
     ],
-    onChange: () => console.log('Filter changed'),
   },
 };
 
@@ -223,7 +240,6 @@ export const LoadingState: Story = {
       },
     ],
     loading: true,
-    onChange: () => console.log('Filter changed'),
   },
 };
 


### PR DESCRIPTION
Resolves #8089 (FR-3232)

> **Stacked on** #7940 (FR-3011) — merge that first.

## Problem

In Storybook, both **BAIPropertyFilter** and **BAIGraphQLPropertyFilter** stories were completely non-interactive: pressing Enter / clicking the search button did not add a filter tag, and the tag close button and the reset button did not remove tags. Every story looked frozen.

## Root cause

Both components always render in **controlled** mode. They call `useControllableValue({ value: propValue, ..., onChange: propOnChange })`, and because the object literal always contains a `value` key, ahooks computes `isControlled = hasOwnProperty(props, 'value')` as `true` regardless of whether the consumer actually passed `value`. In controlled mode the hook never keeps internal state — it renders exactly what the `value` prop holds and only emits changes via `onChange`.

The stories supplied a no-op `onChange` (`console.log(...)` / `action(...)`) that never fed the new value back into the displayed value, so it never changed → the filters appeared broken.

## Fix

Stories only — **no component change**. The components work correctly when wired as controlled inputs (proven by the existing FR-2965 controlled-wrapper tests).

For each stories file, add a meta-level `render` that holds the value in **local `useState`** (seeded from `args.value`) and feeds each emitted value back, so every story instance is independently interactive.

> **Why `useState` and not `useArgs`:** an earlier revision used Storybook `useArgs` to write the value back into the story args. That works in the **Canvas** view but in the **autodocs** page only the *Primary* story's `updateArgs` is wired — every other story in the "Stories" section stayed frozen. Local `useState` works for every rendered instance in both views.

- `BAIPropertyFilter.stories.tsx`: removed the per-story no-op `onChange` overrides (the `argTypes` `action: 'filterChanged'` still logs to the Actions panel); normalized pre-applied `value` strings to the canonical quoted form (`name ilike "%test%"`).
- `BAIGraphQLPropertyFilter.stories.tsx`: kept the per-story `action(...)` handlers (distinct labels; still the Actions-panel loggers).

## Verification

- `scripts/verify.sh`: Relay / Lint / Format / TypeScript all **PASS**. (The unrelated, pre-existing "Vite warmup paths" failure reproduces on a clean tree without this change.)
- Live Storybook (headless Playwright), **Canvas**: add a condition + Enter → tag added; close icon → removed; pre-applied tags render and remove individually — for both components.
- Live Storybook, **autodocs page** (the originally-broken view): every non-strict story is interactive (BAIPropertyFilter 5/6 blocks add a tag — the 6th is the email-validation story that correctly rejects; BAIGraphQLPropertyFilter 14/20 — the rest are strict-selection / datetime / custom-input stories).

### Canvas
| BAIPropertyFilter | BAIGraphQLPropertyFilter |
|---|---|
| ![add tag](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8090/20260630-164830-property-filter-add-tag.png) | ![add condition](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8090/20260630-171450-graphql-property-filter-add-condition.png) |

### Autodocs page — every story now interactive
![autodocs all stories interactive](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8090/20260630-172819-autodocs-all-stories-interactive.png)