### PR TITLE
fix(FR-3419): list failed users when bulk user creation partially fails

### DIFF
--- a/react/src/components/BulkCreateUserFailure.tsx
+++ b/react/src/components/BulkCreateUserFailure.tsx
@@ -1,0 +1,120 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { Text } from '@astryxdesign/core/Text';
+import {
+  BAIBulkErrorModal,
+  type BAIBulkErrorModalProps,
+  type BAIColumnsType,
+  BAIText,
+} from 'backend.ai-ui';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * One user `adminBulkCreateUsersWithKeypairV2` refused to create, shaped for a
+ * table. `key` comes from the failure's `index` — its original position in the
+ * submitted list, which is unique per response.
+ */
+export interface FailedUserCreation {
+  key: string;
+  email: string;
+  username: string;
+  message: string;
+}
+
+/** The `failed` list as returned by either bulk-create mutation. */
+type BulkCreateFailures = ReadonlyArray<{
+  readonly index: number;
+  readonly email: string;
+  readonly username: string;
+  readonly message: string;
+}>;
+
+export const toFailedUserCreations = (
+  failed: BulkCreateFailures,
+): FailedUserCreation[] =>
+  failed.map((failure) => ({
+    key: String(failure.index),
+    email: failure.email,
+    username: failure.username,
+    message: failure.message,
+  }));
+
+const useFailedUserColumns = (): BAIColumnsType<FailedUserCreation> => {
+  'use memo';
+  const { t } = useTranslation();
+
+  return [
+    {
+      key: 'email',
+      title: t('general.E-Mail'),
+      dataIndex: 'email',
+    },
+    {
+      key: 'username',
+      title: t('credential.UserName'),
+      dataIndex: 'username',
+    },
+    {
+      key: 'message',
+      title: t('dialog.error.Error'),
+      dataIndex: 'message',
+      render: (message: string) => <BAIText type="danger">{message}</BAIText>,
+    },
+  ];
+};
+
+interface BulkCreateUserErrorModalProps extends Omit<
+  BAIBulkErrorModalProps<FailedUserCreation>,
+  'columns' | 'dataSource' | 'alertDescription'
+> {
+  failedUsers: FailedUserCreation[];
+  /**
+   * How many users the server actually created. Reported by the mutation rather
+   * than derived from the submitted count — the server may reject rows the
+   * client considered valid.
+   */
+  createdCount: number;
+}
+
+/**
+ * Lists the users a bulk create failed on, in its own modal — the single
+ * failure report for both bulk-create entry points (FR-3419). Shown over the
+ * still-open create form: immediately when every user failed (no keypairs to
+ * show first), or as the next step after the admin dismisses the
+ * generated-keypair modal when some users succeeded. Never shown alongside
+ * the keypair modal — the two are sequential, single-purpose screens, not
+ * merged into one.
+ */
+export const BulkCreateUserErrorModal: React.FC<
+  BulkCreateUserErrorModalProps
+> = ({ failedUsers, createdCount, ...bulkErrorModalProps }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const columns = useFailedUserColumns();
+
+  return (
+    <BAIBulkErrorModal<FailedUserCreation>
+      alertDescription={
+        <>
+          {t('credential.BulkCreateUserPartialFailureDescription')}{' '}
+          {/* The counts are a secondary aside to the description above, so they
+              are de-emphasized — same treatment as `AssignRoleModal`'s
+              partial-failure counts (FR-3357), expressed through Astryx `Text`
+              props rather than a hand-rolled `fontSize` token. */}
+          <Text color="secondary" size="sm">
+            {t('credential.BulkCreateUserPartialFailure', {
+              successCount: createdCount,
+              failCount: failedUsers.length,
+            })}
+          </Text>
+        </>
+      }
+      columns={columns}
+      dataSource={failedUsers}
+      {...bulkErrorModalProps}
+    />
+  );
+};

--- a/react/src/components/BulkCreateUserFailure.tsx
+++ b/react/src/components/BulkCreateUserFailure.tsx
@@ -1,0 +1,123 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { theme, Typography } from 'antd';
+import {
+  BAIBulkErrorModal,
+  type BAIBulkErrorModalProps,
+  type BAIColumnsType,
+} from 'backend.ai-ui';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * One user `adminBulkCreateUsersWithKeypairV2` refused to create, shaped for a
+ * table. `key` comes from the failure's `index` — its original position in the
+ * submitted list, which is unique per response.
+ */
+export interface FailedUserCreation {
+  key: string;
+  email: string;
+  username: string;
+  message: string;
+}
+
+/** The `failed` list as returned by either bulk-create mutation. */
+type BulkCreateFailures = ReadonlyArray<{
+  readonly index: number;
+  readonly email: string;
+  readonly username: string;
+  readonly message: string;
+}>;
+
+export const toFailedUserCreations = (
+  failed: BulkCreateFailures,
+): FailedUserCreation[] =>
+  failed.map((failure) => ({
+    key: String(failure.index),
+    email: failure.email,
+    username: failure.username,
+    message: failure.message,
+  }));
+
+const useFailedUserColumns = (): BAIColumnsType<FailedUserCreation> => {
+  'use memo';
+  const { t } = useTranslation();
+
+  return [
+    {
+      key: 'email',
+      title: t('general.E-Mail'),
+      dataIndex: 'email',
+    },
+    {
+      key: 'username',
+      title: t('credential.UserName'),
+      dataIndex: 'username',
+    },
+    {
+      key: 'message',
+      title: t('dialog.error.Error'),
+      dataIndex: 'message',
+      render: (message: string) => (
+        <Typography.Text type="danger">{message}</Typography.Text>
+      ),
+    },
+  ];
+};
+
+interface BulkCreateUserErrorModalProps extends Omit<
+  BAIBulkErrorModalProps<FailedUserCreation>,
+  'columns' | 'dataSource' | 'alertDescription'
+> {
+  failedUsers: FailedUserCreation[];
+  /**
+   * How many users the server actually created. Reported by the mutation rather
+   * than derived from the submitted count — the server may reject rows the
+   * client considered valid.
+   */
+  createdCount: number;
+}
+
+/**
+ * Lists the users a bulk create failed on, in its own modal — the single
+ * failure report for both bulk-create entry points (FR-3419). Shown over the
+ * still-open create form: immediately when every user failed (no keypairs to
+ * show first), or as the next step after the admin dismisses the
+ * generated-keypair modal when some users succeeded. Never shown alongside
+ * the keypair modal — the two are sequential, single-purpose screens, not
+ * merged into one.
+ */
+export const BulkCreateUserErrorModal: React.FC<
+  BulkCreateUserErrorModalProps
+> = ({ failedUsers, createdCount, ...bulkErrorModalProps }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const columns = useFailedUserColumns();
+
+  return (
+    <BAIBulkErrorModal<FailedUserCreation>
+      alertDescription={
+        <>
+          {t('credential.BulkCreateUserPartialFailureDescription')}{' '}
+          <Typography.Text
+            style={{
+              color: token.colorTextSecondary,
+              fontSize: token.fontSizeSM,
+            }}
+          >
+            {t('credential.BulkCreateUserPartialFailure', {
+              successCount: createdCount,
+              failCount: failedUsers.length,
+            })}
+          </Typography.Text>
+        </>
+      }
+      columns={columns}
+      dataSource={failedUsers}
+      {...bulkErrorModalProps}
+    />
+  );
+};

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -30,6 +30,11 @@ import { useCurrentDomainValue } from '../hooks';
 import { theme } from '../theme-shim';
 import BAIFormItem from './BAIFormItem';
 import BAIPanelItem from './BAIPanelItem';
+import {
+  BulkCreateUserErrorModal,
+  type FailedUserCreation,
+  toFailedUserCreations,
+} from './BulkCreateUserFailure';
 import GeneratedKeypairListModal from './GeneratedKeypairListModal';
 import { passwordPattern } from './LoginFormPanel';
 import ProjectSelect from './ProjectSelect';
@@ -58,7 +63,9 @@ import {
   BAIRowWrapWithDividers,
   BAITable,
   BAIText,
+  BAIUnmountAfterClose,
   badgeVariantForTagColor,
+  filterOutNullAndUndefined,
   useBAILogger,
   useBAISignedRequestWithPromise,
 } from 'backend.ai-ui';
@@ -141,13 +148,6 @@ interface ValidatedRow {
   isValid: boolean;
 }
 
-interface FailedUserRow {
-  index: number;
-  username: string;
-  email: string;
-  message: string;
-}
-
 // ─── Props ───────────────────────────────────────────────────────────────────
 
 interface BulkCreateUserFromCSVModalProps extends Omit<
@@ -196,7 +196,10 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
   const [dynamicColumnAliases, setDynamicColumnAliases] = useState<
     Record<string, string>
   >({});
-  const [failedRows, setFailedRows] = useState<FailedUserRow[]>([]);
+  // Users the server refused to create. Reported inside the generated-keypair
+  // result modal when some users were created, or in a standalone modal over
+  // the preview when none were.
+  const [failedUsers, setFailedUsers] = useState<FailedUserCreation[]>([]);
   // The server's actual created count from the last partial-failure submit.
   // Not derived from client stats — the server may reject rows the client
   // considered valid.
@@ -499,7 +502,6 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
 
   const canSubmit = stats.total > 0 && stats.withErrors === 0;
   const hasFile = fileName !== null;
-  const hasFailures = failedRows.length > 0;
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
@@ -508,7 +510,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
     setRawRows([]);
     setPresentColumns(new Set());
     setOnlyErrors(false);
-    setFailedRows([]);
+    setFailedUsers([]);
     setCreatedCount(0);
     setCreatedKeypairs(null);
   };
@@ -551,7 +553,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
     setRawRows(extractRawUserRows(records, headerMap));
     setPresentColumns(columnsInFile);
     setOnlyErrors(false);
-    setFailedRows([]);
+    setFailedUsers([]);
   };
 
   const handleFileInput = (files: FileList | null) => {
@@ -634,8 +636,9 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           }
           const createdList =
             res.adminBulkCreateUsersWithKeypairV2?.created ?? [];
-          const createdCount = createdList.length;
+          const succeededCount = createdList.length;
           const failed = res.adminBulkCreateUsersWithKeypairV2?.failed ?? [];
+          setCreatedCount(succeededCount);
           // Surface keypairs first: secret keys are one-time and must be shown
           // regardless of whether some rows failed.
           const keypairs = _.map(createdList, (created) => created.keypair);
@@ -643,21 +646,23 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
             setCreatedKeypairs(keypairs);
           }
           if (failed.length > 0) {
-            setFailedRows([...failed]);
-            setCreatedCount(createdCount);
-            message.warning(
+            // Immediate failure notice as a toast on top of the detail modal
+            // (matches FR-3357's AssignRoleModal) — the modal carries the
+            // per-user table, the message the at-a-glance cue.
+            message.error(
               t('credential.BulkCreateUserPartialFailure', {
-                successCount: createdCount,
+                successCount: succeededCount,
                 failCount: failed.length,
               }),
             );
-            logger.error('Bulk create partial failures:', failed);
-            if (keypairs.length === 0) {
-              onRequestClose(true);
-            }
+            // The per-user reasons only reach the admin through the error
+            // modal, so nothing closes here — it renders on top of the preview
+            // (or of the keypair list, when some users were created), leaving
+            // the loaded CSV in place for a retry.
+            setFailedUsers(toFailedUserCreations(failed));
           } else {
             message.success(
-              t('credential.BulkCreateUserSuccess', { count: createdCount }),
+              t('credential.BulkCreateUserSuccess', { count: succeededCount }),
             );
             if (keypairs.length === 0) {
               onRequestClose(true);
@@ -940,81 +945,15 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
     },
   ]);
 
