### PR TITLE
feat(FR-3243): add SFTP resource group settings from the Resource Group page

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIStorageProxySelectQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIStorageProxySelectQuery.graphql.ts
@@ -1,0 +1,139 @@
+/**
+ * @generated SignedSource<<d09af534edf474e3d59b59003cfc7c73>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type BAIStorageProxySelectQuery$variables = {
+  limit: number;
+};
+export type BAIStorageProxySelectQuery$data = {
+  readonly storage_volume_list: {
+    readonly items: ReadonlyArray<{
+      readonly proxy: string | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
+};
+export type BAIStorageProxySelectQuery = {
+  response: BAIStorageProxySelectQuery$data;
+  variables: BAIStorageProxySelectQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "limit"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Literal",
+    "name": "offset",
+    "value": 0
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "proxy",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "BAIStorageProxySelectQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "StorageVolumeList",
+        "kind": "LinkedField",
+        "name": "storage_volume_list",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "StorageVolume",
+            "kind": "LinkedField",
+            "name": "items",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "BAIStorageProxySelectQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "StorageVolumeList",
+        "kind": "LinkedField",
+        "name": "storage_volume_list",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "StorageVolume",
+            "kind": "LinkedField",
+            "name": "items",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b18d8c964bbf7af60d564f4fa0f82338",
+    "id": null,
+    "metadata": {},
+    "name": "BAIStorageProxySelectQuery",
+    "operationKind": "query",
+    "text": "query BAIStorageProxySelectQuery(\n  $limit: Int!\n) {\n  storage_volume_list(limit: $limit, offset: 0) {\n    items {\n      proxy\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e0ada7211322acef77d2fdb321215b0b";
+
+export default node;

--- a/packages/backend.ai-ui/src/components/fragments/BAIStorageProxySelect.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIStorageProxySelect.stories.tsx
@@ -1,0 +1,367 @@
+import RelayResolver from '../../tests/RelayResolver';
+import BAIStorageProxySelect from './BAIStorageProxySelect';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+// =============================================================================
+// Mock Data
+// =============================================================================
+
+// The component derives the proxy list from `storage_volume_list.items[].proxy`,
+// so mock data is shaped as volumes (a proxy can back multiple volumes).
+const sampleVolumes = [
+  { proxy: 'local' },
+  { proxy: 'ceph-proxy' },
+  { proxy: 'pure-proxy' },
+];
+
+// Multiple volumes share the same proxy — the component dedupes to distinct
+// proxy names (3 unique proxies from 6 volumes here).
+const sampleVolumesWithDuplicateProxies = [
+  { proxy: 'local' },
+  { proxy: 'local' },
+  { proxy: 'ceph-proxy' },
+  { proxy: 'ceph-proxy' },
+  { proxy: 'pure-proxy' },
+  { proxy: 'local' },
+];
+
+const sampleManyVolumes = Array.from({ length: 15 }, (_, i) => ({
+  proxy: `proxy-${i + 1}`,
+}));
+
+/**
+ * BAIStorageProxySelect is a specialized Select component that fetches storage
+ * volumes and derives the distinct storage-proxy names from them using GraphQL.
+ *
+ * Key features:
+ * - Automatic data fetching via GraphQL query
+ * - Distinct proxy names are derived from the volume list and deduplicated
+ * - Built-in search functionality
+ * - Internationalized placeholder text
+ *
+ * @see BAIStorageProxySelect.tsx for implementation details
+ */
+const meta: Meta<typeof BAIStorageProxySelect> = {
+  title: 'Fragments/BAIStorageProxySelect',
+  component: BAIStorageProxySelect,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIStorageProxySelect** extends [BAISelect](/?path=/docs/components-input-baiselect--docs) to fetch storage volumes and present the distinct storage-proxy names.
+
+## Features
+- Fetches volumes from GraphQL query \`BAIStorageProxySelectQuery\` and derives distinct proxy names
+- Automatically removes duplicate proxy names using \`_.uniq\` + \`_.compact\`
+- Built-in search functionality enabled by default
+- Internationalized placeholder using \`comp:BAIStorageProxySelect.SelectStorageProxy\`
+- Uses the proxy name as both label and value
+
+## GraphQL Query
+\`\`\`graphql
+query BAIStorageProxySelectQuery($limit: Int!) {
+  storage_volume_list(limit: $limit, offset: 0) {
+    items {
+      proxy
+    }
+  }
+}
+\`\`\`
+
+There is no dedicated storage-proxy list field yet, so proxies are derived from the volume list (see the \`TODO(needs-backend)\` in the source).
+
+## Usage
+\`\`\`tsx
+<BAIStorageProxySelect
+  autoSelectOption
+  onChange={(value) => console.log(value)}
+/>
+\`\`\`
+
+For all other props, refer to [BAISelect](/?path=/docs/components-input-baiselect--docs).
+        `,
+      },
+    },
+  },
+  argTypes: {
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text when no value is selected',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: {
+          summary: 'i18n: comp:BAIStorageProxySelect.SelectStorageProxy',
+        },
+      },
+    },
+    autoSelectOption: {
+      control: { type: 'boolean' },
+      description:
+        'Auto-select the first option once options load and no value is set',
+      table: {
+        type: { summary: 'boolean | ((options) => value)' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the select is disabled',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    allowClear: {
+      control: { type: 'boolean' },
+      description: 'Show clear button',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    onChange: {
+      action: 'changed',
+      description: 'Callback when selection changes',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIStorageProxySelect>;
+
+/**
+ * Basic usage with 3 sample storage proxies.
+ */
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Basic usage showing 3 storage proxies. Search functionality is enabled by default, and the placeholder is internationalized.',
+      },
+    },
+  },
+  args: {},
+  render: (args) => (
+    <RelayResolver
+      mockResolvers={{
+        Query: () => ({
+          storage_volume_list: { items: sampleVolumes },
+        }),
+      }}
+    >
+      <BAIStorageProxySelect {...args} style={{ width: '300px' }} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Empty state when no storage volumes (and thus no proxies) are available.
+ */
+export const Empty: Story = {
+  name: 'EmptyState',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows the component when no storage proxies are configured.',
+      },
+    },
+  },
+  args: {},
+  render: (args) => (
+    <RelayResolver
+      mockResolvers={{
+        Query: () => ({
+          storage_volume_list: { items: [] },
+        }),
+      }}
+    >
+      <BAIStorageProxySelect {...args} style={{ width: '300px' }} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Automatic deduplication of proxy names derived from multiple volumes.
+ */
+export const WithDuplicates: Story = {
+  name: 'AutomaticDeduplication',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates automatic deduplication when multiple volumes share the same proxy. Only distinct proxy names are shown (3 unique proxies from 6 volumes).',
+      },
+    },
+  },
+  args: {},
+  render: (args) => (
+    <RelayResolver
+      mockResolvers={{
+        Query: () => ({
+          storage_volume_list: { items: sampleVolumesWithDuplicateProxies },
+        }),
+      }}
+    >
+      <BAIStorageProxySelect {...args} style={{ width: '300px' }} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Auto-select the first proxy once options load.
+ */
+export const AutoSelectFirst: Story = {
+  name: 'AutoSelectFirstOption',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With `autoSelectOption`, the first proxy is selected automatically once options load and no value is set — used by the SFTP Resource Group settings modal. This requires a controlled `value`/`onChange` pair (as a real consumer, e.g. an antd `Form.Item`, would provide) — `autoSelectOption` only *calls* `onChange`, it does not maintain the selection itself.',
+      },
+    },
+  },
+  args: {
+    autoSelectOption: true,
+  },
+  render: (args) => {
+    const [value, setValue] = useState<string>();
+    return (
+      <RelayResolver
+        mockResolvers={{
+          Query: () => ({
+            storage_volume_list: { items: sampleVolumes },
+          }),
+        }}
+      >
+        <BAIStorageProxySelect
+          {...args}
+          value={value}
+          onChange={setValue}
+          style={{ width: '300px' }}
+        />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Multiple selection mode, picking from existing proxy options.
+ */
+export const MultiSelect: Story = {
+  name: 'MultipleSelection',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With `mode="multiple"`, users can select several proxies from the existing options (as opposed to `mode="tags"`, which also allows free text entry).',
+      },
+    },
+  },
+  args: {
+    mode: 'multiple',
+    defaultValue: ['local', 'ceph-proxy'],
+  },
+  render: (args) => (
+    <RelayResolver
+      mockResolvers={{
+        Query: () => ({
+          storage_volume_list: { items: sampleVolumes },
+        }),
+      }}
+    >
+      <BAIStorageProxySelect {...args} style={{ width: '300px' }} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Disabled state of the select.
+ */
+export const Disabled: Story = {
+  name: 'DisabledState',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows the component in a disabled state where users cannot interact with it.',
+      },
+    },
+  },
+  args: {
+    disabled: true,
+  },
+  render: (args) => (
+    <RelayResolver
+      mockResolvers={{
+        Query: () => ({
+          storage_volume_list: { items: sampleVolumes },
+        }),
+      }}
+    >
+      <BAIStorageProxySelect {...args} style={{ width: '300px' }} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Select with clear button enabled.
+ */
+export const WithClearButton: Story = {
+  name: 'ClearButton',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Select with allowClear enabled, allowing users to clear their selection.',
+      },
+    },
+  },
+  args: {
+    allowClear: true,
+  },
+  render: (args) => (
+    <RelayResolver
+      mockResolvers={{
+        Query: () => ({
+          storage_volume_list: { items: sampleVolumes },
+        }),
+      }}
+    >
+      <BAIStorageProxySelect {...args} style={{ width: '300px' }} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Select with many storage proxies.
+ */
+export const ManyProxies: Story = {
+  name: 'ManyOptions',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the component with 15 storage proxies, showing a scrollable dropdown with search functionality.',
+      },
+    },
+  },
+  args: {
+    allowClear: true,
+  },
+  render: (args) => (
+    <RelayResolver
+      mockResolvers={{
+        Query: () => ({
+          storage_volume_list: { items: sampleManyVolumes },
+        }),
+      }}
+    >
+      <BAIStorageProxySelect {...args} style={{ width: '300px' }} />
+    </RelayResolver>
+  ),
+};

