### PR TITLE
fix(FR-3354): pause and re-anchor BAIFetchKeyButton countdown border during in-flight refresh

### DIFF
--- a/packages/backend.ai-ui/src/components/BAICountdownBorder.tsx
+++ b/packages/backend.ai-ui/src/components/BAICountdownBorder.tsx
@@ -41,6 +41,13 @@ export interface BAICountdownBorderProps {
    */
   resetKey?: React.Key;
   /**
+   * When true, freezes the fill animation at its current position
+   * (`animation-play-state: paused`) instead of advancing. Use it to hold the
+   * countdown while the wrapped control's refresh is in flight, so the border
+   * does not complete or loop before the real refresh happens.
+   */
+  paused?: boolean;
+  /**
    * Style for the wrapper element. The border's own appearance is taken from
    * the same object via standard CSS properties:
    * - `stroke` — border color (default `colorPrimaryHover`)
@@ -72,6 +79,7 @@ const BAICountdownBorder: React.FC<BAICountdownBorderProps> = ({
   className,
   style,
   resetKey,
+  paused = false,
 }) => {
   'use memo';
   const { token } = theme.useToken();
@@ -136,7 +144,10 @@ const BAICountdownBorder: React.FC<BAICountdownBorderProps> = ({
             pathLength={100}
             strokeDasharray={100}
             className={styles.fill}
-            style={{ animationDuration: `${durationMs}ms` }}
+            style={{
+              animationDuration: `${durationMs}ms`,
+              animationPlayState: paused ? 'paused' : 'running',
+            }}
           />
         </svg>
       )}

--- a/packages/backend.ai-ui/src/components/BAICountdownBorder.tsx
+++ b/packages/backend.ai-ui/src/components/BAICountdownBorder.tsx
@@ -41,10 +41,10 @@ export interface BAICountdownBorderProps {
    */
   resetKey?: React.Key;
   /**
-   * When true, freezes the fill animation at its current position
-   * (`animation-play-state: paused`) instead of advancing. Use it to hold the
-   * countdown while the wrapped control's refresh is in flight, so the border
-   * does not complete or loop before the real refresh happens.
+   * When true, freezes the fill animation (`animation-play-state: paused`) and
+   * hides the border entirely (`visibility: hidden`) instead of advancing. Use
+   * it while the wrapped control's refresh is in flight, so no stale countdown
+   * is visible before the real refresh happens.
    */
   paused?: boolean;
   /**
@@ -128,6 +128,10 @@ const BAICountdownBorder: React.FC<BAICountdownBorderProps> = ({
             overflow: 'visible',
             pointerEvents: 'none',
             zIndex: 1,
+            // While paused (refresh in flight) the border must be fully
+            // invisible — even at offset 100 the dash boundary can render a
+            // tiny stroke sliver at the path start.
+            visibility: paused ? 'hidden' : 'visible',
           }}
         >
           <rect

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.stories.tsx
@@ -334,6 +334,57 @@ export const CountdownBorder: Story = {
   },
 };
 
+export const CountdownBorderPausesWhileLoading: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reproduces FR-3354: with a short auto-refresh interval (3s) but a `loading` refresh that stays in flight LONGER than the interval (~6s), the countdown border does not complete or loop while loading. Instead it freezes (`animation-play-state: paused`) at its current position for the whole request, then re-anchors and restarts from empty the instant `loading` returns to false — so the exposed countdown stays in sync with the real (end-anchored) refresh. Click the button (or wait for an auto-refresh) to trigger the long load and watch the border pause.',
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+    // Short interval (3s) but a long in-flight load (6s) — the load outlasts a
+    // full countdown cycle, so without the fix the border would complete/loop
+    // while the real refresh is still pending.
+    const [delay] = useState<number | null>(3000);
+    const [counter, setCounter] = useState(0);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      setCounter((prev) => prev + 1);
+      // Simulate a slow API call that outlasts the 3s interval.
+      setTimeout(() => {
+        setLoading(false);
+      }, 6000);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 220 }}>3s interval, 6s load:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            autoUpdateDelay={delay}
+            showLastLoadTime={true}
+          />
+          <span>Refresh count: {counter}</span>
+        </BAIFlex>
+        <div style={{ fontSize: '12px', color: '#666' }}>
+          {loading
+            ? 'Loading… border is FROZEN (paused) until the load finishes.'
+            : 'Idle — border fills over 3s, then restarts fresh after each load.'}
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
 export const CustomOptions: Story = {
   parameters: {
     docs: {

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.stories.tsx
@@ -377,7 +377,7 @@ export const CountdownBorderPausesWhileLoading: Story = {
         </BAIFlex>
         <div style={{ fontSize: '12px', color: '#666' }}>
           {loading
-            ? 'Loading… border is FROZEN (paused) until the load finishes.'
+            ? 'Loading… border is HIDDEN until the load finishes.'
             : 'Idle — border fills over 3s, then restarts fresh after each load.'}
         </div>
       </BAIFlex>

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
@@ -212,6 +212,20 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
     cycleKey,
   );
 
+  // When a consumer-supplied `loading` refresh finishes, re-anchor the countdown
+  // to this moment. `useInterval` already restarts the paused interval on the
+  // same `loading` true->false transition (its delay flips from null back to
+  // `selectedDelay`); bumping `cycleKey` here restarts the border animation from
+  // empty at the same instant, so the newly exposed countdown stays accurate
+  // instead of finishing early on its request-start anchor.
+  const [prevLoading, setPrevLoading] = useState(loading);
+  if (loading !== prevLoading) {
+    setPrevLoading(loading);
+    if (!loading) {
+      setCycleKey((key) => key + 1);
+    }
+  }
+
   const tooltipTitle = showLastLoadTime ? loadTimeMessage : undefined;
   const isAutoRefreshOn = selectedDelay !== null;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -228,6 +242,16 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
     undefined,
   );
   if (selectedDelay !== trackedDelay) {
+    // On a real interval change (not the initial render), re-anchor the
+    // countdown to this moment: `useInterval` already restarts its schedule on
+    // the new delay, so bump `cycleKey` to remount `BAICountdownBorder` and
+    // refill from empty over the new duration — instead of morphing the
+    // in-flight fill to the new speed mid-cycle. `undefined` (the initial
+    // `trackedDelay`) means "first render", where the border mounts fresh
+    // anyway, so skip the bump there.
+    if (trackedDelay !== undefined) {
+      setCycleKey((key) => key + 1);
+    }
     setTrackedDelay(selectedDelay);
     if (
       selectedDelay !== null &&
@@ -256,12 +280,17 @@ const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
   // `BAICountdownBorder` so its border fills clockwise, once per selected
   // interval, restarting exactly on `cycleKey` (see `triggerRefresh` above) so
   // it never drifts out of sync with the real refresh — whether the cycle was
-  // completed automatically or cut short by a manual click.
+  // completed automatically or cut short by a manual click. While a
+  // consumer-supplied `loading` refresh is in flight the border is frozen
+  // (`paused={loading}`) instead of advancing, and it is re-anchored (via the
+  // `cycleKey` bump on the `loading` true->false edge above) when the refresh
+  // completes, so it never finishes or loops ahead of the real reload.
   const withCountdownBorder = (node: React.ReactNode) =>
     isAutoRefreshOn && showCountdownBorder ? (
       <BAICountdownBorder
         durationMs={selectedDelay as number}
         resetKey={cycleKey}
+        paused={loading}
       >
         {node}
       </BAICountdownBorder>


### PR DESCRIPTION
Resolves #8355 (FR-3354)

## Problem

When a consumer passes a `loading` flag to `BAIFetchKeyButton` (e.g. `ContainerLogModal` with `loading={isPending || isRefetching}`), the shared auto-refresh interval is paused via `useInterval(triggerRefresh, loading ? null : selectedDelay, ...)`, so the next real refresh only fires `selectedDelay` ms after the request **finishes**.

The animated countdown border, however, kept running its CSS animation (`animation-iteration-count: infinite`) independently: it was reset only at request **start** (in `triggerRefresh`) and was never paused or re-anchored on the `loading` true→false edge. So the border completed a full clockwise cycle `selectedDelay` ms after the request *started*, while the actual next refresh happened `selectedDelay` ms after it *ended* — the visible countdown lied about when the refresh occurs. With `ContainerLogModal`'s **15s** `get_logs()` timeout and **10s** default interval, the border could complete (and start looping again) before the current request even ended.

## Fix

- **`BAICountdownBorder`**: add an optional `paused` prop that pauses the fill animation (`animation-play-state: paused`) **and hides the border entirely** (`visibility: hidden` on the overlay svg) — even at `strokeDashoffset` 100 (empty) the dash boundary renders a tiny stroke sliver at the path start, so a merely-frozen border still showed a small orange mark during loading.
- **`BAIFetchKeyButton`**:
  - pass `paused={loading}` so the border is hidden while a refresh is in flight (instead of completing/looping);
  - re-anchor the countdown (bump `cycleKey`) on the `loading` true→false edge using the existing render-phase state-sync pattern (mirrors the `trackedDelay` block — **no `useEffect`, no `eslint-disable`**). `useInterval` already restarts the paused interval on that same transition, so the border and the real refresh now share a single anchor instant.
- **`BAIFetchKeyButton`** (interval change): when the user picks a new interval from the dropdown, bump `cycleKey` so the countdown border remounts and refills from empty over the new duration — instead of morphing the in-flight fill to the new speed mid-cycle. `useInterval` already restarts its schedule on the new delay, so both stay in lockstep. (Skipped on the initial render.)
- **Storybook**: add `CountdownBorderPausesWhileLoading` (3s interval, 6s simulated load) demonstrating the hidden-while-loading, restart-from-empty behavior.

Consumers that do **not** pass `loading` are unchanged (`paused` defaults to `false`; the undefined→undefined loading never triggers a re-anchor).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript). The one warn-only terminology finding (`error.UserHasNoGroup`) is pre-existing and unrelated.
- Reviewed across three lenses (correctness / regression / lint+React-Compiler) — all approved.

**Checklist:**

- [ ] Documentation
- [ ] Minimum required manager version
- [x] Test case(s) to demonstrate the difference of before/after — new Storybook story `CountdownBorderPausesWhileLoading`

