### PR TITLE
fix(FR-3228): match idle-check utilization tag color with overall reclamation badge

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionIdleChecks.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionIdleChecks.tsx
@@ -7,7 +7,7 @@ import { SessionReclamationStatusCellFragment$key } from '../../__generated__/Se
 import { formatDurationAsDays } from '../../helper';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import SessionReclamationStatusCell from './SessionReclamationStatusCell';
-import { getUtilizationCheckerColor } from './SessionReclamationStatusPopover';
+import { getOverallReclamation } from './SessionReclamationStatusPopover';
 import { Typography } from 'antd';
 import {
   useMemoizedJSONParse,
@@ -64,9 +64,10 @@ export function getIdleChecksTagColor(
     }
   }
 
-  // Determine color based on utilization.
+  // Determine color based on utilization, matching the overall badge color
+  // shown by SessionReclamationStatusCell.
   if (result.extra && (!result.remaining || result.remaining < 3600 * 4)) {
-    return getUtilizationCheckerColor(
+    return getOverallReclamation(
       result.extra.resources,
       result.extra.thresholds_check_operator,
     )?.color;


### PR DESCRIPTION
Related to #8077 (FR-3228)

## Summary

Ports the idle-check tag color fix from #8260 (FR-3318) to the `26.4.3` branch.

`getIdleChecksTagColor` in `SessionIdleChecks.tsx` now derives the utilization tag color via `getOverallReclamation` instead of `getUtilizationCheckerColor`, so the tag color matches the overall badge color shown by `SessionReclamationStatusCell` (same severity aggregation honoring `thresholds_check_operator`).

## Changes

- `react/src/components/ComputeSessionNodeItems/SessionIdleChecks.tsx`
  - Replace `getUtilizationCheckerColor(resources, operator)` call with `getOverallReclamation(resources, operator)?.color`
  - Update import and comment accordingly

## Verification

- `tsc --noEmit` (react): pass
- ESLint / Prettier on the changed file: pass
- `scripts/verify.sh` could not run end-to-end due to a local pnpm version mismatch (environment issue, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCpJAHFRAwwYovxrj8uWsL