### PR TITLE
fix(FR-3341): rework Chat endpoint token selector

### DIFF
--- a/react/src/__generated__/EndpointTokenSelectQuery.graphql.ts
+++ b/react/src/__generated__/EndpointTokenSelectQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b4c2bd16d169a3749d9ec76613a28da2>>
+ * @generated SignedSource<<b0525c4d71a8c4df4d253016febb9402>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,17 +11,20 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { Result } from "relay-runtime";
 export type EndpointTokenSelectQuery$variables = {
-  endpointId: string;
-  isEmptyEndpointId: boolean;
+  deploymentId: string;
 };
 export type EndpointTokenSelectQuery$data = {
-  readonly endpoint_token_list: Result<{
-    readonly items: ReadonlyArray<{
-      readonly created_at: string;
-      readonly id: string | null | undefined;
-      readonly token: string;
-      readonly valid_until: string | null | undefined;
-    } | null | undefined>;
+  readonly deployment: Result<{
+    readonly accessTokens: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly createdAt: string;
+          readonly expiresAt: string | null | undefined;
+          readonly id: string;
+          readonly token: string;
+        };
+      }>;
+    } | null | undefined;
   } | null | undefined, unknown>;
 };
 export type EndpointTokenSelectQuery = {
@@ -34,79 +37,88 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "endpointId"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "isEmptyEndpointId"
+    "name": "deploymentId"
   }
 ],
-v1 = {
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "deploymentId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
   "alias": null,
   "args": [
     {
-      "kind": "Variable",
-      "name": "endpoint_id",
-      "variableName": "endpointId"
-    },
-    {
       "kind": "Literal",
-      "name": "limit",
-      "value": 100
-    },
-    {
-      "kind": "Literal",
-      "name": "offset",
-      "value": 0
+      "name": "orderBy",
+      "value": [
+        {
+          "direction": "DESC",
+          "field": "CREATED_AT"
+        }
+      ]
     }
   ],
-  "concreteType": "EndpointTokenList",
+  "concreteType": "AccessTokenConnection",
   "kind": "LinkedField",
-  "name": "endpoint_token_list",
+  "name": "accessTokens",
   "plural": false,
   "selections": [
     {
       "alias": null,
       "args": null,
-      "concreteType": "EndpointToken",
+      "concreteType": "AccessTokenEdge",
       "kind": "LinkedField",
-      "name": "items",
+      "name": "edges",
       "plural": true,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "id",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "token",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "created_at",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "valid_until",
+          "concreteType": "AccessToken",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v2/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "token",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "createdAt",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "expiresAt",
+              "storageKey": null
+            }
+          ],
           "storageKey": null
         }
       ],
       "storageKey": null
     }
   ],
