### PR TITLE
feat(FR-3281): show idle-checker column by default and fix remaining text

### DIFF
--- a/react/src/components/IdleCheckDescriptionModal.tsx
+++ b/react/src/components/IdleCheckDescriptionModal.tsx
@@ -16,7 +16,7 @@ const IdleCheckDescriptionModal: React.FC<IdleCheckDescriptionModalProps> = ({
 
   return (
     <BAIModal
-      title={t('session.IdleChecks')}
+      title={t('session.ReclamationStatus')}
       footer={null}
       width={700}
       {...modalProps}

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -387,7 +387,7 @@ const SessionDetailContent: React.FC<{
             <Descriptions.Item
               label={
                 <BAIFlex gap="xxs">
-                  {t('session.IdleChecks')}
+                  {t('session.ReclamationStatus')}
                   <Tooltip title={t('button.ClickForMoreDetails')}>
                     <QuestionCircleOutlined
                       style={{ cursor: 'pointer' }}

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -212,7 +212,6 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
       {
         key: 'reclamationStatus',
         title: t('session.ReclamationStatus'),
-        defaultHidden: true,
         render: (__, session) => (
           <SessionReclamationStatusCell sessionFrgmt={session} />
         ),


### PR DESCRIPTION
Resolves #8210 (FR-3281)

Follow-up to FR-3228 (#8101) on the `26.4.3` release maintenance branch.

## Changes

- **Show the reclamation status column by default** in the session list — removed `defaultHidden: true` from the `reclamationStatus` column in `SessionNodes.tsx`. Note: users who already customized column visibility keep their saved preference; the new default applies to fresh settings.
- **Align idle-checker labels with the column name** — the session detail drawer's description label and the detail modal title (opened via the `?` icon) used `session.IdleChecks` ("유휴 상태 검사"); both now reuse the existing `session.ReclamationStatus` key ("자원 수거 상태" / "Reclamation Status"), keeping the term consistent across all languages with no i18n file changes.

## Verification

- `tsc --noEmit` (react): pass
- `prettier --check` on changed files: pass
- ESLint via lint-staged pre-commit: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)