### PR TITLE
fix(FR-3463): treat a missing usage slot as zero, not unlimited

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIStatistic.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIStatistic.test.tsx
@@ -263,7 +263,7 @@ describe('BAIStatistic', () => {
       expect(progress).toHaveAttribute('aria-valuenow', '0');
     });
 
-    it('should return 100% when total is 0', () => {
+    it('should return 100% when total is 0 and current is over quota', () => {
       const { container } = render(
         <BAIStatistic
           title="CPU"
@@ -272,7 +272,37 @@ describe('BAIStatistic', () => {
           progressMode="normal"
         />,
       );
-      // When total is 0, returns 100% (line 49: division by zero case)
+      // Allocation against a zero quota is fully over budget.
+      const progress = container.querySelector(
+        '[role="progressbar"]',
+      ) as HTMLElement;
+      expect(progress).toBeInTheDocument();
+      expect(progress).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('should return 0% when both total and current are 0', () => {
+      const { container } = render(
+        <BAIStatistic
+          title="GPU"
+          current={0}
+          total={0}
+          progressMode="normal"
+        />,
+      );
+      // A zero quota with nothing allocated is empty, not full.
+      const progress = container.querySelector(
+        '[role="progressbar"]',
+      ) as HTMLElement;
+      expect(progress).toBeInTheDocument();
+      expect(progress).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('should return 100% when total is 0 and current is undefined', () => {
+      const { container } = render(
+        <BAIStatistic title="CPU" total={0} progressMode="normal" />,
+      );
+      // Only an explicit 0 empties the gauge; an unknown current stays full,
+      // the same as it does against a non-zero total.
       const progress = container.querySelector(
         '[role="progressbar"]',
       ) as HTMLElement;
@@ -284,8 +314,7 @@ describe('BAIStatistic', () => {
       const { container } = render(
         <BAIStatistic title="CPU" total={8} progressMode="normal" />,
       );
-      // When current is undefined: !_.isFinite(undefined) is true at line 49,
-      // so calculatePercent() returns 100 (not 0)
+      // An undefined current is not finite, so it reports as full, not empty.
       const progress = container.querySelector(
         '[role="progressbar"]',
       ) as HTMLElement;

--- a/packages/backend.ai-ui/src/components/BAIStatistic.tsx
+++ b/packages/backend.ai-ui/src/components/BAIStatistic.tsx
@@ -46,7 +46,10 @@ const BAIStatistic: React.FC<BAIStatisticProps> = ({
 
   const calculatePercent = (): number => {
     if (!showProgress || total === undefined || total === Infinity) return 0;
-    if (!_.isFinite(current) || !isFinite(total) || total === 0) return 100;
+    // Nothing allocated out of a zero quota is empty, not full. Anything else
+    // against a zero quota — including a non-finite current — stays full.
+    if (total === 0) return current === 0 ? 0 : 100;
+    if (!_.isFinite(current) || !isFinite(total)) return 100;
     return _.isUndefined(current) ? 0 : Math.round((current / total) * 100);
   };
 

--- a/react/src/components/MyResource.tsx
+++ b/react/src/components/MyResource.tsx
@@ -57,13 +57,21 @@ const MyResource: React.FC<MyResourceProps> = ({
   const resourceSlotsDetails = useResourceSlotsDetails();
 
   const resourceData = (() => {
+    // A failed request is a no-data state, not zero usage across every slot.
+    if (!checkPresetInfo) {
+      return { cpu: null, memory: null, accelerators: [] };
+    }
+
+    // Every `keypair_using` read below defaults to 0: the payload omits slots
+    // the keypair holds no allocation for, and `convertToNumber` would read
+    // that absence as unlimited. Only limits are unlimited when absent.
     const cpuSlot = resourceSlotsDetails?.resourceSlotsInRG?.['cpu'];
     const memSlot = resourceSlotsDetails?.resourceSlotsInRG?.['mem'];
 
     const cpuData = cpuSlot
       ? {
           used: {
-            current: convertToNumber(checkPresetInfo?.keypair_using.cpu),
+            current: convertToNumber(checkPresetInfo.keypair_using.cpu ?? 0),
             total: convertToNumber(resourceLimitsWithoutResourceGroup.cpu?.max),
           },
           free: {
@@ -81,7 +89,7 @@ const MyResource: React.FC<MyResourceProps> = ({
       ? {
           used: {
             current: processMemoryValue(
-              checkPresetInfo?.keypair_using.mem,
+              checkPresetInfo.keypair_using.mem ?? 0,
               memSlot.display_unit,
             ),
             total: processMemoryValue(
@@ -116,7 +124,7 @@ const MyResource: React.FC<MyResourceProps> = ({
             key,
             used: {
               current: convertToNumber(
-                checkPresetInfo?.keypair_using[key as ResourceSlotName],
+                checkPresetInfo.keypair_using[key as ResourceSlotName] ?? 0,
               ),
               total: convertToNumber(
                 resourceLimitsWithoutResourceGroup.accelerators[key]?.max,


### PR DESCRIPTION
Resolves #8576 (FR-3463)

## Symptom

On the Dashboard **My Resource Usage** (나의 총자원 사용량) panel, GPU usage rendered as **Unlimited (제한없음)** for users who actually have a finite GPU limit. The progress gauge sat at 100% and the tooltip read `∞ fGPU / 0.5 fGPU`.

| | Before | After |
|---|---|---|
| Big number | `제한없음` | `0` |
| Gauge | full | empty |
| Tooltip | `∞ fGPU / 0.5 fGPU` | `0 fGPU / 0.5 fGPU` |

**Before** — a keypair limited to `0.5` fGPU, running CPU-only sessions. GPU reads `제한없음` under a full gauge.

![My Resource Usage before the fix](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8583/20260804-171447-my-resource-usage-before.png)

**After** — same account, same sessions. GPU reads `0 fGPU` and the gauge is empty.

![My Resource Usage after the fix](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8583/20260804-171456-my-resource-usage-after.png)

## How to reproduce

The condition is **partial occupancy**: a GPU limit exists, but nothing is allocated against it.

1. Create or edit a keypair resource policy (Resource Policy page) and set a finite GPU value in `total_resource_slots` — e.g. `cuda.shares: 0.5`. Uncheck **Unlimited** on that slot.
   Use a dedicated policy rather than editing `default`, which is shared by every keypair referencing it.
2. Attach that policy to a test keypair (Credentials → the keypair → Resource Policy). `modify_keypair` swaps the policy in place, so there is no need to recreate the key.
3. Log in with that keypair and start **only CPU sessions** — no GPU session at all.
4. Open the Dashboard and look at the **My Resource Usage** panel.

Observed on `main`: GPU shows `제한없음` with a full gauge. Starting any GPU session makes the bug disappear, because the missing key gets filled in.

## Root cause

`POST /resource/check-presets` omits a slot key from `keypair_using` when the keypair has no allocation for that slot — the manager only zero-fills when the *entire* list is empty, so partial occupancy leaves holes (26.3.0+ normalized-table path). `keypair_limits` stays complete, which is what makes the two sides disagree.

On the WebUI side, `convertToNumber` maps a missing value to `Infinity`. That convention is correct for **limits** (no value = unlimited) and wrong for **usage** (no value = no allocation). `MyResource.tsx` fed `keypair_using` through it, so the absent GPU key became `∞` and hit the "Unlimited" display branch.

A backend-side consistency fix (always zero-fill `using`) is tracked separately; WebUI needs its own fix regardless, since it must work against already-released managers.

## Changes

`convertToNumber` and `processMemoryValue` are **untouched** — `free`/`total` still need missing → `∞`, and both are exported from `backend.ai-ui` and consumed by `AgentStats` and `TotalResourceWithinResourceGroup`. Nothing is added to the `backend.ai-ui` public API.

- **`MyResource.tsx`** — coalesce the `keypair_using` reads to `0` at the call site, for `used.current` only (cpu / mem / accelerators). `free.current` and `total` are unchanged. This matches the existing idiom in `AgentStats.tsx` and `TotalResourceWithinResourceGroup.tsx`, which already write `convertToNumber(capacity['cpu'] || 0)`.

  An earlier revision wrapped the coalesce in `convertUsageToNumber` / `processMemoryUsageValue` helpers. That was dropped on review: hiding the fallback behind a name conceals exactly what went wrong here — what a missing value turns into. `?? 0` at the call site is the thing a reader needs to see.

- **`BAIStatistic.tsx`** — `calculatePercent` returned 100% whenever `total === 0`. That was masked while usage arrived as `∞`; with usage fixed, a slot the policy denies outright would render `0 / 0` under a full bar. Nothing allocated out of a zero quota is empty, not full.

- **`MyResource.tsx`** — render the existing no-data state when `checkPresetInfo` is `null`. Without this, a failed `check-presets` request would report a confident `0` across every slot, which reads as a genuinely idle account. Matches the guard already in `AgentStats.tsx`.

### Deliberately out of scope

`MyResourceWithinResourceGroup.tsx` carries the same `// TODO: convertToNumber should not handle 'undefined' as Infinity.` comment, but it guards every slot with `_.isUndefined` already, so it has no visible defect. Its cleanup also requires updating the `backend.ai-ui` mock in `MyResourceWithinResourceGroup.test.tsx`, which makes it a refactor rather than part of this bug fix. Left for a separate change.

## Blast radius

`calculatePercent` is the only shared behavior change. `BAIStatistic` consumers:

| Consumer | `progressMode` | Affected |
|---|---|---|
| `SessionCountDashboardItem` | `hidden` | no — returns 0 before the branch |
| `MyResourceWithinResourceGroup` | `ghost` | no — the ghost branch ignores `percent` |
| `MyResource` | `normal` | **target** |
| `AgentStats` | `normal` | yes |
| `TotalResourceWithinResourceGroup` | `normal` | yes |

For the last two, a slot with zero capacity changes from a full gauge to an empty one. That is the same misreport being corrected, not a regression — an agent with no GPU should not show its GPU bar at 100%.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Terminology)
- Unit: `backend.ai-ui` 368 passed + 1 skipped, `react` 1048 passed. No existing test needed its assertions changed.
- New test: `BAIStatistic.test.tsx` gains the `total === 0 && current === 0 → 0%` case. The existing `total === 0` test keeps its 100% assertion (it passes `current={5}`) and was only renamed to say which half it covers.
- Manual: reproduce per the steps above; the panel shows `0 fGPU / 0.5 fGPU` with an empty gauge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuogmY1Avy9wnsuWrQHA29

