### PR TITLE
feat(FR-3309): review overlay walking skeleton — pin-to-Teams round trip (dev-only Vite plugin)

### DIFF
--- a/react/vite-plugins/reviewOverlay.ts
+++ b/react/vite-plugins/reviewOverlay.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Plugin } from 'vite';
+
+/**
+ * FR-3309 — dev-only review overlay (walking skeleton).
+ *
+ * Injects a same-origin <script> into the dev document that mounts a
+ * Shadow-DOM review overlay (element pick → pin → comment → Teams thread
+ * round trip). The overlay talks to the REVIEWER'S OWN local board app relay
+ * (`http://localhost:7777/api/teams/*`, FR-3306/FR-3309 in lablup/claude-mp)
+ * — never to this dev server, which has no review middleware at all
+ * (spec pr-devserver-review.md §7/§8 + Revision 2 R2.2).
+ *
+ * Dev-only by construction:
+ *  - `apply: 'serve'` — the plugin does not exist during `vite build`, so
+ *    production output contains no trace of the overlay.
+ *  - The script is served same-origin at /__review/overlay.js by a
+ *    `configureServer` middleware (same pattern as `monacoStaticPlugin`),
+ *    so it rides the viewer's tunnel and passes the dev CSP
+ *    (`script-src 'self'`; the relay call is covered by the dev
+ *    `connect-src … http:`).
+ *
+ * Registration note: must be registered AFTER `projectRootStaticPlugin` in
+ * the plugins array — that plugin's `order: 'pre'` transformIndexHtml
+ * handler discards the incoming html and re-reads the template, so anything
+ * injected before it is thrown away. This plugin uses `order: 'post'` tag
+ * injection on top of the resolved template.
+ */
+
+const OVERLAY_URL = '/__review/overlay.js';
+
+const clientFile = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  'reviewOverlayClient.js',
+);
+
+export function devReviewOverlayPlugin(): Plugin {
+  return {
+    name: 'bai-dev-review-overlay',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url || req.url.split('?')[0] !== OVERLAY_URL) return next();
+        res.setHeader('Content-Type', 'application/javascript');
+        // Always re-read: overlay iteration shows up on plain reload
+        // without restarting the dev server (the file is tiny).
+        res.setHeader('Cache-Control', 'no-store');
+        res.end(readFileSync(clientFile, 'utf-8'));
+      });
+    },
+    transformIndexHtml: {
+      order: 'post',
+      handler(html) {
+        return {
+          html,
+          tags: [
+            {
+              tag: 'script',
+              attrs: { type: 'module', src: OVERLAY_URL },
+              injectTo: 'body',
+            },
+          ],
+        };
+      },
+    },
+  };
+}

