### PR TITLE
test(FR-3383): heal e2e specs broken by the scope-aware routing and route-error redesign

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-07-23
+> **Last Updated:** 2026-07-27
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 308 / 453 features covered (68%)**
+**Overall (in-scope routes): 309 / 454 features covered (68%)**
 
 | Page                     | Route                                  | Features | Covered | Status  |
 | ------------------------ | -------------------------------------- | :------: | :-----: | :-----: |
@@ -31,7 +31,7 @@
 | Storage Host             | `/storage-settings/:hostname`          |    3     |    0    |  ❌ 0%  |
 | My Environment           | `/my-environment`                      |    2     |    2    | ✅ 100% |
 | Environment              | `/environment`                         |    27    |   21    | 🔶 78%  |
-| Configurations           | `/settings`                            |    10    |    8    | 🔶 80%  |
+| Configurations           | `/settings`                            |    11    |    9    | 🔶 82%  |
 | Resources                | `/agent-summary`, `/agent`             |    10    |    3    | 🔶 30%  |
 | Resource Policy          | `/resource-policy`                     |    13    |   10    | 🔶 77%  |
 | User Credentials         | `/credential`                          |    22    |   15    | 🔶 68%  |
@@ -49,7 +49,7 @@
 | RBAC Management          | `/rbac`                                |    22    |   21    | 🔶 95%  |
 | Auto Scaling Rule Preset | `/admin-serving?tab=auto-scaling-rule` |    33    |   32    | 🔶 97%  |
 | Deployments              | `/deployments`, `/deployments/:id`     |    16    |   12    | 🔶 75%  |
-| **Total**                |                                        | **469**  | **320** | **68%** |
+| **Total**                |                                        | **470**  | **321** | **68%** |
 
 ---
 
@@ -338,56 +338,56 @@
 **Bulk actions (Deleted):** Restore → `RestoreVFolderModal`
 **Row actions:** Share → `InviteFolderSettingModal`, Permission info → `SharedFolderPermissionInfoModal`
 
