### PR TITLE
test(FR-3476): add e2e coverage for runtime variant preset UI metadata

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 312 / 457 features covered (68%)**
+**Overall (in-scope routes): 317 / 462 features covered (68%)**
 
 | Page                     | Route                                  | Features | Covered | Status  |
 | ------------------------ | -------------------------------------- | :------: | :-----: | :-----: |
@@ -50,8 +50,9 @@
 | Auto Scaling Rule Preset | `/admin-serving?tab=auto-scaling-rule` |    33    |   32    | 🔶 97%  |
 | Deployments              | `/deployments`, `/deployments/:id`     |    17    |   14    | 🔶 82%  |
 | Admin Deployment Preset  | `/admin/deployments/deployment-presets/new` |    4     |    4    | ✅ 100% |
+| Runtime Variant Preset   | `/admin/deployments?tab=runtime-variant-presets` |    5     |    5    | ✅ 100% |
 | Project-Agnostic Scope   | `/admin/*` (except `admin-dashboard`)  |    5     |    5    | ✅ 100% |
-| **Total**                |                                        | **477**  | **329** | **69%** |
+| **Total**                |                                        | **482**  | **334** | **69%** |
 
 ---
 
@@ -1208,6 +1209,53 @@
 | Revision rollback / promote from Revision History                                  | ❌     | -                                                                                                                        |
 
 **Coverage: 🔶 12/16 features (4 deferred to backend-surface testing or future work)**
+
+---
+
+### 31. Admin - Runtime Variant Preset Metadata (`/admin/deployments?tab=runtime-variant-presets`)
+
+**Test files:** [`e2e/runtime-variant-preset/preset-ui-metadata.spec.ts`](runtime-variant-preset/preset-ui-metadata.spec.ts)
+
+**Requires:** Superadmin login, `runtime-variant-preset-ui-metadata` feature flag (manager ≥ 26.9.0) — tests skip gracefully on older managers instead of failing.
+**Primary action:** "Create Preset" → `BAIRuntimeVariantPresetSettingModal`
+**Row actions:** Edit → `BAIRuntimeVariantPresetSettingModal`, Delete → `BAIDeleteConfirmModal` (`requireConfirmInput`, so the spec types the preset name before confirming)
+
+#### Create Preset — Category / Display Name / UI Option
+
+| Feature                                                                    | Status | Test                                                                                          |
+| --------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| Create with Category, Display Name, SELECT UI option (add + remove a choice row) | ✅     | `Superadmin can create a preset with Category, Display Name, and a SELECT UI option`            |
+| Create with a SLIDER UI option, values round-trip on reopen                 | ✅     | `Superadmin can create a preset with a SLIDER UI option`                                        |
+| Validation: Slider Minimum and Maximum both required                        | ✅     | `Superadmin cannot save a SLIDER UI option without Minimum/Maximum`                             |
+| Validation: Slider Step must be positive                                    | ✅     | `Superadmin cannot save a SLIDER UI option with a negative Step`                                |
+
+#### Edit Preset
+
+| Feature                                                                     | Status | Test                                                                                             |
+| ---------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------|
+| Edit round-trip preserves Category, Display Name, and multiple choice rows   | ✅     | `Editing a SELECT preset re-populates category, display name, and every choice row`               |
+
+**Coverage: ✅ 5/5 features**
+
+---
+
+### 32. Project-Agnostic Scope — header project context (the project-agnostic `/admin/*` routes)
+
+**Test files:** [`e2e/admin-scope/admin-header-project-selector.spec.ts`](admin-scope/admin-header-project-selector.spec.ts), [`e2e/admin-scope/admin-data-folder-create.spec.ts`](admin-scope/admin-data-folder-create.spec.ts)
+
+FR-3414 / FR-3415 / ADR-0001: the project-agnostic routes — every `/admin/*`
+route except `admin-dashboard`, which still depends on the ambient project and
+is deliberately out of scope — operate above project scope — the header project selector is hidden there, folder creation asks for the target project inside the modal, and the Environments page selects its project in the page. The route list is derived from `react/src/helper/projectAgnosticRoutes.ts` (minus the feature-flag-gated `scheduler` / `rbac` / `reservoir`, which are not navigable on every test cluster), so a newly gated page is covered automatically.
+
+| Feature                                                                  | Covered | Test                                                                               |
+| ------------------------------------------------------------------------ | :-----: | ---------------------------------------------------------------------------------- |
+| Header project selector absent on every project-agnostic route           |   ✅    | `selector is absent on every project-agnostic route`                               |
+| Environments page offers in-page project selection instead               |   ✅    | `the Environments page selects its project in the page, not the header`            |
+| Header project selector present on the user Data page                    |   ✅    | `selector is present on the user Data page`                                        |
+| Leaving an admin route restores the previous selection untouched         |   ✅    | `leaving an admin route restores the previous selection untouched`                 |
+| Folder created from admin Data page lands in the in-modal chosen project |   ✅    | `folder created from the admin Data page lands in the project chosen in the modal` |
+
+**Coverage: 5 / 5 features (100%)**
 
 ---
 

