### PR TITLE
fix(FR-3230): prevent AgentDetailDrawer crash when stopped agent has empty live_stat

### DIFF
--- a/react/src/components/AgentDetailDrawerContent.tsx
+++ b/react/src/components/AgentDetailDrawerContent.tsx
@@ -8,6 +8,7 @@ import AgentActionButtons from './AgentNodeItems/AgentActionButtons';
 import AgentComputePlugins from './AgentNodeItems/AgentComputePlugins';
 import AgentResources from './AgentNodeItems/AgentResources';
 import AgentStatusTag from './AgentNodeItems/AgentStatusTag';
+import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { Descriptions, Grid, Tabs, theme, Typography } from 'antd';
 import {
@@ -150,7 +151,11 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
           {
             key: 'resources',
             label: t('agent.Resources'),
-            children: <AgentResources agentNodeFrgmt={agent} />,
+            children: (
+              <ErrorBoundaryWithNullFallback>
+                <AgentResources agentNodeFrgmt={agent} />
+              </ErrorBoundaryWithNullFallback>
+            ),
           },
         ]}
       />

--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -215,187 +215,192 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
             </BAIFlex>
           }
         >
-          <Row gutter={[16, 16]}>
-            <Col xs={24} sm={12} key={'cpu_util'}>
-              <SimpleProgressWithLabel
-                key={'cpu_util'}
-                size="default"
-                title={mergedResourceSlots?.cpu?.human_readable_name}
-                percent={(
-                  Math.min(
-                    _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
-                      100 /
-                      (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
-                    1,
-                  ) * 100
-                ).toString()}
-                description={`${toFixedFloorWithoutTrailingZeros(
-                  Math.min(
-                    _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
-                      100 /
-                      (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
-                    1,
-                  ) * 100,
-                  2,
-                )}%`}
-              />
-            </Col>
-            <Col xs={24} sm={12} key={'mem'}>
-              <SimpleProgressWithLabel
-                key={'mem'}
-                size="default"
-                title={mergedResourceSlots?.mem?.human_readable_name}
-                percent={toFixedFloorWithoutTrailingZeros(
-                  (parsedLiveStat?.node?.mem?.current /
-                    (parsedAvailableSlots?.mem ||
-                      parsedLiveStat?.node?.mem?.capacity)) *
-                    100 || 0,
-                  2,
-                )}
-                description={`${toFixedFloorWithoutTrailingZeros(
-                  convertToBinaryUnit(
-                    parsedLiveStat?.node?.mem?.current || '0',
-                    convertUnitValue(
-                      _.toString(parsedLiveStat?.node?.mem.capacity),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.number || 0,
-                  2,
-                )} / ${toFixedFloorWithoutTrailingZeros(
-                  convertToBinaryUnit(
-                    parsedAvailableSlots?.mem ||
-                      parsedLiveStat?.node?.mem?.capacity ||
-                      '0',
-                    convertUnitValue(
-                      _.toString(
-                        parsedAvailableSlots?.mem ||
-                          parsedLiveStat?.node?.mem.capacity,
-                      ),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.number || 0,
-                  2,
-                )}${
-                  convertToBinaryUnit(
-                    parsedLiveStat?.node?.mem?.capacity || '0',
-                    convertUnitValue(
-                      _.toString(parsedLiveStat?.node?.mem.capacity),
-                      'auto',
-                    )?.unit || 'g',
-                  )?.displayUnit
-                }  (${toFixedFloorWithoutTrailingZeros(
-                  parsedLiveStat?.node?.mem?.pct || 0,
-                  2,
-                )}%)`}
-              />
-            </Col>
-            {_.map(_.keys(parsedLiveStat?.node), (statKey) => {
-              if (['cpu_util', 'mem', 'disk'].includes(statKey)) {
-                return null;
-              }
-              if (_.includes(statKey, '_util')) {
-                const deviceName =
-                  _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                const current = _.toFinite(
-                  parsedLiveStat?.node?.[statKey]?.current,
-                );
-                const capacity =
-                  _.toFinite(parsedLiveStat?.node?.[statKey]?.capacity) || 100;
-                const percent = (current / capacity) * 100 || 0;
-                return (
-                  <Col xs={24} sm={12} key={statKey}>
-                    <SimpleProgressWithLabel
-                      size="default"
-                      title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(util)`}
-                      percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
-                      description={`${toFixedFloorWithoutTrailingZeros(percent, 1)}%`}
-                    />
-                  </Col>
-                );
-              }
-              if (_.includes(statKey, '_mem')) {
-                const deviceName =
-                  _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                const current = _.toFinite(
-                  parsedLiveStat?.node?.[statKey]?.current,
-                );
-                const capacity = _.toFinite(
-                  parsedLiveStat?.node?.[statKey]?.capacity,
-                );
-                const baseUnit =
-                  convertUnitValue(_.toString(capacity), 'auto')?.unit || 'g';
-                const percent = (current / capacity) * 100 || 0;
-                return (
-                  <Col xs={24} sm={12} key={statKey}>
-                    <SimpleProgressWithLabel
-                      size="default"
-                      title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(mem)`}
-                      percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
-                      description={`${
-                        convertToBinaryUnit(_.toString(current), baseUnit)
-                          ?.numberFixed
-                      } / ${
-                        convertToBinaryUnit(_.toString(capacity), baseUnit)
-                          ?.displayValue
-                      }`}
-                    />
-                  </Col>
-                );
-              }
-              if (_.includes(statKey, '_power')) {
-                const deviceName =
-                  _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                const humanReadableName =
-                  mergedResourceSlots?.[deviceName]?.human_readable_name;
+          {_.isEmpty(parsedLiveStat?.node) ? (
+            <BAIText type="secondary">-</BAIText>
+          ) : (
+            <Row gutter={[16, 16]}>
+              <Col xs={24} sm={12} key={'cpu_util'}>
+                <SimpleProgressWithLabel
+                  key={'cpu_util'}
+                  size="default"
+                  title={mergedResourceSlots?.cpu?.human_readable_name}
+                  percent={(
+                    Math.min(
+                      _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
+                        100 /
+                        (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
+                      1,
+                    ) * 100
+                  ).toString()}
+                  description={`${toFixedFloorWithoutTrailingZeros(
+                    Math.min(
+                      _.toFinite(parsedLiveStat?.node?.cpu_util?.pct) /
+                        100 /
+                        (_.keys(parsedLiveStat?.devices?.cpu_util).length || 1),
+                      1,
+                    ) * 100,
+                    2,
+                  )}%`}
+                />
+              </Col>
+              <Col xs={24} sm={12} key={'mem'}>
+                <SimpleProgressWithLabel
+                  key={'mem'}
+                  size="default"
+                  title={mergedResourceSlots?.mem?.human_readable_name}
+                  percent={toFixedFloorWithoutTrailingZeros(
+                    (parsedLiveStat?.node?.mem?.current /
+                      (parsedAvailableSlots?.mem ||
+                        parsedLiveStat?.node?.mem?.capacity)) *
+                      100 || 0,
+                    2,
+                  )}
+                  description={`${toFixedFloorWithoutTrailingZeros(
+                    convertToBinaryUnit(
+                      parsedLiveStat?.node?.mem?.current || '0',
+                      convertUnitValue(
+                        _.toString(parsedLiveStat?.node?.mem?.capacity),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.number || 0,
+                    2,
+                  )} / ${toFixedFloorWithoutTrailingZeros(
+                    convertToBinaryUnit(
+                      parsedAvailableSlots?.mem ||
+                        parsedLiveStat?.node?.mem?.capacity ||
+                        '0',
+                      convertUnitValue(
+                        _.toString(
+                          parsedAvailableSlots?.mem ||
+                            parsedLiveStat?.node?.mem?.capacity,
+                        ),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.number || 0,
+                    2,
+                  )}${
+                    convertToBinaryUnit(
+                      parsedLiveStat?.node?.mem?.capacity || '0',
+                      convertUnitValue(
+                        _.toString(parsedLiveStat?.node?.mem?.capacity),
+                        'auto',
+                      )?.unit || 'g',
+                    )?.displayUnit
+                  }  (${toFixedFloorWithoutTrailingZeros(
+                    parsedLiveStat?.node?.mem?.pct || 0,
+                    2,
+                  )}%)`}
+                />
+              </Col>
+              {_.map(_.keys(parsedLiveStat?.node), (statKey) => {
+                if (['cpu_util', 'mem', 'disk'].includes(statKey)) {
+                  return null;
+                }
+                if (_.includes(statKey, '_util')) {
+                  const deviceName =
+                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                  const current = _.toFinite(
+                    parsedLiveStat?.node?.[statKey]?.current,
+                  );
+                  const capacity =
+                    _.toFinite(parsedLiveStat?.node?.[statKey]?.capacity) ||
+                    100;
+                  const percent = (current / capacity) * 100 || 0;
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <SimpleProgressWithLabel
+                        size="default"
+                        title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(util)`}
+                        percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
+                        description={`${toFixedFloorWithoutTrailingZeros(percent, 1)}%`}
+                      />
+                    </Col>
+                  );
+                }
+                if (_.includes(statKey, '_mem')) {
+                  const deviceName =
+                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                  const current = _.toFinite(
+                    parsedLiveStat?.node?.[statKey]?.current,
+                  );
+                  const capacity = _.toFinite(
+                    parsedLiveStat?.node?.[statKey]?.capacity,
+                  );
+                  const baseUnit =
+                    convertUnitValue(_.toString(capacity), 'auto')?.unit || 'g';
+                  const percent = (current / capacity) * 100 || 0;
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <SimpleProgressWithLabel
+                        size="default"
+                        title={`${mergedResourceSlots?.[deviceName]?.human_readable_name}(mem)`}
+                        percent={toFixedFloorWithoutTrailingZeros(percent, 1)}
+                        description={`${
+                          convertToBinaryUnit(_.toString(current), baseUnit)
+                            ?.numberFixed
+                        } / ${
+                          convertToBinaryUnit(_.toString(capacity), baseUnit)
+                            ?.displayValue
+                        }`}
+                      />
+                    </Col>
+                  );
+                }
+                if (_.includes(statKey, '_power')) {
+                  const deviceName =
+                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                  const humanReadableName =
+                    mergedResourceSlots?.[deviceName]?.human_readable_name;
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <BAIFlex justify="between" gap="xxs">
+                        <BAIText>{`${humanReadableName}(power)`}</BAIText>
+                        <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} ${parsedLiveStat?.node?.[statKey]?.unit_hint ?? ''}`}</BAIText>
+                      </BAIFlex>
+                    </Col>
+                  );
+                }
+                if (_.includes(statKey, '_temperature')) {
+                  const deviceName =
+                    _.split(statKey, '_').slice(0, -1).join('-') + '.device';
+                  const humanReadableName =
+                    mergedResourceSlots?.[deviceName]?.human_readable_name;
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <BAIFlex justify="between" gap="xxs">
+                        <BAIText>{`${humanReadableName}(temp)`}</BAIText>
+                        <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} °C`}</BAIText>
+                      </BAIFlex>
+                    </Col>
+                  );
+                }
+                if (['net_rx', 'net_tx'].includes(statKey)) {
+                  const convertedValue = convertToDecimalUnit(
+                    parsedLiveStat?.node?.[statKey]?.current,
+                    'auto',
+                  );
+                  return (
+                    <Col xs={24} sm={12} key={statKey}>
+                      <BAIFlex justify="between" gap="xxs">
+                        <BAIText>
+                          {statKey === 'net_rx' ? 'Net Rx' : 'Net Tx'}
+                        </BAIText>
+                        <BAIText>{`${convertedValue?.numberFixed ?? 0} ${convertedValue?.unit.toUpperCase() ?? ''}bps`}</BAIText>
+                      </BAIFlex>
+                    </Col>
+                  );
+                }
                 return (
                   <Col xs={24} sm={12} key={statKey}>
                     <BAIFlex justify="between" gap="xxs">
-                      <BAIText>{`${humanReadableName}(power)`}</BAIText>
-                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} ${parsedLiveStat?.node?.[statKey]?.unit_hint ?? ''}`}</BAIText>
+                      <BAIText>{statKey}</BAIText>
+                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current ?? 0, 2)}${parsedLiveStat?.node?.[statKey]?.unit_hint ? ` ${parsedLiveStat?.node?.[statKey]?.unit_hint}` : ''}`}</BAIText>
                     </BAIFlex>
                   </Col>
                 );
-              }
-              if (_.includes(statKey, '_temperature')) {
-                const deviceName =
-                  _.split(statKey, '_').slice(0, -1).join('-') + '.device';
-                const humanReadableName =
-                  mergedResourceSlots?.[deviceName]?.human_readable_name;
-                return (
-                  <Col xs={24} sm={12} key={statKey}>
-                    <BAIFlex justify="between" gap="xxs">
-                      <BAIText>{`${humanReadableName}(temp)`}</BAIText>
-                      <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current, 2)} °C`}</BAIText>
-                    </BAIFlex>
-                  </Col>
-                );
-              }
-              if (['net_rx', 'net_tx'].includes(statKey)) {
-                const convertedValue = convertToDecimalUnit(
-                  parsedLiveStat?.node?.[statKey]?.current,
-                  'auto',
-                );
-                return (
-                  <Col xs={24} sm={12} key={statKey}>
-                    <BAIFlex justify="between" gap="xxs">
-                      <BAIText>
-                        {statKey === 'net_rx' ? 'Net Rx' : 'Net Tx'}
-                      </BAIText>
-                      <BAIText>{`${convertedValue?.numberFixed ?? 0} ${convertedValue?.unit.toUpperCase() ?? ''}bps`}</BAIText>
-                    </BAIFlex>
-                  </Col>
-                );
-              }
-              return (
-                <Col xs={24} sm={12} key={statKey}>
-                  <BAIFlex justify="between" gap="xxs">
-                    <BAIText>{statKey}</BAIText>
-                    <BAIText>{`${toFixedFloorWithoutTrailingZeros(parsedLiveStat?.node?.[statKey]?.current ?? 0, 2)}${parsedLiveStat?.node?.[statKey]?.unit_hint ? ` ${parsedLiveStat?.node?.[statKey]?.unit_hint}` : ''}`}</BAIText>
-                  </BAIFlex>
-                </Col>
-              );
-            })}
-          </Row>
+              })}
+            </Row>
+          )}
         </Descriptions.Item>
       </Descriptions>
       <AgentDetailModal


### PR DESCRIPTION
Resolves #8085 (FR-3230)

> Stacked on #8087

## Summary

Once #8087 allows stopping an agent directly from the Agent detail drawer, a stopped agent's `live_stat` no longer contains `node.mem`. `AgentResources` accessed `parsedLiveStat?.node?.mem.capacity` (no optional chaining after `mem`) in three places, throwing a `TypeError` that crashed the whole AgentDetailDrawer.

- Add the missing optional chaining (`mem?.capacity`) at the three call sites in `AgentResources.tsx`.
- Render `-` in the **Utilization** section when `live_stat.node` is empty, instead of misleading 0% / NaN values.
- Wrap `<AgentResources>` with `ErrorBoundaryWithNullFallback` in `AgentDetailDrawerContent.tsx` so a stat-parsing failure can never take down the entire drawer again.

## How to test

On the `10.82.0.130` test server (superadmin):

1. Open the Agent detail drawer and stop the agent (added in #8087).
2. Reopen the drawer for the stopped agent — it should render normally, with `-` shown for Utilization, instead of crashing.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
