### PR TITLE
fix(FR-627): prevent page scrollbar from encroaching on top header

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -180,24 +180,21 @@ function MainLayout() {
         >
           <BAIContentWithDrawerArea drawerWidth={DRAWER_WIDTH}>
             <BAIFlex
-              ref={contentScrollFlexRef}
               direction="column"
               align="stretch"
               style={{
-                paddingLeft: token.paddingContentHorizontalLG,
-                paddingRight: token.paddingContentHorizontalLG,
-                paddingBottom: token.paddingContentVertical,
                 height: '100vh',
-                overflow: 'auto',
               }}
             >
               <BAIErrorBoundary>
+                {/* Header lives outside the scroll container so the page
+                    scrollbar never runs across it and its width stays
+                    constant regardless of content overflow (FR-627). */}
                 <div
                   style={{
-                    margin: `0 -${token.paddingContentHorizontalLG}px 0 -${token.paddingContentHorizontalLG}px`,
-                    position: 'sticky',
-                    top: 0,
+                    position: 'relative',
                     zIndex: HEADER_Z_INDEX_IN_MAIN_LAYOUT,
+                    flexShrink: 0,
                   }}
                 >
                   <Suspense
@@ -214,86 +211,101 @@ function MainLayout() {
                       onClickMenuIcon={() => setSideCollapsed((v) => !v)}
                     />
                   </Suspense>
-                  {/* sticky Alert components with banner props */}
+                  {/* Alert components with banner props, pinned with the header */}
                   <ErrorBoundaryWithNullFallback>
                     <Suspense fallback={null}>
                       <NetworkStatusBanner />
                     </Suspense>
                   </ErrorBoundaryWithNullFallback>
                 </div>
-                {/* Non sticky Alert components */}
-                <Suspense fallback={<div style={{ minHeight: '0px' }} />}>
-                  <BAIFlex
-                    direction="column"
-                    gap={'sm'}
-                    align="stretch"
-                    className={styles.alertWrapper}
-                  >
-                    {/* Dev-only: warn when the connected backend differs from
+                <BAIFlex
+                  ref={contentScrollFlexRef}
+                  direction="column"
+                  align="stretch"
+                  style={{
+                    paddingLeft: token.paddingContentHorizontalLG,
+                    paddingRight: token.paddingContentHorizontalLG,
+                    paddingBottom: token.paddingContentVertical,
+                    flex: 1,
+                    minHeight: 0,
+                    overflow: 'auto',
+                  }}
+                >
+                  {/* Non sticky Alert components */}
+                  <Suspense fallback={<div style={{ minHeight: '0px' }} />}>
+                    <BAIFlex
+                      direction="column"
+                      gap={'sm'}
+                      align="stretch"
+                      className={styles.alertWrapper}
+                    >
+                      {/* Dev-only: warn when the connected backend differs from
                         VITE_DEFAULT_API_ENDPOINT. Guarded by import.meta.env.DEV
                         so it is dead-code eliminated from production builds. */}
-                    {import.meta.env.DEV && (
-                      <ErrorBoundaryWithNullFallback>
-                        <DevApiEndpointMismatchAlert />
-                      </ErrorBoundaryWithNullFallback>
-                    )}
-                    <ErrorBoundaryWithNullFallback>
-                      <ThemePreviewModeAlert />
-                    </ErrorBoundaryWithNullFallback>
-                    <ErrorBoundaryWithNullFallback>
-                      <ProjectAdminScopeAlert />
-                    </ErrorBoundaryWithNullFallback>
-                    <ErrorBoundaryWithNullFallback>
-                      <NoResourceGroupAlert />
-                    </ErrorBoundaryWithNullFallback>
-                    <ErrorBoundaryWithNullFallback>
-                      <PasswordChangeRequestAlert
-                        showIcon
-                        icon={undefined}
-                        banner={false}
-                        closable
-                      />
-                    </ErrorBoundaryWithNullFallback>
-                  </BAIFlex>
-                </Suspense>
-                <Suspense>
-                  <ErrorBoundaryWithNullFallback>
-                    {/* ForceTOTPChecker is a component for previous version of manager which don't support TOTP registration before login.  */}
-                    {/* https://github.com/lablup/backend.ai/pull/4354 */}
-                    <ForceTOTPChecker />
-                  </ErrorBoundaryWithNullFallback>
-                </Suspense>
-                <Suspense>
-                  <ErrorBoundaryWithNullFallback>
-                    <PageAccessGuard emptyErrorPage>
-                      {isHiddenBreadcrumb ? (
-                        <div
-                          style={{
-                            marginBottom: token.marginMD,
-                          }}
-                        />
-                      ) : (
-                        <WebUIBreadcrumb
-                          style={{
-                            marginBottom: token.marginMD,
-                            marginLeft: token.paddingContentHorizontalLG * -1,
-                            marginRight: token.paddingContentHorizontalLG * -1,
-                          }}
-                        />
+                      {import.meta.env.DEV && (
+                        <ErrorBoundaryWithNullFallback>
+                          <DevApiEndpointMismatchAlert />
+                        </ErrorBoundaryWithNullFallback>
                       )}
-                    </PageAccessGuard>
-                  </ErrorBoundaryWithNullFallback>
-                  <BAIErrorBoundary>
-                    <AutoAdminPrimaryColorProvider>
-                      <PageAccessGuard>
-                        <Outlet />
+                      <ErrorBoundaryWithNullFallback>
+                        <ThemePreviewModeAlert />
+                      </ErrorBoundaryWithNullFallback>
+                      <ErrorBoundaryWithNullFallback>
+                        <ProjectAdminScopeAlert />
+                      </ErrorBoundaryWithNullFallback>
+                      <ErrorBoundaryWithNullFallback>
+                        <NoResourceGroupAlert />
+                      </ErrorBoundaryWithNullFallback>
+                      <ErrorBoundaryWithNullFallback>
+                        <PasswordChangeRequestAlert
+                          showIcon
+                          icon={undefined}
+                          banner={false}
+                          closable
+                        />
+                      </ErrorBoundaryWithNullFallback>
+                    </BAIFlex>
+                  </Suspense>
+                  <Suspense>
+                    <ErrorBoundaryWithNullFallback>
+                      {/* ForceTOTPChecker is a component for previous version of manager which don't support TOTP registration before login.  */}
+                      {/* https://github.com/lablup/backend.ai/pull/4354 */}
+                      <ForceTOTPChecker />
+                    </ErrorBoundaryWithNullFallback>
+                  </Suspense>
+                  <Suspense>
+                    <ErrorBoundaryWithNullFallback>
+                      <PageAccessGuard emptyErrorPage>
+                        {isHiddenBreadcrumb ? (
+                          <div
+                            style={{
+                              marginBottom: token.marginMD,
+                            }}
+                          />
+                        ) : (
+                          <WebUIBreadcrumb
+                            style={{
+                              marginBottom: token.marginMD,
+                              marginLeft: token.paddingContentHorizontalLG * -1,
+                              marginRight:
+                                token.paddingContentHorizontalLG * -1,
+                            }}
+                          />
+                        )}
                       </PageAccessGuard>
-                    </AutoAdminPrimaryColorProvider>
-                  </BAIErrorBoundary>
-                </Suspense>
-                <ErrorBoundaryWithNullFallback>
-                  <PluginLoader />
-                </ErrorBoundaryWithNullFallback>
+                    </ErrorBoundaryWithNullFallback>
+                    <BAIErrorBoundary>
+                      <AutoAdminPrimaryColorProvider>
+                        <PageAccessGuard>
+                          <Outlet />
+                        </PageAccessGuard>
+                      </AutoAdminPrimaryColorProvider>
+                    </BAIErrorBoundary>
+                  </Suspense>
+                  <ErrorBoundaryWithNullFallback>
+                    <PluginLoader />
+                  </ErrorBoundaryWithNullFallback>
+                </BAIFlex>
               </BAIErrorBoundary>
             </BAIFlex>
           </BAIContentWithDrawerArea>


### PR DESCRIPTION
Resolves #3313 (FR-627)

## Problem

The page scroll container in `MainLayout` was a `100vh` flex with `overflow: auto`, and `WebUIHeader` was rendered **inside** it as a `position: sticky` element. As a result:

- The vertical scrollbar track spanned the full viewport height, visually running across the header's right edge.
- Classic scrollbars consume layout width inside the scroll container, so whenever page content overflowed, the header shrank by the scrollbar width (measured: 15px in Chromium) and grew back on short pages — the header size changed on every page transition.

The 2px slim scrollbar styling does not mitigate this: `scrollbar-width: 2px` is an invalid value in Firefox (only `auto | thin | none`), and `::-webkit-scrollbar { max-width: 2px }` does not constrain the vertical scrollbar's occupied width (measured 15px with the style applied).

## Changes

- Moved `WebUIHeader` and `NetworkStatusBanner` out of the scroll container into a fixed (non-scrolling) top area of the layout.
- The content area below the header is now the scroll container (`flex: 1; min-height: 0; overflow: auto`), keeping the same horizontal/bottom padding, so the scrollbar is confined to the content area and never touches the header.
- `contentScrollFlexRef` (`mainContentDivRefState`) now points to the content scroll container; its only consumer (`SessionLauncherPage`, `scrollTo(0, 0)`) behaves the same.
- The header keeps `z-index: 100` (`HEADER_Z_INDEX_IN_MAIN_LAYOUT`) via `position: relative` for safety, and the previous negative-margin hack (used to escape the scroll container's padding) is no longer needed.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- Playwright measurement against the live dev app (Chromium, classic scrollbars enabled):
  - Before fix: header width 800px → 785px when content overflows (repro of the reported bug).
  - After fix: header width stays constant (1040px at 1280px viewport) with or without overflow; scrollbar (15px) appears only inside the content area below the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
