### PR TITLE
feat(FR-3247): link the legacy RTD manual from the version switcher and prep the domain takeover

### DIFF
--- a/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
+++ b/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
@@ -112,6 +112,20 @@ PR title format: `feat(FR-XXXX): publish 26.5 to docs site` (replace
 `FR-XXXX` with the Jira ticket created for the release-publish task and
 `26.5` with the actual minor).
 
+### 4. Update `amplify-redirects.json` and re-apply it in the Amplify console
+
+`packages/backend.ai-webui-docs/amplify-redirects.json` hardcodes the
+latest minor in its redirect targets (the root rule `/` → `/26.4/` and,
+since FR-3248, the legacy deep-link rules `/<lang>/<*>` → `/26.4/<lang>/`).
+When `latest: true` moves to a new minor:
+
+- Update every `/26.4/...` target in the file to the new minor (same PR
+  as step 3 is fine).
+- Amplify does **not** read this file from the repo — after the PR
+  merges, re-apply the rules in the Amplify console ("App settings →
+  Rewrites and redirects") or via
+  `aws amplify update-app --custom-rules file://packages/backend.ai-webui-docs/amplify-redirects.json`.
+
 ---
 
 ## What is NOT a runbook step

--- a/packages/backend.ai-webui-docs/amplify-redirects.json
+++ b/packages/backend.ai-webui-docs/amplify-redirects.json
@@ -16,12 +16,25 @@
     "    flip moves to a new minor (e.g., 26.5), update both this file",
     "    AND re-apply the rules in the console. A future toolkit helper",
     "    may emit this list from `versions[latest=true]` automatically.",
-    "  - Deep-link redirects (/<lang>/<*> -> /<latest>/<lang>/<*>) are",
-    "    intentionally out of scope for v1. Tracked in FR-2742.",
+    "  - Legacy RTD-style deep links (FR-3248): the pre-Amplify manual",
+    "    (readthedocs, Sphinx) served /<lang>/latest/<slug> URLs on this",
+    "    domain. Old bookmarks and search-engine results must not 404,",
+    "    so /<lang>/<*> redirects to the latest version's per-language",
+    "    index. Slug-level mapping is impossible (the Sphinx manual and",
+    "    this site have entirely different page slugs), hence the index",
+    "    target — this SUPERSEDES the per-slug idea once tracked in",
+    "    FR-2742. Order matters: keep these AFTER the exact-match root",
+    "    rule and remember /<lang>/ paths never collide with the new",
+    "    site's own URLs (those all live under /<version>/... or",
+    "    /assets/...).",
     "",
     "Status codes:",
     "  301 — Permanent redirect. Used for the root because /26.4/ is",
     "        the deliberate canonical landing page until the next",
+    "        latest-stable shift.",
+    "  302 — Temporary redirect. Used for the legacy /<lang>/ deep links",
+    "        because their target embeds the CURRENT latest minor and",
+    "        must not be cached by browsers/crawlers across the next",
     "        latest-stable shift."
   ],
   "customRules": [
@@ -29,6 +42,26 @@
       "source": "/",
       "target": "/26.4/",
       "status": "301"
+    },
+    {
+      "source": "/en/<*>",
+      "target": "/26.4/en/",
+      "status": "302"
+    },
+    {
+      "source": "/ko/<*>",
+      "target": "/26.4/ko/",
+      "status": "302"
+    },
+    {
+      "source": "/ja/<*>",
+      "target": "/26.4/ja/",
+      "status": "302"
+    },
+    {
+      "source": "/th/<*>",
+      "target": "/26.4/th/",
+      "status": "302"
     }
   ]
 }

--- a/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
+++ b/packages/backend.ai-webui-docs/docs-toolkit.config.yaml
@@ -67,6 +67,17 @@ versions:
     latest: true
     pdfTag: "v26.4.10"
 
