### PR TITLE
test(FR-3358): trim redundant waits from e2e vfolder cleanup path

### DIFF
--- a/e2e/utils/cleanup-util.ts
+++ b/e2e/utils/cleanup-util.ts
@@ -195,7 +195,11 @@ export async function sweepVFolders(
     );
     if (!name) break;
     try {
-      await moveToTrashAndVerify(page, name, dataPath);
+      // skipTrashVerify: the immediate deleteForeverAndVerifyFromTrash call
+      // re-asserts the folder in Trash, so the extra verify pass is redundant.
+      await moveToTrashAndVerify(page, name, dataPath, {
+        skipTrashVerify: true,
+      });
       await deleteForeverAndVerifyFromTrash(page, name, dataPath);
       removed++;
     } catch (error) {
@@ -270,7 +274,12 @@ export async function cleanupVFolderSafely(
   dataPath: string = 'data',
 ): Promise<void> {
   try {
-    await moveToTrashAndVerify(page, folderName, dataPath);
+    // skipTrashVerify: deleteForeverAndVerifyFromTrash asserts the folder's
+    // presence in Trash itself, so the intermediate verification pass (a full
+    // page reload + filter cycle) would be pure overhead here.
+    await moveToTrashAndVerify(page, folderName, dataPath, {
+      skipTrashVerify: true,
+    });
     await deleteForeverAndVerifyFromTrash(page, folderName, dataPath);
     return;
   } catch (error) {

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -485,6 +485,7 @@ export async function moveToTrashAndVerify(
   page: Page,
   folderName: string,
   dataPath: string = 'data',
+  options: { skipTrashVerify?: boolean } = {},
 ) {
   // Use navigateTo to ensure a clean navigation to the data page regardless of current state
   await navigateTo(page, dataPath);
@@ -533,7 +534,14 @@ export async function moveToTrashAndVerify(
     );
   }
   await removeSearchButton(page, folderName);
-  await verifyVFolder(page, folderName, 'Trash', dataPath);
+  // Callers that immediately follow with deleteForeverAndVerifyFromTrash (e.g.
+  // cleanupVFolderSafely) can skip this verification pass: that helper already
+  // asserts the folder's presence in Trash before deleting, so verifying here
+  // would add a full page reload + filter cycle for no extra signal. The
+  // successful DELETE /folders response above still guards the move itself.
+  if (!options.skipTrashVerify) {
+    await verifyVFolder(page, folderName, 'Trash', dataPath);
+  }
 }
 
 export async function deleteForeverAndVerifyFromTrash(
@@ -579,17 +587,18 @@ export async function deleteForeverAndVerifyFromTrash(
   // i18n key: data.folders.FolderDeletedForever → "Permanently deleted the ... folder."
   // antd 6 message.success() renders a plain <div> (no ARIA role="alert"),
   // so we use a text-based locator scoped to the antd message container.
+  // Don't wait for the toast to disappear: antd messages auto-dismiss after
+  // ~3s, so a toBeHidden wait adds fixed dead time to every deletion, and the
+  // message layer doesn't intercept pointer events outside its own box. The
+  // row-gone assertion below is the authoritative deletion signal.
   const deletionNotification = page
     .locator('.ant-message-notice')
     .filter({ hasText: /permanently deleted/i });
   await expect(deletionNotification).toBeVisible({ timeout: 15000 });
-  await expect(deletionNotification).toBeHidden({ timeout: 15000 });
 
-  // After the "Delete forever" button is clicked, wait for the folder to
-  // disappear from the Trash tab. The success toast is too transient to assert
-  // reliably; the row-gone check is the authoritative signal that the deletion
-  // was accepted by the backend.
-  // After the notification is hidden, verify the folder row is gone
+  // After the "Delete forever" button is clicked, verify the folder row is
+  // gone from the Trash tab — re-applying the Name filter forces a fresh
+  // fetch, making this the authoritative check that the backend deleted it.
   await clearAllFilters(page);
   await selectPropertyFilter(page, 'Name', folderName);
   const folderRowAfterDelete = page.getByRole('row').filter({


### PR DESCRIPTION
Follow-up to #8366 ([FR-3358](https://lablup.atlassian.net/browse/FR-3358)) — trims fixed dead time from the vfolder cleanup helpers that every vfolder e2e test (and the FR-3358 regression test) pays on teardown.

## What changed

1. **`moveToTrashAndVerify` gains an opt-in `skipTrashVerify` option.** The happy path of `cleanupVFolderSafely` (and the active-folder sweep loop) calls `moveToTrashAndVerify` and then immediately `deleteForeverAndVerifyFromTrash`. The latter already navigates to the Trash tab, filters by name, and asserts the row is present before deleting — so the trailing `verifyVFolder(..., 'Trash')` inside `moveToTrashAndVerify` was a redundant full page reload + filter cycle (~5–10s per folder). The move itself is still guarded by the `DELETE /folders` response check. Default behavior is unchanged for all other 20+ call sites.

2. **`deleteForeverAndVerifyFromTrash` no longer waits for the success toast to auto-dismiss.** The `toBeHidden` wait on the antd message added a fixed ~3s per deletion. The toast `toBeVisible` check (backend accepted the request) and the authoritative row-gone assertion (with a forced filter re-apply) are kept. The antd message layer does not intercept pointer events outside its own box, so subsequent filter-chip clicks are unaffected.

## Impact

- `cleanupVFolderSafely` happy path: one fewer full SPA reload + filter cycle, and ~3s less toast idling → roughly 8–13s faster per test that creates a vfolder.
- Sweep loops (`sweepVFolders`, global teardown) get the same savings per removed folder.

## Risk

- Behavior-preserving for all existing callers: `skipTrashVerify` defaults to off; only `cleanupVFolderSafely` and the sweep loop opt in, and both are immediately followed by a helper that re-verifies Trash presence.
- The removed `toBeHidden` wait was not load-bearing: the row-gone check remains the deletion signal, per the existing comment in the helper itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FR-3358]: https://lablup.atlassian.net/browse/FR-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