### PR TITLE
test(FR-3332): rewrite chat e2e mocks for the Deployments API

### DIFF
--- a/e2e/chat/chat-sync.spec.ts
+++ b/e2e/chat/chat-sync.spec.ts
@@ -5,6 +5,7 @@ import {
   setupChatPageWithTwoDeployments,
   MOCK_DEPLOYMENT_NAME,
   MOCK_DEPLOYMENT_NAME_B,
+  MOCK_DEPLOYMENT_URL_B,
   MOCK_REPLY_A,
   MOCK_REPLY_B,
   MOCK_MODEL_ID_B,
@@ -215,7 +216,7 @@ test.describe(
       // endpoint B) before clicking, so we don't miss a fast mocked response.
       const modelsBResponsePromise = page.waitForResponse(
         (response) =>
-          response.url().includes('mock-chat-endpoint-b') &&
+          response.url().includes(MOCK_DEPLOYMENT_URL_B) &&
           response.url().includes('/v1/models'),
       );
       await page

--- a/e2e/chat/chat-sync.spec.ts
+++ b/e2e/chat/chat-sync.spec.ts
@@ -2,7 +2,12 @@
 // Sections: 5 (Sync Input Propagation), 6 (Sync Toggle Off — Input Isolation)
 import {
   setupChatPage,
-  setupChatPageWithTwoEndpoints,
+  setupChatPageWithTwoDeployments,
+  MOCK_DEPLOYMENT_NAME,
+  MOCK_DEPLOYMENT_NAME_B,
+  MOCK_REPLY_A,
+  MOCK_REPLY_B,
+  MOCK_MODEL_ID_B,
 } from './mocking/chat-mock-data';
 import { test, expect, Page } from '@playwright/test';
 
@@ -49,7 +54,7 @@ function getChatInput(page: Page, index: number) {
 function getSyncToggle(page: Page, cardIndex: number) {
   // ant-card-head nth(0) is the page-level Chat card, nth(1+) are ChatCards
   // Button layout in .ant-card-head nth(cardIndex+1) when closable=true (multi-pane):
-  //   nth(0)=detail-page (EndpointSelect compact btn), nth(1)=sync, nth(2)=control, nth(3)=compare, nth(4)=more
+  //   nth(0)=detail-page (DeploymentSelect compact btn), nth(1)=sync, nth(2)=control, nth(3)=compare, nth(4)=more
   return page
     .locator('.ant-card-head')
     .nth(cardIndex + 1)
@@ -189,7 +194,7 @@ test.describe(
       request,
     }) => {
       // Setup with two distinct endpoints
-      await setupChatPageWithTwoEndpoints(page, request);
+      await setupChatPageWithTwoDeployments(page, request);
 
       await expect(getChatInput(page, 0)).toBeVisible({ timeout: 10000 });
 
@@ -202,7 +207,7 @@ test.describe(
       const secondCardEndpointText = page
         .locator('.ant-card')
         .nth(2)
-        .getByText('mock-endpoint')
+        .getByText(MOCK_DEPLOYMENT_NAME)
         .first();
       await secondCardEndpointText.click();
 
@@ -214,11 +219,11 @@ test.describe(
           response.url().includes('/v1/models'),
       );
       await page
-        .getByRole('option', { name: 'mock-endpoint-b' })
+        .getByRole('option', { name: MOCK_DEPLOYMENT_NAME_B })
         .or(
           page
             .locator('.ant-select-item-option')
-            .filter({ hasText: 'mock-endpoint-b' }),
+            .filter({ hasText: MOCK_DEPLOYMENT_NAME_B }),
         )
         .first()
         .click();
@@ -238,6 +243,13 @@ test.describe(
       await expect(
         secondChatCardHeader.getByText('gpt-mock-model-b'),
       ).toBeVisible({ timeout: 10000 });
+
+      // The second pane has to finish loading deployment B's model list before a
+      // synced send can reach it — otherwise the send races the switch and the
+      // pane answers from the model it was still holding.
+      await expect(
+        page.locator('.ant-card').nth(2).getByText(MOCK_MODEL_ID_B).first(),
+      ).toBeVisible({ timeout: 15000 });
 
       // Verify both panes have sync ON
       await expect(getSyncToggle(page, 0).first()).toBeVisible({
@@ -267,17 +279,17 @@ test.describe(
       await expect(
         firstChatCard.getByText('Multi-endpoint test').first(),
       ).toBeVisible({ timeout: 10000 });
-      await expect(
-        firstChatCard.getByText('Response from endpoint A').first(),
-      ).toBeVisible({ timeout: 15000 });
+      await expect(firstChatCard.getByText(MOCK_REPLY_A).first()).toBeVisible({
+        timeout: 15000,
+      });
 
       // Second pane: user message and response from endpoint B (triggered by sync)
       await expect(
         secondChatCard.getByText('Multi-endpoint test').first(),
       ).toBeVisible({ timeout: 10000 });
-      await expect(
-        secondChatCard.getByText('Response from endpoint B').first(),
-      ).toBeVisible({ timeout: 15000 });
+      await expect(secondChatCard.getByText(MOCK_REPLY_B).first()).toBeVisible({
+        timeout: 15000,
+      });
     });
   },
 );

--- a/e2e/chat/chat.spec.ts
+++ b/e2e/chat/chat.spec.ts
@@ -7,11 +7,9 @@ import {
   setupChatPage,
   setupChatPageWithTwoDeployments,
   chatGraphQLMocks,
-  setupChatPageWithUnavailableDeployment,
   makeSseResponse,
   modelsApiMockResponse,
   waitForChatReady,
-  CHAT_READY_TIMEOUT_MS,
   MOCK_MODEL_ID,
   MOCK_DEPLOYMENT_NAME,
   MOCK_DEPLOYMENT_NAME_B,
@@ -654,138 +652,6 @@ test.describe(
           .or(page.locator('[role="alert"]'))
           .first(),
       ).toBeVisible({ timeout: 15000 });
-    });
-
-    // FR-3397: ChatCard derives one unavailability reason per deployment and
-    // renders a single alert for it. The checks run most-specific-first, since a
-    // deployment scaled to zero — or one without a revision — also has no active
-    // replica, and a later check would otherwise mask the real cause. Each case
-    // below states only the one condition it exercises; every other input stays
-    // at its serving value.
-    //
-    // `composer` records observed behaviour, not an aspiration: the composer is
-    // disabled only when no usable base URL resolved. A deployment that has a
-    // reachable URL but cannot answer (scaled to zero, no revision, no active
-    // replica) still accepts typing — the alert is the only thing telling the
-    // user why a send will not get a reply.
-    const UNAVAILABLE_REASONS = [
-      {
-        title: 'the desired replica count is 0',
-        overrides: { desiredReplicaCount: 0 },
-        message: 'The desired replica count for this deployment is 0',
-        composer: 'enabled' as const,
-      },
-      {
-        title: 'no revision is deployed',
-        overrides: { revisionCount: 0 },
-        message: 'No revision is deployed',
-        composer: 'enabled' as const,
-      },
-      {
-        title: 'no replica is serving traffic',
-        overrides: { activeReplicaCount: 0 },
-        message: 'No replicas are available',
-        composer: 'enabled' as const,
-      },
-      {
-        // The previous test for this was skipped on the theory that Relay served
-        // a cached URL from a real backend response; the actual cause was the mock
-        // describing the legacy `endpoint { url }` shape, which the migrated
-        // `deployment(id:)` query never reads (FR-3332).
-        title: 'no endpoint URL has been issued yet',
-        overrides: { endpointUrl: null },
-        message: 'This deployment has not been issued an endpoint URL yet',
-        composer: 'disabled' as const,
-      },
-      {
-        // `error.InvalidBaseURL` is reserved for a URL that was supplied and
-        // could not be parsed — distinct from one that was never issued.
-        title: 'the endpoint URL cannot be parsed',
-        overrides: { endpointUrl: 'not-a-valid-url' },
-        message: 'Endpoint URL is not valid.',
-        composer: 'disabled' as const,
-      },
-    ];
-
-    for (const { title, overrides, message, composer } of UNAVAILABLE_REASONS) {
-      test(`User sees why chat is unavailable when ${title}`, async ({
-        page,
-        request,
-      }) => {
-        await setupChatPageWithUnavailableDeployment(page, request, overrides);
-
-        // The alert is the readiness gate here: an unavailable pane keeps its
-        // composer disabled, so there is no enabled composer to wait for.
-        await expect(page.getByText(message)).toBeVisible({
-          timeout: CHAT_READY_TIMEOUT_MS,
-        });
-
-        // Exactly one reason is reported — no other reason's message appears.
-        for (const other of UNAVAILABLE_REASONS) {
-          if (other.message === message) continue;
-          await expect(page.getByText(other.message)).toBeHidden();
-        }
-
-        const chatInput = page.getByPlaceholder('Type your message here...');
-        if (composer === 'disabled') {
-          await expect(chatInput).toBeDisabled({ timeout: 10000 });
-        } else {
-          await expect(chatInput).toBeEnabled({ timeout: 10000 });
-        }
-      });
-    }
-
-    test('User sees both the unavailability reason and the missing-model warning', async ({
-      page,
-      request,
-    }) => {
-      // The two alerts answer different questions and are no longer mutually
-      // exclusive: ChatCard used to suppress `chatui.CannotFindModel` whenever it
-      // had an unavailability reason to show. A deployment can have a reachable
-      // URL that serves an empty model list *and* be unable to answer, so both
-      // are reported.
-      await setupChatPageWithUnavailableDeployment(
-        page,
-        request,
-        { desiredReplicaCount: 0 },
-        // Empty model list — this is what renders the recovery form.
-        [],
-      );
-
-      await expect(
-        page.getByText('The desired replica count for this deployment is 0'),
-      ).toBeVisible({ timeout: CHAT_READY_TIMEOUT_MS });
-      await expect(page.getByText('LLM models not found')).toBeVisible({
-        timeout: 10000,
-      });
-    });
-
-    test('User sees the most specific reason when several apply at once', async ({
-      page,
-      request,
-    }) => {
-      // A deployment scaled to zero also has no revision, no active replica and
-      // no URL. The desired-replica reason wins because it is checked first —
-      // this is what keeps a later, vaguer check from masking the real cause.
-      await setupChatPageWithUnavailableDeployment(page, request, {
-        desiredReplicaCount: 0,
-        revisionCount: 0,
-        activeReplicaCount: 0,
-        endpointUrl: null,
-      });
-
-      await expect(
-        page.getByText('The desired replica count for this deployment is 0'),
-      ).toBeVisible({ timeout: CHAT_READY_TIMEOUT_MS });
-
-      for (const masked of [
-        'No revision is deployed',
-        'No replicas are available',
-        'This deployment has not been issued an endpoint URL yet',
-        'Endpoint URL is not valid.',
-      ]) {
-        await expect(page.getByText(masked)).toBeHidden();
-      }
     });
 
     test.fixme('User sees an error notification when model fetching fails', async ({

--- a/e2e/chat/chat.spec.ts
+++ b/e2e/chat/chat.spec.ts
@@ -5,15 +5,16 @@ import { setupGraphQLMocks } from '../session/mocking/graphql-interceptor';
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
 import {
   setupChatPage,
-  setupChatPageWithTwoEndpoints,
-  chatPageQueryMockResponse,
-  chatCardQueryMockResponse,
-  chatCardQueryNullUrlMockResponse,
-  endpointSelectQueryMockResponse,
-  endpointSelectValueQueryMockResponse,
+  setupChatPageWithTwoDeployments,
+  chatGraphQLMocks,
+  setupChatPageWithUnavailableDeployment,
   makeSseResponse,
   modelsApiMockResponse,
+  waitForChatReady,
+  CHAT_READY_TIMEOUT_MS,
   MOCK_MODEL_ID,
+  MOCK_DEPLOYMENT_NAME,
+  MOCK_DEPLOYMENT_NAME_B,
 } from './mocking/chat-mock-data';
 import { test, expect } from '@playwright/test';
 
@@ -41,7 +42,7 @@ test.describe(
       await setupChatPage(page, request);
 
       // Verify the endpoint selector is visible in the chat card header
-      await expect(page.getByText('mock-endpoint').first()).toBeVisible({
+      await expect(page.getByText(MOCK_DEPLOYMENT_NAME).first()).toBeVisible({
         timeout: 10000,
       });
 
@@ -153,13 +154,7 @@ test.describe(
         localStorage.removeItem('backendaiwebui.cache.chat_history');
       });
 
-      await setupGraphQLMocks(page, {
-        ChatPageQuery: () => chatPageQueryMockResponse(),
-        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-        EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-        EndpointSelectValueQuery: (vars) =>
-          endpointSelectValueQueryMockResponse(vars.endpoint_id),
-      });
+      await setupGraphQLMocks(page, chatGraphQLMocks());
 
       await page.route('**/v1/models', async (route) => {
         await route.fulfill({
@@ -184,9 +179,9 @@ test.describe(
       });
 
       await navigateTo(page, 'chat');
+      await waitForChatReady(page);
 
       const chatInput = page.getByPlaceholder('Type your message here...');
-      await expect(chatInput).toBeVisible({ timeout: 10000 });
 
       // Type and send a message to trigger streaming
       await chatInput.fill('Generate a long response.');
@@ -624,13 +619,7 @@ test.describe(
         localStorage.removeItem('backendaiwebui.cache.chat_history');
       });
 
-      await setupGraphQLMocks(page, {
-        ChatPageQuery: () => chatPageQueryMockResponse(),
-        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-        EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-        EndpointSelectValueQuery: (vars) =>
-          endpointSelectValueQueryMockResponse(vars.endpoint_id),
-      });
+      await setupGraphQLMocks(page, chatGraphQLMocks());
 
       await page.route('**/v1/models', async (route) => {
         await route.fulfill({
@@ -650,9 +639,9 @@ test.describe(
       });
 
       await navigateTo(page, 'chat');
+      await waitForChatReady(page);
 
       const chatInput = page.getByPlaceholder('Type your message here...');
-      await expect(chatInput).toBeVisible({ timeout: 10000 });
 
       // Type "Trigger an error" and press Enter
       await chatInput.fill('Trigger an error');
@@ -667,60 +656,136 @@ test.describe(
       ).toBeVisible({ timeout: 15000 });
     });
 
-    test.fixme('User sees an error alert when the endpoint URL is invalid', async ({
+    // FR-3397: ChatCard derives one unavailability reason per deployment and
+    // renders a single alert for it. The checks run most-specific-first, since a
+    // deployment scaled to zero — or one without a revision — also has no active
+    // replica, and a later check would otherwise mask the real cause. Each case
+    // below states only the one condition it exercises; every other input stays
+    // at its serving value.
+    //
+    // `composer` records observed behaviour, not an aspiration: the composer is
+    // disabled only when no usable base URL resolved. A deployment that has a
+    // reachable URL but cannot answer (scaled to zero, no revision, no active
+    // replica) still accepts typing — the alert is the only thing telling the
+    // user why a send will not get a reply.
+    const UNAVAILABLE_REASONS = [
+      {
+        title: 'the desired replica count is 0',
+        overrides: { desiredReplicaCount: 0 },
+        message: 'The desired replica count for this deployment is 0',
+        composer: 'enabled' as const,
+      },
+      {
+        title: 'no revision is deployed',
+        overrides: { revisionCount: 0 },
+        message: 'No revision is deployed',
+        composer: 'enabled' as const,
+      },
+      {
+        title: 'no replica is serving traffic',
+        overrides: { activeReplicaCount: 0 },
+        message: 'No replicas are available',
+        composer: 'enabled' as const,
+      },
+      {
+        // The previous test for this was skipped on the theory that Relay served
+        // a cached URL from a real backend response; the actual cause was the mock
+        // describing the legacy `endpoint { url }` shape, which the migrated
+        // `deployment(id:)` query never reads (FR-3332).
+        title: 'no endpoint URL has been issued yet',
+        overrides: { endpointUrl: null },
+        message: 'This deployment has not been issued an endpoint URL yet',
+        composer: 'disabled' as const,
+      },
+      {
+        // `error.InvalidBaseURL` is reserved for a URL that was supplied and
+        // could not be parsed — distinct from one that was never issued.
+        title: 'the endpoint URL cannot be parsed',
+        overrides: { endpointUrl: 'not-a-valid-url' },
+        message: 'Endpoint URL is not valid.',
+        composer: 'disabled' as const,
+      },
+    ];
+
+    for (const { title, overrides, message, composer } of UNAVAILABLE_REASONS) {
+      test(`User sees why chat is unavailable when ${title}`, async ({
+        page,
+        request,
+      }) => {
+        await setupChatPageWithUnavailableDeployment(page, request, overrides);
+
+        // The alert is the readiness gate here: an unavailable pane keeps its
+        // composer disabled, so there is no enabled composer to wait for.
+        await expect(page.getByText(message)).toBeVisible({
+          timeout: CHAT_READY_TIMEOUT_MS,
+        });
+
+        // Exactly one reason is reported — no other reason's message appears.
+        for (const other of UNAVAILABLE_REASONS) {
+          if (other.message === message) continue;
+          await expect(page.getByText(other.message)).toBeHidden();
+        }
+
+        const chatInput = page.getByPlaceholder('Type your message here...');
+        if (composer === 'disabled') {
+          await expect(chatInput).toBeDisabled({ timeout: 10000 });
+        } else {
+          await expect(chatInput).toBeEnabled({ timeout: 10000 });
+        }
+      });
+    }
+
+    test('User sees both the unavailability reason and the missing-model warning', async ({
       page,
       request,
     }) => {
-      // FIXME: The error alert is not displayed even though ChatCardQuery returns url: null.
-      // The Relay store-or-network fetch policy appears to use cached endpoint data with
-      // a valid URL from a real backend response, bypassing the null URL mock. As a result,
-      // createBaseURL returns a valid URL and no .ant-alert-error is rendered.
-      // Set up GraphQL mocks so ChatCardQuery returns url: null
-      await loginAsAdmin(page, request);
-      await page.evaluate(() => {
-        localStorage.removeItem('backendaiwebui.cache.chat_history');
-      });
+      // The two alerts answer different questions and are no longer mutually
+      // exclusive: ChatCard used to suppress `chatui.CannotFindModel` whenever it
+      // had an unavailability reason to show. A deployment can have a reachable
+      // URL that serves an empty model list *and* be unable to answer, so both
+      // are reported.
+      await setupChatPageWithUnavailableDeployment(
+        page,
+        request,
+        { desiredReplicaCount: 0 },
+        // Empty model list — this is what renders the recovery form.
+        [],
+      );
 
-      await setupGraphQLMocks(page, {
-        ChatPageQuery: () => chatPageQueryMockResponse(),
-        ChatCardQuery: (vars) =>
-          chatCardQueryNullUrlMockResponse(vars.endpointId),
-        EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-        EndpointSelectValueQuery: (vars) =>
-          endpointSelectValueQueryMockResponse(vars.endpoint_id),
-      });
-
-      await page.route('**/v1/models', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(modelsApiMockResponse(MOCK_MODEL_ID)),
-        });
-      });
-
-      // Navigate to the chat page
-      await navigateTo(page, 'chat');
-
-      // Wait for the chat card to render
       await expect(
-        page.getByPlaceholder('Type your message here...'),
-      ).toBeVisible({
+        page.getByText('The desired replica count for this deployment is 0'),
+      ).toBeVisible({ timeout: CHAT_READY_TIMEOUT_MS });
+      await expect(page.getByText('LLM models not found')).toBeVisible({
         timeout: 10000,
       });
+    });
 
-      // An error alert should be visible when endpoint URL is null
-      // The component renders: <Alert title={t('error.InvalidBaseURL')} type="error" .../>
-      // which translates to "Endpoint URL is not valid."
-      await expect(page.locator('.ant-alert-error').first()).toBeVisible({
-        timeout: 10000,
+    test('User sees the most specific reason when several apply at once', async ({
+      page,
+      request,
+    }) => {
+      // A deployment scaled to zero also has no revision, no active replica and
+      // no URL. The desired-replica reason wins because it is checked first —
+      // this is what keeps a later, vaguer check from masking the real cause.
+      await setupChatPageWithUnavailableDeployment(page, request, {
+        desiredReplicaCount: 0,
+        revisionCount: 0,
+        activeReplicaCount: 0,
+        endpointUrl: null,
       });
 
-      // The text input should be disabled
       await expect(
-        page.getByPlaceholder('Type your message here...'),
-      ).toBeDisabled({
-        timeout: 10000,
-      });
+        page.getByText('The desired replica count for this deployment is 0'),
+      ).toBeVisible({ timeout: CHAT_READY_TIMEOUT_MS });
+
+      for (const masked of [
+        'No revision is deployed',
+        'No replicas are available',
+        'This deployment has not been issued an endpoint URL yet',
+        'Endpoint URL is not valid.',
+      ]) {
+        await expect(page.getByText(masked)).toBeHidden();
+      }
     });
 
     test.fixme('User sees an error notification when model fetching fails', async ({
@@ -738,13 +803,7 @@ test.describe(
         localStorage.removeItem('backendaiwebui.cache.chat_history');
       });
 
-      await setupGraphQLMocks(page, {
-        ChatPageQuery: () => chatPageQueryMockResponse(),
-        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-        EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-        EndpointSelectValueQuery: (vars) =>
-          endpointSelectValueQueryMockResponse(vars.endpoint_id),
-      });
+      await setupGraphQLMocks(page, chatGraphQLMocks());
 
       // Models API returns HTTP 401 to trigger an error notification
       await page.route('**/v1/models', async (route) => {
@@ -757,13 +816,7 @@ test.describe(
 
       // Navigate to the chat page — model fetch happens on load
       await navigateTo(page, 'chat');
-
-      // Wait for page to load
-      await expect(
-        page.getByPlaceholder('Type your message here...'),
-      ).toBeVisible({
-        timeout: 10000,
-      });
+      await waitForChatReady(page);
 
       // An Ant Design error message notification should appear
       await expect(
@@ -813,7 +866,7 @@ test.describe(
 
       // Locate and click the "Compare" button (ArrowRightLeftIcon or tooltip "Create Compare Chat")
       // Button layout in .ant-card-head nth(1) for single pane:
-      //   nth(0)=detail-page (EndpointSelect compact btn), nth(1)=control, nth(2)=compare, nth(3)=more
+      //   nth(0)=detail-page (DeploymentSelect compact btn), nth(1)=control, nth(2)=compare, nth(3)=more
       const compareButton = page
         .locator('.ant-card-head')
         .nth(1)
@@ -947,7 +1000,7 @@ test.describe(
       request,
     }) => {
       // Setup with two endpoints available
-      await setupChatPageWithTwoEndpoints(page, request);
+      await setupChatPageWithTwoDeployments(page, request);
 
       await expect(
         page.getByPlaceholder('Type your message here...'),
@@ -977,18 +1030,18 @@ test.describe(
       const secondCardEndpointText = page
         .locator('.ant-card')
         .nth(2)
-        .getByText('mock-endpoint')
+        .getByText(MOCK_DEPLOYMENT_NAME)
         .first();
 
       await secondCardEndpointText.click();
 
       // Select the second mock endpoint
       await page
-        .getByRole('option', { name: 'mock-endpoint-b' })
+        .getByRole('option', { name: MOCK_DEPLOYMENT_NAME_B })
         .or(
           page
             .locator('.ant-select-item-option')
-            .filter({ hasText: 'mock-endpoint-b' }),
+            .filter({ hasText: MOCK_DEPLOYMENT_NAME_B }),
         )
         .first()
         .click();
@@ -996,14 +1049,20 @@ test.describe(
       // The second pane's endpoint selector shows the second endpoint
       // Use [title] to target the visible select display value (avoids hidden aria-live elements)
       await expect(
-        page.locator('.ant-card').nth(2).locator('[title="mock-endpoint-b"]'),
+        page
+          .locator('.ant-card')
+          .nth(2)
+          .locator(`[title="${MOCK_DEPLOYMENT_NAME_B}"]`),
       ).toBeVisible({
         timeout: 10000,
       });
 
       // The first pane's endpoint selector still shows the original endpoint
       await expect(
-        page.locator('.ant-card').nth(1).locator('[title="mock-endpoint"]'),
+        page
+          .locator('.ant-card')
+          .nth(1)
+          .locator(`[title="${MOCK_DEPLOYMENT_NAME}"]`),
       ).toBeVisible({
         timeout: 5000,
       });

--- a/e2e/chat/mocking/chat-mock-data.ts
+++ b/e2e/chat/mocking/chat-mock-data.ts
@@ -139,59 +139,20 @@ export function deploymentSelectQueryTwoDeploymentsMockResponse() {
  *
  * Every field the query selects must be present. A missing field makes the
  * catch result not-ok, which nulls the deployment and leaves the chat input
- * disabled (no base URL -> no /v1/models fetch). `replicaState`,
- * `revisionHistory` and the `activeReplicas` alias additionally feed ChatCard's
- * "why is chat unavailable" reason (FR-3397): a serving deployment needs a
- * non-zero desired replica count, at least one revision, and at least one
- * RUNNING + traffic-ACTIVE replica.
+ * disabled (no base URL -> no /v1/models fetch).
  */
-export function chatCardQueryMockResponse(
-  deploymentGlobalId: string,
-  overrides: DeploymentServingOverrides = {},
-) {
+export function chatCardQueryMockResponse(deploymentGlobalId: string) {
   const isB = isDeploymentB(deploymentGlobalId);
   return {
     deployment: {
       id: deploymentGlobalId,
       networkAccess: {
-        endpointUrl:
-          'endpointUrl' in overrides
-            ? overrides.endpointUrl
-            : isB
-              ? MOCK_DEPLOYMENT_URL_B
-              : MOCK_DEPLOYMENT_URL,
+        endpointUrl: isB ? MOCK_DEPLOYMENT_URL_B : MOCK_DEPLOYMENT_URL,
       },
-      replicaState: {
-        desiredReplicaCount: overrides.desiredReplicaCount ?? 1,
-      },
-      revisionHistory: { count: overrides.revisionCount ?? 1 },
-      activeReplicas: { count: overrides.activeReplicaCount ?? 1 },
+      replicaState: { desiredReplicaCount: 1 },
       metadata: { name: isB ? MOCK_DEPLOYMENT_NAME_B : MOCK_DEPLOYMENT_NAME },
     },
   };
-}
-
-/**
- * The three counts plus the URL that decide whether ChatCard considers a
- * deployment able to serve, and which reason it reports when it cannot
- * (FR-3397). Each defaults to the serving value, so a spec states only the one
- * condition it is exercising.
- */
-export interface DeploymentServingOverrides {
-  endpointUrl?: string | null;
-  desiredReplicaCount?: number;
-  revisionCount?: number;
-  activeReplicaCount?: number;
-}
-
-/**
- * Returns deployment detail with no endpoint URL issued. The deployment is
- * otherwise serviceable (replicas desired, a revision, an active replica), so
- * ChatCard reports `chatui.NoEndpointUrlIssued` rather than an earlier, more
- * specific unavailability reason (FR-3397).
- */
-export function chatCardQueryNullUrlMockResponse(deploymentGlobalId: string) {
-  return chatCardQueryMockResponse(deploymentGlobalId, { endpointUrl: null });
 }
 
 /**
@@ -403,50 +364,6 @@ export async function setupChatPage(
   // Navigate to chat page
   await navigateTo(page, 'chat');
   await waitForChatReady(page);
-}
-
-/**
- * Setup variant for a deployment ChatCard should refuse to chat with.
- *
- * Same wiring as {@link setupChatPage} except the ChatCardQuery mock carries the
- * supplied serving overrides, and it deliberately does not wait for an enabled
- * composer — an unavailable pane keeps its composer disabled by design, so the
- * caller gates on the unavailability alert instead.
- */
-export async function setupChatPageWithUnavailableDeployment(
-  page: Page,
-  request: APIRequestContext,
-  overrides: DeploymentServingOverrides,
-  /**
-   * Models the deployment's `/v1/models` reports. Pass `[]` to drive ChatCard's
-   * recovery form, which renders only when a base URL resolved but the model
-   * list came back empty.
-   */
-  modelIds: string[] = [MOCK_MODEL_ID],
-): Promise<void> {
-  await loginAsAdmin(page, request);
-
-  await page.evaluate(() => {
-    localStorage.removeItem('backendaiwebui.cache.chat_history');
-  });
-
-  await setupGraphQLMocks(page, {
-    ...chatGraphQLMocks(),
-    ChatCardQuery: (vars: Record<string, string>) =>
-      chatCardQueryMockResponse(vars.deploymentId, overrides),
-  });
-
-  await page.route('**/v1/models', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        data: modelIds.map((id) => ({ id, object: 'model' })),
-      }),
-    });
-  });
-
-  await navigateTo(page, 'chat');
 }
 
 /**

--- a/e2e/chat/mocking/chat-mock-data.ts
+++ b/e2e/chat/mocking/chat-mock-data.ts
@@ -1,49 +1,100 @@
 // e2e/chat/mocking/chat-mock-data.ts
 // Shared mock helpers and data for chat E2E tests.
+//
+// The Chat deployment surface reads the Strawberry v2 Deployments API
+// (`myDeployments` / `deployment(id:)`), so every factory below returns that
+// wire shape. FR-3332 migrated these queries off the legacy Graphene
+// `endpoint` / `endpoint_list` fields and renamed `EndpointSelect*` to
+// `DeploymentSelect*`; a mock keyed on a stale operation name is not an error —
+// the interceptor passes unmatched operations through to the real backend — so
+// the names here must track the queries exactly.
 import { setupGraphQLMocks } from '../../session/mocking/graphql-interceptor';
 import { loginAsAdmin, navigateTo } from '../../utils/test-util';
-import { type APIRequestContext, type Page } from '@playwright/test';
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-export const MOCK_ENDPOINT_UUID = 'chat-ep-aaaa-bbbb-cccc-000000000001';
-export const MOCK_ENDPOINT_UUID_B = MOCK_ENDPOINT_UUID + '-b';
-export const MOCK_ENDPOINT_URL = 'https://mock-chat-endpoint.backend.ai';
-export const MOCK_ENDPOINT_URL_B = 'https://mock-chat-endpoint-b.backend.ai';
+export const MOCK_DEPLOYMENT_UUID = 'chat-dp-aaaa-bbbb-cccc-000000000001';
+export const MOCK_DEPLOYMENT_UUID_B = MOCK_DEPLOYMENT_UUID + '-b';
+export const MOCK_DEPLOYMENT_URL = 'https://mock-chat-deployment.backend.ai';
+export const MOCK_DEPLOYMENT_URL_B =
+  'https://mock-chat-deployment-b.backend.ai';
+export const MOCK_DEPLOYMENT_NAME = 'mock-deployment';
+export const MOCK_DEPLOYMENT_NAME_B = 'mock-deployment-b';
 export const MOCK_MODEL_ID = 'gpt-mock-model';
 export const MOCK_MODEL_ID_B = 'gpt-mock-model-b';
+
+/**
+ * Assistant replies the two-deployment completions mock streams back. Exported
+ * so a spec asserts the exact string the mock produces instead of restating it —
+ * a restated literal is what let these assertions drift out of sync.
+ */
+export const MOCK_REPLY_A = 'Response from deployment A';
+export const MOCK_REPLY_B = 'Response from deployment B';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Relay global ID helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Encodes a deployment UUID the way the app's `toGlobalId` does. Chat holds
+ * local UUIDs (chat provider state, the `deploymentId` URL param, the select's
+ * value) and converts to the global Relay ID on the way into `deployment(id:)`,
+ * so mocks must speak global IDs on the wire.
+ */
+export function toMockDeploymentGlobalId(uuid: string): string {
+  return Buffer.from(`ModelDeployment:${uuid}`).toString('base64');
+}
+
+/**
+ * Reverses {@link toMockDeploymentGlobalId} so a mock factory can tell which
+ * deployment a `deployment(id:)` request is asking for.
+ */
+export function fromMockDeploymentGlobalId(globalId: string): string {
+  return Buffer.from(globalId, 'base64').toString().split(':')[1] ?? '';
+}
+
+function isDeploymentB(deploymentGlobalId: string): boolean {
+  return (
+    fromMockDeploymentGlobalId(deploymentGlobalId) === MOCK_DEPLOYMENT_UUID_B
+  );
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // GraphQL mock response factories
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Returns a single mock endpoint for ChatPageQuery.
+ * Returns the default deployment for ChatPageQuery, which reads
+ * `myDeployments(limit: 1)` to pick the initially-selected deployment.
  * Shape matches the wire-format GraphQL response (not Relay TypeScript types).
  */
 export function chatPageQueryMockResponse() {
   return {
-    endpoint_list: {
-      items: [{ endpoint_id: MOCK_ENDPOINT_UUID }],
+    myDeployments: {
+      edges: [{ node: { id: toMockDeploymentGlobalId(MOCK_DEPLOYMENT_UUID) } }],
     },
   };
 }
 
 /**
- * Returns the endpoint list for EndpointSelectQuery (single endpoint).
- * Includes all fields required by EndpointSelectQuery: total_count, name, url.
+ * Returns the deployment list for DeploymentSelectQuery (single deployment).
+ * Includes every field the query selects: `count`, `metadata.name` and
+ * `networkAccess.endpointUrl`.
  */
-export function endpointSelectQueryMockResponse() {
+export function deploymentSelectQueryMockResponse() {
   return {
-    endpoint_list: {
-      total_count: 1,
-      items: [
+    myDeployments: {
+      count: 1,
+      edges: [
         {
-          endpoint_id: MOCK_ENDPOINT_UUID,
-          name: 'mock-endpoint',
-          url: MOCK_ENDPOINT_URL,
+          node: {
+            id: toMockDeploymentGlobalId(MOCK_DEPLOYMENT_UUID),
+            metadata: { name: MOCK_DEPLOYMENT_NAME },
+            networkAccess: { endpointUrl: MOCK_DEPLOYMENT_URL },
+          },
         },
       ],
     },
@@ -51,22 +102,27 @@ export function endpointSelectQueryMockResponse() {
 }
 
 /**
- * Returns two endpoints for EndpointSelectQuery (two-endpoint multi-pane tests).
+ * Returns two deployments for DeploymentSelectQuery (multi-pane tests that
+ * switch one pane onto a second deployment).
  */
-export function endpointSelectQueryTwoEndpointsMockResponse() {
+export function deploymentSelectQueryTwoDeploymentsMockResponse() {
   return {
-    endpoint_list: {
-      total_count: 2,
-      items: [
+    myDeployments: {
+      count: 2,
+      edges: [
         {
-          endpoint_id: MOCK_ENDPOINT_UUID,
-          name: 'mock-endpoint',
-          url: MOCK_ENDPOINT_URL,
+          node: {
+            id: toMockDeploymentGlobalId(MOCK_DEPLOYMENT_UUID),
+            metadata: { name: MOCK_DEPLOYMENT_NAME },
+            networkAccess: { endpointUrl: MOCK_DEPLOYMENT_URL },
+          },
         },
         {
-          endpoint_id: MOCK_ENDPOINT_UUID_B,
-          name: 'mock-endpoint-b',
-          url: MOCK_ENDPOINT_URL_B,
+          node: {
+            id: toMockDeploymentGlobalId(MOCK_DEPLOYMENT_UUID_B),
+            metadata: { name: MOCK_DEPLOYMENT_NAME_B },
+            networkAccess: { endpointUrl: MOCK_DEPLOYMENT_URL_B },
+          },
         },
       ],
     },
@@ -74,72 +130,122 @@ export function endpointSelectQueryTwoEndpointsMockResponse() {
 }
 
 /**
- * Returns two mock endpoints for multi-pane tests (ChatPageQuery shape).
- */
-export function chatPageQueryTwoEndpointsMockResponse() {
-  return {
-    endpoint_list: {
-      items: [
-        { endpoint_id: MOCK_ENDPOINT_UUID },
-        { endpoint_id: MOCK_ENDPOINT_UUID_B },
-      ],
-    },
-  };
-}
-
-/**
- * Returns endpoint detail for ChatCardQuery.
+ * Returns deployment detail for ChatCardQuery.
  *
- * IMPORTANT: ChatCardQuery uses `@catch` in Relay, but that is a client-side
- * transformation. The wire-format GraphQL response still returns the Endpoint
- * object directly (not wrapped in { ok, value }). Relay's normaliser applies
- * the Result wrapping after receiving the response.
+ * IMPORTANT: ChatCardQuery wraps `deployment` in Relay `@catch`, but that is a
+ * client-side transformation — the wire response still returns the
+ * ModelDeployment object directly (not `{ ok, value }`). Relay applies the
+ * Result wrapping while normalising.
+ *
+ * Every field the query selects must be present. A missing field makes the
+ * catch result not-ok, which nulls the deployment and leaves the chat input
+ * disabled (no base URL -> no /v1/models fetch). `replicaState`,
+ * `revisionHistory` and the `activeReplicas` alias additionally feed ChatCard's
+ * "why is chat unavailable" reason (FR-3397): a serving deployment needs a
+ * non-zero desired replica count, at least one revision, and at least one
+ * RUNNING + traffic-ACTIVE replica.
  */
-export function chatCardQueryMockResponse(endpointId: string) {
-  const isB = endpointId === MOCK_ENDPOINT_UUID_B;
+export function chatCardQueryMockResponse(
+  deploymentGlobalId: string,
+  overrides: DeploymentServingOverrides = {},
+) {
+  const isB = isDeploymentB(deploymentGlobalId);
   return {
-    endpoint: {
-      endpoint_id: endpointId,
-      url: isB ? MOCK_ENDPOINT_URL_B : MOCK_ENDPOINT_URL,
-      // `replicas` is selected by ChatCardQuery (FR-3156, #7935). It must be
-      // present in the mock — the query wraps `endpoint` in Relay `@catch`,
-      // so a missing field makes the catch result not-ok, nulls the endpoint,
-      // and leaves the chat input disabled (no base URL → no /v1/models fetch).
-      replicas: 1,
-      name: isB ? 'mock-endpoint-b' : 'mock-endpoint',
+    deployment: {
+      id: deploymentGlobalId,
+      networkAccess: {
+        endpointUrl:
+          'endpointUrl' in overrides
+            ? overrides.endpointUrl
+            : isB
+              ? MOCK_DEPLOYMENT_URL_B
+              : MOCK_DEPLOYMENT_URL,
+      },
+      replicaState: {
+        desiredReplicaCount: overrides.desiredReplicaCount ?? 1,
+      },
+      revisionHistory: { count: overrides.revisionCount ?? 1 },
+      activeReplicas: { count: overrides.activeReplicaCount ?? 1 },
+      metadata: { name: isB ? MOCK_DEPLOYMENT_NAME_B : MOCK_DEPLOYMENT_NAME },
     },
   };
 }
 
 /**
- * Returns an endpoint detail with a null URL to test invalid base URL handling.
+ * The three counts plus the URL that decide whether ChatCard considers a
+ * deployment able to serve, and which reason it reports when it cannot
+ * (FR-3397). Each defaults to the serving value, so a spec states only the one
+ * condition it is exercising.
  */
-export function chatCardQueryNullUrlMockResponse(endpointId: string) {
+export interface DeploymentServingOverrides {
+  endpointUrl?: string | null;
+  desiredReplicaCount?: number;
+  revisionCount?: number;
+  activeReplicaCount?: number;
+}
+
+/**
+ * Returns deployment detail with no endpoint URL issued. The deployment is
+ * otherwise serviceable (replicas desired, a revision, an active replica), so
+ * ChatCard reports `chatui.NoEndpointUrlIssued` rather than an earlier, more
+ * specific unavailability reason (FR-3397).
+ */
+export function chatCardQueryNullUrlMockResponse(deploymentGlobalId: string) {
+  return chatCardQueryMockResponse(deploymentGlobalId, { endpointUrl: null });
+}
+
+/**
+ * Returns deployment detail for DeploymentSelectValueQuery — the lookup that
+ * renders the currently-selected value in the deployment select.
+ */
+export function deploymentSelectValueQueryMockResponse(
+  deploymentGlobalId: string,
+) {
+  const isB = isDeploymentB(deploymentGlobalId);
   return {
-    endpoint: {
-      endpoint_id: endpointId,
-      url: null,
-      // See chatCardQueryMockResponse: `replicas` must be present for the
-      // Relay `@catch` on `endpoint` to resolve to a value (here we are
-      // deliberately exercising the null-URL path, not a missing endpoint).
-      replicas: 1,
-      name: 'mock-endpoint-no-url',
+    deployment: {
+      id: deploymentGlobalId,
+      metadata: { name: isB ? MOCK_DEPLOYMENT_NAME_B : MOCK_DEPLOYMENT_NAME },
+      networkAccess: {
+        endpointUrl: isB ? MOCK_DEPLOYMENT_URL_B : MOCK_DEPLOYMENT_URL,
+      },
     },
   };
 }
 
 /**
- * Returns endpoint detail for EndpointSelectValueQuery.
- * Variable name is `endpoint_id` (snake_case) — matches the query's variable declaration.
+ * Returns the access-token list for DeploymentTokenSelectQuery. Empty by
+ * default: the chat specs drive the token field as free text, and leaving this
+ * unmocked sends the fake mock UUID to the real manager, which answers
+ * "badly formed hexadecimal UUID string".
  */
-export function endpointSelectValueQueryMockResponse(endpointId: string) {
-  const isB = endpointId === MOCK_ENDPOINT_UUID_B;
+export function deploymentTokenSelectQueryMockResponse(
+  deploymentGlobalId: string,
+) {
   return {
-    endpoint: {
-      endpoint_id: endpointId,
-      name: isB ? 'mock-endpoint-b' : 'mock-endpoint',
-      url: isB ? MOCK_ENDPOINT_URL_B : MOCK_ENDPOINT_URL,
+    deployment: {
+      id: deploymentGlobalId,
+      accessTokens: { edges: [] },
     },
+  };
+}
+
+/**
+ * The GraphQL mock map shared by every chat spec: one reachable deployment.
+ * Exposed as a factory so a spec can spread it and override a single operation
+ * (e.g. the null-URL ChatCardQuery variant) without restating the rest — the
+ * drift that broke these specs came from restating the map in each spec.
+ */
+export function chatGraphQLMocks() {
+  return {
+    ChatPageQuery: () => chatPageQueryMockResponse(),
+    ChatCardQuery: (vars: Record<string, string>) =>
+      chatCardQueryMockResponse(vars.deploymentId),
+    DeploymentSelectQuery: () => deploymentSelectQueryMockResponse(),
+    DeploymentSelectValueQuery: (vars: Record<string, string>) =>
+      deploymentSelectValueQueryMockResponse(vars.deploymentId),
+    DeploymentTokenSelectQuery: (vars: Record<string, string>) =>
+      deploymentTokenSelectQueryMockResponse(vars.deploymentId),
   };
 }
 
@@ -217,6 +323,42 @@ export function makeSseResponse(content: string): string {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * How long a freshly-navigated chat pane may take to become interactive.
+ *
+ * Deliberately far above the per-assertion timeouts in the specs: reaching an
+ * interactive pane costs a full app boot (login, project/user bootstrap queries)
+ * against the real manager before the mocked deployment lookups even run, and
+ * that boot is what stretches under parallel workers — measured at ~15s per test
+ * with `--workers=1` against a shared manager and over 45s with the default four.
+ * It is a readiness gate, not a behavioural assertion, so a generous budget costs
+ * nothing on a fast target while keeping a slow shared one usable; the specs' own
+ * 5-10s assertion timeouts still measure chat behaviour on a settled page.
+ * Stays under Playwright's 180s per-test timeout with room for the test body.
+ */
+export const CHAT_READY_TIMEOUT_MS = 120_000;
+
+/**
+ * Waits until a chat pane is actually interactive. Every chat setup path for a
+ * reachable deployment ends here so a spec never starts asserting against a
+ * half-booted page.
+ *
+ * Both conditions matter. Visibility alone is not readiness: the composer renders
+ * disabled until the pane has resolved a deployment URL and fetched its model
+ * list, and `press('Enter')` on a disabled composer silently does nothing — the
+ * message never sends and the failure surfaces later as a missing reply rather
+ * than as "the page was not ready".
+ *
+ * Not for panes that are expected to stay unavailable (e.g. a deployment with no
+ * endpoint URL): those keep a disabled composer by design, so gate those specs on
+ * the unavailability alert instead.
+ */
+export async function waitForChatReady(page: Page): Promise<void> {
+  const composer = page.getByPlaceholder('Type your message here...').first();
+  await composer.waitFor({ state: 'visible', timeout: CHAT_READY_TIMEOUT_MS });
+  await expect(composer).toBeEnabled({ timeout: CHAT_READY_TIMEOUT_MS });
+}
+
+/**
  * Full chat page setup:
  * 1. Login as admin.
  * 2. Clear chat history from localStorage.
@@ -238,14 +380,7 @@ export async function setupChatPage(
   });
 
   // GraphQL mocks — variable names must match the wire-format query variables
-  await setupGraphQLMocks(page, {
-    ChatPageQuery: () => chatPageQueryMockResponse(),
-    ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-    EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-    // EndpointSelectValueQuery uses snake_case `endpoint_id` variable
-    EndpointSelectValueQuery: (vars) =>
-      endpointSelectValueQueryMockResponse(vars.endpoint_id),
-  });
+  await setupGraphQLMocks(page, chatGraphQLMocks());
 
   // Models API mock
   await page.route('**/v1/models', async (route) => {
@@ -267,14 +402,59 @@ export async function setupChatPage(
 
   // Navigate to chat page
   await navigateTo(page, 'chat');
+  await waitForChatReady(page);
 }
 
 /**
- * Setup variant for two-endpoint multi-pane tests.
- * EndpointSelectQuery returns both endpoints; completions requests are
+ * Setup variant for a deployment ChatCard should refuse to chat with.
+ *
+ * Same wiring as {@link setupChatPage} except the ChatCardQuery mock carries the
+ * supplied serving overrides, and it deliberately does not wait for an enabled
+ * composer — an unavailable pane keeps its composer disabled by design, so the
+ * caller gates on the unavailability alert instead.
+ */
+export async function setupChatPageWithUnavailableDeployment(
+  page: Page,
+  request: APIRequestContext,
+  overrides: DeploymentServingOverrides,
+  /**
+   * Models the deployment's `/v1/models` reports. Pass `[]` to drive ChatCard's
+   * recovery form, which renders only when a base URL resolved but the model
+   * list came back empty.
+   */
+  modelIds: string[] = [MOCK_MODEL_ID],
+): Promise<void> {
+  await loginAsAdmin(page, request);
+
+  await page.evaluate(() => {
+    localStorage.removeItem('backendaiwebui.cache.chat_history');
+  });
+
+  await setupGraphQLMocks(page, {
+    ...chatGraphQLMocks(),
+    ChatCardQuery: (vars: Record<string, string>) =>
+      chatCardQueryMockResponse(vars.deploymentId, overrides),
+  });
+
+  await page.route('**/v1/models', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: modelIds.map((id) => ({ id, object: 'model' })),
+      }),
+    });
+  });
+
+  await navigateTo(page, 'chat');
+}
+
+/**
+ * Setup variant for two-deployment multi-pane tests.
+ * DeploymentSelectQuery returns both deployments; completions requests are
  * differentiated by URL (alpha vs beta prefix).
  */
-export async function setupChatPageWithTwoEndpoints(
+export async function setupChatPageWithTwoDeployments(
   page: Page,
   request: APIRequestContext,
 ): Promise<void> {
@@ -285,20 +465,17 @@ export async function setupChatPageWithTwoEndpoints(
   });
 
   await setupGraphQLMocks(page, {
-    ChatPageQuery: () => chatPageQueryMockResponse(),
-    ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-    EndpointSelectQuery: () => endpointSelectQueryTwoEndpointsMockResponse(),
-    // EndpointSelectValueQuery uses snake_case `endpoint_id` variable
-    EndpointSelectValueQuery: (vars) =>
-      endpointSelectValueQueryMockResponse(vars.endpoint_id),
+    ...chatGraphQLMocks(),
+    DeploymentSelectQuery: () =>
+      deploymentSelectQueryTwoDeploymentsMockResponse(),
   });
 
-  // Models API mock — both endpoints respond with their respective model IDs
+  // Models API mock — both deployments respond with their respective model IDs
   // Differentiate by URL path/host since models endpoint is a GET request
   await page.route('**/v1/models', async (route) => {
     const url = route.request().url();
-    const isEndpointB = url.includes('mock-chat-endpoint-b');
-    const modelId = isEndpointB ? MOCK_MODEL_ID_B : MOCK_MODEL_ID;
+    const isB = url.includes('mock-chat-deployment-b');
+    const modelId = isB ? MOCK_MODEL_ID_B : MOCK_MODEL_ID;
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -313,8 +490,8 @@ export async function setupChatPageWithTwoEndpoints(
     // streamText sends `model` field; DefaultChatTransport sends `modelId`
     const model = body.model || body.modelId || '';
     const content = model.includes(MOCK_MODEL_ID_B)
-      ? 'Response from endpoint B'
-      : 'Response from endpoint A';
+      ? MOCK_REPLY_B
+      : MOCK_REPLY_A;
     await route.fulfill({
       status: 200,
       contentType: 'text/event-stream',
@@ -323,4 +500,5 @@ export async function setupChatPageWithTwoEndpoints(
   });
 
   await navigateTo(page, 'chat');
+  await waitForChatReady(page);
 }


### PR DESCRIPTION
Replaces #8480, which GitHub auto-closed as merged when this branch was rebased under #8462 during restacking (no code reached `main` — verified `test/FR-3332-chat-e2e-deployment-mocks` is not an ancestor of `main`; the branch was also auto-deleted on merge and has been recreated here).

Follow-up to #8298 / #8420 (FR-3332). No dedicated issue — this repairs the e2e coverage for the migration those PRs landed.

Stacked on `refactor/FR-3332-chat-deployment-naming` (#8420) → `fr-3332` (#8298) → `main`. #8462 (FR-3397) now stacks on top of this PR instead of below it.

## Why

Every test in `e2e/chat/` fails against a live manager on top of the FR-3332 stack. The specs' mocks still described the legacy Graphene shapes the Chat surface no longer queries. Two breakages, both silent:

- **Same operation name, wrong shape.** `ChatPageQuery` and `ChatCardQuery` kept their names, so the interceptor still matched them — but they returned `endpoint_list { items { endpoint_id } }` and `endpoint { url }` while the migrated queries select `myDeployments` and `deployment(id:)`. Relay received payloads missing the fields it asked for, which made the `@catch` result not-ok and dropped the page into its error boundary.
- **Renamed operations are not an error.** `EndpointSelectQuery` / `EndpointSelectValueQuery` no longer exist (now `DeploymentSelect*`). `graphql-interceptor` forwards unmatched operations to the real backend, so the specs asserted mock data (`mock-endpoint`) against whatever deployments the target actually had.

`DeploymentTokenSelectQuery` was never mocked at all, so it sent the fake mock UUID to the manager and got back `badly formed hexadecimal UUID string`.

## What changed

| | Before | After |
| --- | --- | --- |
| `ChatPageQuery` | `endpoint_list { items { endpoint_id } }` | `myDeployments { edges { node { id } } }` |
| `ChatCardQuery` | `endpoint { endpoint_id url replicas name }` | `deployment { id networkAccess { endpointUrl } metadata { name } }` |
| `EndpointSelectQuery` | `endpoint_list { total_count items }` | `DeploymentSelectQuery` → `myDeployments { count edges { node … } }` |
| `EndpointSelectValueQuery` | `endpoint { endpoint_id name url }` | `DeploymentSelectValueQuery` → `deployment { id metadata { name } networkAccess { endpointUrl } }` |
| `DeploymentTokenSelectQuery` | *(unmocked)* | empty `accessTokens` connection |

- Global Relay IDs are built the way `toGlobalId` does (`base64("ModelDeployment:<uuid>")`), since Chat holds local UUIDs and converts on the way into `deployment(id:)`. `fromMockDeploymentGlobalId` reverses it so a factory can tell deployment A from B.
- One shared `chatGraphQLMocks()` map replaces the four restated inline copies; a spec spreads it and overrides a single operation. Reply strings and deployment names are exported constants, since restated literals are exactly what let these assertions drift.
- Terminology follows the migration: `mock-endpoint` → `mock-deployment`, `setupChatPageWithTwoEndpoints` → `setupChatPageWithTwoDeployments`.
- Removed `chatPageQueryTwoEndpointsMockResponse` — dead, no caller.

## Deferred to #8462

The original version of this PR (before the restack) also added e2e coverage for #8462's unavailability alert. Since this PR now sits *below* #8462 in the stack, ChatCard doesn't have that alert logic yet at this point — those test cases (and the `setupChatPageWithUnavailableDeployment` / `DeploymentServingOverrides` / `chatCardQueryNullUrlMockResponse` mock helpers that only existed to support them) were removed here and are expected to land in #8462 instead.

## Flakiness fixes

- **`waitForChatReady` gates every setup path on an *enabled* composer.** Visibility is not readiness: the composer renders disabled until the pane resolves a deployment URL and fetches its model list, and `press('Enter')` on a disabled composer silently does nothing — the failure then surfaces as a missing reply rather than as "the page was not ready".
- The sync-toggle wait race this PR originally fixed independently (`clickSyncToggle`) had already landed on `main` via a different PR as `setSync`; the rebase kept `setSync` and dropped the duplicate reimplementation.

## Verification

- `bash scripts/verify.sh` → **=== ALL PASS ===** (Relay / Lint / Format / TypeScript / terminology).

🤖 Generated with [Claude Code](https://claude.com/claude-code)