### PR TITLE
feat(FR-3252): show sessions assigned to the agent in agent detail panel

### DIFF
--- a/react/src/__generated__/AgentSessionListQuery.graphql.ts
+++ b/react/src/__generated__/AgentSessionListQuery.graphql.ts
@@ -1,0 +1,664 @@
+/**
+ * @generated SignedSource<<e7e24aea15e0b292c8cc852839196a13>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type AgentSessionListQuery$variables = {
+  filter?: string | null | undefined;
+  first?: number | null | undefined;
+  offset?: number | null | undefined;
+};
+export type AgentSessionListQuery$data = {
+  readonly compute_session_nodes: {
+    readonly count: number | null | undefined;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly id: string;
+        readonly " $fragmentSpreads": FragmentRefs<"SessionNodesFragment">;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
+};
+export type AgentSessionListQuery = {
+  response: AgentSessionListQuery$data;
+  variables: AgentSessionListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "first"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "offset"
+},
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  },
+  {
+    "kind": "Variable",
+    "name": "offset",
+    "variableName": "offset"
+  },
+  {
+    "kind": "Literal",
+    "name": "order",
+    "value": "-created_at"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "row_id",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status_info",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "tag",
+  "storageKey": null
+},
+v11 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "key",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "value",
+    "storageKey": null
+  }
+],
+v12 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "ComputeSessionEdge",
+    "kind": "LinkedField",
+    "name": "edges",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ComputeSessionNode",
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  (v5/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AgentSessionListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "ComputeSessionConnection",
+        "kind": "LinkedField",
+        "name": "compute_session_nodes",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ComputeSessionEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ComputeSessionNode",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "SessionNodesFragment"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "AgentSessionListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "ComputeSessionConnection",
+        "kind": "LinkedField",
+        "name": "compute_session_nodes",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ComputeSessionEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ComputeSessionNode",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "type",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "service_ports",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "user_id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "agent_ids",
+                    "storageKey": null
+                  },
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "status_data",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "queue_position",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "created_at",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "starts_at",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "terminated_at",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "occupied_slots",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "requested_slots",
+                    "storageKey": null
+                  },
+                  (v10/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "KernelConnection",
+                    "kind": "LinkedField",
+                    "name": "kernel_nodes",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "KernelEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "KernelNode",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "live_stat",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cluster_role",
+                                "storageKey": null
+                              },
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ImageNode",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "base_image_name",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "version",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "architecture",
+                                    "storageKey": null
+                                  },
+                                  (v7/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "KVPair",
+                                    "kind": "LinkedField",
+                                    "name": "tags",
+                                    "plural": true,
+                                    "selections": (v11/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "KVPair",
+                                    "kind": "LinkedField",
+                                    "name": "labels",
+                                    "plural": true,
+                                    "selections": (v11/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "registry",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "namespace",
+                                    "storageKey": null
+                                  },
+                                  (v10/*: any*/),
+                                  (v4/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              (v6/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cluster_hostname",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cluster_idx",
+                                "storageKey": null
+                              },
+                              (v8/*: any*/),
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "agent_id",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "container_id",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "project_id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "UserNode",
+                    "kind": "LinkedField",
+                    "name": "owner",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "email",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "resource_opts",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "vfolder_mounts",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "VirtualFolderConnection",
+                    "kind": "LinkedField",
+                    "name": "vfolder_nodes",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "VirtualFolderEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "VirtualFolderNode",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v6/*: any*/),
+                              (v7/*: any*/),
+                              (v4/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "scaling_group",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "idle_checks",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "startup_command",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ComputeSessionConnection",
+                    "kind": "LinkedField",
+                    "name": "dependees",
+                    "plural": false,
+                    "selections": (v12/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ComputeSessionConnection",
+                    "kind": "LinkedField",
+                    "name": "dependents",
+                    "plural": false,
+                    "selections": (v12/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "access_key",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "commit_status",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "priority",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cluster_mode",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cluster_size",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b2e7f5bdea63e4e252cc792cd1c49219",
+    "id": null,
+    "metadata": {},
+    "name": "AgentSessionListQuery",
+    "operationKind": "query",
+    "text": "query AgentSessionListQuery(\n  $offset: Int\n  $first: Int\n  $filter: String\n) {\n  compute_session_nodes(offset: $offset, first: $first, filter: $filter, order: \"-created_at\") {\n    edges {\n      node {\n        id\n        ...SessionNodesFragment\n      }\n    }\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks @since(version: \"24.12.0\")\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f6f3c5572715167fd1552ec5b7610f42";
+
+export default node;

--- a/react/src/components/AgentDetailDrawerContent.tsx
+++ b/react/src/components/AgentDetailDrawerContent.tsx
@@ -7,9 +7,10 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import AgentActionButtons from './AgentNodeItems/AgentActionButtons';
 import AgentComputePlugins from './AgentNodeItems/AgentComputePlugins';
 import AgentResources from './AgentNodeItems/AgentResources';
+import AgentSessionList from './AgentNodeItems/AgentSessionList';
 import AgentStatusTag from './AgentNodeItems/AgentStatusTag';
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
-import { Descriptions, Grid, Tabs, theme, Typography } from 'antd';
+import { Descriptions, Grid, Skeleton, Tabs, theme, Typography } from 'antd';
 import {
   BAIDoubleTag,
   BAIFlex,
@@ -18,7 +19,7 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
@@ -26,7 +27,7 @@ interface AgentDetailDrawerContentProps {
   agentNodeFrgmt?: AgentDetailDrawerContentFragment$key | null;
 }
 
-type TabKey = 'resources';
+type TabKey = 'resources' | 'sessions';
 
 const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
   agentNodeFrgmt,
@@ -151,6 +152,17 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
             key: 'resources',
             label: t('agent.Resources'),
             children: <AgentResources agentNodeFrgmt={agent} />,
+          },
+          {
+            key: 'sessions',
+            label: t('agent.Sessions'),
+            children: (
+              <Suspense fallback={<Skeleton active />}>
+                {agent?.row_id ? (
+                  <AgentSessionList agentId={agent.row_id} />
+                ) : null}
+              </Suspense>
+            ),
           },
         ]}
       />

--- a/react/src/components/AgentNodeItems/AgentSessionList.tsx
+++ b/react/src/components/AgentNodeItems/AgentSessionList.tsx
@@ -1,0 +1,101 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { AgentSessionListQuery } from '../../__generated__/AgentSessionListQuery.graphql';
+import { useWebUINavigate } from '../../hooks';
+import { useBAIPaginationOptionState } from '../../hooks/reactPaginationQueryOptions';
+import SessionNodes from '../SessionNodes';
+import { filterOutNullAndUndefined, mergeFilterValues } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { useDeferredValue } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+interface AgentSessionListProps {
+  // The agent's row id (matches the values stored in a session's `agent_ids`).
+  agentId: string;
+}
+
+const AgentSessionList: React.FC<AgentSessionListProps> = ({ agentId }) => {
+  'use memo';
+  const webUINavigate = useWebUINavigate();
+
+  const {
+    baiPaginationOption,
+    tablePaginationOption,
+    setTablePaginationOption,
+  } = useBAIPaginationOptionState({ current: 1, pageSize: 5 });
+
+  // Sessions currently assigned to (running on) this agent. `agent_ids` is a
+  // list column and the manager supports the `ilike` operator on it (the same
+  // operator the admin session list uses for its agent filter). Note that
+  // `ilike` is a substring match, so an agent id that is a prefix of another
+  // (e.g. "i-agent1" vs "i-agent10") could over-match; the manager exposes no
+  // exact list-containment operator for this column today. Only
+  // non-terminated sessions actually consume the agent's resources.
+  const queryVariables = {
+    offset: baiPaginationOption.offset,
+    first: baiPaginationOption.first,
+    filter: mergeFilterValues([
+      `agent_ids ilike "%${agentId}%"`,
+      'status != "TERMINATED" & status != "CANCELLED"',
+    ]),
+  };
+  const deferredQueryVariables = useDeferredValue(queryVariables);
+
+  const { compute_session_nodes } = useLazyLoadQuery<AgentSessionListQuery>(
+    graphql`
+      query AgentSessionListQuery($offset: Int, $first: Int, $filter: String) {
+        compute_session_nodes(
+          offset: $offset
+          first: $first
+          filter: $filter
+          order: "-created_at"
+        ) {
+          edges {
+            node {
+              id
+              ...SessionNodesFragment
+            }
+          }
+          count
+        }
+      }
+    `,
+    deferredQueryVariables,
+  );
+
+  const sessions = filterOutNullAndUndefined(
+    compute_session_nodes?.edges?.map((e) => e?.node),
+  );
+
+  return (
+    <SessionNodes
+      disableSorter
+      sessionsFrgmt={sessions}
+      loading={deferredQueryVariables !== queryVariables}
+      onClickSessionName={(session) => {
+        // The `sessionDetail` opener is mounted on the session pages (not on
+        // the agent page), so navigate there to open the detail drawer.
+        webUINavigate({
+          pathname: '/session',
+          search: new URLSearchParams({
+            sessionDetail: session.row_id,
+          }).toString(),
+        });
+      }}
+      pagination={{
+        pageSize: tablePaginationOption.pageSize,
+        current: tablePaginationOption.current,
+        total: compute_session_nodes?.count ?? 0,
+        onChange: (current, pageSize) => {
+          if (_.isNumber(current) && _.isNumber(pageSize)) {
+            setTablePaginationOption({ current, pageSize });
+          }
+        },
+      }}
+    />
+  );
+};
+
+export default AgentSessionList;

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -227,6 +227,7 @@
     "Resources": "Ressourcen",
     "Running": "Laufen",
     "Schedulable": "Planbar",
+    "Sessions": "Sitzungen",
     "Settings": "Einstellungen",
     "Starts": "Startet",
     "StartsAt": "Gestartet am",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -227,6 +227,7 @@
     "Resources": "Πόροι",
     "Running": "Τρέξιμο",
     "Schedulable": "Προγραμματιζόμενο",
+    "Sessions": "Συνεδρίες",
     "Settings": "Ρυθμίσεις",
     "Starts": "Ξεκινά",
     "StartsAt": "Ξεκίνησε στις",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -227,6 +227,7 @@
     "Resources": "Resources",
     "Running": "Running",
     "Schedulable": "Schedulable",
+    "Sessions": "Sessions",
     "Settings": "Settings",
     "Starts": "Starts",
     "StartsAt": "Started At",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -227,6 +227,7 @@
     "Resources": "Recursos",
     "Running": "Ejecutar",
     "Schedulable": "Programable",
+    "Sessions": "Sesiones",
     "Settings": "Configuración",
     "Starts": "Inicia",
     "StartsAt": "Iniciado en",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -227,6 +227,7 @@
     "Resources": "Resurssit",
     "Running": "Running",
     "Schedulable": "Aikataulutettavissa",
+    "Sessions": "Istunnot",
     "Settings": "Asetukset",
     "Starts": "Alkaa",
     "StartsAt": "Aloitusaika",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -227,6 +227,7 @@
     "Resources": "Ressources",
     "Running": "En cours",
     "Schedulable": "Programmable",
+    "Sessions": "Sessions",
     "Settings": "Paramètres",
     "Starts": "Départs",
     "StartsAt": "Démarré le",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -227,6 +227,7 @@
     "Resources": "Sumber daya",
     "Running": "Jalankan",
     "Schedulable": "Dapat dijadwalkan",
+    "Sessions": "Sesi",
     "Settings": "Pengaturan",
     "Starts": "Mulai",
     "StartsAt": "Dimulai pada",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -227,6 +227,7 @@
     "Resources": "risorse",
     "Running": "In esecuzione",
     "Schedulable": "Programmabile",
+    "Sessions": "Sessioni",
     "Settings": "Impostazioni",
     "Starts": "Inizia",
     "StartsAt": "Avviato il",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -227,6 +227,7 @@
     "Resources": "リソース",
     "Running": "ランニング",
     "Schedulable": "スケジューリング可能かどうか",
+    "Sessions": "セッション",
     "Settings": "設定",
     "Starts": "開始",
     "StartsAt": "開始時刻",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -227,6 +227,7 @@
     "Resources": "자원",
     "Running": "실행 중",
     "Schedulable": "스케줄링 가능",
+    "Sessions": "세션",
     "Settings": "설정",
     "Starts": "시작",
     "StartsAt": "생성일",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -227,6 +227,7 @@
     "Resources": "Нөөц",
     "Running": "Ажиллаж байна",
     "Schedulable": "Хуваарьтай",
+    "Sessions": "Session-үүд",
     "Settings": "Тохиргоо",
     "Starts": "Эхлэв",
     "StartsAt": "Эхэлсэн огноо",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -227,6 +227,7 @@
     "Resources": "Sumber",
     "Running": "Berlari",
     "Schedulable": "Boleh dijadualkan",
+    "Sessions": "Sesi",
     "Settings": "Tetapan",
     "Starts": "Bermula",
     "StartsAt": "Mula pada",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -227,6 +227,7 @@
     "Resources": "Zasoby",
     "Running": "Bieganie",
     "Schedulable": "Możliwość planowania",
+    "Sessions": "Sesje",
     "Settings": "Ustawienia",
     "Starts": "Rozpoczyna się",
     "StartsAt": "Rozpoczęto",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -227,6 +227,7 @@
     "Resources": "Recursos",
     "Running": "Corrida",
     "Schedulable": "Programável",
+    "Sessions": "Sessões",
     "Settings": "Configurações",
     "Starts": "Começa",
     "StartsAt": "Iniciado em",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -227,6 +227,7 @@
     "Resources": "Recursos",
     "Running": "Corrida",
     "Schedulable": "Programável",
+    "Sessions": "Sessões",
     "Settings": "Configurações",
     "Starts": "Começa",
     "StartsAt": "Iniciado em",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -227,6 +227,7 @@
     "Resources": "Ресурсы",
     "Running": "Выполнение",
     "Schedulable": "Планируемый",
+    "Sessions": "Сессии",
     "Settings": "Настройки",
     "Starts": "Начинается",
     "StartsAt": "Запущено",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -227,6 +227,7 @@
     "Resources": "ทรัพยากร",
     "Running": "กำลังทำงาน",
     "Schedulable": "จัดตารางได้",
+    "Sessions": "เซสชัน",
     "Settings": "การตั้งค่า",
     "Starts": "เริ่มต้น",
     "StartsAt": "เริ่มเมื่อ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -227,6 +227,7 @@
     "Resources": "Kaynaklar",
     "Running": "Koşu",
     "Schedulable": "Planlanabilir",
+    "Sessions": "Oturumlar",
     "Settings": "Ayarlar",
     "Starts": "başlar",
     "StartsAt": "Başlama Zamanı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -227,6 +227,7 @@
     "Resources": "Tài nguyên",
     "Running": "Đang chạy",
     "Schedulable": "Có thể được lập lịch",
+    "Sessions": "Phiên",
     "Settings": "Cài đặt",
     "Starts": "Bắt đầu",
     "StartsAt": "Bắt đầu lúc",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -227,6 +227,7 @@
     "Resources": "资源",
     "Running": "跑步",
     "Schedulable": "可预定",
+    "Sessions": "会话",
     "Settings": "设置",
     "Starts": "开始",
     "StartsAt": "启动时间",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -227,6 +227,7 @@
     "Resources": "資源",
     "Running": "跑步",
     "Schedulable": "可预定",
+    "Sessions": "會話",
     "Settings": "設定",
     "Starts": "開始",
     "StartsAt": "開始時間",


### PR DESCRIPTION
Resolves #8136 (FR-3252)

## Summary

Adds a **Sessions** tab to the agent detail drawer that lists the compute sessions currently assigned to (running on) the agent.

## Changes

- New `AgentSessionList` (`react/src/components/AgentNodeItems/AgentSessionList.tsx`): queries `compute_session_nodes` filtered by `agent_ids ilike "%<agent row_id>%"` (the same operator the admin session list's agent filter uses) plus non-terminated status, ordered by `-created_at`, with local table pagination (`useBAIPaginationOptionState`, page size 5).
- Reuses the existing `SessionNodes` table (name / status / resources / elapsed time columns), so behavior and columns stay consistent with the session list pages. `BAITable`'s built-in empty state is used, so pagination and the table header remain visible when a page is empty.
- Session name click navigates to `/session?sessionDetail=<row_id>` (the `sessionDetail` opener is mounted on the session pages, not on the agent page — same pattern as `VFolderNodesV2`'s mounted-sessions links).
- `AgentDetailDrawerContent`: adds a `sessions` tab beside `resources`, wrapped in `Suspense` + `Skeleton` so the query loads lazily inside the drawer.
- Added the `agent.Sessions` i18n key to `en.json` and all 20 other locales.

## Notes

- Admin-scoped view: rendered inside the agent detail drawer reached from the agents list; existing permission boundaries of the agent page apply.
- Uses the legacy `compute_session_nodes` connection (offset mode with `first` + `offset`, consistent with `AdminComputeSessionListPage`); no V2 dependency, so this PR is independent of the agentsV2 migration (FR-3251, currently deferred on a backend dependency).
- `ilike` is a substring match; an agent id that is a prefix of another could over-match. The manager exposes no exact list-containment operator for `agent_ids` today — limitation is documented in a code comment.

## Verification

- `bash scripts/verify.sh`: `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Vite warmup), re-run after review fixes and after restacking onto latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
