### PR TITLE
feat(FR-3412): FileBrowser/SFTP take an explicit project with a disabled-state tooltip

### DIFF
--- a/docs/adr/0001-explicit-project-prop-contract.md
+++ b/docs/adr/0001-explicit-project-prop-contract.md
@@ -111,8 +111,21 @@ narrowing helper for the loosely-typed ambient value).
     model-folder picker, the resource form, and in-modal folder creation.
     When the project cannot be resolved, submission is visibly disabled
     instead of falling back to ambient.
-- Subsequent tickets convert session-launch buttons and mismatch alerts
-  (FR-3412), then hide the header selector per admin route.
+- Fourth application (FR-3412): `FileBrowserButtonV2` and `SFTPServerButtonV2`
+  (button tier — required `project: ProjectContextOrNull` plus
+  `noProjectTooltip?`; `null` renders the button disabled with the
+  caller-provided reason, non-null keys the storage-host permission lookup,
+  the per-project volume-host fetch (`useVHostInfo(projectId)` replaces the
+  ambient derived-atom read), and the created session to exactly that
+  project). `useStartSession` gained an explicit `projectName` input that
+  pins `group_name` without reusing the `owner` branch (which is coupled to
+  `owner_access_key`); callers that omit it keep the ambient fallback as a
+  sanctioned interim state. `FolderExplorerHeaderV2` passes the prop
+  through; the globally-mounted `FolderExplorerModalV2` still narrows the
+  ambient project and hands it on explicitly until its own conversion
+  (FR-3413).
+- Subsequent tickets convert mismatch alerts, then hide the header selector
+  per admin route.
 
 ## How to comply (checklist for new/converted components)
 

