### PR TITLE
refactor(FR-3353): replace useContext with React 19 use API

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
@@ -28,13 +28,7 @@ import {
 import type { TableColumnsType } from 'antd';
 import { FormInstance } from 'antd/lib';
 import * as _ from 'lodash-es';
-import React, {
-  useRef,
-  useState,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
+import React, { use, useRef, useState, useCallback, useMemo } from 'react';
 
 /**
  * Form values interface for the table setting modal
@@ -102,7 +96,7 @@ const RowContext = React.createContext<RowContextProps>({});
  */
 const DragHandle: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
   'use memo';
-  const { setActivatorNodeRef, listeners } = useContext(RowContext);
+  const { setActivatorNodeRef, listeners } = use(RowContext);
   const { token } = theme.useToken();
   return (
     <Typography.Text

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useAnonymousBAIClient.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useAnonymousBAIClient.ts
@@ -1,13 +1,14 @@
 import useBAILogger from '../../../../hooks/useBAILogger';
 import { BAIAnonymousClientContext } from '../context';
 import { BAIClient } from '../types';
-import { useContext } from 'react';
+import { use } from 'react';
 
 const useBAIAnonymousClient = (apiEndpoint: string): BAIClient => {
   const { logger } = useBAILogger();
+  // `use` cannot be called inside try/catch, so read the context first.
+  const baiAnonymousClient = use(BAIAnonymousClientContext);
 
   try {
-    const baiAnonymousClient = useContext(BAIAnonymousClientContext);
     if (!baiAnonymousClient) {
       throw new Error(
         'useBAIAnonymousClient must be used within a BAIClientProvider',

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useConnectedBAIClient.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useConnectedBAIClient.ts
@@ -1,9 +1,9 @@
 import { BAIClientContext } from '../context';
 import { BAIClient } from '../types';
-import { use, useContext } from 'react';
+import { use } from 'react';
 
 const useConnectedBAIClient = (): BAIClient => {
-  const baiClientPromise = useContext(BAIClientContext);
+  const baiClientPromise = use(BAIClientContext);
   if (!baiClientPromise) {
     throw new Error('useBAIClient must be used within a BAIClientProvider');
   }

--- a/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIDeviceMetaData.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIMetaDataProvider/hooks/useBAIDeviceMetaData.ts
@@ -1,11 +1,12 @@
 import useBAILogger from '../../../../hooks/useBAILogger';
 import { BAIDeviceMetaDataContext } from '../context';
-import { useContext } from 'react';
+import { use } from 'react';
 
 const useBAIDeviceMetaData = () => {
   const { logger } = useBAILogger();
+  // `use` cannot be called inside try/catch, so read the context first.
+  const context = use(BAIDeviceMetaDataContext);
   try {
-    const context = useContext(BAIDeviceMetaDataContext);
     if (!context) {
       throw new Error(
         'useBAIDeviceMetaData must be used within a BAIMetaDataProvider',

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -32,7 +32,7 @@ import {
 import { filterOutEmpty, BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { ArrowLeftIcon, ShieldUserIcon } from 'lucide-react';
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { use, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
@@ -47,7 +47,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
   const { token } = theme.useToken();
   const { themeConfig } = useCustomThemeConfig();
 
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const currentSiderTheme =
     config.theme?.algorithm === theme.darkAlgorithm ? 'dark' : 'light';
 
@@ -367,7 +367,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
 
 const WebUISiderWithCustomTheme: React.FC<WebUISiderProps> = (props) => {
   const { themeConfig } = useCustomThemeConfig();
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
 
   const shouldReverse =

--- a/react/src/components/ReverseThemeProvider.tsx
+++ b/react/src/components/ReverseThemeProvider.tsx
@@ -5,7 +5,7 @@
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { theme, ConfigProvider, type ConfigProviderProps } from 'antd';
 import * as _ from 'lodash-es';
-import React, { useContext } from 'react';
+import React, { use } from 'react';
 
 interface ReverseThemeProviderProps extends ConfigProviderProps {
   className?: string;
@@ -15,7 +15,7 @@ const ReverseThemeProvider: React.FC<ReverseThemeProviderProps> = ({
 }) => {
   'use memo';
   const { themeConfig } = useCustomThemeConfig();
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
 
   return (

--- a/react/src/components/ThemeAdminProvider.tsx
+++ b/react/src/components/ThemeAdminProvider.tsx
@@ -11,12 +11,12 @@ import {
   type ThemeConfig,
 } from 'antd';
 import * as _ from 'lodash-es';
-import React, { useContext } from 'react';
+import React, { use } from 'react';
 
 const ThemeAdminProvider: React.FC<ConfigProviderProps> = ({ ...props }) => {
   'use memo';
   const { themeConfig } = useCustomThemeConfig();
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
   const primaryColors = usePrimaryColors();
 

--- a/react/src/components/ThemeSecondaryProvider.tsx
+++ b/react/src/components/ThemeSecondaryProvider.tsx
@@ -11,14 +11,14 @@ import {
   type ThemeConfig,
 } from 'antd';
 import * as _ from 'lodash-es';
-import React, { useContext } from 'react';
+import React, { use } from 'react';
 
 const ThemeSecondaryProvider: React.FC<ConfigProviderProps> = ({
   ...props
 }) => {
   'use memo';
   const { themeConfig } = useCustomThemeConfig();
-  const config = useContext(ConfigProvider.ConfigContext);
+  const config = use(ConfigProvider.ConfigContext);
   const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
   const primaryColors = usePrimaryColors();
 

--- a/react/src/hooks/useThemeMode.tsx
+++ b/react/src/hooks/useThemeMode.tsx
@@ -6,7 +6,7 @@ import { useLocalStorageGlobalState } from './useLocalStorageGlobalState';
 import {
   PropsWithChildren,
   createContext,
-  useContext,
+  use,
   useEffect,
   useState,
 } from 'react';
@@ -91,7 +91,7 @@ export const ThemeModeProvider: React.FC<PropsWithChildren> = ({
 };
 
 export const useThemeMode = () => {
-  const context = useContext(ThemeModeContext);
+  const context = use(ThemeModeContext);
   if (context === undefined) {
     throw new Error(
       'useThemeModeContext must be used within a ThemeModeProvider',


### PR DESCRIPTION
Resolves #8353 ([FR-3353](https://lablup.atlassian.net/browse/FR-3353))

## Summary

- Replace all 10 remaining `useContext` call sites (9 files) in `react/src` and `packages/backend.ai-ui/src` with the React 19 `use` API, which is the recommended superset of `useContext`.
- `useAnonymousBAIClient` / `useBAIDeviceMetaData`: hoist the context read out of the `try/catch` block since `use` cannot be called inside try/catch. `useContext` never throws, so behavior is unchanged.
- `useConnectedBAIClient` now uses `use` consistently for both the context read and the promise unwrap (previously mixed `useContext` + `use`).
- Pure mechanical rename otherwise — no behavior change.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript)
- `grep -rn useContext react/src packages/backend.ai-ui/src` (excluding `__generated__`) → no remaining call sites

## Test plan

- [ ] Theme providers (admin/secondary/reverse) still pick up parent dark/light algorithm correctly
- [ ] Sider theme follows custom theme config as before
- [ ] Table setting modal drag handle still works

[FR-3353]: https://lablup.atlassian.net/browse/FR-3353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