### PR TITLE
feat(FR-3214): exclude pnpm store from the dev type-check watcher to cut per-process watch FDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,11 @@ data/merged_schema.graphql
 # webui release download temp directories (safe to delete)
 scripts/temp-releases/
 
+# derived type-check tsconfig generated at dev startup (FR-3214): excludes the
+# machine-specific pnpm store path from vite-plugin-checker's TS watch program
+react/tsconfig.checker.json
+react/tsconfig.checker.json.*.tmp
+
 # ignore playwright mcp test files
 .playwright-mcp/
 

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -1,7 +1,15 @@
 import react from '@vitejs/plugin-react';
 import compression from 'compression';
 import { execSync } from 'node:child_process';
-import { createReadStream, existsSync, readFileSync, statSync } from 'node:fs';
+import {
+  createReadStream,
+  existsSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import {
   basename,
@@ -13,7 +21,7 @@ import {
   resolve,
 } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig, loadEnv, type Plugin } from 'vite';
+import { defineConfig, loadEnv, normalizePath, type Plugin } from 'vite';
 import checker from 'vite-plugin-checker';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { VitePWA } from 'vite-plugin-pwa';
@@ -24,6 +32,18 @@ import { devReviewOverlayPlugin } from './vite-plugins/reviewOverlay';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, '..');
 const require = createRequire(import.meta.url);
+
+const baseTsconfigPath = resolve(__dirname, 'tsconfig.json');
+const checkerTsconfigPath = resolve(__dirname, 'tsconfig.checker.json');
+
+// Deletes a path we are abandoning anyway; never throws.
+function removeQuietly(path: string): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    // Cleanup is best-effort.
+  }
+}
 
 // With `enableGlobalVirtualStore: true` (pnpm-workspace.yaml), pnpm hard-links
 // every dependency into a single global store outside this repo, with the
@@ -68,6 +88,53 @@ function resolvePnpmStorePath(): string | undefined {
       err instanceof Error ? err.message : err,
     );
     return undefined;
