### PR TITLE
feat(FR-3385): add BAIVFolderPathPicker for choosing a path inside a vfolder

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIDirectoryPickerModalQuery.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIDirectoryPickerModalQuery.graphql.ts
@@ -1,0 +1,120 @@
+/**
+ * @generated SignedSource<<017bc87d2eaebdb21012626918b83ad4>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type BAIDirectoryPickerModalQuery$variables = {
+  vfolderGlobalId: string;
+};
+export type BAIDirectoryPickerModalQuery$data = {
+  readonly vfolder_node: {
+    readonly name: string | null | undefined;
+    readonly permissions: ReadonlyArray<any | null | undefined> | null | undefined;
+  } | null | undefined;
+};
+export type BAIDirectoryPickerModalQuery = {
+  response: BAIDirectoryPickerModalQuery$data;
+  variables: BAIDirectoryPickerModalQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "vfolderGlobalId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "vfolderGlobalId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "permissions",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "BAIDirectoryPickerModalQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "VirtualFolderNode",
+        "kind": "LinkedField",
+        "name": "vfolder_node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "BAIDirectoryPickerModalQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "VirtualFolderNode",
+        "kind": "LinkedField",
+        "name": "vfolder_node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6324566f7c4a12b37f72eb612354aa1e",
+    "id": null,
+    "metadata": {},
+    "name": "BAIDirectoryPickerModalQuery",
+    "operationKind": "query",
+    "text": "query BAIDirectoryPickerModalQuery(\n  $vfolderGlobalId: String!\n) {\n  vfolder_node(id: $vfolderGlobalId) {\n    name\n    permissions\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a0dd2f262e613fcc30acd13d604f3f30";
+
+export default node;

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
@@ -7,9 +7,9 @@ import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIFlex from '../../BAIFlex';
 import BAIModal, { BAIModalProps } from '../../BAIModal';
 import BAIFileExplorer from './BAIFileExplorer';
-import { Button, Skeleton, Typography } from 'antd';
+import { Button, Typography } from 'antd';
 import * as _ from 'lodash-es';
-import { Suspense, useEffect, useEffectEvent, useState } from 'react';
+import { useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 
 // The picker works with sub paths ('' = vfolder root) while BAIFileExplorer
@@ -49,25 +49,30 @@ export interface BAIDirectoryPickerModalProps extends Omit<
 }
 
 /**
- * The suspending part of the modal: the preloaded `vfolder_node` query and the
- * `BAIFileExplorer` (which resolves the BAIClient via `use()`). Kept in a child
- * component so the modal shell can wrap it in its own `<Suspense>` and stay
- * self-contained — callers do not need to provide an outer boundary.
+ * A directory-only picker built on `BAIFileExplorer`'s `directoryPicker`
+ * mode: browse the vfolder (files visible but disabled, folder CRUD
+ * available) and confirm the current location with the footer button.
+ *
+ * Suspends until the preloaded `vfolder_node` query (and the BAIClient
+ * promise consumed inside `BAIFileExplorer`) resolves, so it mounts fully
+ * ready — folder name in the title, permissions applied. Openers must
+ * therefore mount it inside a transition (`loadQuery` + open-state update
+ * wrapped in `startTransition`, as `BAIVFolderPathPicker` does, surfacing
+ * `isPending` on the trigger) or provide their own Suspense boundary.
  */
-const DirectoryPickerModalContent: React.FC<{
-  vfolderUuid: string;
-  queryRef: PreloadedQuery<BAIDirectoryPickerModalQuery>;
-  defaultPath: string;
-  onChangeCurrentPath: (currentPath: string) => void;
-  onLoadFolderName: (folderName?: string) => void;
-}> = ({
+const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
   vfolderUuid,
   queryRef,
   defaultPath,
-  onChangeCurrentPath,
-  onLoadFolderName,
+  onRequestClose,
+  ...modalProps
 }) => {
   'use memo';
+
+  const { t } = useBAIi18n();
+  const [currentPath, setCurrentPath] = useState(
+    toExplorerPath(defaultPath ?? ''),
+  );
 
   // Folder CRUD inside the picker follows the caller's effective permissions
   // on this vfolder, same as FolderExplorerModal.
@@ -84,59 +89,13 @@ const DirectoryPickerModalContent: React.FC<{
     'delete_content',
   );
 
-  // Lift the resolved folder name up so the modal title can show it once the
-  // query settles, without pulling the suspending query into the shell.
-  const notifyFolderName = useEffectEvent(() => {
-    onLoadFolderName(vfolder_node?.name ?? undefined);
-  });
-  useEffect(() => {
-    notifyFolderName();
-  }, [vfolder_node?.name]);
-
-  return (
-    <BAIFileExplorer
-      mode="directoryPicker"
-      targetVFolderId={vfolderUuid}
-      targetVFolderName={vfolder_node?.name ?? undefined}
-      defaultPath={toExplorerPath(defaultPath)}
-      onChangeCurrentPath={onChangeCurrentPath}
-      enableWrite={hasWriteContentPermission}
-      enableDelete={hasDeleteContentPermission}
-    />
-  );
-};
-
-/**
- * A directory-only picker built on `BAIFileExplorer`'s `directoryPicker`
- * mode: browse the vfolder (files visible but disabled, folder CRUD
- * available) and confirm the current location with the footer button.
- *
- * Self-contained: the suspending content (preloaded query + explorer) sits
- * behind an internal `<Suspense>`, so the modal frame renders immediately and
- * no outer Suspense boundary is required.
- */
-const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
-  vfolderUuid,
-  queryRef,
-  defaultPath,
-  onRequestClose,
-  ...modalProps
-}) => {
-  'use memo';
-
-  const { t } = useBAIi18n();
-  const [currentPath, setCurrentPath] = useState(
-    toExplorerPath(defaultPath ?? ''),
-  );
-  const [folderName, setFolderName] = useState<string>();
-
   return (
     <BAIModal
       width={800}
       title={
-        folderName
+        vfolder_node?.name
           ? t('comp:VFolderPathPicker.SelectAPathInFolder', {
-              folderName,
+              folderName: vfolder_node.name,
             })
           : t('comp:VFolderPathPicker.SelectAPath')
       }
@@ -161,15 +120,15 @@ const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
       }
       {...modalProps}
     >
-      <Suspense fallback={<Skeleton active paragraph={{ rows: 6 }} />}>
-        <DirectoryPickerModalContent
-          vfolderUuid={vfolderUuid}
-          queryRef={queryRef}
-          defaultPath={defaultPath ?? ''}
-          onChangeCurrentPath={setCurrentPath}
-          onLoadFolderName={setFolderName}
-        />
-      </Suspense>
+      <BAIFileExplorer
+        mode="directoryPicker"
+        targetVFolderId={vfolderUuid}
+        targetVFolderName={vfolder_node?.name ?? undefined}
+        defaultPath={toExplorerPath(defaultPath ?? '')}
+        onChangeCurrentPath={setCurrentPath}
+        enableWrite={hasWriteContentPermission}
+        enableDelete={hasDeleteContentPermission}
+      />
     </BAIModal>
   );
 };

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
@@ -3,7 +3,6 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { BAIDirectoryPickerModalQuery } from '../../../__generated__/BAIDirectoryPickerModalQuery.graphql';
-import { toGlobalId } from '../../../helper';
 import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIFlex from '../../BAIFlex';
 import BAIModal, { BAIModalProps } from '../../BAIModal';
@@ -11,7 +10,7 @@ import BAIFileExplorer from './BAIFileExplorer';
 import { Button, Typography } from 'antd';
 import * as _ from 'lodash-es';
 import { useState } from 'react';
-import { graphql, useLazyLoadQuery } from 'react-relay';
+import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 
 // The picker works with sub paths ('' = vfolder root) while BAIFileExplorer
 // uses '.' as its root path.
@@ -19,11 +18,30 @@ const toExplorerPath = (subPath: string) => (subPath === '' ? '.' : subPath);
 const toSubPath = (explorerPath: string) =>
   explorerPath === '.' ? '' : explorerPath;
 
