### PR TITLE
feat(FR-3259): hide app launcher for batch sessions when hideAppsOnBatchSession is enabled

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -5,14 +5,14 @@
 import { AppLauncherModalFragment$key } from '../../__generated__/AppLauncherModalFragment.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import {
-  TCP_APPS,
-  useBackendAIAppLauncher,
-} from '../../hooks/useBackendAIAppLauncher';
-import {
   ServicePort,
   TemplateItem,
   useSuspendedFilteredAppTemplate,
-} from '../../hooks/useSuspendedFilteredAppTemplate';
+} from '../../hooks/useAppTemplate';
+import {
+  TCP_APPS,
+  useBackendAIAppLauncher,
+} from '../../hooks/useBackendAIAppLauncher';
 import AppLaunchConfirmationModal from './AppLaunchConfirmationModal';
 import SFTPConnectionInfoModal from './SFTPConnectionInfoModal';
 import TCPConnectionInfoModal from './TCPConnectionInfoModal';

--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../__generated__/SessionActionButtonsFragment.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import { useCurrentUserInfo } from '../../hooks/backendai';
+import { useSuspendedAppTemplateConfig } from '../../hooks/useAppTemplate';
 import { useBackendAIAppLauncher } from '../../hooks/useBackendAIAppLauncher';
 import ErrorBoundaryWithNullFallback from '../ErrorBoundaryWithNullFallback';
 import AppLauncherModal from './AppLauncherModal';
