### PR TITLE
refactor(FR-3234): type BAIGraphQLPropertyFilter against real schema filter types

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -956,6 +956,15 @@ input AppConfigAllowListFilter
 
   """Filter by last update datetime."""
   updatedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [AppConfigAllowListFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [AppConfigAllowListFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [AppConfigAllowListFilter!] = null
 }
 
 """Added in 26.7.0. Specifies ordering for app config allow-list results."""
@@ -1040,6 +1049,15 @@ input AppConfigDefinitionFilter
 
   """Filter by last update datetime."""
   updatedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [AppConfigDefinitionFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [AppConfigDefinitionFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [AppConfigDefinitionFilter!] = null
 }
 
 """Added in 26.7.0. Specifies ordering for app config definition results."""
@@ -2692,6 +2710,15 @@ input CategoryFilter
 {
   """Filter by name."""
   name: StringFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [CategoryFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [CategoryFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [CategoryFilter!] = null
 }
 
 """Added in 26.3.0. Specifies ordering for query preset category results."""
@@ -3331,6 +3358,15 @@ input ContainerRegistryV2Filter
   registryName: StringFilter = null
   type: ContainerRegistryTypeFilter = null
   isGlobal: Boolean = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [ContainerRegistryV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [ContainerRegistryV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [ContainerRegistryV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for container registries."""
@@ -5816,6 +5852,15 @@ input DeploymentRevisionPresetFilter
 
   """Variant ID filter."""
   runtimeVariantId: UUIDFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [DeploymentRevisionPresetFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [DeploymentRevisionPresetFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [DeploymentRevisionPresetFilter!] = null
 }
 
 """Added in 26.4.2. Order specification for deployment revision presets."""
@@ -8841,6 +8886,15 @@ input KeypairResourcePolicyV2Filter
   Added in 26.4.4. Filter policies by their assigned keypairs. A policy matches if at least one of its keypairs satisfies the conditions.
   """
   keypair: KeypairResourcePolicyKeypairNestedFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [KeypairResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [KeypairResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [KeypairResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for keypair resource policies."""
@@ -9125,6 +9179,15 @@ input LoginClientTypeFilter
 
   """Filter by last modification datetime."""
   modifiedAt: DateTimeFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [LoginClientTypeFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [LoginClientTypeFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [LoginClientTypeFilter!] = null
 }
 
 """Added in 26.4.2. Specifies ordering for login client type results."""
@@ -13340,6 +13403,15 @@ input ProjectResourcePolicyV2Filter
   maxVfolderCount: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxNetworkCount: IntFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [ProjectResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [ProjectResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [ProjectResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for project resource policies."""
@@ -17335,6 +17407,15 @@ input RuntimeVariantFilter
 {
   """Name filter."""
   name: StringFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [RuntimeVariantFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [RuntimeVariantFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [RuntimeVariantFilter!] = null
 }
 
 """Added in 24.03.5."""
@@ -17450,6 +17531,15 @@ input RuntimeVariantPresetFilter
 
   """Variant ID filter."""
   runtimeVariantId: UUIDFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [RuntimeVariantPresetFilter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [RuntimeVariantPresetFilter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [RuntimeVariantPresetFilter!] = null
 }
 
 """Added in 26.4.2. Order specification."""
@@ -20628,6 +20718,15 @@ input UserResourcePolicyV2Filter
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null
   maxCustomizedImageCount: IntFilter = null
+
+  """Added in 26.7.0. Match all of the given sub-filters."""
+  AND: [UserResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Match any of the given sub-filters."""
+  OR: [UserResourcePolicyV2Filter!] = null
+
+  """Added in 26.7.0. Negate the given sub-filters."""
+  NOT: [UserResourcePolicyV2Filter!] = null
 }
 
 """Added in 26.4.2. Ordering specification for user resource policies."""

--- a/packages/backend.ai-ui/src/__generated__/BAIAdminKeypairResourcePolicySelectPaginatedQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminKeypairResourcePolicySelectPaginatedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b7102066f31a29e34c374442f165e11d>>
+ * @generated SignedSource<<97e628f43650bf3b6b07cade634d5ac0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,9 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type KeypairResourcePolicyV2Filter = {
+  AND?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
+  NOT?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
+  OR?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
   idleTimeout?: IntFilter | null | undefined;
   keypair?: KeypairResourcePolicyKeypairNestedFilter | null | undefined;

--- a/packages/backend.ai-ui/src/__generated__/BAIAvailablePresetSelectPaginatedQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAvailablePresetSelectPaginatedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ccd0b42128ee9876a6c925d590346f83>>
+ * @generated SignedSource<<e33887fd0a9719629ac8fe014f4766c5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,9 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type DeploymentRevisionPresetFilter = {
+  AND?: ReadonlyArray<DeploymentRevisionPresetFilter> | null | undefined;
+  NOT?: ReadonlyArray<DeploymentRevisionPresetFilter> | null | undefined;
+  OR?: ReadonlyArray<DeploymentRevisionPresetFilter> | null | undefined;
   id?: UUIDFilter | null | undefined;
   name?: StringFilter | null | undefined;
   runtimeVariantId?: UUIDFilter | null | undefined;

--- a/packages/backend.ai-ui/src/__generated__/BAIRuntimeVariantSelectPaginatedQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIRuntimeVariantSelectPaginatedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f958c20da0cc845ddba98a3df2b8cba0>>
+ * @generated SignedSource<<623235abf6b564ad3dfa9125adda9df5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,9 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type RuntimeVariantFilter = {
+  AND?: ReadonlyArray<RuntimeVariantFilter> | null | undefined;
+  NOT?: ReadonlyArray<RuntimeVariantFilter> | null | undefined;
+  OR?: ReadonlyArray<RuntimeVariantFilter> | null | undefined;
   name?: StringFilter | null | undefined;
 };
 export type StringFilter = {

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -177,13 +177,15 @@ export type FilterProperty = BaseFilterProperty &
     | { defaultOperator?: never; fixedOperator?: never } // No operator preference
   );
 
-export interface BAIGraphQLPropertyFilterProps extends Omit<
+export interface BAIGraphQLPropertyFilterProps<
+  TFilter extends GraphQLFilter = GraphQLFilter,
+> extends Omit<
   ComponentProps<typeof BAIFlex>,
   'value' | 'onChange' | 'defaultValue'
 > {
-  value?: GraphQLFilter;
-  onChange?: (value: GraphQLFilter | undefined) => void;
-  defaultValue?: GraphQLFilter;
+  value?: TFilter;
+  onChange?: (value: TFilter | undefined) => void;
+  defaultValue?: TFilter;
   filterProperties: Array<FilterProperty>;
   loading?: boolean;
   combinationMode?: 'AND' | 'OR';
@@ -483,7 +485,9 @@ function convertGraphQLFilterToConditions(
   return conditions;
 }
 
-const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
+const BAIGraphQLPropertyFilter = <
+  TFilter extends GraphQLFilter = GraphQLFilter,
+>({
   filterProperties,
   value: propValue,
   onChange: propOnChange,
@@ -491,7 +495,7 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
   combinationMode = 'AND',
   singleCondition = false,
   ...containerProps
-}) => {
+}: BAIGraphQLPropertyFilterProps<TFilter>) => {
   'use memo';
 
   const { token } = theme.useToken();
@@ -508,7 +512,7 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
     });
   };
 
-  const [value, setValue] = useControllableValue<GraphQLFilter | undefined>({
+  const [value, setValue] = useControllableValue<TFilter | undefined>({
     value: propValue,
     defaultValue: defaultValue,
     onChange: propOnChange,
@@ -593,7 +597,11 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
       filterProperties,
       combinationMode,
     );
-    setValue(filter);
+    // The converter emits a loose GraphQLFilter; narrow it back to the caller's
+    // concrete filter type. This single internal cast is what lets consumers
+    // bind `value`/`onChange` to a real schema filter type without casting at
+    // each call site.
+    setValue(filter as TFilter | undefined);
   };
 
   // Get effective options and strictSelection based on property type
@@ -863,7 +871,5 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
     </BAIFlex>
   );
 };
-
-BAIGraphQLPropertyFilter.displayName = 'BAIGraphQLPropertyFilter';
 
 export default BAIGraphQLPropertyFilter;

--- a/packages/backend.ai-ui/src/components/fragments/BAIAvailablePresetSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAvailablePresetSelect.tsx
@@ -124,10 +124,10 @@ const BAIAvailablePresetSelect: React.FC<BAIAvailablePresetSelectProps> = ({
       },
     );
 
-  // `DeploymentRevisionPresetFilter` has no AND/OR combinators — its fields
-  // already AND together — so we merge by setting each field on a single
-  // object. `null` when no filter is active so the query field receives the
-  // schema default.
+  // Fields set on a single filter object are AND-ed together, so we merge the
+  // runtime-variant and search conditions onto one object rather than using an
+  // explicit AND combinator. `null` when no filter is active so the query field
+  // receives the schema default.
   const mergedFilter: NonNullable<
     BAIAvailablePresetSelectPaginatedQuery['variables']['filter']
   > | null =

--- a/react/src/__generated__/AdminDeploymentPresetListPageQuery.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b2c649500e1dc94be2461e41a3d37f47>>
+ * @generated SignedSource<<079c40ad13707c84813ca28db8024f88>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,9 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type DeploymentRevisionPresetOrderField = "CREATED_AT" | "NAME" | "RANK" | "%future added value";
 export type DeploymentRevisionPresetFilter = {
+  AND?: ReadonlyArray<DeploymentRevisionPresetFilter> | null | undefined;
+  NOT?: ReadonlyArray<DeploymentRevisionPresetFilter> | null | undefined;
+  OR?: ReadonlyArray<DeploymentRevisionPresetFilter> | null | undefined;
   id?: UUIDFilter | null | undefined;
   name?: StringFilter | null | undefined;
   runtimeVariantId?: UUIDFilter | null | undefined;

--- a/react/src/__generated__/UserFolderPermissionPanelV2Query.graphql.ts
+++ b/react/src/__generated__/UserFolderPermissionPanelV2Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dedd9173f1132b85b34c2133f4526604>>
+ * @generated SignedSource<<6748c2318a3ebab0d4ce27101c62a844>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,9 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type KeypairResourcePolicyV2Filter = {
+  AND?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
+  NOT?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
+  OR?: ReadonlyArray<KeypairResourcePolicyV2Filter> | null | undefined;
   createdAt?: DateTimeFilter | null | undefined;
   idleTimeout?: IntFilter | null | undefined;
   keypair?: KeypairResourcePolicyKeypairNestedFilter | null | undefined;

--- a/react/src/__generated__/useRuntimeParameterSchemaPresetsQuery.graphql.ts
+++ b/react/src/__generated__/useRuntimeParameterSchemaPresetsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<20f2d6fcb470e62d08c07b83a1caea9d>>
+ * @generated SignedSource<<54e75e80e21e939f803e3767e95d62ab>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,9 @@ export type PresetTarget = "ARGS" | "ENV" | "%future added value";
 export type PresetValueType = "BOOL" | "FLAG" | "FLOAT" | "INT" | "STR" | "%future added value";
 export type RuntimeVariantPresetOrderField = "CREATED_AT" | "NAME" | "RANK" | "%future added value";
 export type RuntimeVariantPresetFilter = {
+  AND?: ReadonlyArray<RuntimeVariantPresetFilter> | null | undefined;
+  NOT?: ReadonlyArray<RuntimeVariantPresetFilter> | null | undefined;
+  OR?: ReadonlyArray<RuntimeVariantPresetFilter> | null | undefined;
   name?: StringFilter | null | undefined;
   runtimeVariantId?: UUIDFilter | null | undefined;
 };

--- a/react/src/__generated__/useRuntimeParameterSchemaVariantsQuery.graphql.ts
+++ b/react/src/__generated__/useRuntimeParameterSchemaVariantsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5f18317b31f423d3077ab4400ed19dda>>
+ * @generated SignedSource<<7d0e4e3601e640a3fb5ab0e3bd35ae9a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,9 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { Result } from "relay-runtime";
 export type RuntimeVariantFilter = {
+  AND?: ReadonlyArray<RuntimeVariantFilter> | null | undefined;
+  NOT?: ReadonlyArray<RuntimeVariantFilter> | null | undefined;
+  OR?: ReadonlyArray<RuntimeVariantFilter> | null | undefined;
   name?: StringFilter | null | undefined;
 };
 export type StringFilter = {

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -5,6 +5,7 @@
 import {
   AdminUserManagementQuery,
   AdminUserManagementQuery$data,
+  UserV2Filter,
   UserV2OrderBy,
 } from '../__generated__/AdminUserManagementQuery.graphql';
 import { AdminUserManagementUpdateUserMutation } from '../__generated__/AdminUserManagementUpdateUserMutation.graphql';
@@ -35,7 +36,6 @@ import {
   BAIFlex,
   BAIGraphQLFilterProperty,
   BAIGraphQLPropertyFilter,
-  GraphQLFilter,
   useBAILogger,
   BAIFetchKeyButton,
   BAIAdminUserV2Table,
@@ -73,7 +73,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
 
   const [queryParams, setQueryParams] = useQueryStates(
     {
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<UserV2Filter>((value) => value as UserV2Filter),
       order: parseAsStringLiteral(availableUserV2SorterValues),
       status: parseAsStringLiteral(['ACTIVE', 'INACTIVE']).withDefault(
         'ACTIVE',
@@ -440,7 +440,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
               },
             ]}
           />
-          <BAIGraphQLPropertyFilter
+          <BAIGraphQLPropertyFilter<UserV2Filter>
             filterProperties={filterProperties}
             value={queryParams.filter ?? undefined}
             onChange={(value) => {

--- a/react/src/components/AutoScalingRuleListNodes.tsx
+++ b/react/src/components/AutoScalingRuleListNodes.tsx
@@ -15,13 +15,11 @@ import {
   BAITable,
   filterOutNullAndUndefined,
 } from 'backend.ai-ui';
-import type { BAITableProps, GraphQLFilter } from 'backend.ai-ui';
+import type { BAITableProps } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-
-type DateTimeFilter = { before?: string | null; after?: string | null };
 
 export type AutoScalingRuleNode = NonNullable<
   AutoScalingRuleListNodesFragment$data[number]
@@ -87,31 +85,6 @@ const renderCondition = (
   }
 
   return '-';
-};
-
-type AutoScalingRuleFilterInput = {
-  createdAt?: DateTimeFilter | null;
-  lastTriggeredAt?: DateTimeFilter | null;
-  AND?: AutoScalingRuleFilterInput[];
-  OR?: AutoScalingRuleFilterInput[];
-  NOT?: AutoScalingRuleFilterInput[];
-};
-
-/** Maps BAIGraphQLPropertyFilter output → AutoScalingRuleFilter, preserving AND/OR/NOT. */
-export const toAutoScalingRuleFilter = (
-  filter: GraphQLFilter,
-): AutoScalingRuleFilterInput => {
-  const result: AutoScalingRuleFilterInput = {};
-  if (filter.createdAt) result.createdAt = filter.createdAt as DateTimeFilter;
-  if (filter.lastTriggeredAt)
-    result.lastTriggeredAt = filter.lastTriggeredAt as DateTimeFilter;
-  if (Array.isArray(filter.AND))
-    result.AND = filter.AND.map(toAutoScalingRuleFilter);
-  if (Array.isArray(filter.OR))
-    result.OR = filter.OR.map(toAutoScalingRuleFilter);
-  if (Array.isArray(filter.NOT))
-    result.NOT = filter.NOT.map(toAutoScalingRuleFilter);
-  return result;
 };
 
 interface AutoScalingRuleListNodesProps extends Omit<

--- a/react/src/components/DeploymentAutoScalingCard.tsx
+++ b/react/src/components/DeploymentAutoScalingCard.tsx
@@ -3,16 +3,17 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { DeploymentAutoScalingCardDeleteMutation } from '../__generated__/DeploymentAutoScalingCardDeleteMutation.graphql';
-import { DeploymentAutoScalingCardListQuery } from '../__generated__/DeploymentAutoScalingCardListQuery.graphql';
+import {
+  AutoScalingRuleFilter,
+  DeploymentAutoScalingCardListQuery,
+} from '../__generated__/DeploymentAutoScalingCardListQuery.graphql';
 import { DeploymentAutoScalingCardPresetsQuery } from '../__generated__/DeploymentAutoScalingCardPresetsQuery.graphql';
 import { DeploymentAutoScalingCard_deployment$key } from '../__generated__/DeploymentAutoScalingCard_deployment.graphql';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import AutoScalingRuleEditorModal from './AutoScalingRuleEditorModal';
-import AutoScalingRuleListNodes, {
-  toAutoScalingRuleFilter,
-} from './AutoScalingRuleListNodes';
+import AutoScalingRuleListNodes from './AutoScalingRuleListNodes';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { App, Skeleton, Tooltip, theme } from 'antd';
 import {
@@ -29,7 +30,6 @@ import {
   useFetchKey,
   useMutationWithPromise,
 } from 'backend.ai-ui';
-import type { GraphQLFilter } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { PlusIcon } from 'lucide-react';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
@@ -155,7 +155,9 @@ const DeploymentAutoScalingCardContent: React.FC<
         'createdAt',
         '-createdAt',
       ] as const).withDefault('-createdAt'),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<AutoScalingRuleFilter>(
+        (value) => value as AutoScalingRuleFilter,
+      ),
     },
     { history: 'replace' },
   );
@@ -169,10 +171,6 @@ const DeploymentAutoScalingCardContent: React.FC<
     setTablePaginationOption,
   } = useBAIPaginationOptionStateOnSearchParam({ current: 1, pageSize: 10 });
 
-  const filterInput = graphQLFilter
-    ? toAutoScalingRuleFilter(graphQLFilter)
-    : null;
-
   const queryVariables = {
     deploymentId,
     offset: baiPaginationOption.offset,
@@ -185,7 +183,7 @@ const DeploymentAutoScalingCardContent: React.FC<
           | 'DESC',
       },
     ],
-    filter: filterInput,
+    filter: graphQLFilter ?? null,
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);
 
@@ -285,7 +283,7 @@ const DeploymentAutoScalingCardContent: React.FC<
     <>
       <BAIFlex direction="column" align="stretch" gap="sm">
         <BAIFlex align="center" gap="xs">
-          <BAIGraphQLPropertyFilter
+          <BAIGraphQLPropertyFilter<AutoScalingRuleFilter>
             style={{ flex: 1 }}
             filterProperties={[
               {

--- a/react/src/components/ProjectStoragePermissionTable.tsx
+++ b/react/src/components/ProjectStoragePermissionTable.tsx
@@ -38,7 +38,6 @@ import {
   BAITable,
   type BAITableProps,
   BAIUnmountAfterClose,
-  type GraphQLFilter,
   toLocalId,
   useFetchKey,
 } from 'backend.ai-ui';
@@ -142,7 +141,7 @@ const ProjectStoragePermissionTable: React.FC<
     tablePaginationOption,
     setTablePaginationOption,
   } = useBAIPaginationOptionState({ current: 1, pageSize: 10 });
-  const [filter, setFilter] = useState<GraphQLFilter | undefined>(undefined);
+  const [filter, setFilter] = useState<ProjectV2Filter | undefined>(undefined);
   const [order, setOrder] = useState<string | undefined>(undefined);
 
   const [fetchKey, updateFetchKey] = useFetchKey();
@@ -153,7 +152,7 @@ const ProjectStoragePermissionTable: React.FC<
     skip: !selectedDomainName,
     limit: baiPaginationOption.limit,
     offset: baiPaginationOption.offset,
-    filter: (filter ?? null) as ProjectV2Filter | null,
+    filter: filter ?? null,
     orderBy: convertToOrderBy<ProjectV2OrderBy>(order) ?? null,
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);
@@ -312,7 +311,7 @@ const ProjectStoragePermissionTable: React.FC<
     <BAIFlex direction="column" align="stretch" gap="xs">
       <BAIFlex align="center" gap="xs">
         <BAIFlex gap="xs" justify="between" align="start" style={{ flex: 1 }}>
-          <BAIGraphQLPropertyFilter
+          <BAIGraphQLPropertyFilter<ProjectV2Filter>
             style={{ flex: 1 }}
             filterProperties={[
               {

--- a/react/src/components/PrometheusPresetTab.tsx
+++ b/react/src/components/PrometheusPresetTab.tsx
@@ -6,6 +6,7 @@ import { PrometheusPresetTabDeleteMutation } from '../__generated__/PrometheusPr
 import {
   PrometheusPresetTabQuery,
   PrometheusPresetTabQuery$variables,
+  QueryDefinitionFilter,
 } from '../__generated__/PrometheusPresetTabQuery.graphql';
 import { PrometheusQueryPresetEditorModalFragment$key } from '../__generated__/PrometheusQueryPresetEditorModalFragment.graphql';
 import { convertToOrderBy } from '../helper';
@@ -20,7 +21,6 @@ import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
-  type GraphQLFilter,
   INITIAL_FETCH_KEY,
   toLocalId,
   useFetchKey,
@@ -41,7 +41,9 @@ const PrometheusPresetTab: React.FC = () => {
 
   const [queryParam, setQueryParam] = useQueryStates(
     {
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<QueryDefinitionFilter>(
+        (value) => value as QueryDefinitionFilter,
+      ),
       order: parseAsString,
     },
     { history: 'replace' },
@@ -130,7 +132,7 @@ const PrometheusPresetTab: React.FC = () => {
   return (
     <BAIFlex direction="column" align="stretch" gap="sm">
       <BAIFlex direction="row" justify="between" wrap="wrap" gap="sm">
-        <BAIGraphQLPropertyFilter
+        <BAIGraphQLPropertyFilter<QueryDefinitionFilter>
           combinationMode="AND"
           value={queryParam.filter ?? undefined}
           onChange={(value) => {

--- a/react/src/components/RoleAssignmentTab.tsx
+++ b/react/src/components/RoleAssignmentTab.tsx
@@ -5,7 +5,10 @@
 import { RoleAssignmentTabBulkAssignMutation } from '../__generated__/RoleAssignmentTabBulkAssignMutation.graphql';
 import { RoleAssignmentTabBulkRevokeMutation } from '../__generated__/RoleAssignmentTabBulkRevokeMutation.graphql';
 import { RoleAssignmentTabFragment$key } from '../__generated__/RoleAssignmentTabFragment.graphql';
-import { RoleAssignmentOrderBy } from '../__generated__/RoleAssignmentTabRefetchQuery.graphql';
+import {
+  RoleAssignmentFilter,
+  RoleAssignmentOrderBy,
+} from '../__generated__/RoleAssignmentTabRefetchQuery.graphql';
 import { RoleAssignmentTab_roleScopeFragment$key } from '../__generated__/RoleAssignmentTab_roleScopeFragment.graphql';
 import { convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
@@ -22,7 +25,6 @@ import {
   BAINameActionCell,
   BAISelectionLabel,
   BAITable,
-  type GraphQLFilter,
   useBAILogger,
   useMutationWithPromise,
 } from 'backend.ai-ui';
@@ -106,7 +108,9 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
       current: parseAsInteger.withDefault(1),
       pageSize: parseAsInteger.withDefault(10),
       order: parseAsStringLiteral(assignmentOrderValues),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<RoleAssignmentFilter>(
+        (value) => value as RoleAssignmentFilter,
+      ),
     },
     {
       history: 'replace',
@@ -202,7 +206,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
     data.adminRoleAssignments?.edges?.map((edge) => edge?.node) ?? [];
 
   const doRefetch = (overrides?: {
-    filter?: GraphQLFilter | null;
+    filter?: RoleAssignmentFilter | null;
     order?: string | null;
     limit?: number;
     offset?: number;
@@ -231,7 +235,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
     });
   };
 
-  const handleFilterChange = (newFilter: GraphQLFilter | undefined) => {
+  const handleFilterChange = (newFilter: RoleAssignmentFilter | undefined) => {
     setQueryParams({ filter: newFilter ?? null, current: 1 });
     doRefetch({ filter: newFilter ?? null, offset: 0 });
   };
@@ -304,7 +308,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
         wrap="wrap"
         style={{ marginBottom: 12 }}
       >
-        <BAIGraphQLPropertyFilter
+        <BAIGraphQLPropertyFilter<RoleAssignmentFilter>
           filterProperties={[
             {
               key: 'email',

--- a/react/src/components/RolePermissionTab.tsx
+++ b/react/src/components/RolePermissionTab.tsx
@@ -5,7 +5,10 @@
 import { CreatePermissionModal_roleScopeFragment$key } from '../__generated__/CreatePermissionModal_roleScopeFragment.graphql';
 import { RolePermissionTabDeleteMutation } from '../__generated__/RolePermissionTabDeleteMutation.graphql';
 import { RolePermissionTabFragment$key } from '../__generated__/RolePermissionTabFragment.graphql';
-import { PermissionOrderBy } from '../__generated__/RolePermissionTabRefetchQuery.graphql';
+import {
+  PermissionFilter,
+  PermissionOrderBy,
+} from '../__generated__/RolePermissionTabRefetchQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import CreatePermissionModal from './CreatePermissionModal';
@@ -19,7 +22,6 @@ import {
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
   BAITable,
-  type GraphQLFilter,
   toLocalId,
   useBAILogger,
   useMutationWithPromise,
@@ -135,7 +137,9 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
       current: parseAsInteger.withDefault(1),
       pageSize: parseAsInteger.withDefault(10),
       order: parseAsStringLiteral(permissionOrderValues),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<PermissionFilter>(
+        (value) => value as PermissionFilter,
+      ),
     },
     {
       history: 'replace',
@@ -234,7 +238,7 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
     data.adminPermissions?.edges?.map((edge) => edge?.node) ?? [];
 
   const doRefetch = (overrides?: {
-    filter?: GraphQLFilter | null;
+    filter?: PermissionFilter | null;
     order?: string | null;
     limit?: number;
     offset?: number;
@@ -263,7 +267,7 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
     });
   };
 
-  const handleFilterChange = (newFilter: GraphQLFilter | undefined) => {
+  const handleFilterChange = (newFilter: PermissionFilter | undefined) => {
     setQueryParams({ filter: newFilter ?? null, current: 1 });
     doRefetch({ filter: newFilter ?? null, offset: 0 });
   };
@@ -315,7 +319,7 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
         wrap="wrap"
         style={{ marginBottom: 12 }}
       >
-        <BAIGraphQLPropertyFilter
+        <BAIGraphQLPropertyFilter<PermissionFilter>
           filterProperties={[
             {
               key: 'scopeType',

--- a/react/src/components/RoleScopeTab.tsx
+++ b/react/src/components/RoleScopeTab.tsx
@@ -3,7 +3,10 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { RoleScopeTabFragment$key } from '../__generated__/RoleScopeTabFragment.graphql';
-import { EntityOrderBy } from '../__generated__/RoleScopeTabRefetchQuery.graphql';
+import {
+  EntityFilter,
+  EntityOrderBy,
+} from '../__generated__/RoleScopeTabRefetchQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { Tag } from 'antd';
@@ -15,7 +18,6 @@ import {
   BAIId,
   BAITable,
   filterOutEmpty,
-  type GraphQLFilter,
 } from 'backend.ai-ui';
 import {
   parseAsInteger,
@@ -49,7 +51,7 @@ const RoleScopeTab: React.FC<RoleScopeTabProps> = ({ queryRef }) => {
       current: parseAsInteger.withDefault(1),
       pageSize: parseAsInteger.withDefault(10),
       order: parseAsStringLiteral(scopeOrderValues),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<EntityFilter>((value) => value as EntityFilter),
     },
     {
       history: 'replace',
@@ -121,7 +123,7 @@ const RoleScopeTab: React.FC<RoleScopeTabProps> = ({ queryRef }) => {
   type ScopeNode = NonNullable<(typeof scopeNodes)[number]>;
 
   const doRefetch = (overrides?: {
-    filter?: GraphQLFilter | null;
+    filter?: EntityFilter | null;
     order?: string | null;
     limit?: number;
     offset?: number;
@@ -146,7 +148,7 @@ const RoleScopeTab: React.FC<RoleScopeTabProps> = ({ queryRef }) => {
     });
   };
 
-  const handleFilterChange = (newFilter: GraphQLFilter | undefined) => {
+  const handleFilterChange = (newFilter: EntityFilter | undefined) => {
     setQueryParams({ filter: newFilter ?? null, current: 1 });
     doRefetch({ filter: newFilter ?? null, offset: 0 });
   };
@@ -186,7 +188,7 @@ const RoleScopeTab: React.FC<RoleScopeTabProps> = ({ queryRef }) => {
         wrap="wrap"
         style={{ marginBottom: 12 }}
       >
-        <BAIGraphQLPropertyFilter
+        <BAIGraphQLPropertyFilter<EntityFilter>
           filterProperties={[
             {
               key: 'entityType',

--- a/react/src/components/UserFolderPermissionPanelV2.tsx
+++ b/react/src/components/UserFolderPermissionPanelV2.tsx
@@ -16,7 +16,6 @@ import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIUserSelect,
-  type GraphQLFilter,
   INITIAL_FETCH_KEY,
   useFetchKey,
 } from 'backend.ai-ui';
@@ -49,9 +48,12 @@ const UserFolderPermissionPanelV2: React.FC<
     storageVolumeFrgmt,
   );
 
-  const [userFilter, setUserFilter] = useState<GraphQLFilter | undefined>();
+  const [userFilter, setUserFilter] = useState<
+    KeypairResourcePolicyV2Filter | undefined
+  >();
   // Extract the picked user's UUID to scope the keypairs connection (Assigned
-  // Keypairs column); `GraphQLFilter` is index-typed so guard down to a string.
+  // Keypairs column); the `equals` operator is nullable, so guard down to a
+  // string.
   const rawUserId = userFilter?.keypair?.userId?.equals;
   const selectedUserId = _.isString(rawUserId) ? rawUserId : undefined;
 
@@ -78,7 +80,7 @@ const UserFolderPermissionPanelV2: React.FC<
 
   const includeKeypairs = !!selectedUserId;
   const queryVariables = {
-    filter: (userFilter ?? null) as KeypairResourcePolicyV2Filter | null,
+    filter: userFilter ?? null,
     limit: baiPaginationOption.limit,
     offset: baiPaginationOption.offset,
     includeKeypairs,
@@ -140,7 +142,7 @@ const UserFolderPermissionPanelV2: React.FC<
       >
         <BAIFlex direction="column" align="stretch" gap="sm">
           <BAIFlex align="start" justify="between" gap="md" wrap="wrap">
-            <BAIGraphQLPropertyFilter
+            <BAIGraphQLPropertyFilter<KeypairResourcePolicyV2Filter>
               style={{ flex: 1 }}
               value={userFilter}
               onChange={setUserFilter}

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -36,7 +36,6 @@ import {
   BAINameActionCell,
   BAIUnmountAfterClose,
   DeploymentOrderValue,
-  GraphQLFilter,
   INITIAL_FETCH_KEY,
   availableDeploymentSorterValues,
   filterOutEmpty,
@@ -89,10 +88,10 @@ const AdminDeploymentListPageContent: React.FC = () => {
 
   const [queryParams, setQueryParams] = useQueryStates(
     {
-      filter: parseAsJson<GraphQLFilter>((value) =>
+      filter: parseAsJson<DeploymentFilter>((value) =>
         typeof value === 'object' && value !== null && !Array.isArray(value)
-          ? (value as GraphQLFilter)
-          : ({} as GraphQLFilter),
+          ? (value as DeploymentFilter)
+          : ({} as DeploymentFilter),
       ),
       order: parseAsStringLiteral(availableDeploymentSorterValues),
       statusCategory: parseAsStringLiteral<DeploymentStatusCategory>([
@@ -118,7 +117,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
   const sort = parseDeploymentOrder(queryParams.order);
   const queryVariables = {
     filter: {
-      ...((queryParams.filter ?? {}) as DeploymentFilter),
+      ...(queryParams.filter ?? {}),
       ...statusCategoryFilter,
     },
     orderBy: sort
@@ -285,7 +284,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
                 },
               ]}
             />
-            <BAIGraphQLPropertyFilter
+            <BAIGraphQLPropertyFilter<DeploymentFilter>
               filterProperties={filterProperties}
               value={queryParams.filter ?? undefined}
               onChange={(value) => {

--- a/react/src/pages/AdminDeploymentPresetListPage.tsx
+++ b/react/src/pages/AdminDeploymentPresetListPage.tsx
@@ -23,7 +23,6 @@ import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
-  type GraphQLFilter,
   INITIAL_FETCH_KEY,
   toLocalId,
   useBAILogger,
@@ -66,7 +65,9 @@ const AdminDeploymentPresetListPage: React.FC = () => {
   const [queryParams, setQueryParams] = useQueryStates(
     {
       order: parseAsString.withDefault('-createdAt'),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<DeploymentRevisionPresetFilter>(
+        (value) => value as DeploymentRevisionPresetFilter,
+      ),
     },
     {
       history: 'replace',
@@ -76,9 +77,7 @@ const AdminDeploymentPresetListPage: React.FC = () => {
   const [fetchKey, updateFetchKey] = useFetchKey();
 
   const queryVariables = {
-    filter: (queryParams.filter ?? undefined) as
-      | DeploymentRevisionPresetFilter
-      | undefined,
+    filter: queryParams.filter ?? undefined,
     orderBy: convertToOrderBy<DeploymentRevisionPresetOrderBy>(
       queryParams.order,
     ),
@@ -156,7 +155,7 @@ const AdminDeploymentPresetListPage: React.FC = () => {
     <BAIFlex direction="column" align="stretch" gap={'sm'}>
       <BAIFlex justify="between" wrap="wrap" gap={'sm'}>
         <BAIFlex gap={'sm'} align="start" wrap="wrap" style={{ flexShrink: 1 }}>
-          <BAIGraphQLPropertyFilter
+          <BAIGraphQLPropertyFilter<DeploymentRevisionPresetFilter>
             filterProperties={[
               {
                 key: 'name',

--- a/react/src/pages/AdminModelCardListPage.tsx
+++ b/react/src/pages/AdminModelCardListPage.tsx
@@ -7,6 +7,7 @@ import type { AdminModelCardListPageDeleteMutation } from '../__generated__/Admi
 import type {
   AdminModelCardListPageQuery,
   AdminModelCardListPageQuery$data,
+  ModelCardV2Filter,
   ModelCardV2OrderBy,
 } from '../__generated__/AdminModelCardListPageQuery.graphql';
 import AdminModelCardSettingModal from '../components/AdminModelCardSettingModal';
@@ -40,7 +41,6 @@ import {
   BAIUnmountAfterClose,
   filterOutEmpty,
   filterOutNullAndUndefined,
-  type GraphQLFilter,
   INITIAL_FETCH_KEY,
   isValidUUID,
   toLocalId,
@@ -105,7 +105,9 @@ const AdminModelCardListPage: React.FC = () => {
   const [queryParams, setQueryParams] = useQueryStates(
     {
       order: parseAsString,
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<ModelCardV2Filter>(
+        (value) => value as ModelCardV2Filter,
+      ),
     },
     {
       history: 'replace',
@@ -331,7 +333,7 @@ const AdminModelCardListPage: React.FC = () => {
     <BAIFlex direction="column" align="stretch" gap={'sm'}>
       <BAIFlex justify="between" wrap="wrap" gap={'sm'}>
         <BAIFlex gap={'sm'} align="start" wrap="wrap" style={{ flexShrink: 1 }}>
-          <BAIGraphQLPropertyFilter
+          <BAIGraphQLPropertyFilter<ModelCardV2Filter>
             filterProperties={[
               {
                 key: 'name',

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -32,7 +32,6 @@ import {
   BAINameActionCell,
   BAIUnmountAfterClose,
   DeploymentOrderValue,
-  GraphQLFilter,
   INITIAL_FETCH_KEY,
   availableDeploymentSorterValues,
   filterOutNullAndUndefined,
@@ -76,10 +75,10 @@ const DeploymentListPageContent: React.FC = () => {
 
   const [queryParams, setQueryParams] = useQueryStates(
     {
-      filter: parseAsJson<GraphQLFilter>((value) =>
+      filter: parseAsJson<DeploymentFilter>((value) =>
         typeof value === 'object' && value !== null && !Array.isArray(value)
-          ? (value as GraphQLFilter)
-          : ({} as GraphQLFilter),
+          ? (value as DeploymentFilter)
+          : ({} as DeploymentFilter),
       ),
       order: parseAsStringLiteral(availableDeploymentSorterValues),
       statusCategory: parseAsStringLiteral<DeploymentStatusCategory>([
@@ -117,7 +116,7 @@ const DeploymentListPageContent: React.FC = () => {
     : {};
   const queryVariables = {
     filter: {
-      ...((queryParams.filter ?? {}) as DeploymentFilter),
+      ...(queryParams.filter ?? {}),
       ...statusCategoryFilter,
       ...projectFilter,
     },
@@ -242,7 +241,7 @@ const DeploymentListPageContent: React.FC = () => {
                 },
               ]}
             />
-            <BAIGraphQLPropertyFilter
+            <BAIGraphQLPropertyFilter<DeploymentFilter>
               filterProperties={filterProperties}
               value={queryParams.filter ?? undefined}
               onChange={(value) => {

--- a/react/src/pages/ModelStoreListPageV2.tsx
+++ b/react/src/pages/ModelStoreListPageV2.tsx
@@ -32,7 +32,6 @@ import {
   BAIGraphQLPropertyFilter,
   BAISelect,
   BAIStorageHostSelect,
-  type GraphQLFilter,
   safeDecodeUuid,
   useUpdatableState,
 } from 'backend.ai-ui';
@@ -74,23 +73,18 @@ const NAME_KEYWORD_OPERATORS = [
   'equals',
 ] as const;
 
-const extractFirstNameKeyword = (filter: GraphQLFilter | undefined): string => {
+const extractFirstNameKeyword = (
+  filter: ModelCardV2Filter | undefined,
+): string => {
   if (!filter) return '';
-  const name = (
-    filter as {
-      name?: Partial<Record<(typeof NAME_KEYWORD_OPERATORS)[number], string>>;
-    }
-  ).name;
+  const name = filter.name;
   if (name) {
     for (const op of NAME_KEYWORD_OPERATORS) {
       const v = name[op];
       if (v) return v;
     }
   }
-  const branches = [
-    (filter as { AND?: GraphQLFilter | GraphQLFilter[] }).AND,
-    (filter as { OR?: GraphQLFilter | GraphQLFilter[] }).OR,
-  ];
+  const branches = [filter.AND, filter.OR];
   for (const branch of branches) {
     if (!branch) continue;
     const items = Array.isArray(branch) ? branch : [branch];
@@ -196,7 +190,7 @@ const ModelCardV2Card: React.FC<{
 
 const ModelCardV2Grid: React.FC<{
   projectId: string;
-  filter?: GraphQLFilter;
+  filter?: ModelCardV2Filter;
   sortField: SortField;
   sortDirection: SortDirection;
   fetchKey: string;
@@ -249,7 +243,7 @@ const ModelCardV2Grid: React.FC<{
     `,
     {
       scope: { projectId },
-      filter: (filter as ModelCardV2Filter) ?? undefined,
+      filter: filter ?? undefined,
       orderBy: [{ field: sortField, direction: sortDirection }],
       limit: pageSize,
       offset,
@@ -312,7 +306,9 @@ const ModelStoreListPageV2: React.FC = () => {
     {
       sort: parseAsStringLiteral(SORT_VALUES).withDefault('CREATED_AT_DESC'),
       modelCard: parseAsString,
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<ModelCardV2Filter>(
+        (value) => value as ModelCardV2Filter,
+      ),
     },
     { history: 'replace' },
   );
@@ -321,7 +317,7 @@ const ModelStoreListPageV2: React.FC = () => {
     queryParams.sort,
   );
 
-  const filter: GraphQLFilter | undefined = queryParams.filter ?? undefined;
+  const filter: ModelCardV2Filter | undefined = queryParams.filter ?? undefined;
   const deferredFilter = useDeferredValue(filter);
   const deferredSortField = useDeferredValue(sortField);
   const deferredSortDirection = useDeferredValue(sortDirection);
@@ -397,7 +393,7 @@ const ModelStoreListPageV2: React.FC = () => {
     <BAIFlex direction="column" align="stretch" justify="center" gap="lg">
       <BAIFlex justify="between" wrap="wrap" gap="sm">
         <BAIFlex gap="sm" align="start" style={{ flexShrink: 1 }} wrap="wrap">
-          <BAIGraphQLPropertyFilter
+          <BAIGraphQLPropertyFilter<ModelCardV2Filter>
             combinationMode="AND"
             value={filter}
             onChange={(value) => {

--- a/react/src/pages/ProjectAdminDataPage.tsx
+++ b/react/src/pages/ProjectAdminDataPage.tsx
@@ -5,6 +5,7 @@
 import type {
   ProjectAdminDataPageQuery,
   ProjectAdminDataPageQuery$data,
+  VFolderFilter,
   VFolderOrderBy,
 } from '../__generated__/ProjectAdminDataPageQuery.graphql';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
@@ -38,7 +39,6 @@ import {
   BAIVFolderDeleteButtonV2,
   filterOutEmpty,
   filterOutNullAndUndefined,
-  type GraphQLFilter,
   INITIAL_FETCH_KEY,
   useFetchKey,
 } from 'backend.ai-ui';
@@ -138,7 +138,7 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
       order: parseAsStringLiteral(availableVFolderSorterValues).withDefault(
         '-created_at',
       ),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<VFolderFilter>((value) => value as VFolderFilter),
       statusCategory:
         parseAsStringLiteral(statusCategoryValues).withDefault('active'),
       mode: parseAsStringLiteral(modeValues).withDefault('all'),
@@ -325,7 +325,7 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
                 },
               ])}
             />
-            <BAIGraphQLPropertyFilter
+            <BAIGraphQLPropertyFilter<VFolderFilter>
               data-testid="vfolder-filter"
               // TODO(needs-backend): V2 `VFolderFilter` does not expose
               // ownership_type or mount-permission filters; only

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -33,7 +33,6 @@ import {
   BAINameActionCell,
   BAIUnmountAfterClose,
   DeploymentOrderValue,
-  GraphQLFilter,
   INITIAL_FETCH_KEY,
   availableDeploymentSorterValues,
   filterOutNullAndUndefined,
@@ -84,10 +83,10 @@ const ProjectAdminDeploymentsContent: React.FC<
 
   const [queryParams, setQueryParams] = useQueryStates(
     {
-      filter: parseAsJson<GraphQLFilter>((value) =>
+      filter: parseAsJson<DeploymentFilter>((value) =>
         typeof value === 'object' && value !== null && !Array.isArray(value)
-          ? (value as GraphQLFilter)
-          : ({} as GraphQLFilter),
+          ? (value as DeploymentFilter)
+          : ({} as DeploymentFilter),
       ),
       order: parseAsStringLiteral(availableDeploymentSorterValues),
       statusCategory: parseAsStringLiteral<DeploymentStatusCategory>([
@@ -114,7 +113,7 @@ const ProjectAdminDeploymentsContent: React.FC<
   const queryVariables = {
     projectId,
     filter: {
-      ...((queryParams.filter ?? {}) as DeploymentFilter),
+      ...(queryParams.filter ?? {}),
       ...statusCategoryFilter,
     },
     orderBy: sort
@@ -248,7 +247,7 @@ const ProjectAdminDeploymentsContent: React.FC<
                 },
               ]}
             />
-            <BAIGraphQLPropertyFilter
+            <BAIGraphQLPropertyFilter<DeploymentFilter>
               filterProperties={filterProperties}
               value={queryParams.filter ?? undefined}
               onChange={(value) => {

--- a/react/src/pages/ProjectAdminSessionPage.tsx
+++ b/react/src/pages/ProjectAdminSessionPage.tsx
@@ -5,6 +5,7 @@
 import type {
   ProjectAdminSessionPageQuery,
   ProjectAdminSessionPageQuery$data,
+  SessionV2Filter,
   SessionV2OrderBy,
   SessionV2Status,
 } from '../__generated__/ProjectAdminSessionPageQuery.graphql';
@@ -24,7 +25,6 @@ import {
   BAINameActionCell,
   BAISelectionLabel,
   BAISessionNodesV2,
-  GraphQLFilter,
   INITIAL_FETCH_KEY,
   availableSessionV2SorterValues,
   filterOutEmpty,
@@ -96,7 +96,7 @@ const ProjectAdminSessionContent: React.FC<ProjectAdminSessionContentProps> = ({
       statusCategory:
         parseAsStringLiteral(statusCategoryValues).withDefault('running'),
       order: parseAsStringLiteral(availableSessionV2SorterValues),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<SessionV2Filter>((value) => value as SessionV2Filter),
     },
     {
       history: 'replace',
@@ -201,7 +201,7 @@ const ProjectAdminSessionContent: React.FC<ProjectAdminSessionContentProps> = ({
               { label: t('session.Finished'), value: 'finished' },
             ]}
           />
-          <BAIGraphQLPropertyFilter
+          <BAIGraphQLPropertyFilter<SessionV2Filter>
             filterProperties={[
               {
                 key: 'id',

--- a/react/src/pages/ProjectAdminUsersPage.tsx
+++ b/react/src/pages/ProjectAdminUsersPage.tsx
@@ -4,6 +4,7 @@
  */
 import type {
   ProjectAdminUsersPageQuery,
+  UserV2Filter,
   UserV2OrderBy,
 } from '../__generated__/ProjectAdminUsersPageQuery.graphql';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
@@ -20,7 +21,6 @@ import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIAdminUserV2Table,
-  GraphQLFilter,
   INITIAL_FETCH_KEY,
   useFetchKey,
 } from 'backend.ai-ui';
@@ -54,7 +54,7 @@ const ProjectAdminUsersContent: React.FC<ProjectAdminUsersContentProps> = ({
     {
       status: parseAsStringLiteral(statusFilterValues).withDefault('ACTIVE'),
       order: parseAsStringLiteral(availableUserV2SorterValues),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<UserV2Filter>((value) => value as UserV2Filter),
     },
     {
       history: 'replace',
@@ -143,7 +143,7 @@ const ProjectAdminUsersContent: React.FC<ProjectAdminUsersContentProps> = ({
               { label: t('general.Inactive'), value: 'INACTIVE' },
             ]}
           />
-          <BAIGraphQLPropertyFilter
+          <BAIGraphQLPropertyFilter<UserV2Filter>
             filterProperties={[
               {
                 key: 'email',

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -7,6 +7,7 @@ import { RBACManagementPageDeactivateRoleMutation } from '../__generated__/RBACM
 import { RBACManagementPagePurgeRoleMutation } from '../__generated__/RBACManagementPagePurgeRoleMutation.graphql';
 import {
   RBACManagementPageQuery,
+  RoleFilter,
   RoleOrderBy,
 } from '../__generated__/RBACManagementPageQuery.graphql';
 import BAIRadioGroup from '../components/BAIRadioGroup';
@@ -29,7 +30,6 @@ import {
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
   filterOutEmpty,
-  type GraphQLFilter,
   INITIAL_FETCH_KEY,
   toLocalId,
   useBAILogger,
@@ -66,7 +66,7 @@ const RBACManagementPage: React.FC = () => {
     {
       status: parseAsStringLiteral(statusFilterValues).withDefault('ACTIVE'),
       order: parseAsStringLiteral(availableRoleSorterValues),
-      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+      filter: parseAsJson<RoleFilter>((value) => value as RoleFilter),
     },
     {
       history: 'replace',
@@ -243,7 +243,7 @@ const RBACManagementPage: React.FC = () => {
                 { label: t('rbac.Inactive'), value: 'DELETED' },
               ]}
             />
-            <BAIGraphQLPropertyFilter
+            <BAIGraphQLPropertyFilter<RoleFilter>
               filterProperties={[
                 {
                   key: 'name',


### PR DESCRIPTION
Resolves #8092 (FR-3234)

> Stacked on #8090

## Summary

`BAIGraphQLPropertyFilter` returned a loose, index-typed `GraphQLFilter`, so consumers bridged it to the real schema filter inputs with `as` casts, `parseAsJson<GraphQLFilter>`, `useState<GraphQLFilter>`, manual `AND`/`OR` extraction, and a hand-written converter — because the schema filter inputs lacked `AND`/`OR`/`NOT`. The schema now adds `AND`/`OR`/`NOT` to those inputs, so we can type the filter end-to-end against the real schema type.

## Changes

- **Genericize** `BAIGraphQLPropertyFilter<TFilter extends GraphQLFilter = GraphQLFilter>` — `value`/`onChange`/`defaultValue` are now `TFilter`, with a single internal cast. The default type parameter keeps every existing consumer source-compatible.
- **Migrate 20 consumers** off the `GraphQLFilter` + `as` workarounds to the real schema filter type (typed URL parsers / local state, dropped redundant query-boundary casts, `<BAIGraphQLPropertyFilter<XFilter>>`):
  - Pages: `AdminDeploymentListPage`, `AdminDeploymentPresetListPage`, `AdminModelCardListPage`, `DeploymentListPage`, `ModelStoreListPageV2`, `ProjectAdminDataPage`, `ProjectAdminDeploymentsPage`, `ProjectAdminSessionPage`, `ProjectAdminUsersPage`, `RBACManagementPage`
  - Components: `AdminUserManagement`, `DeploymentAutoScalingCard`, `PrometheusPresetTab`, `ProjectStoragePermissionTable`, `RoleAssignmentTab`, `RolePermissionTab`, `RoleScopeTab`, `UserFolderPermissionPanelV2`
- **Remove workarounds**: deleted the hand-written `toAutoScalingRuleFilter` converter and the duplicated `AutoScalingRuleFilterInput` type (which mistyped `lastTriggeredAt` as `DateTimeFilter` instead of `NullableDateTimeFilter`) in favor of `AutoScalingRuleFilter`; retyped `ModelStoreListPageV2`'s name-keyword extractor to `ModelCardV2Filter`; fixed the now-false "no AND/OR combinators" comment in `BAIAvailablePresetSelect`.

The remaining `as` casts are only the inherent JSON-parse casts inside `parseAsJson<XFilter>((v) => v as XFilter)`, now typed to the real schema types.

## Schema

Includes `data/schema.graphql` (`AND`/`OR`/`NOT` added to filter inputs, "Added in 26.7.0") and the regenerated `__generated__` artifacts.

## Verification (`bash scripts/verify.sh`)

- **Lint · Format · TypeScript: PASS**
- Relay / Vite-warmup FAILs in local runs are unrelated: Relay flags the (committed here) regenerated artifacts as "drift" only when uncommitted; the warmup check is a pre-existing `vite.config.ts` false-positive untouched by this PR.

No runtime behavior change — pure typing refactor.