### PR TITLE
test: e2e auto-heal 2026-08-10

### DIFF
--- a/e2e/environment/environment.spec.ts
+++ b/e2e/environment/environment.spec.ts
@@ -215,7 +215,13 @@ test.describe(
       // In Ant Design 6, use role-based selector for dialog
       const modal = page.getByRole('dialog', { name: /Manage Apps/i });
       await expect(modal).toBeVisible();
-      await expect(modal.locator('.ant-form-item').first()).toBeVisible();
+      // Gate on the always-rendered Add button rather than the first app
+      // form-item: an image whose `ai.backend.service-ports` label is absent
+      // legitimately opens the modal with zero apps, and the baseline count
+      // must stay valid in that case.
+      await expect(
+        modal.getByRole('button', { name: 'Add', exact: true }),
+      ).toBeVisible();
       const numberOfAppsBeforeAdd = await modal
         .locator('.ant-form-item')
         .count();

--- a/e2e/environment/environment.spec.ts
+++ b/e2e/environment/environment.spec.ts
@@ -215,6 +215,7 @@ test.describe(
       // In Ant Design 6, use role-based selector for dialog
       const modal = page.getByRole('dialog', { name: /Manage Apps/i });
       await expect(modal).toBeVisible();
+      await expect(modal.locator('.ant-form-item').first()).toBeVisible();
       const numberOfAppsBeforeAdd = await modal
         .locator('.ant-form-item')
         .count();
@@ -243,7 +244,34 @@ test.describe(
         await page.getByRole('button', { name: 'OK' }).nth(1).click();
       }
 
-      // Verify app is added
+      // Verify app is added. Reopening the modal picks up whatever row
+      // reference the list currently holds; a click made before the
+      // post-submit refetch resolves captures the *pre-add* row and (since
+      // the modal is `destroyOnHidden`) freezes on stale data rather than
+      // updating in place. Poll the full reopen+read+close cycle — not just
+      // an assertion on an already-open modal — until the refetch lands.
+      const openManageAppsModalAndCountApps = async () => {
+        await firstRow
+          .locator('.ant-table-cell')
+          .nth(controlColumnIndex)
+          .getByRole('button', { name: 'appstore' })
+          .click();
+        const dialog = page.getByRole('dialog', { name: /Manage Apps/i });
+        await expect(dialog).toBeVisible();
+        const count = await dialog.locator('.ant-form-item').count();
+        await dialog.getByRole('button', { name: 'Cancel' }).click();
+        await expect(dialog).toBeHidden();
+        return count;
+      };
+      await expect
+        .poll(openManageAppsModalAndCountApps, {
+          message: 'Waiting for the added app row to appear after refetch',
+          timeout: 20000,
+        })
+        .toBe(numberOfAppsBeforeAdd + 1);
+
+      // Reopen once more now that the refetched data is confirmed fresh, to
+      // assert on the added row's field values and perform cleanup.
       await firstRow
         .locator('.ant-table-cell')
         .nth(controlColumnIndex)
@@ -252,9 +280,6 @@ test.describe(
       // In Ant Design 6, use role-based selector for dialog
       const modalAfterAdd = page.getByRole('dialog', { name: /Manage Apps/i });
       await expect(modalAfterAdd).toBeVisible();
-      // Retry the count assertion: the freshly-reopened modal renders its
-      // app form-items asynchronously, so a one-shot `.count()` can read the
-      // old total before the added row mounts (flaky off by one).
       await expect(modalAfterAdd.locator('.ant-form-item')).toHaveCount(
         numberOfAppsBeforeAdd + 1,
       );

--- a/e2e/project/project-crud.spec.ts
+++ b/e2e/project/project-crud.spec.ts
@@ -140,7 +140,7 @@ test.describe(
       // "Project" -> "Projects", see webui.menu.Projects in ProjectPage.tsx)
       await expect(
         page.getByRole('tab', { name: 'Projects', selected: true }),
-      ).toBeVisible();
+      ).toBeVisible({ timeout: 10000 });
 
       // 3. Verify table columns are visible
       await expect(

--- a/e2e/rbac/rbac-role-detail.spec.ts
+++ b/e2e/rbac/rbac-role-detail.spec.ts
@@ -697,7 +697,7 @@ test.describe(
         await navigateTo(adminPage, 'credential');
         await expect(
           adminPage.getByRole('tab', { name: 'Users' }),
-        ).toBeVisible();
+        ).toBeVisible({ timeout: 10000 });
         await adminPage.getByRole('button', { name: 'Create User' }).click();
         const userSettingModal = new UserSettingModal(adminPage);
         await userSettingModal.createUser(


### PR DESCRIPTION
Produced automatically by the **daily webui digest** auto-heal stage (2026-08-10 run).

Three e2e failures from last night's full-suite run were triaged as **test-side drift** (no app regression) and healed. Each healed test was re-run and verified before this PR was created.

## Healed

| Spec | Test | Change | Verification |
|---|---|---|---|
| `e2e/environment/environment.spec.ts` | user can manage apps | Reopen-and-count is now an `expect.poll` over the full click → open → count → close cycle instead of a single reopen + retrying `toHaveCount` | ✅ PASS (18.7s) |
| `e2e/project/project-crud.spec.ts` | Admin can see project list with expected columns | `toBeVisible({ timeout: 10000 })` on the selected `Projects` tab, matching the pattern used elsewhere in the file | ✅ PASS (10.2s) |
| `e2e/rbac/rbac-role-detail.spec.ts` | Superadmin can revoke a single user from a role | `toBeVisible({ timeout: 10000 })` on the admin Credential page `Users` tab in the `RBAC Role Assignments Management` `beforeAll`, matching sibling assertions in the same file | ⚠️ Healed step verified (see below) |

### Note on the `environment` fix

The count mismatch was **not** a slow render. `ManageAppsModal` is `destroyOnHidden`, and `ImageList.tsx` refreshes the row's Relay fragment ref only after the mutation resolves (`startTransition(() => updateFetchKey())`). Reopening the modal before that refetch lands captures the *pre-add* row reference and freezes the modal on stale data — no amount of assertion timeout fixes it, because the open modal never updates. Bumping the timeout to 15s reproduced a stable `Expected 9 / Received 8` across all 18 retries, which is what ruled out the race hypothesis. Polling the whole reopen cycle is the correct fix.

### Note on the `rbac` fix

`e2e/rbac/rbac-role-detail.spec.ts` also contains four other failures (lines 385, 502, 617, 743) plus `rbac-role-crud.spec.ts:114` that belong to a **known app-side issue** — the Create Role modal never closes after OK, suspected server-side `adminCreateRole` failure, open since 2026-07-29. Those are deliberately **not** touched here.

After this change the revoke test progresses past the `beforeAll` Users-tab assertion into the test body and then fails at the shared `createTestRole` helper for that known reason. The healed step itself is confirmed fixed; the remaining failure is out of scope for auto-heal and stays in the needs-human queue.

## Not healed (needs human)

7 of the 10 failures were triaged `HUMAN` and are **not** addressed by this PR:

- `e2e/agent/agent.spec.ts` — 0 connected agents in the test cluster (환경, 지속 3일째)
- `e2e/config/config.spec.ts` — image catalog returns 0 search results (환경, 지속 5일째)
- `e2e/rbac/*` 5건 — Create Role modal never closes (앱/백엔드 의심, 지속 6일째)

## Scope

Only files under `e2e/` are modified. No application source under `react/` or `packages/` was touched.

Report doc: `/home/ubuntu/e2e-digest-reports/report-2026-08-10.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
