### PR TITLE
fix(FR-3294): make deployment revision e2e specs self-provision their fixtures

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-07-07
+> **Last Updated:** 2026-07-09
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -48,7 +48,8 @@
 | Plugin System            | (config-based)                         |    12    |   12    | ✅ 100% |
 | RBAC Management          | `/rbac`                                |    22    |   21    | 🔶 95%  |
 | Auto Scaling Rule Preset | `/admin-serving?tab=auto-scaling-rule` |    33    |   32    | 🔶 97%  |
-| **Total**                |                                        | **452**  | **307** | **68%** |
+| Deployments              | `/deployments`, `/deployments/:id`     |    16    |   12    | 🔶 75%  |
+| **Total**                |                                        | **468**  | **319** | **68%** |
 
 ---
 
@@ -1104,6 +1105,57 @@
 
 ---
 
+### 30. Deployments (`/deployments`, `/deployments/:id`)
+
+**Test files:** [`e2e/serving/deployment-lifecycle.spec.ts`](serving/deployment-lifecycle.spec.ts), [`e2e/serving/deployment-access-token.spec.ts`](serving/deployment-access-token.spec.ts)
+
+**Requires:** Superadmin login; `deployment-preset` feature flag (manager ≥ 26.4.x) for the revision-attach and access-token tests (they skip with an auditable reason otherwise), plus at least one `bai/ngc-pytorch` or python image. No hand-seeded preset or folder is required — [`e2e/utils/deployment-fixtures.ts`](utils/deployment-fixtures.ts) self-provisions the preset (find-or-create) and model folder per run.
+**Primary action:** "Create Deployment" → detail page → "Add Revision" (`Preset` / `Advanced` mode)
+
+#### List Page
+
+| Feature                                                                   | Status | Test                                                                     |
+| ------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------ |
+| List columns, Running/Terminated toggle, reload & Create controls         | ✅     | `Admin can view the deployments list with expected columns and controls` |
+| Create deployment (defaults, auto-redirect) + typed-name permanent delete | ✅     | `Admin can create a new deployment and permanently delete it`            |
+
+#### Detail Page
+
+| Feature                                                                                                            | Status | Test                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------- |
+| Basic Information card, revision tabs, Replicas / Auto-scaling sections, Access Tokens disabled without a revision | ✅     | `Admin can view the Basic Information and empty-state sections of a newly created deployment` |
+| Edit deployment — Desired Replicas save persists; Cancel does not                                                  | ✅     | `Admin can update a deployment's Desired Replicas via the Edit modal`                         |
+| Revision History tab — URL tab param, filter, table structure, empty state                                         | ✅     | `Admin can view the Revision History tab structure`                                           |
+
+#### Add Revision Modal
+
+| Feature                                                        | Status | Test                                                                  |
+| -------------------------------------------------------------- | ------ | --------------------------------------------------------------------- |
+| Preset Mode field set renders                                  | ✅     | `Admin can view Preset Mode fields in the Add Revision modal`         |
+| Advanced Mode field set renders                                | ✅     | `Admin can view Advanced Mode fields in the Add Revision modal`       |
+| Add revision in Preset Mode (found-or-created preset + folder) | ✅     | `Admin can add a revision in Preset Mode and see it attached`         |
+| Add revision manually in Advanced Mode (no preset)             | ✅     | `Admin can add a revision manually in Advanced Mode without a preset` |
+
+#### Auto-scaling
+
+| Feature                                           | Status | Test                                                    |
+| ------------------------------------------------- | ------ | ------------------------------------------------------- |
+| Add Auto Scaling Rule modal field set renders     | ✅     | `Admin can view the Add Auto Scaling Rule modal fields` |
+| Create + delete an auto-scaling rule (`cpu_util`) | ✅     | `Admin can create and then delete an auto-scaling rule` |
+
+#### Access Tokens
+
+| Feature                                                                            | Status | Test                                                                                                                     |
+| ---------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
+| Create Access Token disabled without a revision → enabled after one → token issued | ✅     | `Admin can issue an access token after adding a revision to a deployment`                                                |
+| Issued token appears as a table row / revoke                                       | ❌     | Deferred — list-refresh is non-deterministic while the deployment is still Deploying; belongs to backend-surface testing |
+| Replica scheduling completion (Lifecycle leaves Pending → replica scheduled)       | ❌     | Deferred — measured ~40s–20min+ on the shared cluster; out of scope for webui e2e                                        |
+| Revision rollback / promote from Revision History                                  | ❌     | -                                                                                                                        |
+
+**Coverage: 🔶 12/16 features (4 deferred to backend-surface testing or future work)**
+
+---
+
 ## Visual Regression Tests
 
 Visual regression tests exist for most pages but only capture screenshots, not functional behavior.
@@ -1220,6 +1272,7 @@ To efficiently build new E2E tests, these POMs should be created:
 | `/serving/:serviceId`                  |        🔶        |      ❌      |    P3    |
 | `/service/start`                       |        ❌        |      ❌      |  **P1**  |
 | `/service/update/:endpointId`          |        ❌        |      ❌      |    P3    |
+| `/deployments`, `/deployments/:id`     |        🔶        |      ❌      |    -     |
 | `/data`                                |        🔶        |      ✅      |    P2    |
 | `/model-store`                         |        ❌        |      ❌      |    P3    |
 | `/storage-settings/:hostname`          |        ❌        |      ❌      |    P3    |

--- a/e2e/global-cleanup.teardown.ts
+++ b/e2e/global-cleanup.teardown.ts
@@ -22,11 +22,16 @@
  * dot-prefixed auto-mount folder, etc.). Broad matching is safe HERE — unlike in
  * a per-test `sweepVFolders` call — because the teardown runs after every other
  * project has finished, so no parallel test owns a live `e2e-*` folder.
+ *
+ * It also purges any leftover `e2e-*` fixture user and `e2e-plan-*` /
+ * `e2e-token-*` deployment via the admin GraphQL API (no browser UI involved),
+ * so those sweeps cannot fail the same way a per-test UI-based cleanup can.
  */
 import {
   createAdminApiContext,
   listUsersByPattern,
   purgeUserViaApi,
+  sweepLeftoverDeploymentsViaApi,
 } from './utils/admin-api';
 import { sweepServices, sweepVFolders } from './utils/cleanup-util';
 import { loginAsAdmin, loginAsUser } from './utils/test-util';
@@ -63,6 +68,28 @@ async function sweepLeftoverE2EUsers(): Promise<void> {
     if (purged > 0) {
       console.log(`[global-cleanup] purged ${purged} leftover e2e-* user(s).`);
     }
+  } finally {
+    await api.dispose();
+  }
+}
+
+/**
+ * Belt-and-suspenders deployment sweep. deployment-lifecycle.spec.ts and
+ * deployment-access-token.spec.ts name their throwaway shells `e2e-plan-*` /
+ * `e2e-token-*`, which neither sweepServices' `/e2e-svc-/` nor sweepVFolders'
+ * `/e2e-/` folder pattern matches — deployments were the one e2e-provisioned
+ * resource this teardown didn't cover. Each spec's own `cleanupDeploymentSafely`
+ * (a UI-delete flow) is the primary cleanup path, but it can fail for the same
+ * reason the test body already failed (e.g. mid-modal, a stuck locator),
+ * leaking a `PENDING` deployment with no other backstop. This purges any
+ * leftover via the admin GraphQL API instead of the UI, so it cannot fail the
+ * same way. API-based, so it does not use `page`; guard it directly (like
+ * sweepLeftoverE2EUsers) so a failure never reds the run.
+ */
+async function sweepLeftoverDeployments(): Promise<void> {
+  const api = await createAdminApiContext();
+  try {
+    await sweepLeftoverDeploymentsViaApi(api);
   } finally {
     await api.dispose();
   }
@@ -118,6 +145,17 @@ test.describe('Global e2e cleanup', () => {
       await sweepLeftoverE2EUsers();
     } catch (error) {
       console.warn('[global-cleanup] user sweep failed (ignored):', error);
+    }
+    // Purge any e2e-plan-*/e2e-token-* deployment a per-spec afterEach failed
+    // to reap. API-based, so it does not use `page`; guard it directly so a
+    // failure never reds the run.
+    try {
+      await sweepLeftoverDeployments();
+    } catch (error) {
+      console.warn(
+        '[global-cleanup] deployment sweep failed (ignored):',
+        error,
+      );
     }
   });
 });