--- a/e2e/runtime-variant-preset/preset-ui-metadata.spec.ts
+++ b/e2e/runtime-variant-preset/preset-ui-metadata.spec.ts
@@ -145,13 +145,13 @@ test.describe(
       );
 
       await modal
-        .getByRole('combobox', { name: 'Category (optional)' })
+        .getByRole('combobox', { name: /^Category/ })
         .fill('e2e_category');
       await modal
-        .getByRole('textbox', { name: 'Display Name (optional)' })
+        .getByRole('textbox', { name: /^Display Name/ })
         .fill('E2E Display Name');
 
-      await modal.getByRole('combobox', { name: 'UI Type (optional)' }).click();
+      await modal.getByRole('combobox', { name: /^UI Type/ }).click();
       await page
         .locator('.ant-select-dropdown')
         .getByText('Select', { exact: true })
@@ -193,7 +193,7 @@ test.describe(
         `E2E_KEY_${Date.now()}`,
       );
 
-      await modal.getByRole('combobox', { name: 'UI Type (optional)' }).click();
+      await modal.getByRole('combobox', { name: /^UI Type/ }).click();
       await page
         .locator('.ant-select-dropdown')
         .getByText('Slider', { exact: true })
@@ -225,7 +225,7 @@ test.describe(
         `E2E_KEY_${Date.now()}`,
       );
 
-      await modal.getByRole('combobox', { name: 'UI Type (optional)' }).click();
+      await modal.getByRole('combobox', { name: /^UI Type/ }).click();
       await page
         .locator('.ant-select-dropdown')
         .getByText('Slider', { exact: true })
@@ -234,6 +234,37 @@ test.describe(
       await modal.getByRole('button', { name: 'Create' }).click();
 
       await expect(modal.getByText('Maximum value is required.')).toBeVisible();
+
+      await modal.getByRole('button', { name: 'Cancel' }).click();
+    });
+
+    test('Superadmin cannot save a SLIDER UI option with a negative Step', async ({
+      page,
+    }) => {
+      test.skip(
+        !(await supportsUIMetadata(page)),
+        'runtime-variant-preset-ui-metadata requires manager >= 26.9.0',
+      );
+
+      const modal = await openCreateModalWithRequiredFields(
+        page,
+        `e2e-preset-slider-negative-step-${Date.now()}`,
+        `E2E_KEY_${Date.now()}`,
+      );
+
+      await modal.getByRole('combobox', { name: /^UI Type/ }).click();
+      await page
+        .locator('.ant-select-dropdown')
+        .getByText('Slider', { exact: true })
+        .click();
+
+      await modal.getByRole('spinbutton', { name: 'Minimum' }).fill('0');
+      await modal.getByRole('spinbutton', { name: 'Maximum' }).fill('8');
+      await modal.getByRole('spinbutton', { name: 'Step' }).fill('-1');
+
+      await modal.getByRole('button', { name: 'Create' }).click();
+
+      await expect(modal.getByText('Step must be minimum 0')).toBeVisible();
 
       await modal.getByRole('button', { name: 'Cancel' }).click();
     });
