### PR TITLE
test: e2e auto-heal 2026-07-28

### DIFF
--- a/e2e/auto-scaling-rule-preset/preset-crud.spec.ts
+++ b/e2e/auto-scaling-rule-preset/preset-crud.spec.ts
@@ -805,9 +805,17 @@ test.describe(
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();
 
-      // The edit modal form does not auto-populate from initialValues on re-open
-      // (persistent Form instance). The Name field is already empty — just save
-      // immediately to trigger the required-field validation error.
+      // FR-3383/PR #8285 fixed the edit modal so it correctly re-applies
+      // initialValues on reopen — the Name field is now pre-populated with
+      // the preset's current name. Explicitly clear it to exercise the
+      // required-field validation.
+      const nameInput = modal.getByRole('textbox', {
+        name: 'Name',
+        exact: true,
+      });
+      await expect(nameInput).toHaveValue(presetName);
+      await nameInput.fill('');
+
       // Click "Save"
       await modal.getByRole('button', { name: 'Save' }).click();
 
@@ -844,14 +852,19 @@ test.describe(
       const modal = page.getByRole('dialog');
       await expect(modal).toBeVisible();
 
-      // The edit modal form does not auto-populate from initialValues on re-open
-      // (persistent Form instance). Fill Name and QueryTemplate to isolate Metric Name
-      // as the only missing required field, then save to trigger its validation error.
-      await modal
-        .getByRole('textbox', { name: 'Name', exact: true })
-        .fill(presetName);
-      await modal.getByRole('textbox', { name: 'Query Template' }).fill('up');
-      // Leave Metric Name empty (already empty from form non-pre-fill behavior)
+      // FR-3383/PR #8285 fixed the edit modal so it correctly re-applies
+      // initialValues on reopen — Name, Metric Name, and Query Template are
+      // now all pre-populated with the preset's current values. Explicitly
+      // clear only the Metric Name field to isolate it as the missing
+      // required field, then save to trigger its validation error.
+      await expect(
+        modal.getByRole('textbox', { name: 'Name', exact: true }),
+      ).toHaveValue(presetName);
+      const metricNameInput = modal.getByRole('textbox', {
+        name: 'Metric Name',
+      });
+      await expect(metricNameInput).toHaveValue('e2e_metric');
+      await metricNameInput.fill('');
 
       // Click "Save"
       await modal.getByRole('button', { name: 'Save' }).click();

--- a/e2e/chat/chat-sync.spec.ts
+++ b/e2e/chat/chat-sync.spec.ts
@@ -57,6 +57,34 @@ function getSyncToggle(page: Page, cardIndex: number) {
     .nth(1);
 }
 
+/**
+ * Clicks a pane's sync toggle and waits until the new state is actually
+ * committed, as reported by the SyncSwitch icon (ToggleRight = on,
+ * ToggleLeft = off).
+ *
+ * ChatHeader wraps `onChangeSync` in `startTransition`, so the pane keeps its
+ * previous `sync` value for a beat after the click. During that window the
+ * pane still mirrors its input into the shared `synchronizedMessage` atom,
+ * so typing right after the click can still propagate to the other panes.
+ * Asserting on the icon is the only signal that the toggle has landed —
+ * checking that the input was cleared does not work, because the clearing
+ * effect is a no-op whenever the input is already empty.
+ */
+async function setSync(
+  page: Page,
+  cardIndex: number,
+  enabled: boolean,
+): Promise<void> {
+  const toggle = getSyncToggle(page, cardIndex).first();
+  await expect(toggle).toBeVisible({ timeout: 10000 });
+  await toggle.click();
+  await expect(
+    toggle.locator(
+      enabled ? 'svg.lucide-toggle-right' : 'svg.lucide-toggle-left',
+    ),
+  ).toBeVisible({ timeout: 10000 });
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 5. Sync Input Propagation Across Two Panes
 // ─────────────────────────────────────────────────────────────────────────────
@@ -211,15 +239,6 @@ test.describe(
         secondChatCardHeader.getByText('gpt-mock-model-b'),
       ).toBeVisible({ timeout: 10000 });
 
-      // Brief stabilization pause: the endpoint switch above involves both a
-      // Relay refetch (endpoint entity) and a TanStack Query refetch (model
-      // list); both must settle on the second pane before it is safe to rely
-      // on the cross-pane sync mechanism to fire a send with the correct
-      // model. There is no further DOM signal to assert on beyond what was
-      // already checked above, so a short fixed delay is used as a last
-      // resort per project convention.
-      await page.waitForTimeout(500);
-
       // Verify both panes have sync ON
       await expect(getSyncToggle(page, 0).first()).toBeVisible({
         timeout: 10000,
@@ -293,12 +312,8 @@ test.describe(
       // Clone a second pane
       await addComparePane(page, 2);
 
-      // Verify both panes have sync ON
-      const syncToggle0 = getSyncToggle(page, 0).first();
-      await expect(syncToggle0).toBeVisible({ timeout: 10000 });
-
-      // Click the sync toggle in the first pane to turn it OFF
-      await syncToggle0.click();
+      // Turn sync OFF on the first pane and wait for the toggle to commit
+      await setSync(page, 0, false);
 
       // The input is cleared when sync is toggled (by design per the spec)
       await expect(getChatInput(page, 0)).toHaveValue('', { timeout: 5000 });
@@ -342,8 +357,7 @@ test.describe(
       });
 
       // Click the sync toggle in the first pane to disable sync
-      const syncToggle0 = getSyncToggle(page, 0).first();
-      await syncToggle0.click();
+      await setSync(page, 0, false);
 
       // The first pane's input is cleared when sync is disabled
       await expect(getChatInput(page, 0)).toHaveValue('', { timeout: 10000 });
@@ -362,9 +376,7 @@ test.describe(
       await addComparePane(page, 2);
 
       // Turn off sync on the first pane
-      const syncToggle0 = getSyncToggle(page, 0).first();
-      await expect(syncToggle0).toBeVisible({ timeout: 10000 });
-      await syncToggle0.click();
+      await setSync(page, 0, false);
 
       // Wait for input to clear after sync toggle
       await expect(getChatInput(page, 0)).toHaveValue('', { timeout: 5000 });
@@ -408,11 +420,8 @@ test.describe(
       // Clone a second pane
       await addComparePane(page, 2);
 
-      const syncToggle0 = getSyncToggle(page, 0).first();
-      await expect(syncToggle0).toBeVisible({ timeout: 10000 });
-
       // Turn off sync on the first pane
-      await syncToggle0.click();
+      await setSync(page, 0, false);
 
       // Wait for input to clear
       await expect(getChatInput(page, 0)).toHaveValue('', { timeout: 5000 });
@@ -425,7 +434,7 @@ test.describe(
       });
 
       // Re-enable sync on the first pane
-      await syncToggle0.click();
+      await setSync(page, 0, true);
 
       // Input is cleared upon toggling sync back on
       await expect(getChatInput(page, 0)).toHaveValue('', { timeout: 10000 });

--- a/e2e/chat/chat-sync.spec.ts
+++ b/e2e/chat/chat-sync.spec.ts
@@ -177,6 +177,14 @@ test.describe(
         .getByText('mock-endpoint')
         .first();
       await secondCardEndpointText.click();
+
+      // Set up the wait for the second pane's own /v1/models fetch (for
+      // endpoint B) before clicking, so we don't miss a fast mocked response.
+      const modelsBResponsePromise = page.waitForResponse(
+        (response) =>
+          response.url().includes('mock-chat-endpoint-b') &&
+          response.url().includes('/v1/models'),
+      );
       await page
         .getByRole('option', { name: 'mock-endpoint-b' })
         .or(
@@ -186,6 +194,31 @@ test.describe(
         )
         .first()
         .click();
+      await modelsBResponsePromise;
+
+      const secondChatCardHeader = page.locator('.ant-card').nth(2);
+
+      // Selecting a new endpoint re-triggers the model list fetch for that
+      // pane (ChatCard's non-suspending isLoadingModels flag), which
+      // disables its ChatInput until the fetch resolves. Wait for the
+      // second pane's input to become enabled again, and for its model
+      // selector to reflect the newly-fetched model — otherwise the synced
+      // send below can race the endpoint/model switch and dispatch against
+      // a stale ('custom') model before React has settled on
+      // 'gpt-mock-model-b'.
+      await expect(getChatInput(page, 1)).toBeEnabled({ timeout: 10000 });
+      await expect(
+        secondChatCardHeader.getByText('gpt-mock-model-b'),
+      ).toBeVisible({ timeout: 10000 });
+
+      // Brief stabilization pause: the endpoint switch above involves both a
+      // Relay refetch (endpoint entity) and a TanStack Query refetch (model
+      // list); both must settle on the second pane before it is safe to rely
+      // on the cross-pane sync mechanism to fire a send with the correct
+      // model. There is no further DOM signal to assert on beyond what was
+      // already checked above, so a short fixed delay is used as a last
+      // resort per project convention.
+      await page.waitForTimeout(500);
 
       // Verify both panes have sync ON
       await expect(getSyncToggle(page, 0).first()).toBeVisible({


### PR DESCRIPTION
## Summary

Automated e2e auto-heal produced by the **daily backend.ai-webui digest** pipeline (run 2026-07-28).

Two spec files were triaged as **HEAL** (test-side drift, no app regression) and fixed. Every healed test was re-run and verified passing before this PR was opened.

## Healed tests (verified re-pass)

- `e2e/auto-scaling-rule-preset/preset-crud.spec.ts`
  - _Superadmin cannot save an edited preset without a Name_
  - _Superadmin cannot save an edited preset without a Metric Name_
  - **Cause:** #8285 fixed the Prometheus preset edit modal to correctly re-apply `initialValues` on reopen. The tests had relied on the previous (buggy) empty-form behavior to trigger required-field validation. Fix: explicitly clear the Name / Metric Name field before Save.

- `e2e/chat/chat-sync.spec.ts`
  - _Sending a message from one synced pane triggers send in all other synced panes_
  - _User can re-enable sync after disabling it and text propagation resumes_ (was already green; re-verified)
  - **Cause:** #8329 made ChatCard's model fetch non-suspending with an `isLoadingModels` flag that disables `ChatInput` during load, exposing a send-after-endpoint-switch race. Fix: wait for the pane's own `/v1/models` response + model header before sending.

## Exhausted / unhealed

None — all four in-scope tests pass reliably on re-run.

## Notes

- Produced automatically; no Jira issue required for auto-heal PRs.
- Report doc: `/home/ubuntu/e2e-digest-reports/report-2026-07-28.md`
- cc reviewers: drift-causing PR author(s) requested below.

🤖 Generated with the daily digest auto-heal pipeline.


---

## Follow-up fix: `chat-sync.spec.ts` flakiness (added after review)

Verification of this PR surfaced a problem the original auto-heal missed. Both
describes in `chat-sync.spec.ts` run in `serial` mode, so the failure of
`Turning off sync isolates input to the individual pane` — a test this PR did not
touch — **skipped the two healed tests entirely**. A file-level run never
executed them, so the "verified passing" claim above only held when the tests
were run individually.

That test was genuinely flaky (2/5 passes in isolation), and the cause is a real
test bug rather than an app regression:

- The tests clicked a pane's sync toggle and then immediately typed, using
  `expect(input).toHaveValue('')` as the gate.
- That gate is a **no-op whenever the input is already empty**, so it returned
  instantly without proving the toggle had landed.
- `ChatHeader` wraps `onChangeSync` in `startTransition`, so the pane keeps its
  previous `sync` value for a beat after the click. Typing inside that window
  still mirrors the text into the shared `synchronizedMessage` atom, and the
  text propagates to the other pane — exactly the failure observed.

Fix: a `setSync` helper that clicks the toggle and waits for the `SyncSwitch`
icon to report the new state, used everywhere sync is toggled. The fixed 500ms
`waitForTimeout` in the multi-endpoint send test was also dropped, since the
deterministic waits around it already cover that settle.

**Result:** `chat-sync.spec.ts` now passes **7/7 with `--retries=0`**, and the
previously-flaky test passes 5/5 on repeat (was 2/5).

### Known remaining issue (out of scope, pre-existing on `main`)

`preset-crud.spec.ts` has flaky tests that are unrelated to this PR and are not
addressed here — `Page Load > pagination controls`, `Edit > update the Metric
Name`, `Edit > update the Time Window`. They pass when re-run and fail
intermittently under parallel load, which points at test isolation between
presets rather than an app defect. Worth a separate heal pass.