--- a/e2e/serving/deployment-access-token.spec.ts
+++ b/e2e/serving/deployment-access-token.spec.ts
@@ -1,0 +1,256 @@
+// spec: e2e/.agent-output/test-plan-e2e-coverage-gaps.md
+//
+// Coverage gap this file fills: deployment-lifecycle.spec.ts only verifies
+// that "Create Access Token" is disabled when a deployment has no revision.
+// This file covers the rest of the Access Token issuance path: the button
+// becoming enabled once a revision is attached, the "Create Access Token"
+// modal's contents, and actually issuing a token (verified via the returned
+// "Token" result dialog).
+//
+// Design notes from live investigation:
+// 1. This test deliberately creates and tears down only ONE deployment
+//    (with one revision attached), doing the full disabled -> enabled ->
+//    open modal -> issue token -> verify-result flow inside a single test,
+//    rather than splitting into multiple tests that would each need their
+//    own revision. Adding a revision is a real scheduling operation on the
+//    shared QA cluster, so this minimizes how many times that happens.
+// 2. The test issues a real token and verifies the manager returned it (the
+//    "Token" result dialog shows the token value + expiration). It does NOT
+//    then assert the token appears as a row in the Access Tokens table, nor
+//    revoke it: live investigation found the manager mints the token
+//    synchronously (the result dialog is reliable) but the list-view refresh
+//    that surfaces the new row does not populate deterministically while the
+//    deployment is still "Deploying" -- the table stayed on "No data" past
+//    the token's creation across repeated runs, the same cluster-scheduling
+//    -latency characteristic documented in deployment-lifecycle.spec.ts.
+//    See the detailed comment at that step. List-refresh timing and revoke
+//    are better covered by backend-surface tests (auto-tester) than this UI
+//    e2e; the throwaway deployment (and its token) is destroyed in cleanup.
+// 3. Per the task brief, clicking the "Create Access Token" button uses
+//    `dispatchEvent('click')` instead of a plain `.click()` -- investigation
+//    found this button can sit underneath an overlapping
+//    `.ant-descriptions-item-content` <td> from the Basic Information card
+//    above it, which fails both a plain `.click()` and `.click({ force:
+//    true })` with "subtree intercepts pointer events". `dispatchEvent`
+//    fires the click directly on the button, bypassing hit-testing
+//    entirely, so it is unaffected by that overlap regardless of timing.
+// 4. Adding a revision auto-opens a "Revision Detail" dialog. This test
+//    closes it explicitly before interacting with "Create Access Token" --
+//    both because that dialog's mask would otherwise block the click, and
+//    to avoid the modal query below matching more than one open dialog.
+//    Every dialog assertion is still scoped by exact accessible name
+//    (`getByRole('dialog', { name: 'Create Access Token' })`, etc.) as a
+//    second layer of disambiguation.
+// 5. This test does not wait for replica scheduling (which can take
+//    anywhere from ~40s to over 20 minutes on this shared cluster, per
+//    deployment-lifecycle.spec.ts's investigation) -- it deletes the
+//    deployment immediately after verifying the token flow.
+import {
+  cleanupDeploymentFixtures,
+  cleanupDeploymentSafely,
+  createDeploymentShell,
+  deleteDeploymentAndVerify,
+  type DeploymentFixtures,
+  provisionDeploymentFixtures,
+  selectRevisionModalOption,
+} from '../utils/deployment-fixtures';
+import { skipUnlessClientFeature } from '../utils/feature-gate-util';
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Adds a revision using the fixtures pair from utils/deployment-fixtures.ts
+ * (a found-or-created GPU-free preset + a freshly provisioned model folder;
+ * see deployment-lifecycle.spec.ts's header comment for why a hand-seeded
+ * fixture pair cannot be assumed). Both dropdowns are selected via search +
+ * keyboard Enter because their virtualized option rows render with a
+ * computed width of 0 and are not clickable -- the full investigation lives
+ * on selectRevisionModalOption.
+ */
+async function addProvisionedRevision(
+  page: Page,
+  fixtures: DeploymentFixtures,
+): Promise<void> {
+  await page
+    .getByRole('tablist')
+    .getByRole('button', { name: 'Add Revision' })
+    .click();
+  const dialog = page.getByRole('dialog', { name: /Add Revision/ });
+  await expect(dialog).toBeVisible({ timeout: 20000 });
+
+  await selectRevisionModalOption(
+    page,
+    '#revisionPresetId',
+    fixtures.presetName,
+  );
+  await selectRevisionModalOption(page, '#modelFolderId', fixtures.folderName);
+
+  await expect(
+    dialog.getByRole('checkbox', { name: 'Apply immediately after adding' }),
+  ).toBeChecked();
+  await dialog.getByRole('button', { name: 'Add Revision' }).click();
+  await expect(dialog).toBeHidden({ timeout: 20000 });
+
+  // Adding a revision auto-opens a "Revision Detail" dialog; close it so it
+  // doesn't block (or ambiguously match against) the next interaction.
+  const revisionDetailDialog = page.getByRole('dialog', {
+    name: 'Revision Detail',
+  });
+  await expect(revisionDetailDialog).toBeVisible({ timeout: 10000 });
+  await revisionDetailDialog.getByRole('button', { name: 'Close' }).click();
+  await expect(revisionDetailDialog).toBeHidden({ timeout: 10000 });
+}
+
+test.describe(
+  'Deployment Access Token Modal',
+  { tag: ['@regression', '@serving', '@functional'] },
+  () => {
+    let createdDeploymentName: string | null = null;
+    let fixtures: DeploymentFixtures | null = null;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      // Deployment first — its revision references the provisioned fixtures.
+      if (createdDeploymentName) {
+        await cleanupDeploymentSafely(page, createdDeploymentName);
+        createdDeploymentName = null;
+      }
+      if (fixtures) {
+        await cleanupDeploymentFixtures(page, fixtures);
+        fixtures = null;
+      }
+    });
+
+    test(
+      'Admin can issue an access token after adding a revision to a deployment',
+      { tag: ['@critical'] },
+      async ({ page }) => {
+        // 360s covers fixture provisioning (model folder + upload + preset
+        // mutation), the revision + token flow, and teardown including
+        // fixture cleanup.
+        test.setTimeout(360_000);
+        const deploymentName = `e2e-token-${Date.now()}`;
+
+        // 0. Ensure the preset + model folder pair the Add Revision flow
+        // selects (a compatible pre-existing preset is reused when the
+        // cluster has one, created otherwise -- no hand-seeded fixture is
+        // assumed either way), gated on the same capability flag the UI
+        // checks.
+        // NOTE: this provisioning (folder create + fixture upload) is the
+        // same heavy /data + storage path that deployment-lifecycle.spec.ts
+        // serializes between its own two revision tests. Cross-FILE overlap
+        // with that spec's provisioning is still possible under local
+        // multi-worker runs and can slow both sides' list/upload waits; CI
+        // runs single-worker (playwright.config.ts), where this cannot
+        // happen.
+        await skipUnlessClientFeature(
+          page,
+          'deployment-preset',
+          "Adding a revision from a preset requires the 'deployment-preset' capability (manager >= 26.4.x)",
+        );
+        fixtures = await provisionDeploymentFixtures(page);
+
+        // 1. Navigate to /deployments and create a deployment shell.
+        await navigateTo(page, 'deployments');
+        await createDeploymentShell(page, deploymentName);
+        createdDeploymentName = deploymentName;
+
+        // 2. Verify "Create Access Token" is disabled before any revision exists.
+        const createAccessTokenButton = page.getByRole('button', {
+          name: 'Create Access Token',
+        });
+        await expect(createAccessTokenButton).toBeDisabled({ timeout: 20000 });
+
+        // 3. Add a revision (found-or-created preset + provisioned model
+        // folder, keyboard-selected, "Apply immediately after adding" left
+        // checked).
+        await addProvisionedRevision(page, fixtures);
+
+        // 4. Wait for "Create Access Token" to become enabled now that a
+        // revision is attached.
+        await expect(createAccessTokenButton).toBeEnabled({ timeout: 30000 });
+
+        // 5. Click "Create Access Token" via dispatchEvent to bypass the
+        // overlapping-cell pointer-interception issue (see header comment).
+        await createAccessTokenButton.dispatchEvent('click');
+
+        // 6. Verify the "Create Access Token" modal opens, scoped by exact
+        // dialog name to avoid ambiguity with any other open dialog.
+        const createTokenDialog = page.getByRole('dialog', {
+          name: 'Create Access Token',
+        });
+        await expect(createTokenDialog).toBeVisible({ timeout: 10000 });
+        await expect(
+          createTokenDialog.getByRole('combobox', { name: 'Expiration' }),
+        ).toBeVisible();
+        await expect(createTokenDialog.getByText('7 Days')).toBeVisible();
+        await expect(
+          createTokenDialog.getByRole('button', { name: 'Cancel' }),
+        ).toBeVisible();
+        await expect(
+          createTokenDialog.getByRole('button', {
+            name: 'Create Access Token',
+          }),
+        ).toBeVisible();
+
+        // 7. Submit with the default "7 Days" expiration to actually issue a
+        // token. The submit button lives inside the modal (scoped via
+        // `createTokenDialog`), so it does not collide with the identically
+        // named card-level trigger button behind it.
+        await createTokenDialog
+          .getByRole('button', { name: 'Create Access Token' })
+          .click();
+
+        // 8. Verify the issued-token result dialog appears with the token value
+        // and expiration. This is the deterministic success signal: the token
+        // was actually minted by the manager and returned to the UI.
+        // NOTE: `exact: true` is required, not just prudent -- getByRole
+        // name matching is substring by default, so a bare 'Token' also
+        // matches the "Create Access Token" modal, which can still be
+        // mid-close (its DOM lingers through the close animation) when this
+        // dialog appears -- observed live as a strict-mode violation.
+        const tokenDialog = page.getByRole('dialog', {
+          name: 'Token',
+          exact: true,
+        });
+        await expect(tokenDialog).toBeVisible({ timeout: 10000 });
+        await expect(
+          tokenDialog.getByText('Access token has been created.'),
+        ).toBeVisible();
+        await expect(tokenDialog.getByText(/^Expiration:/)).toBeVisible();
+        await tokenDialog.getByRole('button', { name: 'Close' }).click();
+        await expect(tokenDialog).toBeHidden({ timeout: 10000 });
+
+        // Deliberately NOT asserted: that the issued token then appears as a
+        // row in the Access Tokens table, nor revoking it. Live investigation
+        // confirmed the manager mints the token synchronously (the "Token"
+        // result dialog above always shows it), but the *list-view refresh*
+        // that surfaces the new row does not populate deterministically while
+        // the deployment is still "Deploying" (replica scheduling in
+        // progress) -- the table stayed on its "No data" empty state well
+        // past the token's creation across repeated runs, the same
+        // cluster-scheduling-latency characteristic documented in
+        // deployment-lifecycle.spec.ts (replica appearance measured at ~40s to
+        // 20min+). Asserting on the row (and thus revoke) would make this
+        // test's outcome hostage to that latency rather than to whether token
+        // issuance works. The "Token" result dialog is the reliable,
+        // deterministic proof that issuance succeeded; list-refresh timing and
+        // revoke are better covered by backend-surface tests (auto-tester)
+        // than by this UI e2e. The token is scoped to this throwaway
+        // deployment and is destroyed with it in cleanup below.
+
+        // 9. Clean up: delete the deployment shell immediately (this tears down
+        // the attached revision and any issued token with it), without waiting
+        // for replica scheduling. The provisioned preset + folder go last (the
+        // revision referenced them).
+        await deleteDeploymentAndVerify(page, deploymentName);
+        createdDeploymentName = null;
+        await cleanupDeploymentFixtures(page, fixtures);
+        fixtures = null;
+      },
+    );
+  },
+);

