### PR TITLE
feat(docs-toolkit): Accept a per-language `title` in book.config.yaml

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/book-config.test.ts
+++ b/packages/backend.ai-docs-toolkit/src/book-config.test.ts
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { loadBookConfig, normalizeTitle } from "./book-config.js";
+import {
+  loadBookConfig,
+  normalizeTitle,
+  resolveBookTitle,
+} from "./book-config.js";
 
 function withSrcDir(yaml: string, fn: (dir: string) => void): void {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "book-config-"));
@@ -193,6 +197,112 @@ languages: [en]
       const cfg = loadBookConfig(dir);
       assert.deepEqual(cfg.navigation, {});
       assert.deepEqual(cfg.navigationGroups, {});
+    },
+  );
+});
+
+// ── Per-language title ────────────────────────────────────────────
+
+test("title — a plain string resolves identically for every language", () => {
+  withSrcDir(
+    ["title: Backend.AI WebUI User Guide", "languages: [en, ko]", "navigation: {}"].join("\n"),
+    (dir) => {
+      const cfg = loadBookConfig(dir);
+      assert.equal(cfg.title, "Backend.AI WebUI User Guide");
+      assert.equal(resolveBookTitle(cfg, "en").title, "Backend.AI WebUI User Guide");
+      assert.equal(resolveBookTitle(cfg, "ko").title, "Backend.AI WebUI User Guide");
+      // A language absent from the config still resolves, never undefined.
+      assert.equal(resolveBookTitle(cfg, "xx").title, "Backend.AI WebUI User Guide");
+    },
+  );
+});
+
+test("title — a block scalar keeps its line breaks in titleMultiline", () => {
+  withSrcDir(
+    ["title: |", "  Backend.AI WebUI", "  User Guide", "languages: [en]", "navigation: {}"].join("\n"),
+    (dir) => {
+      const cfg = loadBookConfig(dir);
+      assert.equal(cfg.title, "Backend.AI WebUI User Guide");
+      assert.equal(cfg.titleMultiline, "Backend.AI WebUI\nUser Guide");
+      assert.equal(
+        resolveBookTitle(cfg, "en").titleMultiline,
+        "Backend.AI WebUI\nUser Guide",
+      );
+    },
+  );
+});
+
+test("title — a per-language map resolves each language to its own title", () => {
+  withSrcDir(
+    [
+      "title:",
+      '  default: "Backend.AI WebUI User Guide"',
+      '  ko: "Backend.AI WebUI 사용자 가이드"',
+      "languages: [en, ko]",
+      "navigation: {}",
+    ].join("\n"),
+    (dir) => {
+      const cfg = loadBookConfig(dir);
+      assert.equal(resolveBookTitle(cfg, "ko").title, "Backend.AI WebUI 사용자 가이드");
+      // No `en` key — falls back to `default`, not to the ko entry.
+      assert.equal(resolveBookTitle(cfg, "en").title, "Backend.AI WebUI User Guide");
+      // `title` remains the default for language-unaware callers.
+      assert.equal(cfg.title, "Backend.AI WebUI User Guide");
+    },
+  );
+});
+
+test("title — a map without `default` falls back to its first entry", () => {
+  withSrcDir(
+    ["title:", '  ko: "한국어 제목"', "languages: [ko]", "navigation: {}"].join("\n"),
+    (dir) => {
+      const cfg = loadBookConfig(dir);
+      assert.equal(cfg.title, "한국어 제목");
+      assert.equal(resolveBookTitle(cfg, "ja").title, "한국어 제목");
+    },
+  );
+});
+
+test("title — per-language block scalars keep their line breaks", () => {
+  withSrcDir(
+    [
+      "title:",
+      "  default: |",
+      "    Backend.AI WebUI",
+      "    User Guide",
+      "  ko: |",
+      "    Backend.AI WebUI",
+      "    사용자 가이드",
+      "languages: [en, ko]",
+      "navigation: {}",
+    ].join("\n"),
+    (dir) => {
+      const cfg = loadBookConfig(dir);
+      assert.equal(
+        resolveBookTitle(cfg, "ko").titleMultiline,
+        "Backend.AI WebUI\n사용자 가이드",
+      );
+      assert.equal(resolveBookTitle(cfg, "ko").title, "Backend.AI WebUI 사용자 가이드");
+      assert.equal(
+        resolveBookTitle(cfg, "en").titleMultiline,
+        "Backend.AI WebUI\nUser Guide",
+      );
+    },
+  );
+});
+
+test("title — a non-string map entry is dropped, not rendered", () => {
+  withSrcDir(
+    [
+      "title:",
+      '  default: "Good"',
+      "  ko: 42",
+      "languages: [en, ko]",
+      "navigation: {}",
+    ].join("\n"),
+    (dir) => {
+      const cfg = loadBookConfig(dir);
+      assert.equal(resolveBookTitle(cfg, "ko").title, "Good");
     },
   );
 });

