### PR TITLE
chore(FR-3335): make dev review overlay opt-in via VITE_DEV_REVIEW_OVERLAY

### DIFF
--- a/react/vite-plugins/reviewOverlay.ts
+++ b/react/vite-plugins/reviewOverlay.ts
@@ -22,6 +22,12 @@ import type { Plugin } from 'vite';
  *    (`script-src 'self'`; the relay call is covered by the dev
  *    `connect-src … http:`).
  *
+ * Opt-in: the overlay is OFF by default so a plain `pnpm dev` never shows the
+ * floating review button. Enable it per-session with `VITE_DEV_REVIEW_OVERLAY`
+ * set to a truthy value (`1` / `true` / `on`) — e.g. in `.env.development.local`
+ * or as a shell var. When unset/falsy the plugin registers no middleware and
+ * injects no script, so it is a complete no-op.
+ *
  * Registration note: must be registered AFTER `projectRootStaticPlugin` in
  * the plugins array — that plugin's `order: 'pre'` transformIndexHtml
  * handler discards the incoming html and re-reads the template, so anything
@@ -36,7 +42,22 @@ const clientFile = resolve(
   'reviewOverlayClient.js',
 );
 
+/**
+ * The overlay is opt-in. `loadEnv()` in `vite.config.ts` runs before the
+ * plugins array is built, so `process.env.VITE_DEV_REVIEW_OVERLAY` reflects any
+ * value from `.env*` files (not just shell vars) by the time this factory runs.
+ */
+function isReviewOverlayEnabled(): boolean {
+  const flag = (process.env.VITE_DEV_REVIEW_OVERLAY ?? '').toLowerCase();
+  return flag === '1' || flag === 'true' || flag === 'on';
+}
+
 export function devReviewOverlayPlugin(): Plugin {
+  // Off by default: return an inert plugin so a plain `pnpm dev` shows no
+  // floating review button. Opt in with VITE_DEV_REVIEW_OVERLAY=1.
+  if (!isReviewOverlayEnabled()) {
+    return { name: 'bai-dev-review-overlay', apply: 'serve' };
+  }
   return {
     name: 'bai-dev-review-overlay',
     apply: 'serve',

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -851,9 +851,11 @@ export default defineConfig(({ command, mode }) => {
       projectRootStaticPlugin(devCspHeaders),
       cspBundleNoncePlugin(),
       devAssetsReloadPlugin(),
-      // FR-3309: dev-only (apply: 'serve') review overlay injection. Must
-      // come after projectRootStaticPlugin — its 'pre' HTML handler discards
-      // earlier transforms (see reviewOverlay.ts).
+      // FR-3309: dev-only (apply: 'serve') review overlay injection. Off by
+      // default — opt in with VITE_DEV_REVIEW_OVERLAY=1; otherwise the plugin
+      // is inert (no middleware, no script injection). Must come after
+      // projectRootStaticPlugin — its 'pre' HTML handler discards earlier
+      // transforms (see reviewOverlay.ts).
       devReviewOverlayPlugin(),
 
       react({


### PR DESCRIPTION
Resolves #8307 (FR-3335)

## Summary

The dev-only review overlay added in FR-3309 was injected unconditionally on every `pnpm dev` boot, so the floating review button showed up for every developer by default. This makes it **opt-in**.

- `react/vite-plugins/reviewOverlay.ts`: the plugin now checks `VITE_DEV_REVIEW_OVERLAY` (accepts `1` / `true` / `on`). When unset/falsy it returns an inert plugin (`{ name, apply: 'serve' }`) — no middleware, no `<script>` injection, a complete no-op.
- `react/vite.config.ts`: updated the registration comment to document the off-by-default / opt-in behavior.

`loadEnv()` runs before the plugins array is built, so the flag is honored from `.env*` files as well as shell vars.

## Test plan

- [ ] `pnpm dev` (no env) → no floating review button, no `/__review/overlay.js` request.
- [ ] `VITE_DEV_REVIEW_OVERLAY=1 pnpm dev` → review overlay button appears and `/__review/overlay.js` is served.
- [ ] `pnpm build` output unchanged (plugin is `apply: 'serve'` only).