### PR TITLE
fix(FR-3478): surface the manager's actual error when start-service fails

### DIFF
--- a/react/src/hooks/__fixtures__/appLaunchBackendErrors.ts
+++ b/react/src/hooks/__fixtures__/appLaunchBackendErrors.ts
@@ -1,0 +1,296 @@
+/**
+ * Mocked error responses that the Backend.AI app-launch path
+ * (start-service → appproxy) can produce.
+ *
+ * Body schemas and error_code values were extracted directly from the
+ * backend.ai sources (main as of 2026-08-11).
+ * - Common body schema: src/ai/backend/common/exception.py BackendAIError
+ *   → { type, title, error_code, msg?, data? }
+ * - manager response header: Content-Type: application/problem+json
+ * - appproxy (coordinator/worker) response header: the exception middleware
+ *   re-serializes via web.json_response, so application/json +
+ *   Access-Control-Allow-Origin: *
+ *
+ * Caveats:
+ * - The manager ServiceUnavailable title carries the actual typo in the code,
+ *   "Serivce unavailable." → never branch on title strings; use error_code or
+ *   the type URL instead.
+ * - Errors sharing the same type/title arise from multiple causes (e.g. the
+ *   four invalid-api-params variants). The cause can only be told apart by the
+ *   E-code inside msg (E20007, E20011, E20002).
+ */
+
+export interface BackendAIErrorBody {
+  type: string;
+  title: string;
+  /** Stable identifier in the "{domain}_{operation}_{error-detail}" format */
+  error_code: string;
+  msg?: string;
+  data?: unknown;
+}
+
+export interface MockedErrorResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: BackendAIErrorBody;
+}
+
+const MANAGER_HEADERS = { 'Content-Type': 'application/problem+json' };
+const APPPROXY_HEADERS = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'Access-Control-Allow-Origin': '*',
+};
+
+// ─────────────────────────────────────────────────────────────
+// Stage 1: manager POST /session/{id}/start-service (via webserver)
+// ─────────────────────────────────────────────────────────────
+export const managerErrors = {
+  /** Session ID does not exist */
+  sessionNotFound: {
+    status: 404,
+    headers: MANAGER_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/object-not-found',
+      title: 'No such session.',
+      error_code: 'session_read_not-found',
+    },
+  },
+  /** Session has no resource group assigned */
+  noScalingGroup: {
+    status: 503,
+    headers: MANAGER_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/service-unavailable',
+      title: 'Serivce unavailable.', // actual typo in the backend code
+      error_code: 'backendai_generic_unavailable',
+      msg: 'Session has no scaling group assigned',
+    },
+  },
+  /** No app proxy address configured for the resource group */
+  noCoordinator: {
+    status: 503,
+    headers: MANAGER_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/service-unavailable',
+      title: 'Serivce unavailable.',
+      error_code: 'backendai_generic_unavailable',
+      msg: 'No coordinator configured for this resource group',
+    },
+  },
+  /** Attempted to run an inference app as interactive */
+  inferenceAppRejected: {
+    status: 400,
+    headers: MANAGER_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/invalid-api-params',
+      title: 'Missing or invalid API parameters.',
+      error_code: 'api_generic_invalid-parameters',
+      msg: 'ttyd is an inference app. Starting inference apps can only be done by starting an inference service.',
+    },
+  },
+  /** The app did not open the requested port */
+  portNotOpened: {
+    status: 400,
+    headers: MANAGER_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/invalid-api-params',
+      title: 'Missing or invalid API parameters.',
+      error_code: 'api_generic_invalid-parameters',
+      msg: 'Service ttyd does not open the port number 7681.',
+    },
+  },
+  /** App name not present in the session's service_ports */
+  appNotFound: {
+    status: 404,
+    headers: MANAGER_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/object-not-found',
+      title: 'No such app service.',
+      error_code: 'backendai_read_not-found',
+      msg: 'mysession:ttyd',
+    },
+  },
+  /** No agent allocated to the main kernel */
+  agentNotAllocated: {
+    status: 500,
+    headers: MANAGER_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/agent-not-allocated',
+      title: 'Agent ID has not been allocated for the session.',
+      error_code: 'agent_access_internal-error',
+      msg: 'Session e961a85c-29b3-429e-b140-b01dcd80b689 main kernel has no agent allocated',
+    },
+  },
+  /**
+   * The app process (ttyd, etc.) failed to start inside the container —
+   * the agent error is carried verbatim in data
+   */
+  appLaunchFailed: {
+    status: 500,
+    headers: MANAGER_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/internal-server-error',
+      title: 'Internal server error.',
+      error_code: 'backendai_generic_internal-error',
+      msg: 'Failed to launch the app service',
+      data: {
+        src: 'other',
+        name: 'RuntimeError',
+        repr: "RuntimeError('ttyd exited unexpectedly')",
+      },
+    },
+  },
+} satisfies Record<string, MockedErrorResponse>;
+
+// ─────────────────────────────────────────────────────────────
+// Stage 2: coordinator GET /v2/proxy/{token}/{session}/add → /v2/proxy/auth
+// ─────────────────────────────────────────────────────────────
+export const coordinatorErrors = {
+  /** Token is not in the coordinator DB (expired / tampered) */
+  tokenNotFound: {
+    status: 404,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/object-not-found',
+      title: 'E00002: No such token.',
+      error_code: 'agent_read_not-found',
+    },
+  },
+  /** Token's session ≠ session_id in the URL */
+  sessionIdMismatch: {
+    status: 401,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/invalid-credentials',
+      title: 'Authentication credentials not valid.',
+      error_code: 'agent_auth_unauthorized',
+      msg: 'E20007: Session ID mismatch',
+    },
+  },
+  /** Unsupported protocol */
+  unsupportedProtocol: {
+    status: 400,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/appproxy/unsupported-protocol',
+      title: 'Unsupported protocol.',
+      error_code: 'agent_request_invalid-parameters',
+      msg: 'GRPC',
+    },
+  },
+  /** No matching worker / port slots exhausted */
+  workerNotAvailable: {
+    status: 503,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/appproxy/worker-not-available',
+      title: 'Worker not available.',
+      error_code: 'agent_access_not-found',
+    },
+  },
+  /** Designated port / subdomain already occupied */
+  portNotAvailable: {
+    status: 409,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/appproxy/port-not-available',
+      title: 'Designated port already occupied.',
+      error_code: 'agent_setup_already-exists',
+    },
+  },
+  /**
+   * Circuit creation failed (the code has no HTTP status mixin, so noted as
+   * 500 — verify against a live deployment when possible)
+   */
+  circuitCreationFailed: {
+    status: 500,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/appproxy/circuit-creation-failed',
+      title: 'Failed to create circuit.',
+      error_code: 'kernel_create_internal-error',
+      msg: 'Failed to create circuit and worker.',
+    },
+  },
+} satisfies Record<string, MockedErrorResponse>;
+
+// ─────────────────────────────────────────────────────────────
+// Stage 3: worker /setup and actual app traffic
+// ─────────────────────────────────────────────────────────────
+export const workerErrors = {
+  /** JWT signature mismatch / tampering */
+  invalidJwt: {
+    status: 401,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/invalid-credentials',
+      title: 'Authentication credentials not valid.',
+      error_code: 'agent_auth_unauthorized',
+    },
+  },
+  /** allowed_client_ips restriction */
+  clientIpNotAllowed: {
+    status: 403,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/client-ip-not-allowed',
+      title: 'Client address not allowed.',
+      error_code: 'appproxy_access_forbidden',
+      msg: 'E20011: Client address not allowed',
+    },
+  },
+  /** Inference app accessed via the interactive path */
+  inferenceNotSupported: {
+    status: 400,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/invalid-api-params',
+      title: 'Missing or invalid API parameters.',
+      error_code: 'agent_request_invalid-parameters',
+      msg: 'E20011: Not supported for inference apps',
+    },
+  },
+  /** Protocol not usable as interactive */
+  protocolNotInteractive: {
+    status: 400,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/invalid-api-params',
+      title: 'Missing or invalid API parameters.',
+      error_code: 'agent_request_invalid-parameters',
+      msg: 'E20002: Protocol not available as interactive app',
+    },
+  },
+  /** Missing worker configuration (traefik/wildcard, etc.) */
+  serverMisconfigured: {
+    status: 500,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/server-misconfigured',
+      title: 'E00001: Service misconfigured.',
+      error_code: 'agent_setup_invalid-parameters',
+      msg: "proxy_worker: Missing 'traefik' config section",
+    },
+  },
+  /** Kernel app port connection refused — the app process died */
+  containerConnectionRefused: {
+    status: 502,
+    headers: APPPROXY_HEADERS,
+    body: {
+      type: 'https://api.backend.ai/probs/appproxy/container-connection-refused',
+      title: 'Cannot connect to Backend.AI kernel.',
+      error_code: 'kernel_access_unreachable',
+    },
+  },
+} satisfies Record<string, MockedErrorResponse>;
+
+// ─────────────────────────────────────────────────────────────
+// Stage 0: network level — cases with no HTTP response at all.
+// fetch itself rejects, so mock these as network errors instead of a
+// Response (e.g. msw: http.get(url, () => HttpResponse.error());
+// jest: fetchMock.mockReject(new TypeError('Failed to fetch'))).
+// ─────────────────────────────────────────────────────────────
+export const networkLevelFailures = {
+  /** The advertised appproxy address is unreachable from the browser (connection refused) */
+  unreachableAppProxy: () => new TypeError('Failed to fetch'),
+} as const;

