### PR TITLE
test: e2e auto-heal 2026-07-26

### DIFF
--- a/e2e/credential/my-keypair-management.spec.ts
+++ b/e2e/credential/my-keypair-management.spec.ts
@@ -729,31 +729,42 @@ test.describe(
         const inactiveRows = getKeypairTableRows(page);
         await expect(inactiveRows.first()).toBeVisible({ timeout: 10000 });
 
-        // Find our deactivated keypair row and click Restore in the Controls cell
+        // Find our deactivated keypair row and click Restore in the Controls cell.
+        // A trailing deferred Relay commit can still detach/replace the row's
+        // DOM node between the visibility check and the click (the table's
+        // dataSource commit can lag a beat behind the query settling, the
+        // same race documented in the "cannot delete a keypair without
+        // typing..." test further below in this file), which can detach the
+        // button mid-click and hang. Retry click-then-popconfirm-appears as a
+        // unit so each attempt re-queries the live DOM instead of holding a
+        // stale handle.
         const targetRow = modal
           .locator('tbody tr:not(.ant-table-measure-row)')
           .filter({ hasText: restoredAccessKey });
         await expect(targetRow).toBeVisible();
-        // Use aria-label from Tooltip to find the Restore button
-        const restoreBtn = targetRow
-          .getByRole('button', { name: /undo/i })
-          .first();
-        if ((await restoreBtn.count()) > 0) {
-          await restoreBtn.click();
-        } else {
-          // Fallback: click the first non-dangerous button
-          await targetRow
-            .locator('td')
-            .nth(1)
-            .locator('button:not(.ant-btn-dangerous)')
-            .first()
-            .click();
-        }
 
-        // Verify Popconfirm appears and confirm restoration
-        await expect(page.getByText(/restore this keypair/i)).toBeVisible({
-          timeout: 8000,
-        });
+        await expect(async () => {
+          // Use aria-label from Tooltip to find the Restore button
+          const restoreBtn = targetRow
+            .getByRole('button', { name: /undo/i })
+            .first();
+          if ((await restoreBtn.count()) > 0) {
+            await restoreBtn.click({ timeout: 3000 });
+          } else {
+            // Fallback: click the first non-dangerous button
+            await targetRow
+              .locator('td')
+              .nth(1)
+              .locator('button:not(.ant-btn-dangerous)')
+              .first()
+              .click({ timeout: 3000 });
+          }
+          await expect(page.getByText(/restore this keypair/i)).toBeVisible({
+            timeout: 3000,
+          });
+        }).toPass({ timeout: 15000 });
+
+        // Confirm restoration
         await page.getByRole('button', { name: 'Confirm' }).click();
 
         // Verify the restored keypair no longer appears in Inactive tab

--- a/e2e/project/project-crud.spec.ts
+++ b/e2e/project/project-crud.spec.ts
@@ -136,9 +136,10 @@ test.describe(
       await loginAsAdmin(page, request);
       await navigateTo(page, 'project');
 
-      // 2. Verify the Project tab is selected
+      // 2. Verify the Projects tab is selected (BAICard tabList label renamed
+      // "Project" -> "Projects", see webui.menu.Projects in ProjectPage.tsx)
       await expect(
-        page.getByRole('tab', { name: 'Project', selected: true }),
+        page.getByRole('tab', { name: 'Projects', selected: true }),
       ).toBeVisible();
 
       // 3. Verify table columns are visible

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -261,7 +261,7 @@ test.describe(
       await expect(drawerPanel).toBeHidden({ timeout: 5000 });
     });
 
-    test('Drawer shows "Scopes", "Permissions", and "Role Assignments" tabs', async ({
+    test('Drawer shows "Role Assignments" and "Permissions" tabs', async ({
       page,
       request,
     }) => {

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -289,8 +289,10 @@ test.describe(
       const drawerPanel = page.locator('.ant-drawer-content-wrapper');
       await expect(drawerPanel).toBeVisible({ timeout: 10000 });
 
-      // 4. Verify three tabs are visible: "Scopes", "Permissions", and "Role Assignments"
-      await expect(drawer.getByRole('tab', { name: 'Scopes' })).toBeVisible();
+      // 4. Verify two tabs are visible: "Permissions" and "Role Assignments".
+      // The former separate "Scopes" tab was merged into "Permissions" (now
+      // "Detailed Permissions" internally) — see the docblock on
+      // RolePermissionDetailTab.tsx.
       await expect(
         drawer.getByRole('tab', { name: 'Permissions' }),
       ).toBeVisible();
@@ -298,29 +300,23 @@ test.describe(
         drawer.getByRole('tab', { name: 'Role Assignments' }),
       ).toBeVisible();
 
-      // 5. Verify "Scopes" tab is active by default
-      await expect(drawer.getByRole('tab', { name: 'Scopes' })).toHaveAttribute(
-        'aria-selected',
-        'true',
-      );
-
-      // 6. Verify the active tab content area is visible
-      await expect(drawer.locator('.ant-tabs-tabpane-active')).toBeVisible({
-        timeout: 5000,
-      });
-
-      // 7. Click the "Permissions" tab
-      await drawer.getByRole('tab', { name: 'Permissions' }).click();
-
-      // 8. Verify the Permissions tab becomes active
+      // 5. Verify "Permissions" tab is active by default
       await expect(
         drawer.getByRole('tab', { name: 'Permissions' }),
       ).toHaveAttribute('aria-selected', 'true');
 
-      // 9. Click the "Role Assignments" tab
+      // 6. Verify the active tab content area is visible. Confirmed live
+      // (via DOM inspection) that this antd/rc-tabs version marks the active
+      // pane with `.ant-tabs-content-active` on the `role="tabpanel"`
+      // element itself -- there is no `.ant-tabs-tabpane-active` class here.
+      await expect(drawer.locator('.ant-tabs-content-active')).toBeVisible({
+        timeout: 10000,
+      });
+
+      // 7. Click the "Role Assignments" tab
       await drawer.getByRole('tab', { name: 'Role Assignments' }).click();
 
-      // 10. Verify the Role Assignments tab becomes active
+      // 8. Verify the Role Assignments tab becomes active
       await expect(
         drawer.getByRole('tab', { name: 'Role Assignments' }),
       ).toHaveAttribute('aria-selected', 'true');

--- a/e2e/session/session-scheduling-history-modal.spec.ts
+++ b/e2e/session/session-scheduling-history-modal.spec.ts
@@ -119,15 +119,20 @@ test.describe(
       page,
     }) => {
       // 1. Open the Session Detail drawer by clicking the first session row
-      await openSessionDetailDrawer(page);
+      const drawer = await openSessionDetailDrawer(page);
 
-      // 2. Locate the Status row and verify the history button is visible
-      const statusRow = page.getByRole('row', { name: /Status/ });
+      // 2. Locate the Status row and verify the history button is visible.
+      // Scope to the drawer AND anchor the pattern to the start of the
+      // accessible name: within the drawer, a second row -- the table
+      // column-header row "Hostname Status Agent ID" -- also contains the
+      // word "Status" and would otherwise cause a strict-mode violation.
+      // The descriptions row we want has accessible name "Status RUNNING
+      // history", which starts with "Status".
+      const statusRow = drawer.getByRole('row', { name: /^Status/ });
       await expect(statusRow).toBeVisible();
 
       // 3. Verify the "history" button (HistoryOutlined icon) is visible next to the status tag.
       // Scope to the drawer to avoid strict mode violation with React Grab toolbar buttons.
-      const drawer = page.getByRole('dialog', { name: 'Session Info' });
       const historyButton = drawer.getByRole('button', {
         name: 'history',
         exact: true,


### PR DESCRIPTION
Produced automatically by the **daily backend.ai-webui digest auto-heal** pipeline (2026-07-26 run).

Each test below was triaged as **HEAL** (test-side drift only — no `react/` or `packages/` source touched) and **re-run verified to pass** before this PR was opened. Reviewers only need to approve/merge.

## ✅ Healed (verified re-pass)

- **`e2e/credential/my-keypair-management.spec.ts`** — "User can restore an inactive keypair back to active status". Wrapped the restore-button click + Popconfirm check in an `expect(async …).toPass()` retry unit (matching the sibling delete-flow already in this file) so a deferred-Relay-commit DOM-detach race retries against a fresh query instead of hanging on a stale handle.
- **`e2e/project/project-crud.spec.ts`** — "Admin can see project list with expected columns". Tab label renamed "Project" → "Projects" (`ProjectPage.tsx` uses `t('webui.menu.Projects')`); updated the stale assertion.
- **`e2e/rbac/rbac-role-detail.spec.ts`** — "Drawer shows Scopes/Permissions/Role Assignments tabs". The "Scopes" tab was merged into "Permissions" (per `RolePermissionDetailTab.tsx`); dropped the stale Scopes expectation, expect "Permissions" active by default, and corrected the active-tabpane class selector (`.ant-tabs-content-active`). Only this test was touched — the other failing tests in this file are triaged HUMAN and left untouched.
- **`e2e/session/session-scheduling-history-modal.spec.ts`** — "Admin can see the scheduling history button…". Fixed a strict-mode violation where `getByRole('row', { name: /Status/ })` matched multiple rows; scoped the locator to the drawer.

## ⛔ Not included

- **`e2e/serving/deployment-lifecycle.spec.ts`** — "Admin can view Preset Mode fields in the Add Revision modal". The label-rename fix ("Select Preset" → "Preset", "Select Folder" → "Model Folder") is correct, but the test still fails: the nightly cluster currently has **0 deployment revision presets**, so the modal renders its `hasNoPresets` empty-state instead of the Preset Mode form. That is an environment/data condition, not test drift — moved to the digest's "needs-human" list. Edit reverted so this PR ships only verified passes.

Report doc: `/home/ubuntu/e2e-digest-reports/report-2026-07-26.md`

cc @ironAiken2 (related changes #7413 project-tab rename, #8191 RBAC Scopes-tab merge)
