### PR TITLE
feat(FR-3387): pilot useKeyedSnapshot render-as-you-fetch tab state on the users page

### DIFF
--- a/packages/backend.ai-ui/src/__generated__/BAIAdminUserV2TableFragment.graphql.ts
+++ b/packages/backend.ai-ui/src/__generated__/BAIAdminUserV2TableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6873a2e8480d63aa479a52e63163e388>>
+ * @generated SignedSource<<47d1f265f2e8be29be972a1654752c18>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -35,8 +35,8 @@ export type BAIAdminUserV2TableFragment$data = ReadonlyArray<{
   readonly security: {
     readonly allowedClientIp: ReadonlyArray<string> | null | undefined;
     readonly sudoSessionEnabled: boolean;
-    readonly totpActivated: boolean | null | undefined;
-    readonly totpActivatedAt: string | null | undefined;
+    readonly totpActivated?: boolean | null | undefined;
+    readonly totpActivatedAt?: string | null | undefined;
   };
   readonly status: {
     readonly needPasswordChange: boolean | null | undefined;
@@ -172,18 +172,25 @@ const node: ReaderFragment = {
       "plural": false,
       "selections": [
         {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totpActivated",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totpActivatedAt",
-          "storageKey": null
+          "condition": "isNotSupportTotp",
+          "kind": "Condition",
+          "passingValue": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totpActivated",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totpActivatedAt",
+              "storageKey": null
+            }
+          ]
         },
         {
           "alias": null,
@@ -296,6 +303,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "cc2d2f87954ec529fdc80352e406cf85";
+(node as any).hash = "2a7ebc6edb19014b896c2fb9c7b8f3e7";
 
 export default node;

--- a/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
@@ -85,8 +85,16 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
           mainAccessKey
         }
         security {
-          totpActivated @skipOnClient(if: $isNotSupportTotp)
-          totpActivatedAt @skipOnClient(if: $isNotSupportTotp)
+          # @skipOnClient strips the field from the request text; the standard
+          # @skip keeps Relay's own operation in step, so the store is not left
+          # permanently missing these fields (which would defeat every
+          # store-or-network cache hit).
+          totpActivated
+            @skipOnClient(if: $isNotSupportTotp)
+            @skip(if: $isNotSupportTotp)
+          totpActivatedAt
+            @skipOnClient(if: $isNotSupportTotp)
+            @skip(if: $isNotSupportTotp)
           sudoSessionEnabled
           allowedClientIp
         }

--- a/react/src/__generated__/AdminUserManagementQuery.graphql.ts
+++ b/react/src/__generated__/AdminUserManagementQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<644afe24085e6b767aceda0dde2e128e>>
+ * @generated SignedSource<<8d7685a59786222e45321d7ca9e1e834>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -420,18 +420,25 @@ return {
                     "plural": false,
                     "selections": [
                       {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "totpActivated",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "totpActivatedAt",
-                        "storageKey": null
+                        "condition": "isNotSupportTotp",
+                        "kind": "Condition",
+                        "passingValue": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "totpActivated",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "totpActivatedAt",
+                            "storageKey": null
+                          }
+                        ]
                       },
                       {
                         "alias": null,
@@ -603,12 +610,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "264d11836dd17b9b30c7cdf2bf4072c1",
+    "cacheID": "186ab3676b344fb26d52e6953250c98a",
     "id": null,
     "metadata": {},
     "name": "AdminUserManagementQuery",
     "operationKind": "query",
-    "text": "query AdminUserManagementQuery(\n  $filter: UserV2Filter\n  $orderBy: [UserV2OrderBy!]\n  $limit: Int\n  $offset: Int\n  $isNotSupportTotp: Boolean!\n) {\n  adminUsersV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        basicInfo {\n          email\n        }\n        ...BAIAdminUserV2TableFragment\n        ...PurgeUsersModalFragment\n        ...UpdateUsersModalFragment\n        ...UserInfoModalFragment\n        ...UserSettingModalFragment\n      }\n    }\n  }\n}\n\nfragment BAIAdminUserV2TableFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n    username\n    description\n    integrationName\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n    totpActivatedAt @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  status {\n    status\n    statusInfo\n    needPasswordChange\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  timestamps {\n    createdAt\n    modifiedAt\n  }\n}\n\nfragment PurgeUsersModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n  }\n}\n\nfragment TOTPActivateModalFragment on UserV2 {\n  basicInfo {\n    email\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n  }\n}\n\nfragment UpdateUsersModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n  }\n}\n\nfragment UserInfoModalFragment on UserV2 {\n  basicInfo {\n    email\n    username\n    fullName\n    description\n  }\n  status {\n    status\n    needPasswordChange\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  projects {\n    edges {\n      node {\n        id\n        basicInfo {\n          name\n        }\n      }\n    }\n  }\n}\n\nfragment UserSettingModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    username\n    fullName\n    description\n  }\n  status {\n    status\n    needPasswordChange\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  projects {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n  ...TOTPActivateModalFragment\n}\n"
+    "text": "query AdminUserManagementQuery(\n  $filter: UserV2Filter\n  $orderBy: [UserV2OrderBy!]\n  $limit: Int\n  $offset: Int\n  $isNotSupportTotp: Boolean!\n) {\n  adminUsersV2(filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        basicInfo {\n          email\n        }\n        ...BAIAdminUserV2TableFragment\n        ...PurgeUsersModalFragment\n        ...UpdateUsersModalFragment\n        ...UserInfoModalFragment\n        ...UserSettingModalFragment\n      }\n    }\n  }\n}\n\nfragment BAIAdminUserV2TableFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n    username\n    description\n    integrationName\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    totpActivatedAt @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  status {\n    status\n    statusInfo\n    needPasswordChange\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  timestamps {\n    createdAt\n    modifiedAt\n  }\n}\n\nfragment PurgeUsersModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n  }\n}\n\nfragment TOTPActivateModalFragment on UserV2 {\n  basicInfo {\n    email\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n  }\n}\n\nfragment UpdateUsersModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n  }\n}\n\nfragment UserInfoModalFragment on UserV2 {\n  basicInfo {\n    email\n    username\n    fullName\n    description\n  }\n  status {\n    status\n    needPasswordChange\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  projects {\n    edges {\n      node {\n        id\n        basicInfo {\n          name\n        }\n      }\n    }\n  }\n}\n\nfragment UserSettingModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    username\n    fullName\n    description\n  }\n  status {\n    status\n    needPasswordChange\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  projects {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n  ...TOTPActivateModalFragment\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/ForceTOTPCheckerQuery.graphql.ts
+++ b/react/src/__generated__/ForceTOTPCheckerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<34fe6fd50d15a60b11fc3b90537753b1>>
+ * @generated SignedSource<<046a28e8ac5f53ed36fbe824ae3eccc4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -126,12 +126,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8fb38b90c90755984db4944f61e7d954",
+    "cacheID": "e9f21b8619bfe5b4c180b49104246aba",
     "id": null,
     "metadata": {},
     "name": "ForceTOTPCheckerQuery",
     "operationKind": "query",
-    "text": "query ForceTOTPCheckerQuery(\n  $isNotSupportTotp: Boolean!\n) {\n  myUserV2 {\n    security {\n      totpActivated @skipOnClient(if: $isNotSupportTotp)\n    }\n    ...TOTPActivateModalFragment\n    id\n  }\n}\n\nfragment TOTPActivateModalFragment on UserV2 {\n  basicInfo {\n    email\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n  }\n}\n"
+    "text": "query ForceTOTPCheckerQuery(\n  $isNotSupportTotp: Boolean!\n) {\n  myUserV2 {\n    security {\n      totpActivated @skipOnClient(if: $isNotSupportTotp)\n    }\n    ...TOTPActivateModalFragment\n    id\n  }\n}\n\nfragment TOTPActivateModalFragment on UserV2 {\n  basicInfo {\n    email\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n  }\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/ProjectAdminUsersPageQuery.graphql.ts
+++ b/react/src/__generated__/ProjectAdminUsersPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4a0dc3ea1381c91b8d367ef0fe60f64b>>
+ * @generated SignedSource<<b4aa3640d57f36b309c538f8df1fb273>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -403,18 +403,25 @@ return {
                     "plural": false,
                     "selections": [
                       {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "totpActivated",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "totpActivatedAt",
-                        "storageKey": null
+                        "condition": "isNotSupportTotp",
+                        "kind": "Condition",
+                        "passingValue": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "totpActivated",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "totpActivatedAt",
+                            "storageKey": null
+                          }
+                        ]
                       },
                       {
                         "alias": null,
@@ -534,12 +541,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fb385584684057ab73f7ce5523c380e3",
+    "cacheID": "92a2c6651885b26e9d49583233cf75d1",
     "id": null,
     "metadata": {},
     "name": "ProjectAdminUsersPageQuery",
     "operationKind": "query",
-    "text": "query ProjectAdminUsersPageQuery(\n  $projectId: UUID!\n  $filter: UserV2Filter\n  $orderBy: [UserV2OrderBy!]\n  $limit: Int\n  $offset: Int\n  $isNotSupportTotp: Boolean!\n) {\n  projectUsersV2(scope: {projectId: $projectId}, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIAdminUserV2TableFragment\n      }\n    }\n  }\n}\n\nfragment BAIAdminUserV2TableFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n    username\n    description\n    integrationName\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n    totpActivatedAt @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  status {\n    status\n    statusInfo\n    needPasswordChange\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  timestamps {\n    createdAt\n    modifiedAt\n  }\n}\n"
+    "text": "query ProjectAdminUsersPageQuery(\n  $projectId: UUID!\n  $filter: UserV2Filter\n  $orderBy: [UserV2OrderBy!]\n  $limit: Int\n  $offset: Int\n  $isNotSupportTotp: Boolean!\n) {\n  projectUsersV2(scope: {projectId: $projectId}, filter: $filter, orderBy: $orderBy, limit: $limit, offset: $offset) {\n    count\n    edges {\n      node {\n        id\n        ...BAIAdminUserV2TableFragment\n      }\n    }\n  }\n}\n\nfragment BAIAdminUserV2TableFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n    username\n    description\n    integrationName\n  }\n  organization {\n    domainName\n    role\n    resourcePolicy\n    mainAccessKey\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    totpActivatedAt @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n    sudoSessionEnabled\n    allowedClientIp\n  }\n  status {\n    status\n    statusInfo\n    needPasswordChange\n  }\n  container {\n    containerUid\n    containerMainGid\n    containerGids\n  }\n  timestamps {\n    createdAt\n    modifiedAt\n  }\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/TOTPActivateModalFragment.graphql.ts
+++ b/react/src/__generated__/TOTPActivateModalFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d38d6a0fa40427f3feb26e4ecf1da514>>
+ * @generated SignedSource<<9859b31d3c8377334607578564096061>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,7 +15,7 @@ export type TOTPActivateModalFragment$data = {
     readonly email: string;
   };
   readonly security: {
-    readonly totpActivated: boolean | null | undefined;
+    readonly totpActivated?: boolean | null | undefined;
   };
   readonly " $fragmentType": "TOTPActivateModalFragment";
 };
@@ -62,11 +62,18 @@ const node: ReaderFragment = {
       "plural": false,
       "selections": [
         {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totpActivated",
-          "storageKey": null
+          "condition": "isNotSupportTotp",
+          "kind": "Condition",
+          "passingValue": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totpActivated",
+              "storageKey": null
+            }
+          ]
         }
       ],
       "storageKey": null
@@ -76,6 +83,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "ea5b0c796463b95ee22c460285ab0847";
+(node as any).hash = "a8097421cb683bde50a7bd7cb9d7c67a";
 
 export default node;

--- a/react/src/__generated__/UserDropdownMenuQuery.graphql.ts
+++ b/react/src/__generated__/UserDropdownMenuQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8a22aaa2d9e458a5c4ae0bce923abbce>>
+ * @generated SignedSource<<c94f74ce5c8174e8b84582c8eb7886b3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -174,12 +174,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a865ccaae64cece26c3ab54e6ccde32f",
+    "cacheID": "112762bc16d5fc1b71485ea4d6fafb7d",
     "id": null,
     "metadata": {},
     "name": "UserDropdownMenuQuery",
     "operationKind": "query",
-    "text": "query UserDropdownMenuQuery(\n  $isNotSupportTotp: Boolean!\n) {\n  myUserV2 {\n    basicInfo {\n      fullName\n    }\n    ...UserProfileSettingModalFragment\n    id\n  }\n  myClientIp {\n    clientIp\n  }\n}\n\nfragment TOTPActivateModalFragment on UserV2 {\n  basicInfo {\n    email\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n  }\n}\n\nfragment UserProfileSettingModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n    allowedClientIp\n  }\n  ...TOTPActivateModalFragment\n}\n"
+    "text": "query UserDropdownMenuQuery(\n  $isNotSupportTotp: Boolean!\n) {\n  myUserV2 {\n    basicInfo {\n      fullName\n    }\n    ...UserProfileSettingModalFragment\n    id\n  }\n  myClientIp {\n    clientIp\n  }\n}\n\nfragment TOTPActivateModalFragment on UserV2 {\n  basicInfo {\n    email\n  }\n  security {\n    totpActivated @skip(if: $isNotSupportTotp) @skipOnClient(if: $isNotSupportTotp)\n  }\n}\n\nfragment UserProfileSettingModalFragment on UserV2 {\n  id\n  basicInfo {\n    email\n    fullName\n  }\n  security {\n    totpActivated @skipOnClient(if: $isNotSupportTotp)\n    allowedClientIp\n  }\n  ...TOTPActivateModalFragment\n}\n"
   }
 };
 })();