--- a/react/vite-plugins/reviewOverlayClient.js
+++ b/react/vite-plugins/reviewOverlayClient.js
@@ -1,0 +1,519 @@
+/**
+ * FR-3309 — review overlay client (walking skeleton). Dev-only: injected by
+ * the `bai-dev-review-overlay` Vite plugin (apply: 'serve').
+ *
+ * Everything lives inside a Shadow DOM host on document.body; the only
+ * global surface is the `window.__baiReviewOverlay` re-entry guard.
+ *
+ * Talks to the reviewer's OWN local board relay (lablup/claude-mp
+ * dev-server-board, spec R2.2): http://localhost:7777/api/teams/*.
+ * The dev server itself has no review backend.
+ */
+
+(() => {
+  if (window.__baiReviewOverlay) return;
+  window.__baiReviewOverlay = true;
+
+  const RELAY = 'http://localhost:7777';
+  const HASH_KEY = 'bai-review';
+  const LS_THREAD_KEY = `bai-review:threadUrl:${location.host}`;
+  const POLL_MS = 12000;
+  const RELAY_HINT =
+    '로컬 보드 릴레이가 필요해요 — 터미널에서 board serve를 실행하세요';
+
+  // ---------------------------------------------------------------- anchor
+
+  const b64encode = (s) =>
+    btoa(String.fromCharCode(...new TextEncoder().encode(s)));
+  const b64decode = (b) =>
+    new TextDecoder().decode(Uint8Array.from(atob(b), (c) => c.charCodeAt(0)));
+
+  /** Selector-only anchor for the walking skeleton (multi-signal is later). */
+  function buildSelector(el) {
+    const esc = (v) => (window.CSS && CSS.escape ? CSS.escape(v) : v);
+    const testid = el.getAttribute && el.getAttribute('data-testid');
+    if (testid) return `[data-testid="${esc(testid)}"]`;
+    if (el.id) return `#${esc(el.id)}`;
+    // tag:nth-of-type path up to the nearest data-testid/id ancestor or body.
+    const parts = [];
+    let node = el;
+    while (node && node.nodeType === 1 && node !== document.body) {
+      const parent = node.parentElement;
+      const anchorId = node.getAttribute('data-testid')
+        ? `[data-testid="${esc(node.getAttribute('data-testid'))}"]`
+        : node.id
+          ? `#${esc(node.id)}`
+          : null;
+      if (anchorId) {
+        parts.unshift(anchorId);
+        break;
+      }
+      const tag = node.tagName.toLowerCase();
+      let nth = 1;
+      let sib = node;
+      while ((sib = sib.previousElementSibling)) {
+        if (sib.tagName === node.tagName) nth++;
+      }
+      parts.unshift(`${tag}:nth-of-type(${nth})`);
+      node = parent;
+    }
+    return parts.join(' > ') || 'body';
+  }
+
+  function encodeAnchor(selector) {
+    return b64encode(JSON.stringify({ v: 1, s: selector, p: location.pathname }));
+  }
+
+  function decodeAnchor(b64) {
+    try {
+      const obj = JSON.parse(b64decode(b64));
+      return obj && typeof obj.s === 'string' ? obj : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function buildDeepLink(selector) {
+    return (
+      location.origin +
+      location.pathname +
+      location.search +
+      `#${HASH_KEY}=` +
+      encodeAnchor(selector)
+    );
+  }
+
+  function anchorFromText(text) {
+    const m = /#bai-review=([A-Za-z0-9+/=_-]+)/.exec(text || '');
+    return m ? decodeAnchor(m[1]) : null;
+  }
+
+  // ---------------------------------------------------------------- host UI
+
+  const host = document.createElement('div');
+  host.setAttribute('data-bai-review-overlay', '');
+  const root = host.attachShadow({ mode: 'open' });
+  document.body.appendChild(host);
+
+  const style = document.createElement('style');
+  style.textContent = `
+    :host { all: initial; }
+    * { box-sizing: border-box; font-family: ui-sans-serif, system-ui, sans-serif; }
+    .toggle {
+      position: fixed; right: 16px; bottom: 16px; z-index: 2147483000;
+      border: none; border-radius: 24px; padding: 10px 16px; cursor: pointer;
+      background: #ff7a00; color: #fff; font-size: 14px; font-weight: 600;
+      box-shadow: 0 2px 10px rgba(0,0,0,.25);
+    }
+    .toggle.active { background: #1f1f1f; }
+    .panel {
+      position: fixed; top: 0; right: 0; bottom: 0; width: 320px;
+      z-index: 2147483000; background: #fff; border-left: 1px solid #ddd;
+      box-shadow: -4px 0 16px rgba(0,0,0,.12); display: none;
+      flex-direction: column; color: #1f1f1f;
+    }
+    .panel.open { display: flex; }
+    .panel header {
+      padding: 10px 12px; border-bottom: 1px solid #eee; font-weight: 700;
+      font-size: 14px; display: flex; align-items: center; gap: 8px;
+    }
+    .panel header .spacer { flex: 1; }
+    .iconbtn {
+      border: 1px solid #ddd; background: #fafafa; border-radius: 6px;
+      cursor: pointer; font-size: 12px; padding: 4px 8px;
+    }
+    .iconbtn.primary { background: #ff7a00; border-color: #ff7a00; color: #fff; }
+    .settings { padding: 10px 12px; border-bottom: 1px solid #eee; }
+    .settings label { font-size: 11px; color: #888; display: block; margin-bottom: 4px; }
+    .settings .row { display: flex; gap: 6px; }
+    .settings input {
+      flex: 1; font-size: 12px; padding: 5px 7px; border: 1px solid #ddd;
+      border-radius: 6px; min-width: 0;
+    }
+    .hint {
+      margin: 8px 12px; padding: 8px 10px; border-radius: 6px; font-size: 12px;
+      background: #fff7e6; border: 1px solid #ffd591; color: #874d00; display: none;
+    }
+    .hint.show { display: block; }
+    .replies { flex: 1; overflow-y: auto; padding: 8px 12px; }
+    .reply { border-bottom: 1px solid #f0f0f0; padding: 8px 0; font-size: 12px; }
+    .reply .meta { color: #888; font-size: 11px; margin-bottom: 3px; display: flex; gap: 6px; align-items: center; }
+    .reply .meta .author { color: #333; font-weight: 600; }
+    .reply .body { white-space: pre-wrap; word-break: break-word; }
+    .reply .pinbtn { border: none; background: none; cursor: pointer; font-size: 13px; padding: 0 2px; }
+    .empty { color: #aaa; font-size: 12px; text-align: center; padding: 24px 0; }
+    .hoverbox {
+      position: fixed; z-index: 2147482998; pointer-events: none; display: none;
+      border: 2px solid #ff7a00; border-radius: 3px;
+      background: rgba(255,122,0,.08);
+    }
+    .pin {
+      position: absolute; z-index: 2147482999; width: 22px; height: 22px;
+      margin: -11px 0 0 -11px; border-radius: 50% 50% 50% 0;
+      transform: rotate(-45deg); background: #ff7a00; color: #fff;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 11px; font-weight: 700; cursor: default;
+      box-shadow: 0 1px 4px rgba(0,0,0,.35);
+    }
+    .pin > span { transform: rotate(45deg); }
+    .pinlayer { position: absolute; top: 0; left: 0; width: 0; height: 0; }
+    .compose {
+      position: fixed; z-index: 2147483001; width: 260px; background: #fff;
+      border: 1px solid #ddd; border-radius: 8px; padding: 10px;
+      box-shadow: 0 4px 18px rgba(0,0,0,.2); display: none;
+    }
+    .compose textarea {
+      width: 100%; height: 64px; font-size: 12px; padding: 6px;
+      border: 1px solid #ddd; border-radius: 6px; resize: vertical;
+    }
+    .compose .actions { display: flex; justify-content: flex-end; gap: 6px; margin-top: 6px; }
+    .compose .err { color: #c0392b; font-size: 11px; margin-top: 4px; display: none; }
+    .toast {
+      position: fixed; z-index: 2147483002; left: 50%; bottom: 64px;
+      transform: translateX(-50%); background: #1f1f1f; color: #fff;
+      font-size: 12px; padding: 8px 14px; border-radius: 16px; display: none;
+      max-width: 70vw;
+    }
+    .flash { outline: 3px solid #ff7a00 !important; outline-offset: 2px; }
+  `;
+  root.appendChild(style);
+
+  const el = (tag, cls, html) => {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (html !== undefined) n.innerHTML = html;
+    return n;
+  };
+
+  const toggle = el('button', 'toggle', '💬 리뷰');
+  const panel = el('div', 'panel');
+  panel.innerHTML = `
+    <header>💬 리뷰 <span class="spacer"></span>
+      <button class="iconbtn primary" data-act="pick">📌 코멘트 모드</button>
+      <button class="iconbtn" data-act="close">✕</button>
+    </header>
+    <div class="settings">
+      <label>Teams 스레드 URL (PR 스레드의 메시지 링크 붙여넣기)</label>
+      <div class="row">
+        <input type="text" placeholder="https://teams.microsoft.com/l/message/..." />
+        <button class="iconbtn" data-act="save">저장</button>
+      </div>
+    </div>
+    <div class="hint"></div>
+    <div class="replies"><div class="empty">스레드 URL을 저장하면 대화를 불러와요</div></div>
+  `;
+  const hoverbox = el('div', 'hoverbox');
+  const pinLayer = el('div', 'pinlayer');
+  const compose = el('div', 'compose');
+  compose.innerHTML = `
+    <textarea placeholder="이 요소에 대한 코멘트…"></textarea>
+    <div class="err"></div>
+    <div class="actions">
+      <button class="iconbtn" data-act="cancel">취소</button>
+      <button class="iconbtn primary" data-act="send">보내기</button>
+    </div>
+  `;
+  const toast = el('div', 'toast');
+  root.append(toggle, panel, hoverbox, pinLayer, compose, toast);
+
+  const threadInput = panel.querySelector('input');
+  const hintBox = panel.querySelector('.hint');
+  const repliesBox = panel.querySelector('.replies');
+  threadInput.value = localStorage.getItem(LS_THREAD_KEY) || '';
+
+  let toastTimer = 0;
+  function showToast(msg, ms = 3500) {
+    toast.textContent = msg;
+    toast.style.display = 'block';
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => (toast.style.display = 'none'), ms);
+  }
+
+  function showHint(msg) {
+    hintBox.textContent = msg;
+    hintBox.classList.add('show');
+  }
+  function clearHint() {
+    hintBox.classList.remove('show');
+  }
+
+  // ---------------------------------------------------------------- pins
+
+  let pinSeq = 0;
+  function dropPin(target) {
+    const rect = target.getBoundingClientRect();
+    const pin = el('div', 'pin');
+    pin.append(el('span', '', String(++pinSeq)));
+    pin.style.left = `${rect.left + window.scrollX + 6}px`;
+    pin.style.top = `${rect.top + window.scrollY + 6}px`;
+    pinLayer.appendChild(pin);
+    return pin;
+  }
+
+  function flash(target) {
+    target.classList.add('flash');
+    setTimeout(() => target.classList.remove('flash'), 2400);
+  }
+
+  // ---------------------------------------------------------------- picking
+
+  let picking = false;
+  let pickTarget = null;
+
+  function isOwn(evt) {
+    return evt.composedPath().includes(host);
+  }
+
+  function onMove(evt) {
+    if (isOwn(evt)) {
+      hoverbox.style.display = 'none';
+      return;
+    }
+    const t = evt.target;
+    if (!(t instanceof Element)) return;
+    const r = t.getBoundingClientRect();
+    Object.assign(hoverbox.style, {
+      display: 'block',
+      left: `${r.left}px`,
+      top: `${r.top}px`,
+      width: `${r.width}px`,
+      height: `${r.height}px`,
+    });
+  }
+
+  function onPickClick(evt) {
+    if (isOwn(evt)) return;
+    evt.preventDefault();
+    evt.stopPropagation();
+    const t = evt.target;
+    if (!(t instanceof Element)) return;
+    stopPicking();
+    pickTarget = t;
+    dropPin(t);
+    openCompose(evt.clientX, evt.clientY);
+  }
+
+  function startPicking() {
+    if (picking) return;
+    picking = true;
+    document.documentElement.style.cursor = 'crosshair';
+    document.addEventListener('mousemove', onMove, true);
+    document.addEventListener('click', onPickClick, true);
+    showToast('코멘트할 요소를 클릭하세요 (Esc 취소)');
+  }
+
+  function stopPicking() {
+    picking = false;
+    document.documentElement.style.cursor = '';
+    document.removeEventListener('mousemove', onMove, true);
+    document.removeEventListener('click', onPickClick, true);
+    hoverbox.style.display = 'none';
+  }
+
+  document.addEventListener('keydown', (evt) => {
+    if (evt.key === 'Escape' && picking) stopPicking();
+  });
+
+  // ---------------------------------------------------------------- compose
+
+  const composeText = compose.querySelector('textarea');
+  const composeErr = compose.querySelector('.err');
+
+  function openCompose(x, y) {
+    composeErr.style.display = 'none';
+    composeText.value = '';
+    compose.style.display = 'block';
+    const w = 260;
+    compose.style.left = `${Math.min(x, window.innerWidth - w - 12)}px`;
+    compose.style.top = `${Math.min(y + 10, window.innerHeight - 160)}px`;
+    composeText.focus();
+  }
+
+  function closeCompose() {
+    compose.style.display = 'none';
+    pickTarget = null;
+  }
+
+  compose.addEventListener('click', async (evt) => {
+    const act = evt.target.dataset && evt.target.dataset.act;
+    if (act === 'cancel') closeCompose();
+    if (act === 'send') {
+      const text = composeText.value.trim();
+      if (!text) return;
+      const threadUrl = (threadInput.value || '').trim();
+      if (!threadUrl) {
+        composeErr.textContent = '패널에서 Teams 스레드 URL을 먼저 저장하세요';
+        composeErr.style.display = 'block';
+        return;
+      }
+      const selector = pickTarget ? buildSelector(pickTarget) : null;
+      const deepLink = selector ? buildDeepLink(selector) : undefined;
+      evt.target.disabled = true;
+      try {
+        const res = await fetch(`${RELAY}/api/teams/reply`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ threadUrl, text, deepLink }),
+        });
+        if (res.status === 401) {
+          composeErr.textContent = RELAY_HINT;
+          composeErr.style.display = 'block';
+          showHint(RELAY_HINT);
+          return;
+        }
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          composeErr.textContent = data.error || `릴레이 오류 (HTTP ${res.status})`;
+          composeErr.style.display = 'block';
+          return;
+        }
+        closeCompose();
+        showToast('Teams 스레드에 전송됐어요 ✅');
+        pollReplies();
+      } catch {
+        composeErr.textContent = RELAY_HINT;
+        composeErr.style.display = 'block';
+        showHint(RELAY_HINT);
+      } finally {
+        evt.target.disabled = false;
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------- replies
+
+  let pollTimer = 0;
+  let pollBusy = false;
+
+  function renderReplies(replies) {
+    repliesBox.textContent = '';
+    if (!replies.length) {
+      repliesBox.appendChild(el('div', 'empty', '아직 답글이 없어요'));
+      return;
+    }
+    for (const r of replies) {
+      const item = el('div', 'reply');
+      const meta = el('div', 'meta');
+      const author = el('span', 'author');
+      author.textContent = r.author || '(unknown)';
+      const when = el('span');
+      when.textContent = (r.createdDateTime || '').replace('T', ' ').slice(0, 16);
+      meta.append(author, when);
+      const anchor = anchorFromText(r.text) || anchorFromText(r.html);
+      if (anchor) {
+        const pinBtn = el('button', 'pinbtn', '📍');
+        pinBtn.title = '이 코멘트의 위치로 이동';
+        pinBtn.addEventListener('click', () => resolveAnchor(anchor));
+        meta.appendChild(pinBtn);
+      }
+      const body = el('div', 'body');
+      body.textContent = r.text || '';
+      item.append(meta, body);
+      repliesBox.appendChild(item);
+    }
+    repliesBox.scrollTop = repliesBox.scrollHeight;
+  }
+
+  async function pollReplies() {
+    const threadUrl = (threadInput.value || '').trim();
+    if (!threadUrl || pollBusy || !panel.classList.contains('open')) return;
+    pollBusy = true;
+    try {
+      const res = await fetch(
+        `${RELAY}/api/teams/replies?threadUrl=${encodeURIComponent(threadUrl)}`,
+      );
+      if (res.status === 401) {
+        showHint(RELAY_HINT);
+        return;
+      }
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        showHint(data.error || `릴레이 오류 (HTTP ${res.status})`);
+        return;
+      }
+      clearHint();
+      renderReplies(data.replies || []);
+    } catch {
+      showHint(RELAY_HINT);
+    } finally {
+      pollBusy = false;
+    }
+  }
+
+  function startPolling() {
+    stopPolling();
+    pollReplies();
+    pollTimer = setInterval(pollReplies, POLL_MS);
+  }
+  function stopPolling() {
+    clearInterval(pollTimer);
+  }
+
+  // ---------------------------------------------------------------- panel
+
+  function openPanel() {
+    panel.classList.add('open');
+    startPolling();
+  }
+  function closePanel() {
+    panel.classList.remove('open');
+    stopPolling();
+  }
+
+  toggle.addEventListener('click', () => {
+    if (panel.classList.contains('open')) {
+      closePanel();
+      toggle.classList.remove('active');
+    } else {
+      openPanel();
+      toggle.classList.add('active');
+    }
+  });
+
+  panel.addEventListener('click', (evt) => {
+    const act = evt.target.dataset && evt.target.dataset.act;
+    if (act === 'close') {
+      closePanel();
+      toggle.classList.remove('active');
+    }
+    if (act === 'pick') startPicking();
+    if (act === 'save') {
+      localStorage.setItem(LS_THREAD_KEY, (threadInput.value || '').trim());
+      showToast('스레드 URL 저장됨');
+      startPolling();
+    }
+  });
+
+  // ------------------------------------------------------- anchor resolve
+
+  function resolveAnchor(anchor, attempt = 0) {
+    if (anchor.p && anchor.p !== location.pathname && attempt === 0) {
+      showToast(`다른 페이지의 코멘트예요: ${anchor.p}`);
+    }
+    let target = null;
+    try {
+      target = document.querySelector(anchor.s);
+    } catch {
+      /* invalid selector */
+    }
+    if (target) {
+      target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      flash(target);
+      dropPin(target);
+      return;
+    }
+    if (attempt < 20) {
+      // SPA content renders asynchronously — retry briefly.
+      setTimeout(() => resolveAnchor(anchor, attempt + 1), 500);
+    } else {
+      showToast('앵커 요소를 찾지 못했어요 — UI가 바뀌었을 수 있어요');
+    }
+  }
+
+  const hashMatch = /[#&]bai-review=([A-Za-z0-9+/=_-]+)/.exec(location.hash);
+  if (hashMatch) {
+    const anchor = decodeAnchor(hashMatch[1]);
+    if (anchor) resolveAnchor(anchor);
+    else showToast('딥링크 앵커를 해석하지 못했어요');
+  }
+})();

--- a/react/vite-plugins/reviewOverlayClient.js
+++ b/react/vite-plugins/reviewOverlayClient.js
@@ -61,7 +61,9 @@
   }
 
   function encodeAnchor(selector) {
-    return b64encode(JSON.stringify({ v: 1, s: selector, p: location.pathname }));
+    return b64encode(
+      JSON.stringify({ v: 1, s: selector, p: location.pathname }),
+    );
   }
 
   function decodeAnchor(b64) {
@@ -73,19 +75,9 @@
     }
   }
 
