### PR TITLE
feat(FR-3267): per-tab URL-persisted table state pattern for multi-tab pages

### DIFF
--- a/.claude/skills/react-url-state/SKILL.md
+++ b/.claude/skills/react-url-state/SKILL.md
@@ -155,31 +155,10 @@ This is the whole transition contract. FR-1683's motivation was that `nuqs`
 
 When tabs represent independent views (session type all/interactive/batch…)
 and each tab should remember its own filter/order/page, cache the per-tab
-queryParams in a ref:
-
-```tsx
-const queryMapRef = useRef({
-  [queryParams.type]: { queryParams, tablePaginationOption },
-});
-
-useEffect(() => {
-  queryMapRef.current[queryParams.type] = { queryParams, tablePaginationOption };
-}, [queryParams, tablePaginationOption]);
-
-<BAITabs
-  activeKey={queryParams.type}
-  onChange={(key) => {
-    const stored = queryMapRef.current[key] || { queryParams: {} };
-    setQueryParams(null);                  // reset to defaults first
-    setQueryParams({ ...stored.queryParams, type: key as TypeFilterType });
-    setTablePaginationOption(stored.tablePaginationOption || { current: 1 });
-  }}
-/>
-```
-
-The `setQueryParams(null)` reset-to-defaults line is important — without it,
-values from the previous tab leak into the next (e.g. filtering by "email"
-stays applied when switching to a tab without that column).
+queryParams in a ref and reset-then-restore on tab change. The full pattern
+(and the page-like vs widget-tab decision that governs when to use it) is
+owned by the **`tab-url-state`** skill — see its Pattern A. Canonical
+implementation: `AdminComputeSessionListPage.tsx`.
 
 ## 6. Controlled modals via URL (deep-link support)
 
@@ -254,6 +233,7 @@ URL state is for: what someone else pasting the URL should see.
 
 ## Related Skills
 
+- **`tab-url-state`** — per-tab URL state policy for tabbed pages/cards (owns the `queryMapRef` save/restore pattern)
 - **`react-suspense-fetching`** — pairing deferred URL variables with `useLazyLoadQuery`
 - **`react-relay-table`** — table pagination / filter / order as URL state
 - **`react-modal-drawer`** — deep-linking a modal via query param
@@ -266,4 +246,5 @@ URL state is for: what someone else pasting the URL should see.
 - [ ] Defaults either live in `.withDefault()` (when omission means the default) or in the derived `queryVariables` (for sort keys that should fall back without appearing in URL).
 - [ ] Query variables and fetchKey wrapped in `useDeferredValue` when feeding `useLazyLoadQuery`.
 - [ ] Pagination binds through `useBAIPaginationOptionStateOnSearchParam`, not hand-rolled.
-- [ ] Tab-scoped per-tab state cached via `useRef`, with a `setQueryParams(null)` reset before applying stored values.
+- [ ] Tab-scoped per-tab state follows the `tab-url-state` skill (Pattern A: `useRef` cache + `setQueryParams(null)` reset before applying stored values).
+- [ ] `useBAIPaginationOptionStateOnSearchParamLegacy` not introduced in new code.

