### PR TITLE
test: e2e auto-heal 2026-07-20

### DIFF
--- a/e2e/admin-model-card/admin-model-card-edit.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-edit.spec.ts
@@ -9,6 +9,25 @@ import {
 } from '../utils/test-util';
 import { test, expect } from '@playwright/test';
 
+// FR-3331/FR-3339 (PRs #8303/#8315) replaced the row's settings-cog icon with a
+// lucide `SquarePenIcon` that carries no accessible name, so the edit action can
+// no longer be located via getByRole('button', { name: 'setting' })
+// (AdminModelCardPage.getSettingButtonForRow/openEditModal, still pending a fix in
+// other in-flight PRs). It is the first button inside the name cell's
+// `.bai-name-action-cell-actions` action group — the second button is the
+// `delete` action, which still has its accessible name.
+async function openEditModalViaRowAction(
+  adminModelCardPage: AdminModelCardPage,
+  name: string,
+): Promise<void> {
+  await adminModelCardPage
+    .getRowByName(name)
+    .locator('.bai-name-action-cell-actions button')
+    .first()
+    .click();
+  await expect(adminModelCardPage.getEditModal()).toBeVisible();
+}
+
 test.describe(
   'Admin Model Card Management - Edit',
   { tag: ['@admin-model-card', '@admin', '@crud'] },
@@ -126,8 +145,8 @@ test.describe(
         timeout: 15000,
       });
 
-      // Click the gear icon in the Name cell for the test card
-      await adminModelCardPage.openEditModal(testCardName);
+      // Click the edit icon in the Name cell for the test card
+      await openEditModalViaRowAction(adminModelCardPage, testCardName);
 
       const modal = adminModelCardPage.getEditModal();
 
@@ -171,7 +190,7 @@ test.describe(
       });
 
       // Open edit modal for the test card
-      await adminModelCardPage.openEditModal(testCardName);
+      await openEditModalViaRowAction(adminModelCardPage, testCardName);
       const modal = adminModelCardPage.getEditModal();
 
       // Clear the Title field and type a new value.
@@ -243,7 +262,7 @@ test.describe(
       });
 
       // Open edit modal
-      await adminModelCardPage.openEditModal(testCardName);
+      await openEditModalViaRowAction(adminModelCardPage, testCardName);
       const modal = adminModelCardPage.getEditModal();
 
       // Clear the Name field completely
@@ -284,7 +303,7 @@ test.describe(
       });
 
       // Open edit modal
-      await adminModelCardPage.openEditModal(testCardName);
+      await openEditModalViaRowAction(adminModelCardPage, testCardName);
       const modal = adminModelCardPage.getEditModal();
 
       // Change the Title to a value that should not be saved.

--- a/e2e/environment/environment.spec.ts
+++ b/e2e/environment/environment.spec.ts
@@ -84,15 +84,22 @@ test.describe(
         imageListTable,
         'Control',
       );
+      // FR-3331 replaced the resource-limit action's settings-cog icon with a
+      // lucide SquarePenIcon (aria-hidden, no accessible name), so it can no
+      // longer be located via getByRole('button', { name: 'setting' }). It is
+      // the first of the two Control-column buttons (the second is "Manage
+      // Apps", whose antd `appstore` icon still carries its accessible name).
       await firstRow
         .locator('.ant-table-cell')
         .nth(controlColumnIndex)
-        .getByRole('button', { name: 'setting' })
+        .locator('button')
+        .first()
         .click();
-      await page.waitForLoadState('networkidle');
       // get resource limit from control modal
       const resourceLimitControlModal = page.getByRole('dialog', {
-        name: /Modify Minimum Image Resource Limit/i,
+        // FR-3339 renamed the modal from "Modify ..." to "Edit ..." as part of
+        // unifying edit terminology across the app.
+        name: /Edit Minimum Image Resource Limit/i,
       });
 
       await expect(resourceLimitControlModal).toBeVisible();
