### PR TITLE
fix(FR-3247): cover bare /<lang> and /<lang>/ paths in the legacy redirect rules

### DIFF
--- a/packages/backend.ai-webui-docs/amplify-redirects.json
+++ b/packages/backend.ai-webui-docs/amplify-redirects.json
@@ -27,6 +27,11 @@
     "    rule and remember /<lang>/ paths never collide with the new",
     "    site's own URLs (those all live under /<version>/... or",
     "    /assets/...).",
+    "  - Bare language paths (/ko, /ko/) get EXPLICIT rules per language.",
+    "    Amplify matches sources literally (no trailing-slash",
+    "    normalization), and /<lang>/<*> is not guaranteed to match the",
+    "    bare or slash-only path — so /<lang> and /<lang>/ are spelled",
+    "    out. Keep the exact rules BEFORE that language's wildcard rule.",
     "",
     "Status codes:",
     "  301 — Permanent redirect. Used for the root because /26.4/ is",
@@ -44,8 +49,28 @@
       "status": "301"
     },
     {
+      "source": "/en",
+      "target": "/26.4/en/",
+      "status": "302"
+    },
+    {
+      "source": "/en/",
+      "target": "/26.4/en/",
+      "status": "302"
+    },
+    {
       "source": "/en/<*>",
       "target": "/26.4/en/",
+      "status": "302"
+    },
+    {
+      "source": "/ko",
+      "target": "/26.4/ko/",
+      "status": "302"
+    },
+    {
+      "source": "/ko/",
+      "target": "/26.4/ko/",
       "status": "302"
     },
     {
@@ -54,8 +79,28 @@
       "status": "302"
     },
     {
+      "source": "/ja",
+      "target": "/26.4/ja/",
+      "status": "302"
+    },
+    {
+      "source": "/ja/",
+      "target": "/26.4/ja/",
+      "status": "302"
+    },
+    {
       "source": "/ja/<*>",
       "target": "/26.4/ja/",
+      "status": "302"
+    },
+    {
+      "source": "/th",
+      "target": "/26.4/th/",
+      "status": "302"
+    },
+    {
+      "source": "/th/",
+      "target": "/26.4/th/",
       "status": "302"
     },
     {


### PR DESCRIPTION
Relates to #8122 (FR-3247) — follow-up to #8128.

## Summary

`https://webui.docs.backend.ai/ko/` (and `/ko`, plus en/ja/th equivalents) must redirect to the latest version's per-language index (`/26.4/ko/`). #8128 added only the wildcard rules (`/<lang>/<*>`), but Amplify matches redirect sources **literally** — no trailing-slash normalization — and the wildcard is not guaranteed to match the bare (`/ko`) or slash-only (`/ko/`) path.

This PR adds explicit exact-match rules per language, placed ahead of that language's wildcard rule:

| Source | Target | Status |
|---|---|---|
| `/en`, `/en/` | `/26.4/en/` | 302 |
| `/ko`, `/ko/` | `/26.4/ko/` | 302 |
| `/ja`, `/ja/` | `/26.4/ja/` | 302 |
| `/th`, `/th/` | `/26.4/th/` | 302 |

302 (not 301) for the same reason as the wildcard rules: the target embeds the current latest minor and must not be cached across the next `latest: true` flip (RELEASE-RUNBOOK step 4 covers the flip).

## Reminder for DevOps

Amplify does not read this file from the repo — after merge, re-apply the full rule set in the Amplify console or via:

```bash
aws amplify update-app --app-id <APP_ID> \
  --custom-rules file://packages/backend.ai-webui-docs/amplify-redirects.json
```

## Verification

- `amplify-redirects.json` parses as valid JSON; 13 rules total, exact-match rules ordered before each language's wildcard rule.
- Config-only change; no build output is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