-| Feature                                                                 | Status | Test                                                                                                                                   |
-| ----------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Create folder (default) → FolderCreateModal                             | ✅     | `User can create default vFolder`                                                                                                      |
-| Create folder (specific location) → FolderCreateModal                   | ✅     | `User can create a vFolder by selecting a specific location`                                                                           |
-| Create model folder → FolderCreateModal                                 | ✅     | `User can create Model vFolder`                                                                                                        |
-| Create cloneable model folder                                           | ✅     | `User can create cloneable Model vFolder`                                                                                              |
-| Create R/W folder                                                       | ✅     | `User can create Read & Write vFolder`                                                                                                 |
-| Create R/O folder                                                       | ✅     | `User can create Read Only vFolder`                                                                                                    |
-| Create auto-mount folder                                                | ✅     | `User can create Auto Mount vFolder`                                                                                                   |
-| Delete / trash / restore / purge                                        | ✅     | `User can create, delete(move to trash), restore, delete forever`                                                                      |
-| Consecutive deletion                                                    | ✅     | `User can create and permanently delete multiple VFolders`                                                                             |
-| Share folder → InviteFolderSettingModal                                 | ✅     | `User can share vFolder` (also asserts inviter email shown in invitation modal — FR-2982)                                              |
-| Leave shared folder → SharedFolderPermissionInfoModal                   | ✅     | `Invitee can leave a shared vFolder`                                                                                                   |
-| File upload (button)                                                    | ✅     | `User can upload a single/multiple files via Upload button`                                                                            |
-| File upload (drag & drop)                                               | ✅     | `User can upload a file via drag and drop`                                                                                             |
-| File upload (duplicate handling)                                        | ✅     | `User sees duplicate confirmation` / `User can cancel duplicate`                                                                       |
-| File upload (permissions)                                               | ✅     | `User cannot upload files to read-only VFolder`                                                                                        |
-| File upload (subdirectory)                                              | ✅     | `User can upload a file to a subdirectory`                                                                                             |
-| Explorer modal (CRUD)                                                   | ✅     | `User can create folders and upload files`                                                                                             |
-| Explorer modal (read-only)                                              | ✅     | `User can view files but cannot upload to read-only`                                                                                   |
-| Explorer modal (error handling)                                         | ✅     | `User sees error message when accessing non-existent`                                                                                  |
-| Explorer modal (open/close)                                             | ✅     | `User can open and close VFolder explorer modal`                                                                                       |
-| Explorer modal (file browser)                                           | ✅     | `User can access File Browser from VFolder explorer`                                                                                   |
-| Explorer modal (file browser fallback, `defaultFileBrowserImage` unset) | ✅     | `File Browser button falls back to an installed image when defaultFileBrowserImage is unset` (env-gated `@requires-image-filebrowser`) |
-| Explorer modal (details view)                                           | ✅     | `User can view VFolder details in the explorer`                                                                                        |
-| Explorer modal (opens despite suspending detail query, URL-param desync) | ✅     | `clicking a folder opens the explorer even when the detail query suspends inside the nuqs transition` (FR-3358 regression)              |
-| File creation (Create File button)                                      | ✅     | `User can see Create File button in file explorer`                                                                                     |
-| File creation (new file)                                                | ✅     | `User can create a new file in the file explorer`                                                                                      |
-| File creation (yaml config)                                             | ✅     | `User can create a yaml configuration file`                                                                                            |
-| File creation (empty name validation)                                   | ✅     | `User cannot create a file with empty name`                                                                                            |
-| File creation (invalid chars validation)                                | ✅     | `User cannot create a file with invalid characters in name`                                                                            |
-| File creation (read-only disabled)                                      | 🚧     | Skipped: `User cannot create files in read-only VFolder`                                                                               |
-| Type selection: User-type default                                       | ✅     | `User can create a User-type vfolder with default selection`                                                                           |
-| Type selection: Project-type (admin)                                    | ✅     | `Admin can create a Project-type vfolder`                                                                                              |
-| Type selection: Project disabled for model mode                         | ✅     | `Project radio is disabled when usage mode is model (non-model-store project)`                                                         |
-| Type selection: Project disabled for automount                          | ✅     | `Project radio is disabled when usage mode is automount`                                                                               |
-| Type selection: Project enabled for general                             | ✅     | `Project radio is enabled when usage mode is general`                                                                                  |
-| Type selection: User-only for regular user                              | ✅     | `Regular user sees only User-type radio (no Project radio)`                                                                            |
-| Type selection: Both types for admin                                    | ✅     | `Admin sees both User-type and Project-type radios`                                                                                    |
-| Active/Deleted tab switching                                            | ❌     | -                                                                                                                                      |
-| Usage mode filtering (general/pipeline/automount/model)                 | ❌     | -                                                                                                                                      |
-| Property filtering (name, status, location)                             | ❌     | -                                                                                                                                      |
-| Folder table sorting                                                    | ❌     | -                                                                                                                                      |
-| Pagination                                                              | ❌     | -                                                                                                                                      |
-| Storage status / quota display                                          | ❌     | -                                                                                                                                      |
-| Bulk trash → DeleteVFolderModal                                         | ❌     | -                                                                                                                                      |
-| Bulk restore → RestoreVFolderModal                                      | ❌     | -                                                                                                                                      |
-| Invitation notifications                                                | ❌     | -                                                                                                                                      |
-| Shared folder permission → SharedFolderPermissionInfoModal              | ❌     | -                                                                                                                                      |
-| File download                                                           | ❌     | -                                                                                                                                      |
+| Feature                                                                  | Status | Test                                                                                                                                   |
+| ------------------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Create folder (default) → FolderCreateModal                              | ✅     | `User can create default vFolder`                                                                                                      |
+| Create folder (specific location) → FolderCreateModal                    | ✅     | `User can create a vFolder by selecting a specific location`                                                                           |
+| Create model folder → FolderCreateModal                                  | ✅     | `User can create Model vFolder`                                                                                                        |
+| Create cloneable model folder                                            | ✅     | `User can create cloneable Model vFolder`                                                                                              |
+| Create R/W folder                                                        | ✅     | `User can create Read & Write vFolder`                                                                                                 |
+| Create R/O folder                                                        | ✅     | `User can create Read Only vFolder`                                                                                                    |
+| Create auto-mount folder                                                 | ✅     | `User can create Auto Mount vFolder`                                                                                                   |
+| Delete / trash / restore / purge                                         | ✅     | `User can create, delete(move to trash), restore, delete forever`                                                                      |
+| Consecutive deletion                                                     | ✅     | `User can create and permanently delete multiple VFolders`                                                                             |
+| Share folder → InviteFolderSettingModal                                  | ✅     | `User can share vFolder` (also asserts inviter email shown in invitation modal — FR-2982)                                              |
+| Leave shared folder → SharedFolderPermissionInfoModal                    | ✅     | `Invitee can leave a shared vFolder`                                                                                                   |
+| File upload (button)                                                     | ✅     | `User can upload a single/multiple files via Upload button`                                                                            |
+| File upload (drag & drop)                                                | ✅     | `User can upload a file via drag and drop`                                                                                             |
+| File upload (duplicate handling)                                         | ✅     | `User sees duplicate confirmation` / `User can cancel duplicate`                                                                       |
+| File upload (permissions)                                                | ✅     | `User cannot upload files to read-only VFolder`                                                                                        |
+| File upload (subdirectory)                                               | ✅     | `User can upload a file to a subdirectory`                                                                                             |
+| Explorer modal (CRUD)                                                    | ✅     | `User can create folders and upload files`                                                                                             |
+| Explorer modal (read-only)                                               | ✅     | `User can view files but cannot upload to read-only`                                                                                   |
+| Explorer modal (error handling)                                          | ✅     | `User sees error message when accessing non-existent`                                                                                  |
+| Explorer modal (open/close)                                              | ✅     | `User can open and close VFolder explorer modal`                                                                                       |
+| Explorer modal (file browser)                                            | ✅     | `User can access File Browser from VFolder explorer`                                                                                   |
+| Explorer modal (file browser fallback, `defaultFileBrowserImage` unset)  | ✅     | `File Browser button falls back to an installed image when defaultFileBrowserImage is unset` (env-gated `@requires-image-filebrowser`) |
+| Explorer modal (details view)                                            | ✅     | `User can view VFolder details in the explorer`                                                                                        |
+| Explorer modal (opens despite suspending detail query, URL-param desync) | ✅     | `clicking a folder opens the explorer even when the detail query suspends inside the nuqs transition` (FR-3358 regression)             |
+| File creation (Create File button)                                       | ✅     | `User can see Create File button in file explorer`                                                                                     |
+| File creation (new file)                                                 | ✅     | `User can create a new file in the file explorer`                                                                                      |
+| File creation (yaml config)                                              | ✅     | `User can create a yaml configuration file`                                                                                            |
+| File creation (empty name validation)                                    | ✅     | `User cannot create a file with empty name`                                                                                            |
+| File creation (invalid chars validation)                                 | ✅     | `User cannot create a file with invalid characters in name`                                                                            |
+| File creation (read-only disabled)                                       | 🚧     | Skipped: `User cannot create files in read-only VFolder`                                                                               |
+| Type selection: User-type default                                        | ✅     | `User can create a User-type vfolder with default selection`                                                                           |
+| Type selection: Project-type (admin)                                     | ✅     | `Admin can create a Project-type vfolder`                                                                                              |
+| Type selection: Project disabled for model mode                          | ✅     | `Project radio is disabled when usage mode is model (non-model-store project)`                                                         |
+| Type selection: Project disabled for automount                           | ✅     | `Project radio is disabled when usage mode is automount`                                                                               |
+| Type selection: Project enabled for general                              | ✅     | `Project radio is enabled when usage mode is general`                                                                                  |
+| Type selection: User-only for regular user                               | ✅     | `Regular user sees only User-type radio (no Project radio)`                                                                            |
+| Type selection: Both types for admin                                     | ✅     | `Admin sees both User-type and Project-type radios`                                                                                    |
+| Active/Deleted tab switching                                             | ❌     | -                                                                                                                                      |
+| Usage mode filtering (general/pipeline/automount/model)                  | ❌     | -                                                                                                                                      |
+| Property filtering (name, status, location)                              | ❌     | -                                                                                                                                      |
+| Folder table sorting                                                     | ❌     | -                                                                                                                                      |
+| Pagination                                                               | ❌     | -                                                                                                                                      |
+| Storage status / quota display                                           | ❌     | -                                                                                                                                      |
+| Bulk trash → DeleteVFolderModal                                          | ❌     | -                                                                                                                                      |
+| Bulk restore → RestoreVFolderModal                                       | ❌     | -                                                                                                                                      |
+| Invitation notifications                                                 | ❌     | -                                                                                                                                      |
+| Shared folder permission → SharedFolderPermissionInfoModal               | ❌     | -                                                                                                                                      |
+| File download                                                            | ❌     | -                                                                                                                                      |
 
 **Coverage: 🔶 33/46 features (includes 1 skipped)**
 