-  // ── Post-submission keypair download screen ───────────────────────────────
-
-  // On full success, replace the form with the generated-keypair download
-  // modal (same UX as single-user creation). `open` is inherited from the
-  // parent via baiModalProps; createdKeypairs is cleared in resetState after
-  // the close animation, so the form never flashes back into view.
-  if (createdKeypairs) {
-    return (
-      <GeneratedKeypairListModal
-        {...baiModalProps}
-        keypairFragment={createdKeypairs}
-        afterClose={resetState}
-        onRequestClose={() => onRequestClose(true)}
-      />
-    );
-  }
-
-  // ── Post-submission failure screen ────────────────────────────────────────
-
-  if (hasFailures) {
-    return (
-      <BAIModal
-        centered
-        title={t('credential.BulkCreateUserFromCSV')}
-        width={680}
-        styles={{ body: { padding: token.paddingLG } }}
-        footer={
-          <BAIFlex justify="end">
-            <BAIButton type="primary" onClick={() => onRequestClose(true)}>
-              {t('button.Close')}
-            </BAIButton>
-          </BAIFlex>
-        }
-        afterClose={resetState}
-        {...baiModalProps}
-      >
-        <BAIFlex direction="column" align="stretch" gap="md">
-          <BAIAlert
-            type="warning"
-            showIcon
-            description={t('credential.BulkCreateUserPartialFailure', {
-              successCount: createdCount,
-              failCount: failedRows.length,
-            })}
-          />
-          <BAITable
-            size="small"
-            rowKey="index"
-            dataSource={failedRows}
-            pagination={false}
-            columns={[
-              {
-                title: t('general.E-Mail'),
-                dataIndex: 'email',
-                key: 'email',
-              },
-              {
-                title: t('credential.UserName'),
-                dataIndex: 'username',
-                key: 'username',
-              },
-              {
-                title: t('dialog.error.Error'),
-                dataIndex: 'message',
-                key: 'message',
-                render: (v: string) => <BAIText type="danger">{v}</BAIText>,
-              },
-            ]}
-          />
-        </BAIFlex>
-      </BAIModal>
-    );
-  }
-
   // ── Main modal ────────────────────────────────────────────────────────────
+
+  // The keypair and failure screens are independent sibling modals layered
+  // over this one (never an early-return swap of the whole return) — this
+  // modal, and everything the admin already typed/uploaded into it, stays
+  // mounted the entire time. Swapping the whole return previously caused the
+  // form to visibly re-mount (a fresh "opening" transition) once the overlay
+  // was dismissed, and skipped this modal's own `afterClose` on a same-render
+  // double state flip (FR-3419).
 
   return (
     <BAIModal
@@ -1047,7 +986,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
       }}
       footer={
         <BAIFlex justify="end" gap="sm">
-          <BAIButton onClick={() => onRequestClose(false)}>
+          <BAIButton onClick={() => onRequestClose(createdCount > 0)}>
             {t('button.Cancel')}
           </BAIButton>
           <BAIButton
@@ -1061,7 +1000,10 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           </BAIButton>
         </BAIFlex>
       }
-      onCancel={() => onRequestClose(false)}
+      // A partial failure leaves this form open, so closing it still has to
+      // report the users that *were* created — otherwise the list behind it
+      // never refetches. `createdCount` is 0 until a submit succeeds in part.
+      onCancel={() => onRequestClose(createdCount > 0)}
       afterClose={resetState}
       {...baiModalProps}
     >
@@ -1487,6 +1429,34 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           />
         )}
       </BAIFlex>
+      <BAIUnmountAfterClose>
+        <GeneratedKeypairListModal
+          open={!!createdKeypairs}
+          keypairFragment={filterOutNullAndUndefined(createdKeypairs)}
+          onRequestClose={() => {
+            const hadFailures = !_.isEmpty(failedUsers);
+            setCreatedKeypairs(null);
+            if (!hadFailures) {
+              // Full success — nothing left to review, finish the whole flow.
+              onRequestClose(true);
+            }
+            // Partial failure: leave failedUsers as-is. The failure modal
+            // below is the next step — its `open` gate flips true now that
+            // createdKeypairs is cleared, showing over this still-open,
+            // still-loaded form (FR-3419).
+          }}
+        />
+      </BAIUnmountAfterClose>
+      {/* The failure report — shown immediately when every row failed (no
+          keypairs to show first), or as the step after the admin dismisses
+          the keypair modal above when some rows succeeded. Never shown
+          together with the keypair modal (FR-3419). */}
+      <BulkCreateUserErrorModal
+        open={!createdKeypairs && !_.isEmpty(failedUsers)}
+        failedUsers={failedUsers}
+        createdCount={createdCount}
+        onRequestClose={() => setFailedUsers([])}
+      />
     </BAIModal>
   );
 };

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -200,10 +200,22 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
   // result modal when some users were created, or in a standalone modal over
   // the preview when none were.
   const [failedUsers, setFailedUsers] = useState<FailedUserCreation[]>([]);
-  // The server's actual created count from the last partial-failure submit.
-  // Not derived from client stats — the server may reject rows the client
-  // considered valid.
+  // The server's actual created count from the LAST submit. Not derived from
+  // client stats — the server may reject rows the client considered valid.
+  // Per-attempt on purpose: it labels that attempt's failure report
+  // ("Success: n, Failed: m"), so a retry must overwrite it, and `resetState`
+  // (which the Remove File button also runs) clears it with the rest of the
+  // loaded file.
   const [createdCount, setCreatedCount] = useState(0);
+  // Whether any user reached the backend during this modal session. Separate
+  // from `createdCount` because that one is per-attempt AND file-scoped:
+  // retrying with 0 successes, or removing the file, would otherwise reset it
+  // to 0 and make the close paths below report "nothing created" even though
+  // an earlier submit did create users. Monotonic, deliberately NOT part of
+  // `resetState` — removing the file does not un-create them. The modal is
+  // unmounted on close (BAIUnmountAfterClose), so the next session starts from
+  // false. Mirrors `AssignRoleModal`'s `hasAssignedAny`.
+  const [hasCreatedAny, setHasCreatedAny] = useState(false);
   // All active groups for the current domain, used to map project name <-> id.
   // The UI (preview, selectors) works with names; only the mutation uses ids.
   const [groupList, setGroupList] = useState<
@@ -505,6 +517,10 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
+  // Clears everything scoped to the loaded file. Shared by `afterClose` and
+  // the Remove File button, so it deliberately leaves `hasCreatedAny` alone —
+  // dropping the file does not un-create the users an earlier submit already
+  // created, and the close paths still have to report them.
   const resetState = () => {
     setFileName(null);
     setRawRows([]);
@@ -639,6 +655,9 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           const succeededCount = createdList.length;
           const failed = res.adminBulkCreateUsersWithKeypairV2?.failed ?? [];
           setCreatedCount(succeededCount);
+          if (succeededCount > 0) {
+            setHasCreatedAny(true);
+          }
           // Surface keypairs first: secret keys are one-time and must be shown
           // regardless of whether some rows failed.
           const keypairs = _.map(createdList, (created) => created.keypair);
@@ -986,7 +1005,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
       }}
       footer={
         <BAIFlex justify="end" gap="sm">
-          <BAIButton onClick={() => onRequestClose(createdCount > 0)}>
+          <BAIButton onClick={() => onRequestClose(hasCreatedAny)}>
             {t('button.Cancel')}
           </BAIButton>
           <BAIButton
@@ -1002,8 +1021,10 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
       }
       // A partial failure leaves this form open, so closing it still has to
       // report the users that *were* created — otherwise the list behind it
-      // never refetches. `createdCount` is 0 until a submit succeeds in part.
-      onCancel={() => onRequestClose(createdCount > 0)}
+      // never refetches. Uses the session-wide `hasCreatedAny` rather than the
+      // per-attempt, file-scoped `createdCount`, so neither a retry that
+      // creates nothing nor a Remove File can erase an earlier success.
+      onCancel={() => onRequestClose(hasCreatedAny)}
       afterClose={resetState}
       {...baiModalProps}
     >

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -26,6 +26,11 @@ import {
 import { downloadBlob, parseCSV } from '../helper/csv-util';
 import { useCurrentDomainValue } from '../hooks';
 import BAIPanelItem from './BAIPanelItem';
+import {
+  BulkCreateUserErrorModal,
+  type FailedUserCreation,
+  toFailedUserCreations,
+} from './BulkCreateUserFailure';
 import GeneratedKeypairListModal from './GeneratedKeypairListModal';
 import { passwordPattern } from './LoginFormPanel';
 import ProjectSelect from './ProjectSelect';
@@ -65,6 +70,8 @@ import {
   BAIQuestionIconWithTooltip,
   BAIRowWrapWithDividers,
   BAIText,
+  BAIUnmountAfterClose,
+  filterOutNullAndUndefined,
   useBAILogger,
   useBAISignedRequestWithPromise,
 } from 'backend.ai-ui';
@@ -137,13 +144,6 @@ interface ValidatedRow {
   isValid: boolean;
 }
 
-interface FailedUserRow {
-  index: number;
-  username: string;
-  email: string;
-  message: string;
-}
-
 // ─── Props ───────────────────────────────────────────────────────────────────
 
 interface BulkCreateUserFromCSVModalProps extends Omit<
@@ -192,7 +192,10 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
   const [dynamicColumnAliases, setDynamicColumnAliases] = useState<
     Record<string, string>
   >({});
-  const [failedRows, setFailedRows] = useState<FailedUserRow[]>([]);
+  // Users the server refused to create. Reported inside the generated-keypair
+  // result modal when some users were created, or in a standalone modal over
+  // the preview when none were.
+  const [failedUsers, setFailedUsers] = useState<FailedUserCreation[]>([]);
   // The server's actual created count from the last partial-failure submit.
   // Not derived from client stats — the server may reject rows the client
   // considered valid.
@@ -495,7 +498,6 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
 
   const canSubmit = stats.total > 0 && stats.withErrors === 0;
   const hasFile = fileName !== null;
-  const hasFailures = failedRows.length > 0;
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
@@ -504,7 +506,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
     setRawRows([]);
     setPresentColumns(new Set());
     setOnlyErrors(false);
-    setFailedRows([]);
+    setFailedUsers([]);
     setCreatedCount(0);
     setCreatedKeypairs(null);
   };
@@ -547,7 +549,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
     setRawRows(extractRawUserRows(records, headerMap));
     setPresentColumns(columnsInFile);
     setOnlyErrors(false);