-  function buildDeepLink(selector) {
-    return (
-      location.origin +
-      location.pathname +
-      location.search +
-      `#${HASH_KEY}=` +
-      encodeAnchor(selector)
-    );
-  }
-
-  function anchorFromText(text) {
+  function anchorKeyFromText(text) {
     const m = /#bai-review=([A-Za-z0-9+/=_-]+)/.exec(text || '');
-    return m ? decodeAnchor(m[1]) : null;
+    return m ? m[1] : null;
   }
 
   // ---------------------------------------------------------------- host UI
@@ -152,7 +144,7 @@
       margin: -11px 0 0 -11px; border-radius: 50% 50% 50% 0;
       transform: rotate(-45deg); background: #ff7a00; color: #fff;
       display: flex; align-items: center; justify-content: center;
-      font-size: 11px; font-weight: 700; cursor: default;
+      font-size: 11px; font-weight: 700; cursor: default; pointer-events: auto;
       box-shadow: 0 1px 4px rgba(0,0,0,.35);
     }
     .pin > span { transform: rotate(45deg); }
@@ -174,7 +166,6 @@
       font-size: 12px; padding: 8px 14px; border-radius: 16px; display: none;
       max-width: 70vw;
     }
-    .flash { outline: 3px solid #ff7a00 !important; outline-offset: 2px; }
   `;
   root.appendChild(style);
 
@@ -240,25 +231,62 @@
   // ---------------------------------------------------------------- pins
 
   let pinSeq = 0;
-  function dropPin(target) {
+  function dropPin(target, anchorKey) {
     const rect = target.getBoundingClientRect();
     const pin = el('div', 'pin');
     pin.append(el('span', '', String(++pinSeq)));
     pin.style.left = `${rect.left + window.scrollX + 6}px`;
     pin.style.top = `${rect.top + window.scrollY + 6}px`;
     pinLayer.appendChild(pin);
+    if (anchorKey) linkPin(pin, anchorKey);
     return pin;
   }
 
+  /** pin→message: clicking a linked pin reveals its reply in the panel. */
+  function linkPin(pin, anchorKey) {
+    if (pin.dataset.anchorKey) return;
+    pin.dataset.anchorKey = anchorKey;
+    pin.style.cursor = 'pointer';
+    pin.title = '이 핀의 코멘트 보기';
+    pin.addEventListener('click', () => revealReply(anchorKey));
+  }
+
+  function revealReply(anchorKey) {
+    if (!panel.classList.contains('open')) {
+      openPanel();
+      toggle.classList.add('active');
+    }
+    const item = repliesBox.querySelector(
+      `.reply[data-anchor-key="${anchorKey}"]`,
+    );
+    if (item) {
+      item.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      flash(item);
+    } else {
+      showToast('해당 코멘트를 아직 불러오지 못했어요');
+    }
+  }
+
+  // `.flash`-style class rules in the shadow-root <style> cannot style
+  // light-DOM host-app elements, so highlight via inline styles instead.
   function flash(target) {
-    target.classList.add('flash');
-    setTimeout(() => target.classList.remove('flash'), 2400);
+    const prev = {
+      outline: target.style.outline,
+      outlineOffset: target.style.outlineOffset,
+    };
+    target.style.outline = '3px solid #ff7a00';
+    target.style.outlineOffset = '2px';
+    setTimeout(() => {
+      target.style.outline = prev.outline;
+      target.style.outlineOffset = prev.outlineOffset;
+    }, 2400);
   }
 
   // ---------------------------------------------------------------- picking
 
   let picking = false;
   let pickTarget = null;
+  let pickPin = null; // pin dropped at pick time, linked to its reply on send
 
   function isOwn(evt) {
     return evt.composedPath().includes(host);
@@ -289,7 +317,7 @@
     if (!(t instanceof Element)) return;
     stopPicking();
     pickTarget = t;
-    dropPin(t);
+    pickPin = dropPin(t);
     openCompose(evt.clientX, evt.clientY);
   }
 
@@ -332,6 +360,7 @@
   function closeCompose() {
     compose.style.display = 'none';
     pickTarget = null;
+    pickPin = null;
   }
 
   compose.addEventListener('click', async (evt) => {
@@ -347,7 +376,13 @@
         return;
       }
       const selector = pickTarget ? buildSelector(pickTarget) : null;
-      const deepLink = selector ? buildDeepLink(selector) : undefined;
+      const anchorKey = selector ? encodeAnchor(selector) : null;
+      const deepLink = anchorKey
+        ? location.origin +
+          location.pathname +
+          location.search +
+          `#${HASH_KEY}=${anchorKey}`
+        : undefined;
       evt.target.disabled = true;
       try {
         const res = await fetch(`${RELAY}/api/teams/reply`, {
@@ -363,10 +398,12 @@
         }
         const data = await res.json().catch(() => ({}));
         if (!res.ok) {
-          composeErr.textContent = data.error || `릴레이 오류 (HTTP ${res.status})`;
+          composeErr.textContent =
+            data.error || `릴레이 오류 (HTTP ${res.status})`;
           composeErr.style.display = 'block';
           return;
         }
+        if (pickPin && anchorKey) linkPin(pickPin, anchorKey);
         closeCompose();
         showToast('Teams 스레드에 전송됐어요 ✅');
         pollReplies();
@@ -397,13 +434,19 @@
       const author = el('span', 'author');
       author.textContent = r.author || '(unknown)';
       const when = el('span');
-      when.textContent = (r.createdDateTime || '').replace('T', ' ').slice(0, 16);
+      when.textContent = (r.createdDateTime || '')
+        .replace('T', ' ')
+        .slice(0, 16);
       meta.append(author, when);
-      const anchor = anchorFromText(r.text) || anchorFromText(r.html);
+      const anchorKey = anchorKeyFromText(r.text) || anchorKeyFromText(r.html);
+      const anchor = anchorKey ? decodeAnchor(anchorKey) : null;
       if (anchor) {
+        item.dataset.anchorKey = anchorKey;
         const pinBtn = el('button', 'pinbtn', '📍');
         pinBtn.title = '이 코멘트의 위치로 이동';
-        pinBtn.addEventListener('click', () => resolveAnchor(anchor));
+        pinBtn.addEventListener('click', () =>
+          resolveAnchor(anchor, anchorKey),
+        );
         meta.appendChild(pinBtn);
       }
       const body = el('div', 'body');
@@ -486,7 +529,7 @@
 
   // ------------------------------------------------------- anchor resolve
 
-  function resolveAnchor(anchor, attempt = 0) {
+  function resolveAnchor(anchor, anchorKey, attempt = 0) {
     if (anchor.p && anchor.p !== location.pathname && attempt === 0) {
       showToast(`다른 페이지의 코멘트예요: ${anchor.p}`);
     }
@@ -499,12 +542,12 @@
     if (target) {
       target.scrollIntoView({ block: 'center', behavior: 'smooth' });
       flash(target);
-      dropPin(target);
+      dropPin(target, anchorKey);
       return;
     }
     if (attempt < 20) {
       // SPA content renders asynchronously — retry briefly.
-      setTimeout(() => resolveAnchor(anchor, attempt + 1), 500);
+      setTimeout(() => resolveAnchor(anchor, anchorKey, attempt + 1), 500);
     } else {
       showToast('앵커 요소를 찾지 못했어요 — UI가 바뀌었을 수 있어요');
     }
@@ -513,7 +556,7 @@
   const hashMatch = /[#&]bai-review=([A-Za-z0-9+/=_-]+)/.exec(location.hash);
   if (hashMatch) {
     const anchor = decodeAnchor(hashMatch[1]);
-    if (anchor) resolveAnchor(anchor);
+    if (anchor) resolveAnchor(anchor, hashMatch[1]);
     else showToast('딥링크 앵커를 해석하지 못했어요');
   }
 })();

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -19,6 +19,8 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { VitePWA } from 'vite-plugin-pwa';
 import svgr from 'vite-plugin-svgr';
 
+import { devReviewOverlayPlugin } from './vite-plugins/reviewOverlay';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, '..');
 const require = createRequire(import.meta.url);
@@ -837,6 +839,10 @@ export default defineConfig(({ command, mode }) => {
       projectRootStaticPlugin(devCspHeaders),
       cspBundleNoncePlugin(),
       devAssetsReloadPlugin(),
+      // FR-3309: dev-only (apply: 'serve') review overlay injection. Must
+      // come after projectRootStaticPlugin — its 'pre' HTML handler discards
+      // earlier transforms (see reviewOverlay.ts).
+      devReviewOverlayPlugin(),
 
       react({
         babel: (id) => {


### PR DESCRIPTION
Resolves #8238 (FR-3309) — overlay half. Relay half: [lablup/claude-mp#123](https://github.com/lablup/claude-mp/pull/123) (stacked on claude-mp#122, the FR-3306 local board app).

## What

Dev-only review overlay walking skeleton per spec `pr-devserver-review.md` §7/§8 + **Revision 2 R2.2**: the overlay in the dev page talks to the **reviewer's own** local board relay (`http://localhost:7777/api/teams/*`), posting as the reviewer's real Teams identity — the dev server itself gets **no** review middleware.

- **`react/vite-plugins/reviewOverlay.ts`** — `bai-dev-review-overlay` plugin, `apply: 'serve'` (does not exist during `vite build`). Serves the overlay same-origin at `/__review/overlay.js` via a `configureServer` middleware (the `monacoStaticPlugin` pattern) and injects the `<script type="module">` tag with an `order: 'post'` `transformIndexHtml` handler — registered **after** `projectRootStaticPlugin`, whose `order: 'pre'` handler discards earlier HTML transforms. Same-origin + dev CSP compatible (`script-src 'self'`; relay call covered by dev `connect-src … http:`).
- **`react/vite-plugins/reviewOverlayClient.js`** — framework-free client, Shadow-DOM host on `document.body`, all styles inside the shadow root, one global (`window.__baiReviewOverlay` re-entry guard):
  - 💬 리뷰 floating toggle → right-side panel: Teams thread URL settings row (persisted per `location.host` in localStorage — pasted once per PR/ticket), reply list, 📌 comment mode button
  - Comment mode: crosshair + hover outline tracking the element under the cursor; click picks the element, drops a numbered pin, opens a compose popover (textarea + 보내기, Esc cancels picking)
  - Anchor (walking skeleton = selector-only): `data-testid` → `id` → `tag:nth-of-type` path; `{v, s: selector, p: pathname}` base64-encoded into a `#bai-review=<b64>` deep link on the current dev URL, sent with the message
  - On load with `#bai-review=` in the hash: decode → `querySelector` with SPA retry (20×500 ms) → scroll + highlight + pin; unresolvable → non-blocking toast
  - Post: `POST http://localhost:7777/api/teams/reply` `{threadUrl, text, deepLink}`; panel polls `GET /api/teams/replies?threadUrl=…` every 12 s while open; replies containing `#bai-review=` render a 📍 that re-resolves the anchor
  - Relay refused/401 → inline hint "로컬 보드 릴레이가 필요해요 — 터미널에서 board serve를 실행하세요" (no auth flow in the page, ever)
- **`react/vite.config.ts`** — one import + registration after `devAssetsReloadPlugin()`.

## AC checklist (honest)

- [x] Dev-only Vite plugin, zero production effect (`apply: 'serve'`; build output grepped clean)
- [x] Same-origin overlay script + `transformIndexHtml` injection following the existing config's patterns
- [x] Shadow-DOM isolation; styles never leak; single window global
- [x] Element pick → numbered pin → compose → POST to reviewer's own relay (R2.2)
- [x] Selector-only anchor + `#bai-review=` deep link round trip (encode on send, resolve on load)
- [x] Reply polling panel (12 s) with 📍 anchor re-resolution
- [x] Relay-unavailable / 401 inline hint
- [ ] Multi-signal anchoring (text snippet / rect / screenshot crop) — later ticket per spec §7
- [ ] General page-level comments, resolve-✅ semantics, screenshots via `hostedContents` — out of walking-skeleton scope
- [ ] Live pin→Teams→reply round trip — manual step below (never automated; relay send is dry-run-able for tests)

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript)
- `node --check reviewOverlayClient.js` OK; targeted `tsc --noEmit` on `reviewOverlay.ts` OK
- Booted plain `PORT=5199 HOST=127.0.0.1 npx vite` (no Portless):
  - `curl /` → `<script type="module" src="/__review/overlay.js"></script>` present in the dev document
  - `curl /__review/overlay.js` → 200, `application/javascript`, bytes identical to the source file
  - Playwright (chromium): shadow host mounts; toggle `💬 리뷰` + panel render; `#bai-review=<b64 of {s:"body"}>` deep link + reload → pin `1` dropped on the target; with no relay running, opening the panel with a saved thread URL shows the exact hint text above
- `npx vite build` → completes; `grep -rl '__review\|bai-review\|reviewOverlay' build/` → no matches (dev-only proof)
- No Teams message was posted during any of this; the relay's send endpoint was exercised only via its `dryRun` mode (in the claude-mp PR). Dev server/browser killed after verification.

## Manual live-demo checklist (deliberate human act)

- [ ] `board serve` (claude-mp #122 + #123) on your box — silent Teams token ready
- [ ] `pnpm dev` this branch, open the dev URL, paste the PR's Teams thread URL into the overlay panel and 저장
- [ ] 📌 pick an element, write a comment, 보내기 → reply appears in the Teams thread **as you**, with the 📍 `#bai-review=` link
- [ ] Reply in Teams from another account/device → appears in the overlay panel within ~12 s
- [ ] Open the message's deep link in a browser with the dev server up → overlay scrolls to and pins the element

🤖 Generated with [Claude Code](https://claude.com/claude-code)
