### PR TITLE
test(FR-3466): pin chat reasoning extraction and rule out the client-side flag

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -341,6 +341,16 @@ const PureChatCard: React.FC<ChatCardProps> = ({
                 middleware: [
                   extractReasoningMiddleware({
                     tagName: 'think',
+                    // Qwen3-style models are handed an opening `<think>` by
+                    // their chat template, so the *response* begins inside
+                    // reasoning and only ever emits the closing `</think>`.
+                    // Waiting for an opening tag that never arrives left the
+                    // reasoning inline in the answer, with a stray `</think>`
+                    // rendered as literal text. Starting in reasoning mode
+                    // costs nothing when a model emits no tags at all — with
+                    // no closing tag there is no match, and the text is passed
+                    // through untouched.
+                    startWithReasoning: true,
                   }),
                   // The openai-compatible provider does not advertise any
                   // `supportedUrls`, so the AI SDK treats a `data:` image

--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -339,18 +339,15 @@ const PureChatCard: React.FC<ChatCardProps> = ({
               model: wrapLanguageModel({
                 model: provider.chatModel(modelId),
                 middleware: [
+                  // NOTE: `startWithReasoning: true` looks like the fix for
+                  // Qwen3-style models, whose chat template supplies the
+                  // opening `<think>` so the response emits only the closing
+                  // tag. It is not: on the streaming path a model that emits
+                  // no tags at all never leaves reasoning mode, so its entire
+                  // answer is hidden. See `chatReasoningExtraction.test.ts`
+                  // and FR-3466 — the fix belongs at the serving layer.
                   extractReasoningMiddleware({
                     tagName: 'think',
-                    // Qwen3-style models are handed an opening `<think>` by
-                    // their chat template, so the *response* begins inside
-                    // reasoning and only ever emits the closing `</think>`.
-                    // Waiting for an opening tag that never arrives left the
-                    // reasoning inline in the answer, with a stray `</think>`
-                    // rendered as literal text. Starting in reasoning mode
-                    // costs nothing when a model emits no tags at all — with
-                    // no closing tag there is no match, and the text is passed
-                    // through untouched.
-                    startWithReasoning: true,
                   }),
                   // The openai-compatible provider does not advertise any
                   // `supportedUrls`, so the AI SDK treats a `data:` image

--- a/react/src/components/Chat/chatReasoningExtraction.test.ts
+++ b/react/src/components/Chat/chatReasoningExtraction.test.ts
@@ -3,7 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 /**
- * Pins the reasoning-extraction contract `ChatCard` relies on.
+ * Pins the reasoning-extraction contract `ChatCard` relies on, and records why
+ * the obvious client-side fix was rejected (FR-3466).
  *
  * Qwen3-style models are handed an opening `<think>` by their chat template,
  * so the response begins *inside* reasoning and only emits the closing
@@ -12,8 +13,16 @@
  * stays inline in the answer and the orphan `</think>` reaches the markdown
  * renderer — which escapes unknown tags and shows them as literal text.
  *
- * These assertions guard the `startWithReasoning: true` decision against an
- * `ai` upgrade quietly changing the semantics underneath it.
+ * `startWithReasoning: true` looks like the fix and is **not** one. On the
+ * streaming path — the one `ChatCard` uses via `streamText` — a model that
+ * emits no think tags never leaves reasoning mode, so its entire answer is
+ * routed to the collapsed panel and the visible message is empty. The
+ * non-streaming path passes the same input through untouched, so the two
+ * disagree and only a streaming test catches it.
+ *
+ * These assertions keep both behaviours visible, so the flag is not enabled
+ * again on the strength of the non-streaming path alone, and so an `ai`
+ * upgrade that changes the semantics fails loudly.
  */
 import { extractReasoningMiddleware } from 'ai';
 import { describe, expect, it } from 'vitest';

--- a/react/src/components/Chat/chatReasoningExtraction.test.ts
+++ b/react/src/components/Chat/chatReasoningExtraction.test.ts
@@ -1,0 +1,83 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Pins the reasoning-extraction contract `ChatCard` relies on.
+ *
+ * Qwen3-style models are handed an opening `<think>` by their chat template,
+ * so the response begins *inside* reasoning and only emits the closing
+ * `</think>`. With the AI SDK's default (`startWithReasoning: false`) the
+ * middleware waits for an opening tag that never arrives, so the reasoning
+ * stays inline in the answer and the orphan `</think>` reaches the markdown
+ * renderer — which escapes unknown tags and shows them as literal text.
+ *
+ * These assertions guard the `startWithReasoning: true` decision against an
+ * `ai` upgrade quietly changing the semantics underneath it.
+ */
+import { extractReasoningMiddleware } from 'ai';
+import { describe, expect, it } from 'vitest';
+
+const extract = async (text: string, startWithReasoning: boolean) => {
+  const middleware = extractReasoningMiddleware({
+    tagName: 'think',
+    startWithReasoning,
+  });
+  const result = await middleware.wrapGenerate?.({
+    doGenerate: async () => ({ content: [{ type: 'text', text }] }),
+  } as never);
+  const content = (result as { content: Array<{ type: string; text: string }> })
+    .content;
+
+  return {
+    reasoning: content.find((part) => part.type === 'reasoning')?.text,
+    text: content.find((part) => part.type === 'text')?.text ?? '',
+  };
+};
+
+describe('extractReasoningMiddleware for chat', () => {
+  // The shape this endpoint actually returns — verified against a live
+  // qwen3.5-4b deployment, which emits no opening tag.
+  const qwen3Style =
+    'Let me create a clear solution.\n</think>\n\n# Reverse a Linked List';
+
+  it('leaves an orphan closing tag in the answer with the SDK default', async () => {
+    const { reasoning, text } = await extract(qwen3Style, false);
+
+    expect(reasoning).toBeUndefined();
+    expect(text).toContain('</think>');
+  });
+
+  it('extracts the reasoning and drops the tag when starting in reasoning', async () => {
+    const { reasoning, text } = await extract(qwen3Style, true);
+
+    expect(reasoning?.trim()).toBe('Let me create a clear solution.');
+    expect(text).not.toContain('</think>');
+    expect(text).toContain('# Reverse a Linked List');
+  });
+
+  it('passes text through untouched when the model emits no tags at all', async () => {
+    const plain = 'Just a plain answer with no reasoning.';
+    const { reasoning, text } = await extract(plain, true);
+
+    expect(reasoning).toBeUndefined();
+    expect(text).toBe(plain);
+  });
+
+  // The one cost of this setting: a model that *does* emit the opening tag
+  // has it prepended a second time, so the literal `<think>` lands at the
+  // head of the reasoning text. The answer is still clean, and the reasoning
+  // panel is collapsed by default, so this is cosmetic — recorded here so the
+  // tradeoff is visible rather than surprising.
+  it('still extracts when a model does emit the opening tag', async () => {
+    const { reasoning, text } = await extract(
+      '<think>weighing options</think>Final answer.',
+      true,
+    );
+
+    expect(reasoning).toContain('weighing options');
+    expect(reasoning).toBe('<think>weighing options');
+    expect(text).toContain('Final answer.');
+    expect(text).not.toContain('think>');
+  });
+});

--- a/react/src/components/Chat/chatReasoningExtraction.test.ts
+++ b/react/src/components/Chat/chatReasoningExtraction.test.ts
@@ -35,6 +35,108 @@ const extract = async (text: string, startWithReasoning: boolean) => {
   };
 };
 
+/**
+ * `ChatCard` calls `streamText`, so production runs through `wrapStream`, not
+ * `wrapGenerate`. These feed the middleware a chunked stream — including a
+ * closing tag split across two chunks, which is the boundary a buffer bug
+ * would fall through.
+ */
+const streamExtract = async (deltas: string[], startWithReasoning: boolean) => {
+  const middleware = extractReasoningMiddleware({
+    tagName: 'think',
+    startWithReasoning,
+  });
+  const doStream = async () => ({
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: 'text-start', id: 'c1' });
+        for (const delta of deltas) {
+          controller.enqueue({ type: 'text-delta', id: 'c1', delta });
+        }
+        controller.enqueue({ type: 'text-end', id: 'c1' });
+        controller.close();
+      },
+    }),
+  });
+
+  const { stream } = (await middleware.wrapStream?.({ doStream } as never)) as {
+    stream: ReadableStream<{ type: string; delta?: string }>;
+  };
+
+  const chunks: Array<{ type: string; delta?: string }> = [];
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const join = (type: string) =>
+    chunks
+      .filter((chunk) => chunk.type === type)
+      .map((chunk) => chunk.delta ?? '')
+      .join('');
+
+  return { reasoning: join('reasoning-delta'), text: join('text-delta') };
+};
+
+describe('extractReasoningMiddleware streaming (the path ChatCard uses)', () => {
+  it('extracts reasoning when the closing tag arrives in one chunk', async () => {
+    const { reasoning, text } = await streamExtract(
+      ['Let me work through it.', '\n</think>\n\n', '# Answer'],
+      true,
+    );
+
+    expect(reasoning.trim()).toBe('Let me work through it.');
+    expect(text).toContain('# Answer');
+    expect(text).not.toContain('think>');
+  });
+
+  it('extracts reasoning when the closing tag is split across chunks', async () => {
+    const { reasoning, text } = await streamExtract(
+      ['Let me work through it.\n</thi', 'nk>\n\n# Answer'],
+      true,
+    );
+
+    expect(reasoning.trim()).toBe('Let me work through it.');
+    expect(text).toContain('# Answer');
+    // The split must not leak either half of the tag into the answer.
+    expect(text).not.toContain('think>');
+    expect(text).not.toContain('</thi');
+  });
+
+  // ⚠️ The streaming path does NOT behave like `wrapGenerate` here.
+  //
+  // With no closing tag the stream never leaves reasoning mode, so the entire
+  // answer is emitted as `reasoning-delta` and the visible message is empty.
+  // `wrapGenerate` passes the same input straight through as text (asserted
+  // below in the non-streaming suite). Since `ChatCard` streams, enabling
+  // `startWithReasoning` globally would hide the whole reply for every model
+  // that does not emit think tags — which is most of them.
+  //
+  // This asymmetry is why the flag must be gated rather than applied to every
+  // client-fetched model.
+  it('swallows the whole answer when no tag ever arrives (hazard)', async () => {
+    const { reasoning, text } = await streamExtract(
+      ['The capital of ', 'France is Paris.'],
+      true,
+    );
+
+    expect(reasoning).toBe('The capital of France is Paris.');
+    expect(text).toBe('');
+  });
+
+  it('is safe for a tagless model when the flag is off', async () => {
+    const { reasoning, text } = await streamExtract(
+      ['The capital of ', 'France is Paris.'],
+      false,
+    );
+
+    expect(reasoning).toBe('');
+    expect(text).toBe('The capital of France is Paris.');
+  });
+});
+
 describe('extractReasoningMiddleware for chat', () => {
   // The shape this endpoint actually returns — verified against a live
   // qwen3.5-4b deployment, which emits no opening tag.


### PR DESCRIPTION
Resolves #8585 (FR-3466)

> **No behaviour change.** This PR started as a one-line fix; the fix turned out to be unsafe, so what remains is the test suite that proves it and a note in `ChatCard` pointing at it. The real fix belongs at the serving layer — see below.

## How to reproduce the bug

Chat session on the dogbowl test server:

`<dogbowl>/project/B200/chat/c4a5b3fa-dbe5-4692-a8d2-b1a7b6767260`

Send a prompt that makes the model reason — e.g. *"Write a Python function to reverse a linked list."* Observed today:

- the chain-of-thought stays inline in the answer instead of moving to the collapsible reasoning panel
- a stray `</think>` is rendered as literal text in the message

## Root cause

Qwen3-style chat templates put the opening `<think>` into the *prompt*, so the model's **response** already begins inside reasoning and only ever emits the **closing** `</think>`.

`extractReasoningMiddleware` defaults to `startWithReasoning: false`, so it waits for an opening tag that never arrives. Nothing is extracted and the orphan closing tag survives into the rendered text. It is *visible* rather than dropped because `react-markdown` runs without `rehype-raw`: unknown tags are escaped into visible text.

Verified against a live `qwen3.5-4b` endpoint (vLLM 0.21.0):

```
HAS OPENING <think>: False
'...Let me create a clear, well-documented solution.\n</think>\n\n# Reverse a Linked List in Python...'
```

The content also opens with the model's own `Thinking Process:` prose — that string is the model talking, not a UI label. The deployment has no reasoning parser configured either (`reasoning` and `reasoning_content` both `null`), so everything arrives inline in `content`.

## Why the obvious fix was rejected

Setting `startWithReasoning: true` makes the Qwen3 case work, and the first version of this PR did exactly that. Review pointed out that the tests covered `wrapGenerate` while `ChatCard` calls `streamText` — so the path that actually runs was untested. Adding streaming coverage found this:

```
streamExtract(['The capital of ', 'France is Paris.'], true)
→ reasoning: "The capital of France is Paris."
   text:      ""
```

On the **streaming** path a model that emits no think tags **never leaves reasoning mode**, so its entire answer is routed to the collapsed panel and the visible message is empty. `wrapGenerate` passes the identical input straight through as text, so the two paths disagree — and only a streaming test catches it.

Since most models emit no think tags, enabling this for every client-fetched, custom, and agent model would blank out ordinary replies. That is a regression far worse than the symptom it fixes, so the change was reverted.

## What is left

- `ChatCard.tsx` — a comment recording why `startWithReasoning` is not the fix, so the next reader does not re-derive the same dead end. No functional change; the diff against `main` is comments only.
- `chatReasoningExtraction.test.ts` — 8 tests pinning the SDK contract on **both** paths:
  - streaming: closing tag in one chunk; closing tag **split across two chunks**; the tagless hazard above; and the same tagless input staying safe with the flag off
  - non-streaming: the default leaving an orphan tag, the flag extracting correctly, tagless passthrough, and the double-tag cosmetic case

If someone tries this flag again, the streaming tests fail loudly instead of looking green from the `wrapGenerate` side.

## The actual fix: serving side

`@ai-sdk/openai-compatible@1.0.42` already reads `reasoning_content` / `reasoning` on both the streaming and non-streaming paths (`dist/index.js:432`, `:587`) and maps them to reasoning parts.

So configuring vLLM with `--reasoning-parser` needs **no frontend change at all**: reasoning arrives as its own field, lands in the collapsible panel, and no tag scraping happens. That is model-accurate rather than heuristic, and it also avoids the bug below. The parser name should be confirmed against the deployed vLLM build.

## Separate pre-existing bug

On `main` today, a fenced code sample that *contains* think tags is destroyed by the middleware — the code block is emptied:

```
SRC : "Example:\n```\n<think>x</think>\n```\nThat is the format."
NOW : reasoning="x"  text="Example:\n```\n\n\n```\nThat is the format."
```

Any tag-scraping approach has this failure mode; a serving-side parser does not. Worth its own issue.

## Also out of scope

Only the client-side fetch path is touched by this middleware at all. It is applied under `fetchOnClient || modelId === 'custom' || agentEndpointUrl`; the other branch is a plain `return fetch(input, init)`, so server-proxied models get no reasoning extraction whatsoever.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Terminology).

`pnpm exec vitest run src/components/Chat/chatReasoningExtraction.test.ts` (in `react/`) → 8 passed.

Not verified in a browser against a live chat session.
