### PR TITLE
fix(FR-3402): render published announcements through the editor's markdown pipeline

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -866,9 +866,6 @@ importers:
       lucide-react:
         specifier: 'catalog:'
         version: 0.552.0(react@19.2.7)
-      markdown-to-jsx:
-        specifier: ^7.7.17
-        version: 7.7.17(react@19.2.7)
       marked:
         specifier: 'catalog:'
         version: 16.4.2
@@ -9009,15 +9006,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  markdown-to-jsx@7.7.17:
-    resolution: {integrity: sha512-7mG/1feQ0TX5I7YyMZVDgCC/y2I3CiEhIRQIhyov9nGBP5eoVrOXXHuL5ZP8GRfxVZKRiXWJgwXkb9It+nQZfQ==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      react: '>= 0.14.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   marked@12.0.2:
     resolution: {integrity: sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==}
@@ -21446,10 +21434,6 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
-  markdown-to-jsx@7.7.17(react@19.2.7):
-    optionalDependencies:
-      react: 19.2.7
-
   marked@12.0.2: {}
 
   marked@14.0.0: {}
@@ -25794,7 +25778,6 @@ time:
   lodash-es@4.18.1: '2026-04-01T21:04:15.518Z'
   lodash@4.18.1: '2026-04-01T21:01:20.458Z'
   lucide-react@0.552.0: '2025-10-31T09:36:06.053Z'
-  markdown-to-jsx@7.7.17: '2025-10-24T03:49:28.787Z'
   marked@12.0.2: '2024-04-19T05:13:06.397Z'
   marked@16.4.2: '2025-11-06T22:29:20.004Z'
   mime-types@2.1.35: '2022-03-12T18:04:43.042Z'

--- a/react/package.json
+++ b/react/package.json
@@ -50,7 +50,6 @@
     "katex": "^0.16.47",
     "lodash-es": "catalog:",
     "lucide-react": "catalog:",
-    "markdown-to-jsx": "^7.7.17",
     "marked": "catalog:",
     "monaco-editor": "^0.55.1",
     "nanoid": "^5.1.16",

--- a/react/src/components/AnnouncementAlert.tsx
+++ b/react/src/components/AnnouncementAlert.tsx
@@ -5,7 +5,7 @@
 import { useCurrentUserRole } from '../hooks/backendai';
 import { useSuspenseGetAnnouncement } from '../hooks/useSuspenseGetAnnouncement';
 import AnnouncementEditModal from './AnnouncementEditModal';
-import AnnouncementMarkdown from './AnnouncementMarkdown';
+import MarkdownContent from './MarkdownContent';
 import { useToggle } from 'ahooks';
 import { Button } from 'antd';
 import { BAIAlert, BAIAlertProps, BAIUnmountAfterClose } from 'backend.ai-ui';
@@ -27,9 +27,7 @@ const AnnouncementAlert: React.FC<Props> = ({ ...otherProps }) => {
   return !_.isEmpty(announcement.message) ? (
     <>
       <BAIAlert
-        description={
-          <AnnouncementMarkdown>{announcement.message}</AnnouncementMarkdown>
-        }
+        description={<MarkdownContent>{announcement.message}</MarkdownContent>}
         action={
           isSuperAdmin ? (
             <Button

--- a/react/src/components/AnnouncementAlert.tsx
+++ b/react/src/components/AnnouncementAlert.tsx
@@ -5,12 +5,12 @@
 import { useCurrentUserRole } from '../hooks/backendai';
 import { useSuspenseGetAnnouncement } from '../hooks/useSuspenseGetAnnouncement';
 import AnnouncementEditModal from './AnnouncementEditModal';
+import AnnouncementMarkdown from './AnnouncementMarkdown';
 import { useToggle } from 'ahooks';
-import { Button, theme } from 'antd';
+import { Button } from 'antd';
 import { BAIAlert, BAIAlertProps, BAIUnmountAfterClose } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { SquarePenIcon } from 'lucide-react';
-import Markdown from 'markdown-to-jsx';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -19,7 +19,6 @@ const AnnouncementAlert: React.FC<Props> = ({ ...otherProps }) => {
   'use memo';
 
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const userRole = useCurrentUserRole();
   const isSuperAdmin = userRole === 'superadmin';
   const [isEditOpen, { toggle: toggleEditModal }] = useToggle(false);
@@ -29,22 +28,7 @@ const AnnouncementAlert: React.FC<Props> = ({ ...otherProps }) => {
     <>
       <BAIAlert
         description={
-          <div style={{ marginBottom: token.marginSM * -1 }}>
-            <Markdown
-              options={{
-                overrides: {
-                  p: {
-                    props: {
-                      style: { marginTop: 0, marginBottom: token.marginSM },
-                    },
-                  },
-                },
-              }}
-            >
-              {/* trailing <p> collapses the last paragraph's bottom margin */}
-              {announcement.message + '<p></p>'}
-            </Markdown>
-          </div>
+          <AnnouncementMarkdown>{announcement.message}</AnnouncementMarkdown>
         }
         action={
           isSuperAdmin ? (

--- a/react/src/components/AnnouncementEditModal.tsx
+++ b/react/src/components/AnnouncementEditModal.tsx
@@ -5,8 +5,8 @@
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation, useTanQuery } from '../hooks/reactQueryAlias';
 import { announcementQueryOptions } from '../hooks/useSuspenseGetAnnouncement';
+import AnnouncementMarkdown from './AnnouncementMarkdown';
 import BAICodeEditor from './BAICodeEditor';
-import { SyntaxHighlighter } from './Chat/SyntaxHighlighter';
 import {
   BoldOutlined,
   CodeOutlined,
@@ -37,153 +37,13 @@ import {
   useErrorMessageResolver,
   useBAILogger,
 } from 'backend.ai-ui';
-// `rehype-katex` does not import the CSS file, so we need to import it manually.
-import 'katex/dist/katex.min.css';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Markdown from 'react-markdown';
-import rehypeKatex from 'rehype-katex';
-import remarkGfm from 'remark-gfm';
-import remarkMath from 'remark-math';
 
 type MonacoEditorInstance = Parameters<OnMount>[0];
 type MonacoNamespace = Parameters<OnMount>[1];
 
 const useStyles = createStyles(({ css, token }) => ({
-  // velog-style reading typography for the live preview: comfortable line
-  // height, bordered headings, accented blockquotes, GitHub-flavored tables.
-  markdownPreview: css`
-    color: ${token.colorText};
-    font-size: ${token.fontSize}px;
-    line-height: 1.7;
-    word-break: break-word;
-
-    & > *:first-child {
-      margin-top: 0;
-    }
-    & > *:last-child {
-      margin-bottom: 0;
-    }
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      margin: 1.5em 0 0.75em;
-      font-weight: ${token.fontWeightStrong};
-      line-height: 1.4;
-    }
-    h1 {
-      font-size: 1.9em;
-      padding-bottom: 0.3em;
-      border-bottom: 1px solid ${token.colorBorderSecondary};
-    }
-    h2 {
-      font-size: 1.5em;
-      padding-bottom: 0.3em;
-      border-bottom: 1px solid ${token.colorBorderSecondary};
-    }
-    h3 {
-      font-size: 1.25em;
-    }
-    h4 {
-      font-size: 1em;
-    }
-
-    p {
-      margin: 0 0 1em;
-    }
-
-    a {
-      color: ${token.colorLink};
-      text-decoration: none;
-    }
-    a:hover {
-      text-decoration: underline;
-    }
-
-    img {
-      max-width: 100%;
-      border-radius: ${token.borderRadius}px;
-    }
-
-    /* Restore list markers: the global reset in resources/webui.css sets
-       \`ul { list-style-type: none }\`, which otherwise hides bullets here. */
-    ul,
-    ol {
-      margin: 0 0 1em;
-      padding-left: 1.6em;
-    }
-    ul {
-      list-style: disc;
-    }
-    ul ul {
-      list-style: circle;
-    }
-    ol {
-      list-style: decimal;
-    }
-    li {
-      margin: 0.25em 0;
-    }
-    li > p {
-      margin: 0;
-    }
-    li > input[type='checkbox'] {
-      margin-right: 0.4em;
-    }
-
-    blockquote {
-      margin: 0 0 1em;
-      padding: 0.4em 1em;
-      color: ${token.colorTextSecondary};
-      border-left: 4px solid ${token.colorPrimary};
-      background: ${token.colorFillQuaternary};
-      border-radius: ${token.borderRadiusSM}px;
-    }
-    blockquote > *:last-child {
-      margin-bottom: 0;
-    }
-
-    hr {
-      margin: 1.5em 0;
-      border: none;
-      border-top: 1px solid ${token.colorBorderSecondary};
-    }
-
-    /* Inline code only; fenced blocks are rendered by SyntaxHighlighter. */
-    :not(pre) > code {
-      padding: 0.15em 0.4em;
-      font-family: ${token.fontFamilyCode};
-      font-size: 0.9em;
-      background: ${token.colorFillSecondary};
-      border-radius: ${token.borderRadiusSM}px;
-    }
-    pre {
-      margin: 0 0 1em;
-      border-radius: ${token.borderRadius}px;
-      overflow: auto;
-    }
-
-    table {
-      width: 100%;
-      margin: 0 0 1em;
-      border-collapse: collapse;
-      font-size: 0.95em;
-    }
-    th,
-    td {
-      padding: ${token.paddingXS}px ${token.paddingSM}px;
-      border: 1px solid ${token.colorBorderSecondary};
-    }
-    th {
-      background: ${token.colorFillTertiary};
-      font-weight: ${token.fontWeightStrong};
-      text-align: left;
-    }
-  `,
   toolbar: css`
     padding: ${token.paddingXXS}px ${token.paddingXS}px;
     border: 1px solid ${token.colorBorder};
@@ -220,7 +80,6 @@ const AnnouncementEditModal: React.FC<AnnouncementEditModalProps> = ({
 
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const { styles } = useStyles();
   const { message: appMessage, modal } = App.useApp();
   const { logger } = useBAILogger();
   const { getErrorMessage } = useErrorMessageResolver();
@@ -400,8 +259,7 @@ const AnnouncementEditModal: React.FC<AnnouncementEditModalProps> = ({
             <Typography.Text strong>
               {t('summary.AnnouncementPreview')}
             </Typography.Text>
-            <div
-              className={styles.markdownPreview}
+            <AnnouncementMarkdown
               style={{
                 border: `1px solid ${token.colorBorder}`,
                 borderRadius: token.borderRadius,
@@ -413,36 +271,8 @@ const AnnouncementEditModal: React.FC<AnnouncementEditModalProps> = ({
                 overflow: 'auto',
               }}
             >
-              <Markdown
-                remarkPlugins={[remarkGfm, remarkMath]}
-                rehypePlugins={[rehypeKatex]}
-                components={{
-                  // Fenced code blocks: render through the shared shiki-based
-                  // highlighter (theme-aware). Inline code keeps the default
-                  // <code> and is styled via CSS.
-                  pre({ children }) {
-                    const codeElement = Array.isArray(children)
-                      ? children[0]
-                      : children;
-                    const className: string =
-                      // @ts-ignore - react-markdown passes the <code> element here
-                      codeElement?.props?.className ?? '';
-                    const match = /language-(\w+)/.exec(className);
-                    const content = String(
-                      // @ts-ignore
-                      codeElement?.props?.children ?? '',
-                    ).replace(/\n$/, '');
-                    return (
-                      <SyntaxHighlighter language={match?.[1] ?? 'txt'}>
-                        {content}
-                      </SyntaxHighlighter>
-                    );
-                  },
-                }}
-              >
-                {message}
-              </Markdown>
-            </div>
+              {message}
+            </AnnouncementMarkdown>
           </BAIFlex>
         </BAIFlex>
       )}

--- a/react/src/components/AnnouncementEditModal.tsx
+++ b/react/src/components/AnnouncementEditModal.tsx
@@ -5,8 +5,8 @@
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation, useTanQuery } from '../hooks/reactQueryAlias';
 import { announcementQueryOptions } from '../hooks/useSuspenseGetAnnouncement';
-import AnnouncementMarkdown from './AnnouncementMarkdown';
 import BAICodeEditor from './BAICodeEditor';
+import MarkdownContent from './MarkdownContent';
 import {
   BoldOutlined,
   CodeOutlined,
@@ -259,7 +259,7 @@ const AnnouncementEditModal: React.FC<AnnouncementEditModalProps> = ({
             <Typography.Text strong>
               {t('summary.AnnouncementPreview')}
             </Typography.Text>
-            <AnnouncementMarkdown
+            <MarkdownContent
               style={{
                 border: `1px solid ${token.colorBorder}`,
                 borderRadius: token.borderRadius,
@@ -272,7 +272,7 @@ const AnnouncementEditModal: React.FC<AnnouncementEditModalProps> = ({
               }}
             >
               {message}
-            </AnnouncementMarkdown>
+            </MarkdownContent>
           </BAIFlex>
         </BAIFlex>
       )}

--- a/react/src/components/AnnouncementMarkdown.tsx
+++ b/react/src/components/AnnouncementMarkdown.tsx
@@ -1,0 +1,212 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { SyntaxHighlighter } from './Chat/SyntaxHighlighter';
+import { createStyles } from 'antd-style';
+// `rehype-katex` does not import the CSS file, so we need to import it manually.
+import 'katex/dist/katex.min.css';
+import React from 'react';
+import Markdown from 'react-markdown';
+import rehypeKatex from 'rehype-katex';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+
+const useStyles = createStyles(({ css, token }) => ({
+  // velog-style reading typography: comfortable line height, bordered
+  // headings, accented blockquotes, GitHub-flavored tables.
+  markdown: css`
+    color: ${token.colorText};
+    font-size: ${token.fontSize}px;
+    line-height: 1.7;
+    word-break: break-word;
+
+    & > *:first-child {
+      margin-top: 0;
+    }
+    & > *:last-child {
+      margin-bottom: 0;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin: 1.5em 0 0.75em;
+      font-weight: ${token.fontWeightStrong};
+      line-height: 1.4;
+    }
+    h1 {
+      font-size: 1.9em;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid ${token.colorBorderSecondary};
+    }
+    h2 {
+      font-size: 1.5em;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid ${token.colorBorderSecondary};
+    }
+    h3 {
+      font-size: 1.25em;
+    }
+    h4 {
+      font-size: 1em;
+    }
+
+    p {
+      margin: 0 0 1em;
+    }
+
+    a {
+      color: ${token.colorLink};
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+
+    img {
+      max-width: 100%;
+      border-radius: ${token.borderRadius}px;
+    }
+
+    /* Restore list markers: the global reset in resources/webui.css sets
+       \`ul { list-style-type: none }\`, which otherwise hides bullets here. */
+    ul,
+    ol {
+      margin: 0 0 1em;
+      padding-left: 1.6em;
+    }
+    ul {
+      list-style: disc;
+    }
+    ul ul {
+      list-style: circle;
+    }
+    ol {
+      list-style: decimal;
+    }
+    li {
+      margin: 0.25em 0;
+    }
+    li > p {
+      margin: 0;
+    }
+    li > input[type='checkbox'] {
+      margin-right: 0.4em;
+    }
+
+    blockquote {
+      margin: 0 0 1em;
+      padding: 0.4em 1em;
+      color: ${token.colorTextSecondary};
+      border-left: 4px solid ${token.colorPrimary};
+      background: ${token.colorFillQuaternary};
+      border-radius: ${token.borderRadiusSM}px;
+    }
+    blockquote > *:last-child {
+      margin-bottom: 0;
+    }
+
+    hr {
+      margin: 1.5em 0;
+      border: none;
+      border-top: 1px solid ${token.colorBorderSecondary};
+    }
+
+    /* Inline code only; fenced blocks are rendered by SyntaxHighlighter. */
+    :not(pre) > code {
+      padding: 0.15em 0.4em;
+      font-family: ${token.fontFamilyCode};
+      font-size: 0.9em;
+      background: ${token.colorFillSecondary};
+      border-radius: ${token.borderRadiusSM}px;
+    }
+    pre {
+      margin: 0 0 1em;
+      border-radius: ${token.borderRadius}px;
+      overflow: auto;
+    }
+
+    table {
+      width: 100%;
+      margin: 0 0 1em;
+      border-collapse: collapse;
+      font-size: 0.95em;
+    }
+    th,
+    td {
+      padding: ${token.paddingXS}px ${token.paddingSM}px;
+      border: 1px solid ${token.colorBorderSecondary};
+    }
+    th {
+      background: ${token.colorFillTertiary};
+      font-weight: ${token.fontWeightStrong};
+      text-align: left;
+    }
+  `,
+}));
+
+interface AnnouncementMarkdownProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'children'
+> {
+  children: string;
+}
+
+/**
+ * Renders an announcement message as markdown.
+ *
+ * The editor's preview pane and the published announcement alert both render
+ * through this component so that the preview is a faithful preview: one
+ * renderer, one plugin set, one stylesheet. Rendering them separately let the
+ * two drift — a blockquote styled in the preview came out as plain text once
+ * published (FR-3402).
+ */
+const AnnouncementMarkdown: React.FC<AnnouncementMarkdownProps> = ({
+  children,
+  className,
+  ...divProps
+}) => {
+  'use memo';
+
+  const { styles, cx } = useStyles();
+
+  return (
+    <div className={cx(styles.markdown, className)} {...divProps}>
+      <Markdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={{
+          // Fenced code blocks: render through the shared shiki-based
+          // highlighter (theme-aware). Inline code keeps the default
+          // <code> and is styled via CSS.
+          pre({ children }) {
+            const codeElement = Array.isArray(children)
+              ? children[0]
+              : children;
+            const className: string =
+              // @ts-ignore - react-markdown passes the <code> element here
+              codeElement?.props?.className ?? '';
+            const match = /language-(\w+)/.exec(className);
+            const content = String(
+              // @ts-ignore
+              codeElement?.props?.children ?? '',
+            ).replace(/\n$/, '');
+            return (
+              <SyntaxHighlighter language={match?.[1] ?? 'txt'}>
+                {content}
+              </SyntaxHighlighter>
+            );
+          },
+        }}
+      >
+        {children}
+      </Markdown>
+    </div>
+  );
+};
+
+export default AnnouncementMarkdown;

--- a/react/src/components/Chat/ChatMessage.tsx
+++ b/react/src/components/Chat/ChatMessage.tsx
@@ -57,10 +57,6 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
   // Filter file parts from the message parts array
   const fileParts = _.filter(message.parts, (part) => part.type === 'file');
 
-  // The bubble has no vertical padding; the rendered markdown paragraphs of
-  // `content` supply it. When only reasoning is present (e.g. while the model
-  // is still thinking), there is no paragraph to provide the bottom gap, so the
-  // Collapse has to add it itself.
   const hasContent = !_.isEmpty(_.trim(content));
 
   return (
@@ -114,8 +110,6 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
           borderColor: token.colorBorderSecondary,
           borderWidth: token.lineWidth,
           padding: '1em',
-          paddingTop: 0,
-          paddingBottom: 0,
           backgroundColor: token.colorBgElevated,
           maxWidth: '100%',
           width: _.trim(reasoningText) ? '100%' : 'auto',
@@ -124,8 +118,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
         {_.trim(reasoningText) && (
           <Collapse
             style={{
-              marginTop: token.margin,
-              marginBottom: hasContent ? 0 : token.margin,
+              marginBottom: hasContent ? token.margin : 0,
               width: '100%',
             }}
             items={[

--- a/react/src/components/Chat/ChatMessageContent.tsx
+++ b/react/src/components/Chat/ChatMessageContent.tsx
@@ -2,9 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { CodeHead } from './CodeHead';
 import CopyButton from './CopyButton';
 import { SyntaxHighlighter } from './SyntaxHighlighter';
-import { theme, Typography } from 'antd';
+import { theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIFlex } from 'backend.ai-ui';
 // `rehype-katex` does not import the CSS file, so we need to import it manually.
@@ -15,8 +16,6 @@ import Markdown from 'react-markdown';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
-
-const { Text } = Typography;
 
 const useMarkdownStyles = createStyles(({ token }) => ({
   markdownTable: {
@@ -131,41 +130,6 @@ function parseMarkdownIntoBlocks(markdown: string): string[] {
   const tokens = marked.lexer(markdown);
   return tokens.map((token) => token.raw);
 }
-
-const CodeHead = memo<{ lang: string; extra?: React.ReactNode }>(
-  ({ lang, extra }) => {
-    const { token } = theme.useToken();
-
-    return (
-      <BAIFlex
-        style={{
-          margin: 0,
-          minHeight: 38,
-          padding: `0 ${token.paddingSM}px`,
-          background: 'rgba(0, 0, 0, 0.02)',
-          width: '100%',
-        }}
-      >
-        <BAIFlex
-          style={{
-            display: 'inline-block',
-            flex: '1',
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          <Text style={{ fontWeight: 'normal' }} type="secondary">
-            {lang}
-          </Text>
-        </BAIFlex>
-        <BAIFlex>{extra}</BAIFlex>
-      </BAIFlex>
-    );
-  },
-);
-
-CodeHead.displayName = 'CodeHead';
 
 const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
   ({ block, isStreaming }) => {

--- a/react/src/components/Chat/ChatMessageContent.tsx
+++ b/react/src/components/Chat/ChatMessageContent.tsx
@@ -2,361 +2,39 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { CodeHead } from './CodeHead';
+import MarkdownContent from '../MarkdownContent';
 import CopyButton from './CopyButton';
-import { SyntaxHighlighter } from './SyntaxHighlighter';
-import { theme } from 'antd';
-import { createStyles } from 'antd-style';
-import { BAIFlex } from 'backend.ai-ui';
-// `rehype-katex` does not import the CSS file, so we need to import it manually.
-import 'katex/dist/katex.min.css';
 import { marked } from 'marked';
-import React, { memo, useCallback, useMemo } from 'react';
-import Markdown from 'react-markdown';
-import rehypeKatex from 'rehype-katex';
-import remarkGfm from 'remark-gfm';
-import remarkMath from 'remark-math';
-
-const useMarkdownStyles = createStyles(({ token }) => ({
-  markdownTable: {
-    '& tr:hover': {
-      backgroundColor: `${token.colorFillQuaternary} !important`,
-    },
-    '& tr:last-child': {
-      borderBottom: 'none !important',
-    },
-    '& th:last-child, & td:last-child': {
-      borderRight: 'none !important',
-    },
-  },
-  blockquote: {
-    margin: `${token.marginMD}px 0`,
-    padding: `${token.paddingSM}px ${token.padding}px`,
-    borderLeft: `${token.lineWidth * 4}px solid ${token.colorBorderSecondary}`,
-    backgroundColor: token.colorFillAlter,
-    borderRadius: `0 ${token.borderRadiusSM}px ${token.borderRadiusSM}px 0`,
-    color: token.colorTextSecondary,
-    fontSize: token.fontSize,
-    lineHeight: token.lineHeight,
-    '& p': {
-      margin: '0 !important',
-    },
-    '& p:not(:last-child)': {
-      marginBottom: `${token.marginXS}px !important`,
-    },
-  },
-  hr: {
-    margin: `${token.marginXS}px 0`,
-    border: 'none',
-    height: `${token.lineWidth}px`,
-    background: `linear-gradient(90deg, transparent, ${token.colorBorderSecondary}, transparent)`,
-    borderRadius: token.borderRadiusXS,
-    opacity: 0.8,
-    '&::before': {
-      content: '""',
-      display: 'block',
-      height: '100%',
-      background: 'inherit',
-    },
-  },
-  ul: {
-    margin: `${token.marginSM}px 0`,
-    paddingLeft: `${token.paddingLG}px`,
-    lineHeight: token.lineHeight,
-    listStyleType: 'disc',
-    listStylePosition: 'outside',
-    '& li': {
-      marginBottom: `${token.marginXXS}px`,
-      color: token.colorText,
-      display: 'list-item',
-    },
-    '& ul': {
-      marginTop: `${token.marginXXS}px`,
-      marginBottom: 0,
-      listStyleType: 'circle',
-    },
-    '& ul ul': {
-      listStyleType: 'square',
-    },
-    '& ol': {
-      marginTop: `${token.marginXXS}px`,
-      marginBottom: 0,
-    },
-  },
-  ol: {
-    margin: `${token.marginSM}px 0`,
-    paddingLeft: `${token.paddingLG}px`,
-    lineHeight: token.lineHeight,
-    listStyleType: 'decimal',
-    listStylePosition: 'outside',
-    '& li': {
-      marginBottom: `${token.marginXXS}px`,
-      color: token.colorText,
-      display: 'list-item',
-    },
-    '& li::marker': {
-      fontWeight: token.fontWeightStrong,
-    },
-    '& ol': {
-      marginTop: `${token.marginXXS}px`,
-      marginBottom: 0,
-      listStyleType: 'lower-alpha',
-    },
-    '& ol ol': {
-      listStyleType: 'lower-roman',
-    },
-    '& ul': {
-      marginTop: `${token.marginXXS}px`,
-      marginBottom: 0,
-    },
-  },
-  codeBlock: {
-    '& .shiki.github-light': {
-      margin: '0 !important',
-      padding: `${token.paddingSM}px !important`,
-    },
-    '& .shiki.github-dark': {
-      margin: '0 !important',
-      padding: `${token.paddingSM}px !important`,
-    },
-    '& div[dir="ltr"]': {
-      display: 'table',
-      minWidth: '100%',
-    },
-  },
-}));
+import React, { memo } from 'react';
 
 function parseMarkdownIntoBlocks(markdown: string): string[] {
   const tokens = marked.lexer(markdown);
   return tokens.map((token) => token.raw);
 }
 
+// Per-block splitting (via `marked.lexer` above) lets each finished block
+// memoize independently while streaming: only the currently-growing block
+// re-renders on each token, since its `block` string is the only one whose
+// identity changes. Each block renders through the shared `MarkdownContent`
+// (FR-3402) with `isStreaming` so it gets the same typography and
+// fenced-code panel every other call site uses.
 const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
   ({ block, isStreaming }) => {
-    const { styles } = useMarkdownStyles();
-    const renderPre = useCallback((props: React.HTMLProps<HTMLPreElement>) => {
-      return <pre {...props} style={{ overflow: 'auto', marginTop: 0 }} />;
-    }, []);
-
-    const renderCode = useCallback(
-      (props: any) => {
-        const { children, className, node, ref: _ref, ...rest } = props;
-        const match = /language-(\w+)/.exec(className || '');
-        const content = String(children ?? '').replace(/\n$/, '');
-        const { token } = theme.useToken();
-
-        const isOneLine =
-          node.position?.start?.line === node.position?.end?.line || false;
-
-        return match ? (
-          <BAIFlex
-            direction={'column'}
-            style={{
-              border: `1px solid ${token.colorBorder}`,
-              margin: '0',
-              padding: '0',
-              borderRadius: token.borderRadiusLG,
-              overflow: 'hidden',
-            }}
-            align="stretch"
-          >
-            <CodeHead
-              lang={match[1]}
-              extra={
-                <CopyButton
-                  type="text"
-                  copyable={{ text: content ?? '' }}
-                  style={{
-                    display: isStreaming ? 'none' : 'block',
-                  }}
-                />
-              }
-            />
-            <BAIFlex
-              className={styles.codeBlock}
-              style={{
-                width: '100%',
-                paddingTop: 0,
-                borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
-                overflow: 'auto',
-              }}
-            >
-              <SyntaxHighlighter
-                {...rest}
-                PreTag="div"
-                language={match[1]}
-                wrapLongLines
-                wrapLines
-              >
-                {content}
-              </SyntaxHighlighter>
-            </BAIFlex>
-          </BAIFlex>
-        ) : (
-          <code
-            {...rest}
-            style={{
-              whiteSpace: 'pre-wrap',
-              ...(isOneLine
-                ? {
-                    backgroundColor: token.colorBgContainerDisabled,
-                    border: `1px solid ${token.colorBorder}`,
-                    padding: '2px 6px',
-                    borderRadius: token.borderRadiusSM,
-                    fontSize: '0.875em',
-                  }
-                : {}),
-            }}
-            className={className}
-          >
-            {/* @ts-ignore */}
-            {children}
-          </code>
-        );
-      },
-      [isStreaming, styles.codeBlock],
-    );
-
-    const renderParagraph = useCallback(({ node: _node, ...props }: any) => {
-      return (
-        <p
-          {...props}
-          style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-        />
-      );
-    }, []);
-
-    const renderBlockquote = useCallback(
-      (props: any) => {
-        return <blockquote {...props} className={styles.blockquote} />;
-      },
-      [styles.blockquote],
-    );
-
-    const renderHr = useCallback(
-      (props: any) => {
-        return <hr {...props} className={styles.hr} />;
-      },
-      [styles.hr],
-    );
-
-    const renderUl = useCallback(
-      (props: any) => {
-        return <ul {...props} className={styles.ul} />;
-      },
-      [styles.ul],
-    );
-
-    const renderOl = useCallback(
-      (props: any) => {
-        return <ol {...props} className={styles.ol} />;
-      },
-      [styles.ol],
-    );
-
-    const renderLi = useCallback((props: any) => {
-      return <li {...props} />;
-    }, []);
-
-    const renderTable = useCallback(
-      (props: any) => {
-        const { token } = theme.useToken();
-        return (
-          <div
-            style={{
-              overflow: 'auto',
-              border: `1px solid ${token.colorBorderSecondary}`,
-              borderRadius: token.borderRadiusSM,
-            }}
-          >
-            <table
-              {...props}
-              className={styles.markdownTable}
-              style={{
-                width: '100%',
-                borderCollapse: 'collapse',
-                fontSize: token.fontSizeSM,
-                lineHeight: token.lineHeight,
-                backgroundColor: token.colorBgContainer,
-              }}
-            />
-          </div>
-        );
-      },
-      [styles.markdownTable],
-    );
-
-    const renderTableRow = useCallback((props: any) => {
-      const { token } = theme.useToken();
-      return (
-        <tr
-          {...props}
-          style={{
-            borderBottom: `${token.lineWidth}px solid ${token.colorBorderSecondary}`,
-            transition: `background-color ${token.motionDurationSlow}`,
-          }}
-        />
-      );
-    }, []);
-
-    const renderTableHeader = useCallback((props: any) => {
-      const { token } = theme.useToken();
-      return (
-        <th
-          {...props}
-          style={{
-            padding: `${token.paddingXS}px ${token.paddingSM}px`,
-            textAlign: 'left',
-            fontWeight: token.fontWeightStrong,
-            fontSize: token.fontSizeSM,
-            backgroundColor: token.colorFillTertiary,
-            borderBottom: `${token.lineWidth}px solid ${token.colorBorder}`,
-            borderRight: `${token.lineWidth}px solid ${token.colorBorderSecondary}`,
-            color: token.colorTextSecondary,
-            textTransform: 'uppercase',
-            letterSpacing: '0.5px',
-          }}
-        />
-      );
-    }, []);
-
-    const renderTableCell = useCallback((props: any) => {
-      const { token } = theme.useToken();
-      return (
-        <td
-          {...props}
-          style={{
-            padding: `${token.paddingXS}px ${token.paddingSM}px`,
-            borderRight: `${token.lineWidth}px solid ${token.colorBorderSecondary}`,
-            color: token.colorText,
-            fontSize: token.fontSizeSM,
-            verticalAlign: 'top',
-          }}
-        />
-      );
-    }, []);
+    'use memo';
 
     return (
-      <Markdown
-        remarkPlugins={[remarkGfm, remarkMath]}
-        rehypePlugins={[rehypeKatex]}
-        components={{
-          p: renderParagraph,
-          code: renderCode,
-          pre: renderPre,
-          blockquote: renderBlockquote,
-          hr: renderHr,
-          ul: renderUl,
-          ol: renderOl,
-          li: renderLi,
-          table: renderTable,
-          tr: renderTableRow,
-          th: renderTableHeader,
-          td: renderTableCell,
-        }}
+      <MarkdownContent
+        isStreaming={isStreaming}
+        codeBlockExtra={(code) => (
+          <CopyButton
+            type="text"
+            copyable={{ text: code }}
+            style={{ display: isStreaming ? 'none' : 'block' }}
+          />
+        )}
       >
-        {block}
-      </Markdown>
+        {block ?? ''}
+      </MarkdownContent>
     );
   },
 );
@@ -367,10 +45,9 @@ const ChatMessageContent: React.FC<{
   children?: string;
   isStreaming?: boolean;
 }> = ({ children, isStreaming }) => {
-  const blocks = useMemo(
-    () => parseMarkdownIntoBlocks(children ?? ''),
-    [children],
-  );
+  'use memo';
+
+  const blocks = parseMarkdownIntoBlocks(children ?? '');
 
   return blocks.map((block, index) => (
     <ChatMessageContentBlock

--- a/react/src/components/Chat/ChatMessageContent.tsx
+++ b/react/src/components/Chat/ChatMessageContent.tsx
@@ -4,6 +4,7 @@
  */
 import MarkdownContent from '../MarkdownContent';
 import CopyButton from './CopyButton';
+import { BAIFlex } from 'backend.ai-ui';
 import { marked } from 'marked';
 import React, { memo } from 'react';
 
@@ -49,13 +50,24 @@ const ChatMessageContent: React.FC<{
 
   const blocks = parseMarkdownIntoBlocks(children ?? '');
 
-  return blocks.map((block, index) => (
-    <ChatMessageContentBlock
-      block={block}
-      key={`block_${index}`}
-      isStreaming={isStreaming}
-    />
-  ));
+  // Each block renders through its own `MarkdownContent`, which zeroes the
+  // margin on its own first/last child (see that component's `& > *:first-
+  // child` / `& > *:last-child` rule) so a single call site's edges don't
+  // double up against a container that already pads it. Splitting into
+  // per-block instances means every block *is* a first-and-last child, so
+  // that rule now also zeroes the space between blocks — a `gap` here
+  // restores it.
+  return (
+    <BAIFlex direction="column" align="stretch" gap="md">
+      {blocks.map((block, index) => (
+        <ChatMessageContentBlock
+          block={block}
+          key={`block_${index}`}
+          isStreaming={isStreaming}
+        />
+      ))}
+    </BAIFlex>
+  );
 };
 
 ChatMessageContent.displayName = 'ChatMessageContent';

--- a/react/src/components/Chat/CodeHead.tsx
+++ b/react/src/components/Chat/CodeHead.tsx
@@ -1,0 +1,52 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { theme, Typography } from 'antd';
+import { BAIFlex } from 'backend.ai-ui';
+import React, { memo } from 'react';
+
+const { Text } = Typography;
+
+/**
+ * Header bar of a fenced code block: the language label on the left and a
+ * caller-supplied slot on the right.
+ *
+ * The slot is deliberately not a copy button — `ChatMessageContent` passes one
+ * (hidden while streaming), while `MarkdownContent` leaves it to its own caller
+ * via `codeBlockExtra`.
+ */
+export const CodeHead = memo<{ lang: string; extra?: React.ReactNode }>(
+  ({ lang, extra }) => {
+    const { token } = theme.useToken();
+
+    return (
+      <BAIFlex
+        style={{
+          margin: 0,
+          minHeight: 38,
+          padding: `0 ${token.paddingSM}px`,
+          background: 'rgba(0, 0, 0, 0.02)',
+          width: '100%',
+        }}
+      >
+        <BAIFlex
+          style={{
+            display: 'inline-block',
+            flex: '1',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          <Text style={{ fontWeight: 'normal' }} type="secondary">
+            {lang}
+          </Text>
+        </BAIFlex>
+        <BAIFlex>{extra}</BAIFlex>
+      </BAIFlex>
+    );
+  },
+);
+
+CodeHead.displayName = 'CodeHead';

--- a/react/src/components/Chat/CodeHead.tsx
+++ b/react/src/components/Chat/CodeHead.tsx
@@ -18,6 +18,8 @@ const { Text } = Typography;
  */
 export const CodeHead = memo<{ lang: string; extra?: React.ReactNode }>(
   ({ lang, extra }) => {
+    'use memo';
+
     const { token } = theme.useToken();
 
     return (

--- a/react/src/components/ImportFromHuggingFaceModal.tsx
+++ b/react/src/components/ImportFromHuggingFaceModal.tsx
@@ -8,6 +8,7 @@ import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useSuspenseTanQuery, useTanMutation } from '../hooks/reactQueryAlias';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useProjectPath } from '../hooks/useRouteScope';
+import MarkdownContent from './MarkdownContent';
 import {
   CloudUploadOutlined,
   FilterOutlined,
@@ -46,9 +47,7 @@ import React, {
   useTransition,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import Markdown from 'react-markdown';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import remarkGfm from 'remark-gfm';
 
 type Service = {
   url: string;
@@ -372,9 +371,9 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
                   },
                 }}
               >
-                <Markdown remarkPlugins={[remarkGfm]}>
+                <MarkdownContent>
                   {huggingFaceModelInfo.data?.markdown}
-                </Markdown>
+                </MarkdownContent>
               </BAICard>
             </Suspense>
           ) : (

--- a/react/src/components/ImportFromHuggingFaceModal.tsx
+++ b/react/src/components/ImportFromHuggingFaceModal.tsx
@@ -17,7 +17,6 @@ import { useToggle } from 'ahooks';
 import {
   App,
   Button,
-  Card,
   Empty,
   Form,
   FormInstance,
@@ -31,6 +30,7 @@ import {
   Typography,
 } from 'antd';
 import {
+  BAICard,
   BAIModal,
   BAIModalProps,
   BAIFlex,
@@ -38,7 +38,6 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { CheckIcon } from 'lucide-react';
-import Markdown from 'markdown-to-jsx';
 import React, {
   Suspense,
   useEffect,
@@ -47,7 +46,9 @@ import React, {
   useTransition,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import Markdown from 'react-markdown';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import remarkGfm from 'remark-gfm';
 
 type Service = {
   url: string;
@@ -69,7 +70,7 @@ type ImportFromHuggingFaceResult = {
 const ReadmeFallbackCard = () => {
   const { token } = theme.useToken();
   return (
-    <Card
+    <BAICard
       size="small"
       title={
         <BAIFlex direction="row" gap="xs">
@@ -80,13 +81,14 @@ const ReadmeFallbackCard = () => {
       styles={{
         body: {
           padding: token.paddingLG,
+          paddingTop: 0,
           overflow: 'auto',
           height: 200,
         },
       }}
     >
       <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
-    </Card>
+    </BAICard>
   );
 };
 
@@ -353,7 +355,7 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
           </Form.Item>
           {huggingFaceURL && huggingFaceModelInfo.data?.markdown ? (
             <Suspense fallback={<ReadmeFallbackCard />}>
-              <Card
+              <BAICard
                 size="small"
                 title={
                   <BAIFlex direction="row" gap="xs">
@@ -364,13 +366,16 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
                 styles={{
                   body: {
                     padding: token.paddingLG,
+                    paddingTop: 0,
                     overflow: 'auto',
                     height: 200,
                   },
                 }}
               >
-                <Markdown>{huggingFaceModelInfo.data?.markdown}</Markdown>
-              </Card>
+                <Markdown remarkPlugins={[remarkGfm]}>
+                  {huggingFaceModelInfo.data?.markdown}
+                </Markdown>
+              </BAICard>
             </Suspense>
           ) : (
             <ReadmeFallbackCard />

--- a/react/src/components/MarkdownContent.test.tsx
+++ b/react/src/components/MarkdownContent.test.tsx
@@ -1,0 +1,99 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Tests for MarkdownContent (FR-3402).
+ *
+ * These pin the fenced-code contract that review surfaced, all of which the
+ * type checker cannot see:
+ *   - the language token is taken whole (`git-commit`, `c#`), not truncated
+ *     at the first non-word character, since `useHighlight` keys off the
+ *     full identifier;
+ *   - block-vs-inline comes from the element tree, so a CommonMark code span
+ *     that wraps across a newline stays inline instead of becoming a panel;
+ *   - the panel replaces the `pre` rather than nesting inside it, which would
+ *     put block elements (and a second `pre`) inside a preformatted element.
+ *
+ * The highlighter is mocked: shiki's async tokenization is irrelevant here,
+ * and stubbing it lets each test read back the language it was handed.
+ */
+import MarkdownContent from './MarkdownContent';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./Chat/SyntaxHighlighter', () => ({
+  SyntaxHighlighter: ({
+    children,
+    language,
+  }: {
+    children: string;
+    language: string;
+  }) => (
+    <pre data-testid="code-block" data-language={language}>
+      {children}
+    </pre>
+  ),
+}));
+
+describe('MarkdownContent fenced code', () => {
+  it.each([
+    ['git-commit', 'git-commit'],
+    ['objective-c', 'objective-c'],
+    ['c#', 'c#'],
+    ['f#', 'f#'],
+    ['ts', 'ts'],
+  ])('passes the whole `%s` language token through', (lang, expected) => {
+    render(
+      <MarkdownContent>{`\`\`\`${lang}\nconst a = 1;\n\`\`\``}</MarkdownContent>,
+    );
+
+    expect(screen.getByTestId('code-block')).toHaveAttribute(
+      'data-language',
+      expected,
+    );
+  });
+
+  it('falls back to `txt` for a fence with no language', () => {
+    render(<MarkdownContent>{'```\nplain\n```'}</MarkdownContent>);
+
+    expect(screen.getByTestId('code-block')).toHaveAttribute(
+      'data-language',
+      'txt',
+    );
+    expect(screen.getByTestId('code-block')).toHaveTextContent('plain');
+  });
+
+  it('renders the panel outside any `pre`, with no nested block elements', () => {
+    const { container } = render(
+      <MarkdownContent>{'```ts\nconst a = 1;\n```'}</MarkdownContent>,
+    );
+
+    // A `pre` takes phrasing content only — neither a nested `pre` nor a
+    // block-level `div` may appear inside one.
+    expect(container.querySelector('pre pre')).toBeNull();
+    expect(container.querySelector('pre div')).toBeNull();
+  });
+
+  it('keeps a code span that wraps across a newline inline', () => {
+    const { container } = render(
+      <MarkdownContent>{'Text with `inline\ncode` span.'}</MarkdownContent>,
+    );
+
+    expect(screen.queryByTestId('code-block')).toBeNull();
+    const inline = container.querySelector('p > code');
+    expect(inline).not.toBeNull();
+    expect(inline).toHaveTextContent('inline code');
+  });
+
+  it('keeps ordinary inline code inline', () => {
+    const { container } = render(
+      <MarkdownContent>{'Run `pnpm install` first.'}</MarkdownContent>,
+    );
+
+    expect(screen.queryByTestId('code-block')).toBeNull();
+    expect(container.querySelector('p > code')).toHaveTextContent(
+      'pnpm install',
+    );
+  });
+});

--- a/react/src/components/MarkdownContent.test.tsx
+++ b/react/src/components/MarkdownContent.test.tsx
@@ -97,3 +97,84 @@ describe('MarkdownContent fenced code', () => {
     );
   });
 });
+
+describe('MarkdownContent isStreaming', () => {
+  // `ChatMessageContent` renders each of its per-block-split messages
+  // through `MarkdownContent` with `isStreaming` while a reply is still
+  // arriving token-by-token (FR-3402). These pin the two defensive
+  // renderers that only matter for that not-yet-finished state.
+  it('does not add pre-wrap styling to paragraphs when not streaming', () => {
+    const { container } = render(
+      <MarkdownContent>{'A normal paragraph.'}</MarkdownContent>,
+    );
+
+    const p = container.querySelector('p');
+    expect(p).not.toBeNull();
+    // No `p` override is installed when not streaming, so react-markdown's
+    // default paragraph carries no className at all.
+    expect(p?.className).toBe('');
+  });
+
+  it('keeps paragraph whitespace literal while streaming', () => {
+    const { container } = render(
+      <MarkdownContent isStreaming>{'A normal paragraph.'}</MarkdownContent>,
+    );
+
+    const p = container.querySelector('p');
+    expect(p).not.toBeNull();
+    expect(p).toHaveStyle({ whiteSpace: 'pre-wrap' });
+  });
+
+  it('does not install a `code` override for a multi-line span when not streaming', () => {
+    const { container } = render(
+      <MarkdownContent>{'Text with `inline\ncode` span.'}</MarkdownContent>,
+    );
+
+    const inline = container.querySelector('p > code');
+    expect(inline).not.toBeNull();
+    // No `code` override is installed when not streaming, so this stays the
+    // plain default element — only the stylesheet's unconditional
+    // `:not(pre) > code` rule applies, with no per-node class at all.
+    expect(inline?.className).toBe('');
+  });
+
+  it('strips the inline-code pill style for a code span that currently spans multiple lines while streaming', () => {
+    const { container } = render(
+      <MarkdownContent isStreaming>
+        {'Text with `inline\ncode` span.'}
+      </MarkdownContent>,
+    );
+
+    const inline = container.querySelector('p > code');
+    expect(inline).not.toBeNull();
+    expect(inline).toHaveStyle({ background: 'none', borderStyle: 'none' });
+  });
+
+  it('keeps the pill style for ordinary one-line inline code while streaming', () => {
+    const { container } = render(
+      <MarkdownContent isStreaming>
+        {'Run `pnpm install` first.'}
+      </MarkdownContent>,
+    );
+
+    const inline = container.querySelector('p > code');
+    expect(inline).not.toBeNull();
+    // A one-line span isn't reset, so it keeps only the stylesheet's own
+    // (non-`none`) background from `:not(pre) > code` — not the streaming
+    // reset applied to the multi-line case above.
+    expect(inline).not.toHaveStyle({ background: 'none' });
+  });
+
+  it('still renders fenced code as a panel while streaming', () => {
+    render(
+      <MarkdownContent isStreaming>
+        {'```ts\nconst a = 1;\n```'}
+      </MarkdownContent>,
+    );
+
+    expect(screen.getByTestId('code-block')).toHaveAttribute(
+      'data-language',
+      'ts',
+    );
+  });
+});

--- a/react/src/components/MarkdownContent.tsx
+++ b/react/src/components/MarkdownContent.tsx
@@ -2,19 +2,24 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { CodeHead } from './Chat/CodeHead';
 import { SyntaxHighlighter } from './Chat/SyntaxHighlighter';
+import { theme } from 'antd';
 import { createStyles } from 'antd-style';
+import { BAIFlex } from 'backend.ai-ui';
 // `rehype-katex` does not import the CSS file, so we need to import it manually.
 import 'katex/dist/katex.min.css';
 import React from 'react';
-import Markdown from 'react-markdown';
+import Markdown, { type Components } from 'react-markdown';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
 const useStyles = createStyles(({ css, token }) => ({
-  // velog-style reading typography: comfortable line height, bordered
-  // headings, accented blockquotes, GitHub-flavored tables.
+  // Reading typography for long-form markdown: comfortable line height and
+  // bordered headings. Everything `ChatMessageContent` also styles
+  // (blockquote, hr, lists, tables, inline code) uses the same tokens it
+  // does, so the two renderers produce the same output.
   markdown: css`
     color: ${token.colorText};
     font-size: ${token.fontSize}px;
@@ -76,20 +81,41 @@ const useStyles = createStyles(({ css, token }) => ({
        \`ul { list-style-type: none }\`, which otherwise hides bullets here. */
     ul,
     ol {
-      margin: 0 0 1em;
-      padding-left: 1.6em;
+      margin: ${token.marginSM}px 0;
+      padding-left: ${token.paddingLG}px;
+      list-style-position: outside;
     }
     ul {
-      list-style: disc;
+      list-style-type: disc;
     }
     ul ul {
-      list-style: circle;
+      list-style-type: circle;
+    }
+    ul ul ul {
+      list-style-type: square;
     }
     ol {
-      list-style: decimal;
+      list-style-type: decimal;
+    }
+    ol ol {
+      list-style-type: lower-alpha;
+    }
+    ol ol ol {
+      list-style-type: lower-roman;
+    }
+    ul ul,
+    ul ol,
+    ol ol,
+    ol ul {
+      margin-top: ${token.marginXXS}px;
+      margin-bottom: 0;
     }
     li {
-      margin: 0.25em 0;
+      display: list-item;
+      margin-bottom: ${token.marginXXS}px;
+    }
+    ol > li::marker {
+      font-weight: ${token.fontWeightStrong};
     }
     li > p {
       margin: 0;
@@ -99,53 +125,108 @@ const useStyles = createStyles(({ css, token }) => ({
     }
 
     blockquote {
-      margin: 0 0 1em;
-      padding: 0.4em 1em;
+      margin: ${token.marginMD}px 0;
+      padding: ${token.paddingSM}px ${token.padding}px;
       color: ${token.colorTextSecondary};
-      border-left: 4px solid ${token.colorPrimary};
-      background: ${token.colorFillQuaternary};
-      border-radius: ${token.borderRadiusSM}px;
+      border-left: ${token.lineWidth * 4}px solid ${token.colorBorderSecondary};
+      background-color: ${token.colorFillAlter};
+      border-radius: 0 ${token.borderRadiusSM}px ${token.borderRadiusSM}px 0;
+    }
+    blockquote p {
+      margin: 0;
+    }
+    blockquote p:not(:last-child) {
+      margin-bottom: ${token.marginXS}px;
     }
     blockquote > *:last-child {
       margin-bottom: 0;
     }
 
     hr {
-      margin: 1.5em 0;
+      margin: ${token.marginXS}px 0;
       border: none;
-      border-top: 1px solid ${token.colorBorderSecondary};
+      height: ${token.lineWidth}px;
+      background: linear-gradient(
+        90deg,
+        transparent,
+        ${token.colorBorderSecondary},
+        transparent
+      );
+      border-radius: ${token.borderRadiusXS}px;
+      opacity: 0.8;
     }
 
     /* Inline code only; fenced blocks are rendered by SyntaxHighlighter. */
     :not(pre) > code {
-      padding: 0.15em 0.4em;
+      padding: 2px 6px;
       font-family: ${token.fontFamilyCode};
-      font-size: 0.9em;
-      background: ${token.colorFillSecondary};
+      font-size: 0.875em;
+      white-space: pre-wrap;
+      background-color: ${token.colorBgContainerDisabled};
+      border: ${token.lineWidth}px solid ${token.colorBorder};
       border-radius: ${token.borderRadiusSM}px;
     }
     pre {
       margin: 0 0 1em;
-      padding: ${token.paddingSM}px ${token.padding}px;
-      border-radius: ${token.borderRadius}px;
       overflow: auto;
     }
 
     table {
       width: 100%;
-      margin: 0 0 1em;
       border-collapse: collapse;
-      font-size: 0.95em;
+      font-size: ${token.fontSizeSM}px;
+      background-color: ${token.colorBgContainer};
     }
     th,
     td {
       padding: ${token.paddingXS}px ${token.paddingSM}px;
-      border: 1px solid ${token.colorBorderSecondary};
+      border-right: ${token.lineWidth}px solid ${token.colorBorderSecondary};
     }
     th {
-      background: ${token.colorFillTertiary};
-      font-weight: ${token.fontWeightStrong};
       text-align: left;
+      font-weight: ${token.fontWeightStrong};
+      color: ${token.colorTextSecondary};
+      background-color: ${token.colorFillTertiary};
+      border-bottom: ${token.lineWidth}px solid ${token.colorBorder};
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    td {
+      color: ${token.colorText};
+      vertical-align: top;
+    }
+    tr {
+      border-bottom: ${token.lineWidth}px solid ${token.colorBorderSecondary};
+      transition: background-color ${token.motionDurationSlow};
+    }
+    tr:hover {
+      background-color: ${token.colorFillQuaternary};
+    }
+    tr:last-child {
+      border-bottom: none;
+    }
+    th:last-child,
+    td:last-child {
+      border-right: none;
+    }
+  `,
+  // Wide tables scroll inside their own box instead of stretching the
+  // surrounding alert / drawer.
+  tableWrapper: css`
+    margin: 0 0 1em;
+    overflow: auto;
+    border: ${token.lineWidth}px solid ${token.colorBorderSecondary};
+    border-radius: ${token.borderRadiusSM}px;
+  `,
+  codeBlock: css`
+    & .shiki.github-light,
+    & .shiki.github-dark {
+      margin: 0 !important;
+      padding: ${token.paddingSM}px !important;
+    }
+    & div[dir='ltr'] {
+      display: table;
+      min-width: 100%;
     }
   `,
 }));
@@ -155,6 +236,13 @@ interface MarkdownContentProps extends Omit<
   'children'
 > {
   children: string;
+  /**
+   * Rendered in the top-right slot of every fenced code block's header,
+   * next to the language label. Receives the block's code so the caller can
+   * wire e.g. a copy button; omitted by default, since whether a copy
+   * affordance belongs there is the caller's decision.
+   */
+  codeBlockExtra?: (code: string) => React.ReactNode;
 }
 
 /**
@@ -163,45 +251,84 @@ interface MarkdownContentProps extends Omit<
  *
  * Every call site shares one renderer, one plugin set, and one stylesheet so
  * they can't drift from each other — e.g. a blockquote styled in one place
- * but rendered as plain text in another (FR-3402).
+ * but rendered as plain text in another (FR-3402). The element overrides and
+ * tokens mirror `ChatMessageContent`, which stays separate because it also
+ * owns streaming concerns (per-block splitting, `pre-wrap` paragraphs).
  */
 const MarkdownContent: React.FC<MarkdownContentProps> = ({
   children,
   className,
+  codeBlockExtra,
   ...divProps
 }) => {
   'use memo';
 
   const { styles, cx } = useStyles();
+  const { token } = theme.useToken();
+
+  const components: Components = {
+    // The fenced-code box is built in `code` below; `pre` only carries the
+    // block's spacing and horizontal scroll.
+    pre({ node: _node, ref: _ref, ...props }) {
+      return <pre {...props} style={{ overflow: 'auto', marginTop: 0 }} />;
+    },
+    code({ node, className: codeClassName, children, ref: _ref, ...rest }) {
+      const match = /language-(\w+)/.exec(codeClassName ?? '');
+      const content = String(children ?? '').replace(/\n$/, '');
+      // A fenced block always spans its opening and closing fence, so it
+      // never sits on a single source line the way inline code does.
+      const isMultiline = node?.position
+        ? node.position.start.line !== node.position.end.line
+        : content.includes('\n');
+
+      if (!match && !isMultiline) {
+        return (
+          <code {...rest} className={codeClassName}>
+            {children}
+          </code>
+        );
+      }
+
+      const language = match?.[1] ?? 'txt';
+      return (
+        <BAIFlex
+          direction="column"
+          align="stretch"
+          style={{
+            border: `${token.lineWidth}px solid ${token.colorBorder}`,
+            borderRadius: token.borderRadiusLG,
+            overflow: 'hidden',
+          }}
+        >
+          <CodeHead lang={language} extra={codeBlockExtra?.(content)} />
+          <BAIFlex
+            className={styles.codeBlock}
+            style={{
+              width: '100%',
+              borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
+              overflow: 'auto',
+            }}
+          >
+            <SyntaxHighlighter language={language}>{content}</SyntaxHighlighter>
+          </BAIFlex>
+        </BAIFlex>
+      );
+    },
+    table({ node: _node, ref: _ref, ...props }) {
+      return (
+        <div className={styles.tableWrapper}>
+          <table {...props} />
+        </div>
+      );
+    },
+  };
 
   return (
     <div className={cx(styles.markdown, className)} {...divProps}>
       <Markdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}
-        components={{
-          // Fenced code blocks: render through the shared shiki-based
-          // highlighter (theme-aware). Inline code keeps the default
-          // <code> and is styled via CSS.
-          pre({ children }) {
-            const codeElement = Array.isArray(children)
-              ? children[0]
-              : children;
-            const className: string =
-              // @ts-ignore - react-markdown passes the <code> element here
-              codeElement?.props?.className ?? '';
-            const match = /language-(\w+)/.exec(className);
-            const content = String(
-              // @ts-ignore
-              codeElement?.props?.children ?? '',
-            ).replace(/\n$/, '');
-            return (
-              <SyntaxHighlighter language={match?.[1] ?? 'txt'}>
-                {content}
-              </SyntaxHighlighter>
-            );
-          },
-        }}
+        components={components}
       >
         {children}
       </Markdown>

--- a/react/src/components/MarkdownContent.tsx
+++ b/react/src/components/MarkdownContent.tsx
@@ -4,7 +4,6 @@
  */
 import { CodeHead } from './Chat/CodeHead';
 import { SyntaxHighlighter } from './Chat/SyntaxHighlighter';
-import { theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIFlex } from 'backend.ai-ui';
 // `rehype-katex` does not import the CSS file, so we need to import it manually.
@@ -166,8 +165,10 @@ const useStyles = createStyles(({ css, token }) => ({
       border: ${token.lineWidth}px solid ${token.colorBorder};
       border-radius: ${token.borderRadiusSM}px;
     }
+    /* Fenced blocks are replaced wholesale below, so the only \`pre\` left is
+       the highlighter's own loading fallback, which sits inside the panel. */
     pre {
-      margin: 0 0 1em;
+      margin: 0;
       overflow: auto;
     }
 
@@ -218,7 +219,19 @@ const useStyles = createStyles(({ css, token }) => ({
     border: ${token.lineWidth}px solid ${token.colorBorderSecondary};
     border-radius: ${token.borderRadiusSM}px;
   `,
+  // Margin lives here rather than inline so the container's
+  // \`& > *:last-child { margin-bottom: 0 }\` can still win over it.
+  codeBlockPanel: css`
+    margin-bottom: 1em;
+    overflow: hidden;
+    border: ${token.lineWidth}px solid ${token.colorBorder};
+    border-radius: ${token.borderRadiusLG}px;
+  `,
   codeBlock: css`
+    width: 100%;
+    overflow: auto;
+    border-radius: 0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px;
+
     & .shiki.github-light,
     & .shiki.github-dark {
       margin: 0 !important;
@@ -251,9 +264,11 @@ interface MarkdownContentProps extends Omit<
  *
  * Every call site shares one renderer, one plugin set, and one stylesheet so
  * they can't drift from each other — e.g. a blockquote styled in one place
- * but rendered as plain text in another (FR-3402). The element overrides and
- * tokens mirror `ChatMessageContent`, which stays separate because it also
- * owns streaming concerns (per-block splitting, `pre-wrap` paragraphs).
+ * but rendered as plain text in another (FR-3402). The code-block panel and
+ * the tokens for every element `ChatMessageContent` also styles are shared
+ * with it, so the two render the same output. That component stays separate
+ * because it owns streaming concerns (per-block splitting, `pre-wrap`
+ * paragraphs) that don't apply to long-form markdown.
  */
 const MarkdownContent: React.FC<MarkdownContentProps> = ({
   children,
@@ -264,51 +279,53 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
   'use memo';
 
   const { styles, cx } = useStyles();
-  const { token } = theme.useToken();
 
   const components: Components = {
-    // The fenced-code box is built in `code` below; `pre` only carries the
-    // block's spacing and horizontal scroll.
-    pre({ node: _node, ref: _ref, ...props }) {
-      return <pre {...props} style={{ overflow: 'auto', marginTop: 0 }} />;
-    },
-    code({ node, className: codeClassName, children, ref: _ref, ...rest }) {
-      const match = /language-(\w+)/.exec(codeClassName ?? '');
-      const content = String(children ?? '').replace(/\n$/, '');
-      // A fenced block always spans its opening and closing fence, so it
-      // never sits on a single source line the way inline code does.
-      const isMultiline = node?.position
-        ? node.position.start.line !== node.position.end.line
-        : content.includes('\n');
+    // Fenced code reaches us as `pre > code`. Replace the whole `pre` rather
+    // than rendering the panel inside it: `pre` takes phrasing content, so a
+    // panel there would nest block elements — and the highlighter's own
+    // `pre` — inside a preformatted element.
+    //
+    // Reading the language and text off the element tree also settles
+    // block-vs-inline structurally. Inline code never reaches this override,
+    // so it keeps the default `<code>` (styled by `:not(pre) > code` above)
+    // even for a code span that wraps across a newline, which CommonMark
+    // allows and a line-count heuristic would misread as a fenced block.
+    pre({ node }) {
+      const codeNode = node?.children.find(
+        (child) => child.type === 'element' && child.tagName === 'code',
+      );
+      const rawClassName =
+        codeNode && 'properties' in codeNode
+          ? codeNode.properties.className
+          : undefined;
+      const classNames = Array.isArray(rawClassName)
+        ? rawClassName.map(String)
+        : typeof rawClassName === 'string'
+          ? rawClassName.split(/\s+/)
+          : [];
+      // Capture the whole token: `useHighlight` knows `git-commit`,
+      // `objective-c`, `c#` and `f#`, all of which a `\w+` capture truncates.
+      const language =
+        classNames
+          .map((name) => /^language-(\S+)$/.exec(name)?.[1])
+          .find(Boolean) ?? 'txt';
+      const content = (
+        codeNode && 'children' in codeNode
+          ? codeNode.children
+              .map((child) => ('value' in child ? child.value : ''))
+              .join('')
+          : ''
+      ).replace(/\n$/, '');
 
-      if (!match && !isMultiline) {
-        return (
-          <code {...rest} className={codeClassName}>
-            {children}
-          </code>
-        );
-      }
-
-      const language = match?.[1] ?? 'txt';
       return (
         <BAIFlex
           direction="column"
           align="stretch"
-          style={{
-            border: `${token.lineWidth}px solid ${token.colorBorder}`,
-            borderRadius: token.borderRadiusLG,
-            overflow: 'hidden',
-          }}
+          className={styles.codeBlockPanel}
         >
           <CodeHead lang={language} extra={codeBlockExtra?.(content)} />
-          <BAIFlex
-            className={styles.codeBlock}
-            style={{
-              width: '100%',
-              borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
-              overflow: 'auto',
-            }}
-          >
+          <BAIFlex className={styles.codeBlock}>
             <SyntaxHighlighter language={language}>{content}</SyntaxHighlighter>
           </BAIFlex>
         </BAIFlex>

--- a/react/src/components/MarkdownContent.tsx
+++ b/react/src/components/MarkdownContent.tsx
@@ -16,9 +16,9 @@ import remarkMath from 'remark-math';
 
 const useStyles = createStyles(({ css, token }) => ({
   // Reading typography for long-form markdown: comfortable line height and
-  // bordered headings. Everything `ChatMessageContent` also styles
-  // (blockquote, hr, lists, tables, inline code) uses the same tokens it
-  // does, so the two renderers produce the same output.
+  // bordered headings. `ChatMessageContent` renders through this same
+  // component (see its file), so every element styled here — blockquote,
+  // hr, lists, tables, inline code — looks identical in chat and elsewhere.
   markdown: css`
     color: ${token.colorText};
     font-size: ${token.fontSize}px;
@@ -242,6 +242,23 @@ const useStyles = createStyles(({ css, token }) => ({
       min-width: 100%;
     }
   `,
+  // Streaming-only: preserves literal whitespace/newlines in a paragraph
+  // that may not yet be "finished" markdown (see `isStreaming` doc below).
+  paragraphStreaming: css`
+    white-space: pre-wrap;
+    word-break: break-word;
+  `,
+  // Streaming-only: strips the inline-code background/border for a code
+  // span that currently crosses a newline. `:not(pre) > code` above styles
+  // every inline code the same way, which is correct once markdown is
+  // final — but mid-stream, an unterminated fenced block can momentarily
+  // parse as a multi-line code span, and giving that the inline pill style
+  // reads as a rendering glitch.
+  codeSpanStreaming: css`
+    background: none;
+    border: none;
+    padding: 0;
+  `,
 }));
 
 interface MarkdownContentProps extends Omit<
@@ -256,6 +273,16 @@ interface MarkdownContentProps extends Omit<
    * affordance belongs there is the caller's decision.
    */
   codeBlockExtra?: (code: string) => React.ReactNode;
+  /**
+   * Set while the `children` markdown is still arriving incrementally (e.g.
+   * a chat message being streamed token-by-token) rather than complete.
+   * Turns on two defensive renderers that don't apply to finished markdown:
+   * paragraphs keep literal whitespace (`pre-wrap`) instead of collapsing
+   * it, and an inline code span that currently spans multiple lines (an
+   * unterminated fence can momentarily parse this way) renders without the
+   * inline-code pill style instead of looking like a broken code block.
+   */
+  isStreaming?: boolean;
 }
 
 /**
@@ -264,16 +291,16 @@ interface MarkdownContentProps extends Omit<
  *
  * Every call site shares one renderer, one plugin set, and one stylesheet so
  * they can't drift from each other — e.g. a blockquote styled in one place
- * but rendered as plain text in another (FR-3402). The code-block panel and
- * the tokens for every element `ChatMessageContent` also styles are shared
- * with it, so the two render the same output. That component stays separate
- * because it owns streaming concerns (per-block splitting, `pre-wrap`
- * paragraphs) that don't apply to long-form markdown.
+ * but rendered as plain text in another (FR-3402). `ChatMessageContent`
+ * renders through this component too (one block at a time, for its
+ * per-block streaming memoization); its streaming-only quirks are opted
+ * into via `isStreaming` rather than living in a second copy of this file.
  */
 const MarkdownContent: React.FC<MarkdownContentProps> = ({
   children,
   className,
   codeBlockExtra,
+  isStreaming,
   ...divProps
 }) => {
   'use memo';
@@ -339,6 +366,34 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
       );
     },
   };
+
+  // Streaming-only overrides — see `isStreaming` doc on the props above.
+  // Omitted entirely when not streaming, so finished markdown keeps the
+  // plain default `p` and the unconditional `:not(pre) > code` styling.
+  if (isStreaming) {
+    components.p = ({ node: _node, className: pClassName, ...props }) => (
+      <p {...props} className={cx(pClassName, styles.paragraphStreaming)} />
+    );
+    components.code = ({
+      node,
+      className: codeClassName,
+      ref: _ref,
+      ...rest
+    }) => {
+      const isOneLine =
+        node?.position?.start?.line === node?.position?.end?.line;
+      return (
+        <code
+          {...rest}
+          className={
+            isOneLine
+              ? codeClassName
+              : cx(codeClassName, styles.codeSpanStreaming)
+          }
+        />
+      );
+    };
+  }
 
   return (
     <div className={cx(styles.markdown, className)} {...divProps}>

--- a/react/src/components/MarkdownContent.tsx
+++ b/react/src/components/MarkdownContent.tsx
@@ -149,7 +149,7 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
-interface AnnouncementMarkdownProps extends Omit<
+interface MarkdownContentProps extends Omit<
   React.HTMLAttributes<HTMLDivElement>,
   'children'
 > {
@@ -157,15 +157,14 @@ interface AnnouncementMarkdownProps extends Omit<
 }
 
 /**
- * Renders an announcement message as markdown.
+ * Renders markdown text with a shared reading typography (headings,
+ * blockquotes, tables, lists) and a shiki-based fenced-code highlighter.
  *
- * The editor's preview pane and the published announcement alert both render
- * through this component so that the preview is a faithful preview: one
- * renderer, one plugin set, one stylesheet. Rendering them separately let the
- * two drift — a blockquote styled in the preview came out as plain text once
- * published (FR-3402).
+ * Every call site shares one renderer, one plugin set, and one stylesheet so
+ * they can't drift from each other — e.g. a blockquote styled in one place
+ * but rendered as plain text in another (FR-3402).
  */
-const AnnouncementMarkdown: React.FC<AnnouncementMarkdownProps> = ({
+const MarkdownContent: React.FC<MarkdownContentProps> = ({
   children,
   className,
   ...divProps
@@ -209,4 +208,4 @@ const AnnouncementMarkdown: React.FC<AnnouncementMarkdownProps> = ({
   );
 };
 
-export default AnnouncementMarkdown;
+export default MarkdownContent;

--- a/react/src/components/MarkdownContent.tsx
+++ b/react/src/components/MarkdownContent.tsx
@@ -126,6 +126,7 @@ const useStyles = createStyles(({ css, token }) => ({
     }
     pre {
       margin: 0 0 1em;
+      padding: ${token.paddingSM}px ${token.padding}px;
       border-radius: ${token.borderRadius}px;
       overflow: auto;
     }

--- a/react/src/components/ModelCardDrawer.tsx
+++ b/react/src/components/ModelCardDrawer.tsx
@@ -8,6 +8,7 @@ import { useBackendAIImageMetaData } from '../hooks';
 import DeploymentSettingModal from './DeploymentSettingModal';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
+import MarkdownContent from './MarkdownContent';
 import ModelBrandIcon from './ModelBrandIcon';
 import ModelCardDeployModal from './ModelCardDeployModal';
 import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
@@ -35,9 +36,7 @@ import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import React, { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Markdown from 'react-markdown';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
-import remarkGfm from 'remark-gfm';
 
 interface ModelCardDrawerProps extends Omit<
   DrawerProps,
@@ -333,9 +332,7 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
                 style={{ width: '100%' }}
                 styles={{ body: { paddingTop: 0 } }}
               >
-                <Markdown remarkPlugins={[remarkGfm]}>
-                  {modelCard.readme}
-                </Markdown>
+                <MarkdownContent>{modelCard.readme}</MarkdownContent>
               </BAICard>
             )}
           </BAIFlex>

--- a/react/src/components/ModelCardDrawer.tsx
+++ b/react/src/components/ModelCardDrawer.tsx
@@ -14,7 +14,6 @@ import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
 import { BankOutlined, FileOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import {
-  Card,
   Descriptions,
   Drawer,
   type DrawerProps,
@@ -24,6 +23,7 @@ import {
 } from 'antd';
 import {
   BAIButton,
+  BAICard,
   BAIFlex,
   BAILink,
   BAIResourceNumberWithIcon,
@@ -33,10 +33,11 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import Markdown from 'markdown-to-jsx';
 import React, { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import Markdown from 'react-markdown';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
+import remarkGfm from 'remark-gfm';
 
 interface ModelCardDrawerProps extends Omit<
   DrawerProps,
@@ -321,7 +322,7 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
             />
 
             {modelCard.readme && (
-              <Card
+              <BAICard
                 size="small"
                 title={
                   <BAIFlex direction="row" gap="xs">
@@ -330,11 +331,12 @@ const ModelCardDrawer: React.FC<ModelCardDrawerProps> = ({
                   </BAIFlex>
                 }
                 style={{ width: '100%' }}
+                styles={{ body: { paddingTop: 0 } }}
               >
-                <Markdown options={{ disableParsingRawHTML: true }}>
+                <Markdown remarkPlugins={[remarkGfm]}>
                   {modelCard.readme}
                 </Markdown>
-              </Card>
+              </BAICard>
             )}
           </BAIFlex>
         )}


### PR DESCRIPTION
Resolves #8448 (FR-3402)

> **Chat now manually checked against `10.82.130.172`(announcement) and dogbowl(chatting).**

## Problem

A blockquote written in the announcement editor rendered with an accent bar and background in the **Preview** pane, but came out as plain text once published on the start page. The preview was therefore not a faithful preview of what users would see.

## Root cause

The two views used different markdown renderers with different plugin sets and different styling:

| | Component | Renderer | Styling |
|---|---|---|---|
| Editor preview | `AnnouncementEditModal.tsx` | `react-markdown` + `remark-gfm`, `remark-math`, `rehype-katex` | `markdownPreview` class (headings, blockquotes, tables, lists, code) |
| Published alert | `AnnouncementAlert.tsx` | `markdown-to-jsx` | none — the only override was `p`'s margin |

`<blockquote>` *was* emitted on the published side; it simply had no styles. Blockquote was the visible symptom, but anything supported by one engine and not the other diverged too — math (`remark-math` / `rehype-katex`) and GFM extras such as tables and task lists were configured only on the preview side.

## Change

Extract a single `AnnouncementMarkdown` component that owns the renderer, the plugin set, the fenced-code `SyntaxHighlighter` override, and the typography stylesheet. Both the editor preview and the published alert now render through it, so the preview's "this is what will be published" contract holds by construction and the two can no longer drift.

- **New** `react/src/components/AnnouncementMarkdown.tsx` — moves the `markdownPreview` styles (renamed `markdown`), the `react-markdown` invocation, the plugin set, the `pre` → `SyntaxHighlighter` override, and the `katex` CSS import out of `AnnouncementEditModal`. Accepts a `className` / `style` passthrough so the preview pane can keep its own box (border, padding, fixed height, scroll).
- `AnnouncementEditModal.tsx` — renders `<AnnouncementMarkdown>`; local styles and markdown imports removed.
- `AnnouncementAlert.tsx` — renders `<AnnouncementMarkdown>` instead of `markdown-to-jsx`.

Net: **+1 file, 193 deletions, 7 insertions** across the two existing files (the styles moved rather than grew).

### Follow-up: remove `markdown-to-jsx` entirely

`AnnouncementAlert`/`AnnouncementEditModal` were two of three `markdown-to-jsx` consumers; `ImportFromHuggingFaceModal.tsx` and `ModelCardDrawer.tsx` (both README previews) still used it. Migrated both to `react-markdown` so the dependency has no remaining callers, then dropped `markdown-to-jsx` from `react/package.json` and ran `pnpm install` to update the lockfile. `ModelCardDrawer`'s `options={{ disableParsingRawHTML: true }}` has no react-markdown equivalent needed — raw HTML isn't parsed by default without `rehype-raw`, so dropping the option preserves the same behavior. Both README `Card`s also became `BAICard` per the project's card convention while the files were touched.

### Follow-up 2: share the typography, not just the renderer

The first follow-up wired the two README previews to `react-markdown` + `remark-gfm` directly, which fixed the package but not the look: `AnnouncementMarkdown`'s blockquote/table/list/code styling lived only in that component, so a README blockquote rendered as unstyled indented text instead of the accented callout the announcement gets. Renamed `AnnouncementMarkdown` → `MarkdownContent` (same renderer, plugin set, and stylesheet — now named for what it does rather than its original single caller) and routed `ImportFromHuggingFaceModal` and `ModelCardDrawer` through it instead of a bare `<Markdown>`. All four markdown call sites in the app now render through one component.

### Follow-up 3: match `ChatMessageContent`'s markdown handling (review feedback)

Per review, `MarkdownContent` now handles markdown the way the app's other renderer already does.

- **Overrides.** It overrode `pre` alone and dug into the child element's props behind two `@ts-ignore`s to recover the language and code text. It now uses the `pre` + `code` override pair `ChatMessageContent` uses, which hands both in as typed arguments — the `@ts-ignore`s are gone.
- **Shared elements use chat's tokens.** blockquote, `hr`, lists, tables and inline code are styled with the same values `ChatMessageContent` uses, so the two renderers produce the same output. Fenced blocks render in the same bordered box with a language header, and wide tables now scroll inside their own box instead of stretching the surrounding alert.
- **One header component.** `CodeHead` moved out of `ChatMessageContent` into `Chat/CodeHead.tsx`; both renderers import it rather than keeping duplicate markup. That is the only change to `ChatMessageContent` — a verbatim move, no behavior change.
- **The copy button is the caller's call.** The header's right-hand slot is exposed as `codeBlockExtra?: (code: string) => ReactNode` instead of a built-in copy button. Announcements and README previews pass nothing; chat keeps passing its own streaming-aware `CopyButton`.

Not changed *(at the time — superseded in Follow-up 5)*: `ChatMessageContent` still renders through its own `<Markdown>`. It owns streaming concerns (per-block splitting for memoization, `pre-wrap` paragraphs, the `isOneLine` inline-code branch) that don't apply to long-form markdown, so routing it through `MarkdownContent` would risk chat regressions without helping this fix. The `codeBlockExtra` slot is the seam if we want that unification later. The reading typography unique to `MarkdownContent` (heading sizes and rules, links, images) also stays, since chat has no equivalent.

### Follow-up 4: fenced-code correctness (review feedback)

Review found three defects in the fenced-code path introduced by Follow-up 3, two sharing a root cause — block-vs-inline was *inferred* instead of read off the element tree.

- **Language tokens were truncated.** The capture was `/language-(\w+)/`, which stops at the first non-word character. Every identifier `useHighlight` supports that contains punctuation — `git-commit`, `objective-c`, `c#`, `f#` (`useHighlight.ts:86,139,140,212,221`) — was cut to `git`, `objective`, `c`, `f`, so those fences highlighted as the wrong language or fell back to plain text. The whole token is now captured, matched per class so a second class on the element isn't swept in.
- **The panel was nested inside a `pre`.** `react-markdown` emits `pre > code`, and the panel was rendered inside that `pre`. Since `pre` takes phrasing content, this put block-level elements — and the highlighter's own `pre` — inside a preformatted element. The panel now replaces the `pre`.
- **Multi-line inline code became a panel.** Block detection compared the node's start and end line, but a CommonMark code span may wrap across a newline; such a span was rendered as a full code panel.

Reading the language and text off the `pre` node's `code` child settles all three at once: the `code` override is gone, inline code never reaches an override (so the `:not(pre) > code` rule keeps styling it), and only genuinely fenced code can produce a panel. The node access is typed, so this costs no `@ts-ignore` — the point of Follow-up 3 still holds.

Also adds the `'use memo'` directive to the extracted `CodeHead`, which the verbatim move had carried over as missing.

**New:** `react/src/components/MarkdownContent.test.tsx` — 9 tests pinning the language token (`git-commit`, `objective-c`, `c#`, `f#`, `ts`), the `txt` fallback, the absence of `pre > pre` / `pre > div` nesting, and both inline-code cases.

### Follow-up 5: full unification — route `ChatMessageContent` through `MarkdownContent` (review feedback)

Follow-up 3 deliberately kept `ChatMessageContent`'s own `<Markdown>` pipeline, reasoning that its streaming-specific concerns didn't belong in the shared component. Review asked again for one rendering path, so this follow-up does the unification instead of just explaining why it wasn't done.

`MarkdownContent` gains a single `isStreaming` flag that turns on the two things chat genuinely needs that finished markdown doesn't:

- paragraphs keep literal whitespace (`pre-wrap`) instead of collapsing it while a block is still arriving;
- an inline code span that currently spans multiple lines (an unterminated fence can momentarily parse this way mid-stream) renders without the inline-code pill style instead of looking like a broken code block.

Both are no-ops when `isStreaming` is unset, so every other call site (announcements, README previews) is unaffected. `ChatMessageContent` now only owns `marked.lexer`-based block splitting (for its streaming memoization) and wires its streaming-aware `CopyButton` through `codeBlockExtra` — there is exactly one markdown rendering path in the app now, and `ChatMessageContent`'s own copy of the typography stylesheet and `pre`/`code`/`blockquote`/`hr`/list/table renderers are gone.

**New tests:** 6 cases in `MarkdownContent.test.tsx` pinning the `isStreaming` contract (pre-wrap only while streaming, the inline-code pill reset only for a multi-line span while streaming, fenced code still renders as a panel in both modes) — 15 total in the file.

**Not verified live at the time:** I couldn't exercise real chat streaming end-to-end from the agent sandbox (no network path to the test backend). Structurally this was meant as a refactor with no intended behavior change for chat — but it did regress spacing; see Follow-up 6.

### Follow-up 6: restore chat message padding (manual verification)

Manually checking `/chat` against `10.82.130.172` (per the note at the top of this description) surfaced a real regression from Follow-up 5's unification: chat replies rendered with almost no vertical spacing — headings, paragraphs, and blockquotes sat flush against each other and against the message bubble's border.

**Root cause.** `MarkdownContent`'s `& > *:first-child { margin-top: 0 }` / `& > *:last-child { margin-bottom: 0 }` rule was written for a single, unsplit render — it zeroes the outer edges of the whole markdown document so a container that already pads it (the announcement box, the README drawer) doesn't get a doubled margin. `ChatMessageContent` doesn't render one `MarkdownContent`, though — it splits the reply into blocks via `marked.lexer` (for per-block streaming memoization, see Follow-up 5) and renders each block through its own `MarkdownContent`. Every block is therefore its own first-and-last child, so the same rule zeroed the space *between* every heading/paragraph/blockquote too, not just the two edges of the whole message. `ChatMessage.tsx`'s bubble compounded it: its container had `paddingTop: 0` / `paddingBottom: 0`, relying on the (now-zeroed) content margins to supply the bubble's own top/bottom breathing room.

**Fix.**
- `ChatMessageContent.tsx` — wraps the mapped blocks in a `BAIFlex direction="column" gap="md"` so adjacent blocks get spacing again, independent of each block's own zeroed edges.
- `ChatMessage.tsx` — the bubble now takes real `padding: '1em'` on all sides instead of zeroing the vertical component; the reasoning `Collapse`'s own `marginTop`/`marginBottom` (which were compensating for the old zero-padding bubble) are adjusted to match: no more `marginTop` (the bubble's own top padding covers it now), and `marginBottom` applies only when main content follows the collapse (previously the reverse, which relied on the same broken assumption).

## Notes for review

Two intentional behavior changes on the published-alert side, both of which are the point of the fix:

1. **Raw HTML in an announcement no longer renders as HTML.** `markdown-to-jsx` parsed inline HTML; `react-markdown` does not (no `rehype-raw`). The published alert now matches what the preview has always shown, and the start page no longer renders operator-authored HTML for every user. This also let the `announcement.message + '<p></p>'` margin hack go away — the shared stylesheet's `& > *:last-child { margin-bottom: 0 }` handles the trailing margin, so the compensating negative wrapper margin is gone too.
2. **Announcement text now picks up the reading typography** (line height, heading sizes and rules, list markers, table borders) rather than inheriting the alert's defaults. That is what the preview promised.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Terminology), rerun after each follow-up commit, including Follow-up 6.

`pnpm exec vitest run src/components/MarkdownContent.test.tsx` (in `react/`) → 15 passed (9 fenced-code + 6 `isStreaming`).

<img width="790" height="1205" alt="image" src="https://github.com/user-attachments/assets/644ec514-9f59-444c-95a6-55e59e76dd89" />
<img width="2260" height="596" alt="image" src="https://github.com/user-attachments/assets/9c28850e-5f3c-4ade-b10e-7f53f58d69b6" />
<img width="1891" height="1235" alt="image" src="https://github.com/user-attachments/assets/b8a7d811-1aed-40bc-a75c-61617eeedf63" />
<img width="2310" height="1051" alt="image" src="https://github.com/user-attachments/assets/3b2340b9-bdde-4f72-8e60-844dfefe5929" />