--- a/packages/backend.ai-ui/src/components/fragments/BAIStorageProxySelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIStorageProxySelect.tsx
@@ -1,0 +1,51 @@
+import { BAIStorageProxySelectQuery } from '../../__generated__/BAIStorageProxySelectQuery.graphql';
+import { useBAIi18n } from '../../hooks/useBAIi18n';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import * as _ from 'lodash-es';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export interface BAIStorageProxySelectProps extends Omit<
+  BAISelectProps,
+  'options'
+> {}
+
+// TODO(needs-backend, FR-3243): there is no dedicated storage-proxy list
+// field; proxies are derived from the (offset-paginated) volume list. Swap
+// this for a dedicated field once one exists. A real deployment's volume
+// count is nowhere near this ceiling, so a single fixed-size fetch is enough
+// to surface every distinct proxy in the meantime.
+const VOLUME_FETCH_LIMIT = 1000;
+
+const BAIStorageProxySelect = (selectProps: BAIStorageProxySelectProps) => {
+  'use memo';
+  const { t } = useBAIi18n();
+
+  const { storage_volume_list } = useLazyLoadQuery<BAIStorageProxySelectQuery>(
+    graphql`
+      query BAIStorageProxySelectQuery($limit: Int!) {
+        storage_volume_list(limit: $limit, offset: 0) {
+          items {
+            proxy
+          }
+        }
+      }
+    `,
+    { limit: VOLUME_FETCH_LIMIT },
+    {},
+  );
+
+  const proxies = _.uniq(
+    _.compact(_.map(storage_volume_list?.items, (item) => item?.proxy)),
+  );
+
+  return (
+    <BAISelect
+      options={_.map(proxies, (proxy) => ({ label: proxy, value: proxy }))}
+      showSearch
+      placeholder={t('comp:BAIStorageProxySelect.SelectStorageProxy')}
+      {...selectProps}
+    />
+  );
+};
+
+export default BAIStorageProxySelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -78,6 +78,8 @@ export { default as BAIProjectResourcePolicySelect } from './BAIProjectResourceP
 export type { BAIProjectResourcePolicySelectProps } from './BAIProjectResourcePolicySelect';
 export { default as BAIResourceGroupSelect } from './BAIResourceGroupSelect';
 export type { BAIResourceGroupSelectProps } from './BAIResourceGroupSelect';
+export { default as BAIStorageProxySelect } from './BAIStorageProxySelect';
+export type { BAIStorageProxySelectProps } from './BAIStorageProxySelect';
 export { default as BAIProjectBulkEditModal } from './BAIProjectBulkEditModal';
 export type { BAIProjectBulkEditModalProps } from './BAIProjectBulkEditModal';
 export { default as BAIAgentTable } from './BAIAgentTable';

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Speicher-Host auswählen"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Speicher-Proxy auswählen"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Beendet um",
     "ErrorCode": "Fehlercode",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Επιλέξτε κεντρικό αποθηκευτικό χώρο"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Επιλέξτε proxy αποθήκευσης"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Έληξε στις",
     "ErrorCode": "Κωδικός σφάλματος",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Select Storage Host"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Select Storage Proxy"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Ended At",
     "ErrorCode": "Error Code",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Seleccionar host de almacenamiento"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Seleccionar proxy de almacenamiento"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Finalizado en",
     "ErrorCode": "Código de error",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Valitse tallennuspalvelin"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Valitse tallennusvälityspalvelin"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Päättymisaika",
     "ErrorCode": "Virhekoodi",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Sélectionner un hôte de stockage"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Sélectionner un proxy de stockage"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Terminé le",
     "ErrorCode": "Code d'erreur",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Pilih Host Penyimpanan"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Pilih Proksi Penyimpanan"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Berakhir pada",
     "ErrorCode": "Kode Kesalahan",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Seleziona host di archiviazione"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Seleziona proxy di archiviazione"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Terminato il",
     "ErrorCode": "Codice di errore",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "ストレージホストを選択"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "ストレージプロキシを選択"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "終了日時",
     "ErrorCode": "エラーコード",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "스토리지 호스트를 선택해주세요"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "스토리지 프록시를 선택해주세요"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "종료일",
     "ErrorCode": "오류 코드",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Хадгалах хост сонгох"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Хадгалалтын прокси сонгох"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Дууссан цаг",
     "ErrorCode": "Алдааны код",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Pilih Hos Storan"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Pilih Proksi Storan"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Berakhir pada",
     "ErrorCode": "Kod Ralat",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Wybierz host pamięci masowej"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Wybierz serwer proxy pamięci masowej"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Zakończono o",
     "ErrorCode": "Kod błędu",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -373,6 +373,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Selecionar host de armazenamento"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Selecionar proxy de armazenamento"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Finalizado em",
     "ErrorCode": "Código de erro",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Selecionar host de armazenamento"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Selecionar proxy de armazenamento"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Finalizado em",
     "ErrorCode": "Código de erro",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Выберите хост хранилища"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Выберите прокси хранилища"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Завершено в",
     "ErrorCode": "Код ошибки",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "เลือกโฮสต์จัดเก็บข้อมูล"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "เลือกพร็อกซีที่เก็บข้อมูล"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "สิ้นสุดเมื่อ",
     "ErrorCode": "รหัสข้อผิดพลาด",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Depolama Sunucusu Seç"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Depolama Proxy'si Seç"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Bitiş Zamanı",
     "ErrorCode": "Hata Kodu",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "Chọn máy chủ lưu trữ"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "Chọn proxy lưu trữ"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "Kết thúc lúc",
     "ErrorCode": "Mã lỗi",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "选择存储主机"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "选择存储代理"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "结束时间",
     "ErrorCode": "错误代码",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -367,6 +367,9 @@
   "comp:BAIStorageHostSelect": {
     "SelectStorageHost": "選擇儲存主機"
   },
+  "comp:BAIStorageProxySelect": {
+    "SelectStorageProxy": "選擇儲存代理"
+  },
   "comp:BAISubStepNodes": {
     "EndedAt": "結束時間",
     "ErrorCode": "錯誤代碼",

--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -69,13 +69,11 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
     ],
     queryFn: () =>
       baiModalProps.open
-        ? baiRequestWithPromise({
+        ? baiRequestWithPromise<{ shared: Array<Invitee> }>({
             method: 'GET',
             url: `/folders/_/shared${vfolderId ? `?${new URLSearchParams({ vfolder_id: vfolderId }).toString()}` : ''}`,
-          }).then((res: { shared: Array<Invitee> }) =>
-            _.sortBy(res.shared, 'shared_to.email'),
-          )
-        : null,
+          }).then((res) => _.sortBy(res.shared, 'shared_to.email'))
+        : [],
     staleTime: 0,
   });
 

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -8,9 +8,13 @@ import {
   ResourceGroupListQuery$data,
 } from '../__generated__/ResourceGroupListQuery.graphql';
 import { ResourceGroupListUpdateMutation } from '../__generated__/ResourceGroupListUpdateMutation.graphql';
+import { useSuspendedBackendaiClient } from '../hooks';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useSFTPProxyResourceGroupsQuery } from '../hooks/useSFTPResourceGroups';
 import BAIRadioGroup from './BAIRadioGroup';
 import ResourceGroupInfoModal from './ResourceGroupInfoModal';
 import ResourceGroupSettingModal from './ResourceGroupSettingModal';
+import UpdateResourceGroupsModal from './UpdateResourceGroupsModal';
 import {
   CheckOutlined,
   CloseOutlined,
@@ -19,7 +23,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { App, theme } from 'antd';
+import { App, Tag, Tooltip, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
   useUpdatableState,
@@ -31,10 +35,13 @@ import {
   BAIDeleteConfirmModal,
   BAIFetchKeyButton,
   BAINameActionCell,
+  BAIQuestionIconWithTooltip,
+  BAISelectionLabel,
+  BAIUnmountAfterClose,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { BanIcon, PlusIcon, UndoIcon } from 'lucide-react';
-import { useState, useTransition } from 'react';
+import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 import { PayloadError } from 'relay-runtime';
@@ -55,17 +62,40 @@ type ResourceGroup = NonNullable<
 >;
 
 const ResourceGroupList: React.FC = () => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const baiClient = useSuspendedBackendaiClient();
   const [activeType, setActiveType] = useState<'active' | 'inactive'>('active');
   const [openCreateModal, { toggle: toggleOpenCreateModal }] = useToggle(false);
   const [openInfoModal, { toggle: toggleOpenInfoModal }] = useToggle(false);
+  const [openSFTPModal, setOpenSFTPModal] = useState(false);
   const [selectedResourceGroup, setSelectedResourceGroup] =
     useState<ResourceGroup>();
   const [selectedResourceGroupName, setSelectedResourceGroupName] =
     useState<string>();
+  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
+  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
+    'table_column_overrides.ResourceGroupList',
+  );
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
+  // Read the `proxy -> resource group names` map from etcd (superadmin-only),
+  // non-blocking (the table renders without waiting on it) and invalidated on
+  // every SFTP write so it stays fresh. Inverted to `group name -> proxies`
+  // to show, per row, which storage proxies handle that group's SFTP.
+  const { data: proxyResourceGroups } = useSFTPProxyResourceGroupsQuery({
+    enabled: baiClient.is_superadmin,
+  });
+  const proxiesByGroupName = _.mapValues(
+    _.groupBy(
+      _.flatMap(_.entries(proxyResourceGroups ?? {}), ([proxy, groupNames]) =>
+        _.map(groupNames, (groupName) => ({ proxy, groupName })),
+      ),
+      'groupName',
+    ),
+    (pairs) => _.map(pairs, 'proxy'),
+  );
   const [isActiveTypePending, startActiveTypeTransition] = useTransition();
   const [isPendingRefetch, startRefetchTransition] = useTransition();
 
@@ -208,15 +238,21 @@ const ResourceGroupList: React.FC = () => {
                 },
               },
             },
-            {
-              key: 'delete',
-              title: t('button.Delete'),
-              icon: <DeleteFilled />,
-              type: 'danger',
-              onClick: () => {
-                setSelectedResourceGroupName(record?.name || '');
-              },
-            },
+            // Deletion is only offered for deactivated groups (Inactive tab);
+            // active groups are deactivated first.
+            ...(activeType === 'inactive'
+              ? [
+                  {
+                    key: 'delete',
+                    title: t('button.Delete'),
+                    icon: <DeleteFilled />,
+                    type: 'danger' as const,
+                    onClick: () => {
+                      setSelectedResourceGroupName(record?.name || '');
+                    },
+                  },
+                ]
+              : []),
           ]}
         />
       ),
@@ -236,6 +272,35 @@ const ResourceGroupList: React.FC = () => {
           <CheckOutlined style={{ color: token.colorSuccess }} />
         ) : (
           <CloseOutlined style={{ color: token.colorTextSecondary }} />
+        );
+      },
+    },
+    {
+      key: 'sftp',
+      title: (
+        <BAIFlex gap="xxs">
+          {t('storageProxy.SFTPStorageProxies')}
+          <BAIQuestionIconWithTooltip
+            title={t('storageProxy.SFTPStorageProxiesDescription')}
+          />
+        </BAIFlex>
+      ),
+      // Reading the assignment needs superadmin (raw etcd), so only they see it.
+      hidden: !baiClient.is_superadmin,
+      render: (_value, record) => {
+        const proxies = record.name
+          ? (proxiesByGroupName[record.name] ?? [])
+          : [];
+        return proxies.length > 0 ? (
+          <BAIFlex gap="xxs" wrap="wrap">
+            {_.map(proxies, (proxy) => (
+              <Tag key={proxy} color="blue">
+                {proxy}
+              </Tag>
+            ))}
+          </BAIFlex>
+        ) : (
+          '-'
         );
       },
     },
@@ -266,6 +331,7 @@ const ResourceGroupList: React.FC = () => {
           onChange={(value) => {
             startActiveTypeTransition(() => {
               setActiveType(value.target.value);
+              setSelectedRowKeys([]);
             });
           }}
           optionType="button"
@@ -281,6 +347,21 @@ const ResourceGroupList: React.FC = () => {
           ]}
         />
         <BAIFlex gap="xs">
