### PR TITLE
fix(FR-3405): resolve the property filter's selected property from current props

### DIFF
--- a/react/src/components/ProjectFolderPermissionPanel.tsx
+++ b/react/src/components/ProjectFolderPermissionPanel.tsx
@@ -9,14 +9,14 @@ import { useCurrentDomainValue } from '../hooks';
 import DomainStoragePermissionTable from './DomainStoragePermissionTable';
 import ProjectStoragePermissionTable from './ProjectStoragePermissionTable';
 import { CheckCircleOutlined } from '@ant-design/icons';
-import { Typography, theme } from 'antd';
+import { Space, Typography, theme } from 'antd';
 import {
   BAIAlert,
   BAICard,
   BAIDomainSelect,
   BAIFetchKeyButton,
   BAIFlex,
-  BAIGraphQLPropertyFilter,
+  BAISelect,
   useFetchKey,
 } from 'backend.ai-ui';
 import React, { useDeferredValue, useState } from 'react';
@@ -114,32 +114,41 @@ const ProjectFolderPermissionPanel: React.FC<
       >
         <BAIFlex direction="column" align="stretch" gap="xs">
           <BAIFlex align="center" justify="between" gap="md" wrap="wrap">
-            <BAIGraphQLPropertyFilter
-              filterProperties={[
-                {
-                  key: 'domainName',
-                  propertyLabel: t('storageHost.permission.Name'),
-                  type: 'uuid',
-                  fixedOperator: 'equals',
-                  renderInput: () => (
-                    <BAIDomainSelect
-                      value={selectedDomainName}
-                      onChange={(value) =>
-                        setSelectedDomainName(
-                          (value as string | undefined) || undefined,
-                        )
-                      }
-                      allowClear
-                      style={{ minWidth: 200 }}
-                    />
-                  ),
-                },
-              ]}
-            />
+            {/* The domain picker drives this panel's own query state rather
+                than a GraphQL filter, so it is a plain compact pair (label
+                select + domain select) instead of BAIGraphQLPropertyFilter,
+                whose renderInput contract expects stateless controls committing
+                via onAddCondition (FR-3405). */}
+            <Space.Compact>
+              <BAISelect
+                popupMatchSelectWidth={false}
+                options={[
+                  {
+                    label: t('storageHost.permission.Name'),
+                    value: 'domainName',
+                  },
+                ]}
+                value="domainName"
+                style={{ minWidth: 150 }}
+              />
+              <BAIDomainSelect
+                value={selectedDomainName ?? null}
+                onChange={(value) =>
+                  setSelectedDomainName(
+                    (value as string | undefined) || undefined,
+                  )
+                }
+                allowClear
+                style={{ minWidth: 200 }}
+              />
+            </Space.Compact>
             <BAIFetchKeyButton
               value={domainFetchKey}
               onChange={updateDomainFetchKey}
-              loading={deferredFetchKey !== domainFetchKey}
+              loading={
+                deferredFetchKey !== domainFetchKey ||
+                deferredQueryVariables !== queryVariables
+              }
             />
           </BAIFlex>
           <DomainStoragePermissionTable
@@ -181,6 +190,10 @@ const ProjectFolderPermissionPanel: React.FC<
           storageVolumeFrgmt={storageVolume}
           domainFrgmt={domain}
           permissionFrgmt={vfolder_host_permissions}
+          loading={
+            deferredFetchKey !== domainFetchKey ||
+            deferredQueryVariables !== queryVariables
+          }
         />
       </BAICard>
     </BAIFlex>

--- a/react/src/components/ProjectStoragePermissionTable.tsx
+++ b/react/src/components/ProjectStoragePermissionTable.tsx
@@ -75,11 +75,18 @@ export interface ProjectStoragePermissionTableProps extends BAITableProps<Projec
    */
   permissionFrgmt:
     ProjectStoragePermissionTable_permissionFrgmt$key | null | undefined;
+  loading?: boolean;
 }
 
 const ProjectStoragePermissionTable: React.FC<
   ProjectStoragePermissionTableProps
