### PR TITLE
fix(docs-toolkit): repair PDF stamp glyphs, one-page cover, and reader outline

### DIFF
--- a/packages/backend.ai-docs-toolkit/package.json
+++ b/packages/backend.ai-docs-toolkit/package.json
@@ -52,7 +52,7 @@
     "yaml": "^2.8.2"
   },
   "peerDependencies": {
-    "playwright": "^1.40.0",
+    "playwright": "^1.42.0",
     "sharp": "^0.34.0"
   },
   "peerDependenciesMeta": {

--- a/packages/backend.ai-docs-toolkit/src/pdf-renderer.ts
+++ b/packages/backend.ai-docs-toolkit/src/pdf-renderer.ts
@@ -233,7 +233,9 @@ async function embedFontFromPath(
     fontBytes = extractFontFromTtc(fontBytes, subIndex);
   }
 
-  const font = await pdfDoc.embedFont(fontBytes, { subset: true });
+  // Never subset: @pdf-lib/fontkit's TrueType subsetter drops composite-glyph
+  // components, rendering subset-embedded CJK fonts as mostly-blank text.
+  const font = await pdfDoc.embedFont(fontBytes, { subset: false });
   return font;
 }
 
@@ -338,6 +340,10 @@ const PDF_OPTIONS = {
   format: 'A4' as const,
   printBackground: true,
   margin: { top: '25mm', bottom: '20mm', left: '20mm', right: '20mm' },
+  // Chromium emits /Outlines (reader-sidebar bookmarks) only for tagged
+  // PDFs — `outline: true` alone produces nothing.
+  tagged: true,
+  outline: true,
 };
 
 const PRINT_WIDTH_PX = Math.round(170 * 96 / 25.4); // 643
@@ -511,6 +517,13 @@ async function getAllSections(
  */
 function pickFontForText(text: string, candidates: EmbeddedFont[]): EmbeddedFont {
   if (candidates.length === 1) return candidates[0];
+  // Pure-ASCII text draws with the Latin font (last candidate) so it never
+  // falls to a CJK face that merely also covers ASCII.
+  let asciiOnly = true;
+  for (const ch of text) {
+    if (ch.codePointAt(0)! > 0x7e) { asciiOnly = false; break; }
+  }
+  if (asciiOnly) return candidates[candidates.length - 1];
   for (const font of candidates) {
     // pdf-lib does not expose hasGlyphForCodePoint publicly, but the
     // underlying fontkit instance is reachable via the embedder.

--- a/packages/backend.ai-docs-toolkit/src/styles.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles.ts
@@ -25,6 +25,15 @@ body {
     "Noto Sans TC", "Noto Sans CJK TC",
     "Noto Sans Thai",
     Helvetica, Arial, sans-serif;
+  font-size: ${theme.baseFontSize};
+  line-height: 1.6;
+  color: ${theme.textPrimary};
+  margin: 0;
+  padding: 0;
+  text-align: justify;
+  text-wrap: pretty;
+  ${isCjk ? 'word-break: keep-all;' : '-webkit-hyphens: auto; hyphens: auto;'}
+  overflow-wrap: break-word;
 }
 
 /* Per-language font priorities so Chromium picks the language-appropriate
@@ -41,15 +50,6 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
     "Noto Sans Thai", "Loma", "Garuda",
     Helvetica, Arial, sans-serif;
-  font-size: ${theme.baseFontSize};
-  line-height: 1.6;
-  color: ${theme.textPrimary};
-  margin: 0;
-  padding: 0;
-  text-align: justify;
-  text-wrap: pretty;
-  ${isCjk ? 'word-break: keep-all;' : '-webkit-hyphens: auto; hyphens: auto;'}
-  overflow-wrap: break-word;
 }
 
 /* ==========================================================================
@@ -61,7 +61,11 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
+  /* A4 297mm − 25mm/20mm print margins (PDF_OPTIONS) − 2mm rounding slack.
+   * Not 100vh: print-viewport height tracks the paper size, not the content
+   * box, so a 100vh cover spills a blank page 2 before the TOC. */
+  height: 250mm;
+  overflow: hidden;
   text-align: center;
   padding: 60px 40px;
 }


### PR DESCRIPTION
Resolves #8269

Part of #8266 (epic; full investigation + font repro matrix there). Consumer report: lablup/backend.ai-fasttrack#5000.

## What

Five PDF-pipeline fixes in `packages/backend.ai-docs-toolkit`, all root-caused from the FastTrack 26.7.0 release PDFs:

1. **Stamp fonts embed with `subset: false`** (`pdf-renderer.ts`). `@pdf-lib/fontkit` 1.1.1's TrueType subsetter keeps composite glyphs but drops their component outlines, so the pdf-lib-stamped header title rendered as `A  t      t t`, footer **page numbers were invisible**, and Korean **section labels were missing**. Every redistributable Korean font tested breaks under the subsetter (NanumSquare Regular/Bold, NanumGothic, NotoSansKR-OTF — the OTF loses Hangul via the CFF path instead); only non-vendorable macOS system fonts survive, so a font swap is not a fix. The stamp pass embeds a single font per document, so the full-embed cost is one font file (~0.7 MB) regardless of page count.
2. **`pickFontForText()` returns the Latin font for pure-ASCII strings**. CJK fallbacks are ordered first, so English titles and page numbers rendered in the consumer's CJK face merely because it also covers ASCII; now Latin-only text always draws with Helvetica.
3. **Cover sized to an explicit `height: 250mm`** (`styles.ts`) instead of `min-height: 100vh`. In Chromium's print pipeline the viewport height tracks the paper size rather than the margin-trimmed content box, so the 100vh cover overflowed page 1 and its empty spill produced a blank (but header/footer-stamped) page 2 before the TOC. 250mm = A4 297mm − 25mm/20mm print margins − 2mm rounding slack.
4. **`tagged: true` + `outline: true` in `PDF_OPTIONS`**. Restores the reader-sidebar bookmark tree lost in the Sphinx/LaTeX → toolkit migration. Empirically, Chromium emits `/Outlines` **only when the PDF is also tagged** — `outline: true` alone produces nothing. The pdf-lib post-processing pass preserves `/Outlines` through the stamping re-save (verified).

5. **Body typography restored** (`styles.ts`, found while implementing the above). dfd734911 (FR-2719) inserted the `:lang(ja)`/`:lang(th)` rules into the middle of the `body` rule, orphaning `font-size`, `line-height`, the margin reset, `text-align: justify`, and the CJK `word-break: keep-all` inside the Thai-only rule — en/ko/ja PDFs have rendered with Chromium default typography ever since. Moved back to `body`; `:lang(th)` keeps only its font-family, matching `:lang(ja)`.

## Verification

`pnpm build` + `pnpm test` clean (268 pass / 1 skip). Then built the patched `dist/` into the FastTrack docs project and rendered the real en+ko book PDFs (~130 pages each):

| Check | Before (26.7.0 release PDFs) | After |
|---|---|---|
| Header (p2+) | `A  t      t t` | `Backend.AI FastTrack Documentation` (Helvetica) |
| Footer page numbers | invisible | visible, both langs |
| KO footer section labels | missing | e.g. `5.3 고급 태스크 설정` (NanumSquare) |
| Page 2 | blank | Table of Contents |
| Bookmarks | none | 564-entry outline tree, both langs |
| Body text | Chromium defaults (16px, ragged right) | 11pt justified, KO `word-break: keep-all` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
