### PR TITLE
feat(FR-3352): dev-only login pre-fill and backend-mismatch banner

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -11,15 +11,18 @@ description: >
   URL reflects the session name (falls back to FR-XXXX from the branch, then
   to the current PR number). When the current branch's PR description names
   a backend test server (bare IP, `host:port`, or full URL), set
-  VITE_DEFAULT_API_ENDPOINT so the login screen pre-fills that endpoint and
-  any stale session targeting a different backend is logged out.
+  VITE_DEFAULT_API_ENDPOINT so the login screen pre-fills that endpoint; when a
+  live session is connected to a different backend a dev-only banner flags the
+  mismatch instead of forcing a logout. When the user supplies dev test
+  credentials, set VITE_DEFAULT_EMAIL / VITE_DEFAULT_PASSWORD to pre-fill the
+  login form too.
   Trigger on: "start dev server", "run dev", "pnpm dev 띄워", "개발 서버 띄워",
   "dev 서버 시작", "boot the dev environment", "실행해줘 dev".
 ---
 
 # Dev Server
 
-Starts the dev server with optional `VITE_THEME_HEADER_COLOR`, `PORTLESS_APP_NAME`, and `VITE_DEFAULT_API_ENDPOINT` derived from this Claude Code session's `/color` / `/rename` history and the current branch's PR description.
+Starts the dev server with optional `VITE_THEME_HEADER_COLOR`, `PORTLESS_APP_NAME`, `VITE_DEFAULT_API_ENDPOINT`, and (when the user supplies them) `VITE_DEFAULT_EMAIL` / `VITE_DEFAULT_PASSWORD`, derived from this Claude Code session's `/color` / `/rename` history, the current branch's PR description, and the user's stated test credentials.
 
 ## 1. Decide the command
 
@@ -95,8 +98,8 @@ Do not invent additional names or alternate hex values. If the user's `/color` a
 
 `react/src/components/LoginView.tsx` reads `VITE_DEFAULT_API_ENDPOINT` (only when `import.meta.env.DEV` is true) and:
 
-- pre-fills the login form's API endpoint with that value, **overriding** any value in `localStorage.backendaiwebui.api_endpoint` and any `api_endpoint` baked into `config.toml`;
-- when an existing in-memory session targets a different backend, logs that session out and shows the login panel instead of attempting silent re-login.
+- pre-fills the login form's API endpoint with that value for a **fresh login** (it also overrides any `api_endpoint` baked into `config.toml` on first entry);
+- does **not** override a live session's backend: if a stored session targets a different server, the app silently reconnects to that server (no bounce to the login screen) and a **dev-only banner** (`DevApiEndpointMismatchAlert`) announces "connected to X, but configured for Y" so multi-server testing doesn't get confusing. There is intentionally no auto-logout on mismatch.
 
 This skill auto-derives the value from the current branch's PR description so dev sessions land on the right per-PR backend without the user re-typing the endpoint on every cold start. Pick a value with this priority:
 
@@ -148,7 +151,22 @@ If the matched candidate is rejected, keep scanning (within the same pass) for t
 
 Silent misconfiguration is the worst failure mode here — it sends the dev session to the wrong backend without anyone noticing.
 
-If the resolved value matches the existing default backend the WebUI would otherwise use (i.e. it has no effect), still pass it — being explicit avoids the auto-logout silently disagreeing with the form on edge cases.
+If the resolved value matches the existing default backend the WebUI would otherwise use (i.e. it has no effect), still pass it — being explicit keeps the login form's pre-fill and the dev mismatch banner in agreement on edge cases.
+
+## 2d. Decide the default login credentials (webui only, optional)
+
+`LoginView.tsx` also reads `VITE_DEFAULT_EMAIL` / `VITE_DEFAULT_PASSWORD` (dev only) and pre-fills the SESSION-mode email + password fields, so a local dev session can sign in without retyping test credentials. These are a pure convenience pre-fill — they do **not** auto-submit the login form.
+
+**Resolve them conservatively — never guess:**
+
+1. **User explicitly supplied credentials** in the prompt or conversation (e.g. "log in as `admin@lablup.com` / `wJalrXUt`", "use the domain-admin test account") → set both vars from what they said.
+2. **A shared team test server's credentials are already known** to this session — e.g. the `dev-server-registry` skill's `--backend-user` / `--backend-password` for the resolved endpoint, or credentials the user pasted earlier for that box → reuse them.
+3. **Otherwise omit both.** Do **not** scrape passwords out of the PR body, invent credentials, or reuse `e2e/envs/.env.playwright` values unless the user pointed you at them. Set the email alone (without a password) only if that is all the user gave.
+
+**Security caveats (state them when you use these):**
+
+- `VITE_DEFAULT_PASSWORD` bakes a **plaintext password into the dev bundle** at build time. It is dev-only (`import.meta.env.DEV`), but still: only ever pass it on the command line or via the user's git-ignored `.env.development.local` — never write it to a committed file, and never for a production build.
+- Prefer non-privileged / disposable test accounts. If the user asks to pre-fill a real admin password, confirm they intend the plaintext-in-dev-bundle tradeoff before doing it.
 
 ## 3. Compose the run
 