-  "storageKey": null
+  "storageKey": "accessTokens(orderBy:[{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"}])"
 };
 return {
   "fragment": {
@@ -117,7 +129,18 @@ return {
     "selections": [
       {
         "kind": "CatchField",
-        "field": (v1/*: any*/),
+        "field": {
+          "alias": null,
+          "args": (v1/*: any*/),
+          "concreteType": "ModelDeployment",
+          "kind": "LinkedField",
+          "name": "deployment",
+          "plural": false,
+          "selections": [
+            (v3/*: any*/)
+          ],
+          "storageKey": null
+        },
         "to": "RESULT"
       }
     ],
@@ -130,20 +153,32 @@ return {
     "kind": "Operation",
     "name": "EndpointTokenSelectQuery",
     "selections": [
-      (v1/*: any*/)
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ModelDeployment",
+        "kind": "LinkedField",
+        "name": "deployment",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
     ]
   },
   "params": {
-    "cacheID": "f8777131f4094de086beaa0e11d6ae09",
+    "cacheID": "804f425e87909bf310afc6b08603997f",
     "id": null,
     "metadata": {},
     "name": "EndpointTokenSelectQuery",
     "operationKind": "query",
-    "text": "query EndpointTokenSelectQuery(\n  $endpointId: UUID!\n  $isEmptyEndpointId: Boolean!\n) {\n  endpoint_token_list(offset: 0, limit: 100, endpoint_id: $endpointId) @skipOnClient(if: $isEmptyEndpointId) {\n    items {\n      id\n      token\n      created_at\n      valid_until\n    }\n  }\n}\n"
+    "text": "query EndpointTokenSelectQuery(\n  $deploymentId: ID!\n) {\n  deployment(id: $deploymentId) {\n    accessTokens(orderBy: [{field: CREATED_AT, direction: DESC}]) {\n      edges {\n        node {\n          id\n          token\n          createdAt\n          expiresAt\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "839fdaad7009de6f1d8dc79de4e35a3d";
+(node as any).hash = "510ee4474805d8ecefee557eab25da84";
 
 export default node;

--- a/react/src/components/Chat/EndpointTokenSelect.tsx
+++ b/react/src/components/Chat/EndpointTokenSelect.tsx
@@ -6,28 +6,47 @@ import type {
   EndpointTokenSelectQuery,
   EndpointTokenSelectQuery$data,
 } from '../../__generated__/EndpointTokenSelectQuery.graphql';
+import WebUILink from '../WebUILink';
+import { SettingOutlined } from '@ant-design/icons';
 import { useControllableValue } from 'ahooks';
-import { Input, Select } from 'antd';
+import { Input, Select, Tooltip, theme } from 'antd';
 import type { SelectProps } from 'antd';
+import {
+  BAIFlex,
+  BAIText,
+  filterOutNullAndUndefined,
+  toGlobalId,
+} from 'backend.ai-ui';
 import dayjs from 'dayjs';
-import { castArray, sortBy } from 'lodash-es';
-import { useMemo } from 'react';
+import { castArray, maxBy } from 'lodash-es';
+import { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
-function sortEndpointTokenList(
-  endpointTokenListData: EndpointTokenSelectQuery$data['endpoint_token_list'],
+function getValidTokenOptions(
+  deploymentData: EndpointTokenSelectQuery$data['deployment'],
 ) {
-  if (!endpointTokenListData.ok) return [];
+  if (!deploymentData.ok) return [];
 
   const now = dayjs();
-  return sortBy(endpointTokenListData.value?.items, 'created_at').map(
-    (item) => ({
-      label: item?.token,
-      value: item?.token,
-      // FIXME: temporally parse UTC and change to timezone (timezone need to be added in server side)
-      disabled: !dayjs.utc(item?.valid_until).tz().isAfter(now),
-    }),
+  const tokens = filterOutNullAndUndefined(
+    deploymentData.value?.accessTokens?.edges?.map((edge) => edge?.node),
+  );
+  return (
+    tokens
+      .map((item) => ({
+        token: item.token ?? '',
+        createdAt: item.createdAt,
+        issued: dayjs(item.createdAt),
+        // A null `expiresAt` means the token never expires — this mirrors the
+        // deployment's Access Tokens table (which shows "No expiration"). Read
+        // the same Strawberry `accessTokens` connection as that page so both
+        // surfaces agree on each token's expiry (FR-3341).
+        expires: item.expiresAt ? dayjs(item.expiresAt) : null,
+      }))
+      // Hide only tokens that have already expired. Never-expiring tokens
+      // (expires === null) are always valid and kept.
+      .filter((item) => !item.expires || item.expires.isAfter(now))
   );
 }
 
@@ -39,56 +58,123 @@ const EndpointTokenSelectWithQuery: React.FC<
   EndpointTokenSelectProps & {
     endpointId: string;
   }
-> = ({ endpointId, ...props }) => {
+> = ({ endpointId, style, ...props }) => {
+  'use memo';
   const { t } = useTranslation();
+  const { token: themeToken } = theme.useToken();
   const [controllableValue, setControllableValue] =
     useControllableValue<string>(props);
 
-  const { endpoint_token_list } = useLazyLoadQuery<EndpointTokenSelectQuery>(
+  const { deployment } = useLazyLoadQuery<EndpointTokenSelectQuery>(
     graphql`
-      query EndpointTokenSelectQuery(
-        $endpointId: UUID!
-        $isEmptyEndpointId: Boolean!
-      ) {
-        endpoint_token_list(offset: 0, limit: 100, endpoint_id: $endpointId)
-          @skipOnClient(if: $isEmptyEndpointId)
-          @catch {
-          items {
-            id
-            token
-            created_at
-            valid_until
+      query EndpointTokenSelectQuery($deploymentId: ID!) {
+        deployment(id: $deploymentId) @catch {
+          accessTokens(orderBy: [{ field: CREATED_AT, direction: DESC }]) {
+            edges {
+              node {
+                id
+                token
+                createdAt
+                expiresAt
+              }
+            }
           }
         }
       }
     `,
     {
-      endpointId: endpointId,
-      isEmptyEndpointId: false,
+      // `endpointId` is the ModelDeployment's local UUID; the Strawberry
+      // `deployment(id:)` field takes the global Relay ID. This component only
+      // mounts with a non-empty endpointId (the outer EndpointTokenSelect
+      // renders a plain Input otherwise), so no client-skip guard is needed.
+      deploymentId: toGlobalId('ModelDeployment', endpointId),
     },
+    // Refetch on mount so returning from token creation (e.g. via the Access
+    // Token Settings shortcut) does not render a stale cached list. This reads
+    // the same `accessTokens` connection the create-token flow writes to, so a
+    // freshly created token shows up here too.
+    { fetchPolicy: 'store-and-network' },
   );
 
-  const selectOptions = useMemo(
-    () => sortEndpointTokenList(endpoint_token_list),
-    [endpoint_token_list],
-  );
+  // Expired tokens are hidden (there are often many). Label each valid option
+  // with a short token-tail chip — the differing end of the JWT, so the user can
+  // match it against a token they hold; raw strings are otherwise
+  // indistinguishable after truncation since they share the eyJhbGci… header —
+  // plus its expiry date. The full issued → expiry timestamps show on hover as a
+  // native tooltip (FR-3341).
+  const validTokens = getValidTokenOptions(deployment);
+  const noExpirationLabel = t('deployment.accessToken.NoExpiration');
+  const selectOptions = validTokens.map((item) => ({
+    // The raw token stays as the value the form submits.
+    value: item.token,
+    label: (
+      <BAIFlex
+        title={`${item.issued.format('lll')} → ${item.expires?.format('lll') ?? noExpirationLabel}`}
+        gap="xs"
+        align="center"
+        style={{ overflow: 'hidden' }}
+      >
+        <BAIText code style={{ flexShrink: 0, margin: 0 }}>
+          …{item.token.slice(-6)}
+        </BAIText>
+        <BAIText
+          type="secondary"
+          ellipsis
+          style={{ flex: 1, minWidth: 0, fontSize: themeToken.fontSizeSM }}
+        >
+          {item.expires ? `~ ${item.expires.format('ll')}` : noExpirationLabel}
+        </BAIText>
+      </BAIFlex>
+    ),
+  }));
 
-  return selectOptions.length <= 0 ? (
-    <Input onChange={(e) => setControllableValue(e.target.value)} />
-  ) : (
-    <Select
-      placeholder={t('chatui.SelectToken')}
-      style={{
-        fontWeight: 'normal',
-        width: '200px',
-      }}
-      options={selectOptions}
-      value={controllableValue}
-      onChange={(_, option) => {
-        setControllableValue(castArray(option)?.[0].value ?? '');
-      }}
-      {...props}
-    />
+  // Default to the most recent valid token (latest created_at) when the field
+  // is still empty. Applied once when tokens load; if the user clears the
+  // selection it is not re-applied.
+  const latestValidToken = maxBy(validTokens, 'createdAt')?.token;
+  const applyDefaultToken = useEffectEvent(() => {
+    if (!controllableValue && latestValidToken) {
+      setControllableValue(latestValidToken);
+    }
+  });
+  useEffect(() => {
+    applyDefaultToken();
+  }, [latestValidToken]);
+
+  // Always render the Select (empty placeholder when there is no valid token)
+  // with a compact link beside it to create a token in the deployment's Access
+  // Tokens — a convenient shortcut shown regardless of whether tokens exist.
+  return (
+    <BAIFlex gap="xs" align="center">
+      <Select
+        placeholder={t('chatui.SelectToken')}
+        // Fixed width so the token field looks the same across panel sizes
+        // instead of following CustomModelForm's responsive 100%/200px width,
+        // while still shrinking to fit narrow screens (maxWidth + minWidth 0).
+        style={{
+          ...style,
+          width: 220,
+          maxWidth: '100%',
+          minWidth: 0,
+          fontWeight: 'normal',
+        }}
+        options={selectOptions}
+        value={controllableValue}
+        onChange={(_, option) => {
+          setControllableValue(castArray(option)?.[0].value ?? '');
+        }}
+        {...props}
+      />
+      <WebUILink
+        to={`/deployments/${endpointId}#access-tokens`}
+        aria-label={t('deployment.AccessTokenSettings')}
+        style={{ flexShrink: 0, display: 'inline-flex' }}
+      >
+        <Tooltip title={t('deployment.AccessTokenSettings')}>
+          <SettingOutlined style={{ color: themeToken.colorTextSecondary }} />
+        </Tooltip>
+      </WebUILink>
+    </BAIFlex>
   );
 };
 
@@ -96,6 +182,7 @@ const EndpointTokenSelect: React.FC<EndpointTokenSelectProps> = ({
   endpointId,
   ...props
 }) => {
+  'use memo';
   const [controllableValue, setControllableValue] =
     useControllableValue<string>(props);
 

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -36,15 +36,33 @@ import {
 } from 'backend.ai-ui';
 import type { GraphQLFormattedError } from 'graphql';
 import { BotMessageSquareIcon, PlusIcon } from 'lucide-react';
-import React, { useRef, useState, useTransition } from 'react';
+import React, {
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
 // Poll interval (ms) for refreshing the page query while a revision rollout is
 // in progress, so the deployment state moves off the "applying" banner once the
 // rollout settles.
 const REVISION_ROLLOUT_POLL_INTERVAL = 5000;
+
+// Smooth-scroll a page section into view, offsetting the sticky header so it is
+// not hidden underneath. Shared by the deep-link handler and the
+// revision/access-token "created" callbacks.
+const scrollSectionIntoView = (
+  el: HTMLElement | null,
+  headerHeight: number | string,
+) => {
+  if (!el) return;
+  el.style.scrollMarginTop = `${headerHeight}px`;
+  el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+};
 
 const DeploymentDetailPage: React.FC = () => {
   'use memo';
@@ -80,6 +98,26 @@ const DeploymentDetailPage: React.FC = () => {
 
   const revisionsSectionRef = useRef<HTMLDivElement>(null);
   const accessTokensSectionRef = useRef<HTMLDivElement>(null);
+
+  // Deep links scroll a section into view via the URL hash (e.g. the Chat token
+  // selector's shortcut lands on `#access-tokens`).
+  const { hash } = useLocation();
+  const scrollToHashSection = useEffectEvent(() => {
+    // To make another section deep-linkable, add a `#hash → section ref` entry.
+    const sectionRefByHash: Record<string, { current: HTMLDivElement | null }> =
+      {
+        '#revisions': revisionsSectionRef,
+        '#access-tokens': accessTokensSectionRef,
+      };
+    scrollSectionIntoView(
+      sectionRefByHash[hash]?.current ?? null,
+      token.Layout?.headerHeight ?? 60,
+    );
+  });
+  useEffect(() => {
+    scrollToHashSection();
+  }, [hash]);
+
   // Fragment ref of the revision just created via the Add Revision modal.
   // When set, its detail drawer opens automatically so the user can confirm
   // the configuration that was actually persisted (FR-3005) — notably fields
@@ -251,13 +289,10 @@ const DeploymentDetailPage: React.FC = () => {
         // refresh or a tab re-mount.
         updateReplicaFetchKey();
       });
-      if (revisionsSectionRef.current) {
-        revisionsSectionRef.current.style.scrollMarginTop = `${token.Layout?.headerHeight ?? 60}px`;
-        revisionsSectionRef.current.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
-      }
+      scrollSectionIntoView(
+        revisionsSectionRef.current,
+        token.Layout?.headerHeight ?? 60,
+      );
     }
   };
 
@@ -415,13 +450,10 @@ const DeploymentDetailPage: React.FC = () => {
           // otherwise the "Private deployment" alert (which is gated on
           // `hasAccessTokens === false`) stays visible after creation.
           handleRefetch();
-          if (accessTokensSectionRef.current) {
-            accessTokensSectionRef.current.style.scrollMarginTop = `${token.Layout?.headerHeight ?? 60}px`;
-            accessTokensSectionRef.current.scrollIntoView({
-              behavior: 'smooth',
-              block: 'start',
-            });
-          }
+          scrollSectionIntoView(
+            accessTokensSectionRef.current,
+            token.Layout?.headerHeight ?? 60,
+          );
         }}
       />
       {/* No page-level Suspense boundary needed: the modal renders its chrome

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Zugriffstoken",
+    "AccessTokenSettings": "Zugriffstoken-Einstellungen",
     "AccessTokens": "Zugriffstoken",
     "ActivePool": "Aktiver Pool",
     "ActivePoolDescription": "Replikate, die derzeit über App Proxy Datenverkehr empfangen.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Διακριτικό πρόσβασης",
+    "AccessTokenSettings": "Ρυθμίσεις διακριτικού πρόσβασης",
     "AccessTokens": "Διακριτικά πρόσβασης",
     "ActivePool": "Ενεργή Ομάδα",
     "ActivePoolDescription": "Αντίγραφα που λαμβάνουν τρέχουσα κίνηση μέσω App Proxy.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -994,6 +994,7 @@
   },
   "deployment": {
     "AccessToken": "Access Token",
+    "AccessTokenSettings": "Access Token Settings",
     "AccessTokens": "Access Tokens",
     "ActivePool": "Active Pool",
     "ActivePoolDescription": "Replicas currently receiving traffic through App Proxy.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Token de acceso",
+    "AccessTokenSettings": "Configuración del token de acceso",
     "AccessTokens": "Tokens de acceso",
     "ActivePool": "Pool Activo",
     "ActivePoolDescription": "Réplicas que actualmente reciben tráfico a través de App Proxy.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Pääsytunnus",
+    "AccessTokenSettings": "Pääsytunnuksen asetukset",
     "AccessTokens": "Pääsytunnukset",
     "ActivePool": "Aktiivinen allas",
     "ActivePoolDescription": "Replikat, jotka vastaanottavat liikennettä App Proxyn kautta.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Jeton d'accès",
+    "AccessTokenSettings": "Paramètres du jeton d'accès",
     "AccessTokens": "Jetons d'accès",
     "ActivePool": "Pool actif",
     "ActivePoolDescription": "Répliques recevant actuellement du trafic via App Proxy.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Token Akses",
+    "AccessTokenSettings": "Pengaturan Token Akses",
     "AccessTokens": "Token Akses",
     "ActivePool": "Pool Aktif",
     "ActivePoolDescription": "Replika yang saat ini menerima lalu lintas melalui App Proxy.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Token di accesso",
+    "AccessTokenSettings": "Impostazioni del token di accesso",
     "AccessTokens": "Token di accesso",
     "ActivePool": "Pool Attivo",
     "ActivePoolDescription": "Repliche che ricevono attualmente traffico tramite App Proxy.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "アクセストークン",
+    "AccessTokenSettings": "アクセストークンの設定",
     "AccessTokens": "アクセストークン",
     "ActivePool": "アクティブプール",
     "ActivePoolDescription": "App Proxy を通じてトラフィックを受信中のレプリカです。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "액세스 토큰",
+    "AccessTokenSettings": "액세스 토큰 설정",
     "AccessTokens": "액세스 토큰",
     "ActivePool": "활성 풀",
     "ActivePoolDescription": "App Proxy를 통해 현재 트래픽을 수신 중인 복제본입니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Хандалтын токен",
+    "AccessTokenSettings": "Хандалтын токены тохиргоо",
     "AccessTokens": "Хандалтын токенууд",
     "ActivePool": "Идэвхтэй сан",
     "ActivePoolDescription": "App Proxy-р дамжуулан одоогоор трафик хүлээн авч буй репликүүд.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Token Akses",
+    "AccessTokenSettings": "Tetapan Token Akses",
     "AccessTokens": "Token Akses",
     "ActivePool": "Pool Aktif",
     "ActivePoolDescription": "Replika yang sedang menerima trafik melalui App Proxy.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Token dostępu",
+    "AccessTokenSettings": "Ustawienia tokenu dostępu",
     "AccessTokens": "Tokeny dostępu",
     "ActivePool": "Aktywna pula",
     "ActivePoolDescription": "Repliki aktualnie odbierające ruch przez App Proxy.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Token de acesso",
+    "AccessTokenSettings": "Definições do token de acesso",
     "AccessTokens": "Tokens de acesso",
     "ActivePool": "Pool Ativo",
     "ActivePoolDescription": "Réplicas atualmente recebendo tráfego pelo App Proxy.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Token de acesso",
+    "AccessTokenSettings": "Definições do token de acesso",
     "AccessTokens": "Tokens de acesso",
     "ActivePool": "Pool Ativo",
     "ActivePoolDescription": "Réplicas a receber tráfego atualmente através do App Proxy.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Токен доступа",
+    "AccessTokenSettings": "Настройки токена доступа",
     "AccessTokens": "Токены доступа",
     "ActivePool": "Активный пул",
     "ActivePoolDescription": "Реплики, в настоящее время получающие трафик через App Proxy.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "โทเค็นการเข้าถึง",
+    "AccessTokenSettings": "การตั้งค่าโทเค็นการเข้าถึง",
     "AccessTokens": "โทเค็นการเข้าถึง",
     "ActivePool": "แอ็กทีฟพูล",
     "ActivePoolDescription": "เรพลิกาที่กำลังรับทราฟฟิกผ่าน App Proxy ในขณะนี้",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Erişim Jetonu",
+    "AccessTokenSettings": "Erişim Jetonu Ayarları",
     "AccessTokens": "Erişim Jetonları",
     "ActivePool": "Aktif Havuz",
     "ActivePoolDescription": "App Proxy aracılığıyla şu anda trafik alan replikalar.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "Mã thông báo truy cập",
+    "AccessTokenSettings": "Cài đặt mã thông báo truy cập",
     "AccessTokens": "Mã thông báo truy cập",
     "ActivePool": "Pool Hoạt Động",
     "ActivePoolDescription": "Các bản sao đang nhận lưu lượng truy cập qua App Proxy.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1007,6 +1007,7 @@
   },
   "deployment": {
     "AccessToken": "访问令牌",
+    "AccessTokenSettings": "访问令牌设置",
     "AccessTokens": "访问令牌",
     "ActivePool": "活跃池",
     "ActivePoolDescription": "当前通过 App Proxy 接收流量的副本。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1008,6 +1008,7 @@
   },
   "deployment": {
     "AccessToken": "存取令牌",
+    "AccessTokenSettings": "存取令牌設置",
     "AccessTokens": "存取令牌",
     "ActivePool": "活躍池",
     "ActivePoolDescription": "目前透過 App Proxy 接收流量的副本。",


### PR DESCRIPTION
Resolves #8322 (FR-3341)

## Problem

In the Playground Chat token selector (`EndpointTokenSelect`), every token was rendered using the raw JWT string as both the option label and value. Because all JWTs share the same header prefix (`eyJhbGci…`) and the label is truncated to the select width, distinct tokens rendered as the same visible string — the user could not tell the options apart.

## Changes

### `react/src/components/Chat/EndpointTokenSelect.tsx`
- **Distinguishable labels** — each option shows the token's **last 6 characters** (the JWT signature tail, the part that actually differs between tokens) as a monospace chip, plus its **expiry date** (`~ Aug 26, 2026`). The full `issued → expiry` timestamps show on hover (native tooltip). Uses `BAIText` and dayjs `ll` / `lll` presets.
- **Hide expired tokens** — expired tokens (often many) are filtered out instead of shown disabled.
- **Auto-select the newest valid token** when the field is empty.
- **Consistent width** — always renders the Select at a fixed width (no longer following `CustomModelForm`'s responsive 100% / 200px flip), shrinking only on narrow screens.
- **Access Token Settings shortcut** — a gear icon beside the field (tooltip: *Access Token Settings*) deep-links to the deployment's Access Tokens section at `/deployments/{id}#access-tokens`.

The raw token string remains the option `value` the form submits.

### `react/src/pages/DeploymentDetailPage.tsx`
- Scrolls the Access Tokens section into view when the page is opened on the `#access-tokens` hash (the deep-link target for the shortcut above).

### i18n
- Added `deployment.AccessTokenSettings` in all languages.

## Notes

- Display / UX; orthogonal to FR-3332.
- Scope grew from the original "indistinguishable labels" bug into a broader token-field UX pass during review (hide-expired, default selection, consistent width, settings shortcut).

## Verification

`scripts/verify.sh` Relay / Format / TypeScript pass; changed files lint clean. (Pre-existing repo-wide react-compiler eslint warnings in unrelated files are unchanged by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="444" height="165" alt="image" src="https://github.com/user-attachments/assets/9a1d3ad8-cac2-46bf-bbe6-a57cb36d41af" />
<img width="565" height="235" alt="image" src="https://github.com/user-attachments/assets/9edbac2c-4bd2-4f88-a7f0-7122cf55bd4a" />
<img width="576" height="210" alt="image" src="https://github.com/user-attachments/assets/7baff6d4-dcea-4343-a7f7-c61def4405bb" />

