### PR TITLE
fix(FR-3338): resolve eslint-plugin-react-hooks 7.1.1 compiler diagnostics

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
@@ -17,13 +17,7 @@ import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import * as _ from 'lodash-es';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import React, {
-  useEffect,
-  useEffectEvent,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 dayjs.extend(duration);
 
@@ -158,6 +152,7 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
         turnOffTimeoutRef.current = null;
       }
       loadingStartTimeRef.current = Date.now();
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- immediate icon-on preserves the min-700ms anti-flicker timing
       setDisplayLoading(true);
     } else if (loadingStartTimeRef.current !== null) {
       // loading finished: keep the icon visible for at least 700ms total
@@ -227,7 +222,13 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
   // switches to another interval — it must not vanish the way a transient
   // injection would. The consumer's `autoUpdateDelayOptions` is never mutated.
   const [seenOffListDelays, setSeenOffListDelays] = useState<number[]>([]);
-  const trackOffListDelay = useEffectEvent(() => {
+  // The `undefined` sentinel (which `selectedDelay: number | null` never
+  // equals) guarantees the first render is evaluated too.
+  const [trackedDelay, setTrackedDelay] = useState<number | null | undefined>(
+    undefined,
+  );
+  if (selectedDelay !== trackedDelay) {
+    setTrackedDelay(selectedDelay);
     if (
       selectedDelay !== null &&
       !autoUpdateDelayOptions.includes(selectedDelay)
@@ -236,10 +237,7 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
         prev.includes(selectedDelay) ? prev : [...prev, selectedDelay],
       );
     }
-  });
-  useEffect(() => {
-    trackOffListDelay();
-  }, [selectedDelay]);
+  }
 
   // Icon-only refresh button. When the interval dropdown is shown, the selected
   // interval label ("Ns") lives on the dropdown trigger, not here.

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -90,12 +90,7 @@ export type GraphQLFilter = BaseFilter & {
 };
 
 export type FilterPropertyType =
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'enum'
-  | 'uuid'
-  | 'datetime';
+  'string' | 'number' | 'boolean' | 'enum' | 'uuid' | 'datetime';
 
 export type FilterOperator =
   // String operators
@@ -743,11 +738,17 @@ const BAIGraphQLPropertyFilter = <
     }
   });
 
