### PR TITLE
refactor(FR-3279): make the router own 404 via scoped catch-alls and a route error boundary

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -9,6 +9,7 @@ import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import { useLogoutEventListeners } from '../../hooks/useLogout';
 import usePrimaryColors from '../../hooks/usePrimaryColors';
 import { useCurrentMenuKey, useRouteScope } from '../../hooks/useRouteScope';
+import { useUrlProjectValidity } from '../../hooks/useUrlProjectValidity';
 import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
 import { useSetupWebUIPluginEffect } from '../../hooks/useWebUIPluginState';
 import Page401 from '../../pages/Page401';
@@ -340,6 +341,16 @@ const PageAccessGuard = ({
 }) => {
   const { isCurrentPageBlocked, isCurrentPageUnauthorized } =
     useWebUIMenuItems();
+  const { isInvalid: isUrlProjectInvalid } = useUrlProjectValidity();
+
+  // When the URL names a project that doesn't resolve for this user, whether
+  // the page would be authorized cannot be decided (the roles are relative to
+  // a project we can't identify). Defer entirely to ProjectScopeLayout, which
+  // renders the "not found / no access" state — the same screen for every
+  // role, so project existence is not leaked via a 401/404 difference.
+  if (isUrlProjectInvalid) {
+    return children;
+  }
 
   const hasError = isCurrentPageUnauthorized || isCurrentPageBlocked;
 

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -326,7 +326,8 @@ const ResourceSlotsWrapper = ({ children }: { children: React.ReactNode }) => {
  * Component that guards page access based on permissions and route validity.
  * - Unauthorized (401): User lacks permission (e.g., regular user accessing admin page)
  * - Blocked (404): Page is in the blocklist configuration (treated as not found)
- * - Not Found (404): Page path is not valid (not in menu, not a plugin page, not a static route)
+ * - Not Found (404) is NOT decided here anymore: unknown paths fall into the
+ *   router-owned scoped catch-all routes (see UnknownRoutePage in routes.tsx).
  *
  * @param emptyErrorPage - If true, renders nothing instead of error pages (401/404)
  */
@@ -337,14 +338,10 @@ const PageAccessGuard = ({
   children: React.ReactNode;
   emptyErrorPage?: boolean;
 }) => {
-  const {
-    isCurrentPageBlocked,
-    isCurrentPageNotFound,
-    isCurrentPageUnauthorized,
-  } = useWebUIMenuItems();
+  const { isCurrentPageBlocked, isCurrentPageUnauthorized } =
+    useWebUIMenuItems();
 
-  const hasError =
-    isCurrentPageUnauthorized || isCurrentPageBlocked || isCurrentPageNotFound;
+  const hasError = isCurrentPageUnauthorized || isCurrentPageBlocked;
 
   if (hasError && emptyErrorPage) {
     return null;
@@ -354,7 +351,7 @@ const PageAccessGuard = ({
     return <Page401 />;
   }
 
-  if (isCurrentPageBlocked || isCurrentPageNotFound) {
+  if (isCurrentPageBlocked) {
     return <Page404 />;
   }
 

--- a/react/src/components/MainLayout/ProjectScopeLayout.tsx
+++ b/react/src/components/MainLayout/ProjectScopeLayout.tsx
@@ -3,23 +3,19 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { buildPath } from '../../helper/pathBuilder';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
+import { useWebUINavigate } from '../../hooks';
 import {
   useCurrentProjectValue,
   useSetCurrentProject,
 } from '../../hooks/useCurrentProject';
 import { getRouteScopeAndKey } from '../../hooks/useRouteScope';
+import { useUrlProjectValidity } from '../../hooks/useUrlProjectValidity';
 import ProjectScopeErrorState from './ProjectScopeErrorState';
 import { Button } from 'antd';
 import { ArrowRightIcon } from 'lucide-react';
 import React, { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet, useLocation, useParams } from 'react-router-dom';
-
-interface BackendAIClientGroups {
-  groups?: string[];
-  groupIds?: Record<string, string>;
-}
+import { Outlet, useLocation } from 'react-router-dom';
 
 /**
  * Layout element for the `/project/:projectName/*` subtree (project + project
@@ -51,28 +47,23 @@ interface BackendAIClientGroups {
 const ProjectScopeLayout: React.FC = () => {
   'use memo';
   const { t } = useTranslation();
-  const baiClient = useSuspendedBackendaiClient();
-  const { projectName: rawProjectName } = useParams<{ projectName: string }>();
   const location = useLocation();
   const currentProject = useCurrentProjectValue();
   const setCurrentProject = useSetCurrentProject();
   const webuiNavigate = useWebUINavigate();
 
-  // `useParams` already decodes percent-encoding; treat a missing param as ''.
-  const projectName = rawProjectName ?? '';
-
-  const clientGroups = baiClient as unknown as BackendAIClientGroups;
-  const groups = clientGroups.groups ?? [];
-  const groupIds = clientGroups.groupIds ?? {};
-
-  const isMember = groups.includes(projectName);
-  const resolvedId = groupIds[projectName];
-  const isValid = isMember && !!resolvedId;
+  // Shared URL-project validation (also consulted by PageAccessGuard and
+  // ProjectAdminScopeAlert so all three agree on "this project doesn't
+  // resolve"). The param is already percent-decoded by react-router.
+  const { urlProjectName, isInvalid, resolvedId, groups } =
+    useUrlProjectValidity();
+  const projectName = urlProjectName ?? '';
+  const isValid = !!urlProjectName && !isInvalid;
 
   // Effect-event reads the latest resolved id / current value; the surrounding
   // effect only re-synchronizes when the URL project name changes.
   const syncProject = useEffectEvent(() => {
-    if (!isValid) {
+    if (!isValid || !resolvedId) {
       return;
     }
     if (currentProject.name !== projectName) {

--- a/react/src/components/ProjectAdminScopeAlert.tsx
+++ b/react/src/components/ProjectAdminScopeAlert.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useRouteScope } from '../hooks/useRouteScope';
+import { useUrlProjectValidity } from '../hooks/useUrlProjectValidity';
 import { BAIAlert, BAIAlertProps } from 'backend.ai-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,8 +21,12 @@ const ProjectAdminScopeAlert: React.FC<ProjectAdminScopeAlertProps> = (
   // `project` prefix) is the single source of truth for this gate.
   const scope = useRouteScope();
   const isProjectAdminPage = scope === 'projectAdmin';
+  // When the URL names a project that doesn't resolve, ProjectScopeLayout
+  // renders its "not found / no access" state instead of the page — this
+  // page-scoped notice must not appear above it.
+  const { isInvalid: isUrlProjectInvalid } = useUrlProjectValidity();
 
-  if (!isProjectAdminPage) return null;
+  if (!isProjectAdminPage || isUrlProjectInvalid) return null;
 
   return (
     <BAIAlert

--- a/react/src/components/RouteErrorBoundary.test.ts
+++ b/react/src/components/RouteErrorBoundary.test.ts
@@ -1,0 +1,55 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Contract tests for the route-error boundary's status resolution
+ * (FR-3279). `getRouteErrorStatus` decides the boundary's entire behavior:
+ *
+ *   404          -> Page404
+ *   401 / 403    -> forbidden page
+ *   other number -> generic unexpected-error notice
+ *   undefined    -> the boundary re-throws so `BAIErrorBoundary` keeps
+ *                   ownership of generic render/Relay errors
+ */
+import { getRouteErrorStatus } from './RouteErrorBoundary';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Shape-compatible with react-router's internal ErrorResponseImpl, which is
+ * what `isRouteErrorResponse` duck-types against (`status` + `statusText` +
+ * `internal` + `data`). Loader/action `throw new Response(...)` reaches the
+ * boundary wrapped in this shape, NOT as a raw Response.
+ */
+const routerErrorResponse = (status: number) => ({
+  status,
+  statusText: '',
+  internal: false,
+  data: null,
+});
+
+describe('getRouteErrorStatus', () => {
+  it('recognizes router ErrorResponse values (loader/action throws)', () => {
+    expect(getRouteErrorStatus(routerErrorResponse(404))).toBe(404);
+    expect(getRouteErrorStatus(routerErrorResponse(401))).toBe(401);
+    expect(getRouteErrorStatus(routerErrorResponse(403))).toBe(403);
+    expect(getRouteErrorStatus(routerErrorResponse(500))).toBe(500);
+  });
+
+  it('recognizes raw Response values (render-time throws)', () => {
+    expect(getRouteErrorStatus(new Response(null, { status: 404 }))).toBe(404);
+    expect(getRouteErrorStatus(new Response(null, { status: 401 }))).toBe(401);
+    expect(getRouteErrorStatus(new Response(null, { status: 403 }))).toBe(403);
+    expect(getRouteErrorStatus(new Response(null, { status: 503 }))).toBe(503);
+  });
+
+  it.each([
+    ['a plain Error', new Error('boom')],
+    ['a string', 'boom'],
+    ['null', null],
+    ['undefined', undefined],
+    ['an object without the ErrorResponse shape', { status: 404 }],
+  ])('returns undefined for %s (boundary re-throws)', (_label, value) => {
+    expect(getRouteErrorStatus(value)).toBeUndefined();
+  });
+});

--- a/react/src/components/RouteErrorBoundary.tsx
+++ b/react/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,43 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import Page401 from '../pages/Page401';
+import Page404 from '../pages/Page404';
+import RouteErrorContent from './RouteErrorContent';
+import { useTranslation } from 'react-i18next';
+import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
+
+/**
+ * Route-level error boundary (react-router `errorElement`) mounted on a
+ * pathless route INSIDE MainLayout, so errors replace only the content area
+ * while the shell (header / sidebar) stays up.
+ *
+ * Pages and future loaders/guards can `throw new Response(null, { status })`
+ * to converge on the shared route-error language:
+ *   404 -> not-found page, 401/403 -> forbidden page,
+ *   anything else -> a minimal unexpected-error notice.
+ */
+const RouteErrorBoundary = () => {
+  'use memo';
+  const { t } = useTranslation();
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    if (error.status === 404) {
+      return <Page404 />;
+    }
+    if (error.status === 401 || error.status === 403) {
+      return <Page401 />;
+    }
+  }
+
+  return (
+    <RouteErrorContent
+      title={t('dialog.ErrorOccurred')}
+      description={t('error.UnexpectedError')}
+    />
+  );
+};
+
+export default RouteErrorBoundary;

--- a/react/src/components/RouteErrorBoundary.tsx
+++ b/react/src/components/RouteErrorBoundary.tsx
@@ -24,19 +24,31 @@ import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
  * expired-login re-login CTA, GraphQL error detail). Only router-thrown
  * `Response`s belong to this boundary.
  */
+/**
+ * Resolves the HTTP status this boundary should handle, or `undefined` for
+ * errors that must be re-thrown to `BAIErrorBoundary`.
+ *
+ * `isRouteErrorResponse` only recognizes the internal ErrorResponseImpl that
+ * react-router creates for loader/action throws; a raw `Response` thrown
+ * during render is a plain Response instance. Accept both. Exported for
+ * direct unit testing (`RouteErrorBoundary.test.ts`).
+ */
+export const getRouteErrorStatus = (error: unknown): number | undefined => {
+  if (isRouteErrorResponse(error)) {
+    return error.status;
+  }
+  if (error instanceof Response) {
+    return error.status;
+  }
+  return undefined;
+};
+
 const RouteErrorBoundary = () => {
   'use memo';
   const { t } = useTranslation();
   const error = useRouteError();
 
-  // `isRouteErrorResponse` only recognizes the internal ErrorResponseImpl that
-  // react-router creates for loader/action throws; a raw `Response` thrown
-  // during render is a plain Response instance. Accept both.
-  const status = isRouteErrorResponse(error)
-    ? error.status
-    : error instanceof Response
-      ? error.status
-      : undefined;
+  const status = getRouteErrorStatus(error);
 
   if (status === undefined) {
     throw error;

--- a/react/src/components/RouteErrorBoundary.tsx
+++ b/react/src/components/RouteErrorBoundary.tsx
@@ -16,20 +16,37 @@ import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
  * Pages and future loaders/guards can `throw new Response(null, { status })`
  * to converge on the shared route-error language:
  *   404 -> not-found page, 401/403 -> forbidden page,
- *   anything else -> a minimal unexpected-error notice.
+ *   other Response statuses -> a minimal unexpected-error notice.
+ *
+ * Non-Response errors (render/Relay throws) are re-thrown: a route
+ * `errorElement` catches BEFORE the React error boundary wrapping the Outlet,
+ * so handling them here would displace `BAIErrorBoundary` (retry/reset,
+ * expired-login re-login CTA, GraphQL error detail). Only router-thrown
+ * `Response`s belong to this boundary.
  */
 const RouteErrorBoundary = () => {
   'use memo';
   const { t } = useTranslation();
   const error = useRouteError();
 
-  if (isRouteErrorResponse(error)) {
-    if (error.status === 404) {
-      return <Page404 />;
-    }
-    if (error.status === 401 || error.status === 403) {
-      return <Page401 />;
-    }
+  // `isRouteErrorResponse` only recognizes the internal ErrorResponseImpl that
+  // react-router creates for loader/action throws; a raw `Response` thrown
+  // during render is a plain Response instance. Accept both.
+  const status = isRouteErrorResponse(error)
+    ? error.status
+    : error instanceof Response
+      ? error.status
+      : undefined;
+
+  if (status === undefined) {
+    throw error;
+  }
+
+  if (status === 404) {
+    return <Page404 />;
+  }
+  if (status === 401 || status === 403) {
+    return <Page401 />;
   }
 
   return (

--- a/react/src/helper/pathBuilder.test.ts
+++ b/react/src/helper/pathBuilder.test.ts
@@ -9,15 +9,9 @@
  * - buildPath() produces correct URLs for each scope
  * - buildPath() encodes project names (spaces / dots / unicode / slashes)
  * - MENU_KEY_TO_SCOPE_FEATURE covers every VALID_MENU_KEYS entry
- * - scopeFeatureToMenuKey() inverts the map to canonical (non-alias) keys
- * - round-trip: menu key -> {scope, feature} -> canonical menu key
  */
 import { VALID_MENU_KEYS } from '../hooks/useWebUIMenuItems';
-import {
-  buildPath,
-  MENU_KEY_TO_SCOPE_FEATURE,
-  scopeFeatureToMenuKey,
-} from './pathBuilder';
+import { buildPath, MENU_KEY_TO_SCOPE_FEATURE } from './pathBuilder';
 
 describe('buildPath', () => {
   it('builds admin paths without a project name', () => {
@@ -146,44 +140,5 @@ describe('MENU_KEY_TO_SCOPE_FEATURE', () => {
     expect(MENU_KEY_TO_SCOPE_FEATURE['job']).toEqual(
       MENU_KEY_TO_SCOPE_FEATURE['session'],
     );
-  });
-});
-
-describe('scopeFeatureToMenuKey', () => {
-  it('inverts the map for canonical keys', () => {
-    expect(scopeFeatureToMenuKey('project', 'session')).toBe('session');
-    expect(scopeFeatureToMenuKey('admin', 'session')).toBe('admin-session');
-    expect(scopeFeatureToMenuKey('projectAdmin', 'session')).toBe(
-      'project-admin-session',
-    );
-    expect(scopeFeatureToMenuKey('admin', 'users')).toBe('credential');
-    expect(scopeFeatureToMenuKey('projectAdmin', 'users')).toBe(
-      'project-admin-users',
-    );
-    expect(scopeFeatureToMenuKey('projectAdmin', 'data')).toBe('project-data');
-    expect(scopeFeatureToMenuKey('admin', 'data')).toBe('admin-data');
-  });
-
-  it('resolves dashboard/session to the canonical key, not the alias', () => {
-    expect(scopeFeatureToMenuKey('project', 'dashboard')).toBe('dashboard');
-    expect(scopeFeatureToMenuKey('project', 'session')).toBe('session');
-  });
-
-  it('returns undefined for unknown combinations', () => {
-    expect(scopeFeatureToMenuKey('admin', 'start')).toBeUndefined();
-    expect(scopeFeatureToMenuKey('project', 'nonexistent')).toBeUndefined();
-    expect(scopeFeatureToMenuKey('projectAdmin', 'agent')).toBeUndefined();
-  });
-
-  it('round-trips every non-alias menu key through scope/feature', () => {
-    const aliases = new Set(['summary', 'job']);
-    for (const [menuKey, { scope, featureKey }] of Object.entries(
-      MENU_KEY_TO_SCOPE_FEATURE,
-    )) {
-      if (aliases.has(menuKey)) {
-        continue;
-      }
-      expect(scopeFeatureToMenuKey(scope, featureKey)).toBe(menuKey);
-    }
   });
 });

--- a/react/src/helper/pathBuilder.ts
+++ b/react/src/helper/pathBuilder.ts
@@ -130,38 +130,3 @@ export const MENU_KEY_TO_SCOPE_FEATURE: Record<string, ScopeFeature> = {
   branding: { scope: 'admin', featureKey: 'branding' },
   information: { scope: 'admin', featureKey: 'information' },
 };
-
-/**
- * Inverse lookup table built from `MENU_KEY_TO_SCOPE_FEATURE`. Keyed by
- * `"<scope>:<featureKey>"`. Alias menu keys (`summary`, `job`) are intentionally
- * skipped so the inverse resolves to the canonical menu key
- * (`dashboard`, `session`).
- */
-const ALIAS_MENU_KEYS: ReadonlySet<string> = new Set(['summary', 'job']);
-
-const SCOPE_FEATURE_TO_MENU_KEY: Record<string, string> = (() => {
-  const table: Record<string, string> = {};
-  for (const [menuKey, { scope, featureKey }] of Object.entries(
-    MENU_KEY_TO_SCOPE_FEATURE,
-  )) {
-    if (ALIAS_MENU_KEYS.has(menuKey)) {
-      continue;
-    }
-    table[`${scope}:${featureKey}`] = menuKey;
-  }
-  return table;
-})();
-
-/**
- * Resolves a `{scope, featureKey}` pair back to its canonical menu key, or
- * `undefined` if the combination is not a known route.
- *
- * e.g. `scopeFeatureToMenuKey('admin', 'session')` -> `'admin-session'`,
- *      `scopeFeatureToMenuKey('project', 'session')` -> `'session'`.
- */
-export const scopeFeatureToMenuKey = (
-  scope: RouteScope,
-  featureKey: FeatureKey,
-): string | undefined => {
-  return SCOPE_FEATURE_TO_MENU_KEY[`${scope}:${featureKey}`];
-};

--- a/react/src/hooks/useUrlProjectValidity.test.tsx
+++ b/react/src/hooks/useUrlProjectValidity.test.tsx
@@ -1,0 +1,109 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Tests for the shared URL-project validation (FR-3279). `isInvalid` decides
+ * whether `PageAccessGuard` bypasses authorization and whether the project
+ * subtree renders the merged not-found/no-access state, so each membership
+ * combination is pinned here.
+ */
+import { useUrlProjectValidity } from './useUrlProjectValidity';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseSuspendedBackendaiClient = vi.fn();
+const mockUseMatches = vi.fn();
+
+vi.mock('.', () => ({
+  useSuspendedBackendaiClient: () => mockUseSuspendedBackendaiClient(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useMatches: () => mockUseMatches(),
+}));
+
+const clientWith = (groups: string[], groupIds: Record<string, string>) => ({
+  groups,
+  groupIds,
+});
+
+const matchWithProject = (projectName?: string) => [
+  { params: {} },
+  { params: projectName ? { projectName } : {} },
+];
+
+describe('useUrlProjectValidity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is not invalid outside project-scoped URLs (no :projectName param)', () => {
+    mockUseSuspendedBackendaiClient.mockReturnValue(
+      clientWith(['alpha'], { alpha: 'id-alpha' }),
+    );
+    mockUseMatches.mockReturnValue(matchWithProject(undefined));
+
+    const { result } = renderHook(() => useUrlProjectValidity());
+    expect(result.current.urlProjectName).toBeUndefined();
+    expect(result.current.isInvalid).toBe(false);
+    expect(result.current.resolvedId).toBeUndefined();
+  });
+
+  it('resolves a valid member project (member + id present)', () => {
+    mockUseSuspendedBackendaiClient.mockReturnValue(
+      clientWith(['alpha', 'beta'], { alpha: 'id-alpha', beta: 'id-beta' }),
+    );
+    mockUseMatches.mockReturnValue(matchWithProject('beta'));
+
+    const { result } = renderHook(() => useUrlProjectValidity());
+    expect(result.current.urlProjectName).toBe('beta');
+    expect(result.current.isInvalid).toBe(false);
+    expect(result.current.resolvedId).toBe('id-beta');
+    expect(result.current.groups).toEqual(['alpha', 'beta']);
+  });
+
+  it('is invalid for a project the user is not a member of', () => {
+    mockUseSuspendedBackendaiClient.mockReturnValue(
+      clientWith(['alpha'], { alpha: 'id-alpha' }),
+    );
+    mockUseMatches.mockReturnValue(matchWithProject('ghost'));
+
+    const { result } = renderHook(() => useUrlProjectValidity());
+    expect(result.current.urlProjectName).toBe('ghost');
+    expect(result.current.isInvalid).toBe(true);
+  });
+
+  it('is invalid for a member project whose id is missing', () => {
+    mockUseSuspendedBackendaiClient.mockReturnValue(clientWith(['alpha'], {}));
+    mockUseMatches.mockReturnValue(matchWithProject('alpha'));
+
+    const { result } = renderHook(() => useUrlProjectValidity());
+    expect(result.current.urlProjectName).toBe('alpha');
+    expect(result.current.isInvalid).toBe(true);
+    expect(result.current.resolvedId).toBeUndefined();
+  });
+
+  it('reads the DEEPEST match carrying a projectName param', () => {
+    mockUseSuspendedBackendaiClient.mockReturnValue(
+      clientWith(['outer', 'inner'], { outer: 'id-o', inner: 'id-i' }),
+    );
+    mockUseMatches.mockReturnValue([
+      { params: { projectName: 'outer' } },
+      { params: { projectName: 'inner' } },
+    ]);
+
+    const { result } = renderHook(() => useUrlProjectValidity());
+    expect(result.current.urlProjectName).toBe('inner');
+    expect(result.current.resolvedId).toBe('id-i');
+  });
+
+  it('tolerates a client without groups/groupIds fields', () => {
+    mockUseSuspendedBackendaiClient.mockReturnValue({});
+    mockUseMatches.mockReturnValue(matchWithProject('any'));
+
+    const { result } = renderHook(() => useUrlProjectValidity());
+    expect(result.current.isInvalid).toBe(true);
+    expect(result.current.groups).toEqual([]);
+  });
+});

--- a/react/src/hooks/useUrlProjectValidity.ts
+++ b/react/src/hooks/useUrlProjectValidity.ts
@@ -1,0 +1,67 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useSuspendedBackendaiClient } from '.';
+import { useMatches } from 'react-router-dom';
+
+interface BackendAIClientGroups {
+  groups?: string[];
+  groupIds?: Record<string, string>;
+}
+
+export interface UrlProjectValidity {
+  /**
+   * The `:projectName` URL param of the deepest matched route, already
+   * percent-decoded by react-router. `undefined` when the current URL is not
+   * under `/project/:projectName/*`.
+   */
+  urlProjectName?: string;
+  /**
+   * True when the URL names a project that does NOT resolve for the current
+   * user (not a member, or no resolvable id). Whether the project is missing
+   * or merely access-restricted is deliberately indistinguishable — the name
+   * is just a name. Always false outside project-scoped URLs.
+   */
+  isInvalid: boolean;
+  /** The resolved project id when the URL project is valid. */
+  resolvedId?: string;
+  /** All project names the current user belongs to. */
+  groups: string[];
+}
+
+/**
+ * Validates the `:projectName` segment of the current URL against the
+ * logged-in user's project membership. Single source of truth shared by
+ * `ProjectScopeLayout` (renders the "not found / no access" state),
+ * `PageAccessGuard` (must not decide 401 against an unresolvable project),
+ * and `ProjectAdminScopeAlert` (must not render for an unresolvable project).
+ *
+ * Reads the param via `useMatches` so it works from ancestors of the project
+ * route (e.g. MainLayout), where `useParams` cannot see child params.
+ */
+export const useUrlProjectValidity = (): UrlProjectValidity => {
+  'use memo';
+  const baiClient = useSuspendedBackendaiClient();
+  const matches = useMatches();
+
+  let urlProjectName: string | undefined;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const params = matches[i]?.params as
+      Record<string, string | undefined> | undefined;
+    if (params?.projectName) {
+      urlProjectName = params.projectName;
+      break;
+    }
+  }
+
+  const clientGroups = baiClient as unknown as BackendAIClientGroups;
+  const groups = clientGroups.groups ?? [];
+  const groupIds = clientGroups.groupIds ?? {};
+
+  const resolvedId = urlProjectName ? groupIds[urlProjectName] : undefined;
+  const isInvalid =
+    !!urlProjectName && !(groups.includes(urlProjectName) && !!resolvedId);
+
+  return { urlProjectName, isInvalid, resolvedId, groups };
+};

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -4,21 +4,13 @@
  */
 import { useSuspendedBackendaiClient } from '.';
 import WebUILink from '../components/WebUILink';
-import {
-  buildPath,
-  MENU_KEY_TO_SCOPE_FEATURE,
-  scopeFeatureToMenuKey,
-} from '../helper/pathBuilder';
+import { buildPath, MENU_KEY_TO_SCOPE_FEATURE } from '../helper/pathBuilder';
 import { useCurrentUserRole } from './backendai';
 import { useDiagnosticsBadgeSeverity } from './useAutoDiagnostics';
 import { useBAISettingUserState } from './useBAISetting';
 import { useEffectiveAdminRole } from './useCurrentUserProjectRoles';
 import { useCustomThemeConfig } from './useCustomThemeConfig';
-import {
-  getRouteScopeAndKey,
-  useActiveProjectName,
-  useCurrentMenuKey,
-} from './useRouteScope';
+import { useActiveProjectName, useCurrentMenuKey } from './useRouteScope';
 import {
   PluginPage,
   useWebUIPluginLoadedValue,
@@ -65,23 +57,6 @@ import {
 } from 'lucide-react';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
-
-// Mutable registry populated by routes.tsx at module initialization time.
-// Using mutable objects (Set / Array) means importers share the same reference
-// and see values added after their own import statement runs.
-export const ROUTER_STATIC_PATHS = new Set<string>();
-export const ROUTER_DYNAMIC_PATTERNS: RegExp[] = [];
-
-export function populateRouterPaths(
-  staticPaths: Set<string>,
-  dynamicPatterns: RegExp[],
-): void {
-  ROUTER_STATIC_PATHS.clear();
-  ROUTER_DYNAMIC_PATTERNS.length = 0;
-  staticPaths.forEach((p) => ROUTER_STATIC_PATHS.add(p));
-  dynamicPatterns.forEach((p) => ROUTER_DYNAMIC_PATTERNS.push(p));
-}
 
 export type MenuGroupName =
   | 'none'
@@ -277,7 +252,6 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   const currentUserRole = useCurrentUserRole();
   const effectiveAdminRole = useEffectiveAdminRole();
 
-  const location = useLocation();
   // Scope-aware current menu key (legacy hyphenated key, e.g. 'admin-session',
   // 'project-data', 'session'). Derived from the matched route `handle.menuKey`
   // (with a pathname-parse fallback) so it stays correct under the new
@@ -872,7 +846,7 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   // Check if current page is in blocklist.
   // `currentMenuKeyFromRoute` is the scope-aware legacy menu key (from the
   // matched route handle), so it equals the feature key for general pages and
-  // the hyphenated admin key for admin pages — exactly what `allValidPaths`,
+  // the hyphenated admin key for admin pages — exactly what
   // `ALL_ADMIN_PAGE_KEYS` and `PROJECT_ADMIN_PAGE_KEY_SET` are keyed on. Empty
   // (`''`) means "root / no feature matched" and is treated as always valid.
   const currentPathKey = currentMenuKeyFromRoute ?? '';
@@ -880,82 +854,6 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   // Root path '/' should not be blocked (it redirects to first available menu)
   const isCurrentPageBlocked =
     currentPathKey !== '' && _.includes(blockList, currentMenuKey);
-
-  // Compute all valid paths from menu items + plugins + static routes
-  const allValidPaths = (() => {
-    const paths = new Set<string>();
-
-    // Add paths from all menus
-    [generalMenu, adminMenu].forEach((menu) => {
-      menu?.forEach((item) => {
-        if (item && 'key' in item && item.key) {
-          paths.add(item.key as string);
-        }
-      });
-    });
-
-    // Add all admin page keys regardless of role, so they are treated as
-    // 401 (unauthorized) rather than 404 (not found) for unprivileged users.
-    ALL_ADMIN_PAGE_KEYS.forEach((key) => paths.add(key));
-
-    // Add plugin pages
-    plugins?.page?.forEach((page) => {
-      if (page?.url) {
-        paths.add(page.url);
-      }
-    });
-
-    // Add static routes from router configuration
-    ROUTER_STATIC_PATHS.forEach((route) => paths.add(route));
-
-    return paths;
-  })();
-
-  // Check if current page matches dynamic route patterns from router configuration
-  const fullPath = location.pathname.slice(1); // Remove leading '/'
-  const matchesDynamicRoute = ROUTER_DYNAMIC_PATTERNS.some((pattern) =>
-    pattern.test(fullPath),
-  );
-
-  // Check if current page is not found
-  // Only check after plugins are loaded to avoid false positives
-  const isCurrentPageNotFound = (() => {
-    // Root path is always valid (redirects to first available menu)
-    if (currentPathKey === '') return false;
-
-    // If plugins haven't loaded yet, assume page is valid to prevent flickering
-    if (!isPluginLoaded) return false;
-
-    // Scope-aware 404: under the `/admin/<feature>` and
-    // `/project/:name/<feature>` (incl. `/project/:name/admin/<feature>`)
-    // namespaces, a feature key that is valid in a *different* scope
-    // (e.g. `/admin/start` where `start` is a user feature, or
-    // `/project/x/agent` where `agent` is admin-only) matches no route and the
-    // scope subtree renders an empty <Outlet/>. Treat such cross-scope URLs as
-    // 404 instead of a blank page.
-    const { scope: pathScope, featureKey: pathFeatureKey } =
-      getRouteScopeAndKey(location.pathname);
-    const hasScopePrefix =
-      location.pathname.startsWith('/admin/') ||
-      location.pathname.startsWith('/project/');
-    if (
-      hasScopePrefix &&
-      pathFeatureKey &&
-      !scopeFeatureToMenuKey(pathScope, pathFeatureKey) &&
-      !matchesDynamicRoute &&
-      !plugins?.page?.some((page) => page?.url === pathFeatureKey)
-    ) {
-      return true;
-    }
-
-    // Check if path is in valid paths set
-    if (allValidPaths.has(currentPathKey)) return false;
-
-    // Check if path matches a dynamic route pattern
-    if (matchesDynamicRoute) return false;
-
-    return true;
-  })();
 
   // Check if current page requires higher permission than user has.
   // Uses static key sets (not role-filtered adminMenu) to ensure correct 401 responses.
@@ -1022,7 +920,6 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
     firstAvailableAdminMenuItem,
     defaultMenuPath,
     isCurrentPageBlocked,
-    isCurrentPageNotFound,
     isCurrentPageUnauthorized,
     isPluginLoaded,
     blockList,

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -68,10 +68,7 @@ export type MenuGroupName =
   | 'mlops';
 
 export type AdminMenuGroupName =
-  | 'none'
-  | 'admin-operations'
-  | 'admin-infrastructure'
-  | 'admin-system';
+  'none' | 'admin-operations' | 'admin-infrastructure' | 'admin-system';
 
 /**
  * Single source of truth for all valid menu keys.
@@ -161,7 +158,7 @@ const PROJECT_ADMIN_PAGE_KEYS = [
   'project-admin-session',
 ] as const;
 
-const PROJECT_ADMIN_PAGE_KEY_SET: ReadonlySet<string> = new Set(
+export const PROJECT_ADMIN_PAGE_KEY_SET: ReadonlySet<string> = new Set(
   PROJECT_ADMIN_PAGE_KEYS,
 );
 

--- a/react/src/pages/UnknownRoutePage.tsx
+++ b/react/src/pages/UnknownRoutePage.tsx
@@ -1,0 +1,40 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { getRouteScopeAndKey } from '../hooks/useRouteScope';
+import {
+  useWebUIPluginLoadedValue,
+  useWebUIPluginValue,
+} from '../hooks/useWebUIPluginState';
+import Page404 from './Page404';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Plugin-aware catch-all (`path: '*'`) element. With the scope subtrees each
+ * carrying their own wildcard, react-router matching IS the existence check —
+ * any URL that reaches this component matches no real route.
+ *
+ * Two cases are still not a 404:
+ *  - plugins have not finished loading (their pages have no React routes),
+ *    so render nothing to avoid a 404 flash on refresh;
+ *  - the feature segment IS a Lit plugin page — the legacy shell renders it,
+ *    so the React side must stay empty.
+ */
+const UnknownRoutePage = () => {
+  'use memo';
+  const location = useLocation();
+  const plugins = useWebUIPluginValue();
+  const isPluginLoaded = useWebUIPluginLoadedValue();
+
+  if (!isPluginLoaded) {
+    return null;
+  }
+  const { featureKey } = getRouteScopeAndKey(location.pathname);
+  if (featureKey && plugins?.page?.some((page) => page?.url === featureKey)) {
+    return null;
+  }
+  return <Page404 />;
+};
+
+export default UnknownRoutePage;

--- a/react/src/routeMatching.test.tsx
+++ b/react/src/routeMatching.test.tsx
@@ -1,0 +1,79 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Contract tests for router-owned 404 (FR-3279).
+ *
+ * The 404 decision now rests entirely on the SHAPE of the route tree:
+ * every scope subtree carries its own `path: '*'` catch-all, and the bare
+ * scope roots carry `index` redirects. That shape is invisible by
+ * inspection and regresses silently when routes are added or moved, so we
+ * pin it here with `matchRoutes` (the exact matcher the data router uses).
+ */
+import { mainLayoutChildRoutes } from './routes';
+import { matchRoutes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Renders the matched route chain as a readable signature, e.g.
+ * `project/:projectName > admin > *` or `admin > [index]`.
+ */
+const matchSignature = (pathname: string): string => {
+  const matches = matchRoutes(mainLayoutChildRoutes, pathname);
+  if (!matches) {
+    return 'NO_MATCH';
+  }
+  return matches
+    .map((m) => (m.route.index ? '[index]' : (m.route.path ?? '[pathless]')))
+    .join(' > ');
+};
+
+describe('scoped catch-alls own unknown URLs', () => {
+  it.each([
+    ['/admin/bogus', 'admin > *'],
+    ['/project/foo/bogus', 'project/:projectName > *'],
+    ['/project/foo/admin/bogus', 'project/:projectName > admin > *'],
+    // A known feature with unknown extra segments is unknown as a whole.
+    ['/project/foo/start/extra', 'project/:projectName > *'],
+    // Root catch-all still serves flat unknown (or Lit-plugin) URLs.
+    ['/bogus', '*'],
+  ])('%s -> %s', (pathname, expected) => {
+    expect(matchSignature(pathname)).toBe(expected);
+  });
+});
+
+describe('bare scope roots redirect via index routes', () => {
+  it.each([
+    ['/admin', 'admin > [index]'],
+    ['/project/foo', 'project/:projectName > [index]'],
+    ['/project/foo/admin', 'project/:projectName > admin > [index]'],
+  ])('%s -> %s', (pathname, expected) => {
+    expect(matchSignature(pathname)).toBe(expected);
+  });
+});
+
+describe('real routes still win over the catch-alls', () => {
+  it.each([
+    ['/admin/session', 'admin > session'],
+    ['/project/foo/start', 'project/:projectName > start'],
+    ['/project/foo/admin/session', 'project/:projectName > admin > session'],
+    ['/usersettings', '/usersettings'],
+  ])('%s -> %s', (pathname, expected) => {
+    expect(matchSignature(pathname)).toBe(expected);
+  });
+});
+
+describe('unicode project names match :projectName', () => {
+  it('matches a raw (unencoded) Korean project name', () => {
+    expect(matchSignature('/project/한글-프로젝트/session')).toBe(
+      'project/:projectName > session > [index]',
+    );
+  });
+
+  it('matches a percent-encoded Korean project name', () => {
+    expect(
+      matchSignature(`/project/${encodeURIComponent('한글 프로젝트')}/session`),
+    ).toBe('project/:projectName > session > [index]');
+  });
+});

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -14,6 +14,7 @@ import LoginView from './components/LoginView';
 import AdminScopeLayout from './components/MainLayout/AdminScopeLayout';
 import MainLayout from './components/MainLayout/MainLayout';
 import ProjectScopeLayout from './components/MainLayout/ProjectScopeLayout';
+import RouteErrorBoundary from './components/RouteErrorBoundary';
 import { STokenLoginBoundary } from './components/STokenLoginBoundary';
 import StorageHostFetchErrorBoundary from './components/StorageHostFetchErrorBoundary';
 import WebUINavigate from './components/WebUINavigate';
@@ -23,15 +24,13 @@ import { useAutoDiagnostics } from './hooks/useAutoDiagnostics';
 import { useBAISettingUserState } from './hooks/useBAISetting';
 import { LogoutEventHandler } from './hooks/useLogout';
 import { useSToken } from './hooks/useSToken';
-import {
-  useWebUIMenuItems,
-  populateRouterPaths,
-} from './hooks/useWebUIMenuItems';
+import { useWebUIMenuItems } from './hooks/useWebUIMenuItems';
 import { pluginApiEndpointState } from './hooks/useWebUIPluginState';
 import { AdminRedirect, ProjectScopedRedirect } from './legacyRedirects';
 // High priority to import the component
 import ComputeSessionListPage from './pages/ComputeSessionListPage';
 import Page404 from './pages/Page404';
+import UnknownRoutePage from './pages/UnknownRoutePage';
 import VFolderNodeListPage from './pages/VFolderNodeListPage';
 import { Skeleton, theme } from 'antd';
 import { BAIFlex, BAICard } from 'backend.ai-ui';
@@ -173,6 +172,9 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     path: 'project/:projectName',
     element: <ProjectScopeLayout />,
     children: [
+      // Router-owned 404: any URL unmatched within this scope falls here
+      // (plugin-aware — see UnknownRoutePage).
+      { path: '*', Component: UnknownRoutePage },
       {
         path: 'start',
         element: (
@@ -410,6 +412,9 @@ export const mainLayoutChildRoutes: RouteObject[] = [
       {
         path: 'admin',
         children: [
+          // Router-owned 404: any URL unmatched within this scope falls here
+          // (plugin-aware — see UnknownRoutePage).
+          { path: '*', Component: UnknownRoutePage },
           {
             path: 'session',
             Component: () => {
@@ -508,6 +513,9 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     path: 'admin',
     element: <AdminScopeLayout />,
     children: [
+      // Router-owned 404: any URL unmatched within this scope falls here
+      // (plugin-aware — see UnknownRoutePage).
+      { path: '*', Component: UnknownRoutePage },
       {
         path: 'session',
         element: (
@@ -1262,13 +1270,12 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     handle: { hideBreadcrumb: true },
     Component: Page404,
   },
-  // Catch-all route for unknown paths
-  // Returns empty element to allow Lit components to handle plugin pages.
-  // The PageAccessGuard in MainLayout checks if the current path is valid
-  // and shows Page404 for truly unknown paths after plugins are loaded.
+  // Router-owned 404: any path that matches no route above falls here.
+  // UnknownRoutePage waits for the plugin list and renders nothing for Lit
+  // plugin pages (they have no React routes); everything else is a real 404.
   {
     path: '*',
-    element: <></>,
+    Component: UnknownRoutePage,
   },
 ];
 
@@ -1521,121 +1528,13 @@ export const routes: RouteObject[] = [
         </DefaultProvidersForReactRoot>
       </BAIErrorBoundary>
     ),
-    children: mainLayoutChildRoutes,
+    children: [
+      {
+        // Pathless boundary: thrown Response errors (404/401/403) from pages
+        // or future loaders render INSIDE the shell via RouteErrorBoundary.
+        errorElement: <RouteErrorBoundary />,
+        children: mainLayoutChildRoutes,
+      },
+    ],
   },
 ];
-
-/**
- * Extract all valid route paths from the route configuration.
- * This includes both static paths and dynamic route patterns.
- */
-function extractRoutePaths(
-  routeObjects: RouteObject[],
-  parentPath = '',
-): { staticPaths: Set<string>; dynamicPatterns: RegExp[] } {
-  const staticPaths = new Set<string>();
-  const dynamicPatterns: RegExp[] = [];
-
-  for (const route of routeObjects) {
-    if (!route.path) {
-      // Index routes or routes without path
-      if (route.children) {
-        const childResult = extractRoutePaths(route.children, parentPath);
-        childResult.staticPaths.forEach((p) => staticPaths.add(p));
-        dynamicPatterns.push(...childResult.dynamicPatterns);
-      }
-      continue;
-    }
-
-    // Skip catch-all routes
-    if (route.path === '*') continue;
-
-    // Build full path
-    let fullPath = route.path;
-    if (!fullPath.startsWith('/') && parentPath) {
-      fullPath = `${parentPath}/${fullPath}`;
-    }
-    // Remove leading slash for consistency with currentPathKey comparison
-    const normalizedPath = fullPath.replace(/^\//, '');
-
-    // Check if path has dynamic segments (e.g., :id, :hostname)
-    if (normalizedPath.includes(':')) {
-      // Convert route pattern to regex
-      // e.g., "serving/:serviceId" -> /^serving\/[^/]+$/
-      // e.g., "chat/:id?" -> /^chat(\/[^/]+)?$/
-      const regexPattern = normalizedPath
-        .split('/')
-        .map((segment) => {
-          if (segment.startsWith(':') && segment.endsWith('?')) {
-            // Optional parameter (e.g., :id?)
-            return `(\\/[^/]+)?`;
-          }
-          if (segment.startsWith(':')) {
-            // Required parameter (e.g., :id)
-            return '[^/]+';
-          }
-          // Static segment
-          return segment;
-        })
-        .join('\\/');
-      dynamicPatterns.push(new RegExp(`^${regexPattern}$`));
-    } else {
-      // Static path - extract first segment for comparison
-      const firstSegment = normalizedPath.split('/')[0];
-      if (firstSegment) {
-        staticPaths.add(firstSegment);
-      }
-    }
-
-    // Recursively process children
-    if (route.children) {
-      const childResult = extractRoutePaths(route.children, fullPath);
-      childResult.staticPaths.forEach((p) => staticPaths.add(p));
-      dynamicPatterns.push(...childResult.dynamicPatterns);
-    }
-  }
-
-  return { staticPaths, dynamicPatterns };
-}
-
-// Populate the shared routerPaths registry so useWebUIMenuItems can read
-// valid paths without importing routes.tsx directly (which would create a
-// circular dependency: routes → useWebUIMenuItems → routes).
-//
-// IMPORTANT (scope-aware routing): the registry must contain the FEATURE
-// segment (e.g. `session`, `data`, `users`, `deployments/:deploymentId`), NOT
-// the scope prefix (`project`/`admin`). `useWebUIMenuItems` derives the current
-// feature/menu key via `useCurrentMenuKey()` (route handle) and validates it
-// against this registry, so feeding it the raw first segment (`project`/
-// `admin`) would break 404 detection. We therefore run `extractRoutePaths` over
-// the un-nested feature route arrays (relative paths == feature keys) plus the
-// legacy redirect shims (so old flat URLs remain "valid" during the transition).
-//
-// The feature route arrays are read back out of the inline `mainLayoutChildRoutes`
-// tree: the `project/:projectName` and `admin` scope subtrees' own `children`
-// (relative feature paths), and the legacy redirect shims that sit between the
-// `admin` subtree and the global `/usersettings` route.
-const projectScopeChildren =
-  mainLayoutChildRoutes.find((route) => route.path === 'project/:projectName')
-    ?.children ?? [];
-const adminScopeChildren =
-  mainLayoutChildRoutes.find((route) => route.path === 'admin')?.children ?? [];
-const legacyRedirectStartIndex =
-  mainLayoutChildRoutes.findIndex((route) => route.path === 'admin') + 1;
-const legacyRedirectEndIndex = mainLayoutChildRoutes.findIndex(
-  (route) => route.path === '/usersettings',
-);
-const legacyRedirectRoutes = mainLayoutChildRoutes.slice(
-  legacyRedirectStartIndex,
-  legacyRedirectEndIndex,
-);
-const staticPaths = new Set<string>();
-const dynamicPatterns: RegExp[] = [];
-[projectScopeChildren, adminScopeChildren, legacyRedirectRoutes].forEach(
-  (routeArray) => {
-    const result = extractRoutePaths(routeArray);
-    result.staticPaths.forEach((p) => staticPaths.add(p));
-    dynamicPatterns.push(...result.dynamicPatterns);
-  },
-);
-populateRouterPaths(staticPaths, dynamicPatterns);

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -174,7 +174,11 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     children: [
       // Router-owned 404: any URL unmatched within this scope falls here
       // (plugin-aware — see UnknownRoutePage).
-      { path: '*', Component: UnknownRoutePage },
+      {
+        path: '*',
+        handle: { hideBreadcrumb: true },
+        Component: UnknownRoutePage,
+      },
       {
         path: 'start',
         element: (
@@ -414,7 +418,11 @@ export const mainLayoutChildRoutes: RouteObject[] = [
         children: [
           // Router-owned 404: any URL unmatched within this scope falls here
           // (plugin-aware — see UnknownRoutePage).
-          { path: '*', Component: UnknownRoutePage },
+          {
+            path: '*',
+            handle: { hideBreadcrumb: true },
+            Component: UnknownRoutePage,
+          },
           {
             path: 'session',
             Component: () => {
@@ -515,7 +523,11 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     children: [
       // Router-owned 404: any URL unmatched within this scope falls here
       // (plugin-aware — see UnknownRoutePage).
-      { path: '*', Component: UnknownRoutePage },
+      {
+        path: '*',
+        handle: { hideBreadcrumb: true },
+        Component: UnknownRoutePage,
+      },
       {
         path: 'session',
         element: (
@@ -1275,6 +1287,7 @@ export const mainLayoutChildRoutes: RouteObject[] = [
   // plugin pages (they have no React routes); everything else is a real 404.
   {
     path: '*',
+    handle: { hideBreadcrumb: true },
     Component: UnknownRoutePage,
   },
 ];

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -23,8 +23,13 @@ import { useSuspendedBackendaiClient } from './hooks';
 import { useAutoDiagnostics } from './hooks/useAutoDiagnostics';
 import { useBAISettingUserState } from './hooks/useBAISetting';
 import { LogoutEventHandler } from './hooks/useLogout';
+import { useActiveProjectName } from './hooks/useRouteScope';
 import { useSToken } from './hooks/useSToken';
-import { useWebUIMenuItems } from './hooks/useWebUIMenuItems';
+import {
+  useWebUIMenuItems,
+  getPathFromMenuKey,
+  PROJECT_ADMIN_PAGE_KEY_SET,
+} from './hooks/useWebUIMenuItems';
 import { pluginApiEndpointState } from './hooks/useWebUIPluginState';
 import { AdminRedirect, ProjectScopedRedirect } from './legacyRedirects';
 // High priority to import the component
@@ -145,6 +150,53 @@ const DefaultMenuRedirect: React.FC = () => {
 };
 
 /**
+ * Index redirect for the bare scope roots `/admin` and
+ * `/project/:name/admin`: send the user to the first menu item valid in that
+ * scope, mirroring what `DefaultMenuRedirect` does for `/` (and for
+ * `/project/:name`, which reuses `DefaultMenuRedirect` directly since its
+ * target is the first *general* menu item).
+ */
+const ScopeIndexRedirect: React.FC<{ scope: 'admin' | 'projectAdmin' }> = ({
+  scope,
+}) => {
+  'use memo';
+  const { firstAvailableAdminMenuItem, defaultMenuPath } = useWebUIMenuItems();
+  const activeProjectName = useActiveProjectName();
+
+  if (scope === 'projectAdmin') {
+    // For project admins the first admin menu item IS a project-admin page.
+    // Super/domain admins carry no project-admin items in their menu (they
+    // see the global equivalents) but can access every project-admin page —
+    // send them to the first one in sider order. Users with no admin role
+    // land on it too and get the regular 401 from PageAccessGuard.
+    const key =
+      firstAvailableAdminMenuItem?.key &&
+      PROJECT_ADMIN_PAGE_KEY_SET.has(firstAvailableAdminMenuItem.key)
+        ? firstAvailableAdminMenuItem.key
+        : 'project-admin-users';
+    return (
+      <WebUINavigate to={getPathFromMenuKey(key, activeProjectName)} replace />
+    );
+  }
+
+  // `/admin`: first admin menu item reachable by the current user; users with
+  // no admin menu at all fall back to their general default page.
+  return (
+    <WebUINavigate
+      to={
+        firstAvailableAdminMenuItem?.key
+          ? getPathFromMenuKey(
+              firstAvailableAdminMenuItem.key,
+              activeProjectName,
+            )
+          : defaultMenuPath
+      }
+      replace
+    />
+  );
+};
+
+/**
  * MainLayout children routes - these are the actual page routes
  */
 export const mainLayoutChildRoutes: RouteObject[] = [
@@ -172,6 +224,9 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     path: 'project/:projectName',
     element: <ProjectScopeLayout />,
     children: [
+      // Bare `/project/:name` -> first available general menu item within
+      // this project (same behavior as the root `/` index).
+      { index: true, Component: DefaultMenuRedirect },
       // Router-owned 404: any URL unmatched within this scope falls here
       // (plugin-aware — see UnknownRoutePage).
       {
@@ -416,6 +471,8 @@ export const mainLayoutChildRoutes: RouteObject[] = [
       {
         path: 'admin',
         children: [
+          // Bare `/project/:name/admin` -> first project-admin menu item.
+          { index: true, element: <ScopeIndexRedirect scope="projectAdmin" /> },
           // Router-owned 404: any URL unmatched within this scope falls here
           // (plugin-aware — see UnknownRoutePage).
           {
@@ -521,6 +578,8 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     path: 'admin',
     element: <AdminScopeLayout />,
     children: [
+      // Bare `/admin` -> first admin menu item reachable by this user.
+      { index: true, element: <ScopeIndexRedirect scope="admin" /> },
       // Router-owned 404: any URL unmatched within this scope falls here
       // (plugin-aware — see UnknownRoutePage).
       {


### PR DESCRIPTION
Resolves #8207 (FR-3279)

Stacked on #7755 (FR-3057) ← #7751 (FR-3055).

## Summary

Move "does this page exist" from a hook-side path registry into the router itself, and add a route-level error boundary (Phase 1 + 3 of the route-error restructure in FR-3279; Phase 2 access-control restructuring is intentionally out of scope).

- **Router-owned 404**: add `{ path: '*', handle: { hideBreadcrumb: true }, Component: UnknownRoutePage }` catch-alls inside each scope subtree (`project/:projectName`, `project/:projectName/admin`, `admin`) and keep the root one. With every subtree carrying its own wildcard, react-router matching IS the existence check — no parallel registry to drift (the FR-3057 cross-scope 404 bug was exactly such a drift).
- **`UnknownRoutePage`** (new): plugin-aware catch-all — renders nothing until plugins finish loading (no 404 flash on refresh), renders nothing when the feature segment is a Lit plugin page (`PluginLoader` activates the element via the `useCurrentMenuKey()` featureKey fallback; the Lit element is a sibling of the router `<Outlet/>`), otherwise renders `Page404`.
- **`RouteErrorBoundary`** (new): react-router `errorElement` on a pathless route inside MainLayout, so thrown `Response` errors replace only the content area while the shell stays up: 404 → `Page404`, 401/403 → `Page401`, other statuses → generic `RouteErrorContent`. Accepts both loader/action-style `ErrorResponseImpl` and raw render-thrown `Response` (`isRouteErrorResponse` only recognizes the former), and **re-throws every non-Response error** so `BAIErrorBoundary` keeps ownership of generic render/Relay errors (retry/reset, expired-login re-login CTA, GraphQL detail in debug mode). Gives pages/loaders a sanctioned way to `throw new Response(null, { status })` and converge entity-level error states later.
- **Delete the parallel existence registry** (net −204 lines): `extractRoutePaths`, `populateRouterPaths`, `ROUTER_STATIC_PATHS`/`ROUTER_DYNAMIC_PATTERNS`, `isCurrentPageNotFound` (incl. the FR-3057 cross-scope special case — now handled naturally by route matching), and the now-unused `scopeFeatureToMenuKey`. `isCurrentPageUnauthorized` / `isCurrentPageBlocked` are untouched.

- **Bare scope roots redirect instead of rendering blank**: `/admin`, `/project/<name>`, `/project/<name>/admin` previously matched only the layout route (a `path: '*'` child does not match an empty remainder) and rendered an empty content area. Each scope subtree now carries an `index` redirect to the first menu item valid in that scope, mirroring the root `/` `DefaultMenuRedirect` behavior: `/project/<name>` → first general menu item (project preserved via `useActiveProjectName`); `/admin` → first admin menu item reachable by the user (general default page when the admin category is unreachable); `/project/<name>/admin` → first project-admin page (super/domain admins → `project-admin-users`; role-less users land there and get the regular 401).
- **`routeMatching.test.tsx`** (new): `matchRoutes` contract tests over `mainLayoutChildRoutes` pin the route-tree shape the 404 decision now rests on — scoped catch-alls own unknown URLs, index routes own bare scope roots, real routes still win, and unicode (Korean) project names match `:projectName` in both raw and percent-encoded form.

- **Uniform invalid-project state on project-admin pages** (`hooks/useUrlProjectValidity.ts`, new): when the URL names a project that doesn't resolve for the user, `/project/<bogus>/admin/*` now renders exactly what `/project/<bogus>/start` renders — the merged "not found or no access" `ProjectScopeErrorState`. `PageAccessGuard` defers (no 401 — the user's role can't be evaluated against an unknown project, and a 401/404 difference would leak project existence) and `ProjectAdminScopeAlert` is hidden above the error state. Policy recorded in FR-3383: page-level 401/404 stay distinct; entity-level states merge.

## Verification (after restack onto main @ 8eb825856)

- `bash scripts/verify.sh`: **ALL PASS** (Relay / Lint / Format / TypeScript / terminology)
- `pnpm --prefix react test`: **1009 tests pass** (54 files, incl. the new `routeMatching` contract tests)
- No stale references to the deleted APIs: grep for `scopeFeatureToMenuKey|populateRouterPaths|ROUTER_STATIC_PATHS|ROUTER_DYNAMIC_PATTERNS|isCurrentPageNotFound` over `react/src` + `e2e` returns nothing