@@ -167,8 +185,12 @@ If step **2b** picked a Portless app name from `/rename` or a PR number, also pr
 
 If step **2c** resolved a default API endpoint, also prefix `VITE_DEFAULT_API_ENDPOINT='<url>'`. If 2c resolved nothing, **omit** the variable entirely — do not pass an empty string.
 
+If step **2d** resolved login credentials, also prefix `VITE_DEFAULT_EMAIL='<email>'` and `VITE_DEFAULT_PASSWORD='<password>'`. If 2d resolved nothing, **omit** both. Never pass an empty string, and never fabricate a value to "fill the slot."
+
+**Shell-escape every interpolated value.** The endpoint, email, and especially the password come from user/conversation text and may contain an apostrophe or shell metacharacters — interpolating them raw inside `'...'` breaks the command and can turn the rest of the value into executable shell. Before building the command line, quote each value shell-safely (e.g. Bash `printf '%q'`), or set them via the user's git-ignored `.env.development.local` instead of the command line. Do not hand-concatenate an untrusted password into a single-quoted string.
+
 ```bash
-VITE_THEME_HEADER_COLOR='#2563EB' PORTLESS_APP_NAME='iphoto-disk-cleanup' VITE_DEFAULT_API_ENDPOINT='http://10.0.1.5:8090' pnpm dev
+VITE_THEME_HEADER_COLOR='#2563EB' PORTLESS_APP_NAME='iphoto-disk-cleanup' VITE_DEFAULT_API_ENDPOINT='http://10.0.1.5:8090' VITE_DEFAULT_EMAIL='admin@lablup.com' VITE_DEFAULT_PASSWORD='wJalrXUt' pnpm dev
 ```
 
 For non-webui projects, substitute the discovered command and package manager. Use whatever color env var the project actually reads (check `vite.config.*`, `next.config.*`, etc., or grep for `*THEME_HEADER_COLOR` / `*_THEME_COLOR`). Apply the prefix only when (a) a color is actually resolved AND (b) the project really consumes that env var. If either is false, skip the prefix. `PORTLESS_APP_NAME` and `VITE_DEFAULT_API_ENDPOINT` are webui-specific.
@@ -222,7 +244,7 @@ After a successful boot — i.e. right after step 5, once the **actual** Portles
 
 ## 7. Edge cases
 
-- **User overrides via env (webui)**: Vite's `loadEnv()` reads `VITE_THEME_HEADER_COLOR`, `VITE_DEFAULT_API_ENDPOINT` from `.env.development.local` and from the shell automatically. If the user already has any of them set, do not override — the user-set value wins. For `PORTLESS_APP_NAME`, the same rule applies: if it's already exported in the inherited env, treat the user-set value as authoritative.
+- **User overrides via env (webui)**: Vite's `loadEnv()` reads `VITE_THEME_HEADER_COLOR`, `VITE_DEFAULT_API_ENDPOINT`, `VITE_DEFAULT_EMAIL`, `VITE_DEFAULT_PASSWORD` from `.env.development.local` and from the shell automatically. If the user already has any of them set, do not override — the user-set value wins. For `PORTLESS_APP_NAME`, the same rule applies: if it's already exported in the inherited env, treat the user-set value as authoritative.
 - **User overrides via prompt**: if the user says "use a green header" or "no color this time" or "name the dev URL <foo>" or "ignore the PR's IP, use 10.0.0.7 instead", honor their words over the conversation-history and PR-description values.
 - **Multiple Claude windows / worktrees**: each Claude Code session has its own conversation, so both color and app name are naturally session-scoped. Don't try to read either from disk — there's no shared state (built-in `/color` and `/rename` are in-memory only). For `VITE_DEFAULT_API_ENDPOINT`, the *PR* is the shared source of truth; reading it via `gh pr view` works the same from any worktree on that branch.
 - **No `/color` in history but user mentioned a color**: treat the user's mention as the source of truth. If they said "use orange", map `orange` → `#EA580C` and prefix accordingly.