@@ -555,6 +555,7 @@
 | Block list menu hiding                               | ✅     | `block list`                                |
 | Inactive list menu disabling                         | ✅     | `inactiveList`                              |
 | 404 for blocked pages                                | ✅     | `404 page when accessing blocklisted pages` |
+| Project-admin page blocklist (canonical + legacy)    | ✅     | `blocklisted project-admin page`            |
 | 401 for unauthorized pages                           | ✅     | `Regular user sees 401 page`                |
 | Root redirect with blocklist                         | ✅     | `redirected to first available page`        |
 | Combined blocklist + inactiveList                    | ✅     | `correct behavior when both configured`     |
@@ -563,7 +564,7 @@
 | Overlay network setting → OverlayNetworkSettingModal | ❌     | -                                           |
 | Scheduler setting → SchedulerSettingModal            | ❌     | -                                           |
 
-**Coverage: 🔶 8/10 features**
+**Coverage: 🔶 9/11 features**
 
 ---
 
@@ -1239,11 +1240,11 @@ These are core user workflows that affect the largest number of users.
 
 ### Shared Utilities
 
-| Utility             | Location                                                                                     | Purpose                                       |
-| ------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `test-util.ts`      | [`e2e/utils/test-util.ts`](utils/test-util.ts)                                               | Login, config modification, TOML helpers      |
-| `test-util-antd.ts` | [`e2e/utils/test-util-antd.ts`](utils/test-util-antd.ts)                                     | Ant Design component interaction helpers      |
-| `SessionAPIHelper`  | [`e2e/utils/classes/session/SessionAPIHelper.ts`](utils/classes/session/SessionAPIHelper.ts) | Create and manage sessions via Backend.AI API |
+| Utility             | Location                                                                                     | Purpose                                                                                                                |
+| ------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `test-util.ts`      | [`e2e/utils/test-util.ts`](utils/test-util.ts)                                               | Login, config modification, TOML helpers, route-error screen locators (`notFoundPageHeading` / `forbiddenPageHeading`) |
+| `test-util-antd.ts` | [`e2e/utils/test-util-antd.ts`](utils/test-util-antd.ts)                                     | Ant Design component interaction helpers                                                                               |
+| `SessionAPIHelper`  | [`e2e/utils/classes/session/SessionAPIHelper.ts`](utils/classes/session/SessionAPIHelper.ts) | Create and manage sessions via Backend.AI API                                                                          |
 
 ### Page Object Models Needed
 

