### PR TITLE
fix(FR-3359): surface TCP connection info failures instead of bogus 127.0.0.1 SSH/SFTP dialog

### DIFF
--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -547,30 +547,73 @@ export const useBackendAIAppLauncher = (
           const redirectCheckUrl = new URL(appConnectUrl.href);
           redirectCheckUrl.searchParams.set('do-not-redirect', 'true');
 
+          // The worker's /setup endpoint answers TCP circuits with
+          // `{ redirectURI: '...?directTCP=true&gateway=tcp://host:port' }`.
+          // Any failure here used to be swallowed, letting the launcher render
+          // a bogus `127.0.0.1:undefined` connection dialog — surface each
+          // failure as a launch error instead, like the Lit-era launcher did.
+          // (FR-3359)
+          let redirectURI: string | undefined;
           try {
             const result = await fetch(redirectCheckUrl.href);
             const body = await result.json();
-            const { redirectURI } = body;
-
-            if (redirectURI) {
-              const redirectURL = new URL(redirectURI);
-
-              // Check if directTCP is supported
-              const directTCPParam = redirectURL.searchParams.get('directTCP');
-              directTCPSupported = directTCPParam === 'true';
-
-              // Extract gateway URI
-              const gatewayURI = redirectURL.searchParams.get('gateway');
-
-              if (directTCPSupported && gatewayURI) {
-                // Parse gateway URL (format: tcp://host:port)
-                const gatewayURL = new URL(gatewayURI.replace('tcp', 'http'));
-                tcpHost = gatewayURL.hostname;
-                tcpPort = gatewayURL.port;
-              }
-            }
+            redirectURI = body?.redirectURI;
           } catch (error) {
             logger.error('Failed to fetch TCP connection info:', error);
+            throw new AppLaunchError(
+              t('session.launcher.ProxyNotReady'),
+              'connecting',
+              error instanceof Error ? error : undefined,
+            );
+          }
+          if (!redirectURI) {
+            throw new AppLaunchError(
+              t('session.launcher.ProxyNotReady'),
+              'connecting',
+            );
+          }
+
+          let redirectURL: URL;
+          try {
+            redirectURL = new URL(redirectURI);
+          } catch (error) {
+            throw new AppLaunchError(
+              t('session.InvalidRedirectURL'),
+              'connecting',
+              error instanceof Error ? error : undefined,
+            );
+          }
+
+          // Check if directTCP is supported
+          directTCPSupported =
+            redirectURL.searchParams.get('directTCP') === 'true';
+          if (!directTCPSupported) {
+            throw new AppLaunchError(
+              t('session.launcher.ProxyDirectTCPNotSupported'),
+              'connecting',
+            );
+          }
+
+          // Extract gateway URI
+          const gatewayURI = redirectURL.searchParams.get('gateway');
+          if (!gatewayURI) {
+            throw new AppLaunchError(
+              t('session.launcher.ProxyNotReady'),
+              'connecting',
+            );
+          }
+
+          try {
+            // Parse gateway URL (format: tcp://host:port)
+            const gatewayURL = new URL(gatewayURI.replace('tcp', 'http'));
+            tcpHost = gatewayURL.hostname;
+            tcpPort = gatewayURL.port;
+          } catch (error) {
+            throw new AppLaunchError(
+              t('session.InvalidRedirectURL'),
+              'connecting',
+              error instanceof Error ? error : undefined,
+            );
           }
         } else {
           // Reused connection: Use appConnectUrl directly
@@ -581,8 +624,13 @@ export const useBackendAIAppLauncher = (
       }
     }
 