-  useEffect(() => {
-    if (selectedDate) {
-      updateSelectedDateEvent(selectedDate);
-    }
-  }, [selectedDate]);
+  // The DatePicker "Now" button fires onChange twice per click; committing
+  // from state adds exactly one condition per pick.
+  useEffect(
+    function commitSelectedDate() {
+      if (selectedDate) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- dedupes the "Now" double onChange
+        updateSelectedDateEvent(selectedDate);
+      }
+    },
+    [selectedDate],
+  );
 
   return (
     <BAIFlex direction="column" gap="xs" align="start" {...containerProps}>

--- a/packages/backend.ai-ui/src/components/BAIModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.tsx
@@ -25,10 +25,7 @@ export const DEFAULT_BAI_MODAL_Z_INDEX = 1001;
 export type WindowState = 'default' | 'minimized' | 'maximized' | 'fullscreen';
 export type WindowAction = 'minimize' | 'maximize' | 'fullscreen';
 export type MinimizedPlacement =
-  | 'bottomRight'
-  | 'bottomLeft'
-  | 'topRight'
-  | 'topLeft';
+  'bottomRight' | 'bottomLeft' | 'topRight' | 'topLeft';
 
 /**
  * Footer render-function form, re-typed from antd's `ModalProps['footer']`.
@@ -132,8 +129,9 @@ const useStyles = createStyles(
         ${type === 'warning' ? `color: ${colorWarning};` : ''}
         ${type === 'error' ? `color: ${colorError};` : ''}
       }
-      ${stickyTitle
-        ? `
+      ${
+        stickyTitle
+          ? `
         .ant-modal-header {
           position: sticky;
           top: 0;
@@ -141,10 +139,12 @@ const useStyles = createStyles(
           background: var(--ant-color-bg-elevated, #fff);
         }
       `
-        : ''}
+          : ''
+      }
 
-      ${windowState === 'maximized'
-        ? `
+      ${
+        windowState === 'maximized'
+          ? `
         &.ant-modal {
           width: calc(100vw - ${marginLG * 2}px) !important;
           max-width: calc(100vw - ${marginLG * 2}px) !important;
@@ -165,10 +165,12 @@ const useStyles = createStyles(
           overflow: auto;
         }
       `
-        : ''}
+          : ''
+      }
 
-      ${windowState === 'fullscreen'
-        ? `
+      ${
+        windowState === 'fullscreen'
+          ? `
         &.ant-modal {
           width: 100vw !important;
           max-width: 100vw !important;
@@ -190,10 +192,12 @@ const useStyles = createStyles(
           overflow: auto;
         }
       `
-        : ''}
+          : ''
+      }
 
-      ${windowState === 'minimized'
-        ? `
+      ${
+        windowState === 'minimized'
+          ? `
         &.ant-modal {
           width: min(320px, calc(100vw - ${marginLG * 2}px)) !important;
           max-width: min(320px, calc(100vw - ${marginLG * 2}px)) !important;
@@ -226,7 +230,8 @@ const useStyles = createStyles(
           overflow: hidden;
         }
       `
-        : ''}
+          : ''
+      }
 
       .ant-modal-content {
         transition:
@@ -302,6 +307,7 @@ const BAIModal: React.FC<BAIModalProps> = ({
   // Reset window state when the modal is closed programmatically (e.g., parent sets open={false})
   useEffect(() => {
     if (!modalProps.open && windowState !== 'default') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- parent callback can't run during render; a prop-driven close has no event handler
       setWindowState('default');
       onWindowStateChange?.('default');
     }

--- a/packages/backend.ai-ui/src/components/BAIProjectResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAIProjectResourceGroupSelect.tsx
@@ -55,6 +55,7 @@ const BAIProjectResourceGroupSelect: React.FC<
       resourceGroups.length > 0 &&
       !_.some(resourceGroups, (item) => item.name === controllableValue)
     ) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- transition-wrapped parent sync; can't run during render, no user event to move into
       setControllableValueWithTransition(undefined);
     }
   }, [resourceGroups, controllableValue, setControllableValueWithTransition]);
@@ -72,6 +73,7 @@ const BAIProjectResourceGroupSelect: React.FC<
 
   useEffect(() => {
     if (autoSelectDefault && autoSelectedOption && !controllableValue) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- transition-wrapped auto-select; can't run during render, no user event to move into
       setControllableValueWithTransition(
         autoSelectedOption.value,
         autoSelectedOption,

--- a/packages/backend.ai-ui/src/components/BAIRowWrapWithDividers.tsx
+++ b/packages/backend.ai-ui/src/components/BAIRowWrapWithDividers.tsx
@@ -33,8 +33,8 @@ const BAIRowWrapWithDividers: React.FC<BAIRowWrapWithDividersProps> = ({
   className,
 }) => {
   const { token } = theme.useToken();
-  rowGap = rowGap ?? token.marginXL;
-  columnGap = columnGap ?? token.marginXXL;
+  const resolvedRowGap = rowGap ?? token.marginXL;
+  const resolvedColumnGap = columnGap ?? token.marginXXL;
   const color = dividerColor ?? token.colorBorderSecondary;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -49,8 +49,10 @@ const BAIRowWrapWithDividers: React.FC<BAIRowWrapWithDividersProps> = ({
   // Expose columnGap as a CSS variable to overlay the divider within the gap (item width unchanged)
   const gapVar = useMemo(
     () =>
-      typeof columnGap === 'number' ? `${columnGap}px` : String(columnGap),
-    [columnGap],
+      typeof resolvedColumnGap === 'number'
+        ? `${resolvedColumnGap}px`
+        : String(resolvedColumnGap),
+    [resolvedColumnGap],
   );
 
   const measure = () => {
@@ -111,8 +113,8 @@ const BAIRowWrapWithDividers: React.FC<BAIRowWrapWithDividersProps> = ({
         {
           display: 'flex',
           flexWrap: wrap ? 'wrap' : 'nowrap',
-          columnGap,
-          rowGap,
+          columnGap: resolvedColumnGap,
+          rowGap: resolvedRowGap,
           alignItems: 'stretch',
           // Provide gap CSS variable for children
           '--bai-gap': gapVar,

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
@@ -186,10 +186,15 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
     actions?.filter((a) => a.showInMenu === 'always') ?? [];
   const autoActionCount = autoActions.length;
 
-  // Reset visibleCount when auto actions change
-  useEffect(() => {
+  // The `undefined` sentinel makes the reset also run on the first render;
+  // the ResizeObserver effect then recomputes the width-constrained count.
+  const [prevAutoActionCount, setPrevAutoActionCount] = useState<
+    number | undefined
+  >(undefined);
+  if (autoActionCount !== prevAutoActionCount) {
+    setPrevAutoActionCount(autoActionCount);
     setVisibleCount(autoActionCount);
-  }, [autoActionCount]);
+  }
 
   const calculateVisibleActions = useEventNotStable(
     (containerWidth: number) => {

--- a/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
@@ -32,8 +32,6 @@ import React, {
   useRef,
   useState,
   useCallback,
-  useEffect,
-  useEffectEvent,
   useContext,
   useMemo,
 } from 'react';
@@ -281,7 +279,11 @@ const BAITableSettingModal: React.FC<TableSettingProps> = ({
     order: initialColumnOrder ?? null,
   });
 
-  const resyncDataSource = useEffectEvent(() => {
+  // `dataSource` is already initialized with the ordered options, so the
+  // initial signature needs no resync — only later changes do.
+  const [prevSyncSignature, setPrevSyncSignature] = useState(syncSignature);
+  if (syncSignature !== prevSyncSignature) {
+    setPrevSyncSignature(syncSignature);
     if (initialColumnOrder) {
       const orderedOptions = [...columnOptions];
       orderedOptions.sort((a, b) => {
@@ -296,11 +298,7 @@ const BAITableSettingModal: React.FC<TableSettingProps> = ({
     } else {
       setDataSource(columnOptions);
     }
-  });
-
-  useEffect(() => {
-    resyncDataSource();
-  }, [syncSignature]);
+  }
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -100,6 +100,9 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
   const { token } = theme.useToken();
 
   const [isDragMode, setIsDragMode] = useState(false);
+  // The container ref is parent-owned; capture its element when dragging starts.
+  const [dragPortalContainer, setDragPortalContainer] =
+    useState<HTMLElement | null>(null);
   const [selectedItems, setSelectedItems] = useState<Array<VFolderFile>>([]);
   const [selectedSingleItem, setSelectedSingleItem] =
     useState<VFolderFile | null>(null);
@@ -270,6 +273,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
   useEffect(() => {
     const handleDragEnter = (e: DragEvent) => {
       e.preventDefault();
+      setDragPortalContainer(fileDropContainerRef?.current ?? null);
       setIsDragMode(true);
     };
     const handleDragLeave = (e: DragEvent) => {
@@ -297,7 +301,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
       document.removeEventListener('dragover', handleDragOver);
       document.removeEventListener('drop', handleDrop);
     };
-  }, []);
+  }, [fileDropContainerRef]);
 
   return (
     <FolderInfoContext.Provider
@@ -309,7 +313,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
     >
       {isDragMode && enableUpload && (
         <DragAndDrop
-          portalContainer={fileDropContainerRef?.current || undefined}
+          portalContainer={dragPortalContainer || undefined}
           onUpload={(files, currentPath) => onUpload(files, currentPath)}
         />
       )}

--- a/packages/backend.ai-ui/src/hooks/useIntervalValue.tsx
+++ b/packages/backend.ai-ui/src/hooks/useIntervalValue.tsx
@@ -67,15 +67,13 @@ export function useIntervalValue<T>(
 ): T {
   const [result, setResult] = useState<T>(calculator());
 
-  const updateCalculator = useEffectEvent(() => {
-    setResult(calculator());
-  });
-
-  useEffect(() => {
+  const [prevTriggerKey, setPrevTriggerKey] = useState(triggerKey);
+  if (triggerKey !== prevTriggerKey) {
+    setPrevTriggerKey(triggerKey);
     if (triggerKey) {
-      updateCalculator();
+      setResult(calculator());
     }
-  }, [triggerKey]);
+  }
 
   useInterval(
     () => {

--- a/packages/backend.ai-ui/src/hooks/usePaginatedQuery.ts
+++ b/packages/backend.ai-ui/src/hooks/usePaginatedQuery.ts
@@ -31,6 +31,7 @@ export function useLazyPaginatedQuery<
   const previousOtherVariablesRef = useRef(otherVariables);
 
   const isNewOtherVariables = !_.isEqual(
+    // eslint-disable-next-line react-hooks/refs -- render-phase previous-page tracking kept per review
     previousOtherVariablesRef.current,
     otherVariables,
   );
@@ -49,10 +50,11 @@ export function useLazyPaginatedQuery<
   const data = useMemo(() => {
     const items = getItem(result);
     if (isNewOtherVariables) {
+      // eslint-disable-next-line react-hooks/refs -- render-phase previous-page tracking kept per review
       previousResult.current = [];
     }
     return items
-      ? _.uniqBy([...previousResult.current, ...items], getId)
+      ? _.uniqBy([...previousResult.current, ...items], getId) // eslint-disable-line react-hooks/refs
       : undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [result]);
@@ -72,6 +74,7 @@ export function useLazyPaginatedQuery<
     // Reset the offset and limit when otherVariables change after success rendering
     if (isNewOtherVariables) {
       previousOtherVariablesRef.current = otherVariables;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- offset reset on variable change kept per review
       setOffset(0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/backend.ai-ui/src/hooks/useSchedulingHistoryExpandable.tsx
+++ b/packages/backend.ai-ui/src/hooks/useSchedulingHistoryExpandable.tsx
@@ -5,7 +5,7 @@ import { Dropdown, theme, Tooltip } from 'antd';
 import * as _ from 'lodash-es';
 import { EllipsisVerticalIcon } from 'lucide-react';
 import * as React from 'react';
-import { useEffect, useEffectEvent, useState } from 'react';
+import { useState } from 'react';
 
 /**
  * Minimal shape shared by every scheduling-history row type
@@ -23,9 +23,7 @@ export interface SchedulingHistoryExpandableRow {
  * the caller (so it can be persisted across reloads / navigations).
  */
 export type SchedulingHistoryExpandMode =
-  | 'expand-all'
-  | 'collapse-all'
-  | 'errors-only';
+  'expand-all' | 'collapse-all' | 'errors-only';
 
 export const DEFAULT_SCHEDULING_HISTORY_EXPAND_MODE: SchedulingHistoryExpandMode =
   'errors-only';
@@ -110,24 +108,15 @@ export const useSchedulingHistoryExpandable = <
     )
     .join('|');
 