+// Exported so openers can `loadQuery` it in the trigger's event handler
+// (render-as-you-fetch): the trigger stays in control of the in-flight state
+// (e.g. BAIVFolderPathPicker's select `loading`) instead of hiding it behind a
+// Suspense gap. Operation name must match the generated artifact; the const
+// name only differs to avoid clashing with the imported generated type.
+export const BAIDirectoryPickerQuery = graphql`
+  query BAIDirectoryPickerModalQuery($vfolderGlobalId: String!) {
+    vfolder_node(id: $vfolderGlobalId) {
+      name
+      permissions
+    }
+  }
+`;
+
 export interface BAIDirectoryPickerModalProps extends Omit<
   BAIModalProps,
   'onOk' | 'onCancel' | 'footer' | 'title'
 > {
   vfolderUuid: string;
+  /**
+   * Preloaded reference to `BAIDirectoryPickerQuery` produced by the opener
+   * via `useQueryLoader`, keyed by this vfolder's global id.
+   */
+  queryRef: PreloadedQuery<BAIDirectoryPickerModalQuery>;
   /** Sub path to start browsing from ('' = vfolder root). */
   defaultPath?: string;
   /** Called with the chosen sub path, or `undefined` when cancelled. */
@@ -37,6 +55,7 @@ export interface BAIDirectoryPickerModalProps extends Omit<
  */
 const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
   vfolderUuid,
+  queryRef,
   defaultPath,
   onRequestClose,
   ...modalProps
@@ -50,16 +69,9 @@ const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
 
   // Folder CRUD inside the picker follows the caller's effective permissions
   // on this vfolder, same as FolderExplorerModal.
-  const { vfolder_node } = useLazyLoadQuery<BAIDirectoryPickerModalQuery>(
-    graphql`
-      query BAIDirectoryPickerModalQuery($vfolderGlobalId: String!) {
-        vfolder_node(id: $vfolderGlobalId) {
-          name
-          permissions
-        }
-      }
-    `,
-    { vfolderGlobalId: toGlobalId('VirtualFolderNode', vfolderUuid) },
+  const { vfolder_node } = usePreloadedQuery<BAIDirectoryPickerModalQuery>(
+    BAIDirectoryPickerQuery,
+    queryRef,
   );
   const hasWriteContentPermission = _.includes(
     vfolder_node?.permissions,

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
@@ -7,9 +7,9 @@ import { useBAIi18n } from '../../../hooks/useBAIi18n';
 import BAIFlex from '../../BAIFlex';
 import BAIModal, { BAIModalProps } from '../../BAIModal';
 import BAIFileExplorer from './BAIFileExplorer';
-import { Button, Typography } from 'antd';
+import { Button, Skeleton, Typography } from 'antd';
 import * as _ from 'lodash-es';
-import { useState } from 'react';
+import { Suspense, useEffect, useEffectEvent, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 
 // The picker works with sub paths ('' = vfolder root) while BAIFileExplorer
@@ -49,23 +49,25 @@ export interface BAIDirectoryPickerModalProps extends Omit<
 }
 
 /**
- * A directory-only picker built on `BAIFileExplorer`'s `directoryPicker`
- * mode: browse the vfolder (files visible but disabled, folder CRUD
- * available) and confirm the current location with the footer button.
+ * The suspending part of the modal: the preloaded `vfolder_node` query and the
+ * `BAIFileExplorer` (which resolves the BAIClient via `use()`). Kept in a child
+ * component so the modal shell can wrap it in its own `<Suspense>` and stay
+ * self-contained — callers do not need to provide an outer boundary.
  */
-const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
+const DirectoryPickerModalContent: React.FC<{
+  vfolderUuid: string;
+  queryRef: PreloadedQuery<BAIDirectoryPickerModalQuery>;
+  defaultPath: string;
+  onChangeCurrentPath: (currentPath: string) => void;
+  onLoadFolderName: (folderName?: string) => void;
+}> = ({
   vfolderUuid,
   queryRef,
   defaultPath,
-  onRequestClose,
-  ...modalProps
+  onChangeCurrentPath,
+  onLoadFolderName,
 }) => {
   'use memo';
-
-  const { t } = useBAIi18n();
-  const [currentPath, setCurrentPath] = useState(
-    toExplorerPath(defaultPath ?? ''),
-  );
 
   // Folder CRUD inside the picker follows the caller's effective permissions
   // on this vfolder, same as FolderExplorerModal.
@@ -82,13 +84,59 @@ const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
     'delete_content',
   );
 
+  // Lift the resolved folder name up so the modal title can show it once the
+  // query settles, without pulling the suspending query into the shell.
+  const notifyFolderName = useEffectEvent(() => {
+    onLoadFolderName(vfolder_node?.name ?? undefined);
+  });
+  useEffect(() => {
+    notifyFolderName();
+  }, [vfolder_node?.name]);
+
+  return (
+    <BAIFileExplorer
+      mode="directoryPicker"
+      targetVFolderId={vfolderUuid}
+      targetVFolderName={vfolder_node?.name ?? undefined}
+      defaultPath={toExplorerPath(defaultPath)}
+      onChangeCurrentPath={onChangeCurrentPath}
+      enableWrite={hasWriteContentPermission}
+      enableDelete={hasDeleteContentPermission}
+    />
+  );
+};
+
+/**
+ * A directory-only picker built on `BAIFileExplorer`'s `directoryPicker`
+ * mode: browse the vfolder (files visible but disabled, folder CRUD
+ * available) and confirm the current location with the footer button.
+ *
+ * Self-contained: the suspending content (preloaded query + explorer) sits
+ * behind an internal `<Suspense>`, so the modal frame renders immediately and
+ * no outer Suspense boundary is required.
+ */
+const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
+  vfolderUuid,
+  queryRef,
+  defaultPath,
+  onRequestClose,
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useBAIi18n();
+  const [currentPath, setCurrentPath] = useState(
+    toExplorerPath(defaultPath ?? ''),
+  );
+  const [folderName, setFolderName] = useState<string>();
+
   return (
     <BAIModal
       width={800}
       title={
-        vfolder_node?.name
+        folderName
           ? t('comp:VFolderPathPicker.SelectAPathInFolder', {
-              folderName: vfolder_node.name,
+              folderName,
             })
           : t('comp:VFolderPathPicker.SelectAPath')
       }
@@ -113,15 +161,15 @@ const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
       }
       {...modalProps}
     >
-      <BAIFileExplorer
-        mode="directoryPicker"
-        targetVFolderId={vfolderUuid}
-        targetVFolderName={vfolder_node?.name ?? undefined}
-        defaultPath={toExplorerPath(defaultPath ?? '')}
-        onChangeCurrentPath={setCurrentPath}
-        enableWrite={hasWriteContentPermission}
-        enableDelete={hasDeleteContentPermission}
-      />
+      <Suspense fallback={<Skeleton active paragraph={{ rows: 6 }} />}>
+        <DirectoryPickerModalContent
+          vfolderUuid={vfolderUuid}
+          queryRef={queryRef}
+          defaultPath={defaultPath ?? ''}
+          onChangeCurrentPath={setCurrentPath}
+          onLoadFolderName={setFolderName}
+        />
+      </Suspense>
     </BAIModal>
   );
 };

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
@@ -1,0 +1,119 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { BAIDirectoryPickerModalQuery } from '../../../__generated__/BAIDirectoryPickerModalQuery.graphql';
+import { toGlobalId } from '../../../helper';
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
+import BAIFlex from '../../BAIFlex';
+import BAIModal, { BAIModalProps } from '../../BAIModal';
+import BAIFileExplorer from './BAIFileExplorer';
+import { Button, Typography } from 'antd';
+import * as _ from 'lodash-es';
+import { useState } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+// The picker works with sub paths ('' = vfolder root) while BAIFileExplorer
+// uses '.' as its root path.
+const toExplorerPath = (subPath: string) => (subPath === '' ? '.' : subPath);
+const toSubPath = (explorerPath: string) =>
+  explorerPath === '.' ? '' : explorerPath;
+
+export interface BAIDirectoryPickerModalProps extends Omit<
+  BAIModalProps,
+  'onOk' | 'onCancel' | 'footer' | 'title'
+> {
+  vfolderUuid: string;
+  vfolderName?: string;
+  /** Sub path to start browsing from ('' = vfolder root). */
+  defaultPath?: string;
+  /** Called with the chosen sub path, or `undefined` when cancelled. */
+  onRequestClose: (selectedSubPath?: string) => void;
+}
+
+/**
+ * A directory-only picker built on `BAIFileExplorer`'s `directoryPicker`
+ * mode: browse the vfolder (files visible but disabled, folder CRUD
+ * available) and confirm the current location with the footer button.
+ */
+const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
+  vfolderUuid,
+  vfolderName,
+  defaultPath,
+  onRequestClose,
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useBAIi18n();
+  const [currentPath, setCurrentPath] = useState(
+    toExplorerPath(defaultPath ?? ''),
+  );
+
+  // Folder CRUD inside the picker follows the caller's effective permissions
+  // on this vfolder, same as FolderExplorerModal.
+  const { vfolder_node } = useLazyLoadQuery<BAIDirectoryPickerModalQuery>(
+    graphql`
+      query BAIDirectoryPickerModalQuery($vfolderGlobalId: String!) {
+        vfolder_node(id: $vfolderGlobalId) {
+          name
+          permissions
+        }
+      }
+    `,
+    { vfolderGlobalId: toGlobalId('VirtualFolderNode', vfolderUuid) },
+  );
+  const hasWriteContentPermission = _.includes(
+    vfolder_node?.permissions,
+    'write_content',
+  );
+  const hasDeleteContentPermission = _.includes(
+    vfolder_node?.permissions,
+    'delete_content',
+  );
+
+  return (
+    <BAIModal
+      width={800}
+      title={
+        (vfolderName ?? vfolder_node?.name)
+          ? t('comp:VFolderPathPicker.SelectAPathInFolder', {
+              folderName: vfolderName ?? vfolder_node?.name,
+            })
+          : t('comp:VFolderPathPicker.SelectAPath')
+      }
+      onCancel={() => {
+        onRequestClose();
+      }}
+      footer={
+        <BAIFlex justify="between" align="center" gap="sm">
+          <Typography.Text type="secondary" ellipsis style={{ maxWidth: 460 }}>
+            {t('comp:VFolderPathPicker.SelectedPath')}:&nbsp;
+            <Typography.Text code>/{toSubPath(currentPath)}</Typography.Text>
+          </Typography.Text>
+          <Button
+            type="primary"
+            onClick={() => {
+              onRequestClose(toSubPath(currentPath));
+            }}
+          >
+            {t('comp:VFolderPathPicker.SelectThisLocation')}
+          </Button>
+        </BAIFlex>
+      }
+      {...modalProps}
+    >
+      <BAIFileExplorer
+        mode="directoryPicker"
+        targetVFolderId={vfolderUuid}
+        targetVFolderName={vfolderName}
+        defaultPath={toExplorerPath(defaultPath ?? '')}
+        onChangeCurrentPath={setCurrentPath}
+        enableWrite={hasWriteContentPermission}
+        enableDelete={hasDeleteContentPermission}
+      />
+    </BAIModal>
+  );
+};
+
+export default BAIDirectoryPickerModal;

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIDirectoryPickerModal.tsx
@@ -24,7 +24,6 @@ export interface BAIDirectoryPickerModalProps extends Omit<
   'onOk' | 'onCancel' | 'footer' | 'title'
 > {
   vfolderUuid: string;
-  vfolderName?: string;
   /** Sub path to start browsing from ('' = vfolder root). */
   defaultPath?: string;
   /** Called with the chosen sub path, or `undefined` when cancelled. */
@@ -38,7 +37,6 @@ export interface BAIDirectoryPickerModalProps extends Omit<
  */
 const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
   vfolderUuid,
-  vfolderName,
   defaultPath,
   onRequestClose,
   ...modalProps
@@ -76,9 +74,9 @@ const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
     <BAIModal
       width={800}
       title={
-        (vfolderName ?? vfolder_node?.name)
+        vfolder_node?.name
           ? t('comp:VFolderPathPicker.SelectAPathInFolder', {
-              folderName: vfolderName ?? vfolder_node?.name,
+              folderName: vfolder_node.name,
             })
           : t('comp:VFolderPathPicker.SelectAPath')
       }
@@ -106,7 +104,7 @@ const BAIDirectoryPickerModal: React.FC<BAIDirectoryPickerModalProps> = ({
       <BAIFileExplorer
         mode="directoryPicker"
         targetVFolderId={vfolderUuid}
-        targetVFolderName={vfolderName}
+        targetVFolderName={vfolder_node?.name ?? undefined}
         defaultPath={toExplorerPath(defaultPath ?? '')}
         onChangeCurrentPath={setCurrentPath}
         enableWrite={hasWriteContentPermission}

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -17,8 +17,14 @@ import EditableFileName from './EditableFileName';
 import ExplorerActionControls from './ExplorerActionControls';
 import FileItemControls from './FileItemControls';
 import { useSearchVFolderFiles } from './hooks';
-import { FolderOutlined } from '@ant-design/icons';
-import { Breadcrumb, Skeleton, theme, type TableColumnsType } from 'antd';
+import { FileOutlined, FolderOutlined } from '@ant-design/icons';
+import {
+  Breadcrumb,
+  Skeleton,
+  theme,
+  Typography,
+  type TableColumnsType,
+} from 'antd';
 import type { ItemType } from 'antd/es/breadcrumb/Breadcrumb';
 import type { RcFile } from 'antd/es/upload';
 import dayjs from 'dayjs';
@@ -28,6 +34,7 @@ import {
   createContext,
   Suspense,
   useEffect,
+  useEffectEvent,
   useImperativeHandle,
   useMemo,
   useState,
@@ -51,7 +58,19 @@ export interface BAIFileExplorerProps {
   targetVFolderId: string;
   targetVFolderName?: string;
   fetchKey?: string;
-  onUpload: (files: Array<RcFile>, currentPath: string) => void;
+  // 'explorer' (default): full file manager — multi-select, upload, file
+  // editing. 'directoryPicker': directory-selection UI — files are visible
+  // but disabled, a row click navigates into the directory, checkbox
+  // selection and file-creation/upload entry points are hidden; folder CRUD
+  // (create / rename / delete) stays available.
+  mode?: 'explorer' | 'directoryPicker';
+  // Path inside the vfolder to start browsing from, in currentPath notation
+  // ('.' = root). Applied once on mount.
+  defaultPath?: string;
+  // Reports currentPath ('.' = root) whenever navigation changes it,
+  // including the initial value on mount.
+  onChangeCurrentPath?: (currentPath: string) => void;
+  onUpload?: (files: Array<RcFile>, currentPath: string) => void;
   tableProps?: Partial<BAITableProps<VFolderFile>>;
   style?: React.CSSProperties;
   fileDropContainerRef?: React.RefObject<HTMLDivElement | null>;
@@ -80,6 +99,9 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
   targetVFolderId,
   targetVFolderName,
   fetchKey,
+  mode = 'explorer',
+  defaultPath,
+  onChangeCurrentPath,
   onUpload,
   tableProps,
   fileDropContainerRef,
@@ -119,6 +141,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
     navigateToPath,
     refetch,
   } = useSearchVFolderFiles(targetVFolderId, fetchKey);
+  const isDirectoryPicker = mode === 'directoryPicker';
 
   useImperativeHandle(
     ref,
@@ -127,6 +150,23 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
     }),
     [refetch],
   );
+
+  // Applied once on mount; idempotent under StrictMode.
+  const navigateToDefaultPath = useEffectEvent(() => {
+    if (defaultPath && defaultPath !== '.') {
+      navigateToPath(defaultPath);
+    }
+  });
+  useEffect(() => {
+    navigateToDefaultPath();
+  }, []);
+
+  const notifyCurrentPath = useEffectEvent(() => {
+    onChangeCurrentPath?.(currentPath);
+  });
+  useEffect(() => {
+    notifyCurrentPath();
+  }, [currentPath]);
 
   const breadCrumbItems: Array<ItemType> = useMemo(() => {
     const pathParts = currentPath === '.' ? [] : currentPath.split('/');
@@ -192,25 +232,35 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
       title: t('comp:FileExplorer.Name'),
       dataIndex: 'name',
       sorter: (a, b) => localeCompare(a.name, b.name),
-      render: (name, record) => (
-        <EditableFileName
-          fileInfo={record}
-          existingFiles={files?.items || []}
-          disabled={!enableWrite}
-          onEndEdit={() => {
-            refetch();
-          }}
-          onClick={(e) => {
-            e.stopPropagation();
-            const targetEl = e.target as HTMLElement;
-            if (targetEl.closest('button')) return;
-            if (record.type === 'DIRECTORY') {
-              navigateDown(name);
-              setSelectedItems([]);
-            }
-          }}
-        />
-      ),
+      render: (name, record) =>
+        isDirectoryPicker && record.type !== 'DIRECTORY' ? (
+          // In the directory picker, files are shown for context but are not
+          // interactive — only directories can be entered and chosen.
+          <BAIFlex gap="xs" style={{ display: 'inline-flex' }}>
+            <FileOutlined style={{ color: token.colorTextDisabled }} />
+            <Typography.Text disabled ellipsis style={{ maxWidth: 200 }}>
+              {name}
+            </Typography.Text>
+          </BAIFlex>
+        ) : (
+          <EditableFileName
+            fileInfo={record}
+            existingFiles={files?.items || []}
+            disabled={!enableWrite}
+            onEndEdit={() => {
+              refetch();
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              const targetEl = e.target as HTMLElement;
+              if (targetEl.closest('button')) return;
+              if (record.type === 'DIRECTORY') {
+                navigateDown(name);
+                setSelectedItems([]);
+              }
+            }}
+          />
+        ),
     },
     {
       title: t('comp:FileExplorer.Controls'),
@@ -226,6 +276,10 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
             ),
           );
 
+        if (isDirectoryPicker && record.type !== 'DIRECTORY') {
+          return null;
+        }
+
         return (
           <Suspense fallback={<Skeleton.Button size="small" active />}>
             <FileItemControls
@@ -234,9 +288,9 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
                 setSelectedSingleItem(record);
               }}
               onClickEdit={() => onClickEditFile?.(record, currentPath)}
-              enableDownload={enableDownload}
+              enableDownload={!isDirectoryPicker && enableDownload}
               enableDelete={enableDelete}
-              enableEdit={enableEdit}
+              enableEdit={!isDirectoryPicker && enableEdit}
               deleteButtonProps={{ loading: isPendingDelete }}
             />
           </Suspense>
@@ -314,7 +368,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
       {isDragMode && enableUpload && (
         <DragAndDrop
           portalContainer={dragPortalContainer || undefined}
-          onUpload={(files, currentPath) => onUpload(files, currentPath)}
+          onUpload={(files, currentPath) => onUpload?.(files, currentPath)}
         />
       )}
       <BAIFlex
@@ -333,11 +387,21 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
           />
           <ExplorerActionControls
             selectedFiles={selectedItems}
+            mode={mode}
             enableDownload={enableDownload}
             enableDelete={enableDelete}
             enableWrite={enableWrite}
             enableUpload={enableUpload}
-            onUpload={(files, currentPath) => onUpload(files, currentPath)}
+            onUpload={(files, currentPath) => onUpload?.(files, currentPath)}
+            onFolderCreated={
+              isDirectoryPicker
+                ? (folderName) => {
+                    // Jump straight into the created folder so "select this
+                    // location" picks it.
+                    navigateDown(folderName);
+                  }
+                : undefined
+            }
             onDeleteFilesInBackground={onDeleteFilesInBackground}
             onClearSelection={() => setSelectedItems([])}
             onRequestClose={(
@@ -384,31 +448,51 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
           // If files have been loaded before, use normal loading style (opacity)
           loading={!isFirstFetching && isFetching}
           pagination={false}
-          rowSelection={{
-            type: 'checkbox',
-            selectedRowKeys: _.map(selectedItems, 'name'),
-            onChange: (selectedRowKeys) => {
-              setSelectedItems(
-                files?.items?.filter((file) =>
-                  selectedRowKeys.includes(file.name),
-                ) || [],
-              );
-            },
-          }}
-          onRow={(record) => ({
-            onClick: () => {
-              const isSelected = selectedItems.some(
-                (item) => item.name === record.name,
-              );
-              if (isSelected) {
-                setSelectedItems(
-                  selectedItems?.filter((item) => item.name !== record.name),
-                );
-              } else {
-                setSelectedItems([...selectedItems, record]);
-              }
-            },
-          })}
+          rowSelection={
+            isDirectoryPicker
+              ? undefined
+              : {
+                  type: 'checkbox',
+                  selectedRowKeys: _.map(selectedItems, 'name'),
+                  onChange: (selectedRowKeys) => {
+                    setSelectedItems(
+                      files?.items?.filter((file) =>
+                        selectedRowKeys.includes(file.name),
+                      ) || [],
+                    );
+                  },
+                }
+          }
+          onRow={(record) =>
+            isDirectoryPicker
+              ? {
+                  onClick: () => {
+                    if (record.type === 'DIRECTORY') {
+                      navigateDown(record.name);
+                    }
+                  },
+                  style:
+                    record.type === 'DIRECTORY'
+                      ? { cursor: 'pointer' }
+                      : { cursor: 'not-allowed' },
+                }
+              : {
+                  onClick: () => {
+                    const isSelected = selectedItems.some(
+                      (item) => item.name === record.name,
+                    );
+                    if (isSelected) {
+                      setSelectedItems(
+                        selectedItems?.filter(
+                          (item) => item.name !== record.name,
+                        ),
+                      );
+                    } else {
+                      setSelectedItems([...selectedItems, record]);
+                    }
+                  },
+                }
+          }
           {...tableProps}
         />
       </BAIFlex>

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
@@ -15,7 +15,7 @@ import BAIVFolderPathPicker from './BAIVFolderPathPicker';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App, Button, Form, Typography } from 'antd';
-import { Suspense, useState } from 'react';
+import { useState } from 'react';
 import { RelayEnvironmentProvider, useQueryLoader } from 'react-relay';
 import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
 
@@ -255,7 +255,10 @@ const MockProviders: React.FC<{ children: React.ReactNode }> = ({
       <QueryClientProvider client={queryClient}>
         <App>
           <BAIClientContext.Provider value={clientPromise}>
-            <Suspense fallback="Loading...">{children}</Suspense>
+            {/* No Suspense boundary here on purpose: BAIVFolderPathPicker and
+                BAIDirectoryPickerModal are self-contained — the modal wraps its
+                own suspending content — so a host never needs to add one. */}
+            {children}
           </BAIClientContext.Provider>
         </App>
       </QueryClientProvider>

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
@@ -1,3 +1,5 @@
+import type { BAIDirectoryPickerModalQuery } from '../../../__generated__/BAIDirectoryPickerModalQuery.graphql';
+import { toGlobalId } from '../../../helper';
 import BAIFlex from '../../BAIFlex';
 import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
 import BAIVFolderSelect from '../../fragments/BAIVFolderSelect';
@@ -6,13 +8,15 @@ import type {
   BAIClient,
   VFolderFile,
 } from '../../provider/BAIClientProvider/types';
-import BAIDirectoryPickerModal from './BAIDirectoryPickerModal';
+import BAIDirectoryPickerModal, {
+  BAIDirectoryPickerQuery,
+} from './BAIDirectoryPickerModal';
 import BAIVFolderPathPicker from './BAIVFolderPathPicker';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App, Button, Form, Typography } from 'antd';
 import { Suspense, useState } from 'react';
-import { RelayEnvironmentProvider } from 'react-relay';
+import { RelayEnvironmentProvider, useQueryLoader } from 'react-relay';
 import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
 
 /**
@@ -268,7 +272,7 @@ const meta: Meta<typeof BAIVFolderPathPicker> = {
     docs: {
       description: {
         component: `
-**BAIVFolderPathPicker** is a sub path picker for a given vfolder: a read-only path field that opens a directory-only picker modal. The vfolder itself is chosen elsewhere (e.g. a [BAIVFolderSelect](/?path=/docs/fragments-baivfolderselect--docs)) and passed in as \`vfolderUuid\`.
+**BAIVFolderPathPicker** is a sub path picker for a given vfolder: a select-like trigger that opens a directory-only picker modal. The vfolder itself is chosen elsewhere (e.g. a [BAIVFolderSelect](/?path=/docs/fragments-baivfolderselect--docs)) and passed in as \`vfolderUuid\`. The modal's vfolder query is preloaded from the open gesture (\`useQueryLoader\` + transition), so the trigger shows its own \`loading\` state while the data is in flight.
 
 The value is the **sub path inside the vfolder** — \`''\` for the vfolder root, \`"sub/path"\` below it, \`undefined\` while nothing is picked — so it plugs directly into a Form.Item; \`value\`/\`onChange\` follow the controllable-state convention, so the component works both controlled and uncontrolled. Files are visible but disabled inside the picker; only directories can be entered and chosen. Folder CRUD (create / rename / delete) stays available via \`BAIFileExplorer\`'s \`directoryPicker\` mode. When the vfolder changes, reset the value — a sub path only makes sense within the vfolder it was picked from.
 
@@ -279,7 +283,7 @@ The value is the **sub path inside the vfolder** — \`''\` for the vfolder root
 | \`value\` | \`string\` | - | Selected sub path (\`''\` = vfolder root) |
 | \`defaultValue\` | \`string\` | - | Initial value for uncontrolled usage |
 | \`onChange\` | \`(selectedSubPath?: string) => void\` | - | Fired when a location is confirmed in the modal |
-| \`inputProps\` | \`InputProps\` subset | - | Forwarded to the sub path trigger field |
+| \`selectProps\` | \`BAISelectProps\` subset | - | Forwarded to the sub path trigger select |
 
 > The stories run against a mock Relay environment and a mock \`BAIClientContext\` client, so vfolder search, browsing, mkdir, rename and delete all work without a backend. The second folder (\`team-shared-data\`) is read-only — pick it in the Form story to see permission gating disable folder CRUD inside the modal.
         `,
@@ -400,46 +404,77 @@ export const WithinForm: Story = {
   },
 };
 
+/**
+ * Drives `BAIDirectoryPickerModal` directly, the way a future wrapper (e.g. a
+ * button component) would: preload `BAIDirectoryPickerQuery` in the click
+ * handler via `useQueryLoader`, then pass the resulting `queryRef` to the
+ * modal. Must live inside `MockProviders` so `useQueryLoader` finds the Relay
+ * environment.
+ */
+const DirectoryPickerModalDemo: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [lastResult, setLastResult] = useState<string | undefined>();
+  const [queryRef, loadQuery] = useQueryLoader<BAIDirectoryPickerModalQuery>(
+    BAIDirectoryPickerQuery,
+  );
+
+  return (
+    <BAIFlex direction="column" gap="md" align="start">
+      <Button
+        type="primary"
+        onClick={() => {
+          loadQuery(
+            {
+              vfolderGlobalId: toGlobalId(
+                'VirtualFolderNode',
+                MOCK_VFOLDERS[0].uuid,
+              ),
+            },
+            { fetchPolicy: 'store-and-network' },
+          );
+          setIsOpen(true);
+        }}
+      >
+        Open directory picker
+      </Button>
+      <Typography.Text type="secondary">
+        Last selection:{' '}
+        <Typography.Text code>
+          {lastResult === undefined ? '(none)' : `/${lastResult}`}
+        </Typography.Text>
+      </Typography.Text>
+      {queryRef != null && (
+        <BAIUnmountAfterClose>
+          <BAIDirectoryPickerModal
+            open={isOpen}
+            vfolderUuid={MOCK_VFOLDERS[0].uuid}
+            queryRef={queryRef}
+            onRequestClose={(selectedSubPath) => {
+              if (selectedSubPath !== undefined) {
+                setLastResult(selectedSubPath);
+              }
+              setIsOpen(false);
+            }}
+          />
+        </BAIUnmountAfterClose>
+      )}
+    </BAIFlex>
+  );
+};
+
 export const PickerModalOnly: Story = {
   name: 'Directory Picker Modal',
   parameters: {
     docs: {
       description: {
         story:
-          '`BAIDirectoryPickerModal` can also be driven directly — pass a vfolder UUID and receive the chosen sub path via `onRequestClose` (`undefined` when cancelled).',
+          '`BAIDirectoryPickerModal` can also be driven directly — preload `BAIDirectoryPickerQuery` with `useQueryLoader` in the opening event, pass the `queryRef`, and receive the chosen sub path via `onRequestClose` (`undefined` when cancelled).',
       },
     },
   },
-  render: () => {
-    const [isOpen, setIsOpen] = useState(false);
-    const [lastResult, setLastResult] = useState<string | undefined>();
-
-    return (
-      <MockProviders>
-        <BAIFlex direction="column" gap="md" align="start">
-          <Button type="primary" onClick={() => setIsOpen(true)}>
-            Open directory picker
-          </Button>
-          <Typography.Text type="secondary">
-            Last selection:{' '}
-            <Typography.Text code>
-              {lastResult === undefined ? '(none)' : `/${lastResult}`}
-            </Typography.Text>
-          </Typography.Text>
-          <BAIUnmountAfterClose>
-            <BAIDirectoryPickerModal
-              open={isOpen}
-              vfolderUuid={MOCK_VFOLDERS[0].uuid}
-              onRequestClose={(selectedSubPath) => {
-                if (selectedSubPath !== undefined) {
-                  setLastResult(selectedSubPath);
-                }
-                setIsOpen(false);
-              }}
-            />
-          </BAIUnmountAfterClose>
-        </BAIFlex>
-      </MockProviders>
-    );
-  },
+  render: () => (
+    <MockProviders>
+      <DirectoryPickerModalDemo />
+    </MockProviders>
+  ),
 };

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
@@ -218,7 +218,11 @@ const MockProviders: React.FC<{ children: React.ReactNode }> = ({
   const [clientPromise] = useState(() => Promise.resolve(createMockClient()));
   const [relayEnvironment] = useState(() => {
     const environment = createMockEnvironment();
-    // The select re-fetches on open/selection; queue enough resolvers.
+    const pickerGlobalIds = MOCK_VFOLDERS.map(({ uuid }) =>
+      toGlobalId('VirtualFolderNode', uuid),
+    );
+    // Queue a resolver and a pending operation per mocked fetch; the picker's
+    // preloaded query hangs unless its operation is registered up front.
     for (let i = 0; i < 20; i++) {
       environment.mock.queueOperationResolver((operation) => {
         // BAIDirectoryPickerModal queries `vfolder_node(id: $vfolderGlobalId)`
@@ -246,6 +250,11 @@ const MockProviders: React.FC<{ children: React.ReactNode }> = ({
           }),
         });
       });
+      pickerGlobalIds.forEach((vfolderGlobalId) =>
+        environment.mock.queuePendingOperation(BAIDirectoryPickerQuery, {
+          vfolderGlobalId,
+        }),
+      );
     }
     return environment;
   });

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
@@ -15,7 +15,7 @@ import BAIVFolderPathPicker from './BAIVFolderPathPicker';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App, Button, Form, Typography } from 'antd';
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { RelayEnvironmentProvider, useQueryLoader } from 'react-relay';
 import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
 
@@ -255,9 +255,10 @@ const MockProviders: React.FC<{ children: React.ReactNode }> = ({
       <QueryClientProvider client={queryClient}>
         <App>
           <BAIClientContext.Provider value={clientPromise}>
-            {/* No Suspense boundary here on purpose: BAIVFolderPathPicker and
-                BAIDirectoryPickerModal are self-contained — the modal wraps its
-                own suspending content — so a host never needs to add one. */}
+            {/* No Suspense boundary here on purpose: every opener mounts
+                BAIDirectoryPickerModal inside a transition (loadQuery + open
+                wrapped in startTransition), so the suspension is absorbed by
+                the transition and a host never needs a boundary. */}
             {children}
           </BAIClientContext.Provider>
         </App>
@@ -410,12 +411,15 @@ export const WithinForm: Story = {
 /**
  * Drives `BAIDirectoryPickerModal` directly, the way a future wrapper (e.g. a
  * button component) would: preload `BAIDirectoryPickerQuery` in the click
- * handler via `useQueryLoader`, then pass the resulting `queryRef` to the
+ * handler via `useQueryLoader` **inside a transition** (the modal suspends on
+ * the preloaded query, and the transition absorbs that suspension — surfaced
+ * as the trigger's loading state), then pass the resulting `queryRef` to the
  * modal. Must live inside `MockProviders` so `useQueryLoader` finds the Relay
  * environment.
  */
 const DirectoryPickerModalDemo: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isOpenPending, startOpenTransition] = useTransition();
   const [lastResult, setLastResult] = useState<string | undefined>();
   const [queryRef, loadQuery] = useQueryLoader<BAIDirectoryPickerModalQuery>(
     BAIDirectoryPickerQuery,
@@ -425,17 +429,20 @@ const DirectoryPickerModalDemo: React.FC = () => {
     <BAIFlex direction="column" gap="md" align="start">
       <Button
         type="primary"
+        loading={isOpenPending}
         onClick={() => {
-          loadQuery(
-            {
-              vfolderGlobalId: toGlobalId(
-                'VirtualFolderNode',
-                MOCK_VFOLDERS[0].uuid,
-              ),
-            },
-            { fetchPolicy: 'store-and-network' },
-          );
-          setIsOpen(true);
+          startOpenTransition(() => {
+            loadQuery(
+              {
+                vfolderGlobalId: toGlobalId(
+                  'VirtualFolderNode',
+                  MOCK_VFOLDERS[0].uuid,
+                ),
+              },
+              { fetchPolicy: 'store-and-network' },
+            );
+            setIsOpen(true);
+          });
         }}
       >
         Open directory picker
@@ -471,7 +478,7 @@ export const PickerModalOnly: Story = {
     docs: {
       description: {
         story:
-          '`BAIDirectoryPickerModal` can also be driven directly — preload `BAIDirectoryPickerQuery` with `useQueryLoader` in the opening event, pass the `queryRef`, and receive the chosen sub path via `onRequestClose` (`undefined` when cancelled).',
+          '`BAIDirectoryPickerModal` can also be driven directly — preload `BAIDirectoryPickerQuery` with `useQueryLoader` in the opening event (wrapped in a transition, since the modal suspends until the query resolves), pass the `queryRef`, and receive the chosen sub path via `onRequestClose` (`undefined` when cancelled).',
       },
     },
   },

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
@@ -1,0 +1,403 @@
+import BAIFlex from '../../BAIFlex';
+import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
+import { BAIClientContext } from '../../provider/BAIClientProvider/context';
+import type {
+  BAIClient,
+  VFolderFile,
+} from '../../provider/BAIClientProvider/types';
+import BAIDirectoryPickerModal from './BAIDirectoryPickerModal';
+import BAIVFolderPathPicker from './BAIVFolderPathPicker';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { App, Button, Form, Typography } from 'antd';
+import { Suspense, useState } from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+
+/**
+ * The picker composes two data sources, both mocked here so every interaction
+ * works end-to-end without a backend:
+ * - the embedded BAIVFolderSelect fetches vfolders via Relay → mock Relay
+ *   environment returning SAMPLE_VFOLDERS;
+ * - the directory modal talks to the REST API through BAIClientContext
+ *   (`vfolder.list_files` / `mkdir` / `rename_file` / `delete_files`) → mock
+ *   client backed by an in-memory directory tree.
+ */
+
+const MOCK_VFOLDERS = [
+  {
+    label: 'my-workspace',
+    uuid: '11111111-1111-1111-1111-111111111111',
+    permissions: ['read_content', 'write_content', 'delete_content'],
+  },
+  {
+    // Read-only folder — demonstrates permission gating: folder CRUD
+    // (create / rename / delete) is disabled inside the picker modal.
+    label: 'team-shared-data',
+    uuid: '22222222-2222-2222-2222-222222222222',
+    permissions: ['read_content'],
+  },
+];
+
+// Relay global ids must decode to the UUIDs the mock REST client is keyed by.
+const SAMPLE_VFOLDERS = MOCK_VFOLDERS.map(({ label, uuid }) => ({
+  node: {
+    id: btoa(`VFolderNode:${uuid}`),
+    name: label,
+    row_id: uuid,
+  },
+}));
+
+const entry = (
+  name: string,
+  type: VFolderFile['type'],
+  modified: string,
+): VFolderFile => ({
+  name,
+  type,
+  size: type === 'FILE' ? 4096 : 0,
+  mode: 0o755,
+  created: modified,
+  modified,
+});
+
+// Directory trees keyed by vfolder UUID, then by the same path notation
+// `useSearchVFolderFiles` uses ('.' = root, 'a/b' below it).
+const createInitialTrees = (): Record<
+  string,
+  Record<string, Array<VFolderFile>>
+> => ({
+  [MOCK_VFOLDERS[0].uuid]: {
+    '.': [
+      entry('models', 'DIRECTORY', '2026-07-21T14:02:00'),
+      entry('datasets', 'DIRECTORY', '2026-07-18T09:45:00'),
+      entry('outputs', 'DIRECTORY', '2026-07-28T22:10:00'),
+      entry('README.md', 'FILE', '2026-07-01T11:20:00'),
+      entry('train.py', 'FILE', '2026-07-25T16:33:00'),
+    ],
+    models: [
+      entry('checkpoints', 'DIRECTORY', '2026-07-27T03:12:00'),
+      entry('llama-3-ft', 'DIRECTORY', '2026-07-26T19:40:00'),
+      entry('model_definition.yaml', 'FILE', '2026-07-22T10:05:00'),
+    ],
+    'models/checkpoints': [
+      entry('epoch-001', 'DIRECTORY', '2026-07-27T03:12:00'),
+      entry('epoch-002', 'DIRECTORY', '2026-07-27T09:47:00'),
+      entry('latest.pt', 'FILE', '2026-07-27T09:47:00'),
+    ],
+    'models/checkpoints/epoch-001': [],
+    'models/checkpoints/epoch-002': [],
+    'models/llama-3-ft': [
+      entry('adapter_config.json', 'FILE', '2026-07-26T19:40:00'),
+    ],
+    datasets: [
+      entry('raw', 'DIRECTORY', '2026-07-18T09:45:00'),
+      entry('cleaned.parquet', 'FILE', '2026-07-19T08:00:00'),
+    ],
+    'datasets/raw': [],
+    outputs: [],
+  },
+  [MOCK_VFOLDERS[1].uuid]: {
+    '.': [
+      entry('shared-corpus', 'DIRECTORY', '2026-07-10T08:00:00'),
+      entry('LICENSE', 'FILE', '2026-07-02T12:00:00'),
+    ],
+    'shared-corpus': [],
+  },
+});
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const splitJoinedPath = (joined: string) => {
+  const parts = joined.split('/').filter((p) => p !== '');
+  const name = parts.pop() ?? '';
+  const parentParts = parts.filter((p) => p !== '.');
+  return {
+    parent: parentParts.length === 0 ? '.' : parentParts.join('/'),
+    name,
+  };
+};
+
+const childKey = (parent: string, name: string) =>
+  parent === '.' ? name : `${parent}/${name}`;
+
+const createMockClient = (): BAIClient => {
+  const trees = createInitialTrees();
+
+  const mockVFolder = {
+    list_files: async (path: string, id: string) => {
+      await delay(250);
+      return { items: trees[id]?.[path] ?? [] };
+    },
+    mkdir: async (path: string, id: string | null) => {
+      await delay(250);
+      const tree = trees[id ?? ''];
+      const { parent, name } = splitJoinedPath(path);
+      if (!tree || !name) throw new Error('Invalid path');
+      if (tree[parent]?.some((item) => item.name === name)) {
+        throw new Error(`Directory already exists: ${name}`);
+      }
+      tree[parent] = [
+        entry(name, 'DIRECTORY', '2026-07-29T12:00:00'),
+        ...(tree[parent] ?? []),
+      ];
+      tree[childKey(parent, name)] = [];
+      return {};
+    },
+    rename_file: async (
+      target_path: string,
+      new_name: string,
+      targetFolder: string,
+    ) => {
+      await delay(250);
+      const tree = trees[targetFolder];
+      const { parent, name } = splitJoinedPath(target_path);
+      const item = tree?.[parent]?.find((i) => i.name === name);
+      if (!tree || !item) throw new Error('Not found');
+      item.name = new_name;
+      const oldKey = childKey(parent, name);
+      const newKey = childKey(parent, new_name);
+      for (const key of Object.keys(tree)) {
+        if (key === oldKey || key.startsWith(`${oldKey}/`)) {
+          tree[key.replace(oldKey, newKey)] = tree[key];
+          delete tree[key];
+        }
+      }
+      return {};
+    },
+    delete_files: async (
+      files: Array<string>,
+      _recursive: boolean,
+      id: string,
+    ) => {
+      await delay(250);
+      const tree = trees[id];
+      if (!tree) throw new Error('Not found');
+      for (const file of files) {
+        const { parent, name } = splitJoinedPath(file);
+        tree[parent] = (tree[parent] ?? []).filter((i) => i.name !== name);
+        const key = childKey(parent, name);
+        for (const treeKey of Object.keys(tree)) {
+          if (treeKey === key || treeKey.startsWith(`${key}/`)) {
+            delete tree[treeKey];
+          }
+        }
+      }
+      return { bgtask_id: null };
+    },
+    request_download_token: async () => {
+      throw new Error('Download is not available in Storybook');
+    },
+  };
+
+  return {
+    vfolder: mockVFolder,
+    supports: () => false,
+    _config: { isDirectorySizeVisible: false },
+  } as unknown as BAIClient;
+};
+
+/**
+ * Wraps stories with everything the integrated picker needs: a mock Relay
+ * environment (for the embedded BAIVFolderSelect queries) and a mock
+ * BAIClientContext client (for the directory modal's REST calls).
+ */
+const MockProviders: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [queryClient] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  const [clientPromise] = useState(() => Promise.resolve(createMockClient()));
+  const [relayEnvironment] = useState(() => {
+    const environment = createMockEnvironment();
+    // The select re-fetches on open/selection; queue enough resolvers.
+    for (let i = 0; i < 20; i++) {
+      environment.mock.queueOperationResolver((operation) => {
+        // BAIDirectoryPickerModal queries `vfolder_node(id: $vfolderGlobalId)`
+        // with a `VirtualFolderNode:<uuid>` global id — answer with the
+        // matching mock folder's name and permissions.
+        const { vfolderGlobalId } = operation.request.variables;
+        const requestedUuid =
+          typeof vfolderGlobalId === 'string'
+            ? atob(vfolderGlobalId).split(':')[1]
+            : undefined;
+        const requestedVFolder =
+          MOCK_VFOLDERS.find((v) => v.uuid === requestedUuid) ??
+          MOCK_VFOLDERS[0];
+
+        return MockPayloadGenerator.generate(operation, {
+          Query: () => ({
+            vfolder_nodes: {
+              count: SAMPLE_VFOLDERS.length,
+              edges: SAMPLE_VFOLDERS,
+            },
+            vfolder_node: {
+              name: requestedVFolder.label,
+              permissions: requestedVFolder.permissions,
+            },
+          }),
+        });
+      });
+    }
+    return environment;
+  });
+
+  return (
+    <RelayEnvironmentProvider environment={relayEnvironment}>
+      <QueryClientProvider client={queryClient}>
+        <App>
+          <BAIClientContext.Provider value={clientPromise}>
+            <Suspense fallback="Loading...">{children}</Suspense>
+          </BAIClientContext.Provider>
+        </App>
+      </QueryClientProvider>
+    </RelayEnvironmentProvider>
+  );
+};
+
+const meta: Meta<typeof BAIVFolderPathPicker> = {
+  title: 'Input/BAIVFolderPathPicker',
+  component: BAIVFolderPathPicker,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIVFolderPathPicker** is an integrated "vfolder + sub path" picker: an embedded [BAIVFolderSelect](/?path=/docs/fragments-baivfolderselect--docs) next to a read-only path field that opens a directory-only picker modal.
+
+The value is a single **name-based** path string — \`"my-workspace"\` for the vfolder root, \`"my-workspace/sub/path"\` below it — so it plugs directly into a Form.Item; \`value\`/\`onChange\` follow the controllable-state convention, so the component works both controlled and uncontrolled. The vfolder's id is tracked internally for the modal's REST calls and is not part of the value. Files are visible but disabled inside the picker; only directories can be entered and chosen. Folder CRUD (create / rename / delete) stays available via \`BAIFileExplorer\`'s \`directoryPicker\` mode.
+
+## BAI-Specific Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`value\` | \`string\` | - | Selected path; first segment is the vfolder's name, the rest is the sub path |
+| \`defaultValue\` | \`string\` | - | Initial value for uncontrolled usage |
+| \`onChange\` | \`(selectedPath?: string) => void\` | - | Fired on vfolder change (path restarts at its root), clear (\`undefined\`), and path confirmation |
+| \`selectProps\` | \`BAIVFolderSelectProps\` subset | - | Forwarded to the embedded vfolder select (\`currentProjectId\`, \`filter\`, \`excludeDeleted\`, …) |
+| \`inputProps\` | \`InputProps\` subset | - | Forwarded to the sub path trigger field |
+
+> The stories run against a mock Relay environment and a mock \`BAIClientContext\` client, so vfolder search, browsing, mkdir, rename and delete all work without a backend. The second folder (\`team-shared-data\`) is read-only — pick it to see permission gating disable folder CRUD inside the modal.
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIVFolderPathPicker>;
+
+export const Default: Story = {
+  name: 'Basic Usage (uncontrolled)',
+  render: () => {
+    const [lastChange, setLastChange] = useState<string | undefined>();
+
+    return (
+      <MockProviders>
+        <BAIFlex
+          direction="column"
+          align="stretch"
+          gap="md"
+          style={{ width: 560 }}
+        >
+          <BAIVFolderPathPicker onChange={setLastChange} />
+          <Typography.Text type="secondary">
+            onChange:{' '}
+            <Typography.Text code>{lastChange ?? 'undefined'}</Typography.Text>
+          </Typography.Text>
+        </BAIFlex>
+      </MockProviders>
+    );
+  },
+};
+
+export const WithinForm: Story = {
+  name: 'Within Form (controlled by Form.Item)',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The path string plugs straight into a Form.Item — the Form injects `value`/`onChange` and the required rule validates it.',
+      },
+    },
+  },
+  render: () => {
+    const [submitted, setSubmitted] = useState<string>();
+
+    return (
+      <MockProviders>
+        <Form<{ destination?: string }>
+          layout="vertical"
+          style={{ width: 560 }}
+          onFinish={(values) => {
+            setSubmitted(JSON.stringify(values.destination));
+          }}
+        >
+          <Form.Item
+            name="destination"
+            label="Destination"
+            rules={[{ required: true }]}
+          >
+            <BAIVFolderPathPicker />
+          </Form.Item>
+          <BAIFlex direction="column" align="start" gap="sm">
+            <Button type="primary" htmlType="submit">
+              Submit
+            </Button>
+            {submitted && (
+              <Typography.Text type="secondary">
+                submitted: <Typography.Text code>{submitted}</Typography.Text>
+              </Typography.Text>
+            )}
+          </BAIFlex>
+        </Form>
+      </MockProviders>
+    );
+  },
+};
+
+export const PickerModalOnly: Story = {
+  name: 'Directory Picker Modal',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`BAIDirectoryPickerModal` can also be driven directly — pass a vfolder UUID and receive the chosen sub path via `onRequestClose` (`undefined` when cancelled).',
+      },
+    },
+  },
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [lastResult, setLastResult] = useState<string | undefined>();
+
+    return (
+      <MockProviders>
+        <BAIFlex direction="column" gap="md" align="start">
+          <Button type="primary" onClick={() => setIsOpen(true)}>
+            Open directory picker
+          </Button>
+          <Typography.Text type="secondary">
+            Last selection:{' '}
+            <Typography.Text code>
+              {lastResult === undefined ? '(none)' : `/${lastResult}`}
+            </Typography.Text>
+          </Typography.Text>
+          <BAIUnmountAfterClose>
+            <BAIDirectoryPickerModal
+              open={isOpen}
+              vfolderUuid={MOCK_VFOLDERS[0].uuid}
+              vfolderName={MOCK_VFOLDERS[0].label}
+              onRequestClose={(selectedSubPath) => {
+                if (selectedSubPath !== undefined) {
+                  setLastResult(selectedSubPath);
+                }
+                setIsOpen(false);
+              }}
+            />
+          </BAIUnmountAfterClose>
+        </BAIFlex>
+      </MockProviders>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
@@ -1,5 +1,6 @@
 import BAIFlex from '../../BAIFlex';
 import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
+import BAIVFolderSelect from '../../fragments/BAIVFolderSelect';
 import { BAIClientContext } from '../../provider/BAIClientProvider/context';
 import type {
   BAIClient,
@@ -15,11 +16,12 @@ import { RelayEnvironmentProvider } from 'react-relay';
 import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
 
 /**
- * The picker composes two data sources, both mocked here so every interaction
- * works end-to-end without a backend:
- * - the embedded BAIVFolderSelect fetches vfolders via Relay → mock Relay
- *   environment returning SAMPLE_VFOLDERS;
- * - the directory modal talks to the REST API through BAIClientContext
+ * The stories mock two data sources so every interaction works end-to-end
+ * without a backend:
+ * - Relay (the directory modal's `vfolder_node` query and the external
+ *   BAIVFolderSelect in the Form story) → mock Relay environment returning
+ *   SAMPLE_VFOLDERS;
+ * - the directory modal's REST calls through BAIClientContext
  *   (`vfolder.list_files` / `mkdir` / `rename_file` / `delete_files`) → mock
  *   client backed by an in-memory directory tree.
  */
@@ -198,9 +200,10 @@ const createMockClient = (): BAIClient => {
 };
 
 /**
- * Wraps stories with everything the integrated picker needs: a mock Relay
- * environment (for the embedded BAIVFolderSelect queries) and a mock
- * BAIClientContext client (for the directory modal's REST calls).
+ * Wraps stories with everything the picker needs: a mock Relay environment
+ * (for the directory modal's `vfolder_node` query and the external
+ * BAIVFolderSelect) and a mock BAIClientContext client (for the directory
+ * modal's REST calls).
  */
 const MockProviders: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -265,20 +268,20 @@ const meta: Meta<typeof BAIVFolderPathPicker> = {
     docs: {
       description: {
         component: `
-**BAIVFolderPathPicker** is an integrated "vfolder + sub path" picker: an embedded [BAIVFolderSelect](/?path=/docs/fragments-baivfolderselect--docs) next to a read-only path field that opens a directory-only picker modal.
+**BAIVFolderPathPicker** is a sub path picker for a given vfolder: a read-only path field that opens a directory-only picker modal. The vfolder itself is chosen elsewhere (e.g. a [BAIVFolderSelect](/?path=/docs/fragments-baivfolderselect--docs)) and passed in as \`vfolderUuid\`.
 
-The value is a single **name-based** path string — \`"my-workspace"\` for the vfolder root, \`"my-workspace/sub/path"\` below it — so it plugs directly into a Form.Item; \`value\`/\`onChange\` follow the controllable-state convention, so the component works both controlled and uncontrolled. The vfolder's id is tracked internally for the modal's REST calls and is not part of the value. Files are visible but disabled inside the picker; only directories can be entered and chosen. Folder CRUD (create / rename / delete) stays available via \`BAIFileExplorer\`'s \`directoryPicker\` mode.
+The value is the **sub path inside the vfolder** — \`''\` for the vfolder root, \`"sub/path"\` below it, \`undefined\` while nothing is picked — so it plugs directly into a Form.Item; \`value\`/\`onChange\` follow the controllable-state convention, so the component works both controlled and uncontrolled. Files are visible but disabled inside the picker; only directories can be entered and chosen. Folder CRUD (create / rename / delete) stays available via \`BAIFileExplorer\`'s \`directoryPicker\` mode. When the vfolder changes, reset the value — a sub path only makes sense within the vfolder it was picked from.
 
 ## BAI-Specific Props
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| \`value\` | \`string\` | - | Selected path; first segment is the vfolder's name, the rest is the sub path |
+| \`vfolderUuid\` | \`string\` | - | UUID of the vfolder to browse; the field stays disabled until provided |
+| \`value\` | \`string\` | - | Selected sub path (\`''\` = vfolder root) |
 | \`defaultValue\` | \`string\` | - | Initial value for uncontrolled usage |
-| \`onChange\` | \`(selectedPath?: string) => void\` | - | Fired on vfolder change (path restarts at its root), clear (\`undefined\`), and path confirmation |
-| \`selectProps\` | \`BAIVFolderSelectProps\` subset | - | Forwarded to the embedded vfolder select (\`currentProjectId\`, \`filter\`, \`excludeDeleted\`, …) |
+| \`onChange\` | \`(selectedSubPath?: string) => void\` | - | Fired when a location is confirmed in the modal |
 | \`inputProps\` | \`InputProps\` subset | - | Forwarded to the sub path trigger field |
 
-> The stories run against a mock Relay environment and a mock \`BAIClientContext\` client, so vfolder search, browsing, mkdir, rename and delete all work without a backend. The second folder (\`team-shared-data\`) is read-only — pick it to see permission gating disable folder CRUD inside the modal.
+> The stories run against a mock Relay environment and a mock \`BAIClientContext\` client, so vfolder search, browsing, mkdir, rename and delete all work without a backend. The second folder (\`team-shared-data\`) is read-only — pick it in the Form story to see permission gating disable folder CRUD inside the modal.
         `,
       },
     },
@@ -301,10 +304,17 @@ export const Default: Story = {
           gap="md"
           style={{ width: 560 }}
         >
-          <BAIVFolderPathPicker onChange={setLastChange} />
+          <BAIVFolderPathPicker
+            vfolderUuid={MOCK_VFOLDERS[0].uuid}
+            onChange={setLastChange}
+          />
           <Typography.Text type="secondary">
             onChange:{' '}
-            <Typography.Text code>{lastChange ?? 'undefined'}</Typography.Text>
+            <Typography.Text code>
+              {lastChange === undefined
+                ? 'undefined'
+                : JSON.stringify(lastChange)}
+            </Typography.Text>
           </Typography.Text>
         </BAIFlex>
       </MockProviders>
@@ -313,33 +323,63 @@ export const Default: Story = {
 };
 
 export const WithinForm: Story = {
-  name: 'Within Form (controlled by Form.Item)',
+  name: 'Within Form (with external BAIVFolderSelect)',
   parameters: {
     docs: {
       description: {
         story:
-          'The path string plugs straight into a Form.Item — the Form injects `value`/`onChange` and the required rule validates it.',
+          'The intended composition: a separate `BAIVFolderSelect` (with `valuePropName="row_id"` so the field holds the UUID) feeds `vfolderUuid`, and the picker plugs into its own Form.Item. Changing the vfolder resets the path field, and the required rule uses a custom validator because `""` (the vfolder root) is a valid pick.',
       },
     },
   },
   render: () => {
+    const [form] = Form.useForm<{
+      vfolderUuid?: string;
+      destination?: string;
+    }>();
+    const vfolderUuid = Form.useWatch('vfolderUuid', form);
     const [submitted, setSubmitted] = useState<string>();
 
     return (
       <MockProviders>
-        <Form<{ destination?: string }>
+        <Form
+          form={form}
           layout="vertical"
           style={{ width: 560 }}
           onFinish={(values) => {
-            setSubmitted(JSON.stringify(values.destination));
+            setSubmitted(JSON.stringify(values));
           }}
         >
           <Form.Item
-            name="destination"
-            label="Destination"
+            name="vfolderUuid"
+            label="Folder"
             rules={[{ required: true }]}
           >
-            <BAIVFolderPathPicker />
+            <BAIVFolderSelect
+              valuePropName="row_id"
+              allowClear
+              onChange={() => {
+                // A sub path belongs to the vfolder it was picked from.
+                form.setFieldValue('destination', undefined);
+              }}
+            />
+          </Form.Item>
+          <Form.Item
+            name="destination"
+            label="Destination"
+            required
+            rules={[
+              {
+                // `''` (vfolder root) is a valid pick, so `required: true`
+                // (which rejects empty strings) cannot be used here.
+                validator: (_rule, value) =>
+                  value === undefined
+                    ? Promise.reject(new Error('Please select a path'))
+                    : Promise.resolve(),
+              },
+            ]}
+          >
+            <BAIVFolderPathPicker vfolderUuid={vfolderUuid} />
           </Form.Item>
           <BAIFlex direction="column" align="start" gap="sm">
             <Button type="primary" htmlType="submit">

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.stories.tsx
@@ -275,7 +275,7 @@ The value is the **sub path inside the vfolder** — \`''\` for the vfolder root
 ## BAI-Specific Props
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| \`vfolderUuid\` | \`string\` | - | UUID of the vfolder to browse; the field stays disabled until provided |
+| \`vfolderUuid\` | \`string\` | - | UUID of the vfolder to browse; pair with \`disabled={!vfolderUuid}\` until one is selected |
 | \`value\` | \`string\` | - | Selected sub path (\`''\` = vfolder root) |
 | \`defaultValue\` | \`string\` | - | Initial value for uncontrolled usage |
 | \`onChange\` | \`(selectedSubPath?: string) => void\` | - | Fired when a location is confirmed in the modal |
@@ -328,7 +328,7 @@ export const WithinForm: Story = {
     docs: {
       description: {
         story:
-          'The intended composition: a separate `BAIVFolderSelect` (with `valuePropName="row_id"` so the field holds the UUID) feeds `vfolderUuid`, and the picker plugs into its own Form.Item. Changing the vfolder resets the path field, and the required rule uses a custom validator because `""` (the vfolder root) is a valid pick.',
+          'The intended composition: a separate `BAIVFolderSelect` (with `valuePropName="row_id"` so the field holds the UUID) feeds `vfolderUuid`, and the picker plugs into its own Form.Item with `disabled={!vfolderUuid}` until a folder is chosen. Changing the vfolder resets the path field, and the required rule uses a custom validator because `""` (the vfolder root) is a valid pick.',
       },
     },
   },
@@ -379,7 +379,10 @@ export const WithinForm: Story = {
               },
             ]}
           >
-            <BAIVFolderPathPicker vfolderUuid={vfolderUuid} />
+            <BAIVFolderPathPicker
+              vfolderUuid={vfolderUuid}
+              disabled={!vfolderUuid}
+            />
           </Form.Item>
           <BAIFlex direction="column" align="start" gap="sm">
             <Button type="primary" htmlType="submit">
@@ -427,7 +430,6 @@ export const PickerModalOnly: Story = {
             <BAIDirectoryPickerModal
               open={isOpen}
               vfolderUuid={MOCK_VFOLDERS[0].uuid}
-              vfolderName={MOCK_VFOLDERS[0].label}
               onRequestClose={(selectedSubPath) => {
                 if (selectedSubPath !== undefined) {
                   setLastResult(selectedSubPath);

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
@@ -2,12 +2,17 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { BAIDirectoryPickerModalQuery } from '../../../__generated__/BAIDirectoryPickerModalQuery.graphql';
+import { toGlobalId } from '../../../helper';
 import { useBAIi18n } from '../../../hooks/useBAIi18n';
+import BAISelect, { type BAISelectProps } from '../../BAISelect';
 import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
-import BAIDirectoryPickerModal from './BAIDirectoryPickerModal';
+import BAIDirectoryPickerModal, {
+  BAIDirectoryPickerQuery,
+} from './BAIDirectoryPickerModal';
 import { useControllableValue } from 'ahooks';
-import { Input, type InputProps } from 'antd';
-import { Suspense, useState } from 'react';
+import { Suspense, useState, useTransition } from 'react';
+import { useQueryLoader } from 'react-relay';
 
 export interface BAIVFolderPathPickerProps {
   /**
@@ -26,15 +31,15 @@ export interface BAIVFolderPathPickerProps {
   onChange?: (selectedSubPath?: string) => void;
   disabled?: boolean;
   style?: React.CSSProperties;
-  /** Forwarded to the sub path trigger Input. */
-  inputProps?: Omit<
-    InputProps,
-    'value' | 'onChange' | 'readOnly' | 'onClick' | 'disabled'
+  /** Forwarded to the sub path trigger select. */
+  selectProps?: Omit<
+    BAISelectProps,
+    'value' | 'onChange' | 'open' | 'onOpenChange' | 'loading' | 'disabled'
   >;
 }
 
 /**
- * A sub path picker for a given vfolder: a read-only path field that opens a
+ * A sub path picker for a given vfolder: a select-like trigger that opens a
  * directory-only picker modal (`BAIDirectoryPickerModal`). The value is the
  * sub path inside the vfolder (`''` = root, `"inner/path"` below it) — the
  * vfolder itself is chosen elsewhere and passed in as `vfolderUuid`.
@@ -46,19 +51,47 @@ export interface BAIVFolderPathPickerProps {
 const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
   'use memo';
 
-  const { vfolderUuid, disabled, style, inputProps } = props;
+  const { vfolderUuid, disabled, style, selectProps } = props;
   const { t } = useBAIi18n();
   const [selectedSubPath, setSelectedSubPath] = useControllableValue<
     string | undefined
   >(props);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [isPickerPending, startPickerTransition] = useTransition();
+  const [pickerQueryRef, loadPickerQuery] =
+    useQueryLoader<BAIDirectoryPickerModalQuery>(BAIDirectoryPickerQuery);
 
-  const canOpenPicker = !disabled;
+  const canOpenPicker = !disabled && !!vfolderUuid;
+
+  const openPicker = () => {
+    if (!canOpenPicker) {
+      return;
+    }
+    // Render-as-you-fetch: kick off the modal's vfolder query here and open it
+    // inside a transition, so while the data is in flight the select shows
+    // `loading` (isPickerPending) instead of a blank Suspense gap.
+    startPickerTransition(() => {
+      loadPickerQuery(
+        { vfolderGlobalId: toGlobalId('VirtualFolderNode', vfolderUuid) },
+        { fetchPolicy: 'store-and-network' },
+      );
+      setIsPickerOpen(true);
+    });
+  };
 
   return (
     <>
-      <Input
-        readOnly
+      <BAISelect
+        // Display-only trigger: the dropdown never opens (`open={false}`);
+        // every open gesture (click, Enter, arrow keys) arrives through
+        // onOpenChange and is redirected to the directory picker modal.
+        open={false}
+        onOpenChange={(nextOpen) => {
+          if (nextOpen) {
+            openPicker();
+          }
+        }}
+        loading={isPickerPending}
         // Leading '/' distinguishes "vfolder root picked" ('' → '/') from
         // "nothing picked yet" (undefined → placeholder).
         value={
@@ -69,44 +102,32 @@ const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
             ? t('comp:VFolderPathPicker.ClickToSelectPath')
             : t('comp:VFolderPathPicker.SelectFolderFirst')
         }
-        disabled={!canOpenPicker}
-        onClick={() => {
-          if (canOpenPicker) {
-            setIsPickerOpen(true);
-          }
-        }}
-        onKeyDown={(e) => {
-          if (canOpenPicker && (e.key === 'Enter' || e.key === ' ')) {
-            e.preventDefault();
-            setIsPickerOpen(true);
-          }
-        }}
-        style={{
-          cursor: canOpenPicker ? 'pointer' : 'not-allowed',
-          ...style,
-        }}
-        {...inputProps}
+        disabled={disabled}
+        style={style}
+        {...selectProps}
       />
-      {/* Mounted only while open (BAIUnmountAfterClose); callers disable the
-          picker until a vfolder is provided, so rendering unconditionally is
-          safe. The modal fetches this vfolder's name and permissions on mount
-          (Suspense). */}
-      <Suspense fallback={null}>
-        <BAIUnmountAfterClose>
-          <BAIDirectoryPickerModal
-            open={isPickerOpen}
-            vfolderUuid={vfolderUuid ?? ''}
-            defaultPath={selectedSubPath ?? ''}
-            onRequestClose={(newSubPath) => {
-              // `undefined` means the modal was cancelled — keep the value.
-              if (newSubPath !== undefined) {
-                setSelectedSubPath(newSubPath);
-              }
-              setIsPickerOpen(false);
-            }}
-          />
-        </BAIUnmountAfterClose>
-      </Suspense>
+      {/* Mounted only while open (BAIUnmountAfterClose) and only after the
+          first loadQuery. The open-state update runs in a transition, so the
+          modal commits once its preloaded query resolves. */}
+      {pickerQueryRef != null && (
+        <Suspense fallback={null}>
+          <BAIUnmountAfterClose>
+            <BAIDirectoryPickerModal
+              open={isPickerOpen}
+              vfolderUuid={vfolderUuid ?? ''}
+              queryRef={pickerQueryRef}
+              defaultPath={selectedSubPath ?? ''}
+              onRequestClose={(newSubPath) => {
+                // `undefined` means the modal was cancelled — keep the value.
+                if (newSubPath !== undefined) {
+                  setSelectedSubPath(newSubPath);
+                }
+                setIsPickerOpen(false);
+              }}
+            />
+          </BAIUnmountAfterClose>
+        </Suspense>
+      )}
     </>
   );
 };

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
@@ -11,7 +11,7 @@ import BAIDirectoryPickerModal, {
   BAIDirectoryPickerQuery,
 } from './BAIDirectoryPickerModal';
 import { useControllableValue } from 'ahooks';
-import { Suspense, useState, useTransition } from 'react';
+import { useState, useTransition } from 'react';
 import { useQueryLoader } from 'react-relay';
 
 export interface BAIVFolderPathPickerProps {
@@ -107,26 +107,24 @@ const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
         {...selectProps}
       />
       {/* Mounted only while open (BAIUnmountAfterClose) and only after the
-          first loadQuery. The open-state update runs in a transition, so the
-          modal commits once its preloaded query resolves. */}
+          first loadQuery. The modal is self-contained (it wraps its own
+          suspending content in a Suspense), so no boundary is needed here. */}
       {pickerQueryRef != null && (
-        <Suspense fallback={null}>
-          <BAIUnmountAfterClose>
-            <BAIDirectoryPickerModal
-              open={isPickerOpen}
-              vfolderUuid={vfolderUuid ?? ''}
-              queryRef={pickerQueryRef}
-              defaultPath={selectedSubPath ?? ''}
-              onRequestClose={(newSubPath) => {
-                // `undefined` means the modal was cancelled — keep the value.
-                if (newSubPath !== undefined) {
-                  setSelectedSubPath(newSubPath);
-                }
-                setIsPickerOpen(false);
-              }}
-            />
-          </BAIUnmountAfterClose>
-        </Suspense>
+        <BAIUnmountAfterClose>
+          <BAIDirectoryPickerModal
+            open={isPickerOpen}
+            vfolderUuid={vfolderUuid ?? ''}
+            queryRef={pickerQueryRef}
+            defaultPath={selectedSubPath ?? ''}
+            onRequestClose={(newSubPath) => {
+              // `undefined` means the modal was cancelled — keep the value.
+              if (newSubPath !== undefined) {
+                setSelectedSubPath(newSubPath);
+              }
+              setIsPickerOpen(false);
+            }}
+          />
+        </BAIUnmountAfterClose>
       )}
     </>
   );

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
@@ -107,8 +107,10 @@ const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
         {...selectProps}
       />
       {/* Mounted only while open (BAIUnmountAfterClose) and only after the
-          first loadQuery. The modal is self-contained (it wraps its own
-          suspending content in a Suspense), so no boundary is needed here. */}
+          first loadQuery. The modal suspends until its preloaded query
+          resolves; because it mounts inside the transition above, React
+          delays the commit (surfaced as the select's `loading`) instead of
+          needing a Suspense boundary here. */}
       {pickerQueryRef != null && (
         <BAIUnmountAfterClose>
           <BAIDirectoryPickerModal

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
@@ -2,40 +2,30 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { toLocalId } from '../../../helper';
 import { useBAIi18n } from '../../../hooks/useBAIi18n';
-import BAIFlex from '../../BAIFlex';
 import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
-import BAIVFolderSelect, {
-  BAIVFolderSelectProps,
-} from '../../fragments/BAIVFolderSelect';
 import BAIDirectoryPickerModal from './BAIDirectoryPickerModal';
 import { useControllableValue } from 'ahooks';
-import { Input, Typography, type InputProps } from 'antd';
-import * as _ from 'lodash-es';
+import { Input, type InputProps } from 'antd';
 import { Suspense, useState } from 'react';
 
 export interface BAIVFolderPathPickerProps {
   /**
-   * The selected path as a single **name-based** string:
-   * `"<vfolderName>"` for the vfolder root, or `"<vfolderName>/<sub/path>"`
-   * below it. The vfolder's id is tracked internally (for the picker modal's
-   * REST calls) and is not part of the value.
-   *
-   * Note: because the value carries no id, a value injected from outside
-   * (initialValues, setFieldsValue) cannot re-open the picker modal until the
-   * user re-picks the vfolder in the select.
+   * UUID of the vfolder to browse. The picker is disabled until it is
+   * provided — pair it with a separate vfolder select and reset the value
+   * when the vfolder changes (a sub path only makes sense within the
+   * vfolder it was picked from).
+   */
+  vfolderUuid?: string;
+  /**
+   * The selected sub path inside the vfolder: `''` for the vfolder root,
+   * `"sub/path"` below it. `undefined` = nothing picked yet.
    */
   value?: string;
   defaultValue?: string;
-  onChange?: (selectedPath?: string) => void;
+  onChange?: (selectedSubPath?: string) => void;
   disabled?: boolean;
   style?: React.CSSProperties;
-  /** Forwarded to the embedded BAIVFolderSelect (scoping, filtering, …). */
-  selectProps?: Omit<
-    BAIVFolderSelectProps,
-    'value' | 'defaultValue' | 'onChange' | 'mode' | 'valuePropName' | 'ref'
-  >;
   /** Forwarded to the sub path trigger Input. */
   inputProps?: Omit<
     InputProps,
@@ -44,122 +34,73 @@ export interface BAIVFolderPathPickerProps {
 }
 
 /**
- * An integrated "vfolder + sub path" picker: a `BAIVFolderSelect` next to a
- * read-only path field that opens a directory-only picker modal
- * (`BAIDirectoryPickerModal`). The value is a single name-based path string
- * (`"test/inner/path"`), so it plugs directly into a Form.Item;
- * `value`/`onChange` follow the controllable-state convention — the component
- * works both controlled and uncontrolled.
- *
- * The vfolder chosen in the select is the starting point of the path:
- * changing it restarts the path at that vfolder's root, clearing it clears
- * the whole value, and confirming a location in the modal appends the sub
- * path. The sub path can only be set through the modal (no free typing);
- * files are visible but not selectable there.
+ * A sub path picker for a given vfolder: a read-only path field that opens a
+ * directory-only picker modal (`BAIDirectoryPickerModal`). The value is the
+ * sub path inside the vfolder (`''` = root, `"inner/path"` below it) — the
+ * vfolder itself is chosen elsewhere and passed in as `vfolderUuid`.
+ * `value`/`onChange` follow the controllable-state convention, so the
+ * component plugs directly into a Form.Item and works both controlled and
+ * uncontrolled. The sub path can only be set through the modal (no free
+ * typing); files are visible but not selectable there.
  */
 const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
   'use memo';
 
-  const { disabled, style, selectProps, inputProps } = props;
+  const { vfolderUuid, disabled, style, inputProps } = props;
   const { t } = useBAIi18n();
-  const [selectedPath, setSelectedPath] = useControllableValue<
+  const [selectedSubPath, setSelectedSubPath] = useControllableValue<
     string | undefined
   >(props);
-  // The selected vfolder's global id — needed for the select display and the
-  // picker modal's REST calls; intentionally kept out of the (name-based)
-  // value.
-  const [vfolderGlobalId, setVFolderGlobalId] = useState<string | undefined>();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
-  // First segment = the vfolder's name, the rest = sub path inside it.
-  const separatorIndex = selectedPath?.indexOf('/') ?? -1;
-  const vfolderName =
-    separatorIndex === -1
-      ? selectedPath
-      : selectedPath?.slice(0, separatorIndex);
-  const subPath =
-    separatorIndex === -1
-      ? ''
-      : (selectedPath?.slice(separatorIndex + 1) ?? '');
-  // Derive the select display from the value: when the value is cleared from
-  // outside (e.g. form.resetFields()), the stale internal id is simply
-  // ignored, so the select clears too without any state synchronization.
-  const hasSelection = !!selectedPath && !!vfolderGlobalId;
-  const canOpenPicker = !disabled && hasSelection;
+  const canOpenPicker = !disabled && !!vfolderUuid;
 
   return (
     <>
-      <BAIFlex gap="xxs" align="center" style={style}>
-        <BAIVFolderSelect
-          style={{ flex: 1, minWidth: 0 }}
-          disabled={disabled}
-          allowClear
-          {...selectProps}
-          value={hasSelection ? vfolderGlobalId : undefined}
-          onChange={(vfolderId, option) => {
-            // `undefined` = cleared via allowClear.
-            if (!vfolderId) {
-              setVFolderGlobalId(undefined);
-              setSelectedPath(undefined);
-              return;
-            }
-            // The selected vfolder is the starting point of the path — any
-            // previously picked sub path belongs to the old vfolder, so the
-            // path simply restarts at the new vfolder's root. The name comes
-            // synchronously from the chosen option's label.
-            const label = _.isArray(option) ? option[0]?.label : option?.label;
-            setVFolderGlobalId(vfolderId);
-            setSelectedPath(_.isString(label) ? label : undefined);
-          }}
-        />
-        <Typography.Text type="secondary">/</Typography.Text>
-        <Input
-          readOnly
-          // The separator between the select and this field already renders
-          // '/', so show the bare sub path only (empty at the vfolder root).
-          value={subPath || undefined}
-          placeholder={
-            hasSelection
-              ? t('comp:VFolderPathPicker.ClickToSelectPath')
-              : t('comp:VFolderPathPicker.SelectFolderFirst')
+      <Input
+        readOnly
+        // Leading '/' distinguishes "vfolder root picked" ('' → '/') from
+        // "nothing picked yet" (undefined → placeholder).
+        value={
+          selectedSubPath === undefined ? undefined : `/${selectedSubPath}`
+        }
+        placeholder={
+          vfolderUuid
+            ? t('comp:VFolderPathPicker.ClickToSelectPath')
+            : t('comp:VFolderPathPicker.SelectFolderFirst')
+        }
+        disabled={!canOpenPicker}
+        onClick={() => {
+          if (canOpenPicker) {
+            setIsPickerOpen(true);
           }
-          disabled={!canOpenPicker}
-          onClick={() => {
-            if (canOpenPicker) {
-              setIsPickerOpen(true);
-            }
-          }}
-          onKeyDown={(e) => {
-            if (canOpenPicker && (e.key === 'Enter' || e.key === ' ')) {
-              e.preventDefault();
-              setIsPickerOpen(true);
-            }
-          }}
-          style={{
-            flex: 1,
-            cursor: canOpenPicker ? 'pointer' : 'not-allowed',
-          }}
-          {...inputProps}
-        />
-      </BAIFlex>
+        }}
+        onKeyDown={(e) => {
+          if (canOpenPicker && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            setIsPickerOpen(true);
+          }
+        }}
+        style={{
+          cursor: canOpenPicker ? 'pointer' : 'not-allowed',
+          ...style,
+        }}
+        {...inputProps}
+      />
       {/* Mounted only while open (BAIUnmountAfterClose), and it can only be
-          opened once a vfolder is selected — so rendering unconditionally is
+          opened once a vfolder is provided — so rendering unconditionally is
           safe. The modal fetches this vfolder's name and permissions on mount
           (Suspense). */}
       <Suspense fallback={null}>
         <BAIUnmountAfterClose>
           <BAIDirectoryPickerModal
             open={isPickerOpen}
-            vfolderUuid={vfolderGlobalId ? toLocalId(vfolderGlobalId) : ''}
-            defaultPath={subPath}
-            onRequestClose={(selectedSubPath) => {
+            vfolderUuid={vfolderUuid ?? ''}
+            defaultPath={selectedSubPath ?? ''}
+            onRequestClose={(newSubPath) => {
               // `undefined` means the modal was cancelled — keep the value.
-              if (selectedSubPath !== undefined && vfolderName) {
-                setSelectedPath(
-                  selectedSubPath
-                    ? `${vfolderName}/${selectedSubPath}`
-                    : vfolderName,
-                );
+              if (newSubPath !== undefined) {
+                setSelectedSubPath(newSubPath);
               }
               setIsPickerOpen(false);
             }}

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
@@ -1,0 +1,173 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { toLocalId } from '../../../helper';
+import { useBAIi18n } from '../../../hooks/useBAIi18n';
+import BAIFlex from '../../BAIFlex';
+import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
+import BAIVFolderSelect, {
+  BAIVFolderSelectProps,
+} from '../../fragments/BAIVFolderSelect';
+import BAIDirectoryPickerModal from './BAIDirectoryPickerModal';
+import { useControllableValue } from 'ahooks';
+import { Input, Typography, type InputProps } from 'antd';
+import * as _ from 'lodash-es';
+import { Suspense, useState } from 'react';
+
+export interface BAIVFolderPathPickerProps {
+  /**
+   * The selected path as a single **name-based** string:
+   * `"<vfolderName>"` for the vfolder root, or `"<vfolderName>/<sub/path>"`
+   * below it. The vfolder's id is tracked internally (for the picker modal's
+   * REST calls) and is not part of the value.
+   *
+   * Note: because the value carries no id, a value injected from outside
+   * (initialValues, setFieldsValue) cannot re-open the picker modal until the
+   * user re-picks the vfolder in the select.
+   */
+  value?: string;
+  defaultValue?: string;
+  onChange?: (selectedPath?: string) => void;
+  disabled?: boolean;
+  style?: React.CSSProperties;
+  /** Forwarded to the embedded BAIVFolderSelect (scoping, filtering, …). */
+  selectProps?: Omit<
+    BAIVFolderSelectProps,
+    'value' | 'defaultValue' | 'onChange' | 'mode' | 'valuePropName' | 'ref'
+  >;
+  /** Forwarded to the sub path trigger Input. */
+  inputProps?: Omit<
+    InputProps,
+    'value' | 'onChange' | 'readOnly' | 'onClick' | 'disabled'
+  >;
+}
+
+/**
+ * An integrated "vfolder + sub path" picker: a `BAIVFolderSelect` next to a
+ * read-only path field that opens a directory-only picker modal
+ * (`BAIDirectoryPickerModal`). The value is a single name-based path string
+ * (`"test/inner/path"`), so it plugs directly into a Form.Item;
+ * `value`/`onChange` follow the controllable-state convention — the component
+ * works both controlled and uncontrolled.
+ *
+ * The vfolder chosen in the select is the starting point of the path:
+ * changing it restarts the path at that vfolder's root, clearing it clears
+ * the whole value, and confirming a location in the modal appends the sub
+ * path. The sub path can only be set through the modal (no free typing);
+ * files are visible but not selectable there.
+ */
+const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
+  'use memo';
+
+  const { disabled, style, selectProps, inputProps } = props;
+  const { t } = useBAIi18n();
+  const [selectedPath, setSelectedPath] = useControllableValue<
+    string | undefined
+  >(props);
+  // The selected vfolder's global id — needed for the select display and the
+  // picker modal's REST calls; intentionally kept out of the (name-based)
+  // value.
+  const [vfolderGlobalId, setVFolderGlobalId] = useState<string | undefined>();
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+
+  // First segment = the vfolder's name, the rest = sub path inside it.
+  const separatorIndex = selectedPath?.indexOf('/') ?? -1;
+  const vfolderName =
+    separatorIndex === -1
+      ? selectedPath
+      : selectedPath?.slice(0, separatorIndex);
+  const subPath =
+    separatorIndex === -1
+      ? ''
+      : (selectedPath?.slice(separatorIndex + 1) ?? '');
+  // Derive the select display from the value: when the value is cleared from
+  // outside (e.g. form.resetFields()), the stale internal id is simply
+  // ignored, so the select clears too without any state synchronization.
+  const hasSelection = !!selectedPath && !!vfolderGlobalId;
+  const canOpenPicker = !disabled && hasSelection;
+
+  return (
+    <>
+      <BAIFlex gap="xxs" align="center" style={style}>
+        <BAIVFolderSelect
+          style={{ flex: 1, minWidth: 0 }}
+          disabled={disabled}
+          allowClear
+          {...selectProps}
+          value={hasSelection ? vfolderGlobalId : undefined}
+          onChange={(vfolderId, option) => {
+            // `undefined` = cleared via allowClear.
+            if (!vfolderId) {
+              setVFolderGlobalId(undefined);
+              setSelectedPath(undefined);
+              return;
+            }
+            // The selected vfolder is the starting point of the path — any
+            // previously picked sub path belongs to the old vfolder, so the
+            // path simply restarts at the new vfolder's root. The name comes
+            // synchronously from the chosen option's label.
+            const label = _.isArray(option) ? option[0]?.label : option?.label;
+            setVFolderGlobalId(vfolderId);
+            setSelectedPath(_.isString(label) ? label : undefined);
+          }}
+        />
+        <Typography.Text type="secondary">/</Typography.Text>
+        <Input
+          readOnly
+          // The separator between the select and this field already renders
+          // '/', so show the bare sub path only (empty at the vfolder root).
+          value={subPath || undefined}
+          placeholder={
+            hasSelection
+              ? t('comp:VFolderPathPicker.ClickToSelectPath')
+              : t('comp:VFolderPathPicker.SelectFolderFirst')
+          }
+          disabled={!canOpenPicker}
+          onClick={() => {
+            if (canOpenPicker) {
+              setIsPickerOpen(true);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (canOpenPicker && (e.key === 'Enter' || e.key === ' ')) {
+              e.preventDefault();
+              setIsPickerOpen(true);
+            }
+          }}
+          style={{
+            flex: 1,
+            cursor: canOpenPicker ? 'pointer' : 'not-allowed',
+          }}
+          {...inputProps}
+        />
+      </BAIFlex>
+      {/* Mounted only while open (BAIUnmountAfterClose), and it can only be
+          opened once a vfolder is selected — so rendering unconditionally is
+          safe. The modal fetches this vfolder's name and permissions on mount
+          (Suspense). */}
+      <Suspense fallback={null}>
+        <BAIUnmountAfterClose>
+          <BAIDirectoryPickerModal
+            open={isPickerOpen}
+            vfolderUuid={vfolderGlobalId ? toLocalId(vfolderGlobalId) : ''}
+            defaultPath={subPath}
+            onRequestClose={(selectedSubPath) => {
+              // `undefined` means the modal was cancelled — keep the value.
+              if (selectedSubPath !== undefined && vfolderName) {
+                setSelectedPath(
+                  selectedSubPath
+                    ? `${vfolderName}/${selectedSubPath}`
+                    : vfolderName,
+                );
+              }
+              setIsPickerOpen(false);
+            }}
+          />
+        </BAIUnmountAfterClose>
+      </Suspense>
+    </>
+  );
+};
+
+export default BAIVFolderPathPicker;

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIVFolderPathPicker.tsx
@@ -11,8 +11,8 @@ import { Suspense, useState } from 'react';
 
 export interface BAIVFolderPathPickerProps {
   /**
-   * UUID of the vfolder to browse. The picker is disabled until it is
-   * provided — pair it with a separate vfolder select and reset the value
+   * UUID of the vfolder to browse. Pair it with a separate vfolder select:
+   * pass `disabled={!vfolderUuid}` until one is chosen, and reset the value
    * when the vfolder changes (a sub path only makes sense within the
    * vfolder it was picked from).
    */
@@ -53,7 +53,7 @@ const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
   >(props);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
-  const canOpenPicker = !disabled && !!vfolderUuid;
+  const canOpenPicker = !disabled;
 
   return (
     <>
@@ -87,8 +87,8 @@ const BAIVFolderPathPicker: React.FC<BAIVFolderPathPickerProps> = (props) => {
         }}
         {...inputProps}
       />
-      {/* Mounted only while open (BAIUnmountAfterClose), and it can only be
-          opened once a vfolder is provided — so rendering unconditionally is
+      {/* Mounted only while open (BAIUnmountAfterClose); callers disable the
+          picker until a vfolder is provided, so rendering unconditionally is
           safe. The modal fetches this vfolder's name and permissions on mount
           (Suspense). */}
       <Suspense fallback={null}>

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx
@@ -14,7 +14,7 @@ import React, { use, useRef } from 'react';
 
 // TODO: swap to BAIModal (already available in this package) instead of antd's Modal
 interface CreateDirectoryModalProps extends ModalProps {
-  onRequestClose: (success: boolean) => void;
+  onRequestClose: (success: boolean, createdFolderName?: string) => void;
 }
 
 const CreateDirectoryModal: React.FC<CreateDirectoryModalProps> = ({
@@ -43,7 +43,7 @@ const CreateDirectoryModal: React.FC<CreateDirectoryModalProps> = ({
             name: targetVFolderId,
           })
           .then(() => {
-            onRequestClose(true);
+            onRequestClose(true, values.folderName);
             message.success(t('comp:FileExplorer.FolderCreatedSuccessfully'));
           })
           .catch((err) => {

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -58,6 +58,14 @@ interface ExplorerActionControlsProps {
   // so callers that don't pass it explicitly keep the previous bundled
   // behavior.
   enableUpload?: boolean;
+  // 'directoryPicker' keeps only the directory-relevant actions (create
+  // folder); file creation and upload entry points are hidden entirely
+  // instead of rendered disabled.
+  mode?: 'explorer' | 'directoryPicker';
+  // Fired with the new folder's name right after a successful mkdir, in
+  // addition to onRequestClose(true). The directory picker uses this to jump
+  // straight into the created folder.
+  onFolderCreated?: (folderName: string) => void;
   // onClickRefresh?: (key: string) => void;
   extra?: React.ReactNode;
 }
@@ -72,6 +80,8 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
   enableDelete = false,
   enableWrite = false,
   enableUpload = enableWrite,
+  mode = 'explorer',
+  onFolderCreated,
   extra,
 }) => {
   const { t } = useBAIi18n();
@@ -136,7 +146,15 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
             <Tooltip title={t('general.button.Delete')} placement="topLeft">
               <Button
                 disabled={!enableDelete}
-                icon={<DeleteFilled style={{ color: token.colorError }} />}
+                icon={
+                  <DeleteFilled
+                    style={{
+                      color: enableDelete
+                        ? token.colorError
+                        : token.colorTextDisabled,
+                    }}
+                  />
+                }
                 onClick={() => {
                   toggleDeleteModal();
                 }}
@@ -149,7 +167,15 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
               >
                 <BAIButton
                   disabled={!enableDownload}
-                  icon={<DownloadIcon style={{ color: token.colorInfo }} />}
+                  icon={
+                    <DownloadIcon
+                      style={{
+                        color: enableDownload
+                          ? token.colorInfo
+                          : token.colorTextDisabled,
+                      }}
+                    />
+                  }
                   action={async () => {
                     const filePaths = selectedFiles.map((file) =>
                       currentPath === '.'
@@ -174,91 +200,95 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
             {lg && t('comp:FileExplorer.CreateFolder')}
           </Button>
         </Tooltip>
-        <Tooltip title={!lg && t('comp:FileExplorer.CreateFile')}>
-          <Button
-            disabled={!enableWrite}
-            icon={<FileAddOutlined />}
-            onClick={() => {
-              toggleCreateFileModal();
-            }}
-          >
-            {lg && t('comp:FileExplorer.CreateFile')}
-          </Button>
-        </Tooltip>
-        <Dropdown
-          disabled={!enableUpload}
-          trigger={['click']}
-          open={openUploadDropdown}
-          onOpenChange={toggleUploadDropdown}
-          popupRender={() => {
-            return (
-              <BAIFlex
-                align="start"
-                direction="column"
-                className={styles.upload}
-                style={{
-                  padding: 5,
-                  backgroundColor: token.colorBgElevated,
-                  borderRadius: token.borderRadiusLG,
-                  boxShadow: token.boxShadowSecondary,
-                }}
-              >
-                <Upload
-                  beforeUpload={(_, fileList) => {
-                    if (fileList !== lastFileListRef.current) {
-                      uploadFiles(fileList, onUpload);
-                    }
-                    lastFileListRef.current = fileList;
-                    return false; // Prevent default upload behavior
-                  }}
-                  multiple
-                  showUploadList={false}
-                >
-                  <Button
-                    type="text"
-                    icon={<FileAddOutlined />}
-                    onClick={() => toggleUploadDropdown()}
-                  >
-                    {t('comp:FileExplorer.UploadFiles')}
-                  </Button>
-                </Upload>
-                <Upload
-                  directory
-                  beforeUpload={(_, fileList) => {
-                    if (fileList !== lastFileListRef.current) {
-                      uploadFiles(fileList, onUpload);
-                    }
-                    lastFileListRef.current = fileList;
-                    return false;
-                  }}
-                  showUploadList={false}
-                >
-                  <Button
-                    type="text"
-                    icon={<FolderAddOutlined />}
-                    onClick={() => toggleUploadDropdown()}
-                  >
-                    {t('comp:FileExplorer.UploadFolder')}
-                  </Button>
-                </Upload>
-              </BAIFlex>
-            );
-          }}
-        >
-          <Tooltip
-            title={
-              !enableUpload
-                ? t('comp:FileExplorer.NoUploadPermissionForHost')
-                : !lg
-                  ? t('general.button.Upload')
-                  : undefined
-            }
-          >
-            <Button icon={<UploadOutlined />} disabled={!enableUpload}>
-              {lg && t('general.button.Upload')}
+        {mode !== 'directoryPicker' && (
+          <Tooltip title={!lg && t('comp:FileExplorer.CreateFile')}>
+            <Button
+              disabled={!enableWrite}
+              icon={<FileAddOutlined />}
+              onClick={() => {
+                toggleCreateFileModal();
+              }}
+            >
+              {lg && t('comp:FileExplorer.CreateFile')}
             </Button>
           </Tooltip>
-        </Dropdown>
+        )}
+        {mode !== 'directoryPicker' && (
+          <Dropdown
+            disabled={!enableUpload}
+            trigger={['click']}
+            open={openUploadDropdown}
+            onOpenChange={toggleUploadDropdown}
+            popupRender={() => {
+              return (
+                <BAIFlex
+                  align="start"
+                  direction="column"
+                  className={styles.upload}
+                  style={{
+                    padding: 5,
+                    backgroundColor: token.colorBgElevated,
+                    borderRadius: token.borderRadiusLG,
+                    boxShadow: token.boxShadowSecondary,
+                  }}
+                >
+                  <Upload
+                    beforeUpload={(_, fileList) => {
+                      if (fileList !== lastFileListRef.current) {
+                        uploadFiles(fileList, onUpload);
+                      }
+                      lastFileListRef.current = fileList;
+                      return false; // Prevent default upload behavior
+                    }}
+                    multiple
+                    showUploadList={false}
+                  >
+                    <Button
+                      type="text"
+                      icon={<FileAddOutlined />}
+                      onClick={() => toggleUploadDropdown()}
+                    >
+                      {t('comp:FileExplorer.UploadFiles')}
+                    </Button>
+                  </Upload>
+                  <Upload
+                    directory
+                    beforeUpload={(_, fileList) => {
+                      if (fileList !== lastFileListRef.current) {
+                        uploadFiles(fileList, onUpload);
+                      }
+                      lastFileListRef.current = fileList;
+                      return false;
+                    }}
+                    showUploadList={false}
+                  >
+                    <Button
+                      type="text"
+                      icon={<FolderAddOutlined />}
+                      onClick={() => toggleUploadDropdown()}
+                    >
+                      {t('comp:FileExplorer.UploadFolder')}
+                    </Button>
+                  </Upload>
+                </BAIFlex>
+              );
+            }}
+          >
+            <Tooltip
+              title={
+                !enableUpload
+                  ? t('comp:FileExplorer.NoUploadPermissionForHost')
+                  : !lg
+                    ? t('general.button.Upload')
+                    : undefined
+              }
+            >
+              <Button icon={<UploadOutlined />} disabled={!enableUpload}>
+                {lg && t('general.button.Upload')}
+              </Button>
+            </Tooltip>
+          </Dropdown>
+        )}
       </BAIFlex>
       <DeleteSelectedItemsModal
         destroyOnHidden
@@ -275,9 +305,12 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
       <CreateDirectoryModal
         destroyOnHidden
         open={openCreateModal}
-        onRequestClose={(success: boolean) => {
+        onRequestClose={(success: boolean, createdFolderName?: string) => {
           if (success) {
             onRequestClose(true);
+            if (createdFolderName) {
+              onFolderCreated?.(createdFolderName);
+            }
           }
           toggleCreateModal();
         }}

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
@@ -93,7 +93,11 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
       <BAIButton
         type="text"
         size="small"
-        icon={<DownloadIcon color={token.colorInfo} />}
+        icon={
+          <DownloadIcon
+            color={enableDownload ? token.colorInfo : token.colorTextDisabled}
+          />
+        }
         disabled={!enableDownload}
         onClick={(e) => e.stopPropagation()}
         action={async () => {
@@ -109,7 +113,13 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
       <BAIButton
         type="text"
         size="small"
-        icon={<DeleteFilled style={{ color: token.colorError }} />}
+        icon={
+          <DeleteFilled
+            style={{
+              color: enableDelete ? token.colorError : token.colorTextDisabled,
+            }}
+          />
+        }
         disabled={!enableDelete}
         onClick={(e) => {
           e.stopPropagation();

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/index.ts
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/index.ts
@@ -10,4 +10,7 @@ export {
   BAIDirectoryPickerQuery,
 } from './BAIDirectoryPickerModal';
 export type { BAIDirectoryPickerModalProps } from './BAIDirectoryPickerModal';
+// Operation type paired with BAIDirectoryPickerQuery so external openers can
+// type `useQueryLoader<BAIDirectoryPickerModalQuery>` without deep imports.
+export type { BAIDirectoryPickerModalQuery } from '../../../__generated__/BAIDirectoryPickerModalQuery.graphql';
 export { useSearchVFolderFiles } from './hooks';

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/index.ts
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/index.ts
@@ -5,6 +5,9 @@ export type {
 } from './BAIFileExplorer';
 export { default as BAIVFolderPathPicker } from './BAIVFolderPathPicker';
 export type { BAIVFolderPathPickerProps } from './BAIVFolderPathPicker';
-export { default as BAIDirectoryPickerModal } from './BAIDirectoryPickerModal';
+export {
+  default as BAIDirectoryPickerModal,
+  BAIDirectoryPickerQuery,
+} from './BAIDirectoryPickerModal';
 export type { BAIDirectoryPickerModalProps } from './BAIDirectoryPickerModal';
 export { useSearchVFolderFiles } from './hooks';

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/index.ts
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/index.ts
@@ -3,4 +3,8 @@ export type {
   BAIFileExplorerProps,
   BAIFileExplorerRef,
 } from './BAIFileExplorer';
+export { default as BAIVFolderPathPicker } from './BAIVFolderPathPicker';
+export type { BAIVFolderPathPickerProps } from './BAIVFolderPathPicker';
+export { default as BAIDirectoryPickerModal } from './BAIDirectoryPickerModal';
+export type { BAIDirectoryPickerModalProps } from './BAIDirectoryPickerModal';
 export { useSearchVFolderFiles } from './hooks';

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -538,6 +538,14 @@
     "UserID": "Benutzer-ID",
     "Username": "Benutzername"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Klicken, um einen Pfad auszuwählen",
+    "SelectAPath": "Einen Pfad auswählen",
+    "SelectAPathInFolder": "Einen Pfad in {{folderName}} auswählen",
+    "SelectFolderFirst": "Zuerst einen Ordner auswählen",
+    "SelectThisLocation": "Diesen Ort auswählen",
+    "SelectedPath": "Ausgewählt"
+  },
   "error": {
     "UnknownError": "Ein unbekannter Fehler ist aufgetreten. \nBitte versuchen Sie es erneut."
   },

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -538,6 +538,14 @@
     "UserID": "Αναγνωριστικό χρήστη",
     "Username": "Όνομα χρήστη"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Κάντε κλικ για να επιλέξετε διαδρομή",
+    "SelectAPath": "Επιλέξτε διαδρομή",
+    "SelectAPathInFolder": "Επιλέξτε διαδρομή στο {{folderName}}",
+    "SelectFolderFirst": "Επιλέξτε πρώτα έναν φάκελο",
+    "SelectThisLocation": "Επιλέξτε αυτή τη θέση",
+    "SelectedPath": "Επιλεγμένο"
+  },
   "error": {
     "UnknownError": "Παρουσιάστηκε ένα άγνωστο σφάλμα. \nΔοκιμάστε ξανά."
   },

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -538,6 +538,14 @@
     "UserID": "User ID",
     "Username": "Username"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Click to select a path",
+    "SelectAPath": "Select a path",
+    "SelectAPathInFolder": "Select a path in {{folderName}}",
+    "SelectFolderFirst": "Select a folder first",
+    "SelectThisLocation": "Select this location",
+    "SelectedPath": "Selected"
+  },
   "error": {
     "UnknownError": "An unknown error occurred. Please try again."
   },

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -538,6 +538,14 @@
     "UserID": "ID de usuario",
     "Username": "Nombre de usuario"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Haga clic para seleccionar una ruta",
+    "SelectAPath": "Seleccionar una ruta",
+    "SelectAPathInFolder": "Seleccionar una ruta en {{folderName}}",
+    "SelectFolderFirst": "Seleccione primero una carpeta",
+    "SelectThisLocation": "Seleccionar esta ubicación",
+    "SelectedPath": "Seleccionado"
+  },
   "error": {
     "UnknownError": "Ocurrió un error desconocido. \nPor favor intente de nuevo."
   },

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -538,6 +538,14 @@
     "UserID": "Käyttäjätunnus",
     "Username": "Käyttäjänimi"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Napsauta valitaksesi polun",
+    "SelectAPath": "Valitse polku",
+    "SelectAPathInFolder": "Valitse polku kansiossa {{folderName}}",
+    "SelectFolderFirst": "Valitse ensin kansio",
+    "SelectThisLocation": "Valitse tämä sijainti",
+    "SelectedPath": "Valittu"
+  },
   "error": {
     "UnknownError": "Tapahtui tuntematon virhe. \nYritä uudelleen."
   },

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -538,6 +538,14 @@
     "UserID": "ID d'utilisateur",
     "Username": "Nom d'utilisateur"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Cliquez pour sélectionner un chemin",
+    "SelectAPath": "Sélectionner un chemin",
+    "SelectAPathInFolder": "Sélectionner un chemin dans {{folderName}}",
+    "SelectFolderFirst": "Sélectionnez d'abord un dossier",
+    "SelectThisLocation": "Sélectionner cet emplacement",
+    "SelectedPath": "Sélectionné"
+  },
   "error": {
     "UnknownError": "Une erreur inconnue s'est produite. \nVeuillez réessayer."
   },

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -538,6 +538,14 @@
     "UserID": "ID Pengguna",
     "Username": "Nama Pengguna"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Klik untuk memilih jalur",
+    "SelectAPath": "Pilih jalur",
+    "SelectAPathInFolder": "Pilih jalur di {{folderName}}",
+    "SelectFolderFirst": "Pilih folder terlebih dahulu",
+    "SelectThisLocation": "Pilih lokasi ini",
+    "SelectedPath": "Terpilih"
+  },
   "error": {
     "UnknownError": "Terjadi kesalahan yang tidak diketahui. \nTolong coba lagi."
   },

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -538,6 +538,14 @@
     "UserID": "ID utente",
     "Username": "Nome utente"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Clicca per selezionare un percorso",
+    "SelectAPath": "Seleziona un percorso",
+    "SelectAPathInFolder": "Seleziona un percorso in {{folderName}}",
+    "SelectFolderFirst": "Seleziona prima una cartella",
+    "SelectThisLocation": "Seleziona questa posizione",
+    "SelectedPath": "Selezionato"
+  },
   "error": {
     "UnknownError": "Si è verificato un errore sconosciuto. \nPer favore riprova."
   },

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -538,6 +538,14 @@
     "UserID": "ユーザーID",
     "Username": "ユーザー名"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "クリックしてパスを選択",
+    "SelectAPath": "パスを選択",
+    "SelectAPathInFolder": "{{folderName}} 内のパスを選択",
+    "SelectFolderFirst": "最初にフォルダを選択してください",
+    "SelectThisLocation": "この場所を選択",
+    "SelectedPath": "選択済み"
+  },
   "error": {
     "UnknownError": "不明なエラーが発生しました。\nもう一度やり直してください。"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -538,6 +538,14 @@
     "UserID": "사용자 ID",
     "Username": "사용자 이름"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "클릭하여 경로 선택",
+    "SelectAPath": "경로 선택",
+    "SelectAPathInFolder": "{{folderName}} 폴더에서 경로 선택",
+    "SelectFolderFirst": "폴더를 먼저 선택하세요",
+    "SelectThisLocation": "이 위치 선택",
+    "SelectedPath": "선택된 경로"
+  },
   "error": {
     "UnknownError": "알 수 없는 오류가 발생했습니다. 다시 시도해 주세요."
   },

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -538,6 +538,14 @@
     "UserID": "Хэрэглэгчийн ID",
     "Username": "Хэрэглэгчийн нэр"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Зам сонгохын тулд дарна уу",
+    "SelectAPath": "Зам сонгох",
+    "SelectAPathInFolder": "{{folderName}} хавтаснаас зам сонгох",
+    "SelectFolderFirst": "Эхлээд хавтас сонгоно уу",
+    "SelectThisLocation": "Энэ байршлыг сонгох",
+    "SelectedPath": "Сонгогдсон"
+  },
   "error": {
     "UnknownError": "Үл мэдэгдэх алдаа гарлаа. \nДахин оролдоно уу."
   },

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -538,6 +538,14 @@
     "UserID": "ID Pengguna",
     "Username": "Nama Pengguna"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Klik untuk memilih laluan",
+    "SelectAPath": "Pilih laluan",
+    "SelectAPathInFolder": "Pilih laluan dalam {{folderName}}",
+    "SelectFolderFirst": "Pilih folder dahulu",
+    "SelectThisLocation": "Pilih lokasi ini",
+    "SelectedPath": "Terpilih"
+  },
   "error": {
     "UnknownError": "Kesalahan yang tidak diketahui berlaku. \nSila cuba lagi."
   },

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -538,6 +538,14 @@
     "UserID": "ID użytkownika",
     "Username": "Nazwa użytkownika"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Kliknij, aby wybrać ścieżkę",
+    "SelectAPath": "Wybierz ścieżkę",
+    "SelectAPathInFolder": "Wybierz ścieżkę w {{folderName}}",
+    "SelectFolderFirst": "Najpierw wybierz folder",
+    "SelectThisLocation": "Wybierz tę lokalizację",
+    "SelectedPath": "Wybrano"
+  },
   "error": {
     "UnknownError": "Wystąpił nieznany błąd. \nSpróbuj ponownie."
   },

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -544,6 +544,14 @@
     "UserID": "ID do usuário",
     "Username": "Nome de usuário"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Clique para selecionar um caminho",
+    "SelectAPath": "Selecionar um caminho",
+    "SelectAPathInFolder": "Selecionar um caminho em {{folderName}}",
+    "SelectFolderFirst": "Selecione primeiro uma pasta",
+    "SelectThisLocation": "Selecionar esta localização",
+    "SelectedPath": "Selecionado"
+  },
   "error": {
     "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
   },

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -538,6 +538,14 @@
     "UserID": "ID do usuário",
     "Username": "Nome de usuário"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Clique para selecionar um caminho",
+    "SelectAPath": "Selecionar um caminho",
+    "SelectAPathInFolder": "Selecionar um caminho em {{folderName}}",
+    "SelectFolderFirst": "Selecione primeiro uma pasta",
+    "SelectThisLocation": "Selecionar esta localização",
+    "SelectedPath": "Selecionado"
+  },
   "error": {
     "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
   },

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -538,6 +538,14 @@
     "UserID": "ID пользователя",
     "Username": "Имя пользователя"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Нажмите, чтобы выбрать путь",
+    "SelectAPath": "Выбрать путь",
+    "SelectAPathInFolder": "Выбрать путь в {{folderName}}",
+    "SelectFolderFirst": "Сначала выберите папку",
+    "SelectThisLocation": "Выбрать это расположение",
+    "SelectedPath": "Выбрано"
+  },
   "error": {
     "UnknownError": "Произошла неизвестная ошибка. \nПожалуйста, попробуйте еще раз."
   },

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -538,6 +538,14 @@
     "UserID": "รหัสผู้ใช้",
     "Username": "ชื่อผู้ใช้"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "คลิกเพื่อเลือกพาธ",
+    "SelectAPath": "เลือกพาธ",
+    "SelectAPathInFolder": "เลือกพาธใน {{folderName}}",
+    "SelectFolderFirst": "กรุณาเลือกโฟลเดอร์ก่อน",
+    "SelectThisLocation": "เลือกตำแหน่งนี้",
+    "SelectedPath": "เลือกแล้ว"
+  },
   "error": {
     "UnknownError": "เกิดข้อผิดพลาดที่ไม่รู้จัก \nโปรดลองอีกครั้ง"
   },

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -538,6 +538,14 @@
     "UserID": "Kullanıcı Kimliği",
     "Username": "Kullanıcı Adı"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Yol seçmek için tıklayın",
+    "SelectAPath": "Bir yol seçin",
+    "SelectAPathInFolder": "{{folderName}} içinde bir yol seçin",
+    "SelectFolderFirst": "Önce bir klasör seçin",
+    "SelectThisLocation": "Bu konumu seç",
+    "SelectedPath": "Seçildi"
+  },
   "error": {
     "UnknownError": "Bilinmeyen bir hata oluştu. \nLütfen tekrar deneyin."
   },

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -538,6 +538,14 @@
     "UserID": "ID người dùng",
     "Username": "Tên người dùng"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "Nhấp để chọn đường dẫn",
+    "SelectAPath": "Chọn đường dẫn",
+    "SelectAPathInFolder": "Chọn đường dẫn trong {{folderName}}",
+    "SelectFolderFirst": "Vui lòng chọn thư mục trước",
+    "SelectThisLocation": "Chọn vị trí này",
+    "SelectedPath": "Đã chọn"
+  },
   "error": {
     "UnknownError": "Một lỗi không xác định xảy ra. \nHãy thử lại."
   },

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -538,6 +538,14 @@
     "UserID": "用户 ID",
     "Username": "用户名"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "点击选择路径",
+    "SelectAPath": "选择路径",
+    "SelectAPathInFolder": "在 {{folderName}} 中选择路径",
+    "SelectFolderFirst": "请先选择文件夹",
+    "SelectThisLocation": "选择此位置",
+    "SelectedPath": "已选择"
+  },
   "error": {
     "UnknownError": "发生了未知错误。\n请重试。"
   },

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -538,6 +538,14 @@
     "UserID": "使用者 ID",
     "Username": "使用者名稱"
   },
+  "comp:VFolderPathPicker": {
+    "ClickToSelectPath": "點擊選擇路徑",
+    "SelectAPath": "選擇路徑",
+    "SelectAPathInFolder": "在 {{folderName}} 中選擇路徑",
+    "SelectFolderFirst": "請先選擇資料夾",
+    "SelectThisLocation": "選擇此位置",
+    "SelectedPath": "已選擇"
+  },
   "error": {
     "UnknownError": "發生了未知錯誤。請重試。"
   },


### PR DESCRIPTION
Resolves #8413 (FR-3385)

## Summary

Adds `BAIVFolderPathPicker` — a reusable BUI component for choosing a directory path *inside* a vfolder, replacing error-prone manual path typing.

- `BAIVFolderPathPicker` (exported): a **sub path picker for a given vfolder** — a display-only `BAISelect` trigger that opens the directory picker modal (the dropdown never opens; every open gesture — click, Enter, arrow keys — is redirected to the modal via `onOpenChange`). The modal's vfolder query is **preloaded from the open gesture** (`useQueryLoader` + `startTransition`, render-as-you-fetch), so the select shows its own `loading` state while the query is in flight instead of a blank Suspense gap. The vfolder itself is chosen elsewhere (e.g. a `BAIVFolderSelect`) and passed in via the **`vfolderUuid`** prop; the field stays disabled (with a "Select a folder first" placeholder) until it is provided. The value is the **sub path inside the vfolder**: `''` for the vfolder root, `"sub/path"` below it, `undefined` while nothing is picked — the vfolder name is *not* part of the value. It plugs directly into a `Form.Item`; `value`/`onChange`/`defaultValue` go through `useControllableValue`, so the component works both controlled and uncontrolled. Cancelling the modal keeps the value; confirming stores the chosen sub path. The field renders the value with a leading `/` (so a picked root shows as `/`, distinct from the empty placeholder state). Because `''` (root) is a valid pick, a required field needs a custom validator instead of `required: true` (which rejects empty strings) — the Form story demonstrates the pattern. When the vfolder changes, the caller resets the value: a sub path only makes sense within the vfolder it was picked from.
- `BAIFileExplorer` gains a **`mode: 'explorer' | 'directoryPicker'`** prop (default `'explorer'`, existing call sites unaffected). In `directoryPicker` mode: files are visible but disabled (grayed name, no controls, click ignored), a row click navigates into the directory, checkbox multi-select is removed, and file-creation/upload entry points are hidden — while folder CRUD (create / rename / delete, with the existing typed-confirmation delete flow) stays available. New supporting props: `defaultPath` (start location) and `onChangeCurrentPath` (path reporting for the confirm footer); `onUpload` becomes optional.
- `BAIDirectoryPickerModal` (exported): a thin wrapper — `BAIModal` + `BAIFileExplorer mode="directoryPicker"` + a confirm footer ("Select this location" confirms the current browsing location, macOS-picker style; closing is via the modal's X/ESC). Root (`''`) is selectable. The modal consumes a **`queryRef`** via `usePreloadedQuery`; the query is exported as **`BAIDirectoryPickerQuery`** so any opener (the picker today, a future button wrapper around the modal) can `loadQuery` it in its own trigger event. The modal suspends as a whole until the preloaded query resolves (no internal Suspense/content split), so it mounts fully ready — folder name in the title, permissions applied; openers must mount it inside a transition (as the picker does, surfacing `isPending` on the trigger) or provide an outer Suspense boundary. Folder CRUD follows the caller's **effective permissions**: the query selects `vfolder_node { permissions }` and gates `enableWrite` on `write_content` and `enableDelete` on `delete_content`, same as `FolderExplorerModal`.
- `ExplorerActionControls` gains the matching `mode` prop (hides Create File / Upload in picker mode) and an `onFolderCreated` callback; `CreateDirectoryModal.onRequestClose` gains an optional `createdFolderName` argument (non-breaking) — together these implement the mkdir → auto-enter-the-new-folder flow. Disabled download/delete icons — both the bulk actions (`ExplorerActionControls`) and the per-row controls (`FileItemControls`) — now render in `colorTextDisabled` instead of their active colors.
- i18n: new `comp:VFolderPathPicker` namespace added to all 21 BUI locales (en/ko authored, others translated consistently with existing `comp:FileExplorer` terminology).
- Storybook: `Input/BAIVFolderPathPicker` stories (`Basic Usage` uncontrolled with a fixed `vfolderUuid` + `Within Form` showing the intended composition — an external `BAIVFolderSelect` with `valuePropName="row_id"` feeding `vfolderUuid`, path reset on vfolder change, custom required validator + `Directory Picker Modal` standalone). The stories combine a mock Relay environment (for the external `BAIVFolderSelect` queries and the modal's per-folder name/permission query) with an in-memory mock client through `BAIClientContext` (`list_files` / `mkdir` / `rename_file` / `delete_files`), so vfolder search, browsing, folder CRUD, and location confirmation all work interactively without a backend. The second mock folder (`team-shared-data`) is read-only to demonstrate permission gating in the modal.

The picker therefore shares the explorer's breadcrumb (with sibling-folder dropdowns), table, refresh button, loading states, and CRUD modals instead of duplicating them — one source of truth for both UIs. All picker behavior is gated behind `variant === 'directoryPicker'`, so the default explorer path is unchanged.

## Screenshots

| State | Screenshot |
|---|---|
| Picker modal — files disabled, folder CRUD available | ![modal](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8447/20260730-062847-cap-modal.png) |
| Read-only vfolder — folder CRUD gated by `permissions` | ![readonly](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8447/20260730-064004-cap-readonly-fixed.png) |

> Field-level screenshots from the earlier revision (which embedded a vfolder select inside the picker) were removed — the picker is now a single path field fed by an external vfolder select. The modal screenshots above are unchanged by that revision.

## Out of scope

- Wiring actual consumers (Start page "From URL" destination path, model definition path) — follow-up FR.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / terminology), re-run after the sub-path-only refactor and again after the preloaded-query/select-trigger revision.
- Storybook stories exercised against the mock client: browse → create folder (auto-enters it) → confirm → value updates to the sub path (e.g. `"models/fine-tune-v2"`); root confirm yields `''` and renders as `/`.
- All 21 locale files validated as JSON; `{{folderName}}` interpolation preserved in every language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


