### PR TITLE
feat(FR-3374): block context-free terminology drift in every language

### DIFF
--- a/packages/backend.ai-webui-docs/TERMINOLOGY.md
+++ b/packages/backend.ai-webui-docs/TERMINOLOGY.md
@@ -173,9 +173,16 @@ These terms match sidebar menu items. Keep documentation references consistent w
 
 ## Terms to Avoid
 
-Each row lists one forbidden term, the language it applies to, its canonical replacement, and the reason. Parenthetical qualifiers in the **Avoid** column (e.g. "group (for project)") indicate the context in which the term is disallowed. A row applies **only to its `Lang`** — the i18n checker scans each language's stores against that language's rows, and non-English rows are always WARN-severity (they never hard-block).
+Each row lists one forbidden term, the language it applies to, its canonical replacement, and the reason. Parenthetical qualifiers in the **Avoid** column (e.g. "group (for project)") indicate the context in which the term is disallowed. A row applies **only to its `Lang`** — the checker scans each language's stores (and doc pages) against that language's rows. What a match does depends on the **context qualifier, not the language** (FR-3374), and on which surface it was found:
 
-**Non-English curation rule (FR-3051).** ko/ja/th have no reliable word boundaries, so the checker matches non-Latin avoid terms by plain **substring**. A non-English `avoid` term must therefore be a **precise multi-token compound** (e.g. `스케일링 그룹`, `スケーリンググループ`) or an **unambiguous deprecated spelling** (e.g. `레플리카`, `슈퍼어드민`) — **never a bare concept noun** (ko `세션` appears in ~200 legitimate values; every one would fire), and never a substring of any `concepts[].preferred[lang]` value. Every non-English row must ship with positive/negative fixtures and a live false-positive budget (default 0) in `terminology.selftest.json`; `pnpm run lint:terminology:selftest` (`scripts/check-terminology-i18n.selftest.mjs`, run as a hard CI gate by `terminology-selftest.yml` on termbase/fixtures/checker changes only) enforces the rule and rejects noisy rows.
+| Row | In an i18n value | In manual prose |
+|---|---|---|
+| context-free | **blocks** (error) | **blocks** (error) |
+| context-qualified | warns | **not checked at all** |
+
+Context-qualified rows are skipped outright on prose because long-form text is full of the word's legitimate sense ("group three GPUs"), which would make the report useless. Those calls stay with docs-lead review.
+
+**Non-English curation rule (FR-3051).** ko/ja/th have no reliable word boundaries, so the checker matches non-Latin avoid terms by plain **substring**. A non-English `avoid` term must therefore be a **precise multi-token compound** (e.g. `스케일링 그룹`, `スケーリンググループ`) or an **unambiguous deprecated spelling** (e.g. `레플리카`, `슈퍼어드민`) — **never a bare concept noun** (ko `세션` appears in ~200 legitimate values; every one would fire), and never a substring of any `concepts[].preferred[lang]` value. Every non-English row must ship with positive/negative fixtures and a live false-positive budget (default 0) in `terminology.selftest.json`; `pnpm run lint:terminology:selftest` (`scripts/check-terminology-i18n.selftest.mjs`, run as a hard CI gate by `terminology-selftest.yml` on termbase/fixtures/checker changes only) enforces the rule and rejects noisy rows. Since FR-3374 the budget is measured over the **manual as well as** the i18n stores, and a context-free non-English row that clears it is **blocking** — so this harness is what earns a ko/ja/th row its teeth. Adding a row without fixtures, or widening one until the budget breaks, is what the gate exists to stop.
 
 <!-- terminology:auto:avoid START -->
 
@@ -248,8 +255,8 @@ A new user-facing noun or verb requires a `terminology.json` entry — carrying 
 
 Enforcement is **partial, and never a substitute for review.** `scripts/check-terminology-i18n.mjs` (wired into `scripts/verify.sh`, `pnpm run lint:terminology`, and — for the manual — `.github/workflows/docs-checks.yml`) scans both the i18n values and the manual's prose. What it does with a finding depends on the row:
 