--- a/react/src/hooks/useBackendAIAppLauncher.errors.test.ts
+++ b/react/src/hooks/useBackendAIAppLauncher.errors.test.ts
@@ -1,0 +1,316 @@
+/**
+ * FR-3478 regression tests: every backend failure on the app-launch path must
+ * surface its real cause to the user, never the blanket
+ * "Proxy configurator is not responding." text (which describes only the v1
+ * `/conf` path).
+ *
+ * The error catalog in `__fixtures__/appLaunchBackendErrors.ts` was extracted
+ * from the backend.ai sources; these environments are hard to reproduce live
+ * (they need a broken agent, a mis-configured resource group, an exhausted
+ * appproxy worker, …), so the catalog + these tests stand in for them.
+ *
+ * The manager stage deliberately runs through the REAL Backend.AI client
+ * (`Client._wrapWithPromise`) with only `fetch` stubbed, because the client's
+ * error transformation — rejecting with a plain object instead of an `Error` —
+ * is the root cause of FR-3478. Re-implementing that transformation in the
+ * test would let the two drift apart. The real client is imported by relative
+ * path on purpose: the bare `backend.ai-client` specifier is aliased to a stub
+ * in vitest.config.ts.
+ */
+import { Client } from '../../../packages/backend.ai-client/src/client';
+import { ClientConfig } from '../../../packages/backend.ai-client/src/client-config';
+import {
+  coordinatorErrors,
+  managerErrors,
+  networkLevelFailures,
+  workerErrors,
+  type MockedErrorResponse,
+} from './__fixtures__/appLaunchBackendErrors';
+import {
+  AppLaunchError,
+  getAppProxyErrorMessage,
+  isSendRequestErrorResponse,
+  isSessionNotFoundError,
+  sendRequest,
+} from './useBackendAIAppLauncher';
+import { renderHook } from '@testing-library/react';
+import { useErrorMessageResolver } from 'backend.ai-ui';
+
+const LEGACY_PROXY_TEXT = 'Proxy configurator is not responding.';
+const FALLBACK = 'Failed to start the app service.';
+
+const STATUS_TEXT: Record<number, string> = {
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  409: 'Conflict',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+};
+
+const stubFetchWith = (mock: MockedErrorResponse) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify(mock.body), {
+          status: mock.status,
+          statusText: STATUS_TEXT[mock.status],
+          headers: mock.headers,
+        }),
+    ),
+  );
+};
+
+const getErrorMessage = () => {
+  const { result } = renderHook(() => useErrorMessageResolver());
+  return result.current.getErrorMessage;
+};
+
+/**
+ * Drive the real client's start-service call against the stubbed fetch and
+ * capture the rejection — the exact value `_resolveV2ProxyUri`'s catch sees.
+ */
+const startServiceRejection = async (
+  mock: MockedErrorResponse,
+): Promise<unknown> => {
+  stubFetchWith(mock);
+  const client = new Client(
+    new ClientConfig(
+      'AKIADUMMYACCESSKEY',
+      'dummy-secret',
+      'http://mock-manager',
+    ),
+    'test-agent',
+  );
+  try {
+    await client.computeSession.startService(
+      'login-session-token',
+      'e961a85c-29b3-429e-b140-b01dcd80b689',
+      'jupyter',
+    );
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected startService to reject');
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('stage 1 — manager start-service rejections through the real client', () => {
+  it.each(Object.entries<MockedErrorResponse>(managerErrors))(
+    '%s: rejects with a plain object carrying statusCode/error_code',
+    async (_name, mock) => {
+      const err = await startServiceRejection(mock);
+
+      // Root cause of FR-3478: the client never rejects with an Error, so an
+      // `err instanceof Error` branch always falls through to its fallback.
+      expect(err).not.toBeInstanceOf(Error);
+      expect(err).toMatchObject({
+        statusCode: mock.status,
+        error_code: mock.body.error_code,
+      });
+    },
+  );
+
+  it.each(Object.entries<MockedErrorResponse>(managerErrors))(
+    '%s: resolves to the manager message + error_code, not the proxy text',
+    async (_name, mock) => {
+      const err = await startServiceRejection(mock);
+      const resolved = getErrorMessage()(err, FALLBACK);
+
+      expect(resolved).not.toBe(LEGACY_PROXY_TEXT);
+      expect(resolved).not.toBe(FALLBACK);
+      // The client folds `body.msg` (or `body.title` when msg is absent) into
+      // its `message`, and getErrorMessage appends the error_code.
+      expect(resolved).toContain(mock.body.msg ?? mock.body.title);
+      expect(resolved).toContain(`(${mock.body.error_code})`);
+    },
+  );
+
+  it.each(Object.entries<MockedErrorResponse>(managerErrors))(
+    '%s: AppLaunchError preserves the payload for the notification',
+    async (_name, mock) => {
+      const err = await startServiceRejection(mock);
+      const wrapped = new AppLaunchError(
+        getErrorMessage()(err, FALLBACK),
+        'configuring',
+        err,
+      );
+
+      expect(wrapped.statusCode).toBe(mock.status);
+      expect(wrapped.errorCode).toBe(mock.body.error_code);
+      // The original payload (incl. traceback/response) must survive for the
+      // notification's extraDescription.
+      expect(wrapped.originalError).toBe(err);
+    },
+  );
+
+  it('treats only session-domain 404s as "session not accessible"', async () => {
+    // 404 with error_code "session_read_not-found" → the session itself is
+    // gone (or created under another access key): show SessionNotAccessible.
+    expect(
+      isSessionNotFoundError(
+        await startServiceRejection(managerErrors.sessionNotFound),
+      ),
+    ).toBe(true);
+
+    // 404 with error_code "backendai_read_not-found" → the *app* was not
+    // found in service_ports; the session is fine. Masking this as "session
+    // not accessible" would misdirect the user.
+    expect(
+      isSessionNotFoundError(
+        await startServiceRejection(managerErrors.appNotFound),
+      ),
+    ).toBe(false);
+
+    // Pre-24.09 managers send no error_code — keep the FR-2586 heuristic.
+    expect(isSessionNotFoundError({ statusCode: 404 })).toBe(true);
+    expect(isSessionNotFoundError({ statusCode: 500 })).toBe(false);
+  });
+
+  it('distinguishes same-title 503 causes only via msg, never via title', async () => {
+    // noScalingGroup and noCoordinator share status, type, the (typo'd)
+    // title "Serivce unavailable." and even error_code — msg is the only
+    // discriminator, and it must reach the user.
+    const scalingGroupMsg = getErrorMessage()(
+      await startServiceRejection(managerErrors.noScalingGroup),
+      FALLBACK,
+    );
+    const coordinatorMsg = getErrorMessage()(
+      await startServiceRejection(managerErrors.noCoordinator),
+      FALLBACK,
+    );
+
+    expect(scalingGroupMsg).toContain('Session has no scaling group assigned');
+    expect(coordinatorMsg).toContain(
+      'No coordinator configured for this resource group',
+    );
+    expect(scalingGroupMsg).not.toBe(coordinatorMsg);
+  });
+});
+
+describe('stage 2/3 — appproxy coordinator & worker errors through sendRequest', () => {
+  const appproxyCatalog: Array<[string, MockedErrorResponse]> = [
+    ...Object.entries<MockedErrorResponse>(coordinatorErrors),
+    ...Object.entries<MockedErrorResponse>(workerErrors),
+  ];
+
+  it.each(appproxyCatalog)(
+    '%s: sendRequest returns a detectable error shape with the real message',
+    async (_name, mock) => {
+      stubFetchWith(mock);
+      const result = await sendRequest({
+        uri: 'http://mock-appproxy/v2/proxy/token/session-id/add',
+        method: 'GET',
+      });
+
+      expect(isSendRequestErrorResponse(result)).toBe(true);
+      if (!isSendRequestErrorResponse(result)) return; // type narrowing
+
+      expect(result.status).toBe(mock.status);
+      const message = getAppProxyErrorMessage(result, FALLBACK);
+      expect(message).toBe(mock.body.msg ?? mock.body.title);
+      expect(message).not.toBe(LEGACY_PROXY_TEXT);
+    },
+  );
+
+  it('coordinator 404 (token not found) is NOT a session-not-found error', () => {
+    // error_code "agent_read_not-found" is outside the session domain, so a
+    // stale/tampered token must not be reported as an inaccessible session.
+    expect(
+      isSessionNotFoundError({
+        statusCode: coordinatorErrors.tokenNotFound.status,
+        error_code: coordinatorErrors.tokenNotFound.body.error_code,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('stage 0 — network-level failures (no HTTP response at all)', () => {
+  it('client path: an unreachable manager still surfaces the fetch failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw networkLevelFailures.unreachableAppProxy();
+      }),
+    );
+    const client = new Client(
+      new ClientConfig(
+        'AKIADUMMYACCESSKEY',
+        'dummy-secret',
+        'http://mock-manager',
+      ),
+      'test-agent',
+    );
+
+    let rejection: unknown;
+    try {
+      await client.computeSession.startService(
+        'token',
+        'session-id',
+        'jupyter',
+      );
+    } catch (err) {
+      rejection = err;
+    }
+
+    expect(rejection).toBeDefined();
+    expect(rejection).not.toBeInstanceOf(Error);
+    expect(isSessionNotFoundError(rejection)).toBe(false);
+    const resolved = getErrorMessage()(rejection, FALLBACK);
+    expect(resolved).not.toBe(LEGACY_PROXY_TEXT);
+    expect(resolved).toContain('Failed to fetch');
+  });
+
+  it('sendRequest path: an unreachable appproxy throws a descriptive Error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw networkLevelFailures.unreachableAppProxy();
+      }),
+    );
+
+    await expect(
+      sendRequest({
+        uri: 'http://mock-appproxy/v2/proxy/token/session-id/add',
+        method: 'GET',
+      }),
+    ).rejects.toThrow('Request failed: Failed to fetch');
+  });
+});
+
+describe('AppLaunchError payload extraction guards', () => {
+  it('extracts statusCode/errorCode only from well-typed fields', () => {
+    const fromPayload = new AppLaunchError('m', 'configuring', {
+      statusCode: 503,
+      error_code: 'backendai_generic_unavailable',
+    });
+    expect(fromPayload.statusCode).toBe(503);
+    expect(fromPayload.errorCode).toBe('backendai_generic_unavailable');
+
+    // The client's overlay types statusCode as number|string; a string status
+    // (or any other mistyped field) must be ignored, not coerced.
+    const mistyped = new AppLaunchError('m', 'configuring', {
+      statusCode: '503',
+      error_code: 42,
+    });
+    expect(mistyped.statusCode).toBeUndefined();
+    expect(mistyped.errorCode).toBeUndefined();
+  });
+
+  it('accepts Error and absent originalError without extraction', () => {
+    const fromError = new AppLaunchError('m', 'requesting', new Error('boom'));
+    expect(fromError.statusCode).toBeUndefined();
+    expect(fromError.errorCode).toBeUndefined();
+    expect(fromError.originalError).toBeInstanceOf(Error);
+
+    const bare = new AppLaunchError('m', 'connecting');
+    expect(bare.originalError).toBeUndefined();
+    expect(bare.statusCode).toBeUndefined();
+  });
+});

--- a/react/src/hooks/useBackendAIAppLauncher.errors.test.ts
+++ b/react/src/hooks/useBackendAIAppLauncher.errors.test.ts
@@ -150,7 +150,7 @@ describe('stage 1 — manager start-service rejections through the real client',
     },
   );
 