--- a/packages/backend.ai-docs-toolkit/src/book-config.ts
+++ b/packages/backend.ai-docs-toolkit/src/book-config.ts
@@ -112,7 +112,11 @@ interface RawNavGroup {
  * the same parsed object.
  */
 export interface RawBookConfig {
-  title: string;
+  /**
+   * Either a single title shared by every language, or a per-language map
+   * keyed the same way `navigation` is. See {@link resolveBookTitle}.
+   */
+  title: string | Record<string, string>;
   description?: string;
   languages: string[];
   navigation: Record<string, RawNavigation>;
@@ -131,10 +135,24 @@ export interface RawBookConfig {
  * cross-language slug map) keep using `navigation` unchanged.
  */
 export interface NormalizedBookConfig {
-  /** Single-line, whitespace-collapsed. Safe for `<title>` and headers. */
+  /**
+   * Single-line, whitespace-collapsed. Safe for `<title>` and headers.
+   *
+   * This is the *default* title — the `default` key of a per-language map, or
+   * its first entry. Language-aware pipelines should call
+   * {@link resolveBookTitle} instead, so a translated build does not stamp the
+   * source language onto every page.
+   */
   title: string;
   /** Raw multi-line form. Use only where line breaks are part of the design. */
   titleMultiline: string;
+  /**
+   * Per-language titles, single-line. Always populated: a string `title`
+   * yields `{ default: "..." }`.
+   */
+  titleByLang: Record<string, string>;
+  /** Per-language titles, multi-line form preserved. */
+  titleMultilineByLang: Record<string, string>;
   description: string;
   languages: string[];
   /** Flat per-language nav list (backward-compatible, used by PDF pipeline). */
@@ -153,6 +171,71 @@ export interface NormalizedBookConfig {
  */
 export function normalizeTitle(raw: string): string {
   return raw.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Resolve the title for one language.
+ *
+ * Mirrors how `branding.subLabel` already resolves in `config.ts`: exact
+ * language, then `default`, then the first entry. A `book.config.yaml` with a
+ * plain string `title` resolves to that string for every language, so existing
+ * projects are unaffected.
+ */
+export function resolveBookTitle(
+  config: NormalizedBookConfig,
+  lang: string,
+): { title: string; titleMultiline: string } {
+  const pick = (map: Record<string, string>, fallback: string): string =>
+    map[lang] ?? map.default ?? Object.values(map)[0] ?? fallback;
+  return {
+    title: pick(config.titleByLang, config.title),
+    titleMultiline: pick(config.titleMultilineByLang, config.titleMultiline),
+  };
+}
+
+/**
+ * Normalize the raw `title` into per-language maps plus the default pair.
+ * A string collapses to a single `default` entry.
+ */
+function normalizeBookTitle(raw: string | Record<string, string> | undefined): {
+  title: string;
+  titleMultiline: string;
+  titleByLang: Record<string, string>;
+  titleMultilineByLang: Record<string, string>;
+} {
+  if (raw && typeof raw === "object") {
+    const titleByLang: Record<string, string> = {};
+    const titleMultilineByLang: Record<string, string> = {};
+    for (const [lang, value] of Object.entries(raw)) {
+      if (typeof value !== "string") {
+        console.warn(
+          `[book.config.yaml] title.${lang}: expected a string, dropping entry`,
+        );
+        continue;
+      }
+      const multiline = value.trimEnd();
+      titleMultilineByLang[lang] = multiline;
+      titleByLang[lang] = normalizeTitle(multiline);
+    }
+    const defaultMultiline =
+      titleMultilineByLang.default ??
+      Object.values(titleMultilineByLang)[0] ??
+      "";
+    return {
+      title: normalizeTitle(defaultMultiline),
+      titleMultiline: defaultMultiline,
+      titleByLang,
+      titleMultilineByLang,
+    };
+  }
+  const titleMultiline = (raw ?? "").trimEnd();
+  const title = normalizeTitle(titleMultiline);
+  return {
+    title,
+    titleMultiline,
+    titleByLang: { default: title },
+    titleMultilineByLang: { default: titleMultiline },
+  };
 }
 
 /**
@@ -268,8 +351,8 @@ export function loadBookConfig(srcDir: string): NormalizedBookConfig {
   const configPath = path.join(srcDir, "book.config.yaml");
   const raw = parseYaml(fs.readFileSync(configPath, "utf-8")) as RawBookConfig;
 
-  const titleMultiline = (raw.title ?? "").trimEnd();
-  const title = normalizeTitle(titleMultiline);
+  const { title, titleMultiline, titleByLang, titleMultilineByLang } =
+    normalizeBookTitle(raw.title);
 
   const navigation: Record<string, NavItem[]> = {};
   const navigationGroups: Record<string, NavGroup[]> = {};
@@ -283,6 +366,8 @@ export function loadBookConfig(srcDir: string): NormalizedBookConfig {
   return {
     title,
     titleMultiline,
+    titleByLang,
+    titleMultilineByLang,
     description: raw.description ?? "",
     languages: raw.languages ?? [],
     navigation,

--- a/packages/backend.ai-docs-toolkit/src/generate-pdf.ts
+++ b/packages/backend.ai-docs-toolkit/src/generate-pdf.ts
@@ -6,7 +6,7 @@ import { buildFullDocument } from './html-builder.js';
 import { renderPdf } from './pdf-renderer.js';
 import { loadTheme, resolveTheme } from './theme.js';
 import { getDocVersion } from './version.js';
-import { loadBookConfig } from './book-config.js';
+import { loadBookConfig, resolveBookTitle } from './book-config.js';
 import type { ResolvedDocConfig } from './config.js';
 
 export interface GeneratePdfOptions {
@@ -169,18 +169,30 @@ export async function generatePdf(
       config,
     );
 
+    // Per-language title: a `book.config.yaml` with a plain string `title`
+    // resolves to that same string for every language, so this is a no-op for
+    // single-title projects.
+    const { title: langTitle, titleMultiline: langTitleMultiline } =
+      resolveBookTitle(bookConfig, lang);
+
     // Build single unified HTML document
     console.log(`[${lang}] Building HTML...`);
     const html = buildFullDocument(
       chapters,
-      { title, titleMultiline, version, lang, note: args.note },
+      {
+        title: langTitle,
+        titleMultiline: langTitleMultiline,
+        version,
+        lang,
+        note: args.note,
+      },
       config,
       theme,
     );
 
     // Render PDF
     const pdfFilename = formatPdfFilename(config.pdfFilenameTemplate, {
-      title,
+      title: langTitle,
       version: versionForFilename,
       lang,
     });
@@ -190,7 +202,7 @@ export async function generatePdf(
     await renderPdf({
       html,
       outputPath,
-      title,
+      title: langTitle,
       version,
       lang,
       theme,

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -122,7 +122,11 @@ export type {
   RawBookConfig,
   RawNavigation,
 } from "./book-config.js";
-export { loadBookConfig, normalizeTitle } from "./book-config.js";
+export {
+  loadBookConfig,
+  normalizeTitle,
+  resolveBookTitle,
+} from "./book-config.js";
 
 // ── SEO (F2) ────────────────────────────────────────────────────
 export type { OgTagOptions, TwitterCardOptions, JsonLdOptions } from "./seo.js";

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -42,6 +42,7 @@ import { generateWebsiteStyles } from "./styles-web.js";
 import { getDocVersion } from "./version.js";
 import {
   loadBookConfig,
+  resolveBookTitle,
   type NavGroup,
   type NormalizedBookConfig,
 } from "./book-config.js";
@@ -716,10 +717,13 @@ export async function generateWebsite(
   } else {
     // Flat (legacy / single-version) mode — preserves FR-2159 behavior.
     for (const lang of languages) {
+      // Per-language title; a plain string `title` resolves identically for
+      // every language, so single-title projects are unaffected.
+      const { title: langTitle } = resolveBookTitle(bookConfig, lang);
       await buildLanguage({
         lang,
         version,
-        title,
+        title: langTitle,
         config,
         bookConfig,
         outRoot: distBase,

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -683,10 +683,11 @@ export async function generateWebsite(
           );
           continue;
         }
+        const { title: langTitle } = resolveBookTitle(versionBookConfig, lang);
         await buildLanguage({
           lang,
           version,
-          title: versionBookConfig.title,
+          title: langTitle,
           config: versionConfig,
           bookConfig: versionBookConfig,
           outRoot: versionDir,


### PR DESCRIPTION
Closes #8629.

`book.config.yaml` keys `navigation` by language but treats `title` as a single global string, so a multi-language project stamps the source language's title onto every page of every translated build.

Measured in Backend.AI FastTrack's Korean 26.8.0rc1 PDF: an English cover, and an English running header on **258 of 260** otherwise-Korean pages — above Korean body text and Korean footers, since the footer derives from document structure. Every Korean web page's `<title>` read `… Documentation - 한국어` too.

## Change

Accept the same shape `navigation` already uses:

```yaml
title:
  default: "Backend.AI WebUI User Guide"
  ko: "Backend.AI WebUI 사용자 가이드"
```

Resolution mirrors `branding.subLabel` in `config.ts` — exact language, then `default`, then the first entry — so both the precedent and the code shape already exist in the toolkit.

## Backward compatibility

A string `title` normalizes to a single `default` entry and resolves to the same value for every language, so existing projects see no change. `NormalizedBookConfig.title` / `.titleMultiline` keep their current meaning as the default pair for language-unaware callers; `titleByLang`, `titleMultilineByLang` and `resolveBookTitle(config, lang)` are additive.

Block scalars keep working per language, so a translated cover can still break across lines where the author intended:

```yaml
title:
  default: |
    Backend.AI WebUI
    User Guide
  ko: |
    Backend.AI WebUI
    사용자 가이드
```

## Wiring

Resolved at the two points where the language is known:

- `generate-pdf.ts` — inside the per-language loop: cover, running header, and the `{title}` filename placeholder.
- `website-generator.ts` — flat-mode per-language loop: `<title>` and the sidebar header.

Deliberately left on the **default** title: the root brand assets (`writeRootBrandAssets`) and the `og:site_name` fallback, since one artifact serves every language. Happy to extend if you'd rather those follow the per-language value in versioned mode too.

## Tests

Six cases added to `book-config.test.ts`, covering the compatibility path as much as the new one:

```
ok - title — a plain string resolves identically for every language
ok - title — a block scalar keeps its line breaks in titleMultiline
ok - title — a per-language map resolves each language to its own title
ok - title — a map without `default` falls back to its first entry
ok - title — per-language block scalars keep their line breaks
ok - title — a non-string map entry is dropped, not rendered
```

Full package suite: **309 passed, 0 failed, 1 skipped**. `tsc --noEmit` clean.

The "no `default` key" and "language absent from the map" cases are covered explicitly because the failure mode there is a silently-`undefined` title rather than a loud error.
