### PR TITLE
fix(FR-3245): use friendlier Korean labels for chat thinking UI

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -458,11 +458,11 @@
     "SelectToken": "토큰 선택",
     "SenderPlaceholder": "여기에 메시지를 입력하세요...",
     "SyncInput": "채팅 입력 동기화",
-    "Thinking": "추론중",
+    "Thinking": "생각 중",
     "TokenCounterTooltip": "TPS는 초당 처리된 토큰 수를 나타냅니다. 이 값은 클라이언트에서 측정한 값으로 네트워크 지연 시간이 포함되어 있습니다. 전체 토큰수는 입력과 채팅 메시지에 포함된 전체 토큰 수를 나타냅니다.",
     "UploadFiles": "파일 업로드",
     "UploadFilesDescription": "파일을 여기 끌어다 놓거나 이 영역을 클릭하세요",
-    "ViewReasoning": "추론 결과 보기",
+    "ViewReasoning": "생각 과정 보기",
     "chat": {
       "parameter": {
         "FrequencyPenalty": "자주 등장한 단어에 패널티를 주어 반복을 줄입니다",


### PR DESCRIPTION
Resolves #8116 (FR-3245)

## Summary

The chat reasoning panel (`react/src/components/Chat/ChatMessage.tsx`) showed two Korean labels that read too technical for conversational, transient UI text. This aligns them with the friendlier tone agreed in the terminology Teams thread, while keeping "추론" for fixed settings (e.g. the thinking-level selector).

| Key (`chatui.*`) | Before | After |
|---|---|---|
| `Thinking` (in progress + spinner) | 추론중 | **생각 중** |
| `ViewReasoning` (collapsed label) | 추론 결과 보기 | **생각 과정 보기** |

### Rationale

- **Tone**: "추론중" is too technical for a transient chat status. Claude uses "생각하는 중", GPT uses "생각 중".
- **Spacing**: the bound noun "중" must be spaced — "추론중" → "추론 중".
- **Accuracy**: the expanded content is the model's *thinking process*, not a *result* (the result is the answer body), so "과정" is more accurate than "결과".
- **Consistency**: "생각 과정 보기" shares the "생각" root with the in-progress "생각 중" label. Chosen over "사고 과정 보기" because "생각" is the softer everyday word.

## Scope

- **`resources/i18n/ko.json` only** — the two conversational labels.
- The thinking-level setting label ("추론 수준") is intentionally **not** changed (a fixed setting keeps the formal term).
- English source strings ("Thinking" / "View reasoning") are unchanged (already friendly).

## Out of scope / future

Showing elapsed time after completion (e.g. "N초 동안 생각함", like GPT mobile) needs timing data — separate task.

## Verification

- `ko.json` parses as valid JSON.
- lint-staged (prettier) ran on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)