### PR TITLE
fix(docs-toolkit): decode HTML entities before slugifying headings

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/markdown-extensions.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-extensions.test.ts
@@ -11,7 +11,11 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseShellSessionLines } from "./markdown-extensions.js";
+import {
+  parseShellSessionLines,
+  decodeHtmlEntities,
+  stripHtmlTags,
+} from "./markdown-extensions.js";
 
 test("parseShellSessionLines — empty input yields no rows", () => {
   assert.deepEqual(parseShellSessionLines(""), []);
@@ -90,4 +94,36 @@ test("parseShellSessionLines — output containing $ mid-line stays as output", 
   assert.deepEqual(parseShellSessionLines("error: cannot expand $HOME"), [
     { type: "output", text: "error: cannot expand $HOME" },
   ]);
+});
+
+test("decodeHtmlEntities — decodes the entities marked emits", () => {
+  assert.equal(
+    decodeHtmlEntities("Manage User&#39;s Keypairs"),
+    "Manage User's Keypairs",
+  );
+  assert.equal(decodeHtmlEntities("a &amp; b"), "a & b");
+  assert.equal(
+    decodeHtmlEntities("&lt;tag&gt; &quot;x&quot; &#x27;y&#x27; &apos;z&apos;"),
+    "<tag> \"x\" 'y' 'z'",
+  );
+});
+
+test("decodeHtmlEntities — collapses double encoding one level (amp last)", () => {
+  // A literal, single-encoded "&#39;" must survive rather than becoming "'".
+  assert.equal(decodeHtmlEntities("&amp;#39;"), "&#39;");
+});
+
+test("decodeHtmlEntities — leaves plain text and invalid refs untouched", () => {
+  assert.equal(decodeHtmlEntities("no entities here"), "no entities here");
+  assert.equal(decodeHtmlEntities("100% & rising"), "100% & rising");
+});
+
+test("decodeHtmlEntities — recovers a clean slug source for escaped apostrophes", () => {
+  // Regression guard: without decoding, `stripHtmlTags` leaves `&#39;`,
+  // which slugify turns into the broken `user39s` anchor. Decoding first
+  // yields the plain apostrophe that slugify then drops → `User's` → `users`.
+  const rendered = "Manage User&#39;s Keypairs";
+  const plain = decodeHtmlEntities(stripHtmlTags(rendered));
+  assert.equal(plain, "Manage User's Keypairs");
+  assert.ok(!/\d9s/.test(plain), "must not contain entity-derived digits");
 });

--- a/packages/backend.ai-docs-toolkit/src/markdown-extensions.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-extensions.ts
@@ -239,3 +239,33 @@ export function stripHtmlTags(str: string): string {
   } while (result !== prev);
   return result;
 }
+
+/**
+ * Decode the small set of HTML entities that `marked` emits when it
+ * escapes inline text (`&` `<` `>` `"` `'`), plus generic numeric
+ * character references (`&#NN;` / `&#xHH;`).
+ *
+ * Used to recover the plain-text form of a heading before slugifying
+ * it. Without this, an escaped apostrophe (`&#39;`) survives
+ * `stripHtmlTags` and `slugify` — which drops `&`, `#` and `;` but
+ * keeps digits — turns `user&#39;s` into the broken anchor `user39s`
+ * instead of `users`. Decoding first yields the correct `users`.
+ * `&amp;` is decoded last so double-encoded input collapses one level
+ * at a time rather than mangling a literal `&amp;` mid-string.
+ */
+export function decodeHtmlEntities(str: string): string {
+  return str
+    .replace(/&#x([0-9a-fA-F]+);/g, (m, hex) => {
+      const cp = parseInt(hex, 16);
+      return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : m;
+    })
+    .replace(/&#(\d+);/g, (m, dec) => {
+      const cp = parseInt(dec, 10);
+      return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : m;
+    })
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}

--- a/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
@@ -23,6 +23,7 @@ import {
   parseShellSessionLines,
   escapeHtml,
   stripHtmlTags,
+  decodeHtmlEntities,
   getFigureLabel,
   parseImageSizeHint,
 } from "./markdown-extensions.js";
