### PR TITLE
feat(FR-3237): confirm endpoint reachability before showing offline banner

### DIFF
--- a/react/src/components/NetworkStatusBanner.test.tsx
+++ b/react/src/components/NetworkStatusBanner.test.tsx
@@ -1,0 +1,151 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Tests for NetworkStatusBanner (FR-3237).
+ *
+ * The point of the PR is that `navigator.onLine` is only a heuristic and
+ * frequently a false positive (VPNs, captive portals, virtualized networks).
+ * So the offline banner must appear ONLY when the browser reports offline
+ * AND a `/health` probe confirms the endpoint is actually unreachable.
+ *
+ * These tests exercise that gating contract at the component level — the
+ * behavior a pure `isEndpointUnreachable` helper test could never cover:
+ *   - online              → no banner, no probe
+ *   - offline + reachable → no banner (the false-positive suppression)
+ *   - offline + unreachable (non-OK / thrown) → banner
+ *   - reconnect           → banner clears, no stale flash
+ */
+import NetworkStatusBanner from './NetworkStatusBanner';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useNetwork } from 'ahooks';
+import { Provider as JotaiProvider, createStore } from 'jotai';
+import {
+  type MockedFunction,
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// The banner only reads `_config.endpoint` off the client.
+vi.mock('../hooks', () => ({
+  useSuspendedBackendaiClient: () => ({
+    _config: { endpoint: 'https://api.test' },
+  }),
+}));
+
+// Keep the rest of ahooks (useDebounce) real; only `useNetwork` is driven.
+vi.mock('ahooks', async () => {
+  const actual = await vi.importActual<typeof import('ahooks')>('ahooks');
+  return { ...actual, useNetwork: vi.fn() };
+});
+
+// Deterministic translations: assert on the raw key.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockedUseNetwork = useNetwork as unknown as MockedFunction<
+  () => { online: boolean }
+>;
+
+const setBrowserOnline = (online: boolean) => {
+  mockedUseNetwork.mockReturnValue({ online });
+};
+
+const mockProbe = (result: Response | Error) => {
+  if (result instanceof Error) {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(result);
+  } else {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(result);
+  }
+};
+
+const renderBanner = () =>
+  render(
+    <JotaiProvider store={createStore()}>
+      <NetworkStatusBanner />
+    </JotaiProvider>,
+  );
+
+const OFFLINE_TEXT = 'webui.YouAreOffline';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe('NetworkStatusBanner offline gating', () => {
+  it('shows nothing and never probes while the browser is online', async () => {
+    setBrowserOnline(true);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    renderBanner();
+
+    expect(screen.queryByText(OFFLINE_TEXT)).not.toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows the offline banner when the browser is offline AND the probe is non-OK', async () => {
+    setBrowserOnline(false);
+    mockProbe(new Response(null, { status: 503 }));
+    renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByText(OFFLINE_TEXT)).toBeInTheDocument();
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://api.test/health',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('shows the offline banner when the probe throws (network / CORS / timeout)', async () => {
+    setBrowserOnline(false);
+    mockProbe(new TypeError('Failed to fetch'));
+    renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByText(OFFLINE_TEXT)).toBeInTheDocument();
+    });
+  });
+
+  it('suppresses the banner when the browser is offline but the endpoint is actually reachable (false positive)', async () => {
+    setBrowserOnline(false);
+    mockProbe(new Response(null, { status: 200 }));
+    renderBanner();
+
+    // Give the probe time to resolve; the banner must stay hidden.
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(OFFLINE_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('clears the banner and resets probe state when connectivity returns', async () => {
+    setBrowserOnline(false);
+    mockProbe(new Response(null, { status: 503 }));
+    const { rerender } = renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByText(OFFLINE_TEXT)).toBeInTheDocument();
+    });
+
+    setBrowserOnline(true);
+    rerender(
+      <JotaiProvider store={createStore()}>
+        <NetworkStatusBanner />
+      </JotaiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(OFFLINE_TEXT)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/react/src/components/NetworkStatusBanner.tsx
+++ b/react/src/components/NetworkStatusBanner.tsx
@@ -2,14 +2,18 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useDebounce, useNetwork } from 'ahooks';
 import { Alert } from 'antd';
 import { createStyles } from 'antd-style';
 import { atom, useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
+import { useEffect, useEffectEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const isDisplayedNetworkStatusState = atom(false);
+
+const REACHABILITY_PROBE_INTERVAL_MS = 5_000;
+const REACHABILITY_PROBE_TIMEOUT_MS = 5_000;
 
 const useStyles = createStyles(({ token, css }) => ({
   borderError: css`
@@ -24,12 +28,15 @@ const useStyles = createStyles(({ token, css }) => ({
   `,
 }));
 const NetworkStatusBanner = () => {
+  'use memo';
   const { t } = useTranslation();
   const network = useNetwork();
+  const client = useSuspendedBackendaiClient();
   const setDisplayedStatus = useSetAtom(isDisplayedNetworkStatusState);
   const { styles } = useStyles();
   const [showSoftTimeoutAlert, setShowSoftTimeoutAlert] = useState(false);
   const [dismissSoftTimeoutAlert, setDismissSoftTimeoutAlert] = useState(false);
+  const [endpointUnreachable, setEndpointUnreachable] = useState(false);
 
   useEffect(() => {
     const softHandler = () => {
@@ -62,7 +69,47 @@ const NetworkStatusBanner = () => {
     wait: 5_000,
   });
 
-  const shouldOpenOfflineAlert = !network.online;
+  const browserOffline = !network.online;
+
+  // `navigator.onLine` is only a heuristic (false positives on VPNs, captive
+  // portals, virtualized networks), so confirm with the endpoint's `/health`
+  // before concluding the user is offline.
+  const probeEndpointReachability = useEffectEvent(async () => {
+    try {
+      const resp = await fetch(`${client._config.endpoint}/health`, {
+        signal: AbortSignal.timeout(REACHABILITY_PROBE_TIMEOUT_MS),
+      });
+      return !resp.ok;
+    } catch {
+      return true;
+    }
+  });
+
+  useEffect(
+    function probeEndpointWhileBrowserOffline() {
+      if (!browserOffline) {
+        return;
+      }
+      let disposed = false;
+      const runProbe = async () => {
+        const unreachable = await probeEndpointReachability();
+        if (!disposed) {
+          setEndpointUnreachable(unreachable);
+        }
+      };
+      runProbe();
+      const intervalId = setInterval(runProbe, REACHABILITY_PROBE_INTERVAL_MS);
+      return function cleanupProbe() {
+        disposed = true;
+        clearInterval(intervalId);
+        // Reset so the next offline episode doesn't flash a stale failure.
+        setEndpointUnreachable(false);
+      };
+    },
+    [browserOffline],
+  );
+
+  const shouldOpenOfflineAlert = browserOffline && endpointUnreachable;
   const shouldOpenSoftAlert =
     !shouldOpenOfflineAlert && debouncedShowAlert && !dismissSoftTimeoutAlert;
 
@@ -85,9 +132,10 @@ const NetworkStatusBanner = () => {
           title={t('webui.NetworkSoftTimeout')}
           className={styles.borderWarning}
           banner
-          closable
-          onClose={() => {
-            setDismissSoftTimeoutAlert(true);
+          closable={{
+            onClose: () => {
+              setDismissSoftTimeoutAlert(true);
+            },
           }}
         />
       )}


### PR DESCRIPTION
Resolves #8096 (FR-3237)

## Problem

`NetworkStatusBanner` decided the "You are offline" banner **solely** from `navigator.onLine` (via ahooks `useNetwork`). `navigator.onLine` is only a heuristic — it is frequently a false positive on VPNs, captive portals, and virtualized networks — so the banner could appear even while the Backend.AI API endpoint was perfectly reachable.

## Solution

When the browser reports offline, confirm reachability with a **plain `fetch` to the endpoint's `/health`** before showing the banner:

- The probe runs from a `useEffect` + `useEffectEvent` while the browser reports offline: once immediately, then every 5s so the banner reflects current reachability. No Relay / react-query layer — the result is a transient local state flag with no caching value.
- The banner shows **only** when `navigator.onLine` is offline **AND** the `/health` probe fails (network error, timeout, or non-OK response). While the probe is in flight, the banner stays hidden.
- The probe is bounded to ~5s via `AbortSignal.timeout`, so a genuinely unreachable endpoint still surfaces the banner promptly.
- The effect cleanup drops in-flight probe results and resets the flag, so each offline episode starts with the banner hidden instead of flashing a stale failure from the previous episode.
- The endpoint URL comes from the authenticated global client (`useSuspendedBackendaiClient()` → `client._config.endpoint`), joined with the same `endpoint + path` convention the client itself uses.

Also migrated the soft-timeout `Alert`'s deprecated top-level `onClose` to the antd v6 `closable` object, and added the `'use memo'` directive to the component (React Compiler convention) since the file was being edited.

## Verification

`bash scripts/verify.sh` — Relay / Lint / Format / TypeScript all **PASS**. (The unrelated "Vite warmup paths" check fails identically on a clean `main` checkout — it validates build artifacts, not this change.)

## Test plan

**How to test**: turn off Wi-Fi (so the browser reports offline), then open DevTools → Network and confirm that requests to `/health` are being fired every ~5s — that is the reachability probe running.

- [ ] With a reachable endpoint, toggle the browser to "Offline" (DevTools Network → Offline, or `navigator.onLine` false): the offline banner should **not** appear because the `/health` probe succeeds.
- [ ] With the endpoint genuinely unreachable (stop the manager / block the host) and the browser offline: the banner appears within ~5s.
- [ ] Restore reachability while still offline: the banner clears on the next probe (~5s).
- [ ] Go back online and offline again: no stale banner flash at the start of the second offline episode.
- [ ] Soft-timeout warning alert still shows and is dismissable.
