### PR TITLE
fix(FR-3255): derive Amplify archive-branch fetch list from docs config

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -156,14 +156,27 @@ applications:
             # `<projectRoot>/.docs-archive/<sanitized-ref>`. With the
             # appRoot set to this package, `<projectRoot>` IS the cwd,
             # so the worktree path is simply
-            # `.docs-archive/<sanitized-ref>`. The list is hardcoded
-            # to `26.4` for v1; future archived minors must be added
-            # here in lockstep with the `versions:` config until a
-            # toolkit helper does it dynamically.
+            # `.docs-archive/<sanitized-ref>`.
+            #
+            # ARCHIVE_REFS is derived DIRECTLY from the config's
+            # `versions:` block (FR-3255) — every `ref: docs-archive/X.Y`
+            # line — so adding a minor to `docs-toolkit.config.yaml`
+            # (which the `docs-version-pdftag-pr.yml` release automation
+            # now does automatically) is picked up here with ZERO
+            # lockstep edits. The `^\s*ref:` anchor matches only real
+            # archive-branch refs, never the `docs-archive/…` mentions
+            # in the surrounding config comments. The
+            # `${ARR[@]+"${ARR[@]}"}` expansion is empty-array-safe under
+            # `set -u` (older bash errors on a bare `"${ARR[@]}"`).
             - |
               set -euo pipefail
-              ARCHIVE_REFS=(docs-archive/26.4)
-              for ref in "${ARCHIVE_REFS[@]}"; do
+              mapfile -t ARCHIVE_REFS < <(
+                grep -oE '^[[:space:]]*ref:[[:space:]]*docs-archive/[0-9]+\.[0-9]+[[:space:]]*$' \
+                  docs-toolkit.config.yaml \
+                  | grep -oE 'docs-archive/[0-9]+\.[0-9]+' | sort -u
+              )
+              echo "Archive refs from config: ${ARCHIVE_REFS[*]:-(none)}"
+              for ref in ${ARCHIVE_REFS[@]+"${ARCHIVE_REFS[@]}"}; do
                 sanitized="${ref//\//__}"
                 worktree=".docs-archive/${sanitized}"
                 # Idempotency check: a plain `[ -d "${worktree}" ]` is


### PR DESCRIPTION
Resolves #8145 (FR-3255)

Follow-up that **completes FR-3255** — the amplify.yml half was missed when #8146 merged (its second commit landed on the branch just after the squash-merge, so only the config/script/workflow changes reached `main`).

## Why this is needed

#8146 added the `26.7` entry to `docs-toolkit.config.yaml`, but `amplify.yml` still **hardcodes** the archive-branch fetch list:

```bash
ARCHIVE_REFS=(docs-archive/26.4)
```

At build time the toolkit iterates `versions:` and, for each `archive-branch` entry, expects a pre-checked-out worktree at `.docs-archive/<sanitized-ref>`. Because `docs-archive/26.7` is never fetched, the toolkit **warn-and-skips** 26.7 — so the version appears in config but **does not render** on the live site. Every future auto-added minor would hit the same wall.

## Change

Derive `ARCHIVE_REFS` **dynamically** from `docs-toolkit.config.yaml`'s `versions:` block — every `ref: docs-archive/X.Y` line (anchored `^\s*ref:` so `docs-archive/…` mentions in comments are excluded). The config is now the single source of truth, so the `docs-version-pdftag-pr.yml` release automation adds a minor with **zero** lockstep edits to `amplify.yml`. The `${ARR[@]+"${ARR[@]}"}` expansion is empty-array-safe under `set -u`.

This realizes the "until a toolkit helper does it dynamically" note the hardcoded list left behind.

## Verification

- Simulated the block under `set -euo pipefail` (bash 5.2) against the current `main` config → resolves to `docs-archive/26.4` + `docs-archive/26.7`, correctly **excludes** the comment mention of `docs-archive/26.4`, and the empty-result case does not abort.
- `docs-archive/26.7` exists on origin and contains `src/`, so the worktree add + toolkit read will succeed.
- `amplify.yml` re-validated as YAML.

## After merge

Confirm the Amplify rebuild shows `next / 26.7 (latest) / 26.4` and that `/latest/` routes to 26.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
