### PR TITLE
test: e2e auto-heal 2026-07-09

### DIFF
--- a/e2e/auto-scaling-rule-preset/preset-crud.spec.ts
+++ b/e2e/auto-scaling-rule-preset/preset-crud.spec.ts
@@ -15,10 +15,12 @@ async function createPreset(
 ): Promise<void> {
   await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
   await page.waitForLoadState('domcontentloaded');
-  await expect(page.getByRole('button', { name: /Add Preset/i })).toBeVisible({
+  await expect(
+    page.getByRole('button', { name: /Create Preset/i }),
+  ).toBeVisible({
     timeout: 60000,
   });
-  await page.getByRole('button', { name: /Add Preset/i }).click();
+  await page.getByRole('button', { name: /Create Preset/i }).click();
   // In this version of Ant Design, .ant-modal itself has role="dialog"
   const modal = page.getByRole('dialog');
   await expect(modal).toBeVisible();
@@ -84,9 +86,9 @@ test.describe(
         page.getByRole('combobox', { name: 'Search' }),
       ).toBeVisible();
 
-      // Verify the "Add Preset" button is visible
+      // Verify the "Create Preset" button is visible
       await expect(
-        page.getByRole('button', { name: /Add Preset/i }),
+        page.getByRole('button', { name: /Create Preset/i }),
       ).toBeVisible();
 
       // Verify the refresh (reload) button is visible
@@ -168,8 +170,8 @@ test.describe(
       // Navigate to the prometheus preset tab
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
 
-      // Click the "Add Preset" button
-      await page.getByRole('button', { name: /Add Preset/i }).click();
+      // Click the "Create Preset" button
+      await page.getByRole('button', { name: /Create Preset/i }).click();
 
       // Verify the modal opens with title "Create Preset"
       // In this version of Ant Design, .ant-modal itself has role="dialog"
@@ -226,8 +228,8 @@ test.describe(
       // Navigate to the prometheus preset tab
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
 
-      // Click the "Add Preset" button
-      await page.getByRole('button', { name: /Add Preset/i }).click();
+      // Click the "Create Preset" button
+      await page.getByRole('button', { name: /Create Preset/i }).click();
       // In this version of Ant Design, .ant-modal itself has role="dialog"
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();
@@ -278,9 +280,9 @@ test.describe(
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
       await page.waitForLoadState('domcontentloaded');
       await expect(
-        page.getByRole('button', { name: /Add Preset/i }),
+        page.getByRole('button', { name: /Create Preset/i }),
       ).toBeVisible({ timeout: 60000 });
-      await page.getByRole('button', { name: /Add Preset/i }).click();
+      await page.getByRole('button', { name: /Create Preset/i }).click();
       // In this version of Ant Design, .ant-modal itself has role="dialog"
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();
@@ -360,7 +362,7 @@ test.describe(
     }) => {
       // Navigate and open modal
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
-      await page.getByRole('button', { name: /Add Preset/i }).click();
+      await page.getByRole('button', { name: /Create Preset/i }).click();
       // In this version of Ant Design, .ant-modal itself has role="dialog"
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();
@@ -390,7 +392,7 @@ test.describe(
     }) => {
       // Navigate and open modal
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
-      await page.getByRole('button', { name: /Add Preset/i }).click();
+      await page.getByRole('button', { name: /Create Preset/i }).click();
       // In this version of Ant Design, .ant-modal itself has role="dialog"
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();
@@ -420,7 +422,7 @@ test.describe(
     }) => {
       // Navigate and open modal
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
-      await page.getByRole('button', { name: /Add Preset/i }).click();
+      await page.getByRole('button', { name: /Create Preset/i }).click();
       // In this version of Ant Design, .ant-modal itself has role="dialog"
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();
@@ -462,9 +464,9 @@ test.describe(
       await expect(paginationInfo).toBeVisible({ timeout: 60000 });
       // Open modal and fill fields
       await expect(
-        page.getByRole('button', { name: /Add Preset/i }),
+        page.getByRole('button', { name: /Create Preset/i }),
       ).toBeVisible({ timeout: 60000 });
-      await page.getByRole('button', { name: /Add Preset/i }).click();
+      await page.getByRole('button', { name: /Create Preset/i }).click();
       // In this version of Ant Design, .ant-modal itself has role="dialog"
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();
@@ -506,7 +508,7 @@ test.describe(
       ).toBeVisible({ timeout: 60000 });
 
       // Attempt to create second preset with same name
-      await page.getByRole('button', { name: /Add Preset/i }).click();
+      await page.getByRole('button', { name: /Create Preset/i }).click();
       // In this version of Ant Design, .ant-modal itself has role="dialog"
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();

--- a/e2e/auto-scaling-rule-preset/preset-filter-sort.spec.ts
+++ b/e2e/auto-scaling-rule-preset/preset-filter-sort.spec.ts
@@ -15,10 +15,12 @@ async function createPreset(
 ): Promise<void> {
   await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
   await page.waitForLoadState('domcontentloaded');
-  await expect(page.getByRole('button', { name: /Add Preset/i })).toBeVisible({
+  await expect(
+    page.getByRole('button', { name: /Create Preset/i }),
+  ).toBeVisible({
     timeout: 60000,
   });
-  await page.getByRole('button', { name: /Add Preset/i }).click();
+  await page.getByRole('button', { name: /Create Preset/i }).click();
   const modal = page.getByRole('dialog');
   await expect(modal).toBeVisible();
   const nameInput = modal.getByRole('textbox', { name: 'Name', exact: true });
@@ -38,7 +40,9 @@ async function createPreset(
 async function deletePreset(page: Page, presetName: string): Promise<void> {
   await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
   await page.waitForLoadState('domcontentloaded');
-  await expect(page.getByRole('button', { name: /Add Preset/i })).toBeVisible({
+  await expect(
+    page.getByRole('button', { name: /Create Preset/i }),
+  ).toBeVisible({
     timeout: 60000,
   });
   const row = page.getByRole('row').filter({ hasText: presetName });
@@ -120,7 +124,7 @@ test.describe(
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
       await page.waitForLoadState('domcontentloaded');
       await expect(
-        page.getByRole('button', { name: /Add Preset/i }),
+        page.getByRole('button', { name: /Create Preset/i }),
       ).toBeVisible({ timeout: 60000 });
 
       // Apply name filter using the unique timestamp part
@@ -149,7 +153,7 @@ test.describe(
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
       await page.waitForLoadState('domcontentloaded');
       await expect(
-        page.getByRole('button', { name: /Add Preset/i }),
+        page.getByRole('button', { name: /Create Preset/i }),
       ).toBeVisible({ timeout: 60000 });
 
       // Apply a filter guaranteed not to match any preset
@@ -177,7 +181,7 @@ test.describe(
       await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
       await page.waitForLoadState('domcontentloaded');
       await expect(
-        page.getByRole('button', { name: /Add Preset/i }),
+        page.getByRole('button', { name: /Create Preset/i }),
       ).toBeVisible({ timeout: 60000 });
 
       // Apply a non-matching filter so the table shows 0 results

--- a/e2e/auto-scaling-rule-preset/preset-table-settings.spec.ts
+++ b/e2e/auto-scaling-rule-preset/preset-table-settings.spec.ts
@@ -15,10 +15,12 @@ async function createPreset(
 ): Promise<void> {
   await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
   await page.waitForLoadState('domcontentloaded');
-  await expect(page.getByRole('button', { name: /Add Preset/i })).toBeVisible({
+  await expect(
+    page.getByRole('button', { name: /Create Preset/i }),
+  ).toBeVisible({
     timeout: 60000,
   });
-  await page.getByRole('button', { name: /Add Preset/i }).click();
+  await page.getByRole('button', { name: /Create Preset/i }).click();
   const modal = page.getByRole('dialog');
   await expect(modal).toBeVisible();
   const nameInput = modal.getByRole('textbox', { name: 'Name', exact: true });
@@ -38,7 +40,9 @@ async function createPreset(
 async function deletePreset(page: Page, presetName: string): Promise<void> {
   await page.goto(`${webuiEndpoint}/admin-serving?tab=prometheus-preset`);
   await page.waitForLoadState('domcontentloaded');
-  await expect(page.getByRole('button', { name: /Add Preset/i })).toBeVisible({
+  await expect(
+    page.getByRole('button', { name: /Create Preset/i }),
+  ).toBeVisible({
     timeout: 60000,
   });
   const row = page.getByRole('row').filter({ hasText: presetName });

--- a/e2e/global-cleanup.teardown.ts
+++ b/e2e/global-cleanup.teardown.ts
@@ -111,10 +111,14 @@ async function safeSweep(
 test.describe('Global e2e cleanup', () => {
   // The sweep may have to trash + delete-forever several leftover folders, each
   // a multi-step navigate/filter/confirm flow, and a stuck folder now fails its
-  // action at the 30s actionTimeout before being skipped. Give the cleanup more
-  // room than the default 180s so it can drain a backlog instead of timing out
-  // mid-sweep and leaving the rest behind.
-  test.describe.configure({ timeout: 300_000 });
+  // action at the 30s actionTimeout before being skipped. `sweepVFolders` bounds
+  // itself to `maxIterations` (default 20) per phase, but on a large backlog
+  // (up to 20 Active + 20 Trash iterations, each a full navigate/verify round
+  // trip) the 300s budget can still be exhausted mid-sweep, leaving the rest of
+  // the backlog behind. Give the cleanup more headroom than the default 180s
+  // (and the previous 300s) so it can drain a larger backlog instead of timing
+  // out mid-sweep.
+  test.describe.configure({ timeout: 600_000 });
 
   test('sweep leftover e2e vfolders (user)', async ({ page, request }) => {
     await loginAsUser(page, request);


### PR DESCRIPTION
Automated draft PR produced by the **daily webui digest auto-heal** run (2026-07-09).

## What happened
The digest e2e run (scope: `auto-scaling-rule-preset`) had 24 failures. Triage classified all of them as **HEAL** (test-side drift, no app regression):

- **21 failures** — stale locator `getByRole('button', { name: /Add Preset/i })`: the button label was renamed to **"Create Preset"** in `react/src/components/PrometheusPresetTab.tsx` by #8118 (FR-3244, unify admin create-button labels). Updated the locator in `preset-crud.spec.ts`, `preset-filter-sort.spec.ts`, and `preset-table-settings.spec.ts` (including each file's local `createPreset`/`deletePreset` helpers).
- **2 failures** — `global-cleanup.teardown.ts` sweep tests hitting the 300s test timeout while iterating a large leftover-vfolder backlog. Raised the teardown timeout to 600s (minimal, test-side-only mitigation).

## Verification
Re-ran the affected specs: **32 passed, 1 skipped (pre-existing `test.fixme()`), 0 failed.** Both teardown sweeps completed inside the new budget (7.5m / 8.0m).

## Healed vs exhausted
- Healed: 24/24 triaged failures (all previously-failing tests re-pass)
- Retry budget exhausted: none

## Notes
- `preset-integration.spec.ts` also contains the stale `/Add Preset/i` locator (lines 55, 358) but its tests were skipped in this run and it was outside the HEAL list — left untouched (follow-up candidate).
- Report doc: `/home/ubuntu/e2e-digest-reports/report-2026-07-09.md` (digest host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)