### PR TITLE
fix(FR-3465): closed notifications reappear when a new notification is shown

### DIFF
--- a/react/src/hooks/__tests__/useBAINotification.test.tsx
+++ b/react/src/hooks/__tests__/useBAINotification.test.tsx
@@ -1,0 +1,187 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  useBAINotificationEffect,
+  useBAINotificationState,
+} from '../useBAINotification';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { App } from 'antd';
+import React from 'react';
+
+vi.mock('..', () => ({
+  useWebUINavigate: () => vi.fn(),
+}));
+
+vi.mock('../useBAISetting', () => ({
+  useBAISettingUserState: () => [false, vi.fn()],
+}));
+
+vi.mock('../../helper', () => ({
+  listenToBackgroundTask: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('../../components/BAINodeNotificationItem', () => ({
+  default: () => <div>node-item</div>,
+}));
+vi.mock('../../components/BAIMultiStepNotificationItem', () => ({
+  default: () => <div>multistep-item</div>,
+}));
+vi.mock('../../components/BAIGeneralNotificationItem', () => ({
+  default: ({ notification }: any) => (
+    <div data-testid={`general-item-${notification.key}`}>
+      {String(notification.description ?? '')}
+    </div>
+  ),
+}));
+
+const Effects: React.FC = () => {
+  useBAINotificationEffect();
+  return null;
+};
+
+let latestState: ReturnType<typeof useBAINotificationState>[0] | null = null;
+let latestSetters: ReturnType<typeof useBAINotificationState>[1] | null = null;
+
+const StateProbe: React.FC = () => {
+  const [notifications, setters] = useBAINotificationState();
+  React.useEffect(() => {
+    latestState = notifications;
+    latestSetters = setters;
+  });
+  return null;
+};
+
+const Harness: React.FC = () => (
+  <App>
+    <Effects />
+    <StateProbe />
+  </App>
+);
+
+const getOpen = (key: string) => latestState?.find((n) => n.key === key)?.open;
+
+const upsertOpen = (key: string) => {
+  act(() => {
+    latestSetters?.upsertNotification({
+      key,
+      description: key,
+      open: true,
+      duration: 0,
+    });
+  });
+};
+
+describe('useBAINotification antd <-> state sync', () => {
+  beforeEach(() => {
+    act(() => {
+      latestSetters?.clearAllNotifications?.();
+    });
+  });
+
+  // Regression: since antd 6.5 (rc-notification 2.x),
+  // `notification.destroy(key)` no longer fires the notice's `onClose`
+  // callback, so closeNotification must flip `open` in the state itself.
+  // Otherwise the reactive opener re-shows the closed notification whenever
+  // any other notification changes ("zombie re-open").
+  it('closeNotification flips state open to false', async () => {
+    render(<Harness />);
+
+    upsertOpen('session-A');
+    await waitFor(() => {
+      expect(screen.getByTestId('general-item-session-A')).toBeInTheDocument();
+    });
+    expect(getOpen('session-A')).toBe(true);
+
+    // Same call as BAIComputeSessionNodeNotificationItem's auto-close on
+    // TERMINATED/CANCELLED.
+    act(() => {
+      latestSetters?.closeNotification('session-A');
+    });
+
+    await waitFor(() => {
+      expect(getOpen('session-A')).toBe(false);
+    });
+    // It remains in the list (drawer) — only hidden.
+    expect(latestState?.some((n) => n.key === 'session-A')).toBe(true);
+  });
+
+  it('a closed notification is not re-opened by an unrelated state change', async () => {
+    render(<Harness />);
+
+    upsertOpen('session-A');
+    await waitFor(() => {
+      expect(screen.getByTestId('general-item-session-A')).toBeInTheDocument();
+    });
+
+    act(() => {
+      latestSetters?.closeNotification('session-A');
+    });
+    await waitFor(() => {
+      expect(getOpen('session-A')).toBe(false);
+    });
+
+    // An unrelated notification appears.
+    upsertOpen('other-B');
+    await waitFor(() => {
+      expect(screen.getByTestId('general-item-other-B')).toBeInTheDocument();
+    });
+
+    // session-A must stay closed.
+    expect(getOpen('session-A')).toBe(false);
+  });
+
+  it('duration-based auto close flips state open to false via onClose', async () => {
+    render(<Harness />);
+
+    act(() => {
+      latestSetters?.upsertNotification({
+        key: 'auto-C',
+        description: 'auto C',
+        open: true,
+        duration: 0.3,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('general-item-auto-C')).toBeInTheDocument();
+    });
+    expect(getOpen('auto-C')).toBe(true);
+
+    await waitFor(
+      () => {
+        expect(getOpen('auto-C')).toBe(false);
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it('clearNotification removes the entry from the list', async () => {
+    render(<Harness />);
+
+    upsertOpen('session-A');
+    await waitFor(() => {
+      expect(screen.getByTestId('general-item-session-A')).toBeInTheDocument();
+    });
+
+    act(() => {
+      latestSetters?.clearNotification('session-A');
+    });
+
+    await waitFor(() => {
+      expect(latestState?.some((n) => n.key === 'session-A')).toBe(false);
+    });
+
+    // A later unrelated notification must not resurrect it.
+    upsertOpen('other-B');
+    await waitFor(() => {
+      expect(screen.getByTestId('general-item-other-B')).toBeInTheDocument();
+    });
+    expect(latestState?.some((n) => n.key === 'session-A')).toBe(false);
+  });
+});

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -91,21 +91,11 @@ export interface NotificationState<T = any> extends Omit<
     steps: Array<{
       label: string;
       status:
-        | 'idle'
-        | 'pending'
-        | 'resolved'
-        | 'rejected'
-        | 'warned'
-        | 'cancelled';
+        'idle' | 'pending' | 'resolved' | 'rejected' | 'warned' | 'cancelled';
       progress?: number;
     }>;
     overallStatus:
-      | 'idle'
-      | 'running'
-      | 'completed'
-      | 'failed'
-      | 'warned'
-      | 'cancelled';
+      'idle' | 'running' | 'completed' | 'failed' | 'warned' | 'cancelled';
   };
 }
 
@@ -463,15 +453,28 @@ export const useSetBAINotification = () => {
    * Function to hide specific notification. It remains in the drawer.
    */
   const closeNotification = (key: React.Key) => {
+    // Since antd 6.5 (rc-notification 2.x), `notification.destroy(key)` no
+    // longer fires the notice's `onClose` callback, so the state must be
+    // marked closed here. Otherwise the reactive opener re-shows this
+    // notification on the next state change (zombie re-open).
+    _.remove(_activeNotificationKeys, (k) => k === key);
     app.notification.destroy(key);
+    setNotifications((prevList) => {
+      const idx = prevList.findIndex((n) => n.key === key);
+      if (idx < 0 || prevList[idx].open === false) return prevList;
+      const newList = [...prevList];
+      newList[idx] = { ...newList[idx], open: false };
+      return newList;
+    });
   };
 
   /**
    * Function to remove specific notification from the list and hide it.
    */
   const clearNotification = (key: React.Key) => {
+    _.remove(_activeNotificationKeys, (k) => k === key);
+    app.notification.destroy(key);
     setNotifications((prev) => prev.filter((n) => n.key !== key));
-    closeNotification(key);
   };
 
   /**


### PR DESCRIPTION
Resolves #8581 (FR-3465)

## Symptom

A notification that has already been closed — e.g. a **session notification that auto-closes ~3s after the session status changes to TERMINATED/CANCELLED** — reappears in the bottom-right toast area whenever any other notification is shown or updated.

## Root cause

`useSetBAINotification().closeNotification(key)` only called `app.notification.destroy(key)` and relied on antd firing the notice's `onClose` callback to flip `open: false` in `notificationListState`.

Since FR-3330 (#8295) bumped antd `6.3.5 → 6.5.0`, antd bundles **@rc-component/notification 2.x**, where the imperative `close(key)` no longer invokes `config.onClose`:

```js
// @rc-component/notification 2.0.7 — Notifications.js
close: key => {
  setConfigList(list => list.filter(item => item.key !== key));
},
```

(In 1.2.0 / antd 6.3.x this was `close: key => { onNoticeClose(key); }`, which called `config.onClose?.()`. The duration-based auto close and the X button still fire `onClose` in 2.x — only imperative closes are affected.)

So after `closeNotification(key)` the atom entry stayed `open: true`, and the reactive opener in `useBAINotificationEffect` re-calls `app.notification.open()` for every `open === true` entry on every state change — the closed notification zombie-reopens as soon as any other notification appears.

## Changes

- `closeNotification(key)` now removes the key from `_activeNotificationKeys`, destroys the antd notice, **and marks the state entry `open: false`** itself instead of relying on antd's `onClose`.
- `clearNotification(key)` likewise cleans `_activeNotificationKeys` and destroys directly (delegating to `closeNotification` would no-op on the just-removed entry).
- Adds regression tests (`react/src/hooks/__tests__/useBAINotification.test.tsx`) rendering the real antd `App` + `useBAINotificationEffect`:
  - imperative close flips `open` to `false` (fails on the previous code)
  - a closed notification is not re-opened by an unrelated state change (fails on the previous code)
  - duration-based auto close still syncs state via `onClose`
  - `clearNotification` removes the entry and it is not resurrected

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `npx vitest run src/hooks/__tests__/useBAINotification.test.tsx` → 4 passed (the two regression cases fail against the previous implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
