### PR TITLE
style(FR-3339): hide the Invalidated At column on the login sessions page

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAILoginSessionTableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAILoginSessionTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3bf8c18c092c8207b75fa939ee3288e8>>
+ * @generated SignedSource<<44a6cdf64de6980568f3b74f0dbd5872>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,6 @@ export type BAILoginSessionTableFragment$data = ReadonlyArray<{
   readonly accessKey: string;
   readonly createdAt: string;
   readonly id: string;
-  readonly invalidatedAt: string | null | undefined;
   readonly user: {
     readonly basicInfo: {
       readonly email: string;
@@ -62,13 +61,6 @@ return {
     {
       "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "invalidatedAt",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
       "concreteType": "UserV2",
       "kind": "LinkedField",
       "name": "user",
@@ -102,6 +94,6 @@ return {
 };
 })();
 
-(node as any).hash = "694171fd979eb4444dc4d4e07bfb034e";
+(node as any).hash = "b191c9ad8bef80db83e6a304d36baeac";
 
 export default node;

--- a/packages/backend.ai-ui/src/components/BAILoginSessionTable.tsx
+++ b/packages/backend.ai-ui/src/components/BAILoginSessionTable.tsx
@@ -47,10 +47,10 @@ export interface BAILoginSessionTableProps extends Omit<
 
 /**
  * BAILoginSessionTable - Presentational table over a `LoginSessionV2` plural
- * fragment. Renders every login-session column; filter, pagination, and query
- * orchestration (plus row-level actions such as revoke) live in the consuming
- * surface via the `customizeColumns` prop. Mirrors the `*Nodes` idiom
- * (`BAIAuditLogNodes`, `SessionNodes`).
+ * fragment. Renders the user, access key, and created-at columns; filter,
+ * pagination, and query orchestration (plus row-level actions such as revoke)
+ * live in the consuming surface via the `customizeColumns` prop. Mirrors the
+ * `*Nodes` idiom (`BAIAuditLogNodes`, `SessionNodes`).
  */
 const BAILoginSessionTable = ({
   loginSessionsFrgmt,
@@ -71,7 +71,6 @@ const BAILoginSessionTable = ({
         # status is intentionally not selected: the backend does not write it
         # yet, so it is neither displayed nor filterable here.
         createdAt
-        invalidatedAt
         user {
           id
           basicInfo {
@@ -112,15 +111,17 @@ const BAILoginSessionTable = ({
         render: (__, record) =>
           record.createdAt ? dayjs(record.createdAt).format('ll LTS') : '-',
       },
-      {
-        key: 'invalidatedAt',
-        title: t('comp:BAILoginSessionTable.InvalidatedAt'),
-        dataIndex: 'invalidatedAt',
-        render: (__, record) =>
-          record.invalidatedAt
-            ? dayjs(record.invalidatedAt).format('ll LTS')
-            : '-',
-      },
+      // invalidatedAt currently receives no value at all, so this column is
+      // disabled until it carries meaningful data.
+      // {
+      //   key: 'invalidatedAt',
+      //   title: t('comp:BAILoginSessionTable.InvalidatedAt'),
+      //   dataIndex: 'invalidatedAt',
+      //   render: (__, record) =>
+      //     record.invalidatedAt
+      //       ? dayjs(record.invalidatedAt).format('ll LTS')
+      //       : '-',
+      // },
     ]),
     (column) => {
       return disableSorter ? _.omit(column, 'sorter') : column;

--- a/react/src/__generated__/LoginSessionQuery.graphql.ts
+++ b/react/src/__generated__/LoginSessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bc76c96312e15186a8c19266351133d9>>
+ * @generated SignedSource<<27c7f5a1b4759ab59e3d9f793bf3f457>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -254,13 +254,6 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "invalidatedAt",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
                     "concreteType": "UserV2",
                     "kind": "LinkedField",
                     "name": "user",
@@ -300,12 +293,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3c52e1ab1acbf8872809ee9723190991",
+    "cacheID": "3e0d75c6f9a233d90ba58b2e40228b66",
     "id": null,
     "metadata": {},
     "name": "LoginSessionQuery",
     "operationKind": "query",
-    "text": "query LoginSessionQuery(\n  $filter: LoginSessionFilter\n  $orderBy: [LoginSessionOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  myLoginSessionsV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAILoginSessionTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAILoginSessionTableFragment on LoginSessionV2 {\n  id\n  accessKey\n  createdAt\n  invalidatedAt\n  user {\n    id\n    basicInfo {\n      email\n    }\n  }\n}\n"
+    "text": "query LoginSessionQuery(\n  $filter: LoginSessionFilter\n  $orderBy: [LoginSessionOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  myLoginSessionsV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        ...BAILoginSessionTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment BAILoginSessionTableFragment on LoginSessionV2 {\n  id\n  accessKey\n  createdAt\n  user {\n    id\n    basicInfo {\n      email\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Resolves #8318 (FR-3339)

## Changes

Hide the **Invalidated At** column on the login sessions page. The backend currently sends no value for `invalidatedAt`, so every row displayed `-`.

- Comment out the column definition in `BAILoginSessionTable` (kept as a comment so it can be re-enabled once the field carries meaningful data).
- Drop `invalidatedAt` from the `BAILoginSessionTableFragment` selection (same idiom as the unselected `status` field) and regenerate Relay artifacts.

## Verification

`bash scripts/verify.sh`:
- Relay: PASS
- Format: PASS
- TypeScript: PASS
- Vite warmup paths: PASS
- Lint: FAIL — 19 pre-existing `eslint-plugin-react-hooks` 7.1.1 compiler diagnostics in untouched files; reproduces identically on `main` and is being addressed in FR-3337/FR-3338. No lint errors in the files changed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeN3vqTfhCts3TAbrmLmuS