### PR TITLE
fix(FR-3321): make docs-toolkit npm publish workable from CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,13 @@ proxy:
 versiontag:
 	@printf "$(GREEN)Tagging version number / index...$(NC)\n"
 	@echo '{ "package": "${BUILD_VERSION}", "buildNumber": "${BUILD_NUMBER}", "buildDate": "${BUILD_DATE}.${BUILD_TIME}", "revision": "${REVISION_INDEX}" }' > version.json
-	@sed -i -E 's/globalThis.packageVersion = "\([^"]*\)"/globalThis.packageVersion = "${BUILD_VERSION}"/g' index.html
-	@sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' manifest.json
-	@sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' react/package.json
-	@sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' packages/backend.ai-ui/package.json
-	@sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' electron-app/package.json
-	@sed -i -E 's/globalThis.buildNumber = "\([^"]*\)"/globalThis.buildNumber = "${BUILD_NUMBER}"/g' index.html
+	@sed -i -E 's/globalThis.packageVersion = "[^"]*"/globalThis.packageVersion = "${BUILD_VERSION}"/g' index.html
+	@sed -i -E 's/"version": "[^"]*"/"version": "${BUILD_VERSION}"/g' manifest.json
+	@sed -i -E 's/"version": "[^"]*"/"version": "${BUILD_VERSION}"/g' react/package.json
+	@sed -i -E 's/"version": "[^"]*"/"version": "${BUILD_VERSION}"/g' packages/backend.ai-ui/package.json
+	@sed -i -E 's/"version": "[^"]*"/"version": "${BUILD_VERSION}"/g' packages/backend.ai-docs-toolkit/package.json
+	@sed -i -E 's/"version": "[^"]*"/"version": "${BUILD_VERSION}"/g' electron-app/package.json
+	@sed -i -E 's/globalThis.buildNumber = "[^"]*"/globalThis.buildNumber = "${BUILD_NUMBER}"/g' index.html
 	@printf "$(YELLOW)Finished$(NC)\n"
 compile_keepversion:
 	@pnpm run build

--- a/packages/backend.ai-docs-toolkit/package.json
+++ b/packages/backend.ai-docs-toolkit/package.json
@@ -1,10 +1,11 @@
 {
   "name": "backend.ai-docs-toolkit",
-  "version": "0.1.0",
+  "version": "26.5.0-alpha.0",
   "description": "A reusable documentation toolkit for generating PDFs and web previews from Markdown content",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lablup/backend.ai-webui/tree/main/packages/backend.ai-docs-toolkit"
+    "url": "git+https://github.com/lablup/backend.ai-webui.git",
+    "directory": "packages/backend.ai-docs-toolkit"
   },
   "bugs": {
     "url": "https://github.com/lablup/backend.ai-webui/issues"
@@ -23,7 +24,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "docs-toolkit": "./bin/docs-toolkit.js"
+    "docs-toolkit": "bin/docs-toolkit.js"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Resolves #8272 (FR-3321)

## Problem

`backend.ai-docs-toolkit` has an npm auto-publish workflow (`publish-backend.ai-docs-toolkit.yml`), but nothing has been published since the initial manual `0.1.0` on 2026-05-24. **99 of the last 100 workflow runs failed** (the one "success" was an alpha tag that skipped publishing).

## Root causes

| # | Cause | Failure mode | Fixed here? |
|---|-------|--------------|-------------|
| 1 | No npm **trusted publisher** configured for `backend.ai-docs-toolkit` (unlike `backend.ai-ui`, which publishes via OIDC with provenance) | Every canary publish: `npm error 404 ... could not be found or you do not have permission` | ❌ npmjs.com setting — see below |
| 2 | `make versiontag` never bumps `packages/backend.ai-docs-toolkit/package.json` | Every release-tag publish: `You cannot publish over the previously published versions: 0.1.0` | ✅ |
| 3 | `"bin": { "docs-toolkit": "./bin/docs-toolkit.js" }` — npm ≥ 11 treats the `./` prefix as invalid and **removes the bin entry at publish time** | Once auth is fixed, the published package would have no CLI (`npm warn publish "bin[docs-toolkit]" script name ... was invalid and removed`) | ✅ |

## Changes

- **Makefile**: add `packages/backend.ai-docs-toolkit/package.json` to the `versiontag` bump list, and make all `versiontag` sed patterns portable. The previous `\(...\)` groups are literal parens under GNU `sed -E`, so on Linux the version bumps were silent no-ops (the known "versiontag bumps only 5 of 7 files on Linux" gotcha). The capture groups were never referenced, so dropping them is behavior-preserving on macOS and fixes Linux.
- **packages/backend.ai-docs-toolkit/package.json**:
  - `version`: `0.1.0` → `26.5.0-alpha.0` (aligned with the monorepo; canary versions are derived from the root `package.json`, and release tags will bump this via `versiontag` from now on)
  - `bin`: `./bin/docs-toolkit.js` → `bin/docs-toolkit.js`
  - `repository`: normalized to canonical `git+https` + `directory` form (removes the other npm publish auto-correct warning)

## Remaining manual step (package owner, npmjs.com)

Canary publishes stay broken until a **Trusted Publisher** is configured for `backend.ai-docs-toolkit` (Package Settings → Publishing access → GitHub Actions), mirroring `backend.ai-ui`:

- Organization: `lablup`
- Repository: `backend.ai-webui`
- Workflow filename: `publish-backend.ai-docs-toolkit.yml`
- Environment: (leave empty)

## Verification

- GNU sed check: old pattern leaves `"version": "0.1.0"` untouched; new pattern rewrites it — verified on this Linux box.
- `make versiontag` run in the worktree bumps all six version locations (index.html ×2, manifest.json, react, backend.ai-ui, backend.ai-docs-toolkit, electron-app).
- `npm publish --dry-run` (npm 12) on the package: bin entry retained, zero `npm warn publish` auto-correct warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
