### PR TITLE
chore(FR-3249): fix stale and misleading code comments across webui

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIDoubleTag.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDoubleTag.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 export type DoubleTagObjectValue = {
   label: string;
   color?: string;
-  style?: React.CSSProperties; // style 속성 추가
+  style?: React.CSSProperties;
 };
 
 export interface BAIDoubleTagProps {

--- a/packages/backend.ai-ui/src/components/BAIDynamicStepInputNumber.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDynamicStepInputNumber.tsx
@@ -14,7 +14,6 @@ export interface BAIDynamicStepInputNumberProps extends Omit<
 }
 
 const BAIDynamicStepInputNumber: React.FC<BAIDynamicStepInputNumberProps> = ({
-  // dynamicSteps = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
   dynamicSteps = [
     0, 0.0625, 0.125, 0.25, 0.5, 0.75, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
     1024, 2048, 4096, 8192, 16384, 32768, 65536,

--- a/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumberWithSlider.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumberWithSlider.tsx
@@ -92,7 +92,6 @@ const BAIDynamicUnitInputNumberWithSlider: React.FC<
           max={max}
           units={units}
           defaultUnit={defaultUnit}
-          // set value to 0mib when min value overs max value
           value={value}
           onChange={(nextValue) => {
             setValue(nextValue);

--- a/packages/backend.ai-ui/src/components/BAIRowWrapWithDividers.tsx
+++ b/packages/backend.ai-ui/src/components/BAIRowWrapWithDividers.tsx
@@ -1,4 +1,4 @@
-// RowWrapWithDividers.tsx
+// BAIRowWrapWithDividers.tsx
 import { theme } from 'antd';
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -125,7 +125,7 @@ export interface BAISelectProps<
   bottomLoading?: boolean;
   header?: React.ReactNode;
   footer?: React.ReactNode;
-  endReached?: () => void; // New prop for endReached
+  endReached?: () => void;
   searchAction?: (value: string) => Promise<void>;
 }
 
@@ -141,7 +141,7 @@ function BAISelect<
   atBottomStateChange,
   header,
   footer,
-  endReached, // Destructure the new prop
+  endReached,
   searchAction,
   ...selectProps
 }: BAISelectProps<ValueType, OptionType>): React.ReactElement {
@@ -231,11 +231,8 @@ function BAISelect<
         popupRender={
           header || footer
             ? (menu) => {
-                // Process with custom popupRender if provided
-                // const renderedMenu = selectProps.popupRender
-                //   ? selectProps.popupRender(menu)
-                //   : menu;
-
+                // Note: a caller-supplied `popupRender` is ignored when
+                // `header`/`footer` is set; only `menu` is rendered here.
                 return (
                   <BAIFlex direction="column" align="stretch">
                     {header ? (

--- a/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.tsx
@@ -63,7 +63,7 @@ const BAIUnmountAfterClose: React.FC<BAIUnmountModalAfterCloseProps> = ({
     if (originalAfterClose) {
       originalAfterClose(...args);
     }
-    // Set internal state to false after the exit animation completes
+    // Mark as closed after the exit animation completes
     setAfterClosed(true);
   };
 
@@ -75,7 +75,7 @@ const BAIUnmountAfterClose: React.FC<BAIUnmountModalAfterCloseProps> = ({
     if (originalAfterOpenChange) {
       originalAfterOpenChange(open);
     }
-    // Set internal state to false after the exit animation completes
+    // Mark as closed after the exit animation completes
     if (!open) {
       setAfterClosed(true);
     }

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx
@@ -12,7 +12,7 @@ import {
 } from 'antd';
 import React, { use, useRef } from 'react';
 
-// FIXME: After migrate BAIModal into backend.ai-ui, should be use BAIModal instead of Antd's Modal
+// TODO: swap to BAIModal (already available in this package) instead of antd's Modal
 interface CreateDirectoryModalProps extends ModalProps {
   onRequestClose: (success: boolean) => void;
 }

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
@@ -10,8 +10,8 @@ import { graphql, useFragment } from 'react-relay';
 
 interface BAISessionAgentIdsProps {
   sessionFrgmt: BAISessionAgentIdsFragment$key;
-  maxInline?: number; // New prop to control max inline display
-  emptyText?: string; // New prop for empty state text
+  maxInline?: number;
+  emptyText?: string;
 }
 const BAISessionAgentIds: React.FC<BAISessionAgentIdsProps> = ({
   sessionFrgmt,

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/types.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/types.ts
@@ -1,9 +1,5 @@
 // Backend.AI Client Interface
 export interface BAIClient {
-  // Add methods and properties of the client here
-  // Example:
-  // request: (endpoint: string, options?: RequestInit) => Promise<any>;
-  // Add more methods as needed based on the actual Backend.AI client API
   isManagerVersionCompatibleWith: (version: string) => boolean;
   vfolder: {
     info: (name: string) => Promise<vfolderInfo>;

--- a/react/src/components/AutoScalingRuleEditorModalLegacy.tsx
+++ b/react/src/components/AutoScalingRuleEditorModalLegacy.tsx
@@ -149,7 +149,6 @@ const AutoScalingRuleEditorModalLegacy: React.FC<
     `);
 
   const handleOk = () => {
-    // TODO: apply mutationToAddAutoScalingRule request
     return formRef.current
       ?.validateFields()
       .then((values) => {
@@ -164,7 +163,8 @@ const AutoScalingRuleEditorModalLegacy: React.FC<
           max_replicas: values.max_replicas,
         };
 
-        // set min and max replicas as same value to avoid validation error
+        // Omit the unused replica bound (min for scale-out, max for scale-in)
+        // so the mutation doesn't fail validation on a field the form doesn't collect
         if (values.type === 'out') {
           delete props.min_replicas;
         } else {

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -434,9 +434,9 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
   const missingRequired = validatedRows.filter(
     (r) => !r.email || !r.username || !r.password,
   ).length;
-  // Categorise off the same conditions the validator uses (lines ~321-324),
-  // not by string-matching the localised error message — that breaks in every
-  // non-English locale.
+  // Categorise off the same conditions the validator uses above (email/role/
+  // status/project checks), not by string-matching the localised error
+  // message — that breaks in every non-English locale.
   const invalidEmail = validatedRows.filter(
     (r) => r.email && !EMAIL_PATTERN.test(r.email),
   ).length;

--- a/react/src/components/Chat/ChatMessage.tsx
+++ b/react/src/components/Chat/ChatMessage.tsx
@@ -6,7 +6,6 @@ import {
   ChatMessageContainer,
   ChatMessagePlacement,
 } from './ChatMessageContainer';
-// ES 2015
 import ChatMessageContent from './ChatMessageContent';
 import { UIMessage } from '@ai-sdk/react';
 import { FileCard } from '@ant-design/x';

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
@@ -115,7 +115,6 @@ const SessionStatusTag: React.FC<SessionStatusTagProps> = ({
             icon={
               isTransitional(session) ? <LoadingOutlined spin /> : undefined
             }
-            // Comment out to match the legacy tag style temporarily
             style={{
               borderRadius: 11,
               paddingLeft: token.paddingSM,

--- a/react/src/components/ComputeSessionNodeItems/VNCConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/VNCConnectionInfoModal.tsx
@@ -19,7 +19,6 @@ const VNCConnectionInfoModal: React.FC<VNCConnectionInfoModalProps> = ({
   'use memo';
   const { t } = useTranslation();
   const vncDisplayUrl = `vnc://${host}:${port}`;
-  // Note: Original code uses ssh:// in href but displays vnc://
   const vncHref = `vnc://${host}:${port}`;
 
   return (

--- a/react/src/components/EduAppLauncher.tsx
+++ b/react/src/components/EduAppLauncher.tsx
@@ -41,11 +41,9 @@ interface EduAppLauncherProps {
 }
 
 /**
- * Classified session-creation error categories.
- *
- * FR-2487 will map these to per-step Card UI messages. For now the state
- * is produced but not rendered; the legacy notification path still fires
- * alongside so the user still sees feedback in this intermediate PR.
+ * Classified session-creation error categories, mapped to the per-step Card
+ * UI Alert (see the errorTitle/errorDetail switch and the <Alert> rendered
+ * in this component's error branch).
  */
 export type EduAppSessionErrorCategory =
   | 'resource-exhausted'
@@ -59,8 +57,8 @@ export type EduAppSessionErrorCategory =
  *
  * Stages progress:
  *   idle -> session -> launching -> done
- * Any stage may transition to `error` with a step label. The Card UI
- * (FR-2487) consumes this state; FR-2484 introduces the machine only.
+ * Any stage may transition to `error` with a step label. This state drives
+ * the Steps/Alert Card UI rendered below.
  *
  * Authentication is owned by the route-level `STokenLoginBoundary` wrapper —
  * by the time this component mounts, `globalThis.backendaiclient` is already

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -276,7 +276,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
         >
           <Radio.Group
             onChange={() => {
-              // Only validate name field if it has a value to prevent excessive validation
+              // Only validate name/type fields if they have a value, to prevent excessive validation
               if (formRef.current?.getFieldValue('name')) {
                 formRef.current.validateFields(['name']);
               }

--- a/react/src/components/ImportArtifactRevisionToFolderModal.tsx
+++ b/react/src/components/ImportArtifactRevisionToFolderModal.tsx
@@ -328,7 +328,7 @@ const ImportArtifactRevisionToFolderModal = ({
           toggleIsOpenCreateModal();
           if (result) {
             // Set the created folder as the selected value in the vfolderId
-            // TODO: FolderCreateModal returns id without '-'.
+            // TODO: FolderCreateModalV2 returns id without '-'.
             formRef.current?.setFieldsValue({
               vfolderId: toGlobalId(
                 'VirtualFolderNode',

--- a/react/src/components/ManageImageResourceLimitModal.tsx
+++ b/react/src/components/ManageImageResourceLimitModal.tsx
@@ -41,10 +41,6 @@ interface ManageImageResourceLimitModalProps extends BAIModalProps {
 const ManageImageResourceLimitModal: React.FC<
   ManageImageResourceLimitModalProps
 > = ({ imageFrgmt, open, onRequestClose, ...BAIModalProps }) => {
-  // Differentiate default max value based on manager version.
-  // The difference between validating a variable type as undefined or none for an unsupplied field value.
-  // [Associated PR links] : https://github.com/lablup/backend.ai/pull/1941
-
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const formRef = useRef<FormInstance>(null);

--- a/react/src/components/MountedVFolderLinks.tsx
+++ b/react/src/components/MountedVFolderLinks.tsx
@@ -13,7 +13,7 @@ import React, { Suspense } from 'react';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 
 interface MountedVFolderLinksProps {
-  sessionFrgmt: MountedVFolderLinksFragment$key; // Replace with actual type if available
+  sessionFrgmt: MountedVFolderLinksFragment$key;
 }
 
 const MountedVFolderLinks: React.FC<MountedVFolderLinksProps> = ({

--- a/react/src/components/MyResource.tsx
+++ b/react/src/components/MyResource.tsx
@@ -60,8 +60,6 @@ const MyResource: React.FC<MyResourceProps> = ({
     const cpuSlot = resourceSlotsDetails?.resourceSlotsInRG?.['cpu'];
     const memSlot = resourceSlotsDetails?.resourceSlotsInRG?.['mem'];
 
-    // Helper function to process memory values
-
     const cpuData = cpuSlot
       ? {
           used: {

--- a/react/src/components/SessionListColums/SessionInfoCell.tsx
+++ b/react/src/components/SessionListColums/SessionInfoCell.tsx
@@ -109,8 +109,6 @@ const SessionInfoCell: React.FC<{
 
   const isPendingRename = mutation.isPending || optimisticName !== session.name;
 
-  // sessions[objectKey].icon = this._getKernelIcon(session.image);
-  //         sessions[objectKey].sessionTags = this._getKernelInfo(session.image);
   return (
     <Form ref={formRef}>
       {editing ? (

--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -44,7 +44,7 @@ interface Props extends Omit<BAISelectProps, 'value' | 'onChange'> {
   value?: string;
   onChange?: (v?: string, vInfo?: VolumeInfo) => void;
 }
-// TODO: use React.forwardRef
+// TODO: forward a ref to the inner Select (React 19 accepts `ref` as a prop; no forwardRef needed)
 const StorageSelect: React.FC<Props> = ({
   autoSelectType,
   showUsageStatus,

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -303,7 +303,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   useEffect(() => {
     _.isFunction(onChangeAutoMountedFolders) &&
       onChangeAutoMountedFolders(autoMountedFolderNames);
-    // Do not need to run when `autoMountedFolderNames` changes
+    // Omit `onChangeAutoMountedFolders` from deps so a parent re-render doesn't retrigger this effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoMountedFolderNames]);
 

--- a/react/src/helper/monacoEditor.ts
+++ b/react/src/helper/monacoEditor.ts
@@ -5,7 +5,8 @@
 
 // Self-host Monaco from /resources/monaco/vs instead of the default jsDelivr
 // CDN, so the editor works in offline and air-gapped environments. The tree
-// is served by the craco dev server (mapped to react/node_modules/monaco-
+// is served by the Vite dev server (monacoStaticPlugin in vite.config.ts,
+// mapped to react/node_modules/monaco-
 // editor/min/vs) and copied to build/web/resources/monaco/vs during the
 // production build (see root `copymonaco` script). The `/resources` prefix
 // is used to nest Monaco inside the existing static-asset namespace (same

--- a/react/src/hooks/useMultiStepNotification.tsx
+++ b/react/src/hooks/useMultiStepNotification.tsx
@@ -520,7 +520,6 @@ export function useMultiStepNotification(
 
         const step = steps[i];
 
-        // Update step to pending
         stepStatesRef.current[i] = { status: 'pending' };
         syncState('running', i);
 


### PR DESCRIPTION
Resolves #8129 (FR-3249)

## Summary

Comment-only cleanup across `react/src/` and `packages/backend.ai-ui/src/`. An audit scanned **691 source files** for comments that no longer match the code they describe. **No logic is touched** — 25 files, 28 insertions / 50 deletions, all comments.

Rule applied: fix only comments that are **factually wrong or valueless**; preserve every load-bearing rationale and human intent. Stale version-gated TODOs get their comment corrected but the underlying code is kept.

## Corrected contradictions / stale references (13)
- `BAIUnmountAfterClose.tsx` — comment said "set state to **false**" but code calls `setAfterClosed(true)` (×2).
- `VNCConnectionInfoModal.tsx` — dropped a copy-pasted "ssh:// vs vnc://" note; both URLs are `vnc://`.
- `SessionStatusTag.tsx` — removed "Comment out … temporarily" note sitting above **live** style code.
- `EduAppLauncher.tsx` — docblocks claimed the error state is "produced but not rendered" / "FR-2487 consumes this state", but the component already renders `<Steps>`/`<Alert>`.
- `AutoScalingRuleEditorModalLegacy.tsx` — removed an already-implemented TODO; corrected "set min/max to same value" (code actually deletes one field).
- `monacoEditor.ts` — "craco dev server" → Vite (`monacoStaticPlugin`).
- Plus `BAIRowWrapWithDividers`, `ImportArtifactRevisionToFolderModal`, `FolderCreateModal`, `ManageImageResourceLimitModal`, `MyResource`, `MountedVFolderLinks`, `VFolderTable`, `BulkCreateUserFromCSVModal`, `StorageSelect`, `CreateDirectoryModal`.

## Removed noise / dead comments (12)
`BAISelect`, `BAISessionAgentIds`, `BAIDoubleTag`, `BAIDynamicStepInputNumber`, `BAIDynamicUnitInputNumberWithSlider`, `BAIClientProvider/types.ts` (scaffold), `Chat/ChatMessage`, `SessionInfoCell`, `useMultiStepNotification`.

## Deliberately kept (preserving intent / tooling)
- `Page401.tsx` `{/* t('webui.…') */}` — these are **i18n extraction markers** (the scanner runs with `trans: false` and only matches `t('…')` string patterns), **not** noise. An initial scan flagged them; verified against `i18n.config.js` and reverted.
- Aging-but-still-valid TODOs (`ErrorLogList`, `DefaultProviders`, `VFolderMountFormItem`, `DeploymentPresetDetailModal`) — the described work is still pending, so the comments still match reality.

## Follow-up candidates (not in this PR)
- `DeploymentPresetDetailModal.tsx` — bump `@since(version: "26.4.4rc7")` to shipped `26.4.4` (code change).
- `CreateDirectoryModal.tsx` / `StorageSelect.tsx` — actually perform the BAIModal swap / ref forwarding the TODOs describe.

## Verification
Comment-only diff. ESLint `max-len` is `off` (verified in `eslint.config.mjs`; 189 pre-existing >80-char comment lines already pass); Prettier does not reflow `//` line comments; Relay/tsc unaffected (no graphql/schema/logic change). Full `scripts/verify.sh` was not run in the worktree (no `node_modules`; fresh-worktree `tsc` is a known false-positive source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)