-  it('treats only session-domain 404s as "session not accessible"', async () => {
+  it('treats 404s as "session not accessible" unless the app-not-found code says otherwise', async () => {
     // 404 with error_code "session_read_not-found" → the session itself is
     // gone (or created under another access key): show SessionNotAccessible.
     expect(
@@ -171,6 +171,18 @@ describe('stage 1 — manager start-service rejections through the real client',
     // Pre-24.09 managers send no error_code — keep the FR-2586 heuristic.
     expect(isSessionNotFoundError({ statusCode: 404 })).toBe(true);
     expect(isSessionNotFoundError({ statusCode: 500 })).toBe(false);
+
+    // Fail-safe direction: an error_code we do not recognize (e.g. the manager
+    // renames its domain prefix) must NOT strip the localized guidance. These
+    // literals are intentionally not sourced from the fixture — reading them
+    // from the same catalog the production code is matched against would make
+    // the assertion self-fulfilling.
+    expect(
+      isSessionNotFoundError({
+        statusCode: 404,
+        error_code: 'compute-session_read_not-found',
+      }),
+    ).toBe(true);
   });
 
   it('distinguishes same-title 503 causes only via msg, never via title', async () => {
@@ -219,15 +231,18 @@ describe('stage 2/3 — appproxy coordinator & worker errors through sendRequest
     },
   );
 
-  it('coordinator 404 (token not found) is NOT a session-not-found error', () => {
-    // error_code "agent_read_not-found" is outside the session domain, so a
-    // stale/tampered token must not be reported as an inaccessible session.
+  it('coordinator 404 (token not found) follows the fail-safe direction', () => {
+    // Under the denylist an out-of-domain code like "agent_read_not-found"
+    // keeps the session-not-found guidance (fail-safe). This never surfaces:
+    // isSessionNotFoundError is called exclusively on the manager's
+    // start-service rejection — coordinator failures are routed through
+    // sendRequest/getAppProxyErrorMessage and never reach it.
     expect(
       isSessionNotFoundError({
         statusCode: coordinatorErrors.tokenNotFound.status,
         error_code: coordinatorErrors.tokenNotFound.body.error_code,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 

--- a/react/src/hooks/useBackendAIAppLauncher.errors.test.ts
+++ b/react/src/hooks/useBackendAIAppLauncher.errors.test.ts
@@ -16,6 +16,11 @@
  * test would let the two drift apart. The real client is imported by relative
  * path on purpose: the bare `backend.ai-client` specifier is aliased to a stub
  * in vitest.config.ts.
+ *
+ * On the frontend side the tests call the same exported helpers the hook
+ * uses in production (`resolveStartServiceErrorMessage`,
+ * `buildAppLaunchFailureExtraDescription`) rather than re-composing their
+ * logic here, so a regression in those paths fails these tests.
  */
 import { Client } from '../../../packages/backend.ai-client/src/client';
 import { ClientConfig } from '../../../packages/backend.ai-client/src/client-config';
@@ -28,9 +33,11 @@ import {
 } from './__fixtures__/appLaunchBackendErrors';
 import {
   AppLaunchError,
+  buildAppLaunchFailureExtraDescription,
   getAppProxyErrorMessage,
   isSendRequestErrorResponse,
   isSessionNotFoundError,
+  resolveStartServiceErrorMessage,
   sendRequest,
 } from './useBackendAIAppLauncher';
 import { renderHook } from '@testing-library/react';
@@ -118,17 +125,21 @@ describe('stage 1 — manager start-service rejections through the real client',
   );
 
   it.each(Object.entries<MockedErrorResponse>(managerErrors))(
-    '%s: resolves to the manager message + error_code, not the proxy text',
+    '%s: resolves to exactly the manager message + error_code',
     async (_name, mock) => {
       const err = await startServiceRejection(mock);
-      const resolved = getErrorMessage()(err, FALLBACK);
+      // The production resolver used by `_resolveV2ProxyUri`'s catch. Equality
+      // (not toContain) so the client's debug prefix ("server responded
+      // failure: 503 Service Unavailable - …") can never leak back in.
+      const resolved = resolveStartServiceErrorMessage(
+        err,
+        getErrorMessage(),
+        FALLBACK,
+      );
 
-      expect(resolved).not.toBe(LEGACY_PROXY_TEXT);
-      expect(resolved).not.toBe(FALLBACK);
-      // The client folds `body.msg` (or `body.title` when msg is absent) into
-      // its `message`, and getErrorMessage appends the error_code.
-      expect(resolved).toContain(mock.body.msg ?? mock.body.title);
-      expect(resolved).toContain(`(${mock.body.error_code})`);
+      expect(resolved).toBe(
+        `${mock.body.msg ?? mock.body.title} (${mock.body.error_code})`,
+      );
     },
   );
 
@@ -137,18 +148,47 @@ describe('stage 1 — manager start-service rejections through the real client',
     async (_name, mock) => {
       const err = await startServiceRejection(mock);
       const wrapped = new AppLaunchError(
-        getErrorMessage()(err, FALLBACK),
+        resolveStartServiceErrorMessage(err, getErrorMessage(), FALLBACK),
         'configuring',
         err,
       );
 
-      expect(wrapped.statusCode).toBe(mock.status);
-      expect(wrapped.errorCode).toBe(mock.body.error_code);
       // The original payload (incl. traceback/response) must survive for the
       // notification's extraDescription.
       expect(wrapped.originalError).toBe(err);
     },
   );
+
+  it.each(Object.entries<MockedErrorResponse>(managerErrors))(
+    '%s: notification details keep diagnostics but never the request body',
+    async (_name, mock) => {
+      const err = await startServiceRejection(mock);
+
+      // Sanity: the raw rejection DOES echo the start-service request body
+      // (incl. the credential) via `requestParameters` — that is what the
+      // builder must strip.
+      expect(JSON.stringify(err)).toContain('login_session_token');
+
+      const wrapped = new AppLaunchError('m', 'configuring', err);
+      const extra = buildAppLaunchFailureExtraDescription(wrapped);
+
+      expect(extra).toBeDefined();
+      expect(extra).not.toContain('login_session_token');
+      expect(extra).not.toContain('requestParameters');
+      expect(extra).toContain(mock.body.error_code);
+      expect(extra).toContain(String(mock.status));
+    },
+  );
+
+  it('notification details fall back to the wrapper when nothing was preserved', () => {
+    const fromError = buildAppLaunchFailureExtraDescription(
+      new AppLaunchError('m', 'requesting', new Error('boom')),
+    );
+    expect(fromError).toContain('boom');
+
+    const bare = new AppLaunchError('m', 'connecting');
+    expect(buildAppLaunchFailureExtraDescription(bare)).toBe(bare.stack);
+  });
 
   it('treats 404s as "session not accessible" unless the app-not-found code says otherwise', async () => {
     // 404 with error_code "session_read_not-found" → the session itself is
@@ -188,21 +228,24 @@ describe('stage 1 — manager start-service rejections through the real client',
   it('distinguishes same-title 503 causes only via msg, never via title', async () => {
     // noScalingGroup and noCoordinator share status, type, the (typo'd)
     // title "Serivce unavailable." and even error_code — msg is the only
-    // discriminator, and it must reach the user.
-    const scalingGroupMsg = getErrorMessage()(
+    // discriminator, and it must reach the user verbatim.
+    const scalingGroupMsg = resolveStartServiceErrorMessage(
       await startServiceRejection(managerErrors.noScalingGroup),
+      getErrorMessage(),
       FALLBACK,
     );
-    const coordinatorMsg = getErrorMessage()(
+    const coordinatorMsg = resolveStartServiceErrorMessage(
       await startServiceRejection(managerErrors.noCoordinator),
+      getErrorMessage(),
       FALLBACK,
     );
 
-    expect(scalingGroupMsg).toContain('Session has no scaling group assigned');
-    expect(coordinatorMsg).toContain(
-      'No coordinator configured for this resource group',
+    expect(scalingGroupMsg).toBe(
+      'Session has no scaling group assigned (backendai_generic_unavailable)',
     );
-    expect(scalingGroupMsg).not.toBe(coordinatorMsg);
+    expect(coordinatorMsg).toBe(
+      'No coordinator configured for this resource group (backendai_generic_unavailable)',
+    );
   });
 });
 
@@ -277,7 +320,11 @@ describe('stage 0 — network-level failures (no HTTP response at all)', () => {
     expect(rejection).toBeDefined();
     expect(rejection).not.toBeInstanceOf(Error);
     expect(isSessionNotFoundError(rejection)).toBe(false);
-    const resolved = getErrorMessage()(rejection, FALLBACK);
+    const resolved = resolveStartServiceErrorMessage(
+      rejection,
+      getErrorMessage(),
+      FALLBACK,
+    );
     expect(resolved).not.toBe(LEGACY_PROXY_TEXT);
     expect(resolved).toContain('Failed to fetch');
   });
@@ -296,36 +343,5 @@ describe('stage 0 — network-level failures (no HTTP response at all)', () => {
         method: 'GET',
       }),
     ).rejects.toThrow('Request failed: Failed to fetch');
-  });
-});
-
-describe('AppLaunchError payload extraction guards', () => {
-  it('extracts statusCode/errorCode only from well-typed fields', () => {
-    const fromPayload = new AppLaunchError('m', 'configuring', {
-      statusCode: 503,
-      error_code: 'backendai_generic_unavailable',
-    });
-    expect(fromPayload.statusCode).toBe(503);
-    expect(fromPayload.errorCode).toBe('backendai_generic_unavailable');
-
-    // The client's overlay types statusCode as number|string; a string status
-    // (or any other mistyped field) must be ignored, not coerced.
-    const mistyped = new AppLaunchError('m', 'configuring', {
-      statusCode: '503',
-      error_code: 42,
-    });
-    expect(mistyped.statusCode).toBeUndefined();
-    expect(mistyped.errorCode).toBeUndefined();
-  });
-
-  it('accepts Error and absent originalError without extraction', () => {
-    const fromError = new AppLaunchError('m', 'requesting', new Error('boom'));
-    expect(fromError.statusCode).toBeUndefined();
-    expect(fromError.errorCode).toBeUndefined();
-    expect(fromError.originalError).toBeInstanceOf(Error);
-
-    const bare = new AppLaunchError('m', 'connecting');
-    expect(bare.originalError).toBeUndefined();
-    expect(bare.statusCode).toBeUndefined();
   });
 });

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -279,7 +279,11 @@ export const useBackendAIAppLauncher = (
       // `instanceof Error` — that check made every start-service failure
       // surface as "Proxy configurator is not responding." (FR-3478).
       throw new AppLaunchError(
-        getErrorMessage(err, t('session.appLauncher.FailedToStartAppService')),
+        resolveStartServiceErrorMessage(
+          err,
+          getErrorMessage,
+          t('session.appLauncher.FailedToStartAppService'),
+        ),
         'configuring',
         err,
       );
@@ -428,13 +432,10 @@ export const useBackendAIAppLauncher = (
     try {
       return await sendRequest(rqst_proxy);
     } catch (err) {
-      // Wrap error in AppLaunchError with proper stage
       throw new AppLaunchError(
-        err instanceof Error && err.message
-          ? err.message
-          : 'Failed to connect to coordinator',
+        getErrorMessage(err, 'Failed to connect to coordinator'),
         'requesting',
-        err instanceof Error ? err : undefined,
+        err,
       );
     }
   };
@@ -806,29 +807,9 @@ export const useBackendAIAppLauncher = (
             };
           },
           rejected: (error: any) => {
-            // Prefer the original rejection payload (manager problem+json with
-            // statusCode/error_code/traceback) over the AppLaunchError wrapper
-            // stack, which carries no diagnostic information (FR-3478).
-            // `requestParameters` is omitted: it echoes the raw start-service
-            // request body — login_session_token and possibly secret-bearing
-            // app envs/args — which must not appear in the copyable
-            // notification details.
-            const original = error?.originalError;
-            const extraDescription =
-              original instanceof Error
-                ? original.stack
-                : original && typeof original === 'object'
-                  ? JSON.stringify(
-                      _.omit(original, 'requestParameters'),
-                      null,
-                      2,
-                    )
-                  : original
-                    ? JSON.stringify(original, null, 2)
-                    : error?.stack || JSON.stringify(error, null, 2);
             return {
               description: getErrorMessage(error),
-              extraDescription,
+              extraDescription: buildAppLaunchFailureExtraDescription(error),
               duration: 0, // Persistent error notification
             };
           },
@@ -1148,8 +1129,6 @@ export class AppLaunchError extends Error {
   // `unknown` — typing it `Error` silently dropped the manager's payload
   // (statusCode/error_code/traceback) at wrap time (FR-3478).
   originalError?: unknown;
-  statusCode?: number;
-  errorCode?: string;
 
   constructor(
     message: string,
@@ -1160,23 +1139,71 @@ export class AppLaunchError extends Error {
     this.name = 'AppLaunchError';
     this.stage = stage;
     this.originalError = originalError;
-    if (originalError && typeof originalError === 'object') {
-      const { statusCode, error_code } = originalError as {
-        statusCode?: unknown;
-        error_code?: unknown;
-      };
-      if (typeof statusCode === 'number') {
-        this.statusCode = statusCode;
-      }
-      if (typeof error_code === 'string') {
-        this.errorCode = error_code;
-      }
-    }
     // Maintains proper stack trace for where our error was thrown (only available on V8)
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AppLaunchError);
     }
   }
+}
+
+/**
+ * Resolve the user-facing message for a start-service rejection.
+ *
+ * The client's `message` is a debug string ("server responded failure:
+ * 503 Service Unavailable - …") and its `msg` is always undefined —
+ * `_wrapWithPromise` copies it off the fetch `Response`, which never carries
+ * one. The clean manager text lives in `description` / `response.msg`, so
+ * slot it into the resolver's preferred field before delegating.
+ */
+export function resolveStartServiceErrorMessage(
+  err: unknown,
+  getErrorMessage: (error: unknown, defaultMessage?: string) => string,
+  fallback: string,
+): string {
+  if (err && typeof err === 'object' && !(err instanceof Error)) {
+    const e = err as {
+      msg?: unknown;
+      description?: unknown;
+      response?: { msg?: unknown; title?: unknown } | null;
+    };
+    const clean = [
+      e.msg,
+      e.description,
+      e.response?.msg,
+      e.response?.title,
+    ].find((v): v is string => typeof v === 'string' && v.length > 0);
+    if (clean) {
+      return getErrorMessage({ ...e, msg: clean }, fallback);
+    }
+  }
+  return getErrorMessage(err, fallback);
+}
+
+/**
+ * Diagnostic payload for the failure notification's copyable details.
+ * Prefers the original rejection (manager problem+json with
+ * statusCode/error_code/traceback) over the AppLaunchError wrapper stack.
+ * `requestParameters` is omitted: it echoes the raw start-service request
+ * body — login_session_token and possibly secret-bearing app envs/args.
+ */
+export function buildAppLaunchFailureExtraDescription(
+  error: unknown,
+): string | undefined {
+  const original =
+    error && typeof error === 'object' && 'originalError' in error
+      ? (error as { originalError?: unknown }).originalError
+      : undefined;
+  if (original instanceof Error) {
+    return original.stack;
+  }
+  if (original && typeof original === 'object') {
+    return JSON.stringify(_.omit(original, 'requestParameters'), null, 2);
+  }
+  if (original) {
+    return JSON.stringify(original, null, 2);
+  }
+  const e = error as { stack?: string } | null | undefined;
+  return e?.stack || JSON.stringify(error, null, 2);
 }
 
 /**

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -1100,23 +1100,33 @@ export const useBackendAIAppLauncher = (
  * the response, so the user-facing copy covers both.
  *
  * Called exclusively from `_resolveV2ProxyUri`'s catch (the `startService`
- * call site). At that endpoint any 404 is by definition "session lookup
- * failed" — the manager produces a `SessionNotFound` exception there with
+ * call site). The manager produces a `SessionNotFound` exception there with
  * varying English titles (`"No such session."`, `"Session ... not found"`,
- * etc.). Keying off `statusCode === 404` alone is therefore the safest
- * heuristic: it is robust against title wording changes, against
- * locale-translated manager responses, and against `_wrapWithPromise`
+ * etc.), so branching on title wording is fragile — it breaks on wording
+ * changes, locale-translated manager responses, and `_wrapWithPromise`
  * reformatting (it concatenates `statusText` into `title`, which is empty
  * on some manager versions).
+ *
+ * A bare `statusCode === 404` is not enough either: start-service also
+ * returns 404 for a missing *app* (`error_code: "backendai_read_not-found"`,
+ * e.g. the app name is not in the session's service_ports), which must NOT
+ * be presented as "session not accessible". Manager ≥24.09 sends a stable
+ * `error_code` ("{domain}_{operation}_{detail}"), so when one is present we
+ * additionally require the `session` domain; when absent (older managers)
+ * we keep the 404-only heuristic from FR-2586.
  */
-function isSessionNotFoundError(err: unknown): boolean {
+export function isSessionNotFoundError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
-  const e = err as { statusCode?: unknown };
-  return e.statusCode === 404;
+  const e = err as { statusCode?: unknown; error_code?: unknown };
+  if (e.statusCode !== 404) return false;
+  if (typeof e.error_code === 'string') {
+    return e.error_code.startsWith('session_');
+  }
+  return true;
 }
 
 // Custom error class for app launch errors
-class AppLaunchError extends Error {
+export class AppLaunchError extends Error {
   stage: 'detecting' | 'configuring' | 'requesting' | 'connecting';
   // The Backend.AI client rejects with a plain object, not an Error
   // (see `_wrapWithPromise` in packages/backend.ai-client), so this must be
@@ -1162,7 +1172,7 @@ class AppLaunchError extends Error {
  * response (which carries no success payload) flows downstream as a
  * pseudo-success. (FR-3027)
  */
-function isSendRequestErrorResponse(
+export function isSendRequestErrorResponse(
   response: unknown,
 ): response is { status: number; statusText?: string; body?: unknown } {
   return (
@@ -1181,7 +1191,7 @@ function isSendRequestErrorResponse(
  * with `title: "Worker not available."`. Prefer `msg` / `title` / `message`
  * from the parsed body, then fall back to `statusText`, then the default.
  */
-function getAppProxyErrorMessage(
+export function getAppProxyErrorMessage(
   response: { status: number; statusText?: string; body?: unknown },
   fallback: string,
 ): string {
@@ -1220,11 +1230,11 @@ const PROXY_REQUEST_TIMEOUT_MS = 30000;
  * @param request - Request configuration object
  * @returns Parsed response body or error object with status
  */
-interface SendRequestConfig extends RequestInit {
+export interface SendRequestConfig extends RequestInit {
   uri: string;
   method?: string;
 }
-async function sendRequest(request: SendRequestConfig) {
+export async function sendRequest(request: SendRequestConfig) {
   try {
     if (request.method === 'GET') {
       request.body = undefined;

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -200,7 +200,7 @@ export const useBackendAIAppLauncher = (
     const response = await sendRequest(rqst);
     if (response === undefined) {
       throw new AppLaunchError(
-        'Proxy configurator is not responding.',
+        t('session.launcher.ProxyConfiguratorNotResponding'),
         'configuring',
       );
     }
@@ -243,8 +243,11 @@ export const useBackendAIAppLauncher = (
       );
 
       if (tokenResponse === undefined) {
+        // The manager answered but without a token payload. This is NOT the
+        // proxy configurator (v1 `/conf`) case — the AppProxy coordinator has
+        // not been contacted at this point in the flow (FR-3478).
         throw new AppLaunchError(
-          'Proxy configurator is not responding.',
+          t('session.appLauncher.FailedToStartAppService'),
           'configuring',
         );
       }
@@ -267,15 +270,18 @@ export const useBackendAIAppLauncher = (
         throw new AppLaunchError(
           t('session.appLauncher.SessionNotAccessible'),
           'configuring',
-          err instanceof Error ? err : undefined,
+          err,
         );
       }
+      // The Backend.AI client rejects with a plain object
+      // (`{ statusCode, title, msg, error_code, ... }`), never an Error, so
+      // resolve the manager's own message instead of pattern-matching on
+      // `instanceof Error` — that check made every start-service failure
+      // surface as "Proxy configurator is not responding." (FR-3478).
       throw new AppLaunchError(
-        err instanceof Error
-          ? err.message
-          : 'Proxy configurator is not responding.',
+        getErrorMessage(err, t('session.appLauncher.FailedToStartAppService')),
         'configuring',
-        err instanceof Error ? err : undefined,
+        err,
       );
     }
   };
@@ -800,9 +806,19 @@ export const useBackendAIAppLauncher = (
             };
           },
           rejected: (error: any) => {
+            // Prefer the original rejection payload (manager problem+json with
+            // statusCode/error_code/traceback) over the AppLaunchError wrapper
+            // stack, which carries no diagnostic information (FR-3478).
+            const original = error?.originalError;
+            const extraDescription =
+              original instanceof Error
+                ? original.stack
+                : original
+                  ? JSON.stringify(original, null, 2)
+                  : error?.stack || JSON.stringify(error, null, 2);
             return {
               description: getErrorMessage(error),
-              extraDescription: error?.stack || JSON.stringify(error, null, 2),
+              extraDescription,
               duration: 0, // Persistent error notification
             };
           },
@@ -1102,17 +1118,35 @@ function isSessionNotFoundError(err: unknown): boolean {
 // Custom error class for app launch errors
 class AppLaunchError extends Error {
   stage: 'detecting' | 'configuring' | 'requesting' | 'connecting';
-  originalError?: Error;
+  // The Backend.AI client rejects with a plain object, not an Error
+  // (see `_wrapWithPromise` in packages/backend.ai-client), so this must be
+  // `unknown` — typing it `Error` silently dropped the manager's payload
+  // (statusCode/error_code/traceback) at wrap time (FR-3478).
+  originalError?: unknown;
+  statusCode?: number;
+  errorCode?: string;
 
   constructor(
     message: string,
     stage: 'detecting' | 'configuring' | 'requesting' | 'connecting',
-    originalError?: Error,
+    originalError?: unknown,
   ) {
     super(message);
     this.name = 'AppLaunchError';
     this.stage = stage;
     this.originalError = originalError;
+    if (originalError && typeof originalError === 'object') {
+      const { statusCode, error_code } = originalError as {
+        statusCode?: unknown;
+        error_code?: unknown;
+      };
+      if (typeof statusCode === 'number') {
+        this.statusCode = statusCode;
+      }
+      if (typeof error_code === 'string') {
+        this.errorCode = error_code;
+      }
+    }
     // Maintains proper stack trace for where our error was thrown (only available on V8)
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AppLaunchError);

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -1122,7 +1122,7 @@ export const useBackendAIAppLauncher = (
  * e.g. the app name is not in the session's service_ports), which must NOT
  * be presented as "session not accessible". Manager ≥24.09 sends a stable
  * `error_code` ("{domain}_{operation}_{detail}"), so when one is present we
- * additionally require the `session` domain; when absent (older managers)
+ * exclude that one known app-not-found code; when absent (older managers)
  * we keep the 404-only heuristic from FR-2586.
  */
 export function isSessionNotFoundError(err: unknown): boolean {
@@ -1130,7 +1130,12 @@ export function isSessionNotFoundError(err: unknown): boolean {
   const e = err as { statusCode?: unknown; error_code?: unknown };
   if (e.statusCode !== 404) return false;
   if (typeof e.error_code === 'string') {
-    return e.error_code.startsWith('session_');
+    // `backendai_read_not-found` means the *app* is absent from service_ports,
+    // not the session. Deliberately a denylist rather than an allowlist on the
+    // `session_` domain: this backend contract cannot be verified from the
+    // frontend, so an unrecognized code must keep the FR-2586 behaviour instead
+    // of silently dropping the localized recovery guidance.
+    return e.error_code !== 'backendai_read_not-found';
   }
   return true;
 }

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -809,13 +809,23 @@ export const useBackendAIAppLauncher = (
             // Prefer the original rejection payload (manager problem+json with
             // statusCode/error_code/traceback) over the AppLaunchError wrapper
             // stack, which carries no diagnostic information (FR-3478).
+            // `requestParameters` is omitted: it echoes the raw start-service
+            // request body — login_session_token and possibly secret-bearing
+            // app envs/args — which must not appear in the copyable
+            // notification details.
             const original = error?.originalError;
             const extraDescription =
               original instanceof Error
                 ? original.stack
-                : original
-                  ? JSON.stringify(original, null, 2)
-                  : error?.stack || JSON.stringify(error, null, 2);
+                : original && typeof original === 'object'
+                  ? JSON.stringify(
+                      _.omit(original, 'requestParameters'),
+                      null,
+                      2,
+                    )
+                  : original
+                    ? JSON.stringify(original, null, 2)
+                    : error?.stack || JSON.stringify(error, null, 2);
             return {
               description: getErrorMessage(error),
               extraDescription,

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2812,6 +2812,7 @@
       "ConfirmAndRun": "Ich habe nachgesehen und ich fange an",
       "ConnectUrlIsNotValid": "Die Verbindungs-URL ist ungültig.",
       "DownloadSSHKey": "SSH-Schlüssel herunterladen",
+      "FailedToStartAppService": "Der App-Dienst konnte nicht gestartet werden.",
       "LaunchingApp": "Die App {{appName}} wird gestartet.",
       "NoExistingConnectionExample": "Keine Verbindung Zu kopierendes Beispiel.",
       "OpenVSCodeRemote": "Lokalen Visual Studio Code öffnen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2810,6 +2810,7 @@
       "ConfirmAndRun": "Έλεγξα και θα ξεκινήσω",
       "ConnectUrlIsNotValid": "Η διεύθυνση URL σύνδεσης δεν είναι έγκυρη.",
       "DownloadSSHKey": "Λήψη κλειδιού SSH",
+      "FailedToStartAppService": "Αποτυχία εκκίνησης της υπηρεσίας εφαρμογής.",
       "LaunchingApp": "Η εφαρμογή {{appName}} εκκινείται.",
       "NoExistingConnectionExample": "Δεν υπάρχει σύνδεση Παράδειγμα προς αντιγραφή.",
       "OpenVSCodeRemote": "Ανοίξτε τον τοπικό κώδικα του Visual Studio",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2798,6 +2798,7 @@
       "ConfirmAndRun": "I checked and I'll start",
       "ConnectUrlIsNotValid": "Connect URL is not valid.",
       "DownloadSSHKey": "Download SSH Key",
+      "FailedToStartAppService": "Failed to start the app service.",
       "LaunchingApp": "Starting {{appName}} app.",
       "NoExistingConnectionExample": "No Connection Example to be copied.",
       "OpenVSCodeRemote": "Open local Visual Studio Code",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2810,6 +2810,7 @@
       "ConfirmAndRun": "Lo he comprobado y voy a empezar",
       "ConnectUrlIsNotValid": "La URL de conexión no es válida.",
       "DownloadSSHKey": "Descargar clave SSH",
+      "FailedToStartAppService": "No se pudo iniciar el servicio de la aplicación.",
       "LaunchingApp": "{{appName}} se está iniciando.",
       "NoExistingConnectionExample": "No hay conexión Ejemplo a copiar.",
       "OpenVSCodeRemote": "Abrir código local de Visual Studio",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2810,6 +2810,7 @@
       "ConfirmAndRun": "Tarkistin ja aloitan",
       "ConnectUrlIsNotValid": "Yhteyden URL-osoite ei kelpaa.",
       "DownloadSSHKey": "Lataa SSH-avain",
+      "FailedToStartAppService": "Sovelluspalvelun käynnistäminen epäonnistui.",
       "LaunchingApp": "Käynnistetään {{appName}}-sovellusta.",
       "NoExistingConnectionExample": "Ei yhteyttä Kopioitava esimerkki.",
       "OpenVSCodeRemote": "Avaa paikallinen Visual Studio Code",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2813,6 +2813,7 @@
       "ConfirmAndRun": "j'ai vérifié et je vais commencer",
       "ConnectUrlIsNotValid": "L'URL de connexion n'est pas valide.",
       "DownloadSSHKey": "Télécharger la clé SSH",
+      "FailedToStartAppService": "Échec du démarrage du service d'application.",
       "LaunchingApp": "Lancement de l'application {{appName}}.",
       "NoExistingConnectionExample": "Aucun exemple de connexion à copier.",
       "OpenVSCodeRemote": "Ouvrir le code local de Visual Studio",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2813,6 +2813,7 @@
       "ConfirmAndRun": "Saya sudah memeriksa dan saya akan mulai",
       "ConnectUrlIsNotValid": "URL koneksi tidak valid.",
       "DownloadSSHKey": "Unduh Kunci SSH",
+      "FailedToStartAppService": "Gagal memulai layanan aplikasi.",
       "LaunchingApp": "Menjalankan aplikasi {{appName}}.",
       "NoExistingConnectionExample": "Tidak Ada Koneksi Contoh untuk disalin.",
       "OpenVSCodeRemote": "Buka kode Visual Studio lokal",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2810,6 +2810,7 @@
       "ConfirmAndRun": "Ho controllato e comincio",
       "ConnectUrlIsNotValid": "L'URL di connessione non è valido.",
       "DownloadSSHKey": "Scarica la chiave SSH",
+      "FailedToStartAppService": "Avvio del servizio app non riuscito.",
       "LaunchingApp": "Avvio dell'app {{appName}} in corso.",
       "NoExistingConnectionExample": "Nessun esempio di connessione da copiare.",
       "OpenVSCodeRemote": "Aprire il codice locale di Visual Studio",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2812,6 +2812,7 @@
       "ConfirmAndRun": "確認して始めます",
       "ConnectUrlIsNotValid": "接続 URL が無効です。",
       "DownloadSSHKey": "SSHキーをダウンロード",
+      "FailedToStartAppService": "アプリサービスを起動できませんでした。",
       "LaunchingApp": "{{appName}} アプリを起動しています。",
       "NoExistingConnectionExample": "コピーする接続例がありません。",
       "OpenVSCodeRemote": "ローカルVisual Studio Codeを開く",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2812,6 +2812,7 @@
       "ConfirmAndRun": "확인했으며 시작하겠습니다",
       "ConnectUrlIsNotValid": "연결 URL이 유효하지 않습니다.",
       "DownloadSSHKey": "SSH 키 다운로드",
+      "FailedToStartAppService": "앱 서비스를 시작하지 못했습니다.",
       "LaunchingApp": "{{appName}} 앱을 실행합니다.",
       "NoExistingConnectionExample": "복사할 접속 예제가 없습니다.",
       "OpenVSCodeRemote": "로컬 Visual Studio Code 열기",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2811,6 +2811,7 @@
       "ConfirmAndRun": "Шалгасан тул эхлүүлж болно",
       "ConnectUrlIsNotValid": "Холбох URL буруу байна.",
       "DownloadSSHKey": "SSH түлхүүр татаж авах",
+      "FailedToStartAppService": "Апп үйлчилгээг эхлүүлж чадсангүй.",
       "LaunchingApp": "{{appName}} апп эхлүүлж байна.",
       "NoExistingConnectionExample": "Хуулбарлах холболтын жишээ байхгүй.",
       "OpenVSCodeRemote": "Орон нутгийн Visual Studio кодыг нээнэ үү",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2810,6 +2810,7 @@
       "ConfirmAndRun": "Saya periksa dan saya akan mulakan",
       "ConnectUrlIsNotValid": "URL Sambung tidak sah.",
       "DownloadSSHKey": "Muat turun Kunci SSH",
+      "FailedToStartAppService": "Gagal memulakan perkhidmatan aplikasi.",
       "LaunchingApp": "Menjalankan aplikasi {{appName}}.",
       "NoExistingConnectionExample": "Tiada Contoh Sambungan untuk disalin.",
       "OpenVSCodeRemote": "Buka Kod Visual Studio tempatan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2813,6 +2813,7 @@
       "ConfirmAndRun": "Sprawdziłem i zacznę",
       "ConnectUrlIsNotValid": "Adres URL połączenia jest nieprawidłowy.",
       "DownloadSSHKey": "Pobierz klucz SSH",
+      "FailedToStartAppService": "Nie udało się uruchomić usługi aplikacji.",
       "LaunchingApp": "Uruchamianie aplikacji {{appName}}.",
       "NoExistingConnectionExample": "Brak przykładu połączenia do skopiowania.",
       "OpenVSCodeRemote": "Otwórz lokalny kod Visual Studio",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2810,6 +2810,7 @@
       "ConfirmAndRun": "Eu verifiquei e vou começar",
       "ConnectUrlIsNotValid": "O URL de conexão não é válido.",
       "DownloadSSHKey": "Baixar chave SSH",
+      "FailedToStartAppService": "Falha ao iniciar o serviço de aplicativo.",
       "LaunchingApp": "Iniciando o aplicativo {{appName}}.",
       "NoExistingConnectionExample": "Não há exemplo de ligação a copiar.",
       "OpenVSCodeRemote": "Abrir o código local do Visual Studio",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2812,6 +2812,7 @@
       "ConfirmAndRun": "Eu verifiquei e vou começar",
       "ConnectUrlIsNotValid": "O URL de conexão não é válido.",
       "DownloadSSHKey": "Baixar chave SSH",
+      "FailedToStartAppService": "Falha ao iniciar o serviço de aplicação.",
       "LaunchingApp": "Iniciando o aplicativo {{appName}}.",
       "NoExistingConnectionExample": "Não há exemplo de ligação a copiar.",
       "OpenVSCodeRemote": "Abrir o código local do Visual Studio",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2810,6 +2810,7 @@
       "ConfirmAndRun": "Я проверил и начну",
       "ConnectUrlIsNotValid": "URL-адрес подключения недействителен.",
       "DownloadSSHKey": "Скачать ключ SSH",
+      "FailedToStartAppService": "Не удалось запустить службу приложения.",
       "LaunchingApp": "Запуск приложения {{appName}}...",
       "NoExistingConnectionExample": "Нет примера подключения для копирования.",
       "OpenVSCodeRemote": "Открыть локальный Visual Studio Code",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2812,6 +2812,7 @@
       "ConfirmAndRun": "ฉันได้ตรวจสอบแล้วและจะเริ่มต้น",
       "ConnectUrlIsNotValid": "URL การเชื่อมต่อไม่ถูกต้อง",
       "DownloadSSHKey": "ดาวน์โหลดคีย์ SSH",
+      "FailedToStartAppService": "ไม่สามารถเริ่มต้นบริการแอปได้",
       "LaunchingApp": "กำลังเรียกใช้แอป {{appName}}.",
       "NoExistingConnectionExample": "ไม่มีตัวอย่างการเชื่อมต่อที่จะคัดลอก",
       "OpenVSCodeRemote": "เปิด Visual Studio Code ในเครื่อง",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2810,6 +2810,7 @@
       "ConfirmAndRun": "kontrol ettim başlıyorum",
       "ConnectUrlIsNotValid": "Bağlantı URL'si geçerli değil.",
       "DownloadSSHKey": "SSH Anahtarını İndirin",
+      "FailedToStartAppService": "Uygulama hizmeti başlatılamadı.",
       "LaunchingApp": "{{appName}} uygulaması başlatılıyor.",
       "NoExistingConnectionExample": "Kopyalanacak Bağlantı Örneği Yok.",
       "OpenVSCodeRemote": "Yerel Visual Studio Kodunu açın",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2812,6 +2812,7 @@
       "ConfirmAndRun": "Tôi đã kiểm tra và tôi sẽ bắt đầu",
       "ConnectUrlIsNotValid": "URL kết nối không hợp lệ.",
       "DownloadSSHKey": "Tải xuống SSH Key",
+      "FailedToStartAppService": "Không thể khởi động dịch vụ ứng dụng.",
       "LaunchingApp": "Đang khởi chạy ứng dụng {{appName}}.",
       "NoExistingConnectionExample": "Không có ví dụ kết nối nào được sao chép.",
       "OpenVSCodeRemote": "Mở mã Visual Studio cục bộ",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2812,6 +2812,7 @@
       "ConfirmAndRun": "我检查过，我会开始",
       "ConnectUrlIsNotValid": "连接 URL 无效。",
       "DownloadSSHKey": "下载 SSH 密钥",
+      "FailedToStartAppService": "启动应用服务失败。",
       "LaunchingApp": "{{appName}} 应用正在启动。",
       "NoExistingConnectionExample": "无连接示例可复制。",
       "OpenVSCodeRemote": "打开本地 Visual Studio 代码",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2814,6 +2814,7 @@
       "ConfirmAndRun": "我檢查過，我會開始",
       "ConnectUrlIsNotValid": "連線 URL 無效。",
       "DownloadSSHKey": "下載 SSH 密鑰",
+      "FailedToStartAppService": "啟動應用程式服務失敗。",
       "LaunchingApp": "正在啟動 {{appName}} 應用程式。",
       "NoExistingConnectionExample": "无连接示例可复制。",
       "OpenVSCodeRemote": "打开本地 Visual Studio 代码",


### PR DESCRIPTION
Resolves [FR-3478](https://lablup.atlassian.net/browse/FR-3478)

> The GitHub clone of FR-3478 has not been created by the Jira webhook yet; this reference will be updated to `Resolves #N (FR-3478)` once it appears.

## Problem

Every failure of `POST /session/{id}/start-service` — 500, 404, 401, timeout, network — was reported to the user as **"Proxy configurator is not responding."**, which points at the AppProxy coordinator even though it is not contacted at that point in the flow. At a customer site this mislabelled 35 backend timeouts over 7 days as a proxy problem (BA-7258).

Root cause: the Backend.AI JS client's `_wrapWithPromise` rejects with a **plain object** (`{ statusCode, statusText, title, msg, error_code, description, traceback }`), never an `Error`. The catch in `_resolveV2ProxyUri` used `err instanceof Error ? err.message : 'Proxy configurator is not responding.'`, so the fallback string won for every failure — and `AppLaunchError.originalError` was typed `Error`, so the manager's payload was dropped entirely at wrap time.

## Changes

- **`_resolveV2ProxyUri` catch**: resolve the manager's own text via the new exported `resolveStartServiceErrorMessage` instead of `instanceof Error`. The client's `msg` field is always `undefined` (`_wrapWithPromise` copies it off the fetch `Response`, which never carries one) and its `message` is a debug string (`server responded failure: 503 Service Unavailable - …`), so the resolver takes the clean text from `description` / `response.msg` / `response.title` and delegates to `useErrorMessageResolver.getErrorMessage`, which appends the `error_code`. The user sees e.g. `Session has no scaling group assigned (backendai_generic_unavailable)`.
- **v1 conf path**: "Proxy configurator is not responding." is kept only where it is accurate (the v1 `PUT {proxyURL}/conf` returning `undefined`), now wired to the previously unused i18n key `session.launcher.ProxyConfiguratorNotResponding`.
- **`AppLaunchError`**: `originalError` widened to `unknown` so the plain-object payload is preserved.
- **Failure notification**: `extraDescription` (extracted as `buildAppLaunchFailureExtraDescription`) shows the original rejection payload (including `traceback` / `error_code`) instead of the wrapper's uninformative stack, with `requestParameters` redacted — it echoes the raw start-service request body including `login_session_token`.
- **`_open_wsproxy` catch**: the same `err instanceof Error ? … : …` shape removed here too, so a non-`Error` rejection keeps its payload in `originalError`.
- **i18n**: new key `session.appLauncher.FailedToStartAppService` added to all 22 languages for the start-service fallback message.

## Acceptance criteria (from FR-3478)

- [x] A 500 from start-service shows the manager's title/error_code, not the proxy text — the message is exactly the manager's `msg`/`title` plus `(error_code)`, without the client's debug prefix.
- [x] A 404 (session gone) shows a session-not-found message — existing `isSessionNotFoundError` branch kept (FR-2586), now also preserving the original payload.
- [x] "Proxy configurator is not responding." appears only on the v1 conf path.
- [x] `session.launcher.ProxyConfiguratorNotResponding` is wired to that path.

## Out of scope

- Localizing the remaining hardcoded `AppLaunchError` messages in `useBackendAIAppLauncher.tsx` (local-proxy-not-ready, coordinator/worker connection failures, TCP-app shell copy). They predate this PR and are untouched by it; localizing them is a separate sweep to be filed as a follow-up FR.

## Tests

The failing environments (broken agent, mis-configured resource group, exhausted appproxy worker, …) are hard to reproduce live, so the backend's actual error responses — extracted from the backend.ai sources (main as of 2026-08-11) — are encoded as fixtures and driven through the **real** Backend.AI client (`_wrapWithPromise`) with only `fetch` stubbed:

- `react/src/hooks/__fixtures__/appLaunchBackendErrors.ts` — manager start-service (8), appproxy coordinator (6), worker (6), and network-level failure shapes.
- `react/src/hooks/useBackendAIAppLauncher.errors.test.ts` — 50 tests. The frontend side calls the same exported helpers the hook uses in production (`resolveStartServiceErrorMessage`, `buildAppLaunchFailureExtraDescription`) rather than re-composing their logic in the test, and message assertions are **equality**, not `toContain`, so the client's debug prefix cannot leak back in unnoticed. The `requestParameters` redaction is asserted against the real client rejection: the raw payload contains `login_session_token`, the notification details must not.

The catalog surfaced one behavioral refinement: start-service 404 can also mean **"no such app"** (`error_code: backendai_read_not-found`), which must not be presented as "session not accessible". `isSessionNotFoundError` excludes that one known app-not-found code (a denylist, so an unrecognized error_code fails safe to the FR-2586 behaviour instead of dropping the localized guidance), and keeps the FR-2586 404-only heuristic for older managers that send none.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, i18n structure, terminology)
`vitest run useBackendAIAppLauncher.errors.test.ts` → 50/50 passing

Related: BA-7258, BA-7261

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FR-3478]: https://lablup.atlassian.net/browse/FR-3478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
