### PR TITLE
fix(FR-3428): rewrite URL project segment in SwitchToProjectButton

### DIFF
--- a/react/eslint.config.js
+++ b/react/eslint.config.js
@@ -4,6 +4,27 @@ import relayPlugin from 'eslint-plugin-relay';
 import globals from 'globals';
 import jsoncParser from 'jsonc-eslint-parser';
 
+// Shared base for `no-restricted-imports` so the per-file allowlist blocks
+// below can re-declare the rule (flat-config rule configs replace, not merge)
+// without duplicating these entries.
+const restrictedImportPatterns = [
+  { group: ['backend.ai-ui/*', '!backend.ai-ui/dist'] },
+  { group: ['@lobehub/fluent-emoji'] },
+];
+const restrictedImportPaths = [
+  {
+    name: 'antd-style',
+    importNames: ['useThemeMode'],
+    message: "Use 'src/hooks/useThemeMode' instead.",
+  },
+  {
+    name: 'react-router-dom',
+    importNames: ['useNavigate', 'Navigate'],
+    message:
+      "Use 'useWebUINavigate' from 'src/hooks' or '<WebUINavigate>' from 'src/components/WebUINavigate' instead.",
+  },
+];
+
 export default [
   ...base,
   ...react,
@@ -37,23 +58,23 @@ export default [
         'error',
         {
           patterns: [
-            'backend.ai-ui/*',
-            '!backend.ai-ui/dist',
-            '@lobehub/fluent-emoji',
-          ],
-          paths: [
+            ...restrictedImportPatterns,
+            // FR-3428: the URL owns the current project on
+            // `/project/:projectName/*` routes (FR-3055). Writing
+            // `currentProjectAtom` directly from a component leaves the URL on
+            // the old project (sider links, reloads, and the next navigation
+            // snap back). Components must switch projects through
+            // `useSwitchProject` from 'src/hooks/useRouteScope', which applies
+            // the scope rule; the raw setter is reserved for the URL→atom sync
+            // layer (see the allowlist block below).
             {
-              name: 'antd-style',
-              importNames: ['useThemeMode'],
-              message: "Use 'src/hooks/useThemeMode' instead.",
-            },
-            {
-              name: 'react-router-dom',
-              importNames: ['useNavigate', 'Navigate'],
+              group: ['**/useCurrentProject'],
+              importNames: ['useSetCurrentProject'],
               message:
-                "Use 'useWebUINavigate' from 'src/hooks' or '<WebUINavigate>' from 'src/components/WebUINavigate' instead.",
+                "Use 'useSwitchProject' from 'src/hooks/useRouteScope' instead — the URL owns the current project on project-scoped routes (FR-3055/FR-3428).",
             },
           ],
+          paths: restrictedImportPaths,
         },
       ],
       // CSP: a raw <style> element carries no nonce and is dropped by a strict
@@ -67,6 +88,31 @@ export default [
           selector: "JSXOpeningElement[name.name='style']",
           message:
             "Direct <style> elements are forbidden (CSP nonce safety). Use createGlobalStyle/createStyles from 'antd-style', or import an external .css file.",
+        },
+      ],
+    },
+  },
+
+  {
+    // Allowlist for the raw `useSetCurrentProject` setter (FR-3428):
+    //  - useCurrentProject.tsx / useRouteScope.ts — the setter's home module
+    //    and the `useSwitchProject` implementation.
+    //  - ProjectScopeLayout.tsx — the URL→atom sync layer that converges the
+    //    atom to the `:projectName` URL segment.
+    //  - WebUIHeader.tsx — the admin-mode-exit confirm flow, which must set
+    //    the atom AND navigate to a goBackPath-derived target in one step.
+    files: [
+      'src/hooks/useCurrentProject.tsx',
+      'src/hooks/useRouteScope.ts',
+      'src/components/MainLayout/ProjectScopeLayout.tsx',
+      'src/components/MainLayout/WebUIHeader.tsx',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: restrictedImportPatterns,
+          paths: restrictedImportPaths,
         },
       ],
     },

--- a/react/src/components/AdminModelCardSettingModal.tsx
+++ b/react/src/components/AdminModelCardSettingModal.tsx
@@ -6,10 +6,8 @@ import type { AdminModelCardSettingModalCreateMutation } from '../__generated__/
 import type { AdminModelCardSettingModalFragment$key } from '../__generated__/AdminModelCardSettingModalFragment.graphql';
 import type { AdminModelCardSettingModalUpdateMutation } from '../__generated__/AdminModelCardSettingModalUpdateMutation.graphql';
 import { useCurrentDomainValue } from '../hooks';
