### PR TITLE
docs(FR-3312): document BAIUncontrolledInput purpose in Storybook

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIUncontrolledInput.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUncontrolledInput.stories.tsx
@@ -4,10 +4,11 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 /**
- * BAIUncontrolledInput is an uncontrolled input with commit-on-blur behavior.
+ * BAIUncontrolledInput is an intentionally uncontrolled input that commits
+ * its value only on Enter or blur — not on every keystroke.
  *
  * Key features:
- * - Uncontrolled mode (uses defaultValue instead of value)
+ * - value/onChange are removed by design (uses defaultValue + onCommit)
  * - Commits value on blur or Enter key press
  * - Shows Enter icon hint when focused
  * - Hides number input spinners
@@ -23,20 +24,29 @@ const meta: Meta<typeof BAIUncontrolledInput> = {
     docs: {
       description: {
         component: `
-**BAIUncontrolledInput** extends [Ant Design Input](https://ant.design/components/input) as an uncontrolled component.
+**BAIUncontrolledInput** extends [Ant Design Input](https://ant.design/components/input) as an **intentionally uncontrolled** component.
+
+## Purpose
+This component exists to keep expensive commit side effects — such as persisting to localStorage — from running on every keystroke. The \`value\`/\`onChange\` props are deliberately removed from its API to steer consumers toward \`onCommit\`, the intended commit path: the new value is delivered only when the user finishes editing. (Per-keystroke handlers inherited from Ant Design Input, such as \`onInput\`/\`onKeyUp\`, still pass through — this is a convention, not an enforced restriction.)
+
+- **Enter key** — commits the value (internally triggers blur)
+- **Blur** — clicking/tabbing away commits the value
+
+While focused, an Enter (⏎) icon appears in the suffix as an explicit visual cue that the value is applied on Enter (or blur), so users understand typing alone does not save.
 
 ## BAI-Specific Features
-- **Uncontrolled mode**: Uses \`defaultValue\` instead of \`value\` prop
+- **Uncontrolled by design**: \`value\`/\`onChange\` are excluded from props; uses \`defaultValue\` + \`onCommit\`
 - **Commit on blur/Enter**: Triggers \`onCommit\` callback when input loses focus or Enter is pressed
-- **Enter icon hint**: Shows ⏎ icon when focused to indicate Enter key support
+- **Enter icon hint**: Shows ⏎ icon when focused to signal the commit-on-Enter behavior
 - **No number spinners**: Hides spinner arrows for number input type
+- **Reset on external change**: Changing \`defaultValue\` remounts the input (via \`key\`), discarding uncommitted edits
 
 ## Usage
 \`\`\`tsx
-// Basic usage
+// Persist a setting only when the user finishes editing
 <BAIUncontrolledInput
-  defaultValue="Initial value"
-  onCommit={(value) => console.log('Committed:', value)}
+  defaultValue={storedValue}
+  onCommit={(value) => saveToLocalStorage(value)}
 />
 
 // Number input without spinners
@@ -50,15 +60,17 @@ const meta: Meta<typeof BAIUncontrolledInput> = {
 ## Props
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| \`defaultValue\` | \`string\` | - | Initial value (uncontrolled) |
+| \`defaultValue\` | \`string\` | - | Initial value (uncontrolled). Changing it resets the input |
 | \`onCommit\` | \`(value: string) => void\` | - | Callback when value is committed (blur or Enter) |
 
-For all other props, refer to [Ant Design Input](https://ant.design/components/input).
+\`value\` and \`onChange\` are intentionally not available. For all other props, refer to [Ant Design Input](https://ant.design/components/input).
 
 ## When to Use
-- When you need to defer value updates until the user finishes editing
+- When committing the value has side effects that must not run per keystroke (e.g. localStorage writes, network requests)
 - For form fields that should only update on blur/Enter (not on every keystroke)
 - When you want to avoid re-renders on every character typed
+
+Use a regular controlled \`Input\` when the UI must react to the value as the user types (live filtering, character counters, inline validation while typing).
         `,
       },
     },

--- a/packages/backend.ai-ui/src/components/BAIUncontrolledInput.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUncontrolledInput.tsx
@@ -17,12 +17,28 @@ const useStyles = createStyles(({ css }) => ({
   `,
 }));
 
-export interface BAIUncontrolledInputProps
-  extends Omit<InputProps, 'value' | 'defaultValue' | 'onChange'> {
+export interface BAIUncontrolledInputProps extends Omit<
+  InputProps,
+  'value' | 'defaultValue' | 'onChange'
+> {
+  /** Initial value. Changing it remounts the input and discards uncommitted edits. */
   defaultValue?: string;
+  /** Called with the current value when the user commits by pressing Enter or blurring. */
   onCommit?: (value: string) => void;
 }
 
+/**
+ * An intentionally uncontrolled Input that commits its value on Enter or
+ * blur — not on every keystroke.
+ *
+ * `value`/`onChange` are removed from the props to steer expensive commit
+ * side effects (e.g. persisting to localStorage) toward `onCommit`, which
+ * fires only when the user finishes editing. This is the intended commit
+ * path rather than an enforced restriction — per-keystroke handlers
+ * inherited from `InputProps` (such as `onInput`/`onKeyUp`) still pass
+ * through. While focused, an Enter (⏎) icon is shown as an explicit cue
+ * that the value is applied on Enter (or blur).
+ */
 const BAIUncontrolledInput: React.FC<BAIUncontrolledInputProps> = ({
   defaultValue,
   onCommit,
@@ -62,6 +78,7 @@ const BAIUncontrolledInput: React.FC<BAIUncontrolledInputProps> = ({
         if (e.key === 'Enter') {
           inputRef.current?.blur();
         }
+        inputProps?.onKeyDown?.(e);
       }}
     />
   );


### PR DESCRIPTION
Resolves #8241 (FR-3312)

## Summary

Per the devops Teams discussion, the purpose of `BAIUncontrolledInput` was unclear even to team members, and the Storybook docs page did not explain **why** the component exists.

- Rewrote the Storybook `docs.description.component` to lead with the purpose: keeping expensive commit side effects (e.g. persisting to localStorage) from running on every keystroke. `value`/`onChange` are deliberately removed from the API to steer consumers toward `onCommit`, the intended commit path — the value is delivered only on **Enter** or **blur** (per-keystroke handlers inherited from `InputProps`, such as `onInput`/`onKeyUp`, still pass through; this is a convention, not an enforced restriction).
- Documented the meaning of the Enter (⏎) suffix icon — an explicit visual cue that typing alone does not save.
- Documented the `defaultValue` remount-reset behavior (`key`-based) and added guidance on when to prefer a controlled `Input` instead (live filtering, character counters, validation while typing).
- Added TSDoc to the component and its props so the intent also surfaces in IDE tooltips and Storybook autodocs.

### Review feedback (Copilot)

- The internal Enter handler now forwards the event to a consumer-provided `onKeyDown` instead of silently overriding it — the only runtime behavior change in this PR.
- Reworded the JSDoc/Storybook claim that per-keystroke updates "cannot" be wired; `onCommit` is described as the intended commit path.

## Verification

`bash scripts/verify.sh`: **ALL PASS** (Relay / Lint / Format / TypeScript) after restacking onto latest `main` — the previously noted pre-existing `UserFolderPermissionPanelV2.tsx` TypeScript errors were fixed on `main` by FR-3282 (#8213).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
