### PR TITLE
feat(FR-3275): trigger Amplify docs rebuild after archive snapshot push

### DIFF
--- a/.github/workflows/docs-archive-orphan-branch.yml
+++ b/.github/workflows/docs-archive-orphan-branch.yml
@@ -238,8 +238,16 @@ jobs:
             echo "::warning::AMPLIFY_DOCS_WEBHOOK_URL secret not set — docs-archive branch was updated, but the live site stays stale until the next main build. Create an Amplify incoming webhook (docs app → Build settings → Incoming webhooks) and store its URL in this secret."
             exit 0
           fi
-          curl -fsS -X POST "$WEBHOOK" -H 'Content-Type: application/json' -d '{}'
-          echo "Amplify rebuild triggered."
+          # The archive force-push above already succeeded, so a flaky
+          # webhook must not fail the workflow. Bound the request (timeout
+          # + retries) and downgrade any failure to a warning — the live
+          # site will still refresh on the next main build.
+          if curl -fsS --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors \
+               -X POST "$WEBHOOK" -H 'Content-Type: application/json' -d '{}'; then
+            echo "Amplify rebuild triggered."
+          else
+            echo "::warning::Amplify webhook POST failed after retries — the docs-archive branch is already updated, so the live site will refresh on the next main build. Re-run this workflow (or POST the webhook manually) to force it sooner."
+          fi
 
       - name: Dry-run summary
         if: ${{ steps.resolve.outputs.dry_run == 'true' }}

--- a/.github/workflows/docs-archive-orphan-branch.yml
+++ b/.github/workflows/docs-archive-orphan-branch.yml
@@ -218,6 +218,29 @@ jobs:
           # docs corrections that should land in the archive.
           git push --force origin "$BRANCH"
 
+      # The live site renders every archive at Amplify build time, but
+      # Amplify only builds on pushes to `main`. Without this step, a
+      # docs-only push to a release branch refreshes the archive branch
+      # yet the deployed /<minor>/ pages stay stale until an unrelated
+      # `main` merge happens to land (FR-3275). POSTing the Amplify
+      # incoming webhook starts a rebuild of the main-HEAD pipeline so
+      # the refreshed archive is re-rendered immediately. The release
+      # path already rebuilds via the auto-opened pdfTag PR merge
+      # (FR-3246); this covers the push/dispatch paths. Skips with a
+      # warning when the secret is not configured, preserving the
+      # previous behavior.
+      - name: Trigger Amplify docs rebuild
+        if: ${{ steps.resolve.outputs.dry_run != 'true' }}
+        env:
+          WEBHOOK: ${{ secrets.AMPLIFY_DOCS_WEBHOOK_URL }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::AMPLIFY_DOCS_WEBHOOK_URL secret not set — docs-archive branch was updated, but the live site stays stale until the next main build. Create an Amplify incoming webhook (docs app → Build settings → Incoming webhooks) and store its URL in this secret."
+            exit 0
+          fi
+          curl -fsS -X POST "$WEBHOOK" -H 'Content-Type: application/json' -d '{}'
+          echo "Amplify rebuild triggered."
+
       - name: Dry-run summary
         if: ${{ steps.resolve.outputs.dry_run == 'true' }}
         env:

--- a/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
+++ b/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
@@ -48,6 +48,17 @@ root cause before continuing — do **not** edit the orphan branch by hand.
 
 Workflow file: `.github/workflows/docs-archive-orphan-branch.yml`.
 
+> **Live-site propagation (FR-3275).** Amplify builds only on pushes to
+> `main`, and each build re-renders every archive branch. After refreshing
+> an archive, the workflow's final step POSTs the Amplify incoming webhook
+> (repo secret `AMPLIFY_DOCS_WEBHOOK_URL`) so the live `/<minor>/` pages
+> re-render immediately — otherwise they stay stale until the next
+> unrelated `main` merge. One-time setup: Amplify console → docs app →
+> App settings → Build settings → **Incoming webhooks** → create a webhook
+> for the branch Amplify builds (`main`), then store its URL as the
+> `AMPLIFY_DOCS_WEBHOOK_URL` repository secret. When the secret is missing
+> the step logs a warning and the workflow still succeeds.
+
 ### 2. Verify FR-2719's `build_docs` job in `package.yml` succeeded
 
 The `build_docs` job in `.github/workflows/package.yml` runs automatically

--- a/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
+++ b/packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md
@@ -43,8 +43,10 @@ gh workflow run docs-archive-orphan-branch.yml \
 ```
 
 Verify success: a new commit appears on `docs-archive/26.5` containing the
-built site files (not the source tree). If the workflow fails, fix the
-root cause before continuing — do **not** edit the orphan branch by hand.
+docs **source** tree (`src/` + `.archive-info.txt`), not built site files —
+the current toolkit on `main` re-renders this source at Amplify build time.
+If the workflow fails, fix the root cause before continuing — do **not**
+edit the orphan branch by hand.
 
 Workflow file: `.github/workflows/docs-archive-orphan-branch.yml`.
 


### PR DESCRIPTION
Resolves FR-3275

## Problem

The multi-version docs deployment automation has one missing link on the **docs-hotfix push path**:

- FR-3242 (#8110): docs `src/**` push to a bare `MAJOR.MINOR` branch (e.g. `26.7`) auto-refreshes `docs-archive/<minor>` ✅
- FR-3246 (#8121+#8131): on a published release, the auto-opened pdfTag PR → `main` merge triggers the Amplify rebuild ✅
- **Gap**: a docs-only push to a release branch refreshes the archive, but `docs-archive-orphan-branch.yml` ends at `git push --force` — nothing rebuilds Amplify, so the live `/<minor>/` pages stay stale until an unrelated `main` merge lands.

Observed today: the WebUI Docs 검수 fixes (#8183–#8190) were cherry-picked to `26.7` and `docs-archive/26.7` refreshed correctly, but https://webui.docs.backend.ai/26.7/ kept serving the stale render (`Web-UI` still visible) for 18+ minutes with no `main` build in sight.

## Change

- **`.github/workflows/docs-archive-orphan-branch.yml`**: add a final `Trigger Amplify docs rebuild` step (non-dry-run only) that POSTs the Amplify **incoming webhook** stored in the `AMPLIFY_DOCS_WEBHOOK_URL` repo secret. When the secret is absent it emits a `::warning::` and exits 0 — current behavior is preserved until ops completes the one-time setup.
- **`packages/backend.ai-webui-docs/RELEASE-RUNBOOK.md`**: document the propagation mechanism and the one-time webhook + secret setup.

Why incoming webhook (vs OIDC + `aws amplify start-job`): no AWS credentials in CI, one-time console setup, and it keeps the single main-HEAD build pipeline design intact — the archive refresh simply becomes a rebuild *reason*.

## ⚠️ One-time ops setup required after merge

1. Amplify console → docs app → App settings → Build settings → **Incoming webhooks** → create a webhook for the branch Amplify builds (`main`).
2. Save the URL as repo secret **`AMPLIFY_DOCS_WEBHOOK_URL`**.
3. Verify: re-run `docs-archive-orphan-branch.yml` via `workflow_dispatch` (`source_ref=v26.7.1`… or simply the current `26.7` HEAD, `minor_label=26.7`) → an Amplify build should start and the live `/26.7/` pages should re-render with the backported fixes.

## Verification

- `python3 -c "yaml.safe_load(...)"` — workflow YAML parses; step lands between the orphan push and the dry-run summary.
- Secret-absent path exits 0 with a visible warning (no behavior change until setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
