### PR TITLE
feat(FR-3307): post-boot auto-register hooks + registry-aware connection info

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -207,7 +207,20 @@ If after ~15s the React URL still hasn't appeared (very rare with Vite), announc
 
 Many projects don't use Portless. Read the dev server's stdout for whatever URL(s) it prints (Vite typically prints `Local:` and `Network:`; Next.js prints `started server on http://localhost:3000`; etc.) and forward all of them to the user verbatim. If the project does use Portless, follow the webui rules above.
 
-## 6. Edge cases
+## 6. Register in the dev-server registry (post-boot)
+
+After a successful boot — i.e. right after step 5, once the **actual** Portless URL is known — register this dev server in the team dev-server registry **if the fw plugin's `dev-server-registry` skill is available** (it ships in the `fw` plugin from lablup/claude-mp; its `scripts/registry.sh` does the write). Teammates then discover the server on the team board instead of asking around.
+
+- Run the skill's **`register`** op from this project's worktree (`--cwd` = the checkout the server serves), passing what you learned during boot:
+  - `--subdomain` — the hostname Portless **actually printed** in step 5 (the part before `.localhost`), not the name you requested in step 2b.
+  - `--backend-endpoint` — the `VITE_DEFAULT_API_ENDPOINT` you resolved in step 2c (omit if you resolved none).
+  - `--backend-user` / `--backend-password` — **only** when the endpoint is a shared team test server (the registry skill's credential policy governs; when unsure, omit and let reviewers ask).
+  - PR number, branch, and Jira key are auto-derived by the script from the worktree — don't recompute them.
+- **Skip silently** (one short sentence, not an error) when the fw plugin / `dev-server-registry` skill isn't installed, or the box isn't initialized (`~/.config/fw/registry-box.json` missing). Do **not** run `init` unprompted — it needs a teammate-reachable host only the user knows.
+- Registration is idempotent per (repo, PR): re-booting the same PR just refreshes the entry. Register on state changes only — never on a timer.
+- **On stop/teardown** — the user says to stop the server, the review session ends, or you kill the background task — run the skill's **`unregister`** op from the same worktree so the board (and the PR's registry comment) doesn't advertise a dead server.
+
+## 7. Edge cases
 
 - **User overrides via env (webui)**: Vite's `loadEnv()` reads `VITE_THEME_HEADER_COLOR`, `VITE_DEFAULT_API_ENDPOINT` from `.env.development.local` and from the shell automatically. If the user already has any of them set, do not override — the user-set value wins. For `PORTLESS_APP_NAME`, the same rule applies: if it's already exported in the inherited env, treat the user-set value as authoritative.
 - **User overrides via prompt**: if the user says "use a green header" or "no color this time" or "name the dev URL <foo>" or "ignore the PR's IP, use 10.0.0.7 instead", honor their words over the conversation-history and PR-description values.
