### PR TITLE
chore(FR-3292): migrate .claude commands to skills with disable-model-invocation

### DIFF
--- a/.claude/skills/bump-alpha-version/SKILL.md
+++ b/.claude/skills/bump-alpha-version/SKILL.md
@@ -1,7 +1,9 @@
 ---
+name: bump-alpha-version
 description: Bump version to next alpha and update dependencies after release.
 argument-hint: [26.1.0-alpha.0]
 model: sonnet
+disable-model-invocation: true
 ---
 
 # Bump to Alpha Version and Update Dependencies

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: create-release
+description: Create a release branch, tag, and GitHub release for Backend.AI WebUI.
+argument-hint: "[26.4.0 | 26.4.0-alpha.1 | 26.4.0-beta.0]"
+model: sonnet
+disable-model-invocation: true
+---
+
 # Create Release
 
 Create a release branch, tag, and GitHub release for Backend.AI WebUI.

--- a/.claude/skills/enhance-component-docs/SKILL.md
+++ b/.claude/skills/enhance-component-docs/SKILL.md
@@ -1,5 +1,9 @@
 ---
+name: enhance-component-docs
+description: Enhance React component documentation with JSDoc, improved Storybook stories, and autodoc configuration.
+argument-hint: "<component-files...>"
 model: sonnet
+disable-model-invocation: true
 ---
 
 # Enhance Component Documentation

--- a/.claude/skills/manage-bui-component-story/SKILL.md
+++ b/.claude/skills/manage-bui-component-story/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: manage-bui-component-story
 description: Create or Update BUI Component Story (project)
 model: sonnet
+disable-model-invocation: true
 ---
 
 # Create or Update BUI Component Story

--- a/.claude/skills/update-storybook-autodoc/SKILL.md
+++ b/.claude/skills/update-storybook-autodoc/SKILL.md
@@ -1,5 +1,9 @@
 ---
+name: update-storybook-autodoc
+description: Update React components with JSDoc and enhanced Storybook stories with autodoc functionality.
+argument-hint: "<component-path>"
 model: sonnet
+disable-model-invocation: true
 ---
 
 # Update Storybook with Autodoc


### PR DESCRIPTION
Resolves #8217 (FR-3292)

## What

Migrates all five `.claude/commands/*.md` slash commands into Skills at `.claude/skills/<name>/SKILL.md`.

Claude Code now unifies slash commands and skills. Skills honor the same frontmatter these commands relied on (`model`, `argument-hint`, `description`, arguments) **plus** `disable-model-invocation`, so behavior is preserved: each remains invocable as `/<name>`, but the model no longer auto-triggers them.

## Migrated (all `disable-model-invocation: true`)

All five are deliberate, human-initiated release / storybook-generation workflows, so none should be auto-invoked by the model:

| Skill | Was |
|---|---|
| `bump-alpha-version` | `/bump-alpha-version` |
| `create-release` | `/create-release` |
| `enhance-component-docs` | `/enhance-component-docs` |
| `manage-bui-component-story` | `/manage-bui-component-story` |
| `update-storybook-autodoc` | `/update-storybook-autodoc` |

## Notes

- Command bodies are preserved verbatim; only frontmatter changed (added `name:`, added `disable-model-invocation: true`; `create-release` and the two docs commands that lacked a `description`/frontmatter got one).
- `.claude/commands/` is now empty and removed.
- The `/manage-bui-component-story` reference in `.github/workflows/storybook-coverage-checker.md` still resolves — slash invocation of a skill uses the same `/<name>` form.
- Companion PR migrates the `fw` plugin's 29 commands on `lablup/claude-mp` (same FR-3292).

🤖 Generated with [Claude Code](https://claude.com/claude-code)