-> = ({ storageVolumeFrgmt, domainFrgmt, permissionFrgmt, ...tableProps }) => {
+> = ({
+  storageVolumeFrgmt,
+  domainFrgmt,
+  permissionFrgmt,
+  loading,
+  ...tableProps
+}) => {
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -345,7 +352,7 @@ const ProjectStoragePermissionTable: React.FC<
           <BAIFetchKeyButton
             value={fetchKey}
             onChange={() => updateFetchKey()}
-            loading={deferredQueryVariables !== queryVariables}
+            loading={deferredQueryVariables !== queryVariables || loading}
           />
         </BAIFlex>
       </BAIFlex>


### PR DESCRIPTION
Resolves #8451 (FR-3405)

## Problem

In **Storage Host Info → Project Folder Permissions → Domains**, clearing the domain selector permanently breaks the panel: the table empties, the selector re-fills itself with the previous domain, and re-picking that domain does nothing. Only re-opening the drawer recovers.

## Root cause

`ProjectFolderPermissionPanel` used `BAIGraphQLPropertyFilter` against its `renderInput` contract. The contract expects a **stateless** control (`value={null}`) that commits picks through `onAddCondition`; the panel instead bound the control to its own state and ignored the callback:

```tsx
renderInput: () => (
  <BAIDomainSelect value={selectedDomainName} onChange={...} allowClear />
)
```

`BAIGraphQLPropertyFilter` seeds the selected property object into state once (`useState(filterProperties[0])`) and never re-syncs it with `filterProperties`, so it keeps rendering the **first render's** `renderInput` closure. That frozen closure always supplies the mount-time `selectedDomainName`:

1. Clear → `onChange(undefined)` fires (state setters are stable) → panel state empties → the query is skipped → the table shows the "select a domain" placeholder.
2. The stale closure re-renders the Select with the **original** domain, so the selector visibly refills itself while panel state is empty.
3. Re-picking that domain is a no-op for antd — its controlled value already equals it — so `onChange` never fires, panel state is never restored, and the query stays skipped.

Instrumented trace on an unfixed build, replaying the exact sequence:

```
[render]   selected="default"  deferred={"domainName":"default","skipDomain":false}
### clear
[onChange] undefined
[render]   selected=undefined  deferred={"domainName":null,"skipDomain":true}
### re-select "default"
(no onChange, no render at all)
rows: 0
```

## Fix

Fix the call site: stop using `BAIGraphQLPropertyFilter` here. This panel never used it as a filter — a single property with `fixedOperator`, `onAddCondition` never called, so no condition tag could ever appear. The visible UI was only the `Space.Compact` pair the filter happened to render: [property select "Name"] + [domain select].

Render that pair directly, keeping the UI identical:

```tsx
<Space.Compact>
  <BAISelect
    options={[{ label: t('storageHost.permission.Name'), value: 'domainName' }]}
    value="domainName"
  />
  <BAIDomainSelect
    value={selectedDomainName ?? null}
    onChange={...}
    allowClear
  />
</Space.Compact>
```

- With no `renderInput` indirection, the domain select re-renders from the panel's current state every render — the frozen-closure path no longer exists.
- `value={selectedDomainName ?? null}` keeps the antd Select controlled when empty. `value={undefined}` flips antd to uncontrolled, which would independently reproduce the "selector refills itself / re-select is a no-op" symptom.
- The fetch-key button spinner and the projects table's loading state are additionally tied to in-flight deferred query variables, so a domain change shows as loading on both tables instead of only the domain table.

`BAIGraphQLPropertyFilter` itself is untouched. An earlier revision of this PR fixed the shared component instead (tracking the selected property by key and resolving the object from current `filterProperties` each render). It was reverted in favor of the call-site change: this panel's control is a plain domain picker driving local query state — not a GraphQL filter — so the real defect was using `renderInput` against its stateless contract. Call sites that follow the contract (e.g. `UserFolderPermissionPanelV2`, migrated in FR-3282) are unaffected by the frozen-object behavior, because their controls are stateless and `onAddCondition` is supplied at call time.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, Terminology)
- The clear → re-select scenario re-run against a live manager for this revision: pending (the earlier revision's live-manager trace above covered the shared-component fix, not this call-site fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
