### PR TITLE
fix(FR-3398): stop an unresponsive wsproxy from blocking session termination

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
@@ -55,6 +55,11 @@ type SessionForTerminateModal = NonNullable<
   TerminateSessionModalFragment$data[number]
 >;
 
+// Budget for the best-effort wsproxy cleanup performed before a session is
+// deleted. A proxy that accepts the TCP connection but never returns an HTTP
+// response would otherwise leave these requests pending forever (FR-3398).
+const WSPROXY_CLEANUP_TIMEOUT_MS = 10_000;
+
 const sendRequest = async (
   rqst: {
     uri: string;
@@ -66,7 +71,13 @@ const sendRequest = async (
     if (rqst.method === 'GET') {
       rqst.body = undefined;
     }
-    resp = await fetch(rqst.uri, rqst);
+    resp = await fetch(rqst.uri, {
+      ...rqst,
+      // Abort an unresponsive proxy instead of hanging. The rejection is
+      // caught below and reported as "no response", which the caller already
+      // treats as "nothing to clean up".
+      signal: rqst.signal ?? AbortSignal.timeout(WSPROXY_CLEANUP_TIMEOUT_MS),
+    });
     const contentType = resp.headers.get('Content-Type');
     if (contentType === null) {
       body = resp.ok;
@@ -115,6 +126,13 @@ const getProxyURL = async (
   wsproxyVersion?: string,
 ) => {
   let url = 'http://127.0.0.1:5050/';
+  // The `_config.proxyURL` branch uses a truthy check, which covers undefined,
+  // null, and empty string. The Backend.AI client initializes
+  // `_config._proxyURL = null` by default, and `config.toml` can ship
+  // `wsproxy.proxyURL = ""`. Both must fall through to the default URL above
+  // instead of overwriting it with a non-string value (which would later throw
+  // in `new URL(...)`). Mirrors the same guard in `useBackendAIAppLauncher`'s
+  // `getProxyURL`.
   if (
     // @ts-ignore
     globalThis.__local_proxy !== undefined &&
@@ -123,7 +141,7 @@ const getProxyURL = async (
   ) {
     // @ts-ignore
     url = globalThis.__local_proxy.url;
-  } else if (baiClient._config.proxyURL !== undefined) {
+  } else if (baiClient._config.proxyURL) {
     url = baiClient._config.proxyURL;
   }
   if (resourceGroupIdOfSession !== undefined && projectId !== undefined) {
@@ -201,6 +219,7 @@ const TerminateSessionModal: React.FC<TerminateSessionModalProps> = ({
   onRequestClose,
   ...modalProps
 }) => {
+  'use memo';
   const openTerminateModal = false;
   const { t } = useTranslation();
   const { styles } = useStyle();
@@ -234,32 +253,28 @@ const TerminateSessionModal: React.FC<TerminateSessionModalProps> = ({
 
   const { pendingCount, trackPromise } = usePromiseTracker();
 
-  const terminateSession = (session: SessionForTerminateModal) => {
-    return terminateApp(
-      session,
-      baiClient._config.accessKey,
-      session.project_id,
-      baiClient,
-    )
-      .catch((e) => {
-        return {
-          error: e,
-        };
-      })
-      .then((result) => {
-        const err = result?.error;
-        if (
-          err === undefined || //no error
-          (err && // Even if wsproxy address is invalid, session must be deleted.
-            err.message &&
-            (err.statusCode === 404 || err.statusCode === 500))
-        ) {
-          // BAI client destroy try to request 3times as default
-          return baiClient.destroy(session.row_id, session.access_key, isForce);
-        } else {
-          throw err;
-        }
-      });
+  // The wsproxy cleanup is best-effort: it releases a leftover app-proxy route
+  // for the session. It must never prevent the deletion the user actually asked
+  // for — an unreachable, misconfigured, or unresponsive proxy is not a reason
+  // to keep a session alive (FR-3398). The previous guard only let `destroy()`
+  // run for a 404/500 cleanup failure and re-threw everything else, so a
+  // network-level failure silently skipped the deletion.
+  //
+  // The step is also time-boxed as a whole, not just at the `fetch` level:
+  // `getWSProxyVersion` goes through the Backend.AI client, which applies no
+  // request timeout of its own.
+  const terminateSession = async (session: SessionForTerminateModal) => {
+    await Promise.race([
+      terminateApp(
+        session,
+        baiClient._config.accessKey,
+        session.project_id,
+        baiClient,
+      ).catch(() => undefined),
+      new Promise((resolve) => setTimeout(resolve, WSPROXY_CLEANUP_TIMEOUT_MS)),
+    ]);
+    // BAI client destroy try to request 3times as default
+    return baiClient.destroy(session.row_id, session.access_key, isForce);
   };
 
   const relayEvn = useRelayEnvironment();


### PR DESCRIPTION
Resolves #8441 (FR-3398)

## Problem

Terminating a compute session could hang forever and **never delete the session**. The confirmation modal's OK button stayed locked in a spinner and no `DELETE /func/session/{id}` was ever sent.

`terminateApp()` — a best-effort wsproxy cleanup that releases a leftover app-proxy route — is awaited *before* the actual deletion. Two defects turned a failure there into a permanently blocked termination:

1. **No timeout.** The local `sendRequest()` helper called `fetch()` with no `AbortSignal`. A proxy that accepts the TCP connection but never returns an HTTP response leaves the promise unsettled forever, so `baiClient.destroy()` is never reached and `usePromiseTracker`'s `pendingCount` never drops (which is what keeps `confirmLoading` on).
2. **The guard was inverted.** Despite a comment reading "Even if wsproxy address is invalid, session must be deleted", the code only allowed `destroy()` to run when the cleanup failed with `statusCode` 404 or 500, and re-threw everything else — so any network-level failure silently skipped the deletion.

### How the request ends up on a local port

The manager reports `wsproxy_version: v2` (remote App Proxy), but `_config.proxyURL` is `http://127.0.0.1:5050/` — the **built-in default**, not a user setting. When `config.toml` ships the unedited `[wsproxy] proxyURL = "[Proxy URL]"` placeholder, `getConfigValueByExists` substitutes that default (`react/src/helper/loginConfig.ts:463-468`). The code then appends `v2/` to a local v1 proxy default and requests `http://127.0.0.1:5050/v2/proxy/...`. If anything occupies port 5050 without serving that route, the request hangs. If the port is free the connection is refused in milliseconds and the `catch` swallows it — which is why this is easy to miss.

## Fix

- Pass `signal: AbortSignal.timeout(WSPROXY_CLEANUP_TIMEOUT_MS)` to the cleanup `fetch`es so an unresponsive proxy aborts instead of hanging.
- Make the cleanup genuinely best-effort: swallow its rejection and **always** run `baiClient.destroy()` afterwards. The user asked for the session to be terminated; an unreachable proxy is not a reason to keep it alive.
- Time-box the cleanup as a whole, not just at the `fetch` level — `getWSProxyVersion()` goes through the Backend.AI client, which applies no request timeout of its own, so a stall there would block just the same.
- Align `getProxyURL()`'s `proxyURL` guard with the truthy check already used by the twin `getProxyURL()` in `useBackendAIAppLauncher.tsx:124-139`, whose comment notes that `_proxyURL` initializes to `null` and `config.toml` can ship `""`. The terminate modal never received that fix.

### Why 10s

Long enough that a slow-but-healthy proxy still completes its cleanup, short enough that a dead one does not strand a user waiting on a deletion they explicitly confirmed. The cleanup is auxiliary — exceeding the budget costs at most a leftover proxy route, while the session itself is still deleted.

## Verification

Reproduced the failure deterministically by binding a listener on `127.0.0.1:5050` that accepts connections and never responds, then driving the real UI (row → Terminate Session → OK) against manager 26.8.0rc1. Identical scenario on both builds:

| | wsproxy request | `DELETE /func/session/...` | final session status |
|---|---|---|---|
| **Before** (v26.8.0-rc.0) | pending, never settles | **never sent** (waited 45s) | **RUNNING** |
| **After** (this branch) | pending, never settles | **sent after 10s** | **TERMINATED** |

The hanging proxy is still hanging in the "after" run — the deletion simply no longer waits on it.

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, Terminology).

## Deferred

Not falling back to the local proxy default when the manager reports `v2` is the deeper coherence fix, but `_config.proxyURL` always holds a value, so an explicitly configured local proxy cannot be distinguished from the default. With the changes here the mismatch is no longer blocking, so this is left as a follow-up on the issue.

## Relation

Same failure class as FR-3212, which added a timeout to the Chat `/v1/models` fetch for an endpoint that "accepts a TCP connection but never returns an HTTP response". This is the equivalent gap in the session termination path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
