### PR TITLE
feat(FR-3317): add one-click project admin assignment action on project page

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -945,6 +945,9 @@ export class Client {
       // bytes as a decimal string, round-trippable into BinarySizeInput.expr)
       // in the 26.8.0 supergraph. Older managers only serve `value`.
       this._features['binary-size-expr'] = true;
+      // RoleFilter gained `mappedScope` (RoleMappedScopeNestedFilter) — look
+      // up roles registered to a specific scope. FR-3317.
+      this._features['role-mapped-scope-filter'] = true;
     }
   }
 

--- a/react/src/__generated__/ProjectAdminSettingModalAssignMutation.graphql.ts
+++ b/react/src/__generated__/ProjectAdminSettingModalAssignMutation.graphql.ts
@@ -1,0 +1,139 @@
+/**
+ * @generated SignedSource<<c9b65995217257a1bbd788a4ec2ccca7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type BulkAssignRoleInput = {
+  projectId?: string | null | undefined;
+  roleId: string;
+  userIds: ReadonlyArray<string>;
+};
+export type ProjectAdminSettingModalAssignMutation$variables = {
+  input: BulkAssignRoleInput;
+};
+export type ProjectAdminSettingModalAssignMutation$data = {
+  readonly adminBulkAssignRole: {
+    readonly assigned: ReadonlyArray<{
+      readonly id: string;
+      readonly userId: string;
+    }>;
+    readonly failed: ReadonlyArray<{
+      readonly message: string;
+      readonly userId: string;
+    }>;
+  } | null | undefined;
+};
+export type ProjectAdminSettingModalAssignMutation = {
+  response: ProjectAdminSettingModalAssignMutation$data;
+  variables: ProjectAdminSettingModalAssignMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "userId",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "BulkAssignRolePayload",
+    "kind": "LinkedField",
+    "name": "adminBulkAssignRole",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "RoleAssignment",
+        "kind": "LinkedField",
+        "name": "assigned",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "BulkAssignRoleError",
+        "kind": "LinkedField",
+        "name": "failed",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "message",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAdminSettingModalAssignMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectAdminSettingModalAssignMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "0895e15aba2f739b5d856c52241c913b",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAdminSettingModalAssignMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectAdminSettingModalAssignMutation(\n  $input: BulkAssignRoleInput!\n) {\n  adminBulkAssignRole(input: $input) {\n    assigned {\n      id\n      userId\n    }\n    failed {\n      userId\n      message\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "474fb5cb856004aac05b39c65c16f2c2";
+
+export default node;

--- a/react/src/__generated__/ProjectAdminSettingModalQuery.graphql.ts
+++ b/react/src/__generated__/ProjectAdminSettingModalQuery.graphql.ts
@@ -1,0 +1,320 @@
+/**
+ * @generated SignedSource<<e4389d6f781625660a6981c609c2184a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type RBACElementType = "AGENT" | "APP_CONFIG" | "APP_CONFIG_ALLOW_LIST" | "APP_CONFIG_DEFINITION" | "APP_CONFIG_FRAGMENT" | "ARTIFACT" | "ARTIFACT_REGISTRY" | "ARTIFACT_REVISION" | "AUDIT_LOG" | "CONTAINER_REGISTRY" | "DEPLOYMENT_POLICY" | "DEPLOYMENT_REVISION" | "DEPLOYMENT_TOKEN" | "DOMAIN" | "DOMAIN_ADMIN_PAGE" | "EVENT_LOG" | "IMAGE" | "IMAGE_ALIAS" | "KERNEL" | "KEYPAIR" | "KEYPAIR_RESOURCE_POLICY" | "MODEL_CARD" | "MODEL_DEPLOYMENT" | "NETWORK" | "NOTIFICATION_CHANNEL" | "NOTIFICATION_RULE" | "PROJECT" | "PROJECT_ADMIN_PAGE" | "PROJECT_RESOURCE_POLICY" | "RESOURCE_GROUP" | "RESOURCE_PRESET" | "ROLE" | "ROLE_ASSIGNMENT" | "ROUTING" | "SESSION" | "SESSION_APP_SERVICE" | "SESSION_TEMPLATE" | "STORAGE_HOST" | "USER" | "USER_EMAIL" | "USER_RESOURCE_POLICY" | "VFOLDER" | "VFOLDER_DATA" | "%future added value";
+export type RoleSource = "CUSTOM" | "SYSTEM" | "%future added value";
+export type RoleStatus = "ACTIVE" | "DELETED" | "INACTIVE" | "%future added value";
+export type RoleFilter = {
+  AND?: ReadonlyArray<RoleFilter> | null | undefined;
+  NOT?: ReadonlyArray<RoleFilter> | null | undefined;
+  OR?: ReadonlyArray<RoleFilter> | null | undefined;
+  assignedUser?: RoleUserNestedFilter | null | undefined;
+  mappedScope?: RoleMappedScopeNestedFilter | null | undefined;
+  name?: StringFilter | null | undefined;
+  source?: RoleSourceFilter | null | undefined;
+  status?: RoleStatusFilter | null | undefined;
+};
+export type StringFilter = {
+  contains?: string | null | undefined;
+  endsWith?: string | null | undefined;
+  equals?: string | null | undefined;
+  iContains?: string | null | undefined;
+  iEndsWith?: string | null | undefined;
+  iEquals?: string | null | undefined;
+  iIn?: ReadonlyArray<string> | null | undefined;
+  iNotContains?: string | null | undefined;
+  iNotEndsWith?: string | null | undefined;
+  iNotEquals?: string | null | undefined;
+  iNotIn?: ReadonlyArray<string> | null | undefined;
+  iNotStartsWith?: string | null | undefined;
+  iStartsWith?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notContains?: string | null | undefined;
+  notEndsWith?: string | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
+  notStartsWith?: string | null | undefined;
+  startsWith?: string | null | undefined;
+};
+export type RoleSourceFilter = {
+  equals?: RoleSource | null | undefined;
+  in?: ReadonlyArray<RoleSource> | null | undefined;
+  notEquals?: RoleSource | null | undefined;
+  notIn?: ReadonlyArray<RoleSource> | null | undefined;
+};
+export type RoleStatusFilter = {
+  equals?: RoleStatus | null | undefined;
+  in?: ReadonlyArray<RoleStatus> | null | undefined;
+  notEquals?: RoleStatus | null | undefined;
+  notIn?: ReadonlyArray<RoleStatus> | null | undefined;
+};
+export type RoleUserNestedFilter = {
+  AND?: ReadonlyArray<RoleUserNestedFilter> | null | undefined;
+  NOT?: ReadonlyArray<RoleUserNestedFilter> | null | undefined;
+  OR?: ReadonlyArray<RoleUserNestedFilter> | null | undefined;
+  userId?: UUIDFilter | null | undefined;
+};
+export type UUIDFilter = {
+  equals?: string | null | undefined;
+  in?: ReadonlyArray<string> | null | undefined;
+  notEquals?: string | null | undefined;
+  notIn?: ReadonlyArray<string> | null | undefined;
+};
+export type RoleMappedScopeNestedFilter = {
+  AND?: ReadonlyArray<RoleMappedScopeNestedFilter> | null | undefined;
+  NOT?: ReadonlyArray<RoleMappedScopeNestedFilter> | null | undefined;
+  OR?: ReadonlyArray<RoleMappedScopeNestedFilter> | null | undefined;
+  scopeId?: StringFilter | null | undefined;
+  scopeType?: RBACElementTypeFilter | null | undefined;
+};
+export type RBACElementTypeFilter = {
+  equals?: RBACElementType | null | undefined;
+  in?: ReadonlyArray<RBACElementType> | null | undefined;
+  notEquals?: RBACElementType | null | undefined;
+  notIn?: ReadonlyArray<RBACElementType> | null | undefined;
+};
+export type ProjectAdminSettingModalQuery$variables = {
+  filter?: RoleFilter | null | undefined;
+  limit?: number | null | undefined;
+  offset?: number | null | undefined;
+};
+export type ProjectAdminSettingModalQuery$data = {
+  readonly adminRoles: {
+    readonly count: number;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly id: string;
+        readonly name: string;
+        readonly users: {
+          readonly count: number;
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly id: string;
+              readonly user: {
+                readonly basicInfo: {
+                  readonly email: string;
+                };
+                readonly id: string;
+              } | null | undefined;
+              readonly userId: string;
+            };
+          }>;
+        } | null | undefined;
+      };
+    }>;
+  } | null | undefined;
+};
+export type ProjectAdminSettingModalQuery = {
+  response: ProjectAdminSettingModalQuery$data;
+  variables: ProjectAdminSettingModalQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "filter"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "limit"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "offset"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "filter",
+        "variableName": "filter"
+      },
+      {
+        "kind": "Literal",
+        "name": "first",
+        "value": 10
+      }
+    ],
+    "concreteType": "RoleConnection",
+    "kind": "LinkedField",
+    "name": "adminRoles",
+    "plural": false,
+    "selections": [
+      (v1/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "RoleEdge",
+        "kind": "LinkedField",
+        "name": "edges",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Role",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "limit",
+                    "variableName": "limit"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "offset",
+                    "variableName": "offset"
+                  }
+                ],
+                "concreteType": "RoleAssignmentConnection",
+                "kind": "LinkedField",
+                "name": "users",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "RoleAssignmentEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "RoleAssignment",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "userId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "UserV2",
+                            "kind": "LinkedField",
+                            "name": "user",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "UserV2BasicInfo",
+                                "kind": "LinkedField",
+                                "name": "basicInfo",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "email",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAdminSettingModalQuery",
+    "selections": (v3/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectAdminSettingModalQuery",
+    "selections": (v3/*: any*/)
+  },
+  "params": {
+    "cacheID": "e7d1bf46cef89b3dbbaa8a24dcee1796",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAdminSettingModalQuery",
+    "operationKind": "query",
+    "text": "query ProjectAdminSettingModalQuery(\n  $filter: RoleFilter\n  $limit: Int\n  $offset: Int\n) {\n  adminRoles(filter: $filter, first: 10) {\n    count\n    edges {\n      node {\n        id\n        name\n        users(limit: $limit, offset: $offset) {\n          count\n          edges {\n            node {\n              id\n              userId\n              user {\n                id\n                basicInfo {\n                  email\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9d31cbe485a291bde3dd5977f0f3db7f";
+
+export default node;

--- a/react/src/__generated__/ProjectAdminSettingModalRevokeMutation.graphql.ts
+++ b/react/src/__generated__/ProjectAdminSettingModalRevokeMutation.graphql.ts
@@ -1,0 +1,93 @@
+/**
+ * @generated SignedSource<<67fbd487a1f68b631e0deef950ab233b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type RevokeRoleInput = {
+  roleId: string;
+  userId: string;
+};
+export type ProjectAdminSettingModalRevokeMutation$variables = {
+  input: RevokeRoleInput;
+};
+export type ProjectAdminSettingModalRevokeMutation$data = {
+  readonly adminRevokeRole: {
+    readonly id: string;
+  } | null | undefined;
+};
+export type ProjectAdminSettingModalRevokeMutation = {
+  response: ProjectAdminSettingModalRevokeMutation$data;
+  variables: ProjectAdminSettingModalRevokeMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "RoleAssignment",
+    "kind": "LinkedField",
+    "name": "adminRevokeRole",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectAdminSettingModalRevokeMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectAdminSettingModalRevokeMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "2e131e9fdff9e117e2008ff193485547",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectAdminSettingModalRevokeMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectAdminSettingModalRevokeMutation(\n  $input: RevokeRoleInput!\n) {\n  adminRevokeRole(input: $input) {\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "4e35cbdc2a87f596043fd9daef274019";
+
+export default node;

--- a/react/src/components/ProjectAdminSettingModal.tsx
+++ b/react/src/components/ProjectAdminSettingModal.tsx
@@ -1,0 +1,311 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { ProjectAdminSettingModalAssignMutation } from '../__generated__/ProjectAdminSettingModalAssignMutation.graphql';
+import { ProjectAdminSettingModalQuery } from '../__generated__/ProjectAdminSettingModalQuery.graphql';
+import { ProjectAdminSettingModalRevokeMutation } from '../__generated__/ProjectAdminSettingModalRevokeMutation.graphql';
+import { useSetBAINotification } from '../hooks/useBAINotification';
+import { App, Form, FormInstance, Tooltip } from 'antd';
+import {
+  BAIAlert,
+  BAIButton,
+  BAIFlex,
+  BAIId,
+  BAIModal,
+  BAIModalProps,
+  BAISelect,
+  BAITable,
+  BAIUserSelect,
+  filterOutNullAndUndefined,
+  toLocalId,
+  useBAILogger,
+  useMutationWithPromise,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { XIcon } from 'lucide-react';
+import { Suspense, useDeferredValue, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  graphql,
+  PreloadedQuery,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
+
+// Exported so the opener can `loadQuery` it in the click event. The backend
+// registers a pair of SYSTEM-source roles on each project scope
+// (`project-<id>-member` / `project-<id>-admin`); the filter looks them up by
+// the project's scope id, the admin one is picked by its name suffix, and the
+// nested `users` connection carries its current assignments.
+export const ProjectAdminSettingQuery = graphql`
+  query ProjectAdminSettingModalQuery(
+    $filter: RoleFilter
+    $limit: Int
+    $offset: Int
+  ) {
+    adminRoles(filter: $filter, first: 10) {
+      count
+      edges {
+        node {
+          id
+          name
+          users(limit: $limit, offset: $offset) {
+            count
+            edges {
+              node {
+                id
+                userId
+                user {
+                  id
+                  basicInfo {
+                    email
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface ProjectAdminSettingModalProps extends Omit<
+  BAIModalProps,
+  'children'
+> {
+  /** Preloaded query reference produced by the opener via `useQueryLoader`. */
+  queryRef: PreloadedQuery<ProjectAdminSettingModalQuery>;
+  /** Local UUID of the target project (also the role's scope id). */
+  projectId: string;
+  /**
+   * Re-run the query after assign / revoke. Same signature as
+   * `useQueryLoader`'s `loadQuery`, so the opener can pass it directly.
+   */
+  onReload: (
+    variables: ProjectAdminSettingModalQuery['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
+
+const ProjectAdminSettingModal = ({
+  open,
+  queryRef,
+  projectId,
+  onReload,
+  onCancel,
+  ...modalProps
+}: ProjectAdminSettingModalProps) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const { logger } = useBAILogger();
+  const { upsertNotification } = useSetBAINotification();
+  const formRef = useRef<FormInstance<{ userIds: string[] }>>(null);
+
+  // Keep the previous result visible while a reload is in flight so the table
+  // shows an inline loading indicator instead of a Suspense fallback.
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetchingInTransition = deferredQueryRef !== queryRef;
+
+  const data = usePreloadedQuery<ProjectAdminSettingModalQuery>(
+    ProjectAdminSettingQuery,
+    deferredQueryRef,
+  );
+
+  const role =
+    _.find(data.adminRoles?.edges, (edge) =>
+      _.endsWith(edge?.node?.name, 'admin'),
+    )?.node ?? null;
+  const assignments = filterOutNullAndUndefined(
+    role?.users?.edges?.map((edge) => edge?.node) ?? [],
+  );
+
+  const mutateBulkAssignRole =
+    useMutationWithPromise<ProjectAdminSettingModalAssignMutation>(graphql`
+      mutation ProjectAdminSettingModalAssignMutation(
+        $input: BulkAssignRoleInput!
+      ) {
+        adminBulkAssignRole(input: $input) {
+          assigned {
+            id
+            userId
+          }
+          failed {
+            userId
+            message
+          }
+        }
+      }
+    `);
+
+  const mutateRevokeRole =
+    useMutationWithPromise<ProjectAdminSettingModalRevokeMutation>(graphql`
+      mutation ProjectAdminSettingModalRevokeMutation(
+        $input: RevokeRoleInput!
+      ) {
+        adminRevokeRole(input: $input) {
+          id
+        }
+      }
+    `);
+
+  const resolveErrorMessage = (error: unknown) => {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : _.get(_.castArray(error)[0], 'message');
+    return errorMessage || t('general.ErrorOccurred');
+  };
+
+  const handleAssign = async () => {
+    if (!role) {
+      return;
+    }
+    await formRef.current
+      ?.validateFields()
+      .then(async (values) => {
+        try {
+          const result = await mutateBulkAssignRole({
+            input: {
+              roleId: toLocalId(role.id),
+              userIds: values.userIds,
+              // Passing projectId auto-adds the project to each user's allowed
+              // project list.
+              projectId,
+            },
+          });
+          const failed = result.adminBulkAssignRole?.failed ?? [];
+          if (failed.length > 0) {
+            message.warning(
+              t('rbac.BulkAssignPartialFailure', { count: failed.length }),
+            );
+            _.forEach(failed, (item) => {
+              upsertNotification({
+                key: `project-admin-assign-failed-${projectId}-${item.userId}`,
+                open: true,
+                duration: 0,
+                type: 'error',
+                message: item.message,
+              });
+            });
+          } else {
+            message.success(t('rbac.UsersAssigned'));
+          }
+          formRef.current?.resetFields();
+          onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+        } catch (error) {
+          logger.error(error);
+          message.error(resolveErrorMessage(error));
+        }
+      })
+      .catch((error) => {
+        // Validation errors are rendered inline on the Form.Item.
+        logger.debug(error);
+      });
+  };
+
+  const handleRevoke = async (userId: string) => {
+    if (!role) {
+      return;
+    }
+    try {
+      await mutateRevokeRole({
+        input: {
+          roleId: toLocalId(role.id),
+          userId,
+        },
+      });
+      message.success(t('rbac.UserRevoked'));
+      onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+    } catch (error) {
+      logger.error(error);
+      message.error(resolveErrorMessage(error));
+    }
+  };
+
+  return (
+    <BAIModal
+      title={t('project.SetProjectAdmin')}
+      open={open}
+      width={600}
+      footer={null}
+      onCancel={onCancel}
+      {...modalProps}
+    >
+      <BAIFlex direction="column" align="stretch" gap="sm">
+        <BAIAlert
+          type="info"
+          showIcon
+          description={t('project.DescSetProjectAdmin')}
+        />
+        <Form ref={formRef}>
+          <BAIFlex gap="xs" align="start">
+            <Suspense
+              fallback={
+                <BAISelect mode="multiple" loading style={{ flex: 1 }} />
+              }
+            >
+              <Form.Item
+                name="userIds"
+                required
+                rules={[
+                  { required: true, message: t('rbac.PleaseSelectUsers') },
+                ]}
+                style={{ flex: 1, marginBottom: 0 }}
+              >
+                <BAIUserSelect
+                  mode="multiple"
+                  valuePropName="id"
+                  maxTagCount="responsive"
+                  style={{ width: '100%' }}
+                  placeholder={t('rbac.SelectUsers')}
+                  aria-label={t('rbac.SelectUsers')}
+                />
+              </Form.Item>
+            </Suspense>
+            <BAIButton type="primary" action={handleAssign}>
+              {t('general.Add')}
+            </BAIButton>
+          </BAIFlex>
+        </Form>
+        <BAITable
+          rowKey="id"
+          size="small"
+          dataSource={assignments}
+          loading={isRefetchingInTransition}
+          columns={[
+            {
+              key: 'email',
+              title: t('general.E-Mail'),
+              render: (__, record) => record.user?.basicInfo?.email || '-',
+            },
+            {
+              key: 'userId',
+              title: t('credential.UserID'),
+              render: (__, record) => <BAIId uuid={record.userId} />,
+            },
+            {
+              key: 'control',
+              title: t('general.Control'),
+              render: (__, record) => (
+                <Tooltip title={t('project.RevokeProjectAdmin')}>
+                  <BAIButton
+                    type="text"
+                    size="small"
+                    danger
+                    icon={<XIcon />}
+                    action={() => handleRevoke(record.userId)}
+                  />
+                </Tooltip>
+              ),
+            },
+          ]}
+        />
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default ProjectAdminSettingModal;

--- a/react/src/pages/ProjectPage.tsx
+++ b/react/src/pages/ProjectPage.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ProjectAdminSettingModalQuery } from '../__generated__/ProjectAdminSettingModalQuery.graphql';
 import { ProjectPageDeactivateMutation } from '../__generated__/ProjectPageDeactivateMutation.graphql';
 import { ProjectPageModifyMutation } from '../__generated__/ProjectPageModifyMutation.graphql';
 import { ProjectPagePurgeMutation } from '../__generated__/ProjectPagePurgeMutation.graphql';
@@ -11,6 +12,10 @@ import {
   ProjectPageQuery$variables,
 } from '../__generated__/ProjectPageQuery.graphql';
 import BAIRadioGroup from '../components/BAIRadioGroup';
+import ProjectAdminSettingModal, {
+  ProjectAdminSettingQuery,
+} from '../components/ProjectAdminSettingModal';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCSVExport } from '../hooks/useCSVExport';
 import { DeleteFilled, SettingOutlined } from '@ant-design/icons';
@@ -29,6 +34,7 @@ import {
   BAIProjectTable,
   BAIPropertyFilter,
   BAISelectionLabel,
+  BAIUnmountAfterClose,
   filterOutEmpty,
   INITIAL_FETCH_KEY,
   isValidUUID,
@@ -39,11 +45,18 @@ import {
   useUpdatableState,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { BanIcon, PlusIcon, UndoIcon } from 'lucide-react';
+import { BanIcon, PlusIcon, ShieldUserIcon, UndoIcon } from 'lucide-react';
 import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  fetchQuery,
+  graphql,
+  useLazyLoadQuery,
+  useMutation,
+  useQueryLoader,
+  useRelayEnvironment,
+} from 'react-relay';
 
 type ProjectNode = NonNullable<
   NonNullable<
@@ -59,6 +72,13 @@ const ProjectPage = () => {
   const { message } = App.useApp();
   const { token } = theme.useToken();
   const { getErrorMessage } = useErrorMessageResolver();
+  const relayEnvironment = useRelayEnvironment();
+  const baiClient = useSuspendedBackendaiClient();
+  // RoleFilter.mappedScope (the role lookup this action relies on) exists
+  // from manager 26.8.0; hide the action on older managers.
+  const supportsProjectAdminSetting = baiClient.supports(
+    'role-mapped-scope-filter',
+  );
   const [openSettingModal, { toggle: toggleSettingModal }] = useToggle(false);
   const [openBulkEditModal, { toggle: toggleBulkEditModal }] = useToggle(false);
   const [selectedProjectList, setSelectedProjectList] = useState<ProjectNode[]>(
@@ -70,6 +90,11 @@ const ProjectPage = () => {
   const [purgingProject, setPurgingProject] = useState<ProjectInList | null>(
     null,
   );
+  const [projectAdminModalProjectId, setProjectAdminModalProjectId] = useState<
+    string | null
+  >(null);
+  const [projectAdminQueryRef, loadProjectAdminQuery] =
+    useQueryLoader<ProjectAdminSettingModalQuery>(ProjectAdminSettingQuery);
   const {
     baiPaginationOption,
     tablePaginationOption,
@@ -179,6 +204,59 @@ const ProjectPage = () => {
       }
     }
   `);
+
+  // Open the project admin setting modal with a preloaded query so the row
+  // action button (not the modal) carries the initial loading state: the
+  // click event awaits `fetchQuery` to warm the store, then `loadQuery`
+  // resolves from it instantly.
+  const openProjectAdminSettingModal = async (project: ProjectInList) => {
+    if (!project.row_id) {
+      return;
+    }
+    const variables: ProjectAdminSettingModalQuery['variables'] = {
+      filter: {
+        source: { equals: 'SYSTEM' },
+        status: { equals: 'ACTIVE' },
+        mappedScope: {
+          scopeType: { equals: 'PROJECT' },
+          scopeId: { equals: project.row_id },
+        },
+      },
+      limit: 100,
+      offset: 0,
+    };
+    let roleData: ProjectAdminSettingModalQuery['response'] | undefined;
+    try {
+      roleData = await fetchQuery<ProjectAdminSettingModalQuery>(
+        relayEnvironment,
+        ProjectAdminSettingQuery,
+        variables,
+      ).toPromise();
+    } catch (error) {
+      logger.error(error);
+      message.error(
+        error instanceof Error ? error.message : t('general.ErrorOccurred'),
+      );
+      return;
+    }
+    // The project admin role is resolved here, before the modal opens; a
+    // project without one only gets an error message. The project scope
+    // carries a member/admin SYSTEM role pair — the admin one is identified
+    // by its name suffix.
+    const hasProjectAdminRole = _.some(roleData?.adminRoles?.edges, (edge) =>
+      _.endsWith(edge?.node?.name, 'admin'),
+    );
+    if (!hasProjectAdminRole) {
+      message.error(
+        t('project.ProjectAdminRoleNotFound', {
+          project: project.name ?? project.row_id,
+        }),
+      );
+      return;
+    }
+    loadProjectAdminQuery(variables, { fetchPolicy: 'store-or-network' });
+    setProjectAdminModalProjectId(project.row_id);
+  };
 
   const removeFromSelection = (projectId: string) => {
     setSelectedProjectList((prev) =>
@@ -432,6 +510,18 @@ const ProjectPage = () => {
                           title={record.name}
                           showActions="always"
                           actions={[
+                            ...(supportsProjectAdminSetting
+                              ? [
+                                  {
+                                    key: 'set-project-admin',
+                                    title: t('project.SetProjectAdmin'),
+                                    icon: <ShieldUserIcon />,
+                                    disabled: isModelStore,
+                                    action: () =>
+                                      openProjectAdminSettingModal(record),
+                                  },
+                                ]
+                              : []),
                             {
                               key: 'edit',
                               title: t('project.EditProject'),
@@ -555,6 +645,17 @@ const ProjectPage = () => {
             toggleBulkEditModal();
           }}
         />
+        {projectAdminQueryRef != null && (
+          <BAIUnmountAfterClose>
+            <ProjectAdminSettingModal
+              open={!!projectAdminModalProjectId}
+              queryRef={projectAdminQueryRef}
+              projectId={projectAdminModalProjectId ?? ''}
+              onReload={loadProjectAdminQuery}
+              onCancel={() => setProjectAdminModalProjectId(null)}
+            />
+          </BAIUnmountAfterClose>
+        )}
         <BAIDeleteConfirmModal
           open={!!purgingProject}
           title={t('project.PurgeProject')}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "Projekt erstellen",
     "Deactivate": "Deaktivieren",
     "DeactivateProject": "Projekt deaktivieren",
+    "DescSetProjectAdmin": "Durch die Vergabe der Projektadministrator-Berechtigung wird das Projekt automatisch zur Liste der zugelassenen Projekte des Benutzers hinzugefügt, und der Benutzer kann anschließend auf dieses Projekt zugreifen.",
     "Domain": "Domäne",
     "EditProject": "Bearbeiten",
     "FailedToActivateProject": "Fehler beim Aktivieren des Projekts.",
@@ -2088,13 +2089,16 @@
     "Name": "Name",
     "Project": "Projekt",
     "ProjectActivated": "Das Projekt wurde aktiviert.",
+    "ProjectAdminRoleNotFound": "Die Projektadministrator-Rolle für das Projekt '{{project}}' konnte nicht gefunden werden.",
     "ProjectDeactivated": "Das Projekt wurde deaktiviert.",
     "ProjectID": "Projekt-ID",
     "ProjectIDFilterRuleMessage": "Ungültige UUID.",
     "ProjectPurged": "Das Projekt wurde endgültig gelöscht.",
     "Purge": "Bereinigen",
     "PurgeProject": "Projekt bereinigen",
-    "ResourcePolicy": "Ressourcenrichtlinie"
+    "ResourcePolicy": "Ressourcenrichtlinie",
+    "RevokeProjectAdmin": "Administratorberechtigung widerrufen",
+    "SetProjectAdmin": "Projektadministrator festlegen"
   },
   "projectMembers": {
     "Email": "E-Mail",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2078,6 +2078,7 @@
     "CreateProject": "Δημιουργία έργου",
     "Deactivate": "Απενεργοποίηση",
     "DeactivateProject": "Απενεργοποίηση έργου",
+    "DescSetProjectAdmin": "Η παραχώρηση δικαιώματος διαχειριστή έργου προσθέτει αυτόματα το έργο στη λίστα επιτρεπόμενων έργων του χρήστη, και ο χρήστης θα μπορεί στη συνέχεια να έχει πρόσβαση σε αυτό το έργο.",
     "Domain": "Τομέας",
     "EditProject": "Επεξεργασία",
     "FailedToActivateProject": "Η ενεργοποίηση του έργου απέτυχε.",
@@ -2086,13 +2087,16 @@
     "Name": "Όνομα",
     "Project": "Έργο",
     "ProjectActivated": "Το έργο έχει ενεργοποιηθεί.",
+    "ProjectAdminRoleNotFound": "Δεν ήταν δυνατή η εύρεση του ρόλου διαχειριστή έργου για το έργο '{{project}}'.",
     "ProjectDeactivated": "Το έργο έχει απενεργοποιηθεί.",
     "ProjectID": "ID έργου",
     "ProjectIDFilterRuleMessage": "Μη έγκυρο UUID.",
     "ProjectPurged": "Το projecth έχει διαγραφεί.",
     "Purge": "Εκκαθάριση",
     "PurgeProject": "Μόνιμη διαγραφή έργου",
-    "ResourcePolicy": "Πολιτική πόρων"
+    "ResourcePolicy": "Πολιτική πόρων",
+    "RevokeProjectAdmin": "Ανάκληση δικαιώματος διαχειριστή",
+    "SetProjectAdmin": "Ορισμός διαχειριστή έργου"
   },
   "projectMembers": {
     "Email": "Email",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2065,6 +2065,7 @@
     "CreateProject": "Create Project",
     "Deactivate": "Deactivate",
     "DeactivateProject": "Deactivate Project",
+    "DescSetProjectAdmin": "Granting project admin permission automatically adds the project to the user's allowed project list, and the user will then be able to access that project.",
     "Domain": "Domain",
     "EditProject": "Edit",
     "FailedToActivateProject": "Failed to activate the project.",
@@ -2073,13 +2074,16 @@
     "Name": "Name",
     "Project": "Project",
     "ProjectActivated": "The project has been activated.",
+    "ProjectAdminRoleNotFound": "Could not find the project admin role for project '{{project}}'.",
     "ProjectDeactivated": "The project has been deactivated.",
     "ProjectID": "Project ID",
     "ProjectIDFilterRuleMessage": "Invalid UUID.",
     "ProjectPurged": "The project has been purged.",
     "Purge": "Purge",
     "PurgeProject": "Purge Project",
-    "ResourcePolicy": "Resource Policy"
+    "ResourcePolicy": "Resource Policy",
+    "RevokeProjectAdmin": "Revoke admin permission",
+    "SetProjectAdmin": "Set Project Admin"
   },
   "projectMembers": {
     "Email": "Email",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2078,6 +2078,7 @@
     "CreateProject": "Crear proyecto",
     "Deactivate": "Desactivar",
     "DeactivateProject": "Desactivar proyecto",
+    "DescSetProjectAdmin": "Al conceder el permiso de administrador del proyecto, el proyecto se añade automáticamente a la lista de proyectos permitidos del usuario, quien podrá entonces acceder a dicho proyecto.",
     "Domain": "Dominio",
     "EditProject": "Editar",
     "FailedToActivateProject": "No se pudo activar el proyecto.",
@@ -2086,13 +2087,16 @@
     "Name": "Nombre",
     "Project": "Proyecto",
     "ProjectActivated": "El proyecto ha sido activado.",
+    "ProjectAdminRoleNotFound": "No se pudo encontrar el rol de administrador del proyecto para el proyecto '{{project}}'.",
     "ProjectDeactivated": "El proyecto ha sido desactivado.",
     "ProjectID": "ID del proyecto",
     "ProjectIDFilterRuleMessage": "UUID no válido.",
     "ProjectPurged": "El proyecto ha sido purgado.",
     "Purge": "Purgar",
     "PurgeProject": "Eliminar proyecto permanentemente",
-    "ResourcePolicy": "Política de recursos"
+    "ResourcePolicy": "Política de recursos",
+    "RevokeProjectAdmin": "Revocar permiso de administrador",
+    "SetProjectAdmin": "Establecer administrador del proyecto"
   },
   "projectMembers": {
     "Email": "Correo electrónico",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2078,6 +2078,7 @@
     "CreateProject": "Luo projekti",
     "Deactivate": "Poista käytöstä",
     "DeactivateProject": "Poista projekti käytöstä",
+    "DescSetProjectAdmin": "Projektin ylläpitäjän käyttöoikeuden myöntäminen lisää projektin automaattisesti käyttäjän sallittujen projektien luetteloon, minkä jälkeen käyttäjä pääsee käsiksi kyseiseen projektiin.",
     "Domain": "Toimialue",
     "EditProject": "Muokkaa",
     "FailedToActivateProject": "Projektin käyttöönotto epäonnistui.",
@@ -2086,13 +2087,16 @@
     "Name": "Nimi",
     "Project": "Projekti",
     "ProjectActivated": "Projekti on otettu käyttöön.",
+    "ProjectAdminRoleNotFound": "Projektin ylläpitäjän roolia ei löytynyt projektille '{{project}}'.",
     "ProjectDeactivated": "Projekti on poistettu käytöstä.",
     "ProjectID": "Projektin tunnus",
     "ProjectIDFilterRuleMessage": "Virheellinen UUID.",
     "ProjectPurged": "Projekti on poistettu pysyvästi.",
     "Purge": "Tyhjennä",
     "PurgeProject": "Poista projekti pysyvästi",
-    "ResourcePolicy": "Resurssipolitiikka"
+    "ResourcePolicy": "Resurssipolitiikka",
+    "RevokeProjectAdmin": "Peruuta ylläpitäjän käyttöoikeus",
+    "SetProjectAdmin": "Aseta projektin ylläpitäjä"
   },
   "projectMembers": {
     "Email": "Sähköposti",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "Créer un projet",
     "Deactivate": "Désactiver",
     "DeactivateProject": "Désactiver le projet",
+    "DescSetProjectAdmin": "L'attribution de la permission d'administrateur de projet ajoute automatiquement le projet à la liste des projets autorisés de l'utilisateur, qui pourra alors accéder à ce projet.",
     "Domain": "Domaine",
     "EditProject": "Modifier",
     "FailedToActivateProject": "Impossible d'activer le projet.",
@@ -2088,13 +2089,16 @@
     "Name": "Nom",
     "Project": "Projet",
     "ProjectActivated": "Le projet a été activé.",
+    "ProjectAdminRoleNotFound": "Impossible de trouver le rôle d'administrateur de projet pour le projet '{{project}}'.",
     "ProjectDeactivated": "Le projet a été désactivé.",
     "ProjectID": "ID du projet",
     "ProjectIDFilterRuleMessage": "UUID invalide.",
     "ProjectPurged": "Le projet a été purgé.",
     "Purge": "Purger",
     "PurgeProject": "Purger le projet",
-    "ResourcePolicy": "Politique de ressources"
+    "ResourcePolicy": "Politique de ressources",
+    "RevokeProjectAdmin": "Révoquer la permission d'administrateur",
+    "SetProjectAdmin": "Définir l'administrateur de projet"
   },
   "projectMembers": {
     "Email": "E-mail",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2081,6 +2081,7 @@
     "CreateProject": "Buat Proyek",
     "Deactivate": "Nonaktifkan",
     "DeactivateProject": "Nonaktifkan Proyek",
+    "DescSetProjectAdmin": "Memberikan izin Admin Proyek akan secara otomatis menambahkan proyek tersebut ke daftar Proyek yang Diizinkan milik pengguna, sehingga pengguna tersebut kemudian dapat mengakses proyek tersebut.",
     "Domain": "Domain",
     "EditProject": "Edit",
     "FailedToActivateProject": "Gagal mengaktifkan proyek.",
@@ -2089,13 +2090,16 @@
     "Name": "Nama",
     "Project": "Proyek",
     "ProjectActivated": "Proyek telah diaktifkan.",
+    "ProjectAdminRoleNotFound": "Tidak dapat menemukan peran Admin Proyek untuk proyek '{{project}}'.",
     "ProjectDeactivated": "Proyek telah dinonaktifkan.",
     "ProjectID": "ID Proyek",
     "ProjectIDFilterRuleMessage": "UUID tidak valid.",
     "ProjectPurged": "Proyek telah dihapus secara permanen.",
     "Purge": "Bersihkan",
     "PurgeProject": "Hapus Proyek Secara Permanen",
-    "ResourcePolicy": "Kebijakan Sumber Daya"
+    "ResourcePolicy": "Kebijakan Sumber Daya",
+    "RevokeProjectAdmin": "Cabut Izin Admin",
+    "SetProjectAdmin": "Atur Admin Proyek"
   },
   "projectMembers": {
     "Email": "Email",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2078,6 +2078,7 @@
     "CreateProject": "Crea progetto",
     "Deactivate": "Disattiva",
     "DeactivateProject": "Disattiva progetto",
+    "DescSetProjectAdmin": "La concessione del permesso di amministratore del progetto aggiunge automaticamente il progetto all'elenco dei progetti consentiti dell'utente, che potrà quindi accedere a tale progetto.",
     "Domain": "Dominio",
     "EditProject": "Modifica",
     "FailedToActivateProject": "Impossibile attivare il progetto.",
@@ -2086,13 +2087,16 @@
     "Name": "Nome",
     "Project": "Progetto",
     "ProjectActivated": "Il progetto è stato attivato.",
+    "ProjectAdminRoleNotFound": "Impossibile trovare il ruolo di amministratore del progetto per il progetto '{{project}}'.",
     "ProjectDeactivated": "Il progetto è stato disattivato.",
     "ProjectID": "ID progetto",
     "ProjectIDFilterRuleMessage": "UUID non valido.",
     "ProjectPurged": "Il progetto è stato eliminato.",
     "Purge": "Svuota",
     "PurgeProject": "Elimina definitivamente il progetto",
-    "ResourcePolicy": "Politica delle risorse"
+    "ResourcePolicy": "Politica delle risorse",
+    "RevokeProjectAdmin": "Revoca permesso amministratore",
+    "SetProjectAdmin": "Imposta amministratore del progetto"
   },
   "projectMembers": {
     "Email": "Email",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "プロジェクトを作成",
     "Deactivate": "無効化",
     "DeactivateProject": "プロジェクトを無効化",
+    "DescSetProjectAdmin": "プロジェクト管理者権限を付与すると、そのプロジェクトがユーザーの許可されたプロジェクトリストに自動的に追加され、以降そのユーザーはそのプロジェクトにアクセスできるようになります。",
     "Domain": "ドメイン",
     "EditProject": "編集",
     "FailedToActivateProject": "プロジェクトの有効化に失敗しました。",
@@ -2088,13 +2089,16 @@
     "Name": "名前",
     "Project": "プロジェクト",
     "ProjectActivated": "プロジェクトは有効化されました。",
+    "ProjectAdminRoleNotFound": "プロジェクト '{{project}}' のプロジェクト管理者ロールが見つかりませんでした。",
     "ProjectDeactivated": "プロジェクトは無効化されました。",
     "ProjectID": "プロジェクトID",
     "ProjectIDFilterRuleMessage": "無効なUUIDです。",
     "ProjectPurged": "プロジェクトは完全に削除されました",
     "Purge": "パージ",
     "PurgeProject": "プロジェクトを完全に削除",
-    "ResourcePolicy": "リソースポリシー"
+    "ResourcePolicy": "リソースポリシー",
+    "RevokeProjectAdmin": "管理者権限を無効化",
+    "SetProjectAdmin": "プロジェクト管理者を設定"
   },
   "projectMembers": {
     "Email": "メール",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "프로젝트 생성",
     "Deactivate": "비활성화",
     "DeactivateProject": "프로젝트 비활성화",
+    "DescSetProjectAdmin": "프로젝트 관리자 권한을 부여하면 사용자의 허용 프로젝트 목록에 해당 프로젝트가 자동으로 추가되며, 이후 사용자는 해당 프로젝트에 접근할 수 있습니다.",
     "Domain": "도메인",
     "EditProject": "수정",
     "FailedToActivateProject": "프로젝트 활성화에 실패했습니다.",
@@ -2088,13 +2089,16 @@
     "Name": "이름",
     "Project": "프로젝트",
     "ProjectActivated": "프로젝트가 활성화됐습니다.",
+    "ProjectAdminRoleNotFound": "'{{project}}' 프로젝트의 프로젝트 관리자 역할을 찾을 수 없습니다.",
     "ProjectDeactivated": "프로젝트가 비활성화됐습니다.",
     "ProjectID": "프로젝트 ID",
     "ProjectIDFilterRuleMessage": "잘못된 UUID입니다.",
     "ProjectPurged": "프로젝트를 삭제했습니다.",
     "Purge": "삭제",
     "PurgeProject": "프로젝트 삭제",
-    "ResourcePolicy": "자원 정책"
+    "ResourcePolicy": "자원 정책",
+    "RevokeProjectAdmin": "관리자 권한 해제",
+    "SetProjectAdmin": "프로젝트 관리자 권한 설정"
   },
   "projectMembers": {
     "Email": "이메일",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2079,6 +2079,7 @@
     "CreateProject": "Төсөл үүсгэх",
     "Deactivate": "Идэвхгүй болгох",
     "DeactivateProject": "Төслийг идэвхгүй болгох",
+    "DescSetProjectAdmin": "Төслийн администраторын зөвшөөрлийг олгосноор тухайн төсөл нь хэрэглэгчийн зөвшөөрөгдсөн төслийн жагсаалтад автоматаар нэмэгдэх бөгөөд, ингэснээр хэрэглэгч тухайн төсөлд хандах боломжтой болно.",
     "Domain": "Домен",
     "EditProject": "Засах",
     "FailedToActivateProject": "Төслийг идэвхжүүлэхэд амжилтгүй боллоо.",
@@ -2087,13 +2088,16 @@
     "Name": "Нэр",
     "Project": "Төсөл",
     "ProjectActivated": "Төсөл идэвхжлээ.",
+    "ProjectAdminRoleNotFound": "'{{project}}' төслийн төслийн администратор үүрэг олдсонгүй.",
     "ProjectDeactivated": "Төсөл идэвхгүй боллоо.",
     "ProjectID": "Төслийн ID",
     "ProjectIDFilterRuleMessage": "UUID хүчин төгөлдөргүй.",
     "ProjectPurged": "Төсөл бүрмөсөн устгагдсан.",
     "Purge": "Устгах",
     "PurgeProject": "Төслийг бүрэн устгах",
-    "ResourcePolicy": "Ресурсийн бодлого"
+    "ResourcePolicy": "Ресурсийн бодлого",
+    "RevokeProjectAdmin": "Админ зөвшөөрлийг цуцлах",
+    "SetProjectAdmin": "Төслийн администратор тохируулах"
   },
   "projectMembers": {
     "Email": "Имэйл",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2078,6 +2078,7 @@
     "CreateProject": "Buat Projek",
     "Deactivate": "Nyahaktifkan",
     "DeactivateProject": "Nyahaktifkan Projek",
+    "DescSetProjectAdmin": "Memberikan kebenaran Pentadbir Projek secara automatik menambahkan projek tersebut ke dalam senarai Projek Dibenarkan pengguna, dan pengguna tersebut kemudiannya akan dapat mengakses projek tersebut.",
     "Domain": "Domain",
     "EditProject": "Sunting",
     "FailedToActivateProject": "Gagal mengaktifkan projek.",
@@ -2086,13 +2087,16 @@
     "Name": "Nama",
     "Project": "Projek",
     "ProjectActivated": "Projek ini telah diaktifkan.",
+    "ProjectAdminRoleNotFound": "Tidak dapat mencari peranan Pentadbir Projek untuk projek '{{project}}'.",
     "ProjectDeactivated": "Projek ini telah dinyahaktifkan.",
     "ProjectID": "ID Projek",
     "ProjectIDFilterRuleMessage": "UUID tidak sah.",
     "ProjectPurged": "Projek telah dipadam",
     "Purge": "Padam",
     "PurgeProject": "Padam Projek",
-    "ResourcePolicy": "Dasar Sumber"
+    "ResourcePolicy": "Dasar Sumber",
+    "RevokeProjectAdmin": "Batalkan Kebenaran Pentadbir",
+    "SetProjectAdmin": "Tetapkan Pentadbir Projek"
   },
   "projectMembers": {
     "Email": "E-mel",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "Utwórz projekt",
     "Deactivate": "Dezaktywuj",
     "DeactivateProject": "Dezaktywuj projekt",
+    "DescSetProjectAdmin": "Nadanie uprawnienia administratora projektu automatycznie dodaje projekt do listy dozwolonych projektów użytkownika, dzięki czemu użytkownik będzie mógł uzyskać dostęp do tego projektu.",
     "Domain": "Domena",
     "EditProject": "Edytuj",
     "FailedToActivateProject": "Nie udało się aktywować projektu.",
@@ -2088,13 +2089,16 @@
     "Name": "Nazwa",
     "Project": "Projekt",
     "ProjectActivated": "Projekt został aktywowany.",
+    "ProjectAdminRoleNotFound": "Nie można znaleźć roli administratora projektu dla projektu '{{project}}'.",
     "ProjectDeactivated": "Projekt został dezaktywowany.",
     "ProjectID": "ID projektu",
     "ProjectIDFilterRuleMessage": "Nieprawidłowy UUID.",
     "ProjectPurged": "Projekt został trwale usunięty.",
     "Purge": "Wyczyść",
     "PurgeProject": "Trwale usuń projekt",
-    "ResourcePolicy": "Polityka zasobów"
+    "ResourcePolicy": "Polityka zasobów",
+    "RevokeProjectAdmin": "Odwołaj uprawnienie administratora",
+    "SetProjectAdmin": "Ustaw administratora projektu"
   },
   "projectMembers": {
     "Email": "E-mail",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2078,6 +2078,7 @@
     "CreateProject": "Criar projeto",
     "Deactivate": "Desativar",
     "DeactivateProject": "Desativar projeto",
+    "DescSetProjectAdmin": "Conceder a permissão de administrador do projeto adiciona automaticamente o projeto à lista de projetos permitidos do usuário, e o usuário poderá então acessar esse projeto.",
     "Domain": "Domínio",
     "EditProject": "Editar",
     "FailedToActivateProject": "Falha ao ativar o projeto.",
@@ -2086,13 +2087,16 @@
     "Name": "Nome",
     "Project": "Projeto",
     "ProjectActivated": "O projeto foi ativado.",
+    "ProjectAdminRoleNotFound": "Não foi possível encontrar a função de administrador do projeto para o projeto '{{project}}'.",
     "ProjectDeactivated": "O projeto foi desativado.",
     "ProjectID": "ID do projeto",
     "ProjectIDFilterRuleMessage": "UUID inválido.",
     "ProjectPurged": "O projeto foi excluído permanentemente.",
     "Purge": "Limpar",
     "PurgeProject": "Excluir projeto",
-    "ResourcePolicy": "Política de Recursos"
+    "ResourcePolicy": "Política de Recursos",
+    "RevokeProjectAdmin": "Revogar permissão de administrador",
+    "SetProjectAdmin": "Definir administrador do projeto"
   },
   "projectMembers": {
     "Email": "E-mail",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "Criar projeto",
     "Deactivate": "Desativar",
     "DeactivateProject": "Desativar projeto",
+    "DescSetProjectAdmin": "Conceder a permissão de administrador do projeto adiciona automaticamente o projeto à lista de projetos permitidos do utilizador, e o utilizador poderá então aceder a esse projeto.",
     "Domain": "Domínio",
     "EditProject": "Editar",
     "FailedToActivateProject": "Falha ao ativar o projeto.",
@@ -2088,13 +2089,16 @@
     "Name": "Nome",
     "Project": "Projeto",
     "ProjectActivated": "O projeto foi ativado.",
+    "ProjectAdminRoleNotFound": "Não foi possível encontrar a função de administrador do projeto para o projeto '{{project}}'.",
     "ProjectDeactivated": "O projeto foi desativado.",
     "ProjectID": "ID do projeto",
     "ProjectIDFilterRuleMessage": "UUID inválido.",
     "ProjectPurged": "O projeto foi purgado",
     "Purge": "Limpar",
     "PurgeProject": "Purgar Projeto",
-    "ResourcePolicy": "Política de Recursos"
+    "ResourcePolicy": "Política de Recursos",
+    "RevokeProjectAdmin": "Revogar permissão de administrador",
+    "SetProjectAdmin": "Definir administrador do projeto"
   },
   "projectMembers": {
     "Email": "E-mail",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2078,6 +2078,7 @@
     "CreateProject": "Создать проект",
     "Deactivate": "Деактивировать",
     "DeactivateProject": "Деактивировать проект",
+    "DescSetProjectAdmin": "Предоставление разрешения администратора проекта автоматически добавляет проект в список разрешённых проектов пользователя, после чего пользователь сможет получить доступ к этому проекту.",
     "Domain": "Домен",
     "EditProject": "Изменить",
     "FailedToActivateProject": "Не удалось активировать проект.",
@@ -2086,13 +2087,16 @@
     "Name": "Имя",
     "Project": "Проект",
     "ProjectActivated": "Проект активирован.",
+    "ProjectAdminRoleNotFound": "Не удалось найти роль администратора проекта для проекта '{{project}}'.",
     "ProjectDeactivated": "Проект деактивирован.",
     "ProjectID": "ID проекта",
     "ProjectIDFilterRuleMessage": "Неверный UUID.",
     "ProjectPurged": "Проект был окончательно удалён.",
     "Purge": "Очистить",
     "PurgeProject": "Полностью удалить проект",
-    "ResourcePolicy": "Политика ресурсов"
+    "ResourcePolicy": "Политика ресурсов",
+    "RevokeProjectAdmin": "Отозвать разрешение администратора",
+    "SetProjectAdmin": "Установить администратора проекта"
   },
   "projectMembers": {
     "Email": "Электронная почта",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "สร้างโปรเจกต์",
     "Deactivate": "ปิดใช้งาน",
     "DeactivateProject": "ปิดการใช้งานโครงการ",
+    "DescSetProjectAdmin": "การให้สิทธิ์ผู้ดูแลโปรเจกต์จะเพิ่มโปรเจกต์นั้นเข้าไปในรายการโปรเจกต์ที่ได้รับอนุญาตของผู้ใช้โดยอัตโนมัติ และผู้ใช้จะสามารถเข้าถึงโปรเจกต์นั้นได้",
     "Domain": "โดเมน",
     "EditProject": "แก้ไข",
     "FailedToActivateProject": "ไม่สามารถเปิดใช้งานโครงการได้",
@@ -2088,13 +2089,16 @@
     "Name": "ชื่อ",
     "Project": "โปรเจกต์",
     "ProjectActivated": "โครงการถูกเปิดใช้งานแล้ว",
+    "ProjectAdminRoleNotFound": "ไม่พบบทบาทผู้ดูแลโปรเจกต์สำหรับโปรเจกต์ '{{project}}'",
     "ProjectDeactivated": "โครงการถูกปิดการใช้งานแล้ว",
     "ProjectID": "รหัสโครงการ",
     "ProjectIDFilterRuleMessage": "UUID ไม่ถูกต้อง.",
     "ProjectPurged": "โครงการถูกลบอย่างถาวร",
     "Purge": "ลบถาวร",
     "PurgeProject": "ลบโปรเจกต์อย่างถาวร",
-    "ResourcePolicy": "นโยบายทรัพยากร"
+    "ResourcePolicy": "นโยบายทรัพยากร",
+    "RevokeProjectAdmin": "เพิกถอนสิทธิ์ผู้ดูแลระบบ",
+    "SetProjectAdmin": "ตั้งค่าผู้ดูแลโปรเจกต์"
   },
   "projectMembers": {
     "Email": "อีเมล",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2078,6 +2078,7 @@
     "CreateProject": "Proje Oluştur",
     "Deactivate": "Devre dışı bırak",
     "DeactivateProject": "Projeyi devre dışı bırak",
+    "DescSetProjectAdmin": "Proje yöneticisi izni verildiğinde, proje otomatik olarak kullanıcının izin verilen projeler listesine eklenir ve kullanıcı bu projeye erişebilir hale gelir.",
     "Domain": "Etki Alanı",
     "EditProject": "Düzenle",
     "FailedToActivateProject": "Proje etkinleştirilemedi.",
@@ -2086,13 +2087,16 @@
     "Name": "Ad",
     "Project": "Proje",
     "ProjectActivated": "Proje etkinleştirildi.",
+    "ProjectAdminRoleNotFound": "'{{project}}' projesi için proje yöneticisi rolü bulunamadı.",
     "ProjectDeactivated": "Proje devre dışı bırakıldı.",
     "ProjectID": "Proje Kimliği",
     "ProjectIDFilterRuleMessage": "Geçersiz UUID.",
     "ProjectPurged": "Proje kalıcı olarak silindi.",
     "Purge": "Temizle",
     "PurgeProject": "Projeyi Temizle",
-    "ResourcePolicy": "Kaynak Politikası"
+    "ResourcePolicy": "Kaynak Politikası",
+    "RevokeProjectAdmin": "Yönetici İznini İptal Et",
+    "SetProjectAdmin": "Proje Yöneticisini Ayarla"
   },
   "projectMembers": {
     "Email": "E-posta",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "Tạo dự án",
     "Deactivate": "Vô hiệu hóa",
     "DeactivateProject": "Vô hiệu hóa dự án",
+    "DescSetProjectAdmin": "Việc cấp quyền quản trị dự án sẽ tự động thêm dự án vào danh sách dự án được phép của người dùng, và người dùng đó sau đó sẽ có thể truy cập vào dự án đó.",
     "Domain": "Miền",
     "EditProject": "Chỉnh sửa",
     "FailedToActivateProject": "Không thể kích hoạt dự án.",
@@ -2088,13 +2089,16 @@
     "Name": "Tên",
     "Project": "Dự án",
     "ProjectActivated": "Dự án đã được kích hoạt.",
+    "ProjectAdminRoleNotFound": "Không thể tìm thấy vai trò quản trị dự án cho dự án '{{project}}'.",
     "ProjectDeactivated": "Dự án đã bị vô hiệu hóa.",
     "ProjectID": "ID dự án",
     "ProjectIDFilterRuleMessage": "UUID không hợp lệ.",
     "ProjectPurged": "Dự án đã bị xóa vĩnh viễn",
     "Purge": "Xóa sạch",
     "PurgeProject": "Xóa vĩnh viễn dự án",
-    "ResourcePolicy": "Chính sách tài nguyên"
+    "ResourcePolicy": "Chính sách tài nguyên",
+    "RevokeProjectAdmin": "Thu hồi quyền quản trị viên",
+    "SetProjectAdmin": "Đặt quản trị dự án"
   },
   "projectMembers": {
     "Email": "Email",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2080,6 +2080,7 @@
     "CreateProject": "创建项目",
     "Deactivate": "停用",
     "DeactivateProject": "停用项目",
+    "DescSetProjectAdmin": "授予项目管理员权限后，系统会自动将该项目添加到用户的允许项目列表中，此后该用户即可访问该项目。",
     "Domain": "域",
     "EditProject": "编辑",
     "FailedToActivateProject": "无法激活该项目。",
@@ -2088,13 +2089,16 @@
     "Name": "名称",
     "Project": "项目",
     "ProjectActivated": "该项目已激活。",
+    "ProjectAdminRoleNotFound": "未能找到项目 '{{project}}' 的项目管理员角色。",
     "ProjectDeactivated": "该项目已被停用。",
     "ProjectID": "项目 ID",
     "ProjectIDFilterRuleMessage": "无效的 UUID。",
     "ProjectPurged": "项目 \"projecth\" 已被清除",
     "Purge": "清除",
     "PurgeProject": "永久删除项目",
-    "ResourcePolicy": "资源策略"
+    "ResourcePolicy": "资源策略",
+    "RevokeProjectAdmin": "撤销管理员权限",
+    "SetProjectAdmin": "设置项目管理员"
   },
   "projectMembers": {
     "Email": "邮箱",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2082,6 +2082,7 @@
     "CreateProject": "建立專案",
     "Deactivate": "停用",
     "DeactivateProject": "停用專案",
+    "DescSetProjectAdmin": "授予專案管理員權限後，系統會自動將該專案新增至使用者的允許專案清單中，此後該使用者即可存取該專案。",
     "Domain": "網域",
     "EditProject": "編輯",
     "FailedToActivateProject": "無法啟用專案。",
@@ -2090,13 +2091,16 @@
     "Name": "名稱",
     "Project": "專案",
     "ProjectActivated": "該專案已啟用。",
+    "ProjectAdminRoleNotFound": "找不到專案 '{{project}}' 的專案管理員角色。",
     "ProjectDeactivated": "該專案已停用。",
     "ProjectID": "專案 ID",
     "ProjectIDFilterRuleMessage": "無效的 UUID。",
     "ProjectPurged": "專案「projecth」已被清除",
     "Purge": "清除",
     "PurgeProject": "永久刪除專案",
-    "ResourcePolicy": "資源策略"
+    "ResourcePolicy": "資源策略",
+    "RevokeProjectAdmin": "撤銷管理員權限",
+    "SetProjectAdmin": "設定專案管理員"
   },
   "projectMembers": {
     "Email": "電子郵件",


### PR DESCRIPTION
Resolves #8256 (FR-3317)

> Stacked on #8194 (`feat/FR-3273-multi-scope-bulk-edit`) — depends on the `RoleFilter.mappedScope` schema addition from that stack.

## Summary

Adds a "Set Project Admin" management modal to the project list so admins can grant/revoke the project admin role without navigating the RBAC page.

- **Row action** (first position, `ShieldUser` icon) on each project row in `ProjectPage`; disabled for `MODEL_STORE` projects.
- **Render-as-you-fetch open**: the click event awaits `fetchQuery` (button carries the initial loading), resolves the project's SYSTEM-source role up front, and opens the modal via `useQueryLoader` / `usePreloadedQuery`. A project without a project admin role only gets a `message.error` — the modal never opens.
- **`ProjectAdminSettingModal`** (`BAIModal`, no footer):
  - `BAIAlert` describing the effect (project auto-added to the user's allowed project list).
  - `BAIUserSelect` (multiple, `maxTagCount="responsive"`) wrapped in a `Form.Item` with a required rule + **Add** `BAIButton` (`action`-based loading). Validation errors render inline via `validateFields()`.
  - Assignment table: email | user id (`BAIId`, ellipsis + copy) | control — an X button with a "Revoke admin permission" tooltip calling `adminRevokeRole({ userId, roleId })`.
  - Assign uses `adminBulkAssignRole({ roleId, userIds, projectId })` — `projectId` is passed so the project is auto-added to each user's allowed project list.
  - After assign/revoke the query reloads (`network-only`) with an inline table loading state; the modal stays open for further edits.
- Feedback follows the `RoleAssignmentTab` convention: `rbac.UsersAssigned` / `rbac.UserRevoked` on success, `rbac.BulkAssignPartialFailure` + per-user error notifications on partial failure.

## i18n

New keys in the `project` section (en/ko): `SetProjectAdmin`, `DescSetProjectAdmin`, `ProjectAdminRoleNotFound`, `RevokeProjectAdmin`. Other locales to be filled by the translation workflow.

## Verification

`bash scripts/verify.sh`: Relay ✅ / Lint ✅ / Format ✅ / TypeScript ✅ (Vite warmup path check fails locally due to missing build artifacts — unrelated to this change.)

Not yet exercised against a live backend; manual QA pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
