### PR TITLE
fix(FR-3241): show empty state on diagnostics page when no failed items

### DIFF
--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -17,6 +17,7 @@ import {
 import {
   Collapse,
   Dropdown,
+  Empty,
   Skeleton,
   Switch,
   Typography,
@@ -261,10 +262,17 @@ const DiagnosticsPage = () => {
     >
       {curTabKey === 'diagnostics' && (
         <BAIFlex direction="column" align="stretch" gap="md">
-          <Collapse
-            defaultActiveKey={['csp', 'storage', 'endpoint', 'config']}
-            items={visibleItems}
-          />
+          {visibleItems.length === 0 ? (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={t('diagnostics.NoFailedItems')}
+            />
+          ) : (
+            <Collapse
+              defaultActiveKey={['csp', 'storage', 'endpoint', 'config']}
+              items={visibleItems}
+            />
+          )}
         </BAIFlex>
       )}
     </BAICard>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Überprüfen Sie den [plugin]-Abschnitt in config.toml und korrigieren Sie die ungültigen Plugin-Namen ({{count}} gefunden).",
     "MissingProxyUrl": "Proxy-URL nicht konfiguriert",
     "MissingProxyUrlDesc": "In config.toml ist kein wsproxy.proxyURL gesetzt. WebSocket-Proxy-Funktionen funktionieren möglicherweise nicht korrekt.",
+    "NoFailedItems": "Keine fehlgeschlagenen Elemente. Alle Diagnosen wurden bestanden.",
     "NoResultsToExport": "Keine Diagnoseergebnisse zum Exportieren verfügbar. Bitte warten Sie, bis die Diagnose abgeschlossen ist.",
     "PlaceholderValue": "Platzhalterwert nicht ersetzt",
     "PlaceholderValueDesc": "{{section}} {{field}} ist auf \"{{value}}\" gesetzt, was wie ein nicht ersetzter Platzhalter aus config.toml.sample aussieht.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Ελέγξτε την ενότητα [plugin] στο config.toml και διορθώστε τα μη έγκυρα ονόματα plugin (βρέθηκαν {{count}}).",
     "MissingProxyUrl": "Η διεύθυνση URL proxy δεν έχει ρυθμιστεί",
     "MissingProxyUrlDesc": "Δεν έχει οριστεί wsproxy.proxyURL στο config.toml. Οι λειτουργίες WebSocket proxy ενδέχεται να μην λειτουργούν σωστά.",
+    "NoFailedItems": "Δεν υπάρχουν αποτυχημένα στοιχεία. Όλα τα διαγνωστικά πέρασαν.",
     "NoResultsToExport": "Δεν υπάρχουν αποτελέσματα διαγνωστικών για εξαγωγή. Παρακαλώ περιμένετε να ολοκληρωθούν τα διαγνωστικά.",
     "PlaceholderValue": "Η τιμή placeholder δεν αντικαταστάθηκε",
     "PlaceholderValueDesc": "Το {{section}} {{field}} έχει οριστεί σε \"{{value}}\" που μοιάζει με μη αντικατεστημένο placeholder από το config.toml.sample.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1280,6 +1280,7 @@
     "InvalidPluginNamesFix": "Check the [plugin] section in config.toml and correct the invalid plugin names ({{count}} found).",
     "MissingProxyUrl": "Proxy URL Not Configured",
     "MissingProxyUrlDesc": "No wsproxy.proxyURL is set in config.toml. WebSocket proxy features may not work correctly.",
+    "NoFailedItems": "No failed items. All diagnostics passed.",
     "NoResultsToExport": "No diagnostics results available to export. Please wait for the diagnostics to complete.",
     "PlaceholderValue": "Placeholder Value Not Replaced",
     "PlaceholderValueDesc": "{{section}} {{field}} is set to \"{{value}}\" which looks like an unreplaced placeholder from config.toml.sample.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Verifique la sección [plugin] en config.toml y corrija los nombres de plugin no válidos ({{count}} encontrados).",
     "MissingProxyUrl": "URL de proxy no configurada",
     "MissingProxyUrlDesc": "No se ha establecido wsproxy.proxyURL en config.toml. Las funciones del proxy WebSocket pueden no funcionar correctamente.",
+    "NoFailedItems": "No hay elementos fallidos. Todos los diagnósticos se han superado.",
     "NoResultsToExport": "No hay resultados de diagnóstico para exportar. Espere a que se complete el diagnóstico.",
     "PlaceholderValue": "Valor de marcador de posición no reemplazado",
     "PlaceholderValueDesc": "{{section}} {{field}} está establecido en \"{{value}}\" que parece un marcador de posición no reemplazado de config.toml.sample.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Tarkista [plugin]-osio config.toml-tiedostossa ja korjaa virheelliset laajennusnimet (löytyi {{count}}).",
     "MissingProxyUrl": "Välityspalvelimen URL puuttuu",
     "MissingProxyUrlDesc": "config.toml-tiedostossa ei ole asetettu wsproxy.proxyURL-arvoa. WebSocket-välityspalvelimen ominaisuudet eivät välttämättä toimi oikein.",
+    "NoFailedItems": "Ei epäonnistuneita kohteita. Kaikki diagnostiikkatarkistukset läpäisivät.",
     "NoResultsToExport": "Ei vietäviä diagnostiikkatuloksia. Odota, kunnes diagnostiikka on valmis.",
     "PlaceholderValue": "Paikkamerkin arvoa ei korvattu",
     "PlaceholderValueDesc": "{{section}} {{field}} on asetettu arvoon \"{{value}}\", joka näyttää korvaamattomalta paikkamerkiltä tiedostosta config.toml.sample.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Vérifiez la section [plugin] dans config.toml et corrigez les noms de plugin non valides ({{count}} trouvé(s)).",
     "MissingProxyUrl": "URL de proxy non configurée",
     "MissingProxyUrlDesc": "Aucun wsproxy.proxyURL n'est défini dans config.toml. Les fonctionnalités du proxy WebSocket peuvent ne pas fonctionner correctement.",
+    "NoFailedItems": "Aucun élément en échec. Tous les diagnostics ont réussi.",
     "NoResultsToExport": "Aucun résultat de diagnostic à exporter. Veuillez attendre la fin du diagnostic.",
     "PlaceholderValue": "Valeur de substitution non remplacée",
     "PlaceholderValueDesc": "{{section}} {{field}} est défini sur \"{{value}}\" qui ressemble à une valeur de substitution non remplacée de config.toml.sample.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Periksa bagian [plugin] di config.toml dan perbaiki nama plugin yang tidak valid ({{count}} ditemukan).",
     "MissingProxyUrl": "URL Proksi Tidak Dikonfigurasi",
     "MissingProxyUrlDesc": "Tidak ada wsproxy.proxyURL yang diatur di config.toml. Fitur proksi WebSocket mungkin tidak berfungsi dengan benar.",
+    "NoFailedItems": "Tidak ada item yang gagal. Semua diagnostik berhasil.",
     "NoResultsToExport": "Tidak ada hasil diagnostik untuk diekspor. Harap tunggu hingga diagnostik selesai.",
     "PlaceholderValue": "Nilai Placeholder Tidak Diganti",
     "PlaceholderValueDesc": "{{section}} {{field}} diatur ke \"{{value}}\" yang terlihat seperti placeholder yang belum diganti dari config.toml.sample.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Controlla la sezione [plugin] in config.toml e correggi i nomi di plugin non validi ({{count}} trovati).",
     "MissingProxyUrl": "URL proxy non configurata",
     "MissingProxyUrlDesc": "Nessun wsproxy.proxyURL impostato in config.toml. Le funzionalità del proxy WebSocket potrebbero non funzionare correttamente.",
+    "NoFailedItems": "Nessun elemento non superato. Tutti i controlli diagnostici sono stati superati.",
     "NoResultsToExport": "Nessun risultato diagnostico disponibile per l'esportazione. Attendere il completamento della diagnostica.",
     "PlaceholderValue": "Valore segnaposto non sostituito",
     "PlaceholderValueDesc": "{{section}} {{field}} è impostato su \"{{value}}\" che sembra un segnaposto non sostituito da config.toml.sample.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1293,6 +1293,7 @@
     "InvalidPluginNamesFix": "config.tomlの[plugin]セクションを確認し、無効なプラグイン名を修正してください（{{count}}件検出）。",
     "MissingProxyUrl": "プロキシURLが未設定",
     "MissingProxyUrlDesc": "config.tomlにwsproxy.proxyURLが設定されていません。WebSocketプロキシ機能が正しく動作しない場合があります。",
+    "NoFailedItems": "失敗した項目はありません。すべての診断に合格しました。",
     "NoResultsToExport": "エクスポートできる診断結果がありません。診断が完了するまでお待ちください。",
     "PlaceholderValue": "プレースホルダー値が未置換",
     "PlaceholderValueDesc": "{{section}} {{field}} が \"{{value}}\" に設定されており、config.toml.sample の未置換プレースホルダーのようです。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1293,6 +1293,7 @@
     "InvalidPluginNamesFix": "config.toml의 [plugin] 섹션을 확인하고 유효하지 않은 플러그인 이름을 수정하세요({{count}}개 발견).",
     "MissingProxyUrl": "프록시 URL 미설정",
     "MissingProxyUrlDesc": "config.toml에 wsproxy.proxyURL이 설정되어 있지 않습니다. WebSocket 프록시 기능이 올바르게 작동하지 않을 수 있습니다.",
+    "NoFailedItems": "실패한 항목이 없습니다. 모든 진단을 통과했습니다.",
     "NoResultsToExport": "내보낼 진단 결과가 없습니다. 진단이 완료될 때까지 기다려 주세요.",
     "PlaceholderValue": "플레이스홀더 값이 대체되지 않음",
     "PlaceholderValueDesc": "{{section}} {{field}}이(가) \"{{value}}\"(으)로 설정되어 있으며, config.toml.sample의 대체되지 않은 플레이스홀더로 보입니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "config.toml дахь [plugin] хэсгийг шалгаж, буруу плагины нэрүүдийг засна уу ({{count}} олдсон).",
     "MissingProxyUrl": "Прокси URL тохируулагдаагүй",
     "MissingProxyUrlDesc": "config.toml дахь wsproxy.proxyURL тохируулагдаагүй байна. WebSocket прокси функцүүд зөв ажиллахгүй байж болзошгүй.",
+    "NoFailedItems": "Алдаатай зүйл алга. Бүх оношлогоо амжилттай өнгөрлөө.",
     "NoResultsToExport": "Экспортлох оношлогооны үр дүн байхгүй. Оношлогоо дуусахыг хүлээнэ үү.",
     "PlaceholderValue": "Орлуулагч утга солигдоогүй",
     "PlaceholderValueDesc": "{{section}} {{field}} нь \"{{value}}\" гэж тохируулагдсан бөгөөд config.toml.sample-ийн солигдоогүй орлуулагч утга шиг харагдаж байна.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Semak bahagian [plugin] dalam config.toml dan betulkan nama plugin yang tidak sah ({{count}} dijumpai).",
     "MissingProxyUrl": "URL Proksi Tidak Dikonfigurasi",
     "MissingProxyUrlDesc": "Tiada wsproxy.proxyURL ditetapkan dalam config.toml. Ciri proksi WebSocket mungkin tidak berfungsi dengan betul.",
+    "NoFailedItems": "Tiada item yang gagal. Semua diagnostik berjaya.",
     "NoResultsToExport": "Tiada keputusan diagnostik untuk dieksport. Sila tunggu sehingga diagnostik selesai.",
     "PlaceholderValue": "Nilai Pemegang Tempat Tidak Diganti",
     "PlaceholderValueDesc": "{{section}} {{field}} ditetapkan kepada \"{{value}}\" yang kelihatan seperti pemegang tempat yang belum diganti daripada config.toml.sample.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Sprawdź sekcję [plugin] w pliku config.toml i popraw nieprawidłowe nazwy wtyczek (znaleziono {{count}}).",
     "MissingProxyUrl": "Adres URL serwera proxy nie jest skonfigurowany",
     "MissingProxyUrlDesc": "W pliku config.toml nie ustawiono wsproxy.proxyURL. Funkcje serwera proxy WebSocket mogą nie działać poprawnie.",
+    "NoFailedItems": "Brak elementów z błędami. Wszystkie diagnostyki zakończyły się pomyślnie.",
     "NoResultsToExport": "Brak wyników diagnostyki do eksportu. Poczekaj na zakończenie diagnostyki.",
     "PlaceholderValue": "Wartość zastępcza nie została zastąpiona",
     "PlaceholderValueDesc": "{{section}} {{field}} jest ustawione na \"{{value}}\", co wygląda na niezastąpioną wartość zastępczą z config.toml.sample.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Verifique a seção [plugin] no config.toml e corrija os nomes de plugin inválidos ({{count}} encontrados).",
     "MissingProxyUrl": "URL do proxy não configurada",
     "MissingProxyUrlDesc": "Nenhum wsproxy.proxyURL está definido no config.toml. Os recursos do proxy WebSocket podem não funcionar corretamente.",
+    "NoFailedItems": "Nenhum item com falha. Todos os diagnósticos foram aprovados.",
     "NoResultsToExport": "Nenhum resultado de diagnóstico disponível para exportação. Aguarde a conclusão do diagnóstico.",
     "PlaceholderValue": "Valor de espaço reservado não substituído",
     "PlaceholderValueDesc": "{{section}} {{field}} está definido como \"{{value}}\" que parece um espaço reservado não substituído de config.toml.sample.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Verifique a secção [plugin] no config.toml e corrija os nomes de plugin inválidos ({{count}} encontrados).",
     "MissingProxyUrl": "URL do proxy não configurado",
     "MissingProxyUrlDesc": "Nenhum wsproxy.proxyURL está definido no config.toml. As funcionalidades do proxy WebSocket podem não funcionar corretamente.",
+    "NoFailedItems": "Nenhum item com falha. Todos os diagnósticos foram aprovados.",
     "NoResultsToExport": "Nenhum resultado de diagnóstico disponível para exportação. Aguarde a conclusão do diagnóstico.",
     "PlaceholderValue": "Valor de marcador de posição não substituído",
     "PlaceholderValueDesc": "{{section}} {{field}} está definido como \"{{value}}\" que parece um marcador de posição não substituído de config.toml.sample.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Проверьте раздел [plugin] в config.toml и исправьте недействительные имена плагинов (найдено {{count}}).",
     "MissingProxyUrl": "URL-адрес прокси не настроен",
     "MissingProxyUrlDesc": "В config.toml не установлен wsproxy.proxyURL. Функции WebSocket-прокси могут работать некорректно.",
+    "NoFailedItems": "Нет элементов с ошибками. Все диагностические проверки пройдены.",
     "NoResultsToExport": "Нет доступных результатов диагностики для экспорта. Пожалуйста, дождитесь завершения диагностики.",
     "PlaceholderValue": "Значение-заполнитель не заменено",
     "PlaceholderValueDesc": "{{section}} {{field}} установлено в \"{{value}}\", что выглядит как незаменённый заполнитель из config.toml.sample.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1293,6 +1293,7 @@
     "InvalidPluginNamesFix": "ตรวจสอบส่วน [plugin] ใน config.toml และแก้ไขชื่อปลั๊กอินที่ไม่ถูกต้อง (พบ {{count}} รายการ)",
     "MissingProxyUrl": "URL พร็อกซีไม่ได้กำหนดค่า",
     "MissingProxyUrlDesc": "ไม่ได้ตั้งค่า wsproxy.proxyURL ใน config.toml คุณลักษณะ WebSocket พร็อกซีอาจทำงานไม่ถูกต้อง",
+    "NoFailedItems": "ไม่มีรายการที่ล้มเหลว การวินิจฉัยทั้งหมดผ่านแล้ว",
     "NoResultsToExport": "ไม่มีผลการวินิจฉัยสำหรับส่งออก กรุณารอให้การวินิจฉัยเสร็จสิ้น",
     "PlaceholderValue": "ค่าตัวแทนที่ยังไม่ถูกแทนที่",
     "PlaceholderValueDesc": "{{section}} {{field}} ถูกตั้งค่าเป็น \"{{value}}\" ซึ่งดูเหมือนตัวแทนที่ยังไม่ถูกแทนที่จาก config.toml.sample",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "config.toml dosyasındaki [plugin] bölümünü kontrol edin ve geçersiz eklenti adlarını düzeltin ({{count}} adet bulundu).",
     "MissingProxyUrl": "Proxy URL'si Yapılandırılmamış",
     "MissingProxyUrlDesc": "config.toml dosyasında wsproxy.proxyURL ayarlanmamış. WebSocket proxy özellikleri düzgün çalışmayabilir.",
+    "NoFailedItems": "Başarısız öğe yok. Tüm tanılamalar başarıyla geçti.",
     "NoResultsToExport": "Dışa aktarılacak tanılama sonucu yok. Lütfen tanılamanın tamamlanmasını bekleyin.",
     "PlaceholderValue": "Yer Tutucu Değer Değiştirilmedi",
     "PlaceholderValueDesc": "{{section}} {{field}}, config.toml.sample dosyasından değiştirilmemiş bir yer tutucu gibi görünen \"{{value}}\" olarak ayarlanmış.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "Kiểm tra phần [plugin] trong config.toml và sửa các tên plugin không hợp lệ (tìm thấy {{count}}).",
     "MissingProxyUrl": "URL Proxy chưa được cấu hình",
     "MissingProxyUrlDesc": "Không có wsproxy.proxyURL được đặt trong config.toml. Các tính năng WebSocket proxy có thể không hoạt động đúng.",
+    "NoFailedItems": "Không có mục lỗi nào. Tất cả chẩn đoán đều đạt.",
     "NoResultsToExport": "Không có kết quả chẩn đoán để xuất. Vui lòng đợi chẩn đoán hoàn tất.",
     "PlaceholderValue": "Giá trị giữ chỗ chưa được thay thế",
     "PlaceholderValueDesc": "{{section}} {{field}} được đặt thành \"{{value}}\" trông giống như một giá trị giữ chỗ chưa được thay thế từ config.toml.sample.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1291,6 +1291,7 @@
     "InvalidPluginNamesFix": "检查 config.toml 中的 [plugin] 部分，修正无效的插件名称（发现 {{count}} 个）。",
     "MissingProxyUrl": "代理 URL 未配置",
     "MissingProxyUrlDesc": "config.toml 中未设置 wsproxy.proxyURL。WebSocket 代理功能可能无法正常工作。",
+    "NoFailedItems": "没有失败项。所有诊断均已通过。",
     "NoResultsToExport": "没有可导出的诊断结果。请等待诊断完成。",
     "PlaceholderValue": "占位符值未替换",
     "PlaceholderValueDesc": "{{section}} {{field}} 设置为 \"{{value}}\"，看起来像是来自 config.toml.sample 的未替换占位符。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1292,6 +1292,7 @@
     "InvalidPluginNamesFix": "檢查 config.toml 中的 [plugin] 部分，修正無效的外掛程式名稱（發現 {{count}} 個）。",
     "MissingProxyUrl": "代理 URL 未配置",
     "MissingProxyUrlDesc": "config.toml 中未設定 wsproxy.proxyURL。WebSocket 代理功能可能無法正常運作。",
+    "NoFailedItems": "沒有失敗項目。所有診斷均已通過。",
     "NoResultsToExport": "沒有可匯出的診斷結果。請等待診斷完成。",
     "PlaceholderValue": "佔位符值未替換",
     "PlaceholderValueDesc": "{{section}} {{field}} 設定為 \"{{value}}\"，看起來像是來自 config.toml.sample 的未替換佔位符。",


### PR DESCRIPTION
Resolves #8106 (FR-3241)

## Problem

On the Diagnostics page, when the **Show only failed items** toggle is enabled and every diagnostic section passes (no failed items), the card body renders empty — a blank area below the header with no feedback. This looks broken.

## Cause

In `react/src/pages/DiagnosticsPage.tsx`, when `showOnlyFailed` is on the visible sections are filtered to those with issues. When none have issues, the resulting list is empty and the `Collapse` renders nothing, leaving the card body blank.

## Fix

Render an `Empty` placeholder (`No failed items. All diagnostics passed.`) when the filtered section list is empty, instead of an empty `Collapse`.

- `react/src/pages/DiagnosticsPage.tsx` — conditional `Empty` state when `visibleItems.length === 0`.
- `resources/i18n/*.json` — new `diagnostics.NoFailedItems` key across all 21 languages.

## Screenshots

| Before (blank body) | After (empty state) |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8107/20260702-054013-before-blank.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8107/20260702-054019-after-empty-state.png) |

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript).
