### PR TITLE
chore(FR-3321): allow manual dispatch of the docs-toolkit publish workflow

### DIFF
--- a/.github/workflows/publish-backend.ai-docs-toolkit.yml
+++ b/.github/workflows/publish-backend.ai-docs-toolkit.yml
@@ -1,6 +1,7 @@
 name: Publish Backend.ai-docs-toolkit to npm registry
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - packages/backend.ai-docs-toolkit/**


### PR DESCRIPTION
Refs #8272 (FR-3321) — follow-up to #8273 / #8305

## Why

The publish workflow only triggers on `packages/backend.ai-docs-toolkit/**` pushes to main (plus release tags). Publish-pipeline fixes that touch only the workflow file — like #8305 — therefore can't be verified until some unrelated docs-toolkit commit happens to land on main, and the npmjs Trusted Publisher configuration can't be smoke-tested on demand either.

## Change

Add `workflow_dispatch:` so the canary publish path can be triggered manually from the Actions tab (or `gh workflow run`). A dispatch on `main` has `github.ref_type == 'branch'`, so it takes the existing canary path unchanged; no other behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
