### PR TITLE
fix: guard writeHashedAsset against path traversal via logicalName

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/asset-hasher.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/asset-hasher.test.ts
@@ -82,6 +82,23 @@ test("writeHashedAsset — different bytes for the same logical name produce dif
   }
 });
 
+test("writeHashedAsset — rejects a logicalName that escapes assetsDir via path traversal", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hasher-"));
+  try {
+    const manifest: AssetManifest = {};
+    assert.throws(
+      () => writeHashedAsset(dir, "../../../../etc/passwd", "pwned", manifest),
+      /refusing to write outside assetsDir/,
+    );
+    // The throw happens before the manifest is updated, and assetsDir
+    // itself stays empty — nothing was written anywhere.
+    assert.deepEqual(manifest, {});
+    assert.deepEqual(fs.readdirSync(dir), []);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("resolveAsset — returns the hashed name for a registered asset", () => {
   const manifest: AssetManifest = { "search.js": "search.cafef00d.js" };
   assert.equal(resolveAsset(manifest, "search.js"), "search.cafef00d.js");

--- a/packages/backend.ai-docs-toolkit/src/asset-hasher.ts
+++ b/packages/backend.ai-docs-toolkit/src/asset-hasher.ts
@@ -45,7 +45,17 @@ export function writeHashedAsset(
   const hash = contentHash(bytes);
   const hashedName = hashedFilename(logicalName, hash);
   fs.mkdirSync(assetsDir, { recursive: true });
-  fs.writeFileSync(path.join(assetsDir, hashedName), bytes);
+  // `logicalName` can carry `../` segments (e.g. a malformed branding config
+  // path); resolve and confirm the write target stays inside `assetsDir`
+  // before touching the filesystem.
+  const resolvedAssetsDir = path.resolve(assetsDir);
+  const targetPath = path.resolve(resolvedAssetsDir, hashedName);
+  if (targetPath !== resolvedAssetsDir && !targetPath.startsWith(resolvedAssetsDir + path.sep)) {
+    throw new Error(
+      `writeHashedAsset: refusing to write outside assetsDir (logicalName: ${JSON.stringify(logicalName)})`,
+    );
+  }
+  fs.writeFileSync(targetPath, bytes);
   manifest[logicalName] = hashedName;
   return hashedName;
 }


### PR DESCRIPTION
## Summary

- `writeHashedAsset()` in `packages/backend.ai-docs-toolkit/src/asset-hasher.ts` joined `assetsDir` with a hash-derived filename via `path.join` without verifying the result stayed inside `assetsDir`. A `logicalName` containing `../` segments (e.g. a malformed branding config path) could escape `assetsDir` and write to an arbitrary path reachable by the docs-toolkit build process.
- Resolves both the target path and `assetsDir`, and throws before writing if the target escapes `assetsDir`.
- Adds a regression test (`asset-hasher.test.ts`) covering the traversal case.

This re-implements the fix originally proposed in #7353 by @tomaioo. That PR's diagnosis and patch are correct, but it can't be merged as-is because the CLA check is unsigned and there's been no activity in ~2 months. See the comment left on #7353.

## Test plan

- [x] `pnpm --filter backend.ai-docs-toolkit run build` (tsc) passes
- [x] `pnpm --filter backend.ai-docs-toolkit run test` — 269 pass, 0 fail (new regression test included)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
