### PR TITLE
fix(FR-3327): reset sibling modals on reopen with BAIUnmountAfterClose

### DIFF
--- a/react/src/components/AgentNodeItems/AgentActionButtons.tsx
+++ b/react/src/components/AgentNodeItems/AgentActionButtons.tsx
@@ -9,7 +9,12 @@ import AgentLifeCycleControlModal, {
 import AgentSettingModal from '../AgentSettingModal';
 import { PlayCircleOutlined, SettingOutlined } from '@ant-design/icons';
 import { Space, Tooltip, theme } from 'antd';
-import { BAIButton, BAIButtonProps, BAITerminateIcon } from 'backend.ai-ui';
+import {
+  BAIButton,
+  BAIButtonProps,
+  BAITerminateIcon,
+  BAIUnmountAfterClose,
+} from 'backend.ai-ui';
 import { RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -86,13 +91,15 @@ const AgentActionButtons: React.FC<AgentActionButtonsProps> = ({
         </Tooltip>
       </Space.Compact>
 
-      <AgentSettingModal
-        agentNodeFrgmt={agent}
-        open={openSettingModal}
-        onRequestClose={() => {
-          setOpenSettingModal(false);
-        }}
-      />
+      <BAIUnmountAfterClose>
+        <AgentSettingModal
+          agentNodeFrgmt={agent}
+          open={openSettingModal}
+          onRequestClose={() => {
+            setOpenSettingModal(false);
+          }}
+        />
+      </BAIUnmountAfterClose>
       <AgentLifeCycleControlModal
         open={!!lifeCycleType}
         lifeCycleType={lifeCycleType}

--- a/react/src/components/DeploymentBasicInfoCard.tsx
+++ b/react/src/components/DeploymentBasicInfoCard.tsx
@@ -399,14 +399,16 @@ const DeploymentBasicInfoCard: React.FC<DeploymentBasicInfoCardProps> = ({
           }
         />
       </BAICard>
-      <DeploymentSettingModal
-        open={settingModalOpen}
-        deploymentFrgmt={deployment}
-        onRequestClose={(success) => {
-          setSettingModalOpen(false);
-          if (success) onRefetch();
-        }}
-      />
+      <BAIUnmountAfterClose>
+        <DeploymentSettingModal
+          open={settingModalOpen}
+          deploymentFrgmt={deployment}
+          onRequestClose={(success) => {
+            setSettingModalOpen(false);
+            if (success) onRefetch();
+          }}
+        />
+      </BAIUnmountAfterClose>
       <BAIDeleteConfirmModal
         open={isDeleteModalOpen}
         title={t('deployment.DeleteDeployment')}

--- a/react/src/components/FolderExplorerOpener.tsx
+++ b/react/src/components/FolderExplorerOpener.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { BAIUnmountAfterClose } from 'backend.ai-ui';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { StringParam, useQueryParam } from 'use-query-params';
@@ -14,15 +15,17 @@ const FolderExplorerOpener = () => {
   const normalizedFolderId = folderId?.replaceAll('-', '');
 
   return (
-    <FolderExplorerModal
-      vfolderID={normalizedFolderId || ''}
-      open={!!normalizedFolderId}
-      onRequestClose={() => {
-        setFolderId(null, 'replaceIn');
-        setCurrentPath(null, 'replaceIn');
-      }}
-      destroyOnHidden
-    />
+    <BAIUnmountAfterClose>
+      <FolderExplorerModal
+        vfolderID={normalizedFolderId || ''}
+        open={!!normalizedFolderId}
+        onRequestClose={() => {
+          setFolderId(null, 'replaceIn');
+          setCurrentPath(null, 'replaceIn');
+        }}
+        destroyOnHidden
+      />
+    </BAIUnmountAfterClose>
   );
 };
 

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -35,6 +35,7 @@ import {
   BAINameActionCell,
   BAIDeleteConfirmModal,
   BAIQuestionIconWithTooltip,
+  BAIUnmountAfterClose,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
@@ -381,23 +382,25 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         }}
       />
       <Suspense>
-        <KeypairResourcePolicySettingModal
-          existingPolicyNames={_.map(
-            keypair_resource_policies,
-            (policy) => policy?.name || '',
-          )}
-          open={!!editingKeypairResourcePolicy || isCreatingPolicySetting}
-          keypairResourcePolicyFrgmt={editingKeypairResourcePolicy || null}
-          onRequestClose={(success) => {
-            setEditingKeypairResourcePolicy(null);
-            setIsCreatingPolicySetting(false);
-            if (success) {
-              startRefetchTransition(() => {
-                updateKeypairResourcePolicyFetchKey();
-              });
-            }
-          }}
-        />
+        <BAIUnmountAfterClose>
+          <KeypairResourcePolicySettingModal
+            existingPolicyNames={_.map(
+              keypair_resource_policies,
+              (policy) => policy?.name || '',
+            )}
+            open={!!editingKeypairResourcePolicy || isCreatingPolicySetting}
+            keypairResourcePolicyFrgmt={editingKeypairResourcePolicy || null}
+            onRequestClose={(success) => {
+              setEditingKeypairResourcePolicy(null);
+              setIsCreatingPolicySetting(false);
+              if (success) {
+                startRefetchTransition(() => {
+                  updateKeypairResourcePolicyFetchKey();
+                });
+              }
+            }}
+          />
+        </BAIUnmountAfterClose>
       </Suspense>
       <KeypairResourcePolicyInfoModal
         open={!!currentResourcePolicy || isPendingInfoModalOpen}

--- a/react/src/components/ModelCardDrawer.tsx
+++ b/react/src/components/ModelCardDrawer.tsx
@@ -359,10 +359,12 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
           />
         </BAIUnmountAfterClose>
       </Suspense>
-      <DeploymentSettingModal
-        open={isCreateDeploymentOpen}
-        onRequestClose={toggleCreateDeployment}
-      />
+      <BAIUnmountAfterClose>
+        <DeploymentSettingModal
+          open={isCreateDeploymentOpen}
+          onRequestClose={toggleCreateDeployment}
+        />
+      </BAIUnmountAfterClose>
     </>
   );
 };

--- a/react/src/components/RoleDetailDrawer.tsx
+++ b/react/src/components/RoleDetailDrawer.tsx
@@ -12,6 +12,7 @@ import {
   BAIButton,
   BAIFetchKeyButton,
   BAIFlex,
+  BAIUnmountAfterClose,
   useFetchKey,
 } from 'backend.ai-ui';
 import { EditIcon } from 'lucide-react';
@@ -106,13 +107,15 @@ const RoleDetailDrawer: React.FC<RoleDetailDrawerProps> = ({
               )}
             </BAIFlex>
             <RoleDetailDrawerContent roleNodeFrgmt={role} />
-            <RoleFormModal
-              open={isEditModalOpen}
-              roleNodeFrgmt={role}
-              onRequestClose={() => {
-                setIsEditModalOpen(false);
-              }}
-            />
+            <BAIUnmountAfterClose>
+              <RoleFormModal
+                open={isEditModalOpen}
+                roleNodeFrgmt={role}
+                onRequestClose={() => {
+                  setIsEditModalOpen(false);
+                }}
+              />
+            </BAIUnmountAfterClose>
           </BAIFlex>
         )}
       </Suspense>

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -63,6 +63,7 @@ import {
   BAISessionClusterMode,
   INITIAL_FETCH_KEY,
   BAIButton,
+  BAIUnmountAfterClose,
   useResourceSlotsDetails,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -723,11 +724,13 @@ const SessionDetailContent: React.FC<{
         }
         onCancel={toggleOpenCodeHighlighterModal}
       />
-      <SessionSchedulingHistoryModal
-        sessionId={id}
-        open={openSessionSchedulingHistoryModal}
-        onCancel={toggleOpenSessionSchedulingHistoryModal}
-      />
+      <BAIUnmountAfterClose>
+        <SessionSchedulingHistoryModal
+          sessionId={id}
+          open={openSessionSchedulingHistoryModal}
+          onCancel={toggleOpenSessionSchedulingHistoryModal}
+        />
+      </BAIUnmountAfterClose>
       <SessionStatusDetailModal
         sessionFrgmt={session}
         open={openStatusDetailModal}

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -697,10 +697,12 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
           />
         </BAIUnmountAfterClose>
       </Suspense>
-      <DeploymentSettingModal
-        open={isCreateDeploymentOpen}
-        onRequestClose={toggleCreateDeployment}
-      />
+      <BAIUnmountAfterClose>
+        <DeploymentSettingModal
+          open={isCreateDeploymentOpen}
+          onRequestClose={toggleCreateDeployment}
+        />
+      </BAIUnmountAfterClose>
     </>
   );
 };

