### PR TITLE
fix(docs): Replace relative example links with absolute GitHub URLs in docs-toolkit README

### DIFF
--- a/packages/backend.ai-docs-toolkit/README.md
+++ b/packages/backend.ai-docs-toolkit/README.md
@@ -4,7 +4,7 @@ Reusable documentation engine for converting multilingual Markdown into producti
 
 ## Getting started — copy the example
 
-The fastest way to evaluate the toolkit is to copy the [example/boilerplate package](../backend.ai-docs-toolkit-example/) and edit it. It is a minimal, runnable project that exercises every consumer-tunable knob (custom logo, brand color, multi-version selector, grouped sidebar, en + ko content for CJK font verification).
+The fastest way to evaluate the toolkit is to copy the [example/boilerplate package](https://github.com/lablup/backend.ai-webui/tree/main/packages/backend.ai-docs-toolkit-example) and edit it. It is a minimal, runnable project that exercises every consumer-tunable knob (custom logo, brand color, multi-version selector, grouped sidebar, en + ko content for CJK font verification).
 
 Run the commands below **from the monorepo root** (`backend.ai-webui/`):
 
@@ -16,7 +16,7 @@ pnpm install
 pnpm build:web
 ```
 
-> See the example's [`README.md`](../backend.ai-docs-toolkit-example/README.md#using-the-example-outside-this-monorepo) for the standalone-repo recipe (the `pnpm --filter` build step needs to be replaced).
+> See the example's [`README.md`](https://github.com/lablup/backend.ai-webui/blob/main/packages/backend.ai-docs-toolkit-example/README.md#using-the-example-outside-this-monorepo) for the standalone-repo recipe (the `pnpm --filter` build step needs to be replaced).
 
 ### Troubleshooting: `docs-toolkit: not found`
 


### PR DESCRIPTION
Resolves #8253

## Summary
- `packages/backend.ai-docs-toolkit/README.md` linked to `backend.ai-docs-toolkit-example` via relative paths (`../backend.ai-docs-toolkit-example/...`).
- `backend.ai-docs-toolkit` is published to npm, but `backend.ai-docs-toolkit-example` is `"private": true` and never published — so those relative links don't resolve when the README is rendered on npmjs.com.
- Replaced with absolute GitHub URLs, matching the pattern used by sibling packages (e.g. `backend.ai-ui/package.json`):
  - Directory link → `https://github.com/lablup/backend.ai-webui/tree/main/packages/backend.ai-docs-toolkit-example`
  - File+anchor link → `https://github.com/lablup/backend.ai-webui/blob/main/packages/backend.ai-docs-toolkit-example/README.md#using-the-example-outside-this-monorepo`

## Test plan
- [x] Links point to valid, existing paths in the repo (verified directory/file exist on `main`)
- [ ] Confirm rendering on npmjs.com after next publish