### PR TITLE
fix(FR-3420): close two rail-grid holes and tokenize the layout values

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
@@ -32,13 +32,23 @@ function styles(): string {
   return generateWebsiteStyles().replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
-/** Extract the body of the first rule whose selector matches exactly. */
+/**
+ * Extract the body of the first top-level rule whose selector matches
+ * exactly. Slices to the first `}`, so it would mis-parse a rule containing
+ * a nested block (CSS nesting / a nested @media). None of the selectors used
+ * here nest today; the assert below fires if one starts to.
+ */
 function ruleBody(css: string, selector: string): string {
   const idx = css.indexOf(`\n${selector} {`);
   assert.notEqual(idx, -1, `expected a "${selector}" rule in the stylesheet`);
   const start = css.indexOf("{", idx);
   const end = css.indexOf("}", start);
-  return css.slice(start + 1, end);
+  const body = css.slice(start + 1, end);
+  assert.ok(
+    !body.includes("{"),
+    `"${selector}" now contains a nested block; ruleBody() cannot parse it`,
+  );
+  return body;
 }
 
 test("generateWebsiteStyles — the in-flow rail is flat, the drawer keeps its surface", () => {
@@ -99,8 +109,8 @@ test("generateWebsiteStyles — the version row is separated by an inset rule", 
 
   const rule = ruleBody(css, ".doc-sidebar-version::after");
   for (const decl of [
-    /left:\s*24px;/,
-    /right:\s*24px;/,
+    /left:\s*var\(--bai-rail-inset\);/,
+    /right:\s*var\(--bai-rail-inset\);/,
     /height:\s*1px;/,
     /background:\s*var\(--bai-border-soft\);/,
   ]) {
@@ -114,12 +124,29 @@ test("generateWebsiteStyles — the version row is separated by an inset rule", 
   assert.match(tocDivider, /background:\s*var\(--bai-border-soft\);/);
 });
 
-test("generateWebsiteStyles — defines the ultrawide shell cap token", () => {
+test("generateWebsiteStyles — the shell cap equals its column budget", () => {
   const css = styles();
   assert.match(
     css,
     /--bai-layout-max:\s*1536px;/,
     "the shell cap token should be declared on :root",
+  );
+
+  // Pin the arithmetic the cap's comment claims, so changing a column token
+  // without revisiting the cap fails here rather than silently squeezing the
+  // article. 1536 - 280 sider - 240 TOC = 1016 for the article column, which
+  // must still clear the prose plus its two gutters.
+  const px = (name: string) => {
+    const m = css.match(new RegExp(`--${name}:\\s*(\\d+)px;`));
+    assert.ok(m, `expected a --${name} token`);
+    return Number(m[1]);
+  };
+  const article = px("bai-layout-max") - px("bai-sider-w") - px("bai-toc-w");
+  assert.equal(article, 1016, "article column budget changed");
+  assert.ok(
+    article >= px("bai-content-max") + 2 * px("bai-gutter"),
+    `article column ${article}px must fit the ${px("bai-content-max")}px prose ` +
+      `plus 2x${px("bai-gutter")}px gutter`,
   );
 });
 
@@ -142,76 +169,145 @@ test("generateWebsiteStyles — defines the rail grid inset", () => {
   );
 });
 
-test("generateWebsiteStyles — full-bleed bars hold the rail grid at every width", () => {
+test("generateWebsiteStyles — the bar inset adds the grid on top of the margin", () => {
   const css = styles();
-  // The bars stay full-bleed (background + border span the viewport) and only
-  // their inline padding grows. The padding must be centering-gutter PLUS the
-  // rail inset, so the brand sits at shell+inset on both sides of the cap.
-  // The tempting max(inset, gutter) form drops the inset term once the gutter
-  // wins, which snaps the brand to shell+0 and visibly shifts the grid as the
-  // window is resized past the cap — assert against that regression too.
+  const decl = css.match(/--bai-bar-inline:([^;]*);/s)?.[1] ?? "";
+  const normalized = decl.replace(/\s+/g, " ").trim();
+
+  assert.ok(
+    normalized.includes("max(0px, (100% - var(--bai-layout-max)) / 2)"),
+    `the bar inset should grow by the centering margin, got: ${normalized}`,
+  );
+  assert.ok(
+    normalized.includes("var(--bai-rail-inset)"),
+    "the bar inset should add the rail inset on top of that margin",
+  );
+  // The only max() allowed is the one flooring the margin at zero. A non-zero
+  // floor — max(20px, margin) — is the regression: it swallows the inset once
+  // the margin wins, snapping content to the shell edge and shifting the grid
+  // as the window crosses the cap.
+  const maxFloors = [...normalized.matchAll(/max\(\s*([^,]+),/g)].map((m) =>
+    m[1].trim(),
+  );
+  assert.deepEqual(
+    maxFloors,
+    ["0px"],
+    `only a 0px max() floor is allowed — a non-zero floor drops the inset ` +
+      `above the cap and shifts the grid. Got: ${normalized}`,
+  );
+});
+
+test("generateWebsiteStyles — both full-bleed bars use that inset, uncapped", () => {
+  const css = styles();
   for (const selector of [".bai-topbar", ".docs-banner"] as const) {
     const body = ruleBody(css, selector);
-    const declaration = body.match(/padding-inline:[^;]*;/s)?.[0] ?? "";
-    assert.ok(
-      declaration,
-      `${selector} should declare padding-inline for the rail grid`,
-    );
-    const normalized = declaration.replace(/\s+/g, " ");
-    assert.ok(
-      normalized.includes("max(0px, (100% - var(--bai-layout-max)) / 2)"),
-      `${selector} should grow by the centering gutter, got: ${normalized}`,
-    );
-    assert.ok(
-      normalized.includes("var(--bai-rail-inset)"),
-      `${selector} should add the rail inset on top of the gutter`,
-    );
-    // The only max() allowed is the one flooring the gutter at zero. A
-    // non-zero floor (max(20px, gutter)) is the regression: it swallows the
-    // inset once the gutter wins, snapping the brand to shell+0.
-    const maxFloors = [...normalized.matchAll(/max\(\s*([^,]+),/g)].map((m) =>
-      m[1].trim(),
-    );
-    assert.deepEqual(
-      maxFloors,
-      ["0px"],
-      `${selector} may only clamp the gutter at 0px — a non-zero max() floor ` +
-        `drops the inset above the cap and shifts the grid. Got: ${normalized}`,
+    assert.match(
+      body,
+      /padding-inline:\s*var\(--bai-bar-inline\);/,
+      `${selector} should take its inline padding from the shared token`,
     );
     assert.ok(
       !/max-width/.test(body),
       `${selector} must stay full-bleed (no max-width) so its background spans the viewport`,
     );
   }
+
+  // Their block padding drives bar height, which version-banner.js measures
+  // into --bai-banner-h and every sticky offset depends on. Pin it.
+  assert.match(ruleBody(css, ".bai-topbar"), /padding-block:\s*0;/);
+  assert.match(ruleBody(css, ".docs-banner"), /padding-block:\s*10px;/);
+
+  // No override of either bar may use the `padding` shorthand: its inline
+  // half silently resets --bai-bar-inline and drops the bar off the grid.
+  // This is exactly the bug that shipped at <=640px, where the banner fell to
+  // 16px while the topbar stayed at 24px. Overrides must use the longhands,
+  // as the <=880px mobile-grid rule does.
+  // Match on the exact selector, not a prefix — `.bai-topbar__search` and
+  // friends legitimately use the shorthand on themselves.
+  const BARS = new Set([".bai-topbar", ".docs-banner"]);
+  let checked = 0;
+  for (const m of css.matchAll(/\n\s*([^{}@\n][^{}]*?)\s*\{([^{}]*)\}/g)) {
+    const hitsABar = m[1]
+      .split(",")
+      .map((s) => s.trim())
+      .some((s) => BARS.has(s));
+    if (!hitsABar) continue;
+    checked++;
+    assert.ok(
+      !/(^|[\s;])padding:\s/.test(m[2]),
+      `"${m[1].trim()}" must not use the 'padding' shorthand — it resets the ` +
+        `rail grid. Use padding-block / padding-inline. Got: ${m[2].trim()}`,
+    );
+  }
+  assert.ok(
+    checked >= 3,
+    `expected to scan the bars' base rules plus their overrides, saw ${checked}`,
+  );
+
+  // Below 880px the sider is gone, so the bars adopt the article's own 16px
+  // gutter instead of the (now nonexistent) rail.
+  const mobile = css.match(
+    /@media \(max-width: 880px\) \{[\s\S]*?\n\}/g,
+  )?.find((blk) => blk.includes(".bai-topbar,"));
+  assert.ok(mobile, "expected a <=880px block pulling the bars onto the article gutter");
+  assert.match(mobile, /padding-inline:\s*16px;/);
+  assert.match(
+    ruleBody(css, ".doc-main"),
+    /max-width:\s*var\(--bai-content-max\);/,
+    "sanity: .doc-main is still the article column this 16px is matched to",
+  );
 });
 
-test("generateWebsiteStyles — the rail's three vertical gaps are uniform", () => {
+test("generateWebsiteStyles — the rail's three vertical gaps come from one token", () => {
   const css = styles();
 
   // The version block used to read top-heavy: 14px above the switcher pill,
-  // 10px from the pill down to the separator, then 16px from the separator
-  // to the first nav item. All three are now 14px, box to box, and each
-  // comes from exactly one declaration so none can drift alone.
+  // 10px from the pill down to the separator, then 16px from the separator to
+  // the first nav item. All three now resolve from --bai-rail-gap, so none can
+  // drift alone.
+  assert.match(css, /--bai-rail-gap:\s*14px;/);
+
   const row = ruleBody(css, ".doc-sidebar-version");
+  // Both block values derive from the one gap token. The end value carries a
+  // +1px correction because the ::after separator is positioned bottom: 0
+  // INSIDE this padding box and consumes its last pixel — without it the
+  // rendered gaps are 14/13/14, not 14/14/14.
   assert.match(
     row,
-    /padding:\s*14px 24px;/,
-    "symmetric padding makes the gap above the pill equal the gap below it",
+    /padding-block:\s*var\(--bai-rail-gap\) calc\(var\(--bai-rail-gap\) \+ 1px\);/,
+    "block padding must derive both gaps from the token, +1px for the rule itself",
+  );
+  assert.match(
+    row,
+    /padding-inline:\s*var\(--bai-rail-inset\);/,
+    "the row's inline padding is what puts the separator on the rail grid",
+  );
+
+  // The popup's offset compensates for that padding-bottom to keep its 6px
+  // gap below the pill. It is a derived constant, so it must move with it.
+  const popup = ruleBody(css, ".bai-select__list--version");
+  assert.match(
+    popup,
+    /top:\s*calc\(100% - 9px\);/,
+    "the version popup offset must track the row's padding-bottom (6px - 15px)",
   );
 
   const scroll = ruleBody(css, ".doc-sidebar__scroll");
   assert.match(
     scroll,
-    /padding:\s*14px 8px 24px;/,
-    "the scrollport's padding-top is the sole owner of the separator -> first item gap",
+    /padding-block:\s*var\(--bai-rail-gap\)/,
+    "the scrollport's block-start padding solely owns the separator -> first item gap",
   );
 
-  // If the intro regained a top margin the gap would become a sum again
-  // (the exact bug this replaced), so pin it to zero.
+  // If the intro regained a top margin the gap would become a sum again --
+  // the exact bug this replaced -- so pin the top edge to zero without
+  // constraining its unrelated side/bottom values.
   const intro = ruleBody(css, ".doc-sidebar-intro");
-  assert.match(
-    intro,
-    /margin:\s*0 6px 4px;/,
-    "the first item must not add its own top margin on top of the scrollport padding",
+  const margin = intro.match(/margin:([^;]*);/)?.[1]?.trim() ?? "";
+  assert.equal(
+    margin.split(/\s+/)[0],
+    "0",
+    `the first item must not add its own top margin on top of the ` +
+      `scrollport padding. Got margin: ${margin}`,
   );
 });

--- a/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.test.ts
@@ -251,10 +251,22 @@ test("generateWebsiteStyles — both full-bleed bars use that inset, uncapped", 
   )?.find((blk) => blk.includes(".bai-topbar,"));
   assert.ok(mobile, "expected a <=880px block pulling the bars onto the article gutter");
   assert.match(mobile, /padding-inline:\s*16px;/);
+  // The 16px is not a free constant — it is the article's own gutter at this
+  // breakpoint. Assert the *responsive* .doc-main rule, not the base one:
+  // ruleBody() returns the first match, so a base-rule assertion here would
+  // stay green while the <=880px gutter moved and the bars fell off the grid.
+  const mobileMain = css
+    .match(/@media \(max-width: 880px\) \{[\s\S]*?\n\}/g)
+    ?.find((blk) => /\n\s*\.doc-main\s*\{/.test(blk));
+  assert.ok(mobileMain, "expected a <=880px block setting the article gutter");
+  const mobileMainBody = mobileMain.match(
+    /\n\s*\.doc-main\s*\{([^{}]*)\}/,
+  )?.[1];
+  assert.ok(mobileMainBody, "expected a .doc-main rule inside the <=880px block");
   assert.match(
-    ruleBody(css, ".doc-main"),
-    /max-width:\s*var\(--bai-content-max\);/,
-    "sanity: .doc-main is still the article column this 16px is matched to",
+    mobileMainBody,
+    /padding:\s*24px 16px 60px;/,
+    "the bars' 16px must stay equal to the article's own <=880px gutter",
   );
 });
 
@@ -283,13 +295,26 @@ test("generateWebsiteStyles — the rail's three vertical gaps come from one tok
     "the row's inline padding is what puts the separator on the rail grid",
   );
 
-  // The popup's offset compensates for that padding-bottom to keep its 6px
-  // gap below the pill. It is a derived constant, so it must move with it.
+  // The popup's offset cancels that padding-bottom to keep its 6px gap below
+  // the pill. It must be *derived* from the gap token, not restated as the
+  // literal it currently evaluates to, or a gap change drifts it again.
   const popup = ruleBody(css, ".bai-select__list--version");
   assert.match(
     popup,
-    /top:\s*calc\(100% - 9px\);/,
-    "the version popup offset must track the row's padding-bottom (6px - 15px)",
+    /top:\s*calc\(100% \+ 5px - var\(--bai-rail-gap\)\);/,
+    "the version popup offset must derive from --bai-rail-gap (6px - (gap + 1px))",
+  );
+  // Both of the popup's clearances come from the same inset token; a literal
+  // width bound would let the left and right gaps disagree.
+  assert.match(
+    popup,
+    /right:\s*var\(--bai-rail-inset\);/,
+    "the popup's right clearance is the rail inset",
+  );
+  assert.match(
+    popup,
+    /max-width:\s*calc\(100% - var\(--bai-rail-inset\) \* 2\);/,
+    "the popup's width bound must reserve the same inset on both sides",
   );
 
   const scroll = ruleBody(css, ".doc-sidebar__scroll");

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -227,35 +227,36 @@ export function generateWebStyles(
   --bai-content-max: 820px;
   --bai-gutter: 32px;
 
-  /* Outer shell cap. The three-column grid (sider + article + TOC) used
-     to stretch to the full viewport width, so on ultrawide displays
-     (21:9 and wider) the sider stuck to the far-left edge and the TOC to
-     the far-right one, leaving the 820px article marooned between two
-     ~600px voids. Capping the shell and centering it keeps the three
-     columns as one readable block; the leftover width becomes symmetric
-     page margin instead of intra-layout dead space.
-
-     1536px = 280 (sider) + 240 (TOC) + 1016 for the article column,
-     which gives the 820px prose ~98px of slack per side — the same
-     column-to-prose ratio the reference layout uses. Below this width
-     nothing changes, so laptop/1440p viewports render exactly as before. */
+  /* FR-3420: cap for the shell (sider + article + TOC). Uncapped, the
+     grid stretched to the viewport, so on 21:9 displays the sider and TOC
+     stuck to opposite screen edges with the article marooned between two
+     ~600px voids. 1536 = 280 sider + 240 TOC + 1016 article column, which
+     leaves the 820px prose ~98px of slack per side. */
   --bai-layout-max: 1536px;
 
-  /* The rail's vertical grid line, measured from the shell's left edge.
-     The sider already puts its VERSION label, the Introduction icon and
-     every group icon at exactly 24px in, at every viewport width. The
-     topbar brand and the banner icon have to land on that same line, or
-     the logo and the menu beneath it read as two different grids.
+  /* FR-3420: distance from the shell's edge to left-aligned content. The
+     sider already sits its VERSION label and every group icon here, so the
+     topbar and banner adopt it rather than inventing a second grid.
 
-     Both bars are full-bleed, so they reach it by adding this inset on
-     top of the centering gutter rather than by being capped:
-       padding-inline: calc(max(0px, (100% - cap) / 2) + inset)
-     Below the cap the gutter term is 0 and the inset alone applies;
-     above it the gutter grows while the inset holds the content on the
-     grid. Using max(inset, gutter) instead — the obvious-looking form —
-     is what breaks it: the brand would sit at +inset below the cap and
-     snap to +0 above it, so the grid shifts as the window is resized. */
+     24px is where the nav items land structurally: .doc-sidebar__scroll's
+     8px padding + .doc-sidebar-group's 6px margin + the summary's 10px
+     inner padding (FR-2758). Everything else on this line is matched to
+     that, so change those three and this together or the grid breaks. */
   --bai-rail-inset: 24px;
+
+  /* FR-3420: the sider's vertical rhythm — above the version pill, pill to
+     its separator, separator to the first nav item. One value so the three
+     cannot drift apart. */
+  --bai-rail-gap: 14px;
+
+  /* FR-3420: inline padding for the full-bleed bars (topbar, banner). They
+     are not capped, so they reach the grid by adding the inset ON TOP of
+     the centering margin. max(inset, margin) is the trap: it drops the
+     inset once the margin wins, snapping content to the shell edge and
+     visibly shifting the grid as the window crosses the cap. */
+  --bai-bar-inline: calc(
+    max(0px, (100% - var(--bai-layout-max)) / 2) + var(--bai-rail-inset)
+  );
 
   /* Legacy aliases used by F3 grid rules (resolve to BAI tokens). */
   --doc-sidebar-width: var(--bai-sider-w);
@@ -359,18 +360,13 @@ body {
   align-items: center;
   gap: 14px;
   height: var(--bai-topbar-h);
-  /* Full-bleed bar with shell-aligned content: the background and bottom
-     border still span the viewport (a sticky bar that stopped short of
-     the edges would read as a floating card), but the brand / search /
-     action row is inset so the logo lands on the sider's +24px grid line
-     and the icon cluster ends on the TOC's right edge, instead of both
-     clinging to the screen corners on ultrawide displays. See
-     --bai-rail-inset for why this is gutter-plus-inset and not
-     max(inset, gutter). */
+  /* FR-3420: full-bleed bar, shell-aligned content. Background and bottom
+     border still span the viewport — a sticky bar stopping short of the
+     edges reads as a floating card — while the brand / search / action row
+     is inset onto the rail grid instead of clinging to the screen corners
+     on ultrawide displays. See --bai-bar-inline. */
   padding-block: 0;
-  padding-inline: calc(
-    max(0px, (100% - var(--bai-layout-max)) / 2) + var(--bai-rail-inset)
-  );
+  padding-inline: var(--bai-bar-inline);
   background: var(--bai-bg);
   border-bottom: 1px solid var(--bai-border);
 }
@@ -814,13 +810,18 @@ body.bai-palette-open .bai-palette {
 }
 
 /* The version popup anchors to the whole .doc-sidebar-version row (the
-   positioned ancestor); right: 24px matches the row's horizontal
-   padding so the popup's right edge lines up with the pill's. The row
-   has 10px bottom padding below the pill, so top: calc(100% - 4px)
-   yields the same ~6px visual gap as the lang popup. */
+   positioned ancestor); the inset matches the row's inline padding so the
+   popup's right edge lines up with the pill's.
+
+   The offset compensates for the row's bottom padding so the popup keeps
+   the same ~6px visual gap below the pill as the lang popup's
+   top: calc(100% + 6px). It therefore depends on that padding: FR-3420
+   changed it from 10px to --bai-rail-gap + 1px (15px), so this went from
+   calc(100% - 4px) to calc(100% - 9px). Re-derive it if the row's
+   padding-bottom changes again — 6px - padding-bottom. */
 .bai-select__list--version {
-  top: calc(100% - 4px);
-  right: 24px;
+  top: calc(100% - 9px);
+  right: var(--bai-rail-inset);
   min-width: 132px;
   max-width: calc(100% - 48px);
 }
@@ -1018,24 +1019,13 @@ body.bai-drawer-open .bai-scrim {
   flex-direction: column;
   overflow: hidden;
   border-right: 1px solid var(--bai-border);
-  /* FR-3420: the in-flow rail carries no surface tint of its own — the
-     page is one continuous surface and the border-right above (paired
-     with .doc-toc's border-left) is what separates the three columns.
-
-     It used to use --bai-bg-sider, which is only 3/255 away from
-     --bai-bg. While the shell was full-bleed that tint was hidden
-     against the viewport edge, but once the shell is capped and centered
-     the rail detaches from the edge and the tint becomes a band with no
-     boundary on its left — too weak to read as a deliberate rail, too
-     strong to read as nothing. Dropping it is the treatment Fumadocs,
-     Tailwind and the React docs use. The alternative (commit to the tint
-     and give the shell a real outer edge on a recessed canvas) needs a
-     new canvas token and changes every viewport, so it stays a separate
-     decision.
-
-     The ≤880px drawer keeps --bai-bg-sider: there the sider is a fixed
-     overlay floating above the article with its own shadow, so it does
-     want a surface distinct from the content beneath it. */
+  /* FR-3420: the in-flow rail carries no surface tint — the page is one
+     continuous surface, and border-right above (paired with .doc-toc's
+     border-left) separates the three columns. Its old --bai-bg-sider is
+     only 3/255 from --bai-bg, which the capped shell turned into a band
+     with no boundary on its left. The ≤880px drawer keeps --bai-bg-sider:
+     there the sider floats above the article with its own shadow, so it
+     does want a surface distinct from the content beneath. */
   background: var(--bai-bg);
 }
 
@@ -1052,14 +1042,13 @@ body.bai-drawer-open .bai-scrim {
      bubbling out and scrolling the article. Same defense applied to
      the mobile drawer override below. */
   overscroll-behavior: contain;
-  /* FR-3420: padding-top is the sole owner of the gap between the
-     version row's separator and the first nav item, and matches the
-     14px on either side of that separator. .doc-sidebar-intro's
-     margin-top is zeroed for this reason — when the gap was a sum of
-     this padding (10px) plus that margin (6px) it was easy to change one
-     and silently shift the rhythm. The 8px sides are load-bearing for
-     the rail grid (8 + 6 group margin + 10 summary padding = 24px). */
-  padding: 14px 8px 24px;
+  /* FR-3420: padding-block's start solely owns the gap from the version
+     row's separator to the first nav item. .doc-sidebar-intro's margin-top
+     is zeroed for this reason — as a sum of this padding (10px) and that
+     margin (6px) it was easy to change one and shift the rhythm. The 8px
+     sides feed --bai-rail-inset; see that token before changing them. */
+  padding-block: var(--bai-rail-gap) 24px;
+  padding-inline: 8px;
 }
 
 .doc-sidebar__scroll::-webkit-scrollbar {
@@ -1181,70 +1170,50 @@ body.bai-drawer-open .bai-scrim {
    image, BAI primary focus outline) so the two site-level controls feel
    like a coordinated pair. */
 .doc-sidebar-version {
-  /* FR-2768: horizontal layout matching the design handoff —
-     uppercase label on the left, switcher pill on the right, soft
-     bottom rule separating it from the scrolling nav below. The
-     wrapper is a fixed-height row outside the scrollport so it stays
-     visible while the nav scrolls.
-
-     Horizontal padding is 24px (vs. the design's 18px) to align with
-     the indentation of nav items below: the .doc-sidebar__scroll
-     wrapper adds 8px padding and .doc-sidebar-group adds 6px margin
-     plus the summary's 10px inner padding (FR-2758 introduced this
-     extra margin). 8 + 6 + 10 = 24px from the sider edge to the
-     category label — the version label needs to sit at the same
-     x-coordinate so the grid aligns. */
+  /* FR-2768: horizontal layout matching the design handoff — uppercase
+     label on the left, switcher pill on the right, and (FR-3420) an inset
+     rule below separating it from the scrolling nav. The wrapper is a
+     fixed-height row outside the scrollport so it stays visible while the
+     nav scrolls. Inline padding comes from --bai-rail-inset (24px, vs the
+     design's 18px) so the label shares the nav items' grid line. */
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
   flex: 0 0 auto;
-  /* FR-3420: symmetric vertical padding so the space above the switcher
-     pill equals the space between the pill and the ::after separator
-     below. It used to be 14px/10px, which pulled the rule toward the
-     pill and made the version block look top-heavy against the 16px
-     that sat on the other side of the rule.
+  /* FR-3420: block padding tuned so the space above the switcher pill, the
+     space from the pill down to the ::after separator, and the space from
+     the separator to the first nav item are all --bai-rail-gap. It was
+     14px/10px, which pulled the rule toward the pill and made the block
+     look top-heavy against the 16px on the other side.
 
-     The three gaps in this rail are now all 14px, measured box to box
-     (the convention .doc-toc__divider already follows with its
-     symmetric 18px margins):
-       sider top    -> pill top          14px  (this padding-top)
-       pill bottom  -> separator         14px  (this padding-bottom)
-       separator    -> first nav item    14px  (.doc-sidebar__scroll)
-     Horizontal padding stays 24px — see the rail-grid note below. */
-  padding: 14px 24px;
+     The +1px is the separator's own height: it is positioned bottom: 0
+     INSIDE this padding box, so it eats the last pixel. Without the +1 the
+     rendered gaps are 14/13/14 rather than 14/14/14. (.doc-toc__divider
+     needs no such correction — it is an in-flow div whose margins sit
+     outside it.) */
+  padding-block: var(--bai-rail-gap) calc(var(--bai-rail-gap) + 1px);
+  padding-inline: var(--bai-rail-inset);
   /* FR-3265: positioning anchor for the .bai-select__list--version
      popup injected by interactions.js. Also the containing block for
      the ::after separator below. */
   position: relative;
 }
 
-/* FR-3420: separate the version row from the nav with an INSET rule,
-   matching .doc-toc__divider (which is inset by the TOC's own padding
-   and separates the outline from the Get-help block).
+/* FR-3420: separate the version row from the nav with an INSET rule on the
+   rail grid, matching .doc-toc__divider. This was a border-bottom on the
+   row, and a border sits outside the padding box, so it always spanned the
+   sider edge to edge — a hard full-width line cutting the rail in two.
 
-   This used to be a border-bottom on the row itself. A border sits
-   outside the padding box, so it always spanned the sider edge to edge
-   — a hard full-width line cutting the rail in two, which reads as
-   heavier than the divider doing the equivalent job in the TOC.
-
-   Inset by the row's own 24px horizontal padding, so the rule starts on
-   the same +24px rail grid as the VERSION label, the group icons and
-   the topbar brand, and ends where the version popup's right edge does
-   (.bai-select__list--version is also right: 24px). Same
-   --bai-border-soft token as the TOC divider, so only the extent
-   differs, not the weight or colour.
-
-   A pseudo-element rather than a real <div> like the TOC's: the version
-   row lives outside .doc-sidebar__scroll, so this needs no markup
-   change and cannot disturb the scrollport's flex sizing. It carries no
-   z-index, so the version popup (z-index 110, opaque) still paints over
-   it. */
+   A pseudo-element rather than a real <div> like the TOC's: the version row
+   lives outside .doc-sidebar__scroll, so this needs no markup change and
+   cannot disturb the scrollport's flex sizing. It carries no z-index, so
+   the version popup (z-index 110, opaque) still paints over it. */
 .doc-sidebar-version::after {
   content: "";
   position: absolute;
-  left: 24px;
-  right: 24px;
+  left: var(--bai-rail-inset);
+  right: var(--bai-rail-inset);
   bottom: 0;
   height: 1px;
   background: var(--bai-border-soft);
@@ -3259,13 +3228,10 @@ export function generateWebsiteStyles(branding?: StyleBrandingTokens): string {
   display: flex;
   align-items: center;
   gap: 10px;
-  /* Same full-bleed-bar / shell-aligned-content split as .bai-topbar, so
-     the banner icon starts on the same +24px rail grid as the brand above
-     it and the sider's icons below it. */
+  /* FR-3420: same full-bleed-bar / shell-aligned-content split as
+     .bai-topbar, so the banner icon starts on the rail grid too. */
   padding-block: 10px;
-  padding-inline: calc(
-    max(0px, (100% - var(--bai-layout-max)) / 2) + var(--bai-rail-inset)
-  );
+  padding-inline: var(--bai-bar-inline);
   border-bottom: 1px solid var(--bai-border);
   /* FR-2758: banner sits sticky right under the topbar so it stays
      visible during scroll (the operator wants this notice to be a
@@ -3360,8 +3326,31 @@ export function generateWebsiteStyles(branding?: StyleBrandingTokens): string {
   background: rgba(255, 255, 255, 0.10);
 }
 
+/* FR-3420: below 880px the sider is hidden, so there is no rail for the
+   full-bleed bars to align to — the article's own 16px gutter (.doc-main)
+   becomes the page grid. Pull both bars onto it so the brand, the banner
+   text and the body text share one left edge on phones; at
+   --bai-rail-inset they would sit 8px outside the article.
+
+   This block has to live AFTER both bars' base rules: .docs-banner is
+   declared further down the sheet than the other ≤880px block, so an
+   override placed up there loses the cascade to it at equal specificity.
+
+   The drawer keeps the sider's internal 24px grid — it is an overlay panel
+   with its own edge, and its nav items derive that 24 structurally. */
+@media (max-width: 880px) {
+  .bai-topbar,
+  .docs-banner {
+    padding-inline: 16px;
+  }
+}
+
 @media (max-width: 640px) {
-  .docs-banner { padding: 10px 16px; font-size: 12.5px; }
+  /* FR-3420: padding-block only. This was a padding shorthand, whose
+     inline half reset the bars' shared inline padding and dropped the
+     banner icon to 16px while the topbar stayed at 24px — 8px off the rail
+     grid. Narrow the vertical padding here if needed, never the inline. */
+  .docs-banner { padding-block: 10px; font-size: 12.5px; }
 }
 .docs-notice {
   display: flex;

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -810,20 +810,18 @@ body.bai-palette-open .bai-palette {
 }
 
 /* The version popup anchors to the whole .doc-sidebar-version row (the
-   positioned ancestor); the inset matches the row's inline padding so the
-   popup's right edge lines up with the pill's.
+   positioned ancestor); both clearances come from --bai-rail-inset so the
+   popup's edges line up with the pill's.
 
-   The offset compensates for the row's bottom padding so the popup keeps
-   the same ~6px visual gap below the pill as the lang popup's
-   top: calc(100% + 6px). It therefore depends on that padding: FR-3420
-   changed it from 10px to --bai-rail-gap + 1px (15px), so this went from
-   calc(100% - 4px) to calc(100% - 9px). Re-derive it if the row's
-   padding-bottom changes again — 6px - padding-bottom. */
+   The offset holds the same ~6px gap below the pill as the lang popup's
+   top: calc(100% + 6px), by cancelling the row's padding-bottom
+   (--bai-rail-gap + 1px): 6px - (gap + 1px) = 5px - gap. Derived from the
+   token so a gap change moves both together. */
 .bai-select__list--version {
-  top: calc(100% - 9px);
+  top: calc(100% + 5px - var(--bai-rail-gap));
   right: var(--bai-rail-inset);
   min-width: 132px;
-  max-width: calc(100% - 48px);
+  max-width: calc(100% - var(--bai-rail-inset) * 2);
 }
 
 .bai-select__option {


### PR DESCRIPTION
Resolves #8481 (FR-3420)

Follow-up to #8482, which squash-merged before this review pass landed. #8482 delivered the issue's own proposal — `--bai-layout-max: 1536px`, the capped and centered `.doc-page`, and the `calc(max(0px, margin) + inset)` grid fix on both full-bleed bars — and all of that reproduced exactly under independent measurement. This PR closes two defects it left behind, both incompleteness of its own idea rather than errors in its approach.

## 1 · The version popup's offset was never re-derived

`.bai-select__list--version`'s `top` exists to compensate for `.doc-sidebar-version`'s `padding-bottom`, so the popup keeps the same **6px** gap below the pill as the language switcher (`.bai-select__list` uses `top: calc(100% + 6px)`). Its own comment says so.

#8482 moved that padding `10px → 14px` and left the offset at `calc(100% - 4px)`, so the gap silently became **10px** — the two site-level switcher popups stopped matching, which is the exact invariant the offset exists to hold.

```css
/* padding-bottom is now --bai-rail-gap + 1px = 15px, so: 6 - 15 = -9 */
.bai-select__list--version { top: calc(100% - 9px); }
```

Measured back at 6px, matching the language popup.

## 2 · The ≤640px banner override defeated the rail grid on phones

```css
@media (max-width: 640px) {
  .docs-banner { padding: 10px 16px; }   /* ← inline half resets the bars' shared inset */
}
```

The `padding` shorthand resets `padding-inline`, so on phones the banner sat at 16px while the topbar sat at 24px. **#8482 made this worse, not better**: it was 22 vs 20 (2px apart) before, 16 vs 24 (8px apart) after — in a PR whose purpose was to align those two bars. Now `padding-block` only.

## 3 · Below 880px there is no rail to align to

The sider is hidden under 880px, so the +24px inset just pushed both bars 8px outside the article's own 16px gutter (`.doc-main { padding: 24px 16px 60px }`). Both bars adopt that 16px there, so brand, banner text and body text share one left edge on phones.

The override has to sit **after both base rules** — `.docs-banner` is declared further down the sheet than the other `≤880px` block, so an override placed up there loses the cascade at equal specificity.

## 4 · The rhythm was 14/13/14, not 14/14/14

The `::after` separator is positioned `bottom: 0` *inside* the row's padding box, so it consumes the last pixel of `padding-bottom`. `padding-block`'s end value now carries an explicit `+1px` for the rule's own height, and the rendered gaps really are 14/14/14. (`.doc-toc__divider` needs no such correction — it is an in-flow div whose margins sit outside it.)

## Tokenizing what encodes an invariant

Values that two places had to agree on were literals, with a comment asserting the agreement. They are tokens now:

| token | replaces |
|---|---|
| `--bai-bar-inline` | the `calc(max(0px, …) + inset)` expression, duplicated verbatim in both bars |
| `--bai-rail-gap: 14px` | the sider's vertical rhythm, written at two sites |
| `--bai-rail-inset` | the separator's own `left`/`right`, and the version row's inline padding |

Comments trimmed toward the file's ~6-line norm — the measurements and rejected alternatives belong in the PR, not the stylesheet.

## Tests

Grew to cover what was unguarded, all four new guards mutation-checked (each fix reverted individually fails its own assertion):

- **No `padding` shorthand on either bar in *any* rule** — the hole that hid defect 2. Matched on the exact selector, since `.bai-topbar__*` children use the shorthand legitimately.
- **`padding-block` pinned** on both bars — bar height feeds the JS-measured `--bai-banner-h` and every sticky offset depends on it.
- **The popup offset**, so a future padding change can't silently drift it again.
- **The mobile grid rule.**
- **The cap's column arithmetic** (`cap − sider − toc == 1016`, and that it still clears the prose plus both gutters) so changing a column token can't silently squeeze the article.

```
pnpm --filter backend.ai-docs-toolkit test   → 315 tests, 314 pass / 0 fail / 1 skipped (pre-existing skip)
pnpm --filter backend.ai-docs-toolkit build  → tsc clean
```

Earlier, on the pre-rebase build: full `build:web --lang all`, then **96 combinations** measured in headless Chromium — 4 locales (en/ko/ja/th) × 2 themes × 12 widths (390 / 640 / 641 / 880 / 881 / 1024 / 1440 / 1536 / 1537 / 1920 / 2560 / 3440). Every one agreed on topbar/banner inline padding parity, the mobile grid matching the article's gutter below 880px, the +24px rail grid wherever the sider is visible, the shell cap, and the flat rail. Vertical rhythm re-measured at 14/14/14 and the popup gap at 6px.

## Verification

Rebased onto `origin/main` (clean, no conflicts) and re-verified:

```
bash scripts/verify.sh
=== ALL PASS ===
```

`node scripts/migration-gates/astryx-token-gate.mjs --strict` reports the same 2 pre-existing findings as `main` (`--bai-dialog-z` in `BAIDialog.css` / `BAIDrawerPortal.css`) — no new ones.

## Review notes

- Read the diff of `styles-web.ts` as four independent fixes plus a token extraction; the token extraction is mechanical (`--bai-bar-inline`, `--bai-rail-gap`, `--bai-rail-inset` replace literals that were already equal).
- Cascade order matters for the new `@media (max-width: 880px)` block: it must stay in `generateWebsiteStyles`, after `.docs-banner`'s base rule. `generateWebsiteStyles` emits `generateWebStyles` first, so it also overrides `.bai-topbar`.
- To check by eye: build the docs site and compare the topbar brand, the banner icon and the sider's VERSION label at 390px, 880px, 1440px and 2560px — all three should share one left edge at every width.

### Known, pre-existing, not addressed here

Japanese admonition text overflows horizontally at 390px (`scrollWidth` 476 vs 390). Verified **identical on the merge-base**, so it predates #8482 — long unbroken CJK strings in `.admonition-content` under `word-break: keep-all`. Worth its own issue; not touched here.

Also worth noting: no CI workflow runs this package's `node:test` suite, and `tsconfig.json` excludes `src/**/*.test.ts`, so these invariants guard local and agent runs rather than merges.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

https://claude.ai/code/session_011RFmSEBxxxvCXyquSPtqVJ
