### PR TITLE
feat(FR-3247): emit a version-agnostic /latest/ alias and make Amplify redirect rules release-invariant

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.test.ts
@@ -1621,6 +1621,82 @@ describe("buildRootRedirectIndexPage — FR-2753 root redirect index", () => {
     // not break in the same release that introduces the rename.
     assert.equal(buildLanguagePickerPage, buildRootRedirectIndexPage);
   });
+
+  describe("basePath mount (FR-3247 `/latest/` alias)", () => {
+    const mounted = () =>
+      buildRootRedirectIndexPage({
+        title: "Docs",
+        productName: "Docs",
+        languages: baseLanguages,
+        fallback: "en",
+        latestVersion: "26.4",
+        basePath: "latest",
+      });
+
+    it("climbs one level in redirect targets and noscript hrefs", () => {
+      const html = mounted();
+      assert.equal(
+        runRedirectScript({ html, pathname: "/latest/" }),
+        "../26.4/en/index.html",
+      );
+      assert.match(html, /href="\.\.\/26\.4\/ko\/index\.html"/);
+      // Root-relative `./26.4/...` hrefs must NOT appear — from
+      // /latest/ they would resolve to /latest/26.4/... (404).
+      assert.doesNotMatch(html, /href="\.\/26\.4\//);
+    });
+
+    it("fires only from the mount point, not from `/` or other paths", () => {
+      const html = mounted();
+      assert.equal(
+        runRedirectScript({ html, pathname: "/latest" }),
+        "../26.4/en/index.html",
+      );
+      assert.equal(
+        runRedirectScript({ html, pathname: "/latest/index.html" }),
+        "../26.4/en/index.html",
+      );
+      for (const pathname of ["/", "/index.html", "/26.3/", "/latest/ko/"]) {
+        assert.equal(
+          runRedirectScript({ html, pathname }),
+          null,
+          `script must NOT fire from ${pathname}`,
+        );
+      }
+    });
+
+    it("does not change behavior when basePath is omitted", () => {
+      const html = buildRootRedirectIndexPage({
+        title: "Docs",
+        productName: "Docs",
+        languages: baseLanguages,
+        fallback: "en",
+        latestVersion: "26.4",
+      });
+      assert.equal(
+        runRedirectScript({ html, pathname: "/" }),
+        "./26.4/en/index.html",
+      );
+      assert.equal(runRedirectScript({ html, pathname: "/latest/" }), null);
+    });
+
+    it("rejects path-breakout basePath values", () => {
+      for (const bad of ["..", ".", "../x", "a/b", ".hidden"]) {
+        assert.throws(
+          () =>
+            buildRootRedirectIndexPage({
+              title: "Docs",
+              productName: "Docs",
+              languages: baseLanguages,
+              fallback: "en",
+              latestVersion: "26.4",
+              basePath: bad,
+            }),
+          /invalid basePath/,
+          `expected ${JSON.stringify(bad)} to be rejected`,
+        );
+      }
+    });
+  });
 });
 
 describe("buildLangRedirectStubPage — FR-3247 per-language redirect stubs", () => {

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -2211,6 +2211,16 @@ export interface RootRedirectIndexPageOptions {
    * flat-mode builds (FR-2710 F1 contract).
    */
   latestVersion?: string;
+  /**
+   * Single path segment the page is mounted under instead of the site
+   * root, e.g. `latest` for `dist/web/latest/index.html` (FR-3247's
+   * version-agnostic alias). Affects two things: the loop-safety guard
+   * accepts `/<basePath>/` pathnames instead of `/`, and the redirect
+   * targets / `<noscript>` hrefs climb one level (`../<version>/...`
+   * instead of `./<version>/...`). Leave undefined for the site-root
+   * page.
+   */
+  basePath?: string;
 }
 
 /** @deprecated Renamed to {@link RootRedirectIndexPageOptions}. */
@@ -2241,12 +2251,27 @@ function safeJsonForScript(value: unknown): string {
 export function buildRootRedirectIndexPage(
   opts: RootRedirectIndexPageOptions,
 ): string {
-  const { title, productName, languages, fallback, latestVersion } = opts;
+  const { title, productName, languages, fallback, latestVersion, basePath } =
+    opts;
   if (languages.length === 0) {
     throw new Error(
       `buildRootRedirectIndexPage: \`languages\` must contain at least one entry`,
     );
   }
+  // Same shape guard as `latestVersion` below: `basePath` is interpolated
+  // into URLs and into the loop-safety guard's regex source, so reject
+  // anything that could break out of a single path segment.
+  if (
+    basePath !== undefined &&
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(basePath)
+  ) {
+    throw new Error(
+      `buildRootRedirectIndexPage: invalid basePath ${JSON.stringify(basePath)}`,
+    );
+  }
+  // Mounted pages (`dist/web/<basePath>/index.html`) sit one level below
+  // the site root, so their version-dir targets climb one level.
+  const hrefBase = basePath ? "../" : "./";
   const safeTitle = escapeHtml(title);
   const safeProduct = escapeHtml(productName);
   // BCP-47 tags are case-insensitive (`zh-CN` ≡ `zh-cn`). The redirect
@@ -2288,9 +2313,16 @@ export function buildRootRedirectIndexPage(
   const noscriptItems = languages
     .map(
       (l) =>
-        `      <li><a hreflang="${escapeHtml(l.lang)}" lang="${escapeHtml(l.lang)}" href="./${versionHrefSegment}${escapeHtml(l.lang)}/index.html">${escapeHtml(l.label)}</a></li>`,
+        `      <li><a hreflang="${escapeHtml(l.lang)}" lang="${escapeHtml(l.lang)}" href="${hrefBase}${versionHrefSegment}${escapeHtml(l.lang)}/index.html">${escapeHtml(l.label)}</a></li>`,
     )
     .join("\n");
+  // Loop-safety guard regex source (see comment inside the script).
+  // For a mounted page the accepted pathnames are `/<basePath>`,
+  // `/<basePath>/`, and `/<basePath>/index.html`; only `.` in the
+  // validated basePath charset is regex-significant, so escape it.
+  const guardSource = basePath
+    ? `^\\/${basePath.replace(/\./g, "\\.")}\\/?(?:index\\.html)?$`
+    : `^\\/?(?:index\\.html)?$`;
 
   // The script is intentionally tiny and CSP-friendly. No fetch, no CDN,
   // no eval. It is placed at the top of <head> so it runs synchronously
@@ -2302,6 +2334,7 @@ export function buildRootRedirectIndexPage(
   var HREFS=${supportedHrefMapJson};
   var FALLBACK=${fallbackJson};
   var VERSION_PREFIX=${versionPrefixJson};
+  var HREF_BASE=${safeJsonForScript(hrefBase)};
   function pick(){
     try{
       var ls=window.localStorage&&window.localStorage.getItem("lang");
@@ -2323,19 +2356,20 @@ export function buildRootRedirectIndexPage(
     }
     return FALLBACK;
   }
-  // Loop-safety guard: only fire from the actual site root (\`/\` or
-  // \`/index.html\`). Anything else — e.g. /26.3/ served by a hosting
-  // 404 fallback that preserves the requested URL — must NOT trigger
-  // the redirect, because \`location.replace("./...")\` would resolve
-  // the relative target against the bogus URL and land the user on a
-  // doubly-broken path.
+  // Loop-safety guard: only fire from the page's own mount point (the
+  // site root, or /<basePath>/ for mounted alias pages). Anything else
+  // — e.g. /26.3/ served by a hosting 404 fallback that preserves the
+  // requested URL — must NOT trigger the redirect, because
+  // \`location.replace(HREF_BASE+"...")\` would resolve the relative
+  // target against the bogus URL and land the user on a doubly-broken
+  // path.
   var p=window.location.pathname||"";
-  if(!/^\\/?(?:index\\.html)?$/i.test(p))return;
+  if(!/${guardSource}/i.test(p))return;
   var picked=pick();
   // Map the matched (lower-cased) tag back to its original config
   // casing so the URL hits the actual on-disk directory name.
   var dir=Object.prototype.hasOwnProperty.call(HREFS,picked)?HREFS[picked]:HREFS[FALLBACK];
-  window.location.replace("./"+VERSION_PREFIX+dir+"/index.html");
+  window.location.replace(HREF_BASE+VERSION_PREFIX+dir+"/index.html");
 })();`;
 
   return `<!DOCTYPE html>

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -857,7 +857,17 @@ export async function generateWebsite(
   // `MAJOR.MINOR` digits or the literal `next` (versions.ts
   // validator), so a language directory can never clash with a
   // version directory.
-  if (loadedVersions.enabled && loadedVersions.latest) {
+  // Guarded on `redirectLanguages.length > 0` for the same reason the
+  // site-root index above is: an empty list (a `--lang` run whose filter
+  // excludes every language the latest version ships) has nothing to
+  // redirect to, and `buildRootRedirectIndexPage` throws on empty
+  // `languages`. The root block already warned-and-skipped for this
+  // case, so skip silently here to stay consistent.
+  if (
+    loadedVersions.enabled &&
+    loadedVersions.latest &&
+    redirectLanguages.length > 0
+  ) {
     for (const stubLang of redirectLanguages) {
       const stubPath = path.join(distBase, stubLang, "index.html");
       fs.mkdirSync(path.dirname(stubPath), { recursive: true });
@@ -873,11 +883,55 @@ export async function generateWebsite(
         "utf-8",
       );
     }
-    if (redirectLanguages.length > 0) {
-      console.log(
-        `Written: <lang>/index.html redirect stubs (${redirectLanguages.join(", ")} → ${loadedVersions.latest.label})`,
+    console.log(
+      `Written: <lang>/index.html redirect stubs (${redirectLanguages.join(", ")} → ${loadedVersions.latest.label})`,
+    );
+
+    // Version-agnostic `/latest/` alias (FR-3247). Hosting-level
+    // redirect rules (amplify-redirects.json) target `/latest/...`
+    // instead of `/<minor>/...`, so the hosting config never has to
+    // change when `latest: true` flips — the mapping from `latest` to
+    // the real minor lives HERE, in the build artifact, and re-points
+    // itself on every deploy. `latest/index.html` is the same
+    // language-picking redirect as the site root (mounted one level
+    // down); `latest/<lang>/index.html` are fixed per-language stubs.
+    // `latest` cannot collide with a real version dir: versions.ts
+    // restricts labels to MAJOR.MINOR digits or the literal `next`.
+    fs.mkdirSync(path.join(distBase, "latest"), { recursive: true });
+    fs.writeFileSync(
+      path.join(distBase, "latest", "index.html"),
+      buildRootRedirectIndexPage({
+        title,
+        productName,
+        languages: redirectLanguages.map((peerLang) => ({
+          lang: peerLang,
+          label: config.languageLabels[peerLang] ?? peerLang,
+        })),
+        fallback: redirectLanguages.includes("en")
+          ? "en"
+          : redirectLanguages[0],
+        latestVersion: loadedVersions.latest.label,
+        basePath: "latest",
+      }),
+      "utf-8",
+    );
+    for (const stubLang of redirectLanguages) {
+      const aliasPath = path.join(distBase, "latest", stubLang, "index.html");
+      fs.mkdirSync(path.dirname(aliasPath), { recursive: true });
+      fs.writeFileSync(
+        aliasPath,
+        buildLangRedirectStubPage({
+          title,
+          lang: stubLang,
+          // Two levels below the site root (latest/<lang>/), hence ../../.
+          target: `../../${canonicalPathFor(loadedVersions, stubLang, "index")}`,
+        }),
+        "utf-8",
       );
     }
+    console.log(
+      `Written: latest/ alias (index + ${redirectLanguages.join(", ")} → ${loadedVersions.latest.label})`,
+    );
   }
 
   console.log(`Website generated at: ${distBase}`);

--- a/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
+++ b/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
@@ -128,26 +128,30 @@ PR title format: `feat(FR-XXXX): publish 26.5 to docs site` (replace
 `FR-XXXX` with the Jira ticket created for the release-publish task and
 `26.5` with the actual minor).
 
-### 4. Update `amplify-redirects.json` and re-apply it in the Amplify console
+### 4. Redirects: nothing to do on a release (release-invariant since FR-3247)
 
-`packages/backend.ai-webui-docs/amplify-redirects.json` hardcodes the
-latest minor in its redirect targets (the root rule `/` → `/26.4/` and,
-since FR-3248, the legacy deep-link rules `/<lang>/<*>` → `/26.4/<lang>/`).
-When `latest: true` moves to a new minor:
+`packages/backend.ai-webui-docs/amplify-redirects.json` targets only the
+version-agnostic `/latest/...` alias, which the docs build emits as part
+of the site artifact and re-points to the `latest: true` minor on every
+deploy. Flipping `latest: true` (step 3) therefore requires **no change
+to the redirect rules and no Amplify console action** — the merged
+config PR's Amplify build updates the alias automatically.
 
-- Update every `/26.4/...` target in the file to the new minor (same PR
-  as step 3 is fine).
-- Amplify does **not** read this file from the repo — after the PR
-  merges, re-apply the rules in the Amplify console ("App settings →
-  Rewrites and redirects", "Open text editor") or via the AWS CLI. The
-  CLI's `--custom-rules` expects a bare JSON **array** of rules, not
-  this file's `{ "_comment": [...], "customRules": [...] }` wrapper —
-  extract the `customRules` value first:
+The rules need (re)application only when the rule **set** itself changes
+in `amplify-redirects.json` (new/removed/edited rules — rare). In that
+case, apply via the Amplify console ("App settings → Rewrites and
+redirects" → "Open text editor", pasting the `customRules` array — not
+the whole file) or via the AWS CLI, whose `--custom-rules` expects a
+bare JSON **array**, not the file's `{ "_comment": ..., "customRules":
+... }` wrapper:
 
-  ```bash
-  aws amplify update-app --app-id <APP_ID> \
-    --custom-rules "$(jq -c '.customRules' packages/backend.ai-webui-docs/amplify-redirects.json)"
-  ```
+```bash
+aws amplify update-app --app-id <APP_ID> \
+  --custom-rules "$(jq -c '.customRules' packages/backend.ai-webui-docs/amplify-redirects.json)"
+```
+
+Do **not** reintroduce version numbers (e.g. `/26.4/`) into rule targets
+— that recreates the manual-reapplication step this design removed.
 
 ---
 

--- a/packages/backend.ai-webui-docs/amplify-redirects.json
+++ b/packages/backend.ai-webui-docs/amplify-redirects.json
@@ -12,114 +12,108 @@
     "\"$(jq -c '.customRules' amplify-redirects.json)\"`. Versioning the",
     "file here keeps the intent reviewable in the repo.",
     "",
-    "Anti-pattern guard:",
-    "  - The root MUST redirect to /26.4/<...>, NOT to /next/<...>.",
-    "    `next` is opt-in only (FR-5).",
-    "  - The /26.4/ target is hardcoded for v1. When the `latest: true`",
-    "    flip moves to a new minor (e.g., 26.5), update both this file",
-    "    AND re-apply the rules in the console. A future toolkit helper",
-    "    may emit this list from `versions[latest=true]` automatically.",
-    "  - Legacy RTD-style deep links (FR-3248): the pre-Amplify manual",
-    "    (readthedocs, Sphinx) served /<lang>/latest/<slug> URLs on this",
-    "    domain. Old bookmarks and search-engine results must not 404,",
-    "    so /<lang>/<*> redirects to the latest version's per-language",
-    "    index. Slug-level mapping is impossible (the Sphinx manual and",
-    "    this site have entirely different page slugs), hence the index",
-    "    target — this SUPERSEDES the per-slug idea once tracked in",
-    "    FR-2742. Order matters: keep these AFTER the exact-match root",
-    "    rule and remember /<lang>/ paths never collide with the new",
-    "    site's own URLs (those all live under /<version>/... or",
-    "    /assets/...).",
-    "  - Bare language paths (/ko, /ko/) get EXPLICIT rules per language.",
+    "RELEASE-INVARIANT DESIGN (FR-3247). Every target points at the",
+    "version-agnostic `/latest/...` alias, which the docs build emits as",
+    "part of the site artifact (`latest/index.html` = language-picking",
+    "redirect, `latest/<lang>/index.html` = per-language redirect into",
+    "the current `latest: true` minor). The alias re-points itself on",
+    "every deploy, so these rules NEVER need to change or be reapplied",
+    "when `latest: true` flips to a new minor. Rules only need",
+    "(re)application when the rule SET itself changes in this file.",
+    "Do not reintroduce version numbers (e.g. /26.4/) into targets —",
+    "that recreates the manual-reapplication drift this design removes.",
+    "",
+    "Rule notes:",
+    "  - The root MUST NOT land readers on /next/ — `next` is opt-in",
+    "    only (FR-5). The build's latest/ alias honors this: it always",
+    "    points at the `latest: true` entry, never `next`.",
+    "  - Legacy RTD-style deep links (/<lang>/latest/<slug> from the",
+    "    pre-Amplify readthedocs manual) are caught by the /<lang>/<*>",
+    "    wildcards. Slug-level mapping is impossible (the Sphinx manual",
+    "    and this site have entirely different page slugs), so they land",
+    "    on the per-language index. Supersedes FR-2742's per-slug idea.",
+    "  - Bare language paths (/ko, /ko/) get EXPLICIT rules per language:",
     "    Amplify matches sources literally (no trailing-slash",
-    "    normalization), and /<lang>/<*> is not guaranteed to match the",
-    "    bare or slash-only path — so /<lang> and /<lang>/ are spelled",
-    "    out. Keep the exact rules BEFORE that language's wildcard rule.",
+    "    normalization) and /<lang>/<*> is not guaranteed to match the",
+    "    bare or slash-only path. Keep the exact rules BEFORE that",
+    "    language's wildcard rule.",
     "",
     "Status codes:",
-    "  302 — Temporary redirect. Used for EVERY rule below, including the",
-    "        root, because every target embeds the CURRENT latest minor",
-    "        and must not be cached by browsers/crawlers past the next",
-    "        latest-stable shift.",
-    "",
-    "  FR-3247 follow-up: the root rule was 301 (permanent) in an earlier",
-    "  revision. That was a bug, not a deliberate choice — 301 tells",
-    "  browsers (Chrome's redirect cache in particular) to remember the",
-    "  mapping indefinitely, ignoring normal Cache-Control expiry AND any",
-    "  later change to this file. A visitor who loads `/` before the next",
-    "  latest-stable shift keeps bouncing straight to the OLD minor",
-    "  forever, without ever re-contacting origin, even after this rule",
-    "  is updated and reapplied in the console. `until the next",
-    "  latest-stable shift` (the original comment's own words) describes",
-    "  a temporary condition — that is 302, never 301. Do not reintroduce",
-    "  301 here unless the target stops embedding a version number (e.g.",
-    "  a stable /latest/ build alias — tracked as a possible follow-up,",
-    "  not yet implemented)."
+    "  301 — root and bare-language rules. Safe to cache permanently:",
+    "        the /latest/... targets are version-agnostic and will never",
+    "        change. (An earlier revision pointed the root at /26.4/",
+    "        with a 301 — that was a bug; browsers cache 301s",
+    "        indefinitely, which would have pinned pre-flip visitors to",
+    "        the old minor forever. Permanent status is only correct",
+    "        BECAUSE the targets no longer embed a version.)",
+    "  302 — /<lang>/<*> wildcard deep links. The source→target mapping",
+    "        is lossy (old slug → language index) and may be improved",
+    "        later, so keep crawlers/browsers re-checking."
   ],
   "customRules": [
     {
       "source": "/",
-      "target": "/26.4/",
-      "status": "302"
+      "target": "/latest/",
+      "status": "301"
     },
     {
       "source": "/en",
-      "target": "/26.4/en/",
-      "status": "302"
+      "target": "/latest/en/",
+      "status": "301"
     },
     {
       "source": "/en/",
-      "target": "/26.4/en/",
-      "status": "302"
+      "target": "/latest/en/",
+      "status": "301"
     },
     {
       "source": "/en/<*>",
-      "target": "/26.4/en/",
+      "target": "/latest/en/",
       "status": "302"
     },
     {
       "source": "/ko",
-      "target": "/26.4/ko/",
-      "status": "302"
+      "target": "/latest/ko/",
+      "status": "301"
     },
     {
       "source": "/ko/",
-      "target": "/26.4/ko/",
-      "status": "302"
+      "target": "/latest/ko/",
+      "status": "301"
     },
     {
       "source": "/ko/<*>",
-      "target": "/26.4/ko/",
+      "target": "/latest/ko/",
       "status": "302"
     },
     {
       "source": "/ja",
-      "target": "/26.4/ja/",
-      "status": "302"
+      "target": "/latest/ja/",
+      "status": "301"
     },
     {
       "source": "/ja/",
-      "target": "/26.4/ja/",
-      "status": "302"
+      "target": "/latest/ja/",
+      "status": "301"
     },
     {
       "source": "/ja/<*>",
-      "target": "/26.4/ja/",
+      "target": "/latest/ja/",
       "status": "302"
     },
     {
       "source": "/th",
-      "target": "/26.4/th/",
-      "status": "302"
+      "target": "/latest/th/",
+      "status": "301"
     },
     {
       "source": "/th/",
-      "target": "/26.4/th/",
-      "status": "302"
+      "target": "/latest/th/",
+      "status": "301"
     },
     {
       "source": "/th/<*>",
-      "target": "/26.4/th/",
+      "target": "/latest/th/",
       "status": "302"
     }
   ]


### PR DESCRIPTION
Relates to #8122 (FR-3247). Stacked on #8143 (which is stacked on #8142).

## Design

Removes the root cause behind both production incidents in this series (unapplied console rules → `/ko/` 404; permanently-cached `301 → /26.4/`): **Amplify redirect targets embedded the current latest minor, so a human had to edit + reapply them on every release.**

Now the hosting rules point only at a version-agnostic `/latest/...` alias, and the mapping from `latest` to the real minor lives in the build artifact:

- `latest/index.html` — the same language-picking redirect as the site root, mounted one level down (`buildRootRedirectIndexPage` gains a `basePath` option: loop-safety guard accepts `/latest{,/,/index.html}`, targets climb one level via `HREF_BASE`).
- `latest/<lang>/index.html` — fixed per-language stubs via `canonicalPathFor` (reuses #8142's `buildLangRedirectStubPage`).

Because the alias is emitted on every deploy, it re-points itself when `latest: true` flips. **The Amplify rules are applied once and never touched again** — RELEASE-RUNBOOK step 4 shrinks to "nothing to do on a release."

## Redirect rules (`amplify-redirects.json`)

| Source | Target | Status |
|---|---|---|
| `/` | `/latest/` | 301 |
| `/en`, `/en/` (× ko/ja/th) | `/latest/<lang>/` | 301 |
| `/en/<*>` (× ko/ja/th) | `/latest/<lang>/` | 302 |

301 returns for root/bare-language rules — now genuinely safe, because the targets are permanent (this is the condition #8143's comment set for ever reintroducing 301). The lossy `/<lang>/<*>` deep-link mappings stay 302 since they may be improved later.

## Alternatives considered

- **CI auto-applies `aws amplify update-app` on merge** — keeps versioned targets but adds AWS secrets + a moving part; config-invariance is strictly better than config-automation.
- **`/latest/` as a full content mirror** (readthedocs-style) — stable deep links, but doubles artifact size and creates duplicate-content SEO surface. Can be adopted later *without touching the Amplify rules* — that flexibility is itself a benefit of this design.

## Verification

- `pnpm --filter backend.ai-docs-toolkit test`: **239 pass / 0 fail** (4 new `basePath` tests: target climbing, mount-point-only guard firing, no behavior change when omitted, path-breakout rejection).
- Local `build:web --lang all` emits `dist/web/latest/{index.html,en,ko,ja,th}`; `latest/index.html` has `HREF_BASE="../"` + `VERSION_PREFIX="26.4/"`; `latest/ko/index.html` targets `../../26.4/ko/index.html`; existing bare-lang stubs unchanged.
- `amplify-redirects.json` parses; 13 rules; every target is version-agnostic (`/latest/...`).

## Post-merge (one-time, DevOps)

Apply the rules once — after this, latest flips need zero console action:

```bash
aws amplify update-app --app-id <APP_ID> \
  --custom-rules "$(jq -c '.customRules' packages/backend.ai-webui-docs/amplify-redirects.json)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