-    setFailedRows([]);
+    setFailedUsers([]);
   };
 
   const handleFileInput = (files: FileList | null) => {
@@ -630,8 +632,9 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           }
           const createdList =
             res.adminBulkCreateUsersWithKeypairV2?.created ?? [];
-          const createdCount = createdList.length;
+          const succeededCount = createdList.length;
           const failed = res.adminBulkCreateUsersWithKeypairV2?.failed ?? [];
+          setCreatedCount(succeededCount);
           // Surface keypairs first: secret keys are one-time and must be shown
           // regardless of whether some rows failed.
           const keypairs = _.map(createdList, (created) => created.keypair);
@@ -639,21 +642,23 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
             setCreatedKeypairs(keypairs);
           }
           if (failed.length > 0) {
-            setFailedRows([...failed]);
-            setCreatedCount(createdCount);
-            message.warning(
+            // Immediate failure notice as a toast on top of the detail modal
+            // (matches FR-3357's AssignRoleModal) — the modal carries the
+            // per-user table, the message the at-a-glance cue.
+            message.error(
               t('credential.BulkCreateUserPartialFailure', {
-                successCount: createdCount,
+                successCount: succeededCount,
                 failCount: failed.length,
               }),
             );
-            logger.error('Bulk create partial failures:', failed);
-            if (keypairs.length === 0) {
-              onRequestClose(true);
-            }
+            // The per-user reasons only reach the admin through the error
+            // modal, so nothing closes here — it renders on top of the preview
+            // (or of the keypair list, when some users were created), leaving
+            // the loaded CSV in place for a retry.
+            setFailedUsers(toFailedUserCreations(failed));
           } else {
             message.success(
-              t('credential.BulkCreateUserSuccess', { count: createdCount }),
+              t('credential.BulkCreateUserSuccess', { count: succeededCount }),
             );
             if (keypairs.length === 0) {
               onRequestClose(true);
@@ -928,84 +933,15 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
     },
   ]);
 
-  // ── Post-submission keypair download screen ───────────────────────────────
-
-  // On full success, replace the form with the generated-keypair download
-  // modal (same UX as single-user creation). `open` is inherited from the
-  // parent via baiModalProps; createdKeypairs is cleared in resetState after
-  // the close animation, so the form never flashes back into view.
-  if (createdKeypairs) {
-    return (
-      <GeneratedKeypairListModal
-        {...baiModalProps}
-        keypairFragment={createdKeypairs}
-        afterClose={resetState}
-        onRequestClose={() => onRequestClose(true)}
-      />
-    );
-  }
-
-  // ── Post-submission failure screen ────────────────────────────────────────
-
-  if (hasFailures) {
-    return (
-      <BAIModal
-        centered
-        title={t('credential.BulkCreateUserFromCSV')}
-        width={680}
-        styles={{ body: { padding: token.paddingLG } }}
-        footer={
-          <BAIFlex justify="end">
-            <BAIButton type="primary" onClick={() => onRequestClose(true)}>
-              {t('button.Close')}
-            </BAIButton>
-          </BAIFlex>
-        }
-        afterClose={resetState}
-        {...baiModalProps}
-      >
-        <BAIFlex direction="column" align="stretch" gap="md">
-          <BAIAlert
-            type="warning"
-            showIcon
-            description={t('credential.BulkCreateUserPartialFailure', {
-              successCount: createdCount,
-              failCount: failedRows.length,
-            })}
-          />
-          <Table
-            size="small"
-            rowKey="index"
-            scroll={{ x: 'max-content' }}
-            dataSource={failedRows}
-            pagination={false}
-            columns={[
-              {
-                title: t('general.E-Mail'),
-                dataIndex: 'email',
-                key: 'email',
-              },
-              {
-                title: t('credential.UserName'),
-                dataIndex: 'username',
-                key: 'username',
-              },
-              {
-                title: t('dialog.error.Error'),
-                dataIndex: 'message',
-                key: 'message',
-                render: (v: string) => (
-                  <Typography.Text type="danger">{v}</Typography.Text>
-                ),
-              },
-            ]}
-          />
-        </BAIFlex>
-      </BAIModal>
-    );
-  }
-
   // ── Main modal ────────────────────────────────────────────────────────────
+
+  // The keypair and failure screens are independent sibling modals layered
+  // over this one (never an early-return swap of the whole return) — this
+  // modal, and everything the admin already typed/uploaded into it, stays
+  // mounted the entire time. Swapping the whole return previously caused the
+  // form to visibly re-mount (a fresh "opening" transition) once the overlay
+  // was dismissed, and skipped this modal's own `afterClose` on a same-render
+  // double state flip (FR-3419).
 
   return (
     <BAIModal
@@ -1040,7 +976,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
       }}
       footer={
         <BAIFlex justify="end" gap="sm">
-          <BAIButton onClick={() => onRequestClose(false)}>
+          <BAIButton onClick={() => onRequestClose(createdCount > 0)}>
             {t('button.Cancel')}
           </BAIButton>
           <BAIButton
@@ -1054,7 +990,10 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           </BAIButton>
         </BAIFlex>
       }
-      onCancel={() => onRequestClose(false)}
+      // A partial failure leaves this form open, so closing it still has to
+      // report the users that *were* created — otherwise the list behind it
+      // never refetches. `createdCount` is 0 until a submit succeeds in part.
+      onCancel={() => onRequestClose(createdCount > 0)}
       afterClose={resetState}
       {...baiModalProps}
     >
@@ -1496,6 +1435,34 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
           />
         )}
       </BAIFlex>
+      <BAIUnmountAfterClose>
+        <GeneratedKeypairListModal
+          open={!!createdKeypairs}
+          keypairFragment={filterOutNullAndUndefined(createdKeypairs)}
+          onRequestClose={() => {
+            const hadFailures = !_.isEmpty(failedUsers);
+            setCreatedKeypairs(null);
+            if (!hadFailures) {
+              // Full success — nothing left to review, finish the whole flow.
+              onRequestClose(true);
+            }
+            // Partial failure: leave failedUsers as-is. The failure modal
+            // below is the next step — its `open` gate flips true now that
+            // createdKeypairs is cleared, showing over this still-open,
+            // still-loaded form (FR-3419).
+          }}
+        />
+      </BAIUnmountAfterClose>
+      {/* The failure report — shown immediately when every row failed (no
+          keypairs to show first), or as the step after the admin dismisses
+          the keypair modal above when some rows succeeded. Never shown
+          together with the keypair modal (FR-3419). */}
+      <BulkCreateUserErrorModal
+        open={!createdKeypairs && !_.isEmpty(failedUsers)}
+        failedUsers={failedUsers}
+        createdCount={createdCount}
+        onRequestClose={() => setFailedUsers([])}
+      />
     </BAIModal>
   );
 };

