### PR TITLE
chore(FR-3297): add e2e smoke coverage for admin resources sub-tabs

### DIFF
--- a/e2e/resources/resources-admin.spec.ts
+++ b/e2e/resources/resources-admin.spec.ts
@@ -1,0 +1,164 @@
+// spec: e2e/.agent-output/test-plan-e2e-coverage-gaps.md
+//
+// Coverage gap this file fills: the admin Resources page's "Storages" and
+// "Resource Group" sub-tabs, and the separate "Scheduler" page, previously had
+// zero render-smoke coverage (visual_regression, which used to cover layout,
+// is fully disabled). e2e/agent/agent.spec.ts already covers the "Agent" tab
+// in depth, so that tab is only smoke-checked here (tab exists / can be
+// switched to) to avoid duplicating that file's assertions.
+//
+// All scenarios in this file are read-only: no resource is created, modified,
+// or deleted.
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import { test, expect } from '@playwright/test';
+
+// The Resources and Scheduler routes render inside the "Admin Settings"
+// nested layout, which is consistently slow to hydrate on the shared QA264
+// cluster (confirmed live, and matches e2e/crawl/route-crawl.spec.ts's
+// SLOW_LANDMARK_TIMEOUT for these exact two routes) -- a bare 5s default
+// `expect` times out flakily on the first landmark of each route, so the
+// first assertion on each route below uses a generous explicit timeout.
+const SLOW_LANDMARK_TIMEOUT = 30_000;
+
+test.describe(
+  'Resources Admin Page',
+  { tag: ['@regression', '@resources', '@functional', '@admin'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test(
+      'Admin can view and switch between Agent, Storages, and Resource Group tabs',
+      { tag: ['@smoke'] },
+      async ({ page }) => {
+        // 1. Navigate to /agent (Resources page).
+        await navigateTo(page, 'agent');
+
+        // 2. Verify the breadcrumb reads "Resources" and all three tabs are present.
+        await expect(
+          page.getByTestId('webui-breadcrumb').getByText('Resources'),
+        ).toBeVisible({ timeout: SLOW_LANDMARK_TIMEOUT });
+        await expect(
+          page.getByRole('tab', { name: 'Agent', selected: true }),
+        ).toBeVisible({ timeout: SLOW_LANDMARK_TIMEOUT });
+        await expect(page.getByRole('tab', { name: 'Storages' })).toBeVisible();
+        await expect(
+          page.getByRole('tab', { name: 'Resource Group' }),
+        ).toBeVisible();
+
+        // 3. Switch to the Storages tab and confirm it becomes selected.
+        await page.getByRole('tab', { name: 'Storages' }).click();
+        await expect(
+          page.getByRole('tab', { name: 'Storages', selected: true }),
+        ).toBeVisible();
+
+        // 4. Switch to the Resource Group tab and confirm it becomes selected.
+        await page.getByRole('tab', { name: 'Resource Group' }).click();
+        await expect(
+          page.getByRole('tab', { name: 'Resource Group', selected: true }),
+        ).toBeVisible();
+      },
+    );
+
+    test('Admin can view storage backend columns in the Storages tab', async ({
+      page,
+    }) => {
+      // 1. Navigate to /agent and wait for the page to hydrate.
+      await navigateTo(page, 'agent');
+      await expect(
+        page.getByTestId('webui-breadcrumb').getByText('Resources'),
+      ).toBeVisible({ timeout: SLOW_LANDMARK_TIMEOUT });
+
+      // 2. Click the Storages tab.
+      await page.getByRole('tab', { name: 'Storages' }).click();
+
+      // 3. Verify the expected column headers and that the table renders.
+      await expect(page.getByRole('table')).toBeVisible({
+        timeout: SLOW_LANDMARK_TIMEOUT,
+      });
+      await expect(
+        page.getByRole('columnheader', { name: 'ID / Endpoint' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Backend Type' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Resources' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Capabilities' }),
+      ).toBeVisible();
+    });
+
+    test('Admin can view the default resource group in the Resource Group tab', async ({
+      page,
+    }) => {
+      // 1. Navigate to /agent and wait for the page to hydrate.
+      await navigateTo(page, 'agent');
+      await expect(
+        page.getByTestId('webui-breadcrumb').getByText('Resources'),
+      ).toBeVisible({ timeout: SLOW_LANDMARK_TIMEOUT });
+
+      // 2. Click the Resource Group tab.
+      await page.getByRole('tab', { name: 'Resource Group' }).click();
+
+      // 3. Verify the expected column headers.
+      await expect(
+        page.getByRole('columnheader', { name: 'Name' }),
+      ).toBeVisible({ timeout: SLOW_LANDMARK_TIMEOUT });
+      await expect(
+        page.getByRole('columnheader', { name: 'Description' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Public' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Driver' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Scheduler' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'App Proxy Server Address' }),
+      ).toBeVisible();
+
+      // 4. Verify the pre-existing "default" resource group row renders.
+      // Scoped on the Description cell's text (rather than the bare "default"
+      // Name cell) to avoid any ambiguity with other rows/columns.
+      await expect(
+        page
+          .getByRole('row')
+          .filter({ hasText: 'The default agent scaling group' }),
+      ).toBeVisible();
+    });
+  },
+);
+
+test.describe(
+  'Scheduler Page',
+  { tag: ['@regression', '@resources', '@functional', '@admin'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test(
+      'Admin can view the Fair Share Setting tab on the Scheduler page',
+      { tag: ['@smoke'] },
+      async ({ page }) => {
+        // 1. Navigate to /scheduler.
+        await navigateTo(page, 'scheduler');
+
+        // 2. Verify the breadcrumb reads "Scheduler" and the "Fair Share
+        // Setting" tab renders (selected by default, since it's the only tab).
+        await expect(
+          page.getByTestId('webui-breadcrumb').getByText('Scheduler'),
+        ).toBeVisible({ timeout: SLOW_LANDMARK_TIMEOUT });
+        await expect(
+          page.getByRole('tab', { name: 'Fair Share Setting', selected: true }),
+        ).toBeVisible({ timeout: SLOW_LANDMARK_TIMEOUT });
+      },
+    );
+  },
+);

--- a/e2e/resources/resources-admin.spec.ts
+++ b/e2e/resources/resources-admin.spec.ts
@@ -13,7 +13,7 @@ import { loginAsAdmin, navigateTo } from '../utils/test-util';
 import { test, expect } from '@playwright/test';
 
 // The Resources and Scheduler routes render inside the "Admin Settings"
-// nested layout, which is consistently slow to hydrate on the shared QA264
+// nested layout, which is consistently slow to hydrate on the shared QA
 // cluster (confirmed live, and matches e2e/crawl/route-crawl.spec.ts's
 // SLOW_LANDMARK_TIMEOUT for these exact two routes) -- a bare 5s default
 // `expect` times out flakily on the first landmark of each route, so the


### PR DESCRIPTION
Resolves #8223 (FR-3297)

Adds read-only smoke coverage for the admin Resources page's sub-tabs and the Scheduler page — surfaces that previously had zero render coverage (visual regression, which used to cover their layout, is fully disabled). The Agent tab is only checked for existence/switchability since `e2e/agent/agent.spec.ts` already covers it in depth.

## Covered E2E Scenarios

| # | Scenario | What it verifies |
|---|---|---|
| 1 | Admin switches between Agent / Storages / Resource Group tabs | All three tabs exist and can be switched to, with the Agent tab selected by default |
| 2 | Storages tab contents | The storage table renders its backend columns (Name, Endpoint, Backend, Capabilities, ...) |
| 3 | Resource Group tab contents | The resource group table renders its columns (Name, Description, Public, Driver, Scheduler, ...) and the default resource group row |
| 4 | Scheduler page Fair Share tab | The Scheduler route renders with the Fair Share Setting tab reachable |

Read-only: no resource is created, modified, or deleted.

## How to verify

1. Copy `e2e/envs/.env.playwright.sample` to `e2e/envs/.env.playwright` and set `E2E_WEBUI_ENDPOINT` / `E2E_WEBSERVER_ENDPOINT` and `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` (`E2E_USER_EMAIL` / `E2E_USER_PASSWORD` are only used by the global cleanup sweep).
2. Preconditions: none beyond an admin login — the tests only read the stock Resources/Scheduler pages (at least one storage host and the `default` resource group exist on any working cluster). Read-only — safe on any cluster.
3. Run (one invocation at a time — concurrent e2e runs against the same shared cluster degrade hydration):
   ```
   pnpm exec playwright test e2e/resources/resources-admin.spec.ts
   ```
4. Expected: **6 passed** (4 spec tests + 2 global-cleanup teardown), ~2 min.
