### PR TITLE
fix(FR-3331): align row-action tooltips with the Edit icon

### DIFF
--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -299,8 +299,8 @@ const AdminUserCredentialList: React.FC = () => {
                   },
                 },
                 {
-                  key: 'settings',
-                  title: t('button.Settings'),
+                  key: 'edit',
+                  title: t('button.Edit'),
                   icon: <SquarePenIcon />,
                   onClick: () => {
                     startSettingModalOpenTransition(() => {

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -132,8 +132,8 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
               },
             },
             {
-              key: 'settings',
-              title: t('button.Settings'),
+              key: 'edit',
+              title: t('button.Edit'),
               icon: <SquarePenIcon />,
               onClick: () => {
                 setEditingKeypairResourcePolicy(row);

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -113,8 +113,8 @@ const ProjectResourcePolicyList: React.FC<
           showActions="always"
           actions={[
             {
-              key: 'settings',
-              title: t('button.Settings'),
+              key: 'edit',
+              title: t('button.Edit'),
               icon: <SquarePenIcon />,
               onClick: () => {
                 setEditingProjectResourcePolicy(row);

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -167,8 +167,8 @@ const ResourceGroupList: React.FC = () => {
               },
             },
             {
-              key: 'settings',
-              title: t('button.Settings'),
+              key: 'edit',
+              title: t('button.Edit'),
               icon: <SquarePenIcon />,
               onClick: () => {
                 setSelectedResourceGroup(record);
@@ -352,7 +352,7 @@ const ResourceGroupList: React.FC = () => {
                 count={selectedRowKeys.length}
                 onClearSelection={() => setSelectedRowKeys([])}
               />
-              <Tooltip title={t('button.Settings')}>
+              <Tooltip title={t('general.BulkEdit')}>
                 <BAIButton
                   icon={<SquarePenIcon style={{ color: token.colorInfo }} />}
                   style={{ backgroundColor: token.colorInfoBg }}

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -108,8 +108,8 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
           showActions="always"
           actions={[
             {
-              key: 'settings',
-              title: t('button.Settings'),
+              key: 'edit',
+              title: t('button.Edit'),
               icon: <SquarePenIcon />,
               onClick: () => {
                 setEditingUserResourcePolicy(row);

--- a/react/src/components/UserResourcePolicyV2.tsx
+++ b/react/src/components/UserResourcePolicyV2.tsx
@@ -254,8 +254,8 @@ const UserResourcePolicyV2 = ({
                       showActions="always"
                       actions={[
                         {
-                          key: 'settings',
-                          title: t('button.Settings'),
+                          key: 'edit',
+                          title: t('button.Edit'),
                           icon: <SquarePenIcon />,
                           onClick: () => {
                             setEditingUserResourcePolicy(


### PR DESCRIPTION
Stacked on #8314 (repo-wide lint stabilization; merge that first).

Resolves #8296 (FR-3331)

Follow-up to #8303: six SquarePen edit actions still carried the old "Settings" (설정) tooltip, so the icon and its label disagreed (reported on the resource policy tables).

## Changes

- Row actions relabeled `button.Settings` → `button.Edit` (수정) and action `key: 'settings'` → `'edit'`, matching the pattern the other converted lists already use:
  - `KeypairResourcePolicyList`, `UserResourcePolicyList`, `ProjectResourcePolicyList`, `UserResourcePolicyV2`
  - `AdminUserCredentialList` (keypair edit)
  - `ResourceGroupList` (row edit action)
- `ResourceGroupList` SFTP bulk button tooltip → `general.BulkEdit` (일괄 수정), matching the "자원 그룹 일괄 수정" modal it opens.

No i18n key changes — all labels reuse existing keys.

## Verification

ESLint (`--max-warnings=0`) and Prettier pass on the six changed files; `bash scripts/verify.sh` passes on the stack base (#8314).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
