### PR TITLE
feat(FR-3257): add BAIListAlert component for list summaries in modals

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIListAlert.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIListAlert.stories.tsx
@@ -1,0 +1,177 @@
+import BAIFlex from './BAIFlex';
+import BAIListAlert from './BAIListAlert';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as _ from 'lodash-es';
+
+const meta: Meta<typeof BAIListAlert> = {
+  title: 'Alert/BAIListAlert',
+  component: BAIListAlert,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIListAlert** extends **BAIAlert** (and therefore [Ant Design Alert](https://ant.design/components/alert)).
+
+It renders a standardized \`ul\` list inside the alert description — used to
+summarize a list of items (e.g. selected resources) inside a modal. The list
+scrolls vertically once it exceeds \`maxHeight\`, so the modal never grows
+unbounded. Item count indication belongs in the consumer-provided \`title\`
+prop (i18n \`count\` interpolation).
+
+## BAI-Specific Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`items\` | \`Array<{ key?: React.Key; content: ReactNode }>\` | — | List entries rendered as \`li\` elements. \`key\` falls back to the array index |
+| \`maxHeight\` | \`CSSProperties['maxHeight']\` | \`165\` | Maximum height of the list before it scrolls vertically |
+
+For all other props, refer to **BAIAlert** and [Ant Design Alert](https://ant.design/components/alert).
+        `,
+      },
+    },
+  },
+  argTypes: {
+    items: {
+      control: false,
+      description:
+        'List entries rendered as li elements; key falls back to the array index',
+      table: {
+        type: { summary: 'Array<{ key?: React.Key; content: ReactNode }>' },
+      },
+    },
+    maxHeight: {
+      control: { type: 'number' },
+      description: 'Maximum height of the list before it scrolls vertically',
+      table: {
+        type: { summary: "CSSProperties['maxHeight']" },
+        defaultValue: { summary: '165' },
+      },
+    },
+    // Hide Ant Design props used in args
+    type: { table: { disable: true } },
+    title: { table: { disable: true } },
+    showIcon: { table: { disable: true } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIListAlert>;
+
+// Default story: Use args for interactive Controls
+export const Default: Story = {
+  name: 'Basic',
+  args: {
+    type: 'info',
+    title: 'The following projects will be updated',
+    showIcon: true,
+    items: [
+      { key: 'a', content: 'project-alpha' },
+      { key: 'b', content: 'project-beta' },
+      { key: 'c', content: 'project-gamma' },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Basic list summary inside an info alert.',
+      },
+    },
+  },
+};
+
+export const LongListWithScroll: Story = {
+  args: {
+    type: 'warning',
+    title: 'The following 30 users will be updated',
+    showIcon: true,
+    items: _.map(_.range(30), (i) => ({
+      key: i,
+      content: `user-${i + 1}@example.com`,
+    })),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A long list is capped at the default maxHeight (165px) and scrolls vertically, keeping the surrounding modal compact.',
+      },
+    },
+  },
+};
+
+export const CustomMaxHeight: Story = {
+  args: {
+    type: 'warning',
+    title: 'Custom maxHeight of 80px',
+    showIcon: true,
+    maxHeight: 80,
+    items: _.map(_.range(10), (i) => ({
+      key: i,
+      content: `item-${i + 1}`,
+    })),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'The scroll cap can be adjusted via the maxHeight prop.',
+      },
+    },
+  },
+};
+
+export const AlertTypes: Story = {
+  render: () => (
+    <BAIFlex direction="column" gap="md" align="stretch">
+      <BAIListAlert
+        type="warning"
+        showIcon
+        title="Warning: these users will be updated"
+        items={[
+          { key: 1, content: 'admin@example.com' },
+          { key: 2, content: 'user@example.com' },
+        ]}
+      />
+      <BAIListAlert
+        type="info"
+        showIcon
+        ghostInfoBg={false}
+        title="Info: these projects will be updated"
+        items={[
+          { key: 1, content: 'project-alpha' },
+          { key: 2, content: 'project-beta' },
+        ]}
+      />
+    </BAIFlex>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Side-by-side comparison of warning and info (ghostInfoBg disabled) variants, matching the modal call sites.',
+      },
+    },
+  },
+};
+
+export const TitleWithCount: Story = {
+  args: {
+    type: 'info',
+    showIcon: true,
+    ghostInfoBg: false,
+    title: '3 folders are excluded because they cannot be deleted',
+    items: [
+      { key: 'f1', content: 'shared-folder' },
+      { key: 'f2', content: 'model-store' },
+      { key: 'f3', content: 'pipeline-data' },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Item count indication stays in the consumer-provided title (i18n count interpolation) — the component does not render counts itself.',
+      },
+    },
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAIListAlert.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIListAlert.test.tsx
@@ -1,0 +1,43 @@
+import BAIListAlert from './BAIListAlert';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+describe('BAIListAlert', () => {
+  it('should render title and list items', () => {
+    render(
+      <BAIListAlert
+        type="warning"
+        title="Following users will be updated"
+        items={[
+          { key: '1', content: 'a@example.com' },
+          { key: '2', content: 'b@example.com' },
+        ]}
+      />,
+    );
+    expect(
+      screen.getByText('Following users will be updated'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('a@example.com')).toBeInTheDocument();
+    expect(screen.getByText('b@example.com')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('should apply the default maxHeight with vertical scroll', () => {
+    render(<BAIListAlert items={[{ content: 'item' }]} />);
+    const list = screen.getByRole('list');
+    expect(list).toHaveStyle({ maxHeight: '165px', overflowY: 'auto' });
+  });
+
+  it('should apply a custom maxHeight', () => {
+    render(<BAIListAlert maxHeight={80} items={[{ content: 'item' }]} />);
+    expect(screen.getByRole('list')).toHaveStyle({ maxHeight: '80px' });
+  });
+
+  it('should render items without explicit keys (index fallback)', () => {
+    render(
+      <BAIListAlert items={[{ content: 'first' }, { content: 'second' }]} />,
+    );
+    expect(screen.getByText('first')).toBeInTheDocument();
+    expect(screen.getByText('second')).toBeInTheDocument();
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIListAlert.tsx
+++ b/packages/backend.ai-ui/src/components/BAIListAlert.tsx
@@ -1,0 +1,85 @@
+import BAIAlert, { BAIAlertProps } from './BAIAlert';
+import { theme } from 'antd';
+import { createStyles } from 'antd-style';
+import * as _ from 'lodash-es';
+import React, { ReactNode } from 'react';
+
+export interface BAIListAlertItem {
+  key?: React.Key | null;
+  content: ReactNode;
+}
+
+export interface BAIListAlertProps extends Omit<BAIAlertProps, 'description'> {
+  items: Array<BAIListAlertItem>;
+  maxHeight?: React.CSSProperties['maxHeight'];
+}
+
+const useStyles = createStyles(({ css, token }) => ({
+  // scrollbar with no track background — only the thumb floats over content
+  transparentScrollbar: css`
+    /* Firefox, Chrome 121+ — thumb / track */
+    scrollbar-color: ${token.colorTextQuaternary} transparent;
+    scrollbar-width: thin;
+
+    /* Safari and older WebKit (ignored where scrollbar-color is supported) */
+    &::-webkit-scrollbar,
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: ${token.colorTextQuaternary};
+      border-radius: 3px;
+    }
+  `,
+}));
+
+/**
+ * Alert that summarizes a list of items (e.g. selected resources in a modal)
+ * as a standardized `ul` inside the alert description. The list scrolls
+ * vertically once it exceeds `maxHeight`, so the surrounding modal never
+ * grows unbounded. Item count indication belongs in the consumer-provided
+ * `title` prop (i18n `count` interpolation).
+ */
+const BAIListAlert: React.FC<BAIListAlertProps> = ({
+  items,
+  // ~7 rows of list content; inherited from the pre-extraction
+  // UpdateUsersModal style that this component standardizes.
+  maxHeight = 165,
+  ...alertProps
+}) => {
+  'use memo';
+  const { token } = theme.useToken();
+  const { styles } = useStyles();
+  return (
+    <BAIAlert
+      {...alertProps}
+      description={
+        _.isEmpty(items) ? undefined : (
+          <ul
+            // make the scrollable region reachable by keyboard
+            tabIndex={0}
+            className={styles.transparentScrollbar}
+            style={{
+              margin: 0,
+              padding: 0,
+              paddingTop: token.paddingXXS,
+              listStyle: 'circle',
+              listStylePosition: 'inside',
+              maxHeight,
+              overflowY: 'auto',
+            }}
+          >
+            {_.map(items, (item, index) => (
+              <li key={item.key ?? `__index-${index}`}>{item.content}</li>
+            ))}
+          </ul>
+        )
+      }
+    />
+  );
+};
+
+export default BAIListAlert;

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectBulkEditModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectBulkEditModal.tsx
@@ -2,12 +2,12 @@ import { BAIProjectBulkEditModalFragment$key } from '../../__generated__/BAIProj
 import { BAIProjectBulkEditModalProjectMutation } from '../../__generated__/BAIProjectBulkEditModalProjectMutation.graphql';
 import { useMutationWithPromise } from '../../hooks';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
-import BAIAlert from '../BAIAlert';
 import BAIFlex from '../BAIFlex';
+import BAIListAlert from '../BAIListAlert';
 import BAIModal, { BAIModalProps } from '../BAIModal';
 import BAISelect from '../BAISelect';
 import BAIProjectResourcePolicySelect from './BAIProjectResourcePolicySelect';
-import { Form, theme } from 'antd';
+import { Form } from 'antd';
 import * as _ from 'lodash-es';
 import { Suspense, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
@@ -21,7 +21,6 @@ const BAIProjectBulkEditModal = ({
   ...tableProps
 }: BAIProjectBulkEditModalProps) => {
   const { t } = useBAIi18n();
-  const { token } = theme.useToken();
   const [form] = Form.useForm();
   const [isSaving, setIsSaving] = useState(false);
   const mutateProjectWithPromise =
@@ -77,27 +76,17 @@ const BAIProjectBulkEditModal = ({
       destroyOnHidden
     >
       <BAIFlex direction="column" align="stretch" gap="md">
-        <BAIAlert
+        <BAIListAlert
           type="info"
           showIcon
           ghostInfoBg={false}
           title={t(
             'comp:BAIProjectBulkEditModal.FollowingProjectsWillBeUpdated',
           )}
-          description={
-            <ul
-              style={{
-                margin: 0,
-                padding: 0,
-                paddingTop: token.paddingXXS,
-                listStyle: 'circle',
-              }}
-            >
-              {_.map(selectedProjects, (project) => (
-                <li key={project.row_id}>{project.name}</li>
-              ))}
-            </ul>
-          }
+          items={_.map(selectedProjects, (project) => ({
+            key: project.row_id,
+            content: project.name,
+          }))}
         />
         <Form form={form}>
           <Suspense

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -80,6 +80,8 @@ export { default as BAIDynamicUnitInputNumberWithSlider } from './BAIDynamicUnit
 export type { BAIDynamicUnitInputNumberWithSliderProps } from './BAIDynamicUnitInputNumberWithSlider';
 export { default as BAIAlert } from './BAIAlert';
 export type { BAIAlertProps } from './BAIAlert';
+export { default as BAIListAlert } from './BAIListAlert';
+export type { BAIListAlertProps, BAIListAlertItem } from './BAIListAlert';
 export { default as BAIProjectResourceGroupSelect } from './BAIProjectResourceGroupSelect';
 export { default as BAITextHighlighter } from './BAITextHighlighter';
 export { default as BooleanTag } from './BooleanTag';

--- a/react/src/components/DeleteVFolderModal.tsx
+++ b/react/src/components/DeleteVFolderModal.tsx
@@ -6,10 +6,10 @@ import { DeleteVFolderModalFragment$key } from '../__generated__/DeleteVFolderMo
 import { VFolderNodesFragment$data } from '../__generated__/VFolderNodesFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { Typography, message, theme } from 'antd';
+import { Typography, message } from 'antd';
 import {
-  BAIAlert,
   BAIFlex,
+  BAIListAlert,
   BAIModal,
   BAIModalProps,
   toLocalId,
@@ -36,7 +36,6 @@ const DeleteVFolderModal: React.FC<DeleteVFolderModalProps> = ({
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
   const { getErrorMessage } = useErrorMessageResolver();
-  const { token } = theme.useToken();
 
   const vfolders = useFragment(
     graphql`
@@ -128,26 +127,16 @@ const DeleteVFolderModal: React.FC<DeleteVFolderModalProps> = ({
       <BAIFlex direction="column" gap={'sm'} align="stretch">
         {vfolders &&
           vfolders.length !== foldersByPermission.deletable?.length && (
-            <BAIAlert
+            <BAIListAlert
               showIcon
               ghostInfoBg={false}
               title={t('data.folders.ExcludedFolders', {
                 count: foldersByPermission.undeletable?.length || 0,
               })}
-              description={
-                <ul
-                  style={{
-                    margin: 0,
-                    padding: 0,
-                    paddingTop: token.paddingXXS,
-                    listStyle: 'circle',
-                  }}
-                >
-                  {_.map(foldersByPermission.undeletable, (vfolder) => (
-                    <li key={vfolder.id}>{vfolder.name}</li>
-                  ))}
-                </ul>
-              }
+              items={_.map(foldersByPermission.undeletable, (vfolder) => ({
+                key: vfolder.id,
+                content: vfolder.name,
+              }))}
             />
           )}
         <Typography.Text>

--- a/react/src/components/UpdateUsersModal.tsx
+++ b/react/src/components/UpdateUsersModal.tsx
@@ -13,9 +13,9 @@ import UserResourcePolicySelect from './UserResourcePolicySelect';
 import { App, Form, InputNumber, theme } from 'antd';
 import { FormInstance } from 'antd/lib';
 import {
-  BAIAlert,
   BAIDomainSelect,
   BAIFlex,
+  BAIListAlert,
   BAIModal,
   BAIModalProps,
   BAISelect,
@@ -178,27 +178,14 @@ const UpdateUsersModal = ({
       }}
     >
       <BAIFlex direction="column" align="stretch">
-        <BAIAlert
+        <BAIListAlert
           type="warning"
           showIcon
           title={t('credential.UpdateUsersWarningAlertTitle')}
-          description={
-            <ul
-              style={{
-                margin: 0,
-                padding: 0,
-                paddingTop: token.paddingXXS,
-                listStyle: 'circle',
-                listStylePosition: 'inside',
-                maxHeight: 165,
-                overflowY: 'auto',
-              }}
-            >
-              {_.map(users, (user) => (
-                <li key={user.id}>{user.basicInfo.email}</li>
-              ))}
-            </ul>
-          }
+          items={_.map(users, (user) => ({
+            key: user.id,
+            content: user.basicInfo.email,
+          }))}
           style={{ marginBottom: token.marginSM }}
         />
         {/* TODO: We need to create a Form.Item component that can distinguish between keeping the default value and clearing the value. */}


### PR DESCRIPTION
Resolves #8151 (FR-3257)

## Summary

Modals that summarize a list of selected items rendered the list inconsistently — ad-hoc inline-styled `ul` elements inside `BAIAlert`, some with a scroll cap and some without. This PR extracts the standardized pattern into a reusable BUI component, `BAIListAlert`, and migrates the three existing ad-hoc call sites to it.

## Component API

`packages/backend.ai-ui/src/components/BAIListAlert.tsx`

```tsx
export interface BAIListAlertItem {
  key?: React.Key; // falls back to array index
  content: ReactNode;
}

export interface BAIListAlertProps extends Omit<BAIAlertProps, 'description'> {
  items: Array<BAIListAlertItem>;
  maxHeight?: React.CSSProperties['maxHeight']; // default 165, applied with overflowY: 'auto'
}
```

- Wraps `BAIAlert` and renders the items as a `ul` in the alert `description` with the standardized style (`listStyle: 'circle'`, `listStylePosition: 'inside'`, margin/padding reset, `paddingTop: token.paddingXXS`).
- The list scrolls vertically once it exceeds `maxHeight` (default `165`), so the surrounding modal never grows unbounded.
- Item count indication stays in the consumer-provided `title` prop (i18n `count` interpolation) — the component does not render counts itself.
- Exported from `packages/backend.ai-ui/src/components/index.ts` (`BAIListAlert`, `BAIListAlertProps`, `BAIListAlertItem`).

## Migrated call sites

| File | Before | After |
|---|---|---|
| `react/src/components/UpdateUsersModal.tsx` | warning `BAIAlert` + inline `ul` with `maxHeight: 165` scroll | `BAIListAlert` with user emails as items |
| `packages/backend.ai-ui/src/components/fragments/BAIProjectBulkEditModal.tsx` | info `BAIAlert` (`ghostInfoBg={false}`) + inline `ul`, no scroll cap | `BAIListAlert` with project names as items (now gains the standardized `listStylePosition: 'inside'` and 165px scroll cap) |
| `react/src/components/DeleteVFolderModal.tsx` | `BAIAlert` (`ghostInfoBg={false}`) + inline `ul`, no scroll cap | `BAIListAlert` with undeletable vfolder names as items (same standardization) |

All existing i18n keys, alert types, and count-in-title behavior are preserved. The now-unused inline `ul` styles and `theme.useToken()` usages were removed from the migrated files.

## Storybook & tests

- `BAIListAlert.stories.tsx` (CSF 3, `Alert/BAIListAlert`): basic list, long list demonstrating the default scroll cap, custom `maxHeight`, warning/info type comparison, and title-with-count.
- `BAIListAlert.test.tsx`: renders title + items, asserts default/custom `maxHeight` with `overflowY: 'auto'`, and index-fallback keys — 4 tests, all passing.

## Verification

`bash scripts/verify.sh`:

- Relay: PASS
- Lint: PASS
- Format: PASS
- TypeScript: PASS
- Vite warmup paths: FAIL — pre-existing environment issue, unrelated to this change. The check's awk range pattern (`/^\s*\},/`) never matches under macOS/BSD awk (no `\s` support), so it swallows all of `vite.config.ts` and flags non-path string literals. It fails identically on a pristine `main` checkout.
- Terminology: warn-only (1 pre-existing warning, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

Captured from the new Storybook stories (`Alert/BAIListAlert`).

### Basic (default `maxHeight: 165`)
![default](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8162/20260706-153936-default.png)

### Long list — scroll cap at 165px (30 items)
![long-list-scroll](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8162/20260706-153939-long-list-scroll.png)

### Alert types (`warning` / `info` with `ghostInfoBg={false}`)
![alert-types](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8162/20260706-153943-alert-types.png)

### Item count in consumer `title` (i18n `count` interpolation)
![title-with-count](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8162/20260706-153947-title-with-count.png)
