### PR TITLE
fix(FR-3358): patch nuqs to recover render-phase updates lost in discarded renders

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,7 @@ patchedDependencies:
   '@lobehub/fluent-emoji@2.0.0': e3910174b171372f01ee0d0f41033c3aed501f7eba649e863c48e7a370886a88
   '@rc-component/form': e4841378d1c17439be3359cd395e44bb49a9b3d1f594e48cba191ea19ecf0b32
   ansi_up@6.0.6: 99856fc7fa4571c6ef4716cfd2dbf1151a025690c737775e248e8b7fe08a4459
+  nuqs@2.9.1: bed5134db3fe86fb094156405a378b05cac9d2fb9dfb56faa8e1a877b8ed82f8
   relay-runtime@20.1.1: cc791a2ea160bc7c87571401d2f1430d50527847c44039d45579a5bfa60effa6
 
 importers:
@@ -724,7 +725,7 @@ importers:
         version: 7.1.1(eslint@9.39.4)
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.64.0(eslint@9.39.4)(typescript@5.5.4)
+        version: 8.64.0(eslint@9.39.4)(typescript@6.0.3)
 
   react:
     dependencies:
@@ -879,8 +880,8 @@ importers:
         specifier: ^5.1.16
         version: 5.1.16
       nuqs:
-        specifier: ^2.9.0
-        version: 2.9.0(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@6.30.4(react@19.2.7))(react@19.2.7)
+        specifier: ^2.9.1
+        version: 2.9.1(patch_hash=bed5134db3fe86fb094156405a378b05cac9d2fb9dfb56faa8e1a877b8ed82f8)(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@6.30.4(react@19.2.7))(react@19.2.7)
       p-queue:
         specifier: ^8.1.1
         version: 8.1.1
@@ -4740,9 +4741,6 @@ packages:
 
   '@splinetool/runtime@0.9.526':
     resolution: {integrity: sha512-qznHbXA5aKwDbCgESAothCNm1IeEZcmNWG145p5aXj4w5uoqR1TZ9qkTHTKLTsUbHeitCwdhzmRqan1kxboLgQ==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -9523,8 +9521,8 @@ packages:
   numeral@2.0.6:
     resolution: {integrity: sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==}
 
-  nuqs@2.9.0:
-    resolution: {integrity: sha512-1ckQBhVHaQYjLZ3kWhhH40A32lPJ7TNTQMa2T+SUvl5azyVt7swCQfUXt9xOXJV3YidWq8VHIHcMzVAJ0knRsw==}
+  nuqs@2.9.1:
+    resolution: {integrity: sha512-xctOTExJ/M2lV9NBXTkLMb3vnGBLk/eMuZyiXSbj0jA24H6ie2d7/LJiaA0C30p5XCIWaDTZl5DEF/N2Yo1LCw==}
     peerDependencies:
       '@remix-run/react': '>=2'
       '@tanstack/react-router': ^1
@@ -16062,8 +16060,6 @@ snapshots:
       on-change: 4.0.2
       semver-compare: 1.0.0
 
-  '@standard-schema/spec@1.0.0': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@stitches/react@1.2.8(react@19.2.7)':
@@ -16716,19 +16712,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4)(typescript@5.5.4))(eslint@9.39.4)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.4)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.4)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.4)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.4)(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.4)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.64.0
       eslint: 9.39.4
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16773,15 +16769,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@9.39.4)(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.64.0(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.4
-      typescript: 5.5.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16806,21 +16802,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(typescript@5.5.4)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.5.4)
-      '@typescript-eslint/types': 8.64.0
-      debug: 4.4.3(supports-color@5.5.0)
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/project-service@8.64.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.64.0
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.64.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      debug: 4.4.3(supports-color@5.5.0)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16843,13 +16839,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.5.4)':
-    dependencies:
-      typescript: 5.5.4
-
   '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@typescript-eslint/type-utils@7.18.0(eslint@9.39.4)(typescript@5.5.4)':
     dependencies:
@@ -16875,15 +16871,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.4)(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.4)(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.4)(typescript@6.0.3)
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.4
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16935,21 +16931,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.5.4)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@5.5.4)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.5.4)
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3(supports-color@5.5.0)
-      minimatch: 10.2.5
-      semver: 7.8.5
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/typescript-estree@8.64.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.64.0(typescript@5.9.3)
@@ -16962,6 +16943,21 @@ snapshots:
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.64.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
+      debug: 4.4.3(supports-color@5.5.0)
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16987,14 +16983,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@9.39.4)(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.64.0(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
       eslint: 9.39.4
-      typescript: 5.5.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22252,9 +22248,9 @@ snapshots:
 
   numeral@2.0.6: {}
 
-  nuqs@2.9.0(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@6.30.4(react@19.2.7))(react@19.2.7):
+  nuqs@2.9.1(patch_hash=bed5134db3fe86fb094156405a378b05cac9d2fb9dfb56faa8e1a877b8ed82f8)(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@6.30.4(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       react: 19.2.7
     optionalDependencies:
       react-router: 6.30.4(react@19.2.7)
@@ -24550,10 +24546,6 @@ snapshots:
     dependencies:
       typescript: 5.5.4
 
-  ts-api-utils@2.5.0(typescript@5.5.4):
-    dependencies:
-      typescript: 5.5.4
-
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -24703,14 +24695,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.64.0(eslint@9.39.4)(typescript@5.5.4):
+  typescript-eslint@8.64.0(eslint@9.39.4)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4)(typescript@5.5.4))(eslint@9.39.4)(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.4)(typescript@5.5.4)
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.4)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
-      typescript: 5.5.4
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -25804,7 +25796,7 @@ time:
   monaco-editor@0.55.1: '2025-11-20T20:26:31.188Z'
   nanoid@5.1.16: '2026-06-24T18:37:08.221Z'
   nodemon@3.1.14: '2026-02-20T23:05:18.913Z'
-  nuqs@2.9.0: '2026-06-30T12:39:10.906Z'
+  nuqs@2.9.1: '2026-07-19T07:22:31.168Z'
   octokit@5.0.5: '2025-10-31T02:27:34.676Z'
   p-queue@8.1.1: '2025-09-07T14:41:05.235Z'
   pdf-lib@1.17.1: '2021-11-06T22:29:49.065Z'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,6 +79,7 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - react@19.2.6
   - react-dom@19.2.6
+  - nuqs@2.9.1
 minimumReleaseAgeIgnoreMissingTime: false
 resolutionMode: time-based
 
@@ -137,4 +138,5 @@ patchedDependencies:
   "@lobehub/fluent-emoji@2.0.0": react/patches/lobehub__fluent-emoji@2.0.0.patch
   "@rc-component/form": react/patches/@rc-component__form.patch
   ansi_up@6.0.6: react/patches/ansi_up@6.0.6.patch
+  nuqs@2.9.1: react/patches/nuqs@2.9.1.patch
   relay-runtime@20.1.1: react/patches/relay-runtime@20.1.1.patch

--- a/react/package.json
+++ b/react/package.json
@@ -54,7 +54,7 @@
     "marked": "catalog:",
     "monaco-editor": "^0.55.1",
     "nanoid": "^5.1.16",
-    "nuqs": "^2.9.0",
+    "nuqs": "^2.9.1",
     "p-queue": "^8.1.1",
     "prettier": "catalog:",
     "prism-react-renderer": "^2.4.1",

--- a/react/patches/nuqs@2.9.1.patch
+++ b/react/patches/nuqs@2.9.1.patch
@@ -1,0 +1,33 @@
+diff --git a/dist/index.js b/dist/index.js
+index 7db6e2df00f85c3bced74950e4817aaf7b7a53f4..913b6cccf0627ab977699b4a71abd497bfc0c717 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -3,7 +3,7 @@ import { c as debounce, i as createEmitter, l as defaultRateLimit, n as useQueue
+ import { i as warn, t as debug } from "./debug-BYu5qEae.js";
+ import { a as useAdapterProcessUrlSearchParams, c as renderQueryString, i as useAdapterDefaultOptions, o as globalSingleton, r as useAdapter } from "./context-DnRmlnQ4.js";
+ import { t as compareQuery } from "./compare-DGz2TUZl.js";
+-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
++import { startTransition as reactStartTransition, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+ //#region src/loader.ts
+ function createLoader(parsers, { urlKeys = {} } = {}) {
+ 	function loadSearchParams(input, { strict = false } = {}) {
+@@ -499,6 +499,19 @@ function useQueryStates(keyMap, options = {}) {
+ 	}
+ 	useEffect(() => {
+ 		committedPathnameRef.current = adapter.pathname ?? location.pathname;
++		// PATCH(backend.ai-webui): a render discarded mid-transition (e.g. a
++		// suspending lazy query behind useQueryState) loses the render-phase
++		// setInternalState issued by reconcile(), while the eager mutations to
++		// queryRef/lastSyncKeyRef/stateRef survive. The hook then stays
++		// permanently desynced from the URL because every later reconcile()
++		// bails on the poisoned cache. Committed paths always keep
++		// internalState === stateRef.current by identity, so a divergence here
++		// means exactly one thing: a lost render-phase update. Re-apply it.
++		// Wrapped in startTransition so content that is still suspending
++		// retries as a transition instead of forcing the nearest fallback.
++		if (stateRef.current !== internalState) reactStartTransition(() => {
++			setInternalState(stateRef.current);
++		});
+ 		reconcile();
+ 	}, [searchParamsSyncKey, adapter.pathname]);
+ 	useEffect(() => {


### PR DESCRIPTION
Resolves #8364 ([FR-3358](https://lablup.atlassian.net/browse/FR-3358))

## Summary

Clicking a folder name on the Data page updated the URL to `?folder=<id>` but the folder explorer modal never opened (a hard refresh on the same URL worked). Regression from the use-query-params → nuqs migration (FR-1943, #5097).

**Root cause** — nuqs 2.9.1 `useQueryStates` runs `reconcile()` during render, issuing a render-phase `setInternalState` while eagerly mutating its internal caches (`queryRef`, `lastSyncKeyRef`, `stateRef`). When that render is discarded — `FolderExplorerModalV2`'s `useLazyLoadQuery` suspends inside nuqs's `startTransition` — React drops the render-phase update but the ref mutations survive, so every later `reconcile()` bails on the poisoned cache and the hook stays permanently desynced from the URL. Any URL-param-driven modal/drawer with suspending content (SessionDetailDrawer, FolderInvitationResponseModalOpener, …) is exposed to the same bug class, so the fix is applied at the library level.

**Fix** — `react/patches/nuqs@2.9.1.patch` (pnpm patch): in the post-commit effect, detect the identity divergence `stateRef.current !== internalState` — on committed paths the two are always the same object, so a divergence is only possible after a lost render-phase update — and re-apply the lost state wrapped in `startTransition` (aliased import `reactStartTransition`; the local `startTransition` option variable shadows React's inside `useQueryStates`).

- `react/package.json`: nuqs `^2.9.0` → `^2.9.1` (latest; no upstream fix available)
- `pnpm-workspace.yaml`: register the patch in `patchedDependencies` + `minimumReleaseAgeExclude` for nuqs@2.9.1
- Healthy code paths are unaffected (identity check only); the healed update is a queued (non-render-phase) update, which survives discarded renders by design

## Test plan

Verified live against the dev server in Chrome (patched bundle confirmed served via code-signature fetch):

- [x] Clean load → first click on a folder opens the explorer modal (previously broken)
- [x] Close via X clears `?folder` param; re-click reopens
- [x] Browser back closes the modal; forward reopens it
- [x] Hard refresh with `?folder=<id>` opens the modal on load
- [x] Other nuqs consumers on the page regress-checked (active/trash tab ↔ `?statusCategory` round-trip)
- [x] No console errors

[FR-3358]: https://lablup.atlassian.net/browse/FR-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