### PR TITLE
fix(FR-3246): disable pnpm cache + trim verbose comments in docs release automation

### DIFF
--- a/.github/workflows/docs-archive-orphan-branch.yml
+++ b/.github/workflows/docs-archive-orphan-branch.yml
@@ -14,26 +14,12 @@
 #   FR-2751 for follow-up build caching that makes this efficient at
 #   archive count >= 2.
 #
-# Triggers:
-#   1. Automatic — `push` to a release-line branch whose name is a bare
-#      `<MAJOR>.<MINOR>` (e.g. `26.4`, `25.15`) that touches the docs
-#      source (`packages/backend.ai-webui-docs/src/**`). This keeps the
-#      `docs-archive/<minor>` snapshot in lockstep with docs changes
-#      landed on a maintenance branch (e.g. a doc fix backported to
-#      `26.4`), so the live site's `26.4` version always reflects the
-#      latest docs on that release line — no manual step per patch.
-#      The `minor_label` is the branch name and the `source_ref` is the
-#      pushed commit SHA.
-#   2. Automatic — `release` (published, non-prerelease). Seeds/refreshes
-#      the archive for that release's minor at publish time, deriving the
-#      minor from the tag (`v26.5.0` -> `26.5`) and snapshotting the tag.
-#      Complements trigger 1: it fires once at release time even when no
-#      docs push landed on the release branch (e.g. the very first release
-#      of a new minor). Pre-releases are skipped by the job-level `if:`.
-#   3. Manual — `workflow_dispatch`. The operator picks any tagged
-#      commit / SHA whose docs source should be parked, plus the minor
-#      label it represents. Use this for one-off backfills (e.g.
-#      re-snapshotting a specific release tag) or a dry run.
+# Triggers (all resolve to a minor + a source ref, then snapshot):
+#   1. push to a bare `<MAJOR>.<MINOR>` branch (e.g. `26.4`) touching
+#      `src/**` — keeps the archive in step with docs fixes on that line.
+#   2. release (published, non-prerelease) — seeds/refreshes the tag's
+#      minor at publish time (fires even if no docs push landed).
+#   3. workflow_dispatch — manual backfill / dry run of any ref + minor.
 #
 # Output: a `docs-archive/<minor>` branch containing ONLY:
 #   src/                          # markdown + book.config.yaml
@@ -52,22 +38,17 @@ name: docs-archive-orphan-branch
 
 on:
   push:
-    # Release-line branches are named as a bare `<MAJOR>.<MINOR>` (e.g.
-    # `26.4`, `25.15`). GitHub filter patterns support `+` as "one or
-    # more of the preceding character", so `[0-9]+.[0-9]+` matches
-    # exactly two dot-separated numeric segments and (being anchored to
-    # the whole ref) will NOT match a three-segment name like `26.4.1`.
+    # Bare `<MAJOR>.<MINOR>` release branches only. In GitHub filter
+    # patterns `+` means "one or more", and the match is whole-ref
+    # anchored, so `[0-9]+.[0-9]+` hits `26.4`/`25.15` but not `26.4.1`.
     branches:
       - "[0-9]+.[0-9]+"
-    # Only re-snapshot when the docs source itself changed. `src/`
-    # holds the markdown + `book.config.yaml` that the archive parks;
-    # unrelated app changes on the release branch must not churn it.
+    # Only when the archived docs source changed.
     paths:
       - "packages/backend.ai-webui-docs/src/**"
   release:
-    # Seed/refresh the archive for a release's minor at publish time. The
-    # minor is derived from the tag in the resolve step; pre-releases are
-    # filtered by the job-level `if:` below.
+    # Minor derived from the tag in the resolve step; pre-releases skipped
+    # by the job-level `if:`.
     types: [published]
   workflow_dispatch:
     inputs:
@@ -88,15 +69,11 @@ on:
 permissions:
   contents: write
 
-# Serialize runs per target so that when several docs changes land on a
-# release branch in quick succession, an older run's force-push to
-# `docs-archive/<minor>` can't overwrite a newer snapshot. Keyed on the
-# branch name (push), the release tag (release), or the input minor
-# (dispatch), so distinct targets still archive in parallel;
-# `cancel-in-progress` lets the newest run win. (GitHub expressions can't
-# split `v26.5.0` into `26.5`, so the release key is the full tag — still
-# unique per release, and a same-minor push/release overlap is rare and
-# produces near-identical source.)
+# Serialize per target (branch / release tag / input minor) so a slower
+# older run can't force-push a stale `docs-archive/<minor>` over a newer
+# one; distinct targets still run in parallel. (The release key is the full
+# tag since GitHub expressions can't split `v26.5.0` into `26.5` — fine, a
+# same-minor push/release overlap is rare and near-identical.)
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref_name || github.event_name == 'release' && github.event.release.tag_name || inputs.minor_label }}
   cancel-in-progress: true
@@ -111,12 +88,10 @@ jobs:
     steps:
       - name: Resolve archive parameters (push / release / manual dispatch)
         id: resolve
