### PR TITLE
refactor(FR-3256): align deployment sort to the shared convention

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
@@ -32,19 +32,20 @@ export type ModelDeploymentNodeInList = NonNullable<
 >;
 
 /**
- * Sortable `DeploymentOrderField` enum values. BAITable column `dataIndex`
- * for sortable columns matches an entry here so antd emits `sorter.field`
- * directly in the server enum's shape — no separate camelCase ↔ enum
- * mapping is needed. `UPDATED_AT` is intentionally omitted because the
- * server enum does not include it.
+ * Sortable column keys, in the same camelCase form every other table uses
+ * (see `AdminDeploymentPresetTable`). A sortable column's `dataIndex` matches
+ * an entry here, and callers bridge these strings to the server
+ * `DeploymentOrderField` enum with the shared `convertToOrderBy` helper
+ * (`createdAt` → `CREATED_AT`, `tag` → `TAG`, …). `updatedAt` is
+ * intentionally omitted because the server enum does not include it.
  */
 const availableDeploymentSorterKeys = [
-  'NAME',
-  'CREATED_AT',
-  'DOMAIN',
-  'PROJECT',
-  'RESOURCE_GROUP',
-  'TAG',
+  'name',
+  'createdAt',
+  'domain',
+  'project',
+  'resourceGroup',
+  'tag',
 ] as const;
 
 export const availableDeploymentSorterValues = [
@@ -57,20 +58,6 @@ export type DeploymentOrderValue =
 
 const isEnableSorter = (key: string) => {
   return _.includes(availableDeploymentSorterKeys, key);
-};
-
-/**
- * Parse a BAITable order string (e.g. `'-CREATED_AT'`) into a single
- * `DeploymentOrderBy` entry the server accepts. Returns `undefined` when
- * `order` is empty so callers can simply skip the `orderBy` variable.
- */
-export const parseDeploymentOrder = (
-  order: string | null | undefined,
-): { field: string; direction: 'ASC' | 'DESC' } | undefined => {
-  if (!order) return undefined;
-  const descending = order.startsWith('-');
-  const field = descending ? order.slice(1) : order;
-  return { field, direction: descending ? 'DESC' : 'ASC' };
 };
 
 export interface BAIModelDeploymentNodesProps extends Omit<
@@ -158,8 +145,8 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         title: t('comp:BAIModelDeploymentNodes.Name'),
         fixed: 'left',
         required: true,
-        dataIndex: 'NAME',
-        sorter: isEnableSorter('NAME'),
+        dataIndex: 'name',
+        sorter: isEnableSorter('name'),
         render: (_value, record) => (
           <BAINameActionCell
             title={record.metadata?.name ?? '-'}
@@ -279,8 +266,8 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         key: 'tags',
         title: t('comp:BAIModelDeploymentNodes.Tags'),
         defaultHidden: true,
-        dataIndex: 'TAG',
-        sorter: isEnableSorter('TAG'),
+        dataIndex: 'tag',
+        sorter: isEnableSorter('tag'),
         render: (__, record) => (
           <BAIDeploymentTagChips
             metadataFrgmt={record.metadata}
@@ -293,8 +280,8 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         key: 'projectId',
         title: t('comp:BAIModelDeploymentNodes.Project'),
         defaultHidden: true,
-        dataIndex: 'PROJECT',
-        sorter: isEnableSorter('PROJECT'),
+        dataIndex: 'project',
+        sorter: isEnableSorter('project'),
         render: (__, record) => {
           const projectId = record.metadata?.projectId;
           if (!projectId) {
@@ -324,8 +311,8 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         key: 'domainName',
         title: t('comp:BAIModelDeploymentNodes.DomainName'),
         defaultHidden: true,
-        dataIndex: 'DOMAIN',
-        sorter: isEnableSorter('DOMAIN'),
+        dataIndex: 'domain',
+        sorter: isEnableSorter('domain'),
         render: (__, record) => {
           const domain = record.metadata?.domainName;
           return domain ? (
@@ -339,8 +326,8 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         key: 'resourceGroup',
         title: t('comp:BAIModelDeploymentNodes.ResourceGroup'),
         defaultHidden: true,
-        dataIndex: 'RESOURCE_GROUP',
-        sorter: isEnableSorter('RESOURCE_GROUP'),
+        dataIndex: 'resourceGroup',
+        sorter: isEnableSorter('resourceGroup'),
         render: (__, record) => {
           const resourceGroup = record.metadata?.resourceGroupName;
           return resourceGroup ? (
@@ -418,8 +405,8 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         key: 'updatedAt',
         title: t('comp:BAIModelDeploymentNodes.UpdatedAt'),
         defaultHidden: true,
-        dataIndex: 'UPDATED_AT',
-        sorter: isEnableSorter('UPDATED_AT'),
+        dataIndex: 'updatedAt',
+        sorter: isEnableSorter('updatedAt'),
         render: (_, record) =>
           record.metadata?.updatedAt
             ? dayjs(record.metadata.updatedAt).format('lll')
@@ -428,8 +415,8 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
       {
         key: 'createdAt',
         title: t('comp:BAIModelDeploymentNodes.CreatedAt'),
-        dataIndex: 'CREATED_AT',
-        sorter: isEnableSorter('CREATED_AT'),
+        dataIndex: 'createdAt',
+        sorter: isEnableSorter('createdAt'),
         defaultSortOrder: 'descend',
         render: (_, record) =>
           record.metadata?.createdAt

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -173,7 +173,6 @@ export type { BAIRouteNodesProps, RouteNodeInList } from './BAIRouteNodes';
 export {
   default as BAIModelDeploymentNodes,
   availableDeploymentSorterValues,
-  parseDeploymentOrder,
 } from './BAIModelDeploymentNodes';
 export type {
   BAIModelDeploymentNodesProps,

--- a/react/src/components/AdminDeployment.tsx
+++ b/react/src/components/AdminDeployment.tsx
@@ -6,10 +6,10 @@ import type { AdminDeploymentDeleteMutation } from '../__generated__/AdminDeploy
 import type {
   AdminDeploymentQuery as AdminDeploymentQueryType,
   DeploymentFilter,
-  DeploymentOrderField,
+  DeploymentOrderBy,
   DeploymentStatus,
-  OrderDirection,
 } from '../__generated__/AdminDeploymentQuery.graphql';
+import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
 import { buildPath } from '../helper/pathBuilder';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
@@ -33,7 +33,6 @@ import {
   filterOutNullAndUndefined,
   isDeploymentInStoppedCategory,
   isValidUUID,
-  parseDeploymentOrder,
   toLocalId,
   useBAILogger,
 } from 'backend.ai-ui';
@@ -132,10 +131,10 @@ const AdminDeployment = ({
     mergedFilter?.status?.in?.includes('STOPPED') ? 'finished' : 'running';
   const userFilter = _.omit(mergedFilter, 'status') as DeploymentFilter;
 
-  const orderEntry = queryRef.variables.orderBy?.[0];
-  const order = orderEntry
-    ? (`${orderEntry.direction === 'DESC' ? '-' : ''}${orderEntry.field}` as DeploymentOrderValue)
-    : undefined;
+  const order =
+    (convertFirstOrderByToString(
+      queryRef.variables.orderBy,
+    ) as DeploymentOrderValue | null) ?? undefined;
 
   const pageSize = queryRef.variables.limit ?? 10;
   const offset = queryRef.variables.offset ?? 0;
@@ -296,18 +295,12 @@ const AdminDeployment = ({
           loading={isRefetching}
           order={order}
           onChangeOrder={(nextOrder) => {
-            const sort = parseDeploymentOrder(nextOrder ?? undefined);
             onReload(
               {
                 ...queryRef.variables,
-                orderBy: sort
-                  ? [
-                      {
-                        field: sort.field as DeploymentOrderField,
-                        direction: sort.direction as OrderDirection,
-                      },
-                    ]
-                  : undefined,
+                orderBy: convertToOrderBy<DeploymentOrderBy>(
+                  nextOrder ?? undefined,
+                ),
                 offset: 0,
               },
               { fetchPolicy: 'network-only' },

--- a/react/src/pages/AdminDeploymentPage.tsx
+++ b/react/src/pages/AdminDeploymentPage.tsx
@@ -5,8 +5,7 @@
 import type {
   AdminDeploymentQuery as AdminDeploymentQueryType,
   DeploymentFilter,
-  DeploymentOrderField,
-  OrderDirection,
+  DeploymentOrderBy,
 } from '../__generated__/AdminDeploymentQuery.graphql';
 import type {
   AdminDeploymentPresetQuery as AdminDeploymentPresetQueryType,
@@ -40,7 +39,7 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { Skeleton } from 'antd';
 import type { CardTabListType } from 'antd/es/card';
-import { BAICard, filterOutEmpty, parseDeploymentOrder } from 'backend.ai-ui';
+import { BAICard, filterOutEmpty } from 'backend.ai-ui';
 import {
   parseAsJson,
   parseAsString,
@@ -84,18 +83,6 @@ const DEFAULT_ORDER_BY_TAB: Record<TabKey, string | null> = {
 type DeploymentTabQueryParams = {
   filter: unknown;
   order: string | null;
-};
-
-// Convert a single `orderBy` entry back into the `DeploymentOrderValue` string
-// the deployments table speaks. The deployment order enum is already in the
-// server's shape (e.g. `CREATED_AT`), so this is a plain sign-prefix, not the
-// camelCase `convertFirstOrderByToString` used by the other tabs.
-const deploymentOrderToString = (
-  orderBy: AdminDeploymentQueryType['variables']['orderBy'],
-): string | null => {
-  const entry = orderBy?.[0];
-  if (!entry) return null;
-  return `${entry.direction === 'DESC' ? '-' : ''}${entry.field}`;
 };
 
 const AdminDeploymentPage: React.FC = () => {
@@ -171,7 +158,7 @@ const AdminDeploymentPage: React.FC = () => {
     const nextOffset = variables.offset ?? 0;
     setQueryParams({
       filter: variables.filter ?? null,
-      order: deploymentOrderToString(variables.orderBy),
+      order: convertFirstOrderByToString(variables.orderBy),
     });
     setTablePaginationOption({
       pageSize: nextLimit,
@@ -267,22 +254,14 @@ const AdminDeploymentPage: React.FC = () => {
         ? (pagination.current - 1) * pagination.pageSize
         : 0;
     switch (tab) {
-      case 'deployments': {
+      case 'deployments':
         if (!deploymentQueryRef) {
-          const sort = parseDeploymentOrder(params.order);
           loadDeploymentQuery(
             {
               filter:
                 (params.filter as DeploymentFilter | null) ??
                 DEPLOYMENT_RUNNING_FILTER,
-              orderBy: sort
-                ? [
-                    {
-                      field: sort.field as DeploymentOrderField,
-                      direction: sort.direction as OrderDirection,
-                    },
-                  ]
-                : undefined,
+              orderBy: convertToOrderBy<DeploymentOrderBy>(params.order),
               limit,
               offset,
             },
@@ -290,7 +269,6 @@ const AdminDeploymentPage: React.FC = () => {
           );
         }
         break;
-      }
       case 'model-store-management': {
         const currentProjectId = currentProject.id;
         // Reload when nothing is loaded yet or the active project changed (the

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -14,6 +14,7 @@ import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import DeploymentSettingModal from '../components/DeploymentSettingModal';
+import { convertToOrderBy } from '../helper';
 import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -37,7 +38,6 @@ import {
   availableDeploymentSorterValues,
   filterOutNullAndUndefined,
   isDeploymentInStoppedCategory,
-  parseDeploymentOrder,
   toLocalId,
   useBAILogger,
   useFetchKey,
@@ -100,15 +100,7 @@ const DeploymentListPageContent: React.FC = () => {
 
   const currentProject = useCurrentProjectValue();
 
-  const sort = parseDeploymentOrder(queryParams.order);
-  const orderBy: DeploymentOrderBy[] | undefined = sort
-    ? [
-        {
-          field: sort.field as DeploymentOrderBy['field'],
-          direction: sort.direction as DeploymentOrderBy['direction'],
-        },
-      ]
-    : undefined;
+  const orderBy = convertToOrderBy<DeploymentOrderBy>(queryParams.order);
   const finishedStatuses: ReadonlyArray<DeploymentStatus> = ['STOPPED'];
   const statusCategoryFilter: DeploymentFilter =
     queryParams.statusCategory === 'finished'

--- a/react/src/pages/ProjectAdminDeploymentsPage.tsx
+++ b/react/src/pages/ProjectAdminDeploymentsPage.tsx
@@ -6,9 +6,8 @@ import type { DeploymentRevisionDetail_revision$key } from '../__generated__/Dep
 import type { ProjectAdminDeploymentsPageDeleteMutation } from '../__generated__/ProjectAdminDeploymentsPageDeleteMutation.graphql';
 import type {
   DeploymentFilter,
-  DeploymentOrderField,
+  DeploymentOrderBy,
   DeploymentStatus,
-  OrderDirection,
   ProjectAdminDeploymentsPageQuery,
 } from '../__generated__/ProjectAdminDeploymentsPageQuery.graphql';
 import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
@@ -16,6 +15,7 @@ import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import DeploymentRevisionDetailDrawer from '../components/DeploymentRevisionDetailDrawer';
 import DeploymentSettingModal from '../components/DeploymentSettingModal';
+import { convertToOrderBy } from '../helper';
 import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -38,7 +38,6 @@ import {
   availableDeploymentSorterValues,
   filterOutNullAndUndefined,
   isDeploymentInStoppedCategory,
-  parseDeploymentOrder,
   toLocalId,
   useBAILogger,
   useFetchKey,
@@ -112,21 +111,13 @@ const ProjectAdminDeploymentsContent: React.FC<
       ? { status: { in: finishedStatuses } }
       : { status: { notIn: finishedStatuses } };
 
-  const sort = parseDeploymentOrder(queryParams.order);
   const queryVariables = {
     projectId,
     filter: {
       ...(queryParams.filter ?? {}),
       ...statusCategoryFilter,
     },
-    orderBy: sort
-      ? [
-          {
-            field: sort.field as DeploymentOrderField,
-            direction: sort.direction as OrderDirection,
-          },
-        ]
-      : undefined,
+    orderBy: convertToOrderBy<DeploymentOrderBy>(queryParams.order),
     limit: baiPaginationOption.limit,
     offset: baiPaginationOption.offset,
   };


### PR DESCRIPTION
> ♻️ **Replaces #8336** — auto-closed by GitHub after an accidental force-push to a rewritten branch; code identical, prior discussion on #8336.

## Summary

Aligns the deployment table's sort with the shared convention every other table uses. `BAIModelDeploymentNodes` sort keys move from the server-enum shape (`NAME`, `CREATED_AT`, …) to camelCase, so callers bridge to the `DeploymentOrderField` enum via the shared `convertToOrderBy` / `convertFirstOrderByToString` helpers. The deployment-specific `parseDeploymentOrder` (and the parent's local `deploymentOrderToString`) are removed; `DeploymentListPage` / `ProjectAdminDeploymentsPage` / `AdminDeployment` migrate to the shared helpers.

### ⚠️ Breaking change (intentional)
- Removes `parseDeploymentOrder` from the published `backend.ai-ui` entry point; external consumers switch to `convertToOrderBy`.
- Internal sort keys change from the server-enum shape to camelCase. Existing `?order=` URL bookmarks stay compatible (`convertToOrderBy` normalizes via `snakeCase().toUpperCase()`).

## Test plan
- [x] `pnpm relay` compiles cleanly
- [x] `tsc --noEmit` passes (react + backend.ai-ui)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
