### PR TITLE
fix(FR-3282): migrate UserFolderPermissionPanelV2 filter to controlled renderInput contract

### DIFF
--- a/react/src/components/UserFolderPermissionPanelV2.tsx
+++ b/react/src/components/UserFolderPermissionPanelV2.tsx
@@ -146,18 +146,30 @@ const UserFolderPermissionPanelV2: React.FC<
               style={{ flex: 1 }}
               value={userFilter}
               onChange={setUserFilter}
+              // Re-picking a user replaces the existing condition instead of
+              // appending — `selectedUserId` is derived from the single
+              // `keypair.userId.equals` condition above.
+              singleCondition
               filterProperties={[
                 {
                   key: 'keypair.userId',
                   propertyLabel: t('storageHost.permission.User'),
                   type: 'uuid',
                   fixedOperator: 'equals',
-                  singleSelect: true,
-                  renderInput: ({ value, onChange }) => (
+                  renderInput: ({ onAddCondition }) => (
                     <BAIUserSelect
                       valuePropName="id"
-                      value={value}
-                      onChange={onChange}
+                      value={null}
+                      onChange={(value, option) =>
+                        // Single-select mode (no `mode` prop) always emits a
+                        // single value. Pass the option label (email) so the
+                        // condition tag stays human-readable while the UUID
+                        // serializes into the GraphQL filter.
+                        onAddCondition(
+                          value as string | undefined,
+                          option?.label,
+                        )
+                      }
                       style={{ minWidth: 200 }}
                     />
                   ),


### PR DESCRIPTION
Resolves #8212 (FR-3282)

## Summary

- **Symptom**: `main` failed the TypeScript check with 3 errors in `react/src/components/UserFolderPermissionPanelV2.tsx` — `singleSelect` does not exist on `FilterProperty`, and `value` / `onChange` do not exist on the `renderInput` props.
- **Root cause**: stacked PR #7940 (FR-3011, 2/2) was authored against an intermediate API of its parent PR #8082, where `FilterProperty` had a per-property `singleSelect` option and `renderInput` received `{ value, onChange }`. The parent's final merged API replaced these with a component-level `singleCondition` prop and a `renderInput` that receives `{ onAddCondition }`. #7940 merged after #8082 without restack verification, so `main` failed tsc.
- **Fix** (call-site-only migration, single file):
  - Added the component-level `singleCondition` prop to `<BAIGraphQLPropertyFilter>` so re-picking a user replaces the previous condition (preserving the old `singleSelect` semantics — the panel derives `selectedUserId` from the single `keypair.userId.equals` condition).
  - Removed `singleSelect: true` from the filter property.
  - Migrated `renderInput` to the documented controlled-commit pattern: `value={null}` keeps `BAIUserSelect` controlled and clears after each commit, and `onChange={(value, option) => onAddCondition(value as string | undefined, option?.label)}` passes the user's email as the label so the condition tag stays human-readable while the UUID serializes into the GraphQL filter. This matches the reference call sites (`AdminModelCardListPage.tsx`, `BAIGraphQLPropertyFilter.stories.tsx`).

## Verification

`bash scripts/verify.sh`:

```
=== Relay ===        --- Relay: PASS ---
=== Lint ===         --- Lint: PASS ---
=== Format ===       --- Format: PASS ---
=== TypeScript ===   --- TypeScript: PASS ---
```

The 3 target tsc errors are resolved. Note: the "Vite warmup paths" check fails identically on pristine `main` on macOS (the check's awk range uses `\s`, unsupported by BSD awk, so it scans past the warmup block and flags unrelated string literals in `vite.config.ts`). It is a pre-existing environmental issue unrelated to this change and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
