### PR TITLE
test: e2e auto-heal 2026-07-29

### DIFF
--- a/e2e/auth/forgot-password.spec.ts
+++ b/e2e/auth/forgot-password.spec.ts
@@ -279,7 +279,7 @@ test.describe('Change password page', () => {
         page.getByRole('textbox', { name: 'Enter email address' }),
       ).toBeVisible();
       await expect(
-        page.getByRole('textbox', { name: 'New password', exact: true }),
+        page.getByRole('textbox', { name: 'New Password', exact: true }),
       ).toBeVisible();
       await expect(
         page.getByRole('textbox', { name: 'New password (again)' }),
@@ -321,7 +321,7 @@ test.describe('Change password page', () => {
         .getByRole('textbox', { name: 'Enter email address' })
         .fill(TEST_EMAIL);
       await page
-        .getByRole('textbox', { name: 'New password', exact: true })
+        .getByRole('textbox', { name: 'New Password', exact: true })
         .fill(TEST_PASSWORD);
       await page
         .getByRole('textbox', { name: 'New password (again)' })
@@ -363,7 +363,7 @@ test.describe('Change password page', () => {
         .getByRole('textbox', { name: 'Enter email address' })
         .fill(TEST_EMAIL);
       await page
-        .getByRole('textbox', { name: 'New password', exact: true })
+        .getByRole('textbox', { name: 'New Password', exact: true })
         .fill(TEST_PASSWORD);
       await page
         .getByRole('textbox', { name: 'New password (again)' })
@@ -439,7 +439,7 @@ test.describe('Change password page', () => {
         .getByRole('textbox', { name: 'Enter email address' })
         .fill(TEST_EMAIL);
       await page
-        .getByRole('textbox', { name: 'New password', exact: true })
+        .getByRole('textbox', { name: 'New Password', exact: true })
         .fill(TEST_PASSWORD);
       await page
         .getByRole('textbox', { name: 'New password (again)' })
@@ -482,7 +482,7 @@ test.describe('Change password page', () => {
         .getByRole('textbox', { name: 'Enter email address' })
         .fill('wrong@example.com');
       await page
-        .getByRole('textbox', { name: 'New password', exact: true })
+        .getByRole('textbox', { name: 'New Password', exact: true })
         .fill(TEST_PASSWORD);
       await page
         .getByRole('textbox', { name: 'New password (again)' })
@@ -542,7 +542,7 @@ test.describe('Change password page', () => {
         .getByRole('textbox', { name: 'Enter email address' })
         .fill(TEST_EMAIL);
       await page
-        .getByRole('textbox', { name: 'New password', exact: true })
+        .getByRole('textbox', { name: 'New Password', exact: true })
         .fill('abc');
       await page
         .getByRole('textbox', { name: 'New password (again)' })
@@ -579,7 +579,7 @@ test.describe('Change password page', () => {
         .getByRole('textbox', { name: 'Enter email address' })
         .fill(TEST_EMAIL);
       await page
-        .getByRole('textbox', { name: 'New password', exact: true })
+        .getByRole('textbox', { name: 'New Password', exact: true })
         .fill('NewPass1!');
       await page
         .getByRole('textbox', { name: 'New password (again)' })

--- a/e2e/auth/password-expiry.spec.ts
+++ b/e2e/auth/password-expiry.spec.ts
@@ -135,14 +135,14 @@ test(
 
     // The password change modal must be fully interactive — its form fields accessible.
     await expect(
-      page.getByLabel('New password', { exact: true }),
+      page.getByLabel('New Password', { exact: true }),
     ).toBeVisible();
     await expect(page.getByLabel('New password (again)')).toBeVisible();
 
     // Verify the password change form is not visually blocked by clicking and
     // typing into the new password field. If the login modal's mask were covering
     // it, the click would fail or the field would not accept input.
-    const newPasswordInput = page.getByLabel('New password', { exact: true });
+    const newPasswordInput = page.getByLabel('New Password', { exact: true });
     await newPasswordInput.click();
     await newPasswordInput.fill('TestPassword1!');
     await expect(newPasswordInput).toHaveValue('TestPassword1!');
@@ -191,7 +191,7 @@ test(
     await triggerPasswordExpiryModal(page);
 
     // Fill the new password fields with the same value as the current password
-    await page.getByLabel('New password', { exact: true }).fill(TEST_PASSWORD);
+    await page.getByLabel('New Password', { exact: true }).fill(TEST_PASSWORD);
     await page.getByLabel('New password (again)').fill(TEST_PASSWORD);
     await page.getByRole('button', { name: 'Update' }).click();
 
@@ -324,7 +324,7 @@ test.describe('real account password change flow', () => {
       });
 
       // ── Fill new password; submit will go through mocked /server/update-password-no-auth ──
-      await page.getByLabel('New password', { exact: true }).fill(NEW_PASSWORD);
+      await page.getByLabel('New Password', { exact: true }).fill(NEW_PASSWORD);
       await page.getByLabel('New password (again)').fill(NEW_PASSWORD);
 
       // Mock the password update endpoint — the real backend returns "Malformed body"


### PR DESCRIPTION
## Summary

Automated e2e auto-heal produced by the **daily backend.ai-webui digest** pipeline (run 2026-07-29).

Two spec files were triaged as **HEAL** (test-side drift, no app regression) and fixed. Every healed test was re-run and verified passing before this PR was opened.

## Root cause

PR #8403 renamed the i18n label `webui.menu.NewPassword` from `"New password"` → `"New Password"` (capital P). This is live in `resources/i18n/en.json` today. Locators in these specs that matched the old casing with `exact: true` no longer resolved — producing `expect(locator).toBeVisible()` assertion failures and downstream `locator.fill: Timeout` errors. `webui.menu.NewPasswordAgain` ("New password (again)") was **not** renamed, so those locators were left untouched.

## Healed tests (verified re-pass)

- `e2e/auth/forgot-password.spec.ts` — 7 locators updated `'New password'` → `'New Password'` (all 16 tests pass)
- `e2e/auth/password-expiry.spec.ts` — 4 locators updated `'New password'` → `'New Password'` (all 7 non-fixme tests pass)

Re-run result: **23 passed, 1 skipped** (pre-existing `test.fixme` requiring a live cluster, untouched).

No app source or i18n files were modified — test-side only.

## Triage / audit trail

Report doc: `~/e2e-digest-reports/report-2026-07-29.md`

cc @yomybaby (related change #8403 — the label rename that caused the drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)