+# Legacy docs link (FR-3248, renders via FR-2733).
+# Appends a localized "Previous versions" (이전 버전 / 以前のバージョン /
+# เวอร์ชันก่อนหน้า) option at the bottom of the version <select>; picking
+# it opens this URL in a new tab (noopener,noreferrer). Points at the
+# readthedocs-hosted Sphinx manual (project `backendai-console-users-guide`),
+# which moves to this domain when `webui.docs.backend.ai` is taken over by
+# the Amplify deployment of THIS site. A single URL is used for all
+# languages by decision (FR-3248) — readthedocs redirects the root to its
+# default language and offers its own language switcher.
+legacyDocsUrl: "https://webui.docs-archive.backend.ai/"
+
 # Product name for log messages
 productName: "Backend.AI WebUI Docs"
 


### PR DESCRIPTION
Resolves #8122 (FR-3247)

## Summary

Prepares the repo side of the `webui.docs.backend.ai` domain takeover: the domain moves from the legacy readthedocs manual to the Amplify deployment of this docs site, and the legacy manual stays reachable from the version switcher.

- **`docs-toolkit.config.yaml`** — set `legacyDocsUrl: https://webui.docs-archive.backend.ai/`. The docs-toolkit already implements the "Previous versions" (이전 버전 / 以前のバージョン / เวอร์ชันก่อนหน้า) option (FR-2733); this config value makes it render at the bottom of the version `<select>` and open the legacy site in a new tab (`noopener,noreferrer`).
- **`amplify-redirects.json`** — add `/<lang>/<*>` → `/26.4/<lang>/` (302) rules for `en/ko/ja/th` so legacy RTD-style deep links (`/en/latest/…`) don't 404 after the domain flip. Slug-level mapping is impossible (the Sphinx manual and this site have entirely different page slugs), so old links land on the latest per-language index. Supersedes the per-slug idea tracked in FR-2742.
- **`RELEASE-RUNBOOK.md`** — new step 4: when `latest: true` flips to a new minor, update the hardcoded `/26.4/...` redirect targets and re-apply the rules in the Amplify console.

## Decisions (with @yomybaby, 2026-07-02)

- Old deep links redirect to the **new** site, not the legacy one.
- Single legacy URL for all languages (no per-language `legacyDocsUrl` map) — readthedocs redirects its root to the default language.
- Legacy domain: `webui.docs-archive.backend.ai` ("archive" matches the repo's `docs-archive/*` branch convention).

## Out of scope — infra steps (DevOps/manual, tracked in FR-3247)

1. Route53: add `webui.docs-archive.backend.ai` CNAME → `readthedocs.io`.
2. readthedocs admin (project `backendai-console-users-guide`): add `webui.docs-archive.backend.ai` as the **canonical** custom domain.
3. Amplify console: connect custom domain `webui.docs.backend.ai` (multi-level subdomains are supported: enter `docs.backend.ai`, "Exclude root", subdomain `webui`) + ACM validation record in Route53.
4. Route53: flip `webui.docs.backend.ai` CNAME from `readthedocs.io` to the Amplify CloudFront target.
5. readthedocs admin: delete the `webui.docs.backend.ai` domain (must happen with/after the DNS flip — while it stays canonical, the RTD slug 302s back to `webui.docs.backend.ai`, which would then be the new site).
6. Apply the updated `amplify-redirects.json` in the Amplify console (`aws amplify update-app --custom-rules file://packages/backend.ai-webui-docs/amplify-redirects.json`).

## Verification

Built with the prebuilt toolkit CLI (`build:web --lang en` / `--lang ko`) against this config:

- `next/en/index.html` renders `<option value="__legacy__">Previous versions</option>` with `data-legacy-url="https://webui.docs-archive.backend.ai/"` on the `<select>`.
- `next/ko/index.html` renders `<option value="__legacy__">이전 버전</option>`.
- `amplify-redirects.json` parses as valid JSON.
- The 26.4 archive-branch version was skipped locally (branch not materialized in this worktree) — the Amplify build fetches it as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