+          {baiClient.is_superadmin && selectedRowKeys.length > 0 && (
+            <BAIFlex align="center" gap="xs">
+              <BAISelectionLabel
+                count={selectedRowKeys.length}
+                onClearSelection={() => setSelectedRowKeys([])}
+              />
+              <Tooltip title={t('button.Settings')}>
+                <BAIButton
+                  icon={<SettingOutlined style={{ color: token.colorInfo }} />}
+                  style={{ backgroundColor: token.colorInfoBg }}
+                  onClick={() => setOpenSFTPModal(true)}
+                />
+              </Tooltip>
+            </BAIFlex>
+          )}
           <BAIFetchKeyButton
             loading={isPendingRefetch}
             value={fetchKey}
@@ -308,6 +389,19 @@ const ResourceGroupList: React.FC = () => {
         columns={columns}
         dataSource={filterOutNullAndUndefined(scaling_groups)}
         loading={isActiveTypePending}
+        rowSelection={
+          baiClient.is_superadmin
+            ? {
+                type: 'checkbox',
+                selectedRowKeys,
+                onChange: (keys) => setSelectedRowKeys(keys),
+              }
+            : undefined
+        }
+        tableSettings={{
+          columnOverrides,
+          onColumnOverridesChange: setColumnOverrides,
+        }}
       />
 
       <BAIDeleteConfirmModal
@@ -380,6 +474,18 @@ const ResourceGroupList: React.FC = () => {
           }
         }}
       />
+      <BAIUnmountAfterClose>
+        <UpdateResourceGroupsModal
+          open={openSFTPModal}
+          resourceGroupNames={selectedRowKeys as string[]}
+          onRequestClose={(success) => {
+            setOpenSFTPModal(false);
+            if (success) {
+              setSelectedRowKeys([]);
+            }
+          }}
+        />
+      </BAIUnmountAfterClose>
     </BAIFlex>
   );
 };

--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -7,7 +7,13 @@ import { ResourceGroupSettingModalCreateMutation } from '../__generated__/Resour
 import { ResourceGroupSettingModalFragment$key } from '../__generated__/ResourceGroupSettingModalFragment.graphql';
 import { ResourceGroupSettingModalUpdateMutation } from '../__generated__/ResourceGroupSettingModalUpdateMutation.graphql';
 import { newLineToBrElement } from '../helper';
