### PR TITLE
fix(FR-3430): force a fresh fetch on FairShare step remount with per-mount fetchKey

### DIFF
--- a/react/src/components/FairShareItems/DomainFairShareStep.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareStep.tsx
@@ -36,12 +36,14 @@ import { graphql, useLazyLoadQuery } from 'react-relay';
 
 interface DomainFairShareStepProps {
   resourceGroupName: string;
+  initialFetchKey: string;
   loading?: boolean;
   onClickDomainName?: (domainName: string) => void;
 }
 
 const DomainFairShareStep: React.FC<DomainFairShareStepProps> = ({
   resourceGroupName,
+  initialFetchKey,
   loading,
   onClickDomainName,
 }) => {
@@ -88,7 +90,9 @@ const DomainFairShareStep: React.FC<DomainFairShareStepProps> = ({
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const [fetchKey, updateFetchKey] = useFetchKey();
-  const deferredFetchKey = useDeferredValue(fetchKey);
+  const effectiveFetchKey =
+    fetchKey === INITIAL_FETCH_KEY ? initialFetchKey : fetchKey;
+  const deferredFetchKey = useDeferredValue(effectiveFetchKey);
 
   const { resourceGroups, domainFairShares } =
     useLazyLoadQuery<DomainFairShareStepQuery>(
@@ -132,7 +136,7 @@ const DomainFairShareStep: React.FC<DomainFairShareStepProps> = ({
       {
         fetchKey: deferredFetchKey,
         fetchPolicy:
-          deferredFetchKey === INITIAL_FETCH_KEY
+          deferredFetchKey === initialFetchKey
             ? 'store-and-network'
             : 'network-only',
       },
@@ -187,7 +191,7 @@ const DomainFairShareStep: React.FC<DomainFairShareStepProps> = ({
           <AutoUpdateFetchKeyButton
             settingId="fair-share-list"
             autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}
-            loading={fetchKey !== deferredFetchKey}
+            loading={effectiveFetchKey !== deferredFetchKey}
             value=""
             onChange={() => {
               updateFetchKey();
@@ -202,7 +206,7 @@ const DomainFairShareStep: React.FC<DomainFairShareStepProps> = ({
         loading={
           loading ||
           queryVariables !== deferredQueryVariables ||
-          fetchKey !== deferredFetchKey
+          effectiveFetchKey !== deferredFetchKey
         }
         selectedRows={selectedRows}
         onRowSelect={(selectedRowKeys, currentPageItems) => {

--- a/react/src/components/FairShareItems/FairShareList.tsx
+++ b/react/src/components/FairShareItems/FairShareList.tsx
@@ -25,7 +25,14 @@ import {
   parseAsString,
   useQueryStates,
 } from 'nuqs';
-import { Suspense, useDeferredValue, useEffect, useEffectEvent } from 'react';
+import {
+  Suspense,
+  useDeferredValue,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -42,6 +49,9 @@ const useStyles = createStyles(({ css, token }) => ({
 type FairShareStepKey = 'resource-group' | 'domain' | 'project' | 'user';
 
 type StepItem = NonNullable<StepsProps['items']>[number];
+
+const generateStepEntryFetchKey = () =>
+  `step-entry-${new Date().toISOString()}`;
 
 const FairShareList: React.FC = () => {
   'use memo';
@@ -80,6 +90,57 @@ const FairShareList: React.FC = () => {
       current: null,
     });
   };
+
+  // Each step entry mints a fresh initial fetchKey so a remounted step never
+  // reuses react-relay's QueryResource entry from a previous visit — that
+  // cache entry outlives the unmount while the Relay store may have GC'd its
+  // records, and reading the combination crashes on @required. The keys live
+  // in this committed parent instead of the step components: a suspended step
+  // transition discards and restarts background renders, so a useState
+  // initializer inside a step would mint a new key per attempt and duplicate
+  // the network request.
+  const [stepEntryFetchKeys, setStepEntryFetchKeys] = useState<
+    Record<FairShareStepKey, string>
+  >(() => {
+    const initialKey = generateStepEntryFetchKey();
+    return {
+      'resource-group': initialKey,
+      domain: initialKey,
+      project: initialKey,
+      user: initialKey,
+    };
+  });
+  const regenerateStepEntryFetchKey = useEffectEvent(() => {
+    const enteredStep: FairShareStepKey = !stepQueryParams.resourceGroup
+      ? 'resource-group'
+      : !stepQueryParams.domain
+        ? 'domain'
+        : !stepQueryParams.project
+          ? 'project'
+          : 'user';
+    setStepEntryFetchKeys((prev) => ({
+      ...prev,
+      [enteredStep]: generateStepEntryFetchKey(),
+    }));
+  });
+  const visitedStepParamsRef = useRef<string | null>(null);
+  useEffect(() => {
+    const paramsSignature = `${stepQueryParams.resourceGroup}|${stepQueryParams.domain}|${stepQueryParams.project}`;
+    if (visitedStepParamsRef.current === paramsSignature) {
+      return;
+    }
+    const isInitialEntry = visitedStepParamsRef.current === null;
+    visitedStepParamsRef.current = paramsSignature;
+    // The mount-time keys already cover the first entry; regenerate only when
+    // the URL actually moves (click, back/forward, or BAIBackButton).
+    if (!isInitialEntry) {
+      regenerateStepEntryFetchKey();
+    }
+  }, [
+    stepQueryParams.resourceGroup,
+    stepQueryParams.domain,
+    stepQueryParams.project,
+  ]);
 
   const isStepTransitionPending = stepQueryParams !== deferredStepQueryParams;
 
@@ -239,6 +300,7 @@ const FairShareList: React.FC = () => {
         <Suspense fallback={null}>
           <ResourceGroupSchedulerTypeAlert
             resourceGroupName={deferredStepQueryParams.resourceGroup}
+            initialFetchKey={stepEntryFetchKeys.domain}
           />
         </Suspense>
       )}
@@ -274,6 +336,7 @@ const FairShareList: React.FC = () => {
         <Suspense fallback={<Skeleton active />}>
           {currentStep === 'resource-group' && (
             <ResourceGroupFairShareStep
+              initialFetchKey={stepEntryFetchKeys['resource-group']}
               loading={isStepTransitionPending}
               onClickResourceGroupName={(resourceGroupName) => {
                 setStepQueryParams({ resourceGroup: resourceGroupName });
@@ -284,6 +347,7 @@ const FairShareList: React.FC = () => {
           {currentStep === 'domain' && (
             <DomainFairShareStep
               resourceGroupName={deferredStepQueryParams.resourceGroup}
+              initialFetchKey={stepEntryFetchKeys.domain}
               loading={isStepTransitionPending}
               onClickDomainName={(domainName) => {
                 setStepQueryParams({ domain: domainName });
@@ -295,6 +359,7 @@ const FairShareList: React.FC = () => {
             <ProjectFairShareStep
               resourceGroupName={deferredStepQueryParams.resourceGroup}
               domainName={deferredStepQueryParams.domain}
+              initialFetchKey={stepEntryFetchKeys.project}
               loading={isStepTransitionPending}
               onClickProjectName={(projectId) => {
                 setStepQueryParams({ project: projectId });
@@ -307,6 +372,7 @@ const FairShareList: React.FC = () => {
               resourceGroupName={deferredStepQueryParams.resourceGroup}
               domainName={deferredStepQueryParams.domain}
               projectId={deferredStepQueryParams.project}
+              initialFetchKey={stepEntryFetchKeys.user}
               loading={isStepTransitionPending}
             />
           )}

--- a/react/src/components/FairShareItems/ProjectFairShareStep.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareStep.tsx
@@ -37,6 +37,7 @@ import { graphql, useLazyLoadQuery } from 'react-relay';
 interface ProjectFairShareStepProps {
   resourceGroupName: string;
   domainName: string;
+  initialFetchKey: string;
   loading?: boolean;
   onClickProjectName?: (projectName: string) => void;
 }
@@ -44,6 +45,7 @@ interface ProjectFairShareStepProps {
 const ProjectFairShareStep: React.FC<ProjectFairShareStepProps> = ({
   resourceGroupName,
   domainName,
+  initialFetchKey,
   loading,
   onClickProjectName,
 }) => {
@@ -91,7 +93,9 @@ const ProjectFairShareStep: React.FC<ProjectFairShareStepProps> = ({
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const [fetchKey, updateFetchKey] = useFetchKey();
-  const deferredFetchKey = useDeferredValue(fetchKey);
+  const effectiveFetchKey =
+    fetchKey === INITIAL_FETCH_KEY ? initialFetchKey : fetchKey;
+  const deferredFetchKey = useDeferredValue(effectiveFetchKey);
 
   const { resourceGroups, projectFairShares } =
     useLazyLoadQuery<ProjectFairShareStepQuery>(
@@ -139,7 +143,7 @@ const ProjectFairShareStep: React.FC<ProjectFairShareStepProps> = ({
       {
         fetchKey: deferredFetchKey,
         fetchPolicy:
-          deferredFetchKey === INITIAL_FETCH_KEY
+          deferredFetchKey === initialFetchKey
             ? 'store-and-network'
             : 'network-only',
       },
@@ -194,7 +198,7 @@ const ProjectFairShareStep: React.FC<ProjectFairShareStepProps> = ({
           <AutoUpdateFetchKeyButton
             settingId="fair-share-list"
             autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}
-            loading={fetchKey !== deferredFetchKey}
+            loading={effectiveFetchKey !== deferredFetchKey}
             value=""
             onChange={() => {
               updateFetchKey();
@@ -209,7 +213,7 @@ const ProjectFairShareStep: React.FC<ProjectFairShareStepProps> = ({
         loading={
           loading ||
           queryVariables !== deferredQueryVariables ||
-          fetchKey !== deferredFetchKey
+          effectiveFetchKey !== deferredFetchKey
         }
         selectedRows={selectedRows}
         onRowSelect={(selectedRowKeys, currentPageItems) => {

--- a/react/src/components/FairShareItems/ResourceGroupFairShareStep.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareStep.tsx
@@ -28,11 +28,13 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 interface ResourceGroupFairShareStepProps {
+  initialFetchKey: string;
   loading?: boolean;
   onClickResourceGroupName?: (resourceGroupName: string) => void;
 }
 
 const ResourceGroupFairShareStep: React.FC<ResourceGroupFairShareStepProps> = ({
+  initialFetchKey,
   loading,
   onClickResourceGroupName,
 }) => {
@@ -72,7 +74,9 @@ const ResourceGroupFairShareStep: React.FC<ResourceGroupFairShareStepProps> = ({
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const [fetchKey, updateFetchKey] = useFetchKey();
-  const deferredFetchKey = useDeferredValue(fetchKey);
+  const effectiveFetchKey =
+    fetchKey === INITIAL_FETCH_KEY ? initialFetchKey : fetchKey;
+  const deferredFetchKey = useDeferredValue(effectiveFetchKey);
 
   const { resourceGroups } = useLazyLoadQuery<ResourceGroupFairShareStepQuery>(
     graphql`
@@ -101,7 +105,7 @@ const ResourceGroupFairShareStep: React.FC<ResourceGroupFairShareStepProps> = ({
     {
       fetchKey: deferredFetchKey,
       fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
+        deferredFetchKey === initialFetchKey
           ? 'store-and-network'
           : 'network-only',
     },
@@ -129,7 +133,7 @@ const ResourceGroupFairShareStep: React.FC<ResourceGroupFairShareStepProps> = ({
         <AutoUpdateFetchKeyButton
           settingId="fair-share-list"
           autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}
-          loading={fetchKey !== deferredFetchKey}
+          loading={effectiveFetchKey !== deferredFetchKey}
           value=""
           onChange={() => {
             updateFetchKey();
@@ -149,7 +153,7 @@ const ResourceGroupFairShareStep: React.FC<ResourceGroupFairShareStepProps> = ({
         loading={
           loading ||
           queryVariables !== deferredQueryVariables ||
-          fetchKey !== deferredFetchKey
+          effectiveFetchKey !== deferredFetchKey
         }
         pagination={{
           pageSize: tablePaginationOption.pageSize,

--- a/react/src/components/FairShareItems/ResourceGroupSchedulerTypeAlert.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupSchedulerTypeAlert.tsx
@@ -9,11 +9,12 @@ import { graphql, useLazyLoadQuery } from 'react-relay';
 
 interface ResourceGroupSchedulerTypeAlertProps extends AlertProps {
   resourceGroupName: string;
+  initialFetchKey: string;
 }
 
 const ResourceGroupSchedulerTypeAlert: React.FC<
   ResourceGroupSchedulerTypeAlertProps
-> = ({ resourceGroupName, ...alertProps }) => {
+> = ({ resourceGroupName, initialFetchKey, ...alertProps }) => {
   'use memo';
 
   const { t } = useTranslation();
@@ -40,7 +41,7 @@ const ResourceGroupSchedulerTypeAlert: React.FC<
         }
       `,
       { resourceGroupName },
-      { fetchPolicy: 'store-and-network' },
+      { fetchPolicy: 'store-and-network', fetchKey: initialFetchKey },
     );
 
   const resourceGroup = resourceGroups?.edges?.[0]?.node;

--- a/react/src/components/FairShareItems/UserFairShareStep.tsx
+++ b/react/src/components/FairShareItems/UserFairShareStep.tsx
@@ -39,6 +39,7 @@ interface UserFairShareStepProps {
   resourceGroupName: string;
   domainName: string;
   projectId: string;
+  initialFetchKey: string;
   loading?: boolean;
 }
 
@@ -46,6 +47,7 @@ const UserFairShareStep: React.FC<UserFairShareStepProps> = ({
   resourceGroupName,
   domainName,
   projectId,
+  initialFetchKey,
   loading,
 }) => {
   'use memo';
@@ -93,7 +95,9 @@ const UserFairShareStep: React.FC<UserFairShareStepProps> = ({
   };
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const [fetchKey, updateFetchKey] = useFetchKey();
-  const deferredFetchKey = useDeferredValue(fetchKey);
+  const effectiveFetchKey =
+    fetchKey === INITIAL_FETCH_KEY ? initialFetchKey : fetchKey;
+  const deferredFetchKey = useDeferredValue(effectiveFetchKey);
 
   const { resourceGroups, userFairShares } =
     useLazyLoadQuery<UserFairShareStepQuery>(
@@ -143,7 +147,7 @@ const UserFairShareStep: React.FC<UserFairShareStepProps> = ({
       {
         fetchKey: deferredFetchKey,
         fetchPolicy:
-          deferredFetchKey === INITIAL_FETCH_KEY
+          deferredFetchKey === initialFetchKey
             ? 'store-and-network'
             : 'network-only',
       },
@@ -215,7 +219,7 @@ const UserFairShareStep: React.FC<UserFairShareStepProps> = ({
           <AutoUpdateFetchKeyButton
             settingId="fair-share-list"
             autoUpdateDelayOptions={LONG_AUTO_UPDATE_DELAY_OPTIONS}
-            loading={fetchKey !== deferredFetchKey}
+            loading={effectiveFetchKey !== deferredFetchKey}
             value=""
             onChange={() => {
               updateFetchKey();
@@ -230,7 +234,7 @@ const UserFairShareStep: React.FC<UserFairShareStepProps> = ({
         loading={
           loading ||
           queryVariables !== deferredQueryVariables ||
-          fetchKey !== deferredFetchKey
+          effectiveFetchKey !== deferredFetchKey
         }
         selectedRows={selectedRows}
         onRowSelect={(selectedRowKeys, currentPageItems) => {


### PR DESCRIPTION
Resolves #8515 (FR-3430)

> Stacked on #8516 (`refactor/FR-3430-fairshare-step-queries`).

## Problem

Revisiting a FairShare step intermittently crashed into the "invalid parameter" `ErrorBoundary` fallback (`Relay: Missing @required value at path 'domainFairShares' ...`) with **zero network requests**, even though every server response in the session was clean. A full page reload always cleared it.

## Root cause

Three layered client-side behaviors combine (verified live in Chrome with an instrumented Relay environment):

1. **Relay store GC** — leaving a step releases its queries into the store's GC release buffer (default **10** slots). The FairShare screens churn released `(query, variables)` combos fast — notably one `*ResourceGroupWarningIconQuery` **per table row** — so a step's query gets evicted and its records garbage-collected after a normal round trip. GC runs as a deferred incremental pass, which is why the crash is intermittent: returning before the pass completes re-retains the data unharmed.
2. **QueryResource cache hit skips the fetch** — every step mounts with the same shared `INITIAL_FETCH_KEY` constant, so a remount reproduces the exact react-relay cache identifier (`fetchPolicy + variables + fetchKey`). `QueryResource.prepare()` then reuses the previous mount's entry and **never issues a network request** (`fetchPolicy` is only consulted on a cache miss — `network-only` would not help; see facebook/relay#3502).
3. **`@required(action: THROW)` fires on GC'd data** — `RelayReader._handleRequiredFieldValue` uses a loose `value == null` check, so records deleted by GC (read as `undefined`) throw exactly like an explicit server `null`.

## Solution

`FairShareList` owns **one entry fetchKey per step** and regenerates the target step's key whenever the step URL params actually move — covering clicks, browser back/forward, and `BAIBackButton` uniformly. Step components substitute that key for `INITIAL_FETCH_KEY`, so a re-entered step always misses the QueryResource cache: `store-and-network` renders surviving cached data instantly (with a background refresh) and suspends until the network response when the data was GC'd.

The keys deliberately live in the **committed parent**, not in a `useState` inside each step: a suspended step transition discards and restarts background renders, so a per-mount initializer in a step would mint a new key per render attempt and duplicate the request (an earlier revision of this fix did exactly that and produced 3-4 identical queries per transition). `ResourceGroupSchedulerTypeAlert` shares the domain-entry key since a GC'd read silently hides the alert instead of crashing. The shared `useFetchKey` hook is unchanged.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- Root-cause A/B repro (per-mount-key revision, automated step round trips incl. GC idle gaps): before — crash within 2 cycles, dangling `rgProjectFairShares` refs in the store, 0 requests at crash time, 0 error/null responses all session; after — 0 errors across 3+ cycles with every re-entry issuing a fresh request.
- ⚠️ The final parent-owned-key revision passed `verify.sh` but its live request-count measurement is **pending** — the backend test server became unreachable mid-verification. Will re-run: expected behavior is exactly 1 step-query request per step entry (no per-attempt duplication).

## Follow-ups (out of scope)

- Fold per-row `*ResourceGroupWarningIconQuery` data into the step queries to cut release-buffer churn (needs backend: `DomainV2`/`ProjectV2` do not expose scaling-group association).
- Consider raising `gcReleaseBufferSize` in `RelayEnvironment.ts` app-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)