### PR TITLE
fix(FR-3386): keep dashboard visible during interval refetch and isolate card suspensions

### DIFF
--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -32,7 +32,7 @@ import {
   useInterval,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { Suspense, useTransition } from 'react';
+import { Suspense, useDeferredValue, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -48,8 +48,15 @@ const DashboardPage: React.FC = () => {
   const buildProjectPath = useProjectPath();
 
   const [fetchKey, updateFetchKey] = useFetchKey();
+  // Deferring the fetchKey keeps the committed board on screen while the
+  // interval-driven `network-only` refetch suspends in the background.
+  // Feeding the raw fetchKey into useLazyLoadQuery made every 15s tick
+  // re-suspend the whole page into the route-level fallback (FR-3386).
+  const deferredFetchKey = useDeferredValue(fetchKey);
   const [isPendingIntervalRefetch, startIntervalRefetchTransition] =
     useTransition();
+  const isRefetching =
+    isPendingIntervalRefetch || fetchKey !== deferredFetchKey;
 
   const [localStorageBoardItems, setLocalStorageBoardItems] =
     useBAISettingUserState('dashboard_board_items');
@@ -90,8 +97,10 @@ const DashboardPage: React.FC = () => {
     },
     {
       fetchPolicy:
-        fetchKey === INITIAL_FETCH_KEY ? 'store-and-network' : 'network-only',
-      fetchKey,
+        deferredFetchKey === INITIAL_FETCH_KEY
+          ? 'store-and-network'
+          : 'network-only',
+      fetchKey: deferredFetchKey,
     },
   );
 
@@ -119,7 +128,7 @@ const DashboardPage: React.FC = () => {
           >
             <SessionCountDashboardItem
               queryRef={queryRef}
-              isRefetching={isPendingIntervalRefetch}
+              isRefetching={isRefetching}
               title={
                 _.isEqual(userRole, 'superadmin')
                   ? t('session.ActiveSessions')
@@ -144,10 +153,14 @@ const DashboardPage: React.FC = () => {
             title={t('webui.menu.MyResources')}
             status="error"
           >
-            <MyResource
-              fetchKey={fetchKey}
-              refetching={isPendingIntervalRefetch}
-            />
+            <Suspense
+              fallback={<Skeleton active style={{ padding: token.marginMD }} />}
+            >
+              <MyResource
+                fetchKey={deferredFetchKey}
+                refetching={isRefetching}
+              />
+            </Suspense>
           </BAIBoardItemErrorBoundary>
         ),
       },
@@ -166,10 +179,14 @@ const DashboardPage: React.FC = () => {
             title={t('webui.menu.MyResourcesInResourceGroup')}
             status="error"
           >
-            <MyResourceWithinResourceGroup
-              fetchKey={fetchKey}
-              refetching={isPendingIntervalRefetch}
-            />
+            <Suspense
+              fallback={<Skeleton active style={{ padding: token.marginMD }} />}
+            >
+              <MyResourceWithinResourceGroup
+                fetchKey={deferredFetchKey}
+                refetching={isRefetching}
+              />
+            </Suspense>
           </BAIBoardItemErrorBoundary>
         ),
       },
@@ -192,7 +209,7 @@ const DashboardPage: React.FC = () => {
               fallback={<Skeleton active style={{ padding: token.marginMD }} />}
             >
               <StorageStatusPanelCard
-                fetchKey={fetchKey}
+                fetchKey={deferredFetchKey}
                 onRequestBadgeClick={() => {
                   webuiNavigate({
                     pathname: buildProjectPath('data'),
@@ -242,7 +259,7 @@ const DashboardPage: React.FC = () => {
         content: queryRef.TotalResourceWithinResourceGroupFragment && (
           <TotalResourceWithinResourceGroup
             queryRef={queryRef.TotalResourceWithinResourceGroupFragment}
-            refetching={isPendingIntervalRefetch}
+            refetching={isRefetching}
           />
         ),
       },
@@ -269,7 +286,7 @@ const DashboardPage: React.FC = () => {
             >
               <AgentStats
                 queryRef={queryRef.AgentStatsFragment}
-                isRefetching={isPendingIntervalRefetch}
+                isRefetching={isRefetching}
               />
             </Suspense>
           ),
@@ -291,7 +308,7 @@ const DashboardPage: React.FC = () => {
             }
           >
             <ActiveAgents
-              fetchKey={fetchKey}
+              fetchKey={deferredFetchKey}
               onChangeFetchKey={() => updateFetchKey()}
             />
           </Suspense>
@@ -310,7 +327,7 @@ const DashboardPage: React.FC = () => {
         content: (
           <RecentlyCreatedSession
             queryRef={queryRef}
-            isRefetching={isPendingIntervalRefetch}
+            isRefetching={isRefetching}
           />
         ),
       },


### PR DESCRIPTION
Resolves #8417 (FR-3386)

## Problem

Refreshing `/dashboard` rendered the board briefly, then the **entire page collapsed into the route-level Suspense `<Skeleton/>` at the first 15-second interval refetch and never escaped**. Reproduced deterministically on `main`: board appears ~20s after reload, stays until ~30s, disappears at ~35s (first interval tick) and never returns (observed 55s+).

Two causes:

1. **Interval refetch suspended the page query.** `DashboardPage` fed the raw `fetchKey` into `useLazyLoadQuery` with `fetchPolicy: 'network-only'`. Every 15s tick created a brand-new operation with no store data, so the whole page fell back to the route-level Suspense. The rest of the codebase already uses the `useDeferredValue(fetchKey)` idiom for exactly this reason (e.g. `AdminComputeSessionListPage`, `DeploymentListPage`, `StorageProxyList`) — the dashboard was the only interval-refetching page without it.
2. **Two cards could hold the whole page hostage.** `MyResource` and `MyResourceWithinResourceGroup` suspend on their own REST query (`useResourceLimitAndRemaining` → `POST /resource/check-presets`, the heaviest manager call on this page) but were wrapped only in `BAIBoardItemErrorBoundary` — which catches errors, not suspension — unlike every other card which has its own `<Suspense>`. On a cold load (refresh), one slow `check-presets` kept the entire page in the route-level skeleton.

## Changes

- Add `const deferredFetchKey = useDeferredValue(fetchKey)` and use it for the page query's `fetchKey`/`fetchPolicy` and all card `fetchKey` props, so interval refetches happen in the background while the committed board stays on screen. `isRefetching` now also covers the `fetchKey !== deferredFetchKey` window.
- Wrap `MyResource` and `MyResourceWithinResourceGroup` in their own `<Suspense fallback={<Skeleton/>}>` (same pattern as the other board cards), so a slow `check-presets` skeletons only those two cards instead of the whole page.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

Behavioral verification on a live dev server (Playwright, superadmin, backend 26.8.0-alpha):

| Scenario | main | this PR |
|---|---|---|
| Refresh, healthy backend, observed 75s (3+ interval ticks) | board disappears at 35s, never returns | board visible from 20s through 75s, no fallback |
| Refresh with `POST /resource/check-presets` held forever | whole page stuck in skeleton 105s+, no recovery even after unblocking | board renders at 15s; only the two resource cards show skeletons; recovers fully once the request completes |

Repro recipe for reviewers: DevTools → Network → block `check-presets` → refresh `/dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)