--- a/react/__test__/resizeObserver.mock.js
+++ b/react/__test__/resizeObserver.mock.js
@@ -1,0 +1,13 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+// Minimal ResizeObserver stub for jsdom (used by rc-resize-observer inside
+// antd components such as Space.Compact / Button wave effects).
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/react/src/__generated__/FileBrowserButtonV2TestQuery.graphql.ts
+++ b/react/src/__generated__/FileBrowserButtonV2TestQuery.graphql.ts
@@ -1,0 +1,135 @@
+/**
+ * @generated SignedSource<<a3c05b0ef424601184ee0c306c842726>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type FileBrowserButtonV2TestQuery$variables = {
+  vfolderId: string;
+};
+export type FileBrowserButtonV2TestQuery$data = {
+  readonly vfolderV2: {
+    readonly " $fragmentSpreads": FragmentRefs<"FileBrowserButtonV2Fragment">;
+  } | null | undefined;
+};
+export type FileBrowserButtonV2TestQuery = {
+  response: FileBrowserButtonV2TestQuery$data;
+  variables: FileBrowserButtonV2TestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "vfolderId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "vfolderId",
+    "variableName": "vfolderId"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FileBrowserButtonV2TestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "VFolder",
+        "kind": "LinkedField",
+        "name": "vfolderV2",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FileBrowserButtonV2Fragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "FileBrowserButtonV2TestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "VFolder",
+        "kind": "LinkedField",
+        "name": "vfolderV2",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "host",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "60112ae1ba2959395759c78a9d26f26f",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "vfolderV2": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "VFolder"
+        },
+        "vfolderV2.host": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "vfolderV2.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        }
+      }
+    },
+    "name": "FileBrowserButtonV2TestQuery",
+    "operationKind": "query",
+    "text": "query FileBrowserButtonV2TestQuery(\n  $vfolderId: UUID!\n) {\n  vfolderV2(vfolderId: $vfolderId) {\n    ...FileBrowserButtonV2Fragment\n    id\n  }\n}\n\nfragment FileBrowserButtonV2Fragment on VFolder {\n  id\n  host\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f0907a3848dc17be7f2abb61cab08bdd";
+
+export default node;

--- a/react/src/__generated__/SFTPServerButtonV2TestQuery.graphql.ts
+++ b/react/src/__generated__/SFTPServerButtonV2TestQuery.graphql.ts
@@ -1,0 +1,135 @@
+/**
+ * @generated SignedSource<<6c14e44113776800267f5d8f7c4185c2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SFTPServerButtonV2TestQuery$variables = {
+  vfolderId: string;
+};
+export type SFTPServerButtonV2TestQuery$data = {
+  readonly vfolderV2: {
+    readonly " $fragmentSpreads": FragmentRefs<"SFTPServerButtonV2Fragment">;
+  } | null | undefined;
+};
+export type SFTPServerButtonV2TestQuery = {
+  response: SFTPServerButtonV2TestQuery$data;
+  variables: SFTPServerButtonV2TestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "vfolderId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "vfolderId",
+    "variableName": "vfolderId"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SFTPServerButtonV2TestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "VFolder",
+        "kind": "LinkedField",
+        "name": "vfolderV2",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SFTPServerButtonV2Fragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SFTPServerButtonV2TestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "VFolder",
+        "kind": "LinkedField",
+        "name": "vfolderV2",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "host",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "adc7a2183bb7de55b41e51dff543bbfa",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "vfolderV2": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "VFolder"
+        },
+        "vfolderV2.host": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "vfolderV2.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        }
+      }
+    },
+    "name": "SFTPServerButtonV2TestQuery",
+    "operationKind": "query",
+    "text": "query SFTPServerButtonV2TestQuery(\n  $vfolderId: UUID!\n) {\n  vfolderV2(vfolderId: $vfolderId) {\n    ...SFTPServerButtonV2Fragment\n    id\n  }\n}\n\nfragment SFTPServerButtonV2Fragment on VFolder {\n  id\n  host\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "be98268f63d95a680c61700ce31ab80a";
+
+export default node;

--- a/react/src/components/FileBrowserButtonV2.test.tsx
+++ b/react/src/components/FileBrowserButtonV2.test.tsx
@@ -11,7 +11,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { App } from 'antd';
 import { Suspense } from 'react';
 import {
   graphql,
@@ -217,14 +216,14 @@ const renderButton = (
   render(
     <RelayEnvironmentProvider environment={environment}>
       <QueryClientProvider client={queryClient}>
-        <App>
+        <>
           <Suspense fallback={null}>
             <TestRenderer
               project={project}
               noProjectTooltip={noProjectTooltip}
             />
           </Suspense>
-        </App>
+        </>
       </QueryClientProvider>
     </RelayEnvironmentProvider>,
   );

--- a/react/src/components/FileBrowserButtonV2.test.tsx
+++ b/react/src/components/FileBrowserButtonV2.test.tsx
@@ -1,0 +1,283 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import type { FileBrowserButtonV2TestQuery } from '../__generated__/FileBrowserButtonV2TestQuery.graphql';
+import { ProjectContextOrNull } from '../types/projectContext';
+import FileBrowserButtonV2 from './FileBrowserButtonV2';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App } from 'antd';
+import { Suspense } from 'react';
+import {
+  graphql,
+  RelayEnvironmentProvider,
+  useLazyLoadQuery,
+} from 'react-relay';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * Contract tests for the explicit project prop contract (ADR-0001, FR-3412).
+ *
+ * FileBrowserButtonV2 is button tier: `project` is required; `null` renders
+ * the button disabled with the caller-provided `noProjectTooltip`, a
+ * non-null project keys the storage-host permission lookup and the created
+ * session to exactly that project. These tests exercise external behavior
+ * only: rendered output, query variables, and REST call payloads.
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: {
+        language: 'en',
+        changeLanguage: () => new Promise(() => {}),
+      },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: {
+      type: '3rdParty',
+      init: () => {},
+    },
+  };
+});
+
+const { mockBaiClient, mockCreateIfNotExists, mockListHosts } = vi.hoisted(
+  () => {
+    const mockCreateIfNotExists = vi.fn().mockResolvedValue({
+      created: true,
+      status: 'PENDING',
+      sessionId: 'created-session-id',
+    });
+    const mockListHosts = vi.fn(() =>
+      Promise.resolve({
+        allowed: ['local:volume1'],
+        default: 'local:volume1',
+        volume_info: {
+          'local:volume1': {
+            backend: 'vfs',
+            capabilities: [],
+            sftp_scaling_groups: [],
+          },
+        },
+      }),
+    );
+    const mockBaiClient = {
+      _config: {
+        accessKey: 'test-access-key',
+        domainName: 'default',
+      },
+      supports: () => false,
+      createIfNotExists: mockCreateIfNotExists,
+      vfolder: {
+        list_hosts: mockListHosts,
+      },
+    };
+    return { mockBaiClient, mockCreateIfNotExists, mockListHosts };
+  },
+);
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => mockBaiClient,
+    useCurrentDomainValue: () => 'default',
+    useWebUINavigate: () => vi.fn(),
+  };
+});
+
+vi.mock('../hooks/useRouteScope', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useRouteScope')>();
+  return {
+    ...originalModule,
+    useProjectPath: () => (path: string) => `/${path}`,
+  };
+});
+
+// Decoy ambient project: the button must never target it. If it did, the
+// `group_name` assertion below would surface `ambient-project-name`.
+vi.mock('../hooks/useCurrentProject', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useCurrentProject')>();
+  return {
+    ...originalModule,
+    useCurrentProjectValue: () => ({
+      id: 'ambient-project-id',
+      name: 'ambient-project-name',
+    }),
+    useCurrentResourceGroupState: () => [null, vi.fn()] as const,
+  };
+});
+
+vi.mock('../hooks/useBAINotification', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useBAINotification')>();
+  return {
+    ...originalModule,
+    useSetBAINotification: () => ({
+      upsertNotification: vi.fn(),
+      closeNotification: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../hooks/useDefaultImagesWithFallback', () => ({
+  useDefaultFileBrowserImageWithFallback: () =>
+    'cr.backend.ai/stable/filebrowser:21.02@x86_64',
+  useDefaultSystemSSHImageWithFallback: () => ({
+    systemSSHImage: 'cr.backend.ai/stable/ssh:latest@x86_64',
+  }),
+}));
+
+const VFOLDER_GLOBAL_ID = btoa('VFolder:folder-0000');
+
+const TestRenderer: React.FC<{
+  project: ProjectContextOrNull;
+  noProjectTooltip?: string;
+}> = ({ project, noProjectTooltip }) => {
+  const data = useLazyLoadQuery<FileBrowserButtonV2TestQuery>(
+    graphql`
+      query FileBrowserButtonV2TestQuery($vfolderId: UUID!)
+      @relay_test_operation {
+        vfolderV2(vfolderId: $vfolderId) {
+          ...FileBrowserButtonV2Fragment
+        }
+      }
+    `,
+    { vfolderId: '00000000-0000-0000-0000-000000000000' },
+  );
+  if (!data.vfolderV2) return null;
+  return (
+    <FileBrowserButtonV2
+      vfolderNodeFrgmt={data.vfolderV2}
+      project={project}
+      noProjectTooltip={noProjectTooltip}
+    />
+  );
+};
+
+const renderButton = (
+  project: ProjectContextOrNull,
+  noProjectTooltip?: string,
+) => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  const resolver = (operation: any) =>
+    MockPayloadGenerator.generate(operation, {
+      VFolder: () => ({
+        id: VFOLDER_GLOBAL_ID,
+        host: 'local:volume1',
+      }),
+      KeyPair: () => ({
+        resource_policy: 'default',
+      }),
+      Domain: () => ({
+        allowed_vfolder_hosts: JSON.stringify({
+          'local:volume1': ['mount-in-session'],
+        }),
+      }),
+      Group: () => ({
+        allowed_vfolder_hosts: '{}',
+      }),
+      KeyPairResourcePolicy: () => ({
+        allowed_vfolder_hosts: '{}',
+      }),
+    });
+  // Operations disappear from the pending list once a queued resolver
+  // handles them, so record every operation (name + variables) as it is
+  // resolved for later assertions. Each queued resolver serves exactly one
+  // operation (and identical references are all dropped together once one
+  // resolves), so queue distinct wrappers — enough for the test query, the
+  // permission queries, and the post-creation lookup.
+  const seenOperations: Array<{ name: string; variables: any }> = [];
+  for (let i = 0; i < 10; i++) {
+    environment.mock.queueOperationResolver((operation: any) => {
+      seenOperations.push({
+        name: operation.request.node.params.name,
+        variables: operation.request.variables,
+      });
+      return resolver(operation);
+    });
+  }
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <QueryClientProvider client={queryClient}>
+        <App>
+          <Suspense fallback={null}>
+            <TestRenderer
+              project={project}
+              noProjectTooltip={noProjectTooltip}
+            />
+          </Suspense>
+        </App>
+      </QueryClientProvider>
+    </RelayEnvironmentProvider>,
+  );
+  return { environment, seenOperations };
+};
+
+describe('FileBrowserButtonV2 project prop contract (ADR-0001, FR-3412)', () => {
+  beforeEach(() => {
+    mockCreateIfNotExists.mockClear();
+    mockListHosts.mockClear();
+  });
+
+  it('renders disabled with the caller-provided tooltip when project is null', async () => {
+    renderButton(null, 'data.CannotLaunchSessionInAdminMenu');
+
+    const launchButton = await screen.findByRole('button', {
+      name: /ExecuteFileBrowser/,
+    });
+    expect(launchButton).toBeDisabled();
+
+    // The reason is the page-provided tooltip — the component itself never
+    // knows why the project is absent.
+    fireEvent.mouseEnter(launchButton.closest('.ant-space-compact')!);
+    expect(
+      await screen.findByText('data.CannotLaunchSessionInAdminMenu'),
+    ).toBeInTheDocument();
+  });
+
+  it('creates the FileBrowser session in exactly the passed project and keys the permission lookup to it', async () => {
+    const user = userEvent.setup();
+    const { seenOperations } = renderButton({
+      id: 'passed-project-id',
+      name: 'passed-project-name',
+    });
+
+    const launchButton = await screen.findByRole('button', {
+      name: /ExecuteFileBrowser/,
+    });
+    await waitFor(() => expect(launchButton).toBeEnabled());
+
+    // The storage-host permission lookup is keyed to the passed project id,
+    // never the ambient decoy.
+    const permissionOperation = seenOperations.find(
+      (op) =>
+        op.name ===
+        'useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery',
+    );
+    expect(permissionOperation?.variables.projectId).toBe(
+      'passed-project-id',
+    );
+
+    await user.click(launchButton);
+
+    await waitFor(() => expect(mockCreateIfNotExists).toHaveBeenCalled());
+    const resources = mockCreateIfNotExists.mock.calls[0][2];
+    // The session is created in exactly the passed project.
+    expect(resources.group_name).toBe('passed-project-name');
+  });
+});

--- a/react/src/components/FileBrowserButtonV2.test.tsx
+++ b/react/src/components/FileBrowserButtonV2.test.tsx
@@ -7,8 +7,8 @@ import '../../__test__/resizeObserver.mock.js';
 import type { FileBrowserButtonV2TestQuery } from '../__generated__/FileBrowserButtonV2TestQuery.graphql';
 import { ProjectContextOrNull } from '../types/projectContext';
 import FileBrowserButtonV2 from './FileBrowserButtonV2';
-import '@testing-library/jest-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
@@ -137,10 +137,7 @@ vi.mock('../hooks/useDefaultImagesWithFallback', () => ({
   useDefaultSystemSSHImageWithFallback: () => ({
     systemSSHImage: 'cr.backend.ai/stable/ssh:latest@x86_64',
   }),
-  // `useStartSession` resolves the image reference through this hook. The
-  // fixtures above are already fully qualified (`:tag@arch`), which the real
-  // implementation passes through untouched — so echoing the input keeps the
-  // mock faithful without needing a Relay image query.
+  // Fixtures are already fully qualified, which the real hook passes through.
   useResolveImageReference: () => async (imageString?: string) => imageString,
 }));
 
@@ -150,6 +147,7 @@ const TestRenderer: React.FC<{
   project: ProjectContextOrNull;
   noProjectTooltip?: string;
 }> = ({ project, noProjectTooltip }) => {
+  'use memo';
   const data = useLazyLoadQuery<FileBrowserButtonV2TestQuery>(
     graphql`
       query FileBrowserButtonV2TestQuery($vfolderId: UUID!)
@@ -274,9 +272,7 @@ describe('FileBrowserButtonV2 project prop contract (ADR-0001, FR-3412)', () => 
         op.name ===
         'useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery',
     );
-    expect(permissionOperation?.variables.projectId).toBe(
-      'passed-project-id',
-    );
+    expect(permissionOperation?.variables.projectId).toBe('passed-project-id');
 
     await user.click(launchButton);
 

--- a/react/src/components/FileBrowserButtonV2.test.tsx
+++ b/react/src/components/FileBrowserButtonV2.test.tsx
@@ -246,7 +246,10 @@ describe('FileBrowserButtonV2 project prop contract (ADR-0001, FR-3412)', () => 
 
     // The reason is the page-provided tooltip — the component itself never
     // knows why the project is absent.
-    fireEvent.mouseEnter(launchButton.closest('.ant-space-compact')!);
+    // antd `Space.Compact` -> Astryx `ButtonGroup`, which exposes itself as
+    // `role="group"` with the group label as its accessible name. The
+    // tooltip stays on the GROUP because a disabled button swallows hover.
+    fireEvent.mouseEnter(launchButton.closest('[role="group"]')!);
     expect(
       await screen.findByText('data.CannotLaunchSessionInAdminMenu'),
     ).toBeInTheDocument();

--- a/react/src/components/FileBrowserButtonV2.test.tsx
+++ b/react/src/components/FileBrowserButtonV2.test.tsx
@@ -137,6 +137,11 @@ vi.mock('../hooks/useDefaultImagesWithFallback', () => ({
   useDefaultSystemSSHImageWithFallback: () => ({
     systemSSHImage: 'cr.backend.ai/stable/ssh:latest@x86_64',
   }),
+  // `useStartSession` resolves the image reference through this hook. The
+  // fixtures above are already fully qualified (`:tag@arch`), which the real
+  // implementation passes through untouched — so echoing the input keeps the
+  // mock faithful without needing a Relay image query.
+  useResolveImageReference: () => async (imageString?: string) => imageString,
 }));
 
 const VFOLDER_GLOBAL_ID = btoa('VFolder:folder-0000');

--- a/react/src/components/FileBrowserButtonV2.tsx
+++ b/react/src/components/FileBrowserButtonV2.tsx
@@ -9,7 +9,6 @@ import {
   useSuspendedBackendaiClient,
   useWebUINavigate,
 } from '../hooks';
-import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDefaultFileBrowserImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
 import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
 import { useProjectPath } from '../hooks/useRouteScope';
@@ -17,6 +16,10 @@ import {
   StartSessionWithDefaultValue,
   useStartSession,
 } from '../hooks/useStartSession';
+import {
+  ProjectContext,
+  ProjectContextOrNull,
+} from '../types/projectContext';
 import { PrimaryAppOption } from './ComputeSessionNodeItems/SessionActionButtons';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
@@ -37,12 +40,72 @@ import { graphql, useFragment } from 'react-relay';
 interface FileBrowserButtonV2Props extends BAIButtonProps {
   showTitle?: boolean;
   vfolderNodeFrgmt: FileBrowserButtonV2Fragment$key;
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3412): the project the
+   * FileBrowser session is created in. With `null` the button renders
+   * disabled and shows the caller-provided `noProjectTooltip` — this
+   * component never knows WHY the project is absent.
+   */
+  project: ProjectContextOrNull;
+  noProjectTooltip?: string;
 }
