### PR TITLE
feat(FR-3258): apply the renderInput (onAddCondition) custom filter-input contract to BAIPropertyFilter

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.stories.tsx
@@ -1,5 +1,6 @@
 import BAIPropertyFilter from './BAIPropertyFilter';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Select } from 'antd';
 
 // import { action } from '@storybook/addon-actions';
 
@@ -16,9 +17,10 @@ const meta: Meta<typeof BAIPropertyFilter> = {
 
 - **Multiple property types**: String and boolean properties with type-specific operators
 - **Dynamic query building**: Visual interface for constructing filter expressions
-- **Autocomplete support**: Predefined options and suggestions for property values  
+- **Autocomplete support**: Predefined options and suggestions for property values
 - **Validation rules**: Custom validation for property values
 - **Query language**: Based on Backend.AI's query filter minilang specification
+- **Custom input via \`renderInput\`**: Replace the default AutoComplete input with any controlled control (e.g., a user or storage-host picker). The control commits a condition via \`onAddCondition(value, label?)\` as soon as a value is selected; pass a human-readable \`label\` when the committed value is opaque (e.g. a UUID) so the condition tag shows the label instead. Give the control \`value={null}\` so it stays controlled and clears after each commit. Same contract as the one \`BAIGraphQLPropertyFilter\` adopts in FR-3011 (#8082), so controls become interchangeable once both land.
 
 The component generates filter query strings that can be used with Backend.AI's query system, enabling powerful data filtering capabilities across the platform.
 
@@ -221,6 +223,57 @@ export const LoadingState: Story = {
       },
     ],
     loading: true,
+    onChange: () => console.log('Filter changed'),
+  },
+};
+
+const sampleOwnerOptions = [
+  { label: 'alice@example.com', value: 'owner-uuid-0001' },
+  { label: 'bob@example.com', value: 'owner-uuid-0002' },
+  { label: 'carol@example.com', value: 'owner-uuid-0003' },
+];
+
+export const WithRenderInput: Story = {
+  name: 'Custom Input via renderInput',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `renderInput` is provided, the default AutoComplete is replaced with a custom control. The control commits a condition via `onAddCondition(value, label?)` as soon as it emits a non-empty value; keep it controlled with `value={null}` so it clears after each commit. Pass the option label as the second argument so the condition tag shows a human-readable label (e.g. an email) instead of the opaque committed value (e.g. a UUID). Same contract as the one `BAIGraphQLPropertyFilter` adopts in FR-3011 (#8082), so controls become interchangeable once both land.',
+      },
+    },
+  },
+  args: {
+    filterProperties: [
+      {
+        key: 'name',
+        propertyLabel: 'Name',
+        type: 'string',
+        defaultOperator: 'ilike',
+      },
+      {
+        key: 'owner',
+        propertyLabel: 'Owner',
+        type: 'string',
+        defaultOperator: '==',
+        renderInput: ({ onAddCondition }) => (
+          <Select
+            showSearch
+            placeholder="Select owner"
+            style={{ minWidth: 220 }}
+            value={null}
+            optionFilterProp="label"
+            options={sampleOwnerOptions}
+            onChange={(next) =>
+              onAddCondition(
+                next ?? undefined,
+                sampleOwnerOptions.find((o) => o.value === next)?.label,
+              )
+            }
+          />
+        ),
+      },
+    ],
     onChange: () => console.log('Filter changed'),
   },
 };

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
@@ -1,6 +1,7 @@
 import BAIPropertyFilter, {
   mergeFilterValues,
   parseFilterValue,
+  type FilterProperty,
 } from './BAIPropertyFilter';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
@@ -525,5 +526,166 @@ describe('BAIPropertyFilter tag removal (FR-2965)', () => {
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith('description ilike "%beta%"');
     });
+  });
+});
+
+// FR-3258: a `renderInput` control committing via `onAddCondition` — the
+// contract `BAIGraphQLPropertyFilter` adopts in FR-3011 (#8082). Plain buttons
+// call `onAddCondition(value)` to exercise commit-on-select without a real
+// picker.
+const ownerCustomProperties: Array<FilterProperty> = [
+  {
+    key: 'owner',
+    propertyLabel: 'Owner',
+    type: 'string',
+    defaultOperator: '==',
+    renderInput: ({ onAddCondition }) => (
+      <>
+        <button type="button" onClick={() => onAddCondition('uuid-alice')}>
+          pick-alice
+        </button>
+        <button type="button" onClick={() => onAddCondition('uuid-bob')}>
+          pick-bob
+        </button>
+      </>
+    ),
+  },
+];
+
+// FR-3258: a `renderInput` control whose committed value is opaque (a UUID)
+// but which passes the human-readable label as the second `onAddCondition`
+// argument, mirroring `BAIUserSelect` with `valuePropName="id"` forwarding
+// `option.label`.
+const ownerLabeledProperties: Array<FilterProperty> = [
+  {
+    key: 'owner',
+    propertyLabel: 'Owner',
+    type: 'string',
+    defaultOperator: '==',
+    renderInput: ({ onAddCondition }) => (
+      <button
+        type="button"
+        onClick={() => onAddCondition('uuid-alice', 'alice@example.com')}
+      >
+        pick-alice
+      </button>
+    ),
+  },
+];
+
+const ControlledCustom = ({
+  onFilterChange,
+  filterProperties: customProperties = ownerCustomProperties,
+}: {
+  onFilterChange?: (value: string) => void;
+  filterProperties?: Array<FilterProperty>;
+}) => {
+  const [value, setValue] = useState<string | undefined>();
+  return (
+    <BAIPropertyFilter
+      filterProperties={customProperties}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onFilterChange?.(next);
+      }}
+    />
+  );
+};
+
+describe('BAIPropertyFilter custom renderInput', () => {
+  it('commits a condition as soon as the controlled input emits a value', async () => {
+    const onFilterChange = vi.fn();
+    render(<ControlledCustom onFilterChange={onFilterChange} />);
+
+    fireEvent.click(screen.getByText('pick-alice'));
+
+    // The emitted value is serialized with the property's default operator.
+    await waitFor(() => {
+      expect(onFilterChange).toHaveBeenCalledWith('owner == "uuid-alice"');
+    });
+    // The tag shows the committed raw value.
+    expect(screen.getByText(/Owner.*uuid-alice/)).toBeVisible();
+  });
+
+  it('stacks each emitted value as a separate tag (AND of filters)', async () => {
+    const onFilterChange = vi.fn();
+    render(<ControlledCustom onFilterChange={onFilterChange} />);
+
+    fireEvent.click(screen.getByText('pick-alice'));
+    await waitFor(() => {
+      expect(screen.getByText(/Owner.*uuid-alice/)).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByText('pick-bob'));
+    await waitFor(() => {
+      expect(screen.getByText(/Owner.*uuid-bob/)).toBeVisible();
+    });
+
+    // Both filters are kept as separate tags and ANDed in the value.
+    expect(screen.getByText(/Owner.*uuid-alice/)).toBeVisible();
+    expect(document.querySelectorAll('.ant-tag')).toHaveLength(2);
+    expect(onFilterChange).toHaveBeenLastCalledWith(
+      'owner == "uuid-alice" & owner == "uuid-bob"',
+    );
+  });
+
+  it('displays the renderInput-supplied label in the tag while keeping the raw value in the filter', async () => {
+    const onFilterChange = vi.fn();
+    render(
+      <ControlledCustom
+        onFilterChange={onFilterChange}
+        filterProperties={ownerLabeledProperties}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('pick-alice'));
+
+    // The filter string still carries the opaque value (UUID), not the label.
+    await waitFor(() => {
+      expect(onFilterChange).toHaveBeenCalledWith('owner == "uuid-alice"');
+    });
+    // The tag shows the human-readable label, not the UUID.
+    expect(screen.getByText(/Owner.*alice@example\.com/)).toBeVisible();
+    expect(screen.queryByText(/uuid-alice/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the label lookup working across the ilike %value% wrapping round-trip', async () => {
+    // The label map is keyed on the raw committed value, while an
+    // `ilike`-serialized filter stores `%value%`; the tag lookup strips the
+    // wrapping via trimFilterValue, so the key must still match.
+    const ilikeLabeledProperties: Array<FilterProperty> = [
+      {
+        key: 'owner',
+        propertyLabel: 'Owner',
+        type: 'string',
+        defaultOperator: 'ilike',
+        renderInput: ({ onAddCondition }) => (
+          <button
+            type="button"
+            onClick={() => onAddCondition('uuid-alice', 'alice@example.com')}
+          >
+            pick-alice
+          </button>
+        ),
+      },
+    ];
+    const onFilterChange = vi.fn();
+    render(
+      <ControlledCustom
+        onFilterChange={onFilterChange}
+        filterProperties={ilikeLabeledProperties}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('pick-alice'));
+
+    // The filter string carries the %-wrapped raw value.
+    await waitFor(() => {
+      expect(onFilterChange).toHaveBeenCalledWith('owner ilike "%uuid-alice%"');
+    });
+    // The tag still resolves the label despite the wrapping.
+    expect(screen.getByText(/Owner.*alice@example\.com/)).toBeVisible();
+    expect(screen.queryByText(/uuid-alice/)).not.toBeInTheDocument();
   });
 });

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -16,13 +16,7 @@ import {
   theme,
 } from 'antd';
 import * as _ from 'lodash-es';
-import React, {
-  ComponentProps,
-  ReactNode,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { ComponentProps, ReactNode, useRef, useState } from 'react';
 
 //github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/models/minilang/queryfilter.py
 export type FilterProperty = {
@@ -38,6 +32,25 @@ export type FilterProperty = {
     message: string;
     validate: (value: string) => boolean;
   };
+  // Replaces the default AutoComplete input with a controlled control (e.g.
+  // `BAIStorageHostSelect`). Calling `onAddCondition(value)` commits the value
+  // as a condition immediately — one condition per call — serialized with the
+  // property's `defaultOperator` (or the type default). Pass `value={null}` to
+  // the control (antd's controlled-empty value, since `value={undefined}` is
+  // treated as uncontrolled) so it stays controlled and clears after each
+  // commit.
+  //
+  // When the committed value is opaque to the user (e.g. a UUID emitted by
+  // `BAIUserSelect` with `valuePropName="id"`), pass the human-readable
+  // label as the optional second argument, e.g.
+  // `onChange={(value, option) => onAddCondition(value, option.label)}`.
+  // The label is shown in the condition tag while the raw value still
+  // serializes into the filter string unchanged. Omit it to display the
+  // value as-is. Same contract as the one `BAIGraphQLPropertyFilter` adopts
+  // in FR-3011 (#8082), so controls become interchangeable once both land.
+  renderInput?: (props: {
+    onAddCondition: (value: string | undefined, label?: string) => void;
+  }) => ReactNode;
 };
 
 export interface BAIPropertyFilterProps extends Omit<
@@ -244,6 +257,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
   defaultValue,
   ...containerProps
 }) => {
+  'use memo';
   const [search, setSearch] = useState<string>();
   const autoCompleteRef = useRef<GetRef<typeof AutoComplete>>(null);
   const [isOpenAutoComplete, setIsOpenAutoComplete] = useState(false);
@@ -254,6 +268,18 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
     onChange: propOnChange,
   });
 
+  // Maps a committed filter value to a human-readable label supplied via a
+  // `renderInput` control's `onAddCondition` (e.g. user UUID -> email).
+  // Filters are re-derived from the `value` string on every render and only
+  // carry the raw value, so the label is kept here and looked up when
+  // rendering tags. Keyed by `${property}::${value}`. Entries are kept for
+  // the component's lifetime (not pruned on tag removal) — the map is
+  // bounded by the values the user actually committed, and keeping them
+  // lets a re-added identical condition show its label again.
+  const [valueLabelMap, setValueLabelMap] = useState<Record<string, string>>(
+    {},
+  );
+
   const generateValueLabel = (label: ReactNode) => {
     // Generate a label for the filter value,
     // if the label is a string or number, return its string representation.
@@ -263,7 +289,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
       : undefined;
   };
 
-  const filtersFromValue = useMemo(() => {
+  const filtersFromValue = (() => {
     if (value === undefined || value === '') return [];
     const filters = value.split('&').map((filter) => filter.trim());
     return filters.map((filter, index) => {
@@ -281,12 +307,17 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
         property,
         operator,
         value,
-        valueLabel: generateValueLabel(option?.label),
+        // Prefer an option label, then a renderInput-supplied label, so
+        // opaque values (e.g. UUIDs) display as something the user
+        // recognizes (e.g. an email).
+        valueLabel:
+          generateValueLabel(option?.label) ??
+          valueLabelMap[`${property}::${trimFilterValue(value)}`],
         propertyLabel: filterProperty?.propertyLabel || property,
         type: filterProperty?.type || 'string',
       };
     });
-  }, [value, filterProperties]);
+  })();
 
   const { t } = useBAIi18n();
   const options = _.map(filterProperties, (filterProperty) => ({
@@ -325,6 +356,20 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
 
   const resetList = () => {
     updateFiltersValue([]);
+  };
+
+  // Persist the value -> label pair supplied to `onAddCondition` so the
+  // condition tag can show the label (e.g. email) instead of the opaque
+  // committed value (e.g. UUID).
+  const rememberValueLabel = (
+    property: string,
+    value: string,
+    label: string,
+  ) => {
+    setValueLabelMap((prev) => ({
+      ...prev,
+      [`${property}::${value}`]: label,
+    }));
   };
 
   const onSearch = (value: string) => {
@@ -383,50 +428,63 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
           }}
           aria-label="Filter property selector"
         />
-        <Tooltip
-          title={isValid || !isFocused ? '' : selectedProperty.rule?.message}
-          open={!isValid && isFocused}
-          color="red"
-        >
-          <AutoComplete
-            ref={autoCompleteRef}
-            value={search}
-            open={isOpenAutoComplete}
-            onOpenChange={setIsOpenAutoComplete}
-            onSelect={onSearch}
-            onChange={(value) => {
-              setIsValid(true);
-              setSearch(value);
-            }}
-            style={{
-              minWidth: 200,
-            }}
-            // @ts-ignore
-            options={_.filter(
-              selectedProperty.options ||
-                DEFAULT_OPTIONS_OF_TYPES[selectedProperty.type],
-              (option) => {
-                return !search
-                  ? true
-                  : option.label?.toString().includes(search);
-              },
-            )}
-            placeholder={t('comp:BAIPropertyFilter.PlaceHolder')}
-            onBlur={() => {
-              setIsFocused(false);
-            }}
-            onFocus={() => {
-              setIsFocused(true);
-            }}
+        {selectedProperty.renderInput ? (
+          selectedProperty.renderInput({
+            onAddCondition: (value, label) => {
+              // Truthy guard: an empty-string label would blank the tag
+              // (`valueLabel ?? …` treats '' as present).
+              if (value != null && label) {
+                rememberValueLabel(selectedProperty.key, value, label);
+              }
+              onSearch(value ?? '');
+            },
+          })
+        ) : (
+          <Tooltip
+            title={isValid || !isFocused ? '' : selectedProperty.rule?.message}
+            open={!isValid && isFocused}
+            color="red"
           >
-            <Input.Search
-              onSearch={onSearch}
-              allowClear
-              status={!isValid && isFocused ? 'error' : undefined}
-              aria-label="Filter value search"
-            />
-          </AutoComplete>
-        </Tooltip>
+            <AutoComplete
+              ref={autoCompleteRef}
+              value={search}
+              open={isOpenAutoComplete}
+              onOpenChange={setIsOpenAutoComplete}
+              onSelect={onSearch}
+              onChange={(value) => {
+                setIsValid(true);
+                setSearch(value);
+              }}
+              style={{
+                minWidth: 200,
+              }}
+              // @ts-ignore
+              options={_.filter(
+                selectedProperty.options ||
+                  DEFAULT_OPTIONS_OF_TYPES[selectedProperty.type],
+                (option) => {
+                  return !search
+                    ? true
+                    : option.label?.toString().includes(search);
+                },
+              )}
+              placeholder={t('comp:BAIPropertyFilter.PlaceHolder')}
+              onBlur={() => {
+                setIsFocused(false);
+              }}
+              onFocus={() => {
+                setIsFocused(true);
+              }}
+            >
+              <Input.Search
+                onSearch={onSearch}
+                allowClear
+                status={!isValid && isFocused ? 'error' : undefined}
+                aria-label="Filter value search"
+              />
+            </AutoComplete>
+          </Tooltip>
+        )}
       </Space.Compact>
       {filtersFromValue.length > 0 && (
         <BAIFlex

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminProjectSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminProjectSelect.tsx
@@ -50,7 +50,7 @@ const BAIAdminProjectSelect: React.FC<BAIAdminProjectSelectProps> = ({
   const { t } = useBAIi18n();
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
   const [controllableValue, setControllableValue] = useControllableValue<
-    string | string[] | undefined
+    string | string[] | null | undefined
   >(selectProps);
   const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
     selectProps,
@@ -194,10 +194,14 @@ const BAIAdminProjectSelect: React.FC<BAIAdminProjectSelectProps> = ({
   // chips.
   const controllableValueWithLabel = !_.isEmpty(deferredControllableValue)
     ? _.castArray(deferredControllableValue).map((value) => ({
-        label: selectedNameByLocalId.get(value) ?? value,
+        label: (value && selectedNameByLocalId.get(value)) ?? value,
         value: value,
       }))
-    : undefined;
+    : // Empty: forward the incoming value as-is. `null` keeps the Select
+      // controlled (and cleared) per antd semantics; `undefined` leaves it
+      // uncontrolled — the consumer decides which by the value it passes
+      // (e.g. `value={null}` for commit-and-clear filter inputs).
+      deferredControllableValue;
 
   const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
     controllableValueWithLabel,

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -22,6 +22,7 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCSVExport } from '../hooks/useCSVExport';
 import { Alert, App, Badge, Button, theme, Tooltip } from 'antd';
 import {
+  BAIAdminProjectSelect,
   BAIFetchKeyButton,
   BAIFlex,
   BAIPropertyFilter,
@@ -312,6 +313,30 @@ const AdminComputeSessionListPage = () => {
             />
             <BAIPropertyFilter
               filterProperties={filterOutEmpty([
+                {
+                  // `project_id` is the compute_session queryfilter field
+                  // mapped to the session's group (project) UUID.
+                  key: 'project_id',
+                  propertyLabel: t('data.Project'),
+                  type: 'string',
+                  defaultOperator: '==',
+                  renderInput: ({ onAddCondition }) => (
+                    <BAIAdminProjectSelect
+                      value={null}
+                      style={{ minWidth: 200 }}
+                      onChange={(value, option) => {
+                        // The picker emits the project UUID; forward the
+                        // option label (project name) so the condition tag
+                        // stays readable.
+                        const label = _.castArray(option)[0]?.label;
+                        onAddCondition(
+                          value as string | undefined,
+                          _.isString(label) ? label : undefined,
+                        );
+                      }}
+                    />
+                  ),
+                },
                 {
                   key: 'name',
                   propertyLabel: t('session.SessionName'),


### PR DESCRIPTION
Resolves #8152 (FR-3258)

## Summary

Brings the controlled custom filter-input contract introduced on `BAIGraphQLPropertyFilter` (FR-3011, #8082) to `BAIPropertyFilter` — the Backend.AI query-filter **minilang** (string) variant. Once #8082 lands (main still carries the older `onConfirm`-based `renderInput` on the GraphQL variant), a custom picker control can be plugged into either filter with the identical `renderInput` / `onAddCondition` interface.

## Changes

### `BAIPropertyFilter` (BUI)
- **`renderInput` contract** — `FilterProperty.renderInput?: ({ onAddCondition }) => ReactNode`. When present, it replaces the default AutoComplete input for that property. `onAddCondition(value: string | undefined, label?: string)` commits the value immediately (one condition per call) through the existing `onSearch` path, so `defaultOperator` resolution, `%value%` wrapping for `ilike`/`like`, `strictSelection`, and `rule` validation all apply unchanged. The control keeps itself controlled by passing `value={null}` (antd's controlled-empty value) so it clears after each commit — identical to the `BAIGraphQLPropertyFilter` contract.
- **Human-readable tag labels** — the optional `label` argument records a `${property}::${value}` → label mapping; condition tags prefer an option label, then the renderInput-supplied label, then the raw value. The raw value (e.g. a UUID) still serializes into the filter string unchanged.
- **React Compiler compliance** — added `'use memo'` and unwrapped the `filtersFromValue` `useMemo` into a plain derivation per the project convention (the label-map lookup would otherwise have required editing the dependency array).

### First consumer — project filter on the admin session list
- `AdminComputeSessionListPage` gains a **Project** filter property backed by `BAIAdminProjectSelect` in `renderInput`. The filter key is `project_id` — the `compute_session` queryfilter field mapped to the session's group (project) UUID — so the committed condition is `project_id == "<uuid>"`.
- The picker emits the project UUID as the value and forwards the option label (project name) to `onAddCondition`, so the condition tag shows the **project name** instead of the UUID while the filter string still carries the UUID.
- `BAIAdminProjectSelect` now forwards an empty incoming `value` as-is instead of normalizing it to `undefined` (value type widened with `null`): `value={null}` keeps the Select controlled per antd semantics, so the picker clears after each commit — the same pass-through `BAIUserSelect` / `BAIStorageHostSelect` adopt in #8082.

### Storybook & tests
- `WithRenderInput` story: an owner picker (antd `Select`, `value={null}`) that forwards the option label, mirroring the `BAIGraphQLPropertyFilter` story.
- Unit tests mirroring the `BAIGraphQLPropertyFilter` ones: commit-on-select, AND-stacking of committed values, and label-in-tag with the raw value kept in the filter string.

## Verification
- `bash scripts/verify.sh` → Relay / Lint / Format / TypeScript **PASS**.
- `BAIPropertyFilter` unit tests: 34 passed (3 new).

## Notes
- Existing `BAIPropertyFilter` usages are unaffected (the new prop is optional and additive); the only consumer change is the new project filter on `AdminComputeSessionListPage`.
- Independent of the FR-3011 stack; based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
