### PR TITLE
fix(FR-3247): emit per-language redirect stubs so bare /<lang>/ URLs work without console rules

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
@@ -19,6 +19,7 @@ import {
   applyImageAttributes,
   buildHomePage,
   buildIndexPage,
+  buildLangRedirectStubPage,
   buildLanguagePickerPage,
   buildRootRedirectIndexPage,
   buildWebPage,
@@ -1619,5 +1620,54 @@ describe("buildRootRedirectIndexPage — FR-2753 root redirect index", () => {
     // The old name is re-exported as an alias so external callers do
     // not break in the same release that introduces the rename.
     assert.equal(buildLanguagePickerPage, buildRootRedirectIndexPage);
+  });
+});
+
+describe("buildLangRedirectStubPage — FR-3247 per-language redirect stubs", () => {
+  it("redirects `<lang>/index.html` to the given target via all three mechanisms", () => {
+    const html = buildLangRedirectStubPage({
+      title: "Backend.AI WebUI User Guide",
+      lang: "ko",
+      target: "../26.4/ko/index.html",
+    });
+    // JS clients: location.replace keeps the stub out of history.
+    assert.match(
+      html,
+      /window\.location\.replace\("\.\.\/26\.4\/ko\/index\.html"\);/,
+    );
+    // JS-disabled clients: meta refresh.
+    assert.match(
+      html,
+      /<meta http-equiv="refresh" content="0; url=\.\.\/26\.4\/ko\/index\.html" \/>/,
+    );
+    // Neither: a plain link.
+    assert.match(html, /href="\.\.\/26\.4\/ko\/index\.html"/);
+    // Crawlers must stay on the real canonical pages.
+    assert.match(html, /<meta name="robots" content="noindex" \/>/);
+    assert.match(html, /<html lang="ko">/);
+  });
+
+  it("escapes the title in HTML context", () => {
+    const html = buildLangRedirectStubPage({
+      title: `Docs <script>alert("x")</script>`,
+      lang: "en",
+      target: "../26.4/en/index.html",
+    });
+    assert.doesNotMatch(html, /<script>alert/);
+    assert.match(html, /&lt;script&gt;/);
+  });
+
+  it("rejects path-breakout lang values", () => {
+    for (const lang of ["..", ".", "../x", "a/b", ".en"]) {
+      assert.throws(
+        () =>
+          buildLangRedirectStubPage({
+            title: "Docs",
+            lang,
+            target: "../26.4/en/index.html",
+          }),
+        /invalid lang/,
+      );
+    }
   });
 });

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -2368,3 +2368,72 @@ ${noscriptItems}
  * same release that introduces the rename.
  */
 export const buildLanguagePickerPage = buildRootRedirectIndexPage;
+
+/**
+ * Build a per-language redirect stub for `dist/web/<lang>/index.html`
+ * (FR-3247). Versioned mode only.
+ *
+ * Why this exists: in versioned mode nothing physically lives at
+ * `/<lang>/` — real pages live at `/<version>/<lang>/...`. Bare
+ * language URLs (`/ko/`, `/en/`) are what readers bookmark and what the
+ * pre-Amplify readthedocs manual used as its entry points, and covering
+ * them with hosting-level redirect rules alone is fragile: the rules
+ * live in the Amplify console, are applied manually, and silently
+ * drift from `amplify-redirects.json` (the exact failure FR-3247
+ * hit in production). This stub is part of the build artifact, so it
+ * deploys atomically with the site and re-points itself on every
+ * `latest: true` flip with zero console interaction.
+ *
+ * This builder owns only the HTML shell; the caller computes `target`
+ * from `canonicalPathFor` (versions.ts) so the versioned-layout
+ * knowledge stays in its single source of truth. The target must be
+ * relative so the page works under any host or path prefix.
+ * `location.replace` keeps the stub out of the browser history; the
+ * `<meta http-equiv="refresh">` covers JS-disabled clients, and a
+ * plain link covers clients that honor neither. `noindex` keeps
+ * crawlers on the real canonical pages.
+ */
+export interface LangRedirectStubPageOptions {
+  title: string;
+  /** Language directory name, e.g. `ko`. Must match the on-disk dir. */
+  lang: string;
+  /**
+   * Relative redirect target as seen from `dist/web/<lang>/index.html`,
+   * e.g. `../26.4/ko/index.html`. Derive it from `canonicalPathFor` —
+   * do not hand-assemble the versioned layout at call sites.
+   */
+  target: string;
+}
+
+export function buildLangRedirectStubPage(
+  opts: LangRedirectStubPageOptions,
+): string {
+  const { title, lang, target } = opts;
+  // Defense-in-depth shape check (same spirit as buildRootRedirectIndexPage):
+  // `lang` names the on-disk directory and lands in the `lang` attribute,
+  // so reject anything that could produce a path breakout.
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(lang)) {
+    throw new Error(
+      `buildLangRedirectStubPage: invalid lang ${JSON.stringify(lang)}`,
+    );
+  }
+  const safeTitle = escapeHtml(title);
+  const safeTarget = escapeHtml(target);
+  const targetJson = safeJsonForScript(target);
+  return `<!DOCTYPE html>
+<html lang="${escapeHtml(lang)}">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${safeTitle}</title>
+  <meta name="robots" content="noindex" />
+  <meta http-equiv="refresh" content="0; url=${safeTarget}" />
+  <script>window.location.replace(${targetJson});</script>
+</head>
+<body>
+  <p style="font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;max-width:30rem;margin:4rem auto;padding:2rem;">
+    <a href="${safeTarget}">${safeTitle}</a>
+  </p>
+</body>
+</html>`;
+}

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -19,6 +19,7 @@ import {
   buildWebPage,
   buildHomePage,
   buildRootRedirectIndexPage,
+  buildLangRedirectStubPage,
   applyImageAttributes,
 } from "./website-builder.js";
 import { buildSearchIndex } from "./search-index-builder.js";
