### PR TITLE
feat(FR-3413): prop-gated mismatch alerts and ownership-derived folder gating

### DIFF
--- a/docs/adr/0001-explicit-project-prop-contract.md
+++ b/docs/adr/0001-explicit-project-prop-contract.md
@@ -121,11 +121,59 @@ narrowing helper for the loosely-typed ambient value).
   pins `group_name` without reusing the `owner` branch (which is coupled to
   `owner_access_key`); callers that omit it keep the ambient fallback as a
   sanctioned interim state. `FolderExplorerHeaderV2` passes the prop
-  through; the globally-mounted `FolderExplorerModalV2` still narrows the
-  ambient project and hands it on explicitly until its own conversion
-  (FR-3413).
-- Subsequent tickets convert mismatch alerts, then hide the header selector
-  per admin route.
+  through.
+- Fifth application (FR-3413) — the display/gating tier:
+  - `SessionDetailContent` (alert tier — required
+    `project: ProjectContextOrNull`; the internal ambient read and the
+    "Project ID is required" throw were deleted, so session detail renders
+    without any project context; the `session.NotInProject` alert renders
+    only when a non-null project is passed and the session's project
+    differs). `SessionDetailDrawer`, the multi-page
+    `SessionDetailAndContainerLogOpenerLegacy`, `RecentlyCreatedSession`,
+    and `DeploymentReplicasCard` are intermediates with a required
+    pass-through: general pages narrow ambient at page level, super-admin
+    pages (`/admin/session`, the scheduler page) pass `null`.
+  - `DeploymentDetailPage` serves three URL spaces; as the PAGE it decides
+    the context via `useIsSuperAdminScopedPage()`: `null` on the admin URL
+    space (no mismatch alert, no `SwitchToProjectButton` shortcut, and the
+    Add-revision CTA is no longer suppressed), narrowed ambient elsewhere.
+  - `EditableVFolderNameV2` and `VFolderNodeDescriptionV2` (ownership/role
+    gating — required `project: ProjectContextOrNull`; rename and
+    mount-permission editing are gated on the folder owner, the
+    `superadmin` effective role, or a page-decided project matching the
+    folder's own `ownership.projectId`; `null` simply never matches the
+    project branch, so super-admin abilities no longer flicker with header
+    state).
+  - The globally-mounted `FolderExplorerModalV2` (see the route-derivation
+    exception below) now keys `useMergedAllowedStorageHostPermission` to
+    the folder's own ownership project when the folder is project-owned;
+    for user-owned folders it narrows ambient only off the super-admin
+    routes (interim), and the hook accepts `projectId: null` to skip the
+    group-scope lookup entirely.
+
+  Remaining follow-up (FR-3414): hide the header selector per admin route.
+
+## Route-derived project context (`useIsSuperAdminScopedPage`)
+
+`react/src/hooks/useIsSuperAdminScopedPage.ts` exposes
+`SUPER_ADMIN_SCOPED_MENU_KEYS = ['admin-session', 'admin-deployments',
+'admin-data']` and a hook that reports whether the current route is one of
+the three super-admin-scoped pages (keyed off the deepest route
+`handle.menuKey`, with a pathname fallback for legacy unprefixed paths).
+
+Who may call it:
+
+- **Pages** (e.g. `DeploymentDetailPage`, which serves three URL spaces from
+  one component) — pages are the sanctioned ambient readers, and a
+  route-scope check at page level is just another page-level input.
+- **Globally-mounted components with no page parent** (e.g.
+  `FolderExplorerModalV2`, mounted once at the router root) — they cannot
+  receive a `project` prop from any page, so consulting the route is their
+  only correct signal. This is the single sanctioned exception.
+
+Converted **leaf components must NOT call it** — they receive the decision
+via their required `project` prop. A leaf that consults the route
+reintroduces the invisible-global failure mode this ADR exists to remove.
 
 ## How to comply (checklist for new/converted components)
 

--- a/docs/adr/0001-explicit-project-prop-contract.md
+++ b/docs/adr/0001-explicit-project-prop-contract.md
@@ -137,13 +137,20 @@ narrowing helper for the loosely-typed ambient value).
     the context via `useIsSuperAdminScopedPage()`: `null` on the admin URL
     space (no mismatch alert, no `SwitchToProjectButton` shortcut, and the
     Add-revision CTA is no longer suppressed), narrowed ambient elsewhere.
-  - `EditableVFolderNameV2` and `VFolderNodeDescriptionV2` (ownership/role
-    gating — required `project: ProjectContextOrNull`; rename and
-    mount-permission editing are gated on the folder owner, the
-    `superadmin` effective role, or a page-decided project matching the
-    folder's own `ownership.projectId`; `null` simply never matches the
-    project branch, so super-admin abilities no longer flicker with header
-    state).
+  - `EditableVFolderNameV2` and `VFolderNodeDescriptionV2` — ownership/role
+    gating. The two gates are NOT the same condition:
+    - **Rename** (`EditableVFolderNameV2`) needs the folder owner or the
+      `superadmin` role. No project is involved, so the component reads
+      `isSuperAdmin` from `useCurrentUserProjectRoles()` directly.
+    - **Mount-permission editing** (`VFolderNodeDescriptionV2`) additionally
+      admits an admin OF THE PROJECT THAT OWNS THE FOLDER — checked against
+      the folder's own `ownership.projectId`, never a page-supplied one.
+      Domain admins are excluded: they hold no implicit per-project
+      ownership rights.
+    Neither consults `useEffectiveAdminRole`, whose target project comes
+    from the ambient value — which is why the `project` prop dropped out of
+    both gates entirely, and why super-admin abilities no longer flicker
+    with header state.
   - The globally-mounted `FolderExplorerModalV2` (see the route-derivation
     exception below) now keys `useMergedAllowedStorageHostPermission` to
     the folder's own ownership project when the folder is project-owned;

--- a/react/src/__generated__/EditableVFolderNameV2TestQuery.graphql.ts
+++ b/react/src/__generated__/EditableVFolderNameV2TestQuery.graphql.ts
@@ -1,0 +1,211 @@
+/**
+ * @generated SignedSource<<9710fbc0728845731f35c4a67224a589>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type EditableVFolderNameV2TestQuery$variables = {
+  vfolderId: string;
+};
+export type EditableVFolderNameV2TestQuery$data = {
+  readonly vfolderV2: {
+    readonly " $fragmentSpreads": FragmentRefs<"EditableVFolderNameV2Fragment">;
+  } | null | undefined;
+};
+export type EditableVFolderNameV2TestQuery = {
+  response: EditableVFolderNameV2TestQuery$data;
+  variables: EditableVFolderNameV2TestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "vfolderId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "vfolderId",
+    "variableName": "vfolderId"
+  }
+],
+v2 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "UUID"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EditableVFolderNameV2TestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "VFolder",
+        "kind": "LinkedField",
+        "name": "vfolderV2",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "EditableVFolderNameV2Fragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "EditableVFolderNameV2TestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "VFolder",
+        "kind": "LinkedField",
+        "name": "vfolderV2",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "status",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "VFolderMetadataInfo",
+            "kind": "LinkedField",
+            "name": "metadata",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "VFolderOwnershipInfo",
+            "kind": "LinkedField",
+            "name": "ownership",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "userId",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "projectId",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "89a2a86e6cc2336bddaca4eb2031f5f9",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "vfolderV2": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "VFolder"
+        },
+        "vfolderV2.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        },
+        "vfolderV2.metadata": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "VFolderMetadataInfo"
+        },
+        "vfolderV2.metadata.name": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "vfolderV2.ownership": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "VFolderOwnershipInfo"
+        },
+        "vfolderV2.ownership.projectId": (v2/*: any*/),
+        "vfolderV2.ownership.userId": (v2/*: any*/),
+        "vfolderV2.status": {
+          "enumValues": [
+            "READY",
+            "CLONING",
+            "DELETE_PENDING",
+            "DELETE_ONGOING",
+            "DELETE_COMPLETE",
+            "DELETE_ERROR"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "VFolderOperationStatus"
+        }
+      }
+    },
+    "name": "EditableVFolderNameV2TestQuery",
+    "operationKind": "query",
+    "text": "query EditableVFolderNameV2TestQuery(\n  $vfolderId: UUID!\n) {\n  vfolderV2(vfolderId: $vfolderId) {\n    ...EditableVFolderNameV2Fragment\n    id\n  }\n}\n\nfragment EditableVFolderNameV2Fragment on VFolder {\n  id\n  status\n  metadata {\n    name\n  }\n  ownership {\n    userId\n    projectId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9cb8af61d6af9b23321b6fb17a5384a1";
+
+export default node;

--- a/react/src/__generated__/useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery.graphql.ts
+++ b/react/src/__generated__/useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<01f84eec24a9462f4d8a239a0f8488c5>>
+ * @generated SignedSource<<9af402f38cf05d6ce8c1dec90443b750>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,12 +13,13 @@ export type useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery$varia
   domainName?: string | null | undefined;
   projectId: string;
   resourcePolicyName?: string | null | undefined;
+  skipProjectScope: boolean;
 };
 export type useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery$data = {
   readonly domain: {
     readonly allowed_vfolder_hosts: string | null | undefined;
   } | null | undefined;
-  readonly group: {
+  readonly group?: {
     readonly allowed_vfolder_hosts: string | null | undefined;
   } | null | undefined;
   readonly keypair_resource_policy: {
@@ -46,6 +47,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "resourcePolicyName"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "skipProjectScope"
   }
 ],
 v1 = [
@@ -75,25 +81,32 @@ v2 = [
     "storageKey": null
   },
   {
-    "alias": null,
-    "args": [
+    "condition": "skipProjectScope",
+    "kind": "Condition",
+    "passingValue": false,
+    "selections": [
       {
-        "kind": "Variable",
-        "name": "domain_name",
-        "variableName": "domainName"
-      },
-      {
-        "kind": "Variable",
-        "name": "id",
-        "variableName": "projectId"
+        "alias": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "domain_name",
+            "variableName": "domainName"
+          },
+          {
+            "kind": "Variable",
+            "name": "id",
+            "variableName": "projectId"
+          }
+        ],
+        "concreteType": "Group",
+        "kind": "LinkedField",
+        "name": "group",
+        "plural": false,
+        "selections": (v1/*: any*/),
+        "storageKey": null
       }
-    ],
-    "concreteType": "Group",
-    "kind": "LinkedField",
-    "name": "group",
-    "plural": false,
-    "selections": (v1/*: any*/),
-    "storageKey": null
+    ]
   },
   {
     "alias": null,
@@ -130,16 +143,16 @@ return {
     "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "f7d16150a7d77cb465733a2933a08261",
+    "cacheID": "d7039e705450efc38a646cd5cdc70184",
     "id": null,
     "metadata": {},
     "name": "useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery",
     "operationKind": "query",
-    "text": "query useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery(\n  $domainName: String\n  $projectId: UUID!\n  $resourcePolicyName: String\n) {\n  domain(name: $domainName) {\n    allowed_vfolder_hosts\n  }\n  group(id: $projectId, domain_name: $domainName) {\n    allowed_vfolder_hosts\n  }\n  keypair_resource_policy(name: $resourcePolicyName) {\n    allowed_vfolder_hosts\n  }\n}\n"
+    "text": "query useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery(\n  $domainName: String\n  $projectId: UUID!\n  $resourcePolicyName: String\n  $skipProjectScope: Boolean!\n) {\n  domain(name: $domainName) {\n    allowed_vfolder_hosts\n  }\n  group(id: $projectId, domain_name: $domainName) @skip(if: $skipProjectScope) {\n    allowed_vfolder_hosts\n  }\n  keypair_resource_policy(name: $resourcePolicyName) {\n    allowed_vfolder_hosts\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "616594ca9d6c787458c32688c1a25b1f";
+(node as any).hash = "ad7ef1c40361740cddc3f40566121f8c";
 
 export default node;

--- a/react/src/components/DeploymentReplicasCard.tsx
+++ b/react/src/components/DeploymentReplicasCard.tsx
@@ -11,6 +11,7 @@ import type { DeploymentRevisionDetail_revision$key } from '../__generated__/Dep
 import { RouteSchedulingHistoryModalQuery } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { ProjectContextOrNull } from '../types/projectContext';
 import { theme } from '../theme-shim';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from './BAIErrorBoundary';
@@ -100,6 +101,12 @@ interface DeploymentReplicasCardProps {
   // and replicas are spawned) — combined with the local manual-refresh key so
   // either event re-issues the list query.
   replicaFetchKey?: string;
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3413): pass-through to the
+   * replica session-detail drawer. The deployment detail page decides the
+   * project context (`null` on the admin URL space).
+   */
+  project: ProjectContextOrNull;
 }
 
 /**
@@ -112,6 +119,7 @@ const DeploymentReplicasCard: React.FC<DeploymentReplicasCardProps> = ({
   deploymentFrgmt,
   deploymentId,
   replicaFetchKey,
+  project,
 }) => {
   'use memo';
   const { t } = useTranslation();
@@ -138,6 +146,7 @@ const DeploymentReplicasCard: React.FC<DeploymentReplicasCardProps> = ({
             deploymentFrgmt={deploymentFrgmt}
             deploymentId={deploymentId}
             replicaFetchKey={replicaFetchKey}
+            project={project}
           />
         </Suspense>
       </BAIErrorBoundary>
@@ -149,6 +158,7 @@ const DeploymentReplicasCardContent: React.FC<DeploymentReplicasCardProps> = ({
   deploymentFrgmt,
   deploymentId,
   replicaFetchKey,
+  project,
 }) => {
   'use memo';
   const { t } = useTranslation();
@@ -607,6 +617,7 @@ const DeploymentReplicasCardContent: React.FC<DeploymentReplicasCardProps> = ({
         <SessionDetailDrawer
           open={!!selectedSessionId}
           sessionId={selectedSessionId ?? undefined}
+          project={project}
           onClose={() => setSelectedSessionId(null)}
         />
       </BAIUnmountAfterClose>

--- a/react/src/components/EditableVFolderNameV2.test.tsx
+++ b/react/src/components/EditableVFolderNameV2.test.tsx
@@ -9,7 +9,6 @@ import EditableVFolderNameV2 from './EditableVFolderNameV2';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { App } from 'antd';
 import { Suspense } from 'react';
 import {
   graphql,
@@ -125,7 +124,7 @@ const TestRenderer: React.FC<{ project: ProjectContextOrNull }> = ({
       vfolderNodeFrgmt={data.vfolderV2}
       project={project}
       enableLink={false}
-      editable={{ triggerType: ['icon'] }}
+      editable
     />
   );
 };
@@ -159,11 +158,11 @@ const renderName = ({
   render(
     <RelayEnvironmentProvider environment={environment}>
       <QueryClientProvider client={queryClient}>
-        <App>
+        <>
           <Suspense fallback={null}>
             <TestRenderer project={project} />
           </Suspense>
-        </App>
+        </>
       </QueryClientProvider>
     </RelayEnvironmentProvider>,
   );

--- a/react/src/components/EditableVFolderNameV2.test.tsx
+++ b/react/src/components/EditableVFolderNameV2.test.tsx
@@ -1,0 +1,226 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import type { EditableVFolderNameV2TestQuery } from '../__generated__/EditableVFolderNameV2TestQuery.graphql';
+import type { EffectiveAdminRole } from '../hooks/useCurrentUserProjectRoles';
+import { ProjectContextOrNull } from '../types/projectContext';
+import EditableVFolderNameV2 from './EditableVFolderNameV2';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { App } from 'antd';
+import { Suspense } from 'react';
+import {
+  graphql,
+  RelayEnvironmentProvider,
+  useLazyLoadQuery,
+} from 'react-relay';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * Contract tests for the ownership/role-based rename gate (ADR-0001,
+ * FR-3413). Rename is allowed for the folder owner, super admins, or when
+ * the page-passed `project` matches the folder's own ownership project —
+ * never derived from the ambient current project. External behavior only:
+ * the presence/absence of the rename (edit) trigger in the rendered output.
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: {
+        language: 'en',
+        changeLanguage: () => new Promise(() => {}),
+      },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: {
+      type: '3rdParty',
+      init: () => {},
+    },
+  };
+});
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => ({
+      supports: () => false,
+      vfolder: { rename: vi.fn() },
+    }),
+  };
+});
+
+vi.mock('../hooks/backendai', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/backendai')>();
+  return {
+    ...originalModule,
+    useCurrentUserInfo: () => [{ uuid: 'current-user-uuid' }, vi.fn()],
+  };
+});
+
+// The effective admin role is pinned per test scenario.
+let mockEffectiveAdminRole: EffectiveAdminRole = 'none';
+vi.mock('../hooks/useCurrentUserProjectRoles', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<
+      typeof import('../hooks/useCurrentUserProjectRoles')
+    >();
+  return {
+    ...originalModule,
+    useEffectiveAdminRole: () => mockEffectiveAdminRole,
+  };
+});
+
+// Decoy ambient project: its id matches the folder's ownership project, so a
+// regression back to ambient-derived gating would make the "null project"
+// scenarios below editable — and fail.
+vi.mock('../hooks/useCurrentProject', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useCurrentProject')>();
+  return {
+    ...originalModule,
+    useCurrentProjectValue: () => ({
+      id: 'folder-project-id',
+      name: 'ambient-project-name',
+    }),
+  };
+});
+
+vi.mock('./FolderExplorerOpener', () => ({
+  useFolderExplorerOpener: () => ({
+    open: vi.fn(),
+    generateFolderPath: (id: string) => `/folder/${id}`,
+  }),
+}));
+
+const TestRenderer: React.FC<{ project: ProjectContextOrNull }> = ({
+  project,
+}) => {
+  const data = useLazyLoadQuery<EditableVFolderNameV2TestQuery>(
+    graphql`
+      query EditableVFolderNameV2TestQuery($vfolderId: UUID!)
+      @relay_test_operation {
+        vfolderV2(vfolderId: $vfolderId) {
+          ...EditableVFolderNameV2Fragment
+        }
+      }
+    `,
+    { vfolderId: '00000000-0000-0000-0000-000000000000' },
+  );
+  if (!data.vfolderV2) return null;
+  return (
+    <EditableVFolderNameV2
+      vfolderNodeFrgmt={data.vfolderV2}
+      project={project}
+      enableLink={false}
+      editable={{ triggerType: ['icon'] }}
+    />
+  );
+};
+
+const renderName = ({
+  project,
+  ownerUserId,
+  ownershipProjectId,
+}: {
+  project: ProjectContextOrNull;
+  ownerUserId: string;
+  ownershipProjectId: string | null;
+}) => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  environment.mock.queueOperationResolver((operation: any) =>
+    MockPayloadGenerator.generate(operation, {
+      VFolder: () => ({
+        id: btoa('VFolder:folder-0000'),
+        status: 'ready',
+        metadata: { name: 'test-folder' },
+        ownership: {
+          userId: ownerUserId,
+          projectId: ownershipProjectId,
+        },
+      }),
+    }),
+  );
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <QueryClientProvider client={queryClient}>
+        <App>
+          <Suspense fallback={null}>
+            <TestRenderer project={project} />
+          </Suspense>
+        </App>
+      </QueryClientProvider>
+    </RelayEnvironmentProvider>,
+  );
+};
+
+const findEditTrigger = async () => {
+  await screen.findByText('test-folder');
+  // antd Typography renders the rename trigger with the
+  // `ant-typography-edit` class when `editable` resolves truthy.
+  return document.querySelector('.ant-typography-edit');
+};
+
+describe('EditableVFolderNameV2 rename gate (ADR-0001, FR-3413)', () => {
+  beforeEach(() => {
+    mockEffectiveAdminRole = 'none';
+  });
+
+  it('lets the folder owner rename regardless of project context (project null)', async () => {
+    renderName({
+      project: null,
+      ownerUserId: 'current-user-uuid',
+      ownershipProjectId: 'folder-project-id',
+    });
+    expect(await findEditTrigger()).toBeInTheDocument();
+  });
+
+  it("lets a super admin rename another user's folder with project null", async () => {
+    mockEffectiveAdminRole = 'superadmin';
+    renderName({
+      project: null,
+      ownerUserId: 'someone-else-uuid',
+      ownershipProjectId: 'folder-project-id',
+    });
+    expect(await findEditTrigger()).toBeInTheDocument();
+  });
+
+  it('lets a member rename when the passed project matches the folder ownership project', async () => {
+    renderName({
+      project: { id: 'folder-project-id', name: 'folder-project' },
+      ownerUserId: 'someone-else-uuid',
+      ownershipProjectId: 'folder-project-id',
+    });
+    expect(await findEditTrigger()).toBeInTheDocument();
+  });
+
+  it('does NOT allow rename with project null for a non-owner non-superadmin, even though the ambient decoy matches', async () => {
+    renderName({
+      project: null,
+      ownerUserId: 'someone-else-uuid',
+      ownershipProjectId: 'folder-project-id',
+    });
+    expect(await findEditTrigger()).not.toBeInTheDocument();
+  });
+
+  it('does NOT allow rename when the passed project differs from the folder ownership project', async () => {
+    renderName({
+      project: { id: 'passed-other-project-id', name: 'other-project' },
+      ownerUserId: 'someone-else-uuid',
+      ownershipProjectId: 'folder-project-id',
+    });
+    expect(await findEditTrigger()).not.toBeInTheDocument();
+  });
+});

--- a/react/src/components/EditableVFolderNameV2.test.tsx
+++ b/react/src/components/EditableVFolderNameV2.test.tsx
@@ -4,7 +4,6 @@
  */
 import '../../__test__/matchMedia.mock.js';
 import type { EditableVFolderNameV2TestQuery } from '../__generated__/EditableVFolderNameV2TestQuery.graphql';
-import type { EffectiveAdminRole } from '../hooks/useCurrentUserProjectRoles';
 import { ProjectContextOrNull } from '../types/projectContext';
 import EditableVFolderNameV2 from './EditableVFolderNameV2';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -67,8 +66,8 @@ vi.mock('../hooks/backendai', async (importOriginal) => {
   };
 });
 