--- a/.claude/skills/tab-url-state/SKILL.md
+++ b/.claude/skills/tab-url-state/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: tab-url-state
+description: >
+  Decides whether a tab's filter/order/pagination belongs in the URL and
+  applies one of the two sanctioned patterns: page-like tabs (full URL state
+  + `queryMapRef` save/restore) or widget tabs on a detail page (tab key
+  only). Use when adding or editing tabs (BAICard `tabList`, BAITabs) whose
+  content contains a filterable/paginated table, or when wiring
+  `onTabChange`. Related: FR-3267.
+---
+
+# Per-Tab URL State Policy
+
+Two distinct situations look identical in JSX (`tabList` on a card) but demand
+opposite URL-state treatment. Decide first, then apply the matching pattern.
+
+## The Decision
+
+Ask: **is each tab acting as a page, or is the tabbed card one widget among
+several on a page?**
+
+| Situation | Example | URL persists |
+|---|---|---|
+| **A. Page-like tabs** — the page IS the tab set; one card fills the page and each tab is a destination users deep-link to | `AdminComputeSessionListPage` (session types), `AdminUsersPage` (users / credentials) | tab key **+ filter/order/pagination** (`filter`, `order`, `current`, `pageSize`) |
+| **B. Widget tabs** — a detail page with multiple cards, one of which happens to have tabs | `DeploymentDetailPage` → `DeploymentRevisionCard` (`revisionTab`) | **tab key only** — nothing else |
+
+Heuristic: if the route menu/sidebar leads to this tab set, or a user would
+share "the credentials page" as a link, it's A. If the tabbed card sits next
+to sibling cards (basic info, replicas, auto-scaling…), it's B — a tab there
+has no claim to page-level query keys.
+
+The decision is about page structure only — which component renders the tabs
+(`BAITabs` or `BAICard tabList`) is orthogonal.
+
+## Pattern A — Page-like tabs: URL state + `queryMapRef` save/restore
+
+Each tab persists its own filter/order/pagination to the URL so direct access
+and reload reproduce the view. But sibling tabs share one query string, so tab
+switching must (1) not leave the previous tab's keys lingering in the URL and
+(2) restore the target tab's last-known state.
+
+Pattern A has **two implementations**. Pick by who declares the tab panels'
+URL state (not by file count — a host with an inline content component in the
+same file is still A-ii if the panels own their state):
+
+- **A-i — the tab component itself declares the state**: tabs and table live
+  in one component that owns the `useQueryStates` schema. Snapshot the
+  *parsed* state per tab. Canonical: `AdminComputeSessionListPage.tsx`.
+- **A-ii — each tab panel declares its own URL state**: tabs render
+  self-contained child components with their own `useQueryStates` /
+  pagination hooks. The host must NOT absorb the children's state — snapshot
+  the *raw query string* per tab and restore it on switch; children stay
+  untouched and independent. Canonical: `AdminUsersPage.tsx`.
+
+### A-i — single component: parsed-state snapshot
+
+```tsx
+const [queryParams, setQueryParams] = useQueryStates(
+  {
+    order: parseAsStringLiteral(availableSorterValues),
+    filter: parseAsString.withDefault(''),
+    type: parseAsStringLiteral(typeFilterValues).withDefault('all'), // tab key
+  },
+  { history: 'replace' },
+);
+
+const {
+  baiPaginationOption,
+  tablePaginationOption,
+  setTablePaginationOption,
+} = useBAIPaginationOptionStateOnSearchParam({ current: 1, pageSize: 10 });
+
+// Snapshot each tab's live state so it can be restored after switching away.
+const queryMapRef = useRef({
+  [queryParams.type]: { queryParams, tablePaginationOption },
+});
+
+useEffect(() => {
+  queryMapRef.current[queryParams.type] = {
+    queryParams,
+    tablePaginationOption,
+  };
+}, [queryParams, tablePaginationOption]);
+
+<BAITabs
+  activeKey={queryParams.type}
+  onChange={(key) => {
+    const storedQuery = queryMapRef.current[key] || {
+      queryParams: {/* per-tab defaults */},
+    };
+    setQueryParams(null); // reset all keys first, then layer stored state (see Gotchas)
+    setQueryParams({ ...storedQuery.queryParams, type: key });
+    // pagination is a SEPARATE nuqs group — setQueryParams(null) does not touch
+    // it, so the unvisited-tab fallback must reset current AND pageSize.
+    setTablePaginationOption(
+      storedQuery.tablePaginationOption || { current: 1, pageSize: 10 },
+    );
+    setSelectedRows([]);
+  }}
+/>
+```
+
+Net effect: the URL always reflects only the *active* tab's state and reload
+reproduces it exactly; `queryMapRef` remembers the other tabs for the session.
+
+### A-ii — host + self-contained child tabs: raw query-string snapshot
+
+When each tab is its own component with its own URL state, the host only
+manages the `tab` key and swaps the whole query string on switch. Do NOT hoist
+the children's params into the host or drill props — the children keep
+working independently, and only one is mounted at a time.
+
+The division of labor: children manage their typed keys with nuqs (as
+always); the host calls `useTabQuerySnapshot(tabParser)` from
+`react/src/hooks`, which owns the whole A-ii mechanism — it derives the tab by
+parsing `location.search`, snapshots each tab's raw query string, and returns
+the `onTabChange` that restores it on switch. The host must NOT read the tab
+with `useQueryState`: nuqs applies externally-caused URL changes (navigate,
+Link, history.pushState) inside a React transition, and when the incoming
+tab's content suspends under the shared Suspense boundary, that transition can
+stay uncommitted indefinitely — the URL changes but the tab UI never switches.
+Deriving the tab from `location.search` keeps the switch an urgent update: the
+tab flips immediately and the boundary shows its fallback while the new
+content loads. (The whole-string restore is below nuqs's declared-keys
+abstraction anyway — the host cannot declare keys it doesn't know.) That
+rationale lives in the hook body — don't re-inline the mechanism in pages.
+
+```tsx
+// Module-level. nuqs parsers are still the validation vocabulary; only the
+// nuqs *hook* is off-limits in the host.
+const tabParser = parseAsStringLiteral(['users', 'credentials']).withDefault(
+  'users',
+);
+
+const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
+
+<BAICard activeTabKey={currentTab} onTabChange={onTabChange} tabList={tabItems}>
+  {currentTab === 'users' && <AdminUserManagement />}
+  {currentTab === 'credentials' && <AdminUserCredentialList />}
+</BAICard>
+```
+
+Because the host swaps the *entire* query string per tab, sibling children may
+keep their generic key names (`filter`, `order`, `current`, `pageSize`) — no
+collision is possible: a stored snapshot is only ever applied together with
+its own tab key, and only that tab's component is mounted to read it.
+
+## Pattern B — Widget tabs on a detail page: tab key ONLY
+
+A tabbed card among sibling cards is not a page. Persist just the active tab
+key with its **own descriptive URL key** — never `tab`, `filter`, `current`,
+or `pageSize`. Canonical implementation: `DeploymentRevisionCard.tsx`.
+
+```tsx
+const [activeRevisionTab, setActiveRevisionTab] = useQueryState('revisionTab', {
+  ...parseAsStringLiteral([
+    'currentRevision',
+    'revisionHistory',
+    'auditLog',
+  ] as const).withDefault('currentRevision'),
+  history: 'replace' as const,
+  scroll: false,
+});
+
+<BAICard
+  activeTabKey={activeRevisionTab}
+  onTabChange={(key) => void setActiveRevisionTab(key)}
+  tabList={[...]}
+/>
+```
+
+Any filter/order/pagination *inside* those tabs stays in local state:
+`useState` for filters, `useBAIPaginationOptionState` (the non-SearchParam
+variant in `react/src/hooks/reactPaginationQueryOptions.tsx` — plain
+`useState`, never writes to the URL) for tables. Reload resets them — that is
+the intended UX; the deep-linkable unit is the detail page + which tab is
+open, not page 3 of a sub-table.
+
+The URL key must be scoped to the card (`revisionTab`, not `tab`) because a
+detail page can grow a second tabbed card later, and because the page-level
+route may already use `tab`.
+
+## Anti-patterns
+
+```tsx
+// ❌ Full query-string replacement on tab switch.
+//    Wipes every other URL key — the departing tab's filter/pagination is
+//    gone from the URL, so reload-after-returning always resets to defaults.
+onTabChange={(key) =>
+  navigate({ pathname: '/credential', search: `?tab=${key}` })
+}
+
+// ❌ "Fixing" the wipe by merely PRESERVING the query string on tab switch.
+//    Sibling children using the same generic keys (`filter`, `order`,
+//    `current`, `pageSize`) then read/write each other's state. The fix is
+//    Pattern A's snapshot/restore (swap, don't preserve) — not per-widget
+//    key prefixes.
+
+// ❌ Hoisting the children's URL state into the host page and drilling
+//    queryParams / onChange / pagination props down. Self-contained child
+//    tabs stay independent — the host manages only the tab key and the raw
+//    query-string snapshot (Pattern A-ii). Prop-drilling the schema couples
+//    every child to the host, duplicates parsers/types, and bloats the host
+//    for zero behavioral gain.
+
+// ❌ Pattern B card persisting table filter/pagination to the URL, even with
+//    card-scoped prefixed keys. A widget's page number is not shareable
+//    state, and it pollutes the detail page's URL with keys that outlive the
+//    card. Existing prefixed examples (`rFilter`/… in
+//    DeploymentReplicasCard.tsx, `rvFilter`/… in
+//    DeploymentRevisionHistoryTab.tsx) predate this policy — don't copy them
+//    into new code.
+```
+
+## Gotchas
+
+- **A-i: `setQueryParams(null)` then `setQueryParams({...stored})` is two
+  calls on purpose** — reset-all, then merge (nuqs semantics: see the
+  `react-url-state` skill's gotchas). Skipping the reset leaks keys the
+  target tab doesn't declare.
+- **A-i: pagination is a separate nuqs group, so `setQueryParams(null)` does
+  NOT reset it.** The unvisited-tab pagination fallback must reset **both**
+  `current` and `pageSize` (`{ current: 1, pageSize: <default> }`). A bare
+  `{ current: 1 }` leaves the departing tab's `pageSize` in place, so a
+  never-visited tab inherits it — a per-tab-state leak.
+- **A-ii: the stored snapshot already contains its own `tab` key** (it was
+  captured while that tab was active), so restoring it is a plain
+  `navigate({ search: stored })`; only the never-visited fallback needs an
+  explicit tab-only string, built via `new URLSearchParams({ tab: key })` so
+  the value is properly encoded.
+- **A-ii: the host never touches nuqs hooks for the tab key.** Not the setter
+  (it merges — writing `tab` preserves every other key, leaking the departing
+  tab's state into the next tab) and not a read-only `useQueryState` either
+  (nuqs applies navigate-caused URL changes in a transition that can hang on
+  the incoming tab's Suspense). `useTabQuerySnapshot` handles both sides;
+  use it instead of re-inlining reads or navigate swaps.
+- **The in-memory view can lie.** With the full-replace anti-pattern, Relay's
+  in-memory query ref makes the old tab *look* preserved when you switch back
+  — the loss only manifests on refresh. Test with a reload, not just tab
+  round-trips.
+- **`queryMapRef` is per-session, by design.** Only the active tab's state is
+  in the URL; a shared/reloaded URL restores that one tab and other tabs
+  start from defaults. Don't "fix" this by writing all tabs' state to the URL.
+- **Row selection is not part of the snapshot.** Clear `selectedRows` on
+  every tab change; restoring a selection against a re-fetched page is a
+  correctness trap.
+- **Pattern B needs `scroll: false`.** Without it nuqs may scroll to top on
+  tab change, which is jarring for a card in the middle of a detail page.
+
+## Verification Checklist
+
+- [ ] Classified the tab set as A (page-like) or B (widget) before writing code.
+- [ ] Pattern A: picked A-i (single component) vs A-ii (host + self-contained children) by who owns the table state; no unconditional `navigate({ search: '?tab=...' })` full-replace (A-ii's never-visited-tab fallback is the one sanctioned use).
+- [ ] A-i: `onTabChange` resets (`setQueryParams(null)`) before restoring. A-ii: host snapshots `location.search` per tab and restores it; children unchanged, no prop drilling.
+- [ ] Pattern B: only a card-scoped tab key in the URL (`history: 'replace'`, `scroll: false`); filters/pagination local.
+- [ ] Reload test on each tab: Pattern A reproduces filter/order/page; Pattern B reproduces only the open tab.
+- [ ] No two sibling tabs read/write the same URL key through separate `useQueryStates` declarations.
+
+## Related
+
+- `react-url-state` skill — nuqs fundamentals (`parseAs*`, `history: 'replace'`, `setQueryParams(null)` reset/merge semantics, `useDeferredValue` pairing).
+- `react-relay-table` skill — wiring the table itself.
+- `.claude/rules/use-bai-card.md` — the layout axis of the same tabbed cards (body padding, header `extra`); orthogonal to URL state.
+- Canonical files: `react/src/pages/AdminComputeSessionListPage.tsx` (A-i), `react/src/pages/AdminUsersPage.tsx` (A-ii), `react/src/components/DeploymentRevisionCard.tsx` (B).
+- FR-3267 — the issue that established this policy and tracks migration of the remaining pages.

--- a/.specs/FR-3267-tab-url-state/migration-targets.md
+++ b/.specs/FR-3267-tab-url-state/migration-targets.md
@@ -1,0 +1,316 @@
+# FR-3267 — tab-url-state Migration Targets
+
+Audit of every tab UI in `react/src/**` against the policy in
+`.claude/skills/tab-url-state/SKILL.md`. Each work item below is scoped to be
+implemented independently by one subagent. Read the skill first; it defines
+Pattern A (page-like tabs: full URL state + `queryMapRef` save/restore) and
+Pattern B (widget tabs on a detail surface: tab key only, table state local).
+
+- Audit date: 2026-07-11 (branch `feat/FR-3267-per-tab-url-state`, base `main` @ 1c5a8e35b)
+- Jira: FR-3267 / GitHub #8173
+
+## Reference implementations (do not modify; copy from these)
+
+| Role | File |
+|---|---|
+| Pattern A-i canonical (single component, parsed-state snapshot) | `react/src/pages/AdminComputeSessionListPage.tsx` |
+| Pattern A-i (nuqs, second example) | `react/src/pages/ComputeSessionListPage.tsx` |
+| Pattern A-ii canonical (host + self-contained children, raw query-string snapshot) | `react/src/pages/AdminUsersPage.tsx` (implemented by A1) |
+| Pattern B canonical (tab key only) | `react/src/components/DeploymentRevisionCard.tsx` (`revisionTab`) |
+| Pattern B table-state model (local pagination) | `react/src/components/DeploymentAuditLogTab.tsx` (`useBAIPaginationOptionState`) |
+
+**A2–A6 all use Pattern A-ii**: the host snapshots `location.search` per tab in
+a `queryMapRef` and restores it on switch. Children keep their own URL state
+untouched — do NOT hoist child params into the host or drill props (see the
+skill's anti-patterns).
+
+**Status: A1–A11 complete; only Pattern B items (B1–B5) remain.**
+
+Also compliant, no action: `VFolderNodeListPage.tsx`, `AdminVFolderNodeListPage.tsx`
+(queryMapRef on the legacy `use-query-params` API — correct behavior, library
+migration is out of FR-3267 scope).
+
+## Verification required for every item
+
+1. `bash scripts/verify.sh` passes.
+2. Reload test per the skill's checklist: for Pattern A, set filter + page on
+   each tab, switch tabs, reload — the active tab's state must reproduce; for
+   Pattern B, only the open tab (where a tab key exists) survives reload.
+3. No two sibling tabs read/write the same URL key via separate declarations.
+
+---
+
+## Pattern A work items (page-like tabs)
+
+### A1. AdminUsersPage — `?tab=` full replace ✅ DONE (Pattern A-ii)
+
+- Files: `react/src/pages/AdminUsersPage.tsx` only — children unchanged.
+- Violations: `onTabChange` did `navigate({ pathname: '/credential', search: `?tab=${key}` })`
+  (full query-string replace), wiping the departing tab's
+  `filter`/`order`/`current`/`pageSize`.
+- Fix applied: host-level `queryMapRef<Record<string, string>>` snapshotting
+  `location.search` per tab (seeded with the current tab, kept fresh by a
+  `useEffect` on `[currentTab, location.search]`); `onTabChange` navigates to
+  the stored string, falling back to `?tab=${key}` for never-visited tabs.
+  Children keep their own URL state (generic keys are fine — the host swaps
+  the whole string, and only one child is mounted at a time).
+  `AdminUserCredentialList` stays on use-query-params (library migration is
+  out of FR-3267 scope).
+
+### A2. AdminDeploymentListPage — `?tab=` full replace + 4-way collision (heaviest) ✅ DONE (Pattern A-ii)
+
+- Files: `react/src/pages/AdminDeploymentListPage.tsx` only — children unchanged.
+- Violations: `onTabChange` navigated with `pathname: '/admin-deployments',
+  search: `?tab=${key}`` (full replace). All four tab children declare their
+  own nuqs URL state with the same generic keys: `filter`(json)/`order` +
+  `current`/`pageSize` (the deployments tab additionally `statusCategory`).
+- Fix applied: added host-level `queryMapRef<Record<string, string>>` at the
+  `AdminDeploymentListPage` wrapper, seeded with the current tab and kept fresh
+  by a named-function `useEffect(function snapshotTabQueryString() {...},
+  [currentTab, location.search])`; `onTabChange` now navigates to the stored
+  raw query string (`navigate({ search: queryMapRef.current[key] ?? `?tab=${key}` })`,
+  no pathname), falling back to `?tab=${key}` for never-visited tabs. Tab read
+  via read-only nuqs `useQueryState` (`parseAsStringLiteral`, default
+  `'deployments'`). All four children stay
+  untouched — the host swaps the whole query string per tab, so their shared
+  generic keys never collide.
+
+### A3. AdminSessionPage — full replace over a nested Pattern-A child ✅ DONE (Pattern A-ii)
+
+- Files: `react/src/pages/AdminSessionPage.tsx` only — children unchanged.
+- Violations: `onTabChange` both wrote nuqs `tab` (`history: 'push'`) AND
+  called `webUINavigate({ search: new URLSearchParams({ tab: key }) })` — a
+  full replace that wiped the nested child's `type`/`filter`/`order`/
+  `statusCategory`/`current`/`pageSize`. `PendingSessionNodeList` uses
+  `...OnSearchParamLegacy` (`current`/`pageSize`), colliding with the
+  sessions child.
+- Fix applied: removed the nuqs `useQueryStates` `tab` schema and the
+  `webUINavigate` double-write entirely; adopted the A-ii idiom —
+  read-only nuqs `useQueryState('tab', parseAsStringLiteral(...))` (default
+  `'compute-sessions'`), `useLocation`, a `queryMapRef<Record<string, string>>`
+  seeded with the current tab, a named-function `snapshotTabQueryString`
+  effect, and `onTabChange` doing `webUINavigate({ search:
+  queryMapRef.current[key] ?? `?tab=${key}` })` (no pathname). The nested
+  Pattern A-i child (`AdminComputeSessionListPage`) works naturally: its keys
+  are part of the raw string being snapshotted. Children untouched.
+
+### A4. EnvironmentPage — lingering keys across tabs (merge setter) ✅ DONE (Pattern A-ii)
+
+- Files: `react/src/pages/EnvironmentPage.tsx` only — children unchanged.
+- Violations: tab key `tab` via use-query-params with merge semantics — keys
+  were never reset, so `image` ↔ `registry` carried each other's
+  `order`/`current`/`pageSize` (both children write those generic keys).
+- Fix applied: replaced the use-query-params `useQueryParam('tab')` merge
+  setter with the A-ii idiom — read-only nuqs `useQueryState` (default `'image'`),
+  `useLocation`, a `queryMapRef` seeded with the current tab, a named-function
+  `snapshotTabQueryString` effect, and an `onTabChange` that navigates to the
+  stored raw query string (swap, don't merge; fallback `?tab=${key}`). Added
+  `'use memo'` to the component body. Children untouched.
+
+### A5. ResourcesPage — state loss on switch, shared keys ✅ DONE (Pattern A-ii)
+
+- Files: `react/src/pages/ResourcesPage.tsx` only — children unchanged.
+- Violations: tab key via use-query-params `updateType: 'replace'` — each
+  switch dropped the other params, so tabs lost filter/page on switch and a
+  reloaded non-default tab couldn't reproduce its view. `agents` and `storages`
+  share `current`/`pageSize` (AgentList also `status`/`filter`/`order`).
+- Fix applied: replaced the `updateType: 'replace'` tab setter with the A-ii
+  idiom — read-only nuqs `useQueryState` (default `'agents'`), `useLocation`, a
+  `queryMapRef` seeded with the current tab, a named-function
+  `snapshotTabQueryString` effect, and an `onTabChange` navigating to the
+  stored raw query string. Removed the now-unused `TabKey` type and the
+  use-query-params import; added `'use memo'`. Also renamed the deprecated
+  `tab:` → `label:` in all three `tabList` items (antd-v6-props). Children
+  untouched. Note: the old setter used history *replace*; the A-ii idiom
+  navigates with *push* (consistent with the pattern's deep-linkable-tab
+  intent), so tab switches now create history entries — deliberate, not a
+  regression.
+
+### A6. ResourcePolicyPage — full-replace idiom, currently benign (small) ✅ DONE (Pattern A-ii)
+
+- Files: `react/src/pages/ResourcePolicyPage.tsx`
+- Violations: `onTabChange` full-replaced via
+  `webUINavigate({ pathname: '/resource-policy', search: URLSearchParams({ tab }) })`.
+  Children declare no URL table state today, so nothing was lost —
+  consistency/latent fix only.
+- Fix applied: replaced the full-replace `onTabChange` with the A-ii
+  snapshot/restore idiom — read-only nuqs `useQueryState` (default `'keypair'`),
+  `useLocation`, a `queryMapRef` seeded with the current tab, a named-function
+  `snapshotTabQueryString` effect, and `webUINavigate({ search:
+  queryMapRef.current[key] ?? `?tab=${key}` })` (no pathname). Dropped the
+  use-query-params import; added `'use memo'`. Future-proofs the page and keeps
+  the idiom uniform.
+
+### A7. SchedulerPage — latent full replace, single tab (small) ✅ DONE (handler removed)
+
+- Files: `react/src/pages/SchedulerPage.tsx`
+- Violations: single tab (`fair-share`) but `onTabChange` full-replaced; child
+  `FairShareItems/FairShareList.tsx` carries significant URL state
+  (`resourceGroup`/`domain`/`project`/`user`/`current`/`pageSize`) that would
+  have been wiped if a second tab is ever added.
+- Fix applied: removed the dangerous full-replace `onTabChange` entirely — a
+  single-tab card never switches, so snapshot machinery would be inert dead
+  code (simplify-pass judgment). Kept a read-only nuqs `useQueryState` read for
+  `activeTabKey`. Dropped the use-query-params import (the
+  `FairShareErrorFallback` nuqs `useQueryStates` is unrelated and kept);
+  added `'use memo'`; renamed the deprecated `tab:` → `label:` in the single
+  `tabList` item.
+
+### A8. ProjectAdminDataPage — missing explicit reset before restore (tiny) ✅ DONE (A-i reset fix)
+
+- Files: `react/src/pages/ProjectAdminDataPage.tsx`
+- Violations: had `queryMapRef` + restore but merged without the
+  `setQueryParams(null)` reset. Worked only because both tabs share an
+  identical key schema; keys could linger when switching to a never-visited tab.
+- Fix applied: added the `setQuery(null)` reset (with the "Set to null first to
+  reset to default values" comment) immediately before applying the stored/
+  spread state in `onChange`, matching the canonical A-i implementation in
+  `AdminComputeSessionListPage.tsx`. Nothing else changed.
+
+### A9. StatisticsPage — full replace wipes child URL state (user-facing) ✅ DONE (Pattern A-ii)
+
+- Files: `react/src/pages/StatisticsPage.tsx` only — children unchanged.
+- Violations: originally misclassified as "no violation" because its children
+  don't share generic keys — but its tab setter used use-query-params
+  `updateType: 'replace'`, which replaces ALL query params, wiping the other
+  tab's child state on switch (`AllocationHistory` → `selectedPeriod`,
+  `UserSessionsMetrics` → `startDate`/`endDate`). Same class of bug as A5.
+- Fix applied: A-ii idiom — read-only nuqs `useQueryState` (default
+  `'allocation-history'`), `useLocation`, `queryMapRef` + named-function
+  `snapshotTabQueryString` effect, navigate swap `onTabChange`. Dropped the
+  use-query-params import; added `'use memo'`; renamed deprecated `tab:` →
+  `label:` in both `tabList` items. Children untouched.
+
+### A10. UserSettingsPage — uniform A-ii protection (user-facing) ✅ DONE (Pattern A-ii)
+
+- Files: `react/src/pages/UserSettingsPage.tsx` only — children unchanged.
+- Rationale: no active bug (merge-semantics setter, children keep table state
+  in memory today), but per the uniform-host policy every page-like multi-tab
+  host carries the A-ii snapshot/restore so children can adopt URL state
+  later without host changes.
+- Fix applied: replaced the use-query-params `useQueryParam('tab')` with
+  read-only nuqs `useQueryState` (literal union of the four tab keys, default
+  `'general'`), `useLocation`, `queryMapRef` + named-function
+  `snapshotTabQueryString` effect, navigate swap `onTabChange`. The lazy
+  Relay query loading keyed on `curTabKey` is untouched. Removed the unused
+  `TabKey` type and `tabParam` const.
+
+### A11. Single-tab pages — dead `onTabChange` + legacy tab setter sweep ✅ DONE
+
+- Files: `react/src/pages/AgentSummaryPage.tsx`, `BrandingPage.tsx`,
+  `ConfigurationsPage.tsx`, `MaintenancePage.tsx`, `MyEnvironmentPage.tsx`,
+  `DiagnosticsPage.tsx`
+- Violations: each single-tab page carried an `onTabChange` that can never
+  fire with a different key, wired to a use-query-params setter
+  (AgentSummaryPage even with the dangerous `updateType: 'replace'`), plus
+  deprecated `tab:` props and missing `'use memo'` in places.
+- Fix applied (SchedulerPage/A7 precedent): removed the dead `onTabChange`
+  and all use-query-params tab machinery; tab key read via read-only nuqs
+  `useQueryState` with a single-literal parser; `'use memo'` where missing,
+  and `tab:` → `label:` renames. ConfigurationsPage's raw antd `Card`
+  migrated to `BAICard` (use-bai-card rule; tabbed card keeps default body
+  padding).
+
+---
+
+## Pattern B work items (widget tabs / cards on detail surfaces)
+
+### B1. DeploymentRevisionHistoryTab — `rv*` keys → local state
+
+- Files: `react/src/components/DeploymentRevisionHistoryTab.tsx`
+- Violations: nuqs `useQueryStates` writes `rvFilter`/`rvOrder`/`rvCurrent`/
+  `rvPageSize` to the deployment detail URL from inside a widget tab.
+- Fix: `useState` for filter/order, `useBAIPaginationOptionState` for
+  pagination — mirror its sibling `DeploymentAuditLogTab.tsx`. Delete the
+  `useQueryStates`/`urlKeys` block. Note: the file's inline comment says URL
+  persistence was added to avoid an out-of-range page index across tab
+  switches — local state also resets the page on remount, so verify paging
+  across tab switches still behaves (BAITable receiving `current` from fresh
+  local state).
+
+### B2. DeploymentReplicasCard — `r*` keys → local state
+
+- Files: `react/src/components/DeploymentReplicasCard.tsx`
+- Violations: writes `rFilter`/`rOrder`/`rCurrent`/`rPageSize`/
+  `rStatusCategory` to the deployment detail URL from a plain (non-tabbed)
+  sibling card.
+- Fix: `useState` for filter/order/statusCategory,
+  `useBAIPaginationOptionState` for pagination. Delete the `useQueryStates`
+  block.
+
+### B3. DeploymentAutoScalingCard — fully generic keys on the detail URL
+
+- Files: `react/src/components/DeploymentAutoScalingCard.tsx`
+- Violations: the worst offender — generic `order`/`filter` via
+  `useQueryStates` (no key remap) plus generic `current`/`pageSize` via
+  `useBAIPaginationOptionStateOnSearchParam`, all on the shared deployment
+  detail URL (collision hazard with sibling cards and any page-level keys).
+- Fix: `useState` for order/filter, `useBAIPaginationOptionState` for
+  pagination. Remove both URL hooks.
+
+### B4. ReservoirArtifactDetailPage — version-list table state → local
+
+- Files: `react/src/pages/ReservoirArtifactDetailPage.tsx`
+- Violations: the Version List card persists `filter` (use-query-params
+  `JsonParam`) and `current`/`pageSize` (`...OnSearchParamLegacy`) to the
+  detail-page URL.
+- Fix: `useState` for filter, `useBAIPaginationOptionState` for pagination;
+  drop the use-query-params import if unused afterward.
+
+### B5. RoleDetailDrawer tabs — `s*`/`p*`/`a*` keys → local state
+
+- Files: `react/src/components/RoleDetailDrawerContent.tsx`,
+  `react/src/components/RoleScopeTab.tsx`,
+  `react/src/components/RolePermissionTab.tsx`,
+  `react/src/components/RoleAssignmentTab.tsx`
+- Scope decision (made for FR-3267): a drawer is a widget surface — Pattern B
+  applies. The active tab key is already local `useState` (fine; a drawer tab
+  need not persist at all).
+- Violations: each tab persists its table state to the URL with prefixed keys
+  (`sCurrent`/`sPageSize`/`sOrder`/`sFilter`, `p*`, `a*`), and
+  `RoleDetailDrawerContent` declares all twelve keys solely to null them out
+  on tab change.
+- Fix: move each tab's filter/order/pagination to local state
+  (`useState` + `useBAIPaginationOptionState`); delete the twelve-key
+  `useQueryStates` reset bookkeeping in `RoleDetailDrawerContent`.
+
+---
+
+## Explicitly out of scope / no action
+
+- **Decorative-tab pages** (static `activeTabKey`, no `onTabChange`, no tab
+  URL key): `ProjectPage`, `RBACManagementPage`, `ReservoirPage`. The other
+  single-tab pages initially listed here were swept in A11, and
+  `UserSettingsPage`/`StatisticsPage` were reclassified as A10/A9 — the
+  uniform-host policy now covers every page-like tab host.
+- **Local-state widget tabs already compliant**: `SessionDetailContent`,
+  `StorageHostDetailDrawerContent`, `AgentDetailDrawerContent`,
+  `FolderExplorerModalV2`, `SettingList`, `RuntimeParameterFormSection`,
+  modals (`StartFromURLModal`, `DownloadModal`).
+- **use-query-params → nuqs migration** is NOT a goal of FR-3267. With the
+  A-ii recipe no item requires it — the raw query-string snapshot is
+  library-agnostic. `VFolderNodeListPage`/`AdminVFolderNodeListPage` and all
+  legacy children stay on the legacy API.
+- **Deprecated `tab:` → `label:`** (antd v6): fixed in every page an A-item
+  touched that still had it (A5, A7, A9, A11; UserSettingsPage/A10 already
+  used `label:`). The only remaining `tab:` is
+  `ReservoirPage` — a decorative single-static-tab page (out of scope; see
+  below), left untouched.
+- **Decorative single-static-tab pages** (`activeTabKey` is a hardcoded
+  literal, no `onTabChange`, no tab URL key — BAICard's `tabList` used purely
+  as a titled header): `ProjectPage`, `RBACManagementPage`, `ReservoirPage`.
+  No tab switching exists, so there is no state to protect. Genuinely out of
+  scope.
+
+## Suggested execution order
+
+1. **B1–B5** — independent, small, no shared files; safe to run in parallel.
+2. **A6, A7, A8** — tiny, independent.
+3. **A1, A4, A5** — medium; independent of each other.
+4. **A2** — heaviest (4 tab children).
+5. **A3** — last: it wraps the canonical `AdminComputeSessionListPage`; doing
+   it after the others means the nested-tab handling gets the benefit of
+   lessons from A1/A2.
+
+All items are file-disjoint except A3's read-dependency on
+`AdminComputeSessionListPage` — no two items should edit the same file.

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -6,9 +6,10 @@ import { getOS, preserveDotStartCase } from '../helper';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import { MenuKeys } from './useWebUIMenuItems';
 import * as _ from 'lodash-es';
-import { useEffect, useMemo, useState } from 'react';
+import type { SingleParserBuilder } from 'nuqs';
+import { useEffect, useMemo, useRef, useState } from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 /**
  * Thin wrapper around `useNavigate` from react-router-dom.
@@ -23,6 +24,49 @@ import { useNavigate } from 'react-router-dom';
  * future cross-cutting navigation concerns.
  */
 export const useWebUINavigate = () => useNavigate();
+
+/**
+ * Thin wrapper around `useLocation` from react-router-dom, paired with
+ * `useWebUINavigate`. Kept as a project-level abstraction point so
+ * cross-cutting location concerns can be added in one place.
+ */
+export const useWebUILocation = () => useLocation();
+
+/**
+ * Per-tab query-string snapshot/restore for page-like tab hosts
+ * (tab-url-state A-ii). Reads the tab from router location, not nuqs —
+ * nuqs applies external URL changes in a transition that can hang on the
+ * incoming tab's Suspense.
+ */
+export const useTabQuerySnapshot = <T extends string>(
+  tabParser: ReturnType<SingleParserBuilder<T>['withDefault']>,
+) => {
+  'use memo';
+  const location = useWebUILocation();
+  const navigate = useWebUINavigate();
+
+  const currentTab =
+    tabParser.parse(new URLSearchParams(location.search).get('tab') ?? '') ??
+    tabParser.defaultValue;
+
+  const queryMapRef = useRef<Record<string, string>>({
+    [currentTab]: location.search,
+  });
+
+  useEffect(() => {
+    queryMapRef.current[currentTab] = location.search;
+  }, [currentTab, location.search]);
+
+  const onTabChange = (key: string) => {
+    // No pathname — a partial { search } resolves against the current location.
+    navigate({
+      search:
+        queryMapRef.current[key] ?? `?${new URLSearchParams({ tab: key })}`,
+    });
+  };
+
+  return { currentTab, onTabChange };
+};
 
 export const useBackendAIConnectedState = () => {
   const [time, setTime] = useState<string>();

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -10,14 +10,17 @@ import type {
   DeploymentStatus,
   OrderDirection,
 } from '../__generated__/AdminDeploymentListPageQuery.graphql';
-import type { DeploymentRevisionDetail_revision$key } from '../__generated__/DeploymentRevisionDetail_revision.graphql';
 import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import DeploymentSettingModal from '../components/DeploymentSettingModal';
 import PrometheusPresetTab from '../components/PrometheusPresetTab';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import {
+  useSuspendedBackendaiClient,
+  useTabQuerySnapshot,
+  useWebUINavigate,
+} from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import AdminDeploymentPresetListPage from './AdminDeploymentPresetListPage';
@@ -53,7 +56,6 @@ import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
-import { useSearchParams } from 'react-router-dom';
 
 type DeploymentStatusCategory = 'running' | 'finished';
 
@@ -71,8 +73,9 @@ const AdminDeploymentListPageContent: React.FC = () => {
   const [deletingDeploymentId, setDeletingDeploymentId] = useState<
     string | null
   >(null);
-  const [drawerRevisionFrgmt, setDrawerRevisionFrgmt] =
-    useState<DeploymentRevisionDetail_revision$key | null>(null);
+  const [revisionDrawerDeploymentId, setRevisionDrawerDeploymentId] = useState<
+    string | null
+  >(null);
 
   const supportsExtendedFilter = baiClient.supports(
     'model-deployment-extended-filter',
@@ -192,6 +195,11 @@ const AdminDeploymentListPageContent: React.FC = () => {
     deletingDeploymentId == null
       ? null
       : (deploymentNodes.find((n) => n.id === deletingDeploymentId) ?? null);
+  const drawerRevisionFrgmt =
+    revisionDrawerDeploymentId == null
+      ? null
+      : (deploymentNodes.find((n) => n.id === revisionDrawerDeploymentId)
+          ?.currentRevision ?? null);
 
   const isLoading =
     deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
@@ -397,14 +405,9 @@ const AdminDeploymentListPageContent: React.FC = () => {
                   next = {
                     ...col,
                     render: (_value, record) => {
-                      // `record` here is narrowed to BAIModelDeploymentNodesFragment;
-                      // recover the wider node (with `...DeploymentRevisionDetail_revision`
-                      // on `currentRevision`) from the page-level query result
-                      // so the drawer receives a fragment ref it can consume.
-                      const wider = deploymentNodes.find(
+                      const revision = deploymentNodes.find(
                         (n) => n.id === record.id,
-                      );
-                      const revision = wider?.currentRevision;
+                      )?.currentRevision;
                       if (revision?.revisionNumber == null) {
                         return (
                           <Typography.Text type="secondary">-</Typography.Text>
@@ -412,7 +415,9 @@ const AdminDeploymentListPageContent: React.FC = () => {
                       }
                       return (
                         <Typography.Link
-                          onClick={() => setDrawerRevisionFrgmt(revision)}
+                          onClick={() =>
+                            setRevisionDrawerDeploymentId(record.id)
+                          }
                         >{`#${revision.revisionNumber}`}</Typography.Link>
                       );
                     },
@@ -508,19 +513,24 @@ const AdminDeploymentListPageContent: React.FC = () => {
         <DeploymentRevisionDetailDrawer
           open={!!drawerRevisionFrgmt}
           revisionFrgmt={drawerRevisionFrgmt}
-          onClose={() => setDrawerRevisionFrgmt(null)}
+          onClose={() => setRevisionDrawerDeploymentId(null)}
         />
       </BAIUnmountAfterClose>
     </>
   );
 };
 
+const tabParser = parseAsStringLiteral([
+  'deployments',
+  'model-store-management',
+  'prometheus-preset',
+  'deployment-presets',
+]).withDefault('deployments');
+
 const AdminDeploymentListPage: React.FC = () => {
   'use memo';
   const { t } = useTranslation();
-  const [searchParams] = useSearchParams();
-  const currentTab = searchParams.get('tab') || 'deployments';
-  const navigate = useWebUINavigate();
+  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
   const baiClient = useSuspendedBackendaiClient();
   const isPrometheusPresetSupported = baiClient.supports(
     'prometheus-query-preset',
@@ -550,12 +560,7 @@ const AdminDeploymentListPage: React.FC = () => {
     <BAICard
       variant="borderless"
       activeTabKey={currentTab}
-      onTabChange={(key) =>
-        navigate({
-          pathname: '/admin-deployments',
-          search: `?tab=${key}`,
-        })
-      }
+      onTabChange={onTabChange}
       tabList={tabItems}
     >
       <Suspense fallback={<Skeleton active />}>

--- a/react/src/pages/AdminSessionPage.tsx
+++ b/react/src/pages/AdminSessionPage.tsx
@@ -5,10 +5,10 @@
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import PendingSessionNodeList from '../components/PendingSessionNodeList';
 import SessionDetailAndContainerLogOpenerLegacy from '../components/SessionDetailAndContainerLogOpenerLegacy';
-import { useWebUINavigate } from '../hooks';
+import { useTabQuerySnapshot } from '../hooks';
 import { Skeleton } from 'antd';
 import { BAICard, filterOutEmpty } from 'backend.ai-ui';
-import { parseAsString, useQueryStates } from 'nuqs';
+import { parseAsStringLiteral } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -16,31 +16,22 @@ const AdminComputeSessionListPage = React.lazy(
   () => import('./AdminComputeSessionListPage'),
 );
 
+const tabParser = parseAsStringLiteral([
+  'compute-sessions',
+  'pending-sessions',
+]).withDefault('compute-sessions');
+
 const AdminSessionPage: React.FC = () => {
   'use memo';
 
   const { t } = useTranslation();
-  const [queryParam, setQueryParam] = useQueryStates(
-    {
-      tab: parseAsString.withDefault('compute-sessions'),
-    },
-    { history: 'push' },
-  );
-  const webUINavigate = useWebUINavigate();
+  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
 
   return (
     <>
       <BAICard
-        activeTabKey={queryParam.tab}
-        onTabChange={(key) => {
-          webUINavigate({
-            pathname: '/admin-session',
-            search: new URLSearchParams({
-              tab: key,
-            }).toString(),
-          });
-          setQueryParam({ tab: key });
-        }}
+        activeTabKey={currentTab}
+        onTabChange={onTabChange}
         tabList={filterOutEmpty([
           {
             key: 'compute-sessions',
@@ -53,12 +44,12 @@ const AdminSessionPage: React.FC = () => {
         ])}
       >
         <Suspense fallback={<Skeleton active />}>
-          {queryParam.tab === 'compute-sessions' && (
+          {currentTab === 'compute-sessions' && (
             <BAIErrorBoundary>
               <AdminComputeSessionListPage />
             </BAIErrorBoundary>
           )}
-          {queryParam.tab === 'pending-sessions' && (
+          {currentTab === 'pending-sessions' && (
             <BAIErrorBoundary>
               <PendingSessionNodeList />
             </BAIErrorBoundary>

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -5,19 +5,23 @@
 import AdminUserCredentialList from '../components/AdminUserCredentialList';
 import AdminUserManagement from '../components/AdminUserManagement';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
-import { useWebUINavigate } from '../hooks';
+import { useTabQuerySnapshot } from '../hooks';
 import { Skeleton } from 'antd';
 import { CardTabListType } from 'antd/es/card';
 import { BAIFlex, BAICard } from 'backend.ai-ui';
+import { parseAsStringLiteral } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
+
+const tabParser = parseAsStringLiteral(['users', 'credentials']).withDefault(
+  'users',
+);
 
 const AdminUsersPage: React.FC = () => {
+  'use memo';
   const { t } = useTranslation();
-  const [searchParams] = useSearchParams();
-  const currentTab = searchParams.get('tab') || 'users';
-  const navigate = useWebUINavigate();
+  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
+
   const tabItems: CardTabListType[] = [
     {
       key: 'users',
@@ -32,12 +36,7 @@ const AdminUsersPage: React.FC = () => {
   return (
     <BAICard
       activeTabKey={currentTab}
-      onTabChange={(key) =>
-        navigate({
-          pathname: '/credential',
-          search: `?tab=${key}`,
-        })
-      }
+      onTabChange={onTabChange}
       tabList={tabItems}
     >
       <Suspense fallback={<Skeleton active />}>

--- a/react/src/pages/AgentSummaryPage.tsx
+++ b/react/src/pages/AgentSummaryPage.tsx
@@ -5,32 +5,29 @@
 import AgentSummaryList from '../components/AgentSummaryList';
 import { Skeleton, theme } from 'antd';
 import { BAICard } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
-type TabKey = 'agent-summary';
-
 interface ResourcesPageProps {}
 
-const tabParam = parseAsString
-  .withDefault('agent-summary')
-  .withOptions({ history: 'replace' });
-
 const ResourcesPage: React.FC<ResourcesPageProps> = () => {
+  'use memo';
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const [curTabKey] = useQueryState(
+    'tab',
+    parseAsStringLiteral(['agent-summary']).withDefault('agent-summary'),
+  );
 
   const { token } = theme.useToken();
 
   return (
     <BAICard
       activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key as TabKey)}
       tabList={[
         {
           key: 'agent-summary',
-          tab: t('webui.menu.AgentSummary'),
+          label: t('webui.menu.AgentSummary'),
         },
       ]}
     >

--- a/react/src/pages/BrandingPage.tsx
+++ b/react/src/pages/BrandingPage.tsx
@@ -6,26 +6,26 @@ import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BrandingSettingList from '../components/BrandingSettingList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-
-const tabParam = parseAsString.withDefault('branding');
 
 const BrandingPage: React.FC = () => {
   'use memo';
 
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const [curTabKey] = useQueryState(
+    'tab',
+    parseAsStringLiteral(['branding']).withDefault('branding'),
+  );
 
   return (
     <BAICard
       activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key)}
       tabList={[
         {
           key: 'branding',
-          tab: t('webui.menu.Branding'),
+          label: t('webui.menu.Branding'),
         },
       ]}
     >

--- a/react/src/pages/ConfigurationsPage.tsx
+++ b/react/src/pages/ConfigurationsPage.tsx
@@ -4,30 +4,29 @@
  */
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ConfigurationsSettingList from '../components/ConfigurationsSettingList';
-import { Card, Skeleton } from 'antd';
-import { filterOutEmpty } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { Skeleton } from 'antd';
+import { BAICard } from 'backend.ai-ui';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
-type TabKey = 'configurations';
-
-const tabParam = parseAsString.withDefault('configurations');
-
 const ConfigurationsPage = () => {
+  'use memo';
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const [curTabKey] = useQueryState(
+    'tab',
+    parseAsStringLiteral(['configurations']).withDefault('configurations'),
+  );
 
   return (
-    <Card
+    <BAICard
       activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key as TabKey)}
-      tabList={filterOutEmpty([
+      tabList={[
         {
           key: 'configurations',
-          tab: t('webui.menu.Configurations'),
+          label: t('webui.menu.Configurations'),
         },
-      ])}
+      ]}
     >
       <Suspense fallback={<Skeleton active />}>
         {curTabKey === 'configurations' && (
@@ -36,7 +35,7 @@ const ConfigurationsPage = () => {
           </BAIErrorBoundary>
         )}
       </Suspense>
-    </Card>
+    </BAICard>
   );
 };
 

--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -24,20 +24,20 @@ import {
   message,
 } from 'antd';
 import { BAIButton, BAICard, BAIFlex, useFetchKey } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { Suspense, useCallback, useRef, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
-type TabKey = 'diagnostics';
 type SectionKey = 'csp' | 'storage' | 'endpoint' | 'config';
-
-const tabParam = parseAsString.withDefault('diagnostics');
 
 const DiagnosticsPage = () => {
   'use memo';
 
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const [curTabKey] = useQueryState(
+    'tab',
+    parseAsStringLiteral(['diagnostics']).withDefault('diagnostics'),
+  );
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [isPending, startTransition] = useTransition();
   const [showOnlyFailed, setShowOnlyFailed] = useState(false);
@@ -218,11 +218,10 @@ const DiagnosticsPage = () => {
   return (
     <BAICard
       activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key as TabKey)}
       tabList={[
         {
           key: 'diagnostics',
-          tab: t('webui.menu.Diagnostics'),
+          label: t('webui.menu.Diagnostics'),
         },
       ]}
       tabBarExtraContent={

--- a/react/src/pages/EnvironmentPage.tsx
+++ b/react/src/pages/EnvironmentPage.tsx
@@ -6,24 +6,29 @@ import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ContainerRegistryList from '../components/ContainerRegistryList';
 import ImageList from '../components/ImageList';
 import ResourcePresetList from '../components/ResourcePresetList';
-import { useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient, useTabQuerySnapshot } from '../hooks';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const tabParam = parseAsString.withDefault('image');
+const tabParser = parseAsStringLiteral([
+  'image',
+  'preset',
+  'registry',
+]).withDefault('image');
 
 const EnvironmentPage = () => {
+  'use memo';
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
   const baiClient = useSuspendedBackendaiClient();
 
   return (
     <BAICard
-      activeTabKey={curTabKey}
-      onTabChange={setCurTabKey}
+      activeTabKey={currentTab}
+      onTabChange={onTabChange}
       tabList={[
         {
           key: 'image',
@@ -44,17 +49,17 @@ const EnvironmentPage = () => {
       ]}
     >
       <Suspense fallback={<Skeleton active />}>
-        {curTabKey === 'image' && (
+        {currentTab === 'image' && (
           <BAIErrorBoundary>
             <ImageList />
           </BAIErrorBoundary>
         )}
-        {curTabKey === 'preset' && (
+        {currentTab === 'preset' && (
           <BAIErrorBoundary>
             <ResourcePresetList />
           </BAIErrorBoundary>
         )}
-        {curTabKey === 'registry' && (
+        {currentTab === 'registry' && (
           <BAIErrorBoundary>
             <ContainerRegistryList />
           </BAIErrorBoundary>

--- a/react/src/pages/MaintenancePage.tsx
+++ b/react/src/pages/MaintenancePage.tsx
@@ -6,26 +6,25 @@ import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import MaintenanceSettingList from '../components/MaintenanceSettingList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
-type TabKey = 'maintenance';
-
-const tabParam = parseAsString.withDefault('maintenance');
-
 const MaintenancePage = () => {
+  'use memo';
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const [curTabKey] = useQueryState(
+    'tab',
+    parseAsStringLiteral(['maintenance']).withDefault('maintenance'),
+  );
 
   return (
     <BAICard
       activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key as TabKey)}
       tabList={[
         {
           key: 'maintenance',
-          tab: t('webui.menu.Maintenance'),
+          label: t('webui.menu.Maintenance'),
         },
       ]}
     >

--- a/react/src/pages/MyEnvironmentPage.tsx
+++ b/react/src/pages/MyEnvironmentPage.tsx
@@ -5,20 +5,21 @@
 import CustomizedImageList from '../components/CustomizedImageList';
 import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import { BAICard } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const tabParam = parseAsString.withDefault('image');
-
 const MyEnvironmentPage = () => {
+  'use memo';
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const [curTabKey] = useQueryState(
+    'tab',
+    parseAsStringLiteral(['image']).withDefault('image'),
+  );
 
   return (
     <BAICard
       activeTabKey={curTabKey}
-      onTabChange={setCurTabKey}
       tabList={[
         {
           key: 'image',

--- a/react/src/pages/ProjectAdminDataPage.tsx
+++ b/react/src/pages/ProjectAdminDataPage.tsx
@@ -249,6 +249,8 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
           const storedQuery = queryMapRef.current[key] || {
             mode: 'all',
           };
+          // Set to null first to reset to default values
+          setQuery(null);
           setQuery(
             {
               ...storedQuery.queryParams,
@@ -257,7 +259,10 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
             { history: 'replace' },
           );
           setTablePaginationOption(
-            storedQuery.tablePaginationOption || { current: 1 },
+            // pagination is a separate nuqs group that setQuery(null) does not
+            // reset, so an unvisited tab must reset current AND pageSize to
+            // defaults — otherwise it inherits the departing tab's pageSize.
+            storedQuery.tablePaginationOption || { current: 1, pageSize: 10 },
           );
           setSelectedFolderList([]);
         }}

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -10,22 +10,25 @@ import UserResourcePolicyList from '../components/UserResourcePolicyList';
 import UserResourcePolicyV2, {
   UserResourcePolicyV2Query,
 } from '../components/UserResourcePolicyV2';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useSuspendedBackendaiClient, useTabQuerySnapshot } from '../hooks';
 import { Skeleton } from 'antd';
 import { filterOutEmpty, BAICard } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral } from 'nuqs';
 import React, { Suspense, useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryLoader } from 'react-relay';
 
-const tabParam = parseAsString.withDefault('keypair');
-
 interface ResourcePolicyPageProps {}
+const tabParser = parseAsStringLiteral([
+  'keypair',
+  'user',
+  'project',
+]).withDefault('keypair');
+
 const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
   'use memo';
   const { t } = useTranslation();
-  const [curTabKey] = useQueryState('tab', tabParam);
-  const webUINavigate = useWebUINavigate();
+  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
   const baiClient = useSuspendedBackendaiClient();
   const supportsSubFilter = baiClient.supports('sub-filter');
   const supportsBinarySizeExpr = baiClient.supports('binary-size-expr');
@@ -37,7 +40,7 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
     if (
       supportsSubFilter &&
       supportsBinarySizeExpr &&
-      curTabKey === 'user' &&
+      currentTab === 'user' &&
       !userResourcePolicyQueryRef
     ) {
       loadUserResourcePolicyQuery(
@@ -54,20 +57,13 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
     function loadUserResourcePolicyOnTabActivation() {
       ensureUserResourcePolicyLoaded();
     },
-    [curTabKey],
+    [currentTab],
   );
 
   return (
     <BAICard
-      activeTabKey={curTabKey}
-      onTabChange={(key) => {
-        webUINavigate({
-          pathname: '/resource-policy',
-          search: new URLSearchParams({
-            tab: key,
-          }).toString(),
-        });
-      }}
+      activeTabKey={currentTab}
+      onTabChange={onTabChange}
       tabList={filterOutEmpty([
         {
           key: 'keypair',
@@ -84,12 +80,12 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
       ])}
     >
       <Suspense fallback={<Skeleton active />}>
-        {curTabKey === 'keypair' && (
+        {currentTab === 'keypair' && (
           <BAIErrorBoundary>
             <KeypairResourcePolicyList />
           </BAIErrorBoundary>
         )}
-        {curTabKey === 'user' && (
+        {currentTab === 'user' && (
           <BAIErrorBoundary>
             {supportsSubFilter && supportsBinarySizeExpr ? (
               userResourcePolicyQueryRef ? (
@@ -105,7 +101,7 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
             )}
           </BAIErrorBoundary>
         )}
-        {curTabKey === 'project' && (
+        {currentTab === 'project' && (
           <BAIErrorBoundary>
             <ProjectResourcePolicyList />
           </BAIErrorBoundary>

--- a/react/src/pages/ResourcesPage.tsx
+++ b/react/src/pages/ResourcesPage.tsx
@@ -6,55 +6,57 @@ import AgentList from '../components/AgentList';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ResourceGroupList from '../components/ResourceGroupList';
 import StorageProxyList from '../components/StorageProxyList';
+import { useTabQuerySnapshot } from '../hooks';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
-type TabKey = 'agents' | 'storages' | 'resourceGroup';
-
 interface ResourcesPageProps {}
 
-const tabParam = parseAsString
-  .withDefault('agents')
-  .withOptions({ history: 'replace' });
+const tabParser = parseAsStringLiteral([
+  'agents',
+  'storages',
+  'resourceGroup',
+]).withDefault('agents');
 
 const ResourcesPage: React.FC<ResourcesPageProps> = () => {
+  'use memo';
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
 
   return (
     <BAICard
-      activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key as TabKey)}
+      activeTabKey={currentTab}
+      onTabChange={onTabChange}
       tabList={[
         {
           key: 'agents',
-          tab: t('agent.Agent'),
+          label: t('agent.Agent'),
         },
         {
           key: 'storages',
-          tab: t('general.StorageProxies'),
+          label: t('general.StorageProxies'),
         },
         {
           key: 'resourceGroup',
-          tab: t('general.ResourceGroup'),
+          label: t('general.ResourceGroup'),
         },
       ]}
     >
       <Suspense fallback={<Skeleton active />}>
-        {curTabKey === 'agents' && (
+        {currentTab === 'agents' && (
           <BAIErrorBoundary>
             <AgentList />
           </BAIErrorBoundary>
         )}
-        {curTabKey === 'storages' && (
+        {currentTab === 'storages' && (
           <BAIErrorBoundary>
             <StorageProxyList />
           </BAIErrorBoundary>
         )}
-        {curTabKey === 'resourceGroup' && (
+        {currentTab === 'resourceGroup' && (
           <BAIErrorBoundary>
             <ResourceGroupList />
           </BAIErrorBoundary>

--- a/react/src/pages/SchedulerPage.tsx
+++ b/react/src/pages/SchedulerPage.tsx
@@ -4,41 +4,38 @@
  */
 import { type ErrorWithGraphQL } from '../components/BAIErrorBoundary';
 import FairShareList from '../components/FairShareItems/FairShareList';
-import { useWebUINavigate } from '../hooks';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, Result, Skeleton, theme, Tooltip } from 'antd';
 import { BAICard, BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { parseAsString, useQueryState, useQueryStates } from 'nuqs';
+import {
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryState,
+  useQueryStates,
+} from 'nuqs';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 
-const tabParam = parseAsString.withDefault('fair-share');
-
 interface SchedulerPageProps {}
 
 const SchedulerPage: React.FC<SchedulerPageProps> = () => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [curTabKey] = useQueryState('tab', tabParam);
-  const webUINavigate = useWebUINavigate();
+  const [currentTab] = useQueryState(
+    'tab',
+    parseAsStringLiteral(['fair-share']).withDefault('fair-share'),
+  );
 
   return (
     <BAICard
-      activeTabKey={curTabKey}
-      onTabChange={(key) => {
-        webUINavigate({
-          pathname: '/fair-share',
-          search: new URLSearchParams({
-            tab: key,
-          }).toString(),
-        });
-      }}
+      activeTabKey={currentTab}
       tabList={[
         {
           key: 'fair-share',
-          tab: (
+          label: (
             <BAIFlex gap="xxs">
               {t('fairShare.FairShareSetting')}
               <Tooltip
@@ -52,7 +49,7 @@ const SchedulerPage: React.FC<SchedulerPageProps> = () => {
       ]}
     >
       <Suspense fallback={<Skeleton active />}>
-        {curTabKey === 'fair-share' && (
+        {currentTab === 'fair-share' && (
           <ErrorBoundary
             fallbackRender={({ error, resetErrorBoundary }) => {
               const gqlError = error as ErrorWithGraphQL;

--- a/react/src/pages/StatisticsPage.tsx
+++ b/react/src/pages/StatisticsPage.tsx
@@ -5,39 +5,40 @@
 import AllocationHistory from '../components/AllocationHistory';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import UserSessionsMetrics from '../components/UserSessionsMetrics';
-import { useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient, useTabQuerySnapshot } from '../hooks';
 import { Skeleton, theme } from 'antd';
 import { filterOutEmpty, BAICard } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface ResourcesPageProps {}
 
-const tabParam = parseAsString.withDefault('allocation-history');
+const tabParser = parseAsStringLiteral([
+  'allocation-history',
+  'user-session-history',
+]).withDefault('allocation-history');
 
 const ResourcesPage: React.FC<ResourcesPageProps> = () => {
+  'use memo';
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
   const { token } = theme.useToken();
 
-  const [curTabKey, setCurTabKey] = useQueryState(
-    'tab',
-    tabParam.withOptions({ history: 'replace' }),
-  );
+  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
 
   return (
     <BAICard
-      activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key)}
+      activeTabKey={currentTab}
+      onTabChange={onTabChange}
       tabList={filterOutEmpty([
         {
           key: 'allocation-history',
-          tab: t('webui.menu.UsageHistory'),
+          label: t('webui.menu.UsageHistory'),
         },
         baiClient?.supports('user-metrics') && {
           key: 'user-session-history',
-          tab: t('webui.menu.UserSessionHistory'),
+          label: t('webui.menu.UserSessionHistory'),
         },
       ])}
       styles={{
@@ -46,7 +47,7 @@ const ResourcesPage: React.FC<ResourcesPageProps> = () => {
         },
       }}
     >
-      {curTabKey === 'allocation-history' ? (
+      {currentTab === 'allocation-history' ? (
         <BAIErrorBoundary>
           <Suspense
             fallback={
@@ -60,7 +61,7 @@ const ResourcesPage: React.FC<ResourcesPageProps> = () => {
           </Suspense>
         </BAIErrorBoundary>
       ) : null}
-      {curTabKey === 'user-session-history' ? (
+      {currentTab === 'user-session-history' ? (
         <BAIErrorBoundary>
           <Suspense
             fallback={

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -14,7 +14,7 @@ import SSHKeypairManagementModal from '../components/SSHKeypairManagementModal';
 import SettingList, { SettingGroup } from '../components/SettingList';
 import ShellScriptEditModal from '../components/ShellScriptEditModal';
 import ThemeAccentColorPicker from '../components/ThemeAccentColorPicker';
-import { useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient, useTabQuerySnapshot } from '../hooks';
 import {
   useBAISettingGeneralState,
   useBAISettingUserState,
@@ -29,15 +29,19 @@ import { useSessionStorageState, useToggle } from 'ahooks';
 import { App, Button, Skeleton, Typography } from 'antd';
 import { BAICard, filterOutEmpty } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsStringLiteral } from 'nuqs';
 import { Suspense, useEffect, useEffectEvent, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useQueryLoader } from 'react-relay';
 
-type TabKey = 'general' | 'logs' | 'login-sessions' | 'login-history';
 export type ShellScriptType = 'bootstrap' | 'userconfig' | undefined;
 
-const tabParam = parseAsString.withDefault('general');
+const tabParser = parseAsStringLiteral([
+  'general',
+  'logs',
+  'login-sessions',
+  'login-history',
+]).withDefault('general');
 
 const UserPreferencesPage = () => {
   'use memo';
@@ -45,7 +49,7 @@ const UserPreferencesPage = () => {
   const { t } = useTranslation();
   const { message } = App.useApp();
   const baiClient = useSuspendedBackendaiClient();
-  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
+  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
 
   const [loginSessionQueryRef, loadLoginSessionQuery] =
     useQueryLoader<LoginSessionQueryType>(LoginSessionQuery);
@@ -55,7 +59,7 @@ const UserPreferencesPage = () => {
   // click and a direct `?tab=...` URL restore), so neither query runs while the
   // General/Logs tabs are shown.
   const ensureActiveTabQueryLoaded = useEffectEvent(() => {
-    if (curTabKey === 'login-sessions' && !loginSessionQueryRef) {
+    if (currentTab === 'login-sessions' && !loginSessionQueryRef) {
       loadLoginSessionQuery(
         {
           orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
@@ -65,7 +69,7 @@ const UserPreferencesPage = () => {
         { fetchPolicy: 'store-and-network' },
       );
     }
-    if (curTabKey === 'login-history' && !loginHistoryQueryRef) {
+    if (currentTab === 'login-history' && !loginHistoryQueryRef) {
       loadLoginHistoryQuery(
         {
           orderBy: [{ field: 'CREATED_AT', direction: 'DESC' }],
@@ -80,7 +84,7 @@ const UserPreferencesPage = () => {
     function loadActiveTabQueryOnActivation() {
       ensureActiveTabQueryLoaded();
     },
-    [curTabKey],
+    [currentTab],
   );
 
   const { themeMode, setThemeMode } = useThemeMode();
@@ -473,8 +477,8 @@ const UserPreferencesPage = () => {
   return (
     <>
       <BAICard
-        activeTabKey={curTabKey}
-        onTabChange={(key) => setCurTabKey(key as TabKey)}
+        activeTabKey={currentTab}
+        onTabChange={onTabChange}
         tabList={[
           {
             key: 'general',
@@ -495,7 +499,7 @@ const UserPreferencesPage = () => {
         ]}
       >
         <Suspense fallback={<Skeleton active />}>
-          {curTabKey === 'general' && (
+          {currentTab === 'general' && (
             <BAIErrorBoundary>
               <SettingList
                 settingGroups={settingGroups}
@@ -505,12 +509,12 @@ const UserPreferencesPage = () => {
               />
             </BAIErrorBoundary>
           )}
-          {curTabKey === 'logs' && (
+          {currentTab === 'logs' && (
             <BAIErrorBoundary>
               <ErrorLogList />
             </BAIErrorBoundary>
           )}
-          {curTabKey === 'login-sessions' && (
+          {currentTab === 'login-sessions' && (
             <BAIErrorBoundary>
               {loginSessionQueryRef ? (
                 <LoginSession
@@ -522,7 +526,7 @@ const UserPreferencesPage = () => {
               )}
             </BAIErrorBoundary>
           )}
-          {curTabKey === 'login-history' && (
+          {currentTab === 'login-history' && (
             <BAIErrorBoundary>
               {loginHistoryQueryRef ? (
                 <LoginHistory


### PR DESCRIPTION
Resolves #8173 (FR-3267)

## Summary

Establishes one consistent, reusable pattern for per-tab URL-persisted table state on multi-tab pages, and migrates every page-like tab host to it. Previously each page invented its own scheme, producing two bugs: (1) `onTabChange` full-replacing the query string wiped other tabs' filter/order/pagination on switch, and (2) sibling tabs reusing generic keys (`filter`/`order`/`current`/`pageSize`) collided once the query string was preserved.

### New pattern (`.claude/skills/tab-url-state/`)
- **Pattern A — page-like tabs** (the tab set *is* the page): persist the tab key **plus** filter/order/pagination.
  - **A-i** — a single component owns the state → parsed-state snapshot in a `queryMapRef` (canonical: `AdminComputeSessionListPage`).
  - **A-ii** — a host with self-contained child tabs → the host calls the new `useTabQuerySnapshot(tabParser)` hook (`react/src/hooks`), which derives the tab key by parsing `location.search`, snapshots each tab's **raw query string**, and returns the `onTabChange` that restores it on switch via `navigate`. Children keep their own URL state untouched — no hoisting, no prop-drilling (canonical: `AdminUsersPage`).
    - The host must NOT read the tab with nuqs `useQueryState`: nuqs applies externally-caused URL changes (navigate/Link) inside a React transition, and when the incoming tab's content suspends under the shared Suspense boundary that transition can stay uncommitted indefinitely — the URL changes but the tab UI never switches (this bit after rebasing onto FR-1943, which removed the urgent use-query-params location subscriptions that previously masked it). Deriving the tab from `location.search` keeps the switch an urgent update (tab flips immediately, boundary shows its skeleton), and the snapshot is always filed under the tab that owns the stored query string. The whole mechanism lives once in the shared hook; hosts collapse to a single call. The tab parser stays a module `tabParser` const (nuqs parsers remain the validation vocabulary; only the nuqs hook is off-limits in the host).
- **Pattern B — widget tabs** on a detail surface: persist **only** the tab key (deferred; see below).

### Migrations
- **Pattern A-ii applied** (host-only; children untouched): `AdminUsersPage`, `AdminDeploymentListPage`, `AdminSessionPage`, `EnvironmentPage`, `ResourcesPage`, `ResourcePolicyPage`, `StatisticsPage`, `UserSettingsPage`.
- **Pattern A-i fix**: `ProjectAdminDataPage` — reset with `setQuery(null)` before restoring stored tab state.
- **Single-tab sweep**: `AgentSummaryPage`, `BrandingPage`, `ConfigurationsPage`, `MaintenancePage`, `MyEnvironmentPage`, `DiagnosticsPage`, `SchedulerPage` — removed dead `onTabChange`, migrated `use-query-params` → read-only nuqs, `tab:` → `label:` (antd v6), added `'use memo'`; `ConfigurationsPage` `Card` → `BAICard`.
- Added a `useWebUILocation` project wrapper (paired with `useWebUINavigate`) and routed the A-ii hosts through it instead of importing `useLocation` from react-router directly.
- `react-url-state` skill §5 trimmed to a pointer at the new `tab-url-state` skill.

### Coverage (menu-accessible page-level tabs)

Scope is the tab UIs reachable from the app's navigation. Of the **22** menu-reachable pages that have page-level tabs, this PR changes the **16** that needed it; the other 6 are intentionally left as-is.

**Changed by this PR (16):**
- **Multi-tab, Pattern A-ii (8)**: `/credential` (Users), `/admin-deployments`, `/admin-session`, `/environment`, `/agent` (Resources), `/resource-policy`, `/statistics`, `/usersettings` (reached via the user-avatar dropdown, deep-linked with `?tab=general` / `?tab=logs`).
- **Multi-tab, Pattern A-i reset fix (1)**: `/project-data`.
- **Single-tab cleanup (7)**: `/scheduler`, `/agent-summary`, `/maintenance`, `/diagnostics`, `/branding`, `/my-environment`, `/settings` (Configurations).

**Unchanged — already compliant (3):** `/session`, `/data`, `/admin-data` already use the A-i `queryMapRef` snapshot/restore correctly (the folder pages on the legacy `use-query-params` lib, which is out of scope to migrate).

**Unchanged — decorative single static tab (3):** `/project`, `/rbac`, `/reservoir` use a hardcoded `activeTabKey` with no `onTabChange` (BAICard `tabList` as a titled header) — no tab switching, nothing to protect.

Menu pages without page-level tabs (`/deployments`, `/model-store`, `/dashboard`, `/chat`, `/ai-agent`, `/start`, `/information`, `/project-admin-*`) are not in scope. Detail-page widget tabs (Pattern B) are drill-down screens, not menu-reachable — deferred below.

### Deferred
Pattern B (deployment-detail cards, `RoleDetailDrawer` tabs) is intentionally out of scope — tracked as B1–B5 in `.specs/FR-3267-tab-url-state/migration-targets.md`.

### Note for reviewers
`ResourcesPage` (A5) previously used history *replace* for its tab setter; the A-ii idiom navigates with *push* (consistent with the pattern's deep-linkable-tab intent), so tab switches now create history entries — deliberate, not a regression.

## Verification

`bash scripts/verify.sh`:
- Relay: PASS
- Lint: PASS
- Format: PASS
- TypeScript: PASS
- (Vite warmup paths: FAIL — pre-existing environment issue, fails identically on a clean tree)

## Test plan
- [ ] On each migrated multi-tab page: set a filter + page on one tab, switch tabs, switch back → the first tab's state is restored; reload reproduces the active tab's filter/order/page.
- [ ] Switching tabs no longer wipes another tab's URL params, and sibling tabs don't leak into each other.
- [ ] Single-tab pages load and deep-link (`?tab=...`) correctly.