--- a/react/src/components/VFolderNodesV2.tsx
+++ b/react/src/components/VFolderNodesV2.tsx
@@ -873,10 +873,12 @@ const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
           />
         </BAIUnmountAfterClose>
       </Suspense>
-      <DeploymentSettingModal
-        open={isCreateDeploymentOpen}
-        onRequestClose={toggleCreateDeployment}
-      />
+      <BAIUnmountAfterClose>
+        <DeploymentSettingModal
+          open={isCreateDeploymentOpen}
+          onRequestClose={toggleCreateDeployment}
+        />
+      </BAIUnmountAfterClose>
       <HostQuotaModal
         open={isHostQuotaModalOpen}
         onCancel={() => setIsHostQuotaModalOpen(false)}

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -449,14 +449,16 @@ const AdminDeploymentListPageContent: React.FC = () => {
           }}
         />
       </BAIFlex>
-      <DeploymentSettingModal
-        open={!!editingDeployment}
-        deploymentFrgmt={editingDeployment ?? null}
-        onRequestClose={(success) => {
-          setEditingDeploymentId(null);
-          if (success) updateFetchKey();
-        }}
-      />
+      <BAIUnmountAfterClose>
+        <DeploymentSettingModal
+          open={!!editingDeployment}
+          deploymentFrgmt={editingDeployment ?? null}
+          onRequestClose={(success) => {
+            setEditingDeploymentId(null);
+            if (success) updateFetchKey();
+          }}
+        />
+      </BAIUnmountAfterClose>
       <BAIDeleteConfirmModal
         open={!!deletingDeployment}
         title={t('deployment.DeleteDeployment')}

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -411,14 +411,16 @@ const ProjectAdminDeploymentsContent: React.FC<
           }}
         />
       </BAIFlex>