@@ -842,6 +843,41 @@ export async function generateWebsite(
     console.log(
       `Written: index.html (root redirect${loadedVersions.latest ? ` → ${loadedVersions.latest.label}` : ""})`,
     );
+  }
+
+  // Per-language redirect stubs (FR-3247). Versioned mode only: emit
+  // `dist/web/<lang>/index.html` for each language of the latest
+  // version, redirecting to the latest version's language index. This
+  // makes bare `/<lang>/` URLs (reader bookmarks; the legacy
+  // readthedocs entry points) work as a build artifact — deployed
+  // atomically with the site and re-pointed automatically on every
+  // `latest: true` flip — instead of depending on manually-applied
+  // hosting redirect rules. In flat mode `/<lang>/` IS the real
+  // content, so no stub. Collision safety: version labels are
+  // `MAJOR.MINOR` digits or the literal `next` (versions.ts
+  // validator), so a language directory can never clash with a
+  // version directory.
+  if (loadedVersions.enabled && loadedVersions.latest) {
+    for (const stubLang of redirectLanguages) {
+      const stubPath = path.join(distBase, stubLang, "index.html");
+      fs.mkdirSync(path.dirname(stubPath), { recursive: true });
+      fs.writeFileSync(
+        stubPath,
+        buildLangRedirectStubPage({
+          title,
+          lang: stubLang,
+          // canonicalPathFor owns the versioned layout; the stub sits
+          // one level below the site root, hence the single `../`.
+          target: `../${canonicalPathFor(loadedVersions, stubLang, "index")}`,
+        }),
+        "utf-8",
+      );
+    }
+    if (redirectLanguages.length > 0) {
+      console.log(
+        `Written: <lang>/index.html redirect stubs (${redirectLanguages.join(", ")} → ${loadedVersions.latest.label})`,
+      );
+    }
   }
 
   console.log(`Website generated at: ${distBase}`);


### PR DESCRIPTION
Relates to #8122 (FR-3247) — production fix for `webui.docs.backend.ai/ko/` returning 404.

## Root cause

The domain flip to Amplify is done (DNS → CloudFront), but the "Rewrites and redirects" custom rules from `amplify-redirects.json` (#8128, #8132) were **never applied in the Amplify console** — Amplify does not read that file from the repo; merging the PRs alone changes nothing at the hosting layer. With no rules active:

- `/` still works only because the build emits a root `index.html` redirect page.
- `/ko/` (and `/en/`, `/ja/`, `/th/`) 404s: nothing physically exists at `/<lang>/` in versioned mode. Amplify's 404 fallback serves the root `index.html` body, but its redirect script has a loop-safety guard that only fires on the `/` pathname — so the reader sees a dead page.

## Fix (structural, console-independent)

Make the bare-language entry points part of the **build artifact** instead of hosting config. The toolkit now emits `dist/web/<lang>/index.html` for each language of the latest version, redirecting to `../<latest>/<lang>/index.html` via three mechanisms (`location.replace` for JS clients — no history entry; `<meta http-equiv="refresh">` for JS-disabled clients; a plain link as final fallback), marked `noindex` so crawlers stay on canonical pages.

Because the stub is a build output:

- it deploys **atomically** with the site on every Amplify build (merging this PR fixes `/ko/` on the next deploy, no console access needed);
- it **re-points itself automatically** when `latest: true` flips to a new minor — this class of drift cannot recur for bare-language URLs.

Versioned mode only; flat-mode builds are untouched (`/<lang>/` is real content there). The redirect target is computed from `canonicalPathFor` (the existing single source of truth for the versioned layout) and passed into the builder, which owns only the HTML shell; a path-breakout guard on `lang` mirrors `buildRootRedirectIndexPage`.

## What this does NOT cover

Legacy deep links (`/ko/latest/<slug>`, `/en/latest/…`) still need the `amplify-redirects.json` rules applied in the Amplify console (or via `aws amplify update-app --custom-rules file://packages/backend.ai-webui-docs/amplify-redirects.json`). That application step is still pending and is what broke `/ko/` in the first place — please run it regardless of this PR.

## Verification

- `pnpm --filter backend.ai-docs-toolkit test`: 235 pass / 0 fail (includes the new `buildLangRedirectStubPage` suite: redirect mechanisms, HTML escaping, `lang` path-breakout rejection).
- Local `build:web --lang all` emits `dist/web/{en,ko,ja,th}/index.html`, each targeting `../26.4/<lang>/index.html`; build log line: `Written: <lang>/index.html redirect stubs (ko, en, ja, th → 26.4)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