--- a/.env.development.local.sample
+++ b/.env.development.local.sample
@@ -34,3 +34,21 @@ VITE_THEME_HEADER_COLOR=#7C3AED
 # VITE_THEME_HEADER_COLOR=#DC2626  # Red
 # VITE_THEME_HEADER_COLOR=#EA580C  # Orange
 # VITE_THEME_HEADER_COLOR=#D97706  # Amber
+
+# Login screen pre-fill (dev only, optional)
+# These are read by react/src/components/LoginView.tsx ONLY when
+# import.meta.env.DEV is true (production builds ignore them). They pre-fill the
+# login form so a local dev session can sign in without retyping.
+#
+# SECURITY: VITE_DEFAULT_PASSWORD bakes a plaintext password into the dev bundle
+# at build time. Keep these in this git-ignored .env.development.local only —
+# never commit them and never set them for a deployed/production build.
+#
+# Full endpoint URL to pre-fill for a fresh login. A live session keeps its own
+# backend (no forced logout / no bounce to the login screen); if that backend
+# differs from this value, a dev-only banner flags the mismatch inside the app.
+# VITE_DEFAULT_API_ENDPOINT=http://127.0.0.1:8090
+#
+# SESSION-mode credentials to pre-fill:
+# VITE_DEFAULT_EMAIL=admin@lablup.com
+# VITE_DEFAULT_PASSWORD=wJalrXUt