--- a/react/src/__generated__/UserInfoModalFragment.graphql.ts
+++ b/react/src/__generated__/UserInfoModalFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0b5b4c9daa0942f8a9b340535ff954a6>>
+ * @generated SignedSource<<3089d654ffa5a269f3af6836bb88eca9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,7 +37,7 @@ export type UserInfoModalFragment$data = {
   } | null | undefined;
   readonly security: {
     readonly sudoSessionEnabled: boolean;
-    readonly totpActivated: boolean | null | undefined;
+    readonly totpActivated?: boolean | null | undefined;
   };
   readonly status: {
     readonly needPasswordChange: boolean | null | undefined;
@@ -134,11 +134,18 @@ const node: ReaderFragment = {
       "plural": false,
       "selections": [
         {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totpActivated",
-          "storageKey": null
+          "condition": "isNotSupportTotp",
+          "kind": "Condition",
+          "passingValue": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totpActivated",
+              "storageKey": null
+            }
+          ]
         },
         {
           "alias": null,
@@ -252,6 +259,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "42b0c8c3a83e175bf5e1e5ab56f161e3";
+(node as any).hash = "cfb112c9d88e1c237eb282c33349c340";
 
 export default node;

--- a/react/src/__generated__/UserSettingModalFragment.graphql.ts
+++ b/react/src/__generated__/UserSettingModalFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5f3d6bdc21d0312e7f33a933e7f11afb>>
+ * @generated SignedSource<<4535281cf97f84428b776aa5e1bc963d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -41,7 +41,7 @@ export type UserSettingModalFragment$data = {
   readonly security: {
     readonly allowedClientIp: ReadonlyArray<string> | null | undefined;
     readonly sudoSessionEnabled: boolean;
-    readonly totpActivated: boolean | null | undefined;
+    readonly totpActivated?: boolean | null | undefined;
   };
   readonly status: {
     readonly needPasswordChange: boolean | null | undefined;
@@ -187,11 +187,18 @@ return {
       "plural": false,
       "selections": [
         {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totpActivated",
-          "storageKey": null
+          "condition": "isNotSupportTotp",
+          "kind": "Condition",
+          "passingValue": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totpActivated",
+              "storageKey": null
+            }
+          ]
         },
         {
           "alias": null,
@@ -287,6 +294,6 @@ return {
 };
 })();
 
-(node as any).hash = "4361007be22259c3a0c1918a3f35db96";
+(node as any).hash = "fe5c9e96f7b5b915441f9784c6cb4b3e";
 
 export default node;

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -88,6 +88,8 @@ type Keypair = NonNullable<
   >['items'][number]
 >;
 
+export const CREDENTIAL_LIST_DEFAULT_PAGE_SIZE = 20;
+
 interface AdminUserCredentialListProps {
   queryRef: PreloadedQuery<AdminUserCredentialListQueryType>;
   onReload: (
@@ -124,7 +126,7 @@ const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
   // funnels changes back through `onReload`.
   const variables = queryRef.variables;
   const activeType = variables.is_active === false ? 'inactive' : 'active';
-  const pageSize = variables.limit ?? 20;
+  const pageSize = variables.limit ?? CREDENTIAL_LIST_DEFAULT_PAGE_SIZE;
   const current = Math.floor((variables.offset ?? 0) / pageSize) + 1;
 
   const deferredQueryRef = useDeferredValue(queryRef);

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -5,13 +5,11 @@
 import { AdminUserCredentialListDeleteMutation } from '../__generated__/AdminUserCredentialListDeleteMutation.graphql';
 import { AdminUserCredentialListModifyMutation } from '../__generated__/AdminUserCredentialListModifyMutation.graphql';
 import {
-  AdminUserCredentialListQuery,
+  AdminUserCredentialListQuery as AdminUserCredentialListQueryType,
   AdminUserCredentialListQuery$data,
-  AdminUserCredentialListQuery$variables,
 } from '../__generated__/AdminUserCredentialListQuery.graphql';
 import { KeypairSettingModalFragment$key } from '../__generated__/KeypairSettingModalFragment.graphql';
 import { App } from '../app-shim';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { theme } from '../theme-shim';
 import BAIRadioGroup from './BAIRadioGroup';
 import KeypairInfoModal from './KeypairInfoModal';
@@ -30,9 +28,7 @@ import {
   BAIDeleteConfirmModal,
   BAISelectionLabel,
   useBAILogger,
-  useUpdatableState,
   BAIText,
-  INITIAL_FETCH_KEY,
   PRIMARY_TAG_VARIANT,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
@@ -46,10 +42,53 @@ import {
   SquarePenIcon,
   UndoIcon,
 } from 'lucide-react';
-import { parseAsString, useQueryState, useQueryStates } from 'nuqs';
-import { useDeferredValue, useEffect, useState, useTransition } from 'react';
+import { useDeferredValue, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  useMutation,
+  usePreloadedQuery,
+  type PreloadedQuery,
+  type UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
+
+export const AdminUserCredentialListQuery = graphql`
+  query AdminUserCredentialListQuery(
+    $limit: Int!
+    $offset: Int!
+    $filter: String
+    $order: String
+    $domain_name: String
+    $email: String
+    $is_active: Boolean
+  ) {
+    keypair_list(
+      limit: $limit
+      offset: $offset
+      filter: $filter
+      order: $order
+      domain_name: $domain_name
+      email: $email
+      is_active: $is_active
+    ) {
+      items {
+        id
+        user_id
+        access_key
+        is_admin
+        resource_policy
+        created_at
+        rate_limit
+        num_queries
+        concurrency_used @since(version: "24.09.0")
+
+        ...KeypairSettingModalFragment
+        ...KeypairInfoModalFragment
+      }
+      total_count
+    }
+  }
+`;
 
 type Keypair = NonNullable<
   NonNullable<
@@ -57,23 +96,25 @@ type Keypair = NonNullable<
   >['items'][number]
 >;
 
-const AdminUserCredentialList: React.FC = () => {
+export const CREDENTIAL_LIST_DEFAULT_PAGE_SIZE = 20;
+
+interface AdminUserCredentialListProps {
+  queryRef: PreloadedQuery<AdminUserCredentialListQueryType>;
+  onReload: (
+    variables: AdminUserCredentialListQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
+
+const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
+  queryRef,
+  onReload,
+}) => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message, modal } = App.useApp();
   const { logger } = useBAILogger();
-
-  const [action, setAction] = useQueryState('action', parseAsString);
-
-  const [fetchKey, updateFetchKey] = useUpdatableState('first');
-  const [queryParams, setQueryParams] = useQueryStates(
-    {
-      activeType: parseAsString.withDefault('active'),
-      order: parseAsString,
-      filter: parseAsString,
-    },
-    { history: 'replace' },
-  );
 
   const [keypairSettingModalFrgmt, setKeypairSettingModalFrgmt] =
     useState<KeypairSettingModalFragment$key | null>(null);
@@ -88,71 +129,20 @@ const AdminUserCredentialList: React.FC = () => {
   const [selectedKeypairs, setSelectedKeypairs] = useState<Keypair[]>([]);
   const [isBulkUpdating, setIsBulkUpdating] = useState(false);
 
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({
-    current: 1,
-    pageSize: 20,
-  });
+  // The page owns URL state and the fetch; this component derives every
+  // filter/order/pagination control from the last requested variables and
+  // funnels changes back through `onReload`.
+  const variables = queryRef.variables;
+  const activeType = variables.is_active === false ? 'inactive' : 'active';
+  const pageSize = variables.limit ?? CREDENTIAL_LIST_DEFAULT_PAGE_SIZE;
+  const current = Math.floor((variables.offset ?? 0) / pageSize) + 1;
 
-  const queryVariables: AdminUserCredentialListQuery$variables = {
-    limit: baiPaginationOption.limit,
-    offset: baiPaginationOption.offset,
-    is_active: queryParams.activeType === 'active',
-    filter: queryParams.filter,
-    order: queryParams.order,
-  };
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isPending = deferredQueryRef !== queryRef;
 
-  const { keypair_list } = useLazyLoadQuery<AdminUserCredentialListQuery>(
-    graphql`
-      query AdminUserCredentialListQuery(
-        $limit: Int!
-        $offset: Int!
-        $filter: String
-        $order: String
-        $domain_name: String
-        $email: String
-        $is_active: Boolean
-      ) {
-        keypair_list(
-          limit: $limit
-          offset: $offset
-          filter: $filter
-          order: $order
-          domain_name: $domain_name
-          email: $email
-          is_active: $is_active
-        ) {
-          items {
-            id
-            user_id
-            access_key
-            is_admin
-            resource_policy
-            created_at
-            rate_limit
-            num_queries
-            concurrency_used @since(version: "24.09.0")
-
-            ...KeypairSettingModalFragment
-            ...KeypairInfoModalFragment
-          }
-          total_count
-        }
-      }
-    `,
-    deferredQueryVariables,
-    {
-      fetchKey: deferredFetchKey,
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-    },
+  const { keypair_list } = usePreloadedQuery<AdminUserCredentialListQueryType>(
+    AdminUserCredentialListQuery,
+    deferredQueryRef,
   );
 
   const [commitModifyKeypair] =
@@ -248,31 +238,22 @@ const AdminUserCredentialList: React.FC = () => {
           );
         }
         setSelectedKeypairs([]);
-        updateFetchKey();
+        onReload(variables, { fetchPolicy: 'network-only' });
       },
     });
   };
-
-  useEffect(() => {
-    if (action === 'add') {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setOpenUserKeypairSettingModal(true);
-
-      setAction(null);
-    }
-  }, [action, setAction]);
 
   return (
     <BAIFlex direction="column" align="stretch" gap="sm">
       <BAIFlex justify="between" align="start" gap="xs" wrap="wrap">
         <BAIFlex gap={'sm'} align="start">
           <BAIRadioGroup
-            value={queryParams.activeType}
+            value={activeType}
             onChange={(value) => {
-              setQueryParams({ activeType: value.target.value });
-              setTablePaginationOption({
-                current: 1,
-                pageSize: tablePaginationOption.pageSize,
+              onReload({
+                ...variables,
+                is_active: value.target.value === 'active',
+                offset: 0,
               });
               setSelectedKeypairs([]);
             }}
@@ -323,9 +304,13 @@ const AdminUserCredentialList: React.FC = () => {
                 type: 'string',
               },
             ]}
-            value={queryParams.filter ?? undefined}
+            value={variables.filter ?? undefined}
             onChange={(value) => {
-              setQueryParams({ filter: value ?? null });
+              onReload({
+                ...variables,
+                filter: value ?? null,
+                offset: 0,
+              });
               setSelectedKeypairs([]);
             }}
           />
@@ -337,7 +322,7 @@ const AdminUserCredentialList: React.FC = () => {
                 count={selectedKeypairs.length}
                 onClearSelection={() => setSelectedKeypairs([])}
               />
-              {queryParams.activeType === 'active' ? (
+              {activeType === 'active' ? (
                 <Tooltip content={t('credential.Deactivate')}>
                   <BAIButton
                     icon={<BanIcon style={{ color: token.colorError }} />}
@@ -358,9 +343,9 @@ const AdminUserCredentialList: React.FC = () => {
           )}
           <Tooltip content={t('button.Refresh')}>
             <BAIButton
-              loading={deferredFetchKey !== fetchKey}
+              loading={isPending}
               onClick={() => {
-                updateFetchKey();
+                onReload(variables, { fetchPolicy: 'network-only' });
               }}
               icon={<RotateCw size="1em" />}
             />
@@ -378,7 +363,7 @@ const AdminUserCredentialList: React.FC = () => {
       </BAIFlex>
       <BAITableAstryx<Keypair>
         rowKey={'id'}
-        loading={deferredQueryVariables !== queryVariables}
+        loading={isPending}
         dataSource={filterOutNullAndUndefined(keypair_list?.items)}
         rowSelection={{
           type: 'checkbox',
@@ -432,7 +417,7 @@ const AdminUserCredentialList: React.FC = () => {
                     });
                   },
                 },
-                ...(queryParams.activeType === 'inactive'
+                ...(activeType === 'inactive'
                   ? [
                       {
                         key: 'activate',
@@ -467,7 +452,9 @@ const AdminUserCredentialList: React.FC = () => {
                                         kp.access_key !== record.access_key,
                                     ),
                                   );
-                                  updateFetchKey();
+                                  onReload(variables, {
+                                    fetchPolicy: 'network-only',
+                                  });
                                   resolve();
                                 },
                                 onError: (error) => {
@@ -482,7 +469,7 @@ const AdminUserCredentialList: React.FC = () => {
                       },
                     ]
                   : []),
-                ...(queryParams.activeType === 'active'
+                ...(activeType === 'active'
                   ? [
                       {
                         key: 'deactivate',
@@ -521,7 +508,9 @@ const AdminUserCredentialList: React.FC = () => {
                                         kp.access_key !== record.access_key,
                                     ),
                                   );
-                                  updateFetchKey();
+                                  onReload(variables, {
+                                    fetchPolicy: 'network-only',
+                                  });
                                   resolve();
                                 },
                                 onError: (error) => {
@@ -631,22 +620,26 @@ const AdminUserCredentialList: React.FC = () => {
           },
         ])}
         pagination={{
-          pageSize: tablePaginationOption.pageSize,
+          pageSize,
           total: keypair_list?.total_count || 0,
-          current: tablePaginationOption.current,
+          current,
           // TODO: need to set more options to export CSV in current page's data
-          onChange(current, pageSize) {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({
-                current,
-                pageSize,
+          onChange(nextCurrent, nextPageSize) {
+            if (_.isNumber(nextCurrent) && _.isNumber(nextPageSize)) {
+              onReload({
+                ...variables,
+                limit: nextPageSize,
+                offset: (nextCurrent - 1) * nextPageSize,
               });
               setSelectedKeypairs([]);
             }
           },
         }}
         onChangeOrder={(nextOrder) => {
-          setQueryParams({ order: nextOrder ?? null });
+          onReload({
+            ...variables,
+            order: nextOrder ?? null,
+          });
           setSelectedKeypairs([]);
         }}
       />
@@ -670,7 +663,7 @@ const AdminUserCredentialList: React.FC = () => {
           setKeypairSettingModalFrgmt(null);
           setOpenUserKeypairSettingModal(false);
           if (success) {
-            updateFetchKey();
+            onReload(variables, { fetchPolicy: 'network-only' });
           }
         }}
       />
@@ -709,7 +702,7 @@ const AdminUserCredentialList: React.FC = () => {
                   ),
                 );
                 setDeletingKeypair(null);
-                updateFetchKey();
+                onReload(variables, { fetchPolicy: 'network-only' });
               },
               onError: (error) => {
                 message.error(error?.message);

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -5,12 +5,10 @@
 import { AdminUserCredentialListDeleteMutation } from '../__generated__/AdminUserCredentialListDeleteMutation.graphql';
 import { AdminUserCredentialListModifyMutation } from '../__generated__/AdminUserCredentialListModifyMutation.graphql';
 import {
-  AdminUserCredentialListQuery,
+  AdminUserCredentialListQuery as AdminUserCredentialListQueryType,
   AdminUserCredentialListQuery$data,
-  AdminUserCredentialListQuery$variables,
 } from '../__generated__/AdminUserCredentialListQuery.graphql';
 import { KeypairSettingModalFragment$key } from '../__generated__/KeypairSettingModalFragment.graphql';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import BAIRadioGroup from './BAIRadioGroup';
 import KeypairInfoModal from './KeypairInfoModal';
 import KeypairSettingModal from './KeypairSettingModal';
@@ -31,17 +29,58 @@ import {
   BAIDeleteConfirmModal,
   BAISelectionLabel,
   useBAILogger,
-  useUpdatableState,
   BAIText,
-  INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { BanIcon, PlusIcon, SquarePenIcon, UndoIcon } from 'lucide-react';
-import { parseAsString, useQueryState, useQueryStates } from 'nuqs';
-import { useDeferredValue, useEffect, useState, useTransition } from 'react';
+import { useDeferredValue, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  useMutation,
+  usePreloadedQuery,
+  type PreloadedQuery,
+  type UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
+
+export const AdminUserCredentialListQuery = graphql`
+  query AdminUserCredentialListQuery(
+    $limit: Int!
+    $offset: Int!
+    $filter: String
+    $order: String
+    $domain_name: String
+    $email: String
+    $is_active: Boolean
+  ) {
+    keypair_list(
+      limit: $limit
+      offset: $offset
+      filter: $filter
+      order: $order
+      domain_name: $domain_name
+      email: $email
+      is_active: $is_active
+    ) {
+      items {
+        id
+        user_id
+        access_key
+        is_admin
+        resource_policy
+        created_at
+        rate_limit
+        num_queries
+        concurrency_used @since(version: "24.09.0")
+
+        ...KeypairSettingModalFragment
+        ...KeypairInfoModalFragment
+      }
+      total_count
+    }
+  }
+`;
 
 type Keypair = NonNullable<
   NonNullable<
@@ -49,23 +88,23 @@ type Keypair = NonNullable<
   >['items'][number]
 >;
 
-const AdminUserCredentialList: React.FC = () => {
+interface AdminUserCredentialListProps {
+  queryRef: PreloadedQuery<AdminUserCredentialListQueryType>;
+  onReload: (
+    variables: AdminUserCredentialListQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
+
+const AdminUserCredentialList: React.FC<AdminUserCredentialListProps> = ({
+  queryRef,
+  onReload,
+}) => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message, modal } = App.useApp();
   const { logger } = useBAILogger();
-
-  const [action, setAction] = useQueryState('action', parseAsString);
-
-  const [fetchKey, updateFetchKey] = useUpdatableState('first');
-  const [queryParams, setQueryParams] = useQueryStates(
-    {
-      activeType: parseAsString.withDefault('active'),
-      order: parseAsString,
-      filter: parseAsString,
-    },
-    { history: 'replace' },
-  );
 
   const [keypairSettingModalFrgmt, setKeypairSettingModalFrgmt] =
     useState<KeypairSettingModalFragment$key | null>(null);
@@ -80,71 +119,24 @@ const AdminUserCredentialList: React.FC = () => {
   const [selectedKeypairs, setSelectedKeypairs] = useState<Keypair[]>([]);
   const [isBulkUpdating, setIsBulkUpdating] = useState(false);
 
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({
-    current: 1,
-    pageSize: 20,
-  });
+  // The page owns URL state and the fetch; this component derives every
+  // filter/order/pagination control from the last requested variables and
+  // funnels changes back through `onReload`.
+  const variables = queryRef.variables;
+  const activeType = variables.is_active === false ? 'inactive' : 'active';
+  const pageSize = variables.limit ?? 20;
+  const current = Math.floor((variables.offset ?? 0) / pageSize) + 1;
 
-  const queryVariables: AdminUserCredentialListQuery$variables = {
-    limit: baiPaginationOption.limit,
-    offset: baiPaginationOption.offset,
-    is_active: queryParams.activeType === 'active',
-    filter: queryParams.filter,
-    order: queryParams.order,
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isPending = deferredQueryRef !== queryRef;
+
+  const reloadCurrentVariables = () => {
+    onReload(variables, { fetchPolicy: 'network-only' });
   };
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
 
-  const { keypair_list } = useLazyLoadQuery<AdminUserCredentialListQuery>(
-    graphql`
-      query AdminUserCredentialListQuery(
-        $limit: Int!
-        $offset: Int!
-        $filter: String
-        $order: String
-        $domain_name: String
-        $email: String
-        $is_active: Boolean
-      ) {
-        keypair_list(
-          limit: $limit
-          offset: $offset
-          filter: $filter
-          order: $order
-          domain_name: $domain_name
-          email: $email
-          is_active: $is_active
-        ) {
-          items {
-            id
-            user_id
-            access_key
-            is_admin
-            resource_policy
-            created_at
-            rate_limit
-            num_queries
-            concurrency_used @since(version: "24.09.0")
-
-            ...KeypairSettingModalFragment
-            ...KeypairInfoModalFragment
-          }
-          total_count
-        }
-      }
-    `,
-    deferredQueryVariables,
-    {
-      fetchKey: deferredFetchKey,
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-    },
+  const { keypair_list } = usePreloadedQuery<AdminUserCredentialListQueryType>(
+    AdminUserCredentialListQuery,
+    deferredQueryRef,
   );
 
   const [commitModifyKeypair] =
@@ -240,31 +232,22 @@ const AdminUserCredentialList: React.FC = () => {
           );
         }
         setSelectedKeypairs([]);
-        updateFetchKey();
+        reloadCurrentVariables();
       },
     });
   };
-
-  useEffect(() => {
-    if (action === 'add') {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setOpenUserKeypairSettingModal(true);
-
-      setAction(null);
-    }
-  }, [action, setAction]);
 
   return (
     <BAIFlex direction="column" align="stretch" gap="sm">
       <BAIFlex justify="between" align="start" gap="xs" wrap="wrap">
         <BAIFlex gap={'sm'} align="start">
           <BAIRadioGroup
-            value={queryParams.activeType}
+            value={activeType}
             onChange={(value) => {
-              setQueryParams({ activeType: value.target.value });
-              setTablePaginationOption({
-                current: 1,
-                pageSize: tablePaginationOption.pageSize,
+              onReload({
+                ...variables,
+                is_active: value.target.value === 'active',
+                offset: 0,
               });
               setSelectedKeypairs([]);
             }}
@@ -315,9 +298,13 @@ const AdminUserCredentialList: React.FC = () => {
                 type: 'string',
               },
             ]}
-            value={queryParams.filter ?? undefined}
+            value={variables.filter ?? undefined}
             onChange={(value) => {
-              setQueryParams({ filter: value ?? null });
+              onReload({
+                ...variables,
+                filter: value ?? null,
+                offset: 0,
+              });
               setSelectedKeypairs([]);
             }}
           />
@@ -329,7 +316,7 @@ const AdminUserCredentialList: React.FC = () => {
                 count={selectedKeypairs.length}
                 onClearSelection={() => setSelectedKeypairs([])}
               />
-              {queryParams.activeType === 'active' ? (
+              {activeType === 'active' ? (
                 <Tooltip title={t('credential.Deactivate')}>
                   <BAIButton
                     icon={<BanIcon style={{ color: token.colorError }} />}
@@ -350,9 +337,9 @@ const AdminUserCredentialList: React.FC = () => {
           )}
           <Tooltip title={t('button.Refresh')}>
             <Button
-              loading={deferredFetchKey !== fetchKey}
+              loading={isPending}
               onClick={() => {
-                updateFetchKey();
+                reloadCurrentVariables();
               }}
               icon={<ReloadOutlined />}
             />
@@ -371,7 +358,7 @@ const AdminUserCredentialList: React.FC = () => {
       <BAITable<Keypair>
         rowKey={'id'}
         scroll={{ x: 'max-content' }}
-        loading={deferredQueryVariables !== queryVariables}
+        loading={isPending}
         dataSource={filterOutNullAndUndefined(keypair_list?.items)}
         rowSelection={{
           type: 'checkbox',
@@ -425,7 +412,7 @@ const AdminUserCredentialList: React.FC = () => {
                     });
                   },
                 },
-                ...(queryParams.activeType === 'inactive'
+                ...(activeType === 'inactive'
                   ? [
                       {
                         key: 'activate',
@@ -460,7 +447,7 @@ const AdminUserCredentialList: React.FC = () => {
                                         kp.access_key !== record.access_key,
                                     ),
                                   );
-                                  updateFetchKey();
+                                  reloadCurrentVariables();
                                   resolve();
                                 },
                                 onError: (error) => {
@@ -475,7 +462,7 @@ const AdminUserCredentialList: React.FC = () => {
                       },
                     ]
                   : []),
-                ...(queryParams.activeType === 'active'
+                ...(activeType === 'active'
                   ? [
                       {
                         key: 'deactivate',
@@ -514,7 +501,7 @@ const AdminUserCredentialList: React.FC = () => {
                                         kp.access_key !== record.access_key,
                                     ),
                                   );
-                                  updateFetchKey();
+                                  reloadCurrentVariables();
                                   resolve();
                                 },
                                 onError: (error) => {
@@ -643,22 +630,26 @@ const AdminUserCredentialList: React.FC = () => {
         ])}
         showSorterTooltip={false}
         pagination={{
-          pageSize: tablePaginationOption.pageSize,
+          pageSize,
           total: keypair_list?.total_count || 0,
-          current: tablePaginationOption.current,
+          current,
           // TODO: need to set more options to export CSV in current page's data
-          onChange(current, pageSize) {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({
-                current,
-                pageSize,
+          onChange(nextCurrent, nextPageSize) {
+            if (_.isNumber(nextCurrent) && _.isNumber(nextPageSize)) {
+              onReload({
+                ...variables,
+                limit: nextPageSize,
+                offset: (nextCurrent - 1) * nextPageSize,
               });
               setSelectedKeypairs([]);
             }
           },
         }}
         onChangeOrder={(nextOrder) => {
-          setQueryParams({ order: nextOrder ?? null });
+          onReload({
+            ...variables,
+            order: nextOrder ?? null,
+          });
           setSelectedKeypairs([]);
         }}
       />
@@ -682,7 +673,7 @@ const AdminUserCredentialList: React.FC = () => {
           setKeypairSettingModalFrgmt(null);
           setOpenUserKeypairSettingModal(false);
           if (success) {
-            updateFetchKey();
+            reloadCurrentVariables();
           }
         }}
       />
@@ -721,7 +712,7 @@ const AdminUserCredentialList: React.FC = () => {
                   ),
                 );
                 setDeletingKeypair(null);
-                updateFetchKey();
+                reloadCurrentVariables();
               },
               onError: (error) => {
                 message.error(error?.message);

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -473,7 +473,6 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = ({
           )}
           <BAIFetchKeyButton
             loading={isPending}
-            value=""
             onChange={() => {
               onReload(variables, { fetchPolicy: 'network-only' });
             }}

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -3,17 +3,15 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import {
-  AdminUserManagementQuery,
+  AdminUserManagementQuery as AdminUserManagementQueryType,
   AdminUserManagementQuery$data,
   UserV2Filter,
   UserV2OrderBy,
 } from '../__generated__/AdminUserManagementQuery.graphql';
 import { AdminUserManagementUpdateUserMutation } from '../__generated__/AdminUserManagementUpdateUserMutation.graphql';
 import { App } from '../app-shim';
-import { convertToOrderBy } from '../helper';
+import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useTOTPSupported } from '../hooks/backendai';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCSVExport } from '../hooks/useCSVExport';
 import { theme } from '../theme-shim';
@@ -36,14 +34,11 @@ import {
   BAINameActionCell,
   BAISelectionLabel,
   BAIUnmountAfterClose,
-  INITIAL_FETCH_KEY,
   UserV2InList,
-  availableUserV2SorterValues,
   filterOutEmpty,
   filterOutNullAndUndefined,
   toLocalId,
   useBAILogger,
-  useFetchKey,
   useToggle,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -56,39 +51,73 @@ import {
   SquarePenIcon,
   UndoIcon,
 } from 'lucide-react';
-import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { useState, useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  useMutation,
+  usePreloadedQuery,
+  type PreloadedQuery,
+  type UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
 
-interface AdminUserManagementProps {}
+export const AdminUserManagementQuery = graphql`
+  query AdminUserManagementQuery(
+    $filter: UserV2Filter
+    $orderBy: [UserV2OrderBy!]
+    $limit: Int
+    $offset: Int
+    $isNotSupportTotp: Boolean!
+  ) {
+    adminUsersV2(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          id
+          basicInfo {
+            email
+          }
+          ...BAIAdminUserV2TableFragment
+          ...PurgeUsersModalFragment
+          ...UpdateUsersModalFragment
+          ...UserInfoModalFragment
+          ...UserSettingModalFragment
+        }
+      }
+    }
+  }
+`;
+
+export const USER_LIST_DEFAULT_PAGE_SIZE = 10;
+
+interface AdminUserManagementProps {
+  queryRef: PreloadedQuery<AdminUserManagementQueryType>;
+  onReload: (
+    variables: AdminUserManagementQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
 
 type UserNode = NonNullable<
   NonNullable<AdminUserManagementQuery$data['adminUsersV2']>['edges']
 >[number];
 
-const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
+const AdminUserManagement: React.FC<AdminUserManagementProps> = ({
+  queryRef,
+  onReload,
+}) => {
   'use memo';
 
   const { logger } = useBAILogger();
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [fetchKey, updateFetchKey] = useFetchKey();
 
   const bailClient = useSuspendedBackendaiClient();
-
-  const [queryParams, setQueryParams] = useQueryStates(
-    {
-      filter: parseAsJson<UserV2Filter>((value) => value as UserV2Filter),
-      order: parseAsStringLiteral(availableUserV2SorterValues),
-      status: parseAsStringLiteral(['ACTIVE', 'INACTIVE']).withDefault(
-        'ACTIVE',
-      ),
-    },
-    {
-      history: 'replace',
-    },
-  );
   const { message } = App.useApp();
 
   const [selectedUserForInfoModal, setSelectedUserForInfoModal] = useState<
@@ -108,35 +137,20 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
   const [openUpdateUsersModal, { toggle: toggleUpdateUsersModal }] =
     useToggle(false);
 
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({
-    current: 1,
-    pageSize: 10,
-  });
+  // The page owns URL state and the fetch; this component derives every
+  // filter/order/pagination control from the last requested variables and
+  // funnels changes back through `onReload`.
+  const variables = queryRef.variables;
+  const isTOTPSupported = !variables.isNotSupportTotp;
+  const statusValue =
+    variables.filter?.status?.equals === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE';
+  const propertyFilterValue = _.omit(variables.filter ?? {}, 'status');
+  const orderValue = convertFirstOrderByToString(variables.orderBy);
+  const pageSize = variables.limit ?? USER_LIST_DEFAULT_PAGE_SIZE;
+  const current = Math.floor((variables.offset ?? 0) / pageSize) + 1;
 
-  const { isTOTPSupported } = useTOTPSupported();
-
-  const statusFilter =
-    queryParams.status === 'ACTIVE'
-      ? ({ equals: 'ACTIVE' } as const)
-      : ({ notEquals: 'ACTIVE' } as const);
-
-  const queryVariables = {
-    filter: {
-      ...(queryParams.filter ?? {}),
-      status: statusFilter,
-    },
-    orderBy: convertToOrderBy<Required<UserV2OrderBy>>(queryParams.order),
-    limit: baiPaginationOption.limit,
-    offset: baiPaginationOption.offset,
-    isNotSupportTotp: !isTOTPSupported,
-  };
-
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isPending = deferredQueryRef !== queryRef;
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.AdminUserManagement',
@@ -144,46 +158,9 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
 
   const { supportedFields, exportCSV } = useCSVExport('users');
 
-  const { adminUsersV2 } = useLazyLoadQuery<AdminUserManagementQuery>(
-    graphql`
-      query AdminUserManagementQuery(
-        $filter: UserV2Filter
-        $orderBy: [UserV2OrderBy!]
-        $limit: Int
-        $offset: Int
-        $isNotSupportTotp: Boolean!
-      ) {
-        adminUsersV2(
-          filter: $filter
-          orderBy: $orderBy
-          limit: $limit
-          offset: $offset
-        ) {
-          count
-          edges {
-            node {
-              id
-              basicInfo {
-                email
-              }
-              ...BAIAdminUserV2TableFragment
-              ...PurgeUsersModalFragment
-              ...UpdateUsersModalFragment
-              ...UserInfoModalFragment
-              ...UserSettingModalFragment
-            }
-          }
-        }
-      }
-    `,
-    deferredQueryVariables,
-    {
-      fetchKey: deferredFetchKey,
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-    },
+  const { adminUsersV2 } = usePreloadedQuery<AdminUserManagementQueryType>(
+    AdminUserManagementQuery,
+    deferredQueryRef,
   );
 
   // >= 26.4.0: adminUpdateUserV2 — status toggle keyed by userId.
@@ -259,7 +236,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
                   setSelectedUserList((prev) =>
                     prev.filter((user) => user?.node?.id !== record?.id),
                   );
-                  updateFetchKey();
+                  onReload(variables, { fetchPolicy: 'network-only' });
                 };
 
                 if (record?.id) {
@@ -426,11 +403,18 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
       <BAIFlex justify="between" align="start" gap="xs" wrap="wrap">
         <BAIFlex direction="row" gap={'sm'} align="start" wrap="wrap">
           <BAIRadioGroup
-            value={queryParams.status}
+            value={statusValue}
             onChange={(e) => {
-              setQueryParams({ status: e.target.value });
-              setTablePaginationOption({
-                current: 1,
+              onReload({
+                ...variables,
+                filter: {
+                  ...propertyFilterValue,
+                  status:
+                    e.target.value === 'ACTIVE'
+                      ? { equals: 'ACTIVE' }
+                      : { notEquals: 'ACTIVE' },
+                },
+                offset: 0,
               });
               setSelectedUserList([]);
             }}
@@ -448,10 +432,20 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           />
           <BAIGraphQLPropertyFilter<UserV2Filter>
             filterProperties={filterProperties}
-            value={queryParams.filter ?? undefined}
+            value={
+              _.isEmpty(propertyFilterValue)
+                ? undefined
+                : (propertyFilterValue as UserV2Filter)
+            }
             onChange={(value) => {
-              setQueryParams({ filter: value ?? null });
-              setTablePaginationOption({ current: 1 });
+              onReload({
+                ...variables,
+                filter: {
+                  ...(value ?? {}),
+                  status: variables.filter?.status,
+                },
+                offset: 0,
+              });
               setSelectedUserList([]);
             }}
           />
@@ -467,7 +461,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
                 icon={<SquarePenIcon style={{ color: token.colorInfo }} />}
                 onClick={toggleUpdateUsersModal}
               />
-              {queryParams.status === 'INACTIVE' && (
+              {statusValue === 'INACTIVE' && (
                 <BAIButton
                   icon={
                     <Trash2 style={{ color: token.colorError }} size="1em" />
@@ -478,9 +472,11 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
             </BAIFlex>
           )}
           <BAIFetchKeyButton
-            loading={deferredFetchKey !== fetchKey}
-            value={fetchKey}
-            onChange={updateFetchKey}
+            loading={isPending}
+            value=""
+            onChange={() => {
+              onReload(variables, { fetchPolicy: 'network-only' });
+            }}
           />
           {/* ONE attached control, not two adjacent buttons.
               `ButtonGroup` joins its children through CONTEXT, not through
@@ -590,14 +586,15 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           ];
         }}
         pagination={{
-          pageSize: tablePaginationOption.pageSize,
+          pageSize,
           total: adminUsersV2?.count || 0,
-          current: tablePaginationOption.current,
-          onChange: (current, pageSize) => {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({
-                current,
-                pageSize,
+          current,
+          onChange: (nextCurrent, nextPageSize) => {
+            if (_.isNumber(nextCurrent) && _.isNumber(nextPageSize)) {
+              onReload({
+                ...variables,
+                limit: nextPageSize,
+                offset: (nextCurrent - 1) * nextPageSize,
               });
               setSelectedUserList([]);
             }
@@ -618,14 +615,14 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           ),
         }}
         onChangeOrder={(nextOrder) => {
-          setQueryParams({ order: nextOrder });
+          onReload({
+            ...variables,
+            orderBy: convertToOrderBy<Required<UserV2OrderBy>>(nextOrder),
+          });
           setSelectedUserList([]);
         }}
-        order={queryParams.order}
-        loading={
-          deferredQueryVariables !== queryVariables ||
-          deferredFetchKey !== fetchKey
-        }
+        order={orderValue}
+        loading={isPending}
         tableSettings={{
           columnOverrides: columnOverrides,
           onColumnOverridesChange: setColumnOverrides,
@@ -636,7 +633,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
                 supportedFields,
                 onExport: async (selectedExportKeys) => {
                   await exportCSV(selectedExportKeys, {
-                    status: [_.toLower(queryParams.status)],
+                    status: [_.toLower(statusValue)],
                   }).catch((err) => {
                     message.error(t('general.ErrorOccurred'));
                     logger.error(err);
@@ -660,7 +657,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onRequestClose={(success) => {
             setSelectedUserForSettingModal(null);
             if (success) {
-              updateFetchKey();
+              onReload(variables, { fetchPolicy: 'network-only' });
             }
           }}
         />
@@ -674,7 +671,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
             setOpenCreateModal(false);
             setOpenBulkCreateModal(false);
             if (success) {
-              updateFetchKey();
+              onReload(variables, { fetchPolicy: 'network-only' });
             }
           }}
         />
@@ -685,7 +682,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onRequestClose={(success) => {
             setOpenBulkCreateCSVModal(false);
             if (success) {
-              updateFetchKey();
+              onReload(variables, { fetchPolicy: 'network-only' });
             }
           }}
         />
@@ -696,7 +693,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onOk={() => {
             togglePurgeUsersModal();
             setSelectedUserList([]);
-            updateFetchKey();
+            onReload(variables, { fetchPolicy: 'network-only' });
           }}
           onCancel={() => {
             togglePurgeUsersModal();
@@ -712,7 +709,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
               prev.filter((user) => user?.node?.id !== purgeTargetId),
             );
             setPurgeTargetId(null);
-            updateFetchKey();
+            onReload(variables, { fetchPolicy: 'network-only' });
           }}
           onCancel={() => {
             setPurgeTargetId(null);
@@ -730,7 +727,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onOk={() => {
             toggleUpdateUsersModal();
             setSelectedUserList([]);
-            updateFetchKey();
+            onReload(variables, { fetchPolicy: 'network-only' });
           }}
           onCancel={() => {
             toggleUpdateUsersModal();

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -3,16 +3,15 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import {
-  AdminUserManagementQuery,
+  AdminUserManagementQuery as AdminUserManagementQueryType,
   AdminUserManagementQuery$data,
   UserV2Filter,
   UserV2OrderBy,
 } from '../__generated__/AdminUserManagementQuery.graphql';
 import { AdminUserManagementUpdateUserMutation } from '../__generated__/AdminUserManagementUpdateUserMutation.graphql';
-import { convertToOrderBy } from '../helper';
+import { convertFromOrderBy, convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTOTPSupported } from '../hooks/backendai';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCSVExport } from '../hooks/useCSVExport';
 import BAIRadioGroup from './BAIRadioGroup';
@@ -44,44 +43,74 @@ import {
   BAISelectionLabel,
   BAINameActionCell,
   BAIUnmountAfterClose,
-  INITIAL_FETCH_KEY,
-  useFetchKey,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { BanIcon, PlusIcon, SquarePenIcon, UndoIcon } from 'lucide-react';
-import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { useState, useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  useMutation,
+  usePreloadedQuery,
+  type PreloadedQuery,
+  type UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
 
-interface AdminUserManagementProps {}
+export const AdminUserManagementQuery = graphql`
+  query AdminUserManagementQuery(
+    $filter: UserV2Filter
+    $orderBy: [UserV2OrderBy!]
+    $limit: Int
+    $offset: Int
+    $isNotSupportTotp: Boolean!
+  ) {
+    adminUsersV2(
+      filter: $filter
+      orderBy: $orderBy
+      limit: $limit
+      offset: $offset
+    ) {
+      count
+      edges {
+        node {
+          id
+          basicInfo {
+            email
+          }
+          ...BAIAdminUserV2TableFragment
+          ...PurgeUsersModalFragment
+          ...UpdateUsersModalFragment
+          ...UserInfoModalFragment
+          ...UserSettingModalFragment
+        }
+      }
+    }
+  }
+`;
+
+interface AdminUserManagementProps {
+  queryRef: PreloadedQuery<AdminUserManagementQueryType>;
+  onReload: (
+    variables: AdminUserManagementQueryType['variables'],
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => void;
+}
 
 type UserNode = NonNullable<
   NonNullable<AdminUserManagementQuery$data['adminUsersV2']>['edges']
 >[number];
 
-const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
+const AdminUserManagement: React.FC<AdminUserManagementProps> = ({
+  queryRef,
+  onReload,
+}) => {
   'use memo';
 
   const { logger } = useBAILogger();
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [fetchKey, updateFetchKey] = useFetchKey();
 
   const bailClient = useSuspendedBackendaiClient();
-
-  const [queryParams, setQueryParams] = useQueryStates(
-    {
-      filter: parseAsJson<UserV2Filter>((value) => value as UserV2Filter),
-      order: parseAsStringLiteral(availableUserV2SorterValues),
-      status: parseAsStringLiteral(['ACTIVE', 'INACTIVE']).withDefault(
-        'ACTIVE',
-      ),
-    },
-    {
-      history: 'replace',
-    },
-  );
   const { message } = App.useApp();
 
   const [selectedUserForInfoModal, setSelectedUserForInfoModal] = useState<
@@ -101,35 +130,26 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
   const [openUpdateUsersModal, { toggle: toggleUpdateUsersModal }] =
     useToggle(false);
 
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParam({
-    current: 1,
-    pageSize: 10,
-  });
-
   const { isTOTPSupported } = useTOTPSupported();
 
-  const statusFilter =
-    queryParams.status === 'ACTIVE'
-      ? ({ equals: 'ACTIVE' } as const)
-      : ({ notEquals: 'ACTIVE' } as const);
+  // The page owns URL state and the fetch; this component derives every
+  // filter/order/pagination control from the last requested variables and
+  // funnels changes back through `onReload`.
+  const variables = queryRef.variables;
+  const statusValue =
+    variables.filter?.status?.equals === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE';
+  const propertyFilterValue = _.omit(variables.filter ?? {}, 'status');
+  const orderValue = convertFromOrderBy(variables.orderBy) as
+    (typeof availableUserV2SorterValues)[number] | null;
+  const pageSize = variables.limit ?? 10;
+  const current = Math.floor((variables.offset ?? 0) / pageSize) + 1;
 
-  const queryVariables = {
-    filter: {
-      ...(queryParams.filter ?? {}),
-      status: statusFilter,
-    },
-    orderBy: convertToOrderBy<Required<UserV2OrderBy>>(queryParams.order),
-    limit: baiPaginationOption.limit,
-    offset: baiPaginationOption.offset,
-    isNotSupportTotp: !isTOTPSupported,
+  const deferredQueryRef = useDeferredValue(queryRef);
+  const isPending = deferredQueryRef !== queryRef;
+
+  const reloadCurrentVariables = () => {
+    onReload(variables, { fetchPolicy: 'network-only' });
   };
-
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.AdminUserManagement',
@@ -137,46 +157,9 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
 
   const { supportedFields, exportCSV } = useCSVExport('users');
 
-  const { adminUsersV2 } = useLazyLoadQuery<AdminUserManagementQuery>(
-    graphql`
-      query AdminUserManagementQuery(
-        $filter: UserV2Filter
-        $orderBy: [UserV2OrderBy!]
-        $limit: Int
-        $offset: Int
-        $isNotSupportTotp: Boolean!
-      ) {
-        adminUsersV2(
-          filter: $filter
-          orderBy: $orderBy
-          limit: $limit
-          offset: $offset
-        ) {
-          count
-          edges {
-            node {
-              id
-              basicInfo {
-                email
-              }
-              ...BAIAdminUserV2TableFragment
-              ...PurgeUsersModalFragment
-              ...UpdateUsersModalFragment
-              ...UserInfoModalFragment
-              ...UserSettingModalFragment
-            }
-          }
-        }
-      }
-    `,
-    deferredQueryVariables,
-    {
-      fetchKey: deferredFetchKey,
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-    },
+  const { adminUsersV2 } = usePreloadedQuery<AdminUserManagementQueryType>(
+    AdminUserManagementQuery,
+    deferredQueryRef,
   );
 
   // >= 26.4.0: adminUpdateUserV2 — status toggle keyed by userId.
@@ -252,7 +235,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
                   setSelectedUserList((prev) =>
                     prev.filter((user) => user?.node?.id !== record?.id),
                   );
-                  updateFetchKey();
+                  reloadCurrentVariables();
                 };
 
                 if (record?.id) {
@@ -419,11 +402,18 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
       <BAIFlex justify="between" align="start" gap="xs" wrap="wrap">
         <BAIFlex direction="row" gap={'sm'} align="start" wrap="wrap">
           <BAIRadioGroup
-            value={queryParams.status}
+            value={statusValue}
             onChange={(e) => {
-              setQueryParams({ status: e.target.value });
-              setTablePaginationOption({
-                current: 1,
+              onReload({
+                ...variables,
+                filter: {
+                  ...propertyFilterValue,
+                  status:
+                    e.target.value === 'ACTIVE'
+                      ? { equals: 'ACTIVE' }
+                      : { notEquals: 'ACTIVE' },
+                },
+                offset: 0,
               });
               setSelectedUserList([]);
             }}
@@ -441,10 +431,20 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           />
           <BAIGraphQLPropertyFilter<UserV2Filter>
             filterProperties={filterProperties}
-            value={queryParams.filter ?? undefined}
+            value={
+              _.isEmpty(propertyFilterValue)
+                ? undefined
+                : (propertyFilterValue as UserV2Filter)
+            }
             onChange={(value) => {
-              setQueryParams({ filter: value ?? null });
-              setTablePaginationOption({ current: 1 });
+              onReload({
+                ...variables,
+                filter: {
+                  ...(value ?? {}),
+                  status: variables.filter?.status,
+                },
+                offset: 0,
+              });
               setSelectedUserList([]);
             }}
           />
@@ -460,7 +460,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
                 icon={<SquarePenIcon style={{ color: token.colorInfo }} />}
                 onClick={toggleUpdateUsersModal}
               />
-              {queryParams.status === 'INACTIVE' && (
+              {statusValue === 'INACTIVE' && (
                 <BAIButton
                   icon={<DeleteFilled style={{ color: token.colorError }} />}
                   onClick={togglePurgeUsersModal}
@@ -469,9 +469,11 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
             </BAIFlex>
           )}
           <BAIFetchKeyButton
-            loading={deferredFetchKey !== fetchKey}
-            value={fetchKey}
-            onChange={updateFetchKey}
+            loading={isPending}
+            value=""
+            onChange={() => {
+              reloadCurrentVariables();
+            }}
           />
           <Space.Compact>
             <BAIButton
@@ -536,15 +538,16 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
         }}
         scroll={{ x: 'max-content' }}
         pagination={{
-          pageSize: tablePaginationOption.pageSize,
+          pageSize,
           total: adminUsersV2?.count || 0,
-          current: tablePaginationOption.current,
+          current,
           style: { marginRight: token.marginXS },
-          onChange: (current, pageSize) => {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({
-                current,
-                pageSize,
+          onChange: (nextCurrent, nextPageSize) => {
+            if (_.isNumber(nextCurrent) && _.isNumber(nextPageSize)) {
+              onReload({
+                ...variables,
+                limit: nextPageSize,
+                offset: (nextCurrent - 1) * nextPageSize,
               });
               setSelectedUserList([]);
             }
@@ -565,14 +568,14 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           ),
         }}
         onChangeOrder={(nextOrder) => {
-          setQueryParams({ order: nextOrder });
+          onReload({
+            ...variables,
+            orderBy: convertToOrderBy<Required<UserV2OrderBy>>(nextOrder),
+          });
           setSelectedUserList([]);
         }}
-        order={queryParams.order}
-        loading={
-          deferredQueryVariables !== queryVariables ||
-          deferredFetchKey !== fetchKey
-        }
+        order={orderValue}
+        loading={isPending}
         tableSettings={{
           columnOverrides: columnOverrides,
           onColumnOverridesChange: setColumnOverrides,
@@ -583,7 +586,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
                 supportedFields,
                 onExport: async (selectedExportKeys) => {
                   await exportCSV(selectedExportKeys, {
-                    status: [_.toLower(queryParams.status)],
+                    status: [_.toLower(statusValue)],
                   }).catch((err) => {
                     message.error(t('general.ErrorOccurred'));
                     logger.error(err);
@@ -607,7 +610,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onRequestClose={(success) => {
             setSelectedUserForSettingModal(null);
             if (success) {
-              updateFetchKey();
+              reloadCurrentVariables();
             }
           }}
         />
@@ -621,7 +624,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
             setOpenCreateModal(false);
             setOpenBulkCreateModal(false);
             if (success) {
-              updateFetchKey();
+              reloadCurrentVariables();
             }
           }}
         />
@@ -632,7 +635,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onRequestClose={(success) => {
             setOpenBulkCreateCSVModal(false);
             if (success) {
-              updateFetchKey();
+              reloadCurrentVariables();
             }
           }}
         />
@@ -643,7 +646,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onOk={() => {
             togglePurgeUsersModal();
             setSelectedUserList([]);
-            updateFetchKey();
+            reloadCurrentVariables();
           }}
           onCancel={() => {
             togglePurgeUsersModal();
@@ -659,7 +662,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
               prev.filter((user) => user?.node?.id !== purgeTargetId),
             );
             setPurgeTargetId(null);
-            updateFetchKey();
+            reloadCurrentVariables();
           }}
           onCancel={() => {
             setPurgeTargetId(null);
@@ -677,7 +680,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
           onOk={() => {
             toggleUpdateUsersModal();
             setSelectedUserList([]);
-            updateFetchKey();
+            reloadCurrentVariables();
           }}
           onCancel={() => {
             toggleUpdateUsersModal();

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -88,6 +88,8 @@ export const AdminUserManagementQuery = graphql`
   }
 `;
 
+export const USER_LIST_DEFAULT_PAGE_SIZE = 10;
+
 interface AdminUserManagementProps {
   queryRef: PreloadedQuery<AdminUserManagementQueryType>;
   onReload: (
@@ -139,9 +141,10 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = ({
   const statusValue =
     variables.filter?.status?.equals === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE';
   const propertyFilterValue = _.omit(variables.filter ?? {}, 'status');
-  const orderValue = convertFromOrderBy(variables.orderBy) as
-    (typeof availableUserV2SorterValues)[number] | null;
-  const pageSize = variables.limit ?? 10;
+  const orderValue = convertFromOrderBy<
+    (typeof availableUserV2SorterValues)[number]
+  >(variables.orderBy);
+  const pageSize = variables.limit ?? USER_LIST_DEFAULT_PAGE_SIZE;
   const current = Math.floor((variables.offset ?? 0) / pageSize) + 1;
 
   const deferredQueryRef = useDeferredValue(queryRef);

--- a/react/src/components/TOTPActivateModal.tsx
+++ b/react/src/components/TOTPActivateModal.tsx
@@ -50,7 +50,9 @@ const TOTPActivateModal: React.FC<Props> = ({
           email
         }
         security {
-          totpActivated @skipOnClient(if: $isNotSupportTotp)
+          totpActivated
+            @skipOnClient(if: $isNotSupportTotp)
+            @skip(if: $isNotSupportTotp)
         }
       }
     `,

--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -50,7 +50,9 @@ const UserInfoModal: React.FC<Props> = ({
           needPasswordChange
         }
         security {
-          totpActivated @skipOnClient(if: $isNotSupportTotp)
+          totpActivated
+            @skipOnClient(if: $isNotSupportTotp)
+            @skip(if: $isNotSupportTotp)
           sudoSessionEnabled
         }
         organization {

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -276,7 +276,9 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
           mainAccessKey
         }
         security {
-          totpActivated @skipOnClient(if: $isNotSupportTotp)
+          totpActivated
+            @skipOnClient(if: $isNotSupportTotp)
+            @skip(if: $isNotSupportTotp)
           sudoSessionEnabled
           allowedClientIp
         }

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -856,11 +856,7 @@ export function isIpIncludedInList(ip: string, entries: string[]): boolean {
 }
 
 type SSEHandlerKeys =
-  | 'onUpdated'
-  | 'onDone'
-  | 'onFailed'
-  | 'onTaskFailed'
-  | 'onTaskCancelled';
+  'onUpdated' | 'onDone' | 'onFailed' | 'onTaskFailed' | 'onTaskCancelled';
 
 export type SSEEventHandlerTypes<
   BaseType = unknown,
@@ -986,4 +982,19 @@ export const convertToOrderBy = <
       direction: isDescending ? 'DESC' : 'ASC',
     } as TOrderBy,
   ];
+};
+
+/**
+ * Inverse of `convertToOrderBy`: an orderBy list back to the sorter string
+ * (`'-createdAt'` style). Only the first entry is used, mirroring
+ * `convertToOrderBy` producing a single-entry list.
+ */
+export const convertFromOrderBy = (
+  orderBy:
+    ReadonlyArray<{ field?: string; direction?: string }> | null | undefined,
+): string | null => {
+  const first = orderBy?.[0];
+  if (!first?.field) return null;
+  const name = _.camelCase(first.field.toLowerCase());
+  return first.direction === 'DESC' ? `-${name}` : name;
 };

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -989,12 +989,12 @@ export const convertToOrderBy = <
  * (`'-createdAt'` style). Only the first entry is used, mirroring
  * `convertToOrderBy` producing a single-entry list.
  */
-export const convertFromOrderBy = (
+export const convertFromOrderBy = <T extends string = string>(
   orderBy:
     ReadonlyArray<{ field?: string; direction?: string }> | null | undefined,
-): string | null => {
+): T | null => {
   const first = orderBy?.[0];
   if (!first?.field) return null;
   const name = _.camelCase(first.field.toLowerCase());
-  return first.direction === 'DESC' ? `-${name}` : name;
+  return (first.direction === 'DESC' ? `-${name}` : name) as T;
 };

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -306,6 +306,27 @@ export const useTOTPSupported = () => {
   return { isTOTPSupported: isManagerSupportingTOTP, isLoading };
 };
 
+/**
+ * Suspending counterpart of `useTOTPSupported`, for callers that must not
+ * render — or issue a query — while the capability is still `undefined`
+ * (e.g. a page that builds `isNotSupportTotp` into preloaded query variables
+ * once). Shares the same TanQuery key, so it resolves from the cache the app
+ * shell has usually already filled.
+ */
+export const useSuspendedTOTPSupported = () => {
+  'use memo';
+  const baiClient = useSuspendedBackendaiClient();
+  const { data: isTOTPSupported } = useSuspenseTanQuery<boolean>({
+    queryKey: ['isManagerSupportingTOTP'],
+    queryFn: () => {
+      return baiClient.isManagerSupportingTOTP();
+    },
+    staleTime: 1000,
+  });
+
+  return isTOTPSupported;
+};
+
 export interface InvitationItem {
   id: string;
   vfolder_id: string;

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -5,9 +5,11 @@
 import { getOS, preserveDotStartCase } from '../helper';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import { MenuKeys } from './useWebUIMenuItems';
+import { useEventListener } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import type { SingleParserBuilder } from 'nuqs';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useOptimisticSearchParams } from 'nuqs/adapters/react-router/v6';
+import { useEffect, useMemo, useRef, useState, useEffectEvent } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -67,6 +69,101 @@ export const useTabQuerySnapshot = <T extends string>(
   };
 
   return { currentTab, onTabChange };
+};
+
+/**
+ * Per-key value snapshots with an uncontrolled current key. The caller
+ * defines the snapshot shape `V` (e.g. `{ queryParams,
+ * tablePaginationOption }`) and passes its live value every render; the
+ * first-render value — typically parsed from the query string — seeds the
+ * initial key's snapshot.
+ *
+ * `sourceKey` seeds the key state and re-syncs it whenever the argument's
+ * value changes (e.g. the caller derives it from the URL and the user
+ * navigates back/forward). The sync is change-triggered, not
+ * difference-triggered: right after `setAfterSnapshot` the caller's async URL
+ * mirror still reports the departing key, but since the argument hasn't
+ * changed, no bounce-back occurs. It also runs during render, so effects only
+ * ever observe a settled key/value pair.
+ *
+ * `setAfterSnapshot(nextKey)` snapshots the current key's value, switches the
+ * key, and synchronously returns the value stored for `nextKey` (`undefined`
+ * if never visited) — so the caller can start a preloaded query and mirror
+ * the URL inside the same event handler (render-as-you-fetch).
+ */
+export const useKeyedSnapshot = <K extends string, V>(
+  sourceKey: K,
+  value: V,
+): [K, (nextKey: K) => V | undefined] => {
+  'use memo';
+  const [currentKey, setCurrentKey] = useState(sourceKey);
+  const [prevSourceKey, setPrevSourceKey] = useState(sourceKey);
+  const snapshotMapRef = useRef<Partial<Record<K, V>>>({
+    [currentKey]: value,
+  } as Partial<Record<K, V>>);
+
+  if (sourceKey !== prevSourceKey) {
+    setPrevSourceKey(sourceKey);
+    if (sourceKey !== currentKey) {
+      setCurrentKey(sourceKey);
+    }
+  }
+
+  useEffect(() => {
+    snapshotMapRef.current[currentKey] = value;
+  }, [currentKey, value]);
+
+  const setAfterSnapshot = (nextKey: K): V | undefined => {
+    snapshotMapRef.current[currentKey] = value;
+    setCurrentKey(nextKey);
+    return snapshotMapRef.current[nextKey];
+  };
+
+  return [currentKey, setAfterSnapshot];
+};
+
+/** Key order doesn't matter for "are these the same query string?". */
+const normalizeSearch = (search: string | URLSearchParams) => {
+  const params = new URLSearchParams(search);
+  params.sort();
+  return params.toString();
+};
+
+/**
+ * Runs `onSettled` after a browser back/forward, once nuqs' query state
+ * matches the address bar — so callers can read their nuqs state inside the
+ * callback without comparing it against `location.search` themselves.
+ *
+ * The wait is the point: nuqs applies `popstate` inside a `startTransition`,
+ * so for at least one render after the event every `useQueryStates` value
+ * still describes the page the user just left.
+ */
+export const useBrowserPopstateEffect = (onSettled: () => void) => {
+  'use memo';
+  const handleSettled = useEffectEvent(onSettled);
+  // nuqs' view of the URL; a fresh object per popstate re-runs the effect below.
+  const nuqsSearchParams = useOptimisticSearchParams();
+  // Distinguishes back/forward from the page's own `setQueryParams` writes.
+  const isSettlePendingRef = useRef(false);
+
+  useEventListener('popstate', () => {
+    isSettlePendingRef.current = true;
+  });
+
+  useEffect(
+    function runOnceQueryStateCaughtUp() {
+      if (!isSettlePendingRef.current) return;
+      if (
+        normalizeSearch(nuqsSearchParams) !==
+        normalizeSearch(window.location.search)
+      ) {
+        return;
+      }
+      isSettlePendingRef.current = false;
+      handleSettled();
+    },
+    [nuqsSearchParams],
+  );
 };
 
 export const useBackendAIConnectedState = () => {

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -81,10 +81,9 @@ export const useTabQuerySnapshot = <T extends string>(
  * `sourceKey` seeds the key state and re-syncs it whenever the argument's
  * value changes (e.g. the caller derives it from the URL and the user
  * navigates back/forward). The sync is change-triggered, not
- * difference-triggered: right after `setAfterSnapshot` the caller's async URL
- * mirror still reports the departing key, but since the argument hasn't
- * changed, no bounce-back occurs. It also runs during render, so effects only
- * ever observe a settled key/value pair.
+ * difference-triggered, so a rerender whose `sourceKey` still reports the
+ * departing key cannot undo `setAfterSnapshot`. It runs during render, so
+ * effects only ever observe a settled key/value pair.
  *
  * `setAfterSnapshot(nextKey)` snapshots the current key's value, switches the
  * key, and synchronously returns the value stored for `nextKey` (`undefined`

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -82,18 +82,19 @@ export const useTabQuerySnapshot = <T extends string>(
  * value changes (e.g. the caller derives it from the URL and the user
  * navigates back/forward). The sync is change-triggered, not
  * difference-triggered, so a rerender whose `sourceKey` still reports the
- * departing key cannot undo `setAfterSnapshot`. It runs during render, so
+ * departing key cannot undo `setKey`. It runs during render, so
  * effects only ever observe a settled key/value pair.
  *
- * `setAfterSnapshot(nextKey)` snapshots the current key's value, switches the
- * key, and synchronously returns the value stored for `nextKey` (`undefined`
- * if never visited) — so the caller can start a preloaded query and mirror
- * the URL inside the same event handler (render-as-you-fetch).
+ * `setKey(nextKey)` snapshots the current key's value and switches the key.
+ * `peekSnapshot(key)` reads the value stored for `key` (`undefined` if never
+ * visited) without touching any state — together they let the caller start a
+ * preloaded query and mirror the URL inside the same event handler
+ * (render-as-you-fetch).
  */
 export const useKeyedSnapshot = <K extends string, V>(
   sourceKey: K,
   value: V,
-): [K, (nextKey: K) => V | undefined] => {
+): [K, (nextKey: K) => void, (key: K) => V | undefined] => {
   'use memo';
   const [currentKey, setCurrentKey] = useState(sourceKey);
   const [prevSourceKey, setPrevSourceKey] = useState(sourceKey);
@@ -112,13 +113,17 @@ export const useKeyedSnapshot = <K extends string, V>(
     snapshotMapRef.current[currentKey] = value;
   }, [currentKey, value]);
 
-  const setAfterSnapshot = (nextKey: K): V | undefined => {
+  const setKey = (nextKey: K) => {
     snapshotMapRef.current[currentKey] = value;
     setCurrentKey(nextKey);
-    return snapshotMapRef.current[nextKey];
   };
 
-  return [currentKey, setAfterSnapshot];
+  // The current key answers with the live value: its ref entry is only as
+  // fresh as the last commit's effect.
+  const peekSnapshot = (key: K): V | undefined =>
+    key === currentKey ? value : snapshotMapRef.current[key];
+
+  return [currentKey, setKey, peekSnapshot];
 };
 
 /** Key order doesn't matter for "are these the same query string?". */

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -69,19 +69,19 @@ export const useTabQuerySnapshot = <T extends string>(
 };
 
 /**
- * Per-key value snapshots with an uncontrolled current key.
+ * Per-key value snapshots with an uncontrolled current key. The caller
+ * defines the snapshot shape `V` (e.g. `{ queryParams,
+ * tablePaginationOption }`) and passes its live value every render; the
+ * first-render value — typically parsed from the query string — seeds the
+ * initial key's snapshot.
  *
  * `sourceKey` seeds the key state and re-syncs it whenever the argument's
  * value changes (e.g. the caller derives it from the URL and the user
  * navigates back/forward). The sync is change-triggered, not
  * difference-triggered: right after `setAfterSnapshot` the caller's async URL
  * mirror still reports the departing key, but since the argument hasn't
- * changed, no bounce-back occurs.
- *
- * `getValue` reads the value to snapshot for a key; keying the read this way
- * (instead of taking the active value directly) keeps every map write an
- * internally consistent key/value pair even on renders where the key is
- * mid-transition.
+ * changed, no bounce-back occurs. It also runs during render, so effects only
+ * ever observe a settled key/value pair.
  *
  * `setAfterSnapshot(nextKey)` snapshots the current key's value, switches the
  * key, and synchronously returns the value stored for `nextKey` (`undefined`
@@ -90,12 +90,14 @@ export const useTabQuerySnapshot = <T extends string>(
  */
 export const useKeyedSnapshot = <K extends string, V>(
   sourceKey: K,
-  getValue: (key: K) => V,
+  value: V,
 ): [K, (nextKey: K) => V | undefined] => {
   'use memo';
   const [currentKey, setCurrentKey] = useState(sourceKey);
   const [prevSourceKey, setPrevSourceKey] = useState(sourceKey);
-  const snapshotMapRef = useRef<Partial<Record<K, V>>>({});
+  const snapshotMapRef = useRef<Partial<Record<K, V>>>({
+    [currentKey]: value,
+  } as Partial<Record<K, V>>);
 
   if (sourceKey !== prevSourceKey) {
     setPrevSourceKey(sourceKey);
@@ -105,11 +107,11 @@ export const useKeyedSnapshot = <K extends string, V>(
   }
 
   useEffect(() => {
-    snapshotMapRef.current[currentKey] = getValue(currentKey);
-  });
+    snapshotMapRef.current[currentKey] = value;
+  }, [currentKey, value]);
 
   const setAfterSnapshot = (nextKey: K): V | undefined => {
-    snapshotMapRef.current[currentKey] = getValue(currentKey);
+    snapshotMapRef.current[currentKey] = value;
     setCurrentKey(nextKey);
     return snapshotMapRef.current[nextKey];
   };

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -68,6 +68,55 @@ export const useTabQuerySnapshot = <T extends string>(
   return { currentTab, onTabChange };
 };
 
+/**
+ * Per-key value snapshots with an uncontrolled current key.
+ *
+ * `sourceKey` seeds the key state and re-syncs it whenever the argument's
+ * value changes (e.g. the caller derives it from the URL and the user
+ * navigates back/forward). The sync is change-triggered, not
+ * difference-triggered: right after `setAfterSnapshot` the caller's async URL
+ * mirror still reports the departing key, but since the argument hasn't
+ * changed, no bounce-back occurs.
+ *
+ * `getValue` reads the value to snapshot for a key; keying the read this way
+ * (instead of taking the active value directly) keeps every map write an
+ * internally consistent key/value pair even on renders where the key is
+ * mid-transition.
+ *
+ * `setAfterSnapshot(nextKey)` snapshots the current key's value, switches the
+ * key, and synchronously returns the value stored for `nextKey` (`undefined`
+ * if never visited) — so the caller can start a preloaded query and mirror
+ * the URL inside the same event handler (render-as-you-fetch).
+ */
+export const useKeyedSnapshot = <K extends string, V>(
+  sourceKey: K,
+  getValue: (key: K) => V,
+): [K, (nextKey: K) => V | undefined] => {
+  'use memo';
+  const [currentKey, setCurrentKey] = useState(sourceKey);
+  const [prevSourceKey, setPrevSourceKey] = useState(sourceKey);
+  const snapshotMapRef = useRef<Partial<Record<K, V>>>({});
+
+  if (sourceKey !== prevSourceKey) {
+    setPrevSourceKey(sourceKey);
+    if (sourceKey !== currentKey) {
+      setCurrentKey(sourceKey);
+    }
+  }
+
+  useEffect(() => {
+    snapshotMapRef.current[currentKey] = getValue(currentKey);
+  });
+
+  const setAfterSnapshot = (nextKey: K): V | undefined => {
+    snapshotMapRef.current[currentKey] = getValue(currentKey);
+    setCurrentKey(nextKey);
+    return snapshotMapRef.current[nextKey];
+  };
+
+  return [currentKey, setAfterSnapshot];
+};
+
 export const useBackendAIConnectedState = () => {
   const [time, setTime] = useState<string>();
 

--- a/react/src/hooks/useBrowserPopstateEffect.test.tsx
+++ b/react/src/hooks/useBrowserPopstateEffect.test.tsx
@@ -1,0 +1,92 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * `useBrowserPopstateEffect` is the most delicate assembly in the page-owned
+ * keyed-snapshot pilot (FR-3387). A `popstate` arms a ref, and the callback is
+ * held back until nuqs' query state — applied inside a transition, so it lags
+ * the address bar by at least one render — describes the entry the user
+ * navigated to. The three cases below pin that state machine: silent while
+ * nuqs lags, exactly one call on the render it catches up, and silent for the
+ * page's own `setQueryParams` writes.
+ */
+import { useBrowserPopstateEffect } from '.';
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseOptimisticSearchParams = vi.fn();
+
+vi.mock('nuqs/adapters/react-router/v6', () => ({
+  useOptimisticSearchParams: () => mockUseOptimisticSearchParams(),
+}));
+
+/** nuqs hands out a fresh object every time its parsed state moves. */
+const nuqsRendersWith = (search: string) => {
+  mockUseOptimisticSearchParams.mockReturnValue(new URLSearchParams(search));
+};
+
+/** Back/forward: the address bar moves first, and only then nuqs follows. */
+const browserNavigatesTo = (search: string) => {
+  window.history.replaceState({}, '', search);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
+describe('useBrowserPopstateEffect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '?tab=users');
+    nuqsRendersWith('?tab=users');
+  });
+
+  it('stays silent while nuqs has not caught up with the address bar', () => {
+    const onSettled = vi.fn();
+    const { rerender } = renderHook(() => useBrowserPopstateEffect(onSettled));
+
+    act(() => {
+      browserNavigatesTo('?tab=credentials');
+    });
+    // The transition renders once more with the departed entry's params.
+    nuqsRendersWith('?tab=users');
+    rerender();
+
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+
+  it('fires exactly once, on the render where nuqs catches up', () => {
+    const onSettled = vi.fn();
+    const { rerender } = renderHook(() => useBrowserPopstateEffect(onSettled));
+
+    act(() => {
+      browserNavigatesTo('?tab=credentials&status=INACTIVE');
+    });
+    nuqsRendersWith('?tab=users');
+    rerender();
+    expect(onSettled).not.toHaveBeenCalled();
+
+    // Key order is not a difference — the hook compares sorted params.
+    nuqsRendersWith('?status=INACTIVE&tab=credentials');
+    rerender();
+    expect(onSettled).toHaveBeenCalledTimes(1);
+
+    // The navigation is consumed: later renders must not replay it.
+    nuqsRendersWith('?status=INACTIVE&tab=credentials');
+    rerender();
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent for the page's own query-param writes", () => {
+    const onSettled = vi.fn();
+    const { rerender } = renderHook(() => useBrowserPopstateEffect(onSettled));
+
+    // `setQueryParams` updates nuqs and writes the URL through
+    // `pushState`/`replaceState`, neither of which emits `popstate`.
+    act(() => {
+      window.history.replaceState({}, '', '?tab=users&filter=email');
+    });
+    nuqsRendersWith('?tab=users&filter=email');
+    rerender();
+
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+});

--- a/react/src/hooks/useBrowserPopstateEffect.test.tsx
+++ b/react/src/hooks/useBrowserPopstateEffect.test.tsx
@@ -3,13 +3,12 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 /**
- * `useBrowserPopstateEffect` is the most delicate assembly in the page-owned
- * keyed-snapshot pilot (FR-3387). A `popstate` arms a ref, and the callback is
- * held back until nuqs' query state — applied inside a transition, so it lags
- * the address bar by at least one render — describes the entry the user
- * navigated to. The three cases below pin that state machine: silent while
- * nuqs lags, exactly one call on the render it catches up, and silent for the
- * page's own `setQueryParams` writes.
+ * `useBrowserPopstateEffect` exists so a caller can read its own nuqs state
+ * inside the callback (FR-3387). nuqs applies `popstate` in a transition, so a
+ * render can still carry the departed entry's params after the address bar has
+ * moved — the hook's job is to withhold the callback until the two agree. That
+ * window is not guaranteed to occur, only tolerated, so the cases below drive
+ * it by hand.
  */
 import { useBrowserPopstateEffect } from '.';
 import { renderHook, act } from '@testing-library/react';
@@ -34,7 +33,6 @@ const browserNavigatesTo = (search: string) => {
 
 describe('useBrowserPopstateEffect', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     window.history.replaceState({}, '', '?tab=users');
     nuqsRendersWith('?tab=users');
   });
@@ -46,14 +44,14 @@ describe('useBrowserPopstateEffect', () => {
     act(() => {
       browserNavigatesTo('?tab=credentials');
     });
-    // The transition renders once more with the departed entry's params.
+    // A render still carrying the departed entry's params must not release it.
     nuqsRendersWith('?tab=users');
     rerender();
 
     expect(onSettled).not.toHaveBeenCalled();
   });
 
-  it('fires exactly once, on the render where nuqs catches up', () => {
+  it("fires exactly once, once nuqs' params match the address bar", () => {
     const onSettled = vi.fn();
     const { rerender } = renderHook(() => useBrowserPopstateEffect(onSettled));
 
@@ -64,7 +62,7 @@ describe('useBrowserPopstateEffect', () => {
     rerender();
     expect(onSettled).not.toHaveBeenCalled();
 
-    // Key order is not a difference — the hook compares sorted params.
+    // Key order is not a difference.
     nuqsRendersWith('?status=INACTIVE&tab=credentials');
     rerender();
     expect(onSettled).toHaveBeenCalledTimes(1);
@@ -81,9 +79,7 @@ describe('useBrowserPopstateEffect', () => {
 
     // `setQueryParams` updates nuqs and writes the URL through
     // `pushState`/`replaceState`, neither of which emits `popstate`.
-    act(() => {
-      window.history.replaceState({}, '', '?tab=users&filter=email');
-    });
+    window.history.replaceState({}, '', '?tab=users&filter=email');
     nuqsRendersWith('?tab=users&filter=email');
     rerender();
 

--- a/react/src/hooks/useKeyedSnapshot.test.tsx
+++ b/react/src/hooks/useKeyedSnapshot.test.tsx
@@ -25,15 +25,10 @@ describe('useKeyedSnapshot', () => {
     act(() => {
       result.current[1]('credentials');
     });
-    let restored: string | undefined;
-    act(() => {
-      restored = result.current[1]('users');
-    });
-
-    expect(restored).toBe('users-initial');
+    expect(result.current[2]('users')).toBe('users-initial');
   });
 
-  it('snapshots the departing key and returns the target key value', () => {
+  it('snapshots the departing key and peeks the target key value', () => {
     const { result, rerender } = renderKeyedSnapshot('users', 'users-initial');
 
     rerender({ sourceKey: 'users', value: 'users-edited' });
@@ -42,29 +37,31 @@ describe('useKeyedSnapshot', () => {
     });
     rerender({ sourceKey: 'credentials', value: 'credentials-edited' });
 
-    let restoredUsers: string | undefined;
+    expect(result.current[2]('users')).toBe('users-edited');
     act(() => {
-      restoredUsers = result.current[1]('users');
+      result.current[1]('users');
     });
-    expect(restoredUsers).toBe('users-edited');
     expect(result.current[0]).toBe('users');
-
-    let restoredCredentials: string | undefined;
-    act(() => {
-      restoredCredentials = result.current[1]('credentials');
-    });
-    expect(restoredCredentials).toBe('credentials-edited');
+    expect(result.current[2]('credentials')).toBe('credentials-edited');
   });
 
-  it('returns undefined for a key that was never visited', () => {
+  it('peeks the live value for the current key', () => {
+    const { result, rerender } = renderKeyedSnapshot('users', 'users-initial');
+
+    rerender({ sourceKey: 'users', value: 'users-edited' });
+
+    expect(result.current[2]('users')).toBe('users-edited');
+  });
+
+  it('returns undefined for a key that was never visited, without switching', () => {
     const { result } = renderKeyedSnapshot('users', 'users-initial');
 
-    let restored: string | undefined = 'not-undefined';
-    act(() => {
-      restored = result.current[1]('credentials');
-    });
+    expect(result.current[2]('credentials')).toBeUndefined();
+    expect(result.current[0]).toBe('users');
 
-    expect(restored).toBeUndefined();
+    act(() => {
+      result.current[1]('credentials');
+    });
     expect(result.current[0]).toBe('credentials');
   });
 
@@ -78,7 +75,7 @@ describe('useKeyedSnapshot', () => {
 
     // A rerender arrives with `sourceKey` still describing the tab the user
     // just left: an unchanged `sourceKey` must never override a key that was
-    // set through `setAfterSnapshot`.
+    // set through `setKey`.
     rerender({ sourceKey: 'users', value: 'users-initial' });
     expect(result.current[0]).toBe('credentials');
   });
@@ -87,7 +84,7 @@ describe('useKeyedSnapshot', () => {
     const { result, rerender } = renderKeyedSnapshot('users', 'users-initial');
 
     // A browser navigation changes the source key without going through
-    // setAfterSnapshot.
+    // setKey.
     rerender({ sourceKey: 'credentials', value: 'credentials-from-url' });
 
     expect(result.current[0]).toBe('credentials');

--- a/react/src/hooks/useKeyedSnapshot.test.tsx
+++ b/react/src/hooks/useKeyedSnapshot.test.tsx
@@ -76,21 +76,11 @@ describe('useKeyedSnapshot', () => {
     });
     expect(result.current[0]).toBe('credentials');
 
-    // The case the hook's docblock defends: a rerender arrives with
-    // `sourceKey` still describing the tab the user just left. The sync is
-    // change-triggered, so an unchanged argument must not bounce the key back.
+    // A rerender arrives with `sourceKey` still describing the tab the user
+    // just left: an unchanged `sourceKey` must never override a key that was
+    // set through `setAfterSnapshot`.
     rerender({ sourceKey: 'users', value: 'users-initial' });
     expect(result.current[0]).toBe('credentials');
-
-    rerender({ sourceKey: 'credentials', value: 'credentials-initial' });
-    expect(result.current[0]).toBe('credentials');
-
-    // …and the departing key's snapshot survived that render.
-    let restored: string | undefined;
-    act(() => {
-      restored = result.current[1]('users');
-    });
-    expect(restored).toBe('users-initial');
   });
 
   it('re-syncs the current key when the source key changes', () => {

--- a/react/src/hooks/useKeyedSnapshot.test.tsx
+++ b/react/src/hooks/useKeyedSnapshot.test.tsx
@@ -68,6 +68,31 @@ describe('useKeyedSnapshot', () => {
     expect(result.current[0]).toBe('credentials');
   });
 
+  it('holds the new key while the source key still reports the departing one', () => {
+    const { result, rerender } = renderKeyedSnapshot('users', 'users-initial');
+
+    act(() => {
+      result.current[1]('credentials');
+    });
+    expect(result.current[0]).toBe('credentials');
+
+    // The case the hook's docblock defends: a rerender arrives with
+    // `sourceKey` still describing the tab the user just left. The sync is
+    // change-triggered, so an unchanged argument must not bounce the key back.
+    rerender({ sourceKey: 'users', value: 'users-initial' });
+    expect(result.current[0]).toBe('credentials');
+
+    rerender({ sourceKey: 'credentials', value: 'credentials-initial' });
+    expect(result.current[0]).toBe('credentials');
+
+    // …and the departing key's snapshot survived that render.
+    let restored: string | undefined;
+    act(() => {
+      restored = result.current[1]('users');
+    });
+    expect(restored).toBe('users-initial');
+  });
+
   it('re-syncs the current key when the source key changes', () => {
     const { result, rerender } = renderKeyedSnapshot('users', 'users-initial');
 

--- a/react/src/hooks/useKeyedSnapshot.test.tsx
+++ b/react/src/hooks/useKeyedSnapshot.test.tsx
@@ -92,8 +92,7 @@ describe('useKeyedSnapshot', () => {
 
     expect(result.current[0]).toBe('credentials');
 
-    // The source key holding still (the async URL mirror after a tab click)
-    // must not move the key back.
+    // An unchanged source key is a no-op.
     rerender({ sourceKey: 'credentials', value: 'credentials-from-url' });
     expect(result.current[0]).toBe('credentials');
   });

--- a/react/src/hooks/useKeyedSnapshot.test.tsx
+++ b/react/src/hooks/useKeyedSnapshot.test.tsx
@@ -1,0 +1,85 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useKeyedSnapshot } from '.';
+import { renderHook, act } from '@testing-library/react';
+
+type Tab = 'users' | 'credentials';
+
+const renderKeyedSnapshot = (initialKey: Tab, initialValue: string) =>
+  renderHook(
+    ({ sourceKey, value }: { sourceKey: Tab; value: string }) =>
+      useKeyedSnapshot<Tab, string>(sourceKey, value),
+    { initialProps: { sourceKey: initialKey, value: initialValue } },
+  );
+
+describe('useKeyedSnapshot', () => {
+  it('seeds the initial key with the first rendered value', () => {
+    const { result } = renderKeyedSnapshot('users', 'users-initial');
+
+    expect(result.current[0]).toBe('users');
+
+    // Leave and come back: the value present on the first render must be what
+    // the initial key restores to.
+    act(() => {
+      result.current[1]('credentials');
+    });
+    let restored: string | undefined;
+    act(() => {
+      restored = result.current[1]('users');
+    });
+
+    expect(restored).toBe('users-initial');
+  });
+
+  it('snapshots the departing key and returns the target key value', () => {
+    const { result, rerender } = renderKeyedSnapshot('users', 'users-initial');
+
+    rerender({ sourceKey: 'users', value: 'users-edited' });
+    act(() => {
+      result.current[1]('credentials');
+    });
+    rerender({ sourceKey: 'credentials', value: 'credentials-edited' });
+
+    let restoredUsers: string | undefined;
+    act(() => {
+      restoredUsers = result.current[1]('users');
+    });
+    expect(restoredUsers).toBe('users-edited');
+    expect(result.current[0]).toBe('users');
+
+    let restoredCredentials: string | undefined;
+    act(() => {
+      restoredCredentials = result.current[1]('credentials');
+    });
+    expect(restoredCredentials).toBe('credentials-edited');
+  });
+
+  it('returns undefined for a key that was never visited', () => {
+    const { result } = renderKeyedSnapshot('users', 'users-initial');
+
+    let restored: string | undefined = 'not-undefined';
+    act(() => {
+      restored = result.current[1]('credentials');
+    });
+
+    expect(restored).toBeUndefined();
+    expect(result.current[0]).toBe('credentials');
+  });
+
+  it('re-syncs the current key when the source key changes', () => {
+    const { result, rerender } = renderKeyedSnapshot('users', 'users-initial');
+
+    // A browser navigation changes the source key without going through
+    // setAfterSnapshot.
+    rerender({ sourceKey: 'credentials', value: 'credentials-from-url' });
+
+    expect(result.current[0]).toBe('credentials');
+
+    // The source key holding still (the async URL mirror after a tab click)
+    // must not move the key back.
+    rerender({ sourceKey: 'credentials', value: 'credentials-from-url' });
+    expect(result.current[0]).toBe('credentials');
+  });
+});

--- a/react/src/hooks/useLogout.test.ts
+++ b/react/src/hooks/useLogout.test.ts
@@ -40,12 +40,15 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
 // ---------------------------------------------------------------------------
 
 // Mock react-i18next so that t() returns the key as-is, making assertions
-// independent of the actual translation strings.
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+// independent of the actual translation strings. The rest of the module stays
+// intact — BUI's locale bootstrap imports `initReactI18next` from here.
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>();
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Helper: set up a fake backendaiclient on globalThis

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -47,13 +47,41 @@ type UsersVariables = AdminUserManagementQueryType['variables'];
 type CredentialsVariables = AdminUserCredentialListQueryType['variables'];
 type TabVariables = UsersVariables | CredentialsVariables;
 
+// The per-tab snapshot shape useKeyedSnapshot holds: the page's URL state
+// (minus the tab key itself) plus table pagination.
+type TabSnapshot = {
+  queryParams: {
+    filter: string | null;
+    order: string | null;
+    status: 'ACTIVE' | 'INACTIVE';
+    activeType: 'active' | 'inactive';
+  };
+  tablePaginationOption: { current: number; pageSize: number };
+};
+
+const defaultSnapshotOf = (tab: TabKey): TabSnapshot => ({
+  queryParams: {
+    filter: null,
+    order: null,
+    status: 'ACTIVE',
+    activeType: 'active',
+  },
+  tablePaginationOption: {
+    current: 1,
+    pageSize:
+      tab === 'users'
+        ? USER_LIST_DEFAULT_PAGE_SIZE
+        : CREDENTIAL_LIST_DEFAULT_PAGE_SIZE,
+  },
+});
+
 /**
  * FR-3387 pilot: the page is the single owner of URL state and query
- * fetching. The URL seeds the initial tab and variables at mount and is a
- * write-only mirror afterwards; per-tab variables are snapshotted by
- * `useKeyedSnapshot`, restored synchronously on tab change, and loaded via
- * `useQueryLoader` (render-as-you-fetch). Children receive `queryRef` +
- * `onReload` and own no URL state.
+ * fetching. The URL seeds the initial tab and snapshot at mount and is a
+ * write-only mirror afterwards; each tab's URL state is snapshotted by
+ * `useKeyedSnapshot`, restored synchronously on tab change, and its GraphQL
+ * variables loaded via `useQueryLoader` (render-as-you-fetch). Children
+ * receive `queryRef` + `onReload` and own no URL state.
  */
 const AdminUsersPage: React.FC = () => {
   'use memo';
@@ -74,11 +102,9 @@ const AdminUsersPage: React.FC = () => {
     },
     { history: 'replace' },
   );
-  const { baiPaginationOption, setTablePaginationOption } =
+  const { tablePaginationOption, setTablePaginationOption } =
     useBAIPaginationOptionStateOnSearchParam(
-      queryParams.tab === 'credentials'
-        ? { current: 1, pageSize: CREDENTIAL_LIST_DEFAULT_PAGE_SIZE }
-        : { current: 1, pageSize: USER_LIST_DEFAULT_PAGE_SIZE },
+      defaultSnapshotOf(queryParams.tab).tablePaginationOption,
     );
 
   const [usersQueryRef, loadUsersQuery] =
@@ -88,119 +114,110 @@ const AdminUsersPage: React.FC = () => {
       AdminUserCredentialListQuery,
     );
 
-  // The retained queryRefs hold each tab's last requested variables; the
-  // snapshot hook reads them per key so every capture is a consistent pair.
-  const [currentTab, setAfterSnapshot] = useKeyedSnapshot<
-    TabKey,
-    TabVariables | undefined
-  >(queryParams.tab, (tab) =>
-    tab === 'users' ? usersQueryRef?.variables : credentialsQueryRef?.variables,
+  const [currentTab, setAfterSnapshot] = useKeyedSnapshot<TabKey, TabSnapshot>(
+    queryParams.tab,
+    {
+      queryParams: _.omit(queryParams, 'tab'),
+      tablePaginationOption,
+    },
   );
 
-  const buildInitialUsersVariables = (): UsersVariables => {
-    const urlFilter = queryParams.filter
+  const usersVariablesOf = (snapshot: TabSnapshot): UsersVariables => {
+    const { queryParams: params, tablePaginationOption: pagination } = snapshot;
+    const filter = params.filter
       ? parseAsJson<UserV2Filter>((value) => value as UserV2Filter).parse(
-          queryParams.filter,
+          params.filter,
         )
       : null;
-    const order = _.includes(availableUserV2SorterValues, queryParams.order)
-      ? queryParams.order
+    const order = _.includes(availableUserV2SorterValues, params.order)
+      ? params.order
       : null;
     return {
       filter: {
-        ..._.omit(urlFilter ?? {}, 'status'),
+        ..._.omit(filter ?? {}, 'status'),
         status:
-          queryParams.status === 'ACTIVE'
+          params.status === 'ACTIVE'
             ? { equals: 'ACTIVE' }
             : { notEquals: 'ACTIVE' },
       },
       orderBy: convertToOrderBy<Required<UserV2OrderBy>>(order),
-      limit: baiPaginationOption.limit,
-      offset: baiPaginationOption.offset,
+      limit: pagination.pageSize,
+      offset: (pagination.current - 1) * pagination.pageSize,
       isNotSupportTotp: !isTOTPSupported,
     };
   };
 
-  const buildInitialCredentialsVariables = (): CredentialsVariables => ({
-    limit: baiPaginationOption.limit,
-    offset: baiPaginationOption.offset,
-    is_active: queryParams.activeType !== 'inactive',
-    filter: queryParams.filter,
-    order: queryParams.order,
-  });
+  const credentialsVariablesOf = (
+    snapshot: TabSnapshot,
+  ): CredentialsVariables => {
+    const { queryParams: params, tablePaginationOption: pagination } = snapshot;
+    return {
+      limit: pagination.pageSize,
+      offset: (pagination.current - 1) * pagination.pageSize,
+      is_active: params.activeType !== 'inactive',
+      filter: params.filter,
+      order: params.order,
+    };
+  };
 
-  const defaultUsersVariables = (): UsersVariables => ({
-    filter: { status: { equals: 'ACTIVE' } },
-    limit: USER_LIST_DEFAULT_PAGE_SIZE,
-    offset: 0,
-    isNotSupportTotp: !isTOTPSupported,
-  });
-
-  const defaultCredentialsVariables = (): CredentialsVariables => ({
-    limit: CREDENTIAL_LIST_DEFAULT_PAGE_SIZE,
-    offset: 0,
-    is_active: true,
-  });
-
-  const mirrorVariablesToUrl = (
+  const applySnapshotToUrl = (
     tab: TabKey,
-    variables: TabVariables,
+    snapshot: TabSnapshot,
     historyMode: 'push' | 'replace',
   ) => {
-    if (tab === 'users') {
-      const v = variables as UsersVariables;
-      const restFilter = _.omit(v.filter ?? {}, 'status');
-      setQueryParams(
-        {
-          tab,
-          filter: _.isEmpty(restFilter) ? null : JSON.stringify(restFilter),
-          order: convertFromOrderBy(v.orderBy),
-          status: v.filter?.status?.equals === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE',
-          activeType: null,
-        },
-        { history: historyMode },
-      );
-    } else {
-      const v = variables as CredentialsVariables;
-      setQueryParams(
-        {
-          tab,
-          filter: v.filter ?? null,
-          order: v.order ?? null,
-          status: null,
-          activeType: v.is_active === false ? 'inactive' : 'active',
-        },
-        { history: historyMode },
-      );
-    }
-    const pageSize =
-      variables.limit ??
-      (tab === 'users'
-        ? USER_LIST_DEFAULT_PAGE_SIZE
-        : CREDENTIAL_LIST_DEFAULT_PAGE_SIZE);
-    setTablePaginationOption({
-      current: Math.floor((variables.offset ?? 0) / pageSize) + 1,
-      pageSize,
-    });
+    setQueryParams({ tab, ...snapshot.queryParams }, { history: historyMode });
+    setTablePaginationOption(snapshot.tablePaginationOption);
   };
 
   const handleTabChange = (key: string) => {
     const tab = tabParser.parse(key) ?? tabParser.defaultValue;
     if (tab === currentTab) return;
-    const restored = setAfterSnapshot(tab);
-    const variables =
-      restored ??
-      (tab === 'users'
-        ? defaultUsersVariables()
-        : defaultCredentialsVariables());
+    const snapshot = setAfterSnapshot(tab) ?? defaultSnapshotOf(tab);
     // A revisited tab's retained queryRef already holds its data — show it
     // without refetching (freshness is the child's refresh button's job).
     if (tab === 'users' && !usersQueryRef) {
-      loadUsersQuery(variables as UsersVariables);
+      loadUsersQuery(usersVariablesOf(snapshot));
     } else if (tab === 'credentials' && !credentialsQueryRef) {
-      loadCredentialsQuery(variables as CredentialsVariables);
+      loadCredentialsQuery(credentialsVariablesOf(snapshot));
     }
-    mirrorVariablesToUrl(tab, variables, 'push');
+    applySnapshotToUrl(tab, snapshot, 'push');
+  };
+
+  // Child-driven changes arrive as complete GraphQL variables; mirror them
+  // back to the URL keys so the snapshot effect captures the new state.
+  const snapshotOfVariables = (
+    tab: TabKey,
+    variables: TabVariables,
+  ): TabSnapshot => {
+    const pageSize =
+      variables.limit ?? defaultSnapshotOf(tab).tablePaginationOption.pageSize;
+    const tablePaginationOption = {
+      current: Math.floor((variables.offset ?? 0) / pageSize) + 1,
+      pageSize,
+    };
+    if (tab === 'users') {
+      const v = variables as UsersVariables;
+      const restFilter = _.omit(v.filter ?? {}, 'status');
+      return {
+        queryParams: {
+          filter: _.isEmpty(restFilter) ? null : JSON.stringify(restFilter),
+          order: convertFromOrderBy(v.orderBy),
+          status: v.filter?.status?.equals === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE',
+          activeType: 'active',
+        },
+        tablePaginationOption,
+      };
+    }
+    const v = variables as CredentialsVariables;
+    return {
+      queryParams: {
+        filter: v.filter ?? null,
+        order: v.order ?? null,
+        status: 'ACTIVE',
+        activeType: v.is_active === false ? 'inactive' : 'active',
+      },
+      tablePaginationOption,
+    };
   };
 
   const handleUsersReload = (
@@ -208,7 +225,11 @@ const AdminUsersPage: React.FC = () => {
     options?: UseQueryLoaderLoadQueryOptions,
   ) => {
     loadUsersQuery(variables, options);
-    mirrorVariablesToUrl('users', variables, 'replace');
+    applySnapshotToUrl(
+      'users',
+      snapshotOfVariables('users', variables),
+      'replace',
+    );
   };
 
   const handleCredentialsReload = (
@@ -216,18 +237,26 @@ const AdminUsersPage: React.FC = () => {
     options?: UseQueryLoaderLoadQueryOptions,
   ) => {
     loadCredentialsQuery(variables, options);
-    mirrorVariablesToUrl('credentials', variables, 'replace');
+    applySnapshotToUrl(
+      'credentials',
+      snapshotOfVariables('credentials', variables),
+      'replace',
+    );
   };
 
   // Entries that bypass the tab-change handler (initial mount, direct URL
-  // entry, reload) build the active tab's variables from the URL; a tab
-  // reached with a warm queryRef (back/forward) needs no load at all.
+  // entry, reload) build the active tab's variables from the URL-seeded
+  // snapshot; a tab reached with a warm queryRef (back/forward) needs no load.
   const ensureActiveTabLoaded = useEffectEvent(() => {
+    const snapshot: TabSnapshot = {
+      queryParams: _.omit(queryParams, 'tab'),
+      tablePaginationOption,
+    };
     if (currentTab === 'users' && !usersQueryRef) {
-      loadUsersQuery(buildInitialUsersVariables());
+      loadUsersQuery(usersVariablesOf(snapshot));
     }
     if (currentTab === 'credentials' && !credentialsQueryRef) {
-      loadCredentialsQuery(buildInitialCredentialsVariables());
+      loadCredentialsQuery(credentialsVariablesOf(snapshot));
     }
   });
   useEffect(() => {

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -160,29 +160,6 @@ const AdminUsersPage: React.FC = () => {
     };
   };
 
-  const applySnapshotToUrl = (
-    tab: TabKey,
-    snapshot: TabSnapshot,
-    historyMode: 'push' | 'replace',
-  ) => {
-    setQueryParams({ tab, ...snapshot.queryParams }, { history: historyMode });
-    setTablePaginationOption(snapshot.tablePaginationOption);
-  };
-
-  const handleTabChange = (key: string) => {
-    const tab = tabParser.parse(key) ?? tabParser.defaultValue;
-    if (tab === currentTab) return;
-    const snapshot = setAfterSnapshot(tab) ?? defaultSnapshotOf(tab);
-    // A revisited tab's retained queryRef already holds its data — show it
-    // without refetching (freshness is the child's refresh button's job).
-    if (tab === 'users' && !usersQueryRef) {
-      loadUsersQuery(usersVariablesOf(snapshot));
-    } else if (tab === 'credentials' && !credentialsQueryRef) {
-      loadCredentialsQuery(credentialsVariablesOf(snapshot));
-    }
-    applySnapshotToUrl(tab, snapshot, 'push');
-  };
-
   // Child-driven changes arrive as complete GraphQL variables; mirror them
   // back to the URL keys so the snapshot effect captures the new state.
   const snapshotOfVariables = (
@@ -225,11 +202,12 @@ const AdminUsersPage: React.FC = () => {
     options?: UseQueryLoaderLoadQueryOptions,
   ) => {
     loadUsersQuery(variables, options);
-    applySnapshotToUrl(
-      'users',
-      snapshotOfVariables('users', variables),
-      'replace',
+    const snapshot = snapshotOfVariables('users', variables);
+    setQueryParams(
+      { tab: 'users', ...snapshot.queryParams },
+      { history: 'replace' },
     );
+    setTablePaginationOption(snapshot.tablePaginationOption);
   };
 
   const handleCredentialsReload = (
@@ -237,31 +215,31 @@ const AdminUsersPage: React.FC = () => {
     options?: UseQueryLoaderLoadQueryOptions,
   ) => {
     loadCredentialsQuery(variables, options);
-    applySnapshotToUrl(
-      'credentials',
-      snapshotOfVariables('credentials', variables),
-      'replace',
+    const snapshot = snapshotOfVariables('credentials', variables);
+    setQueryParams(
+      { tab: 'credentials', ...snapshot.queryParams },
+      { history: 'replace' },
     );
+    setTablePaginationOption(snapshot.tablePaginationOption);
   };
 
-  // Entries that bypass the tab-change handler (initial mount, direct URL
-  // entry, reload) build the active tab's variables from the URL-seeded
-  // snapshot; a tab reached with a warm queryRef (back/forward) needs no load.
-  const ensureActiveTabLoaded = useEffectEvent(() => {
+  // First visit (mount / direct URL entry / reload) queries once from the
+  // URL-seeded snapshot. Every tab change afterwards restores its snapshot and
+  // queries inside onTabChange.
+  const loadInitialTabFromUrl = useEffectEvent(() => {
     const snapshot: TabSnapshot = {
       queryParams: _.omit(queryParams, 'tab'),
       tablePaginationOption,
     };
-    if (currentTab === 'users' && !usersQueryRef) {
+    if (currentTab === 'users') {
       loadUsersQuery(usersVariablesOf(snapshot));
-    }
-    if (currentTab === 'credentials' && !credentialsQueryRef) {
+    } else {
       loadCredentialsQuery(credentialsVariablesOf(snapshot));
     }
   });
   useEffect(() => {
-    ensureActiveTabLoaded();
-  }, [currentTab]);
+    loadInitialTabFromUrl();
+  }, []);
 
   const tabItems: CardTabListType[] = [
     {
@@ -277,7 +255,18 @@ const AdminUsersPage: React.FC = () => {
   return (
     <BAICard
       activeTabKey={currentTab}
-      onTabChange={handleTabChange}
+      onTabChange={(key) => {
+        const tab = tabParser.parse(key) ?? tabParser.defaultValue;
+        if (tab === currentTab) return;
+        const snapshot = setAfterSnapshot(tab) ?? defaultSnapshotOf(tab);
+        if (tab === 'users') {
+          loadUsersQuery(usersVariablesOf(snapshot));
+        } else {
+          loadCredentialsQuery(credentialsVariablesOf(snapshot));
+        }
+        setQueryParams({ tab, ...snapshot.queryParams }, { history: 'push' });
+        setTablePaginationOption(snapshot.tablePaginationOption);
+      }}
       tabList={tabItems}
     >
       <Suspense fallback={<Skeleton active />}>

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -2,27 +2,254 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import AdminUserCredentialList from '../components/AdminUserCredentialList';
-import AdminUserManagement from '../components/AdminUserManagement';
+import { AdminUserCredentialListQuery as AdminUserCredentialListQueryType } from '../__generated__/AdminUserCredentialListQuery.graphql';
+import {
+  AdminUserManagementQuery as AdminUserManagementQueryType,
+  UserV2Filter,
+  UserV2OrderBy,
+} from '../__generated__/AdminUserManagementQuery.graphql';
+import AdminUserCredentialList, {
+  AdminUserCredentialListQuery,
+  CREDENTIAL_LIST_DEFAULT_PAGE_SIZE,
+} from '../components/AdminUserCredentialList';
+import AdminUserManagement, {
+  AdminUserManagementQuery,
+  USER_LIST_DEFAULT_PAGE_SIZE,
+} from '../components/AdminUserManagement';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
-import { useTabQuerySnapshot } from '../hooks';
 import { BAISkeleton } from 'backend.ai-ui';
+import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
+import { useBrowserPopstateEffect, useKeyedSnapshot } from '../hooks';
+import { useSuspendedTOTPSupported } from '../hooks/backendai';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 // The tab-list item shape now comes from `BAICard` itself (`BAICardTabItem`,
 // restated in BUI when the card stopped being antd's) instead of the deep
 // `antd/es/card` subpath the frontier note used to point at (P15).
-import { BAIFlex, BAICard, type BAICardTabItem } from 'backend.ai-ui';
-import { parseAsStringLiteral } from 'nuqs';
-import { Suspense } from 'react';
+import {
+  BAIFlex,
+  BAICard,
+  availableUserV2SorterValues,
+  type BAICardTabItem,
+} from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import {
+  parseAsJson,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs';
+import { Suspense, useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  useQueryLoader,
+  type UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
 
 const tabParser = parseAsStringLiteral(['users', 'credentials']).withDefault(
   'users',
 );
+const statusParser = parseAsStringLiteral(['ACTIVE', 'INACTIVE']).withDefault(
+  'ACTIVE',
+);
+const activeTypeParser = parseAsStringLiteral([
+  'active',
+  'inactive',
+]).withDefault('active');
+
+type TabKey = 'users' | 'credentials';
+type UsersVariables = AdminUserManagementQueryType['variables'];
+type CredentialsVariables = AdminUserCredentialListQueryType['variables'];
+type TabVariables = UsersVariables | CredentialsVariables;
+
+type TabSnapshot = {
+  queryParams: {
+    filter: string | null;
+    order: string | null;
+    status: 'ACTIVE' | 'INACTIVE';
+    activeType: 'active' | 'inactive';
+  };
+  tablePaginationOption: { current: number; pageSize: number };
+};
+
+const defaultSnapshotOf = (tab: TabKey): TabSnapshot => ({
+  queryParams: {
+    filter: null,
+    order: null,
+    status: statusParser.defaultValue,
+    activeType: activeTypeParser.defaultValue,
+  },
+  tablePaginationOption: {
+    current: 1,
+    pageSize:
+      tab === 'users'
+        ? USER_LIST_DEFAULT_PAGE_SIZE
+        : CREDENTIAL_LIST_DEFAULT_PAGE_SIZE,
+  },
+});
 
 const AdminUsersPage: React.FC = () => {
   'use memo';
   const { t } = useTranslation();
-  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
+  const isTOTPSupported = useSuspendedTOTPSupported();
+
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      tab: tabParser,
+      filter: parseAsString,
+      order: parseAsString,
+      status: statusParser,
+      activeType: activeTypeParser,
+    },
+    { history: 'replace' },
+  );
+  const { tablePaginationOption, setTablePaginationOption } =
+    useBAIPaginationOptionStateOnSearchParam(
+      defaultSnapshotOf(queryParams.tab).tablePaginationOption,
+    );
+
+  const [usersQueryRef, loadUsersQuery] =
+    useQueryLoader<AdminUserManagementQueryType>(AdminUserManagementQuery);
+  const [credentialsQueryRef, loadCredentialsQuery] =
+    useQueryLoader<AdminUserCredentialListQueryType>(
+      AdminUserCredentialListQuery,
+    );
+
+  // What the URL currently describes — both the snapshot `useKeyedSnapshot`
+  // stores for the active tab and what a browser navigation reloads from.
+  const currentSnapshot: TabSnapshot = {
+    queryParams: _.omit(queryParams, 'tab'),
+    tablePaginationOption,
+  };
+
+  const [currentTab, setAfterSnapshot] = useKeyedSnapshot<TabKey, TabSnapshot>(
+    queryParams.tab,
+    currentSnapshot,
+  );
+
+  const usersVariablesOf = (snapshot: TabSnapshot): UsersVariables => {
+    const { queryParams: params, tablePaginationOption: pagination } = snapshot;
+    const filter = params.filter
+      ? parseAsJson<UserV2Filter>((value) => value as UserV2Filter).parse(
+          params.filter,
+        )
+      : null;
+    const order = _.includes(availableUserV2SorterValues, params.order)
+      ? params.order
+      : null;
+    return {
+      filter: {
+        ..._.omit(filter ?? {}, 'status'),
+        status:
+          params.status === 'ACTIVE'
+            ? { equals: 'ACTIVE' }
+            : { notEquals: 'ACTIVE' },
+      },
+      orderBy: convertToOrderBy<Required<UserV2OrderBy>>(order),
+      limit: pagination.pageSize,
+      offset: (pagination.current - 1) * pagination.pageSize,
+      isNotSupportTotp: !isTOTPSupported,
+    };
+  };
+
+  const credentialsVariablesOf = (
+    snapshot: TabSnapshot,
+  ): CredentialsVariables => {
+    const { queryParams: params, tablePaginationOption: pagination } = snapshot;
+    return {
+      limit: pagination.pageSize,
+      offset: (pagination.current - 1) * pagination.pageSize,
+      is_active: params.activeType !== 'inactive',
+      filter: params.filter,
+      order: params.order,
+    };
+  };
+
+  // Child-driven changes arrive as complete GraphQL variables; mirror them
+  // back to the URL keys so the snapshot effect captures the new state.
+  const snapshotOfVariables = (
+    tab: TabKey,
+    variables: TabVariables,
+  ): TabSnapshot => {
+    const pageSize =
+      variables.limit ?? defaultSnapshotOf(tab).tablePaginationOption.pageSize;
+    const tablePaginationOption = {
+      current: Math.floor((variables.offset ?? 0) / pageSize) + 1,
+      pageSize,
+    };
+    if (tab === 'users') {
+      const v = variables as UsersVariables;
+      const restFilter = _.omit(v.filter ?? {}, 'status');
+      return {
+        queryParams: {
+          filter: _.isEmpty(restFilter) ? null : JSON.stringify(restFilter),
+          order: convertFirstOrderByToString(v.orderBy),
+          status: v.filter?.status?.equals === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE',
+          activeType: 'active',
+        },
+        tablePaginationOption,
+      };
+    }
+    const v = variables as CredentialsVariables;
+    return {
+      queryParams: {
+        filter: v.filter ?? null,
+        order: v.order ?? null,
+        status: 'ACTIVE',
+        activeType: v.is_active === false ? 'inactive' : 'active',
+      },
+      tablePaginationOption,
+    };
+  };
+
+  const handleUsersReload = (
+    variables: UsersVariables,
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => {
+    loadUsersQuery(variables, options);
+    const snapshot = snapshotOfVariables('users', variables);
+    setQueryParams(
+      { tab: 'users', ...snapshot.queryParams },
+      { history: 'replace' },
+    );
+    setTablePaginationOption(snapshot.tablePaginationOption);
+  };
+
+  const handleCredentialsReload = (
+    variables: CredentialsVariables,
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => {
+    loadCredentialsQuery(variables, options);
+    const snapshot = snapshotOfVariables('credentials', variables);
+    setQueryParams(
+      { tab: 'credentials', ...snapshot.queryParams },
+      { history: 'replace' },
+    );
+    setTablePaginationOption(snapshot.tablePaginationOption);
+  };
+
+  const loadTabQuery = (tab: TabKey, snapshot: TabSnapshot) => {
+    if (tab === 'users') {
+      loadUsersQuery(usersVariablesOf(snapshot));
+    } else {
+      loadCredentialsQuery(credentialsVariablesOf(snapshot));
+    }
+  };
+
+  // Queries the tab the URL currently describes. Every tab change afterwards
+  // restores its snapshot and queries inside onTabChange.
+  const loadTabFromQueryParams = () => {
+    loadTabQuery(queryParams.tab, currentSnapshot);
+  };
+
+  // First visit: mount, direct URL entry, reload.
+  const loadTabOnMount = useEffectEvent(loadTabFromQueryParams);
+  useEffect(() => {
+    loadTabOnMount();
+  }, []);
+
+  // Back/forward: the hook holds the callback until `queryParams` and
+  // `tablePaginationOption` describe the URL the user navigated to.
+  useBrowserPopstateEffect(loadTabFromQueryParams);
 
   const tabItems: BAICardTabItem[] = [
     {
@@ -38,21 +265,42 @@ const AdminUsersPage: React.FC = () => {
   return (
     <BAICard
       activeTabKey={currentTab}
-      onTabChange={onTabChange}
+      onTabChange={(key) => {
+        const tab = tabParser.parse(key) ?? tabParser.defaultValue;
+        if (tab === currentTab) return;
+        const snapshot = setAfterSnapshot(tab) ?? defaultSnapshotOf(tab);
+        loadTabQuery(tab, snapshot);
+        setQueryParams({ tab, ...snapshot.queryParams }, { history: 'push' });
+        setTablePaginationOption(snapshot.tablePaginationOption);
+      }}
       tabList={tabItems}
     >
       <Suspense fallback={<BAISkeleton />}>
         {currentTab === 'users' && (
           <BAIErrorBoundary>
             <BAIFlex direction="column" align="stretch">
-              <AdminUserManagement />
+              {usersQueryRef ? (
+                <AdminUserManagement
+                  queryRef={usersQueryRef}
+                  onReload={handleUsersReload}
+                />
+              ) : (
+                <BAISkeletonAstryx />
+              )}
             </BAIFlex>
           </BAIErrorBoundary>
         )}
         {currentTab === 'credentials' && (
           <BAIErrorBoundary>
             <BAIFlex direction="column" align="stretch">
-              <AdminUserCredentialList />
+              {credentialsQueryRef ? (
+                <AdminUserCredentialList
+                  queryRef={credentialsQueryRef}
+                  onReload={handleCredentialsReload}
+                />
+              ) : (
+                <BAISkeletonAstryx />
+              )}
             </BAIFlex>
           </BAIErrorBoundary>
         )}

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -2,25 +2,234 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import AdminUserCredentialList from '../components/AdminUserCredentialList';
-import AdminUserManagement from '../components/AdminUserManagement';
+import { AdminUserCredentialListQuery as AdminUserCredentialListQueryType } from '../__generated__/AdminUserCredentialListQuery.graphql';
+import {
+  AdminUserManagementQuery as AdminUserManagementQueryType,
+  UserV2Filter,
+  UserV2OrderBy,
+} from '../__generated__/AdminUserManagementQuery.graphql';
+import AdminUserCredentialList, {
+  AdminUserCredentialListQuery,
+} from '../components/AdminUserCredentialList';
+import AdminUserManagement, {
+  AdminUserManagementQuery,
+} from '../components/AdminUserManagement';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
-import { useTabQuerySnapshot } from '../hooks';
+import { convertFromOrderBy, convertToOrderBy } from '../helper';
+import { useKeyedSnapshot } from '../hooks';
+import { useTOTPSupported } from '../hooks/backendai';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { Skeleton } from 'antd';
 import { CardTabListType } from 'antd/es/card';
-import { BAIFlex, BAICard } from 'backend.ai-ui';
-import { parseAsStringLiteral } from 'nuqs';
-import { Suspense } from 'react';
+import { BAIFlex, BAICard, availableUserV2SorterValues } from 'backend.ai-ui';
+import * as _ from 'lodash-es';
+import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
+import { Suspense, useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  useQueryLoader,
+  type UseQueryLoaderLoadQueryOptions,
+} from 'react-relay';
 
 const tabParser = parseAsStringLiteral(['users', 'credentials']).withDefault(
   'users',
 );
 
+type TabKey = 'users' | 'credentials';
+type UsersVariables = AdminUserManagementQueryType['variables'];
+type CredentialsVariables = AdminUserCredentialListQueryType['variables'];
+type TabVariables = UsersVariables | CredentialsVariables;
+
+/**
+ * FR-3387 pilot: the page is the single owner of URL state and query
+ * fetching. The URL seeds the initial tab and variables at mount and is a
+ * write-only mirror afterwards; per-tab variables are snapshotted by
+ * `useKeyedSnapshot`, restored synchronously on tab change, and loaded via
+ * `useQueryLoader` (render-as-you-fetch). Children receive `queryRef` +
+ * `onReload` and own no URL state.
+ */
 const AdminUsersPage: React.FC = () => {
   'use memo';
   const { t } = useTranslation();
-  const { currentTab, onTabChange } = useTabQuerySnapshot(tabParser);
+  const { isTOTPSupported } = useTOTPSupported();
+
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      tab: tabParser,
+      filter: parseAsString,
+      order: parseAsString,
+      status: parseAsStringLiteral(['ACTIVE', 'INACTIVE']).withDefault(
+        'ACTIVE',
+      ),
+      activeType: parseAsStringLiteral(['active', 'inactive']).withDefault(
+        'active',
+      ),
+    },
+    { history: 'replace' },
+  );
+  const { tablePaginationOption, setTablePaginationOption } =
+    useBAIPaginationOptionStateOnSearchParam(
+      queryParams.tab === 'credentials'
+        ? { current: 1, pageSize: 20 }
+        : { current: 1, pageSize: 10 },
+    );
+
+  const [usersQueryRef, loadUsersQuery] =
+    useQueryLoader<AdminUserManagementQueryType>(AdminUserManagementQuery);
+  const [credentialsQueryRef, loadCredentialsQuery] =
+    useQueryLoader<AdminUserCredentialListQueryType>(
+      AdminUserCredentialListQuery,
+    );
+
+  // The retained queryRefs hold each tab's last requested variables; the
+  // snapshot hook reads them per key so every capture is a consistent pair.
+  const [currentTab, setAfterSnapshot] = useKeyedSnapshot<
+    TabKey,
+    TabVariables | undefined
+  >(queryParams.tab, (tab) =>
+    tab === 'users' ? usersQueryRef?.variables : credentialsQueryRef?.variables,
+  );
+
+  const buildInitialUsersVariables = (): UsersVariables => {
+    let urlFilter: UserV2Filter | null = null;
+    try {
+      urlFilter = queryParams.filter
+        ? (JSON.parse(queryParams.filter) as UserV2Filter)
+        : null;
+    } catch {
+      urlFilter = null;
+    }
+    const order = _.includes(availableUserV2SorterValues, queryParams.order)
+      ? queryParams.order
+      : null;
+    return {
+      filter: {
+        ..._.omit(urlFilter ?? {}, 'status'),
+        status:
+          queryParams.status === 'ACTIVE'
+            ? { equals: 'ACTIVE' }
+            : { notEquals: 'ACTIVE' },
+      },
+      orderBy: convertToOrderBy<Required<UserV2OrderBy>>(order),
+      limit: tablePaginationOption.pageSize,
+      offset:
+        (tablePaginationOption.current - 1) * tablePaginationOption.pageSize,
+      isNotSupportTotp: !isTOTPSupported,
+    };
+  };
+
+  const buildInitialCredentialsVariables = (): CredentialsVariables => ({
+    limit: tablePaginationOption.pageSize,
+    offset:
+      (tablePaginationOption.current - 1) * tablePaginationOption.pageSize,
+    is_active: queryParams.activeType !== 'inactive',
+    filter: queryParams.filter,
+    order: queryParams.order,
+  });
+
+  const defaultUsersVariables = (): UsersVariables => ({
+    filter: { status: { equals: 'ACTIVE' } },
+    limit: 10,
+    offset: 0,
+    isNotSupportTotp: !isTOTPSupported,
+  });
+
+  const defaultCredentialsVariables = (): CredentialsVariables => ({
+    limit: 20,
+    offset: 0,
+    is_active: true,
+  });
+
+  const mirrorVariablesToUrl = (
+    tab: TabKey,
+    variables: TabVariables,
+    historyMode: 'push' | 'replace',
+  ) => {
+    if (tab === 'users') {
+      const v = variables as UsersVariables;
+      const restFilter = _.omit(v.filter ?? {}, 'status');
+      setQueryParams(
+        {
+          tab,
+          filter: _.isEmpty(restFilter) ? null : JSON.stringify(restFilter),
+          order: convertFromOrderBy(v.orderBy),
+          status: v.filter?.status?.equals === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE',
+          activeType: null,
+        },
+        { history: historyMode },
+      );
+      setTablePaginationOption({
+        current: Math.floor((v.offset ?? 0) / (v.limit ?? 10)) + 1,
+        pageSize: v.limit ?? 10,
+      });
+    } else {
+      const v = variables as CredentialsVariables;
+      setQueryParams(
+        {
+          tab,
+          filter: v.filter ?? null,
+          order: v.order ?? null,
+          status: null,
+          activeType: v.is_active === false ? 'inactive' : 'active',
+        },
+        { history: historyMode },
+      );
+      setTablePaginationOption({
+        current: Math.floor((v.offset ?? 0) / (v.limit ?? 20)) + 1,
+        pageSize: v.limit ?? 20,
+      });
+    }
+  };
+
+  const handleTabChange = (key: string) => {
+    const tab = tabParser.parse(key) ?? tabParser.defaultValue;
+    if (tab === currentTab) return;
+    const restored = setAfterSnapshot(tab);
+    const variables =
+      restored ??
+      (tab === 'users'
+        ? defaultUsersVariables()
+        : defaultCredentialsVariables());
+    // A revisited tab's retained queryRef already holds its data — show it
+    // without refetching (freshness is the child's refresh button's job).
+    if (tab === 'users' && !usersQueryRef) {
+      loadUsersQuery(variables as UsersVariables);
+    } else if (tab === 'credentials' && !credentialsQueryRef) {
+      loadCredentialsQuery(variables as CredentialsVariables);
+    }
+    mirrorVariablesToUrl(tab, variables, 'push');
+  };
+
+  const handleUsersReload = (
+    variables: UsersVariables,
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => {
+    loadUsersQuery(variables, options);
+    mirrorVariablesToUrl('users', variables, 'replace');
+  };
+
+  const handleCredentialsReload = (
+    variables: CredentialsVariables,
+    options?: UseQueryLoaderLoadQueryOptions,
+  ) => {
+    loadCredentialsQuery(variables, options);
+    mirrorVariablesToUrl('credentials', variables, 'replace');
+  };
+
+  // Entries that bypass the tab-change handler (initial mount, direct URL
+  // entry, reload) build the active tab's variables from the URL; a tab
+  // reached with a warm queryRef (back/forward) needs no load at all.
+  const ensureActiveTabLoaded = useEffectEvent(() => {
+    if (currentTab === 'users' && !usersQueryRef) {
+      loadUsersQuery(buildInitialUsersVariables());
+    }
+    if (currentTab === 'credentials' && !credentialsQueryRef) {
+      loadCredentialsQuery(buildInitialCredentialsVariables());
+    }
+  });
+  useEffect(() => {
+    ensureActiveTabLoaded();
+  }, [currentTab]);
 
   const tabItems: CardTabListType[] = [
     {
@@ -36,21 +245,35 @@ const AdminUsersPage: React.FC = () => {
   return (
     <BAICard
       activeTabKey={currentTab}
-      onTabChange={onTabChange}
+      onTabChange={handleTabChange}
       tabList={tabItems}
     >
       <Suspense fallback={<Skeleton active />}>
         {currentTab === 'users' && (
           <BAIErrorBoundary>
             <BAIFlex direction="column" align="stretch">
-              <AdminUserManagement />
+              {usersQueryRef ? (
+                <AdminUserManagement
+                  queryRef={usersQueryRef}
+                  onReload={handleUsersReload}
+                />
+              ) : (
+                <Skeleton active />
+              )}
             </BAIFlex>
           </BAIErrorBoundary>
         )}
         {currentTab === 'credentials' && (
           <BAIErrorBoundary>
             <BAIFlex direction="column" align="stretch">
-              <AdminUserCredentialList />
+              {credentialsQueryRef ? (
+                <AdminUserCredentialList
+                  queryRef={credentialsQueryRef}
+                  onReload={handleCredentialsReload}
+                />
+              ) : (
+                <Skeleton active />
+              )}
             </BAIFlex>
           </BAIErrorBoundary>
         )}

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -17,7 +17,6 @@ import AdminUserManagement, {
   USER_LIST_DEFAULT_PAGE_SIZE,
 } from '../components/AdminUserManagement';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
-import { BAISkeleton } from 'backend.ai-ui';
 import { convertFirstOrderByToString, convertToOrderBy } from '../helper';
 import { useBrowserPopstateEffect, useKeyedSnapshot } from '../hooks';
 import { useSuspendedTOTPSupported } from '../hooks/backendai';
@@ -28,6 +27,7 @@ import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginati
 import {
   BAIFlex,
   BAICard,
+  BAISkeleton,
   availableUserV2SorterValues,
   type BAICardTabItem,
 } from 'backend.ai-ui';
@@ -295,7 +295,7 @@ const AdminUsersPage: React.FC = () => {
                   onReload={handleUsersReload}
                 />
               ) : (
-                <BAISkeletonAstryx />
+                <BAISkeleton />
               )}
             </BAIFlex>
           </BAIErrorBoundary>
@@ -309,7 +309,7 @@ const AdminUsersPage: React.FC = () => {
                   onReload={handleCredentialsReload}
                 />
               ) : (
-                <BAISkeletonAstryx />
+                <BAISkeleton />
               )}
             </BAIFlex>
           </BAIErrorBoundary>

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -121,10 +121,10 @@ const AdminUsersPage: React.FC = () => {
     tablePaginationOption,
   };
 
-  const [currentTab, setAfterSnapshot] = useKeyedSnapshot<TabKey, TabSnapshot>(
-    queryParams.tab,
-    currentSnapshot,
-  );
+  const [currentTab, setCurrentTab, peekTabSnapshot] = useKeyedSnapshot<
+    TabKey,
+    TabSnapshot
+  >(queryParams.tab, currentSnapshot);
 
   const usersVariablesOf = (snapshot: TabSnapshot): UsersVariables => {
     const { queryParams: params, tablePaginationOption: pagination } = snapshot;
@@ -278,7 +278,8 @@ const AdminUsersPage: React.FC = () => {
       onTabChange={(key) => {
         const tab = tabParser.parse(key) ?? tabParser.defaultValue;
         if (tab === currentTab) return;
-        const snapshot = setAfterSnapshot(tab) ?? defaultSnapshotOf(tab);
+        const snapshot = peekTabSnapshot(tab) ?? defaultSnapshotOf(tab);
+        setCurrentTab(tab);
         loadTabQuery(tab, snapshot);
         setQueryParams({ tab, ...snapshot.queryParams }, { history: 'push' });
         setTablePaginationOption(snapshot.tablePaginationOption);

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -10,9 +10,11 @@ import {
 } from '../__generated__/AdminUserManagementQuery.graphql';
 import AdminUserCredentialList, {
   AdminUserCredentialListQuery,
+  CREDENTIAL_LIST_DEFAULT_PAGE_SIZE,
 } from '../components/AdminUserCredentialList';
 import AdminUserManagement, {
   AdminUserManagementQuery,
+  USER_LIST_DEFAULT_PAGE_SIZE,
 } from '../components/AdminUserManagement';
 import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import { convertFromOrderBy, convertToOrderBy } from '../helper';
@@ -23,7 +25,12 @@ import { Skeleton } from 'antd';
 import { CardTabListType } from 'antd/es/card';
 import { BAIFlex, BAICard, availableUserV2SorterValues } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
+import {
+  parseAsJson,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs';
 import { Suspense, useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -67,11 +74,11 @@ const AdminUsersPage: React.FC = () => {
     },
     { history: 'replace' },
   );
-  const { tablePaginationOption, setTablePaginationOption } =
+  const { baiPaginationOption, setTablePaginationOption } =
     useBAIPaginationOptionStateOnSearchParam(
       queryParams.tab === 'credentials'
-        ? { current: 1, pageSize: 20 }
-        : { current: 1, pageSize: 10 },
+        ? { current: 1, pageSize: CREDENTIAL_LIST_DEFAULT_PAGE_SIZE }
+        : { current: 1, pageSize: USER_LIST_DEFAULT_PAGE_SIZE },
     );
 
   const [usersQueryRef, loadUsersQuery] =
@@ -91,14 +98,11 @@ const AdminUsersPage: React.FC = () => {
   );
 
   const buildInitialUsersVariables = (): UsersVariables => {
-    let urlFilter: UserV2Filter | null = null;
-    try {
-      urlFilter = queryParams.filter
-        ? (JSON.parse(queryParams.filter) as UserV2Filter)
-        : null;
-    } catch {
-      urlFilter = null;
-    }
+    const urlFilter = queryParams.filter
+      ? parseAsJson<UserV2Filter>((value) => value as UserV2Filter).parse(
+          queryParams.filter,
+        )
+      : null;
     const order = _.includes(availableUserV2SorterValues, queryParams.order)
       ? queryParams.order
       : null;
@@ -111,17 +115,15 @@ const AdminUsersPage: React.FC = () => {
             : { notEquals: 'ACTIVE' },
       },
       orderBy: convertToOrderBy<Required<UserV2OrderBy>>(order),
-      limit: tablePaginationOption.pageSize,
-      offset:
-        (tablePaginationOption.current - 1) * tablePaginationOption.pageSize,
+      limit: baiPaginationOption.limit,
+      offset: baiPaginationOption.offset,
       isNotSupportTotp: !isTOTPSupported,
     };
   };
 
   const buildInitialCredentialsVariables = (): CredentialsVariables => ({
-    limit: tablePaginationOption.pageSize,
-    offset:
-      (tablePaginationOption.current - 1) * tablePaginationOption.pageSize,
+    limit: baiPaginationOption.limit,
+    offset: baiPaginationOption.offset,
     is_active: queryParams.activeType !== 'inactive',
     filter: queryParams.filter,
     order: queryParams.order,
@@ -129,13 +131,13 @@ const AdminUsersPage: React.FC = () => {
 
   const defaultUsersVariables = (): UsersVariables => ({
     filter: { status: { equals: 'ACTIVE' } },
-    limit: 10,
+    limit: USER_LIST_DEFAULT_PAGE_SIZE,
     offset: 0,
     isNotSupportTotp: !isTOTPSupported,
   });
 
   const defaultCredentialsVariables = (): CredentialsVariables => ({
-    limit: 20,
+    limit: CREDENTIAL_LIST_DEFAULT_PAGE_SIZE,
     offset: 0,
     is_active: true,
   });
@@ -158,10 +160,6 @@ const AdminUsersPage: React.FC = () => {
         },
         { history: historyMode },
       );
-      setTablePaginationOption({
-        current: Math.floor((v.offset ?? 0) / (v.limit ?? 10)) + 1,
-        pageSize: v.limit ?? 10,
-      });
     } else {
       const v = variables as CredentialsVariables;
       setQueryParams(
@@ -174,11 +172,16 @@ const AdminUsersPage: React.FC = () => {
         },
         { history: historyMode },
       );
-      setTablePaginationOption({
-        current: Math.floor((v.offset ?? 0) / (v.limit ?? 20)) + 1,
-        pageSize: v.limit ?? 20,
-      });
     }
+    const pageSize =
+      variables.limit ??
+      (tab === 'users'
+        ? USER_LIST_DEFAULT_PAGE_SIZE
+        : CREDENTIAL_LIST_DEFAULT_PAGE_SIZE);
+    setTablePaginationOption({
+      current: Math.floor((variables.offset ?? 0) / pageSize) + 1,
+      pageSize,
+    });
   };
 
   const handleTabChange = (key: string) => {

--- a/react/src/pages/AdminUsersPage.tsx
+++ b/react/src/pages/AdminUsersPage.tsx
@@ -205,7 +205,10 @@ const AdminUsersPage: React.FC = () => {
     variables: UsersVariables,
     options?: UseQueryLoaderLoadQueryOptions,
   ) => {
-    loadUsersQuery(variables, options);
+    loadUsersQuery(variables, {
+      fetchPolicy: 'store-and-network',
+      ...options,
+    });
     const snapshot = snapshotOfVariables('users', variables);
     setQueryParams(
       { tab: 'users', ...snapshot.queryParams },
@@ -218,7 +221,10 @@ const AdminUsersPage: React.FC = () => {
     variables: CredentialsVariables,
     options?: UseQueryLoaderLoadQueryOptions,
   ) => {
-    loadCredentialsQuery(variables, options);
+    loadCredentialsQuery(variables, {
+      fetchPolicy: 'store-and-network',
+      ...options,
+    });
     const snapshot = snapshotOfVariables('credentials', variables);
     setQueryParams(
       { tab: 'credentials', ...snapshot.queryParams },
@@ -229,9 +235,13 @@ const AdminUsersPage: React.FC = () => {
 
   const loadTabQuery = (tab: TabKey, snapshot: TabSnapshot) => {
     if (tab === 'users') {
-      loadUsersQuery(usersVariablesOf(snapshot));
+      loadUsersQuery(usersVariablesOf(snapshot), {
+        fetchPolicy: 'store-and-network',
+      });
     } else {
-      loadCredentialsQuery(credentialsVariablesOf(snapshot));
+      loadCredentialsQuery(credentialsVariablesOf(snapshot), {
+        fetchPolicy: 'store-and-network',
+      });
     }
   };
 


### PR DESCRIPTION
Resolves #8418 (FR-3387)

## Summary

Pilot of a page-level keyed-snapshot tab-state architecture on the admin users page (Users / Credentials tabs). The page becomes the single owner of URL state and query fetching; the tab components become preloaded-query consumers that own no query-string state.

### Hooks (`react/src/hooks/index.tsx`)

- **`useKeyedSnapshot(sourceKey, value)`** — per-key snapshots of a caller-defined value, returned as `[currentKey, setKey, peekSnapshot]`. The caller decides the snapshot shape (here `{ queryParams, tablePaginationOption }`, seeded from the query string on the first render). `peekSnapshot(key)` is a pure read of the stored value (`undefined` if never visited); `setKey(nextKey)` snapshots the departing key and switches — so a tab click can restore state and start its query inside the same event handler (render-as-you-fetch). The pair started as one `setAfterSnapshot(nextKey)` that switched *and* returned, but a `set*` that callers depend on for its return value contradicts the setter convention, so it was split along the setter/getter seam (`peek` over `get` to avoid the false friend with `useSyncExternalStore`'s no-arg, current-state `getSnapshot`). The first argument also re-syncs the key when it changes, which is how the tab UI follows browser back/forward.
- **`useBrowserPopstateEffect(onSettled)`** — runs a callback after a browser back/forward, **once nuqs' query state matches the address bar**. nuqs applies `popstate` inside a `startTransition`, so for at least one render every `useQueryStates` value still describes the page the user just left; the hook arms a ref on `popstate` and holds the callback until `useOptimisticSearchParams()` and `window.location.search` normalize equal, then disarms. That guard is what lets callers read their nuqs state inside the callback instead of re-parsing `location.search` themselves. `pushState`/`replaceState` emit no `popstate`, so the page's own URL writes never arm it.

### `AdminUsersPage`

- One page-level `useQueryStates` group (plus the existing pagination hook) mirrors the active tab's state — **push** on tab switch, **replace** within a tab, matching what `useTabQuerySnapshot` did before.
- Two `useQueryLoader` refs; a tab click restores its snapshot and loads immediately.
- Mount / direct URL entry / reload load once; back/forward reload through `useBrowserPopstateEffect`.

### Children

`AdminUserManagement` and `AdminUserCredentialList` drop every piece of URL state — nuqs groups, pagination-on-search-param, and `fetchKey`. They receive `queryRef` + `onReload(variables, options)` (the `LoginSession` / `LoginHistory` contract): displayed values derive from `queryRef.variables`, pending UX from a deferred queryRef, and refresh is a network-only reload of the current variables.

The credential list's `?action=add` opener (an effect that opened the keypair-creation modal from the query string, then cleared the param) is **removed, not relocated**. Nothing in the repo produces that URL — it had no reachable consumer — so the modal is now opened only by the Add button on screen. Flagging it explicitly since it was a deep link an external doc could in principle have linked to; if one does, it should come back as a page-level read rather than child-owned query state.

### Follow-ups folded in after the first review

- **Back/forward now reloads.** The tab flipped but the query ref kept the departed tab's rows. The reload runs through `useBrowserPopstateEffect`, so by the time it builds its snapshot the page's nuqs state already describes the entry the user navigated to — no second URL parser, and no callback firing against stale params.
- **TOTP capability resolved before the first load.** `isTOTPSupported` was `undefined` on the first render, so the one-shot load sent `isNotSupportTotp: true` and never re-issued. The page now reads it through a new suspending `useSuspendedTOTPSupported` sharing the same TanQuery key; `useTOTPSupported` is untouched for its `useLazyLoadQuery` callers.
- **`@skipOnClient` no longer defeats the Relay store.** The directive strips those fields from the request text while the compiled operation still expected them, so the users query was permanently "missing" in the store and every `store-or-network` load hit the network — a skeleton on every visit to the tab. Pairing it with the standard `@skip(if:)` puts a `Condition` node in the normalization AST, so the store can satisfy the query. Also benefits `ForceTOTPCheckerQuery`, `ProjectAdminUsersPageQuery` and `UserDropdownMenuQuery`, which spread the same fragments.
- **Page-driven loads are `store-and-network`.** `loadQuery` defaults to `store-or-network`, which — with the store now able to satisfy these queries — would serve any variable combination the user has already seen without revalidating it (back to page 1, a tab round-trip, a user created on the other tab). `DEFAULT_LOAD_OPTIONS` sets `store-and-network` for the tab-entry path and for child-driven variable changes; the children still override with `network-only` for a manual refresh or after their own mutation. This costs no skeleton — with a complete cached record `usePreloadedQuery` reads synchronously and does not suspend.
- `convertFirstOrderByToString` from main (FR-3256) is reused instead of the branch's own inverse helper, resolved during the merge.

`useTabQuerySnapshot` and the other 8 pages are untouched; rollout is a follow-up pending this pilot's review.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Terminology)
- `vitest run src/hooks` → 26 files, 349 tests passing, including `renderHook` cases for both hooks:
  - `useKeyedSnapshot.test.tsx` — seeds the initial key from the first rendered value / snapshots the departing key and peeks the target's / peeks the live value for the current key / `undefined` for a never-visited key without switching / holds the new key while `sourceKey` still reports the departing one / re-syncs when `sourceKey` changes.
  - `useBrowserPopstateEffect.test.tsx` — silent while nuqs has not caught up with the address bar / fires exactly once on the render it catches up (and does not replay) / silent for the page's own `setQueryParams` writes.
- **Manual QA against a live cluster**, driven through Chrome DevTools on the reported sequence — users(INACTIVE) → credentials → users → filter → Back ×2 → Forward ×2:

  | Step | URL | Rendered filter |
  |---|---|---|
  | filter applied | `…&status=INACTIVE&filter={…zzz}` | `email ⊃ zzz` |
  | Back ×1 | `?tab=credentials&pageSize=20` | — |
  | Back ×2 | `?status=INACTIVE` | none |
  | Forward ×1 | `?tab=credentials&pageSize=20` | — |
  | Forward ×2 | `…&status=INACTIVE&filter={…zzz}` | `email ⊃ zzz` |

  URL and rendered state agree at every step, per-tab state survives tab round-trips, and a filter change is mirrored to the URL.

- Still worth a human pass: revisiting a tab should paint from cache with no skeleton while it revalidates, and the cold-start deep link where the TOTP capability query has not warmed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqm1FB6FRr9H7C1yCD6CTK
