### PR TITLE
feat(FR-3214): make the resident dev type checker opt-in

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -15,14 +15,16 @@ description: >
   live session is connected to a different backend a dev-only banner flags the
   mismatch instead of forcing a logout. When the user supplies dev test
   credentials, set VITE_DEFAULT_EMAIL / VITE_DEFAULT_PASSWORD to pre-fill the
-  login form too.
+  login form too. Dev servers run without the resident TypeScript program
+  (~1.3 GB per server) by default; pass VITE_DEV_TYPECHECK=on only when the
+  user explicitly asked for type checking, and say either way in the reply.
   Trigger on: "start dev server", "run dev", "pnpm dev 띄워", "개발 서버 띄워",
   "dev 서버 시작", "boot the dev environment", "실행해줘 dev".
 ---
 
 # Dev Server
 
-Starts the dev server with optional `VITE_THEME_HEADER_COLOR`, `PORTLESS_APP_NAME`, `VITE_DEFAULT_API_ENDPOINT`, and (when the user supplies them) `VITE_DEFAULT_EMAIL` / `VITE_DEFAULT_PASSWORD`, derived from this Claude Code session's `/color` / `/rename` history, the current branch's PR description, and the user's stated test credentials.
+Starts the dev server with optional `VITE_THEME_HEADER_COLOR`, `PORTLESS_APP_NAME`, `VITE_DEFAULT_API_ENDPOINT`, `VITE_DEV_TYPECHECK`, and (when the user supplies them) `VITE_DEFAULT_EMAIL` / `VITE_DEFAULT_PASSWORD`, derived from this Claude Code session's `/color` / `/rename` history, the current branch's PR description, and the user's stated test credentials.
 
 ## 1. Decide the command
 
@@ -168,6 +170,29 @@ If the resolved value matches the existing default backend the WebUI would other
 - `VITE_DEFAULT_PASSWORD` bakes a **plaintext password into the dev bundle** at build time. It is dev-only (`import.meta.env.DEV`), but still: only ever pass it on the command line or via the user's git-ignored `.env.development.local` — never write it to a committed file, and never for a production build.
 - Prefer non-privileged / disposable test accounts. If the user asks to pre-fill a real admin password, confirm they intend the plaintext-in-dev-bundle tradeoff before doing it.
 
+### 2e. Type checking (`VITE_DEV_TYPECHECK`) — off unless asked
+
+**Omit the variable.** Dev servers run without the type checker by default, so there is nothing to pass in the normal case.
+
+**Pass `VITE_DEV_TYPECHECK=on` only on an explicit request** for type checking in this server ("타입체크 켜서 띄워줘", "I want the type errors in the overlay", or a task that is specifically about fixing type errors).
+
+Do not try to infer the answer from how many servers are running, whether the session looks interactive, or who is going to read the output. Those judgments come out differently every session, which is worse than a flat rule with one explicit override.
+
+`vite-plugin-checker` holds a resident TypeScript program so type errors appear in the dev terminal and as a browser overlay. That program is the single most expensive thing in a dev server — measured on this repo's `react/` server, module graph warmed:
+
+| | vite RSS |
+|---|---|
+| checker on | 2,195 MB |
+| checker off | 853 MB |
+
+A dev server here is usually one of several, next to editors, agents, and other worktrees, so that ~1.3 GB decides how many fit on the machine.
+
+This is the behaviour of `react/vite.config.ts` itself, not something this skill imposes — a hand-typed `pnpm dev` is checker-less too.
+
+**Say which mode you started, in your reply, every time.** Checker off: name the fallback — e.g. *"Type checking is off in this server (the default); `bash scripts/verify.sh` before committing, or `pnpm --filter ./react exec tsc --noEmit` for a one-shot check."* Checker on: say so, and that it costs ~1.3 GB. Vite prints a matching warning on startup when the checker is off. Never let a checker-less server be reported as if it were type-clean.
+
+Running without it costs no real type safety: `scripts/verify.sh`, the Husky pre-commit hook, and CI each run one-shot `tsc --noEmit` independently of the dev server, and the IDE's own tsserver still flags errors while editing. What is lost is only the in-terminal / in-browser feedback loop while the server runs. If a specific check is needed on a checker-less server, run `pnpm --filter ./react exec tsc --noEmit` once rather than restarting with the checker enabled — a one-shot check frees its memory when it exits, a resident watcher does not.
+
 ## 3. Compose the run
 
 **Default: no env vars.** If you cannot resolve a color from step 2a (no `/color` in history, or the most recent was `default`, or anything ambiguous), run the command with **no `VITE_THEME_HEADER_COLOR` prefix at all**. Do not invent a color, do not pick a "neutral" default, do not pass an empty string. Just omit the env var. Same goes for `PORTLESS_APP_NAME` from step 2b.
