### PR TITLE
fix(FR-3328): refetch user list after bulk purge

### DIFF
--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -651,7 +651,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onOk={() => {
             togglePurgeUsersModal();
             setSelectedUserList([]);
-            // updateFetchKey();
+            updateFetchKey();
           }}
           onCancel={() => {
             togglePurgeUsersModal();


### PR DESCRIPTION
Resolves #8289 (FR-3328)

## Problem

After a **bulk** user purge, the Active/Inactive user table was not refetched, so purged rows stayed visible with stale data until the user manually clicked the toolbar reload button. Basic CUD actions should reflect in the list immediately, without the user pressing refresh.

## Root cause

Regression from FR-3019 (PR #7673, "migrate Purge/Update user modals to UserV2 fragment"), which commented out the `updateFetchKey()` call in the **bulk** purge modal's `onOk` in `AdminUserManagement.tsx`:

```tsx
onOk={() => {
  togglePurgeUsersModal();
  setSelectedUserList([]);
  // updateFetchKey();   ← accidentally commented out in FR-3019
}}
```

The single-row purge modal (same `PurgeUsersModal` component) kept its `updateFetchKey()`, and every other CUD path in this component (create, bulk-create, CSV bulk-create, update) already refetches — only the bulk purge path regressed. It was originally correct in FR-1820 (PR #5001).

`PurgeUsersModal` invokes the parent `onOk` only when `purgedCount > 0` (i.e. after a successful purge), so restoring the call refetches at the correct moment.

## Fix

Restore the `updateFetchKey()` call in the bulk purge `onOk`.

## Relation to PR #8288

PR #8288 (daily e2e auto-heal) papered over this by clicking the toolbar reload button before asserting purged rows are hidden. Its own description already flagged this as a "suspected real app bug." Once this fix lands, those explicit-reload workarounds in the e2e tests should be reverted so the tests verify the real auto-refetch behavior. (Left a review on #8288 noting this.)

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)