### PR TITLE
fix(FR-3388): unify URL project validation on the header project selector source

### DIFF
--- a/react/src/__generated__/useAccessibleProjectsQuery.graphql.ts
+++ b/react/src/__generated__/useAccessibleProjectsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f1e307e971d3ef542439a5905fd43dd4>>
+ * @generated SignedSource<<e0f6e62cfb2655ac1d4433a24c1d28f6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,12 +9,12 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type ProjectSelectorQuery$variables = {
+export type useAccessibleProjectsQuery$variables = {
   domain_name?: string | null | undefined;
   email?: string | null | undefined;
   type?: ReadonlyArray<string | null | undefined> | null | undefined;
 };
-export type ProjectSelectorQuery$data = {
+export type useAccessibleProjectsQuery$data = {
   readonly groups: ReadonlyArray<{
     readonly id: string | null | undefined;
     readonly is_active: boolean | null | undefined;
@@ -29,9 +29,9 @@ export type ProjectSelectorQuery$data = {
     } | null | undefined> | null | undefined;
   } | null | undefined;
 };
-export type ProjectSelectorQuery = {
-  response: ProjectSelectorQuery$data;
-  variables: ProjectSelectorQuery$variables;
+export type useAccessibleProjectsQuery = {
+  response: useAccessibleProjectsQuery$data;
+  variables: useAccessibleProjectsQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -141,7 +141,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "ProjectSelectorQuery",
+    "name": "useAccessibleProjectsQuery",
     "selections": [
       (v3/*: any*/),
       {
@@ -164,7 +164,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "ProjectSelectorQuery",
+    "name": "useAccessibleProjectsQuery",
     "selections": [
       (v3/*: any*/),
       {
@@ -183,16 +183,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "90dcbb57bf23f0a95ae6e5494e83920f",
+    "cacheID": "0e48f08cbdc9b490c9bcba124fc9fbcf",
     "id": null,
     "metadata": {},
-    "name": "ProjectSelectorQuery",
+    "name": "useAccessibleProjectsQuery",
     "operationKind": "query",
-    "text": "query ProjectSelectorQuery(\n  $domain_name: String\n  $email: String\n  $type: [String]\n) {\n  groups(domain_name: $domain_name, is_active: true, type: $type) {\n    id\n    is_active\n    name\n    resource_policy\n    type\n  }\n  user(email: $email) {\n    groups {\n      id\n      name\n    }\n    id\n  }\n}\n"
+    "text": "query useAccessibleProjectsQuery(\n  $domain_name: String\n  $email: String\n  $type: [String]\n) {\n  groups(domain_name: $domain_name, is_active: true, type: $type) {\n    id\n    is_active\n    name\n    resource_policy\n    type\n  }\n  user(email: $email) {\n    groups {\n      id\n      name\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0167dba03af12a144a7f0768d4ea27f0";
+(node as any).hash = "ec6e98396db0fa4784d652440e9d5886";
 
 export default node;

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -257,8 +257,15 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
       destroyOnHidden
       {...modalProps}
       afterOpenChange={(open) => {
-        if (open && initialValidate) {
-          formRef.current?.validateFields();
+        if (open) {
+          if (initialValidate) {
+            formRef.current?.validateFields();
+          } else if (mergedInitialValues.type === 'project') {
+            // The project-folder notice is a warningOnly validator on `type`;
+            // antd runs validators only on interaction, so trigger it here or
+            // the notice stays hidden until the user touches the form.
+            formRef.current?.validateFields(['type']);
+          }
         }
       }}
     >

--- a/react/src/components/FolderCreateModalV2.tsx
+++ b/react/src/components/FolderCreateModalV2.tsx
@@ -388,8 +388,15 @@ const FolderCreateModalV2: React.FC<FolderCreateModalProps> = ({
       destroyOnHidden
       {...modalProps}
       afterOpenChange={(open) => {
-        if (open && initialValidate) {
-          formRef.current?.validateFields();
+        if (open) {
+          if (initialValidate) {
+            formRef.current?.validateFields();
+          } else if (mergedInitialValues.type === 'project') {
+            // The project-folder notice is a warningOnly validator on `type`;
+            // antd runs validators only on interaction, so trigger it here or
+            // the notice stays hidden until the user touches the form.
+            formRef.current?.validateFields(['type']);
+          }
         }
       }}
     >

--- a/react/src/components/MainLayout/ProjectScopeLayout.tsx
+++ b/react/src/components/MainLayout/ProjectScopeLayout.tsx
@@ -24,8 +24,9 @@ import { Outlet, useLocation } from 'react-router-dom';
  * project names.
  *
  * Resolution (render-time, no setState):
- *   - `id = baiClient.groupIds[name]` (name -> uuid)
- *   - membership = `baiClient.groups.includes(name)`
+ *   - name -> id and membership both come from `useUrlProjectValidity`, which
+ *     reads the same accessible-project list the header's `ProjectSelect`
+ *     renders (`useAccessibleProjects`, FR-3388).
  *
  * If the URL project name is invalid (not a member, or no resolvable id), the
  * layout does NOT silently switch to another project — the name is just a name

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -23,6 +23,7 @@ import {
   useCurrentMenuKey,
   useRouteScope,
 } from '../../hooks/useRouteScope';
+import { useUrlProjectValidity } from '../../hooks/useUrlProjectValidity';
 import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
 import BAINotificationButton from '../BAINotificationButton';
 import LoginSessionExtendButton from '../LoginSessionExtendButton';
@@ -39,7 +40,7 @@ import * as _ from 'lodash-es';
 import { MenuIcon } from 'lucide-react';
 import { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useMatches } from 'react-router-dom';
 
 const useStyles = createStyles(({ css }) => ({
   webuiHeader: css`
@@ -67,6 +68,7 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
   const gridBreakpoint = Grid.useBreakpoint();
   const webuiNavigate = useWebUINavigate();
   const location = useLocation();
+  const matches = useMatches();
   const routeScope = useRouteScope();
   const currentMenuKey = useCurrentMenuKey();
   // When the URL carries an invalid/inaccessible `:projectName`, the atom keeps
@@ -79,8 +81,19 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
   const accessibleProjectNames = _.compact(
     _.map(accessibleProjects, (project) => project?.name),
   );
+  // A router-owned 404 outside any project context (e.g. an invalid scope
+  // prefix like `/admi/...`) corresponds to no project at all — show the
+  // selector placeholder there too. Scoped 404s under a valid
+  // `/project/:projectName/*` URL keep their project context (the param is
+  // present), so only the projectless catch-alls blank the selector.
+  const deepestHandle = matches[matches.length - 1]?.handle as
+    { notFound?: boolean } | undefined;
+  const { urlProjectName } = useUrlProjectValidity();
+  const isProjectlessNotFound = !!deepestHandle?.notFound && !urlProjectName;
   const isUrlProjectInvalid =
-    !!activeProjectName && !accessibleProjectNames.includes(activeProjectName);
+    (!!activeProjectName &&
+      !accessibleProjectNames.includes(activeProjectName)) ||
+    isProjectlessNotFound;
   const { isSelectedAdminCategoryMenu } = useWebUIMenuItems();
   const effectiveAdminRole = useEffectiveAdminRole();
   const { projectAdminIds } = useCurrentUserProjectRoles();

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -8,6 +8,7 @@ import {
   useSuspendedBackendaiClient,
   useWebUINavigate,
 } from '../../hooks';
+import { useAccessibleProjects } from '../../hooks/useAccessibleProjects';
 import {
   useCurrentProjectValue,
   useSetCurrentProject,
@@ -34,6 +35,7 @@ import { useSessionStorageState } from 'ahooks';
 import { theme, Button, Modal, Typography, Grid, Divider } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIFlex, BAIFlexProps } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
 import { MenuIcon } from 'lucide-react';
 import { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -70,9 +72,13 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
   // When the URL carries an invalid/inaccessible `:projectName`, the atom keeps
   // the last valid project, which would make the header selector look like that
   // project is selected. Detect this and show the selector unselected instead.
+  // Checked against the selector's own accessible-project source (FR-3388) so
+  // this can never disagree with what the selector renders.
   const activeProjectName = useActiveProjectName();
-  const accessibleProjectNames =
-    (baiClient as unknown as { groups?: string[] })?.groups ?? [];
+  const { accessibleProjects } = useAccessibleProjects();
+  const accessibleProjectNames = _.compact(
+    _.map(accessibleProjects, (project) => project?.name),
+  );
   const isUrlProjectInvalid =
     !!activeProjectName && !accessibleProjectNames.includes(activeProjectName);
   const { isSelectedAdminCategoryMenu } = useWebUIMenuItems();

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -7,6 +7,7 @@ import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
 import usePrimaryColors from '../../hooks/usePrimaryColors';
 import { useRouteAccessDecision } from '../../hooks/useRouteAccess';
 import {
+  getRouteScopeAndKey,
   rewriteProjectNameInPath,
   useActiveProjectName,
   useCurrentMenuKey,
@@ -141,9 +142,21 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
             // projects while in admin mode, rewrite its `:projectName` segment
             // to the current project so "go back" lands on the active project,
             // not the stale one. Non-project paths pass through unchanged.
+            //
+            // Healing guard: a stored path that itself parses to an admin
+            // scope (e.g. `/admin` polluted by the pre-fix bare-scope-root
+            // bug, possibly persisted in sessionStorage from an older build)
+            // would make "go back" a no-op loop — fall back to the default
+            // general page instead of navigating back into admin.
+            const storedTarget = goBackPath
+              ? rewriteProjectNameInPath(goBackPath, activeProjectName)
+              : undefined;
+            const isStoredTargetAdmin =
+              !!storedTarget &&
+              getRouteScopeAndKey(storedTarget).scope !== 'project';
             webuiNavigate(
-              goBackPath
-                ? rewriteProjectNameInPath(goBackPath, activeProjectName)
+              storedTarget && !isStoredTargetAdmin
+                ? storedTarget
                 : defaultMenuPath,
             );
           }}

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -2,9 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { ProjectSelectorQuery } from '../__generated__/ProjectSelectorQuery.graphql';
-import { useSuspendedBackendaiClient } from '../hooks';
-import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
+import { useAccessibleProjects } from '../hooks/useAccessibleProjects';
 import useControllableState_deprecated from '../hooks/useControllableState';
 import { useCurrentUserProjectRoles } from '../hooks/useCurrentUserProjectRoles';
 import { InfoCircleOutlined } from '@ant-design/icons';
@@ -14,7 +12,6 @@ import * as _ from 'lodash-es';
 import { ShieldUser } from 'lucide-react';
 import React, { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery } from 'react-relay';
 
 type ProjectInfo = {
   label: React.ReactNode;
@@ -42,55 +39,18 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [currentUser] = useCurrentUserInfo();
-  const baiClient = useSuspendedBackendaiClient();
-  const blockList = baiClient?._config?.blockList ?? null;
 
   const [value, setValue] = useControllableState_deprecated(selectProps);
-  const userRole = useCurrentUserRole();
   const { projectAdminIds } = useCurrentUserProjectRoles();
-  const { groups, user } = useLazyLoadQuery<ProjectSelectorQuery>(
-    graphql`
-      query ProjectSelectorQuery(
-        $domain_name: String
-        $email: String
-        $type: [String]
-      ) {
-        groups(domain_name: $domain_name, is_active: true, type: $type) {
-          id
-          is_active
-          name
-          resource_policy
-          type
-        }
-        user(email: $email) {
-          groups {
-            id
-            name
-          }
-        }
-      }
-    `,
-    {
-      domain_name: domain,
-      email: currentUser.email,
-      type:
-        (userRole === 'admin' || userRole === 'superadmin') &&
-        _.includes(blockList, 'model-store')
-          ? ['GENERAL']
-          : ['GENERAL', 'MODEL_STORE'],
-    },
-    {
-      fetchPolicy: 'network-only',
-    },
-  );
+  // Shared accessible-project source (FR-3388): the same hook backs
+  // `useUrlProjectValidity`, so the selector and URL validation cannot
+  // disagree. `network-only` keeps the selector's refresh-on-mount behavior.
+  const { groups, accessibleProjects: memberProjects } = useAccessibleProjects({
+    domain,
+    fetchPolicy: 'network-only',
+  });
 
-  // temporary filtering groups by accessible groups according to user query
-  const accessibleProjects = disableDefaultFilter
-    ? groups
-    : groups?.filter((project) =>
-        user?.groups?.map((group) => group?.id).includes(project?.id),
-      );
+  const accessibleProjects = disableDefaultFilter ? groups : memberProjects;
 
   const lockedProjectIds = !lockedProjectTypes?.length
     ? []

--- a/react/src/hooks/useAccessibleProjects.tsx
+++ b/react/src/hooks/useAccessibleProjects.tsx
@@ -1,0 +1,94 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '.';
+import { useAccessibleProjectsQuery } from '../__generated__/useAccessibleProjectsQuery.graphql';
+import { useCurrentUserInfo, useCurrentUserRole } from './backendai';
+import * as _ from 'lodash-es';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import type { FetchPolicy } from 'relay-runtime';
+
+interface UseAccessibleProjectsOptions {
+  /**
+   * Domain to list projects for. Defaults to the current domain
+   * (`useCurrentDomainValue`). Pass the same value the header passes to
+   * `ProjectSelect` so both read the same Relay store records.
+   */
+  domain?: string;
+  /**
+   * Relay fetch policy. Defaults to `'store-or-network'` so validation
+   * consumers reuse the store; `ProjectSelect` passes `'network-only'` to
+   * keep its refresh-on-mount behavior.
+   */
+  fetchPolicy?: FetchPolicy;
+}
+
+/**
+ * The single source of truth for "which projects can the current user
+ * enter" (FR-3388). This is exactly the data the header's `ProjectSelect`
+ * renders: active projects of the domain (GENERAL + MODEL_STORE, unless an
+ * admin's config blocklist hides the model store) intersected with the
+ * user's project membership.
+ *
+ * URL project validation (`useUrlProjectValidity`) and the header's
+ * unselected-state check consume this hook instead of the login-time
+ * `baiClient.groups` list, which only contains GENERAL-type projects and
+ * therefore disagreed with the selector for model-store projects.
+ *
+ * RBAC role assignments are deliberately NOT consulted (decision on
+ * FR-3388): whatever the selector offers is considered enterable.
+ */
+export const useAccessibleProjects = (
+  options?: UseAccessibleProjectsOptions,
+) => {
+  'use memo';
+  const baiClient = useSuspendedBackendaiClient();
+  const currentDomainName = useCurrentDomainValue();
+  const [currentUser] = useCurrentUserInfo();
+  const userRole = useCurrentUserRole();
+  const blockList = baiClient?._config?.blockList ?? null;
+
+  const { groups, user } = useLazyLoadQuery<useAccessibleProjectsQuery>(
+    graphql`
+      query useAccessibleProjectsQuery(
+        $domain_name: String
+        $email: String
+        $type: [String]
+      ) {
+        groups(domain_name: $domain_name, is_active: true, type: $type) {
+          id
+          is_active
+          name
+          resource_policy
+          type
+        }
+        user(email: $email) {
+          groups {
+            id
+            name
+          }
+        }
+      }
+    `,
+    {
+      domain_name: options?.domain ?? currentDomainName,
+      email: currentUser.email,
+      type:
+        (userRole === 'admin' || userRole === 'superadmin') &&
+        _.includes(blockList, 'model-store')
+          ? ['GENERAL']
+          : ['GENERAL', 'MODEL_STORE'],
+    },
+    {
+      fetchPolicy: options?.fetchPolicy ?? 'store-or-network',
+    },
+  );
+
+  // Membership filter: only projects the user actually belongs to.
+  const accessibleProjects = groups?.filter((project) =>
+    user?.groups?.map((group) => group?.id).includes(project?.id),
+  );
+
+  return { groups, accessibleProjects };
+};

--- a/react/src/hooks/useRouteScope.ts
+++ b/react/src/hooks/useRouteScope.ts
@@ -186,14 +186,15 @@ export const useActiveProjectName = (): string | undefined => {
   const matches = useMatches();
   const currentProject = useCurrentProjectValue();
 
-  // Find the deepest match that carries a `projectName` param.
+  // Find the deepest match that carries a `projectName` param. Router params
+  // are already percent-decoded — decoding again would corrupt project names
+  // that contain a literal escape sequence (e.g. `a%20b`).
   for (let i = matches.length - 1; i >= 0; i--) {
     const params = matches[i]?.params as
-      | Record<string, string | undefined>
-      | undefined;
+      Record<string, string | undefined> | undefined;
     const name = params?.projectName;
     if (name) {
-      return decodeSafe(name);
+      return name;
     }
   }
 

--- a/react/src/hooks/useUrlProjectValidity.test.tsx
+++ b/react/src/hooks/useUrlProjectValidity.test.tsx
@@ -3,29 +3,33 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 /**
- * Tests for the shared URL-project validation (FR-3279). `isInvalid` decides
- * whether `PageAccessGuard` bypasses authorization and whether the project
- * subtree renders the merged not-found/no-access state, so each membership
- * combination is pinned here.
+ * Tests for the shared URL-project validation (FR-3279, FR-3388). `isInvalid`
+ * decides whether `PageAccessGuard` bypasses authorization and whether the
+ * project subtree renders the merged not-found/no-access state, so each
+ * membership combination is pinned here.
+ *
+ * Since FR-3388 the membership source is `useAccessibleProjects` (the same
+ * GraphQL-backed list the header's `ProjectSelect` renders), not the
+ * login-time `baiClient.groups` list — MODEL_STORE projects are therefore
+ * valid whenever the selector offers them.
  */
 import { useUrlProjectValidity } from './useUrlProjectValidity';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockUseSuspendedBackendaiClient = vi.fn();
+const mockUseAccessibleProjects = vi.fn();
 const mockUseMatches = vi.fn();
 
-vi.mock('.', () => ({
-  useSuspendedBackendaiClient: () => mockUseSuspendedBackendaiClient(),
+vi.mock('./useAccessibleProjects', () => ({
+  useAccessibleProjects: () => mockUseAccessibleProjects(),
 }));
 
 vi.mock('react-router-dom', () => ({
   useMatches: () => mockUseMatches(),
 }));
 
-const clientWith = (groups: string[], groupIds: Record<string, string>) => ({
-  groups,
-  groupIds,
+const accessible = (projects: { id: string; name: string }[]) => ({
+  accessibleProjects: projects,
 });
 
 const matchWithProject = (projectName?: string) => [
@@ -39,8 +43,8 @@ describe('useUrlProjectValidity', () => {
   });
 
   it('is not invalid outside project-scoped URLs (no :projectName param)', () => {
-    mockUseSuspendedBackendaiClient.mockReturnValue(
-      clientWith(['alpha'], { alpha: 'id-alpha' }),
+    mockUseAccessibleProjects.mockReturnValue(
+      accessible([{ id: 'id-alpha', name: 'alpha' }]),
     );
     mockUseMatches.mockReturnValue(matchWithProject(undefined));
 
@@ -50,9 +54,12 @@ describe('useUrlProjectValidity', () => {
     expect(result.current.resolvedId).toBeUndefined();
   });
 
-  it('resolves a valid member project (member + id present)', () => {
-    mockUseSuspendedBackendaiClient.mockReturnValue(
-      clientWith(['alpha', 'beta'], { alpha: 'id-alpha', beta: 'id-beta' }),
+  it('resolves a valid accessible project', () => {
+    mockUseAccessibleProjects.mockReturnValue(
+      accessible([
+        { id: 'id-beta', name: 'beta' },
+        { id: 'id-alpha', name: 'alpha' },
+      ]),
     );
     mockUseMatches.mockReturnValue(matchWithProject('beta'));
 
@@ -63,9 +70,9 @@ describe('useUrlProjectValidity', () => {
     expect(result.current.groups).toEqual(['alpha', 'beta']);
   });
 
-  it('is invalid for a project the user is not a member of', () => {
-    mockUseSuspendedBackendaiClient.mockReturnValue(
-      clientWith(['alpha'], { alpha: 'id-alpha' }),
+  it('is invalid for a project the selector does not offer', () => {
+    mockUseAccessibleProjects.mockReturnValue(
+      accessible([{ id: 'id-alpha', name: 'alpha' }]),
     );
     mockUseMatches.mockReturnValue(matchWithProject('ghost'));
 
@@ -74,19 +81,12 @@ describe('useUrlProjectValidity', () => {
     expect(result.current.isInvalid).toBe(true);
   });
 
-  it('is invalid for a member project whose id is missing', () => {
-    mockUseSuspendedBackendaiClient.mockReturnValue(clientWith(['alpha'], {}));
-    mockUseMatches.mockReturnValue(matchWithProject('alpha'));
-
-    const { result } = renderHook(() => useUrlProjectValidity());
-    expect(result.current.urlProjectName).toBe('alpha');
-    expect(result.current.isInvalid).toBe(true);
-    expect(result.current.resolvedId).toBeUndefined();
-  });
-
   it('reads the DEEPEST match carrying a projectName param', () => {
-    mockUseSuspendedBackendaiClient.mockReturnValue(
-      clientWith(['outer', 'inner'], { outer: 'id-o', inner: 'id-i' }),
+    mockUseAccessibleProjects.mockReturnValue(
+      accessible([
+        { id: 'id-o', name: 'outer' },
+        { id: 'id-i', name: 'inner' },
+      ]),
     );
     mockUseMatches.mockReturnValue([
       { params: { projectName: 'outer' } },
@@ -98,8 +98,10 @@ describe('useUrlProjectValidity', () => {
     expect(result.current.resolvedId).toBe('id-i');
   });
 
-  it('tolerates a client without groups/groupIds fields', () => {
-    mockUseSuspendedBackendaiClient.mockReturnValue({});
+  it('tolerates an undefined accessible-project list', () => {
+    mockUseAccessibleProjects.mockReturnValue({
+      accessibleProjects: undefined,
+    });
     mockUseMatches.mockReturnValue(matchWithProject('any'));
 
     const { result } = renderHook(() => useUrlProjectValidity());

--- a/react/src/hooks/useUrlProjectValidity.ts
+++ b/react/src/hooks/useUrlProjectValidity.ts
@@ -2,13 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useSuspendedBackendaiClient } from '.';
+import { useAccessibleProjects } from './useAccessibleProjects';
+import * as _ from 'lodash-es';
 import { useMatches } from 'react-router-dom';
-
-interface BackendAIClientGroups {
-  groups?: string[];
-  groupIds?: Record<string, string>;
-}
 
 export interface UrlProjectValidity {
   /**
@@ -19,30 +15,36 @@ export interface UrlProjectValidity {
   urlProjectName?: string;
   /**
    * True when the URL names a project that does NOT resolve for the current
-   * user (not a member, or no resolvable id). Whether the project is missing
-   * or merely access-restricted is deliberately indistinguishable — the name
-   * is just a name. Always false outside project-scoped URLs.
+   * user (not offered by the header project selector). Whether the project
+   * is missing or merely access-restricted is deliberately
+   * indistinguishable — the name is just a name. Always false outside
+   * project-scoped URLs.
    */
   isInvalid: boolean;
   /** The resolved project id when the URL project is valid. */
   resolvedId?: string;
-  /** All project names the current user belongs to. */
+  /** Names of all projects the current user can enter, sorted. */
   groups: string[];
 }
 
 /**
- * Validates the `:projectName` segment of the current URL against the
- * logged-in user's project membership. Single source of truth shared by
- * `ProjectScopeLayout` (renders the "not found / no access" state),
- * `PageAccessGuard` (must not decide 401 against an unresolvable project),
- * and `ProjectAdminScopeAlert` (must not render for an unresolvable project).
+ * Validates the `:projectName` segment of the current URL against the same
+ * accessible-project list the header's `ProjectSelect` renders
+ * (`useAccessibleProjects`, FR-3388) — NOT the login-time `baiClient.groups`
+ * list, which only contains GENERAL-type projects and wrongly rejected
+ * MODEL_STORE projects the selector offers.
+ *
+ * Single source of truth shared by `ProjectScopeLayout` (renders the "not
+ * found / no access" state), `PageAccessGuard` (must not decide 401 against
+ * an unresolvable project), and `ProjectAdminScopeAlert` (must not render
+ * for an unresolvable project).
  *
  * Reads the param via `useMatches` so it works from ancestors of the project
  * route (e.g. MainLayout), where `useParams` cannot see child params.
  */
 export const useUrlProjectValidity = (): UrlProjectValidity => {
   'use memo';
-  const baiClient = useSuspendedBackendaiClient();
+  const { accessibleProjects } = useAccessibleProjects();
   const matches = useMatches();
 
   let urlProjectName: string | undefined;
@@ -55,13 +57,14 @@ export const useUrlProjectValidity = (): UrlProjectValidity => {
     }
   }
 
-  const clientGroups = baiClient as unknown as BackendAIClientGroups;
-  const groups = clientGroups.groups ?? [];
-  const groupIds = clientGroups.groupIds ?? {};
-
-  const resolvedId = urlProjectName ? groupIds[urlProjectName] : undefined;
-  const isInvalid =
-    !!urlProjectName && !(groups.includes(urlProjectName) && !!resolvedId);
+  const groups = _.sortBy(
+    _.compact(_.map(accessibleProjects, (project) => project?.name)),
+  );
+  const resolvedId = urlProjectName
+    ? (_.find(accessibleProjects, (project) => project?.name === urlProjectName)
+        ?.id ?? undefined)
+    : undefined;
+  const isInvalid = !!urlProjectName && !resolvedId;
 
   return { urlProjectName, isInvalid, resolvedId, groups };
 };

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -10,7 +10,11 @@ import { useDiagnosticsBadgeSeverity } from './useAutoDiagnostics';
 import { useBAISettingUserState } from './useBAISetting';
 import { useEffectiveAdminRole } from './useCurrentUserProjectRoles';
 import { useCustomThemeConfig } from './useCustomThemeConfig';
-import { useActiveProjectName, useCurrentMenuKey } from './useRouteScope';
+import {
+  getRouteScopeAndKey,
+  useActiveProjectName,
+  useCurrentMenuKey,
+} from './useRouteScope';
 import {
   PluginPage,
   useWebUIPluginLoadedValue,
@@ -57,6 +61,7 @@ import {
 } from 'lucide-react';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 export type MenuGroupName =
   | 'none'
@@ -241,6 +246,7 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   // `location.pathname.split('/')[1]` would return the scope prefix
   // ('project'/'admin') instead of the feature key.
   const currentMenuKeyFromRoute = useCurrentMenuKey();
+  const routerLocation = useLocation();
   // Active project NAME (URL `:projectName` if present, else current project
   // atom). Used to build scope-aware menu `to` paths via `getPathFromMenuKey` /
   // `buildPath` so every menu link points at `/project/<name>/<feature>` (or
@@ -805,9 +811,17 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   // `/project-admin-users`, or a user switched into a project where they
   // lack admin rights).
   const currentPageMenuKey = currentMenuKeyFromRoute ?? '';
+  // Also treat any admin-scoped URL as admin category, keyed on the URL scope
+  // itself. The menu-key sets alone miss the bare scope roots (`/admin`,
+  // `/project/:name/admin`): their feature key is empty during the index
+  // redirect, which used to classify them as "general" and pollute the
+  // sider's `goBackPath` with `/admin` — making "go back" a no-op loop
+  // (FR-3388, deep-link-then-login repro).
+  const currentUrlScope = getRouteScopeAndKey(routerLocation.pathname).scope;
   const isCurrentPathAdminCategory =
     ALL_ADMIN_PAGE_KEYS.has(currentPageMenuKey) ||
-    PROJECT_ADMIN_PAGE_KEY_SET.has(currentPageMenuKey);
+    PROJECT_ADMIN_PAGE_KEY_SET.has(currentPageMenuKey) ||
+    currentUrlScope !== 'project';
 
   // Get the first available menu item from groupedGeneralMenu
   // (after blocklist filtering, excluding disabled/inactive items)

--- a/react/src/pages/AdminDeploymentListPage.tsx
+++ b/react/src/pages/AdminDeploymentListPage.tsx
@@ -376,7 +376,10 @@ const AdminDeploymentListPageContent: React.FC = () => {
                           title={record.metadata?.name ?? '-'}
                           onTitleClick={() =>
                             webUINavigate(
-                              `/admin-deployments/${toLocalId(record.id)}`,
+                              buildPath(
+                                'admin',
+                                `deployments/${toLocalId(record.id)}`,
+                              ),
                             )
                           }
                           copyable

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -329,7 +329,7 @@ const DeploymentListPageContent: React.FC = () => {
                           title={record.metadata?.name ?? '-'}
                           onTitleClick={() =>
                             webuiNavigate(
-                              `/deployments/${toLocalId(record.id)}`,
+                              `${buildProjectPath('deployments')}/${toLocalId(record.id)}`,
                             )
                           }
                           copyable

--- a/react/src/pages/Page404.tsx
+++ b/react/src/pages/Page404.tsx
@@ -33,18 +33,18 @@ const Page404 = () => {
   const defaultPageTitle =
     firstAvailableMenuItem?.labelText ?? t('webui.menu.FirstPageNameAlias');
 
-  // The pill shows the unknown path with its LAST segment marked broken —
-  // that is the part the router could not resolve. Long paths are capped
-  // with a leading ellipsis so detail-page URLs stay readable.
+  // The pill echoes the unknown path with all segments neutral: a 404 cannot
+  // know WHICH segment failed to resolve (e.g. `/admi/default/start` breaks
+  // on the first segment, not the last), so marking one would be a guess.
+  // Error states that DO know the failing segment (ProjectScopeErrorState)
+  // keep their `broken` marking. Long paths are capped with a leading
+  // ellipsis so detail-page URLs stay readable.
   const rawSegments = location.pathname.split('/').filter(Boolean);
   const capped =
     rawSegments.length > MAX_SEGMENTS
       ? ['…', ...rawSegments.slice(-(MAX_SEGMENTS - 1))]
       : rawSegments;
-  const segments: RouteErrorSegment[] = capped.map((text, i) => ({
-    text,
-    broken: i === capped.length - 1,
-  }));
+  const segments: RouteErrorSegment[] = capped.map((text) => ({ text }));
 
   return (
     <RouteErrorContent


### PR DESCRIPTION
Resolves #8422 (FR-3388)

Follow-up to the stack-wide review on #8409 (routing stack #8208 → #8408 → #8409). Bundles the agreed fixes in one PR, stacked on top of `test/FR-3383-e2e-heal`.

## Decisions applied

- **The header project selector's content is the single source of truth** for URL project validation (no RBAC consideration).
- Admin-scope project switching stays atom-only (no project segment on `/admin/*` URLs) — unchanged by design.

## Changes

1. **New `useAccessibleProjects` hook** — extracts the exact query + membership filter the header `ProjectSelect` renders (`groups(type: [GENERAL, MODEL_STORE])` ∩ `user.groups`). `ProjectSelect` is refactored to consume it (`network-only`, behavior unchanged), so the selector and every validation consumer read the same Relay store records and cannot diverge.
2. **`useUrlProjectValidity`** now validates the URL `:projectName` against that list instead of the login-time `baiClient.groups`/`groupIds` (GENERAL-only). Fixes review item 1: `/project/<model-store>/*` always rendered the not-found/no-access state (runtime-confirmed before the fix).
3. **`ProjectScopeLayout` escape button** (review item 2) now inherits the same source via the hook — it only offers selector-offered projects.
4. **`WebUIHeader` unselected-state check** reads the same source, so the selector correctly shows the model-store project as selected after the admin model-store folder flow switches the atom (review item 3's visible symptom).
5. **`FolderCreateModal` / `FolderCreateModalV2`** (review item 4): the `data.folders.ProjectFolderCreationHelp` notice is a `warningOnly` validator that antd never runs on mount; `afterOpenChange` now validates `['type']` on open when the initial type is `project`, so the notice shows immediately without tripping the required-name error.
6. **`useActiveProjectName`** (review comment): removed the double `decodeURIComponent` on the already-decoded router param, which corrupted project names containing literal escape sequences. The pathname-parsing fallback (`getRouteScopeAndKey`) keeps its decode, since it handles raw segments.

Review item “admin deep-link → sider back button cannot escape to the general menu” gets no dedicated change: the basic path was verified working at the top of the stack, and the failing variants trace to items 1–3 above (the back target landing on a project that failed validation).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `vitest` — `useUrlProjectValidity.test.tsx` (rewritten against the new source) + `useRouteScope.test.ts`: 21/21 pass
- Runtime (backend 10.82.0.130): `/project/model-store/start` renders the Start page with the selector showing the model-store project (was: “Project ‘model-store’ was not found…”); admin deep-link → sider back button lands on the general menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Also included (remaining #7751 / #7755 review threads, second commit)

7. **`DeploymentListPage` name-cell click** now navigates to the scope-aware `/project/:name/deployments/:id` path (was the legacy flat `/deployments/:id`) — #7751 thread.
8. **`Page404` path pill: broken marking removed** (all segments neutral). A 404 cannot know which segment failed (`/admi/…` breaks on the first, not the last), so marking one was a guess; `ProjectScopeErrorState` keeps its accurate `broken` marking — #7755 thread (decision: remove rather than mark-all).
9. **Header selector blanks on projectless 404s** (`notFound` catch-all without a `:projectName` param, e.g. `/admi/default/start`); scoped 404s under a valid project URL (e.g. `/project/default/303`) keep their project context — #7755 thread.

10. **`AdminDeploymentListPage` name-cell click** now builds the canonical `/admin/deployments/:id` path (was the legacy `/admin-deployments/:id` alias, working only via the redirect shim) — found in a full sweep of deployment links; every other deployment navigation already goes through `buildProjectPath`/`buildPath`.

11. **Sider Go Back no longer loops after deep-linking to the bare `/admin` scope root** (reported repro: `/admin` → login → Go Back stuck on `/admin/users`). The bare scope roots have an empty feature key during their index redirect, so `isCurrentPathAdminCategory` classified them as "general" and polluted `goBackPath` with `/admin`. `useWebUIMenuItems` now also keys the admin-category check on the URL scope itself, and the sider's Go Back adds a healing guard: a stored target that parses to a non-project scope (old-build pollution persisted in sessionStorage) falls back to the default general page. Runtime-verified both the fresh repro and the pre-polluted case.

The admin-theme-on-404 thread (#7755) is deliberately **not** changed in this stack (agreed: not critical, keep for now).

Runtime-verified: `/admi/default/start` shows the selector placeholder with a neutral pill; `/project/default/303` keeps the `default` selection; deployment name click lands on `/project/default/deployments/<id>`. `scripts/verify.sh` → ALL PASS.

