### PR TITLE
test: e2e auto-heal 2026-07-10

### DIFF
--- a/e2e/rbac/rbac-role-crud.spec.ts
+++ b/e2e/rbac/rbac-role-crud.spec.ts
@@ -36,6 +36,13 @@ test.describe.serial(
       ).toBeVisible({ timeout: 10000 });
     }
 
+    // Scope status-filter clicks to the radiogroup — the AutoAssign column
+    // also renders per-row "Active"/"Inactive" tags, which collide with a
+    // bare getByText locator (strict-mode violation).
+    function statusFilterOption(page: Page, status: 'Active' | 'Inactive') {
+      return page.getByRole('radiogroup').getByText(status, { exact: true });
+    }
+
     async function clearRoleSearch(page: Page) {
       // Remove any active filter chip — scope to the filter-chip area so we
       // don't accidentally click tag close icons in the table itself.
@@ -52,7 +59,7 @@ test.describe.serial(
 
     async function cleanupTestRole(page: Page, roleName: string) {
       // Check Active tab first
-      await page.getByText('Active', { exact: true }).click();
+      await statusFilterOption(page, 'Active').click();
       await clearRoleSearch(page);
       const activeRow = page.getByRole('row').filter({ hasText: roleName });
       const isActiveVisible = await activeRow
@@ -75,7 +82,7 @@ test.describe.serial(
       }
 
       // Check Inactive tab
-      await page.getByText('Inactive', { exact: true }).click();
+      await statusFilterOption(page, 'Inactive').click();
       await clearRoleSearch(page);
       const inactiveRow = page.getByRole('row').filter({ hasText: roleName });
       const isInactiveVisible = await inactiveRow
@@ -100,7 +107,7 @@ test.describe.serial(
       }
 
       // Return to Active tab
-      await page.getByText('Active', { exact: true }).click();
+      await statusFilterOption(page, 'Active').click();
       await clearRoleSearch(page);
     }
 
@@ -306,7 +313,7 @@ test.describe.serial(
       await navigateTo(page, 'rbac');
 
       // 3. Ensure "Active" filter is selected
-      await page.getByText('Active', { exact: true }).click();
+      await statusFilterOption(page, 'Active').click();
 
       // 4. Search for the test role by name (using the edited name from previous test)
       await searchForRole(page, ROLE_NAME_EDITED);
@@ -337,7 +344,7 @@ test.describe.serial(
       ).toBeVisible({ timeout: 10000 });
 
       // 8. Click the "Inactive" filter to verify the role appears there
-      await page.getByText('Inactive', { exact: true }).click();
+      await statusFilterOption(page, 'Inactive').click();
       await searchForRole(page, ROLE_NAME_EDITED);
     });
 
@@ -352,7 +359,7 @@ test.describe.serial(
       await navigateTo(page, 'rbac');
 
       // 3. Click the "Inactive" filter button
-      await page.getByText('Inactive', { exact: true }).click();
+      await statusFilterOption(page, 'Inactive').click();
 
       // 4. Search for the test role by name and locate the row
       await searchForRole(page, ROLE_NAME_EDITED);
@@ -388,7 +395,7 @@ test.describe.serial(
       await expect(inactiveRoleRow).toBeHidden({ timeout: 10000 });
 
       // 9. Click the "Active" filter and verify the role reappears there
-      await page.getByText('Active', { exact: true }).click();
+      await statusFilterOption(page, 'Active').click();
       await searchForRole(page, ROLE_NAME_EDITED);
     });
 
@@ -403,7 +410,7 @@ test.describe.serial(
       await navigateTo(page, 'rbac');
 
       // 3. Deactivate the role first (so it's in the Inactive state for purging)
-      await page.getByText('Active', { exact: true }).click();
+      await statusFilterOption(page, 'Active').click();
       await searchForRole(page, ROLE_NAME_EDITED);
       const activeRoleRow = page
         .getByRole('row')
@@ -423,7 +430,7 @@ test.describe.serial(
       await expect(activeRoleRow).toBeHidden({ timeout: 10000 });
 
       // 4. Switch to Inactive filter
-      await page.getByText('Inactive', { exact: true }).click();
+      await statusFilterOption(page, 'Inactive').click();
 
       // 5. Search for and locate the deleted test role row
       await searchForRole(page, ROLE_NAME_EDITED);
@@ -472,7 +479,7 @@ test.describe.serial(
       await expect(inactiveRoleRow).toBeHidden({ timeout: 10000 });
 
       // 13. Verify the role also doesn't appear in the Active list
-      await page.getByText('Active', { exact: true }).click();
+      await statusFilterOption(page, 'Active').click();
       await expect(
         page.getByRole('row').filter({ hasText: ROLE_NAME_EDITED }),
       ).toBeHidden({ timeout: 5000 });

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -103,6 +103,13 @@ async function clearRoleSearch(page: Page) {
   }
 }
 
+// Scope status-filter clicks to the radiogroup — the AutoAssign column also
+// renders per-row "Active"/"Inactive" tags, which collide with a bare
+// getByText locator (strict-mode violation).
+function statusFilterOption(page: Page, status: 'Active' | 'Inactive') {
+  return page.getByRole('radiogroup').getByText(status, { exact: true });
+}
+
 async function cleanupTestRole(page: Page) {
   // Close any lingering drawer from a previous test so it doesn't block clicks.
   const openDrawer = page.locator('.ant-drawer-open');
@@ -112,7 +119,7 @@ async function cleanupTestRole(page: Page) {
   }
 
   // Check Active tab first
-  await page.getByText('Active', { exact: true }).click();
+  await statusFilterOption(page, 'Active').click();
   await clearRoleSearch(page);
   // Use name filter to find the role even if it's on a later page
   const filterContainer = page.locator('.ant-space-compact').first();
@@ -156,7 +163,7 @@ async function cleanupTestRole(page: Page) {
   }
 
   // Check Inactive tab
-  await page.getByText('Inactive', { exact: true }).click();
+  await statusFilterOption(page, 'Inactive').click();
   await clearRoleSearch(page);
   const inactivePropertySelect = filterContainer.locator('.ant-select').first();
   await inactivePropertySelect.click();
@@ -199,7 +206,7 @@ async function cleanupTestRole(page: Page) {
   }
 
   // Return to Active tab and clear any search filters
-  await page.getByText('Active', { exact: true }).click();
+  await statusFilterOption(page, 'Active').click();
   await clearRoleSearch(page);
 }
 

--- a/e2e/rbac/rbac-role-list.spec.ts
+++ b/e2e/rbac/rbac-role-list.spec.ts
@@ -30,9 +30,17 @@ test.describe(
         page.getByRole('button', { name: 'Create Role' }),
       ).toBeEnabled();
 
-      // 5. Verify the status filter shows "Active" and "Inactive" options
-      await expect(page.getByText('Active', { exact: true })).toBeVisible();
-      await expect(page.getByText('Inactive', { exact: true })).toBeVisible();
+      // 5. Verify the status filter shows "Active" and "Inactive" options.
+      // Scope to the status filter's radiogroup — the AutoAssign column also
+      // renders per-row "Active"/"Inactive" tags, which collide with a bare
+      // getByText locator (strict-mode violation).
+      const statusFilter = page.getByRole('radiogroup');
+      await expect(
+        statusFilter.getByText('Active', { exact: true }),
+      ).toBeVisible();
+      await expect(
+        statusFilter.getByText('Inactive', { exact: true }),
+      ).toBeVisible();
 
       // 6. Verify the role table is rendered with expected column headers
       await expect(
@@ -77,15 +85,19 @@ test.describe(
         .filter({ hasNot: page.getByRole('columnheader') });
       await expect(activeRows.first()).toBeVisible({ timeout: 10000 });
 
-      // 4. Click the "Inactive" filter button
-      await page.getByText('Inactive', { exact: true }).click();
+      // 4. Click the "Inactive" filter button.
+      // Scope to the status filter's radiogroup — the AutoAssign column also
+      // renders per-row "Active"/"Inactive" tags, which collide with a bare
+      // getByText locator (strict-mode violation).
+      const statusFilter = page.getByRole('radiogroup');
+      await statusFilter.getByText('Inactive', { exact: true }).click();
 
       // 5. Verify the table updates (shows deleted roles or empty state message)
       // Either the table shows rows or an empty state — we only check that there's no error
       await expect(page.locator('.ant-table')).toBeVisible({ timeout: 10000 });
 
       // 6. Click the "Active" filter button
-      await page.getByText('Active', { exact: true }).click();
+      await statusFilter.getByText('Active', { exact: true }).click();
 
       // 7. Verify the table updates back to showing active roles
       await expect(activeRows.first()).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
> Automated draft PR produced by the **daily webui digest auto-heal** (recovery run of the 2026-07-09 23:00 UTC job; suite finished 23:59 UTC, digest posted late on 2026-07-10).

## What this fixes

The RBAC role table's **AutoAssign** column (`react/src/components/RoleNodes.tsx`, introduced in #7696 / FR-3029) now renders an `Active`/`Inactive` `BAITag` on every row. The RBAC specs used unscoped `page.getByText('Active'|'Inactive', { exact: true })` to click the status-filter radio buttons, which now collides with the per-row tags (strict-mode violation: "resolved to 11 elements").

**Test-side fix only** — all ambiguous locators are now scoped to the status filter's `radiogroup`: `page.getByRole('radiogroup').getByText(status, { exact: true })`. No app code changed.

## Healed tests (re-pass verified, isolated per-spec runs)

`e2e/rbac/rbac-role-list.spec.ts`
- ✅ Superadmin can view the RBAC management page with role list table
- ✅ Superadmin can switch to Inactive roles filter and back to Active

`e2e/rbac/rbac-role-crud.spec.ts`
- ✅ Superadmin can create a new custom role with name and description

`e2e/rbac/rbac-role-detail.spec.ts`
- ✅ Superadmin can add a permission to a role
- ✅ Superadmin can delete a permission from a role
- ✅ Superadmin sees empty state in Permissions tab when role has no permissions
- ✅ Superadmin can assign a user to a role
- ✅ Superadmin can revoke a single user from a role
- ✅ Superadmin sees empty state in Role Assignments tab when role has no users

## Exhausted (retry budget) tests

None.

## Notes

- Two credential singleton failures (`bulk-create-from-csv.spec.ts`, `my-keypair-management.spec.ts`) passed on isolated re-run — full-suite contention flakes, no code change needed, not part of this PR.
- The 3 `auto-scaling-rule-preset` specs are already covered by the open heal PR #8216 and were intentionally not re-healed (idempotency guard).
- cc @agatha197 (related change #7696 introduced the AutoAssign tag that caused the locator drift)

Report doc: `/home/ubuntu/.claude/logs/e2e-digest/report-2026-07-10.md` (on the digest runner host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
