### PR TITLE
fix(FR-3321): publish docs-toolkit with pnpm, matching backend.ai-ui

### DIFF
--- a/.github/workflows/publish-backend.ai-docs-toolkit.yml
+++ b/.github/workflows/publish-backend.ai-docs-toolkit.yml
@@ -54,7 +54,7 @@ jobs:
         if: github.ref_type == 'branch'
         run: |
           cd packages/backend.ai-docs-toolkit
-          npm publish --tag canary --access public --no-git-checks
+          pnpm publish --tag canary --access public --no-git-checks
 
       - name: Determine npm tag and publish strategy
         if: github.ref_type == 'tag'
@@ -78,4 +78,4 @@ jobs:
         if: github.ref_type == 'tag' && steps.determine-tag.outputs.should_publish == 'true'
         run: |
           cd packages/backend.ai-docs-toolkit
-          npm publish --tag ${{ steps.determine-tag.outputs.npm_tag }} --access public --no-git-checks
+          pnpm publish --tag ${{ steps.determine-tag.outputs.npm_tag }} --access public --no-git-checks


### PR DESCRIPTION
Refs #8272 (FR-3321) — follow-up to #8273

## Problem

After #8273, `backend.ai-docs-toolkit` publishes still fail — but with a new error that now kills the run **before authentication is even attempted**:

```
npm error code EUNKNOWNCONFIG
npm error Unknown cli flag:
npm error   - --git-checks
```

`--no-git-checks` is a **pnpm** flag, not an npm one. The workflow installs `npm@latest`; npm 11 only warned about the unknown flag ("this will stop working in the next major version"), but npm 12 — now what `npm@latest` resolves to — hard-errors on it. `publish-backend.ai-ui.yml` is unaffected because it uses `pnpm publish`.

## Change

Switch both publish steps from `npm publish` to `pnpm publish`, the proven-working path. After this change the two publish workflows are **identical modulo package name** (verified by diff).

## Note

Once this lands, the run will finally reach the registry auth step. If the npmjs **Trusted Publisher** for `backend.ai-docs-toolkit` (Settings → Publishing access: `lablup/backend.ai-webui`, workflow `publish-backend.ai-docs-toolkit.yml`, no environment) has not been configured yet, the run will fail with the original `npm error 404` — that part is an npmjs.com setting and cannot be fixed in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
