### PR TITLE
fix(FR-3214): kill the whole dev process group on shutdown so leaked watch orphans don't exhaust file descriptors

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -68,8 +68,62 @@ const args = [
   `${portlessSpec}-- pnpm --prefix ./react run start`,
 ];
 
-const child = spawn('concurrently', args, { stdio: 'inherit', env, shell: false });
-const forward = (sig) => child.kill(sig);
-process.on('SIGINT', forward);
-process.on('SIGTERM', forward);
-child.on('exit', (code, signal) => process.exit(signal ? 1 : (code ?? 0)));
+// Spawn concurrently as the leader of its own process group (`detached`).
+// The watch tree below it is deep (concurrently → pnpm → nodemon → pnpm →
+// relay binary), and per-PID signal forwarding breaks at the nodemon hop:
+// killing only `child.pid` orphans the relay watch chain, which then keeps
+// thousands of file-watcher FDs open forever (FR-3214). Signaling the
+// negative PID (= the whole group) reaches every descendant directly, no
+// matter how deep the chain is or whether intermediate layers forward.
+const detached = process.platform !== 'win32';
+const child = spawn('concurrently', args, { stdio: 'inherit', env, shell: false, detached });
+
+// Signal every process in the group (negative PID = the whole group), falling
+// back to a direct kill when the group is already reaped. Win32 has no process
+// groups, so there the whole fix degrades to the plain per-PID kill.
+const signalTree = detached
+  ? (sig) => {
+      try {
+        process.kill(-child.pid, sig);
+      } catch {
+        child.kill(sig); // group already reaped — best-effort direct kill (no-throw)
+      }
+    }
+  : (sig) => child.kill(sig);
+const treeAlive = () => {
+  if (!detached) return false;
+  try {
+    process.kill(-child.pid, 0); // probe: throws ESRCH when no member survives
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Guarantee the group dies even when graceful shutdown hangs (e.g. the relay
+// binary swallowing SIGINT while its parents wait on it): from the first
+// shutdown signal, poll for survivors and escalate to SIGKILL once the grace
+// period runs out. Nothing in this group may outlive dev.mjs.
+const SIGKILL_GRACE_MS = 5000;
+let escalation = null;
+const escalate = async () => {
+  const deadline = Date.now() + SIGKILL_GRACE_MS;
+  while (treeAlive() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (treeAlive()) signalTree('SIGKILL');
+};
+const shutdown = (sig) => {
+  signalTree(sig); // repeated Ctrl+C re-signals; the escalation only starts once
+  return (escalation ??= escalate());
+};
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGHUP', () => shutdown('SIGHUP')); // terminal close no longer HUPs the detached group
+
+child.on('exit', async (code, signal) => {
+  // concurrently is gone; anything still alive in its group is an orphan
+  // (leaked grandchild mid-shutdown). Sweep it before exiting.
+  if (treeAlive()) await shutdown('SIGTERM');
+  process.exit(signal ? 1 : (code ?? 0));
+});


### PR DESCRIPTION
Resolves #8047 (FR-3214)

## Problem

Running several repos' dev servers at once fails with `EMFILE: too many open files`. A major driver turned out to be **leaked orphan watch processes accumulating across dev restarts**: on a live machine, `ps` showed relay watch chains from dev sessions started **3 and 8 days earlier** still alive with `PPID 1` — `nodemon → pnpm run relay --watch → relay-compiler cli.js → native relay --watch binary` — each holding its full set of file-watcher FDs forever.

### Root cause

`dev.mjs` forwarded SIGINT/SIGTERM to **one PID only** (`child.kill(sig)` on the `concurrently` process), and `concurrently --kill-others` likewise signals only its **direct children**. The relay watch tree is unusually deep (`concurrently → pnpm → nodemon → pnpm → node cli.js → native relay binary`), and per-PID signal relay breaks at the nodemon hop — killing the direct child orphans everything below it.

The leak fires on every shutdown path that doesn't broadcast to the terminal's foreground process group:

- IDE/agent task stop (signals the top PID only) — the common case when dev runs under VS Code / code-server / an agent session
- `concurrently --kill-others` after one child dies
- graceful-shutdown chains that hang (a deep child swallowing SIGINT while its parents wait), which leaks even under a real terminal Ctrl+C
- double Ctrl+C interrupting a cleanup in progress

## Fix

`scripts/dev.mjs` now owns the whole tree's lifecycle:

1. **Spawn `concurrently` as a detached process-group leader** (`detached: true`, non-Windows). Every descendant — however deep — inherits the group.
2. **Signal the group, not the PID.** SIGINT/SIGTERM/SIGHUP handlers forward via `process.kill(-child.pid, sig)`, so every member receives the signal directly, with no reliance on intermediate layers relaying it. (SIGHUP is now forwarded explicitly because a detached group no longer receives the terminal's hangup.)
3. **Unconditional kill guarantee.** Two backstops ensure nothing outlives dev.mjs:
   - On any forwarded signal, a 5s timer escalates the whole group to **SIGKILL** if graceful shutdown hangs.
   - On `concurrently` exit (covers the `--kill-others` path, where dev.mjs itself never received a signal), dev.mjs probes the group (`kill(-pgid, 0)`), SIGTERMs survivors, waits up to 5s, then **SIGKILLs** the remainder before exiting.

Windows falls back to direct `child.kill` (negative-PID kill throws there); macOS/Linux — where the leak was observed — get the full group semantics.

This PR previously took a different approach (excluding the pnpm store from vite-plugin-checker's TS watch program via a generated `tsconfig.checker.json`). That reduced per-process FDs but left the actual leak — orphaned watch trees — unfixed; it has been reverted in favor of this root-cause fix.

## Measurements (live, this machine)

**Scenario 1 — single-PID SIGTERM to dev.mjs (the IDE-stop leak path):**

| | before fix | after fix |
|---|---|---|
| group members while running | 11 (tsc, vite, esbuild, portless, nodemon, pnpm×3, relay cli, native relay) | 11 |
| survivors 8s after `kill -TERM <dev.mjs pid>` | relay chain leaked (observed as day-old `PPID 1` zombies) | **0** |

**Scenario 2 — `kill -9` one child (tsc) to trigger `concurrently --kill-others`:**

- All 11 group members gone within 10s, dev.mjs exited with the child's status, log shows the normal `--kill-others` SIGTERM cascade. **0 survivors.**

## Verification

- `bash scripts/verify.sh` — `=== ALL PASS ===` (Relay / Lint / Format / TypeScript).
- `node --check scripts/dev.mjs` passes.
- Both live shutdown scenarios above measured on a real dev boot of this branch (`ps ax -o pid,ppid,pgid` group-membership check before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
