### PR TITLE
fix: rename stale "Sessions All" nav label to Compute Sessions

### DIFF
--- a/packages/backend.ai-webui-docs/src/book.config.yaml
+++ b/packages/backend.ai-webui-docs/src/book.config.yaml
@@ -61,7 +61,7 @@ navigation:
       items:
         - title: Session Page
           path: session_page/session_page.md
-        - title: Sessions All
+        - title: Compute Sessions
           path: sessions_all/sessions_all.md
         - title: Cluster Session
           path: cluster_session/cluster_session.md
@@ -128,7 +128,7 @@ navigation:
       items:
         - title: セッションページ
           path: session_page/session_page.md
-        - title: 全セッション
+        - title: コンピュートセッション
           path: sessions_all/sessions_all.md
         - title: クラスターセッション
           path: cluster_session/cluster_session.md
@@ -195,7 +195,7 @@ navigation:
       items:
         - title: 세션 페이지
           path: session_page/session_page.md
-        - title: 전체 세션
+        - title: 연산 세션
           path: sessions_all/sessions_all.md
         - title: 클러스터 세션
           path: cluster_session/cluster_session.md
@@ -262,7 +262,7 @@ navigation:
       items:
         - title: หน้าเซสชัน
           path: session_page/session_page.md
-        - title: เซสชันทั้งหมด
+        - title: เซสชันการคำนวณ
           path: sessions_all/sessions_all.md
         - title: เซสชันคลัสเตอร์
           path: cluster_session/cluster_session.md

--- a/packages/backend.ai-webui-docs/src/en/index.md
+++ b/packages/backend.ai-webui-docs/src/en/index.md
@@ -23,7 +23,7 @@ The latest versions of this document can be found from sites below:
 - [Dashboard](dashboard/dashboard.md)
 - [Vfolder](vfolder/vfolder.md)
 - [Session Page](session_page/session_page.md)
-- [Sessions All](sessions_all/sessions_all.md)
+- [Compute Sessions](sessions_all/sessions_all.md)
 - [Mount Vfolder](mount_vfolder/mount_vfolder.md)
 - [Share Vfolder](share_vfolder/share_vfolder.md)
 - [Deployment](deployment/deployment.md)

--- a/packages/backend.ai-webui-docs/src/ja/index.md
+++ b/packages/backend.ai-webui-docs/src/ja/index.md
@@ -23,7 +23,7 @@ Backend.AI WebUIは、Backend.AIサーバーと連携するための使いやす
 - [ダッシュボード](dashboard/dashboard.md)
 - [ストレージフォルダ](vfolder/vfolder.md)
 - [セッションページ](session_page/session_page.md)
-- [全セッション](sessions_all/sessions_all.md)
+- [コンピュートセッション](sessions_all/sessions_all.md)
 - [ストレージフォルダのマウント](mount_vfolder/mount_vfolder.md)
 - [ストレージフォルダの共有](share_vfolder/share_vfolder.md)
 - [デプロイ](deployment/deployment.md)

--- a/packages/backend.ai-webui-docs/src/ko/index.md
+++ b/packages/backend.ai-webui-docs/src/ko/index.md
@@ -22,7 +22,7 @@ Backend.AI Web-UI는 웹 또는 앱 형태의 GUI 클라이언트로, Backend.AI
 - [대시보드](dashboard/dashboard.md)
 - [스토리지 폴더](vfolder/vfolder.md)
 - [세션 페이지](session_page/session_page.md)
-- [전체 세션](sessions_all/sessions_all.md)
+- [연산 세션](sessions_all/sessions_all.md)
 - [스토리지 폴더 마운트](mount_vfolder/mount_vfolder.md)
 - [스토리지 폴더 공유](share_vfolder/share_vfolder.md)
 - [배포](deployment/deployment.md)

--- a/packages/backend.ai-webui-docs/src/th/index.md
+++ b/packages/backend.ai-webui-docs/src/th/index.md
@@ -22,7 +22,7 @@ Backend.AI WebUI เป็นเว็บหรือแอปที่ให้
 - [แดชบอร์ด](dashboard/dashboard.md)
 - [โฟลเดอร์จัดเก็บ](vfolder/vfolder.md)
 - [หน้าเซสชัน](session_page/session_page.md)
-- [เซสชันทั้งหมด](sessions_all/sessions_all.md)
+- [เซสชันการคำนวณ](sessions_all/sessions_all.md)
 - [การเมาท์โฟลเดอร์จัดเก็บ](mount_vfolder/mount_vfolder.md)
 - [การแชร์โฟลเดอร์จัดเก็บ](share_vfolder/share_vfolder.md)
 - [การปรับใช้](deployment/deployment.md)


### PR DESCRIPTION
Part of the **WebUI Docs 검수** review (Teams `devops/Frontend` thread, 2026-07-07).

The sidebar/TOC nav label for the Compute Sessions page was stale ("Sessions All" and its translated equivalents), while the page's own H1 titles were already correct. This aligns the nav label in `book.config.yaml` and each language's `index.md` to match the page H1.

## Changes (nav labels only — page H1, filenames, `sessions_all` slug untouched)
- en `Sessions All` → **`Compute Sessions`** (matches existing H1 `# Compute Sessions`)
- ko `전체 세션` → **`연산 세션`**
- ja `全セッション` → **`コンピュートセッション`**
- th `เซสชันทั้งหมด` → **`เซสชันการคำนวณ`**

*review item (Replies 7 & 11): "Sessions All"이 무슨 뜻? → 연산 세션(Compute Session)으로.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