-import {
-  useCurrentProjectValue,
-  useSetCurrentProject,
-} from '../hooks/useCurrentProject';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useSwitchProject } from '../hooks/useRouteScope';
 import FolderCreateModalV2 from './FolderCreateModalV2';
 import FolderLink from './FolderLink';
 import VFolderNodeIdenticonV2 from './VFolderNodeIdenticonV2';
@@ -86,7 +84,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
 
   const currentProject = useCurrentProjectValue();
   const currentDomain = useCurrentDomainValue();
-  const setCurrentProject = useSetCurrentProject();
+  const switchProject = useSwitchProject();
 
   const modelCard = useFragment(
     graphql`
@@ -385,7 +383,7 @@ const AdminModelCardSettingModal: React.FC<AdminModelCardSettingModalProps> = ({
                       onConfirm={() => {
                         if (modelStoreProject?.id && modelStoreProject?.name) {
                           startTransition(() => {
-                            setCurrentProject({
+                            switchProject({
                               projectId: modelStoreProject.id!,
                               projectName: modelStoreProject.name!,
                             });

--- a/react/src/components/ImportArtifactRevisionToFolderModal.tsx
+++ b/react/src/components/ImportArtifactRevisionToFolderModal.tsx
@@ -5,10 +5,8 @@
 import { ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key } from '../__generated__/ImportArtifactRevisionToFolderModalArtifactRevisionFragment.graphql';
 import { ImportArtifactRevisionToFolderModalModelStoreProjectsFragment$key } from '../__generated__/ImportArtifactRevisionToFolderModalModelStoreProjectsFragment.graphql';
 import { ImportArtifactRevisionToFolderModalMutation } from '../__generated__/ImportArtifactRevisionToFolderModalMutation.graphql';
-import {
-  useCurrentProjectValue,
-  useSetCurrentProject,
-} from '../hooks/useCurrentProject';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useSwitchProject } from '../hooks/useRouteScope';
 import FolderCreateModalV2 from './FolderCreateModalV2';
 import { useToggle } from 'ahooks';
 import { Alert, App, Form, FormInstance, Popconfirm, theme } from 'antd';
@@ -74,7 +72,7 @@ const ImportArtifactRevisionToFolderModal = ({
 
   const { logger } = useBAILogger();
   const currentProject = useCurrentProjectValue();
-  const setCurrentProject = useSetCurrentProject();
+  const switchProject = useSwitchProject();
 
   const selectedArtifactRevisions = useFragment(
     graphql`
@@ -292,7 +290,7 @@ const ImportArtifactRevisionToFolderModal = ({
                         modelStoreProject.name
                       ) {
                         startTransition(() => {
-                          setCurrentProject({
+                          switchProject({
                             projectId: modelStoreProject.id!,
                             projectName: modelStoreProject.name!,
                           });

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -21,7 +21,7 @@ import {
   rewriteProjectNameInPath,
   useActiveProjectName,
   useCurrentMenuKey,
-  useRouteScope,
+  useSwitchProject,
 } from '../../hooks/useRouteScope';
 import { useUrlProjectValidity } from '../../hooks/useUrlProjectValidity';
 import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
@@ -40,7 +40,7 @@ import * as _ from 'lodash-es';
 import { MenuIcon } from 'lucide-react';
 import { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useMatches } from 'react-router-dom';
+import { useMatches } from 'react-router-dom';
 
 const useStyles = createStyles(({ css }) => ({
   webuiHeader: css`
@@ -67,10 +67,9 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
   const baiClient = useSuspendedBackendaiClient();
   const gridBreakpoint = Grid.useBreakpoint();
   const webuiNavigate = useWebUINavigate();
-  const location = useLocation();
   const matches = useMatches();
-  const routeScope = useRouteScope();
   const currentMenuKey = useCurrentMenuKey();
+  const switchProject = useSwitchProject();
   // When the URL carries an invalid/inaccessible `:projectName`, the atom keeps
   // the last valid project, which would make the header selector look like that
   // project is selected. Detect this and show the selector unselected instead.
@@ -126,51 +125,13 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {
   }) => {
     setOptimisticProjectId(projectInfo.projectId);
 
-    // On project / project-admin scope the URL owns the current project: stay
-    // on the exact same page and swap ONLY the project name, then let
-    // `ProjectScopeLayout` converge `currentProjectAtom` to the new URL. We
-    // deliberately do NOT call `setCurrentProject` here on these scopes, to
-    // avoid the atom being set twice (once here, once by the layout sync effect).
-    if (routeScope === 'project' || routeScope === 'projectAdmin') {
-      // Replace only the `:projectName` segment, preserving everything after it
-      // (e.g. `/session/start`, a detail `:id`) and the query string, so
-      // in-progress UI state survives — matching the legacy behavior where
-      // changing the project never navigated away (the session launcher form
-      // stays mounted with its contents intact).
-      const segments = location.pathname.split('/');
-      if (segments[1] === 'project' && segments.length > 2) {
-        startProjectChangedTransition(() => {
-          webuiNavigate(
-            rewriteProjectNameInPath(
-              location.pathname,
-              projectInfo.projectName,
-            ) + location.search,
-          );
-        });
-        return;
-      }
-      // Defensive fallback: reconstruct from the current feature key when the
-      // path is not under `/project/:projectName` for some reason.
-      const scopeFeature = currentMenuKey
-        ? MENU_KEY_TO_SCOPE_FEATURE[currentMenuKey]
-        : undefined;
-      const featureKey =
-        scopeFeature && scopeFeature.scope === routeScope
-          ? scopeFeature.featureKey
-          : 'session';
-      startProjectChangedTransition(() => {
-        webuiNavigate(
-          buildPath(routeScope, featureKey, projectInfo.projectName) +
-            location.search,
-        );
-      });
-      return;
-    }
-
-    // Admin (global) scope has no project-aware layout, so preserve today's
-    // behavior: update the atom directly without navigating.
+    // `useSwitchProject` holds the canonical scope rule (FR-3428): on project
+    // / project-admin scope the URL owns the current project, so it stays on
+    // the exact same page and swaps ONLY the `:projectName` segment, letting
+    // `ProjectScopeLayout` converge `currentProjectAtom` to the new URL. On
+    // global admin scope it updates the atom directly.
     startProjectChangedTransition(() => {
-      setCurrentProject(projectInfo);
+      switchProject(projectInfo);
     });
   };
 

--- a/react/src/components/SwitchToProjectButton.tsx
+++ b/react/src/components/SwitchToProjectButton.tsx
@@ -3,7 +3,12 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { SwitchToProjectButtonQuery } from '../__generated__/SwitchToProjectButtonQuery.graphql';
+import { useWebUINavigate } from '../hooks';
 import { useSetCurrentProject } from '../hooks/useCurrentProject';
+import {
+  rewriteProjectNameInPath,
+  useRouteScope,
+} from '../hooks/useRouteScope';
 import {
   BAIButton,
   BAIButtonProps,
@@ -13,6 +18,7 @@ import {
 import React, { Suspense, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import { useLocation } from 'react-router-dom';
 
 interface SwitchToProjectButtonProps extends Omit<BAIButtonProps, 'onClick'> {
   projectId: string;
@@ -26,6 +32,9 @@ const SwitchToProjectButtonContent: React.FC<SwitchToProjectButtonProps> = ({
   const { t } = useTranslation();
   const setCurrentProject = useSetCurrentProject();
   const [isPending, startTransition] = useTransition();
+  const routeScope = useRouteScope();
+  const location = useLocation();
+  const webuiNavigate = useWebUINavigate();
 
   const { group_node } = useLazyLoadQuery<SwitchToProjectButtonQuery>(
     graphql`
@@ -44,6 +53,23 @@ const SwitchToProjectButtonContent: React.FC<SwitchToProjectButtonProps> = ({
     const name = group_node?.name;
     if (id && name) {
       startTransition(() => {
+        // On project / project-admin scope the URL owns the current project
+        // (FR-3055): rewrite only the `:projectName` segment and let
+        // `ProjectScopeLayout` converge `currentProjectAtom` to the new URL.
+        // Setting the atom directly here would leave the URL on the old
+        // project, so sider links, reloads, and the next navigation would all
+        // snap back — the switch would not stick.
+        if (
+          (routeScope === 'project' || routeScope === 'projectAdmin') &&
+          location.pathname.startsWith('/project/')
+        ) {
+          webuiNavigate(
+            rewriteProjectNameInPath(location.pathname, name) + location.search,
+          );
+          return;
+        }
+        // Outside project-scoped URLs there is no `:projectName` segment to
+        // own the project — update the atom directly (same as the header).
         setCurrentProject({
           projectId: id,
           projectName: name,

--- a/react/src/components/SwitchToProjectButton.tsx
+++ b/react/src/components/SwitchToProjectButton.tsx
@@ -3,12 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { SwitchToProjectButtonQuery } from '../__generated__/SwitchToProjectButtonQuery.graphql';
-import { useWebUINavigate } from '../hooks';
-import { useSetCurrentProject } from '../hooks/useCurrentProject';
-import {
-  rewriteProjectNameInPath,
-  useRouteScope,
-} from '../hooks/useRouteScope';
+import { useSwitchProject } from '../hooks/useRouteScope';
 import {
   BAIButton,
   BAIButtonProps,
@@ -18,7 +13,6 @@ import {
 import React, { Suspense, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useLocation } from 'react-router-dom';
 
 interface SwitchToProjectButtonProps extends Omit<BAIButtonProps, 'onClick'> {
   projectId: string;
@@ -30,11 +24,8 @@ const SwitchToProjectButtonContent: React.FC<SwitchToProjectButtonProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const setCurrentProject = useSetCurrentProject();
   const [isPending, startTransition] = useTransition();
-  const routeScope = useRouteScope();
-  const location = useLocation();
-  const webuiNavigate = useWebUINavigate();
+  const switchProject = useSwitchProject();
 
   const { group_node } = useLazyLoadQuery<SwitchToProjectButtonQuery>(
     graphql`
@@ -53,24 +44,11 @@ const SwitchToProjectButtonContent: React.FC<SwitchToProjectButtonProps> = ({
     const name = group_node?.name;
     if (id && name) {
       startTransition(() => {
-        // On project / project-admin scope the URL owns the current project
-        // (FR-3055): rewrite only the `:projectName` segment and let
-        // `ProjectScopeLayout` converge `currentProjectAtom` to the new URL.
-        // Setting the atom directly here would leave the URL on the old
-        // project, so sider links, reloads, and the next navigation would all
-        // snap back — the switch would not stick.
-        if (
-          (routeScope === 'project' || routeScope === 'projectAdmin') &&
-          location.pathname.startsWith('/project/')
-        ) {
-          webuiNavigate(
-            rewriteProjectNameInPath(location.pathname, name) + location.search,
-          );
-          return;
-        }
-        // Outside project-scoped URLs there is no `:projectName` segment to
-        // own the project — update the atom directly (same as the header).
-        setCurrentProject({
+        // `useSwitchProject` applies the canonical scope rule (FR-3428): on
+        // project / project-admin scope it rewrites the `:projectName` URL
+        // segment (the URL owns the project since FR-3055); elsewhere it
+        // updates the atom directly.
+        switchProject({
           projectId: id,
           projectName: name,
         });

--- a/react/src/hooks/useRouteScope.ts
+++ b/react/src/hooks/useRouteScope.ts
@@ -15,8 +15,17 @@
  * / `startsWith('/admin-...')` first-segment check with a single, scope-aware
  * source of truth.
  */
-import { buildPath, RouteScope, FeatureKey } from '../helper/pathBuilder';
-import { useCurrentProjectValue } from './useCurrentProject';
+import { useWebUINavigate } from '.';
+import {
+  buildPath,
+  MENU_KEY_TO_SCOPE_FEATURE,
+  RouteScope,
+  FeatureKey,
+} from '../helper/pathBuilder';
+import {
+  useCurrentProjectValue,
+  useSetCurrentProject,
+} from './useCurrentProject';
 import { useLocation, useMatches } from 'react-router-dom';
 
 /**
@@ -224,5 +233,69 @@ export const useProjectPath = (): ((
 
   return (key: FeatureKey, opts?: ProjectPathOptions): string => {
     return buildPath(opts?.scope ?? scope, key, projectName);
+  };
+};
+
+export interface SwitchProjectInput {
+  projectId: string;
+  projectName: string;
+}
+
+/**
+ * The canonical way to change the current project from a component (FR-3428).
+ *
+ * Since FR-3055 the URL owns the current project on `/project/:projectName/*`
+ * routes: on `project` / `projectAdmin` scope this hook navigates to the same
+ * page with ONLY the `:projectName` segment rewritten (query string preserved)
+ * and lets `ProjectScopeLayout` converge `currentProjectAtom` to the new URL.
+ * Writing the atom directly there would leave the URL on the old project, so
+ * sider links, reloads, and the next navigation would all snap back.
+ *
+ * Outside project-scoped URLs (global `admin` scope) there is no
+ * `:projectName` segment to own the project, so the atom is updated directly.
+ *
+ * Do NOT call `useSetCurrentProject` from components — it is reserved for the
+ * URL→atom sync layer (`ProjectScopeLayout`) and this hook, enforced by the
+ * `no-restricted-imports` rule in `react/eslint.config.js`.
+ */
+export const useSwitchProject = (): ((info: SwitchProjectInput) => void) => {
+  'use memo';
+  const routeScope = useRouteScope();
+  const currentMenuKey = useCurrentMenuKey();
+  const location = useLocation();
+  const webuiNavigate = useWebUINavigate();
+  const setCurrentProject = useSetCurrentProject();
+
+  return ({ projectId, projectName }: SwitchProjectInput): void => {
+    if (routeScope === 'project' || routeScope === 'projectAdmin') {
+      // Stay on the exact same page and swap ONLY the project name, preserving
+      // everything after it (e.g. a detail `:id`) and the query string, so
+      // in-progress UI state survives.
+      const segments = location.pathname.split('/');
+      if (segments[1] === 'project' && segments.length > 2) {
+        webuiNavigate(
+          rewriteProjectNameInPath(location.pathname, projectName) +
+            location.search,
+        );
+        return;
+      }
+      // Defensive fallback: reconstruct from the current feature key when the
+      // path is not under `/project/:projectName` for some reason.
+      const scopeFeature = currentMenuKey
+        ? MENU_KEY_TO_SCOPE_FEATURE[currentMenuKey]
+        : undefined;
+      const featureKey =
+        scopeFeature && scopeFeature.scope === routeScope
+          ? scopeFeature.featureKey
+          : 'session';
+      webuiNavigate(
+        buildPath(routeScope, featureKey, projectName) + location.search,
+      );
+      return;
+    }
+
+    // Global admin scope has no project-aware layout — update the atom
+    // directly.
+    setCurrentProject({ projectId, projectName });
   };
 };


### PR DESCRIPTION
Resolves #8504 (FR-3428)

## Summary

On `DeploymentDetailPage`, the cross-project warning alert's **Switch to '{project}'** button left the app in a half-switched state: it wrote `currentProjectAtom` directly, but since FR-3055 the URL owns the current project on `/project/:projectName/*` routes. The URL kept the old project, so sider links still pointed at the old project, a reload snapped the selection back, and the header selector / page data disagreed with the URL.

The same hazard existed for *any* component calling `useSetCurrentProject` directly, so this PR both fixes the button and structurally prevents the bug class.

## Changes

1. **`useSwitchProject` (new, `react/src/hooks/useRouteScope.ts`)** — the canonical way to change the current project from a component:
   - `project` / `projectAdmin` scope: navigate to the same page with only the `:projectName` segment rewritten (`rewriteProjectNameInPath`, query string preserved, defensive `buildPath` fallback), letting `ProjectScopeLayout` converge the atom to the URL.
   - global `admin` scope (no `:projectName` segment in the URL): update the atom directly — navigation-only is impossible here because the URL does not carry a project.
2. **All component callers migrated to the hook**: `SwitchToProjectButton`, `WebUIHeader.applyProjectChange` (its duplicated inline scope rule is removed), `ImportArtifactRevisionToFolderModal`, `AdminModelCardSettingModal`.
3. **ESLint gate** (`react/eslint.config.js`): `no-restricted-imports` now bans importing `useSetCurrentProject` anywhere except the sync layer, so new direct callers fail lint with a pointer to `useSwitchProject`. Allowlist:
   - `hooks/useCurrentProject.tsx`, `hooks/useRouteScope.ts` — setter home + hook implementation
   - `MainLayout/ProjectScopeLayout.tsx` — the URL→atom sync layer
   - `MainLayout/WebUIHeader.tsx` — the admin-mode-exit confirm flow, which must set the atom and navigate to a `goBackPath`-derived target in one step

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- ESLint negative test: a probe file importing `useSetCurrentProject` from a component fails with the new message; all allowlisted files pass.
- Live repro on a real backend (dev server + Playwright), deployment in project `default` opened under `/project/a한국어가능_cde/deployments/<id>`:
  - **Alert button**: click → URL becomes `/project/default/deployments/<id>`, header selector / sider links / `backendaiclient.current_group` all consistent, mismatch alert disappears, state survives navigation and reload.
  - **Header selector (hook-migrated path)**: switching back to `a한국어가능_cde` on the same page rewrites the URL in place, keeps the deployment detail mounted, and the mismatch alert correctly reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