+  }
+}
+
+// Excludes the pnpm store from the checker's `tsc` watch program (FR-3214).
+// The worker opens one FD per file in the program, including thousands of
+// immutable store `.d.ts`, so concurrent dev servers hit EMFILE. `watchOptions`
+// excludes drop the watcher but not the read, so type-checking stays complete.
+// vite-plugin-checker exposes no inline watchOptions, leaving the tsconfig it
+// reads as the only injection point, and the exclude must be absolute: TS
+// anchors `**/`-globs under the project basePath, which can never match a store
+// realpath outside the repo. That path is machine-specific, hence a gitignored
+// derived config rather than an entry in the committed tsconfig.
+function resolveCheckerTsconfigPath(storeRoot: string | undefined): string {
+  if (!storeRoot) {
+    // Drop a checker config left by an earlier run; the base tsconfig wins here.
+    removeQuietly(checkerTsconfigPath);
+    return baseTsconfigPath;
+  }
+  // TS watchOptions globs use forward slashes, even on Windows.
+  const storeGlob = `${normalizePath(storeRoot)}/**`;
+  // Publish atomically: `writeFileSync` truncates first, so a concurrent dev
+  // server can read an empty file, whereas `rename(2)` is never observed midway.
+  const tmpPath = `${checkerTsconfigPath}.${process.pid}.tmp`;
+  try {
+    writeFileSync(
+      tmpPath,
+      JSON.stringify(
+        {
+          extends: './tsconfig.json',
+          watchOptions: {
+            excludeDirectories: [storeGlob],
+            excludeFiles: [storeGlob],
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    renameSync(tmpPath, checkerTsconfigPath);
+    return checkerTsconfigPath;
+  } catch (err) {
+    removeQuietly(tmpPath);
+    console.warn(
+      '[vite] could not write tsconfig.checker.json; the type-check worker will watch pnpm-store .d.ts files and may hit EMFILE under multi-repo dev:',
+      err instanceof Error ? err.message : err,
+    );
+    return baseTsconfigPath;
   }
 }
 
@@ -921,12 +988,20 @@ export default defineConfig(({ command, mode }) => {
       // terminal and as a browser overlay during `vite dev`. Vite itself
       // only strips types via esbuild, so without this plugin type
       // errors are visible only in the IDE or via `scripts/verify.sh`.
-      // `tsconfigPath` pins the checker to the consumer's tsconfig
-      // (which has the `paths` workaround for pnpm-global-virtual-store
-      // type resolution — see FR-2925).
+      // `tsconfigPath` pins the checker to the consumer's tsconfig (which has
+      // the `paths` workaround for pnpm-global-virtual-store type resolution —
+      // see FR-2925). During dev it is the derived `tsconfig.checker.json`
+      // that excludes the pnpm store from the watch program (FR-3214) — see
+      // `resolveCheckerTsconfigPath` above; for `vite build` it is the plain
+      // base tsconfig.
       checker({
         typescript: {
-          tsconfigPath: resolve(__dirname, 'tsconfig.json'),
+          // Only `serve` owns tsconfig.checker.json; `vite build` reads the base
+          // config and must not write or delete a file a live dev server uses.
+          tsconfigPath:
+            command === 'serve'
+              ? resolveCheckerTsconfigPath(pnpmStorePath)
+              : baseTsconfigPath,
         },
       }),
 


### PR DESCRIPTION
Related to #8047 (FR-3214) — the issue itself is resolved by #8156 (process-group kill); this PR is the complementary footprint reduction, split out per review discussion.

> **Stacked on** #8156

## Problem

Even with orphan leaks fixed in #8156, each *live* dev server still holds far more file descriptors than it needs. Measured on a live dev stack: a single `vite` dev process holds **~5,894 open file descriptors**, of which **~4,481 are regular files inside the pnpm store** (immutable dependency `.d.ts` type declarations, ~3,840 of them).

The holder is **vite-plugin-checker**'s TypeScript watch program (`ts.createWatchProgram`), which installs a per-file watcher on every file in the program — including every dependency `.d.ts` in the store. On macOS each per-file watch costs 1 open FD, so:

- GUI/IDE-launched dev inherits launchd's soft `maxfiles` = **256** → instant EMFILE.
- Terminal-launched dev survives one repo but running N repos multiplies ~5,900 × N toward the kernel limit.

## Fix

Tell the checker's TS watch program **not to watch the pnpm store** via `watchOptions.excludeDirectories` / `excludeFiles`.

Two constraints shape the implementation:

1. **The exclude spec must be an absolute store path.** TS anchors `**/`-globs under the project `basePath` (`combinePaths()`), so they can never match the store realpath which lives *outside* the repo (`~/Library/pnpm/store/v11/...`). Measured: `**/node_modules/**`, `**/store/**` etc. all had **zero** effect. Since the absolute path is machine-specific, it cannot live in the committed `tsconfig.json`.
2. **vite-plugin-checker (0.9.3) has no inline watchOptions API** — it calls `ts.createWatchCompilerHost` without a `watchOptionsToExtend` arg, so the only injection point is the tsconfig file it reads.

Therefore `react/vite.config.ts` now generates a **gitignored `react/tsconfig.checker.json`** at dev startup — `{ extends: './tsconfig.json', watchOptions: { excludeDirectories/excludeFiles: ['<absolute store root>/**'] } }` — and points `checker({ typescript: { tsconfigPath } })` at it. The store root reuses the existing `pnpmStorePath` (from `pnpm store path`).

## Why excluding the store from the watch is safe

- **Type-checking stays complete.** `watchOptions` excludes only drop the *file watcher*, not the *read*. TS still reads every dependency `.d.ts` to build the program — verified: error count identical before/after (real-stack boot: "Found 0 errors" both ways; in an error-injection harness, 296 → 296).
- **CI / pre-commit / `scripts/verify.sh` are untouched.** Those run one-shot `tsc --noEmit` (no `--watch`), which ignores `watchOptions` entirely — and this PR does not modify the committed `react/tsconfig.json` at all. The exclude lives only in the gitignored derived file that the dev-mode checker reads. Every gate that actually enforces type safety is unaffected.
- **`vite build` is untouched.** The derived-config helper is only *called* when `command === 'serve'`; a build is handed the base tsconfig directly and performs no file I/O at all (a one-shot build installs no file watchers anyway).
- **HMR and workspace packages keep full watch.** HMR is Vite's own separate watcher, unrelated to the checker's watchOptions. `backend.ai-ui` / `backend.ai-client` resolve via tsconfig `paths` to `../packages/*/src` — project-internal source outside the store — so they keep normal per-file watch and instant re-check.
- **Graceful fallback.** If the store path can't be resolved (npm/yarn flat installs) or the derived file can't be written, the checker falls back to the plain `tsconfig.json` — original behavior, no exclude.

The only theoretical gap: a dependency `.d.ts` changing **while dev is running, with zero source edits** won't auto-trigger a re-check. In practice `pnpm install/add/update` triggers Vite's dep re-optimization / dev restart (which re-reads the store), and using a new package requires a source edit — which is watched and re-triggers the checker. The store is content-addressed and immutable during normal dev, and CI re-checks everything regardless.

## Measurements (real stack, `lsof` on the live vite pid)

| config | vite open REG files | files held open under pnpm store | type errors | live edit detection |
|---|---|---|---|---|
| before (no watchOptions) | **5,884** | 3,825 | baseline | YES (~2s) |
| after (this PR) | **1,404** (−76%) | **2** | **identical** | **YES (~2s)** |

Also verified this is **not a Vite regression** by actually booting the last pure-craco commit (`00e8431a1`) in a worktree and measuring the same `tsc --watch` program: craco-era = **6,870 FDs** (6,055 in-store) vs current Vite = 5,894 — the Vite stack was already slightly *lighter*; the store-watch cost is inherent to running an in-process TS type-checker, and this PR removes it.

## Changes since the first review

Four follow-up commits, all in `resolveCheckerTsconfigPath` / its call site:

1. **Stale derived config is now removed on the degrade path** (review request). If an earlier run wrote `tsconfig.checker.json` and a later run resolves no store root, the file is unlinked instead of left behind with a stale exclude spec.
2. **The side effects are scoped to `serve`.** The helper is evaluated while the `plugins` array is built, so it previously ran for *every* command — meaning the new cleanup made `vite build` delete `tsconfig.checker.json` out from under a dev server running in another terminal. The call site now guards on `command === 'serve'` and hands `build` the base tsconfig directly.
3. **The config is published atomically** (raised by the Graphite bot). `writeFileSync` opens with `O_TRUNC`, leaving the file zero-length for ~4.9 us p50 / 11.2 us p99; under contention 54,589 of 81,795 concurrent reads saw an empty file. It now writes a pid-unique temp and `rename(2)`s it into place — same stress test after: 0 empty reads. Content was never corrupted (all writers produce byte-identical output in a single `write(2)`); the failure mode was the truncate window, not interleaving.
4. **Cleanup helper extracted** (`removeQuietly`) and two over-long comment blocks trimmed.

**On `excludeFiles` vs `excludeDirectories`** (review question): they are not redundant, and `excludeFiles` is the load-bearing one. TypeScript dispatches the two lists by watcher kind — `watchFile()` is tested only against `excludeFiles`, `watchDirectory()` only against `excludeDirectories` — so a directory-subtree glob cannot suppress the per-file watchers this PR targets. Measured on `react/tsconfig.json`, same program, only `watchOptions` varying:

| variant | total FDs | store `.d.ts` |
|---|---|---|
| no excludes | 6,028 | 3,903 |
| `excludeDirectories` only | 6,028 | 3,903 |
| `excludeFiles` only | 1,485 | **0** |
| both (what ships) | 1,485 | **0** |

`excludeDirectories` contributes nothing measurable here; it is kept only because this is one machine / one TS version / macOS and it costs nothing to leave.

## Verification

- **Re-measured on this stacked branch** (same method both runs: boot `pnpm run dev`, wait for the checker's "Found 0 errors", then `lsof` the vite pid): parent branch without the exclude = **6,056** open REG files (**4,566** under the pnpm store) vs this branch = **87** open REG files (**2** under the store). `tsconfig.checker.json` generated with the correct absolute store glob and confirmed gitignored; checker reports "Found 0 errors" in both runs.
- `bash scripts/verify.sh` — `=== ALL PASS ===` (Relay / Lint / Format / TypeScript), re-run on this stacked branch.
- Real-stack boot test (from the original round of this change): `tsconfig.checker.json` generated correctly, confirmed gitignored, checker reports "Found 0 errors", FD table above.
- Injected a TS2322 into `react/src/index.tsx` via atomic save while dev was running → checker reported it within ~2s (source watch intact); reverting cleared it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

