### PR TITLE
test: e2e auto-heal 2026-07-13

### DIFF
--- a/e2e/dashboard/dashboard.spec.ts
+++ b/e2e/dashboard/dashboard.spec.ts
@@ -38,7 +38,7 @@ test.describe(
         await expect(
           page
             .locator('.bai_grid_item')
-            .filter({ hasText: 'My Total Resources Limit' })
+            .filter({ hasText: 'My Total Resource Usage' })
             .first(),
         ).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
@@ -103,7 +103,7 @@ test.describe(
         await expect(
           page
             .locator('.bai_grid_item')
-            .filter({ hasText: 'My Total Resources Limit' })
+            .filter({ hasText: 'My Total Resource Usage' })
             .first(),
         ).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
@@ -196,7 +196,7 @@ test.describe(
         // 1. Locate the "My Resources" widget
         const widget = page
           .locator('.bai_grid_item')
-          .filter({ hasText: 'My Total Resources Limit' })
+          .filter({ hasText: 'My Total Resource Usage' })
           .first();
         await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 
@@ -213,7 +213,7 @@ test.describe(
         // 1. Locate the "My Resources" widget
         const widget = page
           .locator('.bai_grid_item')
-          .filter({ hasText: 'My Total Resources Limit' })
+          .filter({ hasText: 'My Total Resource Usage' })
           .first();
         await expect(widget).toBeVisible({ timeout: WIDGET_TIMEOUT });
 


### PR DESCRIPTION
## Summary

Auto-generated by the **daily backend.ai-webui digest** (e2e auto-heal). This PR fixes **test-side drift** only — no application source was changed.

## What was healed

**`e2e/dashboard/dashboard.spec.ts`** (4 tests) — PR #8215 renamed the "My Resources" widget title i18n string `webui.menu.MyResources` from `"My Total Resources Limit"` → `"My Total Resource Usage"`. The spec located the widget by `.filter({ hasText: 'My Total Resources Limit' })`, so the locator no longer matched. Updated the 4 occurrences to the new label.

Healed tests (verified re-pass via Playwright):
- ✅ Admin can see all expected dashboard widgets
- ✅ Regular user sees dashboard without admin-only widgets
- ✅ Admin can view CPU and Memory usage in the My Resources widget
- ✅ Admin can manually refresh the My Resources widget

## Not in this PR (already covered by open heal PRs)

The digest's HEAL list also flagged `auto-scaling-rule-preset/*` and `rbac/*` specs, but those are already awaiting review in existing auto-heal PRs (#8216, #8237) and were excluded by the idempotency guard to avoid duplicates.

## Cause / reviewer

cc @yomybaby (related change #8215)

Report: `/home/ubuntu/e2e-digest-reports/report-2026-07-13.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