--- a/react/src/components/GeneratedKeypairListModal.tsx
+++ b/react/src/components/GeneratedKeypairListModal.tsx
@@ -77,7 +77,10 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
   return (
     <BAIModal
       title={t('credential.NewCredentialCreated')}
-      width={600}
+      // 600 left the three columns at 200px each, one of which cannot fit an
+      // access key plus its copy button; 780 clears the table's natural width
+      // so the default view needs no horizontal scroll (FR-3519).
+      width={780}
       destroyOnHidden
       okText={t('button.Download')}
       onOk={handleDownload}
@@ -98,10 +101,11 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
           title={t('credential.GeneratedKeypairWarning')}
         />
         <BAIText>{t('credential.GeneratedKeypairInfo')}</BAIText>
+        {/* No `scroll` prop: Astryx's scroll wrapper owns overflow here, and
+            these columns take their floors from `minWidth`. */}
         <BAITable<KeypairType>
           size="small"
-          style={{ overflowX: 'auto' }}
-          scroll={{ x: 'max-content', y: 500 }}
+          resizable
           pagination={false}
           dataSource={keypairData}
           rowKey={(record) => record?.keypair?.accessKey ?? ''}
@@ -121,6 +125,10 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
               title: t('credential.AccessKey'),
               dataIndex: ['keypair', 'accessKey'],
               key: 'access_key',
+              // Widest cell in the table: 20 monospace chars plus the copy
+              // button. Without a floor it takes an equal third and clips the
+              // button, since `<td>` is `overflow: hidden` (FR-3519).
+              minWidth: 240,
               render: (value) => (
                 <BAIText copyable monospace>
                   {value}

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -264,9 +264,19 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
   // result modal when some users were created, or in a standalone modal over
   // this form when none were.
   const [failedUsers, setFailedUsers] = useState<FailedUserCreation[]>([]);
-  // The server's own created count — the mutation may reject users the form
-  // considered valid, so this is not derived from the requested count.
+  // The server's own created count for the LAST submit — the mutation may
+  // reject users the form considered valid, so this is not derived from the
+  // requested count. Per-attempt on purpose: it labels that attempt's failure
+  // report ("Success: n, Failed: m"), so a retry must overwrite it.
   const [createdCount, setCreatedCount] = useState(0);
+  // Whether any user reached the backend during this modal session. Separate
+  // from `createdCount` because that one is per-attempt: retrying a partially
+  // successful bulk create can succeed 0 times, which would otherwise reset
+  // the count to 0 and make the close below report "nothing created" even
+  // though the first attempt did create users. Monotonic, and never cleared —
+  // the modal is unmounted on close (BAIUnmountAfterClose), so the next
+  // session starts from false. Mirrors `AssignRoleModal`'s `hasAssignedAny`.
+  const [hasCreatedAny, setHasCreatedAny] = useState(false);
 
   const user = useFragment(
     graphql`
@@ -487,6 +497,9 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
               const failedList =
                 res.adminBulkCreateUsersWithKeypairV2?.failed ?? [];
               setCreatedCount(succeededCount);
+              if (succeededCount > 0) {
+                setHasCreatedAny(true);
+              }
 
               // Reveal the generated keypairs (secret keys are returned once).
               const keypairs = _.map(createdList, (created) => created.keypair);
@@ -652,9 +665,12 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
       }
       // A bulk create that partially failed leaves this form open, so its
       // Cancel still has to report the users that *were* created — otherwise
-      // the list behind it never refetches. `createdCount` stays 0 on the
-      // single-create and edit paths, which keeps their behaviour unchanged.
-      onCancel={() => onRequestClose(createdCount > 0)}
+      // the list behind it never refetches. Uses the session-wide
+      // `hasCreatedAny` rather than the per-attempt `createdCount`, so a retry
+      // that creates nothing cannot erase an earlier attempt's success. Stays
+      // false on the single-create and edit paths, which keeps their behaviour
+      // unchanged.
+      onCancel={() => onRequestClose(hasCreatedAny)}
       loading={deferredOpen !== baiModalProps.open}
       {...baiModalProps}
     >

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -21,6 +21,11 @@ import { useTanMutation } from '../hooks/reactQueryAlias';
 import { theme } from '../theme-shim';
 import AccessKeySelect from './AccessKeySelect';
 import BAIFormItem from './BAIFormItem';
+import {
+  BulkCreateUserErrorModal,
+  type FailedUserCreation,
+  toFailedUserCreations,
+} from './BulkCreateUserFailure';
 import GeneratedKeypairListModal from './GeneratedKeypairListModal';
 import ProjectSelect from './ProjectSelect';
 import TOTPActivateModal from './TOTPActivateModal';
@@ -255,6 +260,14 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
   const [createdKeypairs, setCreatedKeypairs] =
     useState<GeneratedKeypairListModalFragment$key | null>();
 
+  // Users the server refused to create. Reported inside the generated-keypair
+  // result modal when some users were created, or in a standalone modal over
+  // this form when none were.
+  const [failedUsers, setFailedUsers] = useState<FailedUserCreation[]>([]);
+  // The server's own created count — the mutation may reject users the form
+  // considered valid, so this is not derived from the requested count.
+  const [createdCount, setCreatedCount] = useState(0);
+
   const user = useFragment(
     graphql`
       fragment UserSettingModalFragment on UserV2 {
@@ -470,31 +483,40 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
 
               const createdList =
                 res.adminBulkCreateUsersWithKeypairV2?.created ?? [];
-              const createdCount = createdList.length;
+              const succeededCount = createdList.length;
               const failedList =
                 res.adminBulkCreateUsersWithKeypairV2?.failed ?? [];
-
-              if (failedList.length > 0) {
-                message.warning(
-                  t('credential.BulkCreateUserPartialFailure', {
-                    successCount: createdCount,
-                    failCount: failedList.length,
-                  }),
-                );
-                logger.error('Bulk create partial failures:', failedList);
-              } else {
-                message.success(
-                  t('credential.BulkCreateUserSuccess', {
-                    count: createdCount,
-                  }),
-                );
-              }
+              setCreatedCount(succeededCount);
 
               // Reveal the generated keypairs (secret keys are returned once).
               const keypairs = _.map(createdList, (created) => created.keypair);
               if (keypairs.length > 0) {
                 setCreatedKeypairs(keypairs);
-              } else {
+              }
+
+              if (failedList.length > 0) {
+                // Immediate failure notice as a toast on top of the detail
+                // modal (matches FR-3357's AssignRoleModal) — the modal
+                // carries the per-user table, the message the at-a-glance cue.
+                message.error(
+                  t('credential.BulkCreateUserPartialFailure', {
+                    successCount: succeededCount,
+                    failCount: failedList.length,
+                  }),
+                );
+                // The per-user reasons only reach the admin through the error
+                // modal — this form (or the keypair list of the users that were
+                // created) stays open behind it, so nothing closes here.
+                setFailedUsers(toFailedUserCreations(failedList));
+                return;
+              }
+
+              message.success(
+                t('credential.BulkCreateUserSuccess', {
+                  count: succeededCount,
+                }),
+              );
+              if (keypairs.length === 0) {
                 onRequestClose(true);
               }
             },
@@ -628,7 +650,11 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
         isInFlightCommitCreateUser ||
         isInFlightBulkCreateUsers
       }
-      onCancel={() => onRequestClose(false)}
+      // A bulk create that partially failed leaves this form open, so its
+      // Cancel still has to report the users that *were* created — otherwise
+      // the list behind it never refetches. `createdCount` stays 0 on the
+      // single-create and edit paths, which keeps their behaviour unchanged.
+      onCancel={() => onRequestClose(createdCount > 0)}
       loading={deferredOpen !== baiModalProps.open}
       {...baiModalProps}
     >
@@ -1291,11 +1317,29 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
             open={!!createdKeypairs}
             keypairFragment={filterOutNullAndUndefined(createdKeypairs)}
             onRequestClose={() => {
+              const hadFailures = !_.isEmpty(failedUsers);
               setCreatedKeypairs(null);
-              onRequestClose(true);
+              if (!hadFailures) {
+                // Full success — nothing left to review, finish the whole flow.
+                onRequestClose(true);
+              }
+              // Partial failure: leave failedUsers as-is. BulkCreateUserErrorModal
+              // below is the next step — its `open` gate flips true now that
+              // createdKeypairs is cleared, showing the failures over the
+              // still-open form (FR-3419).
             }}
           />
         </BAIUnmountAfterClose>
+        {/* The failure report — shown immediately when every user failed (no
+            keypairs to show first), or as the step after the admin dismisses
+            the keypair modal above when some users succeeded. Never shown
+            together with the keypair modal (FR-3419). */}
+        <BulkCreateUserErrorModal
+          open={!createdKeypairs && !_.isEmpty(failedUsers)}
+          failedUsers={failedUsers}
+          createdCount={createdCount}
+          onRequestClose={() => setFailedUsers([])}
+        />
       </Suspense>
     </BAIModal>
   );

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -17,6 +17,11 @@ import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserRole, useTOTPSupported } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import AccessKeySelect from './AccessKeySelect';
+import {
+  BulkCreateUserErrorModal,
+  type FailedUserCreation,
+  toFailedUserCreations,
+} from './BulkCreateUserFailure';
 import GeneratedKeypairListModal from './GeneratedKeypairListModal';
 import ProjectSelect from './ProjectSelect';
 import TOTPActivateModal from './TOTPActivateModal';
@@ -179,6 +184,14 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
 
   const [createdKeypairs, setCreatedKeypairs] =
     useState<GeneratedKeypairListModalFragment$key | null>();
