### PR TITLE
fix(FR-3319): add opt-in polling watcher to survive macOS fseventsd stream drops

### DIFF
--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -755,6 +755,18 @@ export default defineConfig(({ command, mode }) => {
         allow: [projectRoot, ...(pnpmStorePath ? [pnpmStorePath] : [])],
       },
       watch: {
+        // Opt-in escape hatch (`VITE_WATCH_USE_POLLING=1` in
+        // `.env.development.local`) for machines whose macOS `fseventsd`
+        // chronically drops FSEvents client streams
+        // (kFSEventStreamEventFlagUserDropped) under filesystem-event
+        // pressure. chokidar 3 + fsevents has no recovery path from a
+        // dropped stream — the watcher goes permanently silent while the
+        // dev server keeps serving stale module transforms ("HMR dead AND
+        // full refresh still shows old code until a dev-server restart").
+        // Stat-polling bypasses FSEvents entirely, at the cost of steady
+        // background CPU, so it stays off unless a machine needs it.
+        usePolling: process.env.VITE_WATCH_USE_POLLING === '1',
+        interval: 500,
         ignored: [
           '**/node_modules/**',
           '**/build/**',

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -43,7 +43,7 @@ check_warmup_paths() {
       echo "  missing: $path (resolved: $resolved)"
       missing=1
     fi
-  done < <(awk '/warmup: \{/,/^\s*\},/' "$config" \
+  done < <(awk '/warmup: \{/,/^[[:space:]]*\},/' "$config" \
     | grep -oE "'[^']+'" \
     | tr -d "'" \
     | grep -v '^clientFiles$')


### PR DESCRIPTION
Resolves #8261 (FR-3319)

## Summary

Vite's dev server HMR (and even a manual browser refresh) silently stopped reflecting file changes on a developer machine — only killing and restarting the dev server showed the latest code, and the fresh instance could die again within minutes.

Root-caused via direct process instrumentation (fsevents shim + CDP inspection + watchman log analysis): macOS's `fseventsd` drops FSEvents client streams under filesystem-event pressure (`kFSEventStreamEventFlagUserDropped`). Watchman recovers from this by scheduling a tree recrawl, but Vite's watcher (chokidar 3 + the `fsevents` native module) has no recovery path — once the stream is dropped, the watcher goes permanently silent while the HTTP server keeps serving stale module transforms. Evidence: the watchman log showed a `UserDropped` event on this repo's root just 3 seconds after a dev-server start; the root alone recorded 659 historical `UserDropped` events.

Since this is a per-machine OS-level pathology (most machines never hit it), the fix is a minimal opt-in escape hatch rather than always-on machinery:

- Add `usePolling: process.env.VITE_WATCH_USE_POLLING === '1'` (with `interval: 500`) to `server.watch` in `react/vite.config.ts`. Stat-polling bypasses FSEvents entirely, so dropped streams can no longer kill the watcher. Off by default — zero behavior change for everyone else; affected machines enable it via the gitignored `.env.development.local`.
- Fix `scripts/verify.sh`'s "Vite warmup paths" check: the awk window used `\s`, which BSD awk (macOS) doesn't support, causing the check to over-extend its match window and false-fail on macOS.

An earlier revision implemented a sentinel-probe watchdog that auto-restarted the server when the watcher died; it was dropped in favor of this approach because detection-based recovery still leaves tens of seconds of dead HMR, whereas polling avoids the failure class outright, and the problem is machine-specific so always-on shared-config machinery wasn't justified.

## Test plan

- [x] `bash scripts/verify.sh` → `=== ALL PASS ===`
- [x] With `VITE_WATCH_USE_POLLING=1` on the affected machine: an fsevents-instrumentation shim confirms **zero** FSEventStreams are created (fseventsd fully bypassed), file changes are picked up within the 500ms poll interval, and steady-state CPU cost is ~3.6% of one core.
- [x] Without the env var: `usePolling` is `false`, watcher behavior identical to before.