-- A **bare English `avoid[]` row** (no `context` qualifier) is **blocking**: since FR-3049 the checker runs `--strict` in `verify.sh`, and since FR-3373 it also runs on any PR touching the manual. A forbidden term such as "scaling group" cannot land.
-- A **context-qualified** row ("group (for project)") or any **non-English** row is **warn-only** — it needs human judgement, so it never blocks. Context-qualified rows are skipped entirely on manual prose, where the ordinary sense of the word ("group three GPUs", "your organization's SSO") is legitimate and would otherwise be a permanent false-positive stream.
+- A **context-free `avoid[]` row** (no `context` qualifier) is **blocking, in every language**: since FR-3049 the checker runs `--strict` in `verify.sh`, and since FR-3373 it also runs on any PR touching the manual. A forbidden term such as "scaling group" — or `슈퍼관리자`, or `スケーリンググループ` — cannot land. Non-English rows were warn-only until FR-3374; they now block on the strength of the FR-3051 self-test, which proves each one clears a zero false-positive budget over the live i18n stores **and** the manual.
+- A **context-qualified** row ("group (for project)") is **warn-only** in every language — the qualifier means the term is wrong in one sense and fine in another, which no matcher can settle. Context-qualified rows are skipped entirely on manual prose, where the ordinary sense of the word ("group three GPUs", "your organization's SSO") is legitimate and would otherwise be a permanent false-positive stream.
 - An **unknown** term (CHECK 3 — no matching `concepts[].preferred`) is always report-only.
 
 So a green checker means "no forbidden term slipped in", not "this is the right term". The gate itself is satisfied by the docs-lead review that lands the `terminology.json` entry. Treat a checker warning as a prompt to add (or allowlist) the entry, never as the approval itself.

--- a/scripts/check-terminology-i18n.docs.test.ts
+++ b/scripts/check-terminology-i18n.docs.test.ts
@@ -281,10 +281,44 @@ describe("CHECK 1 over a docs store", () => {
     expect(check("en", "You can group three GPUs together.")).toHaveLength(0);
   });
 