+
+  // Users the server refused to create. Reported inside the generated-keypair
+  // result modal when some users were created, or in a standalone modal over
+  // this form when none were.
+  const [failedUsers, setFailedUsers] = useState<FailedUserCreation[]>([]);
+  // The server's own created count — the mutation may reject users the form
+  // considered valid, so this is not derived from the requested count.
+  const [createdCount, setCreatedCount] = useState(0);
 
   const user = useFragment(
     graphql`
@@ -393,31 +406,40 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
 
               const createdList =
                 res.adminBulkCreateUsersWithKeypairV2?.created ?? [];
-              const createdCount = createdList.length;
+              const succeededCount = createdList.length;
               const failedList =
                 res.adminBulkCreateUsersWithKeypairV2?.failed ?? [];
-
-              if (failedList.length > 0) {
-                message.warning(
-                  t('credential.BulkCreateUserPartialFailure', {
-                    successCount: createdCount,
-                    failCount: failedList.length,
-                  }),
-                );
-                logger.error('Bulk create partial failures:', failedList);
-              } else {
-                message.success(
-                  t('credential.BulkCreateUserSuccess', {
-                    count: createdCount,
-                  }),
-                );
-              }
+              setCreatedCount(succeededCount);
 
               // Reveal the generated keypairs (secret keys are returned once).
               const keypairs = _.map(createdList, (created) => created.keypair);
               if (keypairs.length > 0) {
                 setCreatedKeypairs(keypairs);
-              } else {
+              }
+
+              if (failedList.length > 0) {
+                // Immediate failure notice as a toast on top of the detail
+                // modal (matches FR-3357's AssignRoleModal) — the modal
+                // carries the per-user table, the message the at-a-glance cue.
+                message.error(
+                  t('credential.BulkCreateUserPartialFailure', {
+                    successCount: succeededCount,
+                    failCount: failedList.length,
+                  }),
+                );
+                // The per-user reasons only reach the admin through the error
+                // modal — this form (or the keypair list of the users that were
+                // created) stays open behind it, so nothing closes here.
+                setFailedUsers(toFailedUserCreations(failedList));
+                return;
+              }
+
+              message.success(
+                t('credential.BulkCreateUserSuccess', {
+                  count: succeededCount,
+                }),
+              );
+              if (keypairs.length === 0) {
                 onRequestClose(true);
               }
             },
@@ -551,7 +573,11 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
         isInFlightCommitCreateUser ||
         isInFlightBulkCreateUsers
       }
-      onCancel={() => onRequestClose(false)}
+      // A bulk create that partially failed leaves this form open, so its
+      // Cancel still has to report the users that *were* created — otherwise
+      // the list behind it never refetches. `createdCount` stays 0 on the
+      // single-create and edit paths, which keeps their behaviour unchanged.
+      onCancel={() => onRequestClose(createdCount > 0)}
       loading={deferredOpen !== baiModalProps.open}
       {...baiModalProps}
     >
@@ -1170,11 +1196,29 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
             open={!!createdKeypairs}
             keypairFragment={filterOutNullAndUndefined(createdKeypairs)}
             onRequestClose={() => {
+              const hadFailures = !_.isEmpty(failedUsers);
               setCreatedKeypairs(null);
-              onRequestClose(true);
+              if (!hadFailures) {
+                // Full success — nothing left to review, finish the whole flow.
+                onRequestClose(true);
+              }
+              // Partial failure: leave failedUsers as-is. BulkCreateUserErrorModal
+              // below is the next step — its `open` gate flips true now that
+              // createdKeypairs is cleared, showing the failures over the
+              // still-open form (FR-3419).
             }}
           />
         </BAIUnmountAfterClose>
+        {/* The failure report — shown immediately when every user failed (no
+            keypairs to show first), or as the step after the admin dismisses
+            the keypair modal above when some users succeeded. Never shown
+            together with the keypair modal (FR-3419). */}
+        <BulkCreateUserErrorModal
+          open={!createdKeypairs && !_.isEmpty(failedUsers)}
+          failedUsers={failedUsers}
+          createdCount={createdCount}
+          onRequestClose={() => setFailedUsers([])}
+        />
       </Suspense>
     </BAIModal>
   );

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Mehrere Benutzer per CSV erstellen",
     "BulkCreateUserFromCSVSubtitle": "Laden Sie eine CSV-Datei hoch, um mehrere Benutzerkonten auf einmal zu erstellen.",
     "BulkCreateUserPartialFailure": "{{successCount}} Benutzer wurden erstellt. {{failCount}} Benutzer konnten nicht erstellt werden.",
+    "BulkCreateUserPartialFailureDescription": "Einige Benutzer konnten nicht erstellt werden. Bitte überprüfen Sie die Einträge.",
     "BulkCreateUserSuccess": "Erfolgreich {{count}} Benutzer erstellt.",
     "BulkDeactivateCredentials": "Anmeldeinformationen deaktivieren",
     "BulkDeactivateCredentialsDescription": "Sie sind dabei, {{count}} Anmeldeinformation(en) zu deaktivieren. Die Benutzer können diese Anmeldeinformationen danach nicht mehr verwenden.",

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Mehrere Benutzer per CSV erstellen",
     "BulkCreateUserFromCSVSubtitle": "Laden Sie eine CSV-Datei hoch, um mehrere Benutzerkonten auf einmal zu erstellen.",
     "BulkCreateUserPartialFailure": "{{successCount}} Benutzer wurden erstellt. {{failCount}} Benutzer konnten nicht erstellt werden.",
+    "BulkCreateUserPartialFailureDescription": "Einige Benutzer konnten nicht erstellt werden. Bitte überprüfen Sie die Einträge.",
     "BulkCreateUserSuccess": "Erfolgreich {{count}} Benutzer erstellt.",
     "BulkDeactivateCredentials": "Anmeldeinformationen deaktivieren",
     "BulkDeactivateCredentialsDescription": "Sie sind dabei, {{count}} Anmeldeinformation(en) zu deaktivieren. Die Benutzer können diese Anmeldeinformationen danach nicht mehr verwenden.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Μαζική δημιουργία χρηστών από CSV",
     "BulkCreateUserFromCSVSubtitle": "Ανεβάστε ένα CSV για να δημιουργήσετε πολλούς λογαριασμούς χρηστών ταυτόχρονα.",
     "BulkCreateUserPartialFailure": "{{successCount}} χρήστης(ες) δημιουργήθηκαν. {{failCount}} χρήστης(ες) απέτυχαν.",
+    "BulkCreateUserPartialFailureDescription": "Ορισμένοι χρήστες δεν δημιουργήθηκαν. Ελέγξτε τα στοιχεία.",
     "BulkCreateUserSuccess": "Δημιουργήθηκαν με επιτυχία {{count}} χρήστες.",
     "BulkDeactivateCredentials": "Απενεργοποίηση διαπιστευτηρίων",
     "BulkDeactivateCredentialsDescription": "Πρόκειται να απενεργοποιήσετε {{count}} διαπιστευτήριο(α). Οι χρήστες δεν θα μπορούν πλέον να χρησιμοποιούν αυτά τα διαπιστευτήρια.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Μαζική δημιουργία χρηστών από CSV",
     "BulkCreateUserFromCSVSubtitle": "Ανεβάστε ένα CSV για να δημιουργήσετε πολλούς λογαριασμούς χρηστών ταυτόχρονα.",
     "BulkCreateUserPartialFailure": "{{successCount}} χρήστης(ες) δημιουργήθηκαν. {{failCount}} χρήστης(ες) απέτυχαν.",
+    "BulkCreateUserPartialFailureDescription": "Ορισμένοι χρήστες δεν δημιουργήθηκαν. Ελέγξτε τα στοιχεία.",
     "BulkCreateUserSuccess": "Δημιουργήθηκαν με επιτυχία {{count}} χρήστες.",
     "BulkDeactivateCredentials": "Απενεργοποίηση διαπιστευτηρίων",
     "BulkDeactivateCredentialsDescription": "Πρόκειται να απενεργοποιήσετε {{count}} διαπιστευτήριο(α). Οι χρήστες δεν θα μπορούν πλέον να χρησιμοποιούν αυτά τα διαπιστευτήρια.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -526,6 +526,7 @@
     "BulkCreateUserFromCSV": "Bulk Create Users from CSV",
     "BulkCreateUserFromCSVSubtitle": "Upload a CSV to provision multiple user accounts at once.",
     "BulkCreateUserPartialFailure": "{{successCount}} user(s) created. {{failCount}} user(s) failed.",
+    "BulkCreateUserPartialFailureDescription": "Some users could not be created. Please check the items.",
     "BulkCreateUserSuccess": "Successfully created {{count}} user(s).",
     "BulkDeactivateCredentials": "Deactivate credentials",
     "BulkDeactivateCredentialsDescription": "You are about to deactivate {{count}} credential(s). The users will no longer be able to use these credentials.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -511,6 +511,7 @@
     "BulkCreateUserFromCSV": "Bulk Create Users from CSV",
     "BulkCreateUserFromCSVSubtitle": "Upload a CSV to provision multiple user accounts at once.",
     "BulkCreateUserPartialFailure": "{{successCount}} user(s) created. {{failCount}} user(s) failed.",
+    "BulkCreateUserPartialFailureDescription": "Some users could not be created. Please check the items.",
     "BulkCreateUserSuccess": "Successfully created {{count}} user(s).",
     "BulkDeactivateCredentials": "Deactivate credentials",
     "BulkDeactivateCredentialsDescription": "You are about to deactivate {{count}} credential(s). The users will no longer be able to use these credentials.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Crear usuarios en masa desde CSV",
     "BulkCreateUserFromCSVSubtitle": "Sube un CSV para crear múltiples cuentas de usuario a la vez.",
     "BulkCreateUserPartialFailure": "{{successCount}} usuario(s) creado(s). {{failCount}} usuario(s) no creados.",
+    "BulkCreateUserPartialFailureDescription": "Algunos usuarios no se han podido crear. Compruebe los elementos.",
     "BulkCreateUserSuccess": "Se crearon correctamente {{count}} usuario(s).",
     "BulkDeactivateCredentials": "Desactivar credenciales",
     "BulkDeactivateCredentialsDescription": "Está a punto de desactivar {{count}} credencial(es). Los usuarios ya no podrán usar estas credenciales.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Crear usuarios en masa desde CSV",
     "BulkCreateUserFromCSVSubtitle": "Sube un CSV para crear múltiples cuentas de usuario a la vez.",
     "BulkCreateUserPartialFailure": "{{successCount}} usuario(s) creado(s). {{failCount}} usuario(s) no creados.",
+    "BulkCreateUserPartialFailureDescription": "Algunos usuarios no se han podido crear. Compruebe los elementos.",
     "BulkCreateUserSuccess": "Se crearon correctamente {{count}} usuario(s).",
     "BulkDeactivateCredentials": "Desactivar credenciales",
     "BulkDeactivateCredentialsDescription": "Está a punto de desactivar {{count}} credencial(es). Los usuarios ya no podrán usar estas credenciales.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Luo käyttäjiä joukottain CSV-tiedostosta",
     "BulkCreateUserFromCSVSubtitle": "Lataa CSV-tiedosto useiden käyttäjätilien luomiseksi kerralla.",
     "BulkCreateUserPartialFailure": "{{successCount}} käyttäjää luotu. {{failCount}} käyttäjän luominen epäonnistui.",
+    "BulkCreateUserPartialFailureDescription": "Joidenkin käyttäjien luominen epäonnistui. Tarkista kohteet.",
     "BulkCreateUserSuccess": "Onnistuneesti luotiin {{count}} käyttäjää.",
     "BulkDeactivateCredentials": "Poista kirjautumistiedot käytöstä",
     "BulkDeactivateCredentialsDescription": "Olet poistamassa käytöstä {{count}} kirjautumistietoa. Käyttäjät eivät voi enää käyttää näitä kirjautumistietoja.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Luo käyttäjiä joukottain CSV-tiedostosta",
     "BulkCreateUserFromCSVSubtitle": "Lataa CSV-tiedosto useiden käyttäjätilien luomiseksi kerralla.",
     "BulkCreateUserPartialFailure": "{{successCount}} käyttäjää luotu. {{failCount}} käyttäjän luominen epäonnistui.",
+    "BulkCreateUserPartialFailureDescription": "Joidenkin käyttäjien luominen epäonnistui. Tarkista kohteet.",
     "BulkCreateUserSuccess": "Onnistuneesti luotiin {{count}} käyttäjää.",
     "BulkDeactivateCredentials": "Poista kirjautumistiedot käytöstä",
     "BulkDeactivateCredentialsDescription": "Olet poistamassa käytöstä {{count}} kirjautumistietoa. Käyttäjät eivät voi enää käyttää näitä kirjautumistietoja.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Créer des utilisateurs en masse depuis un CSV",
     "BulkCreateUserFromCSVSubtitle": "Téléversez un CSV pour créer plusieurs comptes utilisateurs à la fois.",
     "BulkCreateUserPartialFailure": "{{successCount}} utilisateur(s) créé(s). Échec pour {{failCount}} utilisateur(s).",
+    "BulkCreateUserPartialFailureDescription": "Certains utilisateurs n'ont pas pu être créés. Veuillez vérifier les éléments.",
     "BulkCreateUserSuccess": "Création de {{count}} utilisateur(s) réussie.",
     "BulkDeactivateCredentials": "Désactiver les identifiants",
     "BulkDeactivateCredentialsDescription": "Vous êtes sur le point de désactiver {{count}} identifiant(s). Les utilisateurs ne pourront plus utiliser ces identifiants.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Créer des utilisateurs en masse depuis un CSV",
     "BulkCreateUserFromCSVSubtitle": "Téléversez un CSV pour créer plusieurs comptes utilisateurs à la fois.",
     "BulkCreateUserPartialFailure": "{{successCount}} utilisateur(s) créé(s). Échec pour {{failCount}} utilisateur(s).",
+    "BulkCreateUserPartialFailureDescription": "Certains utilisateurs n'ont pas pu être créés. Veuillez vérifier les éléments.",
     "BulkCreateUserSuccess": "Création de {{count}} utilisateur(s) réussie.",
     "BulkDeactivateCredentials": "Désactiver les identifiants",
     "BulkDeactivateCredentialsDescription": "Vous êtes sur le point de désactiver {{count}} identifiant(s). Les utilisateurs ne pourront plus utiliser ces identifiants.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Buat Pengguna Massal dari CSV",
     "BulkCreateUserFromCSVSubtitle": "Unggah CSV untuk membuat beberapa akun pengguna sekaligus.",
     "BulkCreateUserPartialFailure": "{{successCount}} pengguna berhasil dibuat. {{failCount}} pengguna gagal dibuat.",
+    "BulkCreateUserPartialFailureDescription": "Beberapa pengguna gagal dibuat. Silakan periksa itemnya.",
     "BulkCreateUserSuccess": "Berhasil membuat {{count}} pengguna.",
     "BulkDeactivateCredentials": "Nonaktifkan kredensial",
     "BulkDeactivateCredentialsDescription": "Anda akan menonaktifkan {{count}} kredensial. Pengguna tidak akan bisa lagi menggunakan kredensial ini.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Buat Pengguna Massal dari CSV",
     "BulkCreateUserFromCSVSubtitle": "Unggah CSV untuk membuat beberapa akun pengguna sekaligus.",
     "BulkCreateUserPartialFailure": "{{successCount}} pengguna berhasil dibuat. {{failCount}} pengguna gagal dibuat.",
+    "BulkCreateUserPartialFailureDescription": "Beberapa pengguna gagal dibuat. Silakan periksa itemnya.",
     "BulkCreateUserSuccess": "Berhasil membuat {{count}} pengguna.",
     "BulkDeactivateCredentials": "Nonaktifkan kredensial",
     "BulkDeactivateCredentialsDescription": "Anda akan menonaktifkan {{count}} kredensial. Pengguna tidak akan bisa lagi menggunakan kredensial ini.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Crea utenti in blocco da CSV",
     "BulkCreateUserFromCSVSubtitle": "Carica un CSV per creare più account utente contemporaneamente.",
     "BulkCreateUserPartialFailure": "{{successCount}} utenti creati. {{failCount}} utenti non creati.",
+    "BulkCreateUserPartialFailureDescription": "Alcuni utenti non sono stati creati. Controlla gli elementi.",
     "BulkCreateUserSuccess": "Creato con successo {{count}} utente(i).",
     "BulkDeactivateCredentials": "Disattiva le credenziali",
     "BulkDeactivateCredentialsDescription": "Stai per disattivare {{count}} credenziale(i). Gli utenti non potranno più utilizzare queste credenziali.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Crea utenti in blocco da CSV",
     "BulkCreateUserFromCSVSubtitle": "Carica un CSV per creare più account utente contemporaneamente.",
     "BulkCreateUserPartialFailure": "{{successCount}} utenti creati. {{failCount}} utenti non creati.",
+    "BulkCreateUserPartialFailureDescription": "Alcuni utenti non sono stati creati. Controlla gli elementi.",
     "BulkCreateUserSuccess": "Creato con successo {{count}} utente(i).",
     "BulkDeactivateCredentials": "Disattiva le credenziali",
     "BulkDeactivateCredentialsDescription": "Stai per disattivare {{count}} credenziale(i). Gli utenti non potranno più utilizzare queste credenziali.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "CSVからユーザーを一括作成",
     "BulkCreateUserFromCSVSubtitle": "CSVをアップロードして、複数のユーザーアカウントを一度に作成します。",
     "BulkCreateUserPartialFailure": "{{successCount}}名のユーザーを作成しました。{{failCount}}名のユーザーの作成に失敗しました。",
+    "BulkCreateUserPartialFailureDescription": "一部のユーザーの作成に失敗しました。項目を確認してください。",
     "BulkCreateUserSuccess": "ユーザーを{{count}}名作成しました。",
     "BulkDeactivateCredentials": "資格情報を非アクティブ化",
     "BulkDeactivateCredentialsDescription": "{{count}}件の資格情報を非アクティブ化しようとしています。対象のユーザーはこれらの資格情報を使用できなくなります。",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "CSVからユーザーを一括作成",
     "BulkCreateUserFromCSVSubtitle": "CSVをアップロードして、複数のユーザーアカウントを一度に作成します。",
     "BulkCreateUserPartialFailure": "{{successCount}}名のユーザーを作成しました。{{failCount}}名のユーザーの作成に失敗しました。",
+    "BulkCreateUserPartialFailureDescription": "一部のユーザーの作成に失敗しました。項目を確認してください。",
     "BulkCreateUserSuccess": "ユーザーを{{count}}名作成しました。",
     "BulkDeactivateCredentials": "資格情報を非アクティブ化",
     "BulkDeactivateCredentialsDescription": "{{count}}件の資格情報を非アクティブ化しようとしています。対象のユーザーはこれらの資格情報を使用できなくなります。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "CSV로 사용자 일괄 생성",
     "BulkCreateUserFromCSVSubtitle": "CSV를 업로드하여 여러 사용자 계정을 한 번에 생성합니다.",
     "BulkCreateUserPartialFailure": "{{successCount}}명의 사용자가 생성되었습니다. {{failCount}}명의 사용자 생성에 실패했습니다.",
+    "BulkCreateUserPartialFailureDescription": "일부 사용자 생성에 실패했습니다. 항목을 확인해주세요.",
     "BulkCreateUserSuccess": "{{count}}명의 사용자가 생성되었습니다.",
     "BulkDeactivateCredentials": "자격증명 비활성화",
     "BulkDeactivateCredentialsDescription": "{{count}}개의 자격증명을 비활성화합니다. 해당 사용자는 더 이상 이 자격증명을 사용할 수 없습니다.",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "CSV로 사용자 일괄 생성",
     "BulkCreateUserFromCSVSubtitle": "CSV를 업로드하여 여러 사용자 계정을 한 번에 생성합니다.",
     "BulkCreateUserPartialFailure": "{{successCount}}명의 사용자가 생성되었습니다. {{failCount}}명의 사용자 생성에 실패했습니다.",
+    "BulkCreateUserPartialFailureDescription": "일부 사용자 생성에 실패했습니다. 항목을 확인해주세요.",
     "BulkCreateUserSuccess": "{{count}}명의 사용자가 생성되었습니다.",
     "BulkDeactivateCredentials": "자격증명 비활성화",
     "BulkDeactivateCredentialsDescription": "{{count}}개의 자격증명을 비활성화합니다. 해당 사용자는 더 이상 이 자격증명을 사용할 수 없습니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "CSV-ээс хэрэглэгчдийг бөөнөөр үүсгэх",
     "BulkCreateUserFromCSVSubtitle": "Олон хэрэглэгчийн бүртгэлийг нэг дор үүсгэхийн тулд CSV файл байршуулна уу.",
     "BulkCreateUserPartialFailure": "{{successCount}} хэрэглэгч амжилттай үүслээ. {{failCount}} хэрэглэгч үүсгэхэд амжилтгүй боллоо.",
+    "BulkCreateUserPartialFailureDescription": "Зарим хэрэглэгчийг үүсгэж чадсангүй. Холбогдох зүйлсийг шалгана уу.",
     "BulkCreateUserSuccess": "Амжилттай {{count}} хэрэглэгч үүсгэлээ.",
     "BulkDeactivateCredentials": "Итгэмжлэлүүдийг идэвхгүй болгох",
     "BulkDeactivateCredentialsDescription": "Та {{count}} итгэмжлэлийг идэвхгүй болгох гэж байна. Хэрэглэгчид цаашид эдгээр итгэмжлэлийг ашиглах боломжгүй болно.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "CSV-ээс хэрэглэгчдийг бөөнөөр үүсгэх",
     "BulkCreateUserFromCSVSubtitle": "Олон хэрэглэгчийн бүртгэлийг нэг дор үүсгэхийн тулд CSV файл байршуулна уу.",
     "BulkCreateUserPartialFailure": "{{successCount}} хэрэглэгч амжилттай үүслээ. {{failCount}} хэрэглэгч үүсгэхэд амжилтгүй боллоо.",
+    "BulkCreateUserPartialFailureDescription": "Зарим хэрэглэгчийг үүсгэж чадсангүй. Холбогдох зүйлсийг шалгана уу.",
     "BulkCreateUserSuccess": "Амжилттай {{count}} хэрэглэгч үүсгэлээ.",
     "BulkDeactivateCredentials": "Итгэмжлэлүүдийг идэвхгүй болгох",
     "BulkDeactivateCredentialsDescription": "Та {{count}} итгэмжлэлийг идэвхгүй болгох гэж байна. Хэрэглэгчид цаашид эдгээр итгэмжлэлийг ашиглах боломжгүй болно.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Cipta Pengguna Pukal dari CSV",
     "BulkCreateUserFromCSVSubtitle": "Muat naik CSV untuk mencipta beberapa akaun pengguna sekaligus.",
     "BulkCreateUserPartialFailure": "{{successCount}} pengguna berjaya dibuat. {{failCount}} pengguna gagal dibuat.",
+    "BulkCreateUserPartialFailureDescription": "Beberapa pengguna gagal dibuat. Sila semak item berkenaan.",
     "BulkCreateUserSuccess": "Berjaya mencipta {{count}} pengguna.",
     "BulkDeactivateCredentials": "Nyahaktifkan kelayakan",
     "BulkDeactivateCredentialsDescription": "Anda akan menyahaktifkan {{count}} kelayakan. Pengguna tidak akan dapat lagi menggunakan kelayakan ini.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Cipta Pengguna Pukal dari CSV",
     "BulkCreateUserFromCSVSubtitle": "Muat naik CSV untuk mencipta beberapa akaun pengguna sekaligus.",
     "BulkCreateUserPartialFailure": "{{successCount}} pengguna berjaya dibuat. {{failCount}} pengguna gagal dibuat.",
+    "BulkCreateUserPartialFailureDescription": "Beberapa pengguna gagal dibuat. Sila semak item berkenaan.",
     "BulkCreateUserSuccess": "Berjaya mencipta {{count}} pengguna.",
     "BulkDeactivateCredentials": "Nyahaktifkan kelayakan",
     "BulkDeactivateCredentialsDescription": "Anda akan menyahaktifkan {{count}} kelayakan. Pengguna tidak akan dapat lagi menggunakan kelayakan ini.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Masowe tworzenie użytkowników z CSV",
     "BulkCreateUserFromCSVSubtitle": "Prześlij plik CSV, aby jednocześnie utworzyć wiele kont użytkowników.",
     "BulkCreateUserPartialFailure": "{{successCount}} użytkownik(ów) utworzono. {{failCount}} użytkownik(ów) nie utworzono.",
+    "BulkCreateUserPartialFailureDescription": "Niektórych użytkowników nie udało się utworzyć. Sprawdź pozycje.",
     "BulkCreateUserSuccess": "Pomyślnie utworzono {{count}} użytkownika(ów).",
     "BulkDeactivateCredentials": "Dezaktywuj dane uwierzytelniające",
     "BulkDeactivateCredentialsDescription": "Zamierzasz dezaktywować {{count}} dane uwierzytelniające. Użytkownicy nie będą już mogli używać tych danych uwierzytelniających.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Masowe tworzenie użytkowników z CSV",
     "BulkCreateUserFromCSVSubtitle": "Prześlij plik CSV, aby jednocześnie utworzyć wiele kont użytkowników.",
     "BulkCreateUserPartialFailure": "{{successCount}} użytkownik(ów) utworzono. {{failCount}} użytkownik(ów) nie utworzono.",
+    "BulkCreateUserPartialFailureDescription": "Niektórych użytkowników nie udało się utworzyć. Sprawdź pozycje.",
     "BulkCreateUserSuccess": "Pomyślnie utworzono {{count}} użytkownika(ów).",
     "BulkDeactivateCredentials": "Dezaktywuj dane uwierzytelniające",
     "BulkDeactivateCredentialsDescription": "Zamierzasz dezaktywować {{count}} dane uwierzytelniające. Użytkownicy nie będą już mogli używać tych danych uwierzytelniających.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Criar usuários em massa a partir de CSV",
     "BulkCreateUserFromCSVSubtitle": "Carregue um CSV para criar múltiplas contas de usuário de uma vez.",
     "BulkCreateUserPartialFailure": "{{successCount}} usuário(s) criado(s). {{failCount}} usuário(s) não foram criados.",
+    "BulkCreateUserPartialFailureDescription": "Alguns usuários não foram criados. Verifique os itens.",
     "BulkCreateUserSuccess": "{{count}} usuário(s) criado(s) com sucesso.",
     "BulkDeactivateCredentials": "Desativar credenciais",
     "BulkDeactivateCredentialsDescription": "Você está prestes a desativar {{count}} credencial(is). Os usuários não poderão mais usar essas credenciais.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Criar usuários em massa a partir de CSV",
     "BulkCreateUserFromCSVSubtitle": "Carregue um CSV para criar múltiplas contas de usuário de uma vez.",
     "BulkCreateUserPartialFailure": "{{successCount}} usuário(s) criado(s). {{failCount}} usuário(s) não foram criados.",
+    "BulkCreateUserPartialFailureDescription": "Alguns usuários não foram criados. Verifique os itens.",
     "BulkCreateUserSuccess": "{{count}} usuário(s) criado(s) com sucesso.",
     "BulkDeactivateCredentials": "Desativar credenciais",
     "BulkDeactivateCredentialsDescription": "Você está prestes a desativar {{count}} credencial(is). Os usuários não poderão mais usar essas credenciais.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Criar utilizadores em massa a partir de CSV",
     "BulkCreateUserFromCSVSubtitle": "Carregue um CSV para criar múltiplas contas de utilizador de uma vez.",
     "BulkCreateUserPartialFailure": "Foram criados {{successCount}} usuário(s). Falha ao criar {{failCount}} usuário(s).",
+    "BulkCreateUserPartialFailureDescription": "Alguns utilizadores não foram criados. Verifique os itens.",
     "BulkCreateUserSuccess": "Foram criados com sucesso {{count}} usuário(s).",
     "BulkDeactivateCredentials": "Desativar credenciais",
     "BulkDeactivateCredentialsDescription": "Está prestes a desativar {{count}} credencial(is). Os utilizadores deixarão de poder utilizar estas credenciais.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Criar utilizadores em massa a partir de CSV",
     "BulkCreateUserFromCSVSubtitle": "Carregue um CSV para criar múltiplas contas de utilizador de uma vez.",
     "BulkCreateUserPartialFailure": "Foram criados {{successCount}} usuário(s). Falha ao criar {{failCount}} usuário(s).",
+    "BulkCreateUserPartialFailureDescription": "Alguns utilizadores não foram criados. Verifique os itens.",
     "BulkCreateUserSuccess": "Foram criados com sucesso {{count}} usuário(s).",
     "BulkDeactivateCredentials": "Desativar credenciais",
     "BulkDeactivateCredentialsDescription": "Está prestes a desativar {{count}} credencial(is). Os utilizadores deixarão de poder utilizar estas credenciais.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Массовое создание пользователей из CSV",
     "BulkCreateUserFromCSVSubtitle": "Загрузите CSV для создания нескольких учётных записей пользователей за один раз.",
     "BulkCreateUserPartialFailure": "Создано {{successCount}} пользователей. Не удалось создать {{failCount}} пользователей.",
+    "BulkCreateUserPartialFailureDescription": "Не удалось создать некоторых пользователей. Проверьте элементы.",
     "BulkCreateUserSuccess": "Успешно создано {{count}} пользователь(ей).",
     "BulkDeactivateCredentials": "Деактивировать учетные данные",
     "BulkDeactivateCredentialsDescription": "Вы собираетесь деактивировать {{count}} учетных данных. Пользователи больше не смогут использовать эти учетные данные.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Массовое создание пользователей из CSV",
     "BulkCreateUserFromCSVSubtitle": "Загрузите CSV для создания нескольких учётных записей пользователей за один раз.",
     "BulkCreateUserPartialFailure": "Создано {{successCount}} пользователей. Не удалось создать {{failCount}} пользователей.",
+    "BulkCreateUserPartialFailureDescription": "Не удалось создать некоторых пользователей. Проверьте элементы.",
     "BulkCreateUserSuccess": "Успешно создано {{count}} пользователь(ей).",
     "BulkDeactivateCredentials": "Деактивировать учетные данные",
     "BulkDeactivateCredentialsDescription": "Вы собираетесь деактивировать {{count}} учетных данных. Пользователи больше не смогут использовать эти учетные данные.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "สร้างผู้ใช้จำนวนมากจาก CSV",
     "BulkCreateUserFromCSVSubtitle": "อัปโหลด CSV เพื่อสร้างบัญชีผู้ใช้หลายรายพร้อมกัน",
     "BulkCreateUserPartialFailure": "{{successCount}} ผู้ใช้ถูกสร้างสำเร็จ. {{failCount}} ผู้ใช้สร้างไม่สำเร็จ.",
+    "BulkCreateUserPartialFailureDescription": "ไม่สามารถสร้างผู้ใช้บางรายการได้ โปรดตรวจสอบรายการ",
     "BulkCreateUserSuccess": "สร้างผู้ใช้ {{count}} รายเรียบร้อยแล้ว",
     "BulkDeactivateCredentials": "ปิดใช้งานข้อมูลรับรอง",
     "BulkDeactivateCredentialsDescription": "คุณกำลังจะปิดใช้งานข้อมูลรับรอง {{count}} รายการ ผู้ใช้จะไม่สามารถใช้ข้อมูลรับรองเหล่านี้ได้อีกต่อไป",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "สร้างผู้ใช้จำนวนมากจาก CSV",
     "BulkCreateUserFromCSVSubtitle": "อัปโหลด CSV เพื่อสร้างบัญชีผู้ใช้หลายรายพร้อมกัน",
     "BulkCreateUserPartialFailure": "{{successCount}} ผู้ใช้ถูกสร้างสำเร็จ. {{failCount}} ผู้ใช้สร้างไม่สำเร็จ.",
+    "BulkCreateUserPartialFailureDescription": "ไม่สามารถสร้างผู้ใช้บางรายการได้ โปรดตรวจสอบรายการ",
     "BulkCreateUserSuccess": "สร้างผู้ใช้ {{count}} รายเรียบร้อยแล้ว",
     "BulkDeactivateCredentials": "ปิดใช้งานข้อมูลรับรอง",
     "BulkDeactivateCredentialsDescription": "คุณกำลังจะปิดใช้งานข้อมูลรับรอง {{count}} รายการ ผู้ใช้จะไม่สามารถใช้ข้อมูลรับรองเหล่านี้ได้อีกต่อไป",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "CSV'den Toplu Kullanıcı Oluştur",
     "BulkCreateUserFromCSVSubtitle": "Birden fazla kullanıcı hesabını aynı anda oluşturmak için CSV yükleyin.",
     "BulkCreateUserPartialFailure": "{{successCount}} kullanıcı(lar) oluşturuldu. {{failCount}} kullanıcı(lar) oluşturulamadı.",
+    "BulkCreateUserPartialFailureDescription": "Bazı kullanıcılar oluşturulamadı. Lütfen öğeleri kontrol edin.",
     "BulkCreateUserSuccess": "Başarıyla {{count}} kullanıcı oluşturuldu.",
     "BulkDeactivateCredentials": "Kimlik bilgilerini devre dışı bırak",
     "BulkDeactivateCredentialsDescription": "{{count}} kimlik bilgisini devre dışı bırakmak üzeresiniz. Kullanıcılar artık bu kimlik bilgilerini kullanamayacak.",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "CSV'den Toplu Kullanıcı Oluştur",
     "BulkCreateUserFromCSVSubtitle": "Birden fazla kullanıcı hesabını aynı anda oluşturmak için CSV yükleyin.",
     "BulkCreateUserPartialFailure": "{{successCount}} kullanıcı(lar) oluşturuldu. {{failCount}} kullanıcı(lar) oluşturulamadı.",
+    "BulkCreateUserPartialFailureDescription": "Bazı kullanıcılar oluşturulamadı. Lütfen öğeleri kontrol edin.",
     "BulkCreateUserSuccess": "Başarıyla {{count}} kullanıcı oluşturuldu.",
     "BulkDeactivateCredentials": "Kimlik bilgilerini devre dışı bırak",
     "BulkDeactivateCredentialsDescription": "{{count}} kimlik bilgisini devre dışı bırakmak üzeresiniz. Kullanıcılar artık bu kimlik bilgilerini kullanamayacak.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "Tạo hàng loạt người dùng từ CSV",
     "BulkCreateUserFromCSVSubtitle": "Tải lên CSV để tạo nhiều tài khoản người dùng cùng một lúc.",
     "BulkCreateUserPartialFailure": "{{successCount}} người dùng đã được tạo. {{failCount}} người dùng không được tạo.",
+    "BulkCreateUserPartialFailureDescription": "Một số người dùng không được tạo. Vui lòng kiểm tra các mục.",
     "BulkCreateUserSuccess": "Đã tạo thành công {{count}} người dùng.",
     "BulkDeactivateCredentials": "Vô hiệu hóa thông tin xác thực",
     "BulkDeactivateCredentialsDescription": "Bạn sắp vô hiệu hóa {{count}} thông tin xác thực. Người dùng sẽ không thể sử dụng thông tin xác thực này nữa.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "Tạo hàng loạt người dùng từ CSV",
     "BulkCreateUserFromCSVSubtitle": "Tải lên CSV để tạo nhiều tài khoản người dùng cùng một lúc.",
     "BulkCreateUserPartialFailure": "{{successCount}} người dùng đã được tạo. {{failCount}} người dùng không được tạo.",
+    "BulkCreateUserPartialFailureDescription": "Một số người dùng không được tạo. Vui lòng kiểm tra các mục.",
     "BulkCreateUserSuccess": "Đã tạo thành công {{count}} người dùng.",
     "BulkDeactivateCredentials": "Vô hiệu hóa thông tin xác thực",
     "BulkDeactivateCredentialsDescription": "Bạn sắp vô hiệu hóa {{count}} thông tin xác thực. Người dùng sẽ không thể sử dụng thông tin xác thực này nữa.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "通过 CSV 批量创建用户",
     "BulkCreateUserFromCSVSubtitle": "上传 CSV 文件以一次性创建多个用户账号。",
     "BulkCreateUserPartialFailure": "已创建 {{successCount}} 个用户，{{failCount}} 个用户创建失败。",
+    "BulkCreateUserPartialFailureDescription": "部分用户创建失败。请检查相关条目。",
     "BulkCreateUserSuccess": "已成功创建 {{count}} 名用户。",
     "BulkDeactivateCredentials": "停用凭证",
     "BulkDeactivateCredentialsDescription": "您即将停用 {{count}} 个凭证。用户将无法再使用这些凭证。",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "通过 CSV 批量创建用户",
     "BulkCreateUserFromCSVSubtitle": "上传 CSV 文件以一次性创建多个用户账号。",
     "BulkCreateUserPartialFailure": "已创建 {{successCount}} 个用户，{{failCount}} 个用户创建失败。",
+    "BulkCreateUserPartialFailureDescription": "部分用户创建失败。请检查相关条目。",
     "BulkCreateUserSuccess": "已成功创建 {{count}} 名用户。",
     "BulkDeactivateCredentials": "停用凭证",
     "BulkDeactivateCredentialsDescription": "您即将停用 {{count}} 个凭证。用户将无法再使用这些凭证。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -539,6 +539,7 @@
     "BulkCreateUserFromCSV": "透過 CSV 批次建立使用者",
     "BulkCreateUserFromCSVSubtitle": "上傳 CSV 檔案以一次建立多個使用者帳號。",
     "BulkCreateUserPartialFailure": "{{successCount}} 位使用者已建立。{{failCount}} 位使用者建立失敗。",
+    "BulkCreateUserPartialFailureDescription": "部分使用者建立失敗。請檢查相關項目。",
     "BulkCreateUserSuccess": "成功建立 {{count}} 位使用者。",
     "BulkDeactivateCredentials": "停用憑證",
     "BulkDeactivateCredentialsDescription": "您即將停用 {{count}} 個憑證。使用者將無法再使用這些憑證。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -524,6 +524,7 @@
     "BulkCreateUserFromCSV": "透過 CSV 批次建立使用者",
     "BulkCreateUserFromCSVSubtitle": "上傳 CSV 檔案以一次建立多個使用者帳號。",
     "BulkCreateUserPartialFailure": "{{successCount}} 位使用者已建立。{{failCount}} 位使用者建立失敗。",
+    "BulkCreateUserPartialFailureDescription": "部分使用者建立失敗。請檢查相關項目。",
     "BulkCreateUserSuccess": "成功建立 {{count}} 位使用者。",
     "BulkDeactivateCredentials": "停用憑證",
     "BulkDeactivateCredentialsDescription": "您即將停用 {{count}} 個憑證。使用者將無法再使用這些憑證。",


### PR DESCRIPTION
Resolves #8478 (FR-3419)
Resolves #8708 (FR-3519)

## Summary

Both bulk-create entry points on the Users page (`admin/users` → **Bulk Create Users** and **Bulk Create Users from CSV**) call `adminBulkCreateUsersWithKeypairV2`, whose payload carries a `failed` list with the server's own per-user error message. Neither flow showed it: a partial failure produced a counts-only `message.warning` and sent the reasons to `logger.error`, i.e. the browser console.

The CSV modal *did* have a failure table, but it was unreachable in **every** path:

- **Partial failure** — `if (createdKeypairs) return <GeneratedKeypairListModal/>` precedes the `if (hasFailures)` branch, so the keypair screen always won.
- **Total failure** — the handler called `onRequestClose(true)`, and the parent unconditionally sets `open` to `false`; since the failure-branch modal spread `{...baiModalProps}` last, it rendered closed.

## Approach

Both flows now surface the failures over the still-open create form, as **two sequential, single-purpose screens** rather than one merged modal:

1. **Keypair modal** — unchanged from before this PR, shows the one-time secret keys.
2. **Dismissing it** (if any user failed) reveals the shared `BulkCreateUserErrorModal` next, listing each failure with the server's own message.

When every user fails, the failure modal shows immediately — there are no keypairs to show first. The two screens are never shown together; the failure modal's `open` gate (`!createdKeypairs && !isEmpty(failedUsers)`) only flips true once the keypair modal has been dismissed. Neither screen force-closes the whole flow while there's still something to review: the keypair modal only finalizes (close + refetch) on full success; on partial failure dismissing it returns control to the failure modal, and dismissing *that* returns to the still-open, still-populated form with **no further modal**. The admin leaves the flow by cancelling the form itself, at which point `onCancel={() => onRequestClose(createdCount > 0)}` refetches if anything was created — matching FR-3357's "stay open on failure" contract.

(This went through a merged-single-modal design first, per FR-3334/FR-3357's pattern of layering one error modal over a form — but that pattern assumes no intermediate "here are your one-time secret keys" step. Merging success and failure content into one modal read as cluttered, and reusing the failure modal after a merged dismiss duplicated content already shown. The sequential two-screen design shown here is the one actually shipped.)

**`BulkCreateUserFromCSVModal`'s underlying architecture changed too.** It previously swapped its *entire* `return` between the form and the keypair screen based on `createdKeypairs` (an early return, not a nested sibling). A full success flipped that condition and the parent's `open` to `false` in the same render, so the form's own `<BAIModal afterClose={resetState}>` mounted already-closed instead of transitioning open→closed — `afterClose` never fired, and reopening the modal showed the previous run's file and rows. It's restructured to match `UserSettingModal`'s architecture: the create form modal always renders as one continuous element, with the keypair and failure modals as independent overlay siblings (`BAIUnmountAfterClose` + `filterOutNullAndUndefined`, same pattern `UserSettingModal` already used) that toggle on top of it. This also fixes a visible remount/"re-opening" flash of the underlying form on every dismiss, and lets `afterClose` do the resetting again without an explicit workaround.

### `BulkCreateUserFailure.tsx`

Shared by both entry points so the UX is identical whether the users came from the generated-email form or from a CSV:

- `toFailedUserCreations` maps the mutation's `failed` list to table records keyed by its `index` (each failure's original position in the submitted list).
- `BulkCreateUserErrorModal` — the shared `BAIBulkErrorModal`-based failure report, used identically for the "some succeeded" (after the keypair modal) and "all failed" (immediate) cases.
- Written against **Astryx** throughout — no `antd` import. The error column renders `BAIText type="danger"`, and the de-emphasized failure counts in the alert use Astryx `Text` with `color="secondary" size="sm"` props rather than a `theme.useToken()` read plus an inline `fontSize`/`color` style (the shape `AssignRoleModal` still uses).

### `GeneratedKeypairListModal`

Unchanged from before this PR — pure keypair display, no knowledge of failures.

### `UserSettingModal` / `BulkCreateUserFromCSVModal`

- Partial failures populate `failedUsers`; the keypair modal's dismiss handler leaves it alone (doesn't clear it) so the failure modal's gate can take over as the next step.
- `onCancel` reports `createdCount > 0` so a partially-successful bulk create still refetches the list when the admin dismisses the form. `createdCount` stays `0` on the single-create and edit paths, leaving them unchanged.
- The CSV modal's dead ad-hoc failure screen (local `FailedUserRow` type, hand-rolled `BAIAlert` + `Table`) is removed.

### i18n

One new key in all 21 languages — `credential.BulkCreateUserPartialFailureDescription` ("Some users could not be created. Please check the items.", mirroring `rbac.UserAssignmentsPartialFailureDescription` from FR-3357). The partial-failure toast uses `message.error` (not `warning`), matching `AssignRoleModal`'s severity — both a toast and the modal are shown together deliberately, per that same reference PR's own rationale comment. Counts reuse the existing `credential.BulkCreateUserPartialFailure`; table headers reuse `general.E-Mail` / `credential.UserName` / `dialog.error.Error`.

## How to test

1. Open `admin/users` → **Users** tab → the create dropdown.
2. **Bulk Create Users**: pick an email prefix whose range collides with existing accounts for only part of the range. Submit → the keypair modal (pure, no failure content). Close it → the failure modal appears next, over the same still-open form. Close that → back to the plain, untouched form (values preserved, no flash/remount). Only clicking Cancel on the form itself closes everything, refetching the table since a user was created.
3. Make *every* user collide → no keypair modal; the failure list appears once, directly over the form.
4. **Bulk Create Users from CSV**: upload a CSV where some emails already exist → same two-step sequence; the loaded file and preview survive dismissing both overlay modals, so the rows can be corrected and re-submitted.
5. **CSV full success**: upload a CSV where every row succeeds → success toast, keypair modal, closes and refetches. Reopen **Bulk Create Users from CSV** → starts fresh (no stale filename or rows).

All of the above — including confirming the underlying form's DOM node is never remounted across both dismiss steps — was exercised against a live backend with the mutation response mocked (1 created / 2 failed, 0 created / 2 failed, and a full-success response).

## Screenshots

Light theme, re-captured against the **post-Astryx** UI — the originals predated the antd removal and no longer showed the shipped design. `admin/users` → create dropdown → **Bulk Create Users** / **Bulk Create Users from CSV**.

| | |
|---|---|
| **1. Keypair modal** — pure, no failure content mixed in; the partial-failure toast appears bottom-right | **2. Failure modal** — appears after dismissing the keypair modal above (1 created, 2 failed), over the same still-open form |
| ![keypair modal](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8479/20260812-012533-1-keypair-modal.png) | ![failure modal partial](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8479/20260811-074137-2-failure-modal-partial.png) |
| **3. Failure modal, total failure** — shown immediately, no keypairs to show first (0 created, 2 failed) | **4. CSV form with a loaded file + preview** |
| ![failure modal total](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8479/20260811-074137-3-failure-modal-total.png) | ![csv form](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8479/20260811-074137-4-csv-form.png) |
| **5. CSV entry point — the same failure modal after dismissing its keypair modal.** The loaded file and validated preview are still intact behind it, which is the state preservation this PR is about. | |
| ![csv failure modal](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8479/20260811-074137-5-csv-failure-modal.png) | |

## Rebase onto the post-Astryx `main`

This branch predated the antd removal, so it was rebased onto current `main` (59 commits). Two files conflicted:

- **`BulkCreateUserFromCSVModal.tsx`** — `main` still carried the two dead early-return screens this PR removes (the keypair swap and the unreachable ad-hoc failure table); the conflict resolves to this PR's deletion of both. The import-block conflict keeps both sides.
- **`UserSettingModal.tsx`** — import-block only; `main` had independently gained `BAIUnmountAfterClose` / `filterOutNullAndUndefined` there, which is exactly the sibling-overlay pattern this PR adopts, so the feature change applied unchanged on top.

The only substantive post-rebase edit is the one noted above: `BulkCreateUserFailure.tsx` was authored against `antd` (`Typography.Text`, `theme.useToken()`) and would no longer compile, so it was rewritten in the Astryx idiom.

## Review feedback (Copilot)

Copilot flagged that `createdCount` was doing double duty — the per-attempt count labelling the failure report, and the "did anything reach the backend?" flag the close paths hand to `onRequestClose`. Retrying a partially successful bulk create with 0 successes overwrote it with `0`, so Cancel reported `false` and `AdminUserManagement` skipped `updateFetchKey()` even though the earlier attempt had created users. The CSV modal had the same bug by a second route: **Remove File** shares `resetState` with `afterClose`, which zeroed the count too.

Fixed in eb0e68ed5 by splitting the two roles, matching `AssignRoleModal`'s `succeededRequestCount` / `hasAssignedAny` pair:

- `createdCount` stays **per-attempt** and now only feeds the failure report's "Success: n, Failed: m" label.
- A new **monotonic** `hasCreatedAny` drives every close path. It is deliberately excluded from `resetState` (dropping the file does not un-create users) and needs no explicit reset — both modals are unmounted on close by `BAIUnmountAfterClose`.

## Also here: the clipped Access Key copy button (FR-3519)

Spotted in this PR's own screenshots: the keypair modal sliced the **Access Key** copy button in half at the column edge. It is a pre-existing defect in `GeneratedKeypairListModal` rather than something this PR introduced, but that modal is the screen this flow ends on and the button is the only way to lift a credential the UI shows exactly once — so it is fixed here rather than in a parallel PR.

**Mechanism** — not the modal width on its own. The call site passed `scroll={{ x: 'max-content', y: 500 }}`, but `BAITableAstryx` **accepts and ignores `scroll`** (a documented migration PILOT-DECISION — Astryx's own scroll wrapper owns overflow). So the antd-era `max-content` sizing never applied and the three columns fell back to `proportional(1)`: an equal third of the 600px modal each. 200px does not fit a 20-character monospace access key plus a 24px copy button (content measured **197px** in a **184px** padded box), `<td>` is `overflow: hidden`, and the scroll container reported `scrollWidth == clientWidth` — so there was not even a scrollbar to reach it. Column floors come from `minWidth`, which this call site never set.

**Changes** — `minWidth: 240` on the Access Key column (the actual fix: a floor independent of modal width), modal `width` 600 → 780 so the table's 720px natural width needs no horizontal scroll, `resizable` so columns can be dragged, and the dead `scroll` prop dropped rather than left implying a sizing mode that is not in effect.

**Measured**, live app, 1600×1100, light and dark identical (geometry, not colour):

| Measure | Before | After |
|---|---|---|
| Column widths | 200 / 200 / 200 | 260 / 260 / 260 |
| Copy button vs cell right edge | **+5px (clipped)** | **−55px (inside)** |
| Modal scroller `clientWidth` / `scrollWidth` | 600 / 600 | 780 / 780 |
| Resize handles | 2 | 4 |
| `pageerror` | 0 | 0 |

Screenshot 1 above is re-shot against this fix. Known residue, untouched here and present before it: in dark mode the modal surface renders light while the page is dark.

## Verification

```
bash scripts/verify.sh → === ALL PASS ===
  (Relay / Lint / Format / TypeScript / Vite warmup / StyleX / Astryx theme build / Terminology)
pnpm run test (react)  → 66 files, 1162 tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)