@@ -186,6 +211,8 @@ If step **2b** picked a Portless app name from `/rename` or a PR number, also pr
 If step **2c** resolved a default API endpoint, also prefix `VITE_DEFAULT_API_ENDPOINT='<url>'`. If 2c resolved nothing, **omit** the variable entirely — do not pass an empty string.
 
 If step **2d** resolved login credentials, also prefix `VITE_DEFAULT_EMAIL='<email>'` and `VITE_DEFAULT_PASSWORD='<password>'`. If 2d resolved nothing, **omit** both. Never pass an empty string, and never fabricate a value to "fill the slot."
+
+Per step **2e**, prefix `VITE_DEV_TYPECHECK=on` **only** when the user explicitly asked for type checking; otherwise omit the variable entirely. Either way, say which mode you started in your reply.
 
 **Shell-escape every interpolated value.** The endpoint, email, and especially the password come from user/conversation text and may contain an apostrophe or shell metacharacters — interpolating them raw inside `'...'` breaks the command and can turn the rest of the value into executable shell. Before building the command line, quote each value shell-safely (e.g. Bash `printf '%q'`), or set them via the user's git-ignored `.env.development.local` instead of the command line. Do not hand-concatenate an untrusted password into a single-quoted string.
 

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -138,6 +138,22 @@ function resolveCheckerTsconfigPath(storeRoot: string | undefined): string {
   }
 }
 
+// Dev servers run without the in-process type checker unless asked for it here;
+// `vite build` always type-checks regardless.
+//
+// The checker keeps a resident TypeScript program: `watchOptions` excludes drop
+// the watcher but not the read, so every dependency `.d.ts` is still parsed and
+// held. That is ~1.3 GB per dev server (2,195 MB vs 853 MB measured here), and
+// most servers run next to editors, agents and other worktrees whose callers
+// never read the browser overlay the checker exists to paint.
+//
+// No gate that enforces type safety depends on it — `scripts/verify.sh`, the
+// Husky pre-commit hook and CI each run one-shot `tsc --noEmit`, and the IDE's
+// own tsserver still flags errors while editing. What a checker-less server
+// loses is the in-terminal / in-browser feedback loop, which the startup banner
+// names so such a server can never be mistaken for a type-clean one.
+const isDevTypecheckEnabled = process.env.VITE_DEV_TYPECHECK === 'on';
+
 // `vite-plugin-node-polyfills` injects bare-specifier imports of its own shim
 // paths (`vite-plugin-node-polyfills/shims/{buffer,global,process}`) during
 // production build via `@rollup/plugin-inject`. With