--- a/e2e/admin-model-card/admin-model-card-delete.spec.ts
+++ b/e2e/admin-model-card/admin-model-card-delete.spec.ts
@@ -539,7 +539,7 @@ test.describe(
       await goToTrashLink.click();
       await page.waitForURL(
         (url) => {
-          if (url.pathname !== '/admin-data') return false;
+          if (url.pathname !== '/admin/data') return false;
           if (url.searchParams.get('statusCategory') !== 'deleted')
             return false;
           const rawFilter = url.searchParams.get('filter') ?? '';
@@ -711,7 +711,7 @@ test.describe(
       await goToTrashLink.click();
       await page.waitForURL(
         (url) => {
-          if (url.pathname !== '/admin-data') return false;
+          if (url.pathname !== '/admin/data') return false;
           return url.searchParams.get('statusCategory') === 'deleted';
         },
         { timeout: 30000 },

--- a/e2e/config/config.spec.ts
+++ b/e2e/config/config.spec.ts
@@ -60,8 +60,8 @@ test.describe.parallel(
         await modifyConfigToml(page, request, requestConfig);
         await page.reload();
 
-        // check if the menu items are visible (the reload is a full app boot,
-        // so give the menu render a generous wait)
+        // check if the menu items are visible (the reload is a full app
+        // boot against the remote backend, so allow the re-render to settle)
         await expect(
           page.getByRole('link', { name: 'Start', exact: true }),
         ).toBeVisible({ timeout: 15_000 });

--- a/e2e/config/config.spec.ts
+++ b/e2e/config/config.spec.ts
@@ -2,6 +2,7 @@ import { StartPage } from '../utils/classes/common/StartPage';
 import {
   loginAsAdmin,
   modifyConfigToml,
+  notFoundPageHeading,
   webuiEndpoint,
 } from '../utils/test-util';
 import { test, expect } from '@playwright/test';
@@ -43,20 +44,27 @@ test.describe.parallel(
 
         // check if the pages show 404 content when accessed directly
         await page.goto(`${webuiEndpoint}/start`);
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
         await page.goto(`${webuiEndpoint}/serving`);
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
         await page.goto(`${webuiEndpoint}/job`);
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
         requestConfig.menu.blocklist = '';
         await modifyConfigToml(page, request, requestConfig);
         await page.reload();
 
-        // check if the menu items are visible
+        // check if the menu items are visible (the reload is a full app boot,
+        // so give the menu render a generous wait)
         await expect(
           page.getByRole('link', { name: 'Start', exact: true }),
-        ).toBeVisible();
+        ).toBeVisible({ timeout: 15_000 });
         await expect(
           page.getByRole('menuitem', { name: 'Sessions' }),
         ).toBeVisible();

--- a/e2e/config/page-access-control.spec.ts
+++ b/e2e/config/page-access-control.spec.ts
@@ -155,8 +155,13 @@ test.describe(
         });
         await expect(startMenuItem).toHaveClass(/ant-menu-item-disabled/);
 
-        // 5. Verify the page can still be accessed directly (inactive ≠ blocked)
+        // 5. Verify the page can still be accessed directly (inactive ≠
+        // blocked): wait for real Start-page content — a missing 404 heading
+        // alone would pass before the route resolves.
         await page.goto(`${webuiEndpoint}/start`);
+        await expect(page.getByText('Start Interactive Session')).toBeVisible({
+          timeout: 15_000,
+        });
         await expect(notFoundPageHeading(page)).toBeHidden();
       },
     );
@@ -319,34 +324,56 @@ test.describe(
         // 1. Login as superadmin user
         await loginAsAdmin(page, request);
 
-        // 2. Navigate to /credential (admin page)
+        // Each page asserts positive content: the canonical URL settle plus a
+        // visible breadcrumb. The breadcrumb is hidden on route-error screens,
+        // so its presence proves a real page rendered — a missing forbidden
+        // heading alone would pass before the suspended route resolves.
+        const breadcrumb = page.getByTestId('webui-breadcrumb');
+
+        // 2. Navigate to /credential (admin page; shim → /admin/users)
         await page.goto(`${webuiEndpoint}/credential`);
 
-        // 3. Verify page loads successfully (not 401)
+        // 3. Verify the page really renders (not 401)
+        await expect(page).toHaveURL(/\/admin\/users/, { timeout: 15_000 });
+        await expect(breadcrumb).toBeVisible({ timeout: 15_000 });
         await expect(forbiddenPageHeading(page)).toBeHidden();
 
-        // 4. Navigate to /environment (admin page)
+        // 4. Navigate to /environment (admin page; shim → /admin/environment)
         await page.goto(`${webuiEndpoint}/environment`);
 
-        // 5. Verify page loads successfully (not 401)
+        // 5. Verify the page really renders (not 401)
+        await expect(page).toHaveURL(/\/admin\/environment/, {
+          timeout: 15_000,
+        });
+        await expect(breadcrumb).toBeVisible({ timeout: 15_000 });
         await expect(forbiddenPageHeading(page)).toBeHidden();
 
-        // 6. Navigate to /agent (superadmin page)
+        // 6. Navigate to /agent (superadmin page; shim → /admin/agent)
         await page.goto(`${webuiEndpoint}/agent`);
 
-        // 7. Verify page loads successfully (not 401)
+        // 7. Verify the page really renders (not 401)
+        await expect(page).toHaveURL(/\/admin\/agent/, { timeout: 15_000 });
+        await expect(breadcrumb).toBeVisible({ timeout: 15_000 });
         await expect(forbiddenPageHeading(page)).toBeHidden();
 
-        // 8. Navigate to /settings (superadmin page)
+        // 8. Navigate to /settings (superadmin page; shim → /admin/settings)
         await page.goto(`${webuiEndpoint}/settings`);
 
-        // 9. Verify page loads successfully (not 401)
+        // 9. Verify the page really renders (not 401)
+        await expect(page).toHaveURL(/\/admin\/settings/, {
+          timeout: 15_000,
+        });
+        await expect(breadcrumb).toBeVisible({ timeout: 15_000 });
         await expect(forbiddenPageHeading(page)).toBeHidden();
 
-        // 10. Navigate to /maintenance (superadmin page)
+        // 10. Navigate to /maintenance (superadmin page; shim → /admin/maintenance)
         await page.goto(`${webuiEndpoint}/maintenance`);
 
-        // 11. Verify page loads successfully (not 401)
+        // 11. Verify the page really renders (not 401)
+        await expect(page).toHaveURL(/\/admin\/maintenance/, {
+          timeout: 15_000,
+        });
+        await expect(breadcrumb).toBeVisible({ timeout: 15_000 });
         await expect(forbiddenPageHeading(page)).toBeHidden();
       },
     );
@@ -654,6 +681,9 @@ test.describe(
         await expect(page).toHaveURL(/\/project\/[^/]+\/dashboard/, {
           timeout: 15_000,
         });
+        await expect(
+          page.getByTestId('webui-breadcrumb').getByText('Dashboard'),
+        ).toBeVisible({ timeout: 15_000 });
         await expect(notFoundPageHeading(page)).toBeHidden();
 
         // 9. Click disabled "Dashboard" menu item
@@ -715,10 +745,11 @@ test.describe(
         // 6. Reload page
         await page.reload();
 
-        // 7. Verify "Start" menu item is now visible (post-reload full boot)
+        // 7. Verify "Start" menu item is now visible (the reload is a full
+        // app boot, so wait for the menu to re-render)
         await expect(
           page.getByRole('link', { name: 'Start', exact: true }),
-        ).toBeVisible();
+        ).toBeVisible({ timeout: 15_000 });
 
         // 8. Verify "Dashboard" menu item is now active (not disabled)
         await expect(dashboardMenuItem).not.toHaveClass(
@@ -728,7 +759,12 @@ test.describe(
         // 9. Navigate to /start
         await page.goto(`${webuiEndpoint}/start`);
 
-        // 10. Verify Start page loads successfully (not 404)
+        // 10. Verify Start page loads successfully (not 404): wait for real
+        // Start-page content — a missing 404 heading alone would pass before
+        // the route resolves.
+        await expect(page.getByText('Start Interactive Session')).toBeVisible({
+          timeout: 15_000,
+        });
         await expect(notFoundPageHeading(page)).toBeHidden();
       },
     );

--- a/e2e/config/page-access-control.spec.ts
+++ b/e2e/config/page-access-control.spec.ts
@@ -1,10 +1,12 @@
 // spec: e2e/401-404-Page-Handling-Test-Plan.md
 // Tests for 401/404 page handling, blocklist, and inactiveList configurations
 import {
+  forbiddenPageHeading,
   loginAsAdmin,
   loginAsUser,
   modifyConfigToml,
   modifyThemeJson,
+  notFoundPageHeading,
   webuiEndpoint,
 } from '../utils/test-util';
 import { test, expect } from '@playwright/test';
@@ -51,14 +53,18 @@ test.describe(
         // 5. Navigate directly to /session
         await page.goto(`${webuiEndpoint}/session`);
 
-        // 6. Verify 404 page is displayed with "404 Not Found" image
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        // 6. Verify the route-error 404 screen is displayed
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
         // 7. Navigate directly to /job (sessions page)
         await page.goto(`${webuiEndpoint}/job`);
 
-        // 8. Verify 404 page is displayed with "404 Not Found" image
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        // 8. Verify the route-error 404 screen is displayed
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
       },
     );
 
@@ -91,14 +97,15 @@ test.describe(
         // 5. Verify navigation does not occur (stays on current page)
         await expect(page).toHaveURL(currentUrl);
 
-        // 6. Navigate directly to /dashboard via URL
+        // 6. Navigate directly to /dashboard via URL (legacy shim replace-redirects
+        // to the canonical scope-aware path; the goto is a full app boot)
         await page.goto(`${webuiEndpoint}/dashboard`);
 
         // 7. Verify Dashboard page loads successfully (not 404)
-        await expect(page.getByAltText('404 Not Found')).toBeHidden();
+        await expect(notFoundPageHeading(page)).toBeHidden();
         await expect(
           page.getByTestId('webui-breadcrumb').getByText('Dashboard'),
-        ).toBeVisible();
+        ).toBeVisible({ timeout: 15_000 });
       },
     );
 
@@ -131,7 +138,7 @@ test.describe(
 
         // 5. Verify the page can still be accessed directly (inactive ≠ blocked)
         await page.goto(`${webuiEndpoint}/start`);
-        await expect(page.getByAltText('404 Not Found')).toBeHidden();
+        await expect(notFoundPageHeading(page)).toBeHidden();
       },
     );
 
@@ -167,7 +174,9 @@ test.describe(
         // 5. Reload page
         await page.reload();
 
-        // 6. Verify "Dashboard" menu item is now active (no disabled attribute)
+        // 6. Verify "Dashboard" menu item is now active (no disabled attribute).
+        // The reload is a full app boot; wait for the menu to render first.
+        await expect(dashboardMenuItem).toBeVisible({ timeout: 15_000 });
         await expect(dashboardMenuItem).not.toHaveClass(
           /ant-menu-item-disabled/,
         );
@@ -213,11 +222,15 @@ test.describe(
         // 2. Navigate directly to /credential (Users page - admin)
         await page.goto(`${webuiEndpoint}/credential`);
 
-        // 3. Verify 401 page is displayed with "401 Not Found" image
-        await expect(page.getByAltText('401 Not Found')).toBeVisible();
+        // 3. Verify the forbidden (401) screen is displayed
+        await expect(forbiddenPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
-        // 4. Verify page shows "Unauthorized Access" heading
-        await expect(page.getByText('Unauthorized Access')).toBeVisible();
+        // 4. Verify the forbidden screen shows its description copy
+        await expect(
+          page.getByText("You don't have permission to access this page."),
+        ).toBeVisible();
 
         // 5. Wait for "Go Back to" button to be visible and click it
         const goBackButton = page.getByRole('button', {
@@ -227,25 +240,31 @@ test.describe(
         await goBackButton.click();
 
         // 6. Verify navigation to first available page
-        await expect(page.getByAltText('401 Not Found')).toBeHidden();
+        await expect(forbiddenPageHeading(page)).toBeHidden();
 
         // 7. Navigate directly to /environment (admin page)
         await page.goto(`${webuiEndpoint}/environment`);
 
         // 8. Verify 401 page is displayed
-        await expect(page.getByAltText('401 Not Found')).toBeVisible();
+        await expect(forbiddenPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
         // 9. Navigate directly to /agent (superadmin page)
         await page.goto(`${webuiEndpoint}/agent`);
 
         // 10. Verify 401 page is displayed
-        await expect(page.getByAltText('401 Not Found')).toBeVisible();
+        await expect(forbiddenPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
         // 11. Navigate directly to /settings (superadmin page)
         await page.goto(`${webuiEndpoint}/settings`);
 
         // 12. Verify 401 page is displayed
-        await expect(page.getByAltText('401 Not Found')).toBeVisible();
+        await expect(forbiddenPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
       },
     );
 
@@ -260,31 +279,31 @@ test.describe(
         await page.goto(`${webuiEndpoint}/credential`);
 
         // 3. Verify page loads successfully (not 401)
-        await expect(page.getByAltText('401 Not Found')).toBeHidden();
+        await expect(forbiddenPageHeading(page)).toBeHidden();
 
         // 4. Navigate to /environment (admin page)
         await page.goto(`${webuiEndpoint}/environment`);
 
         // 5. Verify page loads successfully (not 401)
-        await expect(page.getByAltText('401 Not Found')).toBeHidden();
+        await expect(forbiddenPageHeading(page)).toBeHidden();
 
         // 6. Navigate to /agent (superadmin page)
         await page.goto(`${webuiEndpoint}/agent`);
 
         // 7. Verify page loads successfully (not 401)
-        await expect(page.getByAltText('401 Not Found')).toBeHidden();
+        await expect(forbiddenPageHeading(page)).toBeHidden();
 
         // 8. Navigate to /settings (superadmin page)
         await page.goto(`${webuiEndpoint}/settings`);
 
         // 9. Verify page loads successfully (not 401)
-        await expect(page.getByAltText('401 Not Found')).toBeHidden();
+        await expect(forbiddenPageHeading(page)).toBeHidden();
 
         // 10. Navigate to /maintenance (superadmin page)
         await page.goto(`${webuiEndpoint}/maintenance`);
 
         // 11. Verify page loads successfully (not 401)
-        await expect(page.getByAltText('401 Not Found')).toBeHidden();
+        await expect(forbiddenPageHeading(page)).toBeHidden();
       },
     );
   },
@@ -319,11 +338,17 @@ test.describe(
         // 2. Navigate to /nonexistent (invalid route)
         await page.goto(`${webuiEndpoint}/nonexistent`);
 
-        // 3. Verify 404 page is displayed with "404 Not Found" image
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        // 3. Verify the route-error 404 screen is displayed
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
-        // 4. Verify page shows "Not Found" heading
-        await expect(page.getByText('Not Found')).toBeVisible();
+        // 4. Verify the 404 screen shows its description copy
+        await expect(
+          page.getByText(
+            'Sorry, the page you are looking for could not be found.',
+          ),
+        ).toBeVisible();
 
         // 5. Wait for "Go Back to" button to be visible and click it
         const goBackButton = page.getByRole('button', {
@@ -333,19 +358,23 @@ test.describe(
         await goBackButton.click();
 
         // 6. Verify navigation to first available page
-        await expect(page.getByAltText('404 Not Found')).toBeHidden();
+        await expect(notFoundPageHeading(page)).toBeHidden();
 
         // 7. Navigate to /invalid-page
         await page.goto(`${webuiEndpoint}/invalid-page`);
 
         // 8. Verify 404 page is displayed
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
         // 9. Navigate to /random-route-123
         await page.goto(`${webuiEndpoint}/random-route-123`);
 
         // 10. Verify 404 page is displayed
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
       },
     );
 
@@ -353,9 +382,8 @@ test.describe(
       'User sees 404 page when accessing blocklisted pages',
       { tag: ['@404', '@blocklist'] },
       async ({ page, request }) => {
-        // FIXME: Root redirect should skip blocked pages, but currently redirects to blocked page
-        // Expected: Navigate to / should redirect to first non-blocked page
-        // Actual: Redirects to /start which shows 404 because it's blocked
+        // Root redirect skips blocked pages since FR-3279: `/` redirects to the
+        // first menu item that survives blocklist filtering.
         // 1. Modify config.toml to set blocklist
         await modifyConfigToml(page, request, {
           menu: {
@@ -377,8 +405,10 @@ test.describe(
         await page.goto(`${webuiEndpoint}/start`);
 
         // 4. Verify 404 page is displayed (not 401)
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
-        await expect(page.getByAltText('401 Not Found')).toBeHidden();
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
+        await expect(forbiddenPageHeading(page)).toBeHidden();
 
         // 5. Navigate to root /
         await page.goto(`${webuiEndpoint}/`);
@@ -413,9 +443,8 @@ test.describe(
       'User is redirected to first available page when accessing root with blocklist',
       { tag: ['@redirect', '@blocklist'] },
       async ({ page, request }) => {
-        // FIXME: Root redirect should skip blocked pages, but currently redirects to /start even when blocked
-        // Expected: Navigate to / should redirect to first non-blocked page (e.g., /dashboard)
-        // Actual: Redirects to /start which shows 404 because it's blocked
+        // Root redirect skips blocked pages since FR-3279: `/` redirects to the
+        // first menu item that survives blocklist filtering.
         // 1. Modify config.toml to set blocklist = "start" and clear inactiveList
         await modifyConfigToml(page, request, {
           menu: {
@@ -486,9 +515,8 @@ test.describe(
       'User sees correct behavior when both blocklist and inactiveList are configured',
       { tag: ['@config', '@blocklist', '@inactiveList'] },
       async ({ page, request }) => {
-        // FIXME: Root redirect should skip both blocked and inactive pages
-        // Expected: Navigate to / should redirect to first non-blocked, active page
-        // Actual: Redirects to /start which shows 404 because it's blocked
+        // Root redirect skips blocked pages since FR-3279 (inactive pages stay
+        // reachable by design - inactive only greys the menu entry).
         // 1. Modify config.toml with both blocklist and inactiveList
         await modifyConfigToml(page, request, {
           menu: {
@@ -522,16 +550,21 @@ test.describe(
         await page.goto(`${webuiEndpoint}/start`);
 
         // 6. Verify 404 page is displayed (blocked)
-        await expect(page.getByAltText('404 Not Found')).toBeVisible();
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
         // 7. Navigate to /dashboard
         await page.goto(`${webuiEndpoint}/dashboard`);
 
-        // 8. Verify Dashboard page loads successfully (inactive but accessible)
-        await expect(page.getByAltText('404 Not Found')).toBeHidden();
-        // Note: Breadcrumb may not be visible due to PageAccessGuard, but page content should load
-        // Just verify we're on the dashboard page by checking URL
-        expect(page.url()).toContain('/dashboard');
+        // 8. Verify Dashboard page loads successfully (inactive but accessible).
+        // `/dashboard` is a legacy shim that replace-redirects to the canonical
+        // scope-aware path, so wait for the redirect to settle before reading
+        // the URL — capturing it mid-redirect would compare against a stale URL.
+        await expect(page).toHaveURL(/\/project\/[^/]+\/dashboard/, {
+          timeout: 15_000,
+        });
+        await expect(notFoundPageHeading(page)).toBeHidden();
 
         // 9. Click disabled "Dashboard" menu item
         const currentUrl = page.url();
@@ -592,10 +625,10 @@ test.describe(
         // 6. Reload page
         await page.reload();
 
-        // 7. Verify "Start" menu item is now visible
+        // 7. Verify "Start" menu item is now visible (post-reload full boot)
         await expect(
           page.getByRole('link', { name: 'Start', exact: true }),
-        ).toBeVisible();
+        ).toBeVisible({ timeout: 15_000 });
 
         // 8. Verify "Dashboard" menu item is now active (not disabled)
         await expect(dashboardMenuItem).not.toHaveClass(
@@ -606,7 +639,7 @@ test.describe(
         await page.goto(`${webuiEndpoint}/start`);
 
         // 10. Verify Start page loads successfully (not 404)
-        await expect(page.getByAltText('404 Not Found')).toBeHidden();
+        await expect(notFoundPageHeading(page)).toBeHidden();
       },
     );
   },

--- a/e2e/config/page-access-control.spec.ts
+++ b/e2e/config/page-access-control.spec.ts
@@ -50,7 +50,9 @@ test.describe(
           page.getByRole('menuitem', { name: 'Sessions' }),
         ).toBeHidden();
 
-        // 5. Navigate directly to /session
+        // 5. Navigate directly to /session (legacy URL). The guard 404s the
+        // blocklisted page at the legacy URL itself — no redirect happens,
+        // so the URL stays /session while the 404 screen renders.
         await page.goto(`${webuiEndpoint}/session`);
 
         // 6. Verify the route-error 404 screen is displayed
@@ -58,10 +60,27 @@ test.describe(
           timeout: 15_000,
         });
 
-        // 7. Navigate directly to /job (sessions page)
+        // 7. Resolve the project name via a NON-blocked shim (/dashboard
+        // replace-redirects to /project/:name/dashboard), then enter the
+        // canonical scope-aware session URL directly (no shim hop) — the
+        // guard must 404 it identically to the legacy entry.
+        await page.goto(`${webuiEndpoint}/dashboard`);
+        await expect(page).toHaveURL(/\/project\/[^/]+\/dashboard/, {
+          timeout: 15_000,
+        });
+        const projectName = new URL(page.url()).pathname.match(
+          /^\/project\/([^/]+)\//,
+        )?.[1];
+        expect(projectName).toBeTruthy();
+        await page.goto(`${webuiEndpoint}/project/${projectName}/session`);
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
+
+        // 8. Navigate directly to /job (legacy alias for sessions)
         await page.goto(`${webuiEndpoint}/job`);
 
-        // 8. Verify the route-error 404 screen is displayed
+        // 9. Verify the route-error 404 screen is displayed
         await expect(notFoundPageHeading(page)).toBeVisible({
           timeout: 15_000,
         });
@@ -175,7 +194,8 @@ test.describe(
         await page.reload();
 
         // 6. Verify "Dashboard" menu item is now active (no disabled attribute).
-        // The reload is a full app boot; wait for the menu to render first.
+        // The reload is a full app boot against the remote backend, so wait
+        // for the menu to re-render before asserting its class.
         await expect(dashboardMenuItem).toBeVisible({ timeout: 15_000 });
         await expect(dashboardMenuItem).not.toHaveClass(
           /ant-menu-item-disabled/,
@@ -219,7 +239,8 @@ test.describe(
         // 1. Login as regular user (not admin/superadmin)
         await loginAsUser(page, request);
 
-        // 2. Navigate directly to /credential (Users page - admin)
+        // 2. Navigate directly to /credential (legacy URL; the shim
+        // replace-redirects to the canonical /admin/users)
         await page.goto(`${webuiEndpoint}/credential`);
 
         // 3. Verify the forbidden (401) screen is displayed
@@ -232,6 +253,14 @@ test.describe(
           page.getByText("You don't have permission to access this page."),
         ).toBeVisible();
 
+        // 4b. Enter the canonical admin URL directly (no shim hop) — the
+        // handle-declared access guard must forbid it identically.
+        await expect(page).toHaveURL(/\/admin\/users/, { timeout: 15_000 });
+        await page.goto(`${webuiEndpoint}/admin/users`);
+        await expect(forbiddenPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
+
         // 5. Wait for "Go Back to" button to be visible and click it
         const goBackButton = page.getByRole('button', {
           name: /Go Back to|Go back to/,
@@ -241,6 +270,21 @@ test.describe(
 
         // 6. Verify navigation to first available page
         await expect(forbiddenPageHeading(page)).toBeHidden();
+
+        // 6b. Project-admin scope: enter the canonical project-admin URL for
+        // the user's own project directly. The regular e2e user has no
+        // project-admin RBAC role, so the URL-aware guard must forbid it.
+        await expect(page).toHaveURL(/\/project\/[^/]+\//, {
+          timeout: 15_000,
+        });
+        const projectName = new URL(page.url()).pathname.match(
+          /^\/project\/([^/]+)\//,
+        )?.[1];
+        expect(projectName).toBeTruthy();
+        await page.goto(`${webuiEndpoint}/project/${projectName}/admin/users`);
+        await expect(forbiddenPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
 
         // 7. Navigate directly to /environment (admin page)
         await page.goto(`${webuiEndpoint}/environment`);
@@ -416,6 +460,52 @@ test.describe(
         // 6. Verify user is redirected to first available menu item (not /start since it's blocked)
         await page.waitForURL((url) => !url.pathname.endsWith('/'));
         expect(page.url()).not.toContain('/start');
+      },
+    );
+
+    test(
+      'User sees 404 page when accessing a blocklisted project-admin page',
+      { tag: ['@404', '@blocklist', '@project-admin'] },
+      async ({ page, request }) => {
+        // Blocklist keys stay the legacy menu keys (FR-3383), so the
+        // project-admin Users page is still blocked via `project-admin-users`.
+        // 1. Modify config.toml to blocklist the project-admin Users page
+        await modifyConfigToml(page, request, {
+          menu: {
+            blocklist: 'project-admin-users',
+            inactivelist: '',
+          },
+        });
+
+        // 2. Login as superadmin user (has project-admin access everywhere,
+        // so a 404 here proves the blocklist, not a missing permission)
+        await loginAsAdmin(page, request);
+
+        // 3. Resolve the current project name via the /start shim redirect
+        // (the post-login landing page is not guaranteed to be project-scoped)
+        await page.goto(`${webuiEndpoint}/start`);
+        await expect(page).toHaveURL(/\/project\/[^/]+\/start/, {
+          timeout: 15_000,
+        });
+        const projectName = new URL(page.url()).pathname.match(
+          /^\/project\/([^/]+)\//,
+        )?.[1];
+        expect(projectName).toBeTruthy();
+
+        // 4. Enter the canonical project-admin URL directly (no shim hop)
+        await page.goto(`${webuiEndpoint}/project/${projectName}/admin/users`);
+
+        // 5. Verify the route-error 404 screen is displayed (not 401)
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
+        await expect(forbiddenPageHeading(page)).toBeHidden();
+
+        // 6. Enter via the legacy shim URL as well — same 404
+        await page.goto(`${webuiEndpoint}/project-admin-users`);
+        await expect(notFoundPageHeading(page)).toBeVisible({
+          timeout: 15_000,
+        });
       },
     );
   },
@@ -628,7 +718,7 @@ test.describe(
         // 7. Verify "Start" menu item is now visible (post-reload full boot)
         await expect(
           page.getByRole('link', { name: 'Start', exact: true }),
-        ).toBeVisible({ timeout: 15_000 });
+        ).toBeVisible();
 
         // 8. Verify "Dashboard" menu item is now active (not disabled)
         await expect(dashboardMenuItem).not.toHaveClass(

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -276,6 +276,26 @@ export async function logout(page: Page) {
   await page.waitForTimeout(1000);
 }
 
+/**
+ * Locator for the route-level "not found" screen (FR-3279/FR-3383).
+ * The legacy image-based Page404 (`<img alt="404 Not Found">`) was replaced by
+ * the shared RouteErrorContent composition, which renders the i18n heading
+ * `webui.NotFound` ("Oops! Page not Found...") instead of an image.
+ */
+export function notFoundPageHeading(page: Page) {
+  return page.getByText('Page not Found');
+}
+
+/**
+ * Locator for the route-level "forbidden" screen (FR-3383).
+ * The legacy image-based Page401 (`<img alt="401 Not Found">`) was replaced by
+ * ForbiddenPage in the shared RouteErrorContent composition, which renders the
+ * i18n heading `webui.UnauthorizedAccess`.
+ */
+export function forbiddenPageHeading(page: Page) {
+  return page.getByText('Unauthorized Access');
+}
+
 export async function navigateTo(page: Page, path: string) {
   //merge the base url with the path
   const url = new URL(path, webuiEndpoint);


### PR DESCRIPTION
Resolves #8406 (FR-3383)

Stacked on #8408 (FR-3383) ← #8208 (FR-3279) ← #7755 (FR-3057) ← #7751 (FR-3055).

## Summary

The routing stack rewrote the URL scheme (flat paths → `/project/:name/...` and `/admin/...` with legacy replace-redirect shims) and replaced the image-based `Page404`/`Page401` with the shared `RouteErrorContent` composition. This PR heals **only the e2e breakage caused by those route changes** — pre-existing failures were verified against `origin/main` and intentionally left untouched.

### What broke and how it is healed

- **404/401 screen assertions** (`e2e/config/page-access-control.spec.ts`, `e2e/config/config.spec.ts`): tests asserted the removed `<img alt="404 Not Found">` / `<img alt="401 Not Found">`. New shared locators in `e2e/utils/test-util.ts` — `notFoundPageHeading(page)` ("Page not Found") and `forbiddenPageHeading(page)` ("Unauthorized Access") — assert the route-error headings instead. First-paint assertions carry a 15s timeout because the redesigned screens render only after the plugin list and the suspended backend client resolve (`UnknownRoutePage` deliberately waits for plugins to avoid a 404 flash on Lit plugin pages), which is slower than the legacy synchronous image pages.
- **`/admin-data` pathname wait** (`e2e/admin-model-card/admin-model-card-delete.spec.ts` ×2): the Go-to-Trash notification now navigates to the canonical `/admin/data` (`buildPath('admin', 'data')`).
- **Mid-redirect URL capture** (`page-access-control.spec.ts` combined scenario): `page.url()` was captured right after `goto('/dashboard')`, racing the legacy shim's client-side replace-redirect; the later `toHaveURL(currentUrl)` then failed against the settled canonical URL. The test now waits for `/project/:name/dashboard` before capturing.
- **Stale comments**: three FIXME blocks claiming "root redirect goes to the blocked page" were refreshed — the root redirect skips blocklisted pages since FR-3279 (the assertions relying on that behavior now genuinely pass); a note referencing the deleted `PageAccessGuard` was updated.

### Canonical & project-admin coverage (added per review)

- **Canonical direct entry** (no legacy shim hop) is asserted explicitly: blocklisted `/project/:name/session` 404s, and `/admin/users` shows the forbidden screen to a regular user.
- **Project-admin scope**: a new test blocklists `project-admin-users` and verifies `/project/:name/admin/users` 404s for a superadmin via both the canonical URL and the legacy `/project-admin-users` shim; a regular user without the project-admin RBAC role gets the forbidden screen on the same canonical URL.
- The project name is resolved at runtime from a non-blocked shim redirect (no hardcoding). Notably, the guard 404s blocklisted pages **at the legacy URL without redirecting**, so extraction goes through a non-blocked page.

### Why the 15s upper bounds exist

Removing them was re-tested twice (including against a warmed dev server): 7–8 tests reproducibly time out at Playwright's 5s default. A fresh `page.goto` is a full app boot (remote-backend session restore ~5–8s), and the route-error screens additionally suspend on the backend client (the 404 also waits for the plugin list by design). The bounds sit only on first-paint-after-navigation assertions and shim-redirect settles — they are upper bounds, so they cost nothing when the app renders fast.

## Verification (dev server on this branch @ 127.0.0.1:9081 → 10.82.0.130:8090)

| Suite | Before healing | After healing |
|---|---|---|
| `config/page-access-control.spec.ts` (14 tests incl. new project-admin/canonical coverage) | 7 failed | **all pass** |
| `config/config.spec.ts` › block list | failed | **pass** |
| `admin-model-card-delete` › single delete + trash navigation (the healed wait) | failed on pathname | **pass** |
| `auth/login.spec.ts`, `admin-model-card-url-state.spec.ts` | — | pass (isolated run) |

### Pre-existing failures NOT touched (reproduce identically on `origin/main` against the same backend)

- `rbac/rbac-role-list.spec.ts` (all) — RBAC tab renders >10s after navigation on the dev-mode server; page itself works (manually verified: table + roles render at `/admin/rbac`).
- `environment/environment.spec.ts` BAIPropertyFilter group + "user can manage apps" — first-paint slower than the 5s default expect timeout.
- `start/start-page.spec.ts` › "Start From URL modal pre-filled via query parameters".
- `config/config.spec.ts` › `showNonInstalledImages` — backend image-catalog data dependent (dropdown search returns no options for the picked uninstalled image).
- `admin-model-card-delete` › bulk delete — bulk-trash success notification exceeds its 240s wait on the shared backend (fails before the healed line; single-delete flow passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