@@ -215,7 +228,7 @@ Many projects don't use Portless. Read the dev server's stdout for whatever URL(
 - **No `/color` in history but user mentioned a color**: treat the user's mention as the source of truth. If they said "use orange", map `orange` → `#EA580C` and prefix accordingly.
 - **PR description mentions multiple addresses or none**: take the **first** match for the multi-match case; for the no-match case, omit `VITE_DEFAULT_API_ENDPOINT` rather than guessing. The login form will fall back to `localStorage` / `config.toml` like before.
 
-## 7. Out of scope
+## 8. Out of scope
 
-- Don't write any color file (`.claude/.fw-color`, `.env.development.local`, etc.). The env var prefix is the only side effect on env.
-- Don't install deps, run lint, or do any other "while we're here" steps. Just start the server.
+- Don't write any color file (`.claude/.fw-color`, `.env.development.local`, etc.). The only sanctioned side effects are the env var prefix and the registry entry from step 6.
+- Don't install deps, run lint, or do any other "while we're here" steps. Just start the server (and register it, per step 6).

--- a/.claude/skills/webui-connection-info/SKILL.md
+++ b/.claude/skills/webui-connection-info/SKILL.md
@@ -17,13 +17,22 @@ The WebUI dev server runs under [Portless](https://github.com/vercel-labs/portle
 - Branch contains an `FR-XXXX` token → `http://fr-XXXX.localhost:1355` (e.g. `04-24-feat_fr-2701_...` → `fr-2701.localhost`).
 - Otherwise → `<branch>.<project>.localhost:1355` (Portless's default `run` form).
 
-To find the actual URL for a running instance, run `portless list` or check the `pnpm run dev` terminal output.
+**Never assume port `1355`**: when another Portless daemon is already bound there (another Claude session / worktree), the server lands on 1356, 1357, … — always confirm the real port from one of the sources below.
+
+To find the actual URL for a running instance, check these sources in order:
+
+1. **The team dev-server registry** (fw plugin `dev-server-registry` skill, when installed) — the richest source: its `query <PR>` op scans the merged shards (`registry/boxes/*.json` in lablup/frontend-board) and returns, per server, the dev URL with the *real* port, the branch/PR/Jira key it serves, the backend endpoint + login it was booted with, and which box runs it. The team board (each member's own local app at `http://localhost:7777`, `?pr=<N>` deep links) renders the same data. Registry entries carry per-session metadata that `portless list` lacks — prefer them when both exist, and cross-check that the entry's branch/PR matches what you're testing (an entry may be stale until its box re-registers).
+2. `portless list` — live routes on this box.
+3. The `pnpm run dev` terminal output — Portless prints the full URL on startup.
 
 If no dev server is running, tell the user to start it with `pnpm run dev` (requires Portless: `npm install -g portless`).
 
 ## API Endpoint & Credentials
 
-Read `e2e/envs/.env.playwright` to get the current server endpoint and login credentials.
+Two sources, in order:
+
+1. **The dev-server registry entry** (source 1 above), when this box or a teammate's box registered the server: its `backend.endpoint` and `backend.login` are exactly what the running dev server was booted against — no guessing.
+2. Read `e2e/envs/.env.playwright` to get the current server endpoint and login credentials.
 
 Key variables:
 - `E2E_WEBSERVER_ENDPOINT` — Backend.AI API server URL


### PR DESCRIPTION
Part of lablup/frontend-board#152 (FR-3307) — spec `pr-devserver-review.md` §9 **WI-3** (webui skill hooks).

The fw-side registry skill (`dev-server-registry`: init/register/unregister/show + query/boot ops and the idempotent PR comment) ships via **lablup/claude-mp** PRs [#120](https://github.com/lablup/claude-mp/pull/120) (FR-3305) and [#121](https://github.com/lablup/claude-mp/pull/121) (FR-3307, stacked on #120). This PR only adds the *hooks* on the webui side — instruction steps in the repo's markdown skills, no executable code.

## What's in

### `.claude/skills/dev-server/SKILL.md`
- New **step 6 "Register in the dev-server registry (post-boot)"**, anchored right after step 5 (the only point where the *actual* Portless URL is known): run the fw `dev-server-registry` skill's `register` op from the served worktree, passing the subdomain Portless actually printed and the `VITE_DEFAULT_API_ENDPOINT` (+ login only for shared team test servers, per the registry skill's credential policy). PR/branch/Jira key stay auto-derived by the script.
- Skip-silently rule when the fw plugin or `~/.config/fw/registry-box.json` is absent; never run `init` unprompted.
- **`unregister` on stop/teardown** so the board and the PR's registry comment don't advertise a dead server.
- Sections renumbered (Edge cases 6→7, Out of scope 7→8) and the "only side effect" bullet amended — the previous wording *forbade* any write, which would have contradicted the registry step.

### `.claude/skills/webui-connection-info/SKILL.md`
- The team registry becomes the **first** source for the dev server address: `query <PR>` over the merged shards (`registry/boxes/*.json` in lablup/frontend-board) and the per-member local board at `http://localhost:7777` (`?pr=<N>` deep links). Explicit "never assume port 1355" note — exactly the ambiguity the registry resolves — plus a staleness cross-check caveat.
- Registry entry's `backend.endpoint` / `backend.login` become the first source for API endpoint + credentials, ahead of `e2e/envs/.env.playwright`.

## Not included (and why)
- **`dev-server-review` skill**: not tracked in this repo — it lives at user level (`~/.claude/skills/dev-server-review/`), so its auto-register bullet cannot ship in a PR. Its step 3 already delegates boot to the `dev-server` skill, so the step-6 hook added here covers the review flow transitively; migrating that skill into the repo is a separate decision.
- No changes to `scripts/dev.mjs` — per the spec, existing skills are *extended, not replaced*, and the hook is an agent instruction step rather than runtime code.

## Conventions note
Shipped as a plain branch off `origin/main` + `gh pr create` (documented fallback); adopt into Graphite via `gt track` when convenient.

## Verification
- Markdown-only change (2 files, +28/−6); no runtime surface — `scripts/verify.sh` not applicable.
- Anchors verified against the current SKILL.md structure: step 6 sits between "### For other projects" and Edge cases; renumbering leaves no dangling section references (the only in-text references to numbered steps are "step 2b/2c/5/6", all still correct).
- Both edited files verified `git ls-files`-tracked on `origin/main` before editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)