-// The effective admin role is pinned per test scenario.
-let mockEffectiveAdminRole: EffectiveAdminRole = 'none';
+// Super-admin status is pinned per test scenario.
+let mockIsSuperAdmin = false;
 vi.mock('../hooks/useCurrentUserProjectRoles', async (importOriginal) => {
   const originalModule =
     await importOriginal<
@@ -76,7 +75,11 @@ vi.mock('../hooks/useCurrentUserProjectRoles', async (importOriginal) => {
     >();
   return {
     ...originalModule,
-    useEffectiveAdminRole: () => mockEffectiveAdminRole,
+    useCurrentUserProjectRoles: () => ({
+      isSuperAdmin: mockIsSuperAdmin,
+      domainAdminDomains: [],
+      projectAdminIds: [],
+    }),
   };
 });
 
@@ -175,7 +178,7 @@ const findEditTrigger = async () => {
 
 describe('EditableVFolderNameV2 rename gate (ADR-0001, FR-3413)', () => {
   beforeEach(() => {
-    mockEffectiveAdminRole = 'none';
+    mockIsSuperAdmin = false;
   });
 
   it('lets the folder owner rename regardless of project context (project null)', async () => {
@@ -188,7 +191,7 @@ describe('EditableVFolderNameV2 rename gate (ADR-0001, FR-3413)', () => {
   });
 
   it("lets a super admin rename another user's folder with project null", async () => {
-    mockEffectiveAdminRole = 'superadmin';
+    mockIsSuperAdmin = true;
     renderName({
       project: null,
       ownerUserId: 'someone-else-uuid',

--- a/react/src/components/EditableVFolderNameV2.test.tsx
+++ b/react/src/components/EditableVFolderNameV2.test.tsx
@@ -10,6 +10,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import {
   graphql,
   RelayEnvironmentProvider,
@@ -156,23 +157,26 @@ const renderName = ({
     defaultOptions: { queries: { retry: false } },
   });
   render(
-    <RelayEnvironmentProvider environment={environment}>
-      <QueryClientProvider client={queryClient}>
-        <>
+    // The name renders as a router `Link` when `enableLink` is on, and the
+    // component calls `useWebUINavigate()` unconditionally.
+    <MemoryRouter>
+      <RelayEnvironmentProvider environment={environment}>
+        <QueryClientProvider client={queryClient}>
           <Suspense fallback={null}>
             <TestRenderer project={project} />
           </Suspense>
-        </>
-      </QueryClientProvider>
-    </RelayEnvironmentProvider>,
+        </QueryClientProvider>
+      </RelayEnvironmentProvider>
+    </MemoryRouter>,
   );
 };
 
 const findEditTrigger = async () => {
   await screen.findByText('test-folder');
-  // antd Typography renders the rename trigger with the
-  // `ant-typography-edit` class when `editable` resolves truthy.
-  return document.querySelector('.ant-typography-edit');
+  // The rename trigger is a pencil `IconButton` whose accessible name is
+  // `button.Edit` (raw key — see the `react-i18next` mock above). It is
+  // rendered only when the gate resolves truthy.
+  return screen.queryByRole('button', { name: 'button.Edit' });
 };
 
 describe('EditableVFolderNameV2 rename gate (ADR-0001, FR-3413)', () => {

--- a/react/src/components/EditableVFolderNameV2.tsx
+++ b/react/src/components/EditableVFolderNameV2.tsx
@@ -27,7 +27,7 @@ import { Form } from '../form-engine';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { useEffectiveAdminRole } from '../hooks/useCurrentUserProjectRoles';
+import { useCurrentUserProjectRoles } from '../hooks/useCurrentUserProjectRoles';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
 import { ProjectContextOrNull } from '../types/projectContext';
 import BAIFormItem from './BAIFormItem';
@@ -98,7 +98,9 @@ const EditableVFolderNameV2: React.FC<EditableVFolderNameV2Props> = ({
     vfolderNode.metadata?.name,
   );
   const [userInfo] = useCurrentUserInfo();
-  const effectiveAdminRole = useEffectiveAdminRole();
+  // Not `useEffectiveAdminRole` — it resolves its target from the ambient
+  // project, which this contract must not depend on.
+  const { isSuperAdmin } = useCurrentUserProjectRoles();
   const baiClient = useSuspendedBackendaiClient();
   const renameMutation = useTanMutation({
     mutationFn: (input: { id: string; name: string }) => {
@@ -121,7 +123,7 @@ const EditableVFolderNameV2: React.FC<EditableVFolderNameV2Props> = ({
   const isEditingAllowed =
     editable &&
     (userInfo.uuid === vfolderNode.ownership?.userId ||
-      effectiveAdminRole === 'superadmin' ||
+      isSuperAdmin ||
       (project !== null &&
         !!vfolderNode.ownership?.projectId &&
         project.id === vfolderNode.ownership.projectId)) &&

--- a/react/src/components/EditableVFolderNameV2.tsx
+++ b/react/src/components/EditableVFolderNameV2.tsx
@@ -27,8 +27,9 @@ import { Form } from '../form-engine';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useEffectiveAdminRole } from '../hooks/useCurrentUserProjectRoles';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
+import { ProjectContextOrNull } from '../types/projectContext';
 import BAIFormItem from './BAIFormItem';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import { AstryxFormTextInput } from './astryxFormControls';
@@ -49,6 +50,14 @@ import {
 
 interface EditableVFolderNameV2Props {
   vfolderNodeFrgmt: EditableVFolderNameV2Fragment$key;
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3413): the project context
+   * the page decided on, compared against the folder's ownership project for
+   * the rename gate. With `null` (super-admin pages) the project-membership
+   * branch simply doesn't match — the folder owner and super admins keep
+   * their rename power. Never reads the ambient current project.
+   */
+  project: ProjectContextOrNull;
   enableLink?: boolean;
   /** `'title'` renders an Astryx `Heading level={3}`; `'text'` a body `Text`. */
   variant?: 'text' | 'title';
@@ -60,6 +69,7 @@ interface EditableVFolderNameV2Props {
 
 const EditableVFolderNameV2: React.FC<EditableVFolderNameV2Props> = ({
   vfolderNodeFrgmt,
+  project,
   enableLink = true,
   variant = 'text',
   editable = false,
@@ -88,7 +98,7 @@ const EditableVFolderNameV2: React.FC<EditableVFolderNameV2Props> = ({
     vfolderNode.metadata?.name,
   );
   const [userInfo] = useCurrentUserInfo();
-  const currentProject = useCurrentProjectValue();
+  const effectiveAdminRole = useEffectiveAdminRole();
   const baiClient = useSuspendedBackendaiClient();
   const renameMutation = useTanMutation({
     mutationFn: (input: { id: string; name: string }) => {
@@ -104,10 +114,17 @@ const EditableVFolderNameV2: React.FC<EditableVFolderNameV2Props> = ({
   const navigate = useWebUINavigate();
   const [isEditing, setIsEditing] = useState(false);
 
+  // Rename is allowed for the folder owner, super admins (any project —
+  // their power must not flicker with header state), or members of the
+  // page-decided project when the folder belongs to that project. With
+  // `project === null` the membership branch never matches.
   const isEditingAllowed =
     editable &&
     (userInfo.uuid === vfolderNode.ownership?.userId ||
-      currentProject?.id === vfolderNode.ownership?.projectId) &&
+      effectiveAdminRole === 'superadmin' ||
+      (project !== null &&
+        !!vfolderNode.ownership?.projectId &&
+        project.id === vfolderNode.ownership.projectId)) &&
     !isDeletedCategory(vfolderNode.status);
 
   const isPendingRenameMutation =

--- a/react/src/components/FolderExplorerHeaderV2.tsx
+++ b/react/src/components/FolderExplorerHeaderV2.tsx
@@ -25,9 +25,11 @@ interface FolderExplorerHeaderV2Props {
   vfolderNodeFrgmt?: FolderExplorerHeaderV2Fragment$key | null;
   titleStyle?: React.CSSProperties;
   /**
-   * Explicit project prop contract (ADR-0001, FR-3412): pass-through for the
-   * FileBrowser/SFTP session-launch buttons. `null` renders them disabled
-   * with `noProjectTooltip` as the reason.
+   * Explicit project prop contract (ADR-0001, FR-3412/FR-3413): pass-through
+   * for the FileBrowser/SFTP session-launch buttons (`null` renders them
+   * disabled with `noProjectTooltip` as the reason) and for the rename
+   * gating of `EditableVFolderNameV2` (`null` drops the project-membership
+   * branch — owner/super-admin keep their power).
    */
   project: ProjectContextOrNull;
   noProjectTooltip?: string;
@@ -98,6 +100,7 @@ const FolderExplorerHeaderV2: React.FC<FolderExplorerHeaderV2Props> = ({
         {vfolderNode && (
           <EditableVFolderNameV2
             vfolderNodeFrgmt={vfolderNode}
+            project={project}
             enableLink={false}
             variant="title"
             style={{

--- a/react/src/components/FolderExplorerModalV2.test.tsx
+++ b/react/src/components/FolderExplorerModalV2.test.tsx
@@ -8,7 +8,6 @@ import FolderExplorerModalV2 from './FolderExplorerModalV2';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { App } from 'antd';
 import { Suspense } from 'react';
 import { RelayEnvironmentProvider } from 'react-relay';
 import { MemoryRouter } from 'react-router-dom';
@@ -251,7 +250,7 @@ const renderModal = ({
     <RelayEnvironmentProvider environment={environment}>
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <App>
+          <>
             <Suspense fallback={null}>
               <FolderExplorerModalV2
                 vfolderID={VFOLDER_UUID.replaceAll('-', '')}
@@ -259,7 +258,7 @@ const renderModal = ({
                 onRequestClose={vi.fn()}
               />
             </Suspense>
-          </App>
+          </>
         </MemoryRouter>
       </QueryClientProvider>
     </RelayEnvironmentProvider>,

--- a/react/src/components/FolderExplorerModalV2.test.tsx
+++ b/react/src/components/FolderExplorerModalV2.test.tsx
@@ -1,0 +1,362 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import FolderExplorerModalV2 from './FolderExplorerModalV2';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App } from 'antd';
+import { Suspense } from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { MemoryRouter } from 'react-router-dom';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * Contract tests for the globally-mounted folder explorer (ADR-0001,
+ * FR-3413). The modal is the sanctioned route-consulting exception: on
+ * super-admin-scoped routes it feeds `project={null}` (+ tooltip) to the
+ * header's FileBrowser/SFTP buttons and suppresses the ownership-mismatch
+ * alert; permission calculation follows the folder's OWN ownership project
+ * when the folder is project-owned. External behavior only: rendered output
+ * and query variables (with an ambient decoy that must never leak through).
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: {
+        language: 'en',
+        changeLanguage: () => new Promise(() => {}),
+      },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: {
+      type: '3rdParty',
+      init: () => {},
+    },
+  };
+});
+
+const { mockBaiClient, mockListHosts } = vi.hoisted(() => {
+  const mockListHosts = vi.fn(() =>
+    Promise.resolve({
+      allowed: ['local:volume1'],
+      default: 'local:volume1',
+      volume_info: {
+        'local:volume1': {
+          backend: 'vfs',
+          capabilities: [],
+          sftp_scaling_groups: [],
+        },
+      },
+    }),
+  );
+  const mockBaiClient = {
+    _config: {
+      accessKey: 'test-access-key',
+      domainName: 'default',
+    },
+    supports: () => false,
+    vfolder: {
+      list_hosts: mockListHosts,
+    },
+  };
+  return { mockBaiClient, mockListHosts };
+});
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => mockBaiClient,
+    useCurrentDomainValue: () => 'default',
+    useWebUINavigate: () => vi.fn(),
+  };
+});
+
+// Decoy ambient project: on super-admin routes nothing rendered by the modal
+// may key off it — the permission-query and button assertions below would
+// surface `ambient-project-id` if it leaked through.
+vi.mock('../hooks/useCurrentProject', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useCurrentProject')>();
+  return {
+    ...originalModule,
+    useCurrentProjectValue: () => ({
+      id: 'ambient-project-id',
+      name: 'ambient-project-name',
+    }),
+    useCurrentResourceGroupState: () => [null, vi.fn()] as const,
+  };
+});
+
+// Route derivation is covered by useIsSuperAdminScopedPage.test.tsx; here it
+// is pinned per scenario (the sanctioned location mock for route-derived
+// pieces).
+let mockIsSuperAdminScopedPage = false;
+vi.mock('../hooks/useIsSuperAdminScopedPage', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useIsSuperAdminScopedPage')>();
+  return {
+    ...originalModule,
+    useIsSuperAdminScopedPage: () => mockIsSuperAdminScopedPage,
+  };
+});
+
+// Rename gating inside the header has its own contract test
+// (EditableVFolderNameV2.test.tsx); pin a role so no roles query is issued.
+vi.mock('../hooks/useCurrentUserProjectRoles', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<
+      typeof import('../hooks/useCurrentUserProjectRoles')
+    >();
+  return {
+    ...originalModule,
+    useEffectiveAdminRole: () => 'superadmin' as const,
+  };
+});
+
+vi.mock('../hooks/backendai', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/backendai')>();
+  return {
+    ...originalModule,
+    useCurrentUserInfo: () => [{ uuid: 'current-user-uuid' }, vi.fn()],
+  };
+});
+
+vi.mock('../hooks/useBAINotification', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useBAINotification')>();
+  return {
+    ...originalModule,
+    useSetBAINotification: () => ({
+      upsertNotification: vi.fn(),
+      closeNotification: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../hooks/useRouteScope', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useRouteScope')>();
+  return {
+    ...originalModule,
+    useProjectPath: () => (path: string) => `/${path}`,
+  };
+});
+
+vi.mock('../hooks/useDefaultImagesWithFallback', () => ({
+  useDefaultFileBrowserImageWithFallback: () =>
+    'cr.backend.ai/stable/filebrowser:21.02@x86_64',
+  useDefaultSystemSSHImageWithFallback: () => ({
+    systemSSHImage: 'cr.backend.ai/stable/ssh:latest@x86_64',
+  }),
+}));
+
+vi.mock('./FolderExplorerOpener', () => ({
+  useFolderExplorerOpener: () => ({
+    open: vi.fn(),
+    generateFolderPath: (id: string) => `/folder/${id}`,
+  }),
+}));
+
+vi.mock('./FileUploadManager', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('./FileUploadManager')>();
+  return {
+    ...originalModule,
+    useFileUploadManager: () => ({
+      uploadStatus: null,
+      uploadFiles: vi.fn(),
+    }),
+  };
+});
+
+// The file table itself is out of contract scope — stub it.
+vi.mock('backend.ai-ui', async (importOriginal) => {
+  const React = await import('react');
+  const originalModule = await importOriginal<typeof import('backend.ai-ui')>();
+  const MockFileExplorer = React.forwardRef(function MockFileExplorer() {
+    return React.createElement('div', { 'data-testid': 'mock-file-explorer' });
+  });
+  return {
+    ...originalModule,
+    BAIFileExplorer: MockFileExplorer,
+  };
+});
+
+// Probe: surfaces the project the modal hands to the metadata description.
+vi.mock('./VFolderNodeDescriptionV2', async () => {
+  const React = await import('react');
+  return {
+    default: (props: any) =>
+      React.createElement('div', {
+        'data-testid': 'mock-vfolder-description',
+        'data-project-id': props.project?.id ?? '',
+      }),
+  };
+});
+
+const VFOLDER_UUID = '11111111-2222-3333-4444-555555555555';
+
+const renderModal = ({
+  ownershipProjectId,
+}: {
+  ownershipProjectId: string | null;
+}) => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  const resolver = (operation: any) =>
+    MockPayloadGenerator.generate(operation, {
+      VFolder: () => ({
+        id: btoa(`VFolder:${VFOLDER_UUID}`),
+        host: 'local:volume1',
+        unmanagedPath: null,
+        status: 'ready',
+        metadata: { name: 'test-folder' },
+        ownership: {
+          userId: 'someone-else-uuid',
+          projectId: ownershipProjectId,
+          project: ownershipProjectId
+            ? { basicInfo: { name: 'folder-project-name' } }
+            : null,
+        },
+      }),
+      KeyPair: () => ({ resource_policy: 'default' }),
+      Domain: () => ({
+        allowed_vfolder_hosts: JSON.stringify({
+          'local:volume1': ['download-file', 'upload-file'],
+        }),
+      }),
+      Group: () => ({ allowed_vfolder_hosts: '{}' }),
+      KeyPairResourcePolicy: () => ({ allowed_vfolder_hosts: '{}' }),
+    });
+  const seenOperations: Array<{ name: string; variables: any }> = [];
+  for (let i = 0; i < 12; i++) {
+    environment.mock.queueOperationResolver((operation: any) => {
+      seenOperations.push({
+        name: operation.request.node.params.name,
+        variables: operation.request.variables,
+      });
+      return resolver(operation);
+    });
+  }
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <App>
+            <Suspense fallback={null}>
+              <FolderExplorerModalV2
+                vfolderID={VFOLDER_UUID.replaceAll('-', '')}
+                open
+                onRequestClose={vi.fn()}
+              />
+            </Suspense>
+          </App>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </RelayEnvironmentProvider>,
+  );
+  return { seenOperations };
+};
+
+const findPermissionOperation = (
+  seenOperations: Array<{ name: string; variables: any }>,
+) =>
+  seenOperations.find(
+    (op) =>
+      op.name ===
+      'useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery',
+  );
+
+describe('FolderExplorerModalV2 project context (ADR-0001, FR-3413)', () => {
+  beforeEach(() => {
+    mockIsSuperAdminScopedPage = false;
+    mockListHosts.mockClear();
+  });
+
+  it('on a super-admin route: buttons disabled with the admin-menu tooltip, no mismatch alert, permission keyed to the folder ownership project', async () => {
+    mockIsSuperAdminScopedPage = true;
+    const { seenOperations } = renderModal({
+      ownershipProjectId: 'folder-project-id',
+    });
+
+    // FileBrowser / SFTP render their `project === null` disabled branch.
+    const fileBrowserButton = await screen.findByRole('button', {
+      name: 'File Browser',
+    });
+    expect(fileBrowserButton).toBeDisabled();
+    const sftpButton = screen.getByRole('button', { name: 'SSH / SFTP' });
+    expect(sftpButton).toBeDisabled();
+
+    // The page-provided reason surfaces on hover.
+    fireEvent.mouseEnter(fileBrowserButton.closest('.ant-space-compact')!);
+    expect(
+      await screen.findByText('data.CannotLaunchSessionInAdminMenu'),
+    ).toBeInTheDocument();
+
+    // Ownership-mismatch alert is suppressed even though the ambient decoy
+    // differs from the folder's project.
+    expect(screen.queryByText('data.NotInProject')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('data.BelongsToDifferentProject'),
+    ).not.toBeInTheDocument();
+
+    // Permission calculation follows the folder's OWN project — never the
+    // ambient decoy.
+    const permissionOperation = findPermissionOperation(seenOperations);
+    expect(permissionOperation?.variables.projectId).toBe('folder-project-id');
+    expect(permissionOperation?.variables.skipProjectScope).toBe(false);
+
+    // The metadata description receives `null` as well.
+    expect(screen.getByTestId('mock-vfolder-description')).toHaveAttribute(
+      'data-project-id',
+      '',
+    );
+  });
+
+  it('on a super-admin route with a user-owned folder: skips the group-scope permission lookup instead of falling back to the ambient project', async () => {
+    mockIsSuperAdminScopedPage = true;
+    const { seenOperations } = renderModal({ ownershipProjectId: null });
+
+    await screen.findByTestId('mock-file-explorer');
+
+    const permissionOperation = findPermissionOperation(seenOperations);
+    expect(permissionOperation?.variables.skipProjectScope).toBe(true);
+    expect(permissionOperation?.variables.projectId).not.toBe(
+      'ambient-project-id',
+    );
+  });
+
+  it('on a general route: keeps the ownership-mismatch alert and keys permissions to the folder ownership project', async () => {
+    const { seenOperations } = renderModal({
+      ownershipProjectId: 'folder-project-id',
+    });
+
+    // The folder belongs to a different project than the (page-level,
+    // narrowed-ambient) current project — the alert stays, as today.
+    expect(await screen.findByText('data.NotInProject')).toBeInTheDocument();
+
+    // Permission calculation now follows the folder's own project (FR-3413
+    // acceptance criterion) instead of the header selection.
+    const permissionOperation = findPermissionOperation(seenOperations);
+    expect(permissionOperation?.variables.projectId).toBe('folder-project-id');
+
+    // The description receives the page project (narrowed ambient).
+    expect(screen.getByTestId('mock-vfolder-description')).toHaveAttribute(
+      'data-project-id',
+      'ambient-project-id',
+    );
+  });
+});

--- a/react/src/components/FolderExplorerModalV2.test.tsx
+++ b/react/src/components/FolderExplorerModalV2.test.tsx
@@ -296,10 +296,15 @@ describe('FolderExplorerModalV2 project context (ADR-0001, FR-3413)', () => {
     expect(sftpButton).toBeDisabled();
 
     // The page-provided reason surfaces on hover.
-    fireEvent.mouseEnter(fileBrowserButton.closest('.ant-space-compact')!);
+    // antd `Space.Compact` -> Astryx `ButtonGroup` (`role="group"`). The
+    // tooltip stays on the GROUP because a disabled button swallows hover.
+    fireEvent.mouseEnter(fileBrowserButton.closest('[role="group"]')!);
+    // Both launch buttons carry the same page-provided reason, so the text
+    // appears twice — one tooltip per ButtonGroup.
     expect(
-      await screen.findByText('data.CannotLaunchSessionInAdminMenu'),
-    ).toBeInTheDocument();
+      (await screen.findAllByText('data.CannotLaunchSessionInAdminMenu'))
+        .length,
+    ).toBeGreaterThan(0);
 
     // Ownership-mismatch alert is suppressed even though the ambient decoy
     // differs from the folder's project.

--- a/react/src/components/FolderExplorerModalV2.test.tsx
+++ b/react/src/components/FolderExplorerModalV2.test.tsx
@@ -193,15 +193,11 @@ vi.mock('backend.ai-ui', async (importOriginal) => {
   };
 });
 
-// Probe: surfaces the project the modal hands to the metadata description.
 vi.mock('./VFolderNodeDescriptionV2', async () => {
   const React = await import('react');
   return {
-    default: (props: any) =>
-      React.createElement('div', {
-        'data-testid': 'mock-vfolder-description',
-        'data-project-id': props.project?.id ?? '',
-      }),
+    default: () =>
+      React.createElement('div', { 'data-testid': 'mock-vfolder-description' }),
   };
 });
 
@@ -318,12 +314,6 @@ describe('FolderExplorerModalV2 project context (ADR-0001, FR-3413)', () => {
     const permissionOperation = findPermissionOperation(seenOperations);
     expect(permissionOperation?.variables.projectId).toBe('folder-project-id');
     expect(permissionOperation?.variables.skipProjectScope).toBe(false);
-
-    // The metadata description receives `null` as well.
-    expect(screen.getByTestId('mock-vfolder-description')).toHaveAttribute(
-      'data-project-id',
-      '',
-    );
   });
 
   it('on a super-admin route with a user-owned folder: skips the group-scope permission lookup instead of falling back to the ambient project', async () => {
@@ -352,11 +342,5 @@ describe('FolderExplorerModalV2 project context (ADR-0001, FR-3413)', () => {
     // acceptance criterion) instead of the header selection.
     const permissionOperation = findPermissionOperation(seenOperations);
     expect(permissionOperation?.variables.projectId).toBe('folder-project-id');
-
-    // The description receives the page project (narrowed ambient).
-    expect(screen.getByTestId('mock-vfolder-description')).toHaveAttribute(
-      'data-project-id',
-      'ambient-project-id',
-    );
   });
 });

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -25,6 +25,7 @@ import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useIsSuperAdminScopedPage } from '../hooks/useIsSuperAdminScopedPage';
 import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
 import { useBAIBreakpoint } from '../theme-shim';
 import { toProjectContext } from '../types/projectContext';
@@ -114,18 +115,18 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
   const [fetchKey, updateFetchKey] = useFetchKey();
   const baiClient = useSuspendedBackendaiClient();
   const currentDomain = useCurrentDomainValue();
+  // This modal is globally mounted (no page parent), so it is the sanctioned
+  // exception (ADR-0001) that may consult the route to decide its project
+  // context: on the super-admin-scoped routes there is no ambient project
+  // context; elsewhere it narrows the ambient current project (interim state
+  // until a page-owned opener exists).
+  const isSuperAdminScopedPage = useIsSuperAdminScopedPage();
   const currentProject = useCurrentProjectValue();
-  if (!currentProject.id) {
-    throw new Error('Project ID is required for FolderExplorerModalV2');
-  }
+  const pageProject = isSuperAdminScopedPage
+    ? null
+    : toProjectContext(currentProject);
   const currentUserAccessKey = baiClient?._config?.accessKey;
   const fileExplorerRef = useRef<BAIFileExplorerRef>(null);
-  const { unitedAllowedPermissionByVolume } =
-    useMergedAllowedStorageHostPermission(
-      currentDomain,
-      currentProject.id,
-      currentUserAccessKey,
-    );
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
   // The info panel keeps its antd-Splitter geometry: default 45%, min 550px.
@@ -171,6 +172,20 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
         deferredOpen && modalProps.open ? 'store-and-network' : 'store-only',
     },
   );
+
+  // Permission calculation follows the folder's own ownership project when
+  // the folder is project-owned (what the user can do must not depend on the
+  // header selection). For user-owned folders there is no ownership project:
+  // keep the previous ambient scope on general pages, and skip the
+  // group-scope lookup entirely on super-admin routes (`null`).
+  const permissionProjectId =
+    vfolderNode?.ownership?.projectId ?? pageProject?.id ?? null;
+  const { unitedAllowedPermissionByVolume } =
+    useMergedAllowedStorageHostPermission(
+      currentDomain,
+      permissionProjectId,
+      currentUserAccessKey,
+    );
 
   // FIXME: This is a temporary workaround to notify file deletion to use WebUI Notification.
   const { upsertNotification, closeNotification } = useSetBAINotification();
@@ -372,7 +387,10 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
           label: t('explorer.Metadata'),
           children: (
             <div style={infoPanelPanelStyle}>
-              <VFolderNodeDescriptionV2 vfolderNodeFrgmt={vfolderNode} />
+              <VFolderNodeDescriptionV2
+                vfolderNodeFrgmt={vfolderNode}
+                project={pageProject}
+              />
             </div>
           ),
         },
@@ -422,11 +440,15 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
         vfolderNode ? (
           <FolderExplorerHeaderV2
             vfolderNodeFrgmt={vfolderNode}
-            // Sanctioned interim state (ADR-0001): this globally-mounted
-            // modal is not yet converted (FR-3413), so it still narrows the
-            // ambient current project and passes it on explicitly — general
-            // page UX is unchanged.
-            project={toProjectContext(currentProject)}
+            // ADR-0001: on super-admin routes `pageProject` is `null` — the
+            // FileBrowser/SFTP buttons render disabled with the tooltip
+            // below, and rename gating falls back to owner/super-admin.
+            project={pageProject}
+            noProjectTooltip={
+              isSuperAdminScopedPage
+                ? t('data.CannotLaunchSessionInAdminMenu')
+                : undefined
+            }
           />
         ) : (
           <span />
@@ -474,7 +496,8 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
               />
             ) : hasNoPermissions ? (
               <Banner title={t('explorer.NoPermissions')} status="error" />
-            ) : currentProject?.id !== vfolderNode?.ownership?.projectId &&
+            ) : pageProject !== null &&
+              pageProject.id !== vfolderNode?.ownership?.projectId &&
               !!vfolderNode?.ownership?.projectId ? (
               <Banner
                 title={

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -387,10 +387,7 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
           label: t('explorer.Metadata'),
           children: (
             <div style={infoPanelPanelStyle}>
-              <VFolderNodeDescriptionV2
-                vfolderNodeFrgmt={vfolderNode}
-                project={pageProject}
-              />
+              <VFolderNodeDescriptionV2 vfolderNodeFrgmt={vfolderNode} />
             </div>
           ),
         },

--- a/react/src/components/RecentlyCreatedSession.tsx
+++ b/react/src/components/RecentlyCreatedSession.tsx
@@ -3,6 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { RecentlyCreatedSessionFragment$key } from '../__generated__/RecentlyCreatedSessionFragment.graphql';
+import { ProjectContextOrNull } from '../types/projectContext';
 import { theme } from '../theme-shim';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import SessionNodes from './SessionNodes';
@@ -22,11 +23,17 @@ import { graphql, useRefetchableFragment } from 'react-relay';
 interface RecentlyCreatedSessionProps {
   queryRef: RecentlyCreatedSessionFragment$key;
   isRefetching?: boolean;
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3413): pass-through to the
+   * session-detail drawer. The mounting page decides the project context.
+   */
+  project: ProjectContextOrNull;
 }
 
 const RecentlyCreatedSession: React.FC<RecentlyCreatedSessionProps> = ({
   queryRef,
   isRefetching,
+  project,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -129,6 +136,7 @@ const RecentlyCreatedSession: React.FC<RecentlyCreatedSessionProps> = ({
         <SessionDetailDrawer
           open={!!sessionDetailId}
           sessionId={sessionDetailId || undefined}
+          project={project}
           onClose={() => {
             setSessionDetailId(null);
           }}

--- a/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
+++ b/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
@@ -3,13 +3,26 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '../hooks';
+import { ProjectContextOrNull } from '../types/projectContext';
 import ContainerLogModalWithLazyQueryLoader from './ComputeSessionNodeItems/ContainerLogModalWithLazyQueryLoader';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import { BAIUnmountAfterClose } from 'backend.ai-ui';
 import { parseAsString, useQueryState } from 'nuqs';
 import { useState, useEffect, useTransition } from 'react';
 
-const SessionDetailAndContainerLogOpenerLegacy = () => {
+interface SessionDetailAndContainerLogOpenerLegacyProps {
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3413): pass-through to
+   * `SessionDetailDrawer`. This opener is mounted on several pages
+   * (general session list, scheduler, admin session page) — each mounting
+   * page decides the project context (`null` on super-admin pages).
+   */
+  project: ProjectContextOrNull;
+}
+
+const SessionDetailAndContainerLogOpenerLegacy: React.FC<
+  SessionDetailAndContainerLogOpenerLegacyProps
+> = ({ project }) => {
   const [sessionId, setSessionId] = useQueryState(
     'sessionDetail',
     parseAsString.withOptions({ history: 'replace' }),
@@ -40,6 +53,7 @@ const SessionDetailAndContainerLogOpenerLegacy = () => {
           <SessionDetailDrawer
             open={!!sessionId}
             sessionId={sessionId || undefined}
+            project={project}
             onClose={() => {
               setSessionId(null);
             }}

--- a/react/src/components/SessionDetailContent.test.tsx
+++ b/react/src/components/SessionDetailContent.test.tsx
@@ -8,7 +8,6 @@ import { ProjectContextOrNull } from '../types/projectContext';
 import SessionDetailContent from './SessionDetailContent';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { App } from 'antd';
 import { Suspense } from 'react';
 import { RelayEnvironmentProvider } from 'react-relay';
 import { MemoryRouter } from 'react-router-dom';
@@ -154,11 +153,11 @@ const renderSessionDetail = (project: ProjectContextOrNull) => {
   render(
     <RelayEnvironmentProvider environment={environment}>
       <MemoryRouter>
-        <App>
+        <>
           <Suspense fallback={null}>
             <SessionDetailContent id="session-row-id" project={project} />
           </Suspense>
-        </App>
+        </>
       </MemoryRouter>
     </RelayEnvironmentProvider>,
   );

--- a/react/src/components/SessionDetailContent.test.tsx
+++ b/react/src/components/SessionDetailContent.test.tsx
@@ -1,0 +1,194 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import { ProjectContextOrNull } from '../types/projectContext';
+import SessionDetailContent from './SessionDetailContent';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { App } from 'antd';
+import { Suspense } from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { MemoryRouter } from 'react-router-dom';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * Contract tests for the explicit project prop contract (ADR-0001, FR-3413).
+ *
+ * SessionDetailContent is alert tier: `project` is required; with `null`
+ * (super-admin pages) the component renders WITHOUT throwing and the
+ * `session.NotInProject` comparison is suppressed; with a non-null project
+ * the alert renders exactly when the session belongs to a different project.
+ * These tests exercise external behavior only: rendered output given props.
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: {
+        language: 'en',
+        changeLanguage: () => new Promise(() => {}),
+      },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: {
+      type: '3rdParty',
+      init: () => {},
+    },
+  };
+});
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => ({
+      supports: () => false,
+      _config: {},
+    }),
+    useWebUINavigate: () => vi.fn(),
+  };
+});
+
+vi.mock('../hooks/backendai', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/backendai')>();
+  return {
+    ...originalModule,
+    useCurrentUserInfo: () => [{ uuid: 'session-user-uuid' }, vi.fn()],
+    useCurrentUserRole: () => 'user',
+    useResourceSlotsDetails: () => ({ mergedResourceSlots: {} }),
+  };
+});
+
+// Decoy ambient project: the component must never read it. Its id matches the
+// session's project, so if the component compared against the ambient value
+// the mismatch alert below would NOT render — surfacing the regression.
+vi.mock('../hooks/useCurrentProject', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useCurrentProject')>();
+  return {
+    ...originalModule,
+    useCurrentProjectValue: () => ({
+      id: 'session-project-id',
+      name: 'ambient-project-name',
+    }),
+  };
+});
+
+// Presentational children with their own hooks/queries are stubbed — this
+// test covers only the alert-tier contract of SessionDetailContent itself.
+const { stubComponent } = vi.hoisted(() => ({
+  stubComponent: (testId: string) => async () => {
+    const React = await import('react');
+    return {
+      default: () => React.createElement('div', { 'data-testid': testId }),
+    };
+  },
+}));
+vi.mock(
+  './ComputeSessionNodeItems/EditableSessionName',
+  stubComponent('mock-editable-session-name'),
+);
+vi.mock(
+  './ComputeSessionNodeItems/SessionActionButtons',
+  stubComponent('mock-session-action-buttons'),
+);
+vi.mock(
+  './ComputeSessionNodeItems/SessionStatusTag',
+  stubComponent('mock-session-status-tag'),
+);
+vi.mock(
+  './ComputeSessionNodeItems/SessionReservation',
+  stubComponent('mock-session-reservation'),
+);
+vi.mock(
+  './ComputeSessionNodeItems/SessionStatusDetailModal',
+  stubComponent('mock-session-status-detail-modal'),
+);
+vi.mock(
+  './ComputeSessionNodeItems/SessionIdleChecks',
+  stubComponent('mock-session-idle-checks'),
+);
+vi.mock(
+  './ComputeSessionNodeItems/ConnectedKernelList',
+  stubComponent('mock-connected-kernel-list'),
+);
+vi.mock('./ImageNodeSimpleTag', stubComponent('mock-image-node-simple-tag'));
+vi.mock('./MountedVFolderLinks', stubComponent('mock-mounted-vfolder-links'));
+vi.mock('./SessionUsageMonitor', stubComponent('mock-session-usage-monitor'));
+vi.mock(
+  './SessionSchedulingHistoryModal',
+  stubComponent('mock-session-scheduling-history-modal'),
+);
+
+const renderSessionDetail = (project: ProjectContextOrNull) => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  environment.mock.queueOperationResolver((operation: any) =>
+    MockPayloadGenerator.generate(operation, {
+      ComputeSessionNode: () => ({
+        id: btoa('ComputeSessionNode:session-0000'),
+        row_id: 'session-row-id',
+        name: 'test-session',
+        project_id: 'session-project-id',
+        user_id: 'session-user-uuid',
+        status: 'RUNNING',
+        created_at: '2026-07-29T00:00:00Z',
+        requested_slots: '{}',
+        occupied_slots: '{}',
+        idle_checks: '{}',
+        type: 'interactive',
+        startup_command: null,
+        kernel_nodes: { edges: [] },
+        dependees: { edges: [], count: 0 },
+        dependents: { edges: [], count: 0 },
+      }),
+    }),
+  );
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <MemoryRouter>
+        <App>
+          <Suspense fallback={null}>
+            <SessionDetailContent id="session-row-id" project={project} />
+          </Suspense>
+        </App>
+      </MemoryRouter>
+    </RelayEnvironmentProvider>,
+  );
+};
+
+describe('SessionDetailContent project prop contract (ADR-0001, FR-3413)', () => {
+  it('renders without throwing and without the mismatch alert when project is null', async () => {
+    renderSessionDetail(null);
+
+    // Renders session content instead of throwing "Project ID is required".
+    expect(await screen.findByText('session-row-id')).toBeInTheDocument();
+    expect(screen.queryByText('session.NotInProject')).not.toBeInTheDocument();
+  });
+
+  it('renders the mismatch alert when the passed project differs from the session project', async () => {
+    renderSessionDetail({
+      id: 'passed-other-project-id',
+      name: 'passed-other-project',
+    });
+
+    expect(await screen.findByText('session.NotInProject')).toBeInTheDocument();
+  });
+
+  it('renders no mismatch alert when the passed project matches the session project', async () => {
+    renderSessionDetail({
+      id: 'session-project-id',
+      name: 'session-project',
+    });
+
+    expect(await screen.findByText('session-row-id')).toBeInTheDocument();
+    expect(screen.queryByText('session.NotInProject')).not.toBeInTheDocument();
+  });
+});

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -13,8 +13,8 @@ import {
   useResourceSlotsDetails,
 } from '../hooks/backendai';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
-import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
+import { ProjectContextOrNull } from '../types/projectContext';
 import { useBAIBreakpoint } from '../theme-shim';
 import BAIErrorBoundary from './BAIErrorBoundary';
 import CodeHighlighterModal from './CodeHighlighterModal';
@@ -101,17 +101,22 @@ const SessionDetailContent: React.FC<{
   id: string;
   sessionFrgmt?: SessionDetailContentFragment$key | null;
   fetchKey?: string;
-}> = ({ id, fetchKey, sessionFrgmt }) => {
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3413): the project context
+   * the PAGE decided on. Alert tier — with `null` (super-admin pages) the
+   * "not in your project" comparison is suppressed entirely; with a non-null
+   * project the alert renders exactly when the session belongs to a
+   * different project. This component never reads the ambient current
+   * project.
+   */
+  project: ProjectContextOrNull;
+}> = ({ id, fetchKey, sessionFrgmt, project }) => {
   'use memo';
   const { t } = useTranslation();
   const { md } = useBAIBreakpoint();
   const { mergedResourceSlots } = useResourceSlotsDetails();
   const location = useLocation();
 
-  const currentProject = useCurrentProjectValue();
-  if (!currentProject.id) {
-    throw new Error('Project ID is required for SessionDetailContent');
-  }
   const [currentUser] = useCurrentUserInfo();
   const userRole = useCurrentUserRole();
   const baiClient = useSuspendedBackendaiClient();
@@ -338,7 +343,7 @@ const SessionDetailContent: React.FC<{
 
   return session ? (
     <BAIFlex direction="column" gap={'lg'} align="stretch">
-      {resolvedProjectIdOfSession !== currentProject.id && (
+      {project !== null && resolvedProjectIdOfSession !== project.id && (
         <Banner status="warning" title={t('session.NotInProject')} />
       )}
       {currentUser.uuid !== session?.user_id && (

--- a/react/src/components/SessionDetailDrawer.tsx
+++ b/react/src/components/SessionDetailDrawer.tsx
@@ -4,6 +4,7 @@
  */
 import { SessionDetailDrawerFragment$key } from '../__generated__/SessionDetailDrawerFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
+import { ProjectContextOrNull } from '../types/projectContext';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import SessionDetailContent from './SessionDetailContent';
 import BAIDrawer from './astryx-bui/BAIDrawerAstryx';
@@ -27,11 +28,18 @@ interface SessionDetailDrawerProps {
   /** Close request handler (Escape, scrim click, close button). */
   onClose?: () => void;
   sessionId?: string;
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3413): pass-through to
+   * `SessionDetailContent`. The mounting page decides the project context
+   * (`null` on super-admin pages suppresses the project-mismatch alert).
+   */
+  project: ProjectContextOrNull;
 }
 const SessionDetailDrawer: React.FC<SessionDetailDrawerProps> = ({
   sessionId,
   open = false,
   onClose,
+  project,
 }) => {
   const { t } = useTranslation();
   useSuspendedBackendaiClient();
@@ -97,6 +105,7 @@ const SessionDetailDrawer: React.FC<SessionDetailDrawerProps> = ({
             id={sessionId}
             fetchKey={fetchKey}
             sessionFrgmt={cachedSessionFrgmt}
+            project={project}
           />
         )}
       </Suspense>

--- a/react/src/components/VFolderNodeDescriptionV2.tsx
+++ b/react/src/components/VFolderNodeDescriptionV2.tsx
@@ -21,9 +21,8 @@ import { App } from '../app-shim';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { useEffectiveAdminRole } from '../hooks/useCurrentUserProjectRoles';
+import { useCurrentUserProjectRoles } from '../hooks/useCurrentUserProjectRoles';
 import { useVirtualFolderPathV2 } from '../hooks/useVirtualFolderNodePathV2';
-import { ProjectContextOrNull } from '../types/projectContext';
 import VirtualFolderPathV2 from './VirtualFolderNodeItems/VirtualFolderPathV2';
 import BAICopyableText from './astryx-bui/BAICopyableText';
 import { Badge } from '@astryxdesign/core/Badge';
@@ -61,19 +60,10 @@ import {
 
 interface VFolderNodeDescriptionV2Props {
   vfolderNodeFrgmt: VFolderNodeDescriptionV2Fragment$key;
-  /**
-   * Explicit project prop contract (ADR-0001, FR-3413): the project context
-   * the page decided on, used only for the `currentProjectAdmin` branch of
-   * the mount-permission gate. With `null` (super-admin pages) that branch
-   * simply doesn't match — owner and super admins keep their power. Never
-   * reads the ambient current project.
-   */
-  project: ProjectContextOrNull;
 }
 
 const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
   vfolderNodeFrgmt,
-  project,
   ...props
 }) => {
   'use memo';
@@ -84,7 +74,9 @@ const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
   const relayEnv = useRelayEnvironment();
   const baiClient = useSuspendedBackendaiClient();
   const [currentUser] = useCurrentUserInfo();
-  const effectiveAdminRole = useEffectiveAdminRole();
+  // Not `useEffectiveAdminRole` — it resolves its target from the ambient
+  // project. Authorization here is derived from the folder's own ownership.
+  const { isSuperAdmin, projectAdminIds } = useCurrentUserProjectRoles();
 
   // TODO(needs-backend): the mount-permission update still goes through the
   // legacy REST endpoint (`baiClient.vfolder.update_folder`) because the V2
@@ -211,16 +203,13 @@ const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
           </HStack>
         ),
     },
-    // Mount permission editing is allowed for the folder owner, super admins
-    // (any project), or the page-decided project's admin when the folder
-    // belongs to that project (`project === null` — super-admin pages — never
-    // matches this branch). Domain admins are intentionally excluded — they
-    // do not have implicit per-project ownership rights.
+    // Allowed for the folder owner, super admins, or an admin of the project
+    // that owns the folder. Domain admins are excluded — they have no
+    // implicit per-project ownership rights.
     (vfolderNode?.ownership?.userId === currentUser.uuid ||
-      effectiveAdminRole === 'superadmin' ||
-      (effectiveAdminRole === 'currentProjectAdmin' &&
-        project !== null &&
-        vfolderNode?.ownership?.projectId === project.id)) && {
+      isSuperAdmin ||
+      (!!vfolderNode?.ownership?.projectId &&
+        projectAdminIds.includes(vfolderNode.ownership.projectId))) && {
       key: 'permission',
       label: t('data.folders.MountPermission'),
       children: (

--- a/react/src/components/VFolderNodeDescriptionV2.tsx
+++ b/react/src/components/VFolderNodeDescriptionV2.tsx
@@ -21,9 +21,9 @@ import { App } from '../app-shim';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useEffectiveAdminRole } from '../hooks/useCurrentUserProjectRoles';
 import { useVirtualFolderPathV2 } from '../hooks/useVirtualFolderNodePathV2';
+import { ProjectContextOrNull } from '../types/projectContext';
 import VirtualFolderPathV2 from './VirtualFolderNodeItems/VirtualFolderPathV2';
 import BAICopyableText from './astryx-bui/BAICopyableText';
 import { Badge } from '@astryxdesign/core/Badge';
@@ -61,10 +61,19 @@ import {
 
 interface VFolderNodeDescriptionV2Props {
   vfolderNodeFrgmt: VFolderNodeDescriptionV2Fragment$key;
+  /**
+   * Explicit project prop contract (ADR-0001, FR-3413): the project context
+   * the page decided on, used only for the `currentProjectAdmin` branch of
+   * the mount-permission gate. With `null` (super-admin pages) that branch
+   * simply doesn't match — owner and super admins keep their power. Never
+   * reads the ambient current project.
+   */
+  project: ProjectContextOrNull;
 }
 
 const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
   vfolderNodeFrgmt,
+  project,
   ...props
 }) => {
   'use memo';
@@ -73,7 +82,6 @@ const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
   const { getErrorMessage } = useErrorMessageResolver();
 
   const relayEnv = useRelayEnvironment();
-  const currentProject = useCurrentProjectValue();
   const baiClient = useSuspendedBackendaiClient();
   const [currentUser] = useCurrentUserInfo();
   const effectiveAdminRole = useEffectiveAdminRole();
@@ -204,13 +212,15 @@ const VFolderNodeDescriptionV2: React.FC<VFolderNodeDescriptionV2Props> = ({
         ),
     },
     // Mount permission editing is allowed for the folder owner, super admins
-    // (any project), or the current project's admin when the folder belongs to
-    // that project. Domain admins are intentionally excluded — they do not
-    // have implicit per-project ownership rights.
+    // (any project), or the page-decided project's admin when the folder
+    // belongs to that project (`project === null` — super-admin pages — never
+    // matches this branch). Domain admins are intentionally excluded — they
+    // do not have implicit per-project ownership rights.
     (vfolderNode?.ownership?.userId === currentUser.uuid ||
       effectiveAdminRole === 'superadmin' ||
       (effectiveAdminRole === 'currentProjectAdmin' &&
-        vfolderNode?.ownership?.projectId === currentProject?.id)) && {
+        project !== null &&
+        vfolderNode?.ownership?.projectId === project.id)) && {
       key: 'permission',
       label: t('data.folders.MountPermission'),
       children: (

--- a/react/src/hooks/useIsSuperAdminScopedPage.test.tsx
+++ b/react/src/hooks/useIsSuperAdminScopedPage.test.tsx
@@ -1,0 +1,73 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  SUPER_ADMIN_SCOPED_MENU_KEYS,
+  useIsSuperAdminScopedPage,
+} from './useIsSuperAdminScopedPage';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+
+const Probe = () => {
+  const isSuperAdminScopedPage = useIsSuperAdminScopedPage();
+  return <div data-testid="probe">{String(isSuperAdminScopedPage)}</div>;
+};
+
+// Mirrors the shape the route generator attaches in routes.tsx: the three
+// admin feature pages live under `/admin/*` and carry `handle.menuKey`
+// ('admin-session' | 'admin-deployments' | 'admin-data'); legacy unprefixed
+// paths (`/admin-session`, …) have no handle and fall back to the pathname's
+// first segment inside `useCurrentMenuKey`.
+const renderAt = (
+  path: string,
+  routes: Parameters<typeof createMemoryRouter>[0],
+) => {
+  const router = createMemoryRouter(routes, { initialEntries: [path] });
+  return render(<RouterProvider router={router} />);
+};
+
+describe('useIsSuperAdminScopedPage (FR-3413)', () => {
+  it('exports the three super-admin menu keys for FR-3414 reuse', () => {
+    expect(SUPER_ADMIN_SCOPED_MENU_KEYS).toEqual([
+      'admin-session',
+      'admin-deployments',
+      'admin-data',
+    ]);
+  });
+
+  it.each([
+    ['/admin/session', 'admin-session'],
+    ['/admin/deployments/some-deployment-id', 'admin-deployments'],
+    ['/admin/data', 'admin-data'],
+  ])('is true on the handle-marked admin route %s', (path, menuKey) => {
+    renderAt(path, [
+      {
+        path,
+        element: <Probe />,
+        handle: { scope: 'admin', menuKey },
+      },
+    ]);
+    expect(screen.getByTestId('probe')).toHaveTextContent('true');
+  });
+
+  it('is true on a legacy unprefixed admin path without a handle (pathname fallback)', () => {
+    renderAt('/admin-session', [
+      { path: '/admin-session', element: <Probe /> },
+    ]);
+    expect(screen.getByTestId('probe')).toHaveTextContent('true');
+  });
+
+  it.each([
+    ['/project/default/data', { scope: 'project', menuKey: 'data' }],
+    [
+      '/project/default/admin/deployments/dep-1',
+      { scope: 'projectAdmin', menuKey: 'project-admin-deployments' },
+    ],
+    ['/admin/users', { scope: 'admin', menuKey: 'admin-users' }],
+  ])('is false on non-super-admin-scoped route %s', (path, handle) => {
+    renderAt(path, [{ path, element: <Probe />, handle }]);
+    expect(screen.getByTestId('probe')).toHaveTextContent('false');
+  });
+});

--- a/react/src/hooks/useIsSuperAdminScopedPage.ts
+++ b/react/src/hooks/useIsSuperAdminScopedPage.ts
@@ -1,0 +1,44 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useCurrentMenuKey } from './useRouteScope';
+
+/**
+ * The three super-admin-scoped feature pages of FR-3407: on these routes the
+ * header project selector is conceptually irrelevant (the pages operate above
+ * project scope), so ambient-project-derived UI (mismatch alerts,
+ * session-launch buttons, permission scoping) must not key off it.
+ *
+ * Exported as a constant so FR-3414 (hiding the header selector on the same
+ * routes) reuses the exact same list.
+ */
+export const SUPER_ADMIN_SCOPED_MENU_KEYS = [
+  'admin-session',
+  'admin-deployments',
+  'admin-data',
+] as const;
+
+/**
+ * Whether the current route is one of the super-admin-scoped pages
+ * (`SUPER_ADMIN_SCOPED_MENU_KEYS`).
+ *
+ * Implementation: keyed off `useCurrentMenuKey()` — the deepest route
+ * `handle.menuKey` (the admin routes carry `menuKey: 'admin-session' |
+ * 'admin-deployments' | 'admin-data'`), falling back to the pathname's first
+ * segment for legacy unprefixed paths (`/admin-session`, …). This is the
+ * modern equivalent of the pathname-first-segment pattern previously used by
+ * `ProjectAdminScopeAlert`.
+ *
+ * Usage contract (ADR-0001): only **pages** and **globally-mounted
+ * components** (e.g. the folder-explorer modal, which has no page parent) may
+ * call this hook to decide their project context. Converted leaf components
+ * must NOT — they receive the decision via their required `project` prop.
+ */
+export const useIsSuperAdminScopedPage = (): boolean => {
+  'use memo';
+  const menuKey = useCurrentMenuKey();
+  return (SUPER_ADMIN_SCOPED_MENU_KEYS as readonly string[]).includes(
+    menuKey ?? '',
+  );
+};

--- a/react/src/hooks/useMergedAllowedStorageHostPermission.ts
+++ b/react/src/hooks/useMergedAllowedStorageHostPermission.ts
@@ -8,9 +8,20 @@ import { useMergedAllowedStorageHostPermission_KeypairQuery } from '../__generat
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
+// Placeholder UUID sent for the (validated, non-null) `$projectId` variable
+// when the project-scope lookup is skipped. The `group` field is `@skip`ped in
+// that case, so the value never reaches a resolver.
+const NIL_UUID = '00000000-0000-0000-0000-000000000000';
+
 export const useMergedAllowedStorageHostPermission = (
   domain: string,
-  projectId: string,
+  /**
+   * Project to merge group-level `allowed_vfolder_hosts` from. `null` (e.g.
+   * a user-owned folder opened from a super-admin page, where no ambient
+   * project context exists — FR-3413) skips the group-scope lookup and merges
+   * only the domain- and keypair-resource-policy-level permissions.
+   */
+  projectId: string | null,
   userAccessKey: string,
 ) => {
   const baiClient = useSuspendedBackendaiClient();
@@ -42,11 +53,13 @@ export const useMergedAllowedStorageHostPermission = (
           $domainName: String
           $projectId: UUID!
           $resourcePolicyName: String
+          $skipProjectScope: Boolean!
         ) {
           domain(name: $domainName) {
             allowed_vfolder_hosts
           }
-          group(id: $projectId, domain_name: $domainName) {
+          group(id: $projectId, domain_name: $domainName)
+            @skip(if: $skipProjectScope) {
             allowed_vfolder_hosts
           }
           keypair_resource_policy(name: $resourcePolicyName) {
@@ -56,8 +69,9 @@ export const useMergedAllowedStorageHostPermission = (
       `,
       {
         domainName: domain,
-        projectId,
+        projectId: projectId ?? NIL_UUID,
         resourcePolicyName: keypair?.resource_policy,
+        skipProjectScope: projectId === null,
       },
       {
         fetchPolicy: 'store-or-network',

--- a/react/src/pages/AdminDashboardPage.tsx
+++ b/react/src/pages/AdminDashboardPage.tsx
@@ -19,6 +19,7 @@ import {
   useCurrentProjectValue,
   useCurrentResourceGroupValue,
 } from '../hooks/useCurrentProject';
+import { toProjectContext } from '../types/projectContext';
 import { theme } from '../theme-shim';
 import {
   filterOutEmpty,
@@ -204,6 +205,11 @@ const AdminDashboardPage: React.FC = () => {
           <RecentlyCreatedSession
             queryRef={queryRef}
             isRefetching={isPendingIntervalRefetch}
+            // /admin-dashboard is out of FR-3407 scope (page is unused) and
+            // its session list is still ambient-project-scoped (`scopeId`
+            // above) — keep the exact current behavior by passing the
+            // narrowed ambient project (ADR-0001 page-level narrowing).
+            project={toProjectContext(currentProject)}
           />
         ),
       },

--- a/react/src/pages/AdminSessionPage.tsx
+++ b/react/src/pages/AdminSessionPage.tsx
@@ -56,7 +56,10 @@ const AdminSessionPage: React.FC = () => {
           )}
         </Suspense>
       </BAICard>
-      <SessionDetailAndContainerLogOpenerLegacy />
+      {/* Super-admin page (ADR-0001, FR-3413): no ambient project context —
+          the session-detail drawer (also opened from the pending-sessions
+          tab) renders without a project-mismatch alert. */}
+      <SessionDetailAndContainerLogOpenerLegacy project={null} />
     </>
   );
 };

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -24,6 +24,7 @@ import {
   useCurrentResourceGroupValue,
 } from '../hooks/useCurrentProject';
 import { useProjectPath } from '../hooks/useRouteScope';
+import { toProjectContext } from '../types/projectContext';
 import { theme } from '../theme-shim';
 import {
   BAIBoardItemErrorBoundary,
@@ -340,6 +341,10 @@ const DashboardPage: React.FC = () => {
           <RecentlyCreatedSession
             queryRef={queryRef}
             isRefetching={isRefetching}
+            // Page-level ambient narrowing (ADR-0001): the dashboard is
+            // project-scoped, so the drawer compares against the current
+            // project.
+            project={toProjectContext(currentProject)}
           />
         ),
       },

--- a/react/src/pages/DeploymentDetailPage.test.tsx
+++ b/react/src/pages/DeploymentDetailPage.test.tsx
@@ -1,0 +1,266 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import '../../__test__/matchMedia.mock.js';
+import '../../__test__/resizeObserver.mock.js';
+import DeploymentDetailPage from './DeploymentDetailPage';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { App } from 'antd';
+import { Suspense } from 'react';
+import { RelayEnvironmentProvider } from 'react-relay';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import type { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
+
+/**
+ * Contract tests for the page-decided project context (ADR-0001, FR-3413).
+ *
+ * DeploymentDetailPage serves three URL spaces; the PAGE decides the project
+ * context. On the super-admin URL space (`null`): no project-mismatch alert,
+ * no switch-project shortcut, and the Add-revision CTA is NOT suppressed —
+ * even when the ambient decoy differs from the deployment's project. On
+ * general routes the narrowed ambient keeps today's behavior. External
+ * behavior only: rendered output + the props handed to the section cards.
+ */
+
+vi.mock('react-i18next', async () => {
+  const React = await import('react');
+  return {
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: {
+        language: 'en',
+        changeLanguage: () => new Promise(() => {}),
+      },
+      ready: true,
+    }),
+    Trans: (props: any) => React.createElement('span', null, props.i18nKey),
+    initReactI18next: {
+      type: '3rdParty',
+      init: () => {},
+    },
+  };
+});
+
+vi.mock('../hooks', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('../hooks')>();
+  return {
+    ...originalModule,
+    useSuspendedBackendaiClient: () => ({
+      supports: () => false,
+      _config: { blockList: [] },
+    }),
+    useWebUINavigate: () => vi.fn(),
+  };
+});
+
+vi.mock('../hooks/backendai', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/backendai')>();
+  return {
+    ...originalModule,
+    useCurrentUserInfo: () => [{ email: 'me@backend.ai' }, vi.fn()],
+  };
+});
+
+// Decoy ambient project: differs from the deployment's project, so on the
+// admin URL space any leak of ambient-derived mismatch logic would render
+// the alert / suppress the CTA — and fail the assertions below.
+vi.mock('../hooks/useCurrentProject', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useCurrentProject')>();
+  return {
+    ...originalModule,
+    useCurrentProjectValue: () => ({
+      id: 'ambient-project-id',
+      name: 'ambient-project-name',
+    }),
+  };
+});
+
+// Route derivation is covered by useIsSuperAdminScopedPage.test.tsx; pinned
+// per scenario here.
+let mockIsSuperAdminScopedPage = false;
+vi.mock('../hooks/useIsSuperAdminScopedPage', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useIsSuperAdminScopedPage')>();
+  return {
+    ...originalModule,
+    useIsSuperAdminScopedPage: () => mockIsSuperAdminScopedPage,
+  };
+});
+
+vi.mock('../hooks/useRouteScope', async (importOriginal) => {
+  const originalModule =
+    await importOriginal<typeof import('../hooks/useRouteScope')>();
+  return {
+    ...originalModule,
+    useProjectPath: () => (path: string) => `/${path}`,
+    useActiveProjectName: () => 'ambient-project-name',
+  };
+});
+
+vi.mock('../hooks/useWebUIMenuItems', () => ({
+  getPathFromMenuKey: () => '/start',
+  useWebUIMenuItems: () => ({ firstAvailableMenuItem: null }),
+}));
+
+// Section cards/modals are stubbed probes — their internals have their own
+// tests; this test asserts what the PAGE decides and hands down.
+vi.mock('../components/DeploymentBasicInfoCard', async () => {
+  const React = await import('react');
+  return {
+    default: () =>
+      React.createElement('div', { 'data-testid': 'mock-basic-info-card' }),
+  };
+});
+vi.mock('../components/DeploymentRevisionCard', async () => {
+  const React = await import('react');
+  return {
+    default: (props: any) =>
+      React.createElement('div', {
+        'data-testid': 'mock-revision-card',
+        'data-add-revision-disabled': String(props.isAddRevisionDisabled),
+      }),
+  };
+});
+vi.mock('../components/DeploymentReplicasCard', async () => {
+  const React = await import('react');
+  return {
+    default: (props: any) =>
+      React.createElement('div', {
+        'data-testid': 'mock-replicas-card',
+        'data-project-id': props.project?.id ?? '',
+      }),
+  };
+});
+vi.mock('../components/DeploymentAutoScalingCard', async () => {
+  const React = await import('react');
+  return {
+    default: () =>
+      React.createElement('div', { 'data-testid': 'mock-auto-scaling-card' }),
+  };
+});
+vi.mock('../components/DeploymentAccessTokensCard', async () => {
+  const React = await import('react');
+  return {
+    default: () =>
+      React.createElement('div', { 'data-testid': 'mock-access-tokens-card' }),
+  };
+});
+vi.mock('../components/DeploymentAddRevisionModal', async () => {
+  const React = await import('react');
+  return {
+    default: () =>
+      React.createElement('div', { 'data-testid': 'mock-add-revision-modal' }),
+  };
+});
+vi.mock('../components/DeploymentRevisionDetailDrawer', async () => {
+  const React = await import('react');
+  return {
+    default: () =>
+      React.createElement('div', { 'data-testid': 'mock-revision-drawer' }),
+  };
+});
+vi.mock('../components/SwitchToProjectButton', async () => {
+  const React = await import('react');
+  return {
+    default: () =>
+      React.createElement('div', {
+        'data-testid': 'mock-switch-to-project-button',
+      }),
+  };
+});
+
+const renderPage = () => {
+  const environment: RelayMockEnvironment = createMockEnvironment();
+  environment.mock.queueOperationResolver((operation: any) =>
+    MockPayloadGenerator.generate(operation, {
+      ModelDeployment: () => ({
+        id: btoa('ModelDeployment:deployment-0000'),
+        metadata: {
+          name: 'test-deployment',
+          status: 'READY',
+          projectId: 'deployment-project-id',
+        },
+        networkAccess: {
+          openToPublic: true,
+          endpointUrl: 'https://endpoint.example',
+        },
+        replicaState: { desiredReplicaCount: 1 },
+        runningReplicas: { count: 1 },
+        accessTokens: { count: 1 },
+        currentRevision: { id: 'revision-1' },
+        deployingRevision: { id: 'revision-1' },
+        creator: { basicInfo: { email: 'me@backend.ai' } },
+      }),
+    }),
+  );
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <MemoryRouter initialEntries={['/deployments/deployment-0000']}>
+        <App>
+          <Suspense fallback={null}>
+            <Routes>
+              <Route
+                path="/deployments/:deploymentId"
+                element={<DeploymentDetailPage />}
+              />
+            </Routes>
+          </Suspense>
+        </App>
+      </MemoryRouter>
+    </RelayEnvironmentProvider>,
+  );
+};
+
+describe('DeploymentDetailPage project context (ADR-0001, FR-3413)', () => {
+  beforeEach(() => {
+    mockIsSuperAdminScopedPage = false;
+  });
+
+  it('admin URL space (null): no mismatch alert, no switch-project shortcut, Add-revision CTA not suppressed', async () => {
+    mockIsSuperAdminScopedPage = true;
+    renderPage();
+
+    expect(await screen.findByText('test-deployment')).toBeInTheDocument();
+    // The deployment belongs to a different project than the ambient decoy,
+    // but on the admin URL space there is no project context to mismatch.
+    expect(
+      screen.queryByText('deployment.NotInProject'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('mock-switch-to-project-button'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('mock-revision-card')).toHaveAttribute(
+      'data-add-revision-disabled',
+      'false',
+    );
+    // The replica drawer gets `null` too — no mismatch alert inside it.
+    expect(screen.getByTestId('mock-replicas-card')).toHaveAttribute(
+      'data-project-id',
+      '',
+    );
+  });
+
+  it('general URL space (narrowed ambient): mismatch alert + switch shortcut + suppressed CTA, exactly as today', async () => {
+    renderPage();
+
+    expect(
+      await screen.findByText('deployment.NotInProject'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('mock-switch-to-project-button'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('mock-revision-card')).toHaveAttribute(
+      'data-add-revision-disabled',
+      'true',
+    );
+    expect(screen.getByTestId('mock-replicas-card')).toHaveAttribute(
+      'data-project-id',
+      'ambient-project-id',
+    );
+  });
+});

--- a/react/src/pages/DeploymentDetailPage.test.tsx
+++ b/react/src/pages/DeploymentDetailPage.test.tsx
@@ -7,7 +7,6 @@ import '../../__test__/resizeObserver.mock.js';
 import DeploymentDetailPage from './DeploymentDetailPage';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { App } from 'antd';
 import { Suspense } from 'react';
 import { RelayEnvironmentProvider } from 'react-relay';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -201,7 +200,7 @@ const renderPage = () => {
   render(
     <RelayEnvironmentProvider environment={environment}>
       <MemoryRouter initialEntries={['/deployments/deployment-0000']}>
-        <App>
+        <>
           <Suspense fallback={null}>
             <Routes>
               <Route
@@ -210,7 +209,7 @@ const renderPage = () => {
               />
             </Routes>
           </Suspense>
-        </App>
+        </>
       </MemoryRouter>
     </RelayEnvironmentProvider>,
   );

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -79,8 +79,11 @@ const DeploymentDetailPage: React.FC = () => {
   const webuiNavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const currentProject = useCurrentProjectValue();
-  // This shared page serves three URL spaces (/deployments/:id,
-  // /admin-deployments/:id, /project-admin-deployments/:id). Per ADR-0001 the
+  // This shared page serves three URL spaces
+  // (/project/:projectName/deployments/:deploymentId,
+  // /admin/deployments/:deploymentId and
+  // /project/:projectName/admin/deployments/:deploymentId — see routes.tsx).
+  // Per ADR-0001 the
   // PAGE decides the project context: on the super-admin URL space there is
   // no ambient project (`null` — no mismatch alert, no switch-project
   // shortcut, and the Add-revision CTA is not suppressed); elsewhere the

--- a/react/src/pages/DeploymentDetailPage.tsx
+++ b/react/src/pages/DeploymentDetailPage.tsx
@@ -17,11 +17,13 @@ import SwitchToProjectButton from '../components/SwitchToProjectButton';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useIsSuperAdminScopedPage } from '../hooks/useIsSuperAdminScopedPage';
 import { useActiveProjectName, useProjectPath } from '../hooks/useRouteScope';
 import {
   getPathFromMenuKey,
   useWebUIMenuItems,
 } from '../hooks/useWebUIMenuItems';
+import { toProjectContext } from '../types/projectContext';
 import { theme } from '../theme-shim';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
@@ -77,6 +79,16 @@ const DeploymentDetailPage: React.FC = () => {
   const webuiNavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const currentProject = useCurrentProjectValue();
+  // This shared page serves three URL spaces (/deployments/:id,
+  // /admin-deployments/:id, /project-admin-deployments/:id). Per ADR-0001 the
+  // PAGE decides the project context: on the super-admin URL space there is
+  // no ambient project (`null` — no mismatch alert, no switch-project
+  // shortcut, and the Add-revision CTA is not suppressed); elsewhere the
+  // narrowed ambient project keeps today's behavior exactly.
+  const isSuperAdminScopedPage = useIsSuperAdminScopedPage();
+  const pageProject = isSuperAdminScopedPage
+    ? null
+    : toProjectContext(currentProject);
   const buildProjectPath = useProjectPath();
   const isChatBlocked = !!baiClient?._config?.blockList?.includes('chat');
 
@@ -232,7 +244,9 @@ const DeploymentDetailPage: React.FC = () => {
   // cannot act on without switching projects anyway.
   const deploymentProjectId = deployment.metadata.projectId ?? null;
   const isProjectMismatch =
-    !!deploymentProjectId && deploymentProjectId !== currentProject.id;
+    pageProject !== null &&
+    !!deploymentProjectId &&
+    deploymentProjectId !== pageProject.id;
   // Hide the "no revision" warning while a first revision is being applied —
   // the rollout is in flight, the user already knows about it from the
   // "Applying revision …" Alert in the Configuration section, and the
@@ -422,6 +436,7 @@ const DeploymentDetailPage: React.FC = () => {
         deploymentFrgmt={deployment}
         deploymentId={deploymentGlobalId}
         replicaFetchKey={replicaFetchKey}
+        project={pageProject}
       />
       <DeploymentAutoScalingCard deploymentFrgmt={deployment} />
       <DeploymentAccessTokensCard

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -24,6 +24,7 @@ import { persistPostLoginState } from './helper/loginSessionAuth';
 import { useSuspendedBackendaiClient } from './hooks';
 import { useAutoDiagnostics } from './hooks/useAutoDiagnostics';
 import { useBAISettingUserState } from './hooks/useBAISetting';
+import { useCurrentProjectValue } from './hooks/useCurrentProject';
 import { LogoutEventHandler } from './hooks/useLogout';
 import { useActiveProjectName } from './hooks/useRouteScope';
 import { useSToken } from './hooks/useSToken';
@@ -38,6 +39,7 @@ import ComputeSessionListPage from './pages/ComputeSessionListPage';
 import Page404 from './pages/Page404';
 import UnknownRoutePage from './pages/UnknownRoutePage';
 import VFolderNodeListPage from './pages/VFolderNodeListPage';
+import { toProjectContext } from './types/projectContext';
 import { theme } from './theme-shim';
 import { BAIFlex, BAICard } from 'backend.ai-ui';
 import { useSetAtom } from 'jotai';
@@ -304,10 +306,16 @@ export const mainLayoutChildRoutes: RouteObject[] = [
             index: true,
             Component: () => {
               useSuspendedBackendaiClient();
+              // Page-level ambient narrowing (ADR-0001): general session
+              // page — the opener's session-detail drawer compares against
+              // the current project.
+              const currentProject = useCurrentProjectValue();
               return (
                 <Suspense fallback={<BAISkeletonAstryx rows={4} />}>
                   <ComputeSessionListPage />
-                  <SessionDetailAndContainerLogOpenerLegacy />
+                  <SessionDetailAndContainerLogOpenerLegacy
+                    project={toProjectContext(currentProject)}
+                  />
                 </Suspense>
               );
             },
@@ -839,7 +847,9 @@ export const mainLayoutChildRoutes: RouteObject[] = [
           return baiClient?.supports('fair-share-scheduling') ? (
             <Suspense fallback={<BAISkeletonAstryx rows={4} />}>
               <SchedulerPage />
-              <SessionDetailAndContainerLogOpenerLegacy />
+              {/* Super-admin page (ADR-0001): no ambient project context —
+                  the session-detail project-mismatch alert is suppressed. */}
+              <SessionDetailAndContainerLogOpenerLegacy project={null} />
             </Suspense>
           ) : (
             <WebUINavigate to={'/error'} replace />


### PR DESCRIPTION
Resolves #8461 (FR-3413)

> Stacked PR — fifth layer of the FR-3407 stack, on top of #8468 (FR-3412). Base: `feat/FR-3412-filebrowser-sftp-explicit-project`. Stack: #8463 ← #8465 ← #8467 ← #8468 ← this PR.

## What this does

Converts the **display/gating tier** of the explicit project prop contract (ADR-0001):

### A. Session detail (alert tier)
- `SessionDetailContent` takes a **required** `project: ProjectContextOrNull`; the internal ambient read and the `Project ID is required` **throw are deleted** — session detail now renders without any project context. The `session.NotInProject` alert renders only when a non-null project is passed AND the session's project differs.
- Plumbing (required pass-throughs): `SessionDetailDrawer` → `SessionDetailAndContainerLogOpenerLegacy` (mounted on the general session page → narrowed ambient at route/page level; scheduler page → `null`; `/admin/session` page → `null`, which also covers the pending-sessions tab drawer), `RecentlyCreatedSession` (DashboardPage → narrowed ambient; AdminDashboardPage → narrowed ambient, kept as-is because `/admin-dashboard` is explicitly out of FR-3407 scope and its session list is still ambient-scoped), and `DeploymentReplicasCard` (from the deployment detail page).

### B. Deployment detail (page decides per URL space)
- `DeploymentDetailPage` serves `/deployments/:id`, `/admin/deployments/:id` and `/project/:name/admin/deployments/:id` from one component. Per ADR-0001 the PAGE decides: on the admin URL space `project = null` → **no mismatch alert, no `SwitchToProjectButton` shortcut, and the Add-revision CTA is no longer suppressed**; elsewhere the narrowed ambient keeps today's behavior exactly.

### C. Folder explorer (globally mounted — sanctioned route-consulting exception)
- New shared hook `useIsSuperAdminScopedPage` (`react/src/hooks/useIsSuperAdminScopedPage.ts`) + exported `SUPER_ADMIN_SCOPED_MENU_KEYS = ['admin-session', 'admin-deployments', 'admin-data']` for FR-3414 reuse. Keyed off `useCurrentMenuKey()` (deepest route `handle.menuKey`, pathname fallback for legacy unprefixed paths) — the modern equivalent of the first-segment pattern `ProjectAdminScopeAlert` used before the route-handle refactor.
- `FolderExplorerModalV2`: the `Project ID is required` throw is gone. Permission calculation (`useMergedAllowedStorageHostPermission`) follows **the folder's own ownership project** when project-owned; for user-owned folders it narrows ambient only off super-admin routes (documented interim), and on super-admin routes the hook now accepts `projectId: null` and `@skip`s the group-scope lookup (validated placeholder UUID, never resolved). The ownership-mismatch alert renders only off super-admin routes; on general pages behavior is unchanged. FileBrowser/SFTP buttons get `project=null` + `t('data.CannotLaunchSessionInAdminMenu')` on super-admin routes, the narrowed ambient project otherwise (as today).

### D. Ownership-derived folder gating
- `EditableVFolderNameV2` (rename) and `VFolderNodeDescriptionV2` (mount-permission select) never read ambient anymore: gate = folder owner OR `effectiveAdminRole === 'superadmin'` OR the required page-passed `project` matching the folder's own `ownership.projectId` (`null` → that branch simply doesn't match). General/project-admin page behavior preserved (the page passes the same project the ambient held).

### E. Tests (contract vitest, ambient decoys throughout)
- `useIsSuperAdminScopedPage.test.tsx` — handle-based + legacy-pathname route derivation.
- `SessionDetailContent.test.tsx` — `null` → renders (no throw) & no alert; mismatch → alert; match → no alert.
- `DeploymentDetailPage.test.tsx` — admin space: no alert / no switch shortcut / CTA not suppressed / replicas card gets `null`; general space: exactly today.
- `FolderExplorerModalV2.test.tsx` — admin route: disabled buttons + tooltip, no alert, permission keyed to folder ownership project; user-owned on admin route: group scope skipped; general route: alert stays, permission follows folder's own project.
- `EditableVFolderNameV2.test.tsx` — owner / superadmin / matching-project / null-project / mismatching-project gating.

## Notable decisions
- The "pathname first-segment" check was implemented via `useCurrentMenuKey()` because the repo has since moved admin pages to `/admin/*` with `handle.menuKey` (`ProjectAdminScopeAlert` itself now uses route handles); the hook still covers legacy `/admin-session`-style paths via the built-in pathname fallback.
- `useMergedAllowedStorageHostPermission` widened to `projectId: string | null` (all existing callers unchanged) instead of leaving the group lookup keyed to ambient for user-owned folders on admin routes.
- ADR-0001 updated: fifth application + a dedicated section documenting who may call `useIsSuperAdminScopedPage` (pages and globally-mounted components only; converted leaves must not).

## Verification
- `bash scripts/verify.sh` — Relay / Lint / Format / TypeScript / Vite warmup / Terminology all PASS (Relay "out of sync" only before the artifacts were committed).
- `react` vitest: **69 files / 1088 tests pass** (includes the 15 new contract tests).
- Zero UX change outside admin/superadmin pages: general pages pass the same (narrowed ambient) project the components previously read themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