-    // Handle generic TCP apps (non-standard protocols)
-    if (response.url?.includes('protocol=tcp') && redirectUrl) {
+    // Handle generic TCP apps (non-standard protocols). TCP_APPS are already
+    // fully resolved above, so skip them here to avoid a redundant fetch.
+    if (
+      !TCP_APPS.includes(app) &&
+      response.url?.includes('protocol=tcp') &&
+      redirectUrl
+    ) {
       try {
         const redirectResponse = await fetch(redirectUrl);
         const redirectBody = await redirectResponse.json();
@@ -608,20 +656,36 @@ export const useBackendAIAppLauncher = (
         }
       } catch (error) {
         logger.error('Failed to parse generic TCP app URL:', error);
+        throw new AppLaunchError(
+          t('session.launcher.ProxyNotReady'),
+          'connecting',
+          error instanceof Error ? error : undefined,
+        );
+      }
+      // The TCP connection dialog is useless without a resolved gateway —
+      // fail the launch instead of showing `127.0.0.1:undefined`. (FR-3359)
+      if (!tcpHost || !tcpPort) {
+        throw new AppLaunchError(
+          t('session.launcher.ProxyNotReady'),
+          'connecting',
+        );
       }
     }
 
-    // Validate TCP connection info before returning
+    // Validate TCP connection info before returning. Reaching this point
+    // without a host/port means the connection dialog would render
+    // `127.0.0.1:undefined` — fail the launch visibly instead. (FR-3359)
     if (TCP_APPS.includes(app) && (!tcpHost || !tcpPort)) {
-      logger.warn(
-        `TCP connection info not available for ${app}. Using defaults.`,
-        {
-          tcpHost,
-          tcpPort,
-          directTCPSupported,
-          isElectron: globalThis.isElectron,
-          reused,
-        },
+      logger.error(`TCP connection info not available for ${app}.`, {
+        tcpHost,
+        tcpPort,
+        directTCPSupported,
+        isElectron: globalThis.isElectron,
+        reused,
+      });
+      throw new AppLaunchError(
+        t('session.launcher.ProxyNotReady'),
+        'connecting',
       );
     }
 


### PR DESCRIPTION
Resolves [FR-3359](https://lablup.atlassian.net/browse/FR-3359) (GitHub clone issue not yet created by the webhook; will update to `Resolves #N (FR-3359)` once it appears)

## Summary

The 'SSH / SFTP Connection' modal showed `Host: 127.0.0.1 / Port: undefined` (e.g. `sftp -P undefined ... work@127.0.0.1`) even though the AppProxy TCP endpoint was provisioned correctly.

Root cause: for TCP apps in the browser, the launcher resolves the real endpoint by fetching the worker's `/setup` URL and parsing `redirectURI` (`directTCP=true&gateway=tcp://host:port`). Every failure in that step (fetch blocked/unreachable, missing `redirectURI`, `directTCP` unsupported, missing/invalid `gateway`) was silently swallowed, and the connection modals fell back to `127.0.0.1` / `0`. The Lit-era launcher surfaced these as explicit errors (`ProxyNotReady`, `ProxyDirectTCPNotSupported`, `InvalidRedirectURL`), but those branches were lost in the React port (FR-1797, #4975). FR-3027 (#7781) fixed the sibling case at the `/proxy/auth` step only.

## Changes

`react/src/hooks/useBackendAIAppLauncher.tsx` (`_launchApp`):

- Restore the Lit-era explicit error branches for the TCP connection-info step — each failure now throws `AppLaunchError` (stage `connecting`) with the existing i18n messages `session.launcher.ProxyNotReady` / `session.launcher.ProxyDirectTCPNotSupported` / `session.InvalidRedirectURL`, so the launch notification shows the real reason and the SSH/SFTP/VNC/XRDP/VSCode modals never open with bogus values.
- Final guard: reaching the end of `_launchApp` for a TCP app without host/port now fails the launch (was: `logger.warn` + continue).
- Generic TCP apps (non-`TCP_APPS`): same treatment for the `gateway=` parse path, and skip the block for `TCP_APPS` (they are fully resolved earlier; previously this caused a redundant second fetch of the setup URL for `sshd`/`vscode-desktop`).

No i18n changes needed — all three keys already exist in all locales (Lit-era keys still in use).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Terminology)
- Error path exercised against the e2e backend (10.82.0.130): its App Proxy has no TCP worker, so `/proxy/auth` returns 503 → notification shows the backend error (FR-3027 path, unchanged).
- ⚠️ Needs manual verification on qa264 (where FR-3359 was reported): launching SSH/SFTP should now show an explicit "Proxy is not ready yet..." (or DirectTCP-unsupported) error instead of a `127.0.0.1:undefined` modal — and the browser console/network will reveal the underlying infra reason for the failing worker `/setup` fetch (suspected mixed-content or unreachable `api_advertised_addr` of worker-3-tcp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-3359]: https://lablup.atlassian.net/browse/FR-3359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