### PR TITLE
fix(FR-3395): restore expanded-row background alignment with nested tables

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -122,8 +122,7 @@ export interface BAIColumnGroupType<RecordType = AnyObject> extends Omit<
  * Array type for BAI table columns
  */
 export type BAIColumnsType<RecordType = any> = (
-  | BAIColumnGroupType<RecordType>
-  | BAIColumnType<RecordType>
+  BAIColumnGroupType<RecordType> | BAIColumnType<RecordType>
 )[];
 
 /**
@@ -671,10 +670,6 @@ const useStyles = createStyles(({ token, css }) => ({
     thead.ant-table-thead > tr > th.ant-table-cell {
       font-weight: 500;
       color: ${token.colorTextTertiary};
-    }
-    & .ant-table-expanded-row > .ant-table-cell,
-    & .ant-table-expanded-row:hover > .ant-table-cell {
-      background: ${token.colorFillSecondary};
     }
   `,
   zeroWithSelectionColumn: css`

--- a/resources/theme.json
+++ b/resources/theme.json
@@ -30,7 +30,8 @@
       },
       "Table": {
         "headerBg": "#E3E3E3",
-        "headerSplitColor": "rgba(0,0,0,0.25)"
+        "headerSplitColor": "rgba(0,0,0,0.25)",
+        "rowExpandedBg": "#E3E3E3"
       }
     }
   },


### PR DESCRIPTION
Resolves #8438 (FR-3395)

## Summary

The nested (table-in-table) view inside an expanded scheduling-history row had drifted from the outer table's colors, most visibly in dark theme — the expanded row's wrapper cell rendered a distinctly different tone than the nested sub-step table it contains.

## Root cause

`BAITable`'s `neoHeader` style used to background the expanded-row wrapper cell with a light-only hardcoded `#e3e3e3` (matched to `theme.json`'s custom light `Table.headerBg` override), explicitly skipped for dark theme so it fell back to antd's own coordinated `headerBg`/`rowExpandedBg` defaults (both derived from the same `colorFillAlter` token family).

FR-3008 (#7650) replaced that with an unconditional `token.colorFillSecondary` for both themes. `colorFillSecondary` is an unrelated token (set explicitly to `#262626` in dark `theme.json`, for unrelated component fills) — so in dark theme the expanded-row wrapper no longer matches antd's own header/expanded-row color family, producing the visible seam around the nested table. The same override also drifted the light theme away from the custom header color, though less noticeably (default `colorFillSecondary` ≈ `#F0F0F0` vs. the custom `headerBg` `#E3E3E3`).

## Fix

Instead of a hand-rolled CSS override, use antd's own `Table.rowExpandedBg` component token — the token antd itself pairs with `Table.headerBg` for this exact purpose:

- `resources/theme.json`: set light theme's `Table.rowExpandedBg` to `#E3E3E3`, matching the existing custom `Table.headerBg`.
- `packages/backend.ai-ui/src/components/Table/BAITable.tsx`: remove the `.ant-table-expanded-row` background CSS override entirely. Dark theme now falls back to antd's own coordinated `headerBg`/`rowExpandedBg` defaults (no override needed, as before FR-3008).

## Verification

`bash scripts/verify.sh` → **ALL PASS** (Relay, Lint, Format, TypeScript, Terminology).

Manually verified via a Playwright capture against mocked scheduling-history data (Session Scheduling History modal, expanded "schedule-sessions" row), both themes:

### Dark theme

| Before (regression) | After (fix) |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0-unlinked/20260730-063818-fr3395-dark-before.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0-unlinked/20260730-064037-fr3395-dark-after.png) |

Before: the expanded row's left gutter renders a visibly lighter/different tone than the surrounding rows and the nested table. After: it blends seamlessly.

### Light theme

| Before (regression) | After (fix) |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8488/20260730-065135-fr3395-light-before.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8488/20260730-065141-fr3395-light-after.png) |

Subtler than dark, but confirmed by pixel sampling the expanded-row gutter: before = `rgb(240,240,240)` (antd default `colorFillSecondary`) vs. the header's own `rgb(227,227,227)` (`#E3E3E3`) — mismatched. After = `rgb(227,227,227)` for both — matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
