### PR TITLE
style(FR-3325): use token.colorError for used stroke in session statistics chart

### DIFF
--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -247,7 +247,7 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
             <Line
               type="monotone"
               dataKey="used"
-              stroke={token.colorPrimary}
+              stroke={token.colorError}
               strokeWidth={2}
               dot={{ r: 0 }}
             />


### PR DESCRIPTION
Resolves #8280 ([FR-3325](https://lablup.atlassian.net/browse/FR-3325))

## Summary
- Change the stroke color of the `used` line in the user session statistics chart (`SessionMetricGraph`) from `token.colorPrimary` to `token.colorError`, so the used amount is visually distinguished as consumption against capacity.

## Test plan
- [ ] Open the Statistics page and check the user session statistics section.
- [ ] Verify the `used` line is rendered with the error color (red) in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-3325]: https://lablup.atlassian.net/browse/FR-3325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