### PR TITLE
refactor(FR-3256): hoist AdminDeploymentPage tabs to preloaded queries

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -956,6 +956,9 @@ export class Client {
       // conditions on their replicas (e.g. traffic status). backend #12805
       // (BA-6849 "support nested replica deployment filters"). FR-3332.
       this._features['deployment-replica-nested-filter'] = true;
+      // BA-6809 / backend PR #12708 — RuntimeVariantPreset.runtimeVariant
+      // nested field (DataLoader-resolved name/description). FR-3256.
+      this._features['runtime-variant-preset-runtime-variant-field'] = true;
     }
   }
 

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
@@ -35,7 +35,14 @@ export interface BAIFetchKeyButtonProps extends Omit<
   ButtonProps,
   'value' | 'onChange' | 'loading'
 > {
-  value: string;
+  /**
+   * Optional. The button self-generates its fetch key on each refresh
+   * (`onChange(new Date().toISOString())`) and re-anchors its countdown via an
+   * internal `cycleKey`, so it does not read this value. Consumers that drive
+   * refetching directly (e.g. a preloaded `loadQuery(..., 'network-only')` in
+   * `onChange`) can omit it entirely instead of threading a `useFetchKey`.
+   */
+  value?: string;
   loading?: boolean;
   lastLoadTime?: Date;
   showLastLoadTime?: boolean;

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -843,7 +843,7 @@ const BAIGraphQLPropertyFilter = <
           <Tooltip
             title={isValid || !isFocused ? '' : selectedProperty.rule?.message}
             open={!isValid && isFocused}
-            color={token.colorError}
+            color="red"
           >
             <AutoComplete
               ref={autoCompleteRef}

--- a/react/src/__generated__/AdminDeploymentDeleteMutation.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fdc19c22cd2b8cf983872f1c570e9685>>
+ * @generated SignedSource<<1453f4e77362c5be01ae71c6e23a90ab>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,17 +9,20 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type AdminDeploymentPresetListPageDeleteMutation$variables = {
+export type DeleteDeploymentInput = {
   id: string;
 };
-export type AdminDeploymentPresetListPageDeleteMutation$data = {
-  readonly adminDeleteDeploymentRevisionPreset: {
+export type AdminDeploymentDeleteMutation$variables = {
+  input: DeleteDeploymentInput;
+};
+export type AdminDeploymentDeleteMutation$data = {
+  readonly deleteModelDeployment: {
     readonly id: string;
   } | null | undefined;
 };
-export type AdminDeploymentPresetListPageDeleteMutation = {
-  response: AdminDeploymentPresetListPageDeleteMutation$data;
-  variables: AdminDeploymentPresetListPageDeleteMutation$variables;
+export type AdminDeploymentDeleteMutation = {
+  response: AdminDeploymentDeleteMutation$data;
+  variables: AdminDeploymentDeleteMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -27,7 +30,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "id"
+    "name": "input"
   }
 ],
 v1 = [
@@ -36,13 +39,13 @@ v1 = [
     "args": [
       {
         "kind": "Variable",
-        "name": "id",
-        "variableName": "id"
+        "name": "input",
+        "variableName": "input"
       }
     ],
-    "concreteType": "DeleteDeploymentRevisionPresetPayload",
+    "concreteType": "DeleteDeploymentPayload",
     "kind": "LinkedField",
-    "name": "adminDeleteDeploymentRevisionPreset",
+    "name": "deleteModelDeployment",
     "plural": false,
     "selections": [
       {
@@ -61,7 +64,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "AdminDeploymentPresetListPageDeleteMutation",
+    "name": "AdminDeploymentDeleteMutation",
     "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
@@ -70,20 +73,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "AdminDeploymentPresetListPageDeleteMutation",
+    "name": "AdminDeploymentDeleteMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "a6ffc9daa5a94f63ada52181190a4eeb",
+    "cacheID": "6c4d5e089de8847855a360c25b91855b",
     "id": null,
     "metadata": {},
-    "name": "AdminDeploymentPresetListPageDeleteMutation",
+    "name": "AdminDeploymentDeleteMutation",
     "operationKind": "mutation",
-    "text": "mutation AdminDeploymentPresetListPageDeleteMutation(\n  $id: UUID!\n) {\n  adminDeleteDeploymentRevisionPreset(id: $id) {\n    id\n  }\n}\n"
+    "text": "mutation AdminDeploymentDeleteMutation(\n  $input: DeleteDeploymentInput!\n) {\n  deleteModelDeployment(input: $input) {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ef6932db52137481429545d0abf749fe";
+(node as any).hash = "85eb1c4f21f817def12acb84acc36a46";
 
 export default node;

--- a/react/src/__generated__/AdminDeploymentPresetDeleteMutation.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e2b0d12e9ee241317cf98b6b287954f0>>
+ * @generated SignedSource<<0d6ed3264e903db10a5568bf8035f68d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,20 +9,17 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type DeleteDeploymentInput = {
+export type AdminDeploymentPresetDeleteMutation$variables = {
   id: string;
 };
-export type AdminDeploymentListPageDeleteMutation$variables = {
-  input: DeleteDeploymentInput;
-};
-export type AdminDeploymentListPageDeleteMutation$data = {
-  readonly deleteModelDeployment: {
+export type AdminDeploymentPresetDeleteMutation$data = {
+  readonly adminDeleteDeploymentRevisionPreset: {
     readonly id: string;
   } | null | undefined;
 };
-export type AdminDeploymentListPageDeleteMutation = {
-  response: AdminDeploymentListPageDeleteMutation$data;
-  variables: AdminDeploymentListPageDeleteMutation$variables;
+export type AdminDeploymentPresetDeleteMutation = {
+  response: AdminDeploymentPresetDeleteMutation$data;
+  variables: AdminDeploymentPresetDeleteMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -30,7 +27,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "input"
+    "name": "id"
   }
 ],
 v1 = [
@@ -39,13 +36,13 @@ v1 = [
     "args": [
       {
         "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
+        "name": "id",
+        "variableName": "id"
       }
     ],
-    "concreteType": "DeleteDeploymentPayload",
+    "concreteType": "DeleteDeploymentRevisionPresetPayload",
     "kind": "LinkedField",
-    "name": "deleteModelDeployment",
+    "name": "adminDeleteDeploymentRevisionPreset",
     "plural": false,
     "selections": [
       {
@@ -64,7 +61,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "AdminDeploymentListPageDeleteMutation",
+    "name": "AdminDeploymentPresetDeleteMutation",
     "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
@@ -73,20 +70,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "AdminDeploymentListPageDeleteMutation",
+    "name": "AdminDeploymentPresetDeleteMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "102d0bf1e8e60917d9d011759a41790c",
+    "cacheID": "9802c9f782ff33a151e9214c57ff7bc1",
     "id": null,
     "metadata": {},
-    "name": "AdminDeploymentListPageDeleteMutation",
+    "name": "AdminDeploymentPresetDeleteMutation",
     "operationKind": "mutation",
-    "text": "mutation AdminDeploymentListPageDeleteMutation(\n  $input: DeleteDeploymentInput!\n) {\n  deleteModelDeployment(input: $input) {\n    id\n  }\n}\n"
+    "text": "mutation AdminDeploymentPresetDeleteMutation(\n  $id: UUID!\n) {\n  adminDeleteDeploymentRevisionPreset(id: $id) {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2ecece6de837bfaf9eb7065300b85fba";
+(node as any).hash = "47a4cad7e6f8ed1b0d096523f1b3aadf";
 
 export default node;

--- a/react/src/__generated__/AdminDeploymentPresetQuery.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<079c40ad13707c84813ca28db8024f88>>
+ * @generated SignedSource<<f27ae6a82121f2077d921d9a02c909be>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -51,27 +51,27 @@ export type DeploymentRevisionPresetOrderBy = {
   direction?: string;
   field: DeploymentRevisionPresetOrderField;
 };
-export type AdminDeploymentPresetListPageQuery$variables = {
+export type AdminDeploymentPresetQuery$variables = {
   filter?: DeploymentRevisionPresetFilter | null | undefined;
   limit?: number | null | undefined;
   offset?: number | null | undefined;
   orderBy?: ReadonlyArray<DeploymentRevisionPresetOrderBy> | null | undefined;
 };
-export type AdminDeploymentPresetListPageQuery$data = {
+export type AdminDeploymentPresetQuery$data = {
   readonly deploymentRevisionPresets: {
     readonly count: number;
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id: string;
         readonly name: string;
-        readonly " $fragmentSpreads": FragmentRefs<"AdminDeploymentPresetNodesFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"AdminDeploymentPresetTableFragment">;
       };
     }>;
   } | null | undefined;
 };
-export type AdminDeploymentPresetListPageQuery = {
-  response: AdminDeploymentPresetListPageQuery$data;
-  variables: AdminDeploymentPresetListPageQuery$variables;
+export type AdminDeploymentPresetQuery = {
+  response: AdminDeploymentPresetQuery$data;
+  variables: AdminDeploymentPresetQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -148,7 +148,7 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "AdminDeploymentPresetListPageQuery",
+    "name": "AdminDeploymentPresetQuery",
     "selections": [
       {
         "alias": null,
@@ -180,7 +180,7 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "AdminDeploymentPresetNodesFragment"
+                    "name": "AdminDeploymentPresetTableFragment"
                   }
                 ],
                 "storageKey": null
@@ -204,7 +204,7 @@ return {
       (v2/*: any*/)
     ],
     "kind": "Operation",
-    "name": "AdminDeploymentPresetListPageQuery",
+    "name": "AdminDeploymentPresetQuery",
     "selections": [
       {
         "alias": null,
@@ -412,16 +412,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e010668333406a1ca2d16b2541b6a1d3",
+    "cacheID": "0268564a49c64dda3487228965ad3b7f",
     "id": null,
     "metadata": {},
-    "name": "AdminDeploymentPresetListPageQuery",
+    "name": "AdminDeploymentPresetQuery",
     "operationKind": "query",
-    "text": "query AdminDeploymentPresetListPageQuery(\n  $filter: DeploymentRevisionPresetFilter\n  $orderBy: [DeploymentRevisionPresetOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  deploymentRevisionPresets(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        ...AdminDeploymentPresetNodesFragment\n      }\n    }\n  }\n}\n\nfragment AdminDeploymentPresetNodesFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n  }\n  image @since(version: \"26.4.4\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  deploymentDefaults {\n    replicaCount\n    deploymentStrategy\n    openToPublic\n    revisionHistoryLimit\n  }\n  createdAt\n  updatedAt\n}\n"
+    "text": "query AdminDeploymentPresetQuery(\n  $filter: DeploymentRevisionPresetFilter\n  $orderBy: [DeploymentRevisionPresetOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  deploymentRevisionPresets(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        ...AdminDeploymentPresetTableFragment\n      }\n    }\n  }\n}\n\nfragment AdminDeploymentPresetTableFragment on DeploymentRevisionPreset {\n  id\n  name\n  description\n  runtimeVariantId\n  runtimeVariant {\n    id\n    name\n  }\n  cluster {\n    clusterMode\n    clusterSize\n  }\n  execution {\n    imageId\n    startupCommand\n  }\n  image @since(version: \"26.4.4\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  deploymentDefaults {\n    replicaCount\n    deploymentStrategy\n    openToPublic\n    revisionHistoryLimit\n  }\n  createdAt\n  updatedAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5fad3136d3763515c67dc5ad55ab6323";
+(node as any).hash = "1000908b843d647fc0cb73e6ed4c0da2";
 
 export default node;

--- a/react/src/__generated__/AdminDeploymentPresetTableFragment.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentPresetTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f61bb2628b3f3d9819e81a484c24203d>>
+ * @generated SignedSource<<e205c5c49e72a3073c4ad46aca823944>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 export type DeploymentStrategyType = "BLUE_GREEN" | "ROLLING" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
-export type AdminDeploymentPresetNodesFragment$data = ReadonlyArray<{
+export type AdminDeploymentPresetTableFragment$data = ReadonlyArray<{
   readonly cluster: {
     readonly clusterMode: string;
     readonly clusterSize: number;
@@ -43,11 +43,11 @@ export type AdminDeploymentPresetNodesFragment$data = ReadonlyArray<{
   } | null | undefined;
   readonly runtimeVariantId: string;
   readonly updatedAt: string | null | undefined;
-  readonly " $fragmentType": "AdminDeploymentPresetNodesFragment";
+  readonly " $fragmentType": "AdminDeploymentPresetTableFragment";
 } | null | undefined>;
-export type AdminDeploymentPresetNodesFragment$key = ReadonlyArray<{
-  readonly " $data"?: AdminDeploymentPresetNodesFragment$data;
-  readonly " $fragmentSpreads": FragmentRefs<"AdminDeploymentPresetNodesFragment">;
+export type AdminDeploymentPresetTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: AdminDeploymentPresetTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"AdminDeploymentPresetTableFragment">;
 }>;
 
 const node: ReaderFragment = (function(){
@@ -71,7 +71,7 @@ return {
   "metadata": {
     "plural": true
   },
-  "name": "AdminDeploymentPresetNodesFragment",
+  "name": "AdminDeploymentPresetTableFragment",
   "selections": [
     {
       "kind": "RequiredField",
@@ -256,6 +256,6 @@ return {
 };
 })();
 
-(node as any).hash = "a4e1509007a42bdd70eac53b4710e1dc";
+(node as any).hash = "ddc54a723142b6774ad34cfe74fc2123";
 
 export default node;

--- a/react/src/__generated__/AdminDeploymentQuery.graphql.ts
+++ b/react/src/__generated__/AdminDeploymentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7f6ef159deb18d9963b8262b1bb5ac4e>>
+ * @generated SignedSource<<b9e9a305cd8aa481f5206ca65900825c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -115,13 +115,13 @@ export type DeploymentOrderBy = {
   direction?: OrderDirection;
   field: DeploymentOrderField;
 };
-export type AdminDeploymentListPageQuery$variables = {
+export type AdminDeploymentQuery$variables = {
   filter?: DeploymentFilter | null | undefined;
   limit?: number | null | undefined;
   offset?: number | null | undefined;
   orderBy?: ReadonlyArray<DeploymentOrderBy> | null | undefined;
 };
-export type AdminDeploymentListPageQuery$data = {
+export type AdminDeploymentQuery$data = {
   readonly adminDeployments: {
     readonly count: number;
     readonly edges: ReadonlyArray<{
@@ -141,9 +141,9 @@ export type AdminDeploymentListPageQuery$data = {
     }>;
   } | null | undefined;
 };
-export type AdminDeploymentListPageQuery = {
-  response: AdminDeploymentListPageQuery$data;
-  variables: AdminDeploymentListPageQuery$variables;
+export type AdminDeploymentQuery = {
+  response: AdminDeploymentQuery$data;
+  variables: AdminDeploymentQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -286,7 +286,7 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "AdminDeploymentListPageQuery",
+    "name": "AdminDeploymentQuery",
     "selections": [
       {
         "alias": null,
@@ -377,7 +377,7 @@ return {
       (v2/*: any*/)
     ],
     "kind": "Operation",
-    "name": "AdminDeploymentListPageQuery",
+    "name": "AdminDeploymentQuery",
     "selections": [
       {
         "alias": null,
@@ -1055,16 +1055,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "64eecff8e86e47c51ac9c91f155b1ec5",
+    "cacheID": "87a7a8bee561d46689163d801a6232db",
     "id": null,
     "metadata": {},
-    "name": "AdminDeploymentListPageQuery",
+    "name": "AdminDeploymentQuery",
     "operationKind": "query",
-    "text": "query AdminDeploymentListPageQuery(\n  $filter: DeploymentFilter\n  $orderBy: [DeploymentOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminDeployments(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIModelDeploymentNodesFragment\n        ...DeploymentSettingModal_deployment\n        metadata {\n          name\n          status\n        }\n        currentRevision @since(version: \"26.4.3\") {\n          id\n          revisionNumber\n          ...DeploymentRevisionDetail_revision\n        }\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentOwnerInfo_deployment on ModelDeployment {\n  id\n  creator @since(version: \"26.4.3\") {\n    id\n    basicInfo {\n      email\n      username\n      fullName\n    }\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment BAIModelDeploymentNodesFragment on ModelDeployment {\n  id\n  currentRevisionId\n  metadata {\n    projectId\n    domainName\n    name\n    status\n    tags\n    createdAt\n    updatedAt\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    endpointUrl\n    preferredDomainName\n    openToPublic\n  }\n  defaultDeploymentStrategy {\n    type\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n    count\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    modelMountConfig {\n      vfolder {\n        id\n        name\n      }\n    }\n  }\n  ...BAIDeploymentOwnerInfo_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n      preset {\n        name\n        displayName\n        targetSpec {\n          key\n        }\n        id\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
+    "text": "query AdminDeploymentQuery(\n  $filter: DeploymentFilter\n  $orderBy: [DeploymentOrderBy!]\n  $limit: Int\n  $offset: Int\n) {\n  adminDeployments(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIModelDeploymentNodesFragment\n        ...DeploymentSettingModal_deployment\n        metadata {\n          name\n          status\n        }\n        currentRevision @since(version: \"26.4.3\") {\n          id\n          revisionNumber\n          ...DeploymentRevisionDetail_revision\n        }\n      }\n    }\n  }\n}\n\nfragment BAIDeploymentOwnerInfo_deployment on ModelDeployment {\n  id\n  creator @since(version: \"26.4.3\") {\n    id\n    basicInfo {\n      email\n      username\n      fullName\n    }\n  }\n}\n\nfragment BAIDeploymentTagChips_metadata on ModelDeploymentMetadata {\n  tags\n}\n\nfragment BAIModelDeploymentNodesFragment on ModelDeployment {\n  id\n  currentRevisionId\n  metadata {\n    projectId\n    domainName\n    name\n    status\n    tags\n    createdAt\n    updatedAt\n    resourceGroupName\n    projectV2 @since(version: \"26.4.3\") {\n      basicInfo {\n        name\n      }\n      id\n    }\n    ...BAIDeploymentTagChips_metadata\n  }\n  networkAccess {\n    endpointUrl\n    preferredDomainName\n    openToPublic\n  }\n  defaultDeploymentStrategy {\n    type\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n  runningReplicas: replicas(filter: {status: {equals: RUNNING}}) {\n    count\n  }\n  currentRevision @since(version: \"26.4.3\") {\n    id\n    revisionNumber\n    modelMountConfig {\n      vfolder {\n        id\n        name\n      }\n    }\n  }\n  ...BAIDeploymentOwnerInfo_deployment\n}\n\nfragment DeploymentRevisionDetail_revision on ModelRevision {\n  id\n  revisionNumber\n  createdAt\n  clusterConfig {\n    mode\n    size\n  }\n  resourceSlots @since(version: \"26.4.2\") {\n    slotName\n    quantity\n  }\n  resourceConfig {\n    resourceOpts {\n      entries {\n        name\n        value\n      }\n    }\n  }\n  modelRuntimeConfig {\n    runtimeVariant {\n      name\n      id\n    }\n    inferenceRuntimeConfig\n    environ {\n      entries {\n        name\n        value\n      }\n    }\n    runtimeVariantPresetValues @since(version: \"26.4.4rc9\") {\n      presetId\n      value\n      preset {\n        name\n        displayName\n        targetSpec {\n          key\n        }\n        id\n      }\n    }\n  }\n  modelMountConfig {\n    vfolderId\n    mountDestination\n    definitionPath\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  extraMounts {\n    vfolderId\n    mountDestination\n    mountPerm\n    vfolder {\n      id\n      name\n      ...FolderLink_vfolderNode\n    }\n  }\n  imageV2 @since(version: \"26.4.3\") {\n    id\n    identity {\n      canonicalName\n      architecture\n    }\n  }\n  modelDefinition {\n    models {\n      name\n      modelPath\n      service {\n        startCommand\n        shell\n        port\n        preStartActions {\n          action\n          args\n        }\n        healthCheck {\n          path\n          initialDelay\n          maxRetries\n          interval\n          maxWaitTime\n          expectedStatusCode\n        }\n      }\n    }\n  }\n}\n\nfragment DeploymentSettingModal_deployment on ModelDeployment {\n  id\n  metadata {\n    name\n    tags\n    resourceGroupName\n  }\n  networkAccess {\n    openToPublic\n  }\n  replicaState {\n    desiredReplicaCount\n  }\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "577aaad89bda092432ffff9d898d8251";
+(node as any).hash = "2f90f4ea8499deeab9d68ea80474fa66";
 
 export default node;

--- a/react/src/__generated__/AdminModelCardBulkDeleteMutation.graphql.ts
+++ b/react/src/__generated__/AdminModelCardBulkDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<382d87fb7e0cc5a5821ad66091a920c8>>
+ * @generated SignedSource<<177313f73fdcc3ac12c8e3a6c85a65d6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,10 +16,10 @@ export type BulkDeleteModelCardsV2Input = {
 export type DeleteModelCardV2Options = {
   deleteAssociatedVfolder?: boolean;
 };
-export type AdminModelCardListPageBulkDeleteMutation$variables = {
+export type AdminModelCardBulkDeleteMutation$variables = {
   input: BulkDeleteModelCardsV2Input;
 };
-export type AdminModelCardListPageBulkDeleteMutation$data = {
+export type AdminModelCardBulkDeleteMutation$data = {
   readonly adminBulkDeleteModelCardsV2: {
     readonly failed: ReadonlyArray<{
       readonly cardId: string;
@@ -28,9 +28,9 @@ export type AdminModelCardListPageBulkDeleteMutation$data = {
     readonly successes: ReadonlyArray<string>;
   } | null | undefined;
 };
-export type AdminModelCardListPageBulkDeleteMutation = {
-  response: AdminModelCardListPageBulkDeleteMutation$data;
-  variables: AdminModelCardListPageBulkDeleteMutation$variables;
+export type AdminModelCardBulkDeleteMutation = {
+  response: AdminModelCardBulkDeleteMutation$data;
+  variables: AdminModelCardBulkDeleteMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -97,7 +97,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "AdminModelCardListPageBulkDeleteMutation",
+    "name": "AdminModelCardBulkDeleteMutation",
     "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
@@ -106,20 +106,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "AdminModelCardListPageBulkDeleteMutation",
+    "name": "AdminModelCardBulkDeleteMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "74eba942ff74fb006b1ccf73a34b49f4",
+    "cacheID": "41531d617eda12f10098bff2e4623f27",
     "id": null,
     "metadata": {},
-    "name": "AdminModelCardListPageBulkDeleteMutation",
+    "name": "AdminModelCardBulkDeleteMutation",
     "operationKind": "mutation",
-    "text": "mutation AdminModelCardListPageBulkDeleteMutation(\n  $input: BulkDeleteModelCardsV2Input!\n) {\n  adminBulkDeleteModelCardsV2(input: $input) {\n    successes\n    failed {\n      cardId\n      message\n    }\n  }\n}\n"
+    "text": "mutation AdminModelCardBulkDeleteMutation(\n  $input: BulkDeleteModelCardsV2Input!\n) {\n  adminBulkDeleteModelCardsV2(input: $input) {\n    successes\n    failed {\n      cardId\n      message\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "09131356976871fd5c8b7f460995a96f";
+(node as any).hash = "91c710abd67f83d9dce9f866a1c82272";
 
 export default node;

--- a/react/src/__generated__/AdminModelCardDeleteMutation.graphql.ts
+++ b/react/src/__generated__/AdminModelCardDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<93b75220d353e7ee0714bd0ab441e8ca>>
+ * @generated SignedSource<<11cfc1c57cb7ec54ba01d30bb5f996a7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,18 +12,18 @@ import { ConcreteRequest } from 'relay-runtime';
 export type DeleteModelCardV2Options = {
   deleteAssociatedVfolder?: boolean;
 };
-export type AdminModelCardListPageDeleteMutation$variables = {
+export type AdminModelCardDeleteMutation$variables = {
   id: string;
   options?: DeleteModelCardV2Options | null | undefined;
 };
-export type AdminModelCardListPageDeleteMutation$data = {
+export type AdminModelCardDeleteMutation$data = {
   readonly adminDeleteModelCardV2: {
     readonly id: string;
   } | null | undefined;
 };
-export type AdminModelCardListPageDeleteMutation = {
-  response: AdminModelCardListPageDeleteMutation$data;
-  variables: AdminModelCardListPageDeleteMutation$variables;
+export type AdminModelCardDeleteMutation = {
+  response: AdminModelCardDeleteMutation$data;
+  variables: AdminModelCardDeleteMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -75,7 +75,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "AdminModelCardListPageDeleteMutation",
+    "name": "AdminModelCardDeleteMutation",
     "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
@@ -84,20 +84,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "AdminModelCardListPageDeleteMutation",
+    "name": "AdminModelCardDeleteMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "6ea2d9087d639c271482822ea5f5afa4",
+    "cacheID": "2ca7a8106333ce590a04113064d28810",
     "id": null,
     "metadata": {},
-    "name": "AdminModelCardListPageDeleteMutation",
+    "name": "AdminModelCardDeleteMutation",
     "operationKind": "mutation",
-    "text": "mutation AdminModelCardListPageDeleteMutation(\n  $id: UUID!\n  $options: DeleteModelCardV2Options\n) {\n  adminDeleteModelCardV2(id: $id, options: $options) {\n    id\n  }\n}\n"
+    "text": "mutation AdminModelCardDeleteMutation(\n  $id: UUID!\n  $options: DeleteModelCardV2Options\n) {\n  adminDeleteModelCardV2(id: $id, options: $options) {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5f8217e5136af15e1406d703c47af5b4";
+(node as any).hash = "12f399aebf9f17f39e4ca922f19ba040";
 
 export default node;

--- a/react/src/__generated__/AdminModelCardQuery.graphql.ts
+++ b/react/src/__generated__/AdminModelCardQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d5f6aa9a5e5d6228347e3365ff37ab30>>
+ * @generated SignedSource<<aa410523e17105c412fdc223ae016f3a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -53,14 +53,14 @@ export type ModelCardV2OrderBy = {
   direction?: string;
   field: ModelCardV2OrderField;
 };
-export type AdminModelCardListPageQuery$variables = {
+export type AdminModelCardQuery$variables = {
   currentProjectId: string;
   filter?: ModelCardV2Filter | null | undefined;
   limit?: number | null | undefined;
   offset?: number | null | undefined;
   orderBy?: ReadonlyArray<ModelCardV2OrderBy> | null | undefined;
 };
-export type AdminModelCardListPageQuery$data = {
+export type AdminModelCardQuery$data = {
   readonly adminModelCardsV2: {
     readonly count: number;
     readonly edges: ReadonlyArray<{
@@ -96,9 +96,9 @@ export type AdminModelCardListPageQuery$data = {
     readonly name: string | null | undefined;
   } | null | undefined> | null | undefined;
 };
-export type AdminModelCardListPageQuery = {
-  response: AdminModelCardListPageQuery$data;
-  variables: AdminModelCardListPageQuery$variables;
+export type AdminModelCardQuery = {
+  response: AdminModelCardQuery$data;
+  variables: AdminModelCardQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -299,7 +299,7 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "AdminModelCardListPageQuery",
+    "name": "AdminModelCardQuery",
     "selections": [
       {
         "alias": null,
@@ -395,7 +395,7 @@ return {
       (v0/*: any*/)
     ],
     "kind": "Operation",
-    "name": "AdminModelCardListPageQuery",
+    "name": "AdminModelCardQuery",
     "selections": [
       {
         "alias": null,
@@ -526,16 +526,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6763d668d504d9021f5bd0cf7aa7196f",
+    "cacheID": "466fb7e5efb3d335e10a442d73e64031",
     "id": null,
     "metadata": {},
-    "name": "AdminModelCardListPageQuery",
+    "name": "AdminModelCardQuery",
     "operationKind": "query",
-    "text": "query AdminModelCardListPageQuery(\n  $filter: ModelCardV2Filter\n  $orderBy: [ModelCardV2OrderBy!]\n  $limit: Int\n  $offset: Int\n  $currentProjectId: UUID!\n) {\n  adminModelCardsV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        vfolderId\n        vfolder {\n          id\n          metadata {\n            name\n          }\n          ...VFolderNodeIdenticonV2Fragment\n        }\n        domainName\n        projectId\n        accessLevel\n        createdAt\n        metadata {\n          title\n          category\n          task\n        }\n        ...AdminModelCardSettingModalFragment\n      }\n    }\n  }\n  group(id: $currentProjectId) {\n    type @since(version: \"24.03.0\")\n  }\n  groups(is_active: true, type: [\"MODEL_STORE\"]) {\n    id\n    name\n  }\n}\n\nfragment AdminModelCardSettingModalFragment on ModelCardV2 {\n  id\n  name\n  vfolderId\n  vfolder {\n    metadata {\n      name\n    }\n    ...VFolderNodeIdenticonV2Fragment\n    id\n  }\n  domainName\n  projectId\n  readme\n  accessLevel\n  metadata {\n    author\n    title\n    modelVersion\n    description\n    task\n    category\n    architecture\n    framework\n    label\n    license\n  }\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n"
+    "text": "query AdminModelCardQuery(\n  $filter: ModelCardV2Filter\n  $orderBy: [ModelCardV2OrderBy!]\n  $limit: Int\n  $offset: Int\n  $currentProjectId: UUID!\n) {\n  adminModelCardsV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        name\n        vfolderId\n        vfolder {\n          id\n          metadata {\n            name\n          }\n          ...VFolderNodeIdenticonV2Fragment\n        }\n        domainName\n        projectId\n        accessLevel\n        createdAt\n        metadata {\n          title\n          category\n          task\n        }\n        ...AdminModelCardSettingModalFragment\n      }\n    }\n  }\n  group(id: $currentProjectId) {\n    type\n  }\n  groups(is_active: true, type: [\"MODEL_STORE\"]) {\n    id\n    name\n  }\n}\n\nfragment AdminModelCardSettingModalFragment on ModelCardV2 {\n  id\n  name\n  vfolderId\n  vfolder {\n    metadata {\n      name\n    }\n    ...VFolderNodeIdenticonV2Fragment\n    id\n  }\n  domainName\n  projectId\n  readme\n  accessLevel\n  metadata {\n    author\n    title\n    modelVersion\n    description\n    task\n    category\n    architecture\n    framework\n    label\n    license\n  }\n}\n\nfragment VFolderNodeIdenticonV2Fragment on VFolder {\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dffcdfde3a00eee2eacc92d15a8da12e";
+(node as any).hash = "6db7f942cab000050425e544b23f63f5";
 
 export default node;

--- a/react/src/__generated__/AdminPrometheusPresetDeleteMutation.graphql.ts
+++ b/react/src/__generated__/AdminPrometheusPresetDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aeac13974911866c4f620592b52ecb86>>
+ * @generated SignedSource<<5c2bf73ca54fe57875c562e3a071fbd3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,17 +9,17 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type PrometheusPresetTabDeleteMutation$variables = {
+export type AdminPrometheusPresetDeleteMutation$variables = {
   id: string;
 };
-export type PrometheusPresetTabDeleteMutation$data = {
+export type AdminPrometheusPresetDeleteMutation$data = {
   readonly adminDeletePrometheusQueryPreset: {
     readonly id: string;
   } | null | undefined;
 };
-export type PrometheusPresetTabDeleteMutation = {
-  response: PrometheusPresetTabDeleteMutation$data;
-  variables: PrometheusPresetTabDeleteMutation$variables;
+export type AdminPrometheusPresetDeleteMutation = {
+  response: AdminPrometheusPresetDeleteMutation$data;
+  variables: AdminPrometheusPresetDeleteMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -61,7 +61,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "PrometheusPresetTabDeleteMutation",
+    "name": "AdminPrometheusPresetDeleteMutation",
     "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
@@ -70,20 +70,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "PrometheusPresetTabDeleteMutation",
+    "name": "AdminPrometheusPresetDeleteMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "935b661e74d3b19998c03edb04064cbb",
+    "cacheID": "b36af27d5e2d8eb384beacc072fda555",
     "id": null,
     "metadata": {},
-    "name": "PrometheusPresetTabDeleteMutation",
+    "name": "AdminPrometheusPresetDeleteMutation",
     "operationKind": "mutation",
-    "text": "mutation PrometheusPresetTabDeleteMutation(\n  $id: ID!\n) {\n  adminDeletePrometheusQueryPreset(id: $id) {\n    id\n  }\n}\n"
+    "text": "mutation AdminPrometheusPresetDeleteMutation(\n  $id: ID!\n) {\n  adminDeletePrometheusQueryPreset(id: $id) {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "35c4c5d3701db82305c38c36c1375003";
+(node as any).hash = "83b31f89a1ea2a1e314fa98a8be6a6df";
 
 export default node;

--- a/react/src/__generated__/AdminPrometheusPresetQuery.graphql.ts
+++ b/react/src/__generated__/AdminPrometheusPresetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ee038e04e3f6768577812ffbf8f3c9e8>>
+ * @generated SignedSource<<b9c38cf8eee58b45d734c85c1c8f5647>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -51,26 +51,26 @@ export type QueryDefinitionOrderBy = {
   direction?: OrderDirection;
   field: QueryDefinitionOrderField;
 };
-export type PrometheusPresetTabQuery$variables = {
+export type AdminPrometheusPresetQuery$variables = {
   filter?: QueryDefinitionFilter | null | undefined;
   limit?: number | null | undefined;
   offset?: number | null | undefined;
   orderBy?: ReadonlyArray<QueryDefinitionOrderBy> | null | undefined;
 };
-export type PrometheusPresetTabQuery$data = {
+export type AdminPrometheusPresetQuery$data = {
   readonly prometheusQueryPresets: {
     readonly count: number;
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id: string;
-        readonly " $fragmentSpreads": FragmentRefs<"PrometheusQueryPresetNodesFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"PrometheusQueryPresetTableFragment">;
       };
     }>;
   } | null | undefined;
 };
-export type PrometheusPresetTabQuery = {
-  response: PrometheusPresetTabQuery$data;
-  variables: PrometheusPresetTabQuery$variables;
+export type AdminPrometheusPresetQuery = {
+  response: AdminPrometheusPresetQuery$data;
+  variables: AdminPrometheusPresetQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -147,7 +147,7 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "PrometheusPresetTabQuery",
+    "name": "AdminPrometheusPresetQuery",
     "selections": [
       {
         "alias": null,
@@ -178,7 +178,7 @@ return {
                   {
                     "args": null,
                     "kind": "FragmentSpread",
-                    "name": "PrometheusQueryPresetNodesFragment"
+                    "name": "PrometheusQueryPresetTableFragment"
                   }
                 ],
                 "storageKey": null
@@ -202,7 +202,7 @@ return {
       (v3/*: any*/)
     ],
     "kind": "Operation",
-    "name": "PrometheusPresetTabQuery",
+    "name": "AdminPrometheusPresetQuery",
     "selections": [
       {
         "alias": null,
@@ -337,16 +337,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ff40e1b41e12e2ded4dbced18e5916e0",
+    "cacheID": "d064a958630b5e99af03c7761685f600",
     "id": null,
     "metadata": {},
-    "name": "PrometheusPresetTabQuery",
+    "name": "AdminPrometheusPresetQuery",
     "operationKind": "query",
-    "text": "query PrometheusPresetTabQuery(\n  $offset: Int\n  $limit: Int\n  $filter: QueryDefinitionFilter\n  $orderBy: [QueryDefinitionOrderBy!]\n) {\n  prometheusQueryPresets(offset: $offset, limit: $limit, filter: $filter, orderBy: $orderBy) {\n    count\n    edges {\n      node {\n        id\n        ...PrometheusQueryPresetNodesFragment\n      }\n    }\n  }\n}\n\nfragment PrometheusQueryPresetEditorModalFragment on QueryDefinition {\n  id\n  name\n  description\n  categoryId\n  metricName\n  queryTemplate\n  timeWindow\n  options {\n    filterLabels\n    groupLabels\n  }\n}\n\nfragment PrometheusQueryPresetNodesFragment on QueryDefinition {\n  id\n  name\n  description\n  rank\n  categoryId\n  metricName\n  queryTemplate\n  timeWindow\n  options {\n    filterLabels\n    groupLabels\n  }\n  createdAt\n  updatedAt\n  category {\n    id\n    name\n  }\n  ...PrometheusQueryPresetEditorModalFragment\n}\n"
+    "text": "query AdminPrometheusPresetQuery(\n  $offset: Int\n  $limit: Int\n  $filter: QueryDefinitionFilter\n  $orderBy: [QueryDefinitionOrderBy!]\n) {\n  prometheusQueryPresets(offset: $offset, limit: $limit, filter: $filter, orderBy: $orderBy) {\n    count\n    edges {\n      node {\n        id\n        ...PrometheusQueryPresetTableFragment\n      }\n    }\n  }\n}\n\nfragment PrometheusQueryPresetEditorModalFragment on QueryDefinition {\n  id\n  name\n  description\n  categoryId\n  metricName\n  queryTemplate\n  timeWindow\n  options {\n    filterLabels\n    groupLabels\n  }\n}\n\nfragment PrometheusQueryPresetTableFragment on QueryDefinition {\n  id\n  name\n  description\n  rank\n  categoryId\n  metricName\n  queryTemplate\n  timeWindow\n  options {\n    filterLabels\n    groupLabels\n  }\n  createdAt\n  updatedAt\n  category {\n    id\n    name\n  }\n  ...PrometheusQueryPresetEditorModalFragment\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2f5fe1cd9fc99a544b70c3e0cdce2136";
+(node as any).hash = "dbbe09b8911ab3c19ae83e9a91467c68";
 
 export default node;

--- a/react/src/__generated__/DeploymentSettingModalUpdateMutation.graphql.ts
+++ b/react/src/__generated__/DeploymentSettingModalUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5a3a79adc3a1cafc87a22671177ec161>>
+ * @generated SignedSource<<ade1997e9750299a4b03d2ecd53e09c9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,6 +43,17 @@ export type DeploymentSettingModalUpdateMutation$data = {
   readonly updateModelDeployment: {
     readonly deployment: {
       readonly id: string;
+      readonly metadata: {
+        readonly name: string;
+        readonly resourceGroupName: string;
+        readonly tags: ReadonlyArray<string>;
+      };
+      readonly networkAccess: {
+        readonly openToPublic: boolean;
+      };
+      readonly replicaState: {
+        readonly desiredReplicaCount: number;
+      };
     };
   } | null | undefined;
 };
@@ -88,6 +99,74 @@ v1 = [
             "kind": "ScalarField",
             "name": "id",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ModelDeploymentMetadata",
+            "kind": "LinkedField",
+            "name": "metadata",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "tags",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "resourceGroupName",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ModelDeploymentNetworkAccess",
+            "kind": "LinkedField",
+            "name": "networkAccess",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "openToPublic",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ReplicaState",
+            "kind": "LinkedField",
+            "name": "replicaState",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "desiredReplicaCount",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -114,16 +193,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "94d32eceeac74ffa680649dbc39dc4e1",
+    "cacheID": "66f0f082c918737b0cbfd64e4b071f37",
     "id": null,
     "metadata": {},
     "name": "DeploymentSettingModalUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation DeploymentSettingModalUpdateMutation(\n  $input: UpdateDeploymentInput!\n) {\n  updateModelDeployment(input: $input) {\n    deployment {\n      id\n    }\n  }\n}\n"
+    "text": "mutation DeploymentSettingModalUpdateMutation(\n  $input: UpdateDeploymentInput!\n) {\n  updateModelDeployment(input: $input) {\n    deployment {\n      id\n      metadata {\n        name\n        tags\n        resourceGroupName\n      }\n      networkAccess {\n        openToPublic\n      }\n      replicaState {\n        desiredReplicaCount\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "614463acb88e639fdcf663e2c35779a4";
+(node as any).hash = "4c636c058bf69ea1cd7761b401f5a4d0";
 
 export default node;

--- a/react/src/__generated__/PrometheusQueryPresetTableFragment.graphql.ts
+++ b/react/src/__generated__/PrometheusQueryPresetTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d2f56a439e57ee8869789ab739f9fbbb>>
+ * @generated SignedSource<<3a607f622c3ae558059d3c14c9f86daa>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type PrometheusQueryPresetNodesFragment$data = ReadonlyArray<{
+export type PrometheusQueryPresetTableFragment$data = ReadonlyArray<{
   readonly category: {
     readonly id: string;
     readonly name: string;
@@ -30,11 +30,11 @@ export type PrometheusQueryPresetNodesFragment$data = ReadonlyArray<{
   readonly timeWindow: string | null | undefined;
   readonly updatedAt: string;
   readonly " $fragmentSpreads": FragmentRefs<"PrometheusQueryPresetEditorModalFragment">;
-  readonly " $fragmentType": "PrometheusQueryPresetNodesFragment";
+  readonly " $fragmentType": "PrometheusQueryPresetTableFragment";
 }>;
-export type PrometheusQueryPresetNodesFragment$key = ReadonlyArray<{
-  readonly " $data"?: PrometheusQueryPresetNodesFragment$data;
-  readonly " $fragmentSpreads": FragmentRefs<"PrometheusQueryPresetNodesFragment">;
+export type PrometheusQueryPresetTableFragment$key = ReadonlyArray<{
+  readonly " $data"?: PrometheusQueryPresetTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"PrometheusQueryPresetTableFragment">;
 }>;
 
 const node: ReaderFragment = (function(){
@@ -58,7 +58,7 @@ return {
   "metadata": {
     "plural": true
   },
-  "name": "PrometheusQueryPresetNodesFragment",
+  "name": "PrometheusQueryPresetTableFragment",
   "selections": [
     (v0/*: any*/),
     (v1/*: any*/),
@@ -167,6 +167,6 @@ return {
 };
 })();
 
-(node as any).hash = "455118fe7944c6138727a6f6acfd47cb";
+(node as any).hash = "ccd8a8037083c18deb8d492b261cd634";
 
 export default node;

--- a/react/src/components/AdminDeployment.tsx
+++ b/react/src/components/AdminDeployment.tsx
@@ -126,12 +126,10 @@ const AdminDeployment = ({
     'model-deployment-extended-filter',
   );
 
-  const mergedFilter = queryRef.variables.filter as DeploymentFilter | undefined;
-  const statusCategory: DeploymentStatusCategory = mergedFilter?.status?.in?.includes(
-    'STOPPED',
-  )
-    ? 'finished'
-    : 'running';
+  const mergedFilter = queryRef.variables.filter as
+    DeploymentFilter | undefined;
+  const statusCategory: DeploymentStatusCategory =
+    mergedFilter?.status?.in?.includes('STOPPED') ? 'finished' : 'running';
   const userFilter = _.omit(mergedFilter, 'status') as DeploymentFilter;
 
   const orderEntry = queryRef.variables.orderBy?.[0];
@@ -171,9 +169,7 @@ const AdminDeployment = ({
 
   const [commitDeleteMutation, isInFlightDeleteMutation] =
     useMutation<AdminDeploymentDeleteMutation>(graphql`
-      mutation AdminDeploymentDeleteMutation(
-        $input: DeleteDeploymentInput!
-      ) {
+      mutation AdminDeploymentDeleteMutation($input: DeleteDeploymentInput!) {
         deleteModelDeployment(input: $input) {
           id
         }
@@ -247,8 +243,7 @@ const AdminDeployment = ({
             <BAIRadioGroup
               value={statusCategory}
               onChange={(e) => {
-                const nextCategory = e.target
-                  .value as DeploymentStatusCategory;
+                const nextCategory = e.target.value as DeploymentStatusCategory;
                 onReload(
                   {
                     ...queryRef.variables,
@@ -469,7 +464,11 @@ const AdminDeployment = ({
         deploymentFrgmt={editingDeployment ?? null}
         onRequestClose={(success) => {
           setEditingDeploymentId(null);
-          if (success) {
+          // A create adds a new row the offset query can't know about, so it
+          // needs a refetch. An update returns every field, so Relay merges
+          // the record by id into the store and the list reflects it without
+          // one.
+          if (success && editingDeployment === null) {
             onReload(queryRef.variables, { fetchPolicy: 'network-only' });
           }
         }}

--- a/react/src/components/AdminDeployment.tsx
+++ b/react/src/components/AdminDeployment.tsx
@@ -2,35 +2,23 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import type { AdminDeploymentListPageDeleteMutation } from '../__generated__/AdminDeploymentListPageDeleteMutation.graphql';
+import type { AdminDeploymentDeleteMutation } from '../__generated__/AdminDeploymentDeleteMutation.graphql';
 import type {
-  AdminDeploymentListPageQuery,
+  AdminDeploymentQuery as AdminDeploymentQueryType,
   DeploymentFilter,
   DeploymentOrderField,
   DeploymentStatus,
   OrderDirection,
-} from '../__generated__/AdminDeploymentListPageQuery.graphql';
-import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
-import BAIErrorBoundary from '../components/BAIErrorBoundary';
-import BAIRadioGroup from '../components/BAIRadioGroup';
-import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
-import DeploymentSettingModal from '../components/DeploymentSettingModal';
-import PrometheusPresetTab from '../components/PrometheusPresetTab';
+} from '../__generated__/AdminDeploymentQuery.graphql';
 import { buildPath } from '../helper/pathBuilder';
-import {
-  useSuspendedBackendaiClient,
-  useTabQuerySnapshot,
-  useWebUINavigate,
-} from '../hooks';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
-import { useBAISettingUserState } from '../hooks/useBAISetting';
-import AdminDeploymentPresetListPage from './AdminDeploymentPresetListPage';
-import AdminModelCardListPage from './AdminModelCardListPage';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
+import BAIRadioGroup from './BAIRadioGroup';
+import DeploymentRevisionDetailDrawer from './DeploymentRevisionDetailDrawer';
+import DeploymentSettingModal from './DeploymentSettingModal';
 import { DeleteFilled } from '@ant-design/icons';
-import { App, Skeleton, Typography } from 'antd';
-import type { CardTabListType } from 'antd/es/card';
+import { App, Typography } from 'antd';
 import {
-  BAICard,
   BAIDeleteConfirmModal,
   BAIDeploymentTagChips,
   BAIFlex,
@@ -38,10 +26,9 @@ import {
   BAIGraphQLPropertyFilter,
   BAIModelDeploymentNodes,
   BAINameActionCell,
+  type BAITableSettings,
   BAIUnmountAfterClose,
   DeploymentOrderValue,
-  INITIAL_FETCH_KEY,
-  availableDeploymentSorterValues,
   filterOutEmpty,
   filterOutNullAndUndefined,
   isDeploymentInStoppedCategory,
@@ -49,18 +36,77 @@ import {
   parseDeploymentOrder,
   toLocalId,
   useBAILogger,
-  useFetchKey,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { SquarePenIcon } from 'lucide-react';
-import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
-import React, { Suspense, useDeferredValue, useState } from 'react';
+import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  PreloadedQuery,
+  useMutation,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
 
 type DeploymentStatusCategory = 'running' | 'finished';
 
-const AdminDeploymentListPageContent: React.FC = () => {
+export const AdminDeploymentQuery = graphql`
+  query AdminDeploymentQuery(
+    $filter: DeploymentFilter
+    $orderBy: [DeploymentOrderBy!]
+    $limit: Int
+    $offset: Int
+  ) {
+    adminDeployments(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          id
+          ...BAIModelDeploymentNodesFragment
+          ...DeploymentSettingModal_deployment
+          metadata {
+            name
+            status
+          }
+          currentRevision @since(version: "26.4.3") {
+            id
+            revisionNumber
+            ...DeploymentRevisionDetail_revision
+          }
+        }
+      }
+    }
+  }
+`;
+
+export interface AdminDeploymentProps {
+  queryRef: PreloadedQuery<AdminDeploymentQueryType>;
+  onReload: (
+    variables: AdminDeploymentQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+  tableSettings: BAITableSettings;
+}
+
+const finishedStatuses: ReadonlyArray<DeploymentStatus> = ['STOPPED'];
+const statusCategoryFilterFor = (
+  category: DeploymentStatusCategory,
+): DeploymentFilter =>
+  category === 'finished'
+    ? { status: { in: finishedStatuses } }
+    : { status: { notIn: finishedStatuses } };
+
+const AdminDeployment = ({
+  queryRef,
+  onReload,
+  tableSettings,
+}: AdminDeploymentProps) => {
   'use memo';
   const { t } = useTranslation();
   const { message } = App.useApp();
@@ -74,114 +120,35 @@ const AdminDeploymentListPageContent: React.FC = () => {
   const [deletingDeploymentId, setDeletingDeploymentId] = useState<
     string | null
   >(null);
-  const [revisionDrawerDeploymentId, setRevisionDrawerDeploymentId] = useState<
-    string | null
-  >(null);
+  const [drawerRevisionId, setDrawerRevisionId] = useState<string | null>(null);
 
   const supportsExtendedFilter = baiClient.supports(
     'model-deployment-extended-filter',
   );
 
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({
-    current: 1,
-    pageSize: 10,
-  });
+  const mergedFilter = queryRef.variables.filter as DeploymentFilter | undefined;
+  const statusCategory: DeploymentStatusCategory = mergedFilter?.status?.in?.includes(
+    'STOPPED',
+  )
+    ? 'finished'
+    : 'running';
+  const userFilter = _.omit(mergedFilter, 'status') as DeploymentFilter;
 
-  const [queryParams, setQueryParams] = useQueryStates(
-    {
-      filter: parseAsJson<DeploymentFilter>((value) =>
-        typeof value === 'object' && value !== null && !Array.isArray(value)
-          ? (value as DeploymentFilter)
-          : ({} as DeploymentFilter),
-      ),
-      order: parseAsStringLiteral(availableDeploymentSorterValues),
-      statusCategory: parseAsStringLiteral<DeploymentStatusCategory>([
-        'running',
-        'finished',
-      ]).withDefault('running'),
-    },
-    { history: 'replace' },
-  );
+  const orderEntry = queryRef.variables.orderBy?.[0];
+  const order = orderEntry
+    ? (`${orderEntry.direction === 'DESC' ? '-' : ''}${orderEntry.field}` as DeploymentOrderValue)
+    : undefined;
 
-  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
-    'table_column_overrides.AdminDeploymentListPage',
-  );
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
 
-  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
 
-  const finishedStatuses: ReadonlyArray<DeploymentStatus> = ['STOPPED'];
-  const statusCategoryFilter: DeploymentFilter =
-    queryParams.statusCategory === 'finished'
-      ? { status: { in: finishedStatuses } }
-      : { status: { notIn: finishedStatuses } };
-
-  const sort = parseDeploymentOrder(queryParams.order);
-  const queryVariables = {
-    filter: {
-      ...(queryParams.filter ?? {}),
-      ...statusCategoryFilter,
-    },
-    orderBy: sort
-      ? [
-          {
-            field: sort.field as DeploymentOrderField,
-            direction: sort.direction as OrderDirection,
-          },
-        ]
-      : undefined,
-    limit: baiPaginationOption.limit,
-    offset: baiPaginationOption.offset,
-  };
-
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
-
-  const { adminDeployments } = useLazyLoadQuery<AdminDeploymentListPageQuery>(
-    graphql`
-      query AdminDeploymentListPageQuery(
-        $filter: DeploymentFilter
-        $orderBy: [DeploymentOrderBy!]
-        $limit: Int
-        $offset: Int
-      ) {
-        adminDeployments(
-          filter: $filter
-          orderBy: $orderBy
-          limit: $limit
-          offset: $offset
-        ) {
-          count
-          edges {
-            node {
-              id
-              ...BAIModelDeploymentNodesFragment
-              ...DeploymentSettingModal_deployment
-              metadata {
-                name
-                status
-              }
-              currentRevision @since(version: "26.4.3") {
-                id
-                revisionNumber
-                ...DeploymentRevisionDetail_revision
-              }
-            }
-          }
-        }
-      }
-    `,
-    deferredQueryVariables,
-    {
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-      fetchKey: deferredFetchKey,
-    },
+  const { adminDeployments } = usePreloadedQuery<AdminDeploymentQueryType>(
+    AdminDeploymentQuery,
+    deferredQueryRef,
   );
 
   const deploymentNodes = filterOutNullAndUndefined(
@@ -196,18 +163,15 @@ const AdminDeploymentListPageContent: React.FC = () => {
     deletingDeploymentId == null
       ? null
       : (deploymentNodes.find((n) => n.id === deletingDeploymentId) ?? null);
-  const drawerRevisionFrgmt =
-    revisionDrawerDeploymentId == null
+  const drawerRevision =
+    drawerRevisionId == null
       ? null
-      : (deploymentNodes.find((n) => n.id === revisionDrawerDeploymentId)
+      : (deploymentNodes.find((n) => n.id === drawerRevisionId)
           ?.currentRevision ?? null);
 
-  const isLoading =
-    deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
-
   const [commitDeleteMutation, isInFlightDeleteMutation] =
-    useMutation<AdminDeploymentListPageDeleteMutation>(graphql`
-      mutation AdminDeploymentListPageDeleteMutation(
+    useMutation<AdminDeploymentDeleteMutation>(graphql`
+      mutation AdminDeploymentDeleteMutation(
         $input: DeleteDeploymentInput!
       ) {
         deleteModelDeployment(input: $input) {
@@ -281,10 +245,21 @@ const AdminDeploymentListPageContent: React.FC = () => {
         <BAIFlex justify="between" wrap="wrap" gap="sm">
           <BAIFlex gap="sm" align="start" wrap="wrap" style={{ flexShrink: 1 }}>
             <BAIRadioGroup
-              value={queryParams.statusCategory}
+              value={statusCategory}
               onChange={(e) => {
-                setQueryParams({ statusCategory: e.target.value });
-                setTablePaginationOption({ current: 1 });
+                const nextCategory = e.target
+                  .value as DeploymentStatusCategory;
+                onReload(
+                  {
+                    ...queryRef.variables,
+                    filter: {
+                      ...userFilter,
+                      ...statusCategoryFilterFor(nextCategory),
+                    },
+                    offset: 0,
+                  },
+                  { fetchPolicy: 'network-only' },
+                );
               }}
               options={[
                 { label: t('deployment.Running'), value: 'running' },
@@ -296,43 +271,73 @@ const AdminDeploymentListPageContent: React.FC = () => {
             />
             <BAIGraphQLPropertyFilter<DeploymentFilter>
               filterProperties={filterProperties}
-              value={queryParams.filter ?? undefined}
+              value={userFilter ?? undefined}
               onChange={(value) => {
-                setQueryParams({ filter: value ?? null });
-                setTablePaginationOption({ current: 1 });
+                onReload(
+                  {
+                    ...queryRef.variables,
+                    filter: {
+                      ...(value ?? {}),
+                      ...statusCategoryFilterFor(statusCategory),
+                    },
+                    offset: 0,
+                  },
+                  { fetchPolicy: 'network-only' },
+                );
               }}
             />
           </BAIFlex>
           <AutoUpdateFetchKeyButton
             settingId="admin-deployment-list"
             defaultAutoUpdateDelay={15_000}
-            value={fetchKey}
-            onChange={updateFetchKey}
-            loading={isLoading}
+            onChange={() =>
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' })
+            }
+            loading={isRefetching}
           />
         </BAIFlex>
         <BAIModelDeploymentNodes
           deploymentsFrgmt={deploymentNodes}
-          loading={isLoading}
-          order={queryParams.order}
-          onChangeOrder={(order) => {
-            setQueryParams({ order: (order as DeploymentOrderValue) ?? null });
+          loading={isRefetching}
+          order={order}
+          onChangeOrder={(nextOrder) => {
+            const sort = parseDeploymentOrder(nextOrder ?? undefined);
+            onReload(
+              {
+                ...queryRef.variables,
+                orderBy: sort
+                  ? [
+                      {
+                        field: sort.field as DeploymentOrderField,
+                        direction: sort.direction as OrderDirection,
+                      },
+                    ]
+                  : undefined,
+                offset: 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
           }}
           pagination={{
-            current: tablePaginationOption.current,
-            pageSize: tablePaginationOption.pageSize,
+            current,
+            pageSize,
             total,
-            onChange: (current, pageSize) =>
-              setTablePaginationOption({ current, pageSize }),
+            onChange: (nextCurrent, nextPageSize) =>
+              onReload(
+                {
+                  ...queryRef.variables,
+                  limit: nextPageSize,
+                  offset:
+                    nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+                },
+                { fetchPolicy: 'network-only' },
+              ),
           }}
-          tableSettings={{
-            columnOverrides,
-            onColumnOverridesChange: setColumnOverrides,
-          }}
-          // Mirror the column set the legacy `DeploymentList` (mode="admin")
-          // exposed: drop newly-introduced keys (replicas / currentRevisionId
-          // / preferredDomainName / strategyType) and restore the original
-          // default-visible set, including `owner`.
+          tableSettings={tableSettings}
+          // Drop the replicas / currentRevisionId / preferredDomainName /
+          // strategyType columns entirely and show `owner` by default,
+          // alongside name/currentRevisionNumber/status/replicaSummary/
+          // model/createdAt.
           customizeColumns={(base) => {
             const allowedKeys = [
               'name',
@@ -363,9 +368,8 @@ const AdminDeploymentListPageContent: React.FC = () => {
             return base
               .filter((col) => allowedKeys.includes(col.key as string))
               .map((col) => {
-                let next = col;
                 if (col.key === 'name') {
-                  next = {
+                  return {
                     ...col,
                     render: (_value, record) => {
                       const destroying = isDeploymentInStoppedCategory(
@@ -405,30 +409,35 @@ const AdminDeploymentListPageContent: React.FC = () => {
                       );
                     },
                   };
-                } else if (col.key === 'currentRevisionNumber') {
-                  next = {
+                }
+                const defaultHidden = !defaultVisibleKeys.has(
+                  col.key as string,
+                );
+                if (col.key === 'currentRevisionNumber') {
+                  return {
                     ...col,
+                    defaultHidden,
                     render: (_value, record) => {
-                      const revision = deploymentNodes.find(
+                      const revisionNumber = deploymentNodes.find(
                         (n) => n.id === record.id,
-                      )?.currentRevision;
-                      if (revision?.revisionNumber == null) {
+                      )?.currentRevision?.revisionNumber;
+                      if (revisionNumber == null) {
                         return (
                           <Typography.Text type="secondary">-</Typography.Text>
                         );
                       }
                       return (
                         <Typography.Link
-                          onClick={() =>
-                            setRevisionDrawerDeploymentId(record.id)
-                          }
-                        >{`#${revision.revisionNumber}`}</Typography.Link>
+                          onClick={() => setDrawerRevisionId(record.id)}
+                        >{`#${revisionNumber}`}</Typography.Link>
                       );
                     },
                   };
-                } else if (col.key === 'tags') {
-                  next = {
+                }
+                if (col.key === 'tags') {
+                  return {
                     ...col,
+                    defaultHidden,
                     render: (_value, record) => (
                       <BAIDeploymentTagChips
                         metadataFrgmt={record.metadata}
@@ -450,11 +459,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
                     ),
                   };
                 }
-                if (col.key === 'name') return next;
-                return {
-                  ...next,
-                  defaultHidden: !defaultVisibleKeys.has(col.key as string),
-                };
+                return { ...col, defaultHidden };
               });
           }}
         />
@@ -464,7 +469,9 @@ const AdminDeploymentListPageContent: React.FC = () => {
         deploymentFrgmt={editingDeployment ?? null}
         onRequestClose={(success) => {
           setEditingDeploymentId(null);
-          if (success) updateFetchKey();
+          if (success) {
+            onReload(queryRef.variables, { fetchPolicy: 'network-only' });
+          }
         }}
       />
       <BAIDeleteConfirmModal
@@ -503,7 +510,7 @@ const AdminDeploymentListPageContent: React.FC = () => {
               }
               message.success(t('deployment.DeploymentDeleted'));
               setDeletingDeploymentId(null);
-              updateFetchKey();
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' });
             },
             onError: (error) => {
               logger.error('Failed to delete deployment', error);
@@ -515,82 +522,13 @@ const AdminDeploymentListPageContent: React.FC = () => {
       />
       <BAIUnmountAfterClose>
         <DeploymentRevisionDetailDrawer
-          open={!!drawerRevisionFrgmt}
-          revisionFrgmt={drawerRevisionFrgmt}
-          onClose={() => setRevisionDrawerDeploymentId(null)}
+          open={!!drawerRevision}
+          revisionFrgmt={drawerRevision}
+          onClose={() => setDrawerRevisionId(null)}
         />
       </BAIUnmountAfterClose>
     </>
   );
 };
 
-const tabParser = parseAsStringLiteral([
-  'deployments',
-  'model-store-management',
-  'prometheus-preset',
-  'deployment-presets',
-]).withDefault('deployments');
-
-const AdminDeploymentListPage: React.FC = () => {
-  'use memo';
-  const { t } = useTranslation();
-  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
-  const baiClient = useSuspendedBackendaiClient();
-  const isPrometheusPresetSupported = baiClient.supports(
-    'prometheus-query-preset',
-  );
-  const isDeploymentPresetSupported = baiClient.supports('deployment-preset');
-
-  const tabItems: CardTabListType[] = filterOutEmpty([
-    {
-      key: 'deployments',
-      label: t('webui.menu.Deployments'),
-    },
-    {
-      key: 'model-store-management',
-      label: t('adminModelCard.ModelStoreManagement'),
-    },
-    isPrometheusPresetSupported && {
-      key: 'prometheus-preset',
-      label: t('webui.menu.PrometheusPreset'),
-    },
-    isDeploymentPresetSupported && {
-      key: 'deployment-presets',
-      label: t('adminDeploymentPreset.TabTitle'),
-    },
-  ]);
-
-  return (
-    <BAICard
-      variant="borderless"
-      activeTabKey={currentTab}
-      onTabChange={onTabChange}
-      tabList={tabItems}
-    >
-      <Suspense fallback={<Skeleton active />}>
-        {currentTab === 'deployments' && (
-          <BAIErrorBoundary>
-            <AdminDeploymentListPageContent />
-          </BAIErrorBoundary>
-        )}
-        {currentTab === 'model-store-management' && (
-          <BAIErrorBoundary>
-            <AdminModelCardListPage />
-          </BAIErrorBoundary>
-        )}
-        {currentTab === 'prometheus-preset' && isPrometheusPresetSupported && (
-          <BAIErrorBoundary>
-            <PrometheusPresetTab />
-          </BAIErrorBoundary>
-        )}
-        {currentTab === 'deployment-presets' && isDeploymentPresetSupported && (
-          <BAIErrorBoundary>
-            <AdminDeploymentPresetListPage />
-          </BAIErrorBoundary>
-        )}
-      </Suspense>
-    </BAICard>
-  );
-};
-
-export default AdminDeploymentListPage;
+export default AdminDeployment;

--- a/react/src/components/AdminDeploymentPreset.tsx
+++ b/react/src/components/AdminDeploymentPreset.tsx
@@ -2,21 +2,18 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import type { AdminDeploymentPresetListPageDeleteMutation } from '../__generated__/AdminDeploymentPresetListPageDeleteMutation.graphql';
+import type { AdminDeploymentPresetDeleteMutation } from '../__generated__/AdminDeploymentPresetDeleteMutation.graphql';
 import type {
-  AdminDeploymentPresetListPageQuery,
+  AdminDeploymentPresetQuery as AdminDeploymentPresetQueryType,
   DeploymentRevisionPresetFilter,
   DeploymentRevisionPresetOrderBy,
-} from '../__generated__/AdminDeploymentPresetListPageQuery.graphql';
-import AdminDeploymentPresetNodes, {
-  availablePresetSorterValues,
+} from '../__generated__/AdminDeploymentPresetQuery.graphql';
+import AdminDeploymentPresetTable, {
   type DeploymentPresetNodeInList,
-} from '../components/AdminDeploymentPresetNodes';
+} from '../components/AdminDeploymentPresetTable';
 import { convertToOrderBy } from '../helper';
 import { buildPath } from '../helper/pathBuilder';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
-import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { App, theme } from 'antd';
 import {
   BAIButton,
@@ -24,20 +21,62 @@ import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
-  INITIAL_FETCH_KEY,
+  type BAITableSettings,
   toLocalId,
   useBAILogger,
-  useFetchKey,
   filterOutNullAndUndefined,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { PlusIcon } from 'lucide-react';
-import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
-import React, { useDeferredValue, useState } from 'react';
+import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  PreloadedQuery,
+  useMutation,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
 
-const AdminDeploymentPresetListPage: React.FC = () => {
+export const AdminDeploymentPresetQuery = graphql`
+  query AdminDeploymentPresetQuery(
+    $filter: DeploymentRevisionPresetFilter
+    $orderBy: [DeploymentRevisionPresetOrderBy!]
+    $limit: Int
+    $offset: Int
+  ) {
+    deploymentRevisionPresets(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          id
+          name
+          ...AdminDeploymentPresetTableFragment
+        }
+      }
+    }
+  }
+`;
+
+export interface AdminDeploymentPresetProps {
+  queryRef: PreloadedQuery<AdminDeploymentPresetQueryType>;
+  onReload: (
+    variables: AdminDeploymentPresetQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+  tableSettings: BAITableSettings;
+}
+
+const AdminDeploymentPreset = ({
+  queryRef,
+  onReload,
+  tableSettings,
+}: AdminDeploymentPresetProps) => {
   'use memo';
 
   const { t } = useTranslation();
@@ -47,86 +86,26 @@ const AdminDeploymentPresetListPage: React.FC = () => {
   const baiClient = useSuspendedBackendaiClient();
   const webuiNavigate = useWebUINavigate();
 
-  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
-    'table_column_overrides.AdminDeploymentPresetListPage',
-  );
-
   const [deletingPreset, setDeletingPreset] =
     useState<DeploymentPresetNodeInList | null>(null);
 
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({
-    current: 1,
-    pageSize: 10,
-  });
+  const filter = queryRef.variables.filter ?? undefined;
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
 
-  const [queryParams, setQueryParams] = useQueryStates(
-    {
-      order: parseAsString.withDefault('-createdAt'),
-      filter: parseAsJson<DeploymentRevisionPresetFilter>(
-        (value) => value as DeploymentRevisionPresetFilter,
-      ),
-    },
-    {
-      history: 'replace',
-    },
-  );
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
 
-  const [fetchKey, updateFetchKey] = useFetchKey();
-
-  const queryVariables = {
-    filter: queryParams.filter ?? undefined,
-    orderBy: convertToOrderBy<DeploymentRevisionPresetOrderBy>(
-      queryParams.order,
-    ),
-    limit: baiPaginationOption.limit,
-    offset: baiPaginationOption.offset,
-  };
-
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
-
-  const queryRef = useLazyLoadQuery<AdminDeploymentPresetListPageQuery>(
-    graphql`
-      query AdminDeploymentPresetListPageQuery(
-        $filter: DeploymentRevisionPresetFilter
-        $orderBy: [DeploymentRevisionPresetOrderBy!]
-        $limit: Int
-        $offset: Int
-      ) {
-        deploymentRevisionPresets(
-          filter: $filter
-          orderBy: $orderBy
-          limit: $limit
-          offset: $offset
-        ) {
-          count
-          edges {
-            node {
-              id
-              name
-              ...AdminDeploymentPresetNodesFragment
-            }
-          }
-        }
-      }
-    `,
-    deferredQueryVariables,
-    {
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-      fetchKey: deferredFetchKey,
-    },
-  );
+  const { deploymentRevisionPresets } =
+    usePreloadedQuery<AdminDeploymentPresetQueryType>(
+      AdminDeploymentPresetQuery,
+      deferredQueryRef,
+    );
 
   const [commitDeletePreset] =
-    useMutation<AdminDeploymentPresetListPageDeleteMutation>(graphql`
-      mutation AdminDeploymentPresetListPageDeleteMutation($id: UUID!) {
+    useMutation<AdminDeploymentPresetDeleteMutation>(graphql`
+      mutation AdminDeploymentPresetDeleteMutation($id: UUID!) {
         adminDeleteDeploymentRevisionPreset(id: $id) {
           id
         }
@@ -152,9 +131,6 @@ const AdminDeploymentPresetListPage: React.FC = () => {
 
   const isSupported = baiClient.supports('deployment-preset');
 
-  const isLoading =
-    deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
-
   return (
     <BAIFlex direction="column" align="stretch" gap={'sm'}>
       <BAIFlex justify="between" wrap="wrap" gap={'sm'}>
@@ -173,20 +149,21 @@ const AdminDeploymentPresetListPage: React.FC = () => {
                 fixedOperator: 'equals',
               },
             ]}
-            value={queryParams.filter ?? undefined}
+            value={filter as DeploymentRevisionPresetFilter | undefined}
             onChange={(value) => {
-              setQueryParams({ filter: value ?? null });
-              setTablePaginationOption({ current: 1 });
+              onReload(
+                { ...queryRef.variables, filter: value ?? undefined, offset: 0 },
+                { fetchPolicy: 'network-only' },
+              );
             }}
           />
         </BAIFlex>
         <BAIFlex gap={'xs'}>
           <BAIFetchKeyButton
-            loading={isLoading}
-            value={fetchKey}
-            onChange={(newFetchKey) => {
-              updateFetchKey(newFetchKey);
-            }}
+            loading={isRefetching}
+            onChange={() =>
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' })
+            }
           />
           <BAIButton
             type="primary"
@@ -198,30 +175,41 @@ const AdminDeploymentPresetListPage: React.FC = () => {
         </BAIFlex>
       </BAIFlex>
       {isSupported ? (
-        <AdminDeploymentPresetNodes
+        <AdminDeploymentPresetTable
           presetsFrgmt={filterOutNullAndUndefined(
-            _.map(queryRef.deploymentRevisionPresets?.edges, 'node'),
+            _.map(deploymentRevisionPresets?.edges, 'node'),
           )}
-          loading={isLoading}
+          loading={isRefetching}
           onEdit={handleEditPreset}
           onDelete={handleDeletePreset}
-          tableSettings={{
-            columnOverrides: columnOverrides,
-            onColumnOverridesChange: setColumnOverrides,
-          }}
+          tableSettings={tableSettings}
           pagination={{
-            pageSize: tablePaginationOption.pageSize,
-            current: tablePaginationOption.current,
-            total: queryRef.deploymentRevisionPresets?.count ?? 0,
-            onChange: (current, pageSize) => {
-              setTablePaginationOption({ current, pageSize });
+            pageSize,
+            current,
+            total: deploymentRevisionPresets?.count ?? 0,
+            onChange: (nextCurrent, nextPageSize) => {
+              onReload(
+                {
+                  ...queryRef.variables,
+                  limit: nextPageSize,
+                  offset:
+                    nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+                },
+                { fetchPolicy: 'network-only' },
+              );
             },
           }}
           onChangeOrder={(order) => {
-            setQueryParams({
-              order:
-                (order as (typeof availablePresetSorterValues)[number]) || null,
-            });
+            onReload(
+              {
+                ...queryRef.variables,
+                orderBy: convertToOrderBy<DeploymentRevisionPresetOrderBy>(
+                  order ?? undefined,
+                ),
+                offset: 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
           }}
         />
       ) : (
@@ -254,7 +242,7 @@ const AdminDeploymentPresetListPage: React.FC = () => {
                   }
                   message.success(t('adminDeploymentPreset.PresetDeleted'));
                   setDeletingPreset(null);
-                  updateFetchKey();
+                  onReload(queryRef.variables, { fetchPolicy: 'network-only' });
                   resolve();
                 },
                 onError: (error) => {
@@ -272,4 +260,4 @@ const AdminDeploymentPresetListPage: React.FC = () => {
   );
 };
 
-export default AdminDeploymentPresetListPage;
+export default AdminDeploymentPreset;

--- a/react/src/components/AdminDeploymentPresetTable.tsx
+++ b/react/src/components/AdminDeploymentPresetTable.tsx
@@ -3,9 +3,9 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import type {
-  AdminDeploymentPresetNodesFragment$data,
-  AdminDeploymentPresetNodesFragment$key,
-} from '../__generated__/AdminDeploymentPresetNodesFragment.graphql';
+  AdminDeploymentPresetTableFragment$data,
+  AdminDeploymentPresetTableFragment$key,
+} from '../__generated__/AdminDeploymentPresetTableFragment.graphql';
 import { DeleteFilled } from '@ant-design/icons';
 import {
   BAIColumnType,
@@ -26,7 +26,7 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type DeploymentPresetNodeInList = NonNullable<
-  AdminDeploymentPresetNodesFragment$data[number]
+  AdminDeploymentPresetTableFragment$data[number]
 >;
 
 const availablePresetSorterKeys = ['name', 'rank', 'createdAt'] as const;
@@ -40,11 +40,11 @@ const isEnableSorter = (key: string) => {
   return _.includes(availablePresetSorterKeys, key);
 };
 
-interface AdminDeploymentPresetNodesProps extends Omit<
+interface AdminDeploymentPresetTableProps extends Omit<
   BAITableProps<DeploymentPresetNodeInList>,
   'dataSource' | 'columns' | 'onChangeOrder'
 > {
-  presetsFrgmt: AdminDeploymentPresetNodesFragment$key;
+  presetsFrgmt: AdminDeploymentPresetTableFragment$key;
   customizeColumns?: (
     baseColumns: BAIColumnType<DeploymentPresetNodeInList>[],
   ) => BAIColumnType<DeploymentPresetNodeInList>[];
@@ -56,7 +56,7 @@ interface AdminDeploymentPresetNodesProps extends Omit<
   ) => void;
 }
 
-const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
+const AdminDeploymentPresetTable: React.FC<AdminDeploymentPresetTableProps> = ({
   presetsFrgmt,
   customizeColumns,
   disableSorter,
@@ -70,7 +70,7 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
 
   const presets = useFragment(
     graphql`
-      fragment AdminDeploymentPresetNodesFragment on DeploymentRevisionPreset
+      fragment AdminDeploymentPresetTableFragment on DeploymentRevisionPreset
       @relay(plural: true) {
         id @required(action: NONE)
         name @required(action: NONE)
@@ -273,4 +273,4 @@ const AdminDeploymentPresetNodes: React.FC<AdminDeploymentPresetNodesProps> = ({
   );
 };
 
-export default AdminDeploymentPresetNodes;
+export default AdminDeploymentPresetTable;

--- a/react/src/components/AdminModelCard.tsx
+++ b/react/src/components/AdminModelCard.tsx
@@ -2,23 +2,24 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import type { AdminModelCardListPageBulkDeleteMutation } from '../__generated__/AdminModelCardListPageBulkDeleteMutation.graphql';
-import type { AdminModelCardListPageDeleteMutation } from '../__generated__/AdminModelCardListPageDeleteMutation.graphql';
+import type { AdminModelCardBulkDeleteMutation } from '../__generated__/AdminModelCardBulkDeleteMutation.graphql';
+import type { AdminModelCardDeleteMutation } from '../__generated__/AdminModelCardDeleteMutation.graphql';
 import type {
-  AdminModelCardListPageQuery,
-  AdminModelCardListPageQuery$data,
+  AdminModelCardQuery as AdminModelCardQueryType,
+  AdminModelCardQuery$data,
   ModelCardV2Filter,
   ModelCardV2OrderBy,
-} from '../__generated__/AdminModelCardListPageQuery.graphql';
-import AdminModelCardSettingModal from '../components/AdminModelCardSettingModal';
-import { useFolderExplorerOpener } from '../components/FolderExplorerOpener';
-import VFolderNodeIdenticonV2 from '../components/VFolderNodeIdenticonV2';
-import { convertToOrderBy, handleRowSelectionChange } from '../helper';
+} from '../__generated__/AdminModelCardQuery.graphql';
+import {
+  convertFirstOrderByToString,
+  convertToOrderBy,
+  handleRowSelectionChange,
+} from '../helper';
 import { buildPath } from '../helper/pathBuilder';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
-import { useBAISettingUserState } from '../hooks/useBAISetting';
-import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import AdminModelCardSettingModal from './AdminModelCardSettingModal';
+import { useFolderExplorerOpener } from './FolderExplorerOpener';
+import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
 import { DeleteFilled, ExclamationCircleFilled } from '@ant-design/icons';
 import { App, Checkbox, Tooltip, Typography, theme } from 'antd';
 import {
@@ -33,28 +34,32 @@ import {
   BAISelectionLabel,
   BAIStorageHostSelect,
   BAITable,
+  type BAITableSettings,
   BAIText,
   BAITag,
   BAIUnmountAfterClose,
   filterOutEmpty,
   filterOutNullAndUndefined,
-  INITIAL_FETCH_KEY,
   isValidUUID,
   toLocalId,
   useBAILogger,
-  useFetchKey,
   BAIAlert,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { PlusIcon, SquarePenIcon } from 'lucide-react';
-import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
 import React, { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  PreloadedQuery,
+  useMutation,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
 
 type ModelCardNode = NonNullableNodeOnEdges<
-  AdminModelCardListPageQuery$data['adminModelCardsV2']
+  AdminModelCardQuery$data['adminModelCardsV2']
 >;
 
 const availableModelCardSorterKeys = ['name', 'created_at'] as const;
@@ -64,7 +69,70 @@ export const availableModelCardSorterValues = [
   ...availableModelCardSorterKeys.map((key) => `-${key}` as const),
 ] as const;
 
-const AdminModelCardListPage: React.FC = () => {
+export const AdminModelCardQuery = graphql`
+  query AdminModelCardQuery(
+    $filter: ModelCardV2Filter
+    $orderBy: [ModelCardV2OrderBy!]
+    $limit: Int
+    $offset: Int
+    $currentProjectId: UUID!
+  ) {
+    adminModelCardsV2(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          id
+          name
+          vfolderId
+          vfolder {
+            id
+            metadata {
+              name
+            }
+            ...VFolderNodeIdenticonV2Fragment
+          }
+          domainName
+          projectId
+          accessLevel
+          createdAt
+          metadata {
+            title
+            category
+            task
+          }
+          ...AdminModelCardSettingModalFragment
+        }
+      }
+    }
+    group(id: $currentProjectId) {
+      type
+    }
+    groups(is_active: true, type: ["MODEL_STORE"]) {
+      id
+      name
+    }
+  }
+`;
+
+export interface AdminModelCardProps {
+  queryRef: PreloadedQuery<AdminModelCardQueryType>;
+  onReload: (
+    variables: AdminModelCardQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+  tableSettings: BAITableSettings;
+}
+
+const AdminModelCard: React.FC<AdminModelCardProps> = ({
+  queryRef,
+  onReload,
+  tableSettings,
+}) => {
   'use memo';
 
   const { t } = useTranslation();
@@ -73,10 +141,6 @@ const AdminModelCardListPage: React.FC = () => {
   const { logger } = useBAILogger();
   const { upsertNotification } = useSetBAINotification();
   const { generateFolderPath } = useFolderExplorerOpener();
-  const currentProject = useCurrentProjectValue();
-  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
-    'table_column_overrides.AdminModelCardListPage',
-  );
 
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false);
   const [editingModelCardId, setEditingModelCardId] = useState<string | null>(
@@ -90,103 +154,25 @@ const AdminModelCardListPage: React.FC = () => {
   const [alsoDeleteFolder, setAlsoDeleteFolder] = useState(false);
   const [isBulkDeleteOpen, setIsBulkDeleteOpen] = useState(false);
   const [alsoDeleteFoldersBulk, setAlsoDeleteFoldersBulk] = useState(false);
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({
-    current: 1,
-    pageSize: 10,
-  });
 
-  const [queryParams, setQueryParams] = useQueryStates(
-    {
-      order: parseAsString,
-      filter: parseAsJson<ModelCardV2Filter>(
-        (value) => value as ModelCardV2Filter,
-      ),
-    },
-    {
-      history: 'replace',
-    },
-  );
+  const filter = queryRef.variables.filter ?? undefined;
+  const order = convertFirstOrderByToString(queryRef.variables.orderBy);
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
 
-  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
 
-  const queryVariables = {
-    filter: queryParams.filter,
-    orderBy: convertToOrderBy<ModelCardV2OrderBy>(queryParams.order),
-    limit: baiPaginationOption.limit,
-    offset: baiPaginationOption.offset,
-    currentProjectId: currentProject.id!,
-  };
+  const { adminModelCardsV2, group, groups } =
+    usePreloadedQuery<AdminModelCardQueryType>(
+      AdminModelCardQuery,
+      deferredQueryRef,
+    );
 
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
-
-  const queryRef = useLazyLoadQuery<AdminModelCardListPageQuery>(
+  const [commitDeleteModelCard] = useMutation<AdminModelCardDeleteMutation>(
     graphql`
-      query AdminModelCardListPageQuery(
-        $filter: ModelCardV2Filter
-        $orderBy: [ModelCardV2OrderBy!]
-        $limit: Int
-        $offset: Int
-        $currentProjectId: UUID!
-      ) {
-        adminModelCardsV2(
-          filter: $filter
-          orderBy: $orderBy
-          limit: $limit
-          offset: $offset
-        ) {
-          count
-          edges {
-            node {
-              id
-              name
-              vfolderId
-              vfolder {
-                id
-                metadata {
-                  name
-                }
-                ...VFolderNodeIdenticonV2Fragment
-              }
-              domainName
-              projectId
-              accessLevel
-              createdAt
-              metadata {
-                title
-                category
-                task
-              }
-              ...AdminModelCardSettingModalFragment
-            }
-          }
-        }
-        group(id: $currentProjectId) {
-          type @since(version: "24.03.0")
-        }
-        groups(is_active: true, type: ["MODEL_STORE"]) {
-          id
-          name
-        }
-      }
-    `,
-    deferredQueryVariables,
-    {
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-      fetchKey: deferredFetchKey,
-    },
-  );
-
-  const [commitDeleteModelCard] =
-    useMutation<AdminModelCardListPageDeleteMutation>(graphql`
-      mutation AdminModelCardListPageDeleteMutation(
+      mutation AdminModelCardDeleteMutation(
         $id: UUID!
         $options: DeleteModelCardV2Options
       ) {
@@ -194,11 +180,12 @@ const AdminModelCardListPage: React.FC = () => {
           id
         }
       }
-    `);
+    `,
+  );
 
   const [commitBulkDeleteModelCards, isBulkDeleteInFlight] =
-    useMutation<AdminModelCardListPageBulkDeleteMutation>(graphql`
-      mutation AdminModelCardListPageBulkDeleteMutation(
+    useMutation<AdminModelCardBulkDeleteMutation>(graphql`
+      mutation AdminModelCardBulkDeleteMutation(
         $input: BulkDeleteModelCardsV2Input!
       ) {
         adminBulkDeleteModelCardsV2(input: $input) {
@@ -231,7 +218,7 @@ const AdminModelCardListPage: React.FC = () => {
   };
 
   const modelCards =
-    queryRef.adminModelCardsV2?.edges?.map((edge) => edge?.node) ?? [];
+    adminModelCardsV2?.edges?.map((edge) => edge?.node) ?? [];
 
   const editingModelCard = editingModelCardId
     ? modelCards.find((mc) => mc?.id === editingModelCardId)
@@ -369,10 +356,16 @@ const AdminModelCardListPage: React.FC = () => {
                 ),
               },
             ]}
-            value={queryParams.filter ?? undefined}
+            value={filter}
             onChange={(value) => {
-              setQueryParams({ filter: value ?? null });
-              setTablePaginationOption({ current: 1 });
+              onReload(
+                {
+                  ...queryRef.variables,
+                  filter: value ?? undefined,
+                  offset: 0,
+                },
+                { fetchPolicy: 'network-only' },
+              );
             }}
           />
         </BAIFlex>
@@ -391,14 +384,10 @@ const AdminModelCardListPage: React.FC = () => {
             </>
           )}
           <BAIFetchKeyButton
-            loading={
-              deferredQueryVariables !== queryVariables ||
-              deferredFetchKey !== fetchKey
+            loading={isRefetching}
+            onChange={() =>
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' })
             }
-            value={fetchKey}
-            onChange={(newFetchKey) => {
-              updateFetchKey(newFetchKey);
-            }}
           />
           <BAIButton
             type="primary"
@@ -414,7 +403,8 @@ const AdminModelCardListPage: React.FC = () => {
         dataSource={modelCards as ModelCardNode[]}
         columns={columns}
         scroll={{ x: 'max-content' }}
-        loading={deferredQueryVariables !== queryVariables}
+        loading={isRefetching}
+        order={order}
         rowSelection={{
           type: 'checkbox',
           preserveSelectedRowKeys: true,
@@ -428,22 +418,30 @@ const AdminModelCardListPage: React.FC = () => {
           selectedRowKeys: _.map(selectedModelCards, (i) => i.id),
         }}
         onChangeOrder={(order) => {
-          setQueryParams({
-            order:
-              (order as (typeof availableModelCardSorterValues)[number]) ||
-              null,
-          });
+          onReload(
+            {
+              ...queryRef.variables,
+              orderBy: convertToOrderBy<ModelCardV2OrderBy>(order),
+              offset: 0,
+            },
+            { fetchPolicy: 'network-only' },
+          );
         }}
-        tableSettings={{
-          columnOverrides: columnOverrides,
-          onColumnOverridesChange: setColumnOverrides,
-        }}
+        tableSettings={tableSettings}
         pagination={{
-          pageSize: tablePaginationOption.pageSize,
-          current: tablePaginationOption.current,
-          total: queryRef.adminModelCardsV2?.count ?? 0,
-          onChange: (current, pageSize) => {
-            setTablePaginationOption({ current, pageSize });
+          pageSize,
+          current,
+          total: adminModelCardsV2?.count ?? 0,
+          onChange: (nextCurrent, nextPageSize) => {
+            onReload(
+              {
+                ...queryRef.variables,
+                limit: nextPageSize,
+                offset:
+                  nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+              },
+              { fetchPolicy: 'network-only' },
+            );
           },
         }}
       />
@@ -451,13 +449,13 @@ const AdminModelCardListPage: React.FC = () => {
         <AdminModelCardSettingModal
           open={isSettingModalOpen}
           modelCardFrgmt={editingModelCard ?? null}
-          isModelStoreProject={queryRef.group?.type === 'MODEL_STORE'}
-          modelStoreProject={queryRef.groups?.[0] ?? null}
+          isModelStoreProject={group?.type === 'MODEL_STORE'}
+          modelStoreProject={groups?.[0] ?? null}
           onRequestClose={(success) => {
             setIsSettingModalOpen(false);
             setEditingModelCardId(null);
             if (success) {
-              updateFetchKey();
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' });
             }
           }}
         />
@@ -565,7 +563,9 @@ const AdminModelCardListPage: React.FC = () => {
 
                   setDeletingModelCard(null);
                   setAlsoDeleteFolder(false);
-                  updateFetchKey();
+                  onReload(queryRef.variables, {
+                    fetchPolicy: 'network-only',
+                  });
                   resolve();
                 },
                 onError: (error) => {
@@ -713,7 +713,7 @@ const AdminModelCardListPage: React.FC = () => {
                 }
                 setAlsoDeleteFoldersBulk(false);
                 setIsBulkDeleteOpen(false);
-                updateFetchKey();
+                onReload(queryRef.variables, { fetchPolicy: 'network-only' });
                 resolve();
               },
               onError: (error) => {
@@ -733,4 +733,4 @@ const AdminModelCardListPage: React.FC = () => {
   );
 };
 
-export default AdminModelCardListPage;
+export default AdminModelCard;

--- a/react/src/components/AdminModelCard.tsx
+++ b/react/src/components/AdminModelCard.tsx
@@ -217,8 +217,7 @@ const AdminModelCard: React.FC<AdminModelCardProps> = ({
     setIsSettingModalOpen(true);
   };
 
-  const modelCards =
-    adminModelCardsV2?.edges?.map((edge) => edge?.node) ?? [];
+  const modelCards = adminModelCardsV2?.edges?.map((edge) => edge?.node) ?? [];
 
   const editingModelCard = editingModelCardId
     ? modelCards.find((mc) => mc?.id === editingModelCardId)
@@ -437,8 +436,7 @@ const AdminModelCard: React.FC<AdminModelCardProps> = ({
               {
                 ...queryRef.variables,
                 limit: nextPageSize,
-                offset:
-                  nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+                offset: nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
               },
               { fetchPolicy: 'network-only' },
             );
@@ -454,7 +452,11 @@ const AdminModelCard: React.FC<AdminModelCardProps> = ({
           onRequestClose={(success) => {
             setIsSettingModalOpen(false);
             setEditingModelCardId(null);
-            if (success) {
+            // A create adds a new row the offset query can't know about, so it
+            // needs a refetch. An update returns every field, so Relay merges
+            // the record by id into the store and the list reflects it
+            // without one.
+            if (success && editingModelCard === null) {
               onReload(queryRef.variables, { fetchPolicy: 'network-only' });
             }
           }}

--- a/react/src/components/AdminPrometheusPreset.tsx
+++ b/react/src/components/AdminPrometheusPreset.tsx
@@ -3,9 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { AdminPrometheusPresetDeleteMutation } from '../__generated__/AdminPrometheusPresetDeleteMutation.graphql';
-import {
-  AdminPrometheusPresetQuery as AdminPrometheusPresetQueryType,
-} from '../__generated__/AdminPrometheusPresetQuery.graphql';
+import { AdminPrometheusPresetQuery as AdminPrometheusPresetQueryType } from '../__generated__/AdminPrometheusPresetQuery.graphql';
 import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
 import AutoUpdateFetchKeyButton, {
   LONG_AUTO_UPDATE_DELAY_OPTIONS,
@@ -210,7 +208,11 @@ const AdminPrometheusPreset = ({
           onRequestClose={(success) => {
             setIsOpenEditorModal(false);
             setEditingPreset(null);
-            if (success) {
+            // A create adds a new row the offset query can't know about, so it
+            // needs a refetch. An update returns every field, so Relay merges
+            // the record by id into the store and the list reflects it
+            // without one.
+            if (success && editingPreset === null) {
               onReload(queryRef.variables, { fetchPolicy: 'network-only' });
             }
           }}

--- a/react/src/components/AdminPrometheusPreset.tsx
+++ b/react/src/components/AdminPrometheusPreset.tsx
@@ -2,22 +2,18 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { PrometheusPresetTabDeleteMutation } from '../__generated__/PrometheusPresetTabDeleteMutation.graphql';
+import { AdminPrometheusPresetDeleteMutation } from '../__generated__/AdminPrometheusPresetDeleteMutation.graphql';
 import {
-  PrometheusPresetTabQuery,
-  PrometheusPresetTabQuery$variables,
-  QueryDefinitionFilter,
-} from '../__generated__/PrometheusPresetTabQuery.graphql';
-import { convertToOrderBy } from '../helper';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
-import { useBAISettingUserState } from '../hooks/useBAISetting';
+  AdminPrometheusPresetQuery as AdminPrometheusPresetQueryType,
+} from '../__generated__/AdminPrometheusPresetQuery.graphql';
+import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
 import AutoUpdateFetchKeyButton, {
   LONG_AUTO_UPDATE_DELAY_OPTIONS,
 } from './AutoUpdateFetchKeyButton';
 import PrometheusQueryPresetEditorModal from './PrometheusQueryPresetEditorModal';
-import PrometheusQueryPresetNodes, {
+import PrometheusQueryPresetTable, {
   PrometheusQueryPresetNodeInList,
-} from './PrometheusQueryPresetNodes';
+} from './PrometheusQueryPresetTable';
 import { App } from 'antd';
 import {
   BAIButton,
@@ -25,52 +21,85 @@ import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIUnmountAfterClose,
-  INITIAL_FETCH_KEY,
+  type BAITableSettings,
   toLocalId,
-  useFetchKey,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { PlusIcon } from 'lucide-react';
-import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
-import React, { useDeferredValue, useState } from 'react';
+import { useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  PreloadedQuery,
+  useMutation,
+  usePreloadedQuery,
+  UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
+
+export const AdminPrometheusPresetQuery = graphql`
+  query AdminPrometheusPresetQuery(
+    $offset: Int
+    $limit: Int
+    $filter: QueryDefinitionFilter
+    $orderBy: [QueryDefinitionOrderBy!]
+  ) {
+    prometheusQueryPresets(
+      offset: $offset
+      limit: $limit
+      filter: $filter
+      orderBy: $orderBy
+    ) {
+      count
+      edges {
+        node {
+          id
+          ...PrometheusQueryPresetTableFragment
+        }
+      }
+    }
+  }
+`;
 
 type DeletingPresetTarget = { id: string; name: string };
 
-const PrometheusPresetTab: React.FC = () => {
+export interface AdminPrometheusPresetProps {
+  queryRef: PreloadedQuery<AdminPrometheusPresetQueryType>;
+  onReload: (
+    variables: AdminPrometheusPresetQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+  tableSettings: BAITableSettings;
+}
+
+const AdminPrometheusPreset = ({
+  queryRef,
+  onReload,
+  tableSettings,
+}: AdminPrometheusPresetProps) => {
   'use memo';
   const { t } = useTranslation();
   const { message } = App.useApp();
 
-  const [queryParam, setQueryParam] = useQueryStates(
-    {
-      filter: parseAsJson<QueryDefinitionFilter>(
-        (value) => value as QueryDefinitionFilter,
-      ),
-      order: parseAsString,
-    },
-    { history: 'replace' },
-  );
-
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({
-    current: 1,
-    pageSize: 10,
-  });
-
-  const [fetchKey, updateFetchKey] = useFetchKey();
   const [isOpenEditorModal, setIsOpenEditorModal] = useState(false);
   const [editingPreset, setEditingPreset] =
     useState<PrometheusQueryPresetNodeInList | null>(null);
   const [deletingPreset, setDeletingPreset] =
     useState<DeletingPresetTarget | null>(null);
-  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
-    'table_column_overrides.PrometheusPresetTab',
-  );
+
+  const filter = queryRef.variables.filter ?? undefined;
+  const order = convertFirstOrderByToString(queryRef.variables.orderBy);
+  const pageSize = queryRef.variables.limit ?? 10;
+  const offset = queryRef.variables.offset ?? 0;
+  const current = pageSize ? Math.floor(offset / pageSize) + 1 : 1;
+
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isRefetching = deferredQueryRef !== queryRef;
+
+  const { prometheusQueryPresets } =
+    usePreloadedQuery<AdminPrometheusPresetQueryType>(
+      AdminPrometheusPresetQuery,
+      deferredQueryRef,
+    );
 
   // The editor's category picker (`PrometheusCategorySelect`) fetches its own
   // query inside its own Suspense boundary, so opening is a plain state update —
@@ -81,61 +110,13 @@ const PrometheusPresetTab: React.FC = () => {
   };
 
   const [commitDeleteMutation, isInflightDelete] =
-    useMutation<PrometheusPresetTabDeleteMutation>(graphql`
-      mutation PrometheusPresetTabDeleteMutation($id: ID!) {
+    useMutation<AdminPrometheusPresetDeleteMutation>(graphql`
+      mutation AdminPrometheusPresetDeleteMutation($id: ID!) {
         adminDeletePrometheusQueryPreset(id: $id) {
           id
         }
       }
     `);
-
-  const queryVariables: PrometheusPresetTabQuery$variables = {
-    offset: baiPaginationOption.offset,
-    limit: baiPaginationOption.limit,
-    filter: queryParam.filter,
-    orderBy: convertToOrderBy(queryParam.order),
-  };
-
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
-
-  const { prometheusQueryPresets } = useLazyLoadQuery<PrometheusPresetTabQuery>(
-    graphql`
-      query PrometheusPresetTabQuery(
-        $offset: Int
-        $limit: Int
-        $filter: QueryDefinitionFilter
-        $orderBy: [QueryDefinitionOrderBy!]
-      ) {
-        prometheusQueryPresets(
-          offset: $offset
-          limit: $limit
-          filter: $filter
-          orderBy: $orderBy
-        ) {
-          count
-          edges {
-            node {
-              id
-              ...PrometheusQueryPresetNodesFragment
-            }
-          }
-        }
-      }
-    `,
-    deferredQueryVariables,
-    {
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-      fetchKey:
-        deferredFetchKey === INITIAL_FETCH_KEY ? undefined : deferredFetchKey,
-    },
-  );
-
-  const isPending =
-    deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
 
   const presetNodes = _.compact(
     _.map(prometheusQueryPresets?.edges, (edge) => edge?.node),
@@ -144,11 +125,14 @@ const PrometheusPresetTab: React.FC = () => {
   return (
     <BAIFlex direction="column" align="stretch" gap="sm">
       <BAIFlex direction="row" justify="between" wrap="wrap" gap="sm">
-        <BAIGraphQLPropertyFilter<QueryDefinitionFilter>
+        <BAIGraphQLPropertyFilter
           combinationMode="AND"
-          value={queryParam.filter ?? undefined}
+          value={filter}
           onChange={(value) => {
-            setQueryParam({ filter: value ?? null });
+            onReload(
+              { ...queryRef.variables, filter: value ?? undefined, offset: 0 },
+              { fetchPolicy: 'network-only' },
+            );
           }}
           filterProperties={[
             {
@@ -167,9 +151,10 @@ const PrometheusPresetTab: React.FC = () => {
           <AutoUpdateFetchKeyButton
             settingId="prometheus-preset"
             autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}
-            value={fetchKey}
-            onChange={updateFetchKey}
-            loading={isPending}
+            onChange={() =>
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' })
+            }
+            loading={isRefetching}
           />
           <BAIButton
             type="primary"
@@ -180,27 +165,39 @@ const PrometheusPresetTab: React.FC = () => {
           </BAIButton>
         </BAIFlex>
       </BAIFlex>
-      <PrometheusQueryPresetNodes
+      <PrometheusQueryPresetTable
         presetsFrgmt={presetNodes}
-        loading={isPending}
+        loading={isRefetching}
         pagination={{
-          pageSize: tablePaginationOption.pageSize,
-          current: tablePaginationOption.current,
+          pageSize,
+          current,
           total: prometheusQueryPresets?.count,
-          onChange(current, pageSize) {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({ current, pageSize });
+          onChange(nextCurrent, nextPageSize) {
+            if (_.isNumber(nextCurrent) && _.isNumber(nextPageSize)) {
+              onReload(
+                {
+                  ...queryRef.variables,
+                  limit: nextPageSize,
+                  offset:
+                    nextCurrent > 1 ? (nextCurrent - 1) * nextPageSize : 0,
+                },
+                { fetchPolicy: 'network-only' },
+              );
             }
           },
         }}
-        order={queryParam.order}
-        onChangeOrder={(order) => {
-          setQueryParam({ order: order });
+        order={order}
+        onChangeOrder={(nextOrder) => {
+          onReload(
+            {
+              ...queryRef.variables,
+              orderBy: convertToOrderBy(nextOrder ?? undefined),
+              offset: 0,
+            },
+            { fetchPolicy: 'network-only' },
+          );
         }}
-        tableSettings={{
-          columnOverrides,
-          onColumnOverridesChange: setColumnOverrides,
-        }}
+        tableSettings={tableSettings}
         onEditPreset={(preset) => openEditor(preset)}
         onDeletePreset={(preset) => {
           setDeletingPreset({ id: preset.id, name: preset.name });
@@ -214,7 +211,7 @@ const PrometheusPresetTab: React.FC = () => {
             setIsOpenEditorModal(false);
             setEditingPreset(null);
             if (success) {
-              updateFetchKey();
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' });
             }
           }}
         />
@@ -248,7 +245,7 @@ const PrometheusPresetTab: React.FC = () => {
               }
               message.success(t('prometheusQueryPreset.SuccessfullyDeleted'));
               setDeletingPreset(null);
-              updateFetchKey();
+              onReload(queryRef.variables, { fetchPolicy: 'network-only' });
             },
             onError: (error) => {
               message.error(error.message);
@@ -261,4 +258,4 @@ const PrometheusPresetTab: React.FC = () => {
   );
 };
 
-export default PrometheusPresetTab;
+export default AdminPrometheusPreset;

--- a/react/src/components/DeploymentSettingModal.tsx
+++ b/react/src/components/DeploymentSettingModal.tsx
@@ -105,6 +105,17 @@ const DeploymentSettingModal: React.FC<DeploymentSettingModalProps> = ({
         updateModelDeployment(input: $input) {
           deployment {
             id
+            metadata {
+              name
+              tags
+              resourceGroupName
+            }
+            networkAccess {
+              openToPublic
+            }
+            replicaState {
+              desiredReplicaCount
+            }
           }
         }
       }

--- a/react/src/components/PrometheusQueryPresetTable.tsx
+++ b/react/src/components/PrometheusQueryPresetTable.tsx
@@ -3,9 +3,9 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import {
-  PrometheusQueryPresetNodesFragment$data,
-  PrometheusQueryPresetNodesFragment$key,
-} from '../__generated__/PrometheusQueryPresetNodesFragment.graphql';
+  PrometheusQueryPresetTableFragment$data,
+  PrometheusQueryPresetTableFragment$key,
+} from '../__generated__/PrometheusQueryPresetTableFragment.graphql';
 import { DeleteFilled } from '@ant-design/icons';
 import { Tag } from 'antd';
 import {
@@ -26,7 +26,7 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
 export type PrometheusQueryPresetNodeInList = NonNullable<
-  PrometheusQueryPresetNodesFragment$data[number]
+  PrometheusQueryPresetTableFragment$data[number]
 >;
 
 const availablePrometheusQueryPresetSorterKeys = [
@@ -44,11 +44,11 @@ const isEnableSorter = (key: string) => {
   return _.includes(availablePrometheusQueryPresetSorterKeys, key);
 };
 
-interface PrometheusQueryPresetNodesProps extends Omit<
+interface PrometheusQueryPresetTableProps extends Omit<
   BAITableProps<PrometheusQueryPresetNodeInList>,
   'dataSource' | 'columns' | 'onChangeOrder'
 > {
-  presetsFrgmt: PrometheusQueryPresetNodesFragment$key;
+  presetsFrgmt: PrometheusQueryPresetTableFragment$key;
   onDeletePreset?: (preset: PrometheusQueryPresetNodeInList) => void;
   onEditPreset?: (preset: PrometheusQueryPresetNodeInList) => void;
   customizeColumns?: (
@@ -59,7 +59,7 @@ interface PrometheusQueryPresetNodesProps extends Omit<
   ) => void;
 }
 
-const PrometheusQueryPresetNodes: React.FC<PrometheusQueryPresetNodesProps> = ({
+const PrometheusQueryPresetTable: React.FC<PrometheusQueryPresetTableProps> = ({
   presetsFrgmt,
   onDeletePreset,
   onEditPreset,
@@ -72,7 +72,7 @@ const PrometheusQueryPresetNodes: React.FC<PrometheusQueryPresetNodesProps> = ({
 
   const presets = useFragment(
     graphql`
-      fragment PrometheusQueryPresetNodesFragment on QueryDefinition
+      fragment PrometheusQueryPresetTableFragment on QueryDefinition
       @relay(plural: true) {
         id
         name
@@ -296,4 +296,4 @@ const PrometheusQueryPresetNodes: React.FC<PrometheusQueryPresetNodesProps> = ({
   );
 };
 
-export default PrometheusQueryPresetNodes;
+export default PrometheusQueryPresetTable;

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -24,7 +24,43 @@ import {
   toFixedWithTypeValidation,
   addNumberWithUnits,
   subNumberWithUnits,
+  convertFirstOrderByToString,
 } from './index';
+
+describe('convertFirstOrderByToString', () => {
+  it('returns null for empty, null, or undefined input', () => {
+    expect(convertFirstOrderByToString(undefined)).toBeNull();
+    expect(convertFirstOrderByToString(null)).toBeNull();
+    expect(convertFirstOrderByToString([])).toBeNull();
+    expect(convertFirstOrderByToString([{}])).toBeNull();
+  });
+  it('converts an ASC entry to a camelCase string with no prefix', () => {
+    expect(convertFirstOrderByToString([{ field: 'NAME', direction: 'ASC' }])).toBe(
+      'name',
+    );
+  });
+  it('prefixes a DESC entry with a minus sign', () => {
+    expect(convertFirstOrderByToString([{ field: 'NAME', direction: 'DESC' }])).toBe(
+      '-name',
+    );
+  });
+  it('camelCases SCREAMING_SNAKE_CASE enum fields', () => {
+    expect(
+      convertFirstOrderByToString([{ field: 'CREATED_AT', direction: 'ASC' }]),
+    ).toBe('createdAt');
+    expect(
+      convertFirstOrderByToString([{ field: 'CREATED_AT', direction: 'DESC' }]),
+    ).toBe('-createdAt');
+  });
+  it('uses only the first entry', () => {
+    expect(
+      convertFirstOrderByToString([
+        { field: 'NAME', direction: 'DESC' },
+        { field: 'CREATED_AT', direction: 'ASC' },
+      ]),
+    ).toBe('-name');
+  });
+});
 
 describe('isOutsideRange', () => {
   it('should return true if the value is less than the minimum', () => {

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -987,3 +987,30 @@ export const convertToOrderBy = <
     } as TOrderBy,
   ];
 };
+
+/**
+ * Reverses `convertToOrderBy`: converts the first entry of a GraphQL v2
+ * OrderBy array back to a UI order string (e.g., for a `BAITable`'s `order`
+ * prop, or to persist the current sort to the URL).
+ *
+ * @param orderBy - An OrderBy array (or its first entry's `field`/`direction`).
+ * @returns The order string, or `null` if `orderBy` is empty/undefined.
+ *
+ * @example
+ * convertFirstOrderByToString([{ field: 'NAME', direction: 'ASC' }])
+ * // => 'name'
+ *
+ * @example
+ * convertFirstOrderByToString([{ field: 'CREATED_AT', direction: 'DESC' }])
+ * // => '-createdAt'
+ */
+export const convertFirstOrderByToString = (
+  orderBy:
+    | ReadonlyArray<{ field?: string; direction?: string }>
+    | null
+    | undefined,
+): string | null => {
+  const first = orderBy?.[0];
+  if (!first?.field) return null;
+  return `${first.direction === 'DESC' ? '-' : ''}${_.camelCase(first.field)}`;
+};

--- a/react/src/pages/AdminDeploymentPage.tsx
+++ b/react/src/pages/AdminDeploymentPage.tsx
@@ -1,0 +1,495 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type {
+  AdminDeploymentQuery as AdminDeploymentQueryType,
+  DeploymentFilter,
+  DeploymentOrderField,
+  OrderDirection,
+} from '../__generated__/AdminDeploymentQuery.graphql';
+import type {
+  AdminDeploymentPresetQuery as AdminDeploymentPresetQueryType,
+  DeploymentRevisionPresetOrderBy,
+} from '../__generated__/AdminDeploymentPresetQuery.graphql';
+import type {
+  AdminModelCardQuery as AdminModelCardQueryType,
+  ModelCardV2OrderBy,
+} from '../__generated__/AdminModelCardQuery.graphql';
+import type {
+  AdminPrometheusPresetQuery as AdminPrometheusPresetQueryType,
+  QueryDefinitionOrderBy,
+} from '../__generated__/AdminPrometheusPresetQuery.graphql';
+import AdminDeployment, {
+  AdminDeploymentQuery,
+} from '../components/AdminDeployment';
+import AdminDeploymentPreset, {
+  AdminDeploymentPresetQuery,
+} from '../components/AdminDeploymentPreset';
+import AdminModelCard, {
+  AdminModelCardQuery,
+} from '../components/AdminModelCard';
+import AdminPrometheusPreset, {
+  AdminPrometheusPresetQuery,
+} from '../components/AdminPrometheusPreset';
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
+import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
+import { useSuspendedBackendaiClient } from '../hooks';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { Skeleton } from 'antd';
+import type { CardTabListType } from 'antd/es/card';
+import { BAICard, filterOutEmpty, parseDeploymentOrder } from 'backend.ai-ui';
+import {
+  parseAsJson,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs';
+import React, { Suspense, useEffect, useEffectEvent, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { UseQueryLoaderLoadQueryOptions, useQueryLoader } from 'react-relay';
+
+const TAB_KEYS = [
+  'deployments',
+  'model-store-management',
+  'prometheus-preset',
+  'deployment-presets',
+] as const;
+
+type TabKey = (typeof TAB_KEYS)[number];
+
+const tabParser = parseAsStringLiteral(TAB_KEYS).withDefault('deployments');
+
+// Default status scope for the deployments tab: hide terminated deployments.
+// `status` is never a user-settable filter property, so the deployments tab
+// owns it entirely via its running/finished toggle. On first load (no
+// persisted filter) we fall back to "running".
+const DEPLOYMENT_RUNNING_FILTER: DeploymentFilter = {
+  status: { notIn: ['STOPPED'] },
+};
+
+// Per-tab default order. Tabs not listed default to no sort; the presets tabs
+// default to newest-first. Because all tabs now share a single `order` URL key
+// (see below), these defaults are applied explicitly on tab switch and on the
+// initial load of each tab (in `loadTab`).
+const DEFAULT_ORDER_BY_TAB: Record<TabKey, string | null> = {
+  'deployments': null,
+  'model-store-management': null,
+  'prometheus-preset': null,
+  'deployment-presets': '-createdAt',
+};
+
+type DeploymentTabQueryParams = {
+  filter: unknown;
+  order: string | null;
+};
+
+// Convert a single `orderBy` entry back into the `DeploymentOrderValue` string
+// the deployments table speaks. The deployment order enum is already in the
+// server's shape (e.g. `CREATED_AT`), so this is a plain sign-prefix, not the
+// camelCase `convertFirstOrderByToString` used by the other tabs.
+const deploymentOrderToString = (
+  orderBy: AdminDeploymentQueryType['variables']['orderBy'],
+): string | null => {
+  const entry = orderBy?.[0];
+  if (!entry) return null;
+  return `${entry.direction === 'DESC' ? '-' : ''}${entry.field}`;
+};
+
+const AdminDeploymentPage: React.FC = () => {
+  'use memo';
+  const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
+  const currentProject = useCurrentProjectValue();
+  const isPrometheusPresetSupported = baiClient.supports(
+    'prometheus-query-preset',
+  );
+  const isDeploymentPresetSupported = baiClient.supports('deployment-preset');
+
+  // A single `{ tab, filter, order }` URL state is shared by every tab, plus a
+  // single pagination state. Only the active tab's values are ever present in
+  // the URL; on a tab switch we snapshot the current tab's values into
+  // `queryMapRef` and restore the target tab's (or its defaults). This is the
+  // `AdminComputeSessionListPage` idiom. Prefixed / per-tab URL keys are
+  // deliberately avoided: with one shared key set, an inactive tab can never
+  // leak its `filter`/`order` into another tab (the previous per-tab
+  // `useQueryStates` design leaked because every mounted tab read the same
+  // unprefixed `filter`/`order` keys simultaneously).
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      tab: tabParser,
+      order: parseAsString,
+      filter: parseAsJson<unknown>((value) => value),
+    },
+    { history: 'replace' },
+  );
+  const currentTab = queryParams.tab;
+  const { tablePaginationOption, setTablePaginationOption } =
+    useBAIPaginationOptionStateOnSearchParam({ current: 1, pageSize: 10 });
+
+  // Snapshot of each tab's `{ filter, order }` + pagination, so switching away
+  // and back restores what the user had without persisting every tab's state
+  // in the URL at once.
+  const queryMapRef = useRef<
+    Record<
+      string,
+      {
+        queryParams: DeploymentTabQueryParams;
+        tablePaginationOption: { pageSize: number; current: number };
+      }
+    >
+  >({
+    [currentTab]: {
+      queryParams: { filter: queryParams.filter, order: queryParams.order },
+      tablePaginationOption,
+    },
+  });
+  useEffect(() => {
+    queryMapRef.current[currentTab] = {
+      queryParams: { filter: queryParams.filter, order: queryParams.order },
+      tablePaginationOption,
+    };
+  }, [currentTab, queryParams.filter, queryParams.order, tablePaginationOption]);
+
+  // Every tab's query ref is owned here (not inside the tab component) so the
+  // ref — and its already-fetched rows — survive the tab unmounting on a tab
+  // switch; only a full page reload resets it.
+
+  // --- Deployments tab ---
+  const [deploymentQueryRef, loadDeploymentQuery] =
+    useQueryLoader<AdminDeploymentQueryType>(AdminDeploymentQuery);
+  const [deploymentColumnOverrides, setDeploymentColumnOverrides] =
+    useBAISettingUserState('table_column_overrides.AdminDeployment');
+
+  const reloadDeployments = (
+    variables: AdminDeploymentQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => {
+    const nextLimit = variables.limit ?? 10;
+    const nextOffset = variables.offset ?? 0;
+    setQueryParams({
+      filter: variables.filter ?? null,
+      order: deploymentOrderToString(variables.orderBy),
+    });
+    setTablePaginationOption({
+      pageSize: nextLimit,
+      current: nextOffset > 0 ? Math.floor(nextOffset / nextLimit) + 1 : 1,
+    });
+    loadDeploymentQuery(variables, options);
+  };
+
+  // --- Model store management tab ---
+  const [modelCardQueryRef, loadModelCardQuery] =
+    useQueryLoader<AdminModelCardQueryType>(AdminModelCardQuery);
+  const [modelCardColumnOverrides, setModelCardColumnOverrides] =
+    useBAISettingUserState('table_column_overrides.AdminModelCard');
+
+  const reloadModelCards = (
+    variables: AdminModelCardQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => {
+    const nextLimit = variables.limit ?? 10;
+    const nextOffset = variables.offset ?? 0;
+    setQueryParams({
+      filter: variables.filter ?? null,
+      order: convertFirstOrderByToString(variables.orderBy),
+    });
+    setTablePaginationOption({
+      pageSize: nextLimit,
+      current: nextOffset > 0 ? Math.floor(nextOffset / nextLimit) + 1 : 1,
+    });
+    loadModelCardQuery(variables, options);
+  };
+
+  // --- Prometheus preset tab ---
+  const [prometheusQueryRef, loadPrometheusQuery] =
+    useQueryLoader<AdminPrometheusPresetQueryType>(AdminPrometheusPresetQuery);
+  const [prometheusColumnOverrides, setPrometheusColumnOverrides] =
+    useBAISettingUserState('table_column_overrides.AdminPrometheusPreset');
+
+  const reloadPrometheusPresets = (
+    variables: AdminPrometheusPresetQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => {
+    const nextLimit = variables.limit ?? 10;
+    const nextOffset = variables.offset ?? 0;
+    setQueryParams({
+      filter: variables.filter ?? null,
+      order: convertFirstOrderByToString(variables.orderBy),
+    });
+    setTablePaginationOption({
+      pageSize: nextLimit,
+      current: nextOffset > 0 ? Math.floor(nextOffset / nextLimit) + 1 : 1,
+    });
+    loadPrometheusQuery(variables, options);
+  };
+
+  // --- Deployment presets tab ---
+  const [deploymentPresetQueryRef, loadDeploymentPresetQuery] =
+    useQueryLoader<AdminDeploymentPresetQueryType>(AdminDeploymentPresetQuery);
+  const [deploymentPresetColumnOverrides, setDeploymentPresetColumnOverrides] =
+    useBAISettingUserState('table_column_overrides.AdminDeploymentPreset');
+
+  const reloadDeploymentPresets = (
+    variables: AdminDeploymentPresetQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => {
+    const nextLimit = variables.limit ?? 10;
+    const nextOffset = variables.offset ?? 0;
+    setQueryParams({
+      filter: variables.filter ?? null,
+      order: convertFirstOrderByToString(variables.orderBy),
+    });
+    setTablePaginationOption({
+      pageSize: nextLimit,
+      current: nextOffset > 0 ? Math.floor(nextOffset / nextLimit) + 1 : 1,
+    });
+    loadDeploymentPresetQuery(variables, options);
+  };
+
+
+  // Single entry point that lazily loads a tab's query when it becomes active
+  // and isn't already loaded (guarded per-tab by its ref), so a query never
+  // runs while its tab is hidden and returning to a loaded tab shows the same
+  // rows without refetching. `store-and-network` shows cached rows immediately
+  // while revalidating. Derives `limit`/`offset` from the passed pagination so
+  // callers can load with exact values in hand (render-as-you-fetch).
+  const loadTab = (
+    tab: TabKey,
+    params: DeploymentTabQueryParams,
+    pagination: { current: number; pageSize: number },
+  ) => {
+    const limit = pagination.pageSize;
+    const offset =
+      pagination.current > 1
+        ? (pagination.current - 1) * pagination.pageSize
+        : 0;
+    switch (tab) {
+      case 'deployments': {
+        if (!deploymentQueryRef) {
+          const sort = parseDeploymentOrder(params.order);
+          loadDeploymentQuery(
+            {
+              filter:
+                (params.filter as DeploymentFilter | null) ??
+                DEPLOYMENT_RUNNING_FILTER,
+              orderBy: sort
+                ? [
+                    {
+                      field: sort.field as DeploymentOrderField,
+                      direction: sort.direction as OrderDirection,
+                    },
+                  ]
+                : undefined,
+              limit,
+              offset,
+            },
+            { fetchPolicy: 'store-and-network' },
+          );
+        }
+        break;
+      }
+      case 'model-store-management': {
+        const currentProjectId = currentProject.id;
+        // Reload when nothing is loaded yet or the active project changed (the
+        // query is scoped to `currentProjectId`).
+        if (
+          currentProjectId &&
+          (!modelCardQueryRef ||
+            modelCardQueryRef.variables.currentProjectId !== currentProjectId)
+        ) {
+          loadModelCardQuery(
+            {
+              filter:
+                (params.filter as AdminModelCardQueryType['variables']['filter']) ??
+                undefined,
+              orderBy: convertToOrderBy<ModelCardV2OrderBy>(params.order),
+              limit,
+              offset,
+              currentProjectId,
+            },
+            { fetchPolicy: 'store-and-network' },
+          );
+        }
+        break;
+      }
+      case 'prometheus-preset':
+        if (isPrometheusPresetSupported && !prometheusQueryRef) {
+          loadPrometheusQuery(
+            {
+              filter:
+                (params.filter as AdminPrometheusPresetQueryType['variables']['filter']) ??
+                undefined,
+              orderBy: convertToOrderBy<QueryDefinitionOrderBy>(params.order),
+              limit,
+              offset,
+            },
+            { fetchPolicy: 'store-and-network' },
+          );
+        }
+        break;
+      case 'deployment-presets':
+        if (isDeploymentPresetSupported && !deploymentPresetQueryRef) {
+          loadDeploymentPresetQuery(
+            {
+              filter:
+                (params.filter as AdminDeploymentPresetQueryType['variables']['filter']) ??
+                undefined,
+              orderBy: convertToOrderBy<DeploymentRevisionPresetOrderBy>(
+                params.order ?? DEFAULT_ORDER_BY_TAB['deployment-presets'],
+              ),
+              limit,
+              offset,
+            },
+            { fetchPolicy: 'store-and-network' },
+          );
+        }
+        break;
+    }
+  };
+
+  // Render-as-you-fetch: start the target tab's fetch in the click handler,
+  // before the re-render, rather than reacting to the tab change in an effect.
+  const onTabChange = (key: string) => {
+    const tab = key as TabKey;
+    const stored = queryMapRef.current[key] ?? {
+      queryParams: {
+        filter: null,
+        order: DEFAULT_ORDER_BY_TAB[tab] ?? null,
+      },
+      tablePaginationOption: undefined,
+    };
+    const nextPagination = stored.tablePaginationOption ?? {
+      current: 1,
+      pageSize: 10,
+    };
+    // Reset to defaults first, then apply the target tab's snapshot, so no
+    // stale `filter`/`order` from the previous tab bleeds through. Pagination is
+    // shared across tabs, so a tab with no snapshot must reset both `current`
+    // and `pageSize` (a partial nuqs update would leave the previous tab's
+    // `pageSize` untouched).
+    setQueryParams(null);
+    setQueryParams({
+      tab,
+      filter: stored.queryParams.filter,
+      order: stored.queryParams.order,
+    });
+    setTablePaginationOption(nextPagination);
+    loadTab(tab, stored.queryParams, nextPagination);
+  };
+
+  // For entries that don't go through `onTabChange` — the initial mount, a full
+  // reload, or a direct `?tab=...` URL — load the active tab. Keyed on the
+  // project id so the project-scoped model-store tab reloads when the active
+  // project changes; a plain tab switch is already handled by `onTabChange`
+  // (render-as-you-fetch), so `currentTab` is intentionally not a dependency.
+  const loadActiveTab = useEffectEvent(() => {
+    loadTab(
+      currentTab,
+      { filter: queryParams.filter, order: queryParams.order },
+      tablePaginationOption,
+    );
+  });
+  useEffect(() => {
+    loadActiveTab();
+  }, [currentProject.id]);
+
+  const tabItems: CardTabListType[] = filterOutEmpty([
+    {
+      key: 'deployments',
+      label: t('webui.menu.Deployments'),
+    },
+    {
+      key: 'model-store-management',
+      label: t('adminModelCard.ModelStoreManagement'),
+    },
+    isPrometheusPresetSupported && {
+      key: 'prometheus-preset',
+      label: t('webui.menu.PrometheusPreset'),
+    },
+    isDeploymentPresetSupported && {
+      key: 'deployment-presets',
+      label: t('adminDeploymentPreset.TabTitle'),
+    },
+  ]);
+
+  return (
+    <BAICard
+      variant="borderless"
+      activeTabKey={currentTab}
+      onTabChange={onTabChange}
+      tabList={tabItems}
+    >
+      <Suspense fallback={<Skeleton active />}>
+        {currentTab === 'deployments' && (
+          <BAIErrorBoundary>
+            {deploymentQueryRef ? (
+              <AdminDeployment
+                queryRef={deploymentQueryRef}
+                onReload={reloadDeployments}
+                tableSettings={{
+                  columnOverrides: deploymentColumnOverrides,
+                  onColumnOverridesChange: setDeploymentColumnOverrides,
+                }}
+              />
+            ) : (
+              <Skeleton active />
+            )}
+          </BAIErrorBoundary>
+        )}
+        {currentTab === 'model-store-management' && (
+          <BAIErrorBoundary>
+            {modelCardQueryRef ? (
+              <AdminModelCard
+                queryRef={modelCardQueryRef}
+                onReload={reloadModelCards}
+                tableSettings={{
+                  columnOverrides: modelCardColumnOverrides,
+                  onColumnOverridesChange: setModelCardColumnOverrides,
+                }}
+              />
+            ) : (
+              <Skeleton active />
+            )}
+          </BAIErrorBoundary>
+        )}
+        {currentTab === 'prometheus-preset' && isPrometheusPresetSupported && (
+          <BAIErrorBoundary>
+            {prometheusQueryRef ? (
+              <AdminPrometheusPreset
+                queryRef={prometheusQueryRef}
+                onReload={reloadPrometheusPresets}
+                tableSettings={{
+                  columnOverrides: prometheusColumnOverrides,
+                  onColumnOverridesChange: setPrometheusColumnOverrides,
+                }}
+              />
+            ) : (
+              <Skeleton active />
+            )}
+          </BAIErrorBoundary>
+        )}
+        {currentTab === 'deployment-presets' && isDeploymentPresetSupported && (
+          <BAIErrorBoundary>
+            {deploymentPresetQueryRef ? (
+              <AdminDeploymentPreset
+                queryRef={deploymentPresetQueryRef}
+                onReload={reloadDeploymentPresets}
+                tableSettings={{
+                  columnOverrides: deploymentPresetColumnOverrides,
+                  onColumnOverridesChange: setDeploymentPresetColumnOverrides,
+                }}
+              />
+            ) : (
+              <Skeleton active />
+            )}
+          </BAIErrorBoundary>
+        )}
+      </Suspense>
+    </BAICard>
+  );
+};
+
+export default AdminDeploymentPage;

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -79,8 +79,8 @@ const DeploymentListPage = React.lazy(
 const DeploymentDetailPage = React.lazy(
   () => import('./pages/DeploymentDetailPage'),
 );
-const AdminDeploymentListPage = React.lazy(
-  () => import('./pages/AdminDeploymentListPage'),
+const AdminDeploymentPage = React.lazy(
+  () => import('./pages/AdminDeploymentPage'),
 );
 const InteractiveLoginPage = React.lazy(
   () => import('./pages/InteractiveLoginPage'),
@@ -635,7 +635,7 @@ export const mainLayoutChildRoutes: RouteObject[] = [
               return (
                 <BAIErrorBoundary>
                   <Suspense fallback={<BAICard loading />}>
-                    <AdminDeploymentListPage />
+                    <AdminDeploymentPage />
                   </Suspense>
                 </BAIErrorBoundary>
               );


### PR DESCRIPTION
> ♻️ **Replaces #8258** — that PR was auto-closed by GitHub when its branch was accidentally force-pushed to a rewritten (orphan) history and can no longer be reopened. The code here is byte-identical; prior review discussion lives on #8258.

## Summary

Base of the FR-3256 deployment-admin stack. Builds `AdminDeploymentPage` with four tabs — **deployments, model store, prometheus presets, deployment presets** — each loading via a hoisted `preloadedQuery` owned by the page, so switching tabs preserves each tab's already-fetched rows (render-as-you-fetch; only a full page reload resets them). Includes the tab-naming refactor (`…Nodes` → `…Table` for BAITable-owning components, `AdminModelCard`) and the supporting client / UI / i18n changes.

## Test plan
- [x] `pnpm relay` compiles cleanly
- [x] `tsc --noEmit` passes (react + backend.ai-ui)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