-      <DeploymentSettingModal
-        open={!!editingDeployment}
-        deploymentFrgmt={editingDeployment ?? null}
-        onRequestClose={(success) => {
-          setEditingDeploymentId(null);
-          if (success) updateFetchKey();
-        }}
-      />
+      <BAIUnmountAfterClose>
+        <DeploymentSettingModal
+          open={!!editingDeployment}
+          deploymentFrgmt={editingDeployment ?? null}
+          onRequestClose={(success) => {
+            setEditingDeploymentId(null);
+            if (success) updateFetchKey();
+          }}
+        />
+      </BAIUnmountAfterClose>
       <BAIDeleteConfirmModal
         open={!!deletingDeployment}
         title={t('deployment.DeleteDeployment')}

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -29,6 +29,7 @@ import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
+  BAIUnmountAfterClose,
   filterOutEmpty,
   INITIAL_FETCH_KEY,
   toLocalId,
@@ -381,15 +382,17 @@ const RBACManagementPage: React.FC = () => {
           }}
         />
       </BAIFlex>
-      <RoleFormModal
-        open={isCreateModalOpen}
-        onRequestClose={(success) => {
-          setIsCreateModalOpen(false);
-          if (success) {
-            updateFetchKey();
-          }
-        }}
-      />
+      <BAIUnmountAfterClose>
+        <RoleFormModal
+          open={isCreateModalOpen}
+          onRequestClose={(success) => {
+            setIsCreateModalOpen(false);
+            if (success) {
+              updateFetchKey();
+            }
+          }}
+        />
+      </BAIUnmountAfterClose>
       <RoleDetailDrawer
         open={!!selectedRole}
         roleFrgmt={selectedRole}

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -27,7 +27,7 @@ import { useThemeMode } from '../hooks/useThemeMode';
 import { SettingOutlined } from '@ant-design/icons';
 import { useSessionStorageState, useToggle } from 'ahooks';
 import { App, Button, Skeleton, Typography } from 'antd';
