### PR TITLE
fix(FR-3401): show Runtime on the deployment preset review step in edit mode

### DIFF
--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -28,7 +28,6 @@ const STEP2_FIELDS = [
 
 interface PresetReviewSummaryProps {
   form: FormInstance<AdminDeploymentPresetFormValue>;
-  mode: 'create' | 'edit';
   onGoToStep: (index: number) => void;
   runtimeVariants: ReadonlyArray<{ id: string; name: string }>;
   errorFieldNames: string[];
@@ -42,7 +41,6 @@ interface PresetReviewSummaryProps {
 
 const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
   form,
-  mode,
   onGoToStep,
   runtimeVariants,
   errorFieldNames,
@@ -109,11 +107,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
               {values.description}
             </Descriptions.Item>
           )}
-          {mode === 'create' && (
-            <Descriptions.Item label={t('adminDeploymentPreset.Runtime')}>
-              {runtimeName || '-'}
-            </Descriptions.Item>
-          )}
+          <Descriptions.Item label={t('adminDeploymentPreset.Runtime')}>
+            {runtimeName || '-'}
+          </Descriptions.Item>
           <Descriptions.Item label={t('adminDeploymentPreset.Image')}>
             {imageReference ? (
               <Typography.Text

--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -326,8 +326,7 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
   // }`, the shape the section's `initialPresetValues` expects. No explicit
   // useMemo — the React Compiler ('use memo') memoizes this derivation.
   const initialRuntimePresetValues:
-    | ReadonlyArray<RuntimeVariantPresetValueEntry>
-    | undefined =
+    ReadonlyArray<RuntimeVariantPresetValueEntry> | undefined =
     mode === 'edit'
       ? (preset?.presetValues?.map((pv) => ({
           presetId: pv.presetId,
@@ -349,8 +348,7 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
   // the shape the schema helpers operate on.
   const readRuntimeParamStringValues = (): Record<string, string> => {
     const runtimeParams = form.getFieldValue([RUNTIME_PARAMS_NAMESPACE]) as
-      | RuntimeParameterValues
-      | undefined;
+      RuntimeParameterValues | undefined;
     const stringValues: Record<string, string> = {};
     if (!runtimeParams) return stringValues;
     for (const [key, val] of Object.entries(runtimeParams)) {
@@ -418,9 +416,7 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
         imageId: preset.execution?.imageId ?? undefined,
         clusterMode:
           (preset.cluster?.clusterMode as
-            | 'SINGLE_NODE'
-            | 'MULTI_NODE'
-            | undefined) ?? undefined,
+            'SINGLE_NODE' | 'MULTI_NODE' | undefined) ?? undefined,
         clusterSize: preset.cluster?.clusterSize ?? undefined,
         ...(() => {
           const slots = preset.resourceSlots ?? [];
@@ -1112,7 +1108,6 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
                 <Suspense fallback={<Skeleton active />}>
                   <PresetReviewSummary
                     form={form}
-                    mode={mode}
                     onGoToStep={goToStep}
                     runtimeVariants={runtimeVariants}
                     errorFieldNames={errorFieldNames}


### PR DESCRIPTION
Resolves #8445 (FR-3401)

## Problem

On the deployment preset **edit** page, the final **Review** step does not show the **Runtime** row. The runtime is editable in step 1 in edit mode exactly as it is in create mode, and its value is seeded from the preset, but the review summary drops it — so an admin reviewing changes before saving cannot confirm which runtime the preset will use.

## Root cause

`AdminDeploymentPresetReviewSummary.tsx` gated the row on create mode:

```tsx
{mode === 'create' && (
  <Descriptions.Item label={t('adminDeploymentPreset.Runtime')}>
    {runtimeName || '-'}
  </Descriptions.Item>
)}
```

Nothing in the form justifies the gate:

- The `runtimeVariantId` `Form.Item` in `AdminDeploymentPresetSettingPageContent.tsx` is **not** mode-gated — it renders, is required, and is editable in both modes.
- In edit mode the field is populated from the preset (`runtimeVariantId: preset.runtimeVariantId`).
- `runtimeVariantId` is part of step 1's error set, so a validation error on it can turn the Basic Info card red on the review step while the offending field itself is not displayed.

The gate dates back to the feature's original PR (FR-2761), whose description states the review step is a "read-only summary that **mirrors every step**". There is no comment on the condition and no rationale in that PR — it reads as an oversight rather than a decision.

## Fix

- Render the Runtime row unconditionally.
- `mode` had no other reference in this component, so the prop is removed from `PresetReviewSummaryProps`, the component signature, and the call site.

No i18n changes: `adminDeploymentPreset.Runtime` already exists and is used by both the form label and the previously create-only review row.

## Verification

Drove the real edit flow (`/admin/deployments/deployment-presets/{id}/edit` → **Skip to Review**) against manager 26.8.0rc1 with an existing preset, and read the review step's `Descriptions` labels. Identical scenario on both builds:

| | labels on Review | Runtime present | first labels |
|---|---|---|---|
| **Before** (v26.8.0-rc.0) | 12 | **no** | `Name, Image, Resource Slots, …` |
| **After** (this branch) | 13 | **yes** | `Name, Runtime, Image, Resource Slots, …` |

The row lands directly after `Name`, matching step 1's field order. (`Description` is absent in both runs because the preset under test has none — it is conditional on a non-empty value and unrelated to this change.)

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, Terminology).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