@@ -282,12 +313,12 @@ test.describe(
       );
 
       await modal
-        .getByRole('combobox', { name: 'Category (optional)' })
+        .getByRole('combobox', { name: /^Category/ })
         .fill('e2e_category');
       await modal
-        .getByRole('textbox', { name: 'Display Name (optional)' })
+        .getByRole('textbox', { name: /^Display Name/ })
         .fill('E2E Display Name');
-      await modal.getByRole('combobox', { name: 'UI Type (optional)' }).click();
+      await modal.getByRole('combobox', { name: /^UI Type/ }).click();
       await page
         .locator('.ant-select-dropdown')
         .getByText('Select', { exact: true })
@@ -317,10 +348,10 @@ test.describe(
       await expect(editModal).toContainText('Edit Preset');
 
       await expect(
-        editModal.getByRole('combobox', { name: 'Category (optional)' }),
+        editModal.getByRole('combobox', { name: /^Category/ }),
       ).toHaveValue('e2e_category');
       await expect(
-        editModal.getByRole('textbox', { name: 'Display Name (optional)' }),
+        editModal.getByRole('textbox', { name: /^Display Name/ }),
       ).toHaveValue('E2E Display Name');
 
       // The regression this covers: row count used to be right but the

--- a/e2e/runtime-variant-preset/preset-ui-metadata.spec.ts
+++ b/e2e/runtime-variant-preset/preset-ui-metadata.spec.ts
@@ -1,0 +1,338 @@
+// Covers FR-3476: Category / Display Name / UI Option (slider, number,
+// select, checkbox, text) on the Runtime Variant Preset admin create/update
+// modal. These fields are gated behind the `runtime-variant-preset-ui-metadata`
+// client capability (manager >= 26.9.0) — tests that depend on them skip
+// gracefully against an older manager instead of failing.
+import { loginAsAdmin, webuiEndpoint } from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+
+// `/admin-deployments` is a legacy alias that client-side-redirects to this
+// canonical path (see `legacyRedirects.tsx`'s `AdminRedirect`) — navigating
+// here directly avoids the extra redirect hop, which was observed to
+// occasionally desync Playwright's auto-waiting mid-navigation.
+const PRESET_TAB_URL = `${webuiEndpoint}/admin/deployments?tab=runtime-variant-presets`;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function supportsUIMetadata(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          backendaiclient?: { supports: (f: string) => boolean };
+        }
+      ).backendaiclient?.supports('runtime-variant-preset-ui-metadata') ??
+      false,
+  );
+}
+
+/**
+ * Opens the Create Preset modal, selects the first available runtime
+ * variant, and fills the always-required fields.
+ *
+ * The dev server this suite runs against occasionally drops its Vite HMR
+ * websocket and issues a full page reload mid-interaction (observed via
+ * `page.on('load')`, unrelated to anything the app does) — losing the
+ * open modal. Retry the whole sequence once rather than fail on that
+ * environmental hiccup.
+ */
+async function openCreateModalWithRequiredFields(
+  page: Page,
+  name: string,
+  key: string,
+): Promise<ReturnType<Page['getByRole']>> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      await page.goto(PRESET_TAB_URL);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(
+        page.getByRole('button', { name: /Create Preset/i }),
+      ).toBeVisible({ timeout: 60000 });
+      await page.getByRole('button', { name: /Create Preset/i }).click();
+      const modal = page.getByRole('dialog');
+      await expect(modal).toBeVisible();
+
+      // Runtime Variant is a paginated combobox — pick the first option.
+      const runtimeVariantSelect = modal.getByRole('combobox', {
+        name: 'Runtime Variant',
+      });
+      await expect(runtimeVariantSelect).toBeVisible({ timeout: 30000 });
+      await runtimeVariantSelect.click();
+      await page.waitForSelector(
+        '.ant-select-dropdown .ant-select-item-option',
+        { state: 'visible', timeout: 15000 },
+      );
+      await page
+        .locator('.ant-select-dropdown .ant-select-item-option')
+        .first()
+        .click();
+
+      await modal
+        .getByRole('textbox', { name: 'Name', exact: true })
+        .fill(name);
+      await modal.getByRole('textbox', { name: 'Key' }).fill(key);
+      // Confirm the modal (and its filled Name) survived the fill — if a
+      // reload happened, this will already have failed or `modal` will no
+      // longer be attached.
+      await expect(
+        modal.getByRole('textbox', { name: 'Name', exact: true }),
+      ).toHaveValue(name);
+
+      return modal;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
+
+async function deletePreset(page: Page, presetName: string): Promise<void> {
+  await page.goto(PRESET_TAB_URL);
+  await page.waitForLoadState('domcontentloaded');
+  const row = page.getByRole('row').filter({ hasText: presetName });
+  if ((await row.count()) === 0) return;
+  await row.getByRole('button', { name: 'Delete', exact: true }).click();
+  const confirmModal = page.getByRole('dialog');
+  await expect(confirmModal).toBeVisible({ timeout: 15000 });
+  await confirmModal.locator('input').fill(presetName);
+  await confirmModal
+    .getByRole('button', { name: 'Delete', exact: true })
+    .click();
+  await expect(confirmModal).toBeHidden({ timeout: 30000 });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Create — Category / Display Name / UI Option
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe(
+  'Runtime Variant Preset - UI Metadata - Create',
+  { tag: ['@runtime-variant-preset', '@admin', '@crud'] },
+  () => {
+    let presetName: string;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      if (presetName) {
+        try {
+          await deletePreset(page, presetName);
+        } catch {
+          // ignore cleanup errors
+        }
+        presetName = '';
+      }
+    });
+
+    test('Superadmin can create a preset with Category, Display Name, and a SELECT UI option', async ({
+      page,
+    }) => {
+      test.skip(
+        !(await supportsUIMetadata(page)),
+        'runtime-variant-preset-ui-metadata requires manager >= 26.9.0',
+      );
+
+      presetName = `e2e-preset-select-${Date.now()}`;
+      const modal = await openCreateModalWithRequiredFields(
+        page,
+        presetName,
+        `E2E_KEY_${Date.now()}`,
+      );
+
+      await modal
+        .getByRole('combobox', { name: 'Category (optional)' })
+        .fill('e2e_category');
+      await modal
+        .getByRole('textbox', { name: 'Display Name (optional)' })
+        .fill('E2E Display Name');
+
+      await modal.getByRole('combobox', { name: 'UI Type (optional)' }).click();
+      await page
+        .locator('.ant-select-dropdown')
+        .getByText('Select', { exact: true })
+        .click();
+
+      await modal.getByRole('button', { name: /Add Choice/i }).click();
+      await modal.getByRole('button', { name: /Add Choice/i }).click();
+
+      const choiceRows = modal.locator('input[placeholder="e.g., fp16"]');
+      const labelRows = modal.locator('input[placeholder="e.g., FP16"]');
+      await choiceRows.nth(0).fill('fp16');
+      await labelRows.nth(0).fill('FP16');
+      await choiceRows.nth(1).fill('bf16');
+      await labelRows.nth(1).fill('BF16');
+
+      await modal.getByRole('button', { name: 'Create' }).click();
+
+      await expect(
+        page.getByText('Runtime variant preset has been created.'),
+      ).toBeVisible({ timeout: 60000 });
+      await expect(modal).toBeHidden({ timeout: 30000 });
+
+      const newRow = page.getByRole('row').filter({ hasText: presetName });
+      await expect(newRow).toBeVisible({ timeout: 60000 });
+    });
+
+    test('Superadmin can create a preset with a SLIDER UI option', async ({
+      page,
+    }) => {
+      test.skip(
+        !(await supportsUIMetadata(page)),
+        'runtime-variant-preset-ui-metadata requires manager >= 26.9.0',
+      );
+
+      presetName = `e2e-preset-slider-${Date.now()}`;
+      const modal = await openCreateModalWithRequiredFields(
+        page,
+        presetName,
+        `E2E_KEY_${Date.now()}`,
+      );
+
+      await modal.getByRole('combobox', { name: 'UI Type (optional)' }).click();
+      await page
+        .locator('.ant-select-dropdown')
+        .getByText('Slider', { exact: true })
+        .click();
+
+      await modal.getByRole('spinbutton', { name: 'Minimum' }).fill('0');
+      await modal.getByRole('spinbutton', { name: 'Maximum' }).fill('8');
+      await modal.getByRole('spinbutton', { name: 'Step' }).fill('1');
+
+      await modal.getByRole('button', { name: 'Create' }).click();
+
+      await expect(
+        page.getByText('Runtime variant preset has been created.'),
+      ).toBeVisible({ timeout: 60000 });
+      await expect(modal).toBeHidden({ timeout: 30000 });
+    });
+
+    test('Superadmin cannot save a SLIDER UI option without Minimum/Maximum', async ({
+      page,
+    }) => {
+      test.skip(
+        !(await supportsUIMetadata(page)),
+        'runtime-variant-preset-ui-metadata requires manager >= 26.9.0',
+      );
+
+      const modal = await openCreateModalWithRequiredFields(
+        page,
+        `e2e-preset-slider-invalid-${Date.now()}`,
+        `E2E_KEY_${Date.now()}`,
+      );
+
+      await modal.getByRole('combobox', { name: 'UI Type (optional)' }).click();
+      await page
+        .locator('.ant-select-dropdown')
+        .getByText('Slider', { exact: true })
+        .click();
+
+      await modal.getByRole('button', { name: 'Create' }).click();
+
+      await expect(modal.getByText('Maximum value is required.')).toBeVisible();
+
+      await modal.getByRole('button', { name: 'Cancel' }).click();
+    });
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Edit — content must survive round-trip (regression coverage for the
+//    Form.List `preserve={false}` GC bug fixed in this same change)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe(
+  'Runtime Variant Preset - UI Metadata - Edit',
+  { tag: ['@runtime-variant-preset', '@admin', '@crud'] },
+  () => {
+    let presetName: string;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      if (presetName) {
+        try {
+          await deletePreset(page, presetName);
+        } catch {
+          // ignore cleanup errors
+        }
+        presetName = '';
+      }
+    });
+
+    test('Editing a SELECT preset re-populates category, display name, and every choice row', async ({
+      page,
+    }) => {
+      test.skip(
+        !(await supportsUIMetadata(page)),
+        'runtime-variant-preset-ui-metadata requires manager >= 26.9.0',
+      );
+
+      presetName = `e2e-preset-edit-select-${Date.now()}`;
+      const modal = await openCreateModalWithRequiredFields(
+        page,
+        presetName,
+        `E2E_KEY_${Date.now()}`,
+      );
+
+      await modal
+        .getByRole('combobox', { name: 'Category (optional)' })
+        .fill('e2e_category');
+      await modal
+        .getByRole('textbox', { name: 'Display Name (optional)' })
+        .fill('E2E Display Name');
+      await modal.getByRole('combobox', { name: 'UI Type (optional)' }).click();
+      await page
+        .locator('.ant-select-dropdown')
+        .getByText('Select', { exact: true })
+        .click();
+      await modal.getByRole('button', { name: /Add Choice/i }).click();
+      await modal
+        .locator('input[placeholder="e.g., fp16"]')
+        .first()
+        .fill('fp16');
+      await modal
+        .locator('input[placeholder="e.g., FP16"]')
+        .first()
+        .fill('FP16');
+      await modal.getByRole('button', { name: 'Create' }).click();
+      await expect(
+        page.getByText('Runtime variant preset has been created.'),
+      ).toBeVisible({ timeout: 60000 });
+      await expect(modal).toBeHidden({ timeout: 30000 });
+
+      // Reopen for edit and verify every field round-tripped.
+      const row = page.getByRole('row').filter({ hasText: presetName });
+      await expect(row).toBeVisible({ timeout: 60000 });
+      await row.getByRole('button', { name: 'Edit', exact: true }).click();
+
+      const editModal = page.getByRole('dialog');
+      await expect(editModal).toBeVisible();
+      await expect(editModal).toContainText('Edit Preset');
+
+      await expect(
+        editModal.getByRole('combobox', { name: 'Category (optional)' }),
+      ).toHaveValue('e2e_category');
+      await expect(
+        editModal.getByRole('textbox', { name: 'Display Name (optional)' }),
+      ).toHaveValue('E2E Display Name');
+
+      // The regression this covers: row count used to be right but the
+      // value/label inputs came back empty.
+      await expect(
+        editModal.locator('input[placeholder="e.g., fp16"]').first(),
+      ).toHaveValue('fp16');
+      await expect(
+        editModal.locator('input[placeholder="e.g., FP16"]').first(),
+      ).toHaveValue('FP16');
+
+      await editModal.getByRole('button', { name: 'Cancel' }).click();
+    });
+  },
+);

