### PR TITLE
ci(FR-3214): type-check every package in CI

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,112 @@
+# Per-package `tsc --noEmit`. Before this, the only type check in CI was
+# `backend-ai-client-ci.yml`'s, scoped to one package by its path filter;
+# `scripts/verify.sh` covers more but no workflow invokes it, and the Husky
+# hook runs only ESLint + Prettier.
+#
+# One job per package rather than one sweep, so a failure names the package.
+#
+# These checks are advisory. Do not add them to a ruleset without first moving
+# the path filter inside the workflow: an event-level `paths:` miss means the
+# workflow never starts and no check-run is created, so a required check would
+# sit pending and block the merge.
+name: Typecheck
+
+on:
+  pull_request:
+    paths:
+      - "react/**"
+      - "packages/backend.ai-ui/**"
+      - "packages/backend.ai-client/**"
+      - "packages/backend.ai-docs-toolkit/**"
+      - "src/**"
+      - "tsconfig.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/typecheck.yml"
+  push:
+    branches: [main]
+    paths:
+      - "react/**"
+      - "packages/backend.ai-ui/**"
+      - "packages/backend.ai-client/**"
+      - "packages/backend.ai-docs-toolkit/**"
+      - "src/**"
+      - "tsconfig.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  # Keyed by PR number, not branch name: branch names are unique only within a
+  # repository, so two fork PRs both using e.g. `patch-1` would share a group and
+  # cancel each other's runs.
+  group: typecheck-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: typecheck (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Root `tsconfig.json` covers `src/**` — the Backend.AI client library
+          # and the wsproxy. Its `noEmit` is unset, hence the explicit flag.
+          - package: root
+            command: pnpm exec tsc --noEmit -p tsconfig.json
+            relay: false
+          # `react/tsconfig.json` also pulls in `../packages/backend.ai-{ui,client}/src`
+          # via `paths`, so this job is what catches a BUI change breaking the app.
+          # It excludes BUI's tests/stories, which the backend.ai-ui job below covers.
+          - package: react
+            command: pnpm --prefix ./react exec tsc --noEmit
+            relay: true
+          # BUI's own tsconfig additionally includes its tests, stories,
+          # `vite.config.ts` and `setupTests.ts`.
+          - package: backend.ai-ui
+            command: pnpm --filter backend.ai-ui exec tsc --noEmit
+            relay: true
+          # Overlaps `backend-ai-client-ci.yml`, which type-checks this package
+          # only when its own paths change. Kept here so the package is covered
+          # when something else (e.g. the lockfile) moves its types.
+          - package: backend.ai-client
+            command: pnpm --filter backend.ai-client exec tsc --noEmit
+            relay: false
+          - package: backend.ai-docs-toolkit
+            command: pnpm --filter backend.ai-docs-toolkit exec tsc --noEmit
+            relay: false
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
+        with:
+          run_install: false
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - uses: actions/cache@v5
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      # Relay artifacts are committed, so `tsc` would run without this. Compiling
+      # first means the check sees the types the current `graphql` tags actually
+      # produce, not a stale `__generated__` — the same order `vitest.yml` uses.
+      # `relay-drift.yml` reports the drift itself; this keeps it from hiding a
+      # type error behind it.
+      - name: Run relay-compiler
+        if: matrix.relay
+        run: pnpm run relay
+      - name: Typecheck ${{ matrix.package }}
+        run: ${{ matrix.command }}


### PR DESCRIPTION
Related to #8047 (FR-3214).

> **Stacked on** #8395

Note on ordering: #8395 turns the dev-server type checker off by default and points at CI as the remaining gate. That gate is *this* PR, and it sits above #8395 — so between the two merges there is a window where neither the dev checker nor CI type-checks `react/`. Worth merging these two close together, or flipping the order.

## Problem

CI type-checked exactly **one** package before this.

| gate | react / BUI type-checked? |
|---|---|
| `scripts/verify.sh` | ✅ — but it is the local / agent harness, and no workflow invokes it |
| Husky pre-commit | ❌ `lint-staged` runs ESLint + Prettier only |
| CI | ❌ |
| IDE tsserver | ✅ while editing — not a gate |

The only `tsc` in `.github/workflows/` is `backend-ai-client-ci.yml:59`, and its path filter means it runs only when `packages/backend.ai-client/**` or `pnpm-lock.yaml` changes. Nothing covered `react/`, `backend.ai-ui`, `backend.ai-docs-toolkit`, or the root `src/` (Backend.AI client library + wsproxy).

`terminology-content.yml` already spells out the underlying reason in its own header comment — *"verify.sh is the LOCAL / AGENT harness — no workflow invokes it"* — and added a CI gate for the same reason this PR does.

Net effect: a PR introducing a type error in `react/` merged green unless a human happened to run `verify.sh`.

## Fix

A matrix job running `tsc --noEmit` once per package:

| package | command |
|---|---|
| root (`src/**`) | `pnpm exec tsc --noEmit -p tsconfig.json` |
| react | `pnpm --prefix ./react exec tsc --noEmit` |
| backend.ai-ui | `pnpm --filter backend.ai-ui exec tsc --noEmit` |
| backend.ai-client | `pnpm --filter backend.ai-client exec tsc --noEmit` |
| backend.ai-docs-toolkit | `pnpm --filter backend.ai-docs-toolkit exec tsc --noEmit` |

`fail-fast: false`, so one run reports every package instead of stopping at the first. One job per package (rather than a `verify.sh`-style sweep) means a failure names the package.

**react and backend.ai-ui are both present on purpose.** `react/tsconfig.json` pulls BUI and client sources in through `paths` and `include`, so the react job is what catches *a BUI change breaking the app* — but it excludes BUI's `*.test.*` / `*.stories.*` / `*.spec.*`, which BUI's own tsconfig includes. Neither job subsumes the other.

react and backend.ai-ui run `pnpm run relay` first, mirroring `vitest.yml`, so the check sees the types the current `graphql` tags actually produce rather than a stale `__generated__`.

## Conflicts with existing workflows — checked

- **`backend-ai-client-ci.yml`** — genuine overlap: it also runs `tsc` for `backend.ai-client`. On a client-touching PR that package is now checked twice. Left as-is rather than editing another workflow's scope; the duplicate is cheap and the client job here also fires when something *else* (e.g. the lockfile) moves its types. Flagging it in case you'd rather I drop one.
- **`vitest.yml`** — overlapping path filters, different work (lint + relay + vitest). Both will run on the same PRs; no interference.
- **`relay-drift.yml`** — also runs `pnpm run relay`, but to assert no drift. Complementary: drift is reported there, while running relay here stops drift from hiding a type error behind it.
- **Concurrency group** — `typecheck-…` is unique; existing groups are `backend-ai-client-ci-…`, `gh-aw-…`, `docs-version-pdftag-pr-…`, and package.yml's `${{ github.workflow }}-…`.
- **Check names** — renders as `typecheck (react)` etc. No collision with `Analyze (…)`, `CodeQL`, `auto-label`, `triage`, `license/cla`, `sync-project-status`, or Graphite's checks.
- **Action versions** — `actions/checkout@v7`, `actions/setup-node@v6.4.0`, `actions/cache@v5`, `pnpm/action-setup@v5`, matching `vitest.yml` and `backend-ai-client-ci.yml` exactly.

## Still not covered

Out of scope here, but worth knowing the gap is not fully closed — none of these belong to a tsconfig at all:

- `scripts/**`, `e2e/**`, `electron-app/**`
- BUI tests/stories are covered by the `backend.ai-ui` job; react's own tests are covered by the react job.

Also: these checks are **advisory** — they report, but nothing blocks on them. This repo has no required status checks at all today (`main` has no classic branch protection rules; the only ruleset with `required_status_checks`, "backend.ai-client CI", is disabled).

**Do not add these to a ruleset as-is.** The `paths:` filter is at the event level, so on a PR that touches none of those paths the workflow never starts and no `typecheck (...)` check-run is created — a required check would sit pending forever and block the merge. (A job skipped by `if:` *does* report and counts as success; a workflow that never triggers does not.) Making these required means first moving path detection inside the workflow, the way `vitest.yml` does with `check-changes` + `dorny/paths-filter` + `if:`. `vitest.yml` carries the same event-level filter, so its checks have the same constraint.

## Verification

- All five commands pass on `main` as of `a42160818`, so the workflow is green on arrival — confirmed locally by running each one.
- CI step order simulated locally: `pnpm run relay` → `pnpm --prefix ./react exec tsc --noEmit` → `pnpm --filter backend.ai-ui exec tsc --noEmit`, all PASS, with **0 files** of relay drift after compiling.
- `bash scripts/verify.sh` — `=== ALL PASS ===`.
- Workflow parses; no tabs; 5 matrix entries; `.nvmrc` (node 24) present for `node-version-file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



