### PR TITLE
fix: externalize peer subpaths so backend.ai-ui stops bundling react-dom

### DIFF
--- a/packages/backend.ai-ui/vite.config.ts
+++ b/packages/backend.ai-ui/vite.config.ts
@@ -7,7 +7,18 @@ import dts from 'vite-plugin-dts';
 import relay from 'vite-plugin-relay-lite';
 import svgr from 'vite-plugin-svgr';
 
+import { peerDependencies } from './package.json';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Rollup matches `external` strings exactly, so bare names left subpaths like
+// `react-dom/client` bundled — a second renderer that blank-screens consumers
+// on any other React patch (#8595). i18next / react-i18next are dependencies
+// rather than peers, so they stay bundled and keep BUI's i18n isolated.
+const peerDependencyPatterns = Object.keys(peerDependencies).map(
+  // `.` is the only regex metacharacter an npm package name can hold.
+  (name) => new RegExp(`^${name.replaceAll('.', '\\.')}(/.*)?$`),
+);
 
 export default defineConfig(({ mode }) => {
   const isDevMode = mode === 'development';
@@ -36,16 +47,7 @@ export default defineConfig(({ mode }) => {
         formats: ['es'],
       },
       rollupOptions: {
-        external: [
-          'react',
-          'react-dom',
-          'react-router-dom',
-          'relay-runtime',
-          'antd',
-          'antd-style',
-          'graphql',
-          // i18next and react-i18next are bundled to isolate BUI's i18n instance from the host app
-        ],
+        external: peerDependencyPatterns,
       },
       sourcemap: true,
       outDir: 'dist',


### PR DESCRIPTION
Resolves #8595

## Problem

`packages/backend.ai-ui/vite.config.ts` listed externals as plain strings:

```ts
external: ['react', 'react-dom', 'react-router-dom', 'relay-runtime', 'antd', 'antd-style', 'graphql'],
```

Rollup matches those **exactly**, so `react-dom` was external but `react-dom/client` was not — and the whole client renderer got compiled into `dist/backend.ai-ui.js`. `dist/backend.ai-ui.js.map` named the sources:

```
.../react-dom/19.2.7/.../node_modules/react-dom/cjs/react-dom-client.production.js
.../react-dom/19.2.7/.../node_modules/react-dom/cjs/react-dom-client.development.js
.../react-dom/19.2.7/.../node_modules/react-dom/client.js
```

The inlined renderer carries react-dom's own version guard, with the build-time version baked in as a string literal:

```js
var l3 = e.version;               // e = the *external* react
if (l3 !== "19.2.7") throw Error(/* Incompatible React versions */);
```

So a consumer whose `react` is not byte-identical to ours throws while the module initializes. `BAIConfigProvider` never mounts and every page renders blank — dev server and production build alike, one console error and nothing else:

```
Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
  - react:      19.2.6
  - react-dom:  19.2.7
```

That is one patch of drift. `backend.ai-fasttrack` hit it on `react@19.2.6` after adopting a 26.8 canary (lablup/backend.ai-fasttrack#5226) and is currently carrying a `pnpm` override pinning React to exactly 19.2.7 to stay usable (lablup/backend.ai-fasttrack#5232).

Four declared peers were also missing from the list entirely and were bundled whole: **`react-relay` (243 KB), `@tanstack/react-query` (81 KB), `ahooks`, `@ant-design/icons` (77 KB)**. Duplicating those is the same hazard in slower motion — a second copy of a library whose state lives behind a React context silently stops seeing the host's provider.

## Change

`external` stays an array — the entries just become patterns instead of exact strings, derived from `peerDependencies`:

```ts
const peerDependencyPatterns = Object.keys(peerDependencies).map(
  // `.` is the only regex metacharacter an npm package name can hold.
  (name) => new RegExp(`^${name.replaceAll('.', '\\.')}(/.*)?$`),
);
```

(The escape is not decorative: `backend.ai-client` is a plausible future peer in this repo, and unescaped its `.` would also match `backend-ai-client`.)

Declaring a peer is now what makes it external, so the list cannot drift out of sync with the contract again. `i18next` / `react-i18next` are `dependencies` rather than peers, so they stay bundled and BUI's i18n instance stays isolated from the host's — the behavior the old comment described, now enforced by where the package is declared rather than by remembering to leave it off a list.

### Nothing from the old list is dropped

The deleted literal list is a strict subset of `peerDependencies`, so every entry it had — `antd` included — is still external:

| old list entry | `react` | `react-dom` | `react-router-dom` | `relay-runtime` | `antd` | `antd-style` | `graphql` |
|---|---|---|---|---|---|---|---|
| still external | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

Confirmed on the emitted bundles rather than on the config alone — the external imports actually present in `dist/backend.ai-ui.js`:

- **published today:** `antd`, `antd-style`, `react`, `react-dom`, `react-router-dom`, `relay-runtime`
- **this branch:** the same six, plus `@ant-design/icons`, `@tanstack/react-query`, `ahooks`, `react-relay`, `react/jsx-runtime`, `react/compiler-runtime`, `antd/es/form/context`

Dropped from externals: none. (`graphql` appears in neither, before or after — it is a declared peer but nothing in the package imports it at runtime.)

## Effect on the bundle

| | before | after |
|---|---|---|
| `dist/backend.ai-ui.js` | 2.97 MB | **1.67 MB** |
| inlined `node_modules` code | 3.02 MB across 45 packages | **0.71 MB across 24** |
| `react-dom` renderer inlined | yes (1.5 MB) | **no** |
| version guard in bundle | yes | **no** |

Newly external: `@ant-design/icons`, `@tanstack/react-query`, `ahooks`, `react-relay`, `react/jsx-runtime`, `react/compiler-runtime`, `antd/es/form/context`. All are declared peers (or subpaths of one), and both consumers I checked — this repo's `react/` app and `backend.ai-fasttrack` — already have every one of them installed.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, Terminology).
- `pnpm test` in `packages/backend.ai-ui` → 369 passed, 1 skipped.
- `pnpm run build:react-only` → builds clean, so the host app resolves every newly external import.
- **End-to-end against the failing case:** built this branch's `dist` into `backend.ai-fasttrack` running `react@19.2.6` — the exact combination that white-screens today. The app loads and renders normally (tables, `BAIFetchKeyButton` with its countdown border and localized labels), with **zero** console errors and the React DevTools banner logging once instead of twice — i.e. one renderer instance in the page rather than two.

## Suggested follow-up

A `publint` (and `are-the-types-wrong`) check in this package's CI would catch this whole class of packaging regression automatically — this is the second one in a month, after the `types` condition problem fixed in #8590. Happy to open that separately if you want it.