-  it("catches the non-English drift the docs source was added for, at warn severity", () => {
+  it("blocks the non-English drift the docs source was added for", () => {
+    // This is the exact drift FR-3373 found in the ko manual. It was warn-only
+    // then — FR-3374 made context-free rows error in every language, so the
+    // gate that found it can now also stop it.
     const findings = check("ko", "슈퍼관리자는 진단 페이지를 열 수 있습니다.");
     expect(findings).toHaveLength(1);
     expect(findings[0].term).toBe("슈퍼관리자");
+    expect(findings[0].severity).toBe("error");
+  });
+
+  it("keeps a context-qualified row warn-only regardless of language", () => {
+    // Severity keys off `context`, not language (FR-3374). The i18n store is
+    // used here because prose skips context-qualified rows entirely.
+    const findings = runCheck1(
+      [
+        {
+          file: "/i18n/ko.json",
+          label: "resources/i18n",
+          lang: "ko",
+          kind: "i18n",
+          leaves: [
+            { key: "fixture", segment: "fixture", value: "자동 스케일링 규칙" },
+          ],
+        },
+      ],
+      [
+        {
+          avoid: "자동 스케일링",
+          useInstead: "오토스케일링",
+          reason: "UI label",
+          lang: "ko",
+          context: "auto scaling rule",
+        },
+      ],
+      allow,
+      compounds,
+    );
+    expect(findings).toHaveLength(1);
     expect(findings[0].severity).toBe("warn");
   });
 

--- a/scripts/check-terminology-i18n.mjs
+++ b/scripts/check-terminology-i18n.mjs
@@ -70,10 +70,13 @@
  *   --warn           — same as default (explicit).
  *   --strict         — exit non-zero when there are blocking (error-severity)
  *                      CHECK 1 findings. CHECK 2 and CHECK 3 are always
- *                      report-only and never affect the exit code. Non-English
- *                      and context-qualified terminology findings are
- *                      WARN-severity (never block), because they need human
- *                      judgement.
+ *                      report-only and never affect the exit code. Only
+ *                      CONTEXT-QUALIFIED terminology findings are WARN-severity
+ *                      (never block), because a context qualifier means the term
+ *                      is wrong in one sense and fine in another — a human call.
+ *                      Context-free rows block in every language (FR-3374);
+ *                      their precision is proven by the self-test's live budget
+ *                      over both the i18n stores and the manual.
  *
  * Other flags:
  *   --json           Emit machine-readable JSON instead of the text report.
@@ -695,11 +698,25 @@ function runCheck1(stores, avoidRows, allow, approvedCompounds) {
   // Pre-build matchers once per avoid row.
   const matchers = avoidRows.map((row) => ({
     row,
-    // Context-qualified rows (e.g. "group (for project)", "WSProxy as a UI
-    // label") and any non-English row are WARN-severity: they need human
-    // judgement and must never hard-block a PR. Bare English rows with no
-    // context are blocking in --strict.
-    severity: (row.lang && row.lang !== "en") || row.context ? "warn" : "error",
+    // Severity turns on ONE property: does the row need human judgement?
+    //
+    // A context-qualified row ("group (for project)", "WSProxy as a UI label")
+    // says the word is wrong in one sense and fine in another — no matcher can
+    // settle that, so it stays WARN in every language and never hard-blocks.
+    //
+    // A context-free row is unconditional, and is blocking in --strict.
+    // Language is NOT part of this decision (FR-3374). It used to be: every
+    // non-English row was warn-only because ko/ja/th have no word boundaries,
+    // so non-Latin terms match by substring and a bare concept noun would fire
+    // on every legitimate use. FR-3051 replaced that blanket caution with proof
+    // — each non-English row ships fixtures plus a live false-positive budget
+    // (default 0) measured by check-terminology-i18n.selftest.mjs over the real
+    // stores, and terminology-selftest.yml gates it in CI. FR-3374 extended
+    // that budget to the manual, so precision is now proven on both surfaces
+    // the checker reads. A row that clears it does not need human judgement,
+    // and warn-only severity just meant the curated ko/ja/th rows could not
+    // stop the drift they exist to stop.
+    severity: row.context ? "warn" : "error",
     match: buildTermMatcher(row, approvedCompounds),
   }));
 

--- a/scripts/check-terminology-i18n.selftest.mjs
+++ b/scripts/check-terminology-i18n.selftest.mjs
@@ -27,22 +27,33 @@
  *   4. PRECISE    — every negativeFixture (the known longer legitimate
  *                   compounds) produces 0 matches.
  *   5. BUDGET     — the row's live hit-count over the CURRENT i18n stores
- *                   (via the real runCheck1, allowlist applied) is within
- *                   falsePositiveBudget (default 0).
+ *                   AND the user manual (via the real runCheck1, allowlist
+ *                   applied) is within falsePositiveBudget (default 0). The
+ *                   manual joined the corpus in FR-3374, because FR-3373 made
+ *                   it a CHECK 1 source: proving a row precise against short UI
+ *                   labels says nothing about 120 files of long-form prose.
+ *   5b. SEVERITY   — a context-free row yields ERROR findings, a
+ *                   context-qualified row yields WARN findings, through the
+ *                   real runCheck1. This pins FR-3374's severity model.
  *   6. TEETH      — each negativeControls entry (a known-bad bare-noun row,
  *                   e.g. ko "세션") is evaluated the same way and MUST exceed
  *                   the budget by expectAtLeastLiveHits. If a control stops
  *                   firing, the gate itself has silently broken.
  *
- * SEVERITY MODEL (unchanged by this script): this harness gates the DATA
- * (terminology.json curation) and is a HARD gate in CI
- * (.github/workflows/terminology-selftest.yml) — triggered ONLY by the
- * termbase / fixtures / checker paths, never by docs prose or i18n content,
- * so pre-existing content drift can never hard-block an unrelated PR. The
- * drift scan over i18n CONTENT stays WARN-only — in scripts/verify.sh this
- * script runs inside the warn-only terminology section precisely so that new
- * content drift never hard-blocks a build (that is CHECK 1's warn job), while
- * a bad avoid ROW is still caught in CI before it lands.
+ * SEVERITY MODEL: this harness gates the DATA (terminology.json curation) and
+ * is a HARD gate in CI (.github/workflows/terminology-selftest.yml) —
+ * triggered ONLY by the termbase / fixtures / checker paths, never by docs
+ * prose or i18n content, so pre-existing content drift can never hard-block an
+ * unrelated PR. In scripts/verify.sh this script runs report-only; CONTENT
+ * drift is CHECK 1's job, not this harness's.
+ *
+ * Since FR-3374 this harness is also what EARNS a non-English row its teeth.
+ * Severity keys off the row's `context`, not its language: a context-free row
+ * blocks in every language. That is only defensible because gates 3/4/5 prove
+ * the row is precise against both live surfaces. Widening a row until the
+ * budget breaks, or adding one without fixtures, is exactly what this gate
+ * stops — and if it is ever weakened, the severity model must be walked back
+ * with it.
  *
  * Usage: node scripts/check-terminology-i18n.selftest.mjs
  *        (also: pnpm run lint:terminology:selftest)
@@ -51,6 +62,7 @@
  * Dependency-free: native Node ESM only, same as the checker it tests.
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -58,10 +70,13 @@ import {
   TERMINOLOGY_PATH,
   ALLOWLIST_PATH,
   I18N_GLOBS,
+  DOCS_GLOB,
   REPO_ROOT,
   readJson,
   collectLeaves,
   listLocaleFiles,
+  listMarkdownFiles,
+  collectMarkdownLines,
   hasUpper,
   buildTermMatcher,
   buildApprovedCompounds,
@@ -234,7 +249,36 @@ function main() {
       /** @type {Array<{key:string,segment:string,value:string}>} */
       const leaves = [];
       collectLeaves(data, "", glob.keySep, leaves);
-      stores.push({ file, label: glob.label, lang, leaves });
+      stores.push({ file, label: glob.label, lang, leaves, kind: "i18n" });
+    }
+  }
+  // The user manual is a CHECK 1 source too (FR-3373), so the live corpus must
+  // include it (FR-3374). Otherwise a row's precision is proven against short
+  // UI labels only, while the checker also runs it against 120 markdown files
+  // of long-form prose — and FR-3374 raises context-free non-English rows to
+  // ERROR severity on the strength of exactly this budget.
+  const docsLangsNeeded = [...langsNeeded].filter((lang) =>
+    DOCS_GLOB.langs.includes(lang),
+  );
+  for (const lang of docsLangsNeeded) {
+    const langDir = path.join(DOCS_GLOB.dir, lang);
+    for (const file of listMarkdownFiles(langDir)) {
+      let rawText;
+      try {
+        rawText = fs.readFileSync(file, "utf8");
+      } catch {
+        continue;
+      }
+      /** @type {Array<{key:string,segment:string,value:string,raw:string}>} */
+      const leaves = [];
+      collectMarkdownLines(rawText, path.relative(langDir, file), leaves);
+      stores.push({
+        file,
+        label: DOCS_GLOB.label,
+        lang,
+        leaves,
+        kind: "docs",
+      });
     }
   }
   // Every configured store must be present for every language under test —
@@ -248,6 +292,15 @@ function main() {
         "the live false-positive budget would be computed from incomplete data (missing or unparseable locale file)",
       );
     }
+  }
+  // Same wiring guard for the manual: a language the docs ship must actually
+  // contribute pages, or the budget silently ignores the prose surface.
+  for (const lang of docsLangsNeeded) {
+    assertThat(
+      stores.some((s) => s.kind === "docs" && s.lang === lang),
+      `[wiring] no ${lang} pages loaded from ${DOCS_GLOB.label}`,
+      "the live false-positive budget would omit the manual, the surface FR-3373 added and FR-3374 raises severity on",
+    );
   }
 
   const allowRaw = readJson(ALLOWLIST_PATH, false) || {};
@@ -295,15 +348,22 @@ function main() {
         );
       }
 
-      // Regression-guard the severity model: a non-English row must ALWAYS
-      // yield WARN-severity findings (never "error"), so it can never
-      // hard-block under --strict. Exercised through the real runCheck1
-      // pipeline on a synthetic store built from the first positive fixture.
+      // Regression-guard the severity model (FR-3374). Severity keys off the
+      // row's `context`, not its language: a context-qualified row needs human
+      // judgement and must stay WARN, a context-free row is unconditional and
+      // must be ERROR so it actually blocks under --strict. Before FR-3374
+      // every non-English row was pinned to WARN; the budget gate below (now
+      // covering the manual as well as the i18n stores) is what earns the
+      // stricter severity, so this assertion and that budget must move
+      // together. Exercised through the real runCheck1 pipeline on a synthetic
+      // store built from the first positive fixture.
       if (positives.length > 0) {
+        const expected = row.context ? "warn" : "error";
         const syntheticStore = {
           file: "(fixture)",
           label: "(fixture)",
           lang: row.lang,
+          kind: "i18n",
           leaves: [{ key: "fixture", segment: "fixture", value: positives[0] }],
         };
         const findings = runCheck1(
@@ -313,9 +373,13 @@ function main() {
           approvedCompounds,
         );
         assertThat(
-          findings.length > 0 && findings.every((f) => f.severity === "warn"),
-          `[severity] "${row.avoid}" (${row.lang}) produced a non-warn finding through runCheck1`,
-          `non-English rows must stay WARN-only (got: ${JSON.stringify(findings.map((f) => f.severity))})`,
+          findings.length > 0 && findings.every((f) => f.severity === expected),
+          `[severity] "${row.avoid}" (${row.lang}) did not yield ${expected}-severity findings through runCheck1`,
+          `${
+            row.context
+              ? "context-qualified rows must stay WARN-only"
+              : "context-free rows must be ERROR so --strict blocks them"
+          } (got: ${JSON.stringify(findings.map((f) => f.severity))})`,
         );
       }
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -89,9 +89,10 @@ check_terminology_drift() {
   #
   # BLOCKING (FR-3049, team sign-off required): runs in --strict and is invoked
   # INSIDE run_check, so a blocking CHECK 1 finding sets FAIL and prevents
-  # `=== ALL PASS ===`. Only bare-English, context-free avoid rows are
-  # error-severity (checker `runCheck1`); context-qualified and all non-English
-  # rows stay WARN and never block (severity logic unchanged). CHECK 2/3 never
+  # `=== ALL PASS ===`. Context-FREE avoid rows are error-severity in every
+  # language (checker `runCheck1`); only context-qualified rows stay WARN and
+  # never block. Non-English rows were warn-only until FR-3374 raised them on
+  # the strength of the self-test's live false-positive budget. CHECK 2/3 never
   # affect the exit code. To unblock a legitimate false positive without
   # reverting: add the value/key to scripts/terminology-i18n.allowlist.json
   # (ignoreValues/ignoreKeys) or append `[[i18n-term-ok]]` inline. To fully


### PR DESCRIPTION
Resolves #8387 (FR-3374)

## Why

Severity keyed off **language**, so the six curated ko/ja/th `avoid[]` rows could not stop the drift they exist to stop. The `슈퍼관리자` drift FR-3373 found in the ko manual was real, unambiguous, and would still only have produced a warning.

The original rationale was sound at the time: ko/ja/th have no reliable word boundaries, so non-Latin terms match by plain substring, and a bare concept noun as an avoid term would fire on every legitimate use (ko `세션` appears in ~200 values). Blanket warn-only was the safe default *in the absence of proof*.

FR-3051 replaced that absence with proof — fixtures plus a live false-positive budget (default 0) per row, gated in CI by `terminology-selftest.yml`. But that proof covered the **i18n stores only**, and FR-3373 made the manual a CHECK 1 source too. Proving a row precise against short UI labels says nothing about 120 files of long-form prose.

## What changed

**The self-test's live corpus now includes the manual.** `check-terminology-i18n.selftest.mjs` built its stores from `I18N_GLOBS`; it now also walks `DOCS_GLOB` for every language under test, with a wiring guard so a language that ships docs must actually contribute pages (otherwise the budget would silently ignore the prose surface). Result: every non-English row still sits at **budget 0** with 120 markdown files added, and the bare-noun negative controls fire harder than before — the teeth gate got stronger, not weaker.

**Severity keys off `context` alone.**

```diff
-severity: (row.lang && row.lang !== "en") || row.context ? "warn" : "error",
+severity: row.context ? "warn" : "error",
```

A context qualifier ("group (for project)", "WSProxy as a UI label") means the term is wrong in one sense and fine in another — no matcher can settle that, so those stay WARN **in every language**. A context-free row is unconditional and now blocks in every language.

**The self-test's severity assertion moved with it.** It previously pinned "non-English rows must stay WARN-only". It now asserts `context ? warn : error`, so the budget and the severity that budget earns can never drift apart — weakening one fails the other.

**Docs updated**: the checker header, `verify.sh`'s comment block, and three places in `TERMINOLOGY.md` (the avoid-table note, the non-English curation rule, the New-Term Gate).

## Blast radius

The termbase carries exactly 6 non-English rows:

| Row | `context` | After |
|---|---|---|
| ko `레플리카`, `슈퍼관리자`, `슈퍼어드민`, `스케일링 그룹`; ja `スケーリンググループ` | none | **error** |
| ko `자동 스케일링` | `auto scaling rule` | warn |

All five are deprecated *spellings*, not concept nouns. **This blocks 0 findings today** — the same no-op-flip shape as FR-3049's, and reverting is one line.

## Verification

```
bash scripts/verify.sh
=== ALL PASS ===

Terminology self-test: PASS — 352 assertion(s) hold.   (350 before; +2 docs wiring guards)
```

End-to-end, the drift that motivated this:

```
# append 슈퍼관리자 to a ko manual page
error [packages/backend.ai-webui-docs/src/ko] dashboard/dashboard.md:58
  CHECK 1 summary: 1 blocking, 0 warn-only
exit code: 1          # was: warn, exit 0
```

## Review notes

The judgement call worth checking is **the invariant, not the code**: blocking severity is defensible only while the self-test genuinely proves precision. If a future change weakens gates 3/4/5, or adds a non-English row without fixtures, the severity model has to be walked back with it. That coupling is now asserted in the harness and written into both file headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
