### PR TITLE
fix: normalize vfolder host usage percentage fraction from manager >= 26.3

### DIFF
--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { normalizeVFolderHostUsagePercent } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import useControllableState_deprecated from '../hooks/useControllableState';
@@ -88,7 +89,10 @@ const StorageSelect: React.FC<Props> = ({
           host,
           volume_info: vhostInfo?.volume_info?.[host],
         })),
-        'volume_info.usage.percentage',
+        // Normalize so fraction-scaled (manager >= 26.3) and 0-100 scaled
+        // percentages sort on the same scale. See `normalizeVFolderHostUsagePercent`.
+        (item) =>
+          normalizeVFolderHostUsagePercent(item.volume_info?.usage?.percentage),
       )?.host;
       nextHost = lowestUsageHost || nextHost;
     }
@@ -122,7 +126,9 @@ const StorageSelect: React.FC<Props> = ({
       }
       optionLabelProp={showUsageStatus ? 'label' : 'value'}
       options={_.map(vhostInfo?.allowed, (host) => {
-        const usagePercent = vhostInfo?.volume_info?.[host]?.usage?.percentage;
+        const usagePercent = normalizeVFolderHostUsagePercent(
+          vhostInfo?.volume_info?.[host]?.usage?.percentage,
+        );
         const usageLabel =
           usagePercent === undefined
             ? t('data.usage.Unknown')

--- a/react/src/components/VFolderNodesV2.tsx
+++ b/react/src/components/VFolderNodesV2.tsx
@@ -8,6 +8,7 @@ import {
   VFolderNodesV2Fragment$key,
 } from '../__generated__/VFolderNodesV2Fragment.graphql';
 import { VFolderNodesV2RestoreMutation } from '../__generated__/VFolderNodesV2RestoreMutation.graphql';
+import { normalizeVFolderHostUsagePercent } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useSuspenseTanQuery, useTanQuery } from '../hooks/reactQueryAlias';
@@ -275,7 +276,7 @@ const VFolderHostCell: React.FC<VFolderHostCellProps> = ({ host }) => {
 
   const volumeInfo = vhostInfo?.volume_info?.[host];
   const usage = volumeInfo?.usage;
-  const usagePercent = usage?.percentage;
+  const usagePercent = normalizeVFolderHostUsagePercent(usage?.percentage);
   // Match `StorageSelect`'s gating: render the badge whenever the backend
   // attaches a `usage` object — even an empty `{}` — so rows render a neutral
   // (uncolored) marker while percentage data is unavailable. Color is derived

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -24,6 +24,7 @@ import {
   toFixedWithTypeValidation,
   addNumberWithUnits,
   subNumberWithUnits,
+  normalizeVFolderHostUsagePercent,
 } from './index';
 
 describe('isOutsideRange', () => {
@@ -1051,5 +1052,30 @@ describe('subNumberWithUnits', () => {
   it('should handle negative results', () => {
     const result = subNumberWithUnits('2g', '5g', 'g');
     expect(result).toBe('-3g');
+  });
+});
+
+describe('normalizeVFolderHostUsagePercent', () => {
+  it('should scale a 0-1 fraction (manager >= 26.3) up to 0-100', () => {
+    expect(normalizeVFolderHostUsagePercent(0.42)).toBeCloseTo(42);
+    expect(normalizeVFolderHostUsagePercent(0.999)).toBeCloseTo(99.9);
+  });
+
+  it('should treat exactly 1 as a fraction (100%)', () => {
+    expect(normalizeVFolderHostUsagePercent(1)).toBe(100);
+  });
+
+  it('should pass through values already on a 0-100 scale', () => {
+    expect(normalizeVFolderHostUsagePercent(42)).toBe(42);
+    expect(normalizeVFolderHostUsagePercent(99.9)).toBe(99.9);
+    expect(normalizeVFolderHostUsagePercent(100)).toBe(100);
+  });
+
+  it('should pass through 0 unchanged', () => {
+    expect(normalizeVFolderHostUsagePercent(0)).toBe(0);
+  });
+
+  it('should return undefined when the percentage is missing', () => {
+    expect(normalizeVFolderHostUsagePercent(undefined)).toBeUndefined();
   });
 });

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -328,6 +328,16 @@ export const addQuotaScopeTypePrefix = (type: QuotaScopeType, str: string) => {
   return `${type}:${str}`;
 };
 
+// WORKAROUND: manager >= 26.3 returns `volume_info[<host>].usage.percentage`
+// from `vfolder.list_hosts()` as a 0-1 fraction (missing `* 100`, see
+// lablup/backend.ai#12632); normalize so thresholds on a 0-100 scale keep
+// working against both fixed and unfixed managers. A genuinely <=1%-full host
+// from a fixed manager is misread as a fraction, which is harmless (<=1% is
+// "Adequate" either way). Remove once managers older than the upstream fix
+// are out of support.
+export const normalizeVFolderHostUsagePercent = (percentage?: number) =>
+  percentage !== undefined && percentage <= 1 ? percentage * 100 : percentage;
+
 export const usageIndicatorColor = (percentage: number | undefined) => {
   return percentage === undefined
     ? undefined


### PR DESCRIPTION
Resolves #8188

## Symptom

With Backend.AI manager >= 26.3, every storage host in `StorageSelect` renders **"Adequate" / green regardless of actual usage**, and the `autoSelectType === 'usage'` auto-select sorts near-zero values (so "pick the least-used host" is meaningless). The same badge in the folder list's Host column (`VFolderNodesV2`) is affected.

## Root cause

Manager >= 26.3 returns `volume_info[<host>].usage.percentage` from `GET /folders/_/hosts` as a **0–1 fraction** instead of 0–100 — the `* 100` was dropped in lablup/backend.ai#9570. Tracked upstream in lablup/backend.ai#12632 (a manager-side fix is being opened in parallel). WebUI thresholds the value with `< 70` / `< 90` on a 0–100 scale, so a fraction is always "Adequate".

## Why fix it client-side too

Even after the manager fix ships, managers 26.3–26.x already deployed in the field keep returning fractions. This PR adds a defensive normalization (`percentage <= 1 ? percentage * 100 : percentage`) so the usage indicator and the usage-based auto-select work against **both fixed and unfixed managers**. The helper carries a `WORKAROUND` comment referencing lablup/backend.ai#12632 and should be removed once pre-fix managers are out of support.

**Known caveat (from the issue):** a genuinely <= 1%-full host reported by a fixed manager is misread as fraction-scaled. This only affects nearly-empty hosts, which is the harmless end of the scale for both the status buckets and the least-used sort.

## Changes

- `react/src/helper/index.tsx` — new shared `normalizeVFolderHostUsagePercent` helper with the WORKAROUND comment.
- `react/src/components/StorageSelect.tsx` — normalize `usagePercent` (drives the Adequate/Caution/Insufficient label and `StorageUsageBadge` color) and replace the string-path `_.minBy(..., 'volume_info.usage.percentage')` with a callback over the normalized value so the usage auto-select sorts on the same scale.
- `react/src/components/VFolderNodesV2.tsx` — normalize `usagePercent` in `VFolderHostCell` (same label + badge pattern).
- `react/src/helper/index.test.tsx` — unit tests for the helper (fraction scaling, 0/1 boundaries, 0–100 pass-through, `undefined`).

## Other `usage.percentage` consumers audited (no change needed)

- `QuotaPerStorageVolumePanelCard` / `QuotaPerStorageVolumeDashboardItem` / `HostQuotaTrigger` / `HostQuotaModalContent` — read only `capabilities` from `list_hosts()`; quota numbers come from GraphQL `quota_scope` bytes.
- `StorageHostResourcePanel` — computes percent from `used_bytes / capacity_bytes` (GraphQL `StorageVolume.usage` JSON), not from the REST percentage.
- `UsageProgress` — computes percent from quota-scope bytes.
- `diagnostics/rules/storageProxyRules.ts` — computes percentage from raw bytes itself.
- `useCurrentProject` / `useProjectResourceGroups` / BUI `BAIClientProvider` types — declare `usage.percentage` in types but only consume `sftp_scaling_groups`.
- `StorageUsageBadge` (backend.ai-ui) — thresholds its `percent` prop, but both call sites are the two components fixed above; normalization happens before the prop is passed, keeping the BUI package untouched.

## Verification

- `bash scripts/verify.sh`: Relay PASS, Lint PASS, Format PASS, TypeScript PASS. ("Vite warmup paths" FAIL is pre-existing on a clean `origin/main` checkout — reproduced via `git stash`; unrelated to this change.)
- `pnpm run test` in `react/`: 44 files, 915 tests passed (includes the 5 new helper tests).

Closes #8188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