@@ -88,6 +89,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const baiClient = useSuspendedBackendaiClient();
+  const { hideAppsOnBatchSession } = useSuspendedAppTemplateConfig();
 
   const session = useFragment(
     graphql`
@@ -133,6 +135,16 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
     if (
       ['appLauncher', 'terminal', 'containerCommit'].includes(key) &&
       session?.type === 'system'
+    ) {
+      return false;
+    }
+
+    // Hide the app launcher and terminal for batch sessions when configured
+    // to do so.
+    if (
+      (key === 'appLauncher' || key === 'terminal') &&
+      hideAppsOnBatchSession &&
+      session?.type === 'batch'
     ) {
       return false;
     }

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -8,6 +8,7 @@ import {
 } from '../__generated__/SessionNodesFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
+import { useSuspendedAppTemplateConfig } from '../hooks/useAppTemplate';
 import AppLauncherModal from './ComputeSessionNodeItems/AppLauncherModal';
 import SessionReservation from './ComputeSessionNodeItems/SessionReservation';
 import SessionSlotCell from './ComputeSessionNodeItems/SessionSlotCell';
@@ -80,6 +81,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
   const { t } = useTranslation();
   const userRole = useCurrentUserRole();
   const baiClient = useSuspendedBackendaiClient();
+  const { hideAppsOnBatchSession } = useSuspendedAppTemplateConfig();
   const [userInfo] = useCurrentUserInfo();
   const [terminateTarget, setTerminateTarget] =
     useState<SessionNodeInList | null>(null);
@@ -175,13 +177,14 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
                   : undefined
               }
               actions={filterOutEmpty([
-                session.type !== 'system' && {
-                  key: 'appLauncher',
-                  title: t('session.SeeAppDialog'),
-                  icon: <BAIAppIcon />,
-                  disabled: !isAppSupported || !isActive || !isOwner,
-                  onClick: () => setAppLauncherTarget(session),
-                },
+                session.type !== 'system' &&
+                  !(hideAppsOnBatchSession && session.type === 'batch') && {
+                    key: 'appLauncher',
+                    title: t('session.SeeAppDialog'),
+                    icon: <BAIAppIcon />,
+                    disabled: !isAppSupported || !isActive || !isOwner,
+                    onClick: () => setAppLauncherTarget(session),
+                  },
                 {
                   key: 'terminate',
                   title: t('session.TerminateSession'),

--- a/react/src/hooks/useAppTemplate.ts
+++ b/react/src/hooks/useAppTemplate.ts
@@ -18,6 +18,16 @@ export type AppTemplate = {
   [key: string]: TemplateItem[];
 };
 
+export type AppTemplateConfig = {
+  appTemplate: AppTemplate;
+  /**
+   * When true, the app launcher (app control modal) is hidden for batch-type
+   * sessions across the session list, notifications, and the session detail
+   * drawer.
+   */
+  hideAppsOnBatchSession: boolean;
+};
+
 export type ServicePort = {
   container_ports: number[];
   host_ports: number[];
@@ -26,18 +36,33 @@ export type ServicePort = {
   protocol: string;
 };
 
-export const useSuspendedFilteredAppTemplate = (
-  servicePorts?: ServicePort[] | null,
-) => {
-  const { data: appTemplate = {} } = useSuspenseTanQuery<AppTemplate>({
+/**
+ * Reads `resources/app_template.json` and exposes its top-level config: the
+ * `appTemplate` map plus feature flags such as `hideAppsOnBatchSession`. The
+ * raw JSON is cached under a single query key so this hook and
+ * `useSuspendedFilteredAppTemplate` share one fetch.
+ */
+export const useSuspendedAppTemplateConfig = (): AppTemplateConfig => {
+  const { data } = useSuspenseTanQuery<AppTemplateConfig>({
     queryKey: ['backendai-app-template'],
     queryFn: () => {
       return fetch('resources/app_template.json')
         .then((res) => res.json())
-        .then((res) => res.appTemplate);
+        .then((res) => ({
+          appTemplate: res.appTemplate ?? {},
+          hideAppsOnBatchSession: res.hideAppsOnBatchSession ?? false,
+        }));
     },
     staleTime: 1000 * 60 * 60 * 24,
   });
+  return data;
+};
+
+export const useSuspendedFilteredAppTemplate = (
+  servicePorts?: ServicePort[] | null,
+) => {
+  'use memo';
+  const { appTemplate } = useSuspendedAppTemplateConfig();
 
   const baiClient = useSuspendedBackendaiClient();
   const allowTCPApps =

--- a/resources/app_template.json
+++ b/resources/app_template.json
@@ -272,5 +272,6 @@
         "src": "./resources/icons/check-list.svg"
       }
     ]
-  }
+  },
+  "hideAppsOnBatchSession": false
 }


### PR DESCRIPTION
Resolves #8154 (FR-3259)

## Summary

Adds a top-level `hideAppsOnBatchSession` boolean flag to `resources/app_template.json` (sibling to `appTemplate`). When set to `true`, the **app launcher / app control modal** (and the **terminal** quick-launch button) is hidden for **batch-type** sessions across every surface that exposes it:

- **Session list tables** — `ComputeSessionListPage` and `AdminComputeSessionListPage` (via `SessionNodes`).
- **Notification area** — the running-session notification item (via `SessionActionButtons`).
- **Session detail drawer** — `SessionDetailContent` (via `SessionActionButtons`).

Default behavior is unchanged: the key defaults to `false` (and is treated as `false` when absent), and interactive / inference / system sessions are unaffected regardless of the flag.

## Changes

- **`react/src/hooks/useAppTemplate.ts`** (renamed from `useSuspendedFilteredAppTemplate.ts`, since the file now hosts two hooks): added `useSuspendedAppTemplateConfig()` which reads the full `app_template.json` (now cached under the existing `['backendai-app-template']` query key so there is still a single fetch shared with `useSuspendedFilteredAppTemplate`) and exposes `{ appTemplate, hideAppsOnBatchSession }`. Refactored `useSuspendedFilteredAppTemplate` to consume it.
- **`react/src/components/SessionNodes.tsx`**: hide the `appLauncher` name-cell action for `type === 'batch'` sessions when the flag is on.
- **`react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx`**: extended `isVisible` to return `false` for `appLauncher` **and** `terminal` on batch sessions when the flag is on — this single change covers both the notification item and the detail drawer, since both render the app launcher through this component (hiding both the button and its modal).
- **`resources/app_template.json`**: added `"hideAppsOnBatchSession": false` as an explicit, non-breaking default.

## Notes

- `ProjectAdminSessionPage` uses `BAISessionNodesV2`, which does **not** render an app launcher today (only a terminate action; app launcher wiring is deferred by `TODO(FR-2944)`), so there is nothing to hide there. No changes were needed for that page.
- No GraphQL schema/fragment changes: the `type` field is already present on all relevant fragments, so no Relay recompile was required.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript). The one terminology warning (`error.UserHasNoGroup`) is pre-existing and unrelated to this change.