### PR TITLE
feat(FR-3300): set per-consumer auto-refresh defaults by data volatility

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -267,6 +267,7 @@ const AgentList: React.FC<AgentListProps> = ({
             // Heavier cluster-wide query — keep the original ~15s as the
             // fastest option instead of the default set's 5s/10s.
             autoUpdateDelayOptions={[15_000, 30_000, 60_000, 300_000]}
+            defaultAutoUpdateDelay={15_000}
             loading={
               deferredFetchKey !== fetchKey ||
               deferredQueryVariables !== queryVariables

--- a/react/src/components/AutoUpdateFetchKeyButton.tsx
+++ b/react/src/components/AutoUpdateFetchKeyButton.tsx
@@ -1,4 +1,7 @@
-import { useBAISettingUserState } from '../hooks/useBAISetting';
+import {
+  hasStoredUserSetting,
+  useBAISettingUserState,
+} from '../hooks/useBAISetting';
 import { BAIFetchKeyButton } from 'backend.ai-ui';
 import React, { ComponentProps } from 'react';
 
@@ -22,6 +25,7 @@ export type FetchKeyAutoUpdateSettingId =
   | 'deployment-list'
   | 'admin-deployment-list'
   | 'project-admin-deployments'
+  | 'deployment-replicas'
   // VFolder lists
   | 'vfolder-list'
   | 'admin-vfolder-list'
@@ -64,6 +68,15 @@ interface AutoUpdateFetchKeyButtonProps extends Omit<
    * compile time.
    */
   settingId: FetchKeyAutoUpdateSettingId;
+  /**
+   * Interval (ms) used the first time this consumer renders, before the user
+   * has ever picked anything from the dropdown. Once the user picks an
+   * interval (including "Off"), that choice is persisted and always wins over
+   * this default. Pass the consumer's pre-FR-3147 fixed interval here so
+   * pages that already auto-refreshed keep doing so; omit (defaults to `null`
+   * / Off) for consumers newly gaining auto-refresh.
+   */
+  defaultAutoUpdateDelay?: number | null;
 }
 
 /**
@@ -71,8 +84,9 @@ interface AutoUpdateFetchKeyButtonProps extends Omit<
  * interval dropdown (FR-3147) and persists the chosen interval via
  * `useBAISetting`, keyed per consumer by `settingId`.
  *
- * Auto-refresh is off by default; it only runs once the user picks an interval
- * from the dropdown, and the choice is remembered per consumer across reloads.
+ * Auto-refresh starts at `defaultAutoUpdateDelay` (or off, if omitted) until
+ * the user picks an interval from the dropdown; from then on their choice is
+ * remembered per consumer across reloads and always wins over the default.
  *
  * The dropdown shows the default presets ({@link AUTO_UPDATE_DELAY_OPTIONS} in
  * BAIFetchKeyButton). A consumer can offer a different cadence by passing
@@ -81,16 +95,24 @@ interface AutoUpdateFetchKeyButtonProps extends Omit<
  */
 const AutoUpdateFetchKeyButton: React.FC<AutoUpdateFetchKeyButtonProps> = ({
   settingId,
+  defaultAutoUpdateDelay = null,
   ...props
 }) => {
   'use memo';
-  const [autoUpdateDelay, setAutoUpdateDelay] = useBAISettingUserState(
-    `fetchKeyAutoUpdateDelay.${settingId}`,
-  );
+  const settingName = `fetchKeyAutoUpdateDelay.${settingId}` as const;
+  const [autoUpdateDelay, setAutoUpdateDelay] =
+    useBAISettingUserState(settingName);
+  // Only fall back to `defaultAutoUpdateDelay` before the user has ever
+  // touched the dropdown for this consumer. Once they have (including
+  // explicitly choosing "Off"), the persisted value is `null` too, but it
+  // must not be re-overridden by the default on every subsequent render.
+  const resolvedAutoUpdateDelay = hasStoredUserSetting(settingName)
+    ? (autoUpdateDelay ?? null)
+    : defaultAutoUpdateDelay;
   return (
     <BAIFetchKeyButton
       {...props}
-      autoUpdateDelay={autoUpdateDelay ?? null}
+      autoUpdateDelay={resolvedAutoUpdateDelay}
       onChangeAutoUpdateDelay={setAutoUpdateDelay}
     />
   );

--- a/react/src/components/DeploymentReplicasCard.tsx
+++ b/react/src/components/DeploymentReplicasCard.tsx
@@ -11,6 +11,7 @@ import type { DeploymentRevisionDetail_revision$key } from '../__generated__/Dep
 import { RouteSchedulingHistoryModalQuery } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from './BAIErrorBoundary';
 import BAIRadioGroup from './BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
@@ -25,7 +26,6 @@ import {
   BAIButton,
   BAICard,
   BAIColumnType,
-  BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIId,
@@ -556,7 +556,9 @@ const DeploymentReplicasCardContent: React.FC<DeploymentReplicasCardProps> = ({
             }}
           />
         </BAIFlex>
-        <BAIFetchKeyButton
+        <AutoUpdateFetchKeyButton
+          settingId="deployment-replicas"
+          defaultAutoUpdateDelay={10_000}
           loading={isPending}
           value=""
           onChange={() => {

--- a/react/src/components/PendingSessionNodeList.tsx
+++ b/react/src/components/PendingSessionNodeList.tsx
@@ -119,6 +119,7 @@ const PendingSessionNodeList: React.FC = () => {
         </Form.Item>
         <AutoUpdateFetchKeyButton
           settingId="pending-session-list"
+          defaultAutoUpdateDelay={10_000}
           loading={
             deferredQueryVariables !== queryVariables ||
             deferredFetchKey !== fetchKey

--- a/react/src/components/SessionDetailDrawer.tsx
+++ b/react/src/components/SessionDetailDrawer.tsx
@@ -68,6 +68,7 @@ const SessionDetailDrawer: React.FC<SessionDetailDrawerProps> = ({
       extra={
         <AutoUpdateFetchKeyButton
           settingId="session-detail"
+          defaultAutoUpdateDelay={10_000}
           loading={isPendingReload}
           value={fetchKey}
           onChange={(newFetchKey) => {

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -77,6 +77,23 @@ export const useBAISettingUserState = <K extends keyof UserSettings>(
   return useAtom<UserSettings[K]>(SettingAtomFamily('user.' + name));
 };
 
+/**
+ * Whether a user setting has ever been explicitly written to `localStorage`.
+ * Needed because `useBAISettingUserState` collapses "never set" and
+ * "explicitly set to `null`" into the same `null` return value — callers that
+ * need a fallback-only-when-unset default (e.g. a per-consumer auto-refresh
+ * interval where the user can legitimately choose "off") can't tell the two
+ * apart from the hook's value alone.
+ */
+export const hasStoredUserSetting = <K extends keyof UserSettings>(
+  name: K,
+): boolean => {
+  if (typeof window === 'undefined') return false;
+  return (
+    window.localStorage.getItem('backendaiwebui.settings.user.' + name) !== null
+  );
+};
+
 export const useBAISettingGeneralState = <K extends keyof GeneralSettings>(
   name: K,
 ): [GeneralSettings[K], (newValue: GeneralSettings[K]) => void] => {

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -388,6 +388,7 @@ const AdminComputeSessionListPage = () => {
             )}
             <AutoUpdateFetchKeyButton
               settingId="admin-session-list"
+              defaultAutoUpdateDelay={15_000}
               loading={
                 deferredQueryVariables !== queryVariables ||
                 deferredFetchKey !== fetchKey

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -295,6 +295,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
           </BAIFlex>
           <AutoUpdateFetchKeyButton
             settingId="admin-deployment-list"
+            defaultAutoUpdateDelay={15_000}
             value={fetchKey}
             onChange={updateFetchKey}
             loading={isLoading}

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -517,6 +517,7 @@ const ComputeSessionListPage = () => {
               )}
               <AutoUpdateFetchKeyButton
                 settingId="session-list"
+                defaultAutoUpdateDelay={15_000}
                 loading={
                   deferredQueryVariables !== queryVariables ||
                   deferredFetchKey !== fetchKey

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -253,6 +253,7 @@ const DeploymentListPageContent: React.FC = () => {
           <BAIFlex gap="xs" align="center">
             <AutoUpdateFetchKeyButton
               settingId="deployment-list"
+              defaultAutoUpdateDelay={15_000}
               value={fetchKey}
               onChange={updateFetchKey}
               loading={isPending}

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -258,6 +258,7 @@ const ProjectAdminDeploymentsContent: React.FC<
           </BAIFlex>
           <AutoUpdateFetchKeyButton
             settingId="project-admin-deployments"
+            defaultAutoUpdateDelay={15_000}
             loading={isLoading}
             value={fetchKey}
             onChange={(next) => updateFetchKey(next)}

--- a/react/src/pages/ProjectAdminSessionPage.tsx
+++ b/react/src/pages/ProjectAdminSessionPage.tsx
@@ -246,6 +246,7 @@ const ProjectAdminSessionContent: React.FC<ProjectAdminSessionContentProps> = ({
           )}
           <AutoUpdateFetchKeyButton
             settingId="project-admin-session"
+            defaultAutoUpdateDelay={15_000}
             loading={isLoading}
             value={fetchKey}
             onChange={(next) => updateFetchKey(next)}


### PR DESCRIPTION
Part of #8232 (FR-3300)

> **Stacked on** #8233 — review/merge that one first.

## Summary

Follow-up to the auto-refresh interval dropdown (FR-3147) and the countdown border (#8233): give each polling consumer a **default auto-refresh interval chosen by how volatile its data is and whether users actually watch it change**, instead of leaving every list off by default.

The classification below came from reviewing every `BAIFetchKeyButton` / `AutoUpdateFetchKeyButton` call site (54 total) against one rule: *auto-refresh on by default only where values change on their own and the user is there to watch them.*

## Policy

**Default ON:**

- **10s** — live-watch surfaces (single entity or a draining queue):
  - `SessionDetailDrawer` — session status / live utilization / idle countdown
  - `PendingSessionNodeList` — scheduling queue draining
  - `DeploymentReplicasCard` — replica lifecycle / health / traffic status transitions
- **15s** — heavier monitoring lists with live status columns:
  - Compute-session lists (user / admin / project-admin)
  - Deployment lists (user / admin / project-admin)
  - Agent list

**Default OFF** (interval dropdown still available — opt-in): append-only records / audit / history (login history & sessions, audit log), config & policy (fair-share), catalogs, RBAC, resource tiles, storage-proxy, reservoir, and single-entity detail lookups. Once a user picks an interval (including **Off**), that choice is persisted and always wins over the default.

## Mechanics

- Add a `defaultAutoUpdateDelay` prop to `AutoUpdateFetchKeyButton`; it is applied **only until the user first picks an interval**, after which the persisted choice (including an explicit `null` / Off) always wins.
- Add `hasStoredUserSetting` to `useBAISetting` to distinguish "never set" from an explicit `null`.
- Migrate `DeploymentReplicasCard` from a plain `BAIFetchKeyButton` to the auto-update wrapper (`settingId: deployment-replicas`, 10s default) so replica status can be watched live.
- `AgentDetailDrawer` keeps the interval dropdown but defaults **off** (like the other record/detail surfaces): its refresh fires a `rescan_gpu_alloc_maps` mutation, so it should not auto-poll unless the user explicitly opts in.

## Verification

`bash scripts/verify.sh`: **Relay / Lint / Format / TypeScript — PASS.** (The aggregate harness's "Vite warmup paths" check is a pre-existing failure unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
