### PR TITLE
fix(FR-3322): resolve release tag from env so PDF upload survives the Playwright container

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -333,6 +333,13 @@ jobs:
             echo "::warning::No PDFs were produced; nothing to upload."
           fi
 
+      # upload-release.js normally takes the tag from GITHUB_REF_NAME, but its
+      # `git describe` fallback (workflow_dispatch on a branch ref) needs git to
+      # trust the checkout, which is owned by a different UID than the container
+      # user ("detected dubious ownership", FR-3322).
+      - name: Mark workspace safe for git inside the container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Upload PDF release assets
         if: inputs.dry_run != true
         run: node upload-release.js app

--- a/upload-release.js
+++ b/upload-release.js
@@ -7,7 +7,9 @@ const path = require('path')
  * Environment variables
  * GITHUB_TOKEN (Required): GitHub authentication token
  * REPOSITORY: Target repository to upload release asset. defaults to lablup/backend.ai-webui
- * RELEASE_TAG: Release tag, defaults to latest tag
+ * RELEASE_TAG: Release tag. When unset, falls back to GITHUB_REF_NAME if the run is
+ *              on a tag ref (GITHUB_REF_TYPE === 'tag'), and otherwise — e.g. a
+ *              workflow_dispatch on a branch — to the latest tag via `git describe`.
  */
 
 const [OWNER, REPOSITORY] = (process.env.REPOSITORY || 'lablup/backend.ai-webui').split('/')
@@ -33,6 +35,16 @@ const execCommand = async (command, ...args) => {
 const getLatestTag = async () => {
     const [stdout, _] = await execCommand('/usr/bin/env', 'git', 'describe', '--tags', '--abbrev=0')
     return stdout.trim()
+}
+
+// `release: published` events always run on the tag ref, so GITHUB_REF_NAME is
+// the release tag. Prefer it over `git describe`, which cannot run when the
+// job executes inside a container whose UID does not own the checkout
+// ("detected dubious ownership", FR-3322).
+const resolveTag = async () => {
+    if (process.env.RELEASE_TAG) return process.env.RELEASE_TAG
+    if (process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME) return process.env.GITHUB_REF_NAME
+    return await getLatestTag()
 }
 
 const getReleaseIdFromTag = async (tag) => {
@@ -61,7 +73,7 @@ const main = async () => {
 
     console.log(`found ${assets.length} asset(s): ${assets}`)
 
-    const tag = process.env.RELEASE_TAG || (await getLatestTag())
+    const tag = await resolveTag()
     const releaseId = await getReleaseIdFromTag(tag)
     // Fetch the upload URL once — it's constant per release. Calling
     // getUploadURL() per asset wastes API quota and risks rate limiting.


### PR DESCRIPTION
Resolves #8274 (FR-3322)

## Problem

Since FR-3225 (#8074) moved the `build_docs` release job into the official Playwright container, the **"Upload PDF release assets"** step fails on every release:

```
fatal: detected dubious ownership in repository at '/__w/backend.ai-webui/backend.ai-webui'
```

`upload-release.js` resolves the release tag via `git describe --tags --abbrev=0`, but inside the container the checkout is owned by a different UID, so git refuses to read the repo and the script exits 1. As a result **v26.7.1 / v26.7.2 / v26.7.3 shipped with zero User Guide PDF assets** (v26.7.0 failed too; its PDFs were uploaded manually). The PDFs themselves build fine — only the release-asset upload is broken.

## Changes

- **`upload-release.js`** — new `resolveTag()`: `RELEASE_TAG` → `GITHUB_REF_NAME` (when `GITHUB_REF_TYPE == 'tag'`, which is always the case for `release: published` events) → `git describe` fallback. The release path no longer touches git at all, container or not. This also hardens the other three upload call sites (web / mac / desktop) for free.
- **`.github/workflows/package.yml`** — add `git config --global --add safe.directory "$GITHUB_WORKSPACE"` in `build_docs` before the upload step, as defense-in-depth for the `workflow_dispatch` (branch-ref) path where the `git describe` fallback can still run inside the container.

## Verification

- `node --check upload-release.js` passes; workflow YAML parses.
- Functional test outside any git repo (so `git describe` cannot succeed):
  - `GITHUB_REF_TYPE=tag GITHUB_REF_NAME=vTEST` → script proceeds straight to the GitHub API (fails only on the dummy token with 401), proving git is never invoked on the release path.
  - without the env vars → the `git describe` fallback still runs exactly as before.
- Full end-to-end confirmation will come from the next release (or a `workflow_dispatch` dry run, which uploads the PDFs as a workflow artifact).

## Evidence

- v26.7.3 run [28952225661](https://github.com/lablup/backend.ai-webui/actions/runs/28952225661): `build_docs` → "Upload PDF release assets" fails with the dubious-ownership error after successfully building all 4 PDFs; same signature on v26.7.0–v26.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