@@ -353,7 +354,7 @@ function buildWebRenderer(
 
   return {
     heading(text: string, level: number, _raw: string): string {
-      const plainText = stripHtmlTags(text);
+      const plainText = decodeHtmlEntities(stripHtmlTags(text));
       const id = `${chapterSlug}-${slugify(plainText)}`;
       headings.push({ level, text: plainText, id });
       const escapedPlainText = escapeHtml(plainText);

--- a/packages/backend.ai-docs-toolkit/src/markdown-processor.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor.ts
@@ -9,6 +9,7 @@ import {
   parseShellSessionLines,
   escapeHtml as escapeHtmlExt,
   stripHtmlTags,
+  decodeHtmlEntities,
   getFigureLabel,
   parseImageSizeHint,
 } from './markdown-extensions.js';
@@ -456,7 +457,7 @@ export async function processMarkdownFiles(
     const marked = new Marked();
     const renderer = {
       heading(text: string, level: number, _raw: string): string {
-        const plainText = stripHtmlTags(text);
+        const plainText = decodeHtmlEntities(stripHtmlTags(text));
         const id = `${chapterSlug}-${slugify(plainText)}`;
 
         if (level === 1) {
@@ -585,7 +586,7 @@ export async function processCatalogMarkdownForPdf(
     const marked = new Marked();
     const renderer = {
       heading(text: string, level: number, _raw: string): string {
-        const plainText = stripHtmlTags(text);
+        const plainText = decodeHtmlEntities(stripHtmlTags(text));
         const id = `${chapterSlug}-${slugify(plainText)}`;
         headings.push({ level, text: plainText, id });
         return `<h${level} id="${id}">${text}</h${level}>\n`;


### PR DESCRIPTION
From the **WebUI Docs 검수** review (Teams `devops/Frontend` thread, 2026-07-07, Reply 23). This is the **docs-toolkit** follow-up that #8190 flagged but deliberately did not fix (it is a build-tool bug, not a docs-content bug).

## Problem
On `admin_menu.html` the heading **"Manage User's Keypairs"** rendered a broken anchor `admin_menu-manage-user39s-keypairs` and its "On this page" TOC entry showed the literal `&#39;`.

Root cause: the heading renderers slugify `stripHtmlTags(text)`, where `text` is `marked`-rendered HTML in which `'` is already escaped to `&#39;`. `stripHtmlTags` leaves the entity, and `slugify` strips `&` `#` `;` but keeps the digits → `user39s`. The TOC text (`headings[].text`) also carried `&#39;`, which `escapeHtml` re-escaped to `&amp;#39;` → visible `&#39;`.

## Fix
Add a shared `decodeHtmlEntities()` helper (`markdown-extensions.ts`) and decode entities **after** `stripHtmlTags` and **before** `slugify`, in both heading renderers:
- `markdown-processor-web.ts` (the web build — the reported surface)
- `markdown-processor.ts` (the PDF build — same latent bug, fixed for parity)

`&amp;` is decoded last so genuinely double-encoded input collapses one level rather than mangling a literal `&amp;`. The `<hN>${text}</hN>` display still uses the raw (entity-encoded) `text`, so the visible heading is unchanged; only the derived **id** and the **TOC plain-text** are corrected.

Result: `admin_menu-manage-user39s-keypairs` → **`admin_menu-manage-users-keypairs`**, TOC shows a clean `'`. This also now matches the pre-existing explicit `<a id="manage-users-keypairs">` anchor in all four languages.

## Verification
- `pnpm --filter backend.ai-docs-toolkit build` (tsc) — clean.
- Toolkit tests: **262 pass / 0 fail** (added 4 `decodeHtmlEntities` cases incl. the `User&#39;s → users` slug regression guard).
- Rebuilt `build:web --lang en` and confirmed 0 remaining `user39s` / `User&amp;#39;s` occurrences.

## Regression scope
Only **one** heading in the entire manual contains an apostrophe (`## Manage User's Keypairs`), and no cross-reference link targets the old broken `user39s` slug (all use the explicit `manage-users-keypairs` anchor), so no links break. `seo.ts` keeps its own local `decodeHtmlEntities` (intentionally `&amp;`-first for meta-tag double-decoding) — left untouched to avoid changing its tested behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
