### PR TITLE
feat(FR-3214): coalesce TS dev watchers onto parent directories

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -10,6 +10,36 @@ import { spawn, spawnSync } from 'node:child_process';
 
 const env = { ...process.env };
 
+// Both TypeScript watch programs under this script — the root `tsc --watch`
+// child below and the one vite-plugin-checker runs inside the Vite process —
+// default to TS's `UseFsEvents` watch strategy, which installs ONE watcher per
+// file in the program. On macOS that is one open file descriptor per file, so a
+// GUI/IDE-launched dev server (launchd soft `maxfiles` = 256) hits EMFILE.
+//
+// `UseFsEventsOnParentDirectory` coalesces those into one watcher per
+// *directory* instead. It is TypeScript's own documented remedy for watcher
+// exhaustion, read straight from this env var by `createSystemWatchFunctions`,
+// and it composes with the pnpm-store `watchOptions` exclude added alongside it
+// (see `resolveCheckerTsconfigPath` in react/vite.config.ts): the exclude drops
+// the store's thousands of immutable `.d.ts` from the watch set, and this
+// collapses what remains from per-file to per-directory. Measured on the
+// react/ program (Linux, inotify watch descriptors on the tsc pid):
+//
+//   baseline                     9,678
+//   store exclude only           1,604
+//   this env var only            4,288
+//   both                           136   ← under macOS's 256 soft limit
+//
+// Type-check results and change-detection latency are unaffected (same
+// "Found 0 errors", edits still reported in ~1s); RSS/CPU are unchanged, so
+// this buys watcher headroom, not speed. Left overridable so a developer on a
+// filesystem where directory events are unreliable can pin the old strategy
+// with `TSC_WATCHFILE=UseFsEvents pnpm run dev`. An empty export
+// (`TSC_WATCHFILE=`) counts as unset, matching the PORTLESS_PORT handling below.
+if (!env.TSC_WATCHFILE?.trim()) {
+  env.TSC_WATCHFILE = 'UseFsEventsOnParentDirectory';
+}
+
 // Ensure the Portless daemon is running. Portless 0.10+ defaults the daemon
 // to port 443 which requires sudo; we override that to an unprivileged 1355
 // only when the user has not already pinned a port via PORTLESS_PORT. When


### PR DESCRIPTION
Related to #8047 (FR-3214).

> **Stacked on** #8357

## Problem

#8357 stops TypeScript from watching the pnpm store's immutable `.d.ts`. That removes most of the watch set, but **every file that remains still gets its own watcher**: TypeScript's default `watchFile` strategy is `UseFsEvents`, which is one watcher per file — and on macOS one watcher is one open file descriptor.

So after #8357 the `react/` program still installs ~1,600 per-file watchers. If the premise in #8357 is right that GUI/IDE-launched dev inherits launchd's soft `maxfiles` of 256, that is still ~6x over the limit.

## Fix

Set TypeScript's own `TSC_WATCHFILE=UseFsEventsOnParentDirectory` in `scripts/dev.mjs`. It is read directly by TS's `createSystemWatchFunctions` and coalesces per-file watchers into **one watcher per directory**.

Setting it in `dev.mjs` covers both TS watch programs the script owns — the root `tsc --watch` child, and the one `vite-plugin-checker` runs in a worker thread inside the Vite process (worker threads inherit `process.env`, verified below). It is left overridable, so anyone on a filesystem where directory events are unreliable can pin the old strategy with `TSC_WATCHFILE=UseFsEvents pnpm run dev`.

## Why this is complementary, not redundant

The two changes attack different halves of the same product:

| | #8357 (store exclude) | this PR (parent-dir watchers) |
|---|---|---|
| removes | the pnpm store's `.d.ts` **from the watch set** | the **per-file** granularity of what remains |
| depends on | `enableGlobalVirtualStore: true` + a machine-specific absolute path | nothing — one env var |
| covers | the checker only | the checker **and** the root `tsc --watch` |

They multiply. Neither alone gets the program under 256.

## Measurements

`tsc --watch -p react/tsconfig.json --noEmit`, counting inotify watch descriptors in `/proc/<pid>/fdinfo` after the checker reports `Found 0 errors`:

| config | watch descriptors |
|---|---|
| baseline (neither) | 9,678 |
| this env var only | 4,288 (−56%) |
| #8357 only | 1,604 (−83%) |
| **both** | **136 (−98.6%)** |

End-to-end through `vite-plugin-checker`'s worker thread, measured on the whole Vite process (this branch's `react/` dev server, checker enabled):

| config | Vite process watch descriptors |
|---|---|
| #8357 only | 2,743 |
| **+ this PR** | **1,283** (−53%) |

The residual 1,283 is Vite's own chokidar watcher (1,135 measured with the checker disabled) plus ~150 for the checker.

## What this does *not* buy

Worth stating plainly so the change is not oversold: on Linux the resource being conserved is inotify watch descriptors, not FDs, and it is not a load reduction. Measured on the same runs:

| config | watches | RSS | CPU (cumulative) | time to first check |
|---|---|---|---|---|
| baseline | 9,678 | 2,068 MB | 66.1s | 42.4s |
| #8357 only | 1,604 | 2,046 MB | 64.0s | 40.8s |
| both | 136 | 2,044 MB | 64.4s | 40.8s |

RSS moves 1.2% and CPU 2.6% — noise. `watchOptions` excludes drop the *watcher*, not the *read*, so TypeScript still parses every dependency `.d.ts`; that parse is what the ~2 GB is. This PR buys watcher headroom, which is what actually fails hard on macOS.

## Verification

- `bash scripts/verify.sh` — `=== ALL PASS ===` on this branch.
- Change detection intact: with both changes active, injecting a `TS2322` into a watched source file was reported ~1s later, and reverting cleared it. Error counts identical to baseline (`Found 0 errors` before and after).
- Env-var propagation into the checker's worker thread confirmed by the 2,743 → 1,283 Vite-process measurement above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
