### PR TITLE
style(FR-3420): cap the docs site layout width on ultrawide monitors

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
@@ -6,6 +6,9 @@
  * Coverage:
  *   - The ultrawide shell cap: --bai-layout-max is defined and .doc-page is
  *     capped and centered by it.
+ *   - The flat rail: the in-flow sider shares the page surface (its old
+ *     3/255 tint became an unbounded band once the shell was centered),
+ *     while the mobile drawer overlay keeps a surface of its own.
  *   - The rail grid: the two full-bleed sticky bars (topbar, version banner)
  *     inset their content by centering-gutter + --bai-rail-inset, so the
  *     brand and the banner icon stay on the sider's grid line at every
@@ -17,6 +20,15 @@ import assert from "node:assert/strict";
 
 import { generateWebsiteStyles } from "./styles-web.js";
 
+/**
+ * The stylesheet is heavily commented, and those comments name the very
+ * tokens these tests assert on. Matching against raw CSS would let a
+ * comment satisfy an assertion — so every test works on stripped output.
+ */
+function styles(): string {
+  return generateWebsiteStyles().replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
 /** Extract the body of the first rule whose selector matches exactly. */
 function ruleBody(css: string, selector: string): string {
   const idx = css.indexOf(`\n${selector} {`);
@@ -26,8 +38,47 @@ function ruleBody(css: string, selector: string): string {
   return css.slice(start + 1, end);
 }
 
+test("generateWebsiteStyles — the in-flow rail is flat, the drawer keeps its surface", () => {
+  const css = styles();
+
+  // The capped shell detaches the rail from the viewport edge, so a tint
+  // that is only 3/255 from --bai-bg reads as an unbounded band. The rail
+  // must therefore share the page surface and lean on its border instead.
+  const sider = ruleBody(css, ".doc-sidebar");
+  assert.match(
+    sider,
+    /background:\s*var\(--bai-bg\);/,
+    "the in-flow rail must use the page surface, not a near-invisible tint",
+  );
+  assert.ok(
+    !/--bai-bg-sider/.test(sider),
+    "the in-flow rail must not reintroduce --bai-bg-sider",
+  );
+  assert.match(
+    sider,
+    /border-right:\s*1px solid var\(--bai-border\);/,
+    "with the tint gone, the border is the only thing separating rail from article",
+  );
+
+  // ...but the ≤880px drawer is a fixed overlay above the article, so it
+  // does need a surface of its own. Guard that the flattening above was
+  // not applied to it wholesale.
+  assert.match(
+    css,
+    /body\.bai-drawer-open \.doc-sidebar \{[^}]*background:\s*var\(--bai-bg-sider\);/s,
+    "the mobile drawer overlay should keep its own surface",
+  );
+});
+
+test("generateWebsiteStyles — the TOC mirrors the rail's separator", () => {
+  // The two hairlines are now the whole separation story, so they have to
+  // stay symmetric; losing one leaves the shell visibly lopsided.
+  const toc = ruleBody(styles(), ".doc-toc");
+  assert.match(toc, /border-left:\s*1px solid var\(--bai-border\);/);
+});
+
 test("generateWebsiteStyles — defines the ultrawide shell cap token", () => {
-  const css = generateWebsiteStyles();
+  const css = styles();
   assert.match(
     css,
     /--bai-layout-max:\s*1536px;/,
@@ -36,7 +87,7 @@ test("generateWebsiteStyles — defines the ultrawide shell cap token", () => {
 });
 
 test("generateWebsiteStyles — .doc-page is capped and centered by the shell token", () => {
-  const body = ruleBody(generateWebsiteStyles(), ".doc-page");
+  const body = ruleBody(styles(), ".doc-page");
   assert.match(body, /max-width:\s*var\(--bai-layout-max\);/);
   assert.match(
     body,
@@ -46,7 +97,7 @@ test("generateWebsiteStyles — .doc-page is capped and centered by the shell to
 });
 
 test("generateWebsiteStyles — defines the rail grid inset", () => {
-  const css = generateWebsiteStyles();
+  const css = styles();
   assert.match(
     css,
     /--bai-rail-inset:\s*24px;/,
@@ -55,7 +106,7 @@ test("generateWebsiteStyles — defines the rail grid inset", () => {
 });
 
 test("generateWebsiteStyles — full-bleed bars hold the rail grid at every width", () => {
-  const css = generateWebsiteStyles();
+  const css = styles();
   // The bars stay full-bleed (background + border span the viewport) and only
   // their inline padding grows. The padding must be centering-gutter PLUS the
   // rail inset, so the brand sits at shell+inset on both sides of the cap.

--- a/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
@@ -13,6 +13,9 @@
  *     inset their content by centering-gutter + --bai-rail-inset, so the
  *     brand and the banner icon stay on the sider's grid line at every
  *     viewport width instead of shifting as the cap is crossed.
+ *   - The version row's separator: an inset ::after matching
+ *     .doc-toc__divider, rather than a border spanning the sider edge to
+ *     edge, plus the uniform 14px rhythm around it.
  */
 
 import { test } from "node:test";
@@ -180,4 +183,35 @@ test("generateWebsiteStyles — full-bleed bars hold the rail grid at every widt
       `${selector} must stay full-bleed (no max-width) so its background spans the viewport`,
     );
   }
+});
+
+test("generateWebsiteStyles — the rail's three vertical gaps are uniform", () => {
+  const css = styles();
+
+  // The version block used to read top-heavy: 14px above the switcher pill,
+  // 10px from the pill down to the separator, then 16px from the separator
+  // to the first nav item. All three are now 14px, box to box, and each
+  // comes from exactly one declaration so none can drift alone.
+  const row = ruleBody(css, ".doc-sidebar-version");
+  assert.match(
+    row,
+    /padding:\s*14px 24px;/,
+    "symmetric padding makes the gap above the pill equal the gap below it",
+  );
+
+  const scroll = ruleBody(css, ".doc-sidebar__scroll");
+  assert.match(
+    scroll,
+    /padding:\s*14px 8px 24px;/,
+    "the scrollport's padding-top is the sole owner of the separator -> first item gap",
+  );
+
+  // If the intro regained a top margin the gap would become a sum again
+  // (the exact bug this replaced), so pin it to zero.
+  const intro = ruleBody(css, ".doc-sidebar-intro");
+  assert.match(
+    intro,
+    /margin:\s*0 6px 4px;/,
+    "the first item must not add its own top margin on top of the scrollport padding",
+  );
 });

--- a/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
@@ -4,10 +4,12 @@
  * Run: pnpm --filter backend.ai-docs-toolkit test
  *
  * Coverage:
- *   - The ultrawide shell cap: --bai-layout-max is defined, .doc-page is
- *     capped and centered by it, and the two full-bleed sticky bars
- *     (topbar, version banner) inset their content to the same cap while
- *     keeping their original gutter below it.
+ *   - The ultrawide shell cap: --bai-layout-max is defined and .doc-page is
+ *     capped and centered by it.
+ *   - The rail grid: the two full-bleed sticky bars (topbar, version banner)
+ *     inset their content by centering-gutter + --bai-rail-inset, so the
+ *     brand and the banner icon stay on the sider's grid line at every
+ *     viewport width instead of shifting as the cap is crossed.
  */
 
 import { test } from "node:test";
@@ -43,23 +45,50 @@ test("generateWebsiteStyles — .doc-page is capped and centered by the shell to
   );
 });
 
-test("generateWebsiteStyles — full-bleed bars inset their content to the shell cap", () => {
+test("generateWebsiteStyles — defines the rail grid inset", () => {
   const css = generateWebsiteStyles();
-  // The bars stay full-bleed (background + border span the viewport) and
-  // only their inline padding grows, so the brand/banner text lines up
-  // with the sider's left edge on ultrawide viewports. max() preserves the
-  // original gutter at every width below the cap.
-  for (const [selector, gutter] of [
-    [".bai-topbar", "20px"],
-    [".docs-banner", "22px"],
-  ] as const) {
+  assert.match(
+    css,
+    /--bai-rail-inset:\s*24px;/,
+    "the rail grid line should be declared on :root",
+  );
+});
+
+test("generateWebsiteStyles — full-bleed bars hold the rail grid at every width", () => {
+  const css = generateWebsiteStyles();
+  // The bars stay full-bleed (background + border span the viewport) and only
+  // their inline padding grows. The padding must be centering-gutter PLUS the
+  // rail inset, so the brand sits at shell+inset on both sides of the cap.
+  // The tempting max(inset, gutter) form drops the inset term once the gutter
+  // wins, which snaps the brand to shell+0 and visibly shifts the grid as the
+  // window is resized past the cap — assert against that regression too.
+  for (const selector of [".bai-topbar", ".docs-banner"] as const) {
     const body = ruleBody(css, selector);
-    assert.match(
-      body,
-      new RegExp(
-        `padding-inline:\\s*max\\(${gutter},\\s*calc\\(\\(100% - var\\(--bai-layout-max\\)\\) / 2\\)\\);`,
-      ),
-      `${selector} should inset its content to the shell cap`,
+    const declaration = body.match(/padding-inline:[^;]*;/s)?.[0] ?? "";
+    assert.ok(
+      declaration,
+      `${selector} should declare padding-inline for the rail grid`,
+    );
+    const normalized = declaration.replace(/\s+/g, " ");
+    assert.ok(
+      normalized.includes("max(0px, (100% - var(--bai-layout-max)) / 2)"),
+      `${selector} should grow by the centering gutter, got: ${normalized}`,
+    );
+    assert.ok(
+      normalized.includes("var(--bai-rail-inset)"),
+      `${selector} should add the rail inset on top of the gutter`,
+    );
+    // The only max() allowed is the one flooring the gutter at zero. A
+    // non-zero floor (max(20px, gutter)) is the regression: it swallows the
+    // inset once the gutter wins, snapping the brand to shell+0.
+    const maxFloors = [...normalized.matchAll(/max\(\s*([^,]+),/g)].map((m) =>
+      m[1].trim(),
+    );
+    assert.deepEqual(
+      maxFloors,
+      ["0px"],
+      `${selector} may only clamp the gutter at 0px — a non-zero max() floor ` +
+        `drops the inset above the cap and shifts the grid. Got: ${normalized}`,
     );
     assert.ok(
       !/max-width/.test(body),

--- a/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
@@ -77,6 +77,40 @@ test("generateWebsiteStyles — the TOC mirrors the rail's separator", () => {
   assert.match(toc, /border-left:\s*1px solid var\(--bai-border\);/);
 });
 
+test("generateWebsiteStyles — the version row is separated by an inset rule", () => {
+  const css = styles();
+
+  // A border-bottom here would sit outside the padding box and span the
+  // sider edge to edge. The separator has to be inset like the TOC's, and
+  // inset by exactly the rail grid so it starts under the VERSION label.
+  const row = ruleBody(css, ".doc-sidebar-version");
+  assert.ok(
+    !/border-bottom/.test(row),
+    "the version row must not use a full-width border-bottom as its separator",
+  );
+  assert.match(
+    row,
+    /position:\s*relative;/,
+    "the row must stay the containing block for its ::after separator",
+  );
+
+  const rule = ruleBody(css, ".doc-sidebar-version::after");
+  for (const decl of [
+    /left:\s*24px;/,
+    /right:\s*24px;/,
+    /height:\s*1px;/,
+    /background:\s*var\(--bai-border-soft\);/,
+  ]) {
+    assert.match(rule, decl, `inset separator should declare ${decl}`);
+  }
+
+  // Same weight and token as the divider it is copying, so the two rails
+  // separate their sections identically.
+  const tocDivider = ruleBody(css, ".doc-toc__divider");
+  assert.match(tocDivider, /height:\s*1px;/);
+  assert.match(tocDivider, /background:\s*var\(--bai-border-soft\);/);
+});
+
 test("generateWebsiteStyles — defines the ultrawide shell cap token", () => {
   const css = styles();
   assert.match(

--- a/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the website stylesheet generator (styles-web.ts).
+ *
+ * Run: pnpm --filter backend.ai-docs-toolkit test
+ *
+ * Coverage:
+ *   - The ultrawide shell cap: --bai-layout-max is defined, .doc-page is
+ *     capped and centered by it, and the two full-bleed sticky bars
+ *     (topbar, version banner) inset their content to the same cap while
+ *     keeping their original gutter below it.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { generateWebsiteStyles } from "./styles-web.js";
+
+/** Extract the body of the first rule whose selector matches exactly. */
+function ruleBody(css: string, selector: string): string {
+  const idx = css.indexOf(`\n${selector} {`);
+  assert.notEqual(idx, -1, `expected a "${selector}" rule in the stylesheet`);
+  const start = css.indexOf("{", idx);
+  const end = css.indexOf("}", start);
+  return css.slice(start + 1, end);
+}
+
+test("generateWebsiteStyles — defines the ultrawide shell cap token", () => {
+  const css = generateWebsiteStyles();
+  assert.match(
+    css,
+    /--bai-layout-max:\s*1536px;/,
+    "the shell cap token should be declared on :root",
+  );
+});
+
+test("generateWebsiteStyles — .doc-page is capped and centered by the shell token", () => {
+  const body = ruleBody(generateWebsiteStyles(), ".doc-page");
+  assert.match(body, /max-width:\s*var\(--bai-layout-max\);/);
+  assert.match(
+    body,
+    /margin-inline:\s*auto;/,
+    "the capped grid must be centered, otherwise the whole shell hugs the left edge",
+  );
+});
+
+test("generateWebsiteStyles — full-bleed bars inset their content to the shell cap", () => {
+  const css = generateWebsiteStyles();
+  // The bars stay full-bleed (background + border span the viewport) and
+  // only their inline padding grows, so the brand/banner text lines up
+  // with the sider's left edge on ultrawide viewports. max() preserves the
+  // original gutter at every width below the cap.
+  for (const [selector, gutter] of [
+    [".bai-topbar", "20px"],
+    [".docs-banner", "22px"],
+  ] as const) {
+    const body = ruleBody(css, selector);
+    assert.match(
+      body,
+      new RegExp(
+        `padding-inline:\\s*max\\(${gutter},\\s*calc\\(\\(100% - var\\(--bai-layout-max\\)\\) / 2\\)\\);`,
+      ),
+      `${selector} should inset its content to the shell cap`,
+    );
+    assert.ok(
+      !/max-width/.test(body),
+      `${selector} must stay full-bleed (no max-width) so its background spans the viewport`,
+    );
+  }
+});

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -227,6 +227,20 @@ export function generateWebStyles(
   --bai-content-max: 820px;
   --bai-gutter: 32px;
 
+  /* Outer shell cap. The three-column grid (sider + article + TOC) used
+     to stretch to the full viewport width, so on ultrawide displays
+     (21:9 and wider) the sider stuck to the far-left edge and the TOC to
+     the far-right one, leaving the 820px article marooned between two
+     ~600px voids. Capping the shell and centering it keeps the three
+     columns as one readable block; the leftover width becomes symmetric
+     page margin instead of intra-layout dead space.
+
+     1536px = 280 (sider) + 240 (TOC) + 1016 for the article column,
+     which gives the 820px prose ~98px of slack per side — the same
+     column-to-prose ratio the reference layout uses. Below this width
+     nothing changes, so laptop/1440p viewports render exactly as before. */
+  --bai-layout-max: 1536px;
+
   /* Legacy aliases used by F3 grid rules (resolve to BAI tokens). */
   --doc-sidebar-width: var(--bai-sider-w);
   --doc-toc-width: var(--bai-toc-w);
@@ -329,7 +343,15 @@ body {
   align-items: center;
   gap: 14px;
   height: var(--bai-topbar-h);
-  padding: 0 20px;
+  /* Full-bleed bar with shell-aligned content: the background and bottom
+     border still span the viewport (a sticky bar that stopped short of
+     the edges would read as a floating card), but the brand / search /
+     action row is inset to the same --bai-layout-max shell as .doc-page.
+     The brand then lines up with the sider and the icon cluster with the
+     TOC instead of clinging to the screen corners on ultrawide displays.
+     max() keeps the original 20px gutter at every width below the cap. */
+  padding-block: 0;
+  padding-inline: max(20px, calc((100% - var(--bai-layout-max)) / 2));
   background: var(--bai-bg);
   border-bottom: 1px solid var(--bai-border);
 }
@@ -951,6 +973,10 @@ body.bai-drawer-open .bai-scrim {
   grid-template-columns: var(--bai-sider-w) minmax(0, 1fr) var(--bai-toc-w);
   align-items: stretch;
   min-height: calc(100vh - var(--bai-topbar-h));
+  /* Cap + center the whole shell so ultrawide viewports grow the page
+     margins rather than the gaps between sider, article and TOC. */
+  max-width: var(--bai-layout-max);
+  margin-inline: auto;
 }
 
 .doc-sidebar {
@@ -3141,7 +3167,11 @@ export function generateWebsiteStyles(branding?: StyleBrandingTokens): string {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 22px;
+  /* Same full-bleed-bar / shell-aligned-content split as .bai-topbar so
+     the banner text starts on the sider's left edge rather than the
+     viewport's on ultrawide displays. */
+  padding-block: 10px;
+  padding-inline: max(22px, calc((100% - var(--bai-layout-max)) / 2));
   border-bottom: 1px solid var(--bai-border);
   /* FR-2758: banner sits sticky right under the topbar so it stays
      visible during scroll (the operator wants this notice to be a

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1018,7 +1018,25 @@ body.bai-drawer-open .bai-scrim {
   flex-direction: column;
   overflow: hidden;
   border-right: 1px solid var(--bai-border);
-  background: var(--bai-bg-sider);
+  /* FR-3420: the in-flow rail carries no surface tint of its own — the
+     page is one continuous surface and the border-right above (paired
+     with .doc-toc's border-left) is what separates the three columns.
+
+     It used to use --bai-bg-sider, which is only 3/255 away from
+     --bai-bg. While the shell was full-bleed that tint was hidden
+     against the viewport edge, but once the shell is capped and centered
+     the rail detaches from the edge and the tint becomes a band with no
+     boundary on its left — too weak to read as a deliberate rail, too
+     strong to read as nothing. Dropping it is the treatment Fumadocs,
+     Tailwind and the React docs use. The alternative (commit to the tint
+     and give the shell a real outer edge on a recessed canvas) needs a
+     new canvas token and changes every viewport, so it stays a separate
+     decision.
+
+     The ≤880px drawer keeps --bai-bg-sider: there the sider is a fixed
+     overlay floating above the article with its own shadow, so it does
+     want a surface distinct from the content beneath it. */
+  background: var(--bai-bg);
 }
 
 /* The internal scrollport. Holds the synthetic Introduction entry +

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1193,10 +1193,41 @@ body.bai-drawer-open .bai-scrim {
   gap: 10px;
   flex: 0 0 auto;
   padding: 14px 24px 10px;
-  border-bottom: 1px solid var(--bai-border-soft, var(--bai-border));
   /* FR-3265: positioning anchor for the .bai-select__list--version
-     popup injected by interactions.js. */
+     popup injected by interactions.js. Also the containing block for
+     the ::after separator below. */
   position: relative;
+}
+
+/* FR-3420: separate the version row from the nav with an INSET rule,
+   matching .doc-toc__divider (which is inset by the TOC's own padding
+   and separates the outline from the Get-help block).
+
+   This used to be a border-bottom on the row itself. A border sits
+   outside the padding box, so it always spanned the sider edge to edge
+   — a hard full-width line cutting the rail in two, which reads as
+   heavier than the divider doing the equivalent job in the TOC.
+
+   Inset by the row's own 24px horizontal padding, so the rule starts on
+   the same +24px rail grid as the VERSION label, the group icons and
+   the topbar brand, and ends where the version popup's right edge does
+   (.bai-select__list--version is also right: 24px). Same
+   --bai-border-soft token as the TOC divider, so only the extent
+   differs, not the weight or colour.
+
+   A pseudo-element rather than a real <div> like the TOC's: the version
+   row lives outside .doc-sidebar__scroll, so this needs no markup
+   change and cannot disturb the scrollport's flex sizing. It carries no
+   z-index, so the version popup (z-index 110, opaque) still paints over
+   it. */
+.doc-sidebar-version::after {
+  content: "";
+  position: absolute;
+  left: 24px;
+  right: 24px;
+  bottom: 0;
+  height: 1px;
+  background: var(--bai-border-soft);
 }
 .doc-sidebar-version__label {
   font-size: 10.5px;

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -241,6 +241,22 @@ export function generateWebStyles(
      nothing changes, so laptop/1440p viewports render exactly as before. */
   --bai-layout-max: 1536px;
 
+  /* The rail's vertical grid line, measured from the shell's left edge.
+     The sider already puts its VERSION label, the Introduction icon and
+     every group icon at exactly 24px in, at every viewport width. The
+     topbar brand and the banner icon have to land on that same line, or
+     the logo and the menu beneath it read as two different grids.
+
+     Both bars are full-bleed, so they reach it by adding this inset on
+     top of the centering gutter rather than by being capped:
+       padding-inline: calc(max(0px, (100% - cap) / 2) + inset)
+     Below the cap the gutter term is 0 and the inset alone applies;
+     above it the gutter grows while the inset holds the content on the
+     grid. Using max(inset, gutter) instead — the obvious-looking form —
+     is what breaks it: the brand would sit at +inset below the cap and
+     snap to +0 above it, so the grid shifts as the window is resized. */
+  --bai-rail-inset: 24px;
+
   /* Legacy aliases used by F3 grid rules (resolve to BAI tokens). */
   --doc-sidebar-width: var(--bai-sider-w);
   --doc-toc-width: var(--bai-toc-w);
@@ -346,12 +362,15 @@ body {
   /* Full-bleed bar with shell-aligned content: the background and bottom
      border still span the viewport (a sticky bar that stopped short of
      the edges would read as a floating card), but the brand / search /
-     action row is inset to the same --bai-layout-max shell as .doc-page.
-     The brand then lines up with the sider and the icon cluster with the
-     TOC instead of clinging to the screen corners on ultrawide displays.
-     max() keeps the original 20px gutter at every width below the cap. */
+     action row is inset so the logo lands on the sider's +24px grid line
+     and the icon cluster ends on the TOC's right edge, instead of both
+     clinging to the screen corners on ultrawide displays. See
+     --bai-rail-inset for why this is gutter-plus-inset and not
+     max(inset, gutter). */
   padding-block: 0;
-  padding-inline: max(20px, calc((100% - var(--bai-layout-max)) / 2));
+  padding-inline: calc(
+    max(0px, (100% - var(--bai-layout-max)) / 2) + var(--bai-rail-inset)
+  );
   background: var(--bai-bg);
   border-bottom: 1px solid var(--bai-border);
 }
@@ -3167,11 +3186,13 @@ export function generateWebsiteStyles(branding?: StyleBrandingTokens): string {
   display: flex;
   align-items: center;
   gap: 10px;
-  /* Same full-bleed-bar / shell-aligned-content split as .bai-topbar so
-     the banner text starts on the sider's left edge rather than the
-     viewport's on ultrawide displays. */
+  /* Same full-bleed-bar / shell-aligned-content split as .bai-topbar, so
+     the banner icon starts on the same +24px rail grid as the brand above
+     it and the sider's icons below it. */
   padding-block: 10px;
-  padding-inline: max(22px, calc((100% - var(--bai-layout-max)) / 2));
+  padding-inline: calc(
+    max(0px, (100% - var(--bai-layout-max)) / 2) + var(--bai-rail-inset)
+  );
   border-bottom: 1px solid var(--bai-border);
   /* FR-2758: banner sits sticky right under the topbar so it stays
      visible during scroll (the operator wants this notice to be a

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -1052,7 +1052,14 @@ body.bai-drawer-open .bai-scrim {
      bubbling out and scrolling the article. Same defense applied to
      the mobile drawer override below. */
   overscroll-behavior: contain;
-  padding: 10px 8px 24px;
+  /* FR-3420: padding-top is the sole owner of the gap between the
+     version row's separator and the first nav item, and matches the
+     14px on either side of that separator. .doc-sidebar-intro's
+     margin-top is zeroed for this reason — when the gap was a sum of
+     this padding (10px) plus that margin (6px) it was easy to change one
+     and silently shift the rhythm. The 8px sides are load-bearing for
+     the rail grid (8 + 6 group margin + 10 summary padding = 24px). */
+  padding: 14px 8px 24px;
 }
 
 .doc-sidebar__scroll::-webkit-scrollbar {
@@ -1192,7 +1199,20 @@ body.bai-drawer-open .bai-scrim {
   justify-content: space-between;
   gap: 10px;
   flex: 0 0 auto;
-  padding: 14px 24px 10px;
+  /* FR-3420: symmetric vertical padding so the space above the switcher
+     pill equals the space between the pill and the ::after separator
+     below. It used to be 14px/10px, which pulled the rule toward the
+     pill and made the version block look top-heavy against the 16px
+     that sat on the other side of the rule.
+
+     The three gaps in this rail are now all 14px, measured box to box
+     (the convention .doc-toc__divider already follows with its
+     symmetric 18px margins):
+       sider top    -> pill top          14px  (this padding-top)
+       pill bottom  -> separator         14px  (this padding-bottom)
+       separator    -> first nav item    14px  (.doc-sidebar__scroll)
+     Horizontal padding stays 24px — see the rail-grid note below. */
+  padding: 14px 24px;
   /* FR-3265: positioning anchor for the .bai-select__list--version
      popup injected by interactions.js. Also the containing block for
      the ::after separator below. */
@@ -1304,7 +1324,11 @@ body.bai-drawer-open .bai-scrim {
   display: flex;
   align-items: center;
   gap: 9px;
-  margin: 6px 6px 4px;
+  /* FR-3420: no margin-top — .doc-sidebar__scroll's padding-top owns the
+     gap from the version separator down to this first item, so the rail's
+     three 14px gaps each come from exactly one declaration. The 6px
+     sides are the rail-grid nudge (see .doc-sidebar-group) and stay. */
+  margin: 0 6px 4px;
   padding: 8px 10px;
   border-radius: 6px;
   font-family: var(--bai-font-sans);


### PR DESCRIPTION
Resolves #8481 (FR-3420)

The docs site's three-column shell (`.doc-page`: sider + article + right-rail TOC) stretched to the full viewport width. On a 21:9 monitor that pinned the sider to the far-left edge and the TOC to the far-right edge while the 820px article stayed centered — roughly 600px of dead space **on each side, inside the layout**, so the three columns stopped reading as one block.

Fixing that exposed follow-on problems in the rail, all addressed here. Five commits, one file of source (`packages/backend.ai-docs-toolkit/src/styles-web.ts`, shared by `build:web` / `serve:web` and `preview:html`) plus its tests.

All captures below are rendered from a real build of this branch, against a real build of the merge-base (3f1510a0f) — not injected CSS.

![2560 light before/after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-051352-ba-2560-light.png)

![2560 dark before/after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-051352-ba-2560-dark.png)

![rail detail before/after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-051352-ba-rail-detail.png)

![other viewports before/after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-051352-ba-other-views.png)


---

## 1 · Cap and centre the shell

Same pattern as reference doc sites — [seed-design.io](https://seed-design.io/components/action-button) caps its shell at 1552px and lets the leftover width become symmetric page margin. Measured there: the grid resolves to `504px 240px 1112px 200px 504px` at 2560px, a fixed 1552px shell inside growing gutters.

`--bai-layout-max: 1536px` — 280 (sider) + 240 (TOC) + 1016 for the article column, so the 820px prose keeps ~98px of slack per side, the same column-to-prose ratio as the reference. `.doc-page` gets `max-width` + `margin-inline: auto`.

The topbar and version banner stay **full-bleed** — background and bottom border still span the viewport, since a sticky bar that stops short of the edges reads as a floating card — and only their content is inset. No HTML change was needed.

| viewport | before | after |
|---|---|---|
| 1440 | page `1440@0` · sider `280@0` · main `820@330` · toc `240@1200` | **unchanged** (columns) |
| 1920 | page `1920@0` · sider `280@0` · main `820@570` · toc `240@1680` | page `1536@192` · sider `280@192` · main `820@570` · toc `240@1488` |
| 2560 | page `2560@0` · sider `280@0` · main `820@890` · toc `240@2320` | page `1536@512` · sider `280@512` · main `820@890` · toc `240@1808` |
| 3440 | page `3440@0` · sider `280@0` · main `820@1330` · toc `240@3200` | page `1536@952` · sider `280@952` · main `820@1330` · toc `240@2248` |

The article column does not move at any width — only the sider and TOC come inward, so the reading position is unchanged and only the dead space closes.

## 2 · Hold the rail grid across the cap

The first pass wrote the bar inset as `max(20px, centering-gutter)`. That form drops the gutter below the cap and drops the **inset** above it, so the brand sat at `shell+20px` on a laptop and snapped to `shell+0px` past 1536px — the logo and the menu beneath it stopped sharing a vertical grid, and the grid moved as the window was resized.

The sider already had a stable grid: its VERSION label and every group icon sit at exactly `shell+24px`, at every width. Adopted that rather than inventing a second line, reached by adding the inset *on top of* the gutter:

```css
--bai-rail-inset: 24px;
padding-inline: calc(max(0px, (100% - var(--bai-layout-max)) / 2) + var(--bai-rail-inset));
```

Below the cap the gutter term is 0 and the inset alone applies; above it the gutter grows while the inset holds content on the grid.

| viewport | logo | nav / group icon | |
|---|---|---|---|
| ≤ 1536 | +20 | +24 | 4px off |
| ≥ 1920 | +0 | +24 | 24px off |
| **every width, after** | **+24** | **+24** | aligned |

Guide line drawn at `shell + 24px`. Nested nav items (`1. Quickstart` …) stay indented as child hierarchy.

| 1440px (below the cap) | 2560px (above it) |
|---|---|
| ![grid 1440](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-041149-grid-proof-1440.png) | ![grid 2560](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-041149-grid-proof-2560.png) |

This moves the brand 4px right below the cap (+20 → +24). That 4px was the pre-existing misalignment, so **sub-cap rendering is not pixel-identical to `main`** — the column geometry is untouched, but the logo now sits on the grid.

## 3 · Flatten the in-flow rail

Centering the shell also detached the sider from the viewport edge, exposing its background as a band with no boundary on its left — the tint started mid-air. Measured, `--bai-bg-sider` is only **3/255** from `--bai-bg` (`#FCFCFC` vs `#FFFFFF`; `#111114` vs `#0E0E10` in dark): too weak to read as a deliberate rail, too strong to read as nothing. Full-bleed hid the ambiguity against the screen edge.

So the rail drops its tint and the existing `border-right` (paired with `.doc-toc`'s `border-left`) carries the column separation — one continuous surface, the treatment Fumadocs / Tailwind / React docs use.

```css
.doc-sidebar { background: var(--bai-bg); }
```

The **≤880px drawer deliberately keeps `--bai-bg-sider`**: there the sider is a fixed overlay floating above the article with its own shadow, so it does want a surface distinct from the content beneath it. Verified it still resolves to `#FCFCFC` over a `#FFFFFF` body.

<img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-042143-final-drawer-390.png" width="300" alt="mobile drawer keeps its own surface" />

**Alternative considered and deferred.** Commit to the tint instead, and give the shell a real outer edge on a recessed canvas. It reads better as a designed system (the step grows to 5–8 levels), but it needs a new `--bai-bg-canvas` token — reusing `--bai-bg-muted` / `--bai-bg-subtle` **inverts the ramp in dark mode**, where both are *lighter* than `--bai-bg`, making the empty gutters float above the document — and it changes the background tone at every viewport, not just wide ones. That is a site-wide visual decision, so it is not riding along here. A rounded-card variant was also built and rejected: the corners and shadow only exist at scroll-top, since the document never ends.

## 4 · Inset the sider's version divider

The version selector was separated from the nav by a `border-bottom` on the row itself. A border sits *outside* the padding box, so it always spanned the sider edge to edge — a hard full-width line cutting the rail in two. The right rail does the equivalent job (separating the outline from the Get-help block) with `.doc-toc__divider`, which is inset by the TOC's own padding and reads noticeably softer.

Matched that treatment: drop the border, draw the rule as an `::after` inset by the row's own 24px horizontal padding.

![divider before / after / reference](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-043436-divider-compare.png)

| | extent | left end | right end |
|---|---|---|---|
| before | 280px — the full sider | sider edge (+0) | sider edge |
| after | **231px** | **536px = the +24 rail grid** | version popup's right edge |
| TOC divider (reference) | 195px in a 240px rail | +23 | −22 |

Its left end now lands on the same +24px grid as the VERSION label, the group icons and the topbar brand. Same 1px height and `--bai-border-soft` token as the TOC divider, so only the extent changed — not the weight or colour.

A pseudo-element rather than a real `<div>` like the TOC's: the version row lives outside `.doc-sidebar__scroll`, so this needs no markup change and cannot disturb the scrollport's flex sizing. It carries no `z-index`, so the version popup (`z-index: 110`, opaque) still paints over it.

### Uniform rhythm around it

The same block also read top-heavy, because its three vertical gaps were all different:

| gap | before | after |
|---|---|---|
| sider top → switcher pill | 14px | **14px** |
| pill bottom → separator | 10px | **14px** |
| separator → first nav item | 16px | **14px** |

![rhythm before/after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8482/20260730-044510-rhythm-compare.png)

Measured box to box, matching `.doc-toc__divider`'s symmetric 18px margins. Each gap now comes from exactly **one** declaration, which is the part worth keeping: the separator-to-first-item gap used to be a *sum* of `.doc-sidebar__scroll`'s `padding-top` (10px) and `.doc-sidebar-intro`'s `margin-top` (6px), so changing either silently shifted the rhythm. The intro's top margin is zeroed and the scrollport owns that gap outright; both keep their horizontal values, which are load-bearing for the +24px rail grid.

An optically-compensated variant (14/14/**6**, subtracting the nav item's 8px inner padding so the whitespace either side of the rule reads equal *at rest*) was built and rejected — it puts INTRODUCTION's hover pill 6px from the rule, and the separator stops looking like it separates anything. 12/12/12 also reads fine but compresses the block for no gain.

## Verification

- **Surface + grid + overflow swept at 390 / 880 / 1024 / 1440 / 1536 / 1537 / 1920 / 2560 / 3440.** Sider background equals the body background at every width; logo, banner icon, VERSION label and both group icons land on +24 at every width where the sider is visible; `documentElement.scrollWidth === innerWidth` throughout. 1536→1537 is included specifically to cover the cap crossover.
- **Dark mode** verified for every change; **mobile drawer** verified to retain its own surface and `position: fixed`.
- `pnpm --filter backend.ai-docs-toolkit test` — **303 pass / 0 fail / 1 skipped** (pre-existing). Eight new tests in `src/styles-web.test.ts` cover the cap token, the centered `.doc-page`, the `--bai-rail-inset` token, the shape of the bars' `padding-inline`, the flat rail vs. the drawer's retained surface, the TOC's mirrored border, the version row's inset separator, and the uniform 14px rhythm (including the intro's zeroed top margin, so the gap cannot go back to being a sum).
- The tests assert on **comment-stripped** CSS. The stylesheet's comments name the very tokens under test, so matching raw output would let prose satisfy an assertion.
- The new assertions were **mutation-checked**: restoring the rail tint, dropping the TOC border, reintroducing `max(20px, gutter)`, and resetting the version divider to a full-bleed `0 / 0` inset each fail the suite. The `padding-inline` test checks the declaration's *shape* — the only `max()` permitted is the one flooring the gutter at `0px` — so the grid-shifting form cannot come back silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
