### PR TITLE
feat(FR-3246): automate docs release publishing (on-release archive seed + auto pdfTag PR)

### DIFF
--- a/.github/workflows/docs-archive-orphan-branch.yml
+++ b/.github/workflows/docs-archive-orphan-branch.yml
@@ -24,7 +24,13 @@
 #      latest docs on that release line — no manual step per patch.
 #      The `minor_label` is the branch name and the `source_ref` is the
 #      pushed commit SHA.
-#   2. Manual — `workflow_dispatch`. The operator picks any tagged
+#   2. Automatic — `release` (published, non-prerelease). Seeds/refreshes
+#      the archive for that release's minor at publish time, deriving the
+#      minor from the tag (`v26.5.0` -> `26.5`) and snapshotting the tag.
+#      Complements trigger 1: it fires once at release time even when no
+#      docs push landed on the release branch (e.g. the very first release
+#      of a new minor). Pre-releases are skipped by the job-level `if:`.
+#   3. Manual — `workflow_dispatch`. The operator picks any tagged
 #      commit / SHA whose docs source should be parked, plus the minor
 #      label it represents. Use this for one-off backfills (e.g.
 #      re-snapshotting a specific release tag) or a dry run.
@@ -58,6 +64,11 @@ on:
     # unrelated app changes on the release branch must not churn it.
     paths:
       - "packages/backend.ai-webui-docs/src/**"
+  release:
+    # Seed/refresh the archive for a release's minor at publish time. The
+    # minor is derived from the tag in the resolve step; pre-releases are
+    # filtered by the job-level `if:` below.
+    types: [published]
   workflow_dispatch:
     inputs:
       source_ref:
@@ -77,32 +88,40 @@ on:
 permissions:
   contents: write
 
-# Serialize runs per target minor so that when several docs changes land
-# on a release branch in quick succession, an older run's force-push to
+# Serialize runs per target so that when several docs changes land on a
+# release branch in quick succession, an older run's force-push to
 # `docs-archive/<minor>` can't overwrite a newer snapshot. Keyed on the
-# resolved minor (branch name for push, input for dispatch), so distinct
-# minors still archive in parallel; `cancel-in-progress` lets the newest
-# push win.
+# branch name (push), the release tag (release), or the input minor
+# (dispatch), so distinct targets still archive in parallel;
+# `cancel-in-progress` lets the newest run win. (GitHub expressions can't
+# split `v26.5.0` into `26.5`, so the release key is the full tag — still
+# unique per release, and a same-minor push/release overlap is rare and
+# produces near-identical source.)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref_name || inputs.minor_label }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref_name || github.event_name == 'release' && github.event.release.tag_name || inputs.minor_label }}
   cancel-in-progress: true
 
 jobs:
   build-and-archive:
+    # Skip pre-releases (rc/alpha/beta) on the `release` trigger; push and
+    # dispatch always run.
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Resolve archive parameters (release-branch push vs manual dispatch)
+      - name: Resolve archive parameters (push / release / manual dispatch)
         id: resolve
-        # For a push to a release-line branch, derive the minor label from
-        # the branch name (`26.4`) and snapshot the pushed commit. For a
-        # manual dispatch, use the operator-supplied inputs verbatim. A
-        # push always publishes (never a dry run). Values flow through env
-        # vars (NOT inline interpolation) to avoid command injection.
+        # Derive the three event-agnostic values from whichever trigger
+        # fired: a release-line push (minor = branch name, ref = SHA), a
+        # published release (minor = tag's MAJOR.MINOR, ref = tag), or a
+        # manual dispatch (operator inputs verbatim). A push/release always
+        # publishes (never a dry run). Values flow through env vars (NOT
+        # inline interpolation) to avoid command injection.
         env:
           EVENT_NAME: ${{ github.event_name }}
           PUSH_REF_NAME: ${{ github.ref_name }}
           PUSH_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           DISPATCH_MINOR_LABEL: ${{ inputs.minor_label }}
           DISPATCH_SOURCE_REF: ${{ inputs.source_ref }}
           DISPATCH_DRY_RUN: ${{ inputs.dry_run }}