--- a/e2e/runtime-variant-preset/preset-ui-metadata.spec.ts
+++ b/e2e/runtime-variant-preset/preset-ui-metadata.spec.ts
@@ -93,7 +93,17 @@ async function deletePreset(page: Page, presetName: string): Promise<void> {
   await page.goto(PRESET_TAB_URL);
   await page.waitForLoadState('domcontentloaded');
   const row = page.getByRole('row').filter({ hasText: presetName });
-  if ((await row.count()) === 0) return;
+  // `domcontentloaded` fires before the Relay table data renders, and
+  // `.count()` resolves immediately without waiting — so reading it right
+  // after navigation can race the render and report 0 while the table is
+  // still showing its loading skeleton, silently skipping real cleanup.
+  // Wait for the row to actually appear (or definitively time out) instead.
+  const appeared = await row
+    .first()
+    .waitFor({ state: 'visible', timeout: 15000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared) return;
   await row.getByRole('button', { name: 'Delete', exact: true }).click();
   const confirmModal = page.getByRole('dialog');
   await expect(confirmModal).toBeVisible({ timeout: 15000 });
@@ -167,6 +177,23 @@ test.describe(
       await choiceRows.nth(1).fill('bf16');
       await labelRows.nth(1).fill('BF16');
 
+      // Exercise the remove flow too, not just add: a temporary third row
+      // is added, filled, then removed via its own row Delete button. This
+      // verifies the row count drops back to 2 and the remaining rows keep
+      // their own values (i.e. `remove()` targets the right Form.List index)
+      // — a broken remove handler wouldn't fail any test without this.
+      await modal.getByRole('button', { name: /Add Choice/i }).click();
+      await choiceRows.nth(2).fill('int8');
+      await labelRows.nth(2).fill('INT8');
+      await expect(choiceRows).toHaveCount(3);
+      await modal
+        .getByRole('button', { name: 'Delete', exact: true })
+        .last()
+        .click();
+      await expect(choiceRows).toHaveCount(2);
+      await expect(choiceRows.nth(0)).toHaveValue('fp16');
+      await expect(choiceRows.nth(1)).toHaveValue('bf16');
+
       await modal.getByRole('button', { name: 'Create' }).click();
 
       await expect(
@@ -209,6 +236,28 @@ test.describe(
         page.getByText('Runtime variant preset has been created.'),
       ).toBeVisible({ timeout: 60000 });
       await expect(modal).toBeHidden({ timeout: 30000 });
+
+      // Reopen and verify the persisted UI Option actually round-trips with
+      // the exact bounds/step submitted, not just that *some* preset was
+      // created — the assertions above would still pass even if `uiOption`
+      // were dropped or miswritten. The Minimum/Maximum/Step fields only
+      // render at all when `uiType === 'SLIDER'`, so their presence here
+      // doubles as proof the UI type round-tripped too.
+      const row = page.getByRole('row').filter({ hasText: presetName });
+      await expect(row).toBeVisible({ timeout: 60000 });
+      await row.getByRole('button', { name: 'Edit', exact: true }).click();
+      const editModal = page.getByRole('dialog');
+      await expect(editModal).toBeVisible();
+      await expect(
+        editModal.getByRole('spinbutton', { name: 'Minimum' }),
+      ).toHaveValue('0');
+      await expect(
+        editModal.getByRole('spinbutton', { name: 'Maximum' }),
+      ).toHaveValue('8');
+      await expect(
+        editModal.getByRole('spinbutton', { name: 'Step' }),
+      ).toHaveValue('1');
+      await editModal.getByRole('button', { name: 'Cancel' }).click();
     });
 
     test('Superadmin cannot save a SLIDER UI option without Minimum/Maximum', async ({
@@ -219,9 +268,15 @@ test.describe(
         'runtime-variant-preset-ui-metadata requires manager >= 26.9.0',
       );
 
+      // Tracked in `presetName` (read by `afterEach`) even though this
+      // preset is expected to fail validation and never be created: if a
+      // regression makes the required rule silently pass, the mutation
+      // would succeed and leave a persistent preset that global teardown
+      // doesn't sweep.
+      presetName = `e2e-preset-slider-invalid-${Date.now()}`;
       const modal = await openCreateModalWithRequiredFields(
         page,
-        `e2e-preset-slider-invalid-${Date.now()}`,
+        presetName,
         `E2E_KEY_${Date.now()}`,
       );
 
@@ -233,6 +288,10 @@ test.describe(
 
       await modal.getByRole('button', { name: 'Create' }).click();
 
+      // Both Minimum and Maximum are left blank; assert both required
+      // messages so a regression dropping either field's `required` rule
+      // doesn't slip through unnoticed.
+      await expect(modal.getByText('Minimum value is required.')).toBeVisible();
       await expect(modal.getByText('Maximum value is required.')).toBeVisible();
 
       await modal.getByRole('button', { name: 'Cancel' }).click();
@@ -246,9 +305,13 @@ test.describe(
         'runtime-variant-preset-ui-metadata requires manager >= 26.9.0',
       );
 
+      // Tracked in `presetName` for the same reason as the sibling
+      // Minimum/Maximum-required test above: a regression in the
+      // negative-step rule would otherwise leave an unswept preset.
+      presetName = `e2e-preset-slider-negative-step-${Date.now()}`;
       const modal = await openCreateModalWithRequiredFields(
         page,
-        `e2e-preset-slider-negative-step-${Date.now()}`,
+        presetName,
         `E2E_KEY_${Date.now()}`,
       );
 
@@ -264,7 +327,9 @@ test.describe(
 
       await modal.getByRole('button', { name: 'Create' }).click();
 
-      await expect(modal.getByText('Step must be minimum 0')).toBeVisible();
+      await expect(
+        modal.getByText('Step must be greater than 0.'),
+      ).toBeVisible();
 
       await modal.getByRole('button', { name: 'Cancel' }).click();
     });
@@ -323,15 +388,17 @@ test.describe(
         .locator('.ant-select-dropdown')
         .getByText('Select', { exact: true })
         .click();
+      // Two choice rows, not one — a bug that only mishandles the second
+      // (or later) `Form.List` row wouldn't be caught by asserting `.first()`
+      // alone below.
       await modal.getByRole('button', { name: /Add Choice/i }).click();
-      await modal
-        .locator('input[placeholder="e.g., fp16"]')
-        .first()
-        .fill('fp16');
-      await modal
-        .locator('input[placeholder="e.g., FP16"]')
-        .first()
-        .fill('FP16');
+      await modal.getByRole('button', { name: /Add Choice/i }).click();
+      const createChoiceRows = modal.locator('input[placeholder="e.g., fp16"]');
+      const createLabelRows = modal.locator('input[placeholder="e.g., FP16"]');
+      await createChoiceRows.nth(0).fill('fp16');
+      await createLabelRows.nth(0).fill('FP16');
+      await createChoiceRows.nth(1).fill('bf16');
+      await createLabelRows.nth(1).fill('BF16');
       await modal.getByRole('button', { name: 'Create' }).click();
       await expect(
         page.getByText('Runtime variant preset has been created.'),
@@ -355,13 +422,19 @@ test.describe(
       ).toHaveValue('E2E Display Name');
 
       // The regression this covers: row count used to be right but the
-      // value/label inputs came back empty.
-      await expect(
-        editModal.locator('input[placeholder="e.g., fp16"]').first(),
-      ).toHaveValue('fp16');
-      await expect(
-        editModal.locator('input[placeholder="e.g., FP16"]').first(),
-      ).toHaveValue('FP16');
+      // value/label inputs came back empty. Check both rows, not just the
+      // first, so a bug affecting only the second-or-later row is caught.
+      const editChoiceRows = editModal.locator(
+        'input[placeholder="e.g., fp16"]',
+      );
+      const editLabelRows = editModal.locator(
+        'input[placeholder="e.g., FP16"]',
+      );
+      await expect(editChoiceRows).toHaveCount(2);
+      await expect(editChoiceRows.nth(0)).toHaveValue('fp16');
+      await expect(editLabelRows.nth(0)).toHaveValue('FP16');
+      await expect(editChoiceRows.nth(1)).toHaveValue('bf16');
+      await expect(editLabelRows.nth(1)).toHaveValue('BF16');
 
       await editModal.getByRole('button', { name: 'Cancel' }).click();
     });


### PR DESCRIPTION
Resolves #8608 (FR-3476)

Stacked on #8609.

## Summary

Playwright e2e coverage for the runtime variant preset UI metadata feature added in #8609.

- Create with Category, Display Name, and a SELECT UI option (including the choices list editor: add/remove rows, value/label per row)
- Create with a SLIDER UI option (min/max/step)
- SLIDER required-field validation (Maximum required when no value is given)
- SLIDER negative-step validation (new): covers the `{ type: 'number', min: 0 }` rule added on `BAIRuntimeVariantPresetSettingModal.tsx`'s Step field on the parent branch
- Edit-mode round-trip: reopening a SELECT preset re-populates Category, Display Name, and every choice row's value/label — regression coverage for the `Form.List` `preserve={false}` bug fixed in #8609 (row count survived, per-row content didn't)

Tests check `runtime-variant-preset-ui-metadata` support via `backendaiclient.supports(...)` and skip gracefully when the connected manager is older than 26.9.0, rather than failing.

**Fix (this update):** every test touching Category/Display Name/UI Type used an exact-string locator (e.g. `{ name: 'UI Type (optional)' }`), but those fields render a tooltip `question-circle` icon inside the label, so the real accessible name is `"UI Type question-circle (optional)"` — the locators never matched and every one of these tests was failing. Switched to prefix regexes (`/^UI Type/`, `/^Category/`, `/^Display Name/`). Verified against a live dev server with the capability flag temporarily lowered to 26.8.0 client-side (manager itself unchanged) — all 5 scenarios (Create × 4, Edit × 1) now pass for real, not just skip.

## Test plan

- [x] `bash scripts/verify.sh` passes
- [x] Verified locally against the actual `feat/FR-3476-runtime-variant-preset-ui-metadata` dev server (capability flag temporarily lowered to 26.8.0 client-side only, reverted after) — all 5 scenarios pass, including the new negative-step case
- [ ] Confirm green in CI

**Checklist:**

- [ ] Documentation
- [x] Minimum required manager version: 26.9.0 (tests skip below that)
- [ ] Specific setting for review
- [x] Minimum requirements to check during review: locator conventions match `e2e/auto-scaling-rule-preset/*.spec.ts`; cleanup runs in `afterEach`
- [x] Test case(s) to demonstrate the difference of before/after: the edit round-trip test is a direct regression test for the choices-hydration bug fixed in #8609