-        # Derive the three event-agnostic values from whichever trigger
-        # fired: a release-line push (minor = branch name, ref = SHA), a
-        # published release (minor = tag's MAJOR.MINOR, ref = tag), or a
-        # manual dispatch (operator inputs verbatim). A push/release always
-        # publishes (never a dry run). Values flow through env vars (NOT
-        # inline interpolation) to avoid command injection.
+        # Map each trigger to (minor, source_ref): push → (branch, SHA),
+        # release → (tag's MAJOR.MINOR, tag), dispatch → operator inputs.
+        # Values pass via env vars (not inline interpolation) to avoid
+        # command injection.
         env:
           EVENT_NAME: ${{ github.event_name }}
           PUSH_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/docs-version-pdftag-pr.yml
+++ b/.github/workflows/docs-version-pdftag-pr.yml
@@ -1,24 +1,10 @@
-# Open a PR that bumps an archived minor's `pdfTag` in
-# `docs-toolkit.config.yaml` to the just-published release tag.
-#
-# Why a PR and not a direct commit: merging to `main` is what triggers the
-# docs-site Amplify rebuild (watched path `packages/backend.ai-webui-docs/**`),
-# and merging is the deliberate human gate we keep — the automation removes
-# the hand-editing, not the review. The heavy lifting (a comment-preserving,
-# single-line edit) lives in `scripts/set-version-pdftag.mjs`; this workflow
-# only wires it to the release event and opens/refreshes the PR.
-#
-# Scope: bumps `pdfTag` for a minor that ALREADY has a `versions:` entry.
-# The first release of a brand-new minor still needs a manual `versions:`
-# entry + `latest:` move (a release-strategy decision) — the script no-ops
-# and no PR is opened in that case.
-#
-# Companion: `docs-archive-orphan-branch.yml` refreshes the archived docs
-# SOURCE on the same release event; this workflow refreshes the PDF pointer.
-#
-# References:
-#   - FR-3246 (this automation), follow-up to FR-3242.
-#   - RELEASE-RUNBOOK.md step 3 (the manual step this replaces).
+# On a published release, open a PR bumping the released minor's `pdfTag` in
+# `docs-toolkit.config.yaml`. A PR (not a direct commit) because merging to
+# `main` is what triggers the docs Amplify rebuild, and the merge stays the
+# human gate. Only bumps a minor that already has an entry; the edit lives in
+# `scripts/set-version-pdftag.mjs`. Companion `docs-archive-orphan-branch.yml`
+# refreshes the archived SOURCE on the same event. (FR-3246, follow-up to
+# FR-3242; replaces RELEASE-RUNBOOK.md step 3.)
 
 name: docs-version-pdftag-pr
 
@@ -81,10 +67,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
-          # The edit script is Node-stdlib only; pnpm is never invoked here.
-          # setup-node's default package-manager cache probes `pnpm store
-          # path`, which fails ("Unable to locate executable file: pnpm")
-          # since pnpm isn't installed in this job. Disable the cache.
+          # Script is Node-stdlib only; disable the pnpm cache probe (pnpm
+          # isn't installed here, so the default would fail).
           package-manager-cache: false
 
       - name: Apply pdfTag bump (no-op if entry missing or already current)

--- a/.github/workflows/docs-version-pdftag-pr.yml
+++ b/.github/workflows/docs-version-pdftag-pr.yml
@@ -81,6 +81,11 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
+          # The edit script is Node-stdlib only; pnpm is never invoked here.
+          # setup-node's default package-manager cache probes `pnpm store
+          # path`, which fails ("Unable to locate executable file: pnpm")
+          # since pnpm isn't installed in this job. Disable the cache.
+          package-manager-cache: false
 
       - name: Apply pdfTag bump (no-op if entry missing or already current)
         env:

--- a/packages/backend.ai-webui-docs/scripts/set-version-pdftag.mjs
+++ b/packages/backend.ai-webui-docs/scripts/set-version-pdftag.mjs
@@ -1,37 +1,22 @@
 #!/usr/bin/env node
-// Bump the `pdfTag` of an existing archived-minor entry in
-// `docs-toolkit.config.yaml` to a given release tag.
+// Bump the `pdfTag` of an existing archived-minor `versions:` entry in
+// `docs-toolkit.config.yaml`.
 //
-// Usage:  node scripts/set-version-pdftag.mjs v26.4.10
-// Tests:  pnpm run test:scripts   (see set-version-pdftag.test.mjs)
+//   node scripts/set-version-pdftag.mjs v26.4.10   # CLI
+//   pnpm run test:scripts                          # tests
 //