@@ -110,6 +129,12 @@ jobs:
           if [ "$EVENT_NAME" = "push" ]; then
             MINOR_LABEL="$PUSH_REF_NAME"
             SOURCE_REF="$PUSH_SHA"
+            DRY_RUN="false"
+          elif [ "$EVENT_NAME" = "release" ]; then
+            # v26.5.0 / 26.5.0 -> 26.5 (the Validate step rejects anything
+            # that isn't a clean MAJOR.MINOR).
+            MINOR_LABEL="$(printf '%s' "$RELEASE_TAG" | sed -E 's/^v?([0-9]+\.[0-9]+)\..*$/\1/')"
+            SOURCE_REF="$RELEASE_TAG"
             DRY_RUN="false"
           else
             MINOR_LABEL="$DISPATCH_MINOR_LABEL"

--- a/.github/workflows/docs-version-pdftag-pr.yml
+++ b/.github/workflows/docs-version-pdftag-pr.yml
@@ -1,0 +1,127 @@
+# Open a PR that bumps an archived minor's `pdfTag` in
+# `docs-toolkit.config.yaml` to the just-published release tag.
+#
+# Why a PR and not a direct commit: merging to `main` is what triggers the
+# docs-site Amplify rebuild (watched path `packages/backend.ai-webui-docs/**`),
+# and merging is the deliberate human gate we keep — the automation removes
+# the hand-editing, not the review. The heavy lifting (a comment-preserving,
+# single-line edit) lives in `scripts/set-version-pdftag.mjs`; this workflow
+# only wires it to the release event and opens/refreshes the PR.
+#
+# Scope: bumps `pdfTag` for a minor that ALREADY has a `versions:` entry.
+# The first release of a brand-new minor still needs a manual `versions:`
+# entry + `latest:` move (a release-strategy decision) — the script no-ops
+# and no PR is opened in that case.
+#
+# Companion: `docs-archive-orphan-branch.yml` refreshes the archived docs
+# SOURCE on the same release event; this workflow refreshes the PDF pointer.
+#
+# References:
+#   - FR-3246 (this automation), follow-up to FR-3242.
+#   - RELEASE-RUNBOOK.md step 3 (the manual step this replaces).
+
+name: docs-version-pdftag-pr
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sync pdfTag from (e.g. v26.4.10)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# One in-flight PR branch per minor; a later patch on the same minor updates
+# the same branch/PR instead of spawning a second one.
+concurrency:
+  group: docs-version-pdftag-pr-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  bump-pdftag-pr:
+    # Skip pre-releases (rc/alpha/beta); only a stable release should move
+    # the site's PDF pointer. Manual dispatch always runs.
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve tag and minor
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ]; then TAG="$RELEASE_TAG"; else TAG="$DISPATCH_TAG"; fi
+          # Normalize to a leading `v` and extract MAJOR.MINOR.
+          case "$TAG" in v*) ;; *) TAG="v$TAG" ;; esac
+          MINOR="$(printf '%s' "$TAG" | sed -E 's/^v([0-9]+\.[0-9]+)\..*$/\1/')"
+          if ! printf '%s' "$MINOR" | grep -qE '^[0-9]+\.[0-9]+$'; then
+            echo "ERROR: could not derive MAJOR.MINOR from tag '$TAG'"; exit 1
+          fi
+          {
+            echo "tag=$TAG"
+            echo "minor=$MINOR"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=$TAG minor=$MINOR"
+
+      # Check out `main` (NOT the release tag) — we edit main's config and
+      # open the PR against main.
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Apply pdfTag bump (no-op if entry missing or already current)
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: node packages/backend.ai-webui-docs/scripts/set-version-pdftag.mjs "$TAG"
+
+      - name: Open or update PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          MINOR: ${{ steps.resolve.outputs.minor }}
+        run: |
+          set -euo pipefail
+          CONFIG=packages/backend.ai-webui-docs/docs-toolkit.config.yaml
+          if git diff --quiet -- "$CONFIG"; then
+            echo "No pdfTag change needed for ${MINOR} (${TAG}); not opening a PR."
+            exit 0
+          fi
+          BRANCH="automation/docs-pdftag-${MINOR}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add "$CONFIG"
+          git commit -m "chore(docs): bump ${MINOR} pdfTag to ${TAG}"
+          # Force-push so a later patch on the same minor refreshes the branch.
+          git push --force origin "$BRANCH"
+          # Open a PR only if one isn't already open for this head branch.
+          if gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+            echo "PR for ${BRANCH} already open; the force-push updated it."
+          else
+            # Assemble the body with printf (no heredoc — a heredoc's
+            # unindented lines would break this YAML block scalar).
+            BODY=$(printf '%s\n' \
+              "Automated by docs-version-pdftag-pr.yml (FR-3246) on release ${TAG}." \
+              "" \
+              "Bumps the ${MINOR} entry's pdfTag in docs-toolkit.config.yaml so the docs site's ${MINOR} version links the latest release PDFs. Merging this PR triggers the docs Amplify rebuild." \
+              "" \
+              "The archived docs source is refreshed separately by docs-archive-orphan-branch.yml on the same release. Brand-new minors (adding a versions: entry + moving latest:) are not handled here by design; see RELEASE-RUNBOOK.md." \
+              "" \
+              "Note: PRs opened by GITHUB_TOKEN do not spawn Actions check runs, so required checks may show as pending; merge with admin if branch protection blocks.")
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore(docs): bump ${MINOR} pdfTag to ${TAG}" \
+              --body "$BODY"
+          fi

--- a/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
+++ b/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
@@ -1,7 +1,7 @@
 # Release Runbook
 
 Operational checklist for the release manager. This file documents what to
-do *during* a release that goes beyond "tag the commit". Background and
+do _during_ a release that goes beyond "tag the commit". Background and
 design decisions live in the spec docs under `.specs/` (at the repo root);
 this file is the short, testable checklist.
 
@@ -15,12 +15,19 @@ From v1 of the multi-version docs site (Epic
 them in order. The PDFs are produced automatically by CI — there is no
 manual upload step.
 
-### 1. Run `docs-archive-orphan-branch.yml`
+### 1. `docs-archive-orphan-branch.yml` (now automatic on release)
 
-Trigger the workflow manually (`workflow_dispatch`) so the released minor
-gets immortalized on its own orphan branch. The orphan-branch design is
-specified in FR-2710 F6 — past minors are built ONCE with the toolkit they
-shipped with and parked on `docs-archive/<minor>`.
+> **Automated since FR-3246.** Publishing a non-prerelease GitHub Release
+> auto-runs this workflow, deriving `minor_label` from the tag
+> (`v26.5.0` → `26.5`) and snapshotting the tag onto `docs-archive/<minor>`.
+> Docs fixes pushed to the `<minor>` release branch also refresh it
+> automatically (FR-3242). The manual `workflow_dispatch` below is retained
+> as a fallback / one-off backfill — you normally do **not** need to run it.
+
+To run it manually (fallback), trigger via `workflow_dispatch` so the
+released minor gets immortalized on its own orphan branch. The orphan-branch
+design is specified in FR-2710 F6 — past minors are built ONCE with the
+toolkit they shipped with and parked on `docs-archive/<minor>`.
 
 Inputs:
 
@@ -70,6 +77,15 @@ job once the underlying issue is fixed.
 Workflow file: `.github/workflows/package.yml` (job: `build_docs`).
 
 ### 3. Update `versions:` in `docs-toolkit.config.yaml` on `main`
+
+> **Partially automated since FR-3246.** For a minor that **already has a
+> `versions:` entry** (i.e. a subsequent patch on an existing line), the
+> `docs-version-pdftag-pr.yml` workflow auto-opens a PR bumping that entry's
+> `pdfTag` to the new tag on release — just review and merge it (merging
+> triggers the Amplify rebuild). You only need the manual edit below when
+> **introducing a brand-new minor**, which the automation intentionally does
+> not handle (adding the entry and moving `latest:` is a release-strategy
+> decision).
 
 Open a small PR against `main` that edits
 `packages/backend.ai-webui-docs/docs-toolkit.config.yaml`:

--- a/packages/backend.ai-webui-docs/package.json
+++ b/packages/backend.ai-webui-docs/package.json
@@ -34,7 +34,8 @@
     "agents": "docs-toolkit agents",
     "agents:force": "docs-toolkit agents --force",
     "build:terminology": "node scripts/generate-terminology.mjs",
-    "check:terminology-md": "node scripts/generate-terminology.mjs --check"
+    "check:terminology-md": "node scripts/generate-terminology.mjs --check",
+    "test:scripts": "node --test \"scripts/*.test.mjs\""
   },
   "devDependencies": {
     "backend.ai-docs-toolkit": "workspace:*",

--- a/packages/backend.ai-webui-docs/scripts/set-version-pdftag.mjs
+++ b/packages/backend.ai-webui-docs/scripts/set-version-pdftag.mjs
@@ -3,6 +3,7 @@
 // `docs-toolkit.config.yaml` to a given release tag.
 //
 // Usage:  node scripts/set-version-pdftag.mjs v26.4.10
+// Tests:  pnpm run test:scripts   (see set-version-pdftag.test.mjs)
 //
 // Why a line-surgical edit instead of a YAML round-trip: the config file
 // carries ~40 lines of hand-written guidance comments in the `versions:`
@@ -10,103 +11,139 @@
 // reflow those; here we only ever rewrite the single `pdfTag:` line of the
 // matching entry, so every comment, key order, and quote style is untouched.
 //
+// The edit logic is a pure function (`bumpPdfTag`) so it is unit-testable
+// against fixtures and the real config without touching the filesystem — the
+// committed tests also guard the format coupling: if the config's line shape
+// ever changes, a test fails loudly instead of the script silently no-op'ing.
+//
 // Scope (intentional): this ONLY bumps the `pdfTag` of a minor that ALREADY
 // has a `versions:` entry — the exact drift that let 26.4 fall from
 // v26.4.7 to v26.4.10 unnoticed. Introducing a brand-new minor (and moving
 // `latest: true`) is a release-strategy decision and stays a manual edit
 // (see RELEASE-RUNBOOK.md). When the released minor has no entry, this
-// script makes no change and says so — the caller then opens no PR.
-//
-// Exit codes: 0 always on well-formed input (whether or not it changed the
-// file — the caller detects a change via `git diff`); 1 only on a usage or
-// I/O error.
+// makes no change and says so — the caller then opens no PR.
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, resolve } from "node:path";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const CONFIG_PATH = resolve(__dirname, "..", "docs-toolkit.config.yaml");
-
-function fail(msg) {
-  console.error(`ERROR: ${msg}`);
-  process.exit(1);
+/**
+ * Normalize a release tag and derive its MAJOR.MINOR.
+ * Accepts `v26.4.10` or `26.4.10`. Throws on anything that is not a
+ * vMAJOR.MINOR.PATCH tag. `pdfTag` is stored WITH the leading `v`.
+ * @returns {{ tag: string, minor: string }}
+ */
+export function deriveMinor(rawTag) {
+  if (!rawTag) throw new Error("missing release tag argument (e.g. v26.4.10)");
+  const tag = rawTag.startsWith("v") ? rawTag : `v${rawTag}`;
+  const match = tag.match(/^v(\d+\.\d+)\.\d+/);
+  if (!match) {
+    throw new Error(`tag '${rawTag}' is not a vMAJOR.MINOR.PATCH release tag`);
+  }
+  return { tag, minor: match[1] };
 }
 
-const rawTag = process.argv[2];
-if (!rawTag) {
-  fail("missing release tag argument (e.g. v26.4.10)");
-}
+/**
+ * Rewrite the `pdfTag:` line of the `versions:` entry whose `label:` matches
+ * the tag's minor. Pure — takes and returns text, touches nothing else.
+ *
+ * `label:`/`pdfTag:` only occur inside `versions:` (the header comment's
+ * example `pdfTag:` sits before `versions:` and is skipped by the gate).
+ *
+ * @returns {{ changed: boolean, matched: boolean, minor: string,
+ *             previousTag: string|null, newTag: string, text: string }}
+ */
+export function bumpPdfTag(text, rawTag) {
+  const { tag, minor } = deriveMinor(rawTag);
+  const lines = text.split("\n");
 
-// Normalize: accept `v26.4.10` or `26.4.10`; keep the tag verbatim for
-// pdfTag (it is stored WITH the leading `v`, e.g. "v26.4.10").
-const tag = rawTag.startsWith("v") ? rawTag : `v${rawTag}`;
-const minorMatch = tag.match(/^v(\d+\.\d+)\.\d+/);
-if (!minorMatch) {
-  fail(`tag '${rawTag}' is not a vMAJOR.MINOR.PATCH release tag`);
-}
-const minor = minorMatch[1];
+  let inVersions = false;
+  let currentLabel = null;
+  let changed = false;
+  let matched = false;
+  let previousTag = null;
 
-const original = readFileSync(CONFIG_PATH, "utf8");
-const lines = original.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
 
-// Walk the file tracking which `versions:` entry we are inside. Entries are
-// `  - label: "<minor>"`; the target entry's `pdfTag:` line is the one we
-// rewrite. `label:`/`pdfTag:` only appear inside `versions:` (the header
-// comment's example `pdfTag:` sits before `versions:` and is skipped).
-let inVersions = false;
-let currentLabel = null;
-let changed = false;
-let matchedEntry = false;
-let previousTag = null;
+    if (/^versions:\s*$/.test(line)) {
+      inVersions = true;
+      continue;
+    }
+    if (!inVersions) continue;
+    // A new top-level key ends the versions block.
+    if (/^[A-Za-z]/.test(line)) {
+      inVersions = false;
+      continue;
+    }
 
-for (let i = 0; i < lines.length; i++) {
-  const line = lines[i];
+    const labelMatch = line.match(/^\s*-\s*label:\s*"([^"]+)"\s*$/);
+    if (labelMatch) {
+      currentLabel = labelMatch[1];
+      continue;
+    }
 
-  if (/^versions:\s*$/.test(line)) {
-    inVersions = true;
-    continue;
-  }
-  if (!inVersions) continue;
-  // A new top-level key ends the versions block.
-  if (/^[A-Za-z]/.test(line)) {
-    inVersions = false;
-    continue;
-  }
-
-  const labelMatch = line.match(/^\s*-\s*label:\s*"([^"]+)"\s*$/);
-  if (labelMatch) {
-    currentLabel = labelMatch[1];
-    continue;
-  }
-
-  if (currentLabel === minor) {
-    const pdfTagMatch = line.match(/^(\s*)pdfTag:\s*"([^"]*)"\s*$/);
-    if (pdfTagMatch) {
-      matchedEntry = true;
-      previousTag = pdfTagMatch[2];
-      if (previousTag !== tag) {
-        lines[i] = `${pdfTagMatch[1]}pdfTag: "${tag}"`;
-        changed = true;
+    if (currentLabel === minor) {
+      const pdfTagMatch = line.match(/^(\s*)pdfTag:\s*"([^"]*)"\s*$/);
+      if (pdfTagMatch) {
+        matched = true;
+        previousTag = pdfTagMatch[2];
+        if (previousTag !== tag) {
+          lines[i] = `${pdfTagMatch[1]}pdfTag: "${tag}"`;
+          changed = true;
+        }
+        break;
       }
-      break;
     }
   }
+
+  return {
+    changed,
+    matched,
+    minor,
+    previousTag,
+    newTag: tag,
+    text: lines.join("\n"),
+  };
 }
 
-if (!matchedEntry) {
-  console.log(
-    `no-op: no versions entry with a pdfTag for minor ${minor} — ` +
-      `a brand-new minor must be added to versions: manually (see RELEASE-RUNBOOK.md).`,
+// --- CLI ---------------------------------------------------------------
+// Exit 0 on well-formed input (whether or not it changed the file — the
+// caller detects a change via `git diff`); exit 1 only on a usage/IO error.
+function main(argv) {
+  const configPath = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "docs-toolkit.config.yaml",
   );
-  process.exit(0);
+  let result;
+  try {
+    const original = readFileSync(configPath, "utf8");
+    result = bumpPdfTag(original, argv[2]);
+  } catch (err) {
+    console.error(`ERROR: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (!result.matched) {
+    console.log(
+      `no-op: no versions entry with a pdfTag for minor ${result.minor} — ` +
+        `a brand-new minor must be added to versions: manually (see RELEASE-RUNBOOK.md).`,
+    );
+    return;
+  }
+  if (!result.changed) {
+    console.log(
+      `no-op: pdfTag for ${result.minor} is already ${result.newTag}.`,
+    );
+    return;
+  }
+  writeFileSync(configPath, result.text);
+  console.log(
+    `updated: ${result.minor} pdfTag ${result.previousTag} -> ${result.newTag}`,
+  );
 }
 
-if (!changed) {
-  console.log(`no-op: pdfTag for ${minor} is already ${tag}.`);
-  process.exit(0);
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main(process.argv);
 }
-
-writeFileSync(CONFIG_PATH, lines.join("\n"));
-console.log(`updated: ${minor} pdfTag ${previousTag} -> ${tag}`);
-process.exit(0);

--- a/packages/backend.ai-webui-docs/scripts/set-version-pdftag.mjs
+++ b/packages/backend.ai-webui-docs/scripts/set-version-pdftag.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Bump the `pdfTag` of an existing archived-minor entry in
+// `docs-toolkit.config.yaml` to a given release tag.
+//
+// Usage:  node scripts/set-version-pdftag.mjs v26.4.10
+//
+// Why a line-surgical edit instead of a YAML round-trip: the config file
+// carries ~40 lines of hand-written guidance comments in the `versions:`
+// block. A full parse+restringify (even with a comment-preserving lib) can
+// reflow those; here we only ever rewrite the single `pdfTag:` line of the
+// matching entry, so every comment, key order, and quote style is untouched.
+//
+// Scope (intentional): this ONLY bumps the `pdfTag` of a minor that ALREADY
+// has a `versions:` entry — the exact drift that let 26.4 fall from
+// v26.4.7 to v26.4.10 unnoticed. Introducing a brand-new minor (and moving
+// `latest: true`) is a release-strategy decision and stays a manual edit
+// (see RELEASE-RUNBOOK.md). When the released minor has no entry, this
+// script makes no change and says so — the caller then opens no PR.
+//
+// Exit codes: 0 always on well-formed input (whether or not it changed the
+// file — the caller detects a change via `git diff`); 1 only on a usage or
+// I/O error.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = resolve(__dirname, "..", "docs-toolkit.config.yaml");
+
+function fail(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+const rawTag = process.argv[2];
+if (!rawTag) {
+  fail("missing release tag argument (e.g. v26.4.10)");
+}
+
+// Normalize: accept `v26.4.10` or `26.4.10`; keep the tag verbatim for
+// pdfTag (it is stored WITH the leading `v`, e.g. "v26.4.10").
+const tag = rawTag.startsWith("v") ? rawTag : `v${rawTag}`;
+const minorMatch = tag.match(/^v(\d+\.\d+)\.\d+/);
+if (!minorMatch) {
+  fail(`tag '${rawTag}' is not a vMAJOR.MINOR.PATCH release tag`);
+}
+const minor = minorMatch[1];
+
+const original = readFileSync(CONFIG_PATH, "utf8");
+const lines = original.split("\n");
+
+// Walk the file tracking which `versions:` entry we are inside. Entries are
+// `  - label: "<minor>"`; the target entry's `pdfTag:` line is the one we
+// rewrite. `label:`/`pdfTag:` only appear inside `versions:` (the header
+// comment's example `pdfTag:` sits before `versions:` and is skipped).
+let inVersions = false;
+let currentLabel = null;
+let changed = false;
+let matchedEntry = false;
+let previousTag = null;
+
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+
+  if (/^versions:\s*$/.test(line)) {
+    inVersions = true;
+    continue;
+  }
+  if (!inVersions) continue;
+  // A new top-level key ends the versions block.
+  if (/^[A-Za-z]/.test(line)) {
+    inVersions = false;
+    continue;
+  }
+
+  const labelMatch = line.match(/^\s*-\s*label:\s*"([^"]+)"\s*$/);
+  if (labelMatch) {
+    currentLabel = labelMatch[1];
+    continue;
+  }
+
+  if (currentLabel === minor) {
+    const pdfTagMatch = line.match(/^(\s*)pdfTag:\s*"([^"]*)"\s*$/);
+    if (pdfTagMatch) {
+      matchedEntry = true;
+      previousTag = pdfTagMatch[2];
+      if (previousTag !== tag) {
+        lines[i] = `${pdfTagMatch[1]}pdfTag: "${tag}"`;
+        changed = true;
+      }
+      break;
+    }
+  }
+}
+
+if (!matchedEntry) {
+  console.log(
+    `no-op: no versions entry with a pdfTag for minor ${minor} — ` +
+      `a brand-new minor must be added to versions: manually (see RELEASE-RUNBOOK.md).`,
+  );
+  process.exit(0);
+}
+
+if (!changed) {
+  console.log(`no-op: pdfTag for ${minor} is already ${tag}.`);
+  process.exit(0);
+}
+
+writeFileSync(CONFIG_PATH, lines.join("\n"));
+console.log(`updated: ${minor} pdfTag ${previousTag} -> ${tag}`);
+process.exit(0);

--- a/packages/backend.ai-webui-docs/scripts/set-version-pdftag.test.mjs
+++ b/packages/backend.ai-webui-docs/scripts/set-version-pdftag.test.mjs
@@ -1,0 +1,93 @@
+// Unit tests for set-version-pdftag.mjs (run: `node --test scripts/`).
+//
+// These guard the script's deliberate coupling to the config's line format:
+// if `docs-toolkit.config.yaml` is ever reformatted so the label/pdfTag
+// lines no longer match, the "real config" test below fails loudly instead
+// of the bump silently becoming a no-op.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { bumpPdfTag, deriveMinor } from "./set-version-pdftag.mjs";
+
+// Two archived minors + next, so we can assert the edit targets ONLY the
+// intended entry (the real config currently has a single archived minor).
+const FIXTURE = `versions:
+  - label: "next"
+    source:
+      kind: workspace
+  - label: "26.5"
+    source:
+      kind: archive-branch
+      ref: docs-archive/26.5
+    latest: true
+    pdfTag: "v26.5.0"
+  - label: "26.4"
+    source:
+      kind: archive-branch
+      ref: docs-archive/26.4
+    pdfTag: "v26.4.10"
+
+productName: "x"
+`;
+
+test("bumps only the targeted minor's pdfTag", () => {
+  const r = bumpPdfTag(FIXTURE, "v26.4.12");
+  assert.equal(r.matched, true);
+  assert.equal(r.changed, true);
+  assert.equal(r.previousTag, "v26.4.10");
+  // 26.4 updated ...
+  assert.match(r.text, /label: "26.4"[\s\S]*?pdfTag: "v26.4.12"/);
+  // ... and 26.5 left untouched.
+  assert.match(r.text, /pdfTag: "v26.5.0"/);
+  assert.doesNotMatch(r.text, /pdfTag: "v26.4.10"/);
+  // Exactly one line differs from the input.
+  const diff = FIXTURE.split("\n").filter(
+    (l, i) => l !== r.text.split("\n")[i],
+  );
+  assert.equal(diff.length, 1);
+});
+
+test("no-op when the tag is already current", () => {
+  const r = bumpPdfTag(FIXTURE, "v26.4.10");
+  assert.equal(r.matched, true);
+  assert.equal(r.changed, false);
+  assert.equal(r.text, FIXTURE);
+});
+
+test("no-op for a brand-new minor (no entry)", () => {
+  const r = bumpPdfTag(FIXTURE, "v26.9.0");
+  assert.equal(r.matched, false);
+  assert.equal(r.changed, false);
+  assert.equal(r.text, FIXTURE);
+});
+
+test("derives minor across tag shapes", () => {
+  assert.equal(deriveMinor("v26.5.0").minor, "26.5");
+  assert.equal(deriveMinor("v25.15.3").minor, "25.15");
+  assert.equal(deriveMinor("26.4.7").minor, "26.4");
+  assert.equal(deriveMinor("v26.5.0-rc.1").minor, "26.5");
+});
+
+test("throws on a tag that is not vMAJOR.MINOR.PATCH", () => {
+  assert.throws(() => deriveMinor("26.4"), /not a vMAJOR\.MINOR\.PATCH/);
+  assert.throws(() => deriveMinor(""), /missing release tag/);
+});
+
+test("real config: current-tag bump is a matched no-op (guards format coupling)", () => {
+  const real = readFileSync(
+    resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "docs-toolkit.config.yaml",
+    ),
+    "utf8",
+  );
+  // The live config pins 26.4 at v26.4.10; matching it proves the parser
+  // still recognizes the real line format.
+  const r = bumpPdfTag(real, "v26.4.10");
+  assert.equal(r.matched, true);
+  assert.equal(r.changed, false);
+});


### PR DESCRIPTION
Resolves #8120 (FR-3246)

Follow-up to FR-3242 (#8110). After FR-3242, publishing a docs release still needed two manual steps: seeding/refreshing the `docs-archive/<minor>` branch, and bumping the archived minor's `pdfTag`. The `pdfTag` half is drift-prone — it silently fell from v26.4.7 to v26.4.10 unnoticed. This automates both mechanical halves and keeps **PR-merge as the human gate** (merging is what triggers the Amplify rebuild).

## Changes

**1. `docs-archive-orphan-branch.yml` — add `on: release: published`**
- Third trigger (alongside FR-3242's release-branch push and the manual dispatch). The `resolve` step gains a `release` branch that derives the minor from the tag (`v26.5.0` → `26.5`) and snapshots the tag.
- Job-level `if:` skips pre-releases; concurrency key extended to cover the release event.
- Fires once at publish time even when no docs push landed on the release branch (e.g. the first release of a new minor).

**2. `docs-version-pdftag-pr.yml` (new) — auto pdfTag PR**
- On release publish (non-prerelease), bumps the released minor's **existing** `versions:` `pdfTag` and opens/refreshes a PR to `main`.
- The edit is done by a dependency-free Node script `scripts/set-version-pdftag.mjs` that rewrites **only** the matching entry's `pdfTag:` line (every comment / key order preserved). Unit-tested against the real config: correct bump, no-op when already current, no-op for a brand-new minor, error on a malformed tag.

**3. `RELEASE-RUNBOOK.md`** — steps 1 & 3 annotated as now-automated, manual paths retained as fallback.

## Out of scope (kept manual by design)
- **Brand-new minor**: adding a `versions:` entry and moving `latest: true` is a release-strategy decision → the script no-ops, no PR opened.
- **Root redirect** (`/` → `/<latest>/`): one-time Amplify console change (DevOps) or toolkit-generated root index (FR-2740). Not here.

## Verification
- Both workflows parse as valid YAML; `bash -n` clean; prerelease guards confirmed.
- `node --check` + prettier clean; script eslint-ignored (matches existing `scripts/*.mjs`).
- Script covered by committed tests: `pnpm run test:scripts` (node:test, 6 cases incl. multi-entry targeting + a real-config format-drift guard).

> Note: the generated pdfTag PRs are opened with `GITHUB_TOKEN`, which does not spawn Actions check runs — required checks may show pending, so merge those with admin if branch protection blocks.