@@ -638,6 +654,21 @@ export default defineConfig(({ command, mode }) => {
   const pnpmStorePath =
     command === 'serve' ? resolvePnpmStorePath() : undefined;
 
+  // Builds always check; dev servers only on request. See the
+  // `isDevTypecheckEnabled` definition above.
+  const runTypeChecker = command !== 'serve' || isDevTypecheckEnabled;
+
+  // Say it out loud. A dev server with no type checker looks identical to one
+  // with a passing checker — both just print "ready in Nms" — so without this
+  // line it is easy to read silence as "no type errors".
+  if (!runTypeChecker) {
+    console.warn(
+      '[vite] no TypeScript checking in this dev server (no terminal errors, no ' +
+        'browser overlay). Start with `VITE_DEV_TYPECHECK=on` to enable it, or run ' +
+        '`bash scripts/verify.sh` before committing.',
+    );
+  }
+
   // Comma-separated list of additional hostnames to whitelist for the dev
   // server's host check (Vite 6 default-blocks anything outside localhost
   // since CVE-2025-30208). Example for SwitchHosts users:
@@ -994,16 +1025,21 @@ export default defineConfig(({ command, mode }) => {
       // that excludes the pnpm store from the watch program (FR-3214) — see
       // `resolveCheckerTsconfigPath` above; for `vite build` it is the plain
       // base tsconfig.
-      checker({
-        typescript: {
-          // Only `serve` owns tsconfig.checker.json; `vite build` reads the base
-          // config and must not write or delete a file a live dev server uses.
-          tsconfigPath:
-            command === 'serve'
-              ? resolveCheckerTsconfigPath(pnpmStorePath)
-              : baseTsconfigPath,
-        },
-      }),
+      ...(runTypeChecker
+        ? [
+            checker({
+              typescript: {
+                // Only `serve` owns tsconfig.checker.json; `vite build` reads
+                // the base config and must not write or delete a file a live
+                // dev server uses.
+                tsconfigPath:
+                  command === 'serve'
+                    ? resolveCheckerTsconfigPath(pnpmStorePath)
+                    : baseTsconfigPath,
+              },
+            }),
+          ]
+        : []),
 
       // Strategy `generateSW` produces a standalone SW file that precaches
       // the build manifest. We opt out of `registerType: 'autoUpdate'` to


### PR DESCRIPTION
Related to #8047 (FR-3214).

> **Stacked on** #8394

## Problem

#8357 and #8394 between them cut the dev type checker's watcher footprint by 98.6%. Neither touches its **memory**, and memory is what actually limits how many dev servers fit on one machine.

`watchOptions` excludes drop the *watcher*, not the *read* — TypeScript still parses every dependency `.d.ts` into the program and holds it resident. Measured on this repo's `react/` dev server (RSS of the Vite process, module graph warmed):

| | Linux | macOS |
|---|---|---|
| checker on | 2,060 MB | 2,195 MB |
| checker off | 238 MB | 853 MB |

Confirmed independently on Linux: a standalone `tsc --watch -p react/tsconfig.json` sits at 2,044 MB, and the checker-on/checker-off delta inside Vite is 1,962 MB — the same number from both directions. It is the TypeScript program, not the plugin overhead. (The macOS absolute figures are higher on both sides; the delta, ~1.3 GB, is the part that matters and it reproduces.)

A dev server here is rarely alone — it sits next to editors, other worktrees, and parallel agent sessions that each want one and none of which ever look at the browser overlay the checker exists to paint.

## Fix

**The dev type checker is now opt-in.** `vite serve` skips the `checker()` plugin unless `VITE_DEV_TYPECHECK=on` is set.

```ts
const isDevTypecheckEnabled = process.env.VITE_DEV_TYPECHECK === 'on';
// ...
const runTypeChecker = command !== 'serve' || isDevTypecheckEnabled;
```

`vite build` never consults the flag and always type-checks — a build is the one place a missing type check is least acceptable and least visible, so no stray env var can drop it. Both the startup banner and the plugin list read that single predicate, rather than two inverted spellings of the same condition.

`.claude/skills/dev-server/SKILL.md` now passes **nothing** in the normal case, and `VITE_DEV_TYPECHECK=on` only on an explicit request for type checking. The rule it replaced asked the agent to weigh three conditions (another server already running? several requested? background session?); a skill rule that needs judgment gets applied differently every session, so it is a flat default plus one explicit signal. The skill must disclose which mode it started, every time.

## This changes the default for humans too

Worth stating plainly, because the earlier revision of this PR did not do this: a hand-typed `pnpm dev` no longer type-checks either. The previous design kept the checker on for interactive use and dropped it only for skill-launched servers — deliberately asymmetric, on the theory that a person at the screen reads the overlay.

That asymmetry is gone by choice. The cost is that a developer who relied on the in-terminal / in-browser feedback loop has to opt back in with `VITE_DEV_TYPECHECK=on`.

## Does this let type errors slip through?

No gate that enforces type safety runs through the dev server:

- **CI type-checks every package** via #8407, which sits directly *above* this PR in the stack. That workflow is the gate this change leans on — today the only `tsc` in CI is `backend-ai-client-ci.yml`'s, scoped to one package, and the Husky pre-commit hook runs only ESLint + Prettier. Until #8407 lands, turning the dev checker off leaves no automated type gate for `react/`.
- `scripts/verify.sh` also runs one-shot `tsc --noEmit` over react/BUI/client, and the agent workflow in `CLAUDE.md` already requires it — but it is a local harness, not an enforced gate.
- The IDE's own tsserver keeps flagging errors while editing.
- `vite build` still type-checks unconditionally.

What is genuinely lost is the in-terminal / in-browser feedback loop. Three things keep that from turning into a silent hazard:

1. **Vite prints a warning on startup** naming both the fallback and the way back on, so a checker-less server can't be mistaken for a type-clean one:
   ```
   [vite] no TypeScript checking in this dev server (no terminal errors, no browser
   overlay). Start with `VITE_DEV_TYPECHECK=on` to enable it, or run
   `bash scripts/verify.sh` before committing.
   ```
2. **The skill must say which mode it started** in its reply — not just rely on terminal output the user may not be reading.
3. **A one-shot check is the escape hatch**, not a restart: `pnpm --filter ./react exec tsc --noEmit` gives the same answer and frees its memory when it exits, which a resident watcher never does.

## Verification

- `bash scripts/verify.sh` — `=== ALL PASS ===` on this branch.
- Live `pnpm dev`, default (no env var): banner printed, no checker output, no derived `tsconfig.checker.json` written, Vite RSS **625 MB**.
- Live `pnpm dev` with `VITE_DEV_TYPECHECK=on`: no banner, `tsconfig.checker.json` generated, Vite RSS **1,855 MB**.
- Rebased onto the current #8394, which is itself rebased onto the current #8357; the `react/vite.config.ts` conflict against #8357's `serve`-scoped `tsconfigPath` guard was resolved so both survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