-// Why a line-surgical edit instead of a YAML round-trip: the config file
-// carries ~40 lines of hand-written guidance comments in the `versions:`
-// block. A full parse+restringify (even with a comment-preserving lib) can
-// reflow those; here we only ever rewrite the single `pdfTag:` line of the
-// matching entry, so every comment, key order, and quote style is untouched.
-//
-// The edit logic is a pure function (`bumpPdfTag`) so it is unit-testable
-// against fixtures and the real config without touching the filesystem — the
-// committed tests also guard the format coupling: if the config's line shape
-// ever changes, a test fails loudly instead of the script silently no-op'ing.
-//
-// Scope (intentional): this ONLY bumps the `pdfTag` of a minor that ALREADY
-// has a `versions:` entry — the exact drift that let 26.4 fall from
-// v26.4.7 to v26.4.10 unnoticed. Introducing a brand-new minor (and moving
-// `latest: true`) is a release-strategy decision and stays a manual edit
-// (see RELEASE-RUNBOOK.md). When the released minor has no entry, this
-// makes no change and says so — the caller then opens no PR.
+// Rewrites only the matching entry's single `pdfTag:` line (no YAML
+// round-trip) to preserve the block's ~40 lines of guidance comments.
+// Only bumps a minor that already has an entry — adding a new minor and
+// moving `latest:` is a manual release decision (see RELEASE-RUNBOOK.md).
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, resolve } from "node:path";
 
 /**
- * Normalize a release tag and derive its MAJOR.MINOR.
- * Accepts `v26.4.10` or `26.4.10`. Throws on anything that is not a
- * vMAJOR.MINOR.PATCH tag. `pdfTag` is stored WITH the leading `v`.
- * @returns {{ tag: string, minor: string }}
+ * Normalize `v26.4.10` or `26.4.10` to `{ tag: "v26.4.10", minor: "26.4" }`.
+ * Throws on anything that is not a vMAJOR.MINOR.PATCH tag.
  */
 export function deriveMinor(rawTag) {
   if (!rawTag) throw new Error("missing release tag argument (e.g. v26.4.10)");
@@ -45,13 +30,9 @@ export function deriveMinor(rawTag) {
 
 /**
  * Rewrite the `pdfTag:` line of the `versions:` entry whose `label:` matches
- * the tag's minor. Pure — takes and returns text, touches nothing else.
- *
- * `label:`/`pdfTag:` only occur inside `versions:` (the header comment's
- * example `pdfTag:` sits before `versions:` and is skipped by the gate).
- *
- * @returns {{ changed: boolean, matched: boolean, minor: string,
- *             previousTag: string|null, newTag: string, text: string }}
+ * the tag's minor. Pure — returns the new text plus what happened. The
+ * `versions:` gate skips the example `pdfTag:` in the header comment.
+ * @returns {{ changed, matched, minor, previousTag, newTag, text }}
  */
 export function bumpPdfTag(text, rawTag) {
   const { tag, minor } = deriveMinor(rawTag);
@@ -107,9 +88,8 @@ export function bumpPdfTag(text, rawTag) {
   };
 }
 
-// --- CLI ---------------------------------------------------------------
-// Exit 0 on well-formed input (whether or not it changed the file — the
-// caller detects a change via `git diff`); exit 1 only on a usage/IO error.
+// CLI: exit 0 whether or not the file changed (caller detects via `git
+// diff`); exit 1 only on a usage/IO error.
 function main(argv) {
   const configPath = resolve(
     dirname(fileURLToPath(import.meta.url)),

--- a/packages/backend.ai-webui-docs/scripts/set-version-pdftag.test.mjs
+++ b/packages/backend.ai-webui-docs/scripts/set-version-pdftag.test.mjs
@@ -1,9 +1,6 @@
-// Unit tests for set-version-pdftag.mjs (run: `node --test scripts/`).
-//
-// These guard the script's deliberate coupling to the config's line format:
-// if `docs-toolkit.config.yaml` is ever reformatted so the label/pdfTag
-// lines no longer match, the "real config" test below fails loudly instead
-// of the bump silently becoming a no-op.
+// Unit tests for set-version-pdftag.mjs (`pnpm run test:scripts`). The
+// "real config" test guards the line-format coupling: if the config is
+// reformatted so label/pdfTag no longer match, it fails loudly.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";


### PR DESCRIPTION
Follow-up to FR-3246 (#8121), two cleanups:

1. **Fix**: the no-op live smoke (`workflow_dispatch` tag=v26.4.10) failed at **Set up Node** — `setup-node@v5` defaults `package-manager-cache: true`, which probes `pnpm store path`; pnpm isn't installed in this job. The edit script is Node-stdlib only, so set `package-manager-cache: false`.

2. **Comment trim** (review feedback: comments too verbose): condense the header/rationale blocks added in FR-3246 (script ~44→24 comment lines, docs-version-pdftag-pr ~36→20, docs-archive header triggers list) while keeping the load-bearing "why" (comment-preservation, the `[0-9]+.[0-9]+` glob semantics, injection-safety, concurrency race, prerelease guard, format-coupling guard).

Verified: actionlint clean, YAML valid, `pnpm run test:scripts` 6/6, prettier clean. Will re-run the no-op smoke after merge.