--- a/e2e/serving/deployment-lifecycle.spec.ts
+++ b/e2e/serving/deployment-lifecycle.spec.ts
@@ -1,0 +1,1195 @@
+// spec: e2e/.agent-output/test-plan-deployments-ui.md
+// seed: e2e/screenshot-seed.spec.ts
+//
+// Key deviations from the plan discovered during manual browser verification:
+//
+// 1. Creating a deployment auto-navigates directly to its detail page
+//    (`/deployments/{id}`) instead of staying on the list page with the
+//    modal simply closed. Tests assert the detail-page redirect first, then
+//    separately navigate back to the list to verify the row.
+//
+// 2. In the Add Revision modal, selecting a Preset does NOT auto-fill the
+//    Model Folder field -- it must be selected independently (contrary to
+//    the plan's open question about this).
+//
+// 3. The Add Revision modal's Model Folder combobox only lists
+//    Project-owned/user-owned VFolders, not model-store/project-store
+//    catalog resources -- confirmed live: a model-store catalog folder
+//    never appears there, regardless of active project. This turned out to
+//    be intentional behavior, not a bug. The full-lifecycle "add a revision
+//    with a real preset" scenario therefore uses utils/deployment-fixtures.ts
+//    to ensure its preset (reusing a compatible pre-existing one when the
+//    cluster has it, creating a GPU-free `e2e-dfx-*` one otherwise) and to
+//    provision a fresh `e2e-dfx-*` model folder, instead of assuming any
+//    hand-seeded fixture exists on the target cluster -- confirmed via live
+//    end-to-end verification to submit successfully and produce a real
+//    revision. That test deliberately stops at confirming the revision is
+//    attached and scheduling has begun -- it does not wait for a replica to
+//    actually appear as scheduled, because that specific signal was directly
+//    measured (across repeated identical runs) to take anywhere from ~40
+//    seconds to over 20 minutes on this shared cluster, a cluster-level
+//    characteristic outside this test's control that makes it unsuitable
+//    for a CI-practical bounded wait; see the comment in that test for the
+//    full investigation. A sibling Advanced Mode test covers the manual
+//    revision path, which needs no preset at all.
+//
+// 4. Reopening the Edit Deployment modal after a successful save shows a
+//    stale Desired Replicas value (the value from before the save) rather
+//    than the just-persisted one, even though the Basic Information card
+//    behind the modal correctly reflects the saved value. The Cancel-does-
+//    not-persist assertion below verifies the Basic Information card value
+//    directly rather than asserting on the modal's (buggy) pre-fill.
+//
+// Every test in this file creates its own throwaway `e2e-plan-*` deployment
+// shell and deletes it inline. The two revision-attaching tests additionally
+// provision what they need via utils/deployment-fixtures.ts -- the Preset
+// Mode test a found-or-created preset plus a fresh model folder, the
+// Advanced Mode test a fresh model folder only -- attach a real revision,
+// then tear the deployment down through the same delete flow and clean up
+// everything the run itself created.
+import {
+  cleanupDeploymentFixtures,
+  cleanupDeploymentSafely,
+  createDeploymentShell,
+  deleteDeploymentAndVerify,
+  type DeploymentFixtures,
+  escapeForRegExp,
+  provisionDeploymentFixtures,
+  provisionDeploymentModelFolder,
+  selectRevisionModalOption,
+} from '../utils/deployment-fixtures';
+import { skipUnlessClientFeature } from '../utils/feature-gate-util';
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import { getFormItemControlByLabel } from '../utils/test-util-antd';
+import { test, expect } from '@playwright/test';
+
+test.describe(
+  'Deployment List Page',
+  { tag: ['@functional', '@regression', '@serving', '@deployment'] },
+  () => {
+    let createdDeploymentName: string | null = null;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      if (createdDeploymentName) {
+        await cleanupDeploymentSafely(page, createdDeploymentName);
+        createdDeploymentName = null;
+      }
+    });
+
+    test(
+      'Admin can view the deployments list with expected columns and controls',
+      { tag: ['@smoke'] },
+      async ({ page }) => {
+        // 1. Navigate to /deployments.
+        await navigateTo(page, 'deployments');
+
+        // 2. Inspect the page header area and table.
+        await expect(
+          page
+            .getByRole('navigation')
+            .getByText('Deployments', { exact: true }),
+        ).toBeVisible({ timeout: 20000 });
+        await expect(page.getByRole('radio', { name: 'Running' })).toBeChecked({
+          timeout: 20000,
+        });
+        // antd's button-style BAIRadioGroup visually hides the raw <input>
+        // (opacity: 0) and renders the clickable label on the surrounding
+        // `.ant-radio-button-wrapper` -- `toBeVisible()` on the raw radio
+        // always fails ("hidden") even though the option is genuinely
+        // offered. Assert on the visible wrapper instead (confirmed via
+        // live DOM inspection; see also endpoint-route-table.spec.ts for the
+        // same pattern on an analogous Running/Finished toggle).
+        await expect(
+          page.locator('.ant-radio-button-wrapper', { hasText: 'Terminated' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('button', { name: 'reload' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('button', { name: 'Create Deployment' }),
+        ).toBeVisible();
+
+        await expect(page.getByRole('table')).toBeVisible({ timeout: 20000 });
+        await expect(
+          page.getByRole('columnheader', { name: 'Name' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: /Revision/ }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Lifecycle' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: /Replicas/ }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Model' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Created At' }),
+        ).toBeVisible();
+      },
+    );
+
+    test(
+      'Admin can create a new deployment and permanently delete it',
+      { tag: ['@critical'] },
+      async ({ page }) => {
+        const deploymentName = `e2e-plan-deploy-${Date.now()}`;
+
+        // 1. Click "Create Deployment".
+        await navigateTo(page, 'deployments');
+        await page.getByRole('button', { name: 'Create Deployment' }).click();
+
+        // 2. In the modal, fill "Deployment Name" with e2e-plan-deploy-<timestamp>.
+        const createDialog = page.getByRole('dialog', {
+          name: 'Create Deployment',
+        });
+        await expect(createDialog).toBeVisible({ timeout: 20000 });
+        // The dialog shell can become visible slightly before its form
+        // fields finish mounting (observed live: the default 5s timeout is
+        // occasionally not enough for the Deployment Name textbox
+        // specifically) -- give this first field check a generous timeout,
+        // matching this file's convention elsewhere.
+        await expect(
+          createDialog.getByRole('textbox', { name: /Deployment Name/ }),
+        ).toHaveAttribute('placeholder', 'Enter a deployment name', {
+          timeout: 20000,
+        });
+
+        // 3. Leave "Resource Group" at its default (default), "Desired Replicas" at
+        // its default (1), "Tags" empty, and "Open To Public" (Public checkbox)
+        // unchecked.
+        await expect(
+          createDialog.getByRole('spinbutton', { name: /Desired Replicas/ }),
+        ).toHaveValue('1');
+        await expect(
+          createDialog.getByText('Enter tags, separated by commas'),
+        ).toBeVisible();
+        const publicCheckbox = createDialog.getByRole('checkbox', {
+          name: 'Public',
+        });
+        await expect(publicCheckbox).not.toBeChecked();
+        await expect(publicCheckbox).toBeEnabled();
+        await createDialog
+          .getByRole('textbox', { name: /Deployment Name/ })
+          .fill(deploymentName);
+
+        // 4. Click "Create".
+        createdDeploymentName = deploymentName;
+        await createDialog
+          .getByRole('button', { name: 'Create', exact: true })
+          .click();
+
+        // 5. Confirm the modal closes and the new row appears in the list with
+        // Lifecycle "Pending" and Replicas "0 / 1".
+        // NOTE: creating a deployment auto-navigates directly to its detail page
+        // instead of staying on the list with the modal closed -- confirmed by
+        // manual verification (see header comment).
+        await expect(
+          page.getByRole('heading', { level: 3, name: deploymentName }),
+        ).toBeVisible({ timeout: 20000 });
+        await navigateTo(page, 'deployments');
+        const row = page.getByRole('row', {
+          name: new RegExp(escapeForRegExp(deploymentName)),
+        });
+        await expect(row).toBeVisible({ timeout: 20000 });
+        await expect(row.getByRole('cell', { name: 'Pending' })).toBeVisible();
+        await expect(row.getByRole('cell', { name: '0 / 1' })).toBeVisible();
+
+        // 6. Click the new row's "delete" icon.
+        await row.getByRole('button', { name: 'delete' }).click();
+
+        // 7. In the "Delete Deployment" confirmation modal, type the exact
+        // deployment name into the confirmation textbox.
+        const deleteDialog = page.getByRole('dialog', {
+          name: /Delete Deployment/,
+        });
+        await expect(deleteDialog).toBeVisible({ timeout: 10000 });
+        await expect(
+          deleteDialog.getByText(
+            'Are you sure you want to permanently delete Deployment?',
+          ),
+        ).toBeVisible();
+        await expect(
+          deleteDialog.getByText('This action cannot be undone.'),
+        ).toBeVisible();
+        const confirmInput = page.getByPlaceholder(deploymentName);
+        await expect(confirmInput).toBeVisible();
+        const deleteButton = deleteDialog.getByRole('button', {
+          name: 'Delete',
+          exact: true,
+        });
+        await expect(deleteButton).toBeDisabled();
+        await confirmInput.fill(deploymentName);
+
+        // 8. Click "Delete" (disabled until the typed value matches).
+        await expect(deleteButton).toBeEnabled({ timeout: 5000 });
+        await deleteButton.click();
+
+        // 9. Confirm the row is removed from the list.
+        await expect(page.getByText(deploymentName).first()).toBeHidden({
+          timeout: 30000,
+        });
+        // The raw radio input is visually hidden by antd's button-style
+        // radio group; click the visible wrapper instead (see comment in
+        // "Admin can view the deployments list..." above).
+        await page
+          .locator('.ant-radio-button-wrapper', { hasText: 'Terminated' })
+          .click();
+        await expect(page.getByText(deploymentName).first()).toBeHidden({
+          timeout: 10000,
+        });
+
+        createdDeploymentName = null;
+      },
+    );
+  },
+);
+
+test.describe(
+  'Deployment Detail Page',
+  { tag: ['@functional', '@regression', '@serving', '@deployment'] },
+  () => {
+    let createdDeploymentName: string | null = null;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      if (createdDeploymentName) {
+        await cleanupDeploymentSafely(page, createdDeploymentName);
+        createdDeploymentName = null;
+      }
+    });
+
+    test('Admin can view the Basic Information and empty-state sections of a newly created deployment', async ({
+      page,
+    }) => {
+      const deploymentName = `e2e-plan-detail-${Date.now()}`;
+
+      // 1. Click the deployment's name link from the list (or navigate directly
+      // to /deployments/{id}) -- here achieved by creating a fresh shell, which
+      // auto-navigates to its detail page.
+      await navigateTo(page, 'deployments');
+      await createDeploymentShell(page, deploymentName);
+      createdDeploymentName = deploymentName;
+
+      // 2. Inspect the alert banner, header, "Basic Information" card, revision
+      // tabs, "Replicas" section, "Auto-scaling" section, and "Access Tokens"
+      // section.
+      const alert = page.getByRole('alert');
+      await expect(alert).toContainText('No revision is deployed', {
+        timeout: 20000,
+      });
+      await expect(
+        alert.getByRole('button', { name: 'Add Revision' }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('heading', { level: 3, name: deploymentName }),
+      ).toBeVisible();
+      await expect(page.getByText('Pending').first()).toBeVisible();
+
+      // Basic Information card
+      await expect(page.getByRole('button', { name: 'edit Edit' })).toBeVisible(
+        {
+          timeout: 20000,
+        },
+      );
+      await expect(page.getByRole('button', { name: 'More' })).toBeVisible();
+      await expect(
+        page.getByRole('rowheader', { name: 'Lifecycle' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: /Scheduling History/ }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('rowheader', { name: 'Deployment ID' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('rowheader', { name: 'Project' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('rowheader', { name: 'Domain' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('rowheader', { name: 'Resource Group' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('rowheader', { name: 'Endpoint URL' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('rowheader', { name: 'Visibility' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('rowheader', { name: 'Desired Replicas' }),
+      ).toBeVisible();
+      await expect(page.getByRole('rowheader', { name: 'Tags' })).toBeVisible();
+
+      // Revision tabs
+      await expect(
+        page.getByRole('tab', { name: 'Current Revision', selected: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('tab', { name: 'Revision History' }),
+      ).toBeVisible();
+      await expect(page.getByRole('tab', { name: 'Audit Log' })).toBeVisible();
+      await expect(
+        page.getByRole('tablist').getByRole('button', { name: 'Add Revision' }),
+      ).toBeVisible();
+
+      // Replicas section
+      await expect(page.getByText('Replicas', { exact: true })).toBeVisible();
+      // Same hidden-input caveat as the deployments list page's toggle --
+      // assert on the visible `.ant-radio-button-wrapper`, not the raw radio.
+      await expect(
+        page.locator('.ant-radio-button-wrapper', { hasText: 'Running' }),
+      ).toBeVisible();
+      await expect(
+        page.locator('.ant-radio-button-wrapper', { hasText: 'Terminated' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Replica ID' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: /Health Status/ }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: /Traffic Status/ }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Session' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: /Revision \(ID\)/ }),
+      ).toBeVisible();
+
+      // Auto-scaling section
+      await expect(page.getByText('Auto-scaling')).toBeVisible();
+      // The Auto-scaling card's body (button + table) loads via its own
+      // query/Suspense boundary independently of the heading above, and can
+      // take longer than the default 5s timeout to hydrate (observed live,
+      // reproducibly, in both parallel and serial execution) -- give its
+      // first body element a generous explicit timeout, matching this
+      // file's convention for the first assertion of each section.
+      await expect(page.getByRole('button', { name: 'Add Rules' })).toBeVisible(
+        { timeout: 20000 },
+      );
+      await expect(
+        page.getByRole('columnheader', { name: /Metric Source/ }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: /Cooldown Sec\./ }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: /Step Size/ }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: /Min \/ MAX Replicas/ }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: /Last Triggered/ }),
+      ).toBeVisible();
+
+      // Access Tokens section
+      await expect(page.getByText('Access Tokens')).toBeVisible();
+      // Same independently-loading-body caveat as the Auto-scaling section
+      // above.
+      await expect(
+        page.getByRole('button', { name: 'Create Access Token' }),
+      ).toBeDisabled({ timeout: 20000 });
+      await expect(
+        page.getByRole('columnheader', { name: 'Token' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Expiration' }),
+      ).toBeVisible();
+
+      await deleteDeploymentAndVerify(page, deploymentName);
+      createdDeploymentName = null;
+    });
+  },
+);
+
+test.describe(
+  'Add Revision Modal',
+  { tag: ['@functional', '@regression', '@serving', '@deployment'] },
+  () => {
+    let createdDeploymentName: string | null = null;
+    // Tracks whatever this describe's tests provisioned so afterEach can
+    // unwind it — the full preset+folder pair for the Preset Mode test, or
+    // just `{ folderName }` for the Advanced Mode test (which needs no
+    // preset). cleanupDeploymentFixtures accepts either shape and never
+    // touches a reused pre-existing preset (its id is never recorded).
+    let fixtures: Partial<DeploymentFixtures> | null = null;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      // Deployment first — its revision references the provisioned fixtures.
+      if (createdDeploymentName) {
+        await cleanupDeploymentSafely(page, createdDeploymentName);
+        createdDeploymentName = null;
+      }
+      if (fixtures) {
+        await cleanupDeploymentFixtures(page, fixtures);
+        fixtures = null;
+      }
+    });
+
+    test('Admin can view Preset Mode fields in the Add Revision modal', async ({
+      page,
+    }) => {
+      const deploymentName = `e2e-plan-preset-${Date.now()}`;
+      await navigateTo(page, 'deployments');
+      await createDeploymentShell(page, deploymentName);
+      createdDeploymentName = deploymentName;
+
+      // 1. Click "Add Revision" (from either the banner or the tab bar).
+      await page
+        .getByRole('tablist')
+        .getByRole('button', { name: 'Add Revision' })
+        .click();
+      const dialog = page.getByRole('dialog', { name: /Add Revision/ });
+      await expect(dialog).toBeVisible({ timeout: 20000 });
+
+      // 2. Confirm "Preset Mode" is selected by default in the modal's segmented
+      // control.
+      await expect(
+        dialog.getByRole('radio', { name: 'Preset Mode' }),
+      ).toBeChecked();
+      await expect(
+        dialog.getByRole('radio', { name: 'Advanced Mode' }),
+      ).not.toBeChecked();
+
+      // 3. Inspect the Preset Mode fields.
+      await expect(dialog.getByText('Select Preset')).toBeVisible();
+      await expect(
+        dialog.getByRole('button', { name: 'info-circle' }),
+      ).toBeDisabled();
+      await expect(dialog.getByText('Select Folder')).toBeVisible();
+      await expect(
+        dialog.getByRole('checkbox', {
+          name: 'Apply immediately after adding',
+        }),
+      ).toBeChecked();
+      await expect(
+        dialog.getByRole('button', { name: 'Cancel' }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByRole('button', { name: 'Add Revision' }),
+      ).toBeVisible();
+
+      // 4. Click "Cancel" to close without submitting.
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+      await expect(dialog).toBeHidden({ timeout: 10000 });
+
+      await deleteDeploymentAndVerify(page, deploymentName);
+      createdDeploymentName = null;
+    });
+
+    test('Admin can view Advanced Mode fields in the Add Revision modal', async ({
+      page,
+    }) => {
+      const deploymentName = `e2e-plan-advanced-${Date.now()}`;
+      await navigateTo(page, 'deployments');
+      await createDeploymentShell(page, deploymentName);
+      createdDeploymentName = deploymentName;
+
+      // 1. Open "Add Revision".
+      await page
+        .getByRole('tablist')
+        .getByRole('button', { name: 'Add Revision' })
+        .click();
+      const dialog = page.getByRole('dialog', { name: /Add Revision/ });
+      await expect(dialog).toBeVisible({ timeout: 20000 });
+
+      // 2. Select the "Advanced Mode" segmented-control option.
+      await page.locator('label').filter({ hasText: 'Advanced Mode' }).click();
+
+      // 3. Inspect the expanded field set.
+      await expect(dialog.getByText('Model & Runtime')).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(dialog.getByText('Select Folder')).toBeVisible();
+      await expect(
+        dialog.getByRole('combobox', { name: /Runtime/ }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByRole('checkbox', { name: 'Enable Health Check' }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByText('Environments', { exact: true }),
+      ).toBeVisible();
+      await expect(dialog.getByText('Environments / Version')).toBeVisible();
+      await expect(
+        dialog.getByRole('button', { name: 'Add environment variables' }),
+      ).toBeVisible();
+      await expect(dialog.getByText('Cluster & Resources')).toBeVisible({
+        timeout: 20000,
+      });
+      await expect(
+        dialog.getByRole('combobox', { name: 'Resource Presets' }),
+      ).toBeVisible({ timeout: 20000 });
+      await expect(
+        dialog.getByRole('radio', { name: /Multi Node/ }),
+      ).toBeChecked();
+      // Same hidden-input caveat -- assert on the visible wrapper, not the
+      // raw (CSS-hidden) radio input.
+      await expect(
+        dialog.locator('.ant-radio-button-wrapper', { hasText: /Single Node/ }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByRole('button', { name: /Advanced Settings/ }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByRole('checkbox', {
+          name: 'Apply immediately after adding',
+        }),
+      ).toBeChecked();
+
+      // 4. Click "Cancel" to close without submitting.
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+      await expect(dialog).toBeHidden({ timeout: 10000 });
+
+      await deleteDeploymentAndVerify(page, deploymentName);
+      createdDeploymentName = null;
+    });
+
+    // The two revision-attaching tests below each provision a model folder
+    // and upload the mock-server fixtures — a real vfolder create + storage
+    // upload against the shared cluster. Running the two concurrently in
+    // separate workers was directly observed to starve each other's /data
+    // list fetch and upload-completion waits into their timeouts (both
+    // failed only when concurrent; each passes in isolation), so they run
+    // serially. Note serial mode skips the second test if the first fails.
+    test.describe.serial('Revision attach flows', () => {
+      test(
+        'Admin can add a revision in Preset Mode and see it attached',
+        { tag: ['@critical'] },
+        async ({ page }) => {
+          // This test waits up to 180s for the deployment's Lifecycle to
+          // leave "Pending" (real scheduling can take a while) but, per the
+          // comment near the end of this test, deliberately does NOT wait
+          // for the Replicas table to show a scheduled replica -- that
+          // specific signal was directly measured to take anywhere from
+          // ~40s to over 20 minutes on this shared cluster, independent of
+          // this test's own logic. 480s covers fixture provisioning (model
+          // folder + upload + preset ensure), setup, the 180s lifecycle
+          // wait, and teardown (including fixture cleanup) with comfortable
+          // margin.
+          test.setTimeout(480_000);
+
+          // 0. Ensure the preset + model folder pair this test selects in the
+          // Add Revision modal: a compatible pre-existing preset is reused
+          // as-is when the cluster has one, and created (then torn down)
+          // otherwise -- no hand-seeded cluster fixture is assumed either
+          // way. Deployment presets need backend support, so gate on the same
+          // capability flag the UI checks.
+          await skipUnlessClientFeature(
+            page,
+            'deployment-preset',
+            "Adding a revision from a preset requires the 'deployment-preset' capability (manager >= 26.4.x)",
+          );
+          const provisioned = await provisionDeploymentFixtures(page);
+          fixtures = provisioned;
+
+          const deploymentName = `e2e-plan-revision-${Date.now()}`;
+          await navigateTo(page, 'deployments');
+          await createDeploymentShell(page, deploymentName);
+          createdDeploymentName = deploymentName;
+
+          // 1. Open "Add Revision" on the fresh deployment, staying in "Preset Mode".
+          await page
+            .getByRole('tablist')
+            .getByRole('button', { name: 'Add Revision' })
+            .click();
+          const dialog = page.getByRole('dialog', { name: /Add Revision/ });
+          await expect(dialog).toBeVisible({ timeout: 20000 });
+          await expect(
+            dialog.getByRole('radio', { name: 'Preset Mode' }),
+          ).toBeChecked();
+
+          // 2. Select the ensured preset from the "Preset" dropdown. The
+          // dropdown groups options by runtime category and renders virtualized
+          // option rows with a computed width of 0 px, so selection happens via
+          // search + keyboard Enter -- the full investigation lives on
+          // selectRevisionModalOption in utils/deployment-fixtures.ts.
+          await selectRevisionModalOption(
+            page,
+            '#revisionPresetId',
+            provisioned.presetName,
+          );
+
+          // 3. Confirm/select the "Model Folder" (verify whether it auto-populates
+          // from the preset or must be chosen separately). Manual verification
+          // found it does NOT auto-fill -- it must be chosen independently. The
+          // Model Folder combobox only lists Project-owned/user-owned VFolders
+          // (not model-store/project-store catalog resources), which is why the
+          // provisioned folder is created as the e2e admin account's own owned
+          // VFolder. Same zero-width option rows as the preset dropdown --
+          // keyboard selection via the shared helper.
+          await selectRevisionModalOption(
+            page,
+            '#modelFolderId',
+            provisioned.folderName,
+          );
+
+          // 4. Leave "Apply immediately after adding" checked.
+          await expect(
+            dialog.getByRole('checkbox', {
+              name: 'Apply immediately after adding',
+            }),
+          ).toBeChecked();
+
+          // 5. Click "Add Revision" to submit.
+          await dialog.getByRole('button', { name: 'Add Revision' }).click();
+          await expect(dialog).toBeHidden({ timeout: 20000 });
+
+          // 6. Wait for the deployment's Lifecycle/status to leave "Pending" (allow
+          // a generous timeout for scheduling; this is a real model-serving
+          // container pull + start).
+          const lifecycleRow = page.getByRole('row').filter({
+            has: page.getByRole('rowheader', { name: 'Lifecycle' }),
+          });
+          await expect(
+            lifecycleRow.getByRole('cell').first(),
+          ).not.toContainText('Pending', { timeout: 180_000 });
+
+          // 7. Inspect the "Current Revision" tab, confirming the revision is
+          // now actually attached (this is the reliable, deterministic
+          // success signal for "a revision was added and scheduling began" --
+          // see the note below on why this test does not also wait for the
+          // Replicas table's empty state to clear).
+          // NOTE: DeploymentRevisionCard uses BAICard's `tabList` API, which
+          // renders each tab's content as a conditional child of the Card
+          // body rather than inside antd's own `role="tabpanel"` panes --
+          // those panes are always empty placeholders here (confirmed live:
+          // both `#rc-tabs-0-panel-currentRevision` and
+          // `#rc-tabs-0-panel-revisionHistory` have zero children even while
+          // active). Scope on the `.ant-card` itself instead of the
+          // content-less tabpanel role.
+          const currentRevisionCard = page
+            .locator('.ant-card')
+            .filter({ hasText: 'Current Revision' });
+          await expect(currentRevisionCard).not.toContainText(
+            'No revision is deployed',
+            { timeout: 10000 },
+          );
+          // Deliberately not asserted: waiting for the Replicas card's
+          // "No data" empty state to clear (i.e. a scheduled replica actually
+          // appearing). Live investigation directly measured this take
+          // anywhere from ~40s to over 20 minutes across repeated identical
+          // runs (independent of this file's own worker concurrency, which
+          // was ruled out by forcing serial execution; independent of
+          // resource-limit exhaustion, which is Unlimited on this account;
+          // and independent of leftover/queued sessions, of which there were
+          // none) -- a real, cluster-level scheduling-latency characteristic
+          // of this shared QA cluster, not a bug in this test, the locator, or
+          // the application. Across that sampling only 1 of 7 runs finished
+          // within a 5-minute bound, so no CI-practical timeout reliably
+          // captures it; asserting on it would make this test's pass/fail
+          // outcome dominated by cluster noise rather than by whether adding
+          // a revision actually works. The "Current Revision" tab check above
+          // already confirms the functionally important outcome (the
+          // revision was added and is active); replica-level scheduling
+          // completion is best verified manually or via infrastructure
+          // monitoring, not this e2e test.
+
+          // Cleanup: Permanently delete the deployment via the list page's per-row
+          // delete icon and the typed-name "Delete Deployment" modal, which should
+          // tear down the revision/replica along with the deployment shell. The
+          // provisioned preset + folder go last (the revision referenced them).
+          await deleteDeploymentAndVerify(page, deploymentName);
+          createdDeploymentName = null;
+          await cleanupDeploymentFixtures(page, fixtures);
+          fixtures = null;
+        },
+      );
+
+      test(
+        'Admin can add a revision manually in Advanced Mode without a preset',
+        { tag: ['@critical'] },
+        async ({ page }) => {
+          // Advanced (Custom) Mode builds the revision by hand -- model
+          // folder + runtime + start command, with the image and resources
+          // left at the form's own auto-selected defaults -- so it must work
+          // even on a cluster with zero deployment presets. Only the model
+          // folder is provisioned here; no preset is needed, ensured, or
+          // created. 360s covers folder provisioning (create + fixture
+          // upload), the modal flow, and teardown with comfortable margin
+          // (no lifecycle wait -- the Preset Mode test above already covers
+          // that signal).
+          test.setTimeout(360_000);
+          const folderName = await provisionDeploymentModelFolder(page);
+          fixtures = { folderName };
+
+          const deploymentName = `e2e-plan-manual-rev-${Date.now()}`;
+          await navigateTo(page, 'deployments');
+          await createDeploymentShell(page, deploymentName);
+          createdDeploymentName = deploymentName;
+
+          // 1. Open "Add Revision" and switch to Advanced Mode.
+          await page
+            .getByRole('tablist')
+            .getByRole('button', { name: 'Add Revision' })
+            .click();
+          const dialog = page.getByRole('dialog', { name: /Add Revision/ });
+          await expect(dialog).toBeVisible({ timeout: 20000 });
+          await page
+            .locator('label')
+            .filter({ hasText: 'Advanced Mode' })
+            .click();
+          await expect(dialog.getByText('Model & Runtime')).toBeVisible({
+            timeout: 10000,
+          });
+
+          // 2. Select the provisioned model folder -- the Advanced form's
+          // folder Select shares the `#modelFolderId` id and search behavior
+          // with Preset Mode (only one form is mounted at a time), so the
+          // shared helper applies unchanged.
+          await selectRevisionModalOption(page, '#modelFolderId', folderName);
+
+          // 3. Select the "custom" runtime variant. This Select exposes no
+          // accessible option roles and its rows are not clickable (same
+          // zero-width virtualized rendering as the other modal Selects,
+          // confirmed live), and it has no "Total N items" footer either --
+          // so the shared helper's settle gate does not apply. Its variant
+          // list loads via its own query, and keyboard selection silently
+          // no-ops while that list is still empty (observed live under
+          // load) -- so first gate on the filtered "custom" entry actually
+          // existing in the dropdown (attached, not visible: the rows
+          // render zero-width). Then ArrowDown + Enter selects the sole
+          // match; the content assertion proves the intended variant (not
+          // some other row) was selected.
+          await page.locator('#runtimeVariantId').click();
+          await page.locator('#runtimeVariantId').fill('custom');
+          const runtimeDropdown = page
+            .locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')
+            .first();
+          await expect(
+            runtimeDropdown.getByText('custom', { exact: true }).first(),
+          ).toBeAttached({ timeout: 15000 });
+          await page.locator('#runtimeVariantId').press('ArrowDown');
+          await page.locator('#runtimeVariantId').press('Enter');
+          await expect(
+            page
+              .locator('.ant-select', {
+                has: page.locator('#runtimeVariantId'),
+              })
+              .locator('.ant-select-content'),
+          ).toContainText('custom', { timeout: 5000 });
+
+          // 4. The custom runtime reveals the definition-mode control with
+          // "Enter Command" preselected -- fill the start command that runs
+          // the folder's mock server. The image (Environments / Version) is
+          // left at the form's own auto-selected default; resources are set by
+          // hand below to satisfy that image's minimum footprint (the submit
+          // handler itself rejects a missing image, so a cluster with no
+          // usable image fails loudly here rather than silently).
+          const startCommand = page.locator('#startCommand');
+          await expect(startCommand).toBeVisible({ timeout: 10000 });
+          await startCommand.fill('python3 /models/mock_openai_server.py');
+
+          // The Environments / Version selects resolve their default image
+          // asynchronously; submitting before they finish leaves the form's
+          // image empty and the submit handler rejects it, keeping the
+          // modal open (observed live as an intermittent submit "failure").
+          // antd v6 marks a resolved selection with the
+          // `ant-select-content-has-value` class on the content element --
+          // gate on it for both selects before submitting.
+          const envSelects = dialog.locator('.ant-select', {
+            has: page.locator(
+              '#environments_environment, #environments_version',
+            ),
+          });
+          await expect(envSelects).toHaveCount(2, { timeout: 20000 });
+          for (const index of [0, 1]) {
+            await expect(
+              envSelects.nth(index).locator('.ant-select-content'),
+            ).toHaveClass(/ant-select-content-has-value/, { timeout: 30000 });
+          }
+
+          // The Cluster & Resources section mounts via its own
+          // query/Suspense boundary and takes 10s+ on the shared cluster
+          // (the "view Advanced Mode fields" test above waits for the same
+          // landmark). Submitting before it mounts leaves the `resource`
+          // fields unregistered on the form, and the submit handler then
+          // dies on the missing values with no visible error at all --
+          // observed live as a click that produced no form error, no
+          // notification, and no mutation. Gate on the section's landmark.
+          await expect(
+            dialog.getByRole('combobox', { name: 'Resource Presets' }),
+          ).toBeVisible({ timeout: 30000 });
+
+          // The form's auto-selected default image carries a minimum resource
+          // footprint (observed live: CPU >= 5, mem >= 1088MiB) that the
+          // default resource preset does NOT meet, so submitting at the
+          // defaults fails form validation ("CPU must be minimum 5", "The
+          // minimum memory capacity ... is 1088MiB") and silently keeps the
+          // modal open. Set CPU/mem above those minimums by hand -- part of
+          // building a revision manually. The CPU locator is scoped to
+          // `.ant-input-number input` so it targets the number field, not the
+          // paired slider's own input (which `.fill()` cannot set).
+          const cpuInput = dialog
+            .locator(
+              '.ant-form-item-row:has-text("CPU") .ant-input-number input',
+            )
+            .first();
+          await cpuInput.click();
+          await cpuInput.fill('5');
+          await cpuInput.blur();
+          const memInput = dialog
+            .locator(
+              '.ant-form-item-row:has-text("Memory") .ant-input-number input',
+            )
+            .first();
+          await memInput.fill('4'); // GiB (default unit) — comfortably over 1088MiB
+
+          // 5. Submit and confirm the revision is attached -- the same
+          // deterministic success signals as the Preset Mode test: the modal
+          // closes, the auto-opened "Revision Detail" dialog appears (closed
+          // so it cannot mask later assertions), and the "Current Revision"
+          // card leaves its empty state.
+          await dialog.getByRole('button', { name: 'Add Revision' }).click();
+          await expect(dialog).toBeHidden({ timeout: 20000 });
+
+          const revisionDetailDialog = page.getByRole('dialog', {
+            name: 'Revision Detail',
+          });
+          await expect(revisionDetailDialog).toBeVisible({ timeout: 10000 });
+          await revisionDetailDialog
+            .getByRole('button', { name: 'Close' })
+            .click();
+          await expect(revisionDetailDialog).toBeHidden({ timeout: 10000 });
+
+          const currentRevisionCard = page
+            .locator('.ant-card')
+            .filter({ hasText: 'Current Revision' });
+          await expect(currentRevisionCard).not.toContainText(
+            'No revision is deployed',
+            { timeout: 20000 },
+          );
+
+          // Cleanup: deployment first (its revision references the folder),
+          // then the provisioned folder.
+          await deleteDeploymentAndVerify(page, deploymentName);
+          createdDeploymentName = null;
+          await cleanupDeploymentFixtures(page, fixtures);
+          fixtures = null;
+        },
+      );
+    });
+  },
+);
+
+test.describe(
+  'Edit Deployment Modal',
+  { tag: ['@functional', '@regression', '@serving', '@deployment'] },
+  () => {
+    let createdDeploymentName: string | null = null;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      if (createdDeploymentName) {
+        await cleanupDeploymentSafely(page, createdDeploymentName);
+        createdDeploymentName = null;
+      }
+    });
+
+    test("Admin can update a deployment's Desired Replicas via the Edit modal", async ({
+      page,
+    }) => {
+      const deploymentName = `e2e-plan-edit-${Date.now()}`;
+      await navigateTo(page, 'deployments');
+      await createDeploymentShell(page, deploymentName);
+      createdDeploymentName = deploymentName;
+
+      // 1. Click "Edit" in the "Basic Information" card.
+      await page.getByRole('button', { name: 'edit Edit' }).click();
+
+      // 2. Inspect the modal fields.
+      const dialog = page.getByRole('dialog', { name: 'Edit Deployment' });
+      await expect(dialog).toBeVisible({ timeout: 20000 });
+      await expect(
+        dialog.getByRole('textbox', { name: /Deployment Name/ }),
+      ).toHaveValue(deploymentName);
+      // Resource Group is plain text here, not editable -- unlike the Create
+      // modal where it is a combobox.
+      await expect(
+        dialog.getByRole('combobox', { name: /Resource Group/ }),
+      ).toHaveCount(0);
+      const replicasInput = dialog.getByRole('spinbutton', {
+        name: /Desired Replicas/,
+      });
+      await expect(replicasInput).toHaveValue('1');
+      await expect(
+        dialog.getByRole('checkbox', { name: 'Public' }),
+      ).toBeDisabled();
+
+      // 3. Change "Desired Replicas" using the stepper (e.g. increment by 1).
+      await replicasInput.click();
+      await page.keyboard.press('ArrowUp');
+      await expect(replicasInput).toHaveValue('2');
+
+      // 4. Click "Save".
+      await dialog.getByRole('button', { name: 'Save' }).click();
+      await expect(dialog).toBeHidden({ timeout: 20000 });
+      const desiredReplicasCell = page
+        .getByRole('row')
+        .filter({
+          has: page.getByRole('rowheader', { name: 'Desired Replicas' }),
+        })
+        .getByRole('cell')
+        .last();
+      await expect(desiredReplicasCell).toHaveText('2', { timeout: 20000 });
+
+      // 5. Click "Cancel" instead of "Save" on a repeat run to confirm no changes
+      // persist when cancelled.
+      await page.getByRole('button', { name: 'edit Edit' }).click();
+      const dialog2 = page.getByRole('dialog', { name: 'Edit Deployment' });
+      await expect(dialog2).toBeVisible({ timeout: 20000 });
+      const replicasInput2 = dialog2.getByRole('spinbutton', {
+        name: /Desired Replicas/,
+      });
+      await replicasInput2.click();
+      await page.keyboard.press('ArrowUp');
+      await dialog2.getByRole('button', { name: 'Cancel' }).click();
+      await expect(dialog2).toBeHidden({ timeout: 10000 });
+      await expect(desiredReplicasCell).toHaveText('2', { timeout: 20000 });
+
+      await deleteDeploymentAndVerify(page, deploymentName);
+      createdDeploymentName = null;
+    });
+  },
+);
+
+test.describe(
+  'Auto-Scaling Rules',
+  { tag: ['@functional', '@regression', '@serving', '@deployment'] },
+  () => {
+    let createdDeploymentName: string | null = null;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      if (createdDeploymentName) {
+        await cleanupDeploymentSafely(page, createdDeploymentName);
+        createdDeploymentName = null;
+      }
+    });
+
+    test('Admin can view the Add Auto Scaling Rule modal fields', async ({
+      page,
+    }) => {
+      const deploymentName = `e2e-plan-scale-fields-${Date.now()}`;
+      await navigateTo(page, 'deployments');
+      await createDeploymentShell(page, deploymentName);
+      createdDeploymentName = deploymentName;
+
+      // 1. Click "Add Rules" in the "Auto-scaling" section.
+      await page.getByRole('button', { name: 'Add Rules' }).click();
+
+      // 2. Inspect the modal fields.
+      const dialog = page.getByRole('dialog', {
+        name: 'Add Auto Scaling Rule',
+      });
+      await expect(dialog).toBeVisible({ timeout: 20000 });
+      // antd's Select renders its accessible `role="combobox"` on the
+      // internal search <input>, which always has an empty `value` attribute
+      // -- the displayed selection text lives in a sibling
+      // `.ant-select-selection-item`. Read the current value off the
+      // Form.Item's control container instead of the raw combobox (see
+      // `getFormItemControlByLabel` in test-util-antd.ts).
+      await expect(
+        getFormItemControlByLabel(page, 'Metric Source'),
+      ).toContainText('Kernel');
+      await expect(
+        dialog.getByRole('combobox', { name: /Metric Name/ }),
+      ).toBeVisible();
+      // `exact: true` is required here: "Scale In" is a literal prefix
+      // substring of "Scale In & Out", so non-exact name matching resolves
+      // to both radio inputs (strict-mode violation), confirmed live.
+      await expect(
+        dialog.getByRole('radio', { name: 'Scale In', exact: true }),
+      ).not.toBeChecked();
+      await expect(
+        dialog.getByRole('radio', { name: 'Scale Out' }),
+      ).toBeChecked();
+      await expect(
+        dialog.getByRole('radio', { name: 'Scale In & Out' }),
+      ).not.toBeChecked();
+      await expect(
+        dialog.getByRole('spinbutton', { name: 'Max Threshold' }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByRole('spinbutton', { name: /Step Size/ }),
+      ).toHaveValue('1');
+      await expect(
+        dialog.getByRole('spinbutton', { name: /Cooldown Sec\./ }),
+      ).toHaveValue('300');
+      await expect(
+        dialog.getByRole('spinbutton', { name: /Min Replicas/ }),
+      ).toHaveValue('0');
+      await expect(
+        dialog.getByRole('spinbutton', { name: /Max Replicas/ }),
+      ).toHaveValue('5');
+      await expect(
+        dialog.getByRole('button', { name: 'Cancel' }),
+      ).toBeVisible();
+      await expect(
+        dialog.getByRole('button', { name: 'OK', exact: true }),
+      ).toBeVisible();
+
+      // 3. Click "Cancel" to close without submitting.
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+      await expect(dialog).toBeHidden({ timeout: 10000 });
+
+      await deleteDeploymentAndVerify(page, deploymentName);
+      createdDeploymentName = null;
+    });
+
+    test('Admin can create and then delete an auto-scaling rule', async ({
+      page,
+    }) => {
+      const deploymentName = `e2e-plan-scale-crud-${Date.now()}`;
+      await navigateTo(page, 'deployments');
+      await createDeploymentShell(page, deploymentName);
+      createdDeploymentName = deploymentName;
+
+      // 1. Click "Add Rules".
+      await page.getByRole('button', { name: 'Add Rules' }).click();
+      const dialog = page.getByRole('dialog', {
+        name: 'Add Auto Scaling Rule',
+      });
+      await expect(dialog).toBeVisible({ timeout: 20000 });
+
+      // 2. Set "Metric Name" to a valid value appropriate to the selected
+      // "Metric Source".
+      await dialog.getByRole('combobox', { name: /Metric Name/ }).click();
+      await page.getByRole('option', { name: 'cpu_util' }).click();
+
+      // 3. Leave "Condition" at "Scale Out" and set a "Max Threshold" value.
+      await dialog
+        .getByRole('spinbutton', { name: 'Max Threshold' })
+        .fill('80');
+
+      // 4. Leave Step Size (1), Cooldown Sec. (300), Min Replicas (0), Max
+      // Replicas (5) at their defaults.
+
+      // 5. Click "OK".
+      await dialog.getByRole('button', { name: 'OK', exact: true }).click();
+
+      // 6. Confirm the new rule appears as a row in the Auto-scaling table.
+      const ruleRow = page.getByRole('row', { name: /cpu_util/ });
+      await expect(ruleRow).toBeVisible({ timeout: 20000 });
+      await expect(ruleRow).toContainText('80');
+
+      // 7. Delete the rule (locate the row's delete affordance).
+      await ruleRow.getByRole('button', { name: 'delete' }).click();
+      const deleteRuleDialog = page.getByRole('dialog', {
+        name: /Delete Auto Scaling Rule/,
+      });
+      await expect(deleteRuleDialog).toBeVisible({ timeout: 10000 });
+      // Reversible/low-impact action -- confirmed to use a plain confirm modal
+      // (Cancel/Delete buttons), not the typed-name "permanently delete"
+      // pattern, consistent with destructive-confirmation.md.
+      await deleteRuleDialog
+        .getByRole('button', { name: 'Delete', exact: true })
+        .click();
+      await expect(ruleRow).toBeHidden({ timeout: 20000 });
+
+      await deleteDeploymentAndVerify(page, deploymentName);
+      createdDeploymentName = null;
+    });
+  },
+);
+
+test.describe(
+  'Revision History Tab',
+  { tag: ['@functional', '@regression', '@serving', '@deployment'] },
+  () => {
+    let createdDeploymentName: string | null = null;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      if (createdDeploymentName) {
+        await cleanupDeploymentSafely(page, createdDeploymentName);
+        createdDeploymentName = null;
+      }
+    });
+
+    test('Admin can view the Revision History tab structure', async ({
+      page,
+    }) => {
+      const deploymentName = `e2e-plan-history-${Date.now()}`;
+      await navigateTo(page, 'deployments');
+      await createDeploymentShell(page, deploymentName);
+      createdDeploymentName = deploymentName;
+
+      // 1. Click the "Revision History" tab.
+      await page.getByRole('tab', { name: 'Revision History' }).click();
+
+      // 2. Confirm the URL updates to include ?revisionTab=revisionHistory.
+      await expect(page).toHaveURL(/revisionTab=revisionHistory/, {
+        timeout: 20000,
+      });
+
+      // 3. Inspect the filter and table.
+      // NOTE: `getByRole('tabpanel', { name: 'Revision History' })` always
+      // times out here -- DeploymentRevisionCard renders each tab's content
+      // as a conditional child of the BAICard body (see `tabList` usage in
+      // DeploymentRevisionCard.tsx), not inside antd's own tabpanel panes.
+      // Verified live: `#rc-tabs-0-panel-revisionHistory` (the actual
+      // `role="tabpanel"` element) has zero children even while active/
+      // visible -- the real filter+table content is a sibling of the tab
+      // bar, inside the `.ant-card`. Scope on the card instead.
+      const revisionCard = page
+        .locator('.ant-card')
+        .filter({ hasText: 'Revision History' });
+      await expect(revisionCard.getByText('Revision Number')).toBeVisible({
+        timeout: 20000,
+      });
+      await expect(
+        revisionCard.getByRole('columnheader', { name: /Revision \(ID\)/ }),
+      ).toBeVisible();
+      await expect(
+        revisionCard.getByRole('columnheader', { name: 'Created At' }),
+      ).toBeVisible();
+      await expect(
+        revisionCard.getByRole('columnheader', { name: 'Runtime' }),
+      ).toBeVisible();
+      await expect(
+        revisionCard.getByRole('columnheader', { name: /Cluster Mode/ }),
+      ).toBeVisible();
+      // antd's stock `Empty` component (used for the table's empty state)
+      // renders the "No data" string twice: once as the illustration SVG's
+      // accessibility `<title>` (always hidden -- SVG titles are never
+      // rendered) and once as the visible `.ant-empty-description` caption.
+      // `getByText('No data').first()` non-deterministically resolves to the
+      // hidden title (confirmed live), so target the caption class directly.
+      await expect(
+        revisionCard.locator('.ant-empty-description'),
+      ).toBeVisible();
+
+      await deleteDeploymentAndVerify(page, deploymentName);
+      createdDeploymentName = null;
+    });
+  },
+);

--- a/e2e/serving/fixtures/start.sh
+++ b/e2e/serving/fixtures/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Entry point for deployment presets whose startup command is
+# `bash /models/start.sh` (a common convention for hand-made "custom"
+# runtime presets). Delegates to the same GPU-free mock OpenAI server that
+# model-definition.yaml starts, so the provisioned model folder stays
+# startable regardless of which compatible preset a run ends up using.
+exec python3 /models/mock_openai_server.py

--- a/e2e/utils/admin-api.ts
+++ b/e2e/utils/admin-api.ts
@@ -159,3 +159,97 @@ export async function sweepProfileTestUsersViaApi(
   }
   return purged;
 }
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Strawberry Node ids are base64 `TypeName:<uuid>` global ids, but
+ * `deleteModelDeployment`'s input takes the raw UUID (the same decode
+ * documented on `toRawUUID` in deployment-fixtures.ts — duplicated here
+ * rather than imported so this foundational, dependency-free module doesn't
+ * take on a dependency on a higher-level fixture module).
+ */
+function toRawUUID(id: string): string {
+  if (UUID_RE.test(id)) return id;
+  const decoded = Buffer.from(id, 'base64').toString('utf-8');
+  const raw = decoded.split(':').pop() ?? '';
+  if (!UUID_RE.test(raw)) {
+    throw new Error(`Cannot extract a raw UUID from id "${id}" ("${decoded}")`);
+  }
+  return raw;
+}
+
+/**
+ * Lists every deployment whose display name matches `pattern`. `limit: 300`
+ * comfortably covers realistic leak volumes without needing offset
+ * pagination.
+ */
+export async function listDeploymentsByPattern(
+  api: APIRequestContext,
+  pattern: RegExp,
+): Promise<Array<{ id: string; name: string }>> {
+  const data = await gqlAdmin<{
+    adminDeployments: {
+      edges: Array<{ node: { id: string; metadata: { name: string } } }>;
+    };
+  }>(
+    api,
+    `query { adminDeployments(limit: 300) { edges { node { id metadata { name } } } } }`,
+  );
+  return (data.adminDeployments?.edges ?? [])
+    .map((e) => ({ id: e.node.id, name: e.node.metadata.name }))
+    .filter((d) => pattern.test(d.name));
+}
+
+/**
+ * Deletes a single deployment by its (possibly base64 global) id via
+ * `deleteModelDeployment`. This is a soft-delete on the manager side (status
+ * transitions to STOPPED), so it is safe to call even on an
+ * already-terminated deployment. Defensive: swallows a GraphQL error and
+ * returns `false` rather than throwing, so one bad id never blocks the rest
+ * of a sweep.
+ */
+export async function deleteDeploymentViaApi(
+  api: APIRequestContext,
+  id: string,
+): Promise<boolean> {
+  try {
+    await gqlAdmin(
+      api,
+      `mutation($id: ID!) { deleteModelDeployment(input: { id: $id }) { id } }`,
+      { id: toRawUUID(id) },
+    );
+    return true;
+  } catch (error) {
+    console.warn(`[admin-api] could not delete deployment id=${id}:`, error);
+    return false;
+  }
+}
+
+/**
+ * Sweep-deletes every deployment whose display name matches `pattern` — by
+ * default the `e2e-plan-*` / `e2e-token-*` shells the deployment specs
+ * create (deployment-lifecycle.spec.ts / deployment-access-token.spec.ts).
+ * These names are NOT covered by sweepServices'/sweepVFolders' `/e2e-svc-/`
+ * `/e2e-mod-/` patterns in global-cleanup.teardown.ts, and the per-test
+ * `cleanupDeploymentSafely` (a UI-delete flow, same fragility as the test
+ * body it backstops) can itself fail when a test already failed mid-modal —
+ * leaking a PENDING deployment with no other safety net. API-based and
+ * pagination-immune for the same reason `sweepProfileTestUsersViaApi` is.
+ * Returns the number of deployments deleted.
+ */
+export async function sweepLeftoverDeploymentsViaApi(
+  api: APIRequestContext,
+  pattern: RegExp = /^e2e-(plan|token)-/i,
+): Promise<number> {
+  const matches = await listDeploymentsByPattern(api, pattern);
+  let deleted = 0;
+  for (const { id } of matches) {
+    if (await deleteDeploymentViaApi(api, id)) deleted++;
+  }
+  if (deleted > 0) {
+    console.log(`Swept ${deleted} leftover deployment(s) matching ${pattern}`);
+  }
+  return deleted;
+}

--- a/e2e/utils/classes/vfolder/FolderCreationModal.ts
+++ b/e2e/utils/classes/vfolder/FolderCreationModal.ts
@@ -77,7 +77,12 @@ export class FolderCreationModal {
     const RadioContainer = this.modal.locator(
       `.ant-form-item-row:has-text("${label}")`,
     );
-    await expect(RadioContainer).toBeVisible();
+    // The modal shell becomes visible before its form body finishes
+    // mounting, and on a busy shared cluster that hydration was directly
+    // observed to exceed the 5s default expect timeout — give the first
+    // form-row lookup the same generous margin the deployment/session specs
+    // use for form hydration.
+    await expect(RadioContainer).toBeVisible({ timeout: 20000 });
     return RadioContainer;
   }
 

--- a/e2e/utils/deployment-fixtures.ts
+++ b/e2e/utils/deployment-fixtures.ts
@@ -1,0 +1,677 @@
+/**
+ * Self-contained provisioning for the deployment e2e specs.
+ *
+ * The Add Revision flow needs (1) a selectable deployment preset and (2) a
+ * selectable model VFolder. Earlier revisions of the deployment specs assumed
+ * a pre-seeded `mockvllm-preset` + `mockllm-svc` pair existed on the target
+ * cluster, which silently fails on any cluster that has not been hand-seeded.
+ * These helpers make each run self-sufficient instead:
+ *
+ *  - The preset is FOUND-OR-CREATED: if the cluster already has a preset
+ *    compatible with the provisioned model folder (see
+ *    {@link findCompatiblePreset} for the exact criteria), it is reused
+ *    as-is and never modified or deleted; otherwise one is created as the
+ *    admin over GraphQL (`adminCreateDeploymentRevisionPreset` — the admin
+ *    preset-creation wizard is a heavy multi-step form that is not what
+ *    these specs verify) and torn down at cleanup. The required
+ *    `runtimeVariantId`/`imageId` are resolved dynamically by name — they
+ *    are per-cluster UUIDs.
+ *  - The model folder is created through the same UI helpers the vfolder
+ *    specs use, then seeded with `e2e/serving/fixtures/` (a GPU-free mock
+ *    OpenAI server, its model-definition.yaml, and a `start.sh` shim so the
+ *    folder is startable under both this helper's own startup command and
+ *    the common `bash /models/start.sh` convention of hand-made presets).
+ *    Live probing confirmed the Add Revision submit succeeds even with an
+ *    EMPTY folder, but uploading the fixtures keeps the revision genuinely
+ *    startable — if cleanup is ever interrupted, a leaked deployment idles
+ *    as a tiny mock server instead of crash-looping on a missing startup
+ *    file on the shared cluster.
+ *
+ * Both specs verify "revision submit succeeds" only — replica scheduling and
+ * health are cluster-timing-dependent (measured ~40s to 20min+ on the shared
+ * QA cluster) and are deliberately out of scope for webui e2e.
+ */
+import { FolderExplorerModal } from './classes/vfolder/FolderExplorerModal';
+import {
+  createVFolderAndVerify,
+  deleteForeverAndVerifyFromTrash,
+  moveToTrashAndVerify,
+  navigateTo,
+} from './test-util';
+import { expect, Page } from '@playwright/test';
+import path from 'path';
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'serving', 'fixtures');
+
+/**
+ * The runtime variant / image / resources the provisioned preset uses. These
+ * mirror the hand-seeded `mockvllm-preset` this replaces: the "custom" variant
+ * (start command driven by the folder's model-definition.yaml / the preset's
+ * startupCommand — no vLLM/SGLang runtime needed) and a deliberately GPU-free
+ * resource footprint so the revision schedules on any agent.
+ */
+const RUNTIME_VARIANT_NAME = 'custom';
+const PREFERRED_IMAGE_NAME = 'bai/ngc-pytorch';
+const PRESET_RESOURCE_SLOTS = [
+  { resourceType: 'cpu', quantity: '2' },
+  { resourceType: 'mem', quantity: '2147483648' }, // 2 GiB
+];
+
+/** How old an `e2e-dfx-*` preset must be before the stale sweep removes it. */
+const STALE_PRESET_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Shared deployment-shell helpers, used verbatim by both deployment specs
+ * (deployment-lifecycle / deployment-access-token). They live here — the
+ * shared home for deployment e2e utilities — rather than being copy-pasted
+ * into each spec, so the two specs can never drift apart.
+ */
+export function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Creates a deployment shell from the /deployments list page. Caller must
+ * already be on /deployments. Creating a deployment auto-navigates directly
+ * to its detail page, so this resolves once that page has loaded.
+ */
+export async function createDeploymentShell(
+  page: Page,
+  name: string,
+): Promise<void> {
+  await page.getByRole('button', { name: 'Create Deployment' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Create Deployment' });
+  await expect(dialog).toBeVisible({ timeout: 20000 });
+  await dialog.getByRole('textbox', { name: /Deployment Name/ }).fill(name);
+  await dialog.getByRole('button', { name: 'Create', exact: true }).click();
+  await expect(page.getByRole('heading', { level: 3, name })).toBeVisible({
+    timeout: 20000,
+  });
+}
+
+/**
+ * Permanently deletes a deployment via the list page's per-row delete icon
+ * and the typed-name "Delete Deployment" confirmation modal, then verifies
+ * the row is actually gone (not just that the button was clicked).
+ */
+export async function deleteDeploymentAndVerify(
+  page: Page,
+  name: string,
+): Promise<void> {
+  const row = page.getByRole('row', {
+    name: new RegExp(escapeForRegExp(name)),
+  });
+  // The list can take longer to fetch/render while the shared QA cluster is
+  // busy, and it is fetched once per navigation — right after a revision is
+  // attached the backend's list read can lag behind the mutation (observed
+  // live: a row absent across one full in-page wait appeared on the next
+  // fresh navigation). A single in-page wait never refetches, so poll with
+  // re-navigation instead — the same retry-by-refetch pattern as
+  // verifyVFolder in test-util.ts.
+  await expect(async () => {
+    await navigateTo(page, 'deployments');
+    await expect(row).toBeVisible({ timeout: 15000 });
+  }).toPass({ timeout: 60_000 });
+  await row.getByRole('button', { name: 'delete' }).click();
+
+  const dialog = page.getByRole('dialog', { name: /Delete Deployment/ });
+  await expect(dialog).toBeVisible({ timeout: 10000 });
+  const deleteButton = dialog.getByRole('button', {
+    name: 'Delete',
+    exact: true,
+  });
+  await expect(deleteButton).toBeDisabled();
+  await page.getByPlaceholder(name).fill(name);
+  await expect(deleteButton).toBeEnabled({ timeout: 5000 });
+  await deleteButton.click();
+
+  await expect(page.getByText(name).first()).toBeHidden({ timeout: 30000 });
+}
+
+/**
+ * Best-effort safety-net cleanup for a deployment that a test may not have
+ * deleted itself (e.g. due to an earlier assertion failure). Never throws.
+ */
+export async function cleanupDeploymentSafely(
+  page: Page,
+  name: string,
+): Promise<void> {
+  try {
+    await navigateTo(page, 'deployments');
+    const row = page.getByRole('row', {
+      name: new RegExp(escapeForRegExp(name)),
+    });
+    // Use a polling `expect` (not `isVisible()`, which does not reliably
+    // retry) with a generous timeout -- under parallel worker load the
+    // deployments list can take a while to fetch/render after navigation,
+    // and a too-short existence check previously caused this safety net to
+    // silently skip cleanup, leaking `e2e-plan-*` rows (observed live).
+    await expect(row.first()).toBeVisible({ timeout: 15000 });
+    await deleteDeploymentAndVerify(page, name);
+  } catch (error) {
+    console.warn(
+      `[cleanupDeploymentSafely] could not verify cleanup of deployment "${name}":`,
+      error,
+    );
+  }
+}
+
+export interface DeploymentFixtures {
+  /**
+   * Preset name selectable in the Add Revision modal — either a compatible
+   * pre-existing preset that was found on the cluster, or a fresh
+   * `e2e-dfx-*` one this run created.
+   */
+  presetName: string;
+  /**
+   * Raw preset UUID as required by `adminDeleteDeploymentRevisionPreset` —
+   * set ONLY when this run created the preset. Unset when a pre-existing
+   * compatible preset was reused, so cleanup never deletes something this
+   * run does not own.
+   */
+  presetId?: string;
+  /** Unique model VFolder name, selectable in the Add Revision modal. */
+  folderName: string;
+}
+
+/**
+ * Runs a GraphQL operation through the logged-in page's `backendaiclient`.
+ * The strawberry-graph fields used here (runtimeVariants, deployment presets)
+ * are reachable through `client.query` with the session login the e2e helpers
+ * already perform — confirmed by live probing. Throws on any GraphQL error.
+ */
+async function gqlViaClient(
+  page: Page,
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<any> {
+  const result = await page.evaluate(
+    async ({ query, variables }) => {
+      const client = (globalThis as any).backendaiclient;
+      if (!client) {
+        return {
+          ok: false as const,
+          error: 'backendaiclient is not initialized (is the page logged in?)',
+        };
+      }
+      try {
+        return {
+          ok: true as const,
+          data: await client.query(query, variables),
+        };
+      } catch (error: any) {
+        return {
+          ok: false as const,
+          error:
+            (error && (error.message || error.title)) ||
+            JSON.stringify(error)?.slice(0, 500),
+        };
+      }
+    },
+    { query, variables },
+  );
+  if (!result.ok) {
+    throw new Error(`GraphQL operation failed: ${result.error}`);
+  }
+  return result.data;
+}
+
+/**
+ * Strawberry Node ids are base64 `TypeName:<uuid>` global ids, but the
+ * mutation inputs (`runtimeVariantId`, delete-by-id) take the raw UUID —
+ * confirmed by live probing (`RuntimeVariant:7361e24b-…` decoded vs. the raw
+ * `runtimeVariantId` echoed back by the create mutation).
+ */
+function toRawUUID(id: string): string {
+  if (UUID_RE.test(id)) return id;
+  const decoded = Buffer.from(id, 'base64').toString('utf-8');
+  const raw = decoded.split(':').pop() ?? '';
+  if (!UUID_RE.test(raw)) {
+    throw new Error(`Cannot extract a raw UUID from id "${id}" ("${decoded}")`);
+  }
+  return raw;
+}
+
+/**
+ * Best-effort sweep of `e2e-dfx-*` presets leaked by previously interrupted
+ * runs. Presets are the one provisioned resource no existing safety net
+ * covers (the global teardown sweeps `e2e-*` folders/services/users, but not
+ * deployment presets). Only presets older than {@link STALE_PRESET_AGE_MS}
+ * are removed so concurrently-running specs can never sweep each other's
+ * freshly provisioned preset. Never throws.
+ */
+async function sweepStaleDeploymentPresets(page: Page): Promise<void> {
+  try {
+    const data = await gqlViaClient(
+      page,
+      `query {
+        deploymentRevisionPresets(
+          filter: { name: { startsWith: "e2e-dfx-" } }
+          limit: 50
+        ) {
+          edges { node { id name createdAt } }
+        }
+      }`,
+    );
+    const nodes: Array<{ id: string; name: string; createdAt: string }> = (
+      data.deploymentRevisionPresets?.edges ?? []
+    ).map((e: any) => e.node);
+    for (const node of nodes) {
+      const ageMs = Date.now() - new Date(node.createdAt).getTime();
+      if (!(ageMs > STALE_PRESET_AGE_MS)) continue;
+      await gqlViaClient(
+        page,
+        `mutation($id: UUID!) {
+          adminDeleteDeploymentRevisionPreset(id: $id) { id }
+        }`,
+        { id: toRawUUID(node.id) },
+      );
+      console.log(
+        `[deployment-fixtures] swept stale preset "${node.name}" (age ${Math.round(ageMs / 60000)}m)`,
+      );
+    }
+  } catch (error) {
+    console.warn(
+      '[deployment-fixtures] stale preset sweep failed (ignored):',
+      error,
+    );
+  }
+}
+
+/**
+ * Uploads the GPU-free mock-server fixtures into the provisioned model folder
+ * via the FolderExplorerModal (same UI path as serving-deploy-lifecycle).
+ */
+async function uploadDeploymentFixtureFiles(
+  page: Page,
+  folderName: string,
+): Promise<void> {
+  const FIXTURE_FILES = [
+    'mock_openai_server.py',
+    'model-definition.yaml',
+    'start.sh',
+  ];
+
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  // The folder list is fetched once per navigation, and right after the
+  // folder was created the list read can lag behind the mutation — observed
+  // live under concurrent worker load. Poll with re-navigation (the same
+  // retry-by-refetch pattern as verifyVFolder / deleteDeploymentAndVerify)
+  // instead of a single in-page wait that never refetches.
+  const openExplorer = async (): Promise<FolderExplorerModal> => {
+    await expect(async () => {
+      await navigateTo(page, 'data');
+      await expect(folderLink).toBeVisible({ timeout: 15000 });
+    }).toPass({ timeout: 60_000 });
+    await folderLink.click();
+    const modal = new FolderExplorerModal(page);
+    await modal.waitForOpen();
+    await modal.verifyFileExplorerLoaded();
+    return modal;
+  };
+
+  const modal = await openExplorer();
+  const uploadButton = await modal.getUploadButton();
+  await uploadButton.click();
+
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+  ]);
+  await fileChooser.setFiles(
+    FIXTURE_FILES.map((f) => path.join(FIXTURES_DIR, f)),
+  );
+
+  // The explorer's file table refreshes when uploads complete, but with
+  // several files in flight the refresh can land before the last file's
+  // row exists — observed live under load as one of the three rows never
+  // appearing within its wait even though the upload itself succeeded.
+  // Retry once by closing and reopening the explorer, which refetches the
+  // listing (the modal itself has no refresh affordance) — the same
+  // eventual-consistency retry convention as verifyVFolder.
+  try {
+    for (const fileName of FIXTURE_FILES) {
+      await modal.verifyFileVisible(fileName);
+    }
+    await modal.close();
+  } catch (error) {
+    console.warn(
+      `[deployment-fixtures] fixture rows missing after upload; reopening the explorer to refetch the listing:`,
+      error,
+    );
+    await modal.close();
+    const reopened = await openExplorer();
+    for (const fileName of FIXTURE_FILES) {
+      await reopened.verifyFileVisible(fileName);
+    }
+    await reopened.close();
+  }
+}
+
+/**
+ * Finds a pre-existing preset compatible with the provisioned model folder,
+ * or returns null when the cluster has none. Compatibility means the preset
+ * could actually start the folder's mock server:
+ *  - "custom" runtime variant (start command driven, no vLLM/SGLang engine);
+ *  - GPU-free resource slots (only cpu/mem), so it schedules on any agent;
+ *  - a container image is set (revision creation needs one).
+ * Two ownership/uniqueness guards apply on top:
+ *  - `e2e-dfx-*` presets are NEVER reuse candidates: one of those may be a
+ *    concurrently-running test's still-in-flight preset, and its owning run
+ *    deletes it at cleanup — reusing it would let that cleanup pull the
+ *    preset out from under this run. Only genuinely pre-existing
+ *    (hand-seeded) presets are safe to share, since nothing ever deletes
+ *    them.
+ *  - The preset's name must resolve to exactly one preset under the Add
+ *    Revision modal's server-side "contains" search — i.e. no OTHER preset
+ *    name contains it as a substring AND no other preset shares the exact
+ *    same name. {@link selectRevisionModalOption}'s settle gate keys on the
+ *    "Total 1 items" footer, so a name matching two or more presets (common:
+ *    Backend.AI clusters carry same-named presets, one per runtime variant)
+ *    would hang the search. Both conditions collapse to a single count check
+ *    (see the filter below).
+ *
+ * The match is deterministic: candidates are ordered by rank then name, so
+ * repeated runs against the same cluster always pick the same preset.
+ */
+async function findCompatiblePreset(
+  page: Page,
+): Promise<{ name: string } | null> {
+  const data = await gqlViaClient(
+    page,
+    `query {
+      deploymentRevisionPresets(limit: 100) {
+        edges { node {
+          name rank
+          runtimeVariant { name }
+          image { id }
+          resourceSlots { slotName }
+        } }
+      }
+    }`,
+  );
+  const presets: Array<{
+    name: string;
+    rank: number;
+    runtimeVariant: { name: string } | null;
+    image: { id: string } | null;
+    resourceSlots: Array<{ slotName: string }> | null;
+  }> = (data.deploymentRevisionPresets?.edges ?? []).map((e: any) => e.node);
+
+  const allNames = presets.map((p) => p.name);
+  const candidates = presets
+    .filter(
+      (p) =>
+        !p.name.startsWith('e2e-dfx-') &&
+        p.runtimeVariant?.name === RUNTIME_VARIANT_NAME &&
+        p.image != null &&
+        (p.resourceSlots ?? []).every((s) =>
+          ['cpu', 'mem'].includes(s.slotName),
+        ) &&
+        // The name must resolve to EXACTLY ONE preset under the modal's
+        // server-side "contains" search, or selectRevisionModalOption's
+        // "Total 1 items" settle gate never fires. Counting the names that
+        // contain p.name catches both failure modes at once: a longer name
+        // that has p.name as a substring, AND another preset sharing p.name
+        // verbatim (Backend.AI clusters routinely carry same-named presets —
+        // one per runtime variant, e.g. two "cpu-medium"s). An identity
+        // skip (`n === p.name`) cannot express the latter: the duplicate is
+        // an equal string, so it would be skipped as "self".
+        allNames.filter((n) => n.includes(p.name)).length === 1,
+    )
+    .sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name));
+
+  return candidates.length > 0 ? { name: candidates[0].name } : null;
+}
+
+/**
+ * Ensures a preset usable by the Add Revision flow exists, reusing a
+ * compatible pre-existing one when the cluster has it (never modified, never
+ * deleted by us) and creating an `e2e-dfx-*` one as the admin otherwise.
+ * Returns the preset's selectable name plus, ONLY when this call created it,
+ * the raw UUID cleanup should delete.
+ */
+export async function ensureDeploymentPreset(
+  page: Page,
+): Promise<{ presetName: string; presetId?: string }> {
+  await sweepStaleDeploymentPresets(page);
+
+  const existing = await findCompatiblePreset(page);
+  if (existing) {
+    console.log(
+      `[deployment-fixtures] reusing compatible pre-existing preset "${existing.name}"`,
+    );
+    return { presetName: existing.name };
+  }
+
+  const presetName = `e2e-dfx-preset-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+  // Resolve the "custom" runtime variant's raw UUID (per-cluster value).
+  const rvData = await gqlViaClient(
+    page,
+    `query { runtimeVariants(limit: 100) { edges { node { id name } } } }`,
+  );
+  const variant = (rvData.runtimeVariants?.edges ?? [])
+    .map((e: any) => e.node)
+    .find((n: any) => n.name === RUNTIME_VARIANT_NAME);
+  if (!variant) {
+    throw new Error(
+      `No "${RUNTIME_VARIANT_NAME}" runtime variant on this cluster — cannot provision a deployment preset`,
+    );
+  }
+
+  // Resolve a CPU-capable image's raw UUID. Prefer a widely-seeded image
+  // family; fall back to any python-ish image so the helper stays usable on
+  // clusters with a different registry layout.
+  const imgData = await gqlViaClient(
+    page,
+    `query { images(is_operation: false) { id name tag } }`,
+  );
+  const images: Array<{ id: string; name: string; tag: string }> =
+    imgData.images ?? [];
+  const image =
+    images.find((i) => i.name === PREFERRED_IMAGE_NAME) ??
+    images.find((i) => /python/i.test(i.name));
+  if (!image) {
+    throw new Error(
+      `No "${PREFERRED_IMAGE_NAME}" (or python) image on this cluster — cannot provision a deployment preset`,
+    );
+  }
+
+  // Create the preset. `clusterMode`/`clusterSize`/`imageId` are required
+  // input fields (added in 26.4.4); values are a minimal GPU-free footprint
+  // (SINGLE_NODE × 1, rolling, open to public) matching the fixture folder.
+  const created = await gqlViaClient(
+    page,
+    `mutation($input: CreateDeploymentRevisionPresetInput!) {
+      adminCreateDeploymentRevisionPreset(input: $input) {
+        preset { id name }
+      }
+    }`,
+    {
+      input: {
+        name: presetName,
+        runtimeVariantId: toRawUUID(variant.id),
+        imageId: toRawUUID(image.id),
+        replicaCount: 1,
+        openToPublic: true,
+        deploymentStrategy: { type: 'ROLLING' },
+        clusterMode: 'SINGLE_NODE',
+        clusterSize: 1,
+        resourceSlots: PRESET_RESOURCE_SLOTS,
+        startupCommand: 'python3 /models/mock_openai_server.py',
+        description:
+          'Self-provisioned by the webui deployment e2e specs — safe to delete.',
+      },
+    },
+  );
+  console.log(
+    `[deployment-fixtures] no compatible preset on this cluster — created "${presetName}"`,
+  );
+  return {
+    presetName,
+    presetId: toRawUUID(created.adminCreateDeploymentRevisionPreset.preset.id),
+  };
+}
+
+/**
+ * Provisions a uniquely-named `e2e-dfx-*` model folder seeded with the
+ * GPU-free mock-server fixtures, and returns its name. Usable on its own by
+ * flows that need a model folder but no preset (e.g. the Advanced Mode
+ * manual-revision test). Callers must clean it up via
+ * {@link cleanupDeploymentFixtures} (as `{ folderName }`).
+ */
+export async function provisionDeploymentModelFolder(
+  page: Page,
+): Promise<string> {
+  const folderName = `e2e-dfx-fld-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  await createVFolderAndVerify(page, folderName, 'model');
+  try {
+    await uploadDeploymentFixtureFiles(page, folderName);
+  } catch (error) {
+    await cleanupDeploymentFixtures(page, { folderName });
+    throw error;
+  }
+  return folderName;
+}
+
+/**
+ * Provisions the preset + model-folder pair the Add Revision flow needs —
+ * the preset via find-or-create ({@link ensureDeploymentPreset}), the folder
+ * always freshly created. Requires an already-logged-in admin `page` (the
+ * preset mutation is admin-only). If any step fails, everything THIS run
+ * created so far is torn back down before the error is rethrown, so callers
+ * never have to clean up a partially-provisioned state they were never
+ * handed.
+ *
+ * Callers own the returned fixtures and must pass them to
+ * {@link cleanupDeploymentFixtures} when done (typically from `afterEach`).
+ */
+export async function provisionDeploymentFixtures(
+  page: Page,
+): Promise<DeploymentFixtures> {
+  const preset = await ensureDeploymentPreset(page);
+  try {
+    const folderName = await provisionDeploymentModelFolder(page);
+    return { ...preset, folderName };
+  } catch (error) {
+    // The folder helper already unwound itself; unwind the preset only if
+    // this run created it.
+    await cleanupDeploymentFixtures(page, { presetId: preset.presetId });
+    throw error;
+  }
+}
+
+/**
+ * Best-effort teardown of everything THIS RUN created. Never throws — a
+ * cleanup hiccup must not mask the real test result. Accepts a partial
+ * fixtures object so it can also unwind a partially-failed provisioning.
+ * A reused pre-existing preset is naturally left untouched: its
+ * `presetId` is never set on the fixtures object (see
+ * {@link ensureDeploymentPreset}).
+ *
+ * The caller must delete any deployment that references the fixtures BEFORE
+ * calling this (the specs' existing deployment cleanup already does).
+ */
+export async function cleanupDeploymentFixtures(
+  page: Page,
+  fixtures: Partial<DeploymentFixtures>,
+): Promise<void> {
+  if (fixtures.presetId) {
+    try {
+      await gqlViaClient(
+        page,
+        `mutation($id: UUID!) {
+          adminDeleteDeploymentRevisionPreset(id: $id) { id }
+        }`,
+        { id: fixtures.presetId },
+      );
+    } catch (error) {
+      console.warn(
+        `[deployment-fixtures] could not delete preset "${fixtures.presetName ?? fixtures.presetId}":`,
+        error,
+      );
+    }
+  }
+
+  if (fixtures.folderName) {
+    try {
+      await moveToTrashAndVerify(page, fixtures.folderName);
+      await deleteForeverAndVerifyFromTrash(page, fixtures.folderName);
+    } catch (error) {
+      console.warn(
+        `[deployment-fixtures] primary folder cleanup of "${fixtures.folderName}" failed; retrying delete-from-trash:`,
+        error,
+      );
+      // The folder may already be in Trash (move succeeded, purge failed).
+      try {
+        await deleteForeverAndVerifyFromTrash(page, fixtures.folderName);
+      } catch (retryError) {
+        console.warn(
+          `[deployment-fixtures] could not purge folder "${fixtures.folderName}" — the global e2e teardown sweep will collect it:`,
+          retryError,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Searches an Add Revision modal combobox (`#revisionPresetId` /
+ * `#modelFolderId`) and selects `optionName` — which must be unique on the
+ * cluster, as every provisioned `e2e-dfx-*` name is — via keyboard.
+ *
+ * Why keyboard, and why the extra gates (all confirmed by live DOM
+ * investigation on these two Selects):
+ *  - Both Selects search SERVER-side (`filterOption: false` plus a
+ *    searchAction-driven refetch in BAIAvailablePresetSelect /
+ *    BAIVFolderSelect), so after typing, the option list and its
+ *    "Total N items" footer only narrow once the search round-trip lands.
+ *    Until then the footer still shows the unfiltered count and Enter can
+ *    land on a stale highlighted row — or on nothing at all (observed live
+ *    as a missing `.ant-select-selection-item` after the dropdown closed).
+ *    Because the searched name is unique, the search is settled exactly when
+ *    the footer reads "Total 1 items"; only then is Enter trustworthy.
+ *  - The virtualized option rows render with a computed width of 0, so both
+ *    `.click()` and `.click({ force: true })` fail even though the option is
+ *    attached and correctly labeled — ArrowDown + Enter selects the sole
+ *    settled result without depending on the row's bounding box. (ArrowDown
+ *    is a no-op when the single option is already highlighted, and activates
+ *    it when antd did not auto-highlight.)
+ *  - The raw `#…` input's value is not where antd renders the selection.
+ *    antd v6's single-mode Select renders the selected label inside
+ *    `.ant-select-content` (the `.ant-select-selection-item` element of
+ *    antd v5 now only exists in multiple mode — confirmed against
+ *    @rc-component/select's SingleContent). The closing assertion reads that
+ *    container, which proves the intended option (not some other row) was
+ *    selected.
+ */
+export async function selectRevisionModalOption(
+  page: Page,
+  inputSelector: string,
+  optionName: string,
+): Promise<void> {
+  await page.locator(inputSelector).click();
+  await page.locator(inputSelector).fill(optionName);
+  const dropdown = page
+    .locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')
+    .first();
+  await expect(dropdown).toBeVisible({ timeout: 10000 });
+  await expect(dropdown.getByText('Total 1 items')).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(
+    dropdown.getByRole('option', { name: optionName }).first(),
+  ).toBeAttached({ timeout: 15000 });
+  await page.locator(inputSelector).press('ArrowDown');
+  await page.locator(inputSelector).press('Enter');
+  await expect(dropdown).toBeHidden({ timeout: 5000 });
+  await expect(
+    page
+      .locator('.ant-select', { has: page.locator(inputSelector) })
+      .locator('.ant-select-content'),
+  ).toContainText(optionName, { timeout: 5000 });
+}


### PR DESCRIPTION
Resolves #8220 (FR-3294)

## Problem

The deployment revision e2e specs assumed a hand-seeded `mockvllm-preset` + `mockllm-svc` fixture pair existed on the target cluster. That pair only happened to exist on the one QA cluster it was manually created on — the specs silently fail on any clean or CI cluster.

## What this PR does

- **`e2e/utils/deployment-fixtures.ts` (new)** — self-sufficient fixture provisioning:
  - `ensureDeploymentPreset`: **find-or-create** — reuses a compatible pre-existing preset when the cluster has one (custom runtime, GPU-free slots, image set; never modified or deleted by the tests), and otherwise creates a `SINGLE_NODE` GPU-free `e2e-dfx-*` preset as the admin via GraphQL (`runtimeVariantId`/`imageId` resolved dynamically by name) and tears it down at cleanup. `e2e-dfx-*` presets are excluded from the reuse pool so one run can never depend on a preset another concurrent run will delete.
  - `provisionDeploymentModelFolder`: creates a fresh `e2e-dfx-*` model folder and uploads the GPU-free mock-server fixtures (`mock_openai_server.py`, `model-definition.yaml`, and a new `start.sh` shim so the folder is startable under both the created preset's command and the common `bash /models/start.sh` convention of hand-made presets).
  - `cleanupDeploymentFixtures`: best-effort teardown of everything the run itself created; a reused pre-existing preset is structurally impossible to delete (its id is never recorded). A 2-hour age-gated sweep collects `e2e-dfx-*` presets leaked by interrupted runs (presets are the one resource the global teardown does not cover).
  - `selectRevisionModalOption`: shared search + keyboard selection for the modal's server-side-search Selects, with the "Total 1 items" settle gate and an antd-v6 `.ant-select-content` selected-value assertion.
- **`deployment-lifecycle.spec.ts`** — rewired to the fixtures helper; adds a **new Advanced Mode test** that attaches a revision manually (folder + custom runtime + start command, image/resources at form defaults) with **no preset involved at all**, gated on the modal's async-mounting sections (image resolve, Cluster & Resources) whose absence otherwise makes submit fail silently. The two revision-attaching tests run serially — their concurrent folder-create + upload flows were observed starving each other's waits on the shared cluster.
- **`deployment-access-token.spec.ts`** — rewired the same way; also fixes a latent locator bug: `getByRole('dialog', { name: 'Token' })` matches by substring, so it also caught the still-closing "Create Access Token" modal (observed live as a strict-mode violation) — now `exact: true`.
- **`FolderCreationModal.ts`** — widened one form-row visibility wait to 20s (modal shell renders before its form body under load).

## Covered E2E Scenarios

| # | Scenario | What it verifies |
|---|---|---|
| 1 | List page smoke | Deployments list renders its columns, Running/Terminated scope toggle, reload and Create Deployment controls |
| 2 | Create + permanently delete a deployment | Create modal defaults, detail-page auto-redirect on create, list row (Pending, 0/1), typed-name delete confirmation, row gone from both scopes |
| 3 | Detail page structure | Basic Information card, revision tabs, Replicas / Auto-scaling sections, and Access Tokens disabled while no revision exists |
| 4 | Preset Mode fields | Add Revision modal's Preset Mode field set renders (preset/folder selects, auto-apply checkbox) |
| 5 | Advanced Mode fields | Advanced Mode's full field set renders (folder, runtime, health check, environments, cluster & resources) |
| 6 | Add revision in Preset Mode (serial) | Found-or-created preset + provisioned folder selected via keyboard (settle-gated), submit succeeds, deployment lifecycle leaves Pending, Current Revision tab shows the attached revision |
| 7 | Add revision manually in Advanced Mode (serial, **no preset**) | Folder + `custom` runtime + start command entered by hand, image/resources left at form defaults, submit succeeds and the revision attaches — proves manual revisions need no preset |
| 8 | Edit deployment | Desired Replicas save persists to the Basic Information card; Cancel does not persist |
| 9 | Auto-scaling rule modal fields | Metric source/name, conditions, thresholds and defaults render |
| 10 | Auto-scaling rule create + delete | cpu_util rule appears in the table and is removed via its confirm modal |
| 11 | Revision History tab | URL tab param, filter and table structure, empty state |
| 12 | Access token issuance (separate spec) | Create Access Token is disabled without a revision, enabled after one attaches; issuing returns the real token in the result dialog |

Scenarios 6, 7, and 12 create real revisions against the cluster. They deliberately stop at "revision attached" — replica scheduling latency was measured at ~40s to 20+ minutes on the shared cluster and is out of scope for webui e2e (belongs to backend-surface testing).

## How to verify

1. Copy `e2e/envs/.env.playwright.sample` to `e2e/envs/.env.playwright` and set:
   - `E2E_WEBUI_ENDPOINT` / `E2E_WEBSERVER_ENDPOINT` — a live cluster's WebUI and webserver (session-login) endpoints
   - `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` — a superadmin account
   - `E2E_USER_EMAIL` / `E2E_USER_PASSWORD` — any regular user (only used by the global cleanup sweep)
2. Preconditions: manager with the `deployment-preset` capability (>= 26.4.x — the Preset Mode test skips with an auditable reason otherwise) and at least one `bai/ngc-pytorch` or python image registered. **No hand-seeded preset or folder is required — that is the point of this PR.** Run against a cluster where creating/deleting deployments, presets, and vfolders is acceptable.
3. Run (one invocation at a time — concurrent e2e runs against the same shared cluster degrade hydration):
   ```
   pnpm exec playwright test e2e/serving/deployment-lifecycle.spec.ts e2e/serving/deployment-access-token.spec.ts --workers=1
   ```
4. Expected: **14 passed** (12 spec tests + 2 global-cleanup teardown), ~13 min. Afterward the cluster has no leftover `e2e-*` deployment, preset, or folder (each test tears down what it created; a reused pre-existing preset such as `mockvllm-preset` is left untouched). The run log prints which path was taken: `reusing compatible pre-existing preset "…"` or `no compatible preset on this cluster — created "…"`.

## Known follow-up (product, not this PR)

While a revision modal's Cluster & Resources section is still loading, clicking "Add Revision" does nothing at all — no validation error, no notification, no request (the submit handler reads fields that are not registered yet and dies silently). The e2e now gates on the section mounting, but the button should arguably be disabled until the form is fully mounted. Can be filed separately.
