### PR TITLE
feat: increase service launcher health check initial delay default to 600s

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -683,7 +683,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           port: values.commandPort ?? 8000,
           healthCheckPath: values.commandHealthCheck ?? '/health',
           modelMountDestination: values.commandModelMount ?? '/models',
-          initialDelay: values.commandInitialDelay ?? 60,
+          initialDelay: values.commandInitialDelay ?? 600,
           maxRetries: values.commandMaxRetries ?? 10,
         });
 
@@ -1013,7 +1013,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                 port: values.commandPort ?? 8000,
                 healthCheckPath: values.commandHealthCheck ?? '/health',
                 modelMountDestination,
-                initialDelay: values.commandInitialDelay ?? 60,
+                initialDelay: values.commandInitialDelay ?? 600,
                 maxRetries: values.commandMaxRetries ?? 10,
               });
 
@@ -1315,13 +1315,13 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                     startCommand,
                     commandPort: svc.port ?? 8000,
                     commandHealthCheck: svc.healthCheck?.path ?? '/health',
-                    commandInitialDelay: svc.healthCheck?.initialDelay ?? 60,
+                    commandInitialDelay: svc.healthCheck?.initialDelay ?? 600,
                     commandMaxRetries: svc.healthCheck?.maxRetries ?? 10,
                   }
                 : {
                     commandPort: 8000,
                     commandHealthCheck: '/health',
-                    commandInitialDelay: 60,
+                    commandInitialDelay: 600,
                     commandMaxRetries: 10,
                   }),
             };
@@ -1342,7 +1342,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         commandModelMount: '/models',
         commandPort: 8000,
         commandHealthCheck: '/health',
-        commandInitialDelay: 60,
+        commandInitialDelay: 600,
         commandMaxRetries: 10,
         ...RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
         ...(baiClient._config?.default_session_environment && {

--- a/react/src/helper/generateModelDefinitionYaml.ts
+++ b/react/src/helper/generateModelDefinitionYaml.ts
@@ -36,7 +36,7 @@ export interface ModelDefinitionInput {
  *       port: 8000
  *       health_check:
  *         path: /health
- *         initial_delay: 60
+ *         initial_delay: 600
  *         max_retries: 10
  * ```
  */
@@ -78,7 +78,7 @@ ${startCommandLines}
       port: ${input.port}
       health_check:
         path: "${escapeYamlString(input.healthCheckPath)}"
-        initial_delay: ${input.initialDelay ?? 60}
+        initial_delay: ${input.initialDelay ?? 600}
         max_retries: ${input.maxRetries ?? 10}
 `;
 }

--- a/react/src/helper/parseModelDefinitionYaml.test.ts
+++ b/react/src/helper/parseModelDefinitionYaml.test.ts
@@ -84,7 +84,7 @@ models:
     const result = parseModelDefinitionYaml(yaml);
     expect(result).not.toBeNull();
     expect(result!.healthCheckPath).toBe('/health');
-    expect(result!.initialDelay).toBe(60);
+    expect(result!.initialDelay).toBe(600);
     expect(result!.maxRetries).toBe(10);
     expect(result!.modelMountDestination).toBe('/data');
   });

--- a/react/src/helper/parseModelDefinitionYaml.ts
+++ b/react/src/helper/parseModelDefinitionYaml.ts
@@ -75,7 +75,7 @@ export function parseModelDefinitionYaml(
       initialDelay:
         typeof healthCheck.initial_delay === 'number'
           ? healthCheck.initial_delay
-          : 60,
+          : 600,
       maxRetries:
         typeof healthCheck.max_retries === 'number'
           ? healthCheck.max_retries


### PR DESCRIPTION
## Summary
- Increase the default health-check `initial_delay` for the service launcher from **60s to 600s**.
- Applied consistently across all default paths so create and edit flows stay in sync:
  - `ServiceLauncherPageContent.tsx` — form initial values (create/edit) and submit-time `??` fallbacks (5 sites)
  - `generateModelDefinitionYaml.ts` — generator fallback and doc example
  - `parseModelDefinitionYaml.ts` — parser fallback when the YAML omits `initial_delay`
  - `parseModelDefinitionYaml.test.ts` — default-value test expectation updated
- Existing services with an explicitly stored `initial_delay` keep their value; only the default for unset values changes.

## Test plan
- [x] `jest` — `parseModelDefinitionYaml` suite passes (9/9)
- [ ] Create a new service in the service launcher and confirm the Initial Delay field defaults to 600.
- [ ] Edit an existing service whose model-definition.yaml omits `initial_delay` and confirm the field shows 600 (existing explicit values remain unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)