### PR TITLE
test: e2e auto-heal 2026-07-14

### DIFF
--- a/e2e/utils/user-profile-util.ts
+++ b/e2e/utils/user-profile-util.ts
@@ -105,7 +105,16 @@ export async function removeAllIpTags(container: Locator) {
   // Backspace removes the last selected tag in an antd Select. Keep pressing
   // until none remain, with a safety cap so a stuck DOM can't cause an infinite
   // loop. The cap is generous enough for any realistic Allowed Client IP list.
-  const tags = formItem.locator('.ant-select-selection-item');
+  //
+  // The Allowed Client IP field uses a custom `tagRender` (see
+  // UserProfileSettingModal.tsx / UserSettingModal.tsx) that renders each
+  // selected value as a plain antd `<Tag>` (`.ant-tag`) instead of the
+  // default `.ant-select-selection-item` markup. Using the default selector
+  // here made `tags.count()` always resolve to 0, so the loop exited before
+  // ever pressing Backspace — a silent no-op that left the form untouched,
+  // caused the "no changes" message instead of a real update, and left the
+  // modal open (blocking any subsequent reopen click).
+  const tags = formItem.locator('.ant-tag');
   for (let safety = 0; safety < 100; safety++) {
     const remaining = await tags.count();
     if (remaining === 0) break;


### PR DESCRIPTION
## Daily digest auto-heal (2026-07-14)

Produced automatically by the **daily backend.ai-webui digest** e2e auto-heal step. Fixes test-side drift/flakes that were triaged as `HEAL` (safe to auto-fix, no app-intent change). No app source was modified — only e2e test files.

Report doc: `/home/ubuntu/e2e-digest-reports/report-2026-07-14.md`

### ✅ Healed (verified re-pass)
- `e2e/user/user-crud.spec.ts` — "Admin can deactivate and permanently delete (purge) a user" (8/8 pass)
- `e2e/user-profile/user-ip-restriction-enforcement.spec.ts` — "Admin can clean up: remove IP restriction and delete test user" (6/6 pass)
- `e2e/user-profile/user-profile.spec.ts` — "User can clear all allowed client IPs (remove restriction)" (20/20 pass, via shared `e2e/utils/user-profile-util.ts` fix)

### Fixes
- **`removeAllIpTags` was a silent no-op** (`e2e/utils/user-profile-util.ts`): counted tags via `.ant-select-selection-item`, but the Allowed Client IP field uses a custom `tagRender` producing `.ant-tag`. Count was always 0, so no Backspace was ever pressed. Selector corrected to `.ant-tag`.

### 🔄 Reverted after review
- ~~**Bulk-purge doesn't refetch the user list**: the two user-crud tests now click the toolbar reload button after confirming a bulk purge.~~ Reverted per review — the missing refetch was a real app regression (`updateFetchKey()` commented out in `AdminUserManagement.tsx`, introduced in FR-3019 / #7673), not test drift. It was fixed in **FR-3328 / #8290** (merged), so the tests now verify the auto-refetch behavior directly instead of papering over it with a manual reload click.

### ⛔ Retry budget exhausted
None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — daily digest auto-heal
