### PR TITLE
fix(FR-3326): reset Prometheus query preset modal on reopen

### DIFF
--- a/react/src/__generated__/PrometheusCategorySelectQuery.graphql.ts
+++ b/react/src/__generated__/PrometheusCategorySelectQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f8f5012872e11a622e00eee300c26011>>
+ * @generated SignedSource<<f8c4a92f4c53fefe3a60aefecff6ee25>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,16 +9,16 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type PrometheusQueryPresetEditorModalCategoriesQuery$variables = Record<PropertyKey, never>;
-export type PrometheusQueryPresetEditorModalCategoriesQuery$data = {
+export type PrometheusCategorySelectQuery$variables = Record<PropertyKey, never>;
+export type PrometheusCategorySelectQuery$data = {
   readonly prometheusQueryPresetCategories: ReadonlyArray<{
     readonly id: string;
     readonly name: string;
   }> | null | undefined;
 };
-export type PrometheusQueryPresetEditorModalCategoriesQuery = {
-  response: PrometheusQueryPresetEditorModalCategoriesQuery$data;
-  variables: PrometheusQueryPresetEditorModalCategoriesQuery$variables;
+export type PrometheusCategorySelectQuery = {
+  response: PrometheusCategorySelectQuery$data;
+  variables: PrometheusCategorySelectQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -54,7 +54,7 @@ return {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "PrometheusQueryPresetEditorModalCategoriesQuery",
+    "name": "PrometheusCategorySelectQuery",
     "selections": (v0/*: any*/),
     "type": "Query",
     "abstractKey": null
@@ -63,20 +63,20 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "PrometheusQueryPresetEditorModalCategoriesQuery",
+    "name": "PrometheusCategorySelectQuery",
     "selections": (v0/*: any*/)
   },
   "params": {
-    "cacheID": "c28830526d915797ea01849675c06f38",
+    "cacheID": "e817765b1c8f0f8bdcd0bc42497d8b22",
     "id": null,
     "metadata": {},
-    "name": "PrometheusQueryPresetEditorModalCategoriesQuery",
+    "name": "PrometheusCategorySelectQuery",
     "operationKind": "query",
-    "text": "query PrometheusQueryPresetEditorModalCategoriesQuery {\n  prometheusQueryPresetCategories {\n    id\n    name\n  }\n}\n"
+    "text": "query PrometheusCategorySelectQuery {\n  prometheusQueryPresetCategories {\n    id\n    name\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "06a58c02ded799e824d13c84845ee7f2";
+(node as any).hash = "22d271feb4bf2c935814101761d7b03e";
 
 export default node;

--- a/react/src/components/PrometheusCategorySelect.tsx
+++ b/react/src/components/PrometheusCategorySelect.tsx
@@ -1,0 +1,56 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { PrometheusCategorySelectQuery } from '../__generated__/PrometheusCategorySelectQuery.graphql';
+import { BAISelect, BAISelectProps } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * Category picker for the Prometheus query preset editor. Fetches the category
+ * list itself via `useLazyLoadQuery`, so it suspends until the list resolves —
+ * the caller owns the `<Suspense>` boundary (see `PrometheusQueryPresetEditorModal`)
+ * so it can scope the fallback to just this field and keep the rest of the form
+ * interactive. Owns the category-picker defaults (clearable, empty-state copy);
+ * control props injected by the enclosing `Form.Item` flow through to the
+ * underlying select, and callers can still override any default via props.
+ */
+const PrometheusCategorySelect: React.FC<BAISelectProps> = (props) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { prometheusQueryPresetCategories } =
+    useLazyLoadQuery<PrometheusCategorySelectQuery>(
+      graphql`
+        query PrometheusCategorySelectQuery {
+          prometheusQueryPresetCategories {
+            id
+            name
+          }
+        }
+      `,
+      {},
+    );
+
+  // The list query may legitimately return an empty array in dev environments
+  // where no categories are seeded; the form must still submit fine with
+  // categoryId left null.
+  const options = _.map(prometheusQueryPresetCategories ?? [], (category) => ({
+    label: category.name,
+    value: category.id,
+  }));
+
+  return (
+    <BAISelect
+      allowClear
+      placeholder={t('prometheusQueryPreset.NoCategory')}
+      notFoundContent={t('prometheusQueryPreset.NoCategory')}
+      options={options}
+      {...props}
+    />
+  );
+};
+
+export default PrometheusCategorySelect;

--- a/react/src/components/PrometheusPresetTab.tsx
+++ b/react/src/components/PrometheusPresetTab.tsx
@@ -8,7 +8,6 @@ import {
   PrometheusPresetTabQuery$variables,
   QueryDefinitionFilter,
 } from '../__generated__/PrometheusPresetTabQuery.graphql';
-import { PrometheusQueryPresetEditorModalFragment$key } from '../__generated__/PrometheusQueryPresetEditorModalFragment.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -16,13 +15,16 @@ import AutoUpdateFetchKeyButton, {
   LONG_AUTO_UPDATE_DELAY_OPTIONS,
 } from './AutoUpdateFetchKeyButton';
 import PrometheusQueryPresetEditorModal from './PrometheusQueryPresetEditorModal';
-import PrometheusQueryPresetNodes from './PrometheusQueryPresetNodes';
+import PrometheusQueryPresetNodes, {
+  PrometheusQueryPresetNodeInList,
+} from './PrometheusQueryPresetNodes';
 import { App } from 'antd';
 import {
   BAIButton,
   BAIDeleteConfirmModal,
   BAIFlex,
   BAIGraphQLPropertyFilter,
+  BAIUnmountAfterClose,
   INITIAL_FETCH_KEY,
   toLocalId,
   useFetchKey,
@@ -63,12 +65,20 @@ const PrometheusPresetTab: React.FC = () => {
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [isOpenEditorModal, setIsOpenEditorModal] = useState(false);
   const [editingPreset, setEditingPreset] =
-    useState<PrometheusQueryPresetEditorModalFragment$key | null>(null);
+    useState<PrometheusQueryPresetNodeInList | null>(null);
   const [deletingPreset, setDeletingPreset] =
     useState<DeletingPresetTarget | null>(null);
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.PrometheusPresetTab',
   );
+
+  // The editor's category picker (`PrometheusCategorySelect`) fetches its own
+  // query inside its own Suspense boundary, so opening is a plain state update —
+  // no preloading, and the surrounding preset list never suspends.
+  const openEditor = (preset?: PrometheusQueryPresetNodeInList | null) => {
+    setEditingPreset(preset ?? null);
+    setIsOpenEditorModal(true);
+  };
 
   const [commitDeleteMutation, isInflightDelete] =
     useMutation<PrometheusPresetTabDeleteMutation>(graphql`
@@ -164,7 +174,7 @@ const PrometheusPresetTab: React.FC = () => {
           <BAIButton
             type="primary"
             icon={<PlusIcon />}
-            onClick={() => setIsOpenEditorModal(true)}
+            onClick={() => openEditor()}
           >
             {t('prometheusQueryPreset.CreatePreset')}
           </BAIButton>
@@ -191,25 +201,24 @@ const PrometheusPresetTab: React.FC = () => {
           columnOverrides,
           onColumnOverridesChange: setColumnOverrides,
         }}
-        onEditPreset={(preset) => {
-          setIsOpenEditorModal(true);
-          setEditingPreset(preset);
-        }}
+        onEditPreset={(preset) => openEditor(preset)}
         onDeletePreset={(preset) => {
           setDeletingPreset({ id: preset.id, name: preset.name });
         }}
       />
-      <PrometheusQueryPresetEditorModal
-        open={isOpenEditorModal}
-        presetFrgmt={editingPreset}
-        onRequestClose={(success) => {
-          setIsOpenEditorModal(false);
-          setEditingPreset(null);
-          if (success) {
-            updateFetchKey();
-          }
-        }}
-      />
+      <BAIUnmountAfterClose>
+        <PrometheusQueryPresetEditorModal
+          open={isOpenEditorModal}
+          presetFrgmt={editingPreset}
+          onRequestClose={(success) => {
+            setIsOpenEditorModal(false);
+            setEditingPreset(null);
+            if (success) {
+              updateFetchKey();
+            }
+          }}
+        />
+      </BAIUnmountAfterClose>
       <BAIDeleteConfirmModal
         open={!!deletingPreset}
         title={t('prometheusQueryPreset.PermanentlyDeletePreset', {

--- a/react/src/components/PrometheusQueryPresetEditorModal.tsx
+++ b/react/src/components/PrometheusQueryPresetEditorModal.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { PrometheusQueryPresetEditorModalCategoriesQuery } from '../__generated__/PrometheusQueryPresetEditorModalCategoriesQuery.graphql';
 import { PrometheusQueryPresetEditorModalCreateMutation } from '../__generated__/PrometheusQueryPresetEditorModalCreateMutation.graphql';
 import {
   PrometheusQueryPresetEditorModalFragment$data,
@@ -10,6 +9,7 @@ import {
 } from '../__generated__/PrometheusQueryPresetEditorModalFragment.graphql';
 import { PrometheusQueryPresetEditorModalUpdateMutation } from '../__generated__/PrometheusQueryPresetEditorModalUpdateMutation.graphql';
 import { useCurrentUserRole } from '../hooks/backendai';
+import PrometheusCategorySelect from './PrometheusCategorySelect';
 import PrometheusQueryTemplatePreview from './PrometheusQueryTemplatePreview';
 import { App, Form, Input } from 'antd';
 import {
@@ -20,14 +20,9 @@ import {
   useBAILogger,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React, { useDeferredValue } from 'react';
+import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  graphql,
-  useFragment,
-  useLazyLoadQuery,
-  useMutation,
-} from 'react-relay';
+import { graphql, useFragment, useMutation } from 'react-relay';
 
 const { TextArea } = Input;
 
@@ -89,7 +84,6 @@ const PrometheusQueryPresetEditorModal: React.FC<
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const currentUserRole = useCurrentUserRole();
-  const deferredOpen = useDeferredValue(baiModalProps.open);
 
   const preset = useFragment(
     graphql`
@@ -110,40 +104,9 @@ const PrometheusQueryPresetEditorModal: React.FC<
     presetFrgmt ?? null,
   );
 
-  // Only hit the network once the deferred-open state stabilizes; until then
-  // 'store-only' returns cached data (or null) without suspending so the
-  // BAIModal stays mounted and shows its built-in loading state via the
-  // `loading={deferredOpen !== baiModalProps.open}` prop below.
-  const { prometheusQueryPresetCategories } =
-    useLazyLoadQuery<PrometheusQueryPresetEditorModalCategoriesQuery>(
-      graphql`
-        query PrometheusQueryPresetEditorModalCategoriesQuery {
-          prometheusQueryPresetCategories {
-            id
-            name
-          }
-        }
-      `,
-      {},
-      {
-        fetchPolicy:
-          deferredOpen && baiModalProps.open
-            ? 'store-and-network'
-            : 'store-only',
-      },
-    );
-
-  // The list query may legitimately return an empty array in dev environments
-  // where no categories are seeded; the form must still submit fine with
-  // categoryId left null.
-  const categoryOptions = _.map(
-    prometheusQueryPresetCategories ?? [],
-    (category) => ({
-      label: category.name,
-      value: category.id,
-    }),
-  );
-
+  // The parent unmounts this modal on close via `BAIUnmountAfterClose`, so a
+  // fresh form instance re-applies `initialValues` on every open — stale values
+  // are never carried across reopens (FR-3326).
   const [form] = Form.useForm<PrometheusQueryPresetFormValues>();
   const watchedQueryTemplate = Form.useWatch('queryTemplate', form);
 
@@ -321,8 +284,6 @@ const PrometheusQueryPresetEditorModal: React.FC<
       onOk={handleOk}
       onCancel={handleCancel}
       centered
-      destroyOnHidden
-      loading={deferredOpen !== baiModalProps.open}
       title={
         preset
           ? t('prometheusQueryPreset.EditPreset')
@@ -334,7 +295,6 @@ const PrometheusQueryPresetEditorModal: React.FC<
       <Form
         form={form}
         layout="vertical"
-        preserve={false}
         scrollToFirstError
         initialValues={getInitialValues(preset ?? null)}
       >
@@ -359,17 +319,20 @@ const PrometheusQueryPresetEditorModal: React.FC<
           <TextArea autoSize={{ minRows: 2, maxRows: 4 }} />
         </Form.Item>
 
-        <Form.Item
-          label={t('prometheusQueryPreset.Category')}
-          name="categoryId"
+        <Suspense
+          fallback={
+            <Form.Item label={t('prometheusQueryPreset.Category')}>
+              <BAISelect loading />
+            </Form.Item>
+          }
         >
-          <BAISelect
-            allowClear
-            placeholder={t('prometheusQueryPreset.NoCategory')}
-            options={categoryOptions}
-            notFoundContent={t('prometheusQueryPreset.NoCategory')}
-          />
-        </Form.Item>
+          <Form.Item
+            label={t('prometheusQueryPreset.Category')}
+            name="categoryId"
+          >
+            <PrometheusCategorySelect />
+          </Form.Item>
+        </Suspense>
 
         <Form.Item
           label={t('prometheusQueryPreset.MetricName')}

--- a/react/src/components/PrometheusQueryPresetNodes.tsx
+++ b/react/src/components/PrometheusQueryPresetNodes.tsx
@@ -2,7 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { PrometheusQueryPresetEditorModalFragment$key } from '../__generated__/PrometheusQueryPresetEditorModalFragment.graphql';
 import {
   PrometheusQueryPresetNodesFragment$data,
   PrometheusQueryPresetNodesFragment$key,
@@ -51,7 +50,7 @@ interface PrometheusQueryPresetNodesProps extends Omit<
 > {
   presetsFrgmt: PrometheusQueryPresetNodesFragment$key;
   onDeletePreset?: (preset: PrometheusQueryPresetNodeInList) => void;
-  onEditPreset?: (preset: PrometheusQueryPresetEditorModalFragment$key) => void;
+  onEditPreset?: (preset: PrometheusQueryPresetNodeInList) => void;
   customizeColumns?: (
     baseColumns: BAIColumnsType<PrometheusQueryPresetNodeInList>,
   ) => BAIColumnsType<PrometheusQueryPresetNodeInList>;


### PR DESCRIPTION
Resolves #8282 (FR-3326)

## Summary

The admin Prometheus query preset create/edit modal retained stale values from a previous open (e.g. opening the Create modal after editing a preset still showed the prior values).

Root cause: `PrometheusQueryPresetEditorModal` was kept **always-mounted** by `PrometheusPresetTab` (to avoid suspending the surrounding list when its categories query loaded). Its form instance therefore survived close, and Ant Design applies `initialValues` only once per instance lifetime — so later opens with different `initialValues` were ignored. `destroyOnHidden` / `preserve={false}` unmount the `<Form>` body but not the persistent instance, so they did not fix it (same failure mode as FR-3094).

## Approach

Fully unmount the modal on close so a fresh `Form.useForm()` instance re-applies `initialValues` on every open, and let the category picker fetch its own data behind a **local Suspense boundary** instead of preloading it in the parent:

- **`PrometheusQueryPresetEditorModal`** is wrapped in **`BAIUnmountAfterClose`** by `PrometheusPresetTab`, so it fully unmounts on close — a **fresh `Form.useForm()` instance re-applies `initialValues` on every open**, and stale state can no longer carry across reopens. This is the structural staleness fix (deterministic client-side behavior, not dependent on close-animation timing).
- **`PrometheusCategorySelect`** (new) fetches the categories query itself with `useLazyLoadQuery` and **owns its own `Suspense` boundary**. Opening the editor is now a plain state update — no `fetchQuery` / `useQueryLoader` / `usePreloadedQuery` orchestration — and the surrounding preset list never suspends while categories load (the field shows a loading Select).

## Review feedback addressed

- @nowgnuesLee — "No need to manually await `fetchQuery` here — the action already handles the transition." → removed all preloading; opening the editor is a plain state update.
- @nowgnuesLee — "Create a Select component that fetches the query itself, and wrap the select in Suspense." → added `PrometheusCategorySelect`, which self-fetches inside its own Suspense boundary.

## Changes (4 files)

- **`PrometheusCategorySelect.tsx`** (new): self-fetching category picker wrapped in its own Suspense boundary; forwards the `Form.Item` control props through to the inner `BAISelect`, and shows a loading Select as the fallback.
- **`PrometheusQueryPresetEditorModal.tsx`**: dropped the exported categories query, the `categoriesQueryRef` prop, and `usePreloadedQuery`; the Category field now renders `<PrometheusCategorySelect>`. The form staleness fix (fresh `Form.useForm()` per open via unmount) is unchanged.
- **`PrometheusPresetTab.tsx`**: removed the `fetchQuery` + `useQueryLoader` preload dance; `openEditor` is now a plain state update, the Create/Edit triggers use `onClick`, and the modal is always wrapped in `BAIUnmountAfterClose`.
- **`PrometheusQueryPresetNodes.tsx`**: the row Edit action reverts to a synchronous `onClick`.

## How to test

**Test against a production bundle, not `pnpm dev`.** The staleness reproduces reliably only in a real build; dev-server HMR / React Fast Refresh remounts the form instance on edit and masks it.

```bash
# on this branch, from repo root
pnpm install
pnpm run build            # → build/web/
npx serve -s build/web    # or any static file server pointed at build/web
```

Then, logged in as an admin:

1. Open the Deployments admin page → **Prometheus Preset** tab (shown only when the manager supports Prometheus presets).
2. Click a preset's **Edit** action or **Create** — the modal opens immediately; the Category field shows a brief loading state on the first open while its categories load.
3. Edit a field (e.g. the query template), then **Cancel** / close.
4. Reopen — edit a different preset, or click **Create**.
   - **Before this fix:** the modal still shows the previous open's values.
   - **After this fix:** the modal shows the reopened target's own `initialValues` (Create → empty; Edit → that preset's values).

## Verification

- `pnpm relay`, `tsc` (no `react/src` errors), ESLint (0 on changed files), Prettier — all pass on the changed files.
- Note: `scripts/verify.sh` reports pre-existing, unrelated failures present on `main` (a `gpt-tokenizer` `.d.ts` parse issue and React-Compiler lint findings in untouched `packages/backend.ai-ui` components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
