### PR TITLE
fix(FR-3394): keep the accelerator allocation when restoring a session from history

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -292,7 +292,13 @@ const ResourceAllocationFormItems: React.FC<
         allocationPreset: 'auto-select',
       });
     }
-    if (supportedAcceleratorTypesInRGByImage?.length === 0) {
+    if (
+      supportedAcceleratorTypesInRGByImage?.length === 0 &&
+      // `currentImage` is a watched value and lags the store by a render, so
+      // read the image fresh — a restore that just cleared it must not be read
+      // as an image that supports nothing.
+      form.getFieldValue(['environments', 'image'])
+    ) {
       form.setFieldsValue({
         resource: {
           accelerator: 0,

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1445,6 +1445,19 @@ const SessionLauncherPage = () => {
               fieldsValue.sessionName =
                 fieldsValue.sessionName + '-' + generateRandomString(4);
             }
+
+            // A stale `image` makes the resource form judge the accelerator
+            // against the wrong image. Clear it only on a version change —
+            // nothing re-derives it otherwise.
+            if (
+              fieldsValue.environments?.version !==
+              form.getFieldValue(['environments', 'version'])
+            ) {
+              fieldsValue.environments = {
+                ...fieldsValue.environments,
+                image: undefined,
+              };
+            }
             form.setFieldsValue(fieldsValue as SessionLauncherFormData);
             setCurrentStep(steps.length - 1);
             form.validateFields().catch(() => {});


### PR DESCRIPTION
Resolves #8437 (FR-3394)

## Problem

Restoring a session from **Start session from recent history** dropped the accelerator allocation. An entry saved with `0.5` fGPU came back with `0`, and that zero was then synced into the URL, so refreshing the page made the loss permanent.

Only the accelerator was affected — the resource preset, CPU, memory and shared memory all restored correctly.

## Cause

`environments.image` is not persisted with the rest of the form. It is *derived* from `environments.version` and re-resolved by an effect in `ImageEnvironmentSelectFormItems`.

A restore therefore writes the new version and the restored resource values in a single commit, while `environments.image` still points at whatever image was selected beforehand. In that window `ResourceAllocationFormItems` asked the **previous** image whether the resource group's accelerator slot was usable. A CUDA allocation judged against an NPU-only image (`supported_accelerators: ["rngd"]` vs the group's `cuda.shares`) looks unsupported, so the field was cleared.

The image resolved correctly a moment later, but that code path only ever *clears* an allocation — there is no branch that restores one — so the zero stayed.

Instrumented run, in order:

```
AFTER-STORE  imageInStore: null, accel: 0.5      ← restore lands
SITE-A       hasImage: true, accelBefore: 0.5→0  ← judged against the stale image
IMG-EFFECT   matched: true, writing the CUDA image  ← resolves correctly, too late
```

## Fix

Two halves; both are required.

**`SessionLauncherPage`** — drop the derived image when the restored version differs from the current one, so the form reports "image unknown" rather than answering with a stale one. When the version is unchanged the existing image still matches it, and clearing would strand the field: the effect that re-derives the image only reacts to version changes.

**`ResourceAllocationFormItems`** — read the image from the store instead of the watched value before discarding an allocation. `Form.useWatch` lags the store by a render, so the just-cleared image was still visible as present at exactly the moment the decision was made. Reading it fresh removes the timing dependency.

## How to reproduce / test

Backend: `10.100.4.133`

1. Point the WebUI at that server and pick a resource group that exposes a
   `cuda.shares` slot.
2. Start a session on a **CUDA** image with a non-zero fGPU allocation. This
   writes the recent-history entry the test needs.
3. Open the session launcher again and use **Start session from recent
   history**, then click that entry.
4. The accelerator keeps its value. Refresh the page and it is still there.

On `main` the field comes back as `0` at step 4, and the refresh in step 5
makes the loss permanent because the zero is synced into the URL.

Two more cases worth exercising:

- Restore an entry whose image is the one already selected — the accelerator
  field should still show the correct required / min / max markers.
- Switch to an image that genuinely cannot run the accelerator (one whose
  `supported_accelerators` does not cover `cuda`) — the allocation should still
  be cleared, since that is the intended behaviour.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

Checked against a live cluster with a `cuda.shares` slot:

- restoring an entry with `0.5` fGPU keeps the allocation, and it survives a refresh
- restoring an entry that uses the currently selected image still shows correct required / min / max on the accelerator field (the branch that skips clearing)
- switching to an image that genuinely cannot run the accelerator still clears it — no regression in the intended behaviour

## Note on the linked issue

FR-3394 also carries a second report, about environment variable values disappearing when they contain a slash. That was investigated and is **not** a defect in the way it was described: `sanitizeSensitiveEnv` (`react/src/components/EnvVarFormList.tsx`) blanks a value when the variable *name* substring-matches a sensitive pattern, and `TIKTOKEN_CACHE_DIR` matches `/TOKEN/i`. The slash in the value was incidental. That behaviour is out of scope here and the issue text is left as reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdM5kdViXpYxdJ2vCdXvhq

