### PR TITLE
feat(FR-3355): show 'No changes made' message on no-op RBAC permission save

### DIFF
--- a/react/src/components/RoleScopePermissionEditModal.tsx
+++ b/react/src/components/RoleScopePermissionEditModal.tsx
@@ -534,10 +534,13 @@ const RoleScopePermissionEditModal: React.FC<
       });
     });
 
-    // Dirty tracking: nothing changed anywhere → close without any request
-    // (FR-6).
+    // Dirty tracking: nothing changed anywhere → tell the user and close
+    // without any request (FR-6). Report success (→ parent refetch) only
+    // when an earlier partially-failed save already applied changes, same
+    // as the cancel handler — a pristine no-op must not trigger a refetch.
     if (createEntries.length === 0 && deleteEntries.length === 0) {
-      onRequestClose(true);
+      message.info(t('rbac.NoChangesMade'));
+      onRequestClose(appliedCellOverrides.size > 0);
       return;
     }
 

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "Gewährt am",
     "Inactive": "Inaktiv",
     "Name": "Name",
+    "NoChangesMade": "Es wurden keine Änderungen vorgenommen.",
     "NoPermissionsToDisplay": "Keine Berechtigungen vorhanden",
     "NoRolesToDisplay": "Keine Rollen vorhanden",
     "NoScopesToDisplay": "Für diese Rolle sind keine Bereiche konfiguriert",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2175,6 +2175,7 @@
     "GrantedAt": "Εκχωρήθηκε στις",
     "Inactive": "Ανενεργός",
     "Name": "Όνομα",
+    "NoChangesMade": "Δεν έγιναν αλλαγές.",
     "NoPermissionsToDisplay": "Δεν υπάρχουν δικαιώματα για εμφάνιση",
     "NoRolesToDisplay": "Δεν υπάρχουν ρόλοι για εμφάνιση",
     "NoScopesToDisplay": "Δεν έχουν διαμορφωθεί εύρη για αυτόν τον ρόλο",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2162,6 +2162,7 @@
     "GrantedAt": "Granted At",
     "Inactive": "Inactive",
     "Name": "Name",
+    "NoChangesMade": "No changes made.",
     "NoPermissionsToDisplay": "No permissions to display",
     "NoRolesToDisplay": "No roles to display",
     "NoScopesToDisplay": "No scopes are configured for this role",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2175,6 +2175,7 @@
     "GrantedAt": "Concedido el",
     "Inactive": "Inactivo",
     "Name": "Nombre",
+    "NoChangesMade": "No se han realizado cambios.",
     "NoPermissionsToDisplay": "No hay permisos para mostrar",
     "NoRolesToDisplay": "No hay roles para mostrar",
     "NoScopesToDisplay": "No hay ámbitos configurados para este rol",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2175,6 +2175,7 @@
     "GrantedAt": "Myönnetty",
     "Inactive": "Ei-aktiivinen",
     "Name": "Nimi",
+    "NoChangesMade": "Muutoksia ei tehty.",
     "NoPermissionsToDisplay": "Ei näytettäviä käyttöoikeuksia",
     "NoRolesToDisplay": "Ei näytettäviä rooleja",
     "NoScopesToDisplay": "Tälle roolille ei ole määritetty laajuuksia",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "Accordé le",
     "Inactive": "Inactif",
     "Name": "Nom",
+    "NoChangesMade": "Aucun changement n'a été effectué.",
     "NoPermissionsToDisplay": "Aucune permission à afficher",
     "NoRolesToDisplay": "Aucun rôle à afficher",
     "NoScopesToDisplay": "Aucune portée n'est configurée pour ce rôle",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2178,6 +2178,7 @@
     "GrantedAt": "Diberikan Pada",
     "Inactive": "Tidak aktif",
     "Name": "Nama",
+    "NoChangesMade": "Tidak ada perubahan.",
     "NoPermissionsToDisplay": "Tidak ada izin untuk ditampilkan",
     "NoRolesToDisplay": "Tidak ada peran untuk ditampilkan",
     "NoScopesToDisplay": "Tidak ada cakupan yang dikonfigurasi untuk peran ini",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2175,6 +2175,7 @@
     "GrantedAt": "Concesso il",
     "Inactive": "Inattivo",
     "Name": "Nome",
+    "NoChangesMade": "Nessuna modifica apportata.",
     "NoPermissionsToDisplay": "Nessun permesso da visualizzare",
     "NoRolesToDisplay": "Nessun ruolo da visualizzare",
     "NoScopesToDisplay": "Nessun ambito configurato per questo ruolo",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "付与日時",
     "Inactive": "非アクティブ",
     "Name": "名前",
+    "NoChangesMade": "変更はありません。",
     "NoPermissionsToDisplay": "表示する権限がありません",
     "NoRolesToDisplay": "表示するロールがありません",
     "NoScopesToDisplay": "このロールにはスコープが設定されていません",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "부여 일시",
     "Inactive": "비활성",
     "Name": "이름",
+    "NoChangesMade": "변경사항이 없습니다.",
     "NoPermissionsToDisplay": "표시할 세부 권한이 없습니다",
     "NoRolesToDisplay": "표시할 역할이 없습니다",
     "NoScopesToDisplay": "역할이 적용될 범위가 설정되지 않았습니다",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2176,6 +2176,7 @@
     "GrantedAt": "Олгосон огноо",
     "Inactive": "Идэвхгүй",
     "Name": "Нэр",