--- a/react/src/components/DevApiEndpointMismatchAlert.test.tsx
+++ b/react/src/components/DevApiEndpointMismatchAlert.test.tsx
@@ -1,0 +1,87 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Tests for DevApiEndpointMismatchAlert (FR-3352).
+ *
+ * The banner is a dev-only aid: it must appear ONLY when a `VITE_DEFAULT_API_ENDPOINT`
+ * override is set AND the backend the client is actually connected to differs
+ * from it (after trailing-slash normalization). These tests pin that gating
+ * contract at the component level — the three regression conditions the
+ * component introduces:
+ *   - no override set                     → nothing renders
+ *   - override === connected (norm.)      → nothing renders
+ *   - override !== connected              → banner shows BOTH endpoints
+ *
+ * `devApiEndpointOverride` and the connected endpoint are module-level / hook
+ * values, so both are mocked and driven per test.
+ */
+import DevApiEndpointMismatchAlert from './DevApiEndpointMismatchAlert';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable state the mocks read from, so each test can drive the two inputs.
+const mocks = vi.hoisted(() => ({
+  override: undefined as string | undefined,
+  connectedEndpoint: '' as string,
+}));
+
+// `devApiEndpointOverride` is a build-time-frozen module constant in real code;
+// expose it as a getter so the live import binding reflects per-test values.
+vi.mock('../helper/devLoginOverrides', () => ({
+  get devApiEndpointOverride() {
+    return mocks.override;
+  },
+}));
+
+// The banner only reads `_config.endpoint` off the client.
+vi.mock('../hooks', () => ({
+  useSuspendedBackendaiClient: () => ({
+    _config: { endpoint: mocks.connectedEndpoint },
+  }),
+}));
+
+afterEach(() => {
+  mocks.override = undefined;
+  mocks.connectedEndpoint = '';
+});
+
+describe('DevApiEndpointMismatchAlert', () => {
+  it('renders nothing when no dev override is set', () => {
+    mocks.override = undefined;
+    mocks.connectedEndpoint = 'https://api.connected';
+
+    const { container } = render(<DevApiEndpointMismatchAlert />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the connected endpoint matches the override (ignoring a trailing slash)', () => {
+    mocks.override = 'https://api.same';
+    mocks.connectedEndpoint = 'https://api.same/';
+
+    const { container } = render(<DevApiEndpointMismatchAlert />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the connected endpoint is empty', () => {
+    mocks.override = 'https://api.configured';
+    mocks.connectedEndpoint = '';
+
+    const { container } = render(<DevApiEndpointMismatchAlert />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders both endpoints when the connected backend differs from the override', () => {
+    mocks.override = 'https://api.configured';
+    mocks.connectedEndpoint = 'https://api.connected';
+
+    render(<DevApiEndpointMismatchAlert />);
+
+    expect(screen.getByText('https://api.connected')).toBeInTheDocument();
+    expect(screen.getByText('https://api.configured')).toBeInTheDocument();
+  });
+});

--- a/react/src/components/DevApiEndpointMismatchAlert.tsx
+++ b/react/src/components/DevApiEndpointMismatchAlert.tsx
@@ -1,0 +1,61 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { devApiEndpointOverride } from '../helper/devLoginOverrides';
+import { useSuspendedBackendaiClient } from '../hooks';
+import { BAIAlert } from 'backend.ai-ui';
+
+/**
+ * Dev-only banner shown when the backend the app is ACTUALLY connected to
+ * differs from the `VITE_DEFAULT_API_ENDPOINT` this dev session configured.
+ *
+ * Purpose: when testing across several dev backends, make it obvious which
+ * server the current session really talks to — instead of silently bouncing to
+ * the login screen or leaving the developer guessing. This replaces the old
+ * "force re-login on endpoint mismatch" behavior; the session stays connected
+ * and this announcement surfaces the discrepancy.
+ *
+ * Production safety: `devApiEndpointOverride` is `undefined` in production
+ * builds (`import.meta.env.DEV` is statically `false`), so the guard below is
+ * dead-code eliminated and this component always renders `null` — the feature
+ * never ships. The copy is intentionally hard-coded English: it is a developer
+ * aid that never reaches an end user, so it is deliberately kept out of the
+ * translated i18n bundles.
+ */
+const DevApiEndpointMismatchAlert: React.FC = () => {
+  'use memo';
+
+  const baiClient = useSuspendedBackendaiClient();
+
+  // Bail out entirely (and let the bundler drop everything below) when the dev
+  // override is absent — i.e. always in production.
+  if (!devApiEndpointOverride) return null;
+
+  const connectedEndpoint = (baiClient?._config?.endpoint ?? '')
+    .trim()
+    .replace(/\/+$/, '');
+
+  if (!connectedEndpoint || connectedEndpoint === devApiEndpointOverride) {
+    return null;
+  }
+
+  return (
+    <BAIAlert
+      showIcon
+      closable
+      type="warning"
+      title="Dev: connected backend differs from VITE_DEFAULT_API_ENDPOINT"
+      description={
+        <>
+          Connected to <b>{connectedEndpoint}</b>, but this dev session is
+          configured for <b>{devApiEndpointOverride}</b>. The session was kept
+          as-is (no auto-logout) — log out and sign in again if you meant to
+          switch backends.
+        </>
+      }
+    />
+  );
+};
+
+export default DevApiEndpointMismatchAlert;

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -14,6 +14,11 @@
  * firstUpdated() logic.
  */
 import {
+  devApiEndpointOverride,
+  devEmailOverride,
+  devPasswordOverride,
+} from '../helper/devLoginOverrides';
+import {
   getDefaultLoginConfig,
   type LoginConfigState,
 } from '../helper/loginConfig';
@@ -35,7 +40,7 @@ import { pluginApiEndpointState } from '../hooks/useWebUIPluginState';
 import { preloadPostLoginChunks } from '../preload';
 import { jotaiStore } from './DefaultProviders';
 import LoginFormPanel from './LoginFormPanel';
-import { App, Button, ConfigProvider, Form, type MenuProps } from 'antd';
+import { App, Button, ConfigProvider, Form, type MenuProps, Tag } from 'antd';
 import { BAIModal, BAIFlex, useBAILogger } from 'backend.ai-ui';
 import { useAtomValue, useSetAtom } from 'jotai';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -52,24 +57,6 @@ const extractErrorType = (typeUrl?: string): string => {
   const parts = typeUrl.split('/');
   return parts[parts.length - 1] || '';
 };
-
-/**
- * Dev-only override for the API endpoint shown on the login screen.
- *
- * Set `VITE_DEFAULT_API_ENDPOINT` to a full URL (e.g. `http://1.2.3.4:8090`)
- * to pre-fill the login endpoint field and skip silent re-login when a
- * stale session targets a different backend. The dev-server skill derives
- * this value from the current branch's PR description automatically; see
- * `.claude/skills/dev-server/SKILL.md`.
- *
- * Production builds (`import.meta.env.DEV === false`) ignore the variable.
- */
-const devApiEndpointOverride: string | undefined =
-  import.meta.env.DEV &&
-  typeof import.meta.env.VITE_DEFAULT_API_ENDPOINT === 'string' &&
-  import.meta.env.VITE_DEFAULT_API_ENDPOINT.trim() !== ''
-    ? import.meta.env.VITE_DEFAULT_API_ENDPOINT.trim().replace(/\/+$/, '')
-    : undefined;
 
 const STORED_API_ENDPOINT_KEY = 'backendaiwebui.api_endpoint';
 
@@ -116,20 +103,18 @@ const LoginView: React.FC<{
   const [connectionMode, setConnectionMode] =
     useState<ConnectionMode>('SESSION');
   const [apiEndpoint, setApiEndpoint] = useState(() => {
-    if (devApiEndpointOverride) return devApiEndpointOverride;
+    // A stored endpoint means a session may be live against that backend, so
+    // it wins over the dev override: silent re-login then reconnects to the
+    // *actual* session server instead of bouncing to the login screen when
+    // VITE_DEFAULT_API_ENDPOINT points elsewhere. The override only fills the
+    // field here when nothing is stored (a genuinely fresh login) — it is never
+    // re-applied after mount, so it can't clobber an endpoint the user types by
+    // hand. A dev-only banner (`DevApiEndpointMismatchAlert`) surfaces any
+    // mismatch once inside the app so multi-server testing doesn't get confusing.
     const stored = localStorage.getItem(STORED_API_ENDPOINT_KEY);
-    return stored ? stored.replace(/^"+|"+$/g, '') : '';
+    const storedEndpoint = stored ? stored.replace(/^"+|"+$/g, '') : '';
+    return storedEndpoint || devApiEndpointOverride || '';
   });
-  // Persist the dev override so other modules that read
-  // backendaiwebui.api_endpoint (e.g., orchestration's Electron fallback)
-  // observe it too. Kept in an effect — not the useState initializer — so
-  // the initializer stays pure and StrictMode's double-invocation can't
-  // surprise future readers.
-  useEffect(() => {
-    if (devApiEndpointOverride) {
-      localStorage.setItem(STORED_API_ENDPOINT_KEY, devApiEndpointOverride);
-    }
-  }, []);
   const [otpRequired, setOtpRequired] = useState(false);
   const [needsOtpRegistration, setNeedsOtpRegistration] = useState(false);
   const [totpRegistrationToken, setTotpRegistrationToken] = useState('');
@@ -200,11 +185,13 @@ const LoginView: React.FC<{
     const newCfg = atomLoginConfig;
     setLoginConfig(newCfg);
     setConnectionMode(newCfg.connection_mode);
-    // The dev-only env-var override (VITE_DEFAULT_API_ENDPOINT) wins over
-    // both the config.toml api_endpoint and the previously-stored value so
-    // that PR-targeted dev sessions land on the right backend.
+    // An already-resolved endpoint (a stored session's server, kept in `prev`)
+    // wins so a dev override never clobbers the backend a live session targets
+    // — that would re-introduce the login-screen bounce. Fall back to the
+    // config.toml value, then the dev override as a last-resort pre-fill for a
+    // fresh login.
     setApiEndpoint(
-      (prev) => devApiEndpointOverride || newCfg.api_endpoint || prev,
+      (prev) => prev || newCfg.api_endpoint || devApiEndpointOverride || '',
     );
 
     // Handle endpoint visibility
@@ -259,6 +246,18 @@ const LoginView: React.FC<{
       form.setFieldsValue({ api_endpoint: apiEndpoint });
     }
   }, [apiEndpoint, form]);
+
+  // Dev-only: pre-fill SESSION credentials from VITE_DEFAULT_EMAIL /
+  // VITE_DEFAULT_PASSWORD so local dev sessions log in without retyping test
+  // credentials. Runs once on mount; both overrides are `undefined` in
+  // production builds, so this is a no-op there.
+  useEffect(() => {
+    if (devEmailOverride) form.setFieldsValue({ user_id: devEmailOverride });
+    if (devPasswordOverride)
+      form.setFieldsValue({ password: devPasswordOverride });
+    // Mount-only: the override constants are build-time frozen, so no deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Language initialization: bridge selected_language -> general.language
   // (replaces Lit shell's connectedCallback language setup)
@@ -1032,11 +1031,42 @@ const LoginView: React.FC<{
     [endpoints],
   );
 
+  // Dev-only: pin the VITE_DEFAULT_API_ENDPOINT value at the top of the endpoint
+  // history so it is always selectable (even before the first login) and clearly
+  // tagged as coming from the env — distinct from manually-saved endpoints, which
+  // keep their Delete action. `devApiEndpointOverride` is `undefined` in
+  // production builds, so this whole branch is dead-code eliminated there.
+  const savedEndpoints = devApiEndpointOverride
+    ? endpoints.filter((ep) => ep !== devApiEndpointOverride)
+    : endpoints;
+
   const endpointMenuItems: MenuProps['items'] = [
     { key: 'header', label: t('login.EndpointHistory'), disabled: true },
-    ...(endpoints.length === 0
-      ? [{ key: 'empty', label: t('login.NoEndpointSaved') }]
-      : endpoints.map((ep) => ({
+    ...(devApiEndpointOverride
+      ? [
+          {
+            key: devApiEndpointOverride,
+            label: (
+              <BAIFlex
+                justify="between"
+                align="center"
+                gap="sm"
+                style={{ minWidth: 300 }}
+              >
+                <span>{devApiEndpointOverride}</span>
+                <Tag color="blue" style={{ marginInlineEnd: 0 }}>
+                  env
+                </Tag>
+              </BAIFlex>
+            ),
+          },
+        ]
+      : []),
+    ...(savedEndpoints.length === 0
+      ? devApiEndpointOverride
+        ? []
+        : [{ key: 'empty', label: t('login.NoEndpointSaved') }]
+      : savedEndpoints.map((ep) => ({
           key: ep,
           label: (
             <BAIFlex justify="between" align="center" style={{ minWidth: 300 }}>

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -13,6 +13,7 @@ import Page401 from '../../pages/Page401';
 import Page404 from '../../pages/Page404';
 import BAIContentWithDrawerArea from '../BAIContentWithDrawerArea';
 import BAIErrorBoundary from '../BAIErrorBoundary';
+import DevApiEndpointMismatchAlert from '../DevApiEndpointMismatchAlert';
 import ErrorBoundaryWithNullFallback from '../ErrorBoundaryWithNullFallback';
 import ForceTOTPChecker from '../ForceTOTPChecker';
 import NetworkStatusBanner from '../NetworkStatusBanner';
@@ -227,6 +228,14 @@ function MainLayout() {
                     align="stretch"
                     className={styles.alertWrapper}
                   >
+                    {/* Dev-only: warn when the connected backend differs from
+                        VITE_DEFAULT_API_ENDPOINT. Guarded by import.meta.env.DEV
+                        so it is dead-code eliminated from production builds. */}
+                    {import.meta.env.DEV && (
+                      <ErrorBoundaryWithNullFallback>
+                        <DevApiEndpointMismatchAlert />
+                      </ErrorBoundaryWithNullFallback>
+                    )}
                     <ErrorBoundaryWithNullFallback>
                       <ThemePreviewModeAlert />
                     </ErrorBoundaryWithNullFallback>

--- a/react/src/helper/devLoginOverrides.ts
+++ b/react/src/helper/devLoginOverrides.ts
@@ -1,0 +1,53 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Dev-only login overrides read from Vite env vars.
+ *
+ * These let a local dev session pre-fill the login screen so you don't retype
+ * the endpoint/credentials on every cold start. The dev-server skill derives
+ * `VITE_DEFAULT_API_ENDPOINT` from the current branch's PR description; see
+ * `.claude/skills/dev-server/SKILL.md`.
+ *
+ * All three are `undefined` in production builds: `import.meta.env.DEV` is
+ * statically replaced with `false` by Vite, so every branch here (and every
+ * consumer's `if (devXxxOverride)` guard) is dead-code eliminated. The feature
+ * therefore never ships in a production bundle.
+ *
+ * SECURITY: `VITE_DEFAULT_PASSWORD` bakes a plaintext password into the dev
+ * bundle at build time. Only ever set these in a git-ignored
+ * `.env.development.local` or the shell — never in `config.toml`, a committed
+ * `.env`, or any deployed environment.
+ */
+
+/**
+ * Full API endpoint URL to pre-fill on the login screen (dev only).
+ * Trailing slashes are stripped so it compares cleanly against the endpoint
+ * the client actually connects to.
+ */
+export const devApiEndpointOverride: string | undefined =
+  import.meta.env.DEV &&
+  typeof import.meta.env.VITE_DEFAULT_API_ENDPOINT === 'string' &&
+  import.meta.env.VITE_DEFAULT_API_ENDPOINT.trim() !== ''
+    ? import.meta.env.VITE_DEFAULT_API_ENDPOINT.trim().replace(/\/+$/, '')
+    : undefined;
+
+/** SESSION-mode email/username to pre-fill on the login screen (dev only). */
+export const devEmailOverride: string | undefined =
+  import.meta.env.DEV &&
+  typeof import.meta.env.VITE_DEFAULT_EMAIL === 'string' &&
+  import.meta.env.VITE_DEFAULT_EMAIL.trim() !== ''
+    ? import.meta.env.VITE_DEFAULT_EMAIL.trim()
+    : undefined;
+
+/**
+ * SESSION-mode password to pre-fill on the login screen (dev only).
+ * Intentionally not trimmed — a password may contain significant whitespace.
+ */
+export const devPasswordOverride: string | undefined =
+  import.meta.env.DEV &&
+  typeof import.meta.env.VITE_DEFAULT_PASSWORD === 'string' &&
+  import.meta.env.VITE_DEFAULT_PASSWORD !== ''
+    ? import.meta.env.VITE_DEFAULT_PASSWORD
+    : undefined;


### PR DESCRIPTION
Resolves #8351 (FR-3352)

## Summary

- Add dev-only login pre-fill env vars `VITE_DEFAULT_EMAIL` / `VITE_DEFAULT_PASSWORD` (mirroring `VITE_DEFAULT_API_ENDPOINT`) via new `react/src/helper/devLoginOverrides.ts`; `LoginView` pre-fills the SESSION-mode email/password fields on mount.
- Replace the endpoint-mismatch "bounce to login" behavior with a dev-only banner: a stored session's backend now wins so silent re-login reconnects to the real server, and the override only pre-fills a fresh login (in `open()`).
- Add `DevApiEndpointMismatchAlert` to `MainLayout` (guarded by `import.meta.env.DEV`) that announces when the connected backend differs from `VITE_DEFAULT_API_ENDPOINT` — no auto-logout, so multi-server testing stays clear.
- Document the new env vars in `.env.development.local.sample` and the `dev-server` skill (new credentials section + updated mismatch-banner wording).
- All behavior is gated behind `import.meta.env.DEV`, so it is dead-code eliminated from production builds.

## Test plan

- [ ] `bash scripts/verify.sh` passes (Relay, Lint, Format, TypeScript).
- [ ] With `VITE_DEFAULT_EMAIL` / `VITE_DEFAULT_PASSWORD` set, `pnpm dev` login form is pre-filled; without them the fields are empty.
- [ ] Log into server X, set `VITE_DEFAULT_API_ENDPOINT` to a different server Y and restart dev → app stays connected to X (no bounce) and the dev banner shows the X/Y mismatch.
- [ ] A production build renders no banner and ignores all three env vars.