### PR TITLE
feat(FR-3049): i18n terminology drift fails verify.sh (harness warn→fail)

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1479,7 +1479,7 @@
     "UnexpectedError": "An unexpected error occurred. Please try again later or contact support if the problem persists.",
     "UnknownError": "An unknown error occurred. Please try again.",
     "UpdateError": "Update error",
-    "UserHasNoGroup": "User has no group. Please contact administrator to fix it.",
+    "UserHasNoGroup": "User has no project. Please contact administrator to fix it.",
     "UserNameAlreadyExist": "Username already exists. It cannot be duplicated.",
     "VirtualFolderAlreadyExist": "A virtual folder with the same name already exists. Delete your own folder or decline the invitation.",
     "WrongAPIServerAddress": "Wrong API server address."

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -75,15 +75,25 @@ check_relay_drift() {
 check_terminology_drift() {
   # Deterministic i18n terminology checker (read-only). Scans i18n VALUES against
   # packages/backend.ai-webui-docs/terminology.json `avoid[]` (CHECK 1). See
-  # scripts/check-terminology-i18n.mjs. (CHECK 2, key->two-values divergence, is
-  # OFF by default — too noisy today; opt in with `pnpm run lint:terminology -- --check2`.)
+  # scripts/check-terminology-i18n.mjs. (CHECK 2, near-duplicate divergence, is
+  # OFF by default — report-only regardless; opt in with `pnpm run lint:terminology -- --check2`.)
   #
-  # NON-BLOCKING by design: this runs in --warn mode and is invoked OUTSIDE
-  # run_check, so it never sets FAIL and never flips `=== ALL PASS ===`.
-  # Run `pnpm run lint:terminology` for the standalone report. Flipping this to
-  # blocking (via `node scripts/check-terminology-i18n.mjs --strict`) is a
-  # separate future task once the warn-mode findings have been triaged.
-  node scripts/check-terminology-i18n.mjs --warn
+  # BLOCKING (FR-3049, team sign-off required): runs in --strict and is invoked
+  # INSIDE run_check, so a blocking CHECK 1 finding sets FAIL and prevents
+  # `=== ALL PASS ===`. Only bare-English, context-free avoid rows are
+  # error-severity (checker `runCheck1`); context-qualified and all non-English
+  # rows stay WARN and never block (severity logic unchanged). CHECK 2/3 never
+  # affect the exit code. To unblock a legitimate false positive without
+  # reverting: add the value/key to scripts/terminology-i18n.allowlist.json
+  # (ignoreValues/ignoreKeys) or append `[[i18n-term-ok]]` inline. To fully
+  # disable: change --strict back to --warn and move this out of run_check.
+  #
+  # NOTE: verify.sh is NOT run in CI (it is the local/agent harness), so this
+  # flip blocks local + agent runs, not PR merges. A true CI merge-gate would be
+  # a separate workflow — see the FR-3049 PR body for why that must be
+  # diff-aware (fail only on findings a PR introduces), so a pre-existing drift
+  # elsewhere cannot block an unrelated PR.
+  node scripts/check-terminology-i18n.mjs --strict
 }
 
 run_check "Relay" check_relay_drift
@@ -91,19 +101,16 @@ run_check "Lint" pnpm -r --stream lint
 run_check "Format" pnpm run format
 run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit
 run_check "Vite warmup paths" check_warmup_paths
+run_check "Terminology" check_terminology_drift
 
-# Warn-only terminology report. Guarded with `|| true` so `set -e` + the
-# checker's exit code can never abort verify.sh or mark the build failed.
-echo "=== Terminology (warn-only) ==="
-check_terminology_drift || true
 # Non-English avoid-row precision self-test (FR-3051). Report-only HERE so that
-# i18n CONTENT drift stays warn-only in verify.sh (a new drifting value can
-# breach a row's live falsePositiveBudget — that is CHECK 1's warn job). The
-# same script runs as a HARD gate in CI (terminology-selftest.yml), triggered
-# ONLY by the termbase / checker / fixtures paths — never by docs prose or
-# i18n content — which is where bad avoid-row DATA is blocked.
+# i18n CONTENT drift stays warn-only in verify.sh — CHECK 1 (above) owns the
+# blocking decision for content. The self-test runs as a HARD gate in CI
+# (terminology-selftest.yml), triggered ONLY by the termbase / checker /
+# fixtures paths — never by docs prose or i18n content — which is where bad
+# avoid-row DATA is blocked.
+echo "=== Terminology self-test (report-only here; hard gate in CI) ==="
 node scripts/check-terminology-i18n.selftest.mjs || true
-echo "--- Terminology: WARN-ONLY (does not affect build status) ---"
 echo ""
 
 if [ $FAIL -eq 0 ]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -103,12 +103,13 @@ run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit
 run_check "Vite warmup paths" check_warmup_paths
 run_check "Terminology" check_terminology_drift
 
-# Non-English avoid-row precision self-test (FR-3051). Report-only HERE so that
-# i18n CONTENT drift stays warn-only in verify.sh — CHECK 1 (above) owns the
-# blocking decision for content. The self-test runs as a HARD gate in CI
-# (terminology-selftest.yml), triggered ONLY by the termbase / checker /
-# fixtures paths — never by docs prose or i18n content — which is where bad
-# avoid-row DATA is blocked.
+# Non-English avoid-row precision self-test (FR-3051). This gates the avoid-row
+# DATA (are the non-English rows precise?), a separate axis from CHECK 1 above
+# (which gates i18n CONTENT and now BLOCKS on bare-English drift). It is
+# report-only HERE so that the DATA gate lives in exactly one place — the CI
+# workflow terminology-selftest.yml, triggered ONLY by the termbase / checker /
+# fixtures paths (never by docs prose or i18n content) — rather than also
+# hard-failing this local/agent harness on the live-store budget probe.
 echo "=== Terminology self-test (report-only here; hard gate in CI) ==="
 node scripts/check-terminology-i18n.selftest.mjs || true
 echo ""


### PR DESCRIPTION
Resolves #7739 (FR-3049)

Flips the i18n terminology check from **warn** to **fail** inside `scripts/verify.sh` — the local + agent verification harness. This is exactly the mechanical change FR-3049 asks for, scoped honestly to the harness: it is **not** a CI merge-gate (see "What this is / isn't").

## What this does

1. **`resources/i18n/en.json` — clears the sole warn.** `error.UserHasNoGroup` value `"group"` → `"project"` (the user-facing concept is *project*; the string fires from `usePainKiller.tsx` when a user belongs to no project — the issue's recommended Option A). After it, `--strict` reports **0 blocking / 0 warn**. The key name is untouched (keys are never inspected by the checker). Retranslating the other 20 locales (`그룹`→`프로젝트`, etc.) is tracked as **FR-3356**.
2. **`scripts/verify.sh` — warn → fail.** `check_terminology_drift` now runs `--strict` **inside** `run_check`, so a blocking CHECK 1 finding sets `FAIL` and prevents `=== ALL PASS ===`. Severity logic is **unchanged**: only bare-English, context-free avoid rows are error-severity; context-qualified rows (`group (for project)`, `WSProxy`) and **all** non-English rows stay WARN and never block. CHECK 2/3 never affect the exit code. The FR-3051 self-test stays report-only here (its hard gate lives in CI `terminology-selftest.yml`).

## What this is / isn't

- **Is:** the `verify.sh` harness now **fails** on a bare-English forbidden term instead of printing a warn line. Because agents gate on `=== ALL PASS ===` (and many contributors run `verify.sh` pre-push), the **authoring path** now catches new drift before it lands. Day-one impact is zero — the baseline is clean (`0 blocking`).
- **Isn't:** a CI merge-blocker. `verify.sh` is **not executed by any CI workflow** (`grep -rn "run:.*verify.sh" .github/` → none), so a PR whose CI is green can still merge a forbidden term. This PR does not claim otherwise.

Making forbidden terms *un-mergeable* would need a **separate, diff-aware CI workflow** (fail only on findings a PR introduces — a whole-store CI gate would block unrelated PRs on pre-existing drift, the cascade we deliberately kept the FR-3051 self-test scoped away from). That is **out of scope here** and left as an explicit team decision (notes on #7739). A `lint-staged` pre-commit hook is also **intentionally not added** — it scans the whole store and would surprise a contributor editing one unrelated locale.

## Verification

- `node scripts/check-terminology-i18n.mjs --strict` → exit **0**, `{blocking: 0, warn: 0}` repo-wide (both stores, 21 locales).
- `bash scripts/verify.sh` → `=== ALL PASS ===`; `Terminology` now appears as a `run_check` step (PASS).
- **End-to-end adversarial:** injecting a bare `"scaling group"` into an en value makes the full `verify.sh` print `--- Terminology: FAIL ---` → `=== SOME CHECKS FAILED ===`; reverting restores `ALL PASS`.
- `bash -n scripts/verify.sh` clean; `en.json` parses and is Prettier-clean.

## Rollback (no revert needed)

- **False positive:** add the value/key to `scripts/terminology-i18n.allowlist.json` (`ignoreValues` / `ignoreKeys`), or append `[[i18n-term-ok]]` inline.
- **Full disable:** change `--strict` back to `--warn` and move the call out of `run_check`.

## Scope note

The harness-level warn→fail is low-stakes (local/agent only, clean baseline, fully reversible), so it proceeds at this level. The heavier **CI merge-gate** — the piece that would actually make terminology enforcement a merge requirement — remains a separate, open team decision, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)