+    "NoChangesMade": "Өөрчлөлт хийгдээгүй.",
     "NoPermissionsToDisplay": "Харуулах зөвшөөрөл байхгүй",
     "NoRolesToDisplay": "Харуулах үүрэг байхгүй",
     "NoScopesToDisplay": "Энэ үүрэгт хамрах хүрээ тохируулаагүй байна",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2175,6 +2175,7 @@
     "GrantedAt": "Diberikan Pada",
     "Inactive": "Tidak aktif",
     "Name": "Nama",
+    "NoChangesMade": "Tiada perubahan dibuat.",
     "NoPermissionsToDisplay": "Tiada kebenaran untuk dipaparkan",
     "NoRolesToDisplay": "Tiada peranan untuk dipaparkan",
     "NoScopesToDisplay": "Tiada skop dikonfigurasikan untuk peranan ini",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "Przyznano",
     "Inactive": "Nieaktywny",
     "Name": "Nazwa",
+    "NoChangesMade": "Nie wprowadzono żadnych zmian.",
     "NoPermissionsToDisplay": "Brak uprawnień do wyświetlenia",
     "NoRolesToDisplay": "Brak ról do wyświetlenia",
     "NoScopesToDisplay": "Dla tej roli nie skonfigurowano żadnych zakresów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2175,6 +2175,7 @@
     "GrantedAt": "Concedido em",
     "Inactive": "Inativo",
     "Name": "Nome",
+    "NoChangesMade": "Nenhuma alteração foi feita.",
     "NoPermissionsToDisplay": "Nenhuma permissão para exibir",
     "NoRolesToDisplay": "Nenhuma função para exibir",
     "NoScopesToDisplay": "Nenhum escopo configurado para esta função",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "Concedido em",
     "Inactive": "Inativo",
     "Name": "Nome",
+    "NoChangesMade": "Nenhuma alteração foi feita.",
     "NoPermissionsToDisplay": "Sem permissões para apresentar",
     "NoRolesToDisplay": "Sem funções para apresentar",
     "NoScopesToDisplay": "Não existem âmbitos configurados para esta função",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2175,6 +2175,7 @@
     "GrantedAt": "Предоставлено",
     "Inactive": "Неактивный",
     "Name": "Имя",
+    "NoChangesMade": "Изменений не внесено.",
     "NoPermissionsToDisplay": "Нет разрешений для отображения",
     "NoRolesToDisplay": "Нет ролей для отображения",
     "NoScopesToDisplay": "Для этой роли не настроено ни одной области",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "ได้รับเมื่อ",
     "Inactive": "ไม่ได้ใช้งาน",
     "Name": "ชื่อ",
+    "NoChangesMade": "ไม่มีการเปลี่ยนแปลง.",
     "NoPermissionsToDisplay": "ไม่มีสิทธิ์ที่จะแสดง",
     "NoRolesToDisplay": "ไม่มีบทบาทที่จะแสดง",
     "NoScopesToDisplay": "ไม่มีขอบเขตที่กำหนดไว้สำหรับบทบาทนี้",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2175,6 +2175,7 @@
     "GrantedAt": "Verilme Tarihi",
     "Inactive": "Pasif",
     "Name": "Ad",
+    "NoChangesMade": "Hiç değişiklik yapılmadı.",
     "NoPermissionsToDisplay": "Görüntülenecek izin yok",
     "NoRolesToDisplay": "Görüntülenecek rol yok",
     "NoScopesToDisplay": "Bu rol için yapılandırılmış kapsam yok",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "Được cấp lúc",
     "Inactive": "Không hoạt động",
     "Name": "Tên",
+    "NoChangesMade": "Không có thay đổi.",
     "NoPermissionsToDisplay": "Không có quyền để hiển thị",
     "NoRolesToDisplay": "Không có vai trò để hiển thị",
     "NoScopesToDisplay": "Chưa có phạm vi nào được cấu hình cho vai trò này",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2177,6 +2177,7 @@
     "GrantedAt": "授予时间",
     "Inactive": "非活跃",
     "Name": "名称",
+    "NoChangesMade": "未进行任何更改。",
     "NoPermissionsToDisplay": "没有可显示的权限",
     "NoRolesToDisplay": "没有可显示的角色",
     "NoScopesToDisplay": "此角色未配置任何范围",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2179,6 +2179,7 @@
     "GrantedAt": "授予時間",
     "Inactive": "非活躍",
     "Name": "名稱",
+    "NoChangesMade": "未做任何變更。",
     "NoPermissionsToDisplay": "沒有可顯示的權限",
     "NoRolesToDisplay": "沒有可顯示的角色",
     "NoScopesToDisplay": "此角色尚未設定任何範圍",


### PR DESCRIPTION
Resolves #8359 (FR-3355)

Stacked on #8302 (FR-3334).

## Summary

Saving the RBAC scope permission edit modal (`RoleScopePermissionEditModal`) without modifying any cell previously hit the dirty-tracking short-circuit and closed silently — no request, no feedback, which could read as if the save did something.

- The no-op save path now shows an antd info message before closing: `message.info(t('rbac.NoChangesMade'))`.
- New i18n key `rbac.NoChangesMade` added to all 21 languages, copying each language's existing `userSettings.theme.NoChangesMade` translation verbatim ("No changes made." / KO "변경사항이 없습니다.") — no new copy introduced.
- Applies to both single-scope and multi-scope bulk edit (the short-circuit is shared).

## How to test

1. Open RBAC management → a role's scoped permission card → edit permissions for a scope.
2. Click **Save** without changing anything → an info message "No changes made." appears and the modal closes (no network request is issued).
3. Same for multi-scope bulk edit with every cell left as 'Keep as is'.

## Verification

```
bash scripts/verify.sh → === ALL PASS === (Relay / Lint / Format / TypeScript / Vite warmup)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