-  const resetToDefault = useEffectEvent(() => {
+  // Manual per-row toggles persist until a refetch (data signature) or a
+  // `mode` change re-applies the master mode.
+  const [prevDataSignature, setPrevDataSignature] = useState(dataSignature);
+  const [prevMode, setPrevMode] = useState(mode);
+  if (dataSignature !== prevDataSignature || mode !== prevMode) {
+    setPrevDataSignature(dataSignature);
+    setPrevMode(mode);
     setExpandedRowKeys(computeExpandedRowKeysForMode(dataSource, mode));
-  });
-
-  useEffect(() => {
-    resetToDefault();
-  }, [dataSignature]);
-
-  // Re-apply the master mode whenever the controlled mode prop changes so
-  // selecting a menu item immediately re-expands / collapses. `dataSource` is
-  // read fresh via the effect event without being a reactive dependency.
-  const applyMode = useEffectEvent(() => {
-    setExpandedRowKeys(computeExpandedRowKeysForMode(dataSource, mode));
-  });
-
-  useEffect(() => {
-    applyMode();
-  }, [mode]);
+  }
 
   const expandableRowKeys = dataSource
     .filter(isRowExpandable)

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -252,7 +252,6 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
   `;
 
   const loadGroups = useEffectEvent((domainName: string) => {
-    setGroupsLoaded(false);
     fetchQuery<BulkCreateUserFromCSVModalGroupsQuery>(
       relayEnvironment,
       groupsQuery,
@@ -274,6 +273,15 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
         logger.error('Failed to load groups for name resolution', err);
       });
   });
+
+  // A domain change disables validation until the new fetch resolves.
+  const [prevGroupsDomainName, setPrevGroupsDomainName] = useState(
+    globalDefaults.domainName,
+  );
+  if (prevGroupsDomainName !== globalDefaults.domainName) {
+    setPrevGroupsDomainName(globalDefaults.domainName);
+    setGroupsLoaded(false);
+  }
 
   useEffect(() => {
     loadGroups(globalDefaults.domainName);

--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -36,14 +36,7 @@ import {
 } from 'backend.ai-ui';
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
-import React, {
-  memo,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useTransition,
-} from 'react';
+import React, { memo, useEffect, useRef, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -112,6 +105,7 @@ function useModels(
   baseURL?: string,
   effectiveApiKey?: string,
 ) {
+  'use memo';
   const { t } = useTranslation();
   const getModelsErrorMessage = (status?: number) => {
     switch (status) {
@@ -183,14 +177,11 @@ function useModels(
     },
   });
 
-  const modelId = useMemo(
-    () =>
-      provider.modelId &&
-      _.includes(_.map(modelsResult?.data || [], 'id'), provider.modelId)
-        ? provider.modelId
-        : (modelsResult?.data?.[0]?.id ?? 'custom'),
-    [modelsResult?.data, provider.modelId],
-  );
+  const modelId =
+    provider.modelId &&
+    _.includes(_.map(modelsResult?.data || [], 'id'), provider.modelId)
+      ? provider.modelId
+      : (modelsResult?.data?.[0]?.id ?? 'custom');
 
   const modelsError =
     modelsResult.error && getModelsErrorMessage(modelsResult.error);

--- a/react/src/components/Chat/ChatHistory.ts
+++ b/react/src/components/Chat/ChatHistory.ts
@@ -152,6 +152,7 @@ export function useHistory(id: string, provider: ChatProviderData) {
         return;
       }
 
+      // eslint-disable-next-line react-hooks/immutability -- intentional in-place mutation of cached chat data
       chat.chats = chat.chats.filter((chat) => chat.id !== id);
 
       updateHistory({ ...chat });
@@ -172,6 +173,7 @@ export function useHistory(id: string, provider: ChatProviderData) {
         return;
       }
 
+      // eslint-disable-next-line react-hooks/immutability -- intentional in-place mutation of cached chat data
       chat.chats[index] = _.merge({}, chat.chats[index], data);
 
       const currentChat = getChatById(chat.id);
@@ -205,6 +207,7 @@ export function useHistory(id: string, provider: ChatProviderData) {
 
       // Overwrite the last message if it is the same message
       if (lastMessage?.id === id) {
+        // eslint-disable-next-line react-hooks/immutability -- intentional in-place mutation of cached chat data
         chat.chats[index].messages = [
           ...chatData.messages.slice(0, -1),
           _.merge({}, lastMessage, {
@@ -231,6 +234,7 @@ export function useHistory(id: string, provider: ChatProviderData) {
 
         // Only update label if there's actual text content
         if (textContent) {
+          // eslint-disable-next-line react-hooks/immutability -- intentional in-place mutation of cached chat data
           chat.label = textContent;
         }
       }
@@ -267,6 +271,7 @@ export function useHistory(id: string, provider: ChatProviderData) {
         return;
       }
 
+      // eslint-disable-next-line react-hooks/immutability -- intentional in-place mutation of cached chat data
       chat.chats[index].messages = [];
 
       updateHistory({ ...chat });
@@ -279,6 +284,7 @@ export function useHistory(id: string, provider: ChatProviderData) {
     const cachedChat = getChatById(id);
     const chat = cachedChat ? cachedChat : createChat({ provider });
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- legacy id-change re-init kept as-is
     setChat(chat);
     setHistory([...chatHistoryCache.getAll().sort(sortHistoryByUpdatedAt)]);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/react/src/components/Chat/ChatInput.tsx
+++ b/react/src/components/Chat/ChatInput.tsx
@@ -98,6 +98,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
   // If the `inputAttachment` prop exists, the `files` state has to follow it.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- atom-driven files sync kept per review
     setFilesFromInputAttachment(synchronizedAttachment);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [synchronizedAttachment]);

--- a/react/src/components/ConfigurationsSettingList.tsx
+++ b/react/src/components/ConfigurationsSettingList.tsx
@@ -142,6 +142,7 @@ const ConfigurationsSettingList = () => {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- mount-only settings fetch; setState only runs in the async response callbacks
     updateSettings();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/react/src/components/DeploymentAddRevisionModal.tsx
+++ b/react/src/components/DeploymentAddRevisionModal.tsx
@@ -968,6 +968,10 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
 
   useEffect(() => {
     if (effectiveMode === 'custom') {
+      // These prefill helpers call setFieldsValue on the freshly-mounted form
+      // (which only sticks post-mount) alongside tracking-state updates, so they
+      // must run in this mode-transition effect rather than during render.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- setState is coupled to post-mount form prefill and must run in this effect
       consumePresetTransferPrefill();
       applySourcePrefillOnce();
       applyPendingLoadCurrent();
@@ -1068,8 +1072,7 @@ const DeploymentAddRevisionModal: React.FC<DeploymentAddRevisionModalProps> = ({
     // Image errors are shown on the manual-name input if the user typed one,
     // otherwise on the Environments/Version dropdown.
     const imageFieldName:
-      | ['environments', 'manual']
-      | ['environments', 'version'] = manualImageName
+      ['environments', 'manual'] | ['environments', 'version'] = manualImageName
       ? ['environments', 'manual']
       : ['environments', 'version'];
     if (!imageId && manualImageName) {

--- a/react/src/components/EmailVerificationView.tsx
+++ b/react/src/components/EmailVerificationView.tsx
@@ -56,6 +56,7 @@ const EmailVerificationView: React.FC<EmailVerificationViewProps> = ({
           setVerificationState('failed');
         });
     } else {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- missing-token failure state kept per review
       setVerificationState('failed');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/react/src/components/FairShareItems/FairShareList.tsx
+++ b/react/src/components/FairShareItems/FairShareList.tsx
@@ -513,12 +513,12 @@ const FairShareList: React.FC = () => {
     urlInitialLoadEffect();
   }, []);
 
-  const resetSelectedRowsEffect = useEffectEvent(() => {
+  const [prevStepQueryParams, setPrevStepQueryParams] =
+    useState(stepQueryParams);
+  if (prevStepQueryParams !== stepQueryParams) {
+    setPrevStepQueryParams(stepQueryParams);
     setSelectedRows([]);
-  });
-  useEffect(() => {
-    resetSelectedRowsEffect();
-  }, [stepQueryParams]);
+  }
 
   return (
     <BAIFlex direction="column" gap="md" align="stretch">

--- a/react/src/components/FileUploadManager.tsx
+++ b/react/src/components/FileUploadManager.tsx
@@ -96,73 +96,76 @@ const FileUploadManager: React.FC = () => {
   // cycle's notification would be re-fired whenever an unrelated folder
   // updates state.
   const notifiedCyclesRef = useRef<Set<string>>(new Set());
-  const throttledUploadRequests = _.throttle(
-    (vFolderId: string, fileName: string) => {
-      const accumulatedDelta = pendingDeltaBytesRef.current[vFolderId] || 0;
-      pendingDeltaBytesRef.current[vFolderId] = 0;
-
-      setUploadStatus((prev) => {
-        const cycleKey = prev[vFolderId]?.cycleKey;
-        if (!cycleKey) return prev;
-
-        const uploadedFilesCount = prev[vFolderId]?.completedFiles?.length || 0;
-        const totalUploadedFilesCount =
-          (prev[vFolderId]?.completedFiles?.length || 0) +
-          (prev[vFolderId]?.failedFiles?.length || 0) +
-          (prev[vFolderId]?.pendingFiles?.length || 0);
-
-        const totalExpectedSize = prev[vFolderId]?.totalExpectedSize || 0;
-        const currentCompletedBytes =
-          (prev[vFolderId]?.completedBytes || 0) + accumulatedDelta;
-
-        upsertNotification({
-          key: cycleKey,
-          backgroundTask: {
-            status: 'pending',
-            percent:
-              totalExpectedSize > 0
-                ? (currentCompletedBytes / totalExpectedSize) * 100
-                : 0,
-            onChange: {
-              pending: {
-                description: (
-                  <BAIFlex direction="column" align="start">
-                    <Typography.Text>
-                      {t('explorer.UploadingFiles')} ( {uploadedFilesCount} /{' '}
-                      {totalUploadedFilesCount} )
-                    </Typography.Text>
-                    <Typography.Text
-                      ellipsis
-                      type="secondary"
-                      style={{
-                        fontSize: token.fontSizeSM,
-                        maxWidth: '300px',
-                      }}
-                    >
-                      {fileName}
-                    </Typography.Text>
-                  </BAIFlex>
-                ),
-              },
-            },
-          },
-        });
-
-        return {
-          ...prev,
-          [vFolderId]: {
-            ...prev[vFolderId],
-            completedBytes: currentCompletedBytes,
-          },
-        };
-      });
-    },
-    200,
-    { leading: true, trailing: true },
-  );
 
   useEffect(() => {
     if (uploadRequests.length === 0 || !baiClient) return;
+
+    // Created inside the effect so its ref reads happen outside render.
+    const throttledUploadRequests = _.throttle(
+      (vFolderId: string, fileName: string) => {
+        const accumulatedDelta = pendingDeltaBytesRef.current[vFolderId] || 0;
+        pendingDeltaBytesRef.current[vFolderId] = 0;
+
+        setUploadStatus((prev) => {
+          const cycleKey = prev[vFolderId]?.cycleKey;
+          if (!cycleKey) return prev;
+
+          const uploadedFilesCount =
+            prev[vFolderId]?.completedFiles?.length || 0;
+          const totalUploadedFilesCount =
+            (prev[vFolderId]?.completedFiles?.length || 0) +
+            (prev[vFolderId]?.failedFiles?.length || 0) +
+            (prev[vFolderId]?.pendingFiles?.length || 0);
+
+          const totalExpectedSize = prev[vFolderId]?.totalExpectedSize || 0;
+          const currentCompletedBytes =
+            (prev[vFolderId]?.completedBytes || 0) + accumulatedDelta;
+
+          upsertNotification({
+            key: cycleKey,
+            backgroundTask: {
+              status: 'pending',
+              percent:
+                totalExpectedSize > 0
+                  ? (currentCompletedBytes / totalExpectedSize) * 100
+                  : 0,
+              onChange: {
+                pending: {
+                  description: (
+                    <BAIFlex direction="column" align="start">
+                      <Typography.Text>
+                        {t('explorer.UploadingFiles')} ( {uploadedFilesCount} /{' '}
+                        {totalUploadedFilesCount} )
+                      </Typography.Text>
+                      <Typography.Text
+                        ellipsis
+                        type="secondary"
+                        style={{
+                          fontSize: token.fontSizeSM,
+                          maxWidth: '300px',
+                        }}
+                      >
+                        {fileName}
+                      </Typography.Text>
+                    </BAIFlex>
+                  ),
+                },
+              },
+            },
+          });
+
+          return {
+            ...prev,
+            [vFolderId]: {
+              ...prev[vFolderId],
+              completedBytes: currentCompletedBytes,
+            },
+          };
+        });
+      },
+      200,
+      { leading: true, trailing: true },
+    );
 
     uploadRequests.forEach((uploadRequest) => {
       const { vFolderId, vFolderName, uploadFileInfo } = uploadRequest;

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -98,12 +98,15 @@ const isPrivateImage = (image: Image) => {
 const ImageEnvironmentSelectFormItems: React.FC<
   ImageEnvironmentSelectFormItemsProps
 > = ({ filter, showPrivate, searchPrefill }) => {
+  'use memo';
   const form = Form.useFormInstance<ImageEnvironmentFormInput>();
   const environments = Form.useWatch('environments', { form, preserve: true });
   const baiClient = useSuspendedBackendaiClient();
   const supportExtendedImageInfo = baiClient?.supports('extended-image-info');
 
-  const [environmentSearch, setEnvironmentSearch] = useState('');
+  const [environmentSearch, setEnvironmentSearch] = useState(
+    searchPrefill ?? '',
+  );
   const [versionSearch, setVersionSearch] = useState('');
   const { t } = useTranslation();
   const [metadata, { getBaseVersion, getImageMeta, tagAlias }] =
@@ -114,23 +117,31 @@ const ImageEnvironmentSelectFormItems: React.FC<
   const envSelectRef = useRef<RefSelectProps>(null);
   const versionSelectRef = useRef<RefSelectProps>(null);
   const [envSelectOpen, setEnvSelectOpen] = useState<boolean | undefined>(
-    undefined,
+    searchPrefill ? true : undefined,
   );
 
-  useEffect(() => {
-    if (!searchPrefill) {
+  const [prevSearchPrefill, setPrevSearchPrefill] = useState(searchPrefill);
+  if (prevSearchPrefill !== searchPrefill) {
+    setPrevSearchPrefill(searchPrefill);
+    if (searchPrefill) {
+      setEnvironmentSearch(searchPrefill);
+      setEnvSelectOpen(true);
+    } else {
       setEnvironmentSearch('');
       setEnvSelectOpen(undefined);
-      return;
     }
+  }
 
-    setEnvironmentSearch(searchPrefill);
-    // Force open the dropdown and focus the select
-    setEnvSelectOpen(true);
-    queueMicrotask(() => {
-      envSelectRef.current?.focus();
-    });
-  }, [searchPrefill]);
+  useEffect(
+    function focusEnvironmentSelectOnPrefill() {
+      if (searchPrefill) {
+        queueMicrotask(() => {
+          envSelectRef.current?.focus();
+        });
+      }
+    },
+    [searchPrefill],
+  );
 
   const imageEnvironmentSelectFormItemsVariables = baiClient?._config
     ?.showNonInstalledImages
@@ -174,6 +185,69 @@ const ImageEnvironmentSelectFormItems: React.FC<
     },
   );
 
+  const imageGroups: ImageGroup[] = _.sortBy(
+    _.map(
+      _.groupBy(
+        _.filter(images, (image) => {
+          return (
+            (showPrivate ? true : !isPrivateImage(image)) &&
+            (filter ? filter(image) : true)
+          );
+        }),
+        (image) => {
+          // group by using `group` property of image info
+          return (
+            metadata?.imageInfo[getImageMeta(getImageFullName(image) || '').key]
+              ?.group || 'Custom Environments'
+          );
+        },
+      ),
+      (images, groupName) => {
+        return {
+          groupName,
+          groupSortKey: metadata?.groupSortKeyMap?.[groupName] || groupName,
+          environmentGroups: _.sortBy(
+            _.map(
+              // sub group by using (environment) `name` property of image info
+              _.groupBy(images, (image) => {
+                return (
+                  // metadata?.imageInfo[
+                  //   getImageMeta(getImageFullName(image) || "").key
+                  // ]?.name || image?.name
+                  `${image?.registry}/${
+                    supportExtendedImageInfo ? image?.namespace : image?.name
+                  }`
+                );
+              }),
+              (images, environmentName) => {
+                const imageKey = environmentName.split('/')?.[2];
+                const displayName =
+                  (imageKey && metadata?.imageInfo[imageKey]?.name) ||
+                  (_.last(environmentName.split('/')) as string);
+
+                return {
+                  environmentName,
+                  displayName,
+                  prefix: environmentName.split('/').slice(1, -1).join('/'),
+                  images: images.sort(
+                    (a, b) =>
+                      compareVersions(
+                        // latest version comes first
+                        b?.tag?.split('-')?.[0] ?? '',
+                        a?.tag?.split('-')?.[0] ?? '',
+                      ) || localeCompare(a?.architecture, b?.architecture),
+                  ),
+                };
+              },
+            ),
+            (item) => item.displayName,
+          ),
+        };
+      },
+    ),
+    (item) => item.groupSortKey,
+  );
+
   // If not initial value, select first value
   // auto select when relative field is changed
   useEffect(() => {
@@ -192,8 +266,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
     }
 
     let matchedEnvironmentByVersion:
-      | ImageGroup['environmentGroups'][0]
-      | undefined;
+      ImageGroup['environmentGroups'][0] | undefined;
     let matchedImageByVersion: Image | undefined;
     const version = form.getFieldValue('environments')?.version;
 
@@ -319,83 +392,11 @@ const ImageEnvironmentSelectFormItems: React.FC<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [environments?.version, environments?.manual]); // environments?.environment,
 
-  const imageGroups: ImageGroup[] = useMemo(
-    () =>
-      _.sortBy(
-        _.map(
-          _.groupBy(
-            _.filter(images, (image) => {
-              return (
-                (showPrivate ? true : !isPrivateImage(image)) &&
-                (filter ? filter(image) : true)
-              );
-            }),
-            (image) => {
-              // group by using `group` property of image info
-              return (
-                metadata?.imageInfo[
-                  getImageMeta(getImageFullName(image) || '').key
-                ]?.group || 'Custom Environments'
-              );
-            },
-          ),
-          (images, groupName) => {
-            return {
-              groupName,
-              groupSortKey: metadata?.groupSortKeyMap?.[groupName] || groupName,
-              environmentGroups: _.sortBy(
-                _.map(
-                  // sub group by using (environment) `name` property of image info
-                  _.groupBy(images, (image) => {
-                    return (
-                      // metadata?.imageInfo[
-                      //   getImageMeta(getImageFullName(image) || "").key
-                      // ]?.name || image?.name
-                      `${image?.registry}/${
-                        supportExtendedImageInfo
-                          ? image?.namespace
-                          : image?.name
-                      }`
-                    );
-                  }),
-                  (images, environmentName) => {
-                    const imageKey = environmentName.split('/')?.[2];
-                    const displayName =
-                      (imageKey && metadata?.imageInfo[imageKey]?.name) ||
-                      (_.last(environmentName.split('/')) as string);
-
-                    return {
-                      environmentName,
-                      displayName,
-                      prefix: environmentName.split('/').slice(1, -1).join('/'),
-                      images: images.sort(
-                        (a, b) =>
-                          compareVersions(
-                            // latest version comes first
-                            b?.tag?.split('-')?.[0] ?? '',
-                            a?.tag?.split('-')?.[0] ?? '',
-                          ) || localeCompare(a?.architecture, b?.architecture),
-                      ),
-                    };
-                  },
-                ),
-                (item) => item.displayName,
-              ),
-            };
-          },
-        ),
-        (item) => item.groupSortKey,
-      ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [images, metadata, filter, showPrivate],
-  );
-
   // support search image by full name
   const { fullNameMatchedImage } = useMemo(() => {
     let fullNameMatchedImage: Image | undefined;
     let fullNameMatchedImageGroup:
-      | ImageGroup['environmentGroups'][0]
-      | undefined;
+      ImageGroup['environmentGroups'][0] | undefined;
     if (environmentSearch.length) {
       imageGroups
         .flatMap((group) => group.environmentGroups)
@@ -625,8 +626,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
       >
         {({ getFieldValue }) => {
           let selectedEnvironmentGroup:
-            | ImageGroup['environmentGroups'][0]
-            | undefined;
+            ImageGroup['environmentGroups'][0] | undefined;
           _.find(imageGroups, (group) => {
             return _.find(group.environmentGroups, (environment) => {
               if (

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -187,9 +187,15 @@ const LoginView: React.FC<{
     loadConfig();
   }, [loadConfig]);
 
-  // When config finishes loading from the atom, apply it to local state
-  useEffect(() => {
-    if (!isConfigLoaded || !atomLoginConfig) return;
+  const [appliedLoginConfig, setAppliedLoginConfig] = useState<
+    typeof atomLoginConfig | null
+  >(null);
+  if (
+    isConfigLoaded &&
+    atomLoginConfig &&
+    appliedLoginConfig !== atomLoginConfig
+  ) {
+    setAppliedLoginConfig(atomLoginConfig);
 
     const newCfg = atomLoginConfig;
     setLoginConfig(newCfg);
@@ -209,7 +215,7 @@ const LoginView: React.FC<{
       setShowEndpointInput(false);
       setIsEndpointDisabled(true);
     }
-  }, [isConfigLoaded, atomLoginConfig]);
+  }
 
   // Load login plugin when config is ready.
   // Mirrors `PluginLoader.tsx`'s URL resolution so login plugins follow
@@ -454,91 +460,6 @@ const LoginView: React.FC<{
     [endpoints, postConnectSetup],
   );
 
-  const connectUsingSession = useCallback(
-    async (showError = true, endpointOverride?: string) => {
-      const ep = (endpointOverride ?? apiEndpoint).trim();
-      if (ep === '') {
-        setIsBlockPanelOpen(false);
-        open();
-        return;
-      }
-
-      const userId = (form.getFieldValue('user_id') || '').trim();
-      const password = form.getFieldValue('password') || '';
-      const otp = form.getFieldValue('otp') || '';
-
-      const { client } = createBackendAIClient(userId, password, ep, 'SESSION');
-      clientRef.current = client;
-
-      try {
-        await client.get_manager_version();
-      } catch {
-        setIsBlockPanelOpen(false);
-        open();
-        setIsLoading(false);
-        if (showError) {
-          notification(t('error.CannotConnectToServer'));
-        }
-        return;
-      }
-
-      // Check if already logged in
-      let isLogon = false;
-      try {
-        isLogon = !!(await client.check_login());
-      } catch {
-        isLogon = false;
-      }
-
-      if (isLogon) {
-        try {
-          await doGQLConnect(client);
-        } catch (err: unknown) {
-          handleGQLError(err, showError);
-        }
-        return;
-      }
-
-      // Not yet authenticated. Show block panel while connecting (only for user-initiated login).
-      if (showError) {
-        block(t('login.PleaseWait'), t('login.ConnectingToCluster'));
-      }
-
-      // sToken (SSO) URL entry is handled entirely by STokenLoginBoundary
-      // at the route level (see routes.tsx `STokenGuard`). LoginView no
-      // longer reads sToken from the URL; when a token is present the
-      // boundary mounts LoginView only after authentication succeeds.
-
-      // Do session login
-      // client.login() returns only on success (authenticated === true).
-      // All failure cases throw: login errors carry `isLoginError: true` with
-      // `data.type` for classification; server errors carry `isError: true`
-      // with structured info from _wrapWithPromise.
-      try {
-        await client.login(otp, forceLoginApprovedRef.current);
-        await doGQLConnect(client);
-        return;
-      } catch (err: unknown) {
-        setIsBlockPanelOpen(false);
-
-        const handled = handleLoginError(err, showError, userId, password);
-        if (handled === 'keep-open') {
-          // A dedicated modal (password reset, TOTP registration) was opened.
-          // Keep the login panel open to preserve form values for child modals.
-          setIsLoading(false);
-          return;
-        }
-      }
-
-      setIsBlockPanelOpen(false);
-      open();
-      setIsLoading(false);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [apiEndpoint, form, endpoints, doGQLConnect, block, open, notification, t],
-  );
-  connectUsingSessionRef.current = connectUsingSession;
-
   /**
    * Unified login error handler. Classifies errors from client.login() and
    * shows the appropriate notification or opens a dedicated modal.
@@ -776,6 +697,97 @@ const LoginView: React.FC<{
       setIsLoading(false);
     },
     [notification, t, open],
+  );
+
+  const connectUsingSession = useCallback(
+    async (showError = true, endpointOverride?: string) => {
+      const ep = (endpointOverride ?? apiEndpoint).trim();
+      if (ep === '') {
+        setIsBlockPanelOpen(false);
+        open();
+        return;
+      }
+
+      const userId = (form.getFieldValue('user_id') || '').trim();
+      const password = form.getFieldValue('password') || '';
+      const otp = form.getFieldValue('otp') || '';
+
+      const { client } = createBackendAIClient(userId, password, ep, 'SESSION');
+      clientRef.current = client;
+
+      try {
+        await client.get_manager_version();
+      } catch {
+        setIsBlockPanelOpen(false);
+        open();
+        setIsLoading(false);
+        if (showError) {
+          notification(t('error.CannotConnectToServer'));
+        }
+        return;
+      }
+
+      // Check if already logged in
+      let isLogon = false;
+      try {
+        isLogon = !!(await client.check_login());
+      } catch {
+        isLogon = false;
+      }
+
+      if (isLogon) {
+        try {
+          await doGQLConnect(client);
+        } catch (err: unknown) {
+          handleGQLError(err, showError);
+        }
+        return;
+      }
+
+      // Not yet authenticated. Show block panel while connecting (only for user-initiated login).
+      if (showError) {
+        block(t('login.PleaseWait'), t('login.ConnectingToCluster'));
+      }
+
+      // sToken (SSO) URL entry is handled entirely by STokenLoginBoundary
+      // at the route level (see routes.tsx `STokenGuard`). LoginView no
+      // longer reads sToken from the URL; when a token is present the
+      // boundary mounts LoginView only after authentication succeeds.
+
+      // Do session login
+      // client.login() returns only on success (authenticated === true).
+      // All failure cases throw: login errors carry `isLoginError: true` with
+      // `data.type` for classification; server errors carry `isError: true`
+      // with structured info from _wrapWithPromise.
+      try {
+        await client.login(otp, forceLoginApprovedRef.current);
+        await doGQLConnect(client);
+        return;
+      } catch (err: unknown) {
+        setIsBlockPanelOpen(false);
+
+        const handled = handleLoginError(err, showError, userId, password);
+        if (handled === 'keep-open') {
+          // A dedicated modal (password reset, TOTP registration) was opened.
+          // Keep the login panel open to preserve form values for child modals.
+          setIsLoading(false);
+          return;
+        }
+      }
+
+      setIsBlockPanelOpen(false);
+      open();
+      setIsLoading(false);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [apiEndpoint, form, endpoints, doGQLConnect, block, open, notification, t],
+  );
+  // The concurrent-session modal's onOk (in handleLoginError) calls this ref.
+  useEffect(
+    function syncConnectUsingSessionRef() {
+      connectUsingSessionRef.current = connectUsingSession;
+    },
+    [connectUsingSession],
   );
 
   const connectUsingAPI = useCallback(
@@ -1076,6 +1088,12 @@ const LoginView: React.FC<{
     loginWithOpenID(client);
   }, [apiEndpoint]);
 
+  // Credentials are intentionally held in a ref (not state) to keep plaintext
+  // out of React state/DevTools; the ref is set alongside setNeedToResetPassword
+  // which drives the render that reads it here.
+  // eslint-disable-next-line react-hooks/refs -- see comment above
+  const expiredCredentials = expiredCredentialsRef.current;
+
   // Wrapper creates a stacking context above the splash overlay (z-index 10001 > splash 10000).
   // Zero-sized so it doesn't intercept pointer events. Child modals use
   // position:fixed internally so they are visible and interactive.
@@ -1120,7 +1138,7 @@ const LoginView: React.FC<{
             needsOtpRegistration={needsOtpRegistration}
             totpRegistrationToken={totpRegistrationToken}
             needToResetPassword={needToResetPassword}
-            expiredCredentials={expiredCredentialsRef.current}
+            expiredCredentials={expiredCredentials}
             showSignupModal={showSignupModal}
             signupPreloadedToken={signupPreloadedToken}
             showEndpointInput={showEndpointInput}

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -101,12 +101,12 @@ function MainLayout() {
   const isHiddenBreadcrumb = _.last(matches)?.handle?.hideBreadcrumb ?? false;
   const { styles } = useStyle();
 
-  useEffect(() => {
-    if (sideCollapsed !== compactSidebarActive) {
-      setSideCollapsed(!!compactSidebarActive);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [compactSidebarActive]);
+  const [prevCompactSidebarActive, setPrevCompactSidebarActive] =
+    useState(compactSidebarActive);
+  if (prevCompactSidebarActive !== compactSidebarActive) {
+    setPrevCompactSidebarActive(compactSidebarActive);
+    setSideCollapsed(!!compactSidebarActive);
+  }
 
   useKeyboardShortcut(
     (event) => {

--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -185,6 +185,7 @@ const RuntimeParameterFormSection: React.FC<
   // mutation). The initial* prop is read inside initializeValues via
   // useEffectEvent, so it always reflects the latest closure.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- form hydration must run post-mount
     initializeValues();
   }, [runtimeVariant, groups]);
 

--- a/react/src/components/StoragePermissionEditModal.tsx
+++ b/react/src/components/StoragePermissionEditModal.tsx
@@ -11,7 +11,7 @@ import { createStyles } from 'antd-style';
 import type { CheckboxChangeEvent } from 'antd/es/checkbox';
 import { BAIFlex, BAIModal, type BAIModalProps } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import React, { useEffect, useEffectEvent, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // `.ant-modal-title` shrinks to its content by default, so an inner flex's
@@ -85,17 +85,15 @@ const StoragePermissionEditModal: React.FC<Props> = ({
   const [editedKeys, setEditedKeys] = useState<string[]>(initialKeys);
   const [isSaving, setIsSaving] = useState<boolean>(false);
 
-  // Reset editable state when the modal (re-)opens. `targets`/`permissionKeys`
-  // are read via an effect event so a new array identity from the parent does
-  // not spuriously re-fire the reset while the modal is open.
-  const resetState = useEffectEvent(() => {
-    setEditedKeys(initialKeys());
-  });
-  useEffect(() => {
+  // Tracks `open` (not the arrays) so a new `targets`/`permissionKeys`
+  // identity from the parent does not re-fire the reset while open.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (open) {
-      resetState();
+      setEditedKeys(initialKeys());
     }
-  }, [open]);
+  }
 
   const handleOk = async (): Promise<void> => {
     if (hasMountWithoutFileOps(new Set(editedKeys))) {

--- a/react/src/components/UserSessionsMetrics.tsx
+++ b/react/src/components/UserSessionsMetrics.tsx
@@ -182,9 +182,12 @@ const UserSessionsMetrics: React.FC<UserSessionsMetricsProps> = () => {
   const [boardItems, setBoardItems] =
     useState<Array<BAIBoardItem>>(initialBoardItems);
 
-  useEffect(() => {
+  const [prevInitialBoardItems, setPrevInitialBoardItems] =
+    useState(initialBoardItems);
+  if (prevInitialBoardItems !== initialBoardItems) {
+    setPrevInitialBoardItems(initialBoardItems);
     setBoardItems(initialBoardItems);
-  }, [initialBoardItems]);
+  }
 
   return (
     <BAIFlex direction="column" align="stretch" gap="md">

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -200,12 +200,11 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
     id: string;
     name: string;
   } | null>(null);
-  // Discard a stale resolution if the value moves on to something else.
-  useEffect(() => {
-    if (resolvedFallback && resolvedFallback.id !== value) {
-      setResolvedFallback(null);
-    }
-  }, [value, resolvedFallback]);
+  // A stale resolution converges (the next render sees `null`), so the
+  // render-time discard cannot loop.
+  if (resolvedFallback && resolvedFallback.id !== value) {
+    setResolvedFallback(null);
+  }
   const needsRelayLookup =
     !currentValueIsInFilteredOptions &&
     !fallbackFolder &&

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -113,6 +113,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   onValidateSelectedRowKeys,
   ...tableProps
 }) => {
+  'use memo';
   const { generateFolderPath } = useFolderExplorerOpener();
   const getRowKey = React.useMemo(() => {
     return (record: VFolder) => {
@@ -317,26 +318,18 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   }, [currentProject.id]);
 
   const [searchKey, setSearchKey] = useState('');
-  const displayingFolders = useMemo(() => {
-    return _.filter(mountableFoldersByPermission, (vf) => {
-      // Apply external filter for display
-      if (rowFilter && !rowFilter(vf)) {
-        return false;
-      }
-      // Always show selected items
-      if (selectedRowKeys.includes(getRowKey(vf))) {
-        return true;
-      }
-      // Apply search filter
-      return !searchKey || vf.name.includes(searchKey);
-    });
-  }, [
-    mountableFoldersByPermission,
-    rowFilter,
-    selectedRowKeys,
-    getRowKey,
-    searchKey,
-  ]);
+  const displayingFolders = _.filter(mountableFoldersByPermission, (vf) => {
+    // Apply external filter for display
+    if (rowFilter && !rowFilter(vf)) {
+      return false;
+    }
+    // Always show selected items
+    if (selectedRowKeys.includes(getRowKey(vf))) {
+      return true;
+    }
+    // Apply search filter
+    return !searchKey || vf.name.includes(searchKey);
+  });
 
   /**
    * Converts the input path to an aliased path based on the provided name and input.

--- a/react/src/hooks/useControllableState.ts
+++ b/react/src/hooks/useControllableState.ts
@@ -66,6 +66,7 @@ function useControllableState_deprecated<T = any>(
 
   const stateRef = useRef(initialValue);
   if (isControlled) {
+    // eslint-disable-next-line react-hooks/refs -- ref-backed state of this deprecated hook kept per review
     stateRef.current = value;
   }
 
@@ -83,6 +84,7 @@ function useControllableState_deprecated<T = any>(
     }
   }
 
+  // eslint-disable-next-line react-hooks/refs -- ref-backed state of this deprecated hook kept per review
   return [stateRef.current, useMemoizedFn(setState)] as const;
 }
 
@@ -102,7 +104,6 @@ function useMemoizedFn<T extends noop>(fn: T) {
 
   const memoizedFn = useRef<PickFunction<T>>(null);
   if (!memoizedFn.current) {
-    // eslint-disable-next-line react-hooks/unsupported-syntax
     memoizedFn.current = function (this, ...args) {
       return fnRef.current.apply(this, args);
     };

--- a/react/src/hooks/useCurrentProject.tsx
+++ b/react/src/hooks/useCurrentProject.tsx
@@ -187,6 +187,10 @@ export const useSetCurrentProject = () => {
   const baiClient = useSuspendedBackendaiClient();
   const { writeRecentProjectGroup } = useRecentProjectGroup();
 
+  // The returned callback syncs the selected project to the external Backend.AI
+  // client singleton (an imperative API, not React state); the mutation is
+  // intentional and only runs from an event handler.
+  // eslint-disable-next-line react-hooks/immutability
   return useCallback(
     ({
       projectName,

--- a/react/src/hooks/useMemoWithPrevious.tsx
+++ b/react/src/hooks/useMemoWithPrevious.tsx
@@ -12,12 +12,15 @@ export const useMemoWithPrevious = <T,>(
   const prevRef = useRef(initialPrev);
   const [prevResetKey, setPrevResetKey] = useState({});
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Generic utility: `deps` is caller-provided and dynamic, so it cannot be an
+  // array literal as react-hooks/use-memo requires.
+  // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/use-memo
   const current = useMemo(factory, deps);
   const memoizedPrev = useMemo(() => {
     return prevRef.current;
-    // Only update when the reset key changes and deps change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Only update when the reset key changes and deps change.
+    // `deps` is caller-provided and dynamic, so this cannot be an array literal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/use-memo
   }, [...deps, prevResetKey]);
 
   useEffect(() => {

--- a/react/src/hooks/usePaginatedQuery.ts
+++ b/react/src/hooks/usePaginatedQuery.ts
@@ -35,6 +35,7 @@ export function useLazyPaginatedQuery<
   const previousOtherVariablesRef = useRef(otherVariables);
 
   const isNewOtherVariables = !_.isEqual(
+    // eslint-disable-next-line react-hooks/refs -- render-phase previous-page tracking kept per review
     previousOtherVariablesRef.current,
     otherVariables,
   );
@@ -53,10 +54,11 @@ export function useLazyPaginatedQuery<
   const data = useMemo(() => {
     const items = getItem(result);
     if (isNewOtherVariables) {
+      // eslint-disable-next-line react-hooks/refs -- render-phase previous-page tracking kept per review
       previousResult.current = [];
     }
     return items
-      ? _.uniqBy([...previousResult.current, ...items], getId)
+      ? _.uniqBy([...previousResult.current, ...items], getId) // eslint-disable-line react-hooks/refs
       : undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [result]);
@@ -76,6 +78,7 @@ export function useLazyPaginatedQuery<
     // Reset the offset and limit when otherVariables change after success rendering
     if (isNewOtherVariables) {
       previousOtherVariablesRef.current = otherVariables;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- offset reset on variable change kept per review
       setOffset(0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -194,11 +194,7 @@ export type AppOption = {
 };
 
 export type SessionLauncherStepKey =
-  | 'sessionType'
-  | 'environment'
-  | 'storage'
-  | 'network'
-  | 'review';
+  'sessionType' | 'environment' | 'storage' | 'network' | 'review';
 
 type StepItem = NonNullable<StepsProps['items']>[number];
 
@@ -257,6 +253,7 @@ const SessionLauncherPage = () => {
     () => {
       // To sync the latest form values to URL,
       // 'trailing' is set to true, and get the form values here."
+      // eslint-disable-next-line react-hooks/immutability -- forward reference to a later declaration kept as-is
       const currentValue = form.getFieldsValue();
       setQuery({
         formValues: _.assign(
@@ -410,6 +407,7 @@ const SessionLauncherPage = () => {
   useEffect(() => {
     if (finalStepLastValidateTime !== 'first') {
       if (hasError) {
+        // eslint-disable-next-line react-hooks/immutability -- forward reference to a later declaration kept as-is
         setValidationTourOpen(true);
       } else {
         setValidationTourOpen(false);
@@ -428,6 +426,7 @@ const SessionLauncherPage = () => {
   useLayoutEffect(() => {
     if (isQueryReset) {
       form.resetFields();
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- legacy query-reset flow kept as-is
       setIsQueryReset(false);
     }
   }, [isQueryReset, form]);

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -122,6 +122,7 @@ const StartPage: React.FC = () => {
   });
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- mount-only URL-param handling; must run as an effect
     badgeEventHandler();
   }, []);
 

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -107,11 +107,12 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     Array<VFolderNodesType>
   >([]);
 
-  useEffect(() => {
+  // Reset selectedRowKeys when currentProject changes
+  const [prevProjectId, setPrevProjectId] = useState(currentProject.id);
+  if (prevProjectId !== currentProject.id) {
+    setPrevProjectId(currentProject.id);
     setSelectedFolderList([]);
-
-    // Reset selectedRowKeys when currentProject changes
-  }, [currentProject.id]);
+  }
 
   const [isOpenCreateModal, { toggle: toggleCreateModal }] = useToggle(false);
   const [isOpenDeleteModal, { toggle: toggleDeleteModal }] = useToggle(false);
@@ -139,10 +140,12 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   const queryMapRef = useRef({
     [queryParams.statusCategory]: { queryParams, tablePaginationOption },
   });
-  queryMapRef.current[queryParams.statusCategory] = {
-    queryParams,
-    tablePaginationOption,
-  };
+  useEffect(() => {
+    queryMapRef.current[queryParams.statusCategory] = {
+      queryParams,
+      tablePaginationOption,
+    };
+  }, [queryParams, tablePaginationOption]);
 
   function getUsageModeFilter(mode: string) {
     switch (mode) {


### PR DESCRIPTION
Resolves #8312 (FR-3338)

## Problem

#8295 (FR-3330) bumped the pnpm catalog `eslint-plugin-react-hooks` `^7.0.1` → `^7.1.1`. 7.1.1's React-Compiler-powered rules have substantially stronger detection (improved `set-state-in-effect` validation, deeper ref tracking, whole-file error reporting), which flags **63 pre-existing violations** — 44 errors in `react`, 19 in `packages/backend.ai-ui`. On fresh installs (CI) the lint step fails, so vitest never runs and the coverage action errors with ENOENT on `coverage-summary.json`. Local checkouts with pre-bump `node_modules` still resolve 7.0.1 for `eslint-config-bai`, which is why this wasn't caught locally.

## What this PR does

Resolves all 63 diagnostics across 35 files with a mix of real fixes and **34 targeted per-line suppressions** (each with an inline rationale). Five riskier hook/component rewrites flagged during review were reverted to their original implementations and suppressed instead — see "Review updates" below.

- **`react-hooks/set-state-in-effect`** — most sites converted to derive-during-render, the official "adjust state during render" pattern (track prev value in state, compare and reset during render). `EmailVerificationView` and `ChatInput` keep their original effect-based sync with suppressions (reverted per review — the rewrites changed mount-time behavior).
- **`react-hooks/refs`** — removed render-time `.current` reads/writes where a behavior-preserving fix exists: effect/handler-scoped access (`BAIFileExplorer` captures the portal container in the `dragenter` handler) and other state-based conversions. The deprecated `useControllableState` keeps its original ref + forceUpdate implementation, and both `usePaginatedQuery` copies keep their original ref-based page accumulation, all with suppressions (reverted per review — the conversions changed functional-updater semantics / diverged the two copies).
- **`react-hooks/immutability`** — replaced prop/argument mutation with local consts (`BAIRowWrapWithDividers`), and reordered use-before-declaration callbacks (`LoginView`'s `handleGQLError` / `handleLoginError`).
- **`react-hooks/use-memo` / `preserve-manual-memoization`** — unwrapped flagged `useMemo`s into plain consts and added `'use memo'` where the enclosing function wasn't annotated (`VFolderTable`, `ChatCard`'s `useModels`) so the React Compiler owns the memoization.
- **1 stale `react-hooks/unsupported-syntax` disable** removed (`useControllableState`'s `useMemoizedFn` lazy-init — 7.1.1's analysis no longer flags this pattern, so the directive became an unused-disable warning).

### Suppressions (34) — behavior-preserving fix not available, or original behavior deliberately kept

| Site | Why |
|---|---|
| `BAIFetchKeyButton` (1) | minimum-700ms anti-flicker loading display timing |
| `BAIProjectResourceGroupSelect` (2) | `startTransition`-wrapped controlled-value sync to async-fetched options |
| `BAIModal` (1) | parent `onWindowStateChange` notification on programmatic close |
| `BAIGraphQLPropertyFilter` (1) | DatePicker "Now" fires `onChange` twice; the state round-trip batches them so one pick adds exactly one condition |
| `ChatHistory` (6) | complex legacy chat-cache mutation flow intentionally kept as-is (in-place mutations + id-change re-init) |
| `SessionLauncherPage` (3) | complex launcher flow intentionally kept as-is (forward references + legacy query-reset effect) |
| `useCurrentProject` (1) | intentional imperative sync to the external Backend.AI client singleton |
| `useMemoWithPrevious` (2) | generic utility with caller-provided dynamic deps |
| `StartPage` (1) | run-once-on-mount URL-param handling |
| `ConfigurationsSettingList` (1) | mount-only settings fetch (query-library migration out of scope) |
| `DeploymentAddRevisionModal` (1) | `setFieldsValue` prefill must run post-mount |
| `RuntimeParameterFormSection` (1) | form hydration keyed on `runtimeVariant`/`groups` only |
| `LoginView` (1) | `expiredCredentialsRef` deliberately keeps plaintext credentials out of React state |
| `usePaginatedQuery` — `react/` + `backend.ai-ui` (8) | original render-phase previous-page ref tracking and effect-based offset reset kept per review, symmetric across both copies |
| `useControllableState` (2) | deprecated hook; original ref-backed state kept per review to preserve sequential functional-updater semantics |
| `ChatInput` (1) | original atom-driven files sync effect kept per review (mount-time sync of pre-existing shared attachments) |
| `EmailVerificationView` (1) | original effect-based failure state kept per review (missing-token case must fail on mount) |

## Review updates

- `fea53a84` — reverted the review-flagged rewrites of `EmailVerificationView`, `ChatInput`, `useControllableState`, and both `usePaginatedQuery` copies back to their exact pre-PR implementations; the 7.1.1 diagnostics on those lines are suppressed with line-scoped disables instead.
- `8bbb84f4` — appended `-- reason` rationale suffixes to the new directives and restored the original ternary line shape in the two `usePaginatedQuery` copies.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript)
- `pnpm -r lint` → exit 0 (react and backend.ai-ui both clean with plugin 7.1.1 resolved for all importers, zero unused disable directives)
- `react` vitest: 48 files / **944 tests passed**; `backend.ai-ui` vitest: **363 passed**, 1 pre-existing skip

## Follow-up candidate (not in this PR)

The "track-previous-value + adjust-state-during-render" idiom is now inlined ~16 times. Extracting a shared `useResetOnChange(value, callback, { fireOnMount })` hook (one copy per package) would express the pattern once — intentionally left out of this CI-unblock PR to keep the diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