-import { BAICard, filterOutEmpty } from 'backend.ai-ui';
+import { BAICard, BAIUnmountAfterClose, filterOutEmpty } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { Suspense, useEffect, useEffectEvent, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -537,10 +537,12 @@ const UserPreferencesPage = () => {
         </Suspense>
       </BAICard>
       {baiClient?.supports('my-keypairs') ? (
-        <MyKeypairManagementModal
-          open={isOpenSSHKeypairInfoModal}
-          onRequestClose={toggleSSHKeypairInfoModal}
-        />
+        <BAIUnmountAfterClose>
+          <MyKeypairManagementModal
+            open={isOpenSSHKeypairInfoModal}
+            onRequestClose={toggleSSHKeypairInfoModal}
+          />
+        </BAIUnmountAfterClose>
       ) : (
         <MyKeypairInfoModalLegacy
           open={isOpenSSHKeypairInfoModal}


### PR DESCRIPTION
Resolves #8284 (FR-3327)

> **Stacked on** #8285 (FR-3326). Merge that first.

## Summary

Follow-up to #8285 (FR-3326) / #7970 (FR-3094). An audit of all form/query-owning modals found more modals with the same **reopen-staleness** bug: they are kept **always-mounted** by their parent and own component-body state — `Form.useForm()`, a Relay `useLazyLoadQuery`, or un-reset `useState` — that `destroyOnHidden` / `preserve={false}` cannot reset (those unmount the `<Form>` body but not the persistent instance/hook state). So on the next open they show stale values from a previous open.

The fix is uniform and structural: wrap each call site in **`<BAIUnmountAfterClose>`** so the modal fully unmounts on close and remounts with fresh state on the next open — the same canonical approach 8285 uses for the Prometheus preset modal.

## Approach

`<BAIUnmountAfterClose>` keeps its child mounted while `open` is `true`, then unmounts it once the close animation finishes. A fully unmounted modal re-runs `Form.useForm()`, `useLazyLoadQuery`, and `useState` from scratch on the next open, so `initialValues` re-apply and no stale value can carry across reopens. This is deterministic client-side behavior, not dependent on close-animation timing.

The change is purely additive at each call site: add the `BAIUnmountAfterClose` import and wrap the existing modal element. No modal internals, props, or `destroyOnHidden` usages are removed.

## Changes (7 modals, 13 call sites)

| Modal | Leak source | Call site(s) |
|---|---|---|
| `DeploymentSettingModal` | `Form.useForm()` + fragment `initialValues` | `DeploymentBasicInfoCard.tsx`, `ModelCardDrawer.tsx`, `VFolderNodes.tsx`, `VFolderNodesV2.tsx`, `AdminDeploymentListPage.tsx`, `ProjectAdminDeploymentsPage.tsx` |
| `RoleFormModal` | `Form.useForm()` + `useLazyLoadQuery` ×3 | `RoleDetailDrawer.tsx`, `RBACManagementPage.tsx` |
| `AgentSettingModal` | body `useLazyLoadQuery` | `AgentNodeItems/AgentActionButtons.tsx` |
| `KeypairResourcePolicySettingModal` | body `useLazyLoadQuery` | `KeypairResourcePolicyList.tsx` |
| `MyKeypairManagementModal` | body `useLazyLoadQuery` + `useState` | `UserSettingsPage.tsx` |
| `FolderExplorerModalV2` | body `useLazyLoadQuery` + `useState` | `FolderExplorerOpener.tsx` |
| `SessionSchedulingHistoryModal` | body `useLazyLoadQuery` + `useState` | `SessionDetailContent.tsx` |

Note: `DeploymentSettingModal` has 6 call sites here. FR-3094 (#7970) only wrapped `DeploymentListPage.tsx`; the other six live sites (including the three drawer/list embeds `ModelCardDrawer`, `VFolderNodes`, `VFolderNodesV2`) were never reached by that PR.

## Scope notes

- **Excluded as false positives** (audited SAFE — ref-based `<Form>` + `destroyOnHidden`, no body query/state, so they reset correctly): `ResourceGroupSettingModal`, `ResourcePresetSettingModal`, `KeypairSettingModal`, `ManageImageResourceLimitModal`, `ProjectResourcePolicySettingModal`, `UserResourcePolicySettingModal`, `TableColumnsSettingModal`, `FolderCreateModalV2`, `SchedulerSettingModal`.
- **Deferred (borderline, low impact)**: `SignupModal`, `ImportArtifactRevisionToFolderModal` — noted in FR-3327 for later.

## How to test

**Test against a production bundle, not `pnpm dev`.** The staleness reproduces reliably only in a real build; dev-server HMR / React Fast Refresh remounts the component on edit and masks it (same as FR-3326 / FR-3094).

```bash
# on this branch, from repo root
pnpm install
pnpm run build            # → build/web/
npx serve -s build/web    # or any static file server pointed at build/web
```

Then, logged in with the appropriate privileges, for each modal below:

1. Open the modal against one target, change a field (or observe the loaded values), then **Cancel** / close.
2. Reopen against a **different** target (or switch Edit → Create).
   - **Before this fix:** the modal still shows the previous open's values.
   - **After this fix:** the modal shows the reopened target's own values (Create → empty; Edit → that target's values).

| Modal | Where |
|---|---|
| `DeploymentSettingModal` | Deployments list/detail, model card drawer, VFolder rows → **Create / Edit deployment** |
| `RoleFormModal` | RBAC management page + role detail drawer → **Create / Edit role** |
| `AgentSettingModal` | Agent node action buttons → **Edit agent settings** |
| `KeypairResourcePolicySettingModal` | Keypair resource policy list → **Create / Edit policy** |
| `MyKeypairManagementModal` | User settings → **Manage my keypair** |
| `FolderExplorerModalV2` | Open two different folders in succession |
| `SessionSchedulingHistoryModal` | Session detail → scheduling history, across two different sessions |

## Verification

Static checks on the 13 changed files:

- **Relay compile**, **`tsc`** (no `react/src` errors), and **ESLint (0 errors)** all pass. The changes are purely additive (import + wrap), so no type/lint surface changes.
- Pre-existing, unrelated `scripts/verify.sh` failures are present on the #8285 base and untouched here: 19 React-Compiler ESLint errors under `packages/backend.ai-ui/src/**` (none of which 8286 touches) and a Prettier drift in `DeploymentBasicInfoCard.tsx` lines 66–68 (a pre-existing type-union wrap outside this PR's hunks).

Production bundle, served and tested (bundle `26.8.0-alpha.0` build 8450, against a live manager `26.7.0`):

- `pnpm run build` → `serve -s build/web` boots cleanly — login screen renders, **0 console / JS errors**.
- **Reopen-staleness manually verified in the served bundle** across both leak classes plus the flagship modal:
  - **`KeypairResourcePolicySettingModal`** (`useLazyLoadQuery`): Edit `e2e-kp-policy-…` (Name pre-filled) → Cancel → **Create** → Name is **empty** and the whole form reset (Cluster Size 2 → default 1). ✅
  - **`RoleFormModal`** (`Form.useForm()`): Create → type `STALE_TEST_ROLE` → Cancel → reopen Create → Name **empty**. ✅
  - **`DeploymentSettingModal`** (`Form.useForm()` + fragment `initialValues`, 6 sites): Edit deployment A → change Name → Cancel → reopen Edit A → Name **reverts to the real value**; Edit A → Cancel → Edit B → shows **B's** name, not stale A. ✅
- The remaining four modals (`AgentSettingModal`, `MyKeypairManagementModal`, `FolderExplorerModalV2`, `SessionSchedulingHistoryModal`) apply the identical `<BAIUnmountAfterClose>` wrapper over the same leak sources (`useLazyLoadQuery` ± `useState`), already covered by the verified cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
