### PR TITLE
test: e2e auto-heal 2026-08-06

### DIFF
--- a/e2e/chat/chat.spec.ts
+++ b/e2e/chat/chat.spec.ts
@@ -9,8 +9,9 @@ import {
   chatPageQueryMockResponse,
   chatCardQueryMockResponse,
   chatCardQueryNullUrlMockResponse,
-  endpointSelectQueryMockResponse,
-  endpointSelectValueQueryMockResponse,
+  deploymentSelectQueryMockResponse,
+  deploymentSelectValueQueryMockResponse,
+  deploymentTokenSelectQueryMockResponse,
   makeSseResponse,
   modelsApiMockResponse,
   MOCK_MODEL_ID,
@@ -155,10 +156,12 @@ test.describe(
 
       await setupGraphQLMocks(page, {
         ChatPageQuery: () => chatPageQueryMockResponse(),
-        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-        EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-        EndpointSelectValueQuery: (vars) =>
-          endpointSelectValueQueryMockResponse(vars.endpoint_id),
+        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.deploymentId),
+        DeploymentSelectQuery: () => deploymentSelectQueryMockResponse(),
+        DeploymentSelectValueQuery: (vars) =>
+          deploymentSelectValueQueryMockResponse(vars.deploymentId),
+        DeploymentTokenSelectQuery: (vars) =>
+          deploymentTokenSelectQueryMockResponse(vars.deploymentId),
       });
 
       await page.route('**/v1/models', async (route) => {
@@ -626,10 +629,12 @@ test.describe(
 
       await setupGraphQLMocks(page, {
         ChatPageQuery: () => chatPageQueryMockResponse(),
-        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-        EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-        EndpointSelectValueQuery: (vars) =>
-          endpointSelectValueQueryMockResponse(vars.endpoint_id),
+        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.deploymentId),
+        DeploymentSelectQuery: () => deploymentSelectQueryMockResponse(),
+        DeploymentSelectValueQuery: (vars) =>
+          deploymentSelectValueQueryMockResponse(vars.deploymentId),
+        DeploymentTokenSelectQuery: (vars) =>
+          deploymentTokenSelectQueryMockResponse(vars.deploymentId),
       });
 
       await page.route('**/v1/models', async (route) => {
@@ -684,10 +689,12 @@ test.describe(
       await setupGraphQLMocks(page, {
         ChatPageQuery: () => chatPageQueryMockResponse(),
         ChatCardQuery: (vars) =>
-          chatCardQueryNullUrlMockResponse(vars.endpointId),
-        EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-        EndpointSelectValueQuery: (vars) =>
-          endpointSelectValueQueryMockResponse(vars.endpoint_id),
+          chatCardQueryNullUrlMockResponse(vars.deploymentId),
+        DeploymentSelectQuery: () => deploymentSelectQueryMockResponse(),
+        DeploymentSelectValueQuery: (vars) =>
+          deploymentSelectValueQueryMockResponse(vars.deploymentId),
+        DeploymentTokenSelectQuery: (vars) =>
+          deploymentTokenSelectQueryMockResponse(vars.deploymentId),
       });
 
       await page.route('**/v1/models', async (route) => {
@@ -740,10 +747,12 @@ test.describe(
 
       await setupGraphQLMocks(page, {
         ChatPageQuery: () => chatPageQueryMockResponse(),
-        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-        EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-        EndpointSelectValueQuery: (vars) =>
-          endpointSelectValueQueryMockResponse(vars.endpoint_id),
+        ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.deploymentId),
+        DeploymentSelectQuery: () => deploymentSelectQueryMockResponse(),
+        DeploymentSelectValueQuery: (vars) =>
+          deploymentSelectValueQueryMockResponse(vars.deploymentId),
+        DeploymentTokenSelectQuery: (vars) =>
+          deploymentTokenSelectQueryMockResponse(vars.deploymentId),
       });
 
       // Models API returns HTTP 401 to trigger an error notification

--- a/e2e/chat/mocking/chat-mock-data.ts
+++ b/e2e/chat/mocking/chat-mock-data.ts
@@ -16,129 +16,215 @@ export const MOCK_MODEL_ID = 'gpt-mock-model';
 export const MOCK_MODEL_ID_B = 'gpt-mock-model-b';
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Relay global-id helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mirrors `toGlobalId` from `backend.ai-ui` (`btoa(\`${type}:${id}\`)`), but
+ * implemented locally with `Buffer` since this file runs in the Playwright
+ * Node context, not the browser. The Strawberry `deployment(id:)` field and
+ * `myDeployments` connection nodes address deployments by this global id, and
+ * the app decodes it back to the local UUID with `toLocalId`.
+ */
+function toGlobalId(type: string, id: string): string {
+  return Buffer.from(`${type}:${id}`).toString('base64');
+}
+
+const MOCK_DEPLOYMENT_GLOBAL_ID = toGlobalId(
+  'ModelDeployment',
+  MOCK_ENDPOINT_UUID,
+);
+const MOCK_DEPLOYMENT_GLOBAL_ID_B = toGlobalId(
+  'ModelDeployment',
+  MOCK_ENDPOINT_UUID_B,
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // GraphQL mock response factories
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Returns a single mock endpoint for ChatPageQuery.
+ * Returns a single mock deployment for ChatPageQuery (`myDeployments`).
  * Shape matches the wire-format GraphQL response (not Relay TypeScript types).
  */
 export function chatPageQueryMockResponse() {
   return {
-    endpoint_list: {
-      items: [{ endpoint_id: MOCK_ENDPOINT_UUID }],
+    myDeployments: {
+      edges: [{ node: { id: MOCK_DEPLOYMENT_GLOBAL_ID } }],
     },
   };
 }
 
 /**
- * Returns the endpoint list for EndpointSelectQuery (single endpoint).
- * Includes all fields required by EndpointSelectQuery: total_count, name, url.
- */
-export function endpointSelectQueryMockResponse() {
-  return {
-    endpoint_list: {
-      total_count: 1,
-      items: [
-        {
-          endpoint_id: MOCK_ENDPOINT_UUID,
-          name: 'mock-endpoint',
-          url: MOCK_ENDPOINT_URL,
-        },
-      ],
-    },
-  };
-}
-
-/**
- * Returns two endpoints for EndpointSelectQuery (two-endpoint multi-pane tests).
- */
-export function endpointSelectQueryTwoEndpointsMockResponse() {
-  return {
-    endpoint_list: {
-      total_count: 2,
-      items: [
-        {
-          endpoint_id: MOCK_ENDPOINT_UUID,
-          name: 'mock-endpoint',
-          url: MOCK_ENDPOINT_URL,
-        },
-        {
-          endpoint_id: MOCK_ENDPOINT_UUID_B,
-          name: 'mock-endpoint-b',
-          url: MOCK_ENDPOINT_URL_B,
-        },
-      ],
-    },
-  };
-}
-
-/**
- * Returns two mock endpoints for multi-pane tests (ChatPageQuery shape).
+ * Returns two mock deployments for ChatPageQuery's `myDeployments` shape.
+ * Currently unused by the setup helpers below (they only need one default
+ * deployment), kept for parity with `deploymentSelectQueryTwoEndpointsMockResponse`.
  */
 export function chatPageQueryTwoEndpointsMockResponse() {
   return {
-    endpoint_list: {
-      items: [
-        { endpoint_id: MOCK_ENDPOINT_UUID },
-        { endpoint_id: MOCK_ENDPOINT_UUID_B },
+    myDeployments: {
+      edges: [
+        { node: { id: MOCK_DEPLOYMENT_GLOBAL_ID } },
+        { node: { id: MOCK_DEPLOYMENT_GLOBAL_ID_B } },
       ],
     },
   };
 }
 
 /**
- * Returns endpoint detail for ChatCardQuery.
+ * Returns the deployment list for DeploymentSelectQuery (single deployment).
+ * Includes all fields required by DeploymentSelectQuery: count, metadata.name,
+ * networkAccess.endpointUrl.
+ */
+export function deploymentSelectQueryMockResponse() {
+  return {
+    myDeployments: {
+      count: 1,
+      edges: [
+        {
+          node: {
+            id: MOCK_DEPLOYMENT_GLOBAL_ID,
+            metadata: { name: 'mock-endpoint' },
+            networkAccess: { endpointUrl: MOCK_ENDPOINT_URL },
+          },
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Returns two deployments for DeploymentSelectQuery (two-endpoint multi-pane tests).
+ */
+export function deploymentSelectQueryTwoEndpointsMockResponse() {
+  return {
+    myDeployments: {
+      count: 2,
+      edges: [
+        {
+          node: {
+            id: MOCK_DEPLOYMENT_GLOBAL_ID,
+            metadata: { name: 'mock-endpoint' },
+            networkAccess: { endpointUrl: MOCK_ENDPOINT_URL },
+          },
+        },
+        {
+          node: {
+            id: MOCK_DEPLOYMENT_GLOBAL_ID_B,
+            metadata: { name: 'mock-endpoint-b' },
+            networkAccess: { endpointUrl: MOCK_ENDPOINT_URL_B },
+          },
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Returns deployment detail for ChatCardQuery.
  *
  * IMPORTANT: ChatCardQuery uses `@catch` in Relay, but that is a client-side
- * transformation. The wire-format GraphQL response still returns the Endpoint
- * object directly (not wrapped in { ok, value }). Relay's normaliser applies
- * the Result wrapping after receiving the response.
+ * transformation. The wire-format GraphQL response still returns the
+ * ModelDeployment object directly (not wrapped in { ok, value }). Relay's
+ * normalizer applies the Result wrapping after receiving the response.
+ *
+ * `deploymentId` here is the value ChatCardQuery actually sends on the wire —
+ * the Relay *global* id (`toGlobalId('ModelDeployment', localId)`), not the
+ * raw local UUID.
  */
-export function chatCardQueryMockResponse(endpointId: string) {
-  const isB = endpointId === MOCK_ENDPOINT_UUID_B;
+export function chatCardQueryMockResponse(deploymentId: string) {
+  const isB = deploymentId === MOCK_DEPLOYMENT_GLOBAL_ID_B;
   return {
-    endpoint: {
-      endpoint_id: endpointId,
-      url: isB ? MOCK_ENDPOINT_URL_B : MOCK_ENDPOINT_URL,
-      // `replicas` is selected by ChatCardQuery (FR-3156, #7935). It must be
-      // present in the mock — the query wraps `endpoint` in Relay `@catch`,
-      // so a missing field makes the catch result not-ok, nulls the endpoint,
-      // and leaves the chat input disabled (no base URL → no /v1/models fetch).
-      replicas: 1,
-      name: isB ? 'mock-endpoint-b' : 'mock-endpoint',
+    deployment: {
+      id: deploymentId,
+      networkAccess: {
+        endpointUrl: isB ? MOCK_ENDPOINT_URL_B : MOCK_ENDPOINT_URL,
+      },
+      // `replicaState.desiredReplicaCount` is selected by ChatCardQuery
+      // (FR-3332 migration off the legacy `replicas` scalar). It must be
+      // present in the mock — the query wraps `deployment` in Relay `@catch`,
+      // so a missing field makes the catch result not-ok, nulls the
+      // deployment, and leaves the chat input disabled (no base URL → no
+      // /v1/models fetch).
+      replicaState: { desiredReplicaCount: 1 },
+      metadata: { name: isB ? 'mock-endpoint-b' : 'mock-endpoint' },
     },
   };
 }
 
 /**
- * Returns an endpoint detail with a null URL to test invalid base URL handling.
+ * Returns a deployment detail with a null URL to test invalid base URL handling.
  */
-export function chatCardQueryNullUrlMockResponse(endpointId: string) {
+export function chatCardQueryNullUrlMockResponse(deploymentId: string) {
   return {
-    endpoint: {
-      endpoint_id: endpointId,
-      url: null,
-      // See chatCardQueryMockResponse: `replicas` must be present for the
-      // Relay `@catch` on `endpoint` to resolve to a value (here we are
-      // deliberately exercising the null-URL path, not a missing endpoint).
-      replicas: 1,
-      name: 'mock-endpoint-no-url',
+    deployment: {
+      id: deploymentId,
+      networkAccess: { endpointUrl: null },
+      // See chatCardQueryMockResponse: `replicaState` must be present for the
+      // Relay `@catch` on `deployment` to resolve to a value (here we are
+      // deliberately exercising the null-URL path, not a missing deployment).
+      replicaState: { desiredReplicaCount: 1 },
+      metadata: { name: 'mock-endpoint-no-url' },
     },
   };
 }
 
 /**
- * Returns endpoint detail for EndpointSelectValueQuery.
- * Variable name is `endpoint_id` (snake_case) — matches the query's variable declaration.
+ * Returns deployment detail for DeploymentSelectValueQuery.
+ * Variable name is `deploymentId` — matches the query's variable declaration,
+ * and is the Relay global id (see chatCardQueryMockResponse).
  */
-export function endpointSelectValueQueryMockResponse(endpointId: string) {
-  const isB = endpointId === MOCK_ENDPOINT_UUID_B;
+export function deploymentSelectValueQueryMockResponse(deploymentId: string) {
+  const isB = deploymentId === MOCK_DEPLOYMENT_GLOBAL_ID_B;
   return {
-    endpoint: {
-      endpoint_id: endpointId,
-      name: isB ? 'mock-endpoint-b' : 'mock-endpoint',
-      url: isB ? MOCK_ENDPOINT_URL_B : MOCK_ENDPOINT_URL,
+    deployment: {
+      id: deploymentId,
+      metadata: {
+        name: isB ? 'mock-endpoint-b' : 'mock-endpoint',
+        // Not exercised by these tests (only read for the cross-project
+        // "go to detail page" confirm flow); a fixed dummy UUID is enough to
+        // satisfy the non-null field.
+        projectId: '00000000-0000-0000-0000-000000000000',
+      },
+      networkAccess: {
+        endpointUrl: isB ? MOCK_ENDPOINT_URL_B : MOCK_ENDPOINT_URL,
+      },
+    },
+  };
+}
+
+/**
+ * Returns an empty access-token list for DeploymentTokenSelectQuery.
+ *
+ * IMPORTANT: This query is NOT part of the chat "happy path" — it is only
+ * triggered transiently by `CustomModelForm`/`DeploymentTokenSelect`, which
+ * mount for a brief instant before the mocked `/v1/models` response resolves
+ * (`_.isEmpty(models)` is true on the very first render). If this operation
+ * is left unmocked, the request falls through to the real backend, which
+ * rejects the mock deployment id's fake local UUID with a "badly formed
+ * hexadecimal UUID string" GraphQL field error. Because `deployment(id: X)`
+ * is the same field+args (same Relay storageKey) that ChatCardQuery and
+ * DeploymentSelectValueQuery also read on `client:root`, that real error
+ * poisons the shared record and makes ChatCardQuery's `@catch` resolve to
+ * not-ok — leaving the chat composer permanently disabled. Mocking this
+ * operation prevents the real backend from ever seeing the fake deployment id.
+ *
+ * `id` MUST be included even though the component only reads `accessTokens`:
+ * Relay's compiler auto-appends `id` to every selection on a `Node`-like type
+ * (see the generated query text), and Relay's normalizer uses that `id` value
+ * to resolve the record's dataID. Omitting it makes Relay fall back to a
+ * client-generated dataID for this response, which — because `deployment(id:
+ * X)` is the exact same field+args (storageKey) as ChatCardQuery and
+ * DeploymentSelectValueQuery on `client:root` — overwrites the shared root
+ * link with an orphan record that only has `accessTokens`, wiping out
+ * `id`/`networkAccess`/`replicaState` for every other reader of that same
+ * root field (including ChatCardQuery's `@catch`).
+ */
+export function deploymentTokenSelectQueryMockResponse(deploymentId: string) {
+  return {
+    deployment: {
+      id: deploymentId,
+      accessTokens: { edges: [] },
     },
   };
 }
@@ -240,11 +326,12 @@ export async function setupChatPage(
   // GraphQL mocks — variable names must match the wire-format query variables
   await setupGraphQLMocks(page, {
     ChatPageQuery: () => chatPageQueryMockResponse(),
-    ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-    EndpointSelectQuery: () => endpointSelectQueryMockResponse(),
-    // EndpointSelectValueQuery uses snake_case `endpoint_id` variable
-    EndpointSelectValueQuery: (vars) =>
-      endpointSelectValueQueryMockResponse(vars.endpoint_id),
+    ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.deploymentId),
+    DeploymentSelectQuery: () => deploymentSelectQueryMockResponse(),
+    DeploymentSelectValueQuery: (vars) =>
+      deploymentSelectValueQueryMockResponse(vars.deploymentId),
+    DeploymentTokenSelectQuery: (vars) =>
+      deploymentTokenSelectQueryMockResponse(vars.deploymentId),
   });
 
   // Models API mock
@@ -271,7 +358,7 @@ export async function setupChatPage(
 
 /**
  * Setup variant for two-endpoint multi-pane tests.
- * EndpointSelectQuery returns both endpoints; completions requests are
+ * DeploymentSelectQuery returns both deployments; completions requests are
  * differentiated by URL (alpha vs beta prefix).
  */
 export async function setupChatPageWithTwoEndpoints(
@@ -286,11 +373,13 @@ export async function setupChatPageWithTwoEndpoints(
 
   await setupGraphQLMocks(page, {
     ChatPageQuery: () => chatPageQueryMockResponse(),
-    ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.endpointId),
-    EndpointSelectQuery: () => endpointSelectQueryTwoEndpointsMockResponse(),
-    // EndpointSelectValueQuery uses snake_case `endpoint_id` variable
-    EndpointSelectValueQuery: (vars) =>
-      endpointSelectValueQueryMockResponse(vars.endpoint_id),
+    ChatCardQuery: (vars) => chatCardQueryMockResponse(vars.deploymentId),
+    DeploymentSelectQuery: () =>
+      deploymentSelectQueryTwoEndpointsMockResponse(),
+    DeploymentSelectValueQuery: (vars) =>
+      deploymentSelectValueQueryMockResponse(vars.deploymentId),
+    DeploymentTokenSelectQuery: (vars) =>
+      deploymentTokenSelectQueryMockResponse(vars.deploymentId),
   });
 
   // Models API mock — both endpoints respond with their respective model IDs


### PR DESCRIPTION
## 자동 생성 PR (daily digest auto-heal)

이 PR은 **daily webui digest** 파이프라인의 자동 힐링 단계가 생성했습니다.
2026-08-05 23:00–23:37 UTC 전체 e2e 실행에서 발생한 21건의 실패 중, 트리아지가
**테스트 쪽 드리프트(HEAL)** 로 판정한 chat 영역 11건을 수정합니다.

### 근본 원인

FR-3332(#8420, #8298)가 Chat 페이지를 legacy endpoint 쿼리에서 deployment 기반
쿼리로 마이그레이션했습니다.

- `react/src/pages/ChatPage.tsx` — `ChatPageQuery`가 `endpoint_list` → `myDeployments`
- `react/src/components/Chat/ChatCard.tsx` — `ChatCardQuery`가 `endpoint{...}` → `deployment(id) @catch{...}`
- `react/src/components/Chat/DeploymentSelect.tsx` — `EndpointSelectQuery` 폐기, `DeploymentSelectQuery`로 대체

반면 e2e mock(`e2e/chat/mocking/chat-mock-data.ts`)은 여전히 예전 operation 이름과
응답 shape을 가로채고 있었습니다. mock이 매칭되지 않아 deployment id가 끝내
resolve되지 않고, chat 입력 `<textarea>`가 계속 `disabled` 상태로 남아 모든 chat
테스트가 동일 지점에서 실패했습니다. **앱 버그가 아니라 mock 드리프트입니다.**

추가로, 라이브 디버깅 과정에서 두 번째 드리프트를 발견했습니다:
`DeploymentTokenSelectQuery`(`CustomModelForm`/`DeploymentTokenSelect`가
`/v1/models` 첫 응답 전에 잠깐 mount하면서 실행)가 아예 mocking되지 않아 실제
nightly 백엔드로 새어나갔습니다. 이 쿼리는 `ChatCardQuery`/`DeploymentSelectValueQuery`와
**같은 Relay storageKey**(`client:root.deployment(id:"...")`)를 읽기 때문에, 백엔드가
가짜 UUID를 거부하면 공유 레코드가 오염되어 `ChatCardQuery`의 `@catch`가 not-ok로
resolve되고 composer가 영구 `disabled`가 됩니다.

### 변경 내용

- `e2e/chat/mocking/chat-mock-data.ts` — mock factory / operation 이름 / 변수명
  (`endpointId` → `deploymentId`) / 응답 shape(`myDeployments.edges[].node`,
  `deployment.networkAccess.endpointUrl`, `deployment.replicaState.desiredReplicaCount`,
  `deployment.metadata.name`)을 현재 스키마에 맞게 재작성. Relay global id
  (`btoa('ModelDeployment:<uuid>')`) 사용. `deploymentTokenSelectQueryMockResponse()` 신규 추가
  (Relay 컴파일러가 자동 주입하는 `id` 필드 포함 — 빠뜨리면 orphan client record가
  공유 root link를 덮어씀).
- `e2e/chat/chat.spec.ts` — import 및 인라인 `setupGraphQLMocks` 4곳을 새 operation
  이름/변수로 갱신하고 `DeploymentTokenSelectQuery` mock을 연결.

`react/`, `packages/` 등 앱 소스는 **일절 수정하지 않았습니다.**

### 힐링 결과

- ✅ **힐링 성공 11건** (대상 3개 spec 전체 재실행으로 통과 확인 — 24개 테스트 중
  비스킵 23개 전부 pass, skip 6건은 기존 의도된 `test.fixme`)
  - `e2e/chat/chat.spec.ts` — 8건
  - `e2e/chat/chat-sync.spec.ts` — 2건
  - `e2e/chat/chat-attachment.spec.ts` — 1건
- ⛔ **retry budget 소진 0건**

### 리포트

전체 실행 리포트 및 트리아지 판정: `/home/ubuntu/e2e-digest-reports/report-2026-08-06.md`
(digest 실행 박스 로컬 경로)

cc @agatha197 — 드리프트 원인 PR #8420 / #8298 작성자로 리뷰 요청드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
