### PR TITLE
fix(FR-3396): stretch SSH/SFTP connection modal so values render on one line

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
@@ -117,7 +117,12 @@ const SFTPConnectionInfoModal: React.FC<SFTPConnectionInfoModalProps> = ({
       okText={t('session.appLauncher.DownloadSSHKey')}
       onOk={readAndDownloadSSHKey}
     >
-      <BAIFlex className={styles.description} direction="column" gap="md">
+      <BAIFlex
+        className={styles.description}
+        direction="column"
+        align="stretch"
+        gap="md"
+      >
         <Alert
           showIcon
           type="info"


### PR DESCRIPTION
Resolves #8439 (FR-3396)

## Summary
- In the SSH/SFTP connection modal, the "Connection Info" section's outer `BAIFlex` used the default `align="center"`, so its block-level children (including the non-bordered `Descriptions` showing user/host/port) sized to fit-content on the cross axis instead of stretching to the modal's actual width.
- Combined with antd's fixed table layout for `Descriptions` and the content column's `min-width: 1em` CSS rule, the value column collapsed to ~14px, wrapping each value one character per line (e.g. `work` → `w`/`o`/`r`/`k`, `127.0.0.1` → one digit per line).
- Fix: add `align="stretch"` to the outer `BAIFlex`, matching the sibling `VNCConnectionInfoModal` / `XRDPConnectionInfoModal`, which already use `align="stretch"` and don't exhibit this bug.

## Verification
- Reproduced live against `10.122.12.8:8090` with UI language set to Korean (사용자/호스트/포트 labels), confirmed via screenshot before/after.
- `bash scripts/verify.sh` → `=== ALL PASS ===`

## Test plan
- [x] Open a running session's SSH/SFTP connection modal with Korean UI language selected
- [x] Confirm 사용자/호스트/포트 values render on a single line, using the modal's available width
- [x] `scripts/verify.sh` passes

<img width="815" height="832" alt="image" src="https://github.com/user-attachments/assets/bec73fb0-17ab-4871-92d7-cbbbabeff52c" />

<img width="822" height="830" alt="image" src="https://github.com/user-attachments/assets/3479ab8d-b87d-4f5e-b40e-740af0f1cadc" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)