### PR TITLE
fix: stamp the real `BUILD_NUMBER` in release builds instead of `1`

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -40,8 +40,14 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      # Full history: `make versiontag` derives BUILD_NUMBER from
+      # `git rev-list --count`, which returns 1 on the default shallow
+      # (fetch-depth: 1) checkout. Only this job runs versiontag — the desktop
+      # jobs restore build/web/ from the web-build artifact.
       - name: Check out Git repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v5
         name: Install pnpm

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_DATE := $(shell date +%y%m%d)
-BUILD_TIME := $(shell date +%H%m%S)
+BUILD_TIME := $(shell date +%H%M%S)
 BUILD_VERSION := $(shell grep version package.json | head -1 | cut -c 15- | rev | cut -c 3- | rev)
-BUILD_NUMBER := $(shell git rev-list --count $(shell git rev-parse --abbrev-ref HEAD))
+BUILD_NUMBER := $(shell git rev-list --count HEAD)
 REVISION_INDEX := $(shell git --no-pager log --pretty=format:%h -n 1)
 site := $(or $(site),main)
 


### PR DESCRIPTION
Resolves #8571

## Problem

26.8.0 shipped `Build 1`:

```
26.8.0 bundle: { "package": "26.8.0", "buildNumber": "1", "buildDate": "260731.090755", "revision": "d3cee73" }
```

`BUILD_NUMBER` is a commit count, and `package.yml` checks out with `actions/checkout`'s default `fetch-depth: 1` — a shallow clone at a detached tag. Reproduced locally against this repo:

```
$ git clone --depth 1 … shallow && git clone … full
shallow: 1 | full: 8568
shallow detached abbrev-ref: HEAD -> count 1
```

CI has been stamping `1` for a long time — the **26.7.3** bundle's `version.json` says `"buildNumber": "1"` too. It only became visible in 26.8.0 because until 26.7.x the `versiontag` sed used BRE escaping under `-E`:

```make
sed -i -E 's/globalThis.buildNumber = "\([^"]*\)"/.../g' index.html
```

`\(` / `\)` are literal parens in ERE, so the substitution was a silent no-op and `index.html` kept the release manager's locally committed value (26.7.3 shipped `8443`). bfea3e28d (#8273) removed the escapes, the sed started working, and CI's real `1` finally landed.

## Changes

- **`.github/workflows/package.yml`** — `fetch-depth: 0` on `build_web`'s checkout. That is the only job that runs `make dep_web` → `versiontag`; `build_mac` / `build_desktop` restore `build/web/` from the `web-build` artifact, so `dep_web`'s `[ ! -d ./build/web/ ]` guard skips `compile` there and they inherit the correct stamp.
- **`Makefile`** — count from `HEAD` instead of `git rev-parse --abbrev-ref HEAD`. Identical on a branch, and on the detached tag checkout the inner command resolved to the literal string `HEAD` anyway — one less subshell, one less footgun.
- **`Makefile`** — `date +%H%m%S` → `%H%M%S`. `%m` is *month*: `260731.090755` read as hour `09`, month `07`, second `55`. Nothing parses `buildDate`, so this is cosmetic-only.

## Verification

```
$ make -p | grep -E '^BUILD_(NUMBER|TIME)'
BUILD_TIME := 103918
BUILD_NUMBER := 8568
```

Workflow-only + Makefile-only change; `scripts/verify.sh` covers no code touched here. Full end-to-end confirmation comes from the next release (or a `workflow_dispatch` dry run) stamping a real build number instead of `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)