-import { useCurrentDomainValue } from '../hooks';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
+import {
+  computeProxyDelta,
+  proxiesServingGroups,
+  useSFTPProxyResourceGroupsQuery,
+  useSFTPResourceGroups,
+} from '../hooks/useSFTPResourceGroups';
 import { ScalingGroupOpts } from './ResourceGroupList';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import {
@@ -31,9 +37,11 @@ import {
   BAICard,
   BAIFlex,
   BAIDomainSelect,
+  BAIStorageProxySelect,
+  useBAILogger,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { Suspense, useMemo, useRef } from 'react';
+import React, { Suspense, useDeferredValue, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
@@ -49,6 +57,7 @@ type FormInputType = {
   scheduler: string;
   pendingTimeout: number;
   retriesToSkip: number;
+  sftpProxies: string[];
 };
 
 interface ResourceGroupCreateModalProps extends ModalProps {
@@ -61,10 +70,14 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
   onRequestClose,
   ...modalProps
 }) => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const { logger } = useBAILogger();
+  const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
+  const { applyGroupProxyDelta } = useSFTPResourceGroups();
   const formRef = useRef<FormInstance>(null);
 
   const resourceGroup = useFragment(
@@ -82,6 +95,23 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
     `,
     resourceGroupFrgmt,
   );
+
+  // Superadmin-only SFTP proxy membership for this group, read from etcd without
+  // suspending: gate on a deferred `open` so enabling runs in a transition. The
+  // field below skeletons until the map resolves, then mounts with its prefill
+  // as the Form.Item `initialValue` — the rest of the form renders immediately.
+  const deferredOpen = useDeferredValue(modalProps.open);
+  const { data: proxyResourceGroups, isFetching: isSftpMapFetching } =
+    useSFTPProxyResourceGroupsQuery({
+      enabled: baiClient.is_superadmin && !!deferredOpen,
+    });
+  const currentSftpProxies = proxiesServingGroups(
+    proxyResourceGroups,
+    resourceGroup?.name ? [resourceGroup.name] : [],
+  );
+  const isSftpMapLoading =
+    proxyResourceGroups === undefined || isSftpMapFetching;
+
   const [commitUpdateResourceGroup, isInFlightCommitUpdateResourceGroup] =
     useMutation<ResourceGroupSettingModalUpdateMutation>(graphql`
       mutation ResourceGroupSettingModalUpdateMutation(
@@ -192,6 +222,40 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
               wsproxy_api_token: values.wsProxyAPIToken,
             };
 
+            // After the group is saved, sync its SFTP proxy membership to the
+            // selected proxies (add to newly-selected proxies, remove from
+            // deselected ones, preserving other groups on each proxy).
+            // Deselection here removes without a separate confirm — unlike the
+            // bulk modal — because Update is an explicit, per-group edit.
+            // Superadmin-only.
+            const applySftpProxies = (groupName: string): Promise<void> => {
+              if (!baiClient.is_superadmin) {
+                return Promise.resolve();
+              }
+              const { added, removed } = computeProxyDelta(
+                currentSftpProxies,
+                values.sftpProxies ?? [],
+              );
+              return applyGroupProxyDelta([groupName], added, removed).then(
+                (results) => {
+                  const failed = results.filter((r) => r.status === 'rejected');
+                  if (failed.length > 0) {
+                    failed.forEach((r) => {
+                      if (r.status === 'rejected') {
+                        logger.error(
+                          'Failed to update SFTP storage proxies:',
+                          r.reason,
+                        );
+                      }
+                    });
+                    message.error(
+                      t('storageProxy.FailedToUpdateSFTPResourceGroups'),
+                    );
+                  }
+                },
+              );
+            };
+
             if (resourceGroup) {
               commitUpdateResourceGroup({
                 variables: {
@@ -214,7 +278,9 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
                     return;
                   }
                   message.success(t('resourceGroup.ResourceGroupModified'));
-                  onRequestClose?.(true);
+                  applySftpProxies(resourceGroup.name).finally(() =>
+                    onRequestClose?.(true),
+                  );
                 },
                 onError: (err) => {
                   message.error(err.message);
@@ -267,7 +333,9 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
                     }
 
                     message.success(t('resourceGroup.ResourceGroupCreated'));
-                    onRequestClose?.(true);
+                    applySftpProxies(values.name).finally(() =>
+                      onRequestClose?.(true),
+                    );
                   },
                   onError: (err) => {
                     message.error(err.message);
@@ -357,6 +425,28 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
           >
             <Input.Password placeholder={t('resourceGroup.EnterAPIToken')} />
           </Form.Item>
+          {baiClient.is_superadmin ? (
+            isSftpMapLoading ? (
+              <Form.Item label={t('storageProxy.SFTPStorageProxies')}>
+                <Select loading />
+              </Form.Item>
+            ) : (
+              // Wrap the Form.Item (not the select — that would break Form's
+              // value/onChange binding) in Suspense: BAIStorageProxySelect's
+              // proxy-options query suspends. The prefill is registered as the
+              // Form.Item `initialValue`, computed from the now-resolved map.
+              <Suspense fallback={<Select loading />}>
+                <Form.Item
+                  label={t('storageProxy.SFTPStorageProxies')}
+                  name="sftpProxies"
+                  initialValue={currentSftpProxies}
+                  tooltip={t('storageProxy.SFTPStorageProxiesDescription')}
+                >
+                  <BAIStorageProxySelect mode="multiple" allowClear />
+                </Form.Item>
+              </Suspense>
+            )
+          ) : null}
           <Row>
             <Col span={12}>
               <Form.Item

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -77,6 +77,7 @@ type StorageVolume = NonNullable<
 >;
 
 const StorageProxyList = () => {
+  'use memo';
   const { token } = theme.useToken();
   const { t } = useTranslation();
   const [drawerStorageHostId, setDrawerStorageHostId] = useState<string | null>(

--- a/react/src/components/UpdateResourceGroupsModal.tsx
+++ b/react/src/components/UpdateResourceGroupsModal.tsx
@@ -1,0 +1,182 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  proxiesServingGroups,
+  useSFTPProxyResourceGroupsQuery,
+  useSFTPResourceGroups,
+} from '../hooks/useSFTPResourceGroups';
+import { App, Form, Skeleton, Typography } from 'antd';
+import {
+  BAIFlex,
+  BAIListAlert,
+  BAIModal,
+  BAIModalProps,
+  BAIStorageProxySelect,
+  useBAILogger,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import React, { Suspense, useDeferredValue, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+interface UpdateResourceGroupsModalProps extends BAIModalProps {
+  /** Resource group names pre-selected on the caller's list. */
+  resourceGroupNames: string[];
+  onRequestClose: (success: boolean) => void;
+}
+
+const UpdateResourceGroupsModal: React.FC<UpdateResourceGroupsModalProps> = ({
+  resourceGroupNames,
+  onRequestClose,
+  open,
+  ...baiModalProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message, modal } = App.useApp();
+  const { logger } = useBAILogger();
+  const [form] = Form.useForm();
+  const { applyGroupProxyDelta } = useSFTPResourceGroups();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Read the proxy -> resource-groups map without suspending: gate it on a
+  // deferred `open` so enabling the query runs in a transition, and surface the
+  // fetch through the modal's own loading skeleton (below) instead of a Suspense
+  // fallback. The modal body — and thus the form's `initialValues` — only mounts
+  // once the map resolves, so the prefill is always computed from real data.
+  const deferredOpen = useDeferredValue(open);
+  const { data: proxyResourceGroups, isFetching } =
+    useSFTPProxyResourceGroupsQuery({ enabled: !!deferredOpen });
+
+  // Proxies currently serving any of the selected groups: the field prefill and
+  // the baseline for the submit delta.
+  const currentProxies = proxiesServingGroups(
+    proxyResourceGroups,
+    resourceGroupNames,
+  );
+
+  const applyDelta = async (added: string[], removed: string[]) => {
+    setIsSubmitting(true);
+    const results = await applyGroupProxyDelta(
+      resourceGroupNames,
+      added,
+      removed,
+    );
+    setIsSubmitting(false);
+
+    const failed = results.filter((r) => r.status === 'rejected');
+    if (failed.length > 0) {
+      failed.forEach((r) => {
+        if (r.status === 'rejected') {
+          logger.error('Failed to update SFTP resource groups:', r.reason);
+        }
+      });
+      if (failed.length === results.length) {
+        message.error(t('storageProxy.FailedToUpdateSFTPResourceGroups'));
+        return;
+      }
+    }
+    message.success(t('storageProxy.SFTPResourceGroupsUpdated'));
+    onRequestClose(true);
+  };
+
+  const handleOk = () => {
+    return form
+      .validateFields()
+      .then((values) => {
+        const target: string[] = values.proxies ?? [];
+        // Bulk intent: every selected group must end up on every chosen proxy.
+        // `currentProxies` is a union (a proxy shows as selected when it serves
+        // ANY one of the groups), so it can't drive the delta — a proxy that
+        // already serves one selected group would be skipped, leaving the other
+        // groups unassigned. Compute additions from the full per-proxy map: a
+        // chosen proxy needs a write if it is missing at least one selected
+        // group. Removals stay union-based: proxies deselected here drop the
+        // selected groups.
+        const added = target.filter(
+          (proxy) =>
+            _.difference(resourceGroupNames, proxyResourceGroups?.[proxy] ?? [])
+              .length > 0,
+        );
+        const removed = _.difference(currentProxies, target);
+
+        if (added.length === 0 && removed.length === 0) {
+          onRequestClose(true);
+          return;
+        }
+        // Deselecting a proxy removes the selected groups from it, a
+        // destructive change, so confirm first; pure additions apply directly.
+        if (removed.length > 0) {
+          modal.confirm({
+            title: t('storageProxy.ConfirmRemoveSFTPProxiesTitle'),
+            content: (
+              <Trans
+                i18nKey="storageProxy.ConfirmRemoveSFTPProxiesContent"
+                values={{ proxies: removed.join(', ') }}
+                components={{ code: <Typography.Text code /> }}
+              />
+            ),
+            okText: t('button.Remove'),
+            okButtonProps: { danger: true },
+            cancelText: t('button.Cancel'),
+            onOk: () => applyDelta(added, removed),
+          });
+          return;
+        }
+        return applyDelta(added, removed);
+      })
+      .catch((error) => {
+        setIsSubmitting(false);
+        logger.error('SFTP resource group form validation failed:', error);
+      });
+  };
+
+  return (
+    <BAIModal
+      open={open}
+      title={t('resourceGroup.UpdateResourceGroups')}
+      onOk={handleOk}
+      onCancel={() => onRequestClose(false)}
+      confirmLoading={isSubmitting}
+      loading={proxyResourceGroups === undefined || isFetching}
+      destroyOnHidden
+      {...baiModalProps}
+    >
+      <BAIFlex direction="column" align="stretch" gap="md">
+        <BAIListAlert
+          type="info"
+          showIcon
+          ghostInfoBg={false}
+          title={t('storageProxy.FollowingResourceGroupsWillBeConfigured')}
+          items={_.map(resourceGroupNames, (name) => ({
+            key: name,
+            content: name,
+          }))}
+        />
+        <Form
+          form={form}
+          layout="vertical"
+          preserve={false}
+          requiredMark="optional"
+          initialValues={{ proxies: currentProxies }}
+        >
+          {/* The proxy options come from a Relay query that suspends, so wrap
+              the whole Form.Item (not the select — that would break Form's
+              value/onChange binding) in its own Suspense boundary. */}
+          <Suspense fallback={<Skeleton.Input active block />}>
+            <Form.Item
+              name="proxies"
+              label={t('storageProxy.SFTPStorageProxies')}
+              tooltip={t('storageProxy.SFTPStorageProxiesDescription')}
+            >
+              <BAIStorageProxySelect mode="multiple" allowClear />
+            </Form.Item>
+          </Suspense>
+        </Form>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default UpdateResourceGroupsModal;

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -23,7 +23,7 @@ export const newLineToBrElement = (
   });
 };
 
-export const baiSignedRequestWithPromise = ({
+export const baiSignedRequestWithPromise = <ResponseType = any,>({
   method,
   url,
   body = null,
@@ -33,14 +33,14 @@ export const baiSignedRequestWithPromise = ({
   url: string;
   body?: any;
   client: any;
-}) => {
+}): Promise<ResponseType> => {
   const request = client?.newSignedRequest(method, url, body, null);
   return client?._wrapWithPromise(request);
 };
 
 export const useBaiSignedRequestWithPromise = () => {
   const baiClient = useSuspendedBackendaiClient();
-  return ({
+  return <ResponseType = any,>({
     method,
     url,
     body = null,
@@ -48,8 +48,8 @@ export const useBaiSignedRequestWithPromise = () => {
     method: string;
     url: string;
     body?: any;
-  }) =>
-    baiSignedRequestWithPromise({
+  }): Promise<ResponseType> =>
+    baiSignedRequestWithPromise<ResponseType>({
       method,
       url,
       body,

--- a/react/src/hooks/useSFTPResourceGroups.tsx
+++ b/react/src/hooks/useSFTPResourceGroups.tsx
@@ -1,0 +1,194 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useBaiSignedRequestWithPromise } from '../helper';
+import { useTanQuery } from './reactQueryAlias';
+import { queryOptions, useQueryClient } from '@tanstack/react-query';
+import * as _ from 'lodash-es';
+
+type BaiSignedRequest = ReturnType<typeof useBaiSignedRequestWithPromise>;
+
+const SFTP_PROXY_RESOURCE_GROUPS_QUERY_KEY = ['sftpProxyResourceGroups'];
+
+const PROXIES_ETCD_PREFIX = 'volumes/proxies';
+
+const etcdKey = (proxy: string) =>
+  `${PROXIES_ETCD_PREFIX}/${proxy}/sftp_scaling_groups`;
+
+const parseGroups = (value: string | null | undefined): string[] =>
+  typeof value === 'string'
+    ? value
+        .split(',')
+        .map((group) => group.trim())
+        .filter(Boolean)
+    : [];
+
+/**
+ * Read the `proxy -> resource group names` map straight from etcd
+ * (`/config/get` prefix on `volumes/proxies`). We read etcd — not
+ * `vfolder.list_hosts()` — because the manager caches `sftp_scaling_groups`
+ * at proxy-load time, so a fresh `/config/set` is not reflected by
+ * `list_hosts()` until the manager reloads. etcd is the store we write to,
+ * so this is immediately consistent after a write. Superadmin-only.
+ *
+ * The prefix read returns a nested tree keyed by proxy name, e.g.
+ * `{ local: { sftp_scaling_groups: "a,b", client_api: "...", ... }, ... }`.
+ */
+const getProxyResourceGroups = async (
+  baiSignedRequest: BaiSignedRequest,
+): Promise<Record<string, string[]>> => {
+  const res = await baiSignedRequest<{
+    result?: Record<
+      string,
+      { sftp_scaling_groups?: string | null } | null
+    > | null;
+  }>({
+    method: 'POST',
+    url: '/config/get',
+    body: { key: PROXIES_ETCD_PREFIX, prefix: true },
+  });
+  return _.mapValues(res?.result ?? {}, (proxyConfig) =>
+    parseGroups(proxyConfig?.sftp_scaling_groups),
+  );
+};
+
+/**
+ * Single source of truth for the proxy-resource-groups query (key + fetcher),
+ * shared by the suspending and non-suspending reader hooks below and by the
+ * write hook's cache invalidation. Superadmin-only (raw `/config/get`).
+ */
+const sftpProxyResourceGroupsQueryOptions = (
+  baiSignedRequest: BaiSignedRequest,
+) =>
+  queryOptions({
+    queryKey: SFTP_PROXY_RESOURCE_GROUPS_QUERY_KEY,
+    queryFn: () => getProxyResourceGroups(baiSignedRequest),
+  });
+
+/**
+ * The storage proxies currently serving SFTP for any of `groupNames`, derived
+ * from the `proxy -> resource group names` map. Prefills the proxy multi-select
+ * and doubles as the baseline for the submit delta. A union across groups is
+ * correct even when the selected groups' assignments differ: deselecting a
+ * proxy is a per-proxy no-op for groups that weren't on it.
+ */
+export const proxiesServingGroups = (
+  proxyResourceGroups: Record<string, string[]> | undefined,
+  groupNames: string[],
+): string[] =>
+  _.keys(
+    _.pickBy(
+      proxyResourceGroups ?? {},
+      (groups) => _.intersection(groups, groupNames).length > 0,
+    ),
+  );
+
+/**
+ * The proxy-membership change from `initialProxies` to `targetProxies`:
+ * proxies newly selected (to add to) and deselected (to remove from). Callers
+ * need `removed` separately (e.g. to confirm before a destructive removal),
+ * so this stays a pure helper rather than being hidden inside the write.
+ */
+export const computeProxyDelta = (
+  initialProxies: string[],
+  targetProxies: string[],
+) => ({
+  added: _.difference(targetProxies, initialProxies),
+  removed: _.difference(initialProxies, targetProxies),
+});
+
+/**
+ * Write helpers for the per-storage-proxy SFTP resource-group assignment that
+ * lives in etcd at `volumes/proxies/{proxy}/sftp_scaling_groups` (comma-joined).
+ * There is no GraphQL mutation for this key, so writes go through raw superadmin
+ * signed requests against `/config/{get,set}`.
+ *
+ * Every write reads the proxy's current list first and merges, because `set`
+ * overwrites the whole key — this preserves resource groups already assigned to
+ * the proxy that this operation isn't touching.
+ */
+export const useSFTPResourceGroups = () => {
+  'use memo';
+  const baiSignedRequest = useBaiSignedRequestWithPromise();
+  const queryClient = useQueryClient();
+
+  const getGroupsForProxy = (proxy: string): Promise<string[]> =>
+    baiSignedRequest<{ result?: string | null }>({
+      method: 'POST',
+      url: '/config/get',
+      body: { key: etcdKey(proxy), prefix: false },
+    }).then((res) => parseGroups(res?.result));
+
+  const setGroupsForProxy = (
+    proxy: string,
+    groups: string[],
+  ): Promise<unknown> =>
+    // An empty list means the proxy is no longer designated for any group.
+    // Delete the etcd key rather than writing '', because the manager parses
+    // the value with a comma-splitter: '' becomes [''] (a bogus empty-named
+    // group), not the unset state. A deleted key reads back as None, the
+    // documented "all groups" default.
+    groups.length === 0
+      ? baiSignedRequest<unknown>({
+          method: 'POST',
+          url: '/config/delete',
+          body: { key: etcdKey(proxy), prefix: false },
+        })
+      : baiSignedRequest<unknown>({
+          method: 'POST',
+          url: '/config/set',
+          body: { key: etcdKey(proxy), value: groups.join(',') },
+        });
+
+  /**
+   * Apply a proxy-membership delta to a set of groups at once: add every group
+   * in `groupNames` to `addedProxies` and remove them from `removedProxies`,
+   * preserving other groups on each affected proxy. `addedProxies` and
+   * `removedProxies` are disjoint by construction. Runs every proxy write
+   * concurrently and invalidates the cached map once. Shared write path for
+   * both the per-group and bulk SFTP settings flows.
+   */
+  const applyGroupProxyDelta = async (
+    groupNames: string[],
+    addedProxies: string[],
+    removedProxies: string[],
+  ) => {
+    const results = await Promise.allSettled([
+      ...addedProxies.map(async (proxy) => {
+        const existing = await getGroupsForProxy(proxy);
+        await setGroupsForProxy(proxy, _.union(existing, groupNames));
+      }),
+      ...removedProxies.map(async (proxy) => {
+        const existing = await getGroupsForProxy(proxy);
+        await setGroupsForProxy(proxy, _.difference(existing, groupNames));
+      }),
+    ]);
+    queryClient.invalidateQueries({
+      queryKey: SFTP_PROXY_RESOURCE_GROUPS_QUERY_KEY,
+    });
+    return results;
+  };
+
+  return {
+    applyGroupProxyDelta,
+  };
+};
+
+/**
+ * Non-suspending read of the `proxy -> resource group names` map. Used both by
+ * the resource-group list column and by the setting modals, which gate it on a
+ * deferred `open` and surface the fetch through their own loading skeletons
+ * rather than a Suspense boundary. Pass `enabled: false` for non-superadmins,
+ * who cannot read the raw etcd config.
+ */
+export const useSFTPProxyResourceGroupsQuery = (options?: {
+  enabled?: boolean;
+}) => {
+  'use memo';
+  const baiSignedRequest = useBaiSignedRequestWithPromise();
+  return useTanQuery({
+    ...sftpProxyResourceGroupsQueryOptions(baiSignedRequest),
+    enabled: options?.enabled,
+  });
+};

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -433,6 +433,7 @@
     "PushToImage": "Push-Sitzung auf benutzerdefiniertes Bild",
     "Refresh": "Aktualisierung",
     "RefreshModelInformation": "Modellinformationen aktualisieren",
+    "Remove": "Entfernen",
     "Reset": "Zurücksetzen",
     "Retry": "Wiederholen",
     "Revoke": "Widerrufen",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "Domain auswählen",
     "SelectScheduler": "Wählen Sie Planer",
     "TimeoutSeconds": "Sekunden",
-    "TypeResourceGroupNameToDelete": "Geben Sie den Namen der zu löschenden Ressourcengruppe ein"
+    "TypeResourceGroupNameToDelete": "Geben Sie den Namen der zu löschenden Ressourcengruppe ein",
+    "UpdateResourceGroups": "Ressourcengruppen aktualisieren"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Sie sind im Begriff, diese Ressourcenrichtlinie zu löschen:",
@@ -3215,6 +3217,15 @@
       "ProjectFolderPermissions": "Projektordner-Berechtigungen",
       "UserFolderPermissions": "Benutzerordner-Berechtigungen"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Die ausgewählten Ressourcengruppen verwenden diese Speicher-Proxys nicht mehr für SFTP: <code>{{proxies}}</code>. Fortfahren?",
+    "ConfirmRemoveSFTPProxiesTitle": "SFTP-Speicher-Proxy-Einstellung entfernen?",
+    "FailedToUpdateSFTPResourceGroups": "Aktualisierung der SFTP-Ressourcengruppen fehlgeschlagen.",
+    "FollowingResourceGroupsWillBeConfigured": "Die folgenden Ressourcengruppen werden aktualisiert:",
+    "SFTPResourceGroupsUpdated": "SFTP-Ressourcengruppen wurden aktualisiert.",
+    "SFTPStorageProxies": "SFTP-Speicher-Proxys",
+    "SFTPStorageProxiesDescription": "Speicher-Proxys, die genutzt werden, wenn Benutzer dieser Ressourcengruppe Dateien per SFTP in ihre Ordner übertragen."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Aktiviert",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -433,6 +433,7 @@
     "PushToImage": "Σπρώξτε τη συνεδρία σε προσαρμοσμένη εικόνα",
     "Refresh": "Φρεσκάρω",
     "RefreshModelInformation": "Ανανέωση πληροφοριών μοντέλου",
+    "Remove": "Αφαίρεση",
     "Reset": "Επαναφορά",
     "Retry": "Επανάληψη",
     "Revoke": "Ανάκληση",
@@ -2404,7 +2405,8 @@
     "SelectDomain": "Επιλέξτε τομέα",
     "SelectScheduler": "Επιλέξτε Προγραμματιστής",
     "TimeoutSeconds": "δευτερόλεπτα",
-    "TypeResourceGroupNameToDelete": "Πληκτρολογήστε όνομα ομάδας πόρων για διαγραφή"
+    "TypeResourceGroupNameToDelete": "Πληκτρολογήστε όνομα ομάδας πόρων για διαγραφή",
+    "UpdateResourceGroups": "Ενημέρωση ομάδων πόρων"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Πρόκειται να διαγράψετε αυτήν την πολιτική πόρων:",
@@ -3213,6 +3215,15 @@
       "ProjectFolderPermissions": "Άδειες φακέλου έργου",
       "UserFolderPermissions": "Άδειες φακέλου χρήστη"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Οι επιλεγμένες ομάδες πόρων δεν θα χρησιμοποιούν πλέον αυτούς τους διακομιστές μεσολάβησης αποθήκευσης για SFTP: <code>{{proxies}}</code>. Συνέχεια;",
+    "ConfirmRemoveSFTPProxiesTitle": "Αφαίρεση ρύθμισης Proxy αποθήκευσης SFTP;",
+    "FailedToUpdateSFTPResourceGroups": "Αποτυχία ενημέρωσης ομάδων πόρων SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Οι ακόλουθες ομάδες πόρων θα ενημερωθούν:",
+    "SFTPResourceGroupsUpdated": "Οι ομάδες πόρων SFTP ενημερώθηκαν.",
+    "SFTPStorageProxies": "Proxy αποθήκευσης SFTP",
+    "SFTPStorageProxiesDescription": "Διακομιστές μεσολάβησης αποθήκευσης που χρησιμοποιούνται όταν οι χρήστες αυτής της ομάδας πόρων μεταφέρουν αρχεία στους φακέλους τους μέσω SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Ενεργοποιημένη",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -420,6 +420,7 @@
     "PushToImage": "Push session to customized image",
     "Refresh": "Refresh",
     "RefreshModelInformation": "Refresh Model Information",
+    "Remove": "Remove",
     "Reset": "Reset",
     "Retry": "Retry",
     "Revoke": "Revoke",
@@ -2391,7 +2392,8 @@
     "SelectDomain": "Select Domain",
     "SelectScheduler": "Select Scheduler",
     "TimeoutSeconds": "Seconds",
-    "TypeResourceGroupNameToDelete": "Type resource group name to delete"
+    "TypeResourceGroupNameToDelete": "Type resource group name to delete",
+    "UpdateResourceGroups": "Update Resource Groups"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "You are about to delete this resource policy: ",
@@ -3200,6 +3202,15 @@
       "ProjectFolderPermissions": "Project Folder Permissions",
       "UserFolderPermissions": "User Folder Permissions"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "The selected resource groups will no longer use these storage proxies for SFTP: <code>{{proxies}}</code>. Continue?",
+    "ConfirmRemoveSFTPProxiesTitle": "Remove SFTP storage proxy setting?",
+    "FailedToUpdateSFTPResourceGroups": "Failed to update SFTP resource groups.",
+    "FollowingResourceGroupsWillBeConfigured": "The following resource groups will be updated:",
+    "SFTPResourceGroupsUpdated": "SFTP resource groups updated.",
+    "SFTPStorageProxies": "SFTP Storage Proxies",
+    "SFTPStorageProxiesDescription": "Storage proxies used when users in this resource group transfer files to their folders over SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Enabled",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -433,6 +433,7 @@
     "PushToImage": "Enviar sesión a una imagen personalizada",
     "Refresh": "Actualizar",
     "RefreshModelInformation": "Actualizar información del modelo",
+    "Remove": "Quitar",
     "Reset": "Restablecer",
     "Retry": "Reintentar",
     "Revoke": "Revocar",
@@ -2404,7 +2405,8 @@
     "SelectDomain": "Seleccionar dominio",
     "SelectScheduler": "Seleccione Programador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Escriba el nombre del grupo de recursos que desea eliminar"
+    "TypeResourceGroupNameToDelete": "Escriba el nombre del grupo de recursos que desea eliminar",
+    "UpdateResourceGroups": "Actualizar grupos de recursos"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Está a punto de eliminar esta política de recursos:",
@@ -3213,6 +3215,15 @@
       "ProjectFolderPermissions": "Permisos de carpeta de proyecto",
       "UserFolderPermissions": "Permisos de carpeta de usuario"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Los grupos de recursos seleccionados ya no usarán estos proxies de almacenamiento para SFTP: <code>{{proxies}}</code>. ¿Continuar?",
+    "ConfirmRemoveSFTPProxiesTitle": "¿Quitar la configuración de proxy de almacenamiento SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Error al actualizar los grupos de recursos SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Se actualizarán los siguientes grupos de recursos:",
+    "SFTPResourceGroupsUpdated": "Grupos de recursos SFTP actualizados.",
+    "SFTPStorageProxies": "Proxies de almacenamiento SFTP",
+    "SFTPStorageProxiesDescription": "Proxies de almacenamiento que se usan cuando los usuarios de este grupo de recursos transfieren archivos a sus carpetas mediante SFTP."
   },
   "summary": {
     "ATOMEnabled": "NPU ATOM Activada",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -433,6 +433,7 @@
     "PushToImage": "Työnnä istunto mukautettuun kuvaan",
     "Refresh": "Päivitä",
     "RefreshModelInformation": "Päivitä mallin tiedot",
+    "Remove": "Poista",
     "Reset": "Nollaa",
     "Retry": "Yritä uudelleen",
     "Revoke": "Peruuta",
@@ -2404,7 +2405,8 @@
     "SelectDomain": "Valitse verkkotunnus",
     "SelectScheduler": "Valitse Ajastin",
     "TimeoutSeconds": "Sekuntia",
-    "TypeResourceGroupNameToDelete": "Kirjoita poistettavan resurssiryhmän nimi"
+    "TypeResourceGroupNameToDelete": "Kirjoita poistettavan resurssiryhmän nimi",
+    "UpdateResourceGroups": "Päivitä resurssiryhmät"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Olet poistamassa tätä resurssikäytäntöä:",
@@ -3213,6 +3215,15 @@
       "ProjectFolderPermissions": "Projektikansion oikeudet",
       "UserFolderPermissions": "Käyttäjäkansion oikeudet"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Valitut resurssiryhmät eivät enää käytä näitä tallennusvälityspalvelimia SFTP:tä varten: <code>{{proxies}}</code>. Jatketaanko?",
+    "ConfirmRemoveSFTPProxiesTitle": "Poistetaanko SFTP-tallennusvälityspalvelimen asetus?",
+    "FailedToUpdateSFTPResourceGroups": "SFTP-resurssiryhmien päivittäminen epäonnistui.",
+    "FollowingResourceGroupsWillBeConfigured": "Seuraavat resurssiryhmät päivitetään:",
+    "SFTPResourceGroupsUpdated": "SFTP-resurssiryhmät päivitetty.",
+    "SFTPStorageProxies": "SFTP-tallennusvälityspalvelimet",
+    "SFTPStorageProxiesDescription": "Tallennusvälityspalvelimet, joita käytetään, kun tämän resurssiryhmän käyttäjät siirtävät tiedostoja kansioihinsa SFTP:n kautta."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU käytössä",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -433,6 +433,7 @@
     "PushToImage": "Pousser la session vers une image personnalisée",
     "Refresh": "Rafraîchir",
     "RefreshModelInformation": "Actualiser les informations sur le modèle",
+    "Remove": "Supprimer",
     "Reset": "Réinitialisation",
     "Retry": "Réessayer",
     "Revoke": "Révoquer",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "Sélectionnez le domaine",
     "SelectScheduler": "Sélectionnez le planificateur",
     "TimeoutSeconds": "Seconds",
-    "TypeResourceGroupNameToDelete": "Tapez le nom du groupe de ressources à supprimer"
+    "TypeResourceGroupNameToDelete": "Tapez le nom du groupe de ressources à supprimer",
+    "UpdateResourceGroups": "Mettre à jour les groupes de ressources"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Vous êtes sur le point de supprimer cette stratégie de ressources :",
@@ -3216,6 +3218,15 @@
       "ProjectFolderPermissions": "Autorisations des dossiers de projet",
       "UserFolderPermissions": "Autorisations des dossiers utilisateur"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Les groupes de ressources sélectionnés n'utiliseront plus ces proxies de stockage pour le SFTP : <code>{{proxies}}</code>. Continuer ?",
+    "ConfirmRemoveSFTPProxiesTitle": "Supprimer le paramètre de proxy de stockage SFTP ?",
+    "FailedToUpdateSFTPResourceGroups": "Échec de la mise à jour des groupes de ressources SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Les groupes de ressources suivants seront mis à jour :",
+    "SFTPResourceGroupsUpdated": "Groupes de ressources SFTP mis à jour.",
+    "SFTPStorageProxies": "Proxies de stockage SFTP",
+    "SFTPStorageProxiesDescription": "Proxies de stockage utilisés lorsque les utilisateurs de ce groupe de ressources transfèrent des fichiers vers leurs dossiers via SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Activé",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -433,6 +433,7 @@
     "PushToImage": "Sesi dorong ke gambar yang disesuaikan",
     "Refresh": "Segarkan",
     "RefreshModelInformation": "Menyegarkan Informasi Model",
+    "Remove": "Hapus",
     "Reset": "Atur Ulang",
     "Retry": "Coba lagi",
     "Revoke": "Cabut",
@@ -2407,7 +2408,8 @@
     "SelectDomain": "Pilih Domain",
     "SelectScheduler": "Pilih Penjadwal",
     "TimeoutSeconds": "Detik",
-    "TypeResourceGroupNameToDelete": "Ketik nama grup sumber daya yang akan dihapus"
+    "TypeResourceGroupNameToDelete": "Ketik nama grup sumber daya yang akan dihapus",
+    "UpdateResourceGroups": "Perbarui Grup Sumber Daya"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Anda akan menghapus kebijakan sumber daya ini:",
@@ -3217,6 +3219,15 @@
       "ProjectFolderPermissions": "Izin Folder Proyek",
       "UserFolderPermissions": "Izin Folder Pengguna"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Grup sumber daya yang dipilih tidak akan lagi menggunakan proksi penyimpanan ini untuk SFTP: <code>{{proxies}}</code>. Lanjutkan?",
+    "ConfirmRemoveSFTPProxiesTitle": "Hapus pengaturan Proksi Penyimpanan SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Gagal memperbarui grup sumber daya SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Grup sumber daya berikut akan diperbarui:",
+    "SFTPResourceGroupsUpdated": "Grup sumber daya SFTP telah diperbarui.",
+    "SFTPStorageProxies": "Proksi Penyimpanan SFTP",
+    "SFTPStorageProxiesDescription": "Proksi penyimpanan yang digunakan saat pengguna dalam grup sumber daya ini mentransfer berkas ke folder mereka melalui SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Diaktifkan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -433,6 +433,7 @@
     "PushToImage": "Push della sessione all'immagine personalizzata",
     "Refresh": "ricaricare",
     "RefreshModelInformation": "Aggiornare le informazioni sul modello",
+    "Remove": "Rimuovi",
     "Reset": "Reset",
     "Retry": "Riprova",
     "Revoke": "Revoca",
@@ -2404,7 +2405,8 @@
     "SelectDomain": "Seleziona dominio",
     "SelectScheduler": "Seleziona l'agenda",
     "TimeoutSeconds": "Secondi",
-    "TypeResourceGroupNameToDelete": "Digita il nome del gruppo di risorse da eliminare"
+    "TypeResourceGroupNameToDelete": "Digita il nome del gruppo di risorse da eliminare",
+    "UpdateResourceGroups": "Aggiorna gruppi di risorse"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Stai per eliminare questa policy sulle risorse:",
@@ -3213,6 +3215,15 @@
       "ProjectFolderPermissions": "Autorizzazioni cartella di progetto",
       "UserFolderPermissions": "Autorizzazioni cartella utente"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "I gruppi di risorse selezionati non utilizzeranno più questi proxy di archiviazione per SFTP: <code>{{proxies}}</code>. Continuare?",
+    "ConfirmRemoveSFTPProxiesTitle": "Rimuovere l'impostazione del proxy di archiviazione SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Impossibile aggiornare i gruppi di risorse SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "I seguenti gruppi di risorse verranno aggiornati:",
+    "SFTPResourceGroupsUpdated": "Gruppi di risorse SFTP aggiornati.",
+    "SFTPStorageProxies": "Proxy di archiviazione SFTP",
+    "SFTPStorageProxiesDescription": "Proxy di archiviazione usati quando gli utenti di questo gruppo di risorse trasferiscono file nelle loro cartelle tramite SFTP."
   },
   "summary": {
     "ATOMEnabled": "NPU ATOM abilitata",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -433,6 +433,7 @@
     "PushToImage": "セッションをカスタマイズされたイメージにプッシュする",
     "Refresh": "更新",
     "RefreshModelInformation": "モデル情報の更新",
+    "Remove": "削除",
     "Reset": "初期化",
     "Retry": "再試行",
     "Revoke": "無効化",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "ドメインを選択",
     "SelectScheduler": "スケジューラを選択",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "削除するリソースグループ名を入力します"
+    "TypeResourceGroupNameToDelete": "削除するリソースグループ名を入力します",
+    "UpdateResourceGroups": "リソースグループを更新"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "このリソースポリシーを削除しようとしています。",
@@ -3215,6 +3217,15 @@
       "ProjectFolderPermissions": "プロジェクトフォルダーの権限",
       "UserFolderPermissions": "ユーザーフォルダーの権限"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "選択したリソースグループは、これらのストレージプロキシをSFTP用として使用しなくなります: <code>{{proxies}}</code>。続行しますか？",
+    "ConfirmRemoveSFTPProxiesTitle": "SFTPストレージプロキシの設定を解除しますか？",
+    "FailedToUpdateSFTPResourceGroups": "SFTPリソースグループの更新に失敗しました。",
+    "FollowingResourceGroupsWillBeConfigured": "以下のリソースグループを更新します:",
+    "SFTPResourceGroupsUpdated": "SFTPリソースグループが更新されました。",
+    "SFTPStorageProxies": "SFTPストレージプロキシ",
+    "SFTPStorageProxiesDescription": "このリソースグループのユーザーがSFTPでフォルダーにファイルを転送するときに使用するストレージプロキシです。"
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU使用中",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -433,6 +433,7 @@
     "PushToImage": "세션을 사용자 정의된 이미지로 푸시",
     "Refresh": "새로고침",
     "RefreshModelInformation": "모델 정보 새로고침",
+    "Remove": "제거",
     "Reset": "초기화",
     "Retry": "재시도",
     "Revoke": "해지",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "도메인 선택",
     "SelectScheduler": "스케줄러 선택",
     "TimeoutSeconds": "초",
-    "TypeResourceGroupNameToDelete": "삭제하려는 자원 그룹 이름을 다시 한번 입력하세요."
+    "TypeResourceGroupNameToDelete": "삭제하려는 자원 그룹 이름을 다시 한번 입력하세요.",
+    "UpdateResourceGroups": "자원 그룹 업데이트"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "아래의 자원 정책을 삭제하려고 합니다: ",
@@ -3216,6 +3218,15 @@
       "ProjectFolderPermissions": "프로젝트 폴더 권한",
       "UserFolderPermissions": "사용자 폴더 권한"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "선택한 자원 그룹이 다음 스토리지 프록시에서 SFTP용으로 더 이상 사용되지 않습니다: <code>{{proxies}}</code>. 계속하시겠습니까?",
+    "ConfirmRemoveSFTPProxiesTitle": "SFTP 스토리지 프록시 설정을 해제할까요?",
+    "FailedToUpdateSFTPResourceGroups": "SFTP 자원 그룹 업데이트에 실패했습니다.",
+    "FollowingResourceGroupsWillBeConfigured": "다음 자원 그룹을 업데이트합니다:",
+    "SFTPResourceGroupsUpdated": "SFTP 자원 그룹이 업데이트되었습니다.",
+    "SFTPStorageProxies": "SFTP 스토리지 프록시",
+    "SFTPStorageProxiesDescription": "이 자원 그룹의 사용자가 SFTP로 폴더에 파일을 전송할 때 사용하는 스토리지 프록시입니다."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU 사용 중",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -433,6 +433,7 @@
     "PushToImage": "Тохируулсан зураг руу түлхэх сесс",
     "Refresh": "Сэргээх",
     "RefreshModelInformation": "Загварын мэдээллийг шинэчлэх",
+    "Remove": "Хасах",
     "Reset": "Дахин тохируулах",
     "Retry": "Дахин оролдох",
     "Revoke": "Цуцлах",
@@ -2405,7 +2406,8 @@
     "SelectDomain": "Домэйн сонгоно уу",
     "SelectScheduler": "Цагийн хуваарийг сонгоно уу",
     "TimeoutSeconds": "Секунд",
-    "TypeResourceGroupNameToDelete": "Устгахын тулд нөөцийн бүлгийн нэрийг бичнэ үү"
+    "TypeResourceGroupNameToDelete": "Устгахын тулд нөөцийн бүлгийн нэрийг бичнэ үү",
+    "UpdateResourceGroups": "Нөөцийн бүлгүүдийг шинэчлэх"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Та энэ нөөцийн бодлогыг устгах гэж байна:",
@@ -3215,6 +3217,15 @@
       "ProjectFolderPermissions": "Төслийн хавтасны зөвшөөрлүүд",
       "UserFolderPermissions": "Хэрэглэгчийн хавтасны зөвшөөрлүүд"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Сонгосон нөөцийн бүлгүүд эдгээр хадгалалтын проксийг SFTP-д цаашид ашиглахгүй болно: <code>{{proxies}}</code>. Үргэлжлүүлэх үү?",
+    "ConfirmRemoveSFTPProxiesTitle": "SFTP хадгалалтын проксийн тохиргоог хасах уу?",
+    "FailedToUpdateSFTPResourceGroups": "SFTP нөөцийн бүлгүүдийг шинэчлэхэд алдаа гарлаа.",
+    "FollowingResourceGroupsWillBeConfigured": "Дараах нөөцийн бүлгүүдийг шинэчилнэ:",
+    "SFTPResourceGroupsUpdated": "SFTP нөөцийн бүлгүүд шинэчлэгдлээ.",
+    "SFTPStorageProxies": "SFTP хадгалалтын прокси",
+    "SFTPStorageProxiesDescription": "Энэ нөөцийн бүлгийн хэрэглэгчид SFTP-ээр хавтас руугаа файл дамжуулахад ашигладаг хадгалалтын прокси."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU-г идэвхжүүлсэн",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -433,6 +433,7 @@
     "PushToImage": "Sesi tolak ke imej tersuai",
     "Refresh": "Segarkan",
     "RefreshModelInformation": "Refresh Model Maklumat",
+    "Remove": "Buang",
     "Reset": "Tetapkan semula",
     "Retry": "Cuba semula",
     "Revoke": "Batalkan",
@@ -2404,7 +2405,8 @@
     "SelectDomain": "Pilih Domain",
     "SelectScheduler": "Pilih Penjadual",
     "TimeoutSeconds": "Detik",
-    "TypeResourceGroupNameToDelete": "Taipkan nama kumpulan sumber untuk dipadamkan"
+    "TypeResourceGroupNameToDelete": "Taipkan nama kumpulan sumber untuk dipadamkan",
+    "UpdateResourceGroups": "Kemas kini Kumpulan Sumber"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Anda akan memadamkan dasar sumber ini:",
@@ -3213,6 +3215,15 @@
       "ProjectFolderPermissions": "Kebenaran Folder Projek",
       "UserFolderPermissions": "Kebenaran Folder Pengguna"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Kumpulan sumber yang dipilih tidak akan lagi menggunakan proksi storan ini untuk SFTP: <code>{{proxies}}</code>. Teruskan?",
+    "ConfirmRemoveSFTPProxiesTitle": "Buang tetapan Proksi Storan SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Gagal mengemas kini kumpulan sumber SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Kumpulan sumber berikut akan dikemas kini:",
+    "SFTPResourceGroupsUpdated": "Kumpulan sumber SFTP telah dikemas kini.",
+    "SFTPStorageProxies": "Proksi Storan SFTP",
+    "SFTPStorageProxiesDescription": "Proksi storan yang digunakan apabila pengguna dalam kumpulan sumber ini memindahkan fail ke folder mereka melalui SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Didayakan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -433,6 +433,7 @@
     "PushToImage": "Prześlij sesję do spersonalizowanego obrazu",
     "Refresh": "Odświeżać",
     "RefreshModelInformation": "Odświeżanie informacji o modelu",
+    "Remove": "Usuń",
     "Reset": "Reset",
     "Retry": "Ponów",
     "Revoke": "Odwołaj",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "Wybierz domenę",
     "SelectScheduler": "Wybierz harmonogram",
     "TimeoutSeconds": "sekundy",
-    "TypeResourceGroupNameToDelete": "Wpisz nazwę grupy zasobów do usunięcia"
+    "TypeResourceGroupNameToDelete": "Wpisz nazwę grupy zasobów do usunięcia",
+    "UpdateResourceGroups": "Aktualizuj grupy zasobów"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Zamierzasz usunąć tę zasadę dotyczącą zasobów:",
@@ -3216,6 +3218,15 @@
       "ProjectFolderPermissions": "Uprawnienia folderu projektu",
       "UserFolderPermissions": "Uprawnienia folderu użytkownika"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Wybrane grupy zasobów przestaną używać tych serwerów proxy pamięci masowej do SFTP: <code>{{proxies}}</code>. Kontynuować?",
+    "ConfirmRemoveSFTPProxiesTitle": "Usunąć ustawienie serwera proxy pamięci masowej SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Nie udało się zaktualizować grup zasobów SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Następujące grupy zasobów zostaną zaktualizowane:",
+    "SFTPResourceGroupsUpdated": "Grupy zasobów SFTP zostały zaktualizowane.",
+    "SFTPStorageProxies": "Serwery proxy pamięci masowej SFTP",
+    "SFTPStorageProxiesDescription": "Serwery proxy pamięci masowej używane, gdy użytkownicy tej grupy zasobów przesyłają pliki do swoich folderów przez SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Enabled",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -433,6 +433,7 @@
     "PushToImage": "Enviar sessão para imagem personalizada",
     "Refresh": "Atualizar",
     "RefreshModelInformation": "Atualizar informações sobre o modelo",
+    "Remove": "Remover",
     "Reset": "Reiniciar",
     "Retry": "Tentar novamente",
     "Revoke": "Revogar",
@@ -2404,7 +2405,8 @@
     "SelectDomain": "Selecione o domínio",
     "SelectScheduler": "Selecione o Agendador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir"
+    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir",
+    "UpdateResourceGroups": "Atualizar Grupos de Recursos"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Você está prestes a excluir esta política de recursos:",
@@ -3213,6 +3215,15 @@
       "ProjectFolderPermissions": "Permissões de pasta de projeto",
       "UserFolderPermissions": "Permissões de pasta de usuário"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Os grupos de recursos selecionados deixarão de usar esses proxies de armazenamento para SFTP: <code>{{proxies}}</code>. Continuar?",
+    "ConfirmRemoveSFTPProxiesTitle": "Remover a configuração de proxy de armazenamento SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Falha ao atualizar os grupos de recursos SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Os seguintes grupos de recursos serão atualizados:",
+    "SFTPResourceGroupsUpdated": "Grupos de recursos SFTP atualizados.",
+    "SFTPStorageProxies": "Proxies de armazenamento SFTP",
+    "SFTPStorageProxiesDescription": "Proxies de armazenamento usados quando os usuários deste grupo de recursos transferem arquivos para suas pastas via SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Ativado",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -433,6 +433,7 @@
     "PushToImage": "Enviar sessão para imagem personalizada",
     "Refresh": "Atualizar",
     "RefreshModelInformation": "Atualizar informações sobre o modelo",
+    "Remove": "Remover",
     "Reset": "Reiniciar",
     "Retry": "Tentar novamente",
     "Revoke": "Revogar",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "Selecione o domínio",
     "SelectScheduler": "Selecione o Agendador",
     "TimeoutSeconds": "Segundos",
-    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir"
+    "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir",
+    "UpdateResourceGroups": "Atualizar Grupos de Recursos"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Você está prestes a excluir esta política de recursos:",
@@ -3215,6 +3217,15 @@
       "ProjectFolderPermissions": "Permissões de pasta de projeto",
       "UserFolderPermissions": "Permissões de pasta de utilizador"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Os grupos de recursos selecionados deixarão de utilizar estes proxies de armazenamento para SFTP: <code>{{proxies}}</code>. Continuar?",
+    "ConfirmRemoveSFTPProxiesTitle": "Remover a configuração de proxy de armazenamento SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Falha ao atualizar os grupos de recursos SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Os seguintes grupos de recursos serão atualizados:",
+    "SFTPResourceGroupsUpdated": "Grupos de recursos SFTP atualizados.",
+    "SFTPStorageProxies": "Proxies de armazenamento SFTP",
+    "SFTPStorageProxiesDescription": "Proxies de armazenamento usados quando os utilizadores deste grupo de recursos transferem ficheiros para as suas pastas via SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Ativado",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -433,6 +433,7 @@
     "PushToImage": "Отправить сеанс на настроенное изображение",
     "Refresh": "Обновить",
     "RefreshModelInformation": "Обновить информацию о модели",
+    "Remove": "Удалить",
     "Reset": "Перезагрузить",
     "Retry": "Повторить",
     "Revoke": "Отозвать",
@@ -2404,7 +2405,8 @@
     "SelectDomain": "Выбрать домен",
     "SelectScheduler": "Выберите планировщик",
     "TimeoutSeconds": "Секунды",
-    "TypeResourceGroupNameToDelete": "Введите имя группы ресурсов для удаления"
+    "TypeResourceGroupNameToDelete": "Введите имя группы ресурсов для удаления",
+    "UpdateResourceGroups": "Обновить группы ресурсов"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Вы собираетесь удалить эту политику ресурсов:",
@@ -3213,6 +3215,15 @@
       "ProjectFolderPermissions": "Права доступа к папкам проекта",
       "UserFolderPermissions": "Права доступа к папкам пользователя"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Выбранные группы ресурсов больше не будут использовать эти прокси хранилища для SFTP: <code>{{proxies}}</code>. Продолжить?",
+    "ConfirmRemoveSFTPProxiesTitle": "Удалить настройку прокси хранилища SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Не удалось обновить группы ресурсов SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Следующие группы ресурсов будут обновлены:",
+    "SFTPResourceGroupsUpdated": "Группы ресурсов SFTP обновлены.",
+    "SFTPStorageProxies": "Прокси хранилища SFTP",
+    "SFTPStorageProxiesDescription": "Прокси хранилища, используемые, когда пользователи этой группы ресурсов передают файлы в свои папки по SFTP."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Включено",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -433,6 +433,7 @@
     "PushToImage": "ผลักดันเซสชันไปยังอิมเมจที่กำหนดเอง",
     "Refresh": "รีเฟรช",
     "RefreshModelInformation": "รีเฟรชข้อมูลโมเดล",
+    "Remove": "ลบ",
     "Reset": "รีเซ็ต",
     "Retry": "ลองใหม่",
     "Revoke": "เพิกถอน",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "เลือกโดเมน",
     "SelectScheduler": "เลือกตัวจัดกำหนดการ",
     "TimeoutSeconds": "วินาที",
-    "TypeResourceGroupNameToDelete": "พิมพ์ชื่อกลุ่มทรัพยากรเพื่อลบ"
+    "TypeResourceGroupNameToDelete": "พิมพ์ชื่อกลุ่มทรัพยากรเพื่อลบ",
+    "UpdateResourceGroups": "อัปเดตกลุ่มทรัพยากร"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "คุณกำลังจะลบนโยบายทรัพยากรนี้: ",
@@ -3215,6 +3217,15 @@
       "ProjectFolderPermissions": "สิทธิ์โฟลเดอร์โครงการ",
       "UserFolderPermissions": "สิทธิ์โฟลเดอร์ผู้ใช้"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "กลุ่มทรัพยากรที่เลือกจะไม่ใช้พร็อกซีที่เก็บข้อมูลเหล่านี้สำหรับ SFTP อีกต่อไป: <code>{{proxies}}</code> ดำเนินการต่อหรือไม่?",
+    "ConfirmRemoveSFTPProxiesTitle": "นำการตั้งค่าพร็อกซีที่เก็บข้อมูล SFTP ออกหรือไม่?",
+    "FailedToUpdateSFTPResourceGroups": "ไม่สามารถอัปเดตกลุ่มทรัพยากร SFTP ได้",
+    "FollowingResourceGroupsWillBeConfigured": "กลุ่มทรัพยากรต่อไปนี้จะได้รับการอัปเดต:",
+    "SFTPResourceGroupsUpdated": "อัปเดตกลุ่มทรัพยากร SFTP เรียบร้อยแล้ว",
+    "SFTPStorageProxies": "พร็อกซีที่เก็บข้อมูล SFTP",
+    "SFTPStorageProxiesDescription": "พร็อกซีที่เก็บข้อมูลที่ใช้เมื่อผู้ใช้ในกลุ่มทรัพยากรนี้ถ่ายโอนไฟล์ไปยังโฟลเดอร์ของตนผ่าน SFTP"
   },
   "summary": {
     "ATOMEnabled": "เปิดใช้งาน ATOM NPU",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -433,6 +433,7 @@
     "PushToImage": "Oturumu özelleştirilmiş resme aktarın",
     "Refresh": "Yenile",
     "RefreshModelInformation": "Model Bilgilerini Yenile",
+    "Remove": "Kaldır",
     "Reset": "Sıfırla",
     "Retry": "Yeniden Dene",
     "Revoke": "İptal Et",
@@ -2404,7 +2405,8 @@
     "SelectDomain": "Etki Alanı Seç",
     "SelectScheduler": "Zamanlayıcı Seç",
     "TimeoutSeconds": "saniye",
-    "TypeResourceGroupNameToDelete": "Silmek için kaynak grubu adını yazın"
+    "TypeResourceGroupNameToDelete": "Silmek için kaynak grubu adını yazın",
+    "UpdateResourceGroups": "Kaynak Gruplarını Güncelle"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Bu kaynak politikasını silmek üzeresiniz:",
@@ -3213,6 +3215,15 @@
       "ProjectFolderPermissions": "Proje Klasörü İzinleri",
       "UserFolderPermissions": "Kullanıcı Klasörü İzinleri"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Seçili kaynak grupları bu depolama proxy'lerini artık SFTP için kullanmayacak: <code>{{proxies}}</code>. Devam edilsin mi?",
+    "ConfirmRemoveSFTPProxiesTitle": "SFTP Depolama Proxy'si ayarı kaldırılsın mı?",
+    "FailedToUpdateSFTPResourceGroups": "SFTP kaynak grupları güncellenemedi.",
+    "FollowingResourceGroupsWillBeConfigured": "Aşağıdaki kaynak grupları güncellenecektir:",
+    "SFTPResourceGroupsUpdated": "SFTP kaynak grupları güncellendi.",
+    "SFTPStorageProxies": "SFTP Depolama Proxy'leri",
+    "SFTPStorageProxiesDescription": "Bu kaynak grubundaki kullanıcılar SFTP ile klasörlerine dosya aktarırken kullanılan depolama proxy'leri."
   },
   "summary": {
     "ATOMEnabled": "ATOM NPU Etkin",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -433,6 +433,7 @@
     "PushToImage": "Đẩy phiên sang hình ảnh tùy chỉnh",
     "Refresh": "Làm tươi",
     "RefreshModelInformation": "Làm mới thông tin mô hình",
+    "Remove": "Xóa",
     "Reset": "Cài lại",
     "Retry": "Thử lại",
     "Revoke": "Thu hồi",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "Chọn miền",
     "SelectScheduler": "Chọn bộ lập lịch",
     "TimeoutSeconds": "Giây",
-    "TypeResourceGroupNameToDelete": "Nhập tên nhóm tài nguyên để xóa"
+    "TypeResourceGroupNameToDelete": "Nhập tên nhóm tài nguyên để xóa",
+    "UpdateResourceGroups": "Cập nhật nhóm tài nguyên"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "Bạn sắp xóa chính sách tài nguyên này:",
@@ -3215,6 +3217,15 @@
       "ProjectFolderPermissions": "Quyền thư mục dự án",
       "UserFolderPermissions": "Quyền thư mục người dùng"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "Các nhóm tài nguyên đã chọn sẽ không còn sử dụng các proxy lưu trữ này cho SFTP: <code>{{proxies}}</code>. Tiếp tục?",
+    "ConfirmRemoveSFTPProxiesTitle": "Xóa cài đặt proxy lưu trữ SFTP?",
+    "FailedToUpdateSFTPResourceGroups": "Không thể cập nhật nhóm tài nguyên SFTP.",
+    "FollowingResourceGroupsWillBeConfigured": "Các nhóm tài nguyên sau sẽ được cập nhật:",
+    "SFTPResourceGroupsUpdated": "Đã cập nhật nhóm tài nguyên SFTP.",
+    "SFTPStorageProxies": "Proxy lưu trữ SFTP",
+    "SFTPStorageProxiesDescription": "Các proxy lưu trữ được dùng khi người dùng trong nhóm tài nguyên này truyền tệp đến thư mục của họ qua SFTP."
   },
   "summary": {
     "ATOMEnabled": "Đã bật NPU ATOM",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -433,6 +433,7 @@
     "PushToImage": "将会话推送到自定义镜像",
     "Refresh": "刷新",
     "RefreshModelInformation": "刷新机型信息",
+    "Remove": "移除",
     "Reset": "重置",
     "Retry": "重试",
     "Revoke": "撤销",
@@ -2406,7 +2407,8 @@
     "SelectDomain": "选择域",
     "SelectScheduler": "选择调度程序",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "输入要删除的资源组名称"
+    "TypeResourceGroupNameToDelete": "输入要删除的资源组名称",
+    "UpdateResourceGroups": "更新资源组"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "您即将删除此资源策略：",
@@ -3215,6 +3217,15 @@
       "ProjectFolderPermissions": "项目文件夹权限",
       "UserFolderPermissions": "用户文件夹权限"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "所选资源组将不再使用以下存储代理进行 SFTP: <code>{{proxies}}</code>。是否继续？",
+    "ConfirmRemoveSFTPProxiesTitle": "移除 SFTP 存储代理设置？",
+    "FailedToUpdateSFTPResourceGroups": "更新 SFTP 资源组失败。",
+    "FollowingResourceGroupsWillBeConfigured": "以下资源组将被更新:",
+    "SFTPResourceGroupsUpdated": "SFTP 资源组已更新。",
+    "SFTPStorageProxies": "SFTP 存储代理",
+    "SFTPStorageProxiesDescription": "此资源组中的用户通过 SFTP 将文件传输到其文件夹时使用的存储代理。"
   },
   "summary": {
     "ATOMEnabled": "已启用 ATOM NPU",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -433,6 +433,7 @@
     "PushToImage": "將會話推送到自訂鏡像",
     "Refresh": "刷新",
     "RefreshModelInformation": "刷新机型信息",
+    "Remove": "移除",
     "Reset": "重置",
     "Retry": "重試",
     "Revoke": "撤銷",
@@ -2408,7 +2409,8 @@
     "SelectDomain": "選擇域",
     "SelectScheduler": "選擇調度程序",
     "TimeoutSeconds": "秒",
-    "TypeResourceGroupNameToDelete": "輸入要刪除的資源組名稱"
+    "TypeResourceGroupNameToDelete": "輸入要刪除的資源組名稱",
+    "UpdateResourceGroups": "更新資源群組"
   },
   "resourcePolicy": {
     "AboutToDeleteResourcePolicy": "您即將刪除此資源策略：",
@@ -3217,6 +3219,15 @@
       "ProjectFolderPermissions": "專案資料夾權限",
       "UserFolderPermissions": "使用者資料夾權限"
     }
+  },
+  "storageProxy": {
+    "ConfirmRemoveSFTPProxiesContent": "所選資源群組將不再使用以下儲存代理進行 SFTP: <code>{{proxies}}</code>。是否繼續？",
+    "ConfirmRemoveSFTPProxiesTitle": "移除 SFTP 儲存代理設定？",
+    "FailedToUpdateSFTPResourceGroups": "更新 SFTP 資源群組失敗。",
+    "FollowingResourceGroupsWillBeConfigured": "以下資源群組將被更新:",
+    "SFTPResourceGroupsUpdated": "SFTP 資源群組已更新。",
+    "SFTPStorageProxies": "SFTP 儲存代理",
+    "SFTPStorageProxiesDescription": "此資源群組中的使用者透過 SFTP 將檔案傳輸至其資料夾時使用的儲存代理。"
   },
   "summary": {
     "ATOMEnabled": "已启用 ATOM NPU",


### PR DESCRIPTION
Resolves #8113 (FR-3243)

## Summary

Lets superadmins manage, from the **Resource Group** management page, which **storage proxies** a resource group (scaling group) is allowed to use for **SFTP** file transfer. This is the per-proxy etcd allow-list `volumes/proxies/{proxy}/sftp_scaling_groups` (comma-joined); an unset key means "all groups". Every write reads the proxy's current list first and merges, so other groups already on a proxy are never clobbered. Two complementary entry points:

### 1. Bulk — "Update Resource Groups" modal (from the Resource Group list)
- Checkbox multi-select resource-group rows (superadmin only) → a `N selected` label + a gear **Settings** button appears (same pattern as `ProjectStoragePermissionTable`).
- The gear opens a generic **Update Resource Groups** modal: an info alert lists the selected groups, followed by the settings fields (currently just **SFTP Storage Proxies**; the modal is structured so more bulk-editable settings can be added as sibling fields later).
- The proxy field is prefilled with the union of proxies already serving any selected group. On submit, **every selected group ends up on every chosen proxy** (idempotent union-add computed from the full per-proxy map — a proxy already serving one selected group no longer skips the others). Deselecting a proxy removes the selected groups from it, behind a typed confirm.

### 2. Per group (from the Resource Group create/edit modal)
- Superadmin-only **SFTP Storage Proxies** multi-select, **prefilled** with the proxies that currently serve this group.
- On save, this group's membership is **synced** to the selected proxies: added to newly-selected proxies, removed from deselected ones — only *this* group is touched, every other group on each proxy is preserved.

## Implementation

- Shared `useSFTPResourceGroups` hook centralizes the etcd read-merge-write via `applyGroupProxyDelta` (add groups to / remove groups from a set of proxies at once). When a proxy's list becomes empty it **deletes** the etcd key instead of writing `''` — the manager's comma-parser turns `''` into `['']` (a bogus empty-named group), whereas a deleted key reads back as the documented "all groups" default.
- No GraphQL mutation exists for this etcd key, and `Setting.set/get` force-prefix `config/`, so reads/writes use raw superadmin signed requests to `/config/{get,set,delete}`.
- Bulk modal is `UpdateResourceGroupsModal` (generic title + info alert + per-field labels/tooltips); per-group field lives in `ResourceGroupSettingModal`.
- New reusable `BAIStorageProxySelect` in `backend.ai-ui` (+ Storybook), deriving distinct proxy names from `storage_volume_list` (with a `TODO(needs-backend)` for a dedicated field).
- Copy is permission-framed ("groups a proxy is allowed to use for SFTP"): the `sftp_scaling_groups` setting is a per-proxy allow-list and is advisory on the manager side (exposed via `vfolder.list_hosts()`, not gated on compute-session scheduling — that stays a separate `allowed_session_types` concern).
- New `storageProxy` i18n keys + `resourceGroup.UpdateResourceGroups`, across all 21 locales.

## Screenshots

**Single-group edit** — `Modify Resource Group` modal with the SFTP Storage Proxies field:

![single update modal](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8119/20260714-142945-single-update-modal.png)

**Bulk update** — `Update Resource Groups` modal (proxy prefilled from the selected groups):

![bulk update modal](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8119/20260714-142850-multi-update-modal.png)

**Result** — submitting the bulk modal applies the proxy to **all** selected groups (here `test6` / `test2` gained `local` even though `test4` already had it):

![bulk update result](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8119/20260714-142855-multi-update-result.png)

## Verification

```
Relay / Lint / Format / Vite warmup: PASS
```

Manually verified end-to-end against a live backend (superadmin):
- **Single update** — set a proxy on one group via the edit modal; the row reflects it.
- **Bulk update** — selected 3 groups (one already had the proxy), submitted the prefilled modal; **all** selected groups received the proxy.
- **Remove** — cleared the proxy in the bulk modal; the typed confirm fires and the groups drop it.

**Checklist:**

- [ ] Documentation
- [x] Minimum required manager version — none; uses existing `/config/{get,set,delete}` REST (superadmin), no schema change
- [x] Minimum requirements to check during review — both flows preserve other groups on a proxy (merge / delta); the per-group sync only removes *this* group from deselected proxies; empty list deletes the key rather than writing `''`
- [x] Test case(s) to demonstrate the difference of before/after — manual single + bulk + remove flows verified (screenshots above)