@@ -119,9 +126,9 @@ test.describe(
       await expect(cpuFormItemInput).toHaveValue(CPU_CORE);
       await memoryFormItemInput.fill(MEMORY_SIZE + 'g');
       await expect(memoryFormItemInput).toHaveValue(MEMORY_SIZE);
-      // click ok button
+      // click the modal's submit button (renamed "OK" -> "Save" by FR-3339)
       await resourceLimitControlModal
-        .getByRole('button', { name: 'OK' })
+        .getByRole('button', { name: 'Save' })
         .click();
       const reinstallationText = await page
         .getByText('Image reinstallation required')
@@ -133,12 +140,14 @@ test.describe(
       await firstRow
         .locator('.ant-table-cell')
         .nth(controlColumnIndex)
-        .getByRole('button', { name: 'setting' })
+        .locator('button')
+        .first()
         .click();
-      await page.waitForLoadState('networkidle');
       // In Ant Design 6, use role-based selector for dialog
       const modifiedResourceLimitControlModal = page.getByRole('dialog', {
-        name: /Modify Minimum Image Resource Limit/i,
+        // FR-3339 renamed the modal from "Modify ..." to "Edit ..." as part of
+        // unifying edit terminology across the app.
+        name: /Edit Minimum Image Resource Limit/i,
       });
       await expect(modifiedResourceLimitControlModal).toBeVisible();
       const modifiedCpuFormItemInput =
@@ -173,9 +182,9 @@ test.describe(
       await page
         .locator(`.ant-select-item-option-content:has-text("${memorySize}")`)
         .click();
-      // click ok button
+      // click the modal's submit button (renamed "OK" -> "Save" by FR-3339)
       await modifiedResourceLimitControlModal
-        .getByRole('button', { name: 'OK' })
+        .getByRole('button', { name: 'Save' })
         .click();
       const reinstallationTextAfterReset = await page
         .getByText('Image reinstallation required')

--- a/e2e/serving/deployment-lifecycle.spec.ts
+++ b/e2e/serving/deployment-lifecycle.spec.ts
@@ -297,11 +297,14 @@ test.describe(
       await expect(page.getByText('Pending').first()).toBeVisible();
 
       // Basic Information card
-      await expect(page.getByRole('button', { name: 'edit Edit' })).toBeVisible(
-        {
-          timeout: 20000,
-        },
-      );
+      // FR-3331/FR-3315 replaced the settings-cog icon with a lucide edit icon
+      // (no accessible name of its own), leaving the button's accessible name
+      // as just "Edit" instead of the old icon-name-prefixed "edit Edit".
+      await expect(
+        page.getByRole('button', { name: 'Edit', exact: true }),
+      ).toBeVisible({
+        timeout: 20000,
+      });
       await expect(page.getByRole('button', { name: 'More' })).toBeVisible();
       await expect(
         page.getByRole('rowheader', { name: 'Lifecycle' }),
@@ -957,7 +960,7 @@ test.describe(
       createdDeploymentName = deploymentName;
 
       // 1. Click "Edit" in the "Basic Information" card.
-      await page.getByRole('button', { name: 'edit Edit' }).click();
+      await page.getByRole('button', { name: 'Edit', exact: true }).click();
 
       // 2. Inspect the modal fields.
       const dialog = page.getByRole('dialog', { name: 'Edit Deployment' });
@@ -997,7 +1000,7 @@ test.describe(
 
       // 5. Click "Cancel" instead of "Save" on a repeat run to confirm no changes
       // persist when cancelled.
-      await page.getByRole('button', { name: 'edit Edit' }).click();
+      await page.getByRole('button', { name: 'Edit', exact: true }).click();
       const dialog2 = page.getByRole('dialog', { name: 'Edit Deployment' });
       await expect(dialog2).toBeVisible({ timeout: 20000 });
       const replicasInput2 = dialog2.getByRole('spinbutton', {

--- a/e2e/start/start-page.spec.ts
+++ b/e2e/start/start-page.spec.ts
@@ -261,29 +261,32 @@ test.describe(
         await expect(page).toHaveURL(/sessionType.*batch|batch.*sessionType/);
       });
 
-      test('Admin can navigate to the Model Service creation page from the "Start Model Service" card', async ({
+      test('Admin can navigate to the Deployments page from the "Start Deployment" card', async ({
         page,
       }) => {
         const startPage = new StartPage(page);
 
-        // Declarative config gate (FR-3112): the "Start Model Service" card is
-        // rendered only when `enableModelFolders = true` in config.toml
-        // (StartPage.tsx reads `baiClient._config.enableModelFolders`).
+        // Declarative config gate (FR-3112): the "Start Deployment" card
+        // (formerly titled "Start Model Service") is rendered only when
+        // `enableModelFolders = true` in config.toml (StartPage.tsx reads
+        // `baiClient._config.enableModelFolders`).
         await skipUnlessClientConfig(
           page,
           'enableModelFolders',
-          'Start Model Service card requires `enableModelFolders = true` in config.toml',
+          'Start Deployment card requires `enableModelFolders = true` in config.toml',
         );
 
         // 1. The config enables the feature — the card MUST be present; absence is a failure.
-        const card = startPage.getModelServiceCard();
+        const card = startPage.getDeploymentCard();
         await expect(card).toBeVisible({ timeout: CARD_TIMEOUT });
 
-        // 2. Click the "Start Service" button within the card
-        await startPage.getStartServiceButton(card).click();
+        // 2. Click the "Create Deployment" button within the card (renamed
+        // from "Start Service").
+        await startPage.getCreateDeploymentButton(card).click();
 
-        // 3. Verify the URL changes to /service/start
-        await expect(page).toHaveURL(/\/service\/start/);
+        // 3. Verify the URL changes to /deployments (this card no longer
+        // routes through /service/start).
+        await expect(page).toHaveURL(/\/deployments/);
       });
     });
 

--- a/e2e/user/user-crud.spec.ts
+++ b/e2e/user/user-crud.spec.ts
@@ -16,6 +16,22 @@ import {
 } from '../utils/test-util';
 import test, { expect } from '@playwright/test';
 
+// FR-3331/FR-3339 (PRs #8303/#8315) renamed the User Setting modal's submit
+// button from "OK" to "Create" (create mode) / "Save" (edit mode).
+// UserSettingModal.getOkButton()/clickOk() still target the stale "OK" name
+// (a fix is pending in another in-flight PR touching that shared page
+// object), so this spec clicks the modal's submit button directly instead of
+// going through clickOk()/createUser().
+async function submitUserSettingModal(
+  modal: UserSettingModal,
+  label: 'Create' | 'Save',
+): Promise<void> {
+  await modal
+    .getModal()
+    .getByRole('button', { name: label, exact: true })
+    .click();
+}
+
 // Generate unique identifiers for this test run to avoid conflicts
 const TEST_RUN_ID = Date.now().toString(36);
 const EMAIL = `e2e-test-user-${TEST_RUN_ID}@lablup.com`;
@@ -99,7 +115,9 @@ test.describe.serial(
 
       // 6. Create user using the modal class
       const userSettingModal = new UserSettingModal(page);
-      await userSettingModal.createUser(EMAIL, USERNAME, PASSWORD);
+      await userSettingModal.waitForVisible();
+      await userSettingModal.fillRequiredFields(EMAIL, USERNAME, PASSWORD);
+      await submitUserSettingModal(userSettingModal, 'Create');
 
       // 7. Handle the key pair modal that appears after user creation
       const keyPairModal = new KeyPairModal(page);
@@ -148,15 +166,23 @@ test.describe.serial(
         .nth(1)
         .click();
 
-      // 6. Update user name and password using the modal class
-      const editModal = UserSettingModal.forEdit(page);
-      await editModal.waitForVisible();
-      await editModal.fillUserName(MODIFIED_USERNAME);
-      await editModal.fillNewPasswords(NEW_PASSWORD);
-      await editModal.clickOk();
+      // 6. Update user name and password.
+      // FR-3339 renamed this dialog from "Modify User Detail" to "Edit User
+      // Detail" as part of unifying edit terminology across the app.
+      // UserSettingModal.forEdit() still targets the stale dialog name (a fix
+      // is pending in another in-flight PR touching that shared page
+      // object), so this test locates the dialog directly instead.
+      const editDialog = page.getByRole('dialog', { name: 'Edit User Detail' });
+      await expect(editDialog).toBeVisible();
+      const editUserNameInput = editDialog.getByLabel('User Name');
+      await editUserNameInput.fill(MODIFIED_USERNAME);
+      await expect(editUserNameInput).toHaveValue(MODIFIED_USERNAME);
+      await editDialog.getByLabel(/^New Password/).fill(NEW_PASSWORD);
+      await editDialog.getByLabel(/^New password \(again\)/).fill(NEW_PASSWORD);
+      await editDialog.getByRole('button', { name: 'Save' }).click();
 
       // 7. Wait for modal to close
-      await editModal.waitForHidden();
+      await expect(editDialog).toBeHidden({ timeout: 10000 });
 
       // 8. Verify success by checking user info.
       // The info button is the 1st button (index 0) in the action cell.

--- a/e2e/utils/classes/common/StartPage.ts
+++ b/e2e/utils/classes/common/StartPage.ts
@@ -29,8 +29,11 @@ export class StartPage {
   getBatchSessionCard() {
     return this.getCardByTitle('Start Batch Session');
   }
-  getModelServiceCard() {
-    return this.getCardByTitle('Start Model Service');
+  // Renamed from "Start Model Service" to "Start Deployment" (its button text
+  // changed from "Start Service" to "Create Deployment", and it now navigates
+  // straight to /deployments instead of /service/start).
+  getDeploymentCard() {
+    return this.getCardByTitle('Start Deployment');
   }
   getStartFromURLCard() {
     return this.getCardByTitle('Start From URL');
@@ -47,8 +50,8 @@ export class StartPage {
   getStartSessionButton(card: Locator) {
     return card.getByRole('button', { name: 'Start Session' });
   }
-  getStartServiceButton(card: Locator) {
-    return card.getByRole('button', { name: 'Start Service' });
+  getCreateDeploymentButton(card: Locator) {
+    return card.getByRole('button', { name: 'Create Deployment' });
   }
   getBoardItems() {
     return this.page.locator('.bai_grid_item');


### PR DESCRIPTION
## Summary

Automated **e2e auto-heal** produced by the daily backend.ai-webui digest job (run **2026-07-20**). The daily full Playwright suite against the nightly environment (`https://webui-nightly.lablup.ai/`) surfaced **46 failures**; the `e2e-failure-triage` agent classified **34 as HEAL** (test-side drift, safe to auto-fix) and **12 as HUMAN** (suspected app regression / intent change — not touched here).

After the idempotency guard excluded specs already covered by open heal PRs (#8320, #8317, #8288), and applying the per-run cap (`MAX_HEAL_SPECS=5`), this PR heals **5 spec files**. Each fixed test was re-run-verified green before this PR was created.

## Root cause

Most failures trace to two already-merged PRs by @ironAiken2:
- **#8303** — `style(FR-3331): unify edit terminology and edit-action icons, switch edit-form submits to Save`
- **#8315** — `fix(FR-3331): align row-action tooltips with the Edit icon`

These replaced antd icons with lucide `SquarePenIcon` (no aria-label), renamed row actions `settings`/"Settings" → `edit`/"Edit", and relabeled modal submits "OK" → "Save"/"Create". Tests that clicked the old affordances timed out. One additional drift (`start-page`) is the "Start Model Service" → "Start Deployment" card rename.

## Healed (all verified re-passing)

| Spec | Tests | Fix |
|------|-------|-----|
| `admin-model-card/admin-model-card-edit.spec.ts` | 4 | local `openEditModalViaRowAction()` clicks first button in `.bai-name-action-cell-actions` (shared `AdminModelCardPage.ts` left untouched — already in #8317/#8320) |
| `serving/deployment-lifecycle.spec.ts` | 2 | `name: 'edit Edit'` → `name: 'Edit', exact: true` |
| `environment/environment.spec.ts` | 1 | icon-only Control button locator + `Modify…`→`Edit…` dialog title + `OK`→`Save` submit |
| `start/start-page.spec.ts` | 1 | card/button rename → `Start Deployment` / `Create Deployment`, nav `/deployments` (also `StartPage.ts` page object) |
| `user/user-crud.spec.ts` | 6 | local submit helper + `Edit User Detail` dialog locators (shared `UserSettingModal.ts` left untouched — already in #8320) |

**Exhausted (retry budget):** none — all healed within 1–2 attempts.

## Excluded / deferred

- **Idempotency guard** — already covered by open heal PRs, not re-healed here: `admin-model-card-page-load`, `preset-crud` (auto-scaling), `my-keypair-management`, `registry`, `project-crud`, `resource-policy`, `bulk-user-creation`.
- **Heal cap dropped (2):** `user-profile/user-ip-restriction-enforcement.spec.ts`, `user-profile/user-profile.spec.ts` — carried to the next run.
- **HUMAN (12):** session-launcher/config flow (5), RBAC role detail/CRUD (6), project-list columns (1) — flagged for human review in the digest, not test-side drift.

Report doc: `~/e2e-digest-reports/report-2026-07-20.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