+
 const FileBrowserButtonV2: React.FC<FileBrowserButtonV2Props> = ({
   showTitle = true,
   vfolderNodeFrgmt,
+  project,
+  noProjectTooltip,
   ...buttonProps
 }) => {
+  'use memo';
+  const { t } = useTranslation();
+
+  if (project === null) {
+    return (
+      <Tooltip title={noProjectTooltip}>
+        <Space.Compact>
+          <BAIButton
+            icon={
+              <Image
+                width="18px"
+                src="/resources/icons/filebrowser.svg"
+                alt="File Browser"
+                preview={false}
+                style={{
+                  filter: 'grayscale(100%)',
+                }}
+              />
+            }
+            disabled
+            {...buttonProps}
+          >
+            {showTitle && t('data.explorer.ExecuteFileBrowser')}
+          </BAIButton>
+          <BAIButton icon={<EllipsisOutlined />} disabled />
+        </Space.Compact>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <FileBrowserButtonWithProject
+      showTitle={showTitle}
+      vfolderNodeFrgmt={vfolderNodeFrgmt}
+      project={project}
+      {...buttonProps}
+    />
+  );
+};
+
+interface FileBrowserButtonWithProjectProps extends BAIButtonProps {
+  showTitle: boolean;
+  vfolderNodeFrgmt: FileBrowserButtonV2Fragment$key;
+  project: ProjectContext;
+}
+
+const FileBrowserButtonWithProject: React.FC<
+  FileBrowserButtonWithProjectProps
+> = ({ showTitle, vfolderNodeFrgmt, project, ...buttonProps }) => {
   'use memo';
   const { t } = useTranslation();
   const { message, modal } = App.useApp();
@@ -53,15 +116,11 @@ const FileBrowserButtonV2: React.FC<FileBrowserButtonV2Props> = ({
 
   const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
-  const currentProject = useCurrentProjectValue();
-  if (!currentProject.id) {
-    throw new Error('Project ID is required for FileBrowserButtonV2');
-  }
   const currentUserAccessKey = baiClient?._config?.accessKey;
   const { unitedAllowedPermissionByVolume } =
     useMergedAllowedStorageHostPermission(
       currentDomain,
-      currentProject.id,
+      project.id,
       currentUserAccessKey,
     );
 
@@ -143,7 +202,11 @@ const FileBrowserButtonV2: React.FC<FileBrowserButtonV2Props> = ({
             if (!filebrowserImage) {
               return;
             }
-            const fileBrowserFormValue = createFilebrowserLauncherValue();
+            const fileBrowserFormValue = {
+              ...createFilebrowserLauncherValue(),
+              // Pin the session to exactly the passed project (FR-3412).
+              projectName: project.name,
+            };
             await startSessionWithDefault(fileBrowserFormValue)
               .then((results) => {
                 if (results?.fulfilled && results.fulfilled.length > 0) {

--- a/react/src/components/FileBrowserButtonV2.tsx
+++ b/react/src/components/FileBrowserButtonV2.tsx
@@ -23,6 +23,7 @@ import {
 import { PrimaryAppOption } from './ComputeSessionNodeItems/SessionActionButtons';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
+import { IconButton } from '@astryxdesign/core/IconButton';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAIButton,
@@ -62,15 +63,14 @@ const FileBrowserButtonV2: React.FC<FileBrowserButtonV2Props> = ({
 
   if (project === null) {
     return (
-      <Tooltip title={noProjectTooltip}>
-        <Space.Compact>
+      <Tooltip content={noProjectTooltip} isEnabled={!!noProjectTooltip}>
+        <ButtonGroup label={t('data.explorer.ExecuteFileBrowser')}>
           <BAIButton
             icon={
-              <Image
+              <img
                 width="18px"
                 src="/resources/icons/filebrowser.svg"
                 alt="File Browser"
-                preview={false}
                 style={{
                   filter: 'grayscale(100%)',
                 }}
@@ -81,8 +81,12 @@ const FileBrowserButtonV2: React.FC<FileBrowserButtonV2Props> = ({
           >
             {showTitle && t('data.explorer.ExecuteFileBrowser')}
           </BAIButton>
-          <BAIButton icon={<EllipsisOutlined />} disabled />
-        </Space.Compact>
+          <IconButton
+            label={t('import.StartWithOptions')}
+            icon={<Ellipsis size="1em" />}
+            isDisabled
+          />
+        </ButtonGroup>
       </Tooltip>
     );
   }
@@ -255,12 +259,25 @@ const FileBrowserButtonWithProject: React.FC<
             {
               label: t('import.StartWithOptions'),
               onClick: () => {
-                const launcherValue = createFilebrowserLauncherValue();
+                const launcherValue = {
+                  ...createFilebrowserLauncherValue(),
+                  // Pin the session to exactly the passed project (FR-3412),
+                  // matching the primary button above.
+                  projectName: project.name,
+                };
                 const params = new URLSearchParams();
                 params.set('formValues', JSON.stringify(launcherValue));
                 params.set('step', '4');
                 webuiNavigate({
-                  pathname: buildProjectPath('session/start'),
+                  // `SessionLauncherPage` resolves its project from the
+                  // ambient current project, which `ProjectScopeLayout`
+                  // converges from the `:projectName` URL segment — not from
+                  // these form values. So the link itself must carry the
+                  // explicit project, otherwise this entry point could
+                  // launch in a different project than the primary button.
+                  pathname: buildProjectPath('session/start', {
+                    projectName: project.name,
+                  }),
                   search: params.toString(),
                 });
               },

--- a/react/src/components/FileBrowserButtonV2.tsx
+++ b/react/src/components/FileBrowserButtonV2.tsx
@@ -16,10 +16,7 @@ import {
   StartSessionWithDefaultValue,
   useStartSession,
 } from '../hooks/useStartSession';
-import {
-  ProjectContext,
-  ProjectContextOrNull,
-} from '../types/projectContext';
+import { ProjectContext, ProjectContextOrNull } from '../types/projectContext';
 import { PrimaryAppOption } from './ComputeSessionNodeItems/SessionActionButtons';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
@@ -76,8 +73,9 @@ const FileBrowserButtonV2: React.FC<FileBrowserButtonV2Props> = ({
                 }}
               />
             }
-            disabled
             {...buttonProps}
+            // After the spread: a caller must not re-enable this tier.
+            disabled
           >
             {showTitle && t('data.explorer.ExecuteFileBrowser')}
           </BAIButton>
@@ -261,21 +259,17 @@ const FileBrowserButtonWithProject: React.FC<
               onClick: () => {
                 const launcherValue = {
                   ...createFilebrowserLauncherValue(),
-                  // Pin the session to exactly the passed project (FR-3412),
-                  // matching the primary button above.
                   projectName: project.name,
                 };
                 const params = new URLSearchParams();
                 params.set('formValues', JSON.stringify(launcherValue));
                 params.set('step', '4');
                 webuiNavigate({
-                  // `SessionLauncherPage` resolves its project from the
-                  // ambient current project, which `ProjectScopeLayout`
-                  // converges from the `:projectName` URL segment — not from
-                  // these form values. So the link itself must carry the
-                  // explicit project, otherwise this entry point could
-                  // launch in a different project than the primary button.
+                  // The launcher reads the project from the URL, not from
+                  // these form values. `scope` is required too: the launcher
+                  // route exists only in the project subtree.
                   pathname: buildProjectPath('session/start', {
+                    scope: 'project',
                     projectName: project.name,
                   }),
                   search: params.toString(),

--- a/react/src/components/FolderExplorerHeaderV2.tsx
+++ b/react/src/components/FolderExplorerHeaderV2.tsx
@@ -10,6 +10,7 @@
 */
 import { FolderExplorerHeaderV2Fragment$key } from '../__generated__/FolderExplorerHeaderV2Fragment.graphql';
 import { useBAIBreakpoint } from '../theme-shim';
+import { ProjectContextOrNull } from '../types/projectContext';
 import EditableVFolderNameV2 from './EditableVFolderNameV2';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
 import FileBrowserButtonV2 from './FileBrowserButtonV2';
@@ -23,11 +24,20 @@ import { graphql, useFragment } from 'react-relay';
 interface FolderExplorerHeaderV2Props {
   vfolderNodeFrgmt?: FolderExplorerHeaderV2Fragment$key | null;
   titleStyle?: React.CSSProperties;
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3412): pass-through for the
+   * FileBrowser/SFTP session-launch buttons. `null` renders them disabled
+   * with `noProjectTooltip` as the reason.
+   */
+  project: ProjectContextOrNull;
+  noProjectTooltip?: string;
 }
 
 const FolderExplorerHeaderV2: React.FC<FolderExplorerHeaderV2Props> = ({
   vfolderNodeFrgmt,
   titleStyle,
+  project,
+  noProjectTooltip,
 }) => {
   'use memo';
 
@@ -112,12 +122,16 @@ const FolderExplorerHeaderV2: React.FC<FolderExplorerHeaderV2Props> = ({
               <FileBrowserButtonV2
                 vfolderNodeFrgmt={vfolderNode}
                 showTitle={lg}
+                project={project}
+                noProjectTooltip={noProjectTooltip}
               />
             </ErrorBoundaryWithNullFallback>
             <ErrorBoundaryWithNullFallback>
               <SFTPServerButtonV2
                 vfolderNodeFrgmt={vfolderNode}
                 showTitle={lg}
+                project={project}
+                noProjectTooltip={noProjectTooltip}
               />
             </ErrorBoundaryWithNullFallback>
           </Suspense>

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -27,6 +27,7 @@ import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
 import { useBAIBreakpoint } from '../theme-shim';
+import { toProjectContext } from '../types/projectContext';
 import BAIErrorBoundary from './BAIErrorBoundary';
 import BAITabs from './BAITabs';
 import { useFileUploadManager } from './FileUploadManager';
@@ -419,7 +420,14 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
       }}
       headerContent={
         vfolderNode ? (
-          <FolderExplorerHeaderV2 vfolderNodeFrgmt={vfolderNode} />
+          <FolderExplorerHeaderV2
+            vfolderNodeFrgmt={vfolderNode}
+            // Sanctioned interim state (ADR-0001): this globally-mounted
+            // modal is not yet converted (FR-3413), so it still narrows the
+            // ambient current project and passes it on explicitly — general
+            // page UX is unchanged.
+            project={toProjectContext(currentProject)}
+          />
         ) : (
           <span />
         )

--- a/react/src/components/SFTPServerButtonV2.test.tsx
+++ b/react/src/components/SFTPServerButtonV2.test.tsx
@@ -7,8 +7,8 @@ import '../../__test__/resizeObserver.mock.js';
 import type { SFTPServerButtonV2TestQuery } from '../__generated__/SFTPServerButtonV2TestQuery.graphql';
 import { ProjectContextOrNull } from '../types/projectContext';
 import SFTPServerButtonV2 from './SFTPServerButtonV2';
-import '@testing-library/jest-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
@@ -92,22 +92,40 @@ const { mockBaiClient, mockCreateIfNotExists, mockListHosts } = vi.hoisted(
   },
 );
 
+const mockWebUINavigate = vi.fn();
+
 vi.mock('../hooks', async (importOriginal) => {
   const originalModule = await importOriginal<typeof import('../hooks')>();
   return {
     ...originalModule,
     useSuspendedBackendaiClient: () => mockBaiClient,
     useCurrentDomainValue: () => 'default',
-    useWebUINavigate: () => vi.fn(),
+    useWebUINavigate: () => mockWebUINavigate,
   };
 });
 
 vi.mock('../hooks/useRouteScope', async (importOriginal) => {
   const originalModule =
     await importOriginal<typeof import('../hooks/useRouteScope')>();
+  const { buildPath } = await import('../helper/pathBuilder');
   return {
     ...originalModule,
-    useProjectPath: () => (path: string) => `/${path}`,
+    // Ambient scope is projectAdmin — the case where a `projectName`-only
+    // override still resolves into the routeless `/admin/` subtree.
+    useProjectPath:
+      () =>
+      (
+        key: string,
+        opts?: {
+          scope?: 'project' | 'projectAdmin' | 'admin';
+          projectName?: string;
+        },
+      ) =>
+        buildPath(
+          opts?.scope ?? 'projectAdmin',
+          key,
+          opts?.projectName ?? 'ambient-project-name',
+        ),
   };
 });
 
@@ -160,10 +178,7 @@ vi.mock('../hooks/useDefaultImagesWithFallback', () => ({
   useDefaultSystemSSHImageWithFallback: () => ({
     systemSSHImage: 'cr.backend.ai/stable/ssh:latest@x86_64',
   }),
-  // `useStartSession` resolves the image reference through this hook. The
-  // fixtures above are already fully qualified (`:tag@arch`), which the real
-  // implementation passes through untouched — so echoing the input keeps the
-  // mock faithful without needing a Relay image query.
+  // Fixtures are already fully qualified, which the real hook passes through.
   useResolveImageReference: () => async (imageString?: string) => imageString,
 }));
 
@@ -173,6 +188,7 @@ const TestRenderer: React.FC<{
   project: ProjectContextOrNull;
   noProjectTooltip?: string;
 }> = ({ project, noProjectTooltip }) => {
+  'use memo';
   const data = useLazyLoadQuery<SFTPServerButtonV2TestQuery>(
     graphql`
       query SFTPServerButtonV2TestQuery($vfolderId: UUID!)
@@ -260,6 +276,7 @@ describe('SFTPServerButtonV2 project prop contract (ADR-0001, FR-3412)', () => {
   beforeEach(() => {
     mockCreateIfNotExists.mockClear();
     mockListHosts.mockClear();
+    mockWebUINavigate.mockClear();
   });
 
   it('renders disabled with the caller-provided tooltip when project is null', async () => {
@@ -303,9 +320,7 @@ describe('SFTPServerButtonV2 project prop contract (ADR-0001, FR-3412)', () => {
         op.name ===
         'useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery',
     );
-    expect(permissionOperation?.variables.projectId).toBe(
-      'passed-project-id',
-    );
+    expect(permissionOperation?.variables.projectId).toBe('passed-project-id');
 
     await user.click(launchButton);
 
@@ -315,5 +330,37 @@ describe('SFTPServerButtonV2 project prop contract (ADR-0001, FR-3412)', () => {
     // per-project SFTP scaling group.
     expect(resources.group_name).toBe('passed-project-name');
     expect(resources.config.scaling_group).toBe('project-sftp-rg');
+  });
+
+  it('sends "Start with Options" to the passed project\'s launcher route, not the ambient scope', async () => {
+    const user = userEvent.setup();
+    renderButton({
+      id: 'passed-project-id',
+      name: 'passed-project-name',
+    });
+
+    const launchButton = await screen.findByRole('button', {
+      name: /RunSSH\/SFTPserver/,
+    });
+    await waitFor(() => expect(launchButton).toBeEnabled());
+
+    // The dropdown trigger is the second button in the compact group.
+    const menuTrigger = launchButton
+      .closest('.ant-space-compact')!
+      .querySelectorAll('button')[1];
+    await user.click(menuTrigger);
+    await user.click(await screen.findByText('import.StartWithOptions'));
+
+    await waitFor(() => expect(mockWebUINavigate).toHaveBeenCalled());
+    const target = mockWebUINavigate.mock.calls[0][0];
+
+    // Must not keep the ambient projectAdmin scope, which would 404.
+    expect(target.pathname).toBe('/project/passed-project-name/session/start');
+    expect(target.pathname).not.toContain('/admin/');
+
+    const formValues = JSON.parse(
+      new URLSearchParams(target.search).get('formValues')!,
+    );
+    expect(formValues.projectName).toBe('passed-project-name');
   });
 });

--- a/react/src/components/SFTPServerButtonV2.test.tsx
+++ b/react/src/components/SFTPServerButtonV2.test.tsx
@@ -160,6 +160,11 @@ vi.mock('../hooks/useDefaultImagesWithFallback', () => ({
   useDefaultSystemSSHImageWithFallback: () => ({
     systemSSHImage: 'cr.backend.ai/stable/ssh:latest@x86_64',
   }),
+  // `useStartSession` resolves the image reference through this hook. The
+  // fixtures above are already fully qualified (`:tag@arch`), which the real
+  // implementation passes through untouched — so echoing the input keeps the
+  // mock faithful without needing a Relay image query.
+  useResolveImageReference: () => async (imageString?: string) => imageString,
 }));
 
 const VFOLDER_GLOBAL_ID = btoa('VFolder:folder-0000');

--- a/react/src/components/SFTPServerButtonV2.test.tsx
+++ b/react/src/components/SFTPServerButtonV2.test.tsx
@@ -290,7 +290,10 @@ describe('SFTPServerButtonV2 project prop contract (ADR-0001, FR-3412)', () => {
 
     // The reason is the page-provided tooltip — the component itself never
     // knows why the project is absent.
-    fireEvent.mouseEnter(launchButton.closest('.ant-space-compact')!);
+    // antd `Space.Compact` -> Astryx `ButtonGroup`, which exposes itself as
+    // `role="group"` with the group label as its accessible name. The
+    // tooltip stays on the GROUP because a disabled button swallows hover.
+    fireEvent.mouseEnter(launchButton.closest('[role="group"]')!);
     expect(
       await screen.findByText('data.CannotLaunchSessionInAdminMenu'),
     ).toBeInTheDocument();
@@ -345,7 +348,7 @@ describe('SFTPServerButtonV2 project prop contract (ADR-0001, FR-3412)', () => {
 
     // The dropdown trigger is the second button in the compact group.
     const menuTrigger = launchButton
-      .closest('.ant-space-compact')!
+      .closest('[role="group"]')!
       .querySelectorAll('button')[1];
     await user.click(menuTrigger);
     await user.click(await screen.findByText('import.StartWithOptions'));

--- a/react/src/components/SFTPServerButtonV2.test.tsx
+++ b/react/src/components/SFTPServerButtonV2.test.tsx
@@ -11,7 +11,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { App } from 'antd';
 import { Suspense } from 'react';
 import {
   graphql,
@@ -258,14 +257,14 @@ const renderButton = (
   render(
     <RelayEnvironmentProvider environment={environment}>
       <QueryClientProvider client={queryClient}>
-        <App>
+        <>
           <Suspense fallback={null}>
             <TestRenderer
               project={project}
               noProjectTooltip={noProjectTooltip}
             />
           </Suspense>
-        </App>
+        </>
       </QueryClientProvider>
     </RelayEnvironmentProvider>,
   );

--- a/react/src/components/SFTPServerButtonV2.test.tsx
+++ b/react/src/components/SFTPServerButtonV2.test.tsx
@@ -1,0 +1,314 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import type { SFTPServerButtonV2TestQuery } from '../__generated__/SFTPServerButtonV2TestQuery.graphql';
+import { ProjectContextOrNull } from '../types/projectContext';
+import SFTPServerButtonV2 from './SFTPServerButtonV2';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App } from 'antd';
+import { Suspense } from 'react';
+import {
+  graphql,
+  RelayEnvironmentProvider,
+  useLazyLoadQuery,
+} from 'react-relay';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * Contract tests for the explicit project prop contract (ADR-0001, FR-3412).
+ *
+ * SFTPServerButtonV2 is button tier: `project` is required; `null` renders
+ * the button disabled with the caller-provided `noProjectTooltip`, a
+ * non-null project keys the storage-host permission lookup, the per-project
+ * volume-host fetch, and the created session to exactly that project. These
+ * tests exercise external behavior only: rendered output, query variables,
+ * and REST call payloads.
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: {
+        language: 'en',
+        changeLanguage: () => new Promise(() => {}),
+      },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: {
+      type: '3rdParty',
+      init: () => {},
+    },
+  };
+});
+
+const { mockBaiClient, mockCreateIfNotExists, mockListHosts } = vi.hoisted(
+  () => {
+    const mockCreateIfNotExists = vi.fn().mockResolvedValue({
+      created: true,
+      status: 'PENDING',
+      sessionId: 'created-session-id',
+    });
+    // The bare call (no project) backs the merged-permission hook; the
+    // per-project call must carry the passed project id and is the only
+    // source of `sftp_scaling_groups` the button may use.
+    const mockListHosts = vi.fn((projectId?: string) =>
+      Promise.resolve({
+        allowed: ['local:volume1'],
+        default: 'local:volume1',
+        volume_info: {
+          'local:volume1': {
+            backend: 'vfs',
+            capabilities: [],
+            sftp_scaling_groups:
+              projectId === 'passed-project-id'
+                ? ['project-sftp-rg']
+                : ['wrong-source-rg'],
+          },
+        },
+      }),
+    );
+    const mockBaiClient = {
+      _config: {
+        accessKey: 'test-access-key',
+        domainName: 'default',
+      },
+      supports: () => false,
+      createIfNotExists: mockCreateIfNotExists,
+      vfolder: {
+        list_hosts: mockListHosts,
+      },
+    };
+    return { mockBaiClient, mockCreateIfNotExists, mockListHosts };
+  },
+);
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => mockBaiClient,
+    useCurrentDomainValue: () => 'default',
+    useWebUINavigate: () => vi.fn(),
+  };
+});
+
+vi.mock('../hooks/useRouteScope', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useRouteScope')>();
+  return {
+    ...originalModule,
+    useProjectPath: () => (path: string) => `/${path}`,
+  };
+});
+
+// Decoy ambient project: the button must never target it. If it did, the
+// `group_name` assertion below would surface `ambient-project-name`.
+vi.mock('../hooks/useCurrentProject', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useCurrentProject')>();
+  return {
+    ...originalModule,
+    useCurrentProjectValue: () => ({
+      id: 'ambient-project-id',
+      name: 'ambient-project-name',
+    }),
+    useCurrentResourceGroupState: () => [null, vi.fn()] as const,
+    // Decoy derived-atom vhost info: the converted button must not read it.
+    useResourceGroupsForCurrentProject: () => ({
+      nonSftpResourceGroups: undefined,
+      sftpResourceGroups: ['ambient-sftp-rg'],
+      vhostInfo: {
+        allowed: ['local:volume1'],
+        default: 'local:volume1',
+        volume_info: {
+          'local:volume1': {
+            backend: 'vfs',
+            capabilities: [],
+            sftp_scaling_groups: ['ambient-sftp-rg'],
+          },
+        },
+      },
+    }),
+  };
+});
+
+vi.mock('../hooks/useBAINotification', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useBAINotification')>();
+  return {
+    ...originalModule,
+    useSetBAINotification: () => ({
+      upsertNotification: vi.fn(),
+      closeNotification: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../hooks/useDefaultImagesWithFallback', () => ({
+  useDefaultFileBrowserImageWithFallback: () =>
+    'cr.backend.ai/stable/filebrowser:21.02@x86_64',
+  useDefaultSystemSSHImageWithFallback: () => ({
+    systemSSHImage: 'cr.backend.ai/stable/ssh:latest@x86_64',
+  }),
+}));
+
+const VFOLDER_GLOBAL_ID = btoa('VFolder:folder-0000');
+
+const TestRenderer: React.FC<{
+  project: ProjectContextOrNull;
+  noProjectTooltip?: string;
+}> = ({ project, noProjectTooltip }) => {
+  const data = useLazyLoadQuery<SFTPServerButtonV2TestQuery>(
+    graphql`
+      query SFTPServerButtonV2TestQuery($vfolderId: UUID!)
+      @relay_test_operation {
+        vfolderV2(vfolderId: $vfolderId) {
+          ...SFTPServerButtonV2Fragment
+        }
+      }
+    `,
+    { vfolderId: '00000000-0000-0000-0000-000000000000' },
+  );
+  if (!data.vfolderV2) return null;
+  return (
+    <SFTPServerButtonV2
+      vfolderNodeFrgmt={data.vfolderV2}
+      project={project}
+      noProjectTooltip={noProjectTooltip}
+    />
+  );
+};
+
+const renderButton = (
+  project: ProjectContextOrNull,
+  noProjectTooltip?: string,
+) => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  const resolver = (operation: any) =>
+    MockPayloadGenerator.generate(operation, {
+      VFolder: () => ({
+        id: VFOLDER_GLOBAL_ID,
+        host: 'local:volume1',
+      }),
+      KeyPair: () => ({
+        resource_policy: 'default',
+      }),
+      Domain: () => ({
+        allowed_vfolder_hosts: JSON.stringify({
+          'local:volume1': ['mount-in-session'],
+        }),
+      }),
+      Group: () => ({
+        allowed_vfolder_hosts: '{}',
+      }),
+      KeyPairResourcePolicy: () => ({
+        allowed_vfolder_hosts: '{}',
+      }),
+    });
+  // Operations disappear from the pending list once a queued resolver
+  // handles them, so record every operation (name + variables) as it is
+  // resolved for later assertions. Each queued resolver serves exactly one
+  // operation (and identical references are all dropped together once one
+  // resolves), so queue distinct wrappers — enough for the test query, the
+  // permission queries, and the post-creation lookup.
+  const seenOperations: Array<{ name: string; variables: any }> = [];
+  for (let i = 0; i < 10; i++) {
+    environment.mock.queueOperationResolver((operation: any) => {
+      seenOperations.push({
+        name: operation.request.node.params.name,
+        variables: operation.request.variables,
+      });
+      return resolver(operation);
+    });
+  }
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <QueryClientProvider client={queryClient}>
+        <App>
+          <Suspense fallback={null}>
+            <TestRenderer
+              project={project}
+              noProjectTooltip={noProjectTooltip}
+            />
+          </Suspense>
+        </App>
+      </QueryClientProvider>
+    </RelayEnvironmentProvider>,
+  );
+  return { environment, seenOperations };
+};
+
+describe('SFTPServerButtonV2 project prop contract (ADR-0001, FR-3412)', () => {
+  beforeEach(() => {
+    mockCreateIfNotExists.mockClear();
+    mockListHosts.mockClear();
+  });
+
+  it('renders disabled with the caller-provided tooltip when project is null', async () => {
+    renderButton(null, 'data.CannotLaunchSessionInAdminMenu');
+
+    const launchButton = await screen.findByRole('button', {
+      name: /RunSSH\/SFTPserver/,
+    });
+    expect(launchButton).toBeDisabled();
+    // Disabled means no data fetch at all: no per-project vhost lookup.
+    expect(mockListHosts).not.toHaveBeenCalled();
+
+    // The reason is the page-provided tooltip — the component itself never
+    // knows why the project is absent.
+    fireEvent.mouseEnter(launchButton.closest('.ant-space-compact')!);
+    expect(
+      await screen.findByText('data.CannotLaunchSessionInAdminMenu'),
+    ).toBeInTheDocument();
+  });
+
+  it('creates the SFTP session in exactly the passed project, with per-project vhost info and permission lookup', async () => {
+    const user = userEvent.setup();
+    const { seenOperations } = renderButton({
+      id: 'passed-project-id',
+      name: 'passed-project-name',
+    });
+
+    const launchButton = await screen.findByRole('button', {
+      name: /RunSSH\/SFTPserver/,
+    });
+    await waitFor(() => expect(launchButton).toBeEnabled());
+
+    // Volume-host info is fetched per passed project (not the ambient
+    // derived atom, which the decoy above would surface as
+    // `ambient-sftp-rg`).
+    expect(mockListHosts).toHaveBeenCalledWith('passed-project-id');
+
+    // The storage-host permission lookup is keyed to the passed project id.
+    const permissionOperation = seenOperations.find(
+      (op) =>
+        op.name ===
+        'useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery',
+    );
+    expect(permissionOperation?.variables.projectId).toBe(
+      'passed-project-id',
+    );
+
+    await user.click(launchButton);
+
+    await waitFor(() => expect(mockCreateIfNotExists).toHaveBeenCalled());
+    const resources = mockCreateIfNotExists.mock.calls[0][2];
+    // The session is created in exactly the passed project, on the
+    // per-project SFTP scaling group.
+    expect(resources.group_name).toBe('passed-project-name');
+    expect(resources.config.scaling_group).toBe('project-sftp-rg');
+  });
+});

--- a/react/src/components/SFTPServerButtonV2.tsx
+++ b/react/src/components/SFTPServerButtonV2.tsx
@@ -9,10 +9,6 @@ import {
   useSuspendedBackendaiClient,
   useWebUINavigate,
 } from '../hooks';
-import {
-  useCurrentProjectValue,
-  useResourceGroupsForCurrentProject,
-} from '../hooks/useCurrentProject';
 import { useDefaultSystemSSHImageWithFallback } from '../hooks/useDefaultImagesWithFallback';
 import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
 import { useProjectPath } from '../hooks/useRouteScope';
@@ -20,6 +16,11 @@ import {
   StartSessionWithDefaultValue,
   useStartSession,
 } from '../hooks/useStartSession';
+import { useVHostInfo } from '../hooks/useVHostInfo';
+import {
+  ProjectContext,
+  ProjectContextOrNull,
+} from '../types/projectContext';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
@@ -38,13 +39,69 @@ import { graphql, useFragment } from 'react-relay';
 interface SFTPServerButtonV2Props extends BAIButtonProps {
   showTitle?: boolean;
   vfolderNodeFrgmt: SFTPServerButtonV2Fragment$key;
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3412): the project the
+   * SSH/SFTP session is created in. With `null` the button renders disabled
+   * and shows the caller-provided `noProjectTooltip` — this component never
+   * knows WHY the project is absent.
+   */
+  project: ProjectContextOrNull;
+  noProjectTooltip?: string;
 }
 
 const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
   showTitle = true,
   vfolderNodeFrgmt,
+  project,
+  noProjectTooltip,
   ...buttonProps
 }) => {
+  'use memo';
+  const { t } = useTranslation();
+
+  if (project === null) {
+    return (
+      <Tooltip title={noProjectTooltip}>
+        <Space.Compact>
+          <BAIButton
+            disabled
+            icon={
+              <Image
+                width="18px"
+                src="/resources/icons/sftp.png"
+                alt="SSH / SFTP"
+                preview={false}
+              />
+            }
+            {...buttonProps}
+          >
+            {showTitle && t('data.explorer.RunSSH/SFTPserver')}
+          </BAIButton>
+          <BAIButton icon={<EllipsisOutlined />} disabled />
+        </Space.Compact>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <SFTPServerButtonWithProject
+      showTitle={showTitle}
+      vfolderNodeFrgmt={vfolderNodeFrgmt}
+      project={project}
+      {...buttonProps}
+    />
+  );
+};
+
+interface SFTPServerButtonWithProjectProps extends BAIButtonProps {
+  showTitle: boolean;
+  vfolderNodeFrgmt: SFTPServerButtonV2Fragment$key;
+  project: ProjectContext;
+}
+
+const SFTPServerButtonWithProject: React.FC<
+  SFTPServerButtonWithProjectProps
+> = ({ showTitle, vfolderNodeFrgmt, project, ...buttonProps }) => {
   'use memo';
 
   const { logger } = useBAILogger();
@@ -56,19 +113,16 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
 
   const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
-  const currentProject = useCurrentProjectValue();
-  if (!currentProject.id) {
-    throw new Error('Project ID is required for SFTPServerButtonV2');
-  }
   const currentUserAccessKey = baiClient?._config?.accessKey;
   const { unitedAllowedPermissionByVolume } =
     useMergedAllowedStorageHostPermission(
       currentDomain,
-      currentProject.id,
+      project.id,
       currentUserAccessKey,
     );
-  const { vhostInfo: vhostInfoByCurrentProject } =
-    useResourceGroupsForCurrentProject();
+  // Per-project volume host info (FR-3412) — keyed to the passed project,
+  // not the ambient current-project derived atom.
+  const { vhostInfo } = useVHostInfo(project.id);
 
   const { getErrorMessage } = useErrorMessageResolver();
   const { startSessionWithDefault, upsertSessionNotification } =
@@ -86,12 +140,11 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
     vfolderNodeFrgmt,
   );
 
-  // Verify that the current user has access to the volume of the vfolder.
+  // Verify that the passed project has access to the volume of the vfolder.
   // Check the project has SFTP scaling groups for the host of the vfolder.
-  const sftpScalingGroupByCurrentProject =
-    vhostInfoByCurrentProject?.volume_info[vfolderNode?.host || '']
-      ?.sftp_scaling_groups;
-  // Verify that the current project has access to the volumes in the folder.
+  const sftpScalingGroupsByProject =
+    vhostInfo?.volume_info[vfolderNode?.host || '']?.sftp_scaling_groups;
+  // Verify that the passed project has access to the volumes in the folder.
   // Check the user has 'mount-in-session' permission united by domain, project, and keypair resource policy.
   const hasAccessPermission = _.includes(
     unitedAllowedPermissionByVolume[vfolderNode?.host ?? ''],
@@ -101,7 +154,7 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
   const getTooltipTitle = () => {
     if (!hasAccessPermission) {
       return t('data.explorer.NoPermissionToMountFolder');
-    } else if (_.isEmpty(sftpScalingGroupByCurrentProject)) {
+    } else if (_.isEmpty(sftpScalingGroupsByProject)) {
       return t('data.explorer.NoSFTPSupportingScalingGroup');
     } else if (!systemSSHImage) {
       return t('data.explorer.NoImagesSupportingSystemSession');
@@ -129,7 +182,7 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
     cluster_mode: 'single-node',
     cluster_size: 1,
     mount_ids: [toLocalId(vfolderNode?.id || '').replaceAll('-', '')],
-    resourceGroup: sftpScalingGroupByCurrentProject?.[0],
+    resourceGroup: sftpScalingGroupsByProject?.[0],
     reuseIfExists: true,
   });
 
@@ -142,7 +195,7 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
       <ButtonGroup label={t('data.explorer.RunSSH/SFTPserver')}>
         <BAIButton
           disabled={
-            _.isEmpty(sftpScalingGroupByCurrentProject) ||
+            _.isEmpty(sftpScalingGroupsByProject) ||
             !systemSSHImage ||
             !hasAccessPermission
           }
@@ -158,7 +211,11 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
             />
           }
           action={async () => {
-            const sftpSessionConf = createSftpLauncherValue();
+            const sftpSessionConf = {
+              ...createSftpLauncherValue(),
+              // Pin the session to exactly the passed project (FR-3412).
+              projectName: project.name,
+            };
             await startSessionWithDefault(sftpSessionConf)
               .then((results) => {
                 if (results?.fulfilled && results.fulfilled.length > 0) {
@@ -199,7 +256,7 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
             icon: <Ellipsis size="1em" />,
             isIconOnly: true,
             isDisabled:
-              _.isEmpty(sftpScalingGroupByCurrentProject) ||
+              _.isEmpty(sftpScalingGroupsByProject) ||
               !systemSSHImage ||
               !hasAccessPermission,
           }}

--- a/react/src/components/SFTPServerButtonV2.tsx
+++ b/react/src/components/SFTPServerButtonV2.tsx
@@ -65,7 +65,6 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
       <Tooltip content={noProjectTooltip} isEnabled={!!noProjectTooltip}>
         <ButtonGroup label={t('data.explorer.RunSSH/SFTPserver')}>
           <BAIButton
-            disabled
             icon={
               <img
                 width="18"
@@ -75,6 +74,8 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
               />
             }
             {...buttonProps}
+            // After the spread: a caller must not re-enable this tier.
+            disabled
           >
             {showTitle && t('data.explorer.RunSSH/SFTPserver')}
           </BAIButton>
@@ -273,21 +274,17 @@ const SFTPServerButtonWithProject: React.FC<
               onClick: () => {
                 const launcherValue = {
                   ...createSftpLauncherValue(),
-                  // Pin the session to exactly the passed project (FR-3412),
-                  // matching the primary button above.
                   projectName: project.name,
                 };
                 const params = new URLSearchParams();
                 params.set('formValues', JSON.stringify(launcherValue));
                 params.set('step', '4');
                 webuiNavigate({
-                  // `SessionLauncherPage` resolves its project from the
-                  // ambient current project, which `ProjectScopeLayout`
-                  // converges from the `:projectName` URL segment — not from
-                  // these form values. So the link itself must carry the
-                  // explicit project, otherwise this entry point could
-                  // launch in a different project than the primary button.
+                  // The launcher reads the project from the URL, not from
+                  // these form values. `scope` is required too: the launcher
+                  // route exists only in the project subtree.
                   pathname: buildProjectPath('session/start', {
+                    scope: 'project',
                     projectName: project.name,
                   }),
                   search: params.toString(),

--- a/react/src/components/SFTPServerButtonV2.tsx
+++ b/react/src/components/SFTPServerButtonV2.tsx
@@ -23,6 +23,7 @@ import {
 } from '../types/projectContext';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
+import { IconButton } from '@astryxdesign/core/IconButton';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAIButton,
@@ -61,24 +62,28 @@ const SFTPServerButtonV2: React.FC<SFTPServerButtonV2Props> = ({
 
   if (project === null) {
     return (
-      <Tooltip title={noProjectTooltip}>
-        <Space.Compact>
+      <Tooltip content={noProjectTooltip} isEnabled={!!noProjectTooltip}>
+        <ButtonGroup label={t('data.explorer.RunSSH/SFTPserver')}>
           <BAIButton
             disabled
             icon={
-              <Image
-                width="18px"
+              <img
+                width="18"
+                height="18"
                 src="/resources/icons/sftp.png"
                 alt="SSH / SFTP"
-                preview={false}
               />
             }
             {...buttonProps}
           >
             {showTitle && t('data.explorer.RunSSH/SFTPserver')}
           </BAIButton>
-          <BAIButton icon={<EllipsisOutlined />} disabled />
-        </Space.Compact>
+          <IconButton
+            label={t('import.StartWithOptions')}
+            icon={<Ellipsis size="1em" />}
+            isDisabled
+          />
+        </ButtonGroup>
       </Tooltip>
     );
   }
@@ -266,12 +271,25 @@ const SFTPServerButtonWithProject: React.FC<
             {
               label: t('import.StartWithOptions'),
               onClick: () => {
-                const launcherValue = createSftpLauncherValue();
+                const launcherValue = {
+                  ...createSftpLauncherValue(),
+                  // Pin the session to exactly the passed project (FR-3412),
+                  // matching the primary button above.
+                  projectName: project.name,
+                };
                 const params = new URLSearchParams();
                 params.set('formValues', JSON.stringify(launcherValue));
                 params.set('step', '4');
                 webuiNavigate({
-                  pathname: buildProjectPath('session/start'),
+                  // `SessionLauncherPage` resolves its project from the
+                  // ambient current project, which `ProjectScopeLayout`
+                  // converges from the `:projectName` URL segment — not from
+                  // these form values. So the link itself must carry the
+                  // explicit project, otherwise this entry point could
+                  // launch in a different project than the primary button.
+                  pathname: buildProjectPath('session/start', {
+                    projectName: project.name,
+                  }),
                   search: params.toString(),
                 });
               },

--- a/react/src/hooks/useRouteScope.ts
+++ b/react/src/hooks/useRouteScope.ts
@@ -214,24 +214,23 @@ interface ProjectPathOptions {
   scope?: RouteScope;
   /**
    * Build the link for this project instead of the ambient active one
-   * (ADR-0001). Components that took an explicit `project` prop must pass it
-   * here: since FR-3055 the `:projectName` segment owns the current project,
-   * so a link built from the ambient name would land the target page in a
-   * different project than the component was told to act on.
+   * (ADR-0001).
+   *
+   * Replaces the project NAME only — the scope stays ambient, and `buildPath`
+   * ignores this entirely on `admin` scope. Callers that can render outside
+   * `project` scope must pass `scope: 'project'` too, or they build a path
+   * into a subtree where the feature has no route.
    */
   projectName?: string;
 }
 
 /**
- * Returns a link builder bound to the current scope / active project. Pass an
- * explicit `scope` to override (e.g. to build an `admin` link from a project
- * page), or an explicit `projectName` to build the link for a project other
- * than the ambient one.
+ * Returns a link builder bound to the current scope / active project.
  *
  *   const buildLink = useProjectPath();
  *   buildLink('session');                          // current scope + project
  *   buildLink('users', { scope: 'admin' });        // /admin/users
- *   buildLink('session', { projectName: p.name }); // explicit project
+ *   buildLink('session/start', { scope: 'project', projectName: p.name });
  */
 export const useProjectPath = (): ((
   key: FeatureKey,

--- a/react/src/hooks/useRouteScope.ts
+++ b/react/src/hooks/useRouteScope.ts
@@ -212,16 +212,26 @@ export const useActiveProjectName = (): string | undefined => {
 
 interface ProjectPathOptions {
   scope?: RouteScope;
+  /**
+   * Build the link for this project instead of the ambient active one
+   * (ADR-0001). Components that took an explicit `project` prop must pass it
+   * here: since FR-3055 the `:projectName` segment owns the current project,
+   * so a link built from the ambient name would land the target page in a
+   * different project than the component was told to act on.
+   */
+  projectName?: string;
 }
 
 /**
  * Returns a link builder bound to the current scope / active project. Pass an
  * explicit `scope` to override (e.g. to build an `admin` link from a project
- * page).
+ * page), or an explicit `projectName` to build the link for a project other
+ * than the ambient one.
  *
  *   const buildLink = useProjectPath();
  *   buildLink('session');                          // current scope + project
  *   buildLink('users', { scope: 'admin' });        // /admin/users
+ *   buildLink('session', { projectName: p.name }); // explicit project
  */
 export const useProjectPath = (): ((
   key: FeatureKey,
@@ -229,10 +239,14 @@ export const useProjectPath = (): ((
 ) => string) => {
   'use memo';
   const scope = useRouteScope();
-  const projectName = useActiveProjectName();
+  const activeProjectName = useActiveProjectName();
 
   return (key: FeatureKey, opts?: ProjectPathOptions): string => {
-    return buildPath(opts?.scope ?? scope, key, projectName);
+    return buildPath(
+      opts?.scope ?? scope,
+      key,
+      opts?.projectName ?? activeProjectName,
+    );
   };
 };
 

--- a/react/src/hooks/useStartSession.tsx
+++ b/react/src/hooks/useStartSession.tsx
@@ -86,7 +86,17 @@ export type StartSessionValue =
   // Required fields (environments with only version required)
   StartSessionEnvironments &
     // Optional fields from SessionLauncherFormValue
-    Partial<Omit<SessionLauncherFormValue, 'environments'>>;
+    Partial<Omit<SessionLauncherFormValue, 'environments'>> & {
+      /**
+       * Explicit target project (group) name for the created session
+       * (ADR-0001, FR-3412). When set, `group_name` is pinned to exactly
+       * this project instead of the ambient current project. Distinct from
+       * the `owner` branch, which is coupled to `owner_access_key`.
+       * Callers that omit it keep the ambient-project fallback — a
+       * sanctioned interim state until they are converted.
+       */
+      projectName?: string;
+    };
 
 // Type for minimum required values (all fields except those with defaults are required)
 export type StartSessionWithDefaultValue = Omit<
@@ -157,11 +167,17 @@ export const useStartSession = () => {
   ) => {
     const mergedValue = _.merge({}, defaultFormValues, minimumValues);
     return startSession(
-      mergedValue as SessionLauncherFormValue & { dependencies?: string[] },
+      mergedValue as SessionLauncherFormValue & {
+        dependencies?: string[];
+        projectName?: string;
+      },
     );
   };
   const startSession = async (
-    values: SessionLauncherFormValue & { dependencies?: string[] },
+    values: SessionLauncherFormValue & {
+      dependencies?: string[];
+      projectName?: string;
+    },
   ) => {
     // A manual image (the `allowManualImageNameForSession` escape hatch) is
     // used verbatim — the user explicitly typed it, so it must not be
@@ -190,10 +206,13 @@ export const useStartSession = () => {
       architecture,
       resources: {
         enqueueOnly: true,
-        // Project and domain settings
+        // Project and domain settings. `projectName` (explicit project
+        // contract, FR-3412) wins over the ambient current project; the
+        // `owner` branch stays independent because it is coupled to
+        // `owner_access_key`.
         group_name: values.owner?.enabled
           ? values.owner.project
-          : currentProject.name || undefined,
+          : values.projectName || currentProject.name || undefined,
         domain: values.owner?.enabled
           ? values.owner.domainName
           : baiClient._config.domainName,

--- a/react/src/hooks/useVHostInfo.tsx
+++ b/react/src/hooks/useVHostInfo.tsx
@@ -1,0 +1,41 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useSuspendedBackendaiClient } from '.';
+import { useSuspenseTanQuery } from './reactQueryAlias';
+
+interface VHostVolumeInfo {
+  backend: string;
+  capabilities: string[];
+  usage?: {
+    percentage: number;
+  };
+  sftp_scaling_groups?: string[];
+}
+
+export interface VHostInfo {
+  allowed: string[];
+  default: string;
+  volume_info: {
+    [key: string]: VHostVolumeInfo;
+  };
+}
+
+/**
+ * Per-project volume host info (`vfolder.list_hosts(projectId)`), keyed to an
+ * explicitly passed project (ADR-0001, FR-3412) instead of the ambient
+ * current-project derived atom. Suspends while loading.
+ */
+export const useVHostInfo = (projectId: string) => {
+  'use memo';
+  const baiClient = useSuspendedBackendaiClient();
+
+  const { data: vhostInfo } = useSuspenseTanQuery<VHostInfo>({
+    queryKey: ['vhostInfo', projectId],
+    queryFn: () => baiClient.vfolder.list_hosts(projectId),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  return { vhostInfo };
+};

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Der Name des Auto-Mount-Ordners muss mit einem Punkt ('.') beginnen.",
     "AutomountFolders": "Automount-Ordner",
     "BelongsToDifferentProject": "Dieser Ordner gehört zu einem anderen Projekt.",
+    "CannotLaunchSessionInAdminMenu": "Sitzungen können nicht über das Admin-Menü gestartet werden.",
     "CloningIsOnlyPossibleSameHost": "Derzeit ist das Klonen nur auf demselben Host möglich.",
     "Create": "Erstellen",
     "CreateANewStorageFolder": "Erstellen Sie einen neuen Speicherordner",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Το όνομα του φακέλου αυτόματης προσάρτησης πρέπει να αρχίζει με τελεία ('.').",
     "AutomountFolders": "Φάκελοι Automount",
     "BelongsToDifferentProject": "Αυτός ο φάκελος ανήκει σε διαφορετικό έργο.",
+    "CannotLaunchSessionInAdminMenu": "Δεν είναι δυνατή η εκκίνηση συνεδριών από το μενού διαχειριστή.",
     "CloningIsOnlyPossibleSameHost": "Προς το παρόν, η κλωνοποίηση είναι δυνατή μόνο στον ίδιο κεντρικό υπολογιστή.",
     "Create": "Δημιουργώ",
     "CreateANewStorageFolder": "Δημιουργήστε έναν νέο φάκελο αποθήκευσης",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -719,6 +719,7 @@
     "AutomountFolderNameMustStartWithDot": "The name of the auto-mount folder must start with a dot ('.').",
     "AutomountFolders": "Automount Folders",
     "BelongsToDifferentProject": "This folder belongs to a different project.",
+    "CannotLaunchSessionInAdminMenu": "Sessions cannot be launched from the admin menu.",
     "CloningIsOnlyPossibleSameHost": "Currently, cloning is only possible on the same host.",
     "Create": "Create",
     "CreateANewStorageFolder": "Create a new storage folder",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "El nombre de la carpeta de montaje automático debe empezar por un punto ('.').",
     "AutomountFolders": "Carpetas de montaje automático",
     "BelongsToDifferentProject": "Esta carpeta pertenece a otro proyecto.",
+    "CannotLaunchSessionInAdminMenu": "No se pueden iniciar sesiones desde el menú de administración.",
     "CloningIsOnlyPossibleSameHost": "Actualmente, la clonación sólo es posible en el mismo host.",
     "Create": "Cree",
     "CreateANewStorageFolder": "Crear una nueva carpeta de almacenamiento",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Automaattisen kiinnityskansion nimen on alettava pisteellä ('.').",
     "AutomountFolders": "Automount-kansiot",
     "BelongsToDifferentProject": "Tämä kansio kuuluu toiseen projektiin.",
+    "CannotLaunchSessionInAdminMenu": "Istuntoja ei voi käynnistää hallintavalikosta.",
     "CloningIsOnlyPossibleSameHost": "Tällä hetkellä kloonaus on mahdollista vain samassa isännässä.",
     "Create": "Luo",
     "CreateANewStorageFolder": "Luo uusi tallennuskansio",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Le nom du dossier de montage automatique doit commencer par un point ('.').",
     "AutomountFolders": "Dossiers à montage automatique",
     "BelongsToDifferentProject": "Ce dossier appartient à un autre projet.",
+    "CannotLaunchSessionInAdminMenu": "Impossible de lancer des sessions depuis le menu d'administration.",
     "CloningIsOnlyPossibleSameHost": "Actuellement, le clonage n'est possible que sur le même hôte.",
     "Create": "Créer",
     "CreateANewStorageFolder": "Créer un nouveau dossier de stockage",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Nama folder pemasangan otomatis harus dimulai dengan tanda titik ('.').",
     "AutomountFolders": "Folder yang Dipasang Otomatis",
     "BelongsToDifferentProject": "Folder ini milik proyek lain.",
+    "CannotLaunchSessionInAdminMenu": "Sesi tidak dapat dijalankan dari menu admin.",
     "CloningIsOnlyPossibleSameHost": "Saat ini, kloning hanya dapat dilakukan pada host yang sama.",
     "Create": "Buat",
     "CreateANewStorageFolder": "Buat folder penyimpanan baru",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Il nome della cartella di montaggio automatico deve iniziare con un punto ('.').",
     "AutomountFolders": "Cartelle di montaggio automatico",
     "BelongsToDifferentProject": "Questa cartella appartiene a un progetto diverso.",
+    "CannotLaunchSessionInAdminMenu": "Non è possibile avviare sessioni dal menu di amministrazione.",
     "CloningIsOnlyPossibleSameHost": "Attualmente la clonazione è possibile solo sullo stesso host.",
     "Create": "Creare",
     "CreateANewStorageFolder": "Crea una nuova cartella di archiviazione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "自動マウントフォルダー名はドット（'.）",
     "AutomountFolders": "フォルダーの自動マウント",
     "BelongsToDifferentProject": "このフォルダは別のプロジェクトに属しています。",
+    "CannotLaunchSessionInAdminMenu": "管理者メニューからセッションを起動することはできません。",
     "CloningIsOnlyPossibleSameHost": "現在、クローン作成は同じホスト上でのみ可能です。",
     "Create": "作成",
     "CreateANewStorageFolder": "新規ストレージフォルダー作成",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "자동 마운트 폴더의 이름은 \".\"으로 시작 해야합니다.",
     "AutomountFolders": "자동 마운트 폴더",
     "BelongsToDifferentProject": "이 폴더는 다른 프로젝트에 속해 있습니다.",
+    "CannotLaunchSessionInAdminMenu": "관리자 메뉴에서는 세션을 시작할 수 없습니다.",
     "CloningIsOnlyPossibleSameHost": "현재 폴더 복사는 동일한 호스트간에만 가능합니다.",
     "Create": "생성",
     "CreateANewStorageFolder": "새 폴더 추가",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Автомат суурилуулсан фолдерын нэр нь цэгээс эхлэх ёстой ('.').",
     "AutomountFolders": "Автомат хавтас",
     "BelongsToDifferentProject": "Энэхүү хавтас нь өөр төсөлд харьяалагдана.",
+    "CannotLaunchSessionInAdminMenu": "Session-ийг админ цэснээс эхлүүлэх боломжгүй.",
     "CloningIsOnlyPossibleSameHost": "Одоогоор зөвхөн нэг хост дээр клон хийх боломжтой.",
     "Create": "Үүсгэх",
     "CreateANewStorageFolder": "Шинэ хадгалах фолдер үүсгэх",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Nama folder auto-mount mesti bermula dengan titik ('.').",
     "AutomountFolders": "Folder Automatik",
     "BelongsToDifferentProject": "Folder ini milik projek lain.",
+    "CannotLaunchSessionInAdminMenu": "Sesi tidak boleh dilancarkan daripada menu pentadbir.",
     "CloningIsOnlyPossibleSameHost": "Pada masa ini, pengklonan hanya boleh dilakukan pada hos yang sama.",
     "Create": "Buat",
     "CreateANewStorageFolder": "Buat folder storan baru",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Nazwa folderu automatycznego montażu musi zaczynać się od kropki (\".\").",
     "AutomountFolders": "Automatyczne montowanie folderów",
     "BelongsToDifferentProject": "Ten folder należy do innego projektu.",
+    "CannotLaunchSessionInAdminMenu": "Nie można uruchamiać sesji z menu administratora.",
     "CloningIsOnlyPossibleSameHost": "Obecnie klonowanie jest możliwe tylko na tym samym hoście.",
     "Create": "Stwórz",
     "CreateANewStorageFolder": "Utwórz nowy folder przechowywania",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "O nome da pasta de montagem automática deve começar com um ponto ('.').",
     "AutomountFolders": "Pastas Automount",
     "BelongsToDifferentProject": "Esta pasta pertence a um projeto diferente.",
+    "CannotLaunchSessionInAdminMenu": "Não é possível iniciar sessões a partir do menu de administração.",
     "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
     "Create": "Crio",
     "CreateANewStorageFolder": "Crie uma nova pasta de armazenamento",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "O nome da pasta de montagem automática deve começar com um ponto ('.').",
     "AutomountFolders": "Pastas Automount",
     "BelongsToDifferentProject": "Esta pasta pertence a outro projeto.",
+    "CannotLaunchSessionInAdminMenu": "Não é possível iniciar sessões a partir do menu de administração.",
     "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
     "Create": "Crio",
     "CreateANewStorageFolder": "Crie uma nova pasta de armazenamento",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Имя папки автомонтирования должно начинаться с точки ('.').",
     "AutomountFolders": "Автоматически монтировать папки",
     "BelongsToDifferentProject": "Эта папка принадлежит другому проекту.",
+    "CannotLaunchSessionInAdminMenu": "Запуск сессий из меню администратора невозможен.",
     "CloningIsOnlyPossibleSameHost": "В настоящее время клонирование возможно только на том же хосте.",
     "Create": "Создавать",
     "CreateANewStorageFolder": "Создать новую папку для хранения",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "ชื่อของโฟลเดอร์ที่ติดตั้งอัตโนมัติต้องขึ้นต้นด้วยจุด ('.')",
     "AutomountFolders": "โฟลเดอร์เมาท์อัตโนมัติ",
     "BelongsToDifferentProject": "โฟลเดอร์นี้เป็นของโปรเจกต์อื่น.",
+    "CannotLaunchSessionInAdminMenu": "ไม่สามารถเริ่มเซสชันจากเมนูผู้ดูแลระบบได้",
     "CloningIsOnlyPossibleSameHost": "ปัจจุบันการโคลนสามารถทำได้เฉพาะบนโฮสต์เดียวกัน",
     "Create": "สร้าง",
     "CreateANewStorageFolder": "สร้างโฟลเดอร์จัดเก็บใหม่",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Otomatik montaj klasörünün adı bir nokta ('.') ile başlamalıdır.",
     "AutomountFolders": "Klasörleri Otomatik Bağla",
     "BelongsToDifferentProject": "Bu klasör farklı bir projeye ait.",
+    "CannotLaunchSessionInAdminMenu": "Oturumlar yönetici menüsünden başlatılamaz.",
     "CloningIsOnlyPossibleSameHost": "Şu anda klonlama yalnızca aynı ana bilgisayarda mümkündür.",
     "Create": "Oluşturmak",
     "CreateANewStorageFolder": "Yeni bir depolama klasörü oluşturun",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "Tên của thư mục tự động gắn phải bắt đầu bằng dấu chấm ('.').",
     "AutomountFolders": "Thư mục Automount",
     "BelongsToDifferentProject": "Thư mục này thuộc dự án khác.",
+    "CannotLaunchSessionInAdminMenu": "Không thể khởi chạy phiên từ menu quản trị.",
     "CloningIsOnlyPossibleSameHost": "Hiện tại, việc nhân bản chỉ có thể thực hiện được trên cùng một máy chủ.",
     "Create": "Tạo nên",
     "CreateANewStorageFolder": "Tạo một thư mục lưu trữ mới",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "自动挂载文件夹的名称必须以点（'.'）开头。",
     "AutomountFolders": "自动挂载文件夹",
     "BelongsToDifferentProject": "此文件夹属于其他项目。",
+    "CannotLaunchSessionInAdminMenu": "无法从管理员菜单启动会话。",
     "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主机上进行。",
     "Create": "创造",
     "CreateANewStorageFolder": "创建一个新的存储文件夹",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -732,6 +732,7 @@
     "AutomountFolderNameMustStartWithDot": "自动挂载文件夹的名称必须以点（'.'）开头。",
     "AutomountFolders": "自動掛載文件夾",
     "BelongsToDifferentProject": "此資料夾屬於其他專案。",
+    "CannotLaunchSessionInAdminMenu": "無法從管理員選單啟動會話。",
     "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主機上進行。",
     "Create": "創造",
     "CreateANewStorageFolder": "創建一個新的存儲文件夾",


### PR DESCRIPTION
Resolves #8459 (FR-3412)

Fourth layer of the explicit project prop contract stack (ADR-0001, epic FR-3407 / #8453).

## What this does

FileBrowserButtonV2 and SFTPServerButtonV2 become converted button-tier leaves of the explicit project prop contract: they take a **required** `project: ProjectContextOrNull` plus `noProjectTooltip?: string` and never read the ambient current project.

### Buttons (A)
- `project === null` → the launch button **and** its options dropdown render disabled, wrapped in a `Tooltip` showing the caller-provided `noProjectTooltip`. The component never knows WHY the project is absent — no pathname/admin checks inside.
- `project` non-null → exactly today's behavior, keyed to the passed project: `useMergedAllowedStorageHostPermission(currentDomain, project.id, accessKey)` and the launched FileBrowser/SFTP session is created in that project.
- The former `useCurrentProjectValue()` reads + `throw`s are deleted from both buttons.
- Structure: a thin outer component renders the disabled view for `null` and delegates to an inner `*WithProject` component (with `project: ProjectContext`) for the hook-bearing path.
- In the `null` tier `{...buttonProps}` is spread **before** the forced `disabled`, so a caller cannot re-enable a launch button that has no project.

### useStartSession (B)
- `StartSessionValue` (and therefore `StartSessionWithDefaultValue`) gains an optional `projectName?: string` field; `startSession` accepts it too. When set, `group_name` is pinned to exactly that project — **without** touching the `owner` branch, which stays coupled to `owner_access_key`.
- Callers that omit it keep the ambient-project fallback (sanctioned interim state). No other callers converted in this PR.
- Both buttons pass `projectName: project.name` on direct launch.
- The "Start with options" dropdown entry is pinned to the same project. `SessionLauncherPage` resolves its project from the ambient current project (which `ProjectScopeLayout` converges from the `:projectName` URL segment) and ignores the query-string form values for project selection, so the **URL** has to carry the project: `useProjectPath` gained a `projectName` override and both handlers build `session/start` with `{ scope: "project", projectName: project.name }`. `scope` is required, not incidental — the launcher route exists only in the project subtree, so keeping the ambient `projectAdmin` scope would build `/project/<name>/admin/session/start`, which has no route behind it. The launcher form values also carry `projectName`, so both entry points request exactly the same thing.

### SFTP vhost info (C)
- New `useVHostInfo(projectId)` hook (`react/src/hooks/useVHostInfo.tsx`, suspense tan-query): `client.vfolder.list_hosts(project.id)` keyed per passed project (queryKey `['vhostInfo', projectId]`). Replaces the `useResourceGroupsForCurrentProject()` ambient derived-atom read in SFTPServerButtonV2; the SFTP scaling group comes from this per-project payload.

### Call-site plumbing (D)
The buttons' **only** render chain today is: `FolderExplorerOpener` (globally mounted) → `FolderExplorerModalV2` → `FolderExplorerHeaderV2` → buttons.
- `FolderExplorerHeaderV2` gains `project: ProjectContextOrNull` (required) + `noProjectTooltip?` pass-through props.
- `FolderExplorerModalV2` is **not** converted here (that's FR-3413); it feeds the ambient-narrowed project via a one-line `toProjectContext(useCurrentProjectValue())` — the sanctioned interim state, so general-page UX is unchanged.
- The admin Data page reaches these buttons only through that global modal, so the `null` + `data.CannotLaunchSessionInAdminMenu` wiring lands when FR-3413 converts the modal; the contract, disabled UX, and i18n key are all in place now.
- Legacy (non-V2) FileBrowserButton/SFTPServerButton under the legacy FolderExplorerModal are out of scope per the ticket.

### Tests (E)
Contract vitest tests for both buttons (Relay mock environment + tanstack QueryClient), external behavior only:
- `null` → disabled + the caller-provided tooltip text rendered; no per-project vhost fetch fired.
- non-null → `createIfNotExists` called with `resources.group_name === passed project name`; `useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery` variables carry `projectId === passed project id`; SFTP `config.scaling_group` comes from `list_hosts(passed project id)` — with ambient **decoys** (decoy `useCurrentProjectValue`, decoy derived-atom vhost info) that would surface `ambient-*` values if any ambient path were still alive.
- Added `react/__test__/resizeObserver.mock.js` (jsdom lacks ResizeObserver; needed by antd internals).
- Scope regression: with the ambient scope mocked to `projectAdmin`, "Start with options" must navigate to `/project/<name>/session/start` and carry no `/admin/` segment. Removing the `scope: "project"` override makes it fail with `/project/<name>/admin/session/start` — the 404 path.

### i18n (F)
`data.CannotLaunchSessionInAdminMenu` ("Sessions cannot be launched from the admin menu.") added to all 21 locale files in `resources/i18n/`, alphabetically placed in the `data` section.

### Docs
ADR-0001 applications paragraph extended with the FR-3412 button-tier application.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Vite warmup / Terminology)
- react vitest suite: **65 files / 1092 tests passed** (includes the 5 contract tests)
- Diff off `origin/feat/FR-3411-add-revision-deployment-project`: 34 files — the two buttons + tests, useStartSession, new useVHostInfo, FolderExplorerHeaderV2/ModalV2 plumbing, 2 generated test-query artifacts, `useRouteScope` path-builder option, ADR, 21 locale files, ResizeObserver test mock. No unintended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)