### PR TITLE
fix(FR-3303): keep chat endpoint visible while a new revision rolls out

### DIFF
--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -7,7 +7,7 @@ import {
   EndpointSelectQuery$data,
 } from '../../__generated__/EndpointSelectQuery.graphql';
 import { EndpointSelectValueQuery } from '../../__generated__/EndpointSelectValueQuery.graphql';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
+import { useWebUINavigate } from '../../hooks';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import TotalFooter from '../TotalFooter';
 import { useControllableValue } from 'ahooks';
@@ -19,7 +19,12 @@ import {
   Space,
   Tooltip,
 } from 'antd';
-import { BAIEndpointsIcon, BAIFlex, BAISelect } from 'backend.ai-ui';
+import {
+  BAIEndpointsIcon,
+  BAIFlex,
+  BAISelect,
+  mergeFilterValues,
+} from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { InfoIcon } from 'lucide-react';
 import React, { useDeferredValue, useEffect, useRef, useState } from 'react';
@@ -35,7 +40,6 @@ export interface EndpointSelectProps extends Omit<
   'options' | 'labelInValue'
 > {
   fetchKey?: string;
-  lifecycleStageFilter?: LifecycleStage[];
   showDetailPageButton?: boolean;
 }
 
@@ -47,18 +51,20 @@ type LifecycleStage =
   | 'destroying'
   | 'destroyed';
 
+// Terminated lifecycle stages: a deployment in one of these has no serving
+// replica. Everything else may still have a replica serving traffic.
+const TERMINATED_LIFECYCLE_STAGES: LifecycleStage[] = [
+  'destroying',
+  'destroyed',
+];
+
 const EndpointSelect: React.FC<EndpointSelectProps> = ({
   fetchKey,
-  lifecycleStageFilter = ['ready', 'created'],
   showDetailPageButton: showInfoButton,
   loading,
   ...selectPropsWithoutLoading
 }) => {
   const { t } = useTranslation();
-  const baiClient = useSuspendedBackendaiClient();
-  lifecycleStageFilter = baiClient.supports('endpoint-lifecycle-ready-stage')
-    ? ['ready', 'created']
-    : ['created'];
 
   const [controllableValue, setControllableValue] = useControllableValue<
     string | undefined
@@ -77,9 +83,15 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
 
   const selectRef = useRef<GetRef<typeof BAISelect> | null>(null);
 
-  const lifecycleStageFilterStr = lifecycleStageFilter
-    .map((v) => `lifecycle_stage == "${v}"`)
-    .join(' | ');
+  // Show every deployment that is not terminated, so a deployment whose replica
+  // is still alive stays selectable while a new revision is rolling out (e.g.
+  // deploying/pending). Filtering on ready/created alone hid such deployments.
+  // TODO(FR-3303): once the endpoint connection supports nested filters, list
+  // deployments that have at least one replica with an active traffic status
+  // instead of relying on the endpoint-level lifecycle_stage.
+  const lifecycleStageFilterStr = mergeFilterValues(
+    TERMINATED_LIFECYCLE_STAGES.map((stage) => `lifecycle_stage != "${stage}"`),
+  );
 
   const { endpoint: selectedEndpoint } =
     useLazyLoadQuery<EndpointSelectValueQuery>(
@@ -138,13 +150,10 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
       limit: 10,
     },
     {
-      filter: [
+      filter: mergeFilterValues([
         lifecycleStageFilterStr,
         deferredSearchStr ? `name ilike "%${deferredSearchStr}%"` : undefined,
-      ]
-        .filter(Boolean)
-        .map((v) => `(${v})`)
-        .join(' & '),
+      ]),
     },
     // TODO: skip fetch when the option popover is closed
     {

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '../components/Chat/ChatHistory';
 import { type ChatProviderData } from '../components/Chat/ChatModel';
 import WebUINavigate from '../components/WebUINavigate';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useWebUINavigate } from '../hooks';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   Alert,
@@ -25,7 +25,13 @@ import {
   Typography,
 } from 'antd';
 import { createStyles } from 'antd-style';
-import { BAIButton, BAIFlex, BAICard, BAITable } from 'backend.ai-ui';
+import {
+  BAIButton,
+  BAIFlex,
+  BAICard,
+  BAITable,
+  mergeFilterValues,
+} from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import { t } from 'i18next';
 import * as _ from 'lodash-es';
@@ -46,8 +52,6 @@ const useStyles = createStyles(({ css }) => ({
 }));
 
 function useDefaultEndpointId() {
-  const baiClient = useSuspendedBackendaiClient();
-
   const { endpoint_list } = useLazyLoadQuery<ChatPageQuery>(
     graphql`
       query ChatPageQuery($filter: String) {
@@ -59,9 +63,17 @@ function useDefaultEndpointId() {
       }
     `,
     {
-      filter: baiClient.supports('endpoint-lifecycle-ready-stage')
-        ? 'lifecycle_stage == "ready" | lifecycle_stage == "created"'
-        : 'lifecycle_stage == "created"',
+      // Pick any deployment that is not terminated, so its replica can still be
+      // chatted with. Filtering on ready/created alone skipped deployments while
+      // a new revision was rolling out (e.g. deploying/pending) even though a
+      // previous revision's replica was still alive.
+      // TODO(FR-3303): once the endpoint connection supports nested filters,
+      // pick a deployment that has at least one replica with an active traffic
+      // status instead of relying on the endpoint-level lifecycle_stage.
+      filter: mergeFilterValues([
+        'lifecycle_stage != "destroyed"',
+        'lifecycle_stage != "destroying"',
+      ]),
     },
   );
 


### PR DESCRIPTION
Resolves #8235 (FR-3303)

## Problem

In a model deployment, when a new revision is being applied and its inference session is still pending (e.g. resource-constrained), the previous revision's replica is still running and serving traffic — but the deployment disappears from the Playground **Chat** menu, so the user cannot chat against the still-alive replica.

## Cause

The chat endpoint selector filtered endpoints with `lifecycle_stage == "ready" | lifecycle_stage == "created"`, which only matches a **completed** deployment. While a new revision rolls out, the endpoint's `lifecycle_stage` moves to `deploying`/`pending`/`scaling`, so it was filtered out even though a replica was still serving.

## Fix

Filter out only **terminated** endpoints (`destroying` / `destroyed`) instead of matching `ready`/`created`. A deployment whose replica is still serving stays selectable while a new revision rolls out.

- `ChatPage.tsx` (`useDefaultEndpointId`) and `EndpointSelect.tsx` now use `lifecycle_stage != "destroyed" & lifecycle_stage != "destroying"`.
- The exclusion filter is backend-version agnostic (terminal stages exist in all versions), so the now-redundant `endpoint-lifecycle-ready-stage` feature-flag branching and the dead, always-overridden `lifecycleStageFilter` prop on `EndpointSelect` are removed.

> Interim approach per the originating discussion. A follow-up (noted in a code `TODO`) should, once the endpoint connection supports **nested filters**, select deployments that have at least one replica with an **active traffic status** rather than relying on the endpoint-level `lifecycle_stage`.

## Verification

`bash scripts/verify.sh`:

- Relay: **PASS**
- Lint: **PASS**
- Format: **PASS**
- TypeScript: 1 failure in `src/components/FluentEmojiIcon.tsx:17` (`CUSTOM_CDN_URL`) — **pre-existing on `main`**, unrelated to this change (confirmed by re-running verify with the changes stashed). No new type errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
