### PR TITLE
feat(FR-3254): highlight matched query terms in docs web search results

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -933,6 +933,18 @@ body.bai-drawer-open .bai-scrim {
   line-height: 1.4;
 }
 
+/* Query-term highlight inside search-result titles/snippets. Rendered as
+   <mark class="search-highlight"> by search.js; the primary-tinted
+   background keeps the term legible in both light and dark themes without
+   the browser default yellow. */
+.search-result-item mark.search-highlight {
+  background: color-mix(in srgb, var(--ifm-color-primary) 22%, transparent);
+  color: inherit;
+  font-weight: 600;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
 .search-no-results {
   padding: 0.8rem;
   font-size: 0.85rem;

--- a/packages/backend.ai-docs-toolkit/templates/assets/search.js
+++ b/packages/backend.ai-docs-toolkit/templates/assets/search.js
@@ -68,9 +68,8 @@
     return tokens;
   }
 
-  function search(q) {
+  function search(toks) {
     if (!idx) return [];
-    var toks = tokenize(q);
     if (!toks.length) return [];
     var scores = {};
     toks.forEach(function (tok) {
@@ -90,7 +89,86 @@
       .slice(0, 10);
   }
 
-  function render(results) {
+  /* Case-insensitive match ranges of `toks` within `text`, merged so that
+   * overlapping/adjacent hits (e.g. CJK bigrams) collapse into one span.
+   * Indices are computed on the lower-cased copy but applied to the
+   * original text — safe because the scripts we tokenize preserve length
+   * under toLowerCase(). */
+  function matchRanges(text, toks) {
+    var lower = text.toLowerCase();
+    var ranges = [];
+    toks.forEach(function (tok) {
+      if (!tok) return;
+      var from = 0;
+      var i;
+      while ((i = lower.indexOf(tok, from)) !== -1) {
+        ranges.push([i, i + tok.length]);
+        from = i + 1; // step by 1 so overlapping bigrams are all captured
+      }
+    });
+    if (!ranges.length) return ranges;
+    ranges.sort(function (a, b) {
+      return a[0] - b[0];
+    });
+    var merged = [ranges[0].slice()];
+    for (var k = 1; k < ranges.length; k++) {
+      var last = merged[merged.length - 1];
+      if (ranges[k][0] <= last[1]) {
+        if (ranges[k][1] > last[1]) last[1] = ranges[k][1];
+      } else {
+        merged.push(ranges[k].slice());
+      }
+    }
+    return merged;
+  }
+
+  /* Append `text` to `parent`, wrapping matched ranges in <mark>. Builds
+   * DOM nodes (not innerHTML) so the same XSS-safe contract as textContent
+   * is preserved. */
+  function appendHighlighted(parent, text, toks) {
+    var ranges = matchRanges(text, toks);
+    if (!ranges.length) {
+      parent.appendChild(document.createTextNode(text));
+      return;
+    }
+    var pos = 0;
+    ranges.forEach(function (rg) {
+      if (rg[0] > pos)
+        parent.appendChild(document.createTextNode(text.slice(pos, rg[0])));
+      var m = document.createElement('mark');
+      m.className = 'search-highlight';
+      m.textContent = text.slice(rg[0], rg[1]);
+      parent.appendChild(m);
+      pos = rg[1];
+    });
+    if (pos < text.length)
+      parent.appendChild(document.createTextNode(text.slice(pos)));
+  }
+
+  /* Build a ~120-char snippet window centred on the first matched token so
+   * the highlighted term is actually visible; falls back to the head of the
+   * body when nothing matches (e.g. title-only hits). */
+  function buildSnippet(body, toks) {
+    var text = body || '';
+    if (!text) return '';
+    var lower = text.toLowerCase();
+    var first = -1;
+    toks.forEach(function (tok) {
+      if (!tok) return;
+      var i = lower.indexOf(tok);
+      if (i !== -1 && (first === -1 || i < first)) first = i;
+    });
+    var WINDOW = 120;
+    var start = first > 40 ? first - 40 : 0;
+    var slice = text.slice(start, start + WINDOW);
+    return (
+      (start > 0 ? '…' : '') +
+      slice +
+      (start + WINDOW < text.length ? '…' : '')
+    );
+  }
+
+  function render(results, toks) {
     while (res.firstChild) res.removeChild(res.firstChild);
     if (!results.length) {
       var nr = document.createElement('div');
@@ -108,16 +186,16 @@
         !(d.url.startsWith('./') || d.url.startsWith('/'))
       )
         return;
-      var snippet = (d.body || '').slice(0, 100) + '...';
+      var snippet = buildSnippet(d.body, toks);
       var a = document.createElement('a');
       a.className = 'search-result-item';
       a.href = d.url;
       var t = document.createElement('div');
       t.className = 'search-result-title';
-      t.textContent = d.title;
+      appendHighlighted(t, d.title, toks);
       var s = document.createElement('div');
       s.className = 'search-result-snippet';
-      s.textContent = snippet;
+      appendHighlighted(s, snippet, toks);
       a.appendChild(t);
       a.appendChild(s);
       res.appendChild(a);
@@ -134,8 +212,8 @@
       return;
     }
     timer = setTimeout(function () {
-      var r = search(q);
-      render(r);
+      var toks = tokenize(q);
+      render(search(toks), toks);
     }, 200);
   });
   inp.addEventListener('keydown', function (e) {


### PR DESCRIPTION
Resolves #8140 (FR-3254)

## Summary

The docs website's Cmd+K / Ctrl+K search dropdown now **highlights the matched query term** in both the result title and snippet, so users can immediately see why a page matched.

Before, each result showed the title plus a static snippet (the first 100 chars of the body) with no highlighting — and since the snippet was always the head of the body, the matched text was often not even visible.

## Changes

- **`templates/assets/search.js`**
  - Wrap matched query terms in `<mark class="search-highlight">` in the result **title** and **snippet**.
  - Rebuild the snippet as a **~120-char window centred on the first match** (with leading/trailing `…`), falling back to the head of the body for title-only matches.
  - Highlighting is assembled from DOM **text nodes + `<mark>` elements** (not `innerHTML`), preserving the existing XSS-safe `textContent` contract.
  - Case-insensitive; reuses the existing query tokenizer so **Latin words and CJK/Thai bigrams** both highlight correctly (overlapping bigram hits merge into a single contiguous span).
- **`src/styles-web.ts`**
  - Add `.search-result-item mark.search-highlight` with a primary-tinted `color-mix` background that reads well in both light and dark themes (no browser-default yellow).

Existing behavior is unchanged: tokenization, 200ms debounce, Cmd/Ctrl-K shortcut, Escape-to-close, and the `./`|`/` URL allow-list.

## Verification

- `pnpm run build` (toolkit `tsc`) — passes.
- `pnpm test` (toolkit) — 232 passed, 1 skipped.
- `build:web --lang en` — generated `search.<hash>.js` and `styles.<hash>.css` contain the new logic/rule.
- Drove the real `search.js` through a minimal DOM harness for queries `session`, `SESSION`, `new session`, `세션`, `세션을`, and a no-match term. Confirmed correct `<mark>` placement in title + windowed snippet, case-insensitivity, multi-word highlighting, CJK bigram-span merging, and the no-results path.

## Screenshots

_Highlighting renders as a primary-tinted `<mark>` around the matched term in the title and the match-centred snippet._

🤖 Generated with [Claude Code](https://claude.com/claude-code)