### PR TITLE
fix(FR-3270): reset CreatePermissionModal form state by unmounting after close

### DIFF
--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -23,8 +23,9 @@ import { useTranslation } from 'react-i18next';
 import {
   graphql,
   useFragment,
-  useLazyLoadQuery,
   useMutation,
+  usePreloadedQuery,
+  type PreloadedQuery,
 } from 'react-relay';
 
 const DIRECT_OPERATIONS: ReadonlyArray<OperationType> = [
@@ -51,8 +52,24 @@ interface EditingPermission {
   operation: string;
 }
 
+export const PermissionMatrixQuery = graphql`
+  query CreatePermissionModalPermissionMatrixQuery {
+    rbacPermissionMatrix {
+      scopeType
+      entities {
+        entityType
+        actions {
+          requiredPermission
+        }
+      }
+    }
+  }
+`;
+
 interface CreatePermissionModalProps extends BAIModalProps {
   roleId: string;
+  /** Preloaded query reference produced by the opener via `useQueryLoader`. */
+  queryRef: PreloadedQuery<CreatePermissionModalPermissionMatrixQuery>;
   roleScopeFrgmt?: CreatePermissionModal_roleScopeFragment$key | null;
   editingPermission?: EditingPermission | null;
   onRequestClose: (success: boolean) => void;
@@ -60,6 +77,7 @@ interface CreatePermissionModalProps extends BAIModalProps {
 
 const CreatePermissionModal: React.FC<CreatePermissionModalProps> = ({
   roleId,
+  queryRef,
   roleScopeFrgmt,
   editingPermission,
   onRequestClose,
@@ -153,22 +171,9 @@ const CreatePermissionModal: React.FC<CreatePermissionModalProps> = ({
     | undefined;
 
   const { rbacPermissionMatrix } =
-    useLazyLoadQuery<CreatePermissionModalPermissionMatrixQuery>(
-      graphql`
-        query CreatePermissionModalPermissionMatrixQuery {
-          rbacPermissionMatrix {
-            scopeType
-            entities {
-              entityType
-              actions {
-                requiredPermission
-              }
-            }
-          }
-        }
-      `,
-      {},
-      { fetchPolicy: 'store-and-network' },
+    usePreloadedQuery<CreatePermissionModalPermissionMatrixQuery>(
+      PermissionMatrixQuery,
+      queryRef,
     );
 
   // Scope types available for the fallback free-pick UI (role has no scopes):

--- a/react/src/components/RolePermissionTab.tsx
+++ b/react/src/components/RolePermissionTab.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { CreatePermissionModalPermissionMatrixQuery } from '../__generated__/CreatePermissionModalPermissionMatrixQuery.graphql';
 import { CreatePermissionModal_roleScopeFragment$key } from '../__generated__/CreatePermissionModal_roleScopeFragment.graphql';
 import { RolePermissionTabDeleteMutation } from '../__generated__/RolePermissionTabDeleteMutation.graphql';
 import { RolePermissionTabFragment$key } from '../__generated__/RolePermissionTabFragment.graphql';
@@ -11,7 +12,9 @@ import {
 } from '../__generated__/RolePermissionTabRefetchQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
-import CreatePermissionModal from './CreatePermissionModal';
+import CreatePermissionModal, {
+  PermissionMatrixQuery,
+} from './CreatePermissionModal';
 import { DeleteFilled } from '@ant-design/icons';
 import { App, Tag } from 'antd';
 import {
@@ -22,6 +25,7 @@ import {
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
   BAITable,
+  BAIUnmountAfterClose,
   toLocalId,
   useBAILogger,
   useMutationWithPromise,
@@ -35,7 +39,13 @@ import {
 } from 'nuqs';
 import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useRefetchableFragment } from 'react-relay';
+import {
+  fetchQuery,
+  graphql,
+  useQueryLoader,
+  useRefetchableFragment,
+  useRelayEnvironment,
+} from 'react-relay';
 
 interface EditingPermission {
   id: string;
@@ -120,6 +130,11 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
   const supportsRbacFilterWrapper = baiClient.supports('rbac-filter-wrapper');
   const { message } = App.useApp();
   const { logger } = useBAILogger();
+  const relayEnvironment = useRelayEnvironment();
+  const [matrixQueryRef, loadMatrixQuery] =
+    useQueryLoader<CreatePermissionModalPermissionMatrixQuery>(
+      PermissionMatrixQuery,
+    );
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingPermission, setEditingPermission] =
     useState<EditingPermission | null>(null);
@@ -276,21 +291,43 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
     doRefetch();
   };
 
+  // Render-as-you-fetch: warm the store before opening so the modal's
+  // usePreloadedQuery renders synchronously (no Suspense fallback flash);
+  // the awaiting trigger button shows its own loading state meanwhile.
+  const openPermissionModal = async (editing: EditingPermission | null) => {
+    try {
+      await fetchQuery<CreatePermissionModalPermissionMatrixQuery>(
+        relayEnvironment,
+        PermissionMatrixQuery,
+        {},
+      ).toPromise();
+    } catch (error) {
+      logger.error('Failed to load permission matrix', error);
+      message.error(t('general.ErrorOccurred'));
+      return;
+    }
+    loadMatrixQuery({});
+    if (editing) {
+      setEditingPermission(editing);
+    } else {
+      setIsCreateModalOpen(true);
+    }
+  };
+
   const handleEdit = (record: {
     id: string;
     scopeType: string;
     scopeId: string;
     entityType: string;
     operation: string;
-  }) => {
-    setEditingPermission({
+  }) =>
+    openPermissionModal({
       id: toLocalId(record.id),
       scopeType: record.scopeType,
       scopeId: record.scopeId,
       entityType: record.entityType,
       operation: record.operation,
     });
-  };
 
   const handleDelete = (
     record: {
@@ -374,7 +411,7 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
           <BAIButton
             type="primary"
             icon={<PlusIcon />}
-            onClick={() => setIsCreateModalOpen(true)}
+            action={() => openPermissionModal(null)}
           >
             {t('rbac.CreatePermission')}
           </BAIButton>
@@ -427,7 +464,7 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
                       key: 'edit',
                       title: t('button.Edit'),
                       icon: <EditIcon />,
-                      onClick: () => handleEdit(record),
+                      action: () => handleEdit(record),
                     },
                     {
                       key: 'delete',
@@ -462,20 +499,25 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
           },
         ]}
       />
-      <CreatePermissionModal
-        open={isCreateModalOpen || !!editingPermission}
-        roleId={roleId}
-        roleScopeFrgmt={roleScopeFrgmt}
-        editingPermission={editingPermission}
-        onRequestClose={(success) => {
-          setIsCreateModalOpen(false);
-          setEditingPermission(null);
-          if (success) {
-            handleRefresh();
-            onPermissionChange?.();
-          }
-        }}
-      />
+      {matrixQueryRef != null && (
+        <BAIUnmountAfterClose>
+          <CreatePermissionModal
+            open={isCreateModalOpen || !!editingPermission}
+            roleId={roleId}
+            queryRef={matrixQueryRef}
+            roleScopeFrgmt={roleScopeFrgmt}
+            editingPermission={editingPermission}
+            onRequestClose={(success) => {
+              setIsCreateModalOpen(false);
+              setEditingPermission(null);
+              if (success) {
+                handleRefresh();
+                onPermissionChange?.();
+              }
+            }}
+          />
+        </BAIUnmountAfterClose>
+      )}
       <BAIDeleteConfirmModal
         open={!!deletingPermission}
         title={t('rbac.RemovePermission')}


### PR DESCRIPTION
Resolves #8177 (FR-3270)

## Problem

In the RBAC role detail view, `CreatePermissionModal` stayed mounted in `RolePermissionTab` after being closed, so its antd `Form` state persisted across open/close cycles. Opening the modal for permission A, closing it, then reopening it (for creation or for another permission B) still showed A's form values.

## Solution

- Wrap `CreatePermissionModal` with `BAIUnmountAfterClose` (from `backend.ai-ui`) so the modal unmounts after its close animation and remounts with fresh form state on every open — the established project pattern for modals holding form state.
- Since unmounting moves the permission-matrix fetch from tab-load time to open time, the modal's `useLazyLoadQuery` is converted to the **render-as-you-fetch** pattern (same idiom as `RouteSchedulingHistoryModal` / `DeploymentReplicasCard`):
  - `CreatePermissionModal` now exports `PermissionMatrixQuery` and reads it via `usePreloadedQuery(queryRef)`.
  - `RolePermissionTab` owns `useQueryLoader` and warms the store with `fetchQuery` **before** opening, so the trigger buttons (Create button and the row Edit action) show their built-in async loading state while the matrix loads, and the modal renders synchronously without suspending — no Suspense boundary needed at the call site.
  - The modal renders only when `matrixQueryRef` exists.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript)
- Reviewed by lead-frontend-reviewer agent; the Suspense-flash finding was addressed by the render-as-you-fetch refactor above.

**How to test manually**

1. Open a role's detail drawer → Permissions tab.
2. Click Create Permission → the button shows a loading spinner while the permission matrix loads, then the modal opens.
3. Fill in some values, close the modal, reopen it → the form is empty (fresh state).
4. Edit permission A, close, then edit permission B → the form shows B's values, not A's.