### PR TITLE
feat(FR-3240): make all UpdateResourceGroupInput fields editable in resource group modal

### DIFF
--- a/react/src/__generated__/ResourceGroupSettingModalCreateMutation.graphql.ts
+++ b/react/src/__generated__/ResourceGroupSettingModalCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0f5483ae64b5020bfef3f29b675d0f26>>
+ * @generated SignedSource<<f035d9ec2ae1741e36650893fb4a43fa>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,26 +9,20 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type CreateScalingGroupInput = {
+export type CreateResourceGroupInput = {
   description?: string | null | undefined;
-  driver: string;
-  driver_opts?: string | null | undefined;
-  is_active?: boolean | null | undefined;
-  is_public?: boolean | null | undefined;
-  scheduler: string;
-  scheduler_opts?: string | null | undefined;
-  use_host_network?: boolean | null | undefined;
-  wsproxy_addr?: string | null | undefined;
-  wsproxy_api_token?: string | null | undefined;
-};
-export type ResourceGroupSettingModalCreateMutation$variables = {
-  input: CreateScalingGroupInput;
+  domainName: string;
   name: string;
 };
+export type ResourceGroupSettingModalCreateMutation$variables = {
+  input: CreateResourceGroupInput;
+};
 export type ResourceGroupSettingModalCreateMutation$data = {
-  readonly create_scaling_group: {
-    readonly msg: string | null | undefined;
-    readonly ok: boolean | null | undefined;
+  readonly adminCreateResourceGroupV2: {
+    readonly resourceGroup: {
+      readonly id: string;
+      readonly name: string;
+    };
   } | null | undefined;
 };
 export type ResourceGroupSettingModalCreateMutation = {
@@ -37,48 +31,51 @@ export type ResourceGroupSettingModalCreateMutation = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "input"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "name"
-},
-v2 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
   {
     "alias": null,
     "args": [
       {
         "kind": "Variable",
-        "name": "name",
-        "variableName": "name"
-      },
-      {
-        "kind": "Variable",
-        "name": "props",
+        "name": "input",
         "variableName": "input"
       }
     ],
-    "concreteType": "CreateScalingGroup",
+    "concreteType": "CreateResourceGroupPayload",
     "kind": "LinkedField",
-    "name": "create_scaling_group",
+    "name": "adminCreateResourceGroupV2",
     "plural": false,
     "selections": [
       {
         "alias": null,
         "args": null,
-        "kind": "ScalarField",
-        "name": "ok",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "msg",
+        "concreteType": "ResourceGroup",
+        "kind": "LinkedField",
+        "name": "resourceGroup",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          }
+        ],
         "storageKey": null
       }
     ],
@@ -87,38 +84,32 @@ v2 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ResourceGroupSettingModalCreateMutation",
-    "selections": (v2/*: any*/),
+    "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "ResourceGroupSettingModalCreateMutation",
-    "selections": (v2/*: any*/)
+    "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "6d6716d2dedf664e623006a2315b3c66",
+    "cacheID": "7416c1829a2bb249f57f482d08ecc86e",
     "id": null,
     "metadata": {},
     "name": "ResourceGroupSettingModalCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation ResourceGroupSettingModalCreateMutation(\n  $name: String!\n  $input: CreateScalingGroupInput!\n) {\n  create_scaling_group(name: $name, props: $input) {\n    ok\n    msg\n  }\n}\n"
+    "text": "mutation ResourceGroupSettingModalCreateMutation(\n  $input: CreateResourceGroupInput!\n) {\n  adminCreateResourceGroupV2(input: $input) {\n    resourceGroup {\n      id\n      name\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "8642e40e794eaf1f4b0a84e05104d75c";
+(node as any).hash = "2b386f97e3f2956953a62f7b418d7e7c";
 
 export default node;

--- a/react/src/__generated__/ResourceGroupSettingModalLegacyCreateMutation.graphql.ts
+++ b/react/src/__generated__/ResourceGroupSettingModalLegacyCreateMutation.graphql.ts
@@ -1,0 +1,124 @@
+/**
+ * @generated SignedSource<<4f7e5919a441b2af68c91d3f83f915ac>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateScalingGroupInput = {
+  description?: string | null | undefined;
+  driver: string;
+  driver_opts?: string | null | undefined;
+  is_active?: boolean | null | undefined;
+  is_public?: boolean | null | undefined;
+  scheduler: string;
+  scheduler_opts?: string | null | undefined;
+  use_host_network?: boolean | null | undefined;
+  wsproxy_addr?: string | null | undefined;
+  wsproxy_api_token?: string | null | undefined;
+};
+export type ResourceGroupSettingModalLegacyCreateMutation$variables = {
+  input: CreateScalingGroupInput;
+  name: string;
+};
+export type ResourceGroupSettingModalLegacyCreateMutation$data = {
+  readonly create_scaling_group: {
+    readonly msg: string | null | undefined;
+    readonly ok: boolean | null | undefined;
+  } | null | undefined;
+};
+export type ResourceGroupSettingModalLegacyCreateMutation = {
+  response: ResourceGroupSettingModalLegacyCreateMutation$data;
+  variables: ResourceGroupSettingModalLegacyCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "name"
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      },
+      {
+        "kind": "Variable",
+        "name": "props",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "CreateScalingGroup",
+    "kind": "LinkedField",
+    "name": "create_scaling_group",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "ok",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "msg",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResourceGroupSettingModalLegacyCreateMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ResourceGroupSettingModalLegacyCreateMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "3dae9ff6be2c668c721fbda05b8b9c4b",
+    "id": null,
+    "metadata": {},
+    "name": "ResourceGroupSettingModalLegacyCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation ResourceGroupSettingModalLegacyCreateMutation(\n  $name: String!\n  $input: CreateScalingGroupInput!\n) {\n  create_scaling_group(name: $name, props: $input) {\n    ok\n    msg\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "bc1aaeac33d28226ab7fc021d66eb360";
+
+export default node;

--- a/react/src/__generated__/ResourceGroupSettingModalLegacyModifyMutation.graphql.ts
+++ b/react/src/__generated__/ResourceGroupSettingModalLegacyModifyMutation.graphql.ts
@@ -1,0 +1,124 @@
+/**
+ * @generated SignedSource<<cf553751d82dafbd3839b8736fd0b6b5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ModifyScalingGroupInput = {
+  description?: string | null | undefined;
+  driver?: string | null | undefined;
+  driver_opts?: string | null | undefined;
+  is_active?: boolean | null | undefined;
+  is_public?: boolean | null | undefined;
+  scheduler?: string | null | undefined;
+  scheduler_opts?: string | null | undefined;
+  use_host_network?: boolean | null | undefined;
+  wsproxy_addr?: string | null | undefined;
+  wsproxy_api_token?: string | null | undefined;
+};
+export type ResourceGroupSettingModalLegacyModifyMutation$variables = {
+  input: ModifyScalingGroupInput;
+  name: string;
+};
+export type ResourceGroupSettingModalLegacyModifyMutation$data = {
+  readonly modify_scaling_group: {
+    readonly msg: string | null | undefined;
+    readonly ok: boolean | null | undefined;
+  } | null | undefined;
+};
+export type ResourceGroupSettingModalLegacyModifyMutation = {
+  response: ResourceGroupSettingModalLegacyModifyMutation$data;
+  variables: ResourceGroupSettingModalLegacyModifyMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "name"
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      },
+      {
+        "kind": "Variable",
+        "name": "props",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "ModifyScalingGroup",
+    "kind": "LinkedField",
+    "name": "modify_scaling_group",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "ok",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "msg",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResourceGroupSettingModalLegacyModifyMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ResourceGroupSettingModalLegacyModifyMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "dbd797bca3121138258bbe9495e4c10c",
+    "id": null,
+    "metadata": {},
+    "name": "ResourceGroupSettingModalLegacyModifyMutation",
+    "operationKind": "mutation",
+    "text": "mutation ResourceGroupSettingModalLegacyModifyMutation(\n  $name: String!\n  $input: ModifyScalingGroupInput!\n) {\n  modify_scaling_group(name: $name, props: $input) {\n    ok\n    msg\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "5b812b6f8907bc4131f55b8098277952";
+
+export default node;

--- a/react/src/__generated__/ResourceGroupSettingModalPrefillQuery.graphql.ts
+++ b/react/src/__generated__/ResourceGroupSettingModalPrefillQuery.graphql.ts
@@ -1,0 +1,187 @@
+/**
+ * @generated SignedSource<<f0bdeadc1976c76006b384777aa4fdf7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type PreemptionMode = "RESCHEDULE" | "TERMINATE" | "%future added value";
+export type PreemptionOrder = "NEWEST" | "OLDEST" | "%future added value";
+export type ResourceGroupSettingModalPrefillQuery$variables = {
+  name: string;
+};
+export type ResourceGroupSettingModalPrefillQuery$data = {
+  readonly resourceGroup: {
+    readonly name: string;
+    readonly network: {
+      readonly useHostNetwork: boolean;
+    };
+    readonly scheduler: {
+      readonly preemption: {
+        readonly mode: PreemptionMode;
+        readonly order: PreemptionOrder;
+        readonly preemptiblePriority: number;
+      };
+    };
+  } | null | undefined;
+};
+export type ResourceGroupSettingModalPrefillQuery = {
+  response: ResourceGroupSettingModalPrefillQuery$data;
+  variables: ResourceGroupSettingModalPrefillQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "name",
+    "variableName": "name"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ResourceGroupNetworkConfig",
+  "kind": "LinkedField",
+  "name": "network",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "useHostNetwork",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ResourceGroupSchedulerConfig",
+  "kind": "LinkedField",
+  "name": "scheduler",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "PreemptionConfig",
+      "kind": "LinkedField",
+      "name": "preemption",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "preemptiblePriority",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "order",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "mode",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ResourceGroupSettingModalPrefillQuery",
+    "selections": [
+      {
+        "alias": "resourceGroup",
+        "args": (v1/*: any*/),
+        "concreteType": "ResourceGroup",
+        "kind": "LinkedField",
+        "name": "adminResourceGroupV2",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ResourceGroupSettingModalPrefillQuery",
+    "selections": [
+      {
+        "alias": "resourceGroup",
+        "args": (v1/*: any*/),
+        "concreteType": "ResourceGroup",
+        "kind": "LinkedField",
+        "name": "adminResourceGroupV2",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6903dc82a17bdb4558d3b94fc54223e7",
+    "id": null,
+    "metadata": {},
+    "name": "ResourceGroupSettingModalPrefillQuery",
+    "operationKind": "query",
+    "text": "query ResourceGroupSettingModalPrefillQuery(\n  $name: String!\n) {\n  resourceGroup: adminResourceGroupV2(name: $name) {\n    name\n    network {\n      useHostNetwork\n    }\n    scheduler {\n      preemption {\n        preemptiblePriority\n        order\n        mode\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "070f50906c9db3d19217beafc468d9eb";
+
+export default node;

--- a/react/src/__generated__/ResourceGroupSettingModalUpdateMutation.graphql.ts
+++ b/react/src/__generated__/ResourceGroupSettingModalUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a1b15378714e12950a4b3f283d94b043>>
+ * @generated SignedSource<<07bef5e55ad6186f50be9179ab8d3087>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,26 +9,53 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type ModifyScalingGroupInput = {
+export type PreemptionMode = "RESCHEDULE" | "TERMINATE" | "%future added value";
+export type PreemptionOrder = "NEWEST" | "OLDEST" | "%future added value";
+export type SchedulerType = "DRF" | "FAIR_SHARE" | "FIFO" | "LIFO" | "%future added value";
+export type UpdateResourceGroupInput = {
+  appProxyAddr?: string | null | undefined;
+  appproxyApiToken?: string | null | undefined;
   description?: string | null | undefined;
-  driver?: string | null | undefined;
-  driver_opts?: string | null | undefined;
-  is_active?: boolean | null | undefined;
-  is_public?: boolean | null | undefined;
-  scheduler?: string | null | undefined;
-  scheduler_opts?: string | null | undefined;
-  use_host_network?: boolean | null | undefined;
-  wsproxy_addr?: string | null | undefined;
-  wsproxy_api_token?: string | null | undefined;
+  isActive?: boolean | null | undefined;
+  isPublic?: boolean | null | undefined;
+  preemption?: PreemptionConfigInput | null | undefined;
+  resourceGroupName: string;
+  schedulerType?: SchedulerType | null | undefined;
+  useHostNetwork?: boolean | null | undefined;
+};
+export type PreemptionConfigInput = {
+  mode?: PreemptionMode;
+  order?: PreemptionOrder;
+  preemptiblePriority?: number;
 };
 export type ResourceGroupSettingModalUpdateMutation$variables = {
-  input: ModifyScalingGroupInput;
-  name: string;
+  input: UpdateResourceGroupInput;
 };
 export type ResourceGroupSettingModalUpdateMutation$data = {
-  readonly modify_scaling_group: {
-    readonly msg: string | null | undefined;
-    readonly ok: boolean | null | undefined;
+  readonly adminUpdateResourceGroup: {
+    readonly resourceGroup: {
+      readonly id: string;
+      readonly metadata: {
+        readonly description: string | null | undefined;
+      };
+      readonly name: string;
+      readonly network: {
+        readonly useHostNetwork: boolean;
+        readonly wsproxyAddr: string | null | undefined;
+      };
+      readonly scheduler: {
+        readonly preemption: {
+          readonly mode: PreemptionMode;
+          readonly order: PreemptionOrder;
+          readonly preemptiblePriority: number;
+        };
+        readonly type: SchedulerType;
+      };
+      readonly status: {
+        readonly isActive: boolean;
+        readonly isPublic: boolean;
+      };
+    };
   } | null | undefined;
 };
 export type ResourceGroupSettingModalUpdateMutation = {
@@ -37,48 +64,169 @@ export type ResourceGroupSettingModalUpdateMutation = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "input"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "name"
-},
-v2 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
   {
     "alias": null,
     "args": [
       {
         "kind": "Variable",
-        "name": "name",
-        "variableName": "name"
-      },
-      {
-        "kind": "Variable",
-        "name": "props",
+        "name": "input",
         "variableName": "input"
       }
     ],
-    "concreteType": "ModifyScalingGroup",
+    "concreteType": "UpdateResourceGroupPayload",
     "kind": "LinkedField",
-    "name": "modify_scaling_group",
+    "name": "adminUpdateResourceGroup",
     "plural": false,
     "selections": [
       {
         "alias": null,
         "args": null,
-        "kind": "ScalarField",
-        "name": "ok",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "msg",
+        "concreteType": "ResourceGroup",
+        "kind": "LinkedField",
+        "name": "resourceGroup",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ResourceGroupStatus",
+            "kind": "LinkedField",
+            "name": "status",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isActive",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isPublic",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ResourceGroupMetadata",
+            "kind": "LinkedField",
+            "name": "metadata",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "description",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ResourceGroupNetworkConfig",
+            "kind": "LinkedField",
+            "name": "network",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "wsproxyAddr",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "useHostNetwork",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ResourceGroupSchedulerConfig",
+            "kind": "LinkedField",
+            "name": "scheduler",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "type",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PreemptionConfig",
+                "kind": "LinkedField",
+                "name": "preemption",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "preemptiblePriority",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "order",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "mode",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
         "storageKey": null
       }
     ],
@@ -87,38 +235,32 @@ v2 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ResourceGroupSettingModalUpdateMutation",
-    "selections": (v2/*: any*/),
+    "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "ResourceGroupSettingModalUpdateMutation",
-    "selections": (v2/*: any*/)
+    "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "2352dc03b1acef2df9cf7c5f686665a3",
+    "cacheID": "3c5eefa39e52e0b55040d1fc59bac9cb",
     "id": null,
     "metadata": {},
     "name": "ResourceGroupSettingModalUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation ResourceGroupSettingModalUpdateMutation(\n  $name: String!\n  $input: ModifyScalingGroupInput!\n) {\n  modify_scaling_group(name: $name, props: $input) {\n    ok\n    msg\n  }\n}\n"
+    "text": "mutation ResourceGroupSettingModalUpdateMutation(\n  $input: UpdateResourceGroupInput!\n) {\n  adminUpdateResourceGroup(input: $input) {\n    resourceGroup {\n      id\n      name\n      status {\n        isActive\n        isPublic\n      }\n      metadata {\n        description\n      }\n      network {\n        wsproxyAddr\n        useHostNetwork\n      }\n      scheduler {\n        type\n        preemption {\n          preemptiblePriority\n          order\n          mode\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "510c22b428b17c9e16efd58a5f908c3d";
+(node as any).hash = "92f8f3a06fae49a526a2ad73f15ca551";
 
 export default node;

--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -5,9 +5,17 @@
 import { ResourceGroupSettingModalAssociateDomainMutation } from '../__generated__/ResourceGroupSettingModalAssociateDomainMutation.graphql';
 import { ResourceGroupSettingModalCreateMutation } from '../__generated__/ResourceGroupSettingModalCreateMutation.graphql';
 import { ResourceGroupSettingModalFragment$key } from '../__generated__/ResourceGroupSettingModalFragment.graphql';
-import { ResourceGroupSettingModalUpdateMutation } from '../__generated__/ResourceGroupSettingModalUpdateMutation.graphql';
+import { ResourceGroupSettingModalLegacyCreateMutation } from '../__generated__/ResourceGroupSettingModalLegacyCreateMutation.graphql';
+import { ResourceGroupSettingModalLegacyModifyMutation } from '../__generated__/ResourceGroupSettingModalLegacyModifyMutation.graphql';
+import { ResourceGroupSettingModalPrefillQuery } from '../__generated__/ResourceGroupSettingModalPrefillQuery.graphql';
+import {
+  ResourceGroupSettingModalUpdateMutation,
+  SchedulerType,
+  PreemptionOrder,
+  PreemptionMode,
+} from '../__generated__/ResourceGroupSettingModalUpdateMutation.graphql';
 import { newLineToBrElement } from '../helper';
-import { useCurrentDomainValue } from '../hooks';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
 import { ScalingGroupOpts } from './ResourceGroupList';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import {
@@ -35,7 +43,31 @@ import {
 import * as _ from 'lodash-es';
 import { Suspense, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useFragment, useMutation } from 'react-relay';
+import {
+  graphql,
+  useFragment,
+  useLazyLoadQuery,
+  useMutation,
+} from 'react-relay';
+
+// Manager version that exposes the Strawberry `adminCreateResourceGroupV2`
+// mutation (added in 26.4.2) and, transitively, the preemption configuration
+// (added in 26.3.0). Gating the whole new mutation path on 26.4.2 keeps the
+// create/update/preemption features consistent behind a single check.
+const STRAWBERRY_RESOURCE_GROUP_MIN_VERSION = '26.4.2';
+
+const SCHEDULER_TYPE_MAP: Record<string, SchedulerType> = {
+  fifo: 'FIFO',
+  lifo: 'LIFO',
+  drf: 'DRF',
+  'fair-share': 'FAIR_SHARE',
+};
+
+type PreemptionFormValue = {
+  preemptiblePriority: number;
+  order: PreemptionOrder;
+  mode: PreemptionMode;
+};
 
 type FormInputType = {
   name: string;
@@ -49,6 +81,328 @@ type FormInputType = {
   scheduler: string;
   pendingTimeout: number;
   retriesToSkip: number;
+  useHostNetwork?: boolean;
+  preemption?: PreemptionFormValue;
+};
+
+interface ResourceGroupSettingFormProps {
+  formRef: React.RefObject<FormInstance | null>;
+  initialValues: Record<string, unknown>;
+  isEditing: boolean;
+  isStrawberrySupported: boolean;
+}
+
+/**
+ * Renders the resource group form fields. Kept as a standalone component so it
+ * can be mounted either directly (create mode / legacy managers) or wrapped by
+ * the Strawberry prefill loader (edit mode on 26.4.2+).
+ */
+const ResourceGroupSettingForm: React.FC<ResourceGroupSettingFormProps> = ({
+  formRef,
+  initialValues,
+  isEditing,
+  isStrawberrySupported,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  return (
+    <Form ref={formRef} initialValues={initialValues} layout="vertical">
+      <Form.Item
+        label={t('resourceGroup.Name')}
+        name="name"
+        rules={[
+          {
+            required: true,
+            message: t('general.ValueRequired', {
+              name: t('resourceGroup.Name'),
+            }),
+          },
+        ]}
+      >
+        <Input disabled={isEditing} />
+      </Form.Item>
+      {!isEditing ? (
+        <Form.Item
+          label={t('resourceGroup.Domain')}
+          name="domain"
+          rules={[
+            {
+              required: true,
+              message: t('general.ValueRequired', {
+                name: t('resourceGroup.Domain'),
+              }),
+            },
+          ]}
+        >
+          <BAIDomainSelect />
+        </Form.Item>
+      ) : null}
+      <Form.Item label={t('resourceGroup.Description')} name="description">
+        <Input.TextArea />
+      </Form.Item>
+      <Form.Item
+        label={t('resourceGroup.AllowedSessionTypes')}
+        name="allowedSessionTypes"
+        rules={[
+          {
+            required: true,
+            message: t('general.ValueRequired', {
+              name: t('resourceGroup.AllowedSessionTypes'),
+            }),
+          },
+        ]}
+      >
+        <Select
+          mode="multiple"
+          options={[
+            { label: 'Batch', value: 'batch' },
+            { label: 'Interactive', value: 'interactive' },
+            { label: 'Inference', value: 'inference' },
+            { label: 'System', value: 'system' },
+          ]}
+        />
+      </Form.Item>
+      <Form.Item
+        label={t('resourceGroup.AppProxyAddress')}
+        name="wsProxyAddress"
+        rules={[{ type: 'url', message: t('error.InvalidUrl') }]}
+      >
+        <Input placeholder="http://localhost:10200" />
+      </Form.Item>
+      <Form.Item
+        label={t('resourceGroup.AppProxyAPIToken')}
+        name="wsProxyAPIToken"
+      >
+        <Input.Password placeholder={t('resourceGroup.EnterAPIToken')} />
+      </Form.Item>
+      <Row>
+        <Col span={12}>
+          <Form.Item
+            layout="horizontal"
+            label={t('resourceGroup.Active')}
+            name="active"
+          >
+            <Switch />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            layout="horizontal"
+            label={t('resourceGroup.Public')}
+            name="public"
+          >
+            <Switch />
+          </Form.Item>
+        </Col>
+      </Row>
+      {isStrawberrySupported ? (
+        <Form.Item
+          layout="horizontal"
+          label={
+            <BAIFlex gap="xxs">
+              {t('resourceGroup.UseHostNetwork')}
+              <Tooltip
+                title={newLineToBrElement(
+                  t('resourceGroup.UseHostNetworkDesc'),
+                )}
+              >
+                <QuestionCircleOutlined
+                  style={{ color: token.colorTextSecondary }}
+                />
+              </Tooltip>
+            </BAIFlex>
+          }
+          name="useHostNetwork"
+        >
+          <Switch />
+        </Form.Item>
+      ) : null}
+      <Form.Item
+        label={t('resourceGroup.Scheduler')}
+        name="scheduler"
+        rules={[
+          {
+            required: true,
+            message: t('general.ValueRequired', {
+              name: t('resourceGroup.Scheduler'),
+            }),
+          },
+        ]}
+      >
+        <Select
+          options={[
+            {
+              label: 'FIFO',
+              value: 'fifo',
+            },
+            {
+              label: 'LIFO',
+              value: 'lifo',
+            },
+            {
+              label: 'DRF',
+              value: 'drf',
+            },
+            {
+              label: 'Fair Share',
+              value: 'fair-share',
+            },
+          ]}
+        />
+      </Form.Item>
+      <Form.Item label={t('resourceGroup.SchedulerOptions')}>
+        <BAICard styles={{ body: { paddingTop: 0, paddingBottom: 0 } }}>
+          <Form.Item
+            label={
+              <BAIFlex gap="xxs">
+                {t('resourceGroup.PendingTimeout')}
+                <Tooltip
+                  title={newLineToBrElement(
+                    t('resourceGroup.PendingTimeoutDesc'),
+                  )}
+                >
+                  <QuestionCircleOutlined
+                    style={{ color: token.colorTextSecondary }}
+                  />
+                </Tooltip>
+              </BAIFlex>
+            }
+            name="pendingTimeout"
+          >
+            <InputNumber
+              style={{ width: '100%' }}
+              suffix={t('resourceGroup.TimeoutSeconds')}
+              min={0}
+            />
+          </Form.Item>
+          <Form.Item
+            label={
+              <BAIFlex style={{ whiteSpace: 'pre' }}>
+                {t('resourceGroup.RetriesToSkipDesc')}
+              </BAIFlex>
+            }
+            name="retriesToSkip"
+          >
+            <InputNumber
+              style={{ width: '100%' }}
+              suffix={t('resourceGroup.RetriesToSkip')}
+              min={0}
+            />
+          </Form.Item>
+        </BAICard>
+      </Form.Item>
+      {isStrawberrySupported ? (
+        <Form.Item label={t('resourceGroup.Preemption')}>
+          <BAICard styles={{ body: { paddingTop: 0, paddingBottom: 0 } }}>
+            <Form.Item
+              label={
+                <BAIFlex gap="xxs">
+                  {t('resourceGroup.PreemptiblePriority')}
+                  <Tooltip
+                    title={newLineToBrElement(
+                      t('resourceGroup.PreemptiblePriorityDesc'),
+                    )}
+                  >
+                    <QuestionCircleOutlined
+                      style={{ color: token.colorTextSecondary }}
+                    />
+                  </Tooltip>
+                </BAIFlex>
+              }
+              name={['preemption', 'preemptiblePriority']}
+            >
+              <InputNumber style={{ width: '100%' }} min={0} />
+            </Form.Item>
+            <Form.Item
+              label={t('resourceGroup.PreemptionOrder')}
+              name={['preemption', 'order']}
+            >
+              <Select
+                options={[
+                  { label: 'Oldest', value: 'OLDEST' },
+                  { label: 'Newest', value: 'NEWEST' },
+                ]}
+              />
+            </Form.Item>
+            <Form.Item
+              label={t('resourceGroup.PreemptionMode')}
+              name={['preemption', 'mode']}
+            >
+              <Select
+                options={[
+                  { label: 'Terminate', value: 'TERMINATE' },
+                  { label: 'Reschedule', value: 'RESCHEDULE' },
+                ]}
+              />
+            </Form.Item>
+          </BAICard>
+        </Form.Item>
+      ) : null}
+    </Form>
+  );
+};
+
+interface ResourceGroupSettingPrefillFormProps extends Omit<
+  ResourceGroupSettingFormProps,
+  'initialValues' | 'isStrawberrySupported'
+> {
+  resourceGroupName: string;
+  baseInitialValues: Record<string, unknown>;
+}
+
+/**
+ * Fetches the Strawberry `ResourceGroup` node (edit mode, 26.4.2+) to prefill
+ * the fields the legacy `ScalingGroup` fragment cannot provide
+ * (`useHostNetwork`, preemption config), then renders the shared form.
+ */
+const ResourceGroupSettingPrefillForm: React.FC<
+  ResourceGroupSettingPrefillFormProps
+> = ({ resourceGroupName, baseInitialValues, formRef, isEditing }) => {
+  'use memo';
+  const { resourceGroup } =
+    useLazyLoadQuery<ResourceGroupSettingModalPrefillQuery>(
+      graphql`
+        query ResourceGroupSettingModalPrefillQuery($name: String!) {
+          resourceGroup: adminResourceGroupV2(name: $name) {
+            name
+            network {
+              useHostNetwork
+            }
+            scheduler {
+              preemption {
+                preemptiblePriority
+                order
+                mode
+              }
+            }
+          }
+        }
+      `,
+      { name: resourceGroupName },
+      { fetchPolicy: 'store-and-network' },
+    );
+
+  const initialValues = {
+    ...baseInitialValues,
+    useHostNetwork: resourceGroup?.network?.useHostNetwork ?? false,
+    preemption: {
+      preemptiblePriority:
+        resourceGroup?.scheduler?.preemption?.preemptiblePriority ?? 5,
+      order: resourceGroup?.scheduler?.preemption?.order ?? 'OLDEST',
+      mode: resourceGroup?.scheduler?.preemption?.mode ?? 'TERMINATE',
+    },
+  };
+
+  return (
+    <ResourceGroupSettingForm
+      formRef={formRef}
+      initialValues={initialValues}
+      isEditing={isEditing}
+      isStrawberrySupported
+    />
+  );
 };
 
 interface ResourceGroupCreateModalProps extends ModalProps {
@@ -61,11 +415,16 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
   onRequestClose,
   ...modalProps
 }) => {
+  'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const { message } = App.useApp();
+  const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
   const formRef = useRef<FormInstance>(null);
+
+  const isStrawberrySupported = baiClient.isManagerVersionCompatibleWith(
+    STRAWBERRY_RESOURCE_GROUP_MIN_VERSION,
+  );
 
   const resourceGroup = useFragment(
     graphql`
@@ -82,9 +441,59 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
     `,
     resourceGroupFrgmt,
   );
-  const [commitUpdateResourceGroup, isInFlightCommitUpdateResourceGroup] =
+
+  // NEW (Strawberry) mutations — full field coverage of UpdateResourceGroupInput.
+  const [commitUpdateResourceGroupV2, isInFlightUpdateResourceGroupV2] =
     useMutation<ResourceGroupSettingModalUpdateMutation>(graphql`
       mutation ResourceGroupSettingModalUpdateMutation(
+        $input: UpdateResourceGroupInput!
+      ) {
+        adminUpdateResourceGroup(input: $input) {
+          resourceGroup {
+            id
+            name
+            status {
+              isActive
+              isPublic
+            }
+            metadata {
+              description
+            }
+            network {
+              wsproxyAddr
+              useHostNetwork
+            }
+            scheduler {
+              type
+              preemption {
+                preemptiblePriority
+                order
+                mode
+              }
+            }
+          }
+        }
+      }
+    `);
+  const [commitCreateResourceGroupV2, isInFlightCreateResourceGroupV2] =
+    useMutation<ResourceGroupSettingModalCreateMutation>(graphql`
+      mutation ResourceGroupSettingModalCreateMutation(
+        $input: CreateResourceGroupInput!
+      ) {
+        adminCreateResourceGroupV2(input: $input) {
+          resourceGroup {
+            id
+            name
+          }
+        }
+      }
+    `);
+
+  // LEGACY (Graphene) mutations — kept for scheduler_opts (hybrid save) and as
+  // the full fallback path on managers older than 26.4.2.
+  const [commitLegacyModify, isInFlightLegacyModify] =
+    useMutation<ResourceGroupSettingModalLegacyModifyMutation>(graphql`
+      mutation ResourceGroupSettingModalLegacyModifyMutation(
         $name: String!
         $input: ModifyScalingGroupInput!
       ) {
@@ -94,9 +503,9 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
         }
       }
     `);
-  const [commitCreateResourceGroup, isInFlightCommitCreateResourceGroup] =
-    useMutation<ResourceGroupSettingModalCreateMutation>(graphql`
-      mutation ResourceGroupSettingModalCreateMutation(
+  const [commitLegacyCreate, isInFlightLegacyCreate] =
+    useMutation<ResourceGroupSettingModalLegacyCreateMutation>(graphql`
+      mutation ResourceGroupSettingModalLegacyCreateMutation(
         $name: String!
         $input: CreateScalingGroupInput!
       ) {
@@ -127,7 +536,7 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
     [resourceGroup?.scheduler_opts],
   );
 
-  const INITIAL_FORM_VALUES = omitNullAndUndefinedFields({
+  const baseInitialValues = omitNullAndUndefinedFields({
     name: resourceGroup?.name,
     description: resourceGroup?.description,
     domain: currentDomain,
@@ -148,6 +557,39 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
     wsProxyAPIToken: resourceGroup?.wsproxy_api_token,
   });
 
+  // Create mode still shows the preemption / host-network fields when the
+  // manager supports them, prefilled with the schema defaults.
+  const initialValuesForDirectForm = isStrawberrySupported
+    ? {
+        ...baseInitialValues,
+        useHostNetwork: false,
+        preemption: {
+          preemptiblePriority: 5,
+          order: 'OLDEST',
+          mode: 'TERMINATE',
+        },
+      }
+    : baseInitialValues;
+
+  const isInFlight =
+    isInFlightUpdateResourceGroupV2 ||
+    isInFlightCreateResourceGroupV2 ||
+    isInFlightLegacyModify ||
+    isInFlightLegacyCreate ||
+    isInFlightCommitAssociateDomain;
+
+  const reportGraphQLErrors = (
+    errors: ReadonlyArray<{ message: string }> | null | undefined,
+  ) => {
+    if (errors && errors.length > 0) {
+      for (const error of errors) {
+        message.error(error.message);
+      }
+      return true;
+    }
+    return false;
+  };
+
   return (
     <BAIModal
       destroyOnHidden
@@ -161,31 +603,174 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
       }}
       okText={resourceGroup ? t('button.Update') : t('button.Create')}
       okButtonProps={{
-        loading:
-          isInFlightCommitCreateResourceGroup ||
-          isInFlightCommitAssociateDomain ||
-          isInFlightCommitUpdateResourceGroup,
+        loading: isInFlight,
       }}
       onOk={() => {
         formRef.current
           ?.validateFields()
           .then((values: FormInputType) => {
-            const input = {
+            const schedulerOptsJSON = JSON.stringify({
+              allowed_session_types: values.allowedSessionTypes,
+              ...(values.pendingTimeout && {
+                pending_timeout: values.pendingTimeout,
+              }),
+              ...(values.retriesToSkip && {
+                config: {
+                  num_retries_to_skip: values.retriesToSkip,
+                },
+              }),
+            });
+
+            if (isStrawberrySupported) {
+              const schedulerType = SCHEDULER_TYPE_MAP[values.scheduler];
+              const preemptionInput = {
+                preemptiblePriority:
+                  values.preemption?.preemptiblePriority ?? 5,
+                order: values.preemption?.order ?? 'OLDEST',
+                mode: values.preemption?.mode ?? 'TERMINATE',
+              };
+
+              // TODO(needs-backend): FR-3240 — scheduler_opts
+              // (allowedSessionTypes / pendingTimeout / num_retries_to_skip) is
+              // NOT exposed in UpdateResourceGroupInput. Until the backend adds
+              // it, keep persisting scheduler_opts through the legacy
+              // modify_scaling_group mutation (hybrid save) so the field does
+              // not regress.
+              const commitSchedulerOpts = (
+                name: string,
+                onDone: () => void,
+                onFailure?: () => void,
+              ) => {
+                commitLegacyModify({
+                  variables: {
+                    name,
+                    input: { scheduler_opts: schedulerOptsJSON },
+                  },
+                  onCompleted: ({ modify_scaling_group: res }, errors) => {
+                    if (reportGraphQLErrors(errors)) {
+                      onFailure?.();
+                      return;
+                    }
+                    if (!res?.ok) {
+                      message.error(res?.msg);
+                      onFailure?.();
+                      return;
+                    }
+                    onDone();
+                  },
+                  onError: (err) => {
+                    message.error(err.message);
+                    onFailure?.();
+                  },
+                });
+              };
+
+              if (resourceGroup) {
+                commitUpdateResourceGroupV2({
+                  variables: {
+                    input: {
+                      resourceGroupName: resourceGroup.name,
+                      isActive: values.active,
+                      isPublic: values.public,
+                      description: values.description ?? null,
+                      appProxyAddr: values.wsProxyAddress ?? null,
+                      appproxyApiToken: values.wsProxyAPIToken ?? null,
+                      useHostNetwork: values.useHostNetwork ?? false,
+                      schedulerType,
+                      preemption: preemptionInput,
+                    },
+                  },
+                  onCompleted: (_response, errors) => {
+                    if (reportGraphQLErrors(errors)) return;
+                    commitSchedulerOpts(resourceGroup.name, () => {
+                      message.success(t('resourceGroup.ResourceGroupModified'));
+                      onRequestClose?.(true);
+                    });
+                  },
+                  onError: (err) => {
+                    message.error(err.message);
+                  },
+                });
+                return;
+              }
+
+              // Create: adminCreateResourceGroupV2 (name + domain + description),
+              // then adminUpdateResourceGroup for the remaining fields, then the
+              // legacy scheduler_opts write.
+              commitCreateResourceGroupV2({
+                variables: {
+                  input: {
+                    name: values.name,
+                    domainName: values.domain,
+                    description: values.description ?? null,
+                  },
+                },
+                onCompleted: (_response, errors) => {
+                  if (reportGraphQLErrors(errors)) return;
+                  // Create succeeded — the resource group now exists. A failure
+                  // in any subsequent configuration step must not be retried
+                  // through this create path (it would fail with "already
+                  // exists"); surface a distinct message and close so the list
+                  // refetches and the user can finish configuration by editing.
+                  const handlePostCreateFailure = () => {
+                    message.warning(
+                      t(
+                        'resourceGroup.ResourceGroupCreatedButConfigurationFailed',
+                      ),
+                    );
+                    onRequestClose?.(true);
+                  };
+                  commitUpdateResourceGroupV2({
+                    variables: {
+                      input: {
+                        resourceGroupName: values.name,
+                        isActive: values.active,
+                        isPublic: values.public,
+                        description: values.description ?? null,
+                        appProxyAddr: values.wsProxyAddress ?? null,
+                        appproxyApiToken: values.wsProxyAPIToken ?? null,
+                        useHostNetwork: values.useHostNetwork ?? false,
+                        schedulerType,
+                        preemption: preemptionInput,
+                      },
+                    },
+                    onCompleted: (_updateResponse, updateErrors) => {
+                      if (updateErrors && updateErrors.length > 0) {
+                        reportGraphQLErrors(updateErrors);
+                        handlePostCreateFailure();
+                        return;
+                      }
+                      commitSchedulerOpts(
+                        values.name,
+                        () => {
+                          message.success(
+                            t('resourceGroup.ResourceGroupCreated'),
+                          );
+                          onRequestClose?.(true);
+                        },
+                        handlePostCreateFailure,
+                      );
+                    },
+                    onError: (err) => {
+                      message.error(err.message);
+                      handlePostCreateFailure();
+                    },
+                  });
+                },
+                onError: (err) => {
+                  message.error(err.message);
+                },
+              });
+              return;
+            }
+
+            // Legacy fallback (managers older than 26.4.2): unchanged behavior.
+            const legacyInput = {
               driver: 'static',
               scheduler: values.scheduler,
               description: values.description ?? null,
               driver_opts: '{}',
-              scheduler_opts: JSON.stringify({
-                allowed_session_types: values.allowedSessionTypes,
-                ...(values.pendingTimeout && {
-                  pending_timeout: values.pendingTimeout,
-                }),
-                ...(values.retriesToSkip && {
-                  config: {
-                    num_retries_to_skip: values.retriesToSkip,
-                  },
-                }),
-              }),
+              scheduler_opts: schedulerOptsJSON,
               is_public: values.public,
               is_active: values.active,
               wsproxy_addr: values.wsProxyAddress,
@@ -193,24 +778,15 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
             };
 
             if (resourceGroup) {
-              commitUpdateResourceGroup({
+              commitLegacyModify({
                 variables: {
                   name: resourceGroup.name,
-                  input: input,
+                  input: legacyInput,
                 },
                 onCompleted: ({ modify_scaling_group: res }, errors) => {
+                  if (reportGraphQLErrors(errors)) return;
                   if (!res?.ok) {
                     message.error(res?.msg);
-                    return;
-                  }
-                  if (errors && errors.length > 0) {
-                    const errorMsgList = _.map(
-                      errors,
-                      (error) => error.message,
-                    );
-                    for (const error of errorMsgList) {
-                      message.error(error);
-                    }
                     return;
                   }
                   message.success(t('resourceGroup.ResourceGroupModified'));
@@ -223,20 +799,13 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
               return;
             }
 
-            commitCreateResourceGroup({
+            commitLegacyCreate({
               variables: {
                 name: values.name,
-                input: input,
+                input: legacyInput,
               },
               onCompleted: ({ create_scaling_group: res }, errors) => {
-                if (errors && errors.length > 0) {
-                  const errorMsgList = _.map(errors, (error) => error.message);
-                  for (const error of errorMsgList) {
-                    message.error(error);
-                  }
-                  return;
-                }
-
+                if (reportGraphQLErrors(errors)) return;
                 if (!res?.ok) {
                   message.error(res?.msg);
                   return;
@@ -251,21 +820,11 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
                     { associate_scaling_group_with_domain: res },
                     errors,
                   ) => {
+                    if (reportGraphQLErrors(errors)) return;
                     if (!res?.ok) {
                       message.error(res?.msg);
                       return;
                     }
-                    if (errors && errors.length > 0) {
-                      const errorMsgList = _.map(
-                        errors,
-                        (error) => error.message,
-                      );
-                      for (const error of errorMsgList) {
-                        message.error(error);
-                      }
-                      return;
-                    }
-
                     message.success(t('resourceGroup.ResourceGroupCreated'));
                     onRequestClose?.(true);
                   },
@@ -284,174 +843,21 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
       {...modalProps}
     >
       <Suspense fallback={<Skeleton active />}>
-        <Form
-          ref={formRef}
-          initialValues={INITIAL_FORM_VALUES}
-          layout="vertical"
-        >
-          <Form.Item
-            label={t('resourceGroup.Name')}
-            name="name"
-            rules={[
-              {
-                required: true,
-                message: t('general.ValueRequired', {
-                  name: t('resourceGroup.Name'),
-                }),
-              },
-            ]}
-          >
-            <Input disabled={!!resourceGroup} />
-          </Form.Item>
-          {!resourceGroup ? (
-            <Form.Item
-              label={t('resourceGroup.Domain')}
-              name="domain"
-              rules={[
-                {
-                  required: true,
-                  message: t('general.ValueRequired', {
-                    name: t('resourceGroup.Domain'),
-                  }),
-                },
-              ]}
-            >
-              <BAIDomainSelect />
-            </Form.Item>
-          ) : null}
-          <Form.Item label={t('resourceGroup.Description')} name="description">
-            <Input.TextArea />
-          </Form.Item>
-          <Form.Item
-            label={t('resourceGroup.AllowedSessionTypes')}
-            name="allowedSessionTypes"
-            rules={[
-              {
-                required: true,
-                message: t('general.ValueRequired', {
-                  name: t('resourceGroup.AllowedSessionTypes'),
-                }),
-              },
-            ]}
-          >
-            <Select
-              mode="multiple"
-              options={[
-                { label: 'Batch', value: 'batch' },
-                { label: 'Interactive', value: 'interactive' },
-                { label: 'Inference', value: 'inference' },
-                { label: 'System', value: 'system' },
-              ]}
-            />
-          </Form.Item>
-          <Form.Item
-            label={t('resourceGroup.AppProxyAddress')}
-            name="wsProxyAddress"
-            rules={[{ type: 'url', message: t('error.InvalidUrl') }]}
-          >
-            <Input placeholder="http://localhost:10200" />
-          </Form.Item>
-          <Form.Item
-            label={t('resourceGroup.AppProxyAPIToken')}
-            name="wsProxyAPIToken"
-          >
-            <Input.Password placeholder={t('resourceGroup.EnterAPIToken')} />
-          </Form.Item>
-          <Row>
-            <Col span={12}>
-              <Form.Item
-                layout="horizontal"
-                label={t('resourceGroup.Active')}
-                name="active"
-              >
-                <Switch />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item
-                layout="horizontal"
-                label={t('resourceGroup.Public')}
-                name="public"
-              >
-                <Switch />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Form.Item
-            label={t('resourceGroup.Scheduler')}
-            name="scheduler"
-            rules={[
-              {
-                required: true,
-                message: t('general.ValueRequired', {
-                  name: t('resourceGroup.Scheduler'),
-                }),
-              },
-            ]}
-          >
-            <Select
-              options={[
-                {
-                  label: 'FIFO',
-                  value: 'fifo',
-                },
-                {
-                  label: 'LIFO',
-                  value: 'lifo',
-                },
-                {
-                  label: 'DRF',
-                  value: 'drf',
-                },
-                {
-                  label: 'Fair Share',
-                  value: 'fair-share',
-                },
-              ]}
-            />
-          </Form.Item>
-          <Form.Item label={t('resourceGroup.SchedulerOptions')}>
-            <BAICard styles={{ body: { paddingBottom: 0 } }}>
-              <Form.Item
-                label={
-                  <BAIFlex gap="xxs">
-                    {t('resourceGroup.PendingTimeout')}
-                    <Tooltip
-                      title={newLineToBrElement(
-                        t('resourceGroup.PendingTimeoutDesc'),
-                      )}
-                    >
-                      <QuestionCircleOutlined
-                        style={{ color: token.colorTextSecondary }}
-                      />
-                    </Tooltip>
-                  </BAIFlex>
-                }
-                name="pendingTimeout"
-              >
-                <InputNumber
-                  style={{ width: '100%' }}
-                  suffix={t('resourceGroup.TimeoutSeconds')}
-                  min={0}
-                />
-              </Form.Item>
-              <Form.Item
-                label={
-                  <BAIFlex style={{ whiteSpace: 'pre' }}>
-                    {t('resourceGroup.RetriesToSkipDesc')}
-                  </BAIFlex>
-                }
-                name="retriesToSkip"
-              >
-                <InputNumber
-                  style={{ width: '100%' }}
-                  suffix={t('resourceGroup.RetriesToSkip')}
-                  min={0}
-                />
-              </Form.Item>
-            </BAICard>
-          </Form.Item>
-        </Form>
+        {isStrawberrySupported && resourceGroup ? (
+          <ResourceGroupSettingPrefillForm
+            resourceGroupName={resourceGroup.name ?? ''}
+            baseInitialValues={baseInitialValues}
+            formRef={formRef}
+            isEditing
+          />
+        ) : (
+          <ResourceGroupSettingForm
+            formRef={formRef}
+            initialValues={initialValuesForDirectForm}
+            isEditing={!!resourceGroup}
+            isStrawberrySupported={isStrawberrySupported}
+          />
+        )}
       </Suspense>
     </BAIModal>
   );

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2369,10 +2369,16 @@
     "NoScalingGroupAssignedToThisProject": "Dieses Projekt wird keine Ressourcengruppe zugewiesen. \nDie Erstellung der Sitzung und die Erstellung von Bereitstellungen werden eingeschränkt.",
     "PendingTimeout": "Ausstehende Auszeit",
     "PendingTimeoutDesc": "Eine maximale Zeit, die eine Sitzung in einem anhängigen Zustand bleibt.\n\nWenn es auf 0 gesetzt ist, warten Sie auf unbestimmte Zeit ohne Grenzwert.\n\nWenn es nicht festgelegt wird, ist es standardmäßig 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Öffentlich",
     "PublicStatus": "Öffentlicher Status",
     "ResourceGroupAlreadyExist": "Eine Ressourcengruppe mit demselben Namen ist bereits vorhanden.",
     "ResourceGroupCreated": "Ressourcengruppe erfolgreich erstellt",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Ressourcengruppe erfolgreich gelöscht",
     "ResourceGroupDetail": "Ressourcengruppendetail",
     "ResourceGroupModified": "Ressourcengruppe erfolgreich geändert",
@@ -2387,7 +2393,9 @@
     "SelectDomain": "Domain auswählen",
     "SelectScheduler": "Wählen Sie Planer",
     "TimeoutSeconds": "Sekunden",
-    "TypeResourceGroupNameToDelete": "Geben Sie den Namen der zu löschenden Ressourcengruppe ein"
+    "TypeResourceGroupNameToDelete": "Geben Sie den Namen der zu löschenden Ressourcengruppe ein",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Sie sind im Begriff, diese Ressourcenrichtlinie zu löschen:",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2367,10 +2367,16 @@
     "NoScalingGroupAssignedToThisProject": "Καμία ομάδα πόρων δεν έχει ανατεθεί σε αυτό το έργο. \nΗ δημιουργία συνόδων και η δημιουργία αναπτύξεων θα περιοριστεί.",
     "PendingTimeout": "Εκκρεμή χρονικό όριο",
     "PendingTimeoutDesc": "Μέγιστος χρόνος που μπορεί να παραμείνει σε εκκρεμούσα κατάσταση.\n\nΕάν ρυθμιστεί στο 0, θα περιμένει επ 'αόριστον χωρίς όριο.\n\nΕάν αφεθεί unset, προεπιλογές σε 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Δημόσιο",
     "PublicStatus": "Δημόσια κατάσταση",
     "ResourceGroupAlreadyExist": "Υπάρχει ήδη μια ομάδα πόρων με το ίδιο όνομα.",
     "ResourceGroupCreated": "Η ομάδα πόρων δημιουργήθηκε με επιτυχία",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Η ομάδα πόρων διαγράφηκε με επιτυχία",
     "ResourceGroupDetail": "Λεπτομέρεια ομάδας πόρων",
     "ResourceGroupModified": "Η ομάδα πόρων τροποποιήθηκε επιτυχώς",
@@ -2385,7 +2391,9 @@
     "SelectDomain": "Επιλέξτε τομέα",
     "SelectScheduler": "Επιλέξτε Προγραμματιστής",
     "TimeoutSeconds": "δευτερόλεπτα",
-    "TypeResourceGroupNameToDelete": "Πληκτρολογήστε όνομα ομάδας πόρων για διαγραφή"
+    "TypeResourceGroupNameToDelete": "Πληκτρολογήστε όνομα ομάδας πόρων για διαγραφή",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Πρόκειται να διαγράψετε αυτήν την πολιτική πόρων:",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2357,10 +2357,16 @@
     "NoScalingGroupAssignedToThisProject": "No resource group is assigned to this project. Session creation and deployment creation will be restricted.",
     "PendingTimeout": "Pending Timeout",
     "PendingTimeoutDesc": "Maximum time a session can stay in pending state.\nIf set to 0, it will wait indefinitely without a limit.\nIf left unset, it defaults to 0.",
+    "PreemptiblePriority": "Preemptible Priority",
+    "PreemptiblePriorityDesc": "Sessions with priority less than or equal to this value are eligible for preemption. Default is 5.",
+    "Preemption": "Preemption",
+    "PreemptionMode": "Preemption Mode",
+    "PreemptionOrder": "Preemption Order",
     "Public": "Public",
     "PublicStatus": "Public Status",
     "ResourceGroupAlreadyExist": "A resource group with the same name already exists.",
     "ResourceGroupCreated": "Resource group succesfully created",
+    "ResourceGroupCreatedButConfigurationFailed": "The resource group was created, but applying its configuration failed. Edit the resource group to finish configuring it.",
     "ResourceGroupDeleted": "Resource group successfully deleted",
     "ResourceGroupDetail": "Resource Group Detail",
     "ResourceGroupModified": "Resource group successfully modified",
@@ -2375,7 +2381,9 @@
     "SelectDomain": "Select Domain",
     "SelectScheduler": "Select Scheduler",
     "TimeoutSeconds": "Seconds",
-    "TypeResourceGroupNameToDelete": "Type resource group name to delete"
+    "TypeResourceGroupNameToDelete": "Type resource group name to delete",
+    "UseHostNetwork": "Use Host Network",
+    "UseHostNetworkDesc": "Allow sessions in this resource group to use the host network namespace directly instead of container isolation."
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "You are about to delete this resource policy: ",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2367,10 +2367,16 @@
     "NoScalingGroupAssignedToThisProject": "No se asigna ningún grupo de recursos a este proyecto. \nLa creación de sesiones y la creación de despliegues estarán restringidos.",
     "PendingTimeout": "Tiempo de espera pendiente",
     "PendingTimeoutDesc": "Tiempo máximo Una sesión puede permanecer en estado pendiente.\n\nSi se establece en 0, esperará indefinidamente sin un límite.\n\nSi se deja inseguro, es predeterminado a 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Público",
     "PublicStatus": "Estado público",
     "ResourceGroupAlreadyExist": "Ya existe un grupo de recursos con el mismo nombre.",
     "ResourceGroupCreated": "Grupo de recursos creado con éxito",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Grupo de recursos eliminado correctamente",
     "ResourceGroupDetail": "Detalle del grupo de recursos",
     "ResourceGroupModified": "Grupo de recursos modificado correctamente",
@@ -2385,7 +2391,9 @@
     "SelectDomain": "Seleccionar dominio",
     "SelectScheduler": "Seleccione Programador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Escriba el nombre del grupo de recursos que desea eliminar"
+    "TypeResourceGroupNameToDelete": "Escriba el nombre del grupo de recursos que desea eliminar",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Está a punto de eliminar esta política de recursos:",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2367,10 +2367,16 @@
     "NoScalingGroupAssignedToThisProject": "Resurssiryhmää ei ole osoitettu tähän projektiin. \nIstunnon luominen ja käyttöönoton luominen rajoitetaan.",
     "PendingTimeout": "Odotettaessa aikakatkaisua",
     "PendingTimeoutDesc": "Suurin aika, jonka istunto voi pysyä vireillä olevassa tilassa.\n\nJos se on asetettu 0: een, se odottaa määräämättömäksi sanottuna ilman rajaa.\n\nJos se on jätetty, se oletusarvo on 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Julkinen",
     "PublicStatus": "Julkinen asema",
     "ResourceGroupAlreadyExist": "Samanniminen resurssiryhmä on jo olemassa.",
     "ResourceGroupCreated": "Resurssiryhmä luotu onnistuneesti",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Resurssiryhmä onnistuneesti poistettu",
     "ResourceGroupDetail": "Resurssiryhmän tiedot",
     "ResourceGroupModified": "Resurssiryhmän muokkaus onnistui onnistuneesti",
@@ -2385,7 +2391,9 @@
     "SelectDomain": "Valitse verkkotunnus",
     "SelectScheduler": "Valitse Ajastin",
     "TimeoutSeconds": "Sekuntia",
-    "TypeResourceGroupNameToDelete": "Kirjoita poistettavan resurssiryhmän nimi"
+    "TypeResourceGroupNameToDelete": "Kirjoita poistettavan resurssiryhmän nimi",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Olet poistamassa tätä resurssikäytäntöä:",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2369,10 +2369,16 @@
     "NoScalingGroupAssignedToThisProject": "Aucun groupe de ressources n'est affecté à ce projet. \nLa création de session et la création de déploiements seront restreintes.",
     "PendingTimeout": "Délai d'attente en attente",
     "PendingTimeoutDesc": "Temps maximum Une session peut rester dans l'état en attente.\n\nS'il est réglé sur 0, il attendra indéfiniment sans limite.\n\nSi elle est restée, elle est par défaut à 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Public",
     "PublicStatus": "Statut public",
     "ResourceGroupAlreadyExist": "Un groupe de ressources du même nom existe déjà.",
     "ResourceGroupCreated": "Groupe de ressources créé avec succès",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Groupe de ressources supprimé avec succès",
     "ResourceGroupDetail": "Détail du groupe de ressources",
     "ResourceGroupModified": "Groupe de ressources modifié avec succès",
@@ -2387,7 +2393,9 @@
     "SelectDomain": "Sélectionnez le domaine",
     "SelectScheduler": "Sélectionnez le planificateur",
     "TimeoutSeconds": "Seconds",
-    "TypeResourceGroupNameToDelete": "Tapez le nom du groupe de ressources à supprimer"
+    "TypeResourceGroupNameToDelete": "Tapez le nom du groupe de ressources à supprimer",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Vous êtes sur le point de supprimer cette stratégie de ressources :",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2370,10 +2370,16 @@
     "NoScalingGroupAssignedToThisProject": "Tidak ada grup sumber daya yang ditugaskan untuk proyek ini. \nPembuatan Sesi dan Pembuatan Penerapan akan dibatasi.",
     "PendingTimeout": "Waktu tunggu yang tertunda",
     "PendingTimeoutDesc": "Waktu maksimum sesi dapat tetap dalam keadaan tertunda.\n\nJika diatur ke 0, itu akan menunggu tanpa batas tanpa batas.\n\nJika dibiarkan tidak disetel, itu default ke 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Publik",
     "PublicStatus": "Status Publik",
     "ResourceGroupAlreadyExist": "Grup sumber daya dengan nama yang sama sudah ada.",
     "ResourceGroupCreated": "Grup sumber daya berhasil dibuat",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Grup sumber daya berhasil dihapus",
     "ResourceGroupDetail": "Detail Grup Sumber Daya",
     "ResourceGroupModified": "Grup sumber daya berhasil diubah",
@@ -2388,7 +2394,9 @@
     "SelectDomain": "Pilih Domain",
     "SelectScheduler": "Pilih Penjadwal",
     "TimeoutSeconds": "Detik",
-    "TypeResourceGroupNameToDelete": "Ketik nama grup sumber daya yang akan dihapus"
+    "TypeResourceGroupNameToDelete": "Ketik nama grup sumber daya yang akan dihapus",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Anda akan menghapus kebijakan sumber daya ini:",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2367,10 +2367,16 @@
     "NoScalingGroupAssignedToThisProject": "Nessun gruppo di risorse è assegnato a questo progetto. \nLa creazione di sessione e la creazione della distribuzione saranno limitate.",
     "PendingTimeout": "In attesa di timeout",
     "PendingTimeoutDesc": "Tempo massimo Una sessione può rimanere nello stato in sospeso.\n\nSe impostato su 0, aspetterà indefinitamente senza un limite.\n\nSe lasciato Unset, è default a 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Pubblico",
     "PublicStatus": "Stato pubblico",
     "ResourceGroupAlreadyExist": "Esiste già un gruppo di risorse con lo stesso nome.",
     "ResourceGroupCreated": "Gruppo di risorse creato con successo",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Gruppo di risorse eliminato con successo",
     "ResourceGroupDetail": "Dettagli del gruppo di risorse",
     "ResourceGroupModified": "Gruppo di risorse modificato con successo",
@@ -2385,7 +2391,9 @@
     "SelectDomain": "Seleziona dominio",
     "SelectScheduler": "Seleziona l'agenda",
     "TimeoutSeconds": "Secondi",
-    "TypeResourceGroupNameToDelete": "Digita il nome del gruppo di risorse da eliminare"
+    "TypeResourceGroupNameToDelete": "Digita il nome del gruppo di risorse da eliminare",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Stai per eliminare questa policy sulle risorse:",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2372,10 +2372,16 @@
     "NoScalingGroupAssignedToThisProject": "このプロジェクトにはリソースグループが割り当てられていません。\nセッションの作成とデプロイの作成は制限されます。",
     "PendingTimeout": "保留中のタイムアウト",
     "PendingTimeoutDesc": "セッションが保留中の状態にとどまることができる最大時間。\n\n0に設定すると、制限なしに無期限に待機します。\n\n設定されたままにしておくと、デフォルトは0になります。",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "公開",
     "PublicStatus": "公開状況",
     "ResourceGroupAlreadyExist": "同じ名前のリソースグループがすでに存在します。",
     "ResourceGroupCreated": "リソースグループが正常に作成されました",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "リソースグループが正常に削除されました",
     "ResourceGroupDetail": "リソースグループの詳細",
     "ResourceGroupModified": "リソースグループが正常に変更されました",
@@ -2390,7 +2396,9 @@
     "SelectDomain": "ドメインを選択",
     "SelectScheduler": "スケジューラを選択",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "削除するリソースグループ名を入力します"
+    "TypeResourceGroupNameToDelete": "削除するリソースグループ名を入力します",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "このリソースポリシーを削除しようとしています。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2372,10 +2372,16 @@
     "NoScalingGroupAssignedToThisProject": "이 프로젝트에 할당된 자원 그룹이 없습니다. 세션 및 배포 생성이 제한됩니다.",
     "PendingTimeout": "대기 세션 유휴 시간",
     "PendingTimeoutDesc": "세션이 pending 상태로 대기할 수 있는 최대 시간입니다. 0으로 설정하면 제한없이 무한히 대기합니다. 값을 설정하지 않으면 기본값 0이 적용됩니다. ",
+    "PreemptiblePriority": "선점 우선순위",
+    "PreemptiblePriorityDesc": "이 값보다 작거나 같은 우선순위의 세션이 선점 대상이 됩니다. 기본값은 5입니다.",
+    "Preemption": "선점",
+    "PreemptionMode": "선점 모드",
+    "PreemptionOrder": "선점 순서",
     "Public": "공개",
     "PublicStatus": "공개 상태",
     "ResourceGroupAlreadyExist": "같은 이름의 자원 그룹이 이미 있습니다.",
     "ResourceGroupCreated": "자원 그룹이 생성되었습니다.",
+    "ResourceGroupCreatedButConfigurationFailed": "자원 그룹은 생성되었으나 설정 적용에 실패했습니다. 자원 그룹을 편집하여 설정을 완료하세요.",
     "ResourceGroupDeleted": "자원 그룹이 삭제되었습니다.",
     "ResourceGroupDetail": "자원 그룹 세부 정보",
     "ResourceGroupModified": "자원 그룹이 수정되었습니다.",
@@ -2390,7 +2396,9 @@
     "SelectDomain": "도메인 선택",
     "SelectScheduler": "스케줄러 선택",
     "TimeoutSeconds": "초",
-    "TypeResourceGroupNameToDelete": "삭제하려는 자원 그룹 이름을 다시 한번 입력하세요."
+    "TypeResourceGroupNameToDelete": "삭제하려는 자원 그룹 이름을 다시 한번 입력하세요.",
+    "UseHostNetwork": "호스트 네트워크 사용",
+    "UseHostNetworkDesc": "이 자원 그룹의 세션이 컨테이너 격리 대신 호스트 네트워크 네임스페이스를 직접 사용하도록 허용합니다."
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "아래의 자원 정책을 삭제하려고 합니다: ",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2368,10 +2368,16 @@
     "NoScalingGroupAssignedToThisProject": "Энэ төсөлд нөөцийн бүлэгт хуваарилагдаагүй байна. \nХуралдаан үүсгэх ба байршуулалт үүсгэхийг хязгаарлах болно.",
     "PendingTimeout": "Хүлээгдэж буй хугацаа",
     "PendingTimeoutDesc": "Хүлээн авах хугацаа хүлээгдэж буй төлөвт үлдэж болно.\n\nХэрэв 0-ийг тохируулсан бол энэ нь хязгаарлалтгүйгээр тодорхойгүй хугацаагаар хүлээх болно.\n\nХэрэв үлдсэнийг нь орхивол энэ нь 0-ийг анхдагчаар тохируулна.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Олон нийтийн",
     "PublicStatus": "Олон нийтийн статус",
     "ResourceGroupAlreadyExist": "Ижил нэртэй нөөцийн бүлэг аль хэдийн бий болсон.",
     "ResourceGroupCreated": "Нөөцийн бүлэг амжилттай байгуулагдсан",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Нөөцийн бүлгийг амжилттай устгалаа",
     "ResourceGroupDetail": "Нөөцийн бүлгийн дэлгэрэнгүй",
     "ResourceGroupModified": "Нөөцийн бүлгийг амжилттай өөрчилсөн",
@@ -2386,7 +2392,9 @@
     "SelectDomain": "Домэйн сонгоно уу",
     "SelectScheduler": "Цагийн хуваарийг сонгоно уу",
     "TimeoutSeconds": "Секунд",
-    "TypeResourceGroupNameToDelete": "Устгахын тулд нөөцийн бүлгийн нэрийг бичнэ үү"
+    "TypeResourceGroupNameToDelete": "Устгахын тулд нөөцийн бүлгийн нэрийг бичнэ үү",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Та энэ нөөцийн бодлогыг устгах гэж байна:",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2367,10 +2367,16 @@
     "NoScalingGroupAssignedToThisProject": "Tiada kumpulan sumber yang diberikan kepada projek ini. \nPenciptaan sesi dan penciptaan penggunaan akan dihadkan.",
     "PendingTimeout": "Tamat tempoh yang belum selesai",
     "PendingTimeoutDesc": "Masa maksimum sesi boleh tinggal di negeri yang belum selesai.\n\nJika ditetapkan kepada 0, ia akan menunggu selama -lamanya tanpa had.\n\nJika tidak tersendiri, ia mungkir kepada 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Awam",
     "PublicStatus": "Status Awam",
     "ResourceGroupAlreadyExist": "Kumpulan sumber dengan nama yang sama sudah ada.",
     "ResourceGroupCreated": "Kumpulan sumber berjaya dibuat",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Kumpulan sumber berjaya dipadamkan",
     "ResourceGroupDetail": "Perincian Kumpulan Sumber",
     "ResourceGroupModified": "Kumpulan sumber berjaya diubah suai",
@@ -2385,7 +2391,9 @@
     "SelectDomain": "Pilih Domain",
     "SelectScheduler": "Pilih Penjadual",
     "TimeoutSeconds": "Detik",
-    "TypeResourceGroupNameToDelete": "Taipkan nama kumpulan sumber untuk dipadamkan"
+    "TypeResourceGroupNameToDelete": "Taipkan nama kumpulan sumber untuk dipadamkan",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Anda akan memadamkan dasar sumber ini:",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2369,10 +2369,16 @@
     "NoScalingGroupAssignedToThisProject": "Do tego projektu nie jest przypisywana grupa zasobów. \nTworzenie sesji i tworzenie wdrożeń będą ograniczone.",
     "PendingTimeout": "Oczekujący limit czasu",
     "PendingTimeoutDesc": "Maksymalny czas sesji może pozostać w stanie oczekiwanym.\n\nJeśli zostanie ustawiony na 0, będzie czekać na czas bez ograniczeń.\n\nJeśli pozostanie unset, domyślnie 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Publiczny",
     "PublicStatus": "Status publiczny",
     "ResourceGroupAlreadyExist": "Grupa zasobów o tej samej nazwie już istnieje.",
     "ResourceGroupCreated": "Pomyślnie utworzono grupę zasobów",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Grupa zasobów została pomyślnie usunięta",
     "ResourceGroupDetail": "Szczegóły grupy zasobów",
     "ResourceGroupModified": "Grupa zasobów została pomyślnie zmodyfikowana",
@@ -2387,7 +2393,9 @@
     "SelectDomain": "Wybierz domenę",
     "SelectScheduler": "Wybierz harmonogram",
     "TimeoutSeconds": "sekundy",
-    "TypeResourceGroupNameToDelete": "Wpisz nazwę grupy zasobów do usunięcia"
+    "TypeResourceGroupNameToDelete": "Wpisz nazwę grupy zasobów do usunięcia",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Zamierzasz usunąć tę zasadę dotyczącą zasobów:",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2367,10 +2367,16 @@
     "NoScalingGroupAssignedToThisProject": "Nenhum grupo de recursos é atribuído a este projeto. A criação de sessões e a criação de implantações serão restringidas.",
     "PendingTimeout": "Aguardando tempo limite",
     "PendingTimeoutDesc": "Tempo máximo Uma sessão pode permanecer no estado pendente.\n\nSe definido como 0, ele esperará indefinidamente sem um limite.\n\nSe deixado sem serem definidos, é padrão para 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Público",
     "PublicStatus": "Estado público",
     "ResourceGroupAlreadyExist": "Já existe um grupo de recursos com o mesmo nome.",
     "ResourceGroupCreated": "Grupo de recursos criado com sucesso",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Grupo de recursos excluído com sucesso",
     "ResourceGroupDetail": "Detalhe do grupo de recursos",
     "ResourceGroupModified": "Grupo de recursos modificado com sucesso",
@@ -2385,7 +2391,9 @@
     "SelectDomain": "Selecione o domínio",
     "SelectScheduler": "Selecione o Agendador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir"
+    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Você está prestes a excluir esta política de recursos:",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2369,10 +2369,16 @@
     "NoScalingGroupAssignedToThisProject": "Nenhum grupo de recursos é atribuído a este projeto. \nA criação de sessões e a criação de implementações serão restritos.",
     "PendingTimeout": "Aguardando tempo limite",
     "PendingTimeoutDesc": "Tempo máximo Uma sessão pode permanecer no estado pendente.\n\nSe definido como 0, ele esperará indefinidamente sem um limite.\n\nSe deixado sem serem definidos, é padrão para 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Público",
     "PublicStatus": "Estado público",
     "ResourceGroupAlreadyExist": "Já existe um grupo de recursos com o mesmo nome.",
     "ResourceGroupCreated": "Grupo de recursos criado com sucesso",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Grupo de recursos excluído com sucesso",
     "ResourceGroupDetail": "Detalhe do grupo de recursos",
     "ResourceGroupModified": "Grupo de recursos modificado com sucesso",
@@ -2387,7 +2393,9 @@
     "SelectDomain": "Selecione o domínio",
     "SelectScheduler": "Selecione o Agendador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir"
+    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Você está prestes a excluir esta política de recursos:",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2367,10 +2367,16 @@
     "NoScalingGroupAssignedToThisProject": "Никакая группа ресурсов не назначена в этот проект. \nСоздание сеанса и создание развёртываний будет ограничено.",
     "PendingTimeout": "В ожидании тайм -аута",
     "PendingTimeoutDesc": "Максимальное время, когда сессия может оставаться в ожидании.\n\nЕсли установлено на 0, он будет ждать бесконечно без ограничения.\n\nЕсли оставить нерешенность, это по умолчанию до 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Публичный",
     "PublicStatus": "Общественный статус",
     "ResourceGroupAlreadyExist": "Группа ресурсов с таким именем уже существует.",
     "ResourceGroupCreated": "Группа ресурсов успешно создана",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Группа ресурсов успешно удалена",
     "ResourceGroupDetail": "Сведения о группе ресурсов",
     "ResourceGroupModified": "Группа ресурсов успешно изменена",
@@ -2385,7 +2391,9 @@
     "SelectDomain": "Выбрать домен",
     "SelectScheduler": "Выберите планировщик",
     "TimeoutSeconds": "Секунды",
-    "TypeResourceGroupNameToDelete": "Введите имя группы ресурсов для удаления"
+    "TypeResourceGroupNameToDelete": "Введите имя группы ресурсов для удаления",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Вы собираетесь удалить эту политику ресурсов:",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2367,10 +2367,16 @@
     "NoScalingGroupAssignedToThisProject": "Bu projeye hiçbir kaynak grubu atanmadı. \nOturum oluşturma ve dağıtım oluşturma kısıtlanacaktır.",
     "PendingTimeout": "Bekleyen zaman aşımı",
     "PendingTimeoutDesc": "Maksimum Süre Bir oturum bekleyen durumda kalabilir.\n\n0 olarak ayarlanırsa, sınırsız süresiz olarak bekleyecektir.\n\nSet kalmazsa, varsayılan 0 olarakdır.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Kamu",
     "PublicStatus": "Kamu Statüsü",
     "ResourceGroupAlreadyExist": "Aynı ada sahip bir kaynak grubu zaten var.",
     "ResourceGroupCreated": "Kaynak grubu başarıyla oluşturuldu",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Kaynak grubu başarıyla silindi",
     "ResourceGroupDetail": "Kaynak Grubu Ayrıntısı",
     "ResourceGroupModified": "Kaynak grubu başarıyla değiştirildi",
@@ -2385,7 +2391,9 @@
     "SelectDomain": "Etki Alanı Seç",
     "SelectScheduler": "Zamanlayıcı Seç",
     "TimeoutSeconds": "saniye",
-    "TypeResourceGroupNameToDelete": "Silmek için kaynak grubu adını yazın"
+    "TypeResourceGroupNameToDelete": "Silmek için kaynak grubu adını yazın",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Bu kaynak politikasını silmek üzeresiniz:",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2369,10 +2369,16 @@
     "NoScalingGroupAssignedToThisProject": "Không có nhóm tài nguyên nào được gán cho dự án này. \nTạo phiên và tạo triển khai sẽ bị hạn chế.",
     "PendingTimeout": "Chờ hết thời gian chờ",
     "PendingTimeoutDesc": "Thời gian tối đa một phiên có thể ở trong trạng thái chờ xử lý.\n\nNếu được đặt thành 0, nó sẽ đợi vô thời hạn mà không có giới hạn.\n\nNếu bỏ lại, nó mặc định là 0.",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "Công cộng",
     "PublicStatus": "Trạng thái công khai",
     "ResourceGroupAlreadyExist": "Một nhóm tài nguyên có cùng tên đã tồn tại.",
     "ResourceGroupCreated": "Đã tạo thành công nhóm tài nguyên",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "Đã xóa thành công nhóm tài nguyên",
     "ResourceGroupDetail": "Chi tiết Nhóm Tài nguyên",
     "ResourceGroupModified": "Đã sửa đổi thành công nhóm tài nguyên",
@@ -2387,7 +2393,9 @@
     "SelectDomain": "Chọn miền",
     "SelectScheduler": "Chọn bộ lập lịch",
     "TimeoutSeconds": "Giây",
-    "TypeResourceGroupNameToDelete": "Nhập tên nhóm tài nguyên để xóa"
+    "TypeResourceGroupNameToDelete": "Nhập tên nhóm tài nguyên để xóa",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Bạn sắp xóa chính sách tài nguyên này:",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2369,10 +2369,16 @@
     "NoScalingGroupAssignedToThisProject": "没有资源组分配给该项目。\n会话创建和部署创建将受到限制。",
     "PendingTimeout": "等待暂停",
     "PendingTimeoutDesc": "会话可以保持在待处理状态。\n\n如果设置为0，它将无限期地等待而无需限制。\n\n如果保持不设定，则默认为0。",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "公众",
     "PublicStatus": "公众地位",
     "ResourceGroupAlreadyExist": "已存在同名的资源组。",
     "ResourceGroupCreated": "资源组创建成功",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "资源组删除成功",
     "ResourceGroupDetail": "资源组详细信息",
     "ResourceGroupModified": "资源组修改成功",
@@ -2387,7 +2393,9 @@
     "SelectDomain": "选择域",
     "SelectScheduler": "选择调度程序",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "输入要删除的资源组名称"
+    "TypeResourceGroupNameToDelete": "输入要删除的资源组名称",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "您即将删除此资源策略：",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2371,10 +2371,16 @@
     "NoScalingGroupAssignedToThisProject": "沒有資源組分配給該項目。\n會話創建和部署創建將受到限制。",
     "PendingTimeout": "等待暫停",
     "PendingTimeoutDesc": "會話可以保持在待處理狀態。\n如果設置為0，它將無限期地等待而無需限制。\n如果保持不設定，則默認為0。",
+    "PreemptiblePriority": "__NOT_TRANSLATED__",
+    "PreemptiblePriorityDesc": "__NOT_TRANSLATED__",
+    "Preemption": "__NOT_TRANSLATED__",
+    "PreemptionMode": "__NOT_TRANSLATED__",
+    "PreemptionOrder": "__NOT_TRANSLATED__",
     "Public": "公众",
     "PublicStatus": "公众地位",
     "ResourceGroupAlreadyExist": "已存在同名的資源組。",
     "ResourceGroupCreated": "資源組創建成功",
+    "ResourceGroupCreatedButConfigurationFailed": "__NOT_TRANSLATED__",
     "ResourceGroupDeleted": "資源組刪除成功",
     "ResourceGroupDetail": "資源組詳細信息",
     "ResourceGroupModified": "資源組修改成功",
@@ -2389,7 +2395,9 @@
     "SelectDomain": "選擇域",
     "SelectScheduler": "選擇調度程序",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "輸入要刪除的資源組名稱"
+    "TypeResourceGroupNameToDelete": "輸入要刪除的資源組名稱",
+    "UseHostNetwork": "__NOT_TRANSLATED__",
+    "UseHostNetworkDesc": "__NOT_TRANSLATED__"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "您即將刪除此資源策略：",


### PR DESCRIPTION
Resolves #8105 (FR-3240)

## Summary
Migrate the Resource Group setting modal save path from the legacy Graphene mutations (`modify_scaling_group` / `create_scaling_group`) to the Strawberry `adminUpdateResourceGroup` / `adminCreateResourceGroupV2` mutations, and expose all `UpdateResourceGroupInput` fields — adding the two that were previously not editable: **useHostNetwork** and **preemption** (preemptible priority / order / mode).

## Changes
- **Update** → `adminUpdateResourceGroup`; **Create** → `adminCreateResourceGroupV2` (name/domain/description) then `adminUpdateResourceGroup` for the remaining fields.
- Edit-mode prefill of preemption / useHostNetwork reads the Strawberry `ResourceGroup` node (`adminResourceGroupV2`) inside the modal Suspense boundary; the legacy `ScalingGroup` fragment still supplies `scheduler_opts`.
- New mutations and the new fields are gated on manager **≥ 26.4.2**; older managers keep the previous legacy behavior (preemption / host-network fields hidden).
- On create, a failure *after* the group already exists closes the modal (list refetches) and asks the user to finish configuring via edit, avoiding an unrecoverable "already exists" retry.
- i18n: added 8 keys (en + ko translated; other locales carry `__NOT_TRANSLATED__` placeholders).

## Known backend gap (`TODO(needs-backend)`)
`UpdateResourceGroupInput` has **no** field for `scheduler_opts` (allowed session types / pending timeout / num_retries_to_skip). To avoid a regression these are still persisted via the legacy `modify_scaling_group` mutation (hybrid save), marked with `TODO(needs-backend): FR-3240`. A backend change is needed to fold `scheduler_opts` into `UpdateResourceGroupInput` so the legacy call can be dropped.

## Verification
`bash scripts/verify.sh`: Lint ✅ · Format ✅ · TypeScript ✅ · Vite ✅ · Terminology warn-only (pre-existing unrelated `error.UserHasNoGroup`). Relay artifacts committed and idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
