### PR TITLE
chore(FR-3490): add root-level astryx CLI proxy script

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -19,6 +19,7 @@
   ],
   "words": [
     "Antd",
+    "astryx",
     "autodocs",
     "Automount",
     "backend.ai-webserver",

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -31,7 +31,9 @@ repeated here. Depth lives in the on-demand skills listed at the bottom.
   `BAICard`, `BAIText`, `BAITableAstryx`, … They own this project's defaults and wrap the
   Astryx internals.
 - When no BAI equivalent exists, use **Astryx** (`@astryxdesign/core`) directly. Discover
-  before writing: `pnpm exec astryx search "<thing>"`, `pnpm exec astryx component <Name>`.
+  before writing: `astryx search "<thing>"`, `astryx component <Name>`. The CLI lives in
+  the `react` workspace, so run it as `pnpm exec astryx …` from `react/` or
+  `pnpm run astryx …` from the repository root — `pnpm exec` finds no binary at the root.
   See the `ASTRYX` block in `AGENTS.md` / `react/AGENTS.md`.
 - **antd is not a dependency.** `import … from 'antd'` does not resolve and fails `tsc`;
   the workspace is exact-pinned so it cannot re-enter transitively. Never add one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,3 +263,5 @@ MORE CLI:
   upgrade --apply    run after any @astryxdesign/core bump
 <!-- ASTRYX:END -->
 The ASTRYX block above is `astryx init --features agents` output (run from `react/`, where the StyleX compiler is detected) in **StyleX mode**, plus the project-specific MIGRATION RELAXATION line. Canonical generated copy: `react/AGENTS.md`. Re-run the init from `react/` on every `@astryxdesign/core` bump and re-sync this block (keeping the relaxation line).
+
+The block's `pnpm exec astryx <cmd>` assumes you are **inside `react/`**. `@astryxdesign/cli` is a devDependency of that workspace only, so the root `node_modules/.bin` has no `astryx` binary — and `pnpm exec` resolves binaries, not package scripts, so it fails at the root with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`. **From the repository root, run `pnpm run astryx <cmd>` instead** (root `package.json` proxies it to the same CLI). Both forms take identical arguments.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "copyindex": "cp index.html build/web",
     "copymonaco": "mkdir -p build/web/resources/monaco/vs && cp -R react/node_modules/monaco-editor/min/vs/. build/web/resources/monaco/vs/",
     "prepare": "husky",
-    "theme-schema:update": "node scripts/gen-theme-schema.cjs"
+    "theme-schema:update": "node scripts/gen-theme-schema.cjs",
+    "astryx": "pnpm --prefix ./react exec astryx"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
Resolves #8653 (FR-3490)

## Summary

- Add an `astryx` script to the root `package.json` that proxies to the real CLI in the `react` workspace: `pnpm --prefix ./react exec astryx`. This follows the existing `--prefix ./react` idiom already used by `build:react-only`.
- Point the root-facing guidance at the command that actually works there — `AGENTS.md` (and `CLAUDE.md`, which is a symlink to it) plus `.github/instructions/react.instructions.md` now say `pnpm exec astryx …` **from `react/`**, `pnpm run astryx …` **from the repository root**.
- Add `astryx` to `.cspell.json` `words` — the word is used throughout the repo (`AGENTS.md`, `react/package.json`, the `astryx-fix` skill) but was missing from the dictionary.

### Why

`@astryxdesign/cli` is a devDependency of the `react` workspace only, so there is no `astryx` binary in the root `node_modules/.bin`. The agent guidance says to run every Astryx command as `pnpm exec astryx <cmd>` without naming a working directory, and that command fails from the repository root:

```
$ pnpm exec astryx --version
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "astryx" not found
```

The script alone does not fix that command — `pnpm exec` resolves binaries from `node_modules/.bin` and does not dispatch package scripts, so it adds a second, differently-spelled entry point rather than repairing the documented one. Hence the accompanying doc change, which states which spelling belongs where.

The docs note is placed **after** `<!-- ASTRYX:END -->` on purpose: everything inside the markers is `astryx init --features agents` output, regenerated on every `@astryxdesign/core` bump, so a correction written in there would be overwritten. `react/AGENTS.md` is the generated original and is left untouched.

The alternative — adding `@astryxdesign/cli` as a second root devDependency so `pnpm exec` works everywhere — was rejected: it duplicates a version that must then be kept in lockstep with `react/` on every core bump, for no capability the proxy script does not already provide.

## Test plan

- [x] `pnpm run astryx --version` from the repository root prints `0.3.0`
- [x] Arguments are forwarded: `pnpm run astryx component Divider` prints the Divider docs and props table
- [x] `react/`-local invocation is unchanged: `cd react && pnpm exec astryx --version` still prints `0.3.0`
- [x] Both JSON files parse (`JSON.parse` on `package.json` and `.cspell.json`)
- [x] No line inside the `<!-- ASTRYX:START -->` / `<!-- ASTRYX:END -->` markers was modified, so the next `astryx init` re-sync is conflict-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)