### PR TITLE
style(FR-3379): unify bulk action button styles in table selection toolbars

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -149,7 +149,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
               >
                 <BAIButton
                   disabled={!enableDownload}
-                  icon={<DownloadIcon />}
+                  icon={<DownloadIcon style={{ color: token.colorInfo }} />}
                   action={async () => {
                     const filePaths = selectedFiles.map((file) =>
                       currentPath === '.'

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.stories.tsx
@@ -39,8 +39,8 @@ The button automatically determines if vfolders are deletable:
 - **Not Deletable**: No vfolders have 'delete_vfolder' permission
 
 ## Visual States
-- **Enabled**: Error colors (red icon and background)
-- **Disabled**: Disabled colors (gray)
+- **Enabled**: Default bordered button with error-colored (red) icon only
+- **Disabled**: Disabled button chrome (gray border and background) while the icon keeps its error (red) color
 
 For other props, refer to [Ant Design Button](https://ant.design/components/button).
         `,

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.tsx
@@ -30,20 +30,9 @@ const BAIVFolderDeleteButton = ({
 
   return (
     <BAIButton
-      icon={<DeleteOutlined />}
+      icon={<DeleteOutlined style={{ color: token.colorError }} />}
       disabled={buttonProps.disabled || !isDeletable}
-      style={{
-        color:
-          isDeletable && !buttonProps.disabled
-            ? token.colorError
-            : token.colorTextDisabled,
-        backgroundColor:
-          isDeletable && !buttonProps.disabled
-            ? token.colorErrorBg
-            : token.colorBgContainerDisabled,
-        ...buttonProps.style,
-      }}
-      {..._.omit(buttonProps, ['style', 'disabled'])}
+      {..._.omit(buttonProps, ['disabled'])}
     />
   );
 };

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButtonV2.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButtonV2.tsx
@@ -2,7 +2,6 @@ import { BAIVFolderDeleteButtonV2Fragment$key } from '../../__generated__/BAIVFo
 import BAIButton from '../BAIButton';
 import { DeleteOutlined } from '@ant-design/icons';
 import { theme, type ButtonProps } from 'antd';
-import * as _ from 'lodash-es';
 import { graphql, useFragment } from 'react-relay';
 
 export interface BAIVFolderDeleteButtonV2Props extends ButtonProps {
@@ -31,20 +30,10 @@ const BAIVFolderDeleteButtonV2 = ({
   // permission on the folder, so it cannot be used as a gate for delete.
   // Until a proper permission field is exposed, always treat the button as
   // enabled and let the backend reject unauthorized requests.
-  const isEnabled = !buttonProps.disabled;
-
   return (
     <BAIButton
-      icon={<DeleteOutlined />}
-      disabled={buttonProps.disabled}
-      style={{
-        color: isEnabled ? token.colorError : token.colorTextDisabled,
-        backgroundColor: isEnabled
-          ? token.colorErrorBg
-          : token.colorBgContainerDisabled,
-        ...buttonProps.style,
-      }}
-      {..._.omit(buttonProps, ['style', 'disabled'])}
+      icon={<DeleteOutlined style={{ color: token.colorError }} />}
+      {...buttonProps}
     />
   );
 };

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -332,11 +332,7 @@ const AdminUserCredentialList: React.FC = () => {
               {queryParams.activeType === 'active' ? (
                 <Tooltip title={t('credential.Deactivate')}>
                   <BAIButton
-                    icon={<BanIcon />}
-                    style={{
-                      color: token.colorError,
-                      background: token.colorErrorBg,
-                    }}
+                    icon={<BanIcon style={{ color: token.colorError }} />}
                     loading={isBulkUpdating}
                     onClick={() => handleBulkStatusUpdate(false)}
                   />
@@ -344,11 +340,7 @@ const AdminUserCredentialList: React.FC = () => {
               ) : (
                 <Tooltip title={t('credential.Activate')}>
                   <BAIButton
-                    icon={<UndoIcon />}
-                    style={{
-                      color: token.colorSuccess,
-                      background: token.colorSuccessBg,
-                    }}
+                    icon={<UndoIcon style={{ color: token.colorInfo }} />}
                     loading={isBulkUpdating}
                     onClick={() => handleBulkStatusUpdate(true)}
                   />

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -458,18 +458,11 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
               />
               <BAIButton
                 icon={<SquarePenIcon style={{ color: token.colorInfo }} />}
-                style={{
-                  backgroundColor: token.colorInfoBg,
-                }}
                 onClick={toggleUpdateUsersModal}
               />
               {queryParams.status === 'INACTIVE' && (
                 <BAIButton
-                  icon={<DeleteFilled />}
-                  style={{
-                    color: token.colorError,
-                    background: token.colorErrorBg,
-                  }}
+                  icon={<DeleteFilled style={{ color: token.colorError }} />}
                   onClick={togglePurgeUsersModal}
                 />
               )}

--- a/react/src/components/ProjectStoragePermissionTable.tsx
+++ b/react/src/components/ProjectStoragePermissionTable.tsx
@@ -74,9 +74,7 @@ export interface ProjectStoragePermissionTableProps extends BAITableProps<Projec
    * derived from it internally; null/undefined yields an empty key list.
    */
   permissionFrgmt:
-    | ProjectStoragePermissionTable_permissionFrgmt$key
-    | null
-    | undefined;
+    ProjectStoragePermissionTable_permissionFrgmt$key | null | undefined;
 }
 
 const ProjectStoragePermissionTable: React.FC<
@@ -335,7 +333,6 @@ const ProjectStoragePermissionTable: React.FC<
               >
                 <BAIButton
                   icon={<SquarePenIcon style={{ color: token.colorInfo }} />}
-                  style={{ backgroundColor: token.colorInfoBg }}
                   onClick={() =>
                     setEditingRows(
                       rows.filter((row) => selectedRowKeys.includes(row.id)),

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -355,7 +355,6 @@ const ResourceGroupList: React.FC = () => {
               <Tooltip title={t('general.BulkEdit')}>
                 <BAIButton
                   icon={<SquarePenIcon style={{ color: token.colorInfo }} />}
-                  style={{ backgroundColor: token.colorInfoBg }}
                   onClick={() => setOpenSFTPModal(true)}
                 />
               </Tooltip>

--- a/react/src/components/RoleAssignmentTab.tsx
+++ b/react/src/components/RoleAssignmentTab.tsx
@@ -241,12 +241,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
               />
               <Tooltip title={t('rbac.RevokeUser')}>
                 <BAIButton
-                  danger
-                  icon={<DeleteFilled />}
-                  style={{
-                    borderColor: token.colorBorder,
-                    background: token.colorErrorBg,
-                  }}
+                  icon={<DeleteFilled style={{ color: token.colorError }} />}
                   onClick={() => {
                     const userIds = assignments
                       .filter((a) => selectedRowKeys.includes(a?.id ?? ''))

--- a/react/src/components/ScopedRolePermissionCard.tsx
+++ b/react/src/components/ScopedRolePermissionCard.tsx
@@ -18,7 +18,7 @@ import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOption
 import RoleScopePermissionEditModal, {
   resolveScopeName,
 } from './RoleScopePermissionEditModal';
-import { Button, Tag, Tooltip } from 'antd';
+import { Button, Tag, theme, Tooltip } from 'antd';
 import {
   BAICard,
   type BAIColumnsType,
@@ -84,6 +84,7 @@ const ScopedRolePermissionCard: React.FC<ScopedRolePermissionCardProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
+  const { token } = theme.useToken();
 
   const role = useFragment(
     graphql`
@@ -424,7 +425,7 @@ const ScopedRolePermissionCard: React.FC<ScopedRolePermissionCardProps> = ({
                     session list's bulk actions). */}
                 <Tooltip title={t('rbac.EditScopePermissions')}>
                   <Button
-                    icon={<SquarePenIcon />}
+                    icon={<SquarePenIcon style={{ color: token.colorInfo }} />}
                     onClick={() => setIsSelectionEditOpen(true)}
                   />
                 </Tooltip>

--- a/react/src/pages/AdminModelCardListPage.tsx
+++ b/react/src/pages/AdminModelCardListPage.tsx
@@ -383,8 +383,7 @@ const AdminModelCardListPage: React.FC = () => {
                 onClearSelection={() => setSelectedModelCards([])}
               />
               <BAIButton
-                danger
-                icon={<DeleteFilled />}
+                icon={<DeleteFilled style={{ color: token.colorError }} />}
                 onClick={handleBulkDelete}
                 loading={isBulkDeleteInFlight}
               />

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -403,11 +403,6 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
                     <Tooltip title={t('data.folders.MoveToTrash')}>
                       <BAIVFolderDeleteButton
                         vfolderFrgmt={selectedFolderList}
-                        style={{
-                          borderColor: token.colorBorder,
-                        }}
-                        type="text"
-                        variant="outlined"
                         onClick={() => {
                           toggleDeleteModal();
                         }}
@@ -424,13 +419,9 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
                     />
                     <Tooltip title={t('data.folders.Restore')}>
                       <BAIButton
-                        style={{
-                          color: token.colorInfo,
-                          borderColor: token.colorBorder,
-                        }}
-                        type="text"
-                        variant="outlined"
-                        icon={<BAIRestoreIcon />}
+                        icon={
+                          <BAIRestoreIcon style={{ color: token.colorInfo }} />
+                        }
                         onClick={() => {
                           toggleRestoreModal();
                         }}

--- a/react/src/pages/ProjectAdminDataPage.tsx
+++ b/react/src/pages/ProjectAdminDataPage.tsx
@@ -366,9 +366,6 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
                   <Tooltip title={t('data.folders.MoveToTrash')}>
                     <BAIVFolderDeleteButtonV2
                       vfolderFrgmt={selectedFolderList}
-                      style={{ borderColor: token.colorBorder }}
-                      type="text"
-                      variant="outlined"
                       onClick={() => {
                         toggleDeleteModal();
                       }}
@@ -385,13 +382,9 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
                   />
                   <Tooltip title={t('data.folders.Restore')}>
                     <BAIButton
-                      style={{
-                        color: token.colorInfo,
-                        borderColor: token.colorBorder,
-                      }}
-                      type="text"
-                      variant="outlined"
-                      icon={<BAIRestoreIcon />}
+                      icon={
+                        <BAIRestoreIcon style={{ color: token.colorInfo }} />
+                      }
                       onClick={() => {
                         toggleRestoreModal();
                       }}
@@ -399,13 +392,9 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
                   </Tooltip>
                   <Tooltip title={t('data.folders.Delete')}>
                     <BAIButton
-                      style={{
-                        color: token.colorError,
-                        borderColor: token.colorBorder,
-                      }}
-                      type="text"
-                      variant="outlined"
-                      icon={<BAIPurgeIcon />}
+                      icon={
+                        <BAIPurgeIcon style={{ color: token.colorError }} />
+                      }
                       onClick={() => {
                         toggleDeleteForeverModal();
                       }}

--- a/react/src/pages/ProjectPage.tsx
+++ b/react/src/pages/ProjectPage.tsx
@@ -456,7 +456,6 @@ const ProjectPage = () => {
                 <Tooltip title={t('project.BulkEdit')}>
                   <BAIButton
                     icon={<SquarePenIcon style={{ color: token.colorInfo }} />}
-                    style={{ backgroundColor: token.colorInfoBg }}
                     onClick={toggleBulkEditModal}
                   />
                 </Tooltip>

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -364,16 +364,13 @@ const ReservoirPage: React.FC = () => {
                     }
                   >
                     <Button
-                      icon={mode === 'ALIVE' ? <BanIcon /> : <UndoIcon />}
-                      style={{
-                        color:
-                          mode === 'ALIVE' ? token.colorError : token.colorInfo,
-                        backgroundColor:
-                          mode === 'ALIVE'
-                            ? token.colorErrorBg
-                            : token.colorInfoBg,
-                        borderColor: token.colorBorder,
-                      }}
+                      icon={
+                        mode === 'ALIVE' ? (
+                          <BanIcon style={{ color: token.colorError }} />
+                        ) : (
+                          <UndoIcon style={{ color: token.colorInfo }} />
+                        )
+                      }
                       onClick={() => {
                         if (mode === 'ALIVE') {
                           setSelectedArtifacts(

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -481,11 +481,6 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                     <Tooltip title={t('data.folders.MoveToTrash')}>
                       <BAIVFolderDeleteButton
                         vfolderFrgmt={selectedFolderList}
-                        style={{
-                          borderColor: token.colorBorder,
-                        }}
-                        type="text"
-                        variant="outlined"
                         onClick={() => {
                           toggleDeleteModal();
                         }}
@@ -502,13 +497,9 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                     />
                     <Tooltip title={t('data.folders.Restore')}>
                       <BAIButton
-                        style={{
-                          color: token.colorInfo,
-                          borderColor: token.colorBorder,
-                        }}
-                        type="text"
-                        variant="outlined"
-                        icon={<BAIRestoreIcon />}
+                        icon={
+                          <BAIRestoreIcon style={{ color: token.colorInfo }} />
+                        }
                         onClick={() => {
                           toggleRestoreModal();
                         }}


### PR DESCRIPTION
Linked Jira: [FR-3379](https://lablup.atlassian.net/browse/FR-3379) — GitHub clone issue pending (webhook has not fired yet; upgrade to `Resolves #N (FR-3379)` once it appears)

## Summary

Bulk action buttons rendered next to the "N selected" indicator in table selection toolbars were styled inconsistently across pages — some had a red icon inside a red-tinted box, some had red or gray border overrides, and some were plain default buttons. This PR unifies all of them to a single **default bordered icon button** convention:

- Default antd `Button` / `BAIButton` — the standard border stays, in the **default border color** (no `type="text"`, no `danger`, no `borderColor` override).
- No background tint (`colorErrorBg` / `colorInfoBg` boxes removed).
- Only the **icon** carries the semantic color, applied directly on the icon element:
  - Destructive actions (delete / purge / terminate / revoke / ban) → `style={{ color: token.colorError }}`
  - Non-destructive bulk actions (edit / restore / download / usage graph) → `style={{ color: token.colorInfo }}`

Reference pattern:

```tsx
<Button
  disabled={!enableDelete}
  icon={<DeleteFilled style={{ color: token.colorError }} />}
  onClick={() => toggleDeleteModal()}
/>
```

The session-list terminate buttons (`ComputeSessionListPage`, `AdminComputeSessionListPage`, `ProjectAdminSessionPage`) and `FairShareList` already followed this convention on `main`, so they drop out of the diff entirely.

## Changed call sites

**Destructive (default border, `colorError` icon):**
- `react\/src\/components\/AdminUserManagement.tsx` — bulk purge button
- `react\/src\/components\/AdminUserCredentialList.tsx` — bulk Deactivate \/ Activate buttons added by FR-2403 (#6244, merged after this branch was cut): dropped `colorErrorBg` \/ `colorSuccessBg` background boxes, icon-only `colorError` (Ban) \/ `colorInfo` (Undo) — rebased onto latest main to pick these up (dropped `colorErrorBg` box)
- `react/src/components/RoleAssignmentTab.tsx` — bulk revoke-user button (dropped `colorErrorBg` box + `borderColor` override)
- `react/src/pages/AdminModelCardListPage.tsx` — bulk delete button (dropped `danger`)
- `react/src/pages/ReservoirPage.tsx` — Ban (deactivate) / Undo (activate) toggle: color moved onto the icon element (`colorError` / `colorInfo`), dropped background tint + `borderColor` override
- `react/src/pages/ProjectAdminDataPage.tsx` — permanent delete (purge) button (`colorError` icon, dropped `type="text"` / `variant="outlined"` / `borderColor`)

**Shared components (backend.ai-ui):**
- `packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.tsx` / `BAIVFolderDeleteButtonV2.tsx` — replaced the baked-in `colorError`/`colorErrorBg` button styling with an unconditional `colorError` on the `DeleteOutlined` icon only; button itself is a default bordered `BAIButton`. Call sites (VFolder list pages) no longer pass `type="text"` / `variant="outlined"` / `borderColor`.
- `packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx` — bulk delete button kept as the reference pattern (`colorError` icon); bulk download button icon now gets `colorInfo` for consistency

**Non-destructive (default border, `colorInfo` icon):**
- `react/src/components/AdminUserManagement.tsx`, `react/src/components/ProjectStoragePermissionTable.tsx`, `react/src/components/ResourceGroupList.tsx`, `react/src/pages/ProjectPage.tsx` — bulk edit buttons (dropped `colorInfoBg` background)
- `react/src/components/ScopedRolePermissionCard.tsx` — bulk edit-scope-permissions button (now matches the other edit buttons' `colorInfo` icon)
- `react/src/pages/VFolderNodeListPage.tsx`, `react/src/pages/AdminVFolderNodeListPage.tsx`, `react/src/pages/ProjectAdminDataPage.tsx` — move-to-trash / restore buttons: `colorInfo` moved onto the `BAIRestoreIcon`, dropped `type="text"` / `variant="outlined"` / `borderColor`

**Intentionally untouched:** `ImageList.tsx`'s refresh button (standard refresh styling, always visible) and the labeled primary "Install Image" CTA — they are not the icon-only selection-toolbar bulk buttons this issue targets.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup, Terminology).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-3379]: https://lablup.atlassian.net/browse/FR-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