### PR TITLE
fix(FR-3384): add bottom padding to reasoning-only chat message bubbles

### DIFF
--- a/react/src/components/Chat/ChatMessage.tsx
+++ b/react/src/components/Chat/ChatMessage.tsx
@@ -57,6 +57,12 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
   // Filter file parts from the message parts array
   const fileParts = _.filter(message.parts, (part) => part.type === 'file');
 
+  // The bubble has no vertical padding; the rendered markdown paragraphs of
+  // `content` supply it. When only reasoning is present (e.g. while the model
+  // is still thinking), there is no paragraph to provide the bottom gap, so the
+  // Collapse has to add it itself.
+  const hasContent = !_.isEmpty(_.trim(content));
+
   return (
     <ChatMessageContainer
       placement={placement}
@@ -119,12 +125,13 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
           <Collapse
             style={{
               marginTop: token.margin,
+              marginBottom: hasContent ? 0 : token.margin,
               width: '100%',
             }}
             items={[
               {
                 key: 'reasoning',
-                label: _.isEmpty(content) ? (
+                label: !hasContent ? (
                   <BAIFlex gap="xs">
                     <Typography.Text>{t('chatui.Thinking')}</Typography.Text>
                     <Spin size="small" />


### PR DESCRIPTION
Resolves #8411 (FR-3384)

## Summary

When an assistant message contains reasoning but no body text yet, the message bubble rendered with visible spacing above the reasoning collapse but none below it.

**Root cause** — the bubble container in `ChatMessage.tsx` sets `paddingTop: 0, paddingBottom: 0`, so its vertical breathing room comes from the default margins of the markdown `<p>` elements rendered for the message body, not from the container itself. While the model is still thinking, the body is empty, no paragraph is rendered, and the bottom gap disappears. The top gap survives because the `Collapse` carries its own `marginTop`.

**Fix** — give the `Collapse` a `marginBottom` only when the body is empty. Once body text arrives, the paragraph's own margin supplies the gap and the value returns to `0`. The condition is required because the container is a flex parent, where adjacent-sibling margin collapsing does not apply — an unconditional `marginBottom` would double the gap for normal messages.

Also aligned the collapse label condition (`_.isEmpty(content)` → `!hasContent`, which trims) so a whitespace-only body doesn't disagree with the spacing calculation.

## Test plan

- [x] `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript)
- [ ] Send a chat message to a reasoning-capable model; while only `Thinking` / `View reasoning` is shown, confirm the bubble has symmetric top/bottom spacing
- [ ] Once the body text streams in, confirm the spacing does not double up
- [ ] Confirm messages without reasoning are visually unchanged