### PR TITLE
chore(FR-3492): add an astryx-bug-report skill for capture-only UI defect intake

### DIFF
--- a/.claude/skills/astryx-bug-report/SKILL.md
+++ b/.claude/skills/astryx-bug-report/SKILL.md
@@ -32,7 +32,9 @@ the issue.
 - diagnose root cause, read Astryx internals, probe computed styles, or compare
   theme artifacts — that is `astryx-fix`'s "measure before you fix" step, and it
   belongs at fix time, not report time;
-- propose or apply a fix, edit any file, create a branch, or open a PR;
+- propose or apply a fix, edit any file in the repository, create a branch, or
+  open a PR — the only file you write is the scratchpad the description is
+  drafted in (Step 5);
 - run `scripts/verify.sh`, tests, or a build;
 - launch a browser to reproduce, unless the user explicitly asks for it.
 
@@ -119,8 +121,11 @@ Allowed, because it makes the issue actionable later:
 - locate the component file (`react/src/components/**`,
   `packages/backend.ai-ui/src/components/**`) and note the Astryx primitive it
   renders, if it is visible in the first screenful;
-- count how many files import that component (`grep -rl`), to tell "one page" from
-  "everywhere" — list up to 5 of them;
+- count how many files import that component (`grep -rl`) and list up to 5 of
+  them. This records **usage breadth**, not defect scope: the report is not
+  reproduced at each usage, so the count never becomes "it happens everywhere".
+  Scope stays what the reporter saw — `this page only` / `every usage` /
+  `Unknown`;
 - look up the exact UI string in `resources/i18n/en.json` when the reporter
   paraphrased a label.
 
@@ -154,8 +159,9 @@ and skip a link whose only commonality is "also an Astryx bug".
 
 ## Step 5 — Create the issue
 
-Title and description in **English** (project rule), even when the report came in
-Korean. Reply to the user in Korean.
+Title and description in **English** (project rule), whatever language the report
+came in. Talk to the reporter in *their* language — the questions in Step 2 and
+the wrap-up in Step 6 follow the language they reported in.
 
 **Title:** `<Page or Component>: <the defect in one line>`
 
@@ -191,8 +197,8 @@ record its path/URL in the **Evidence** section and hand them the issue URL so
 they can drop it in — or, for a shareable link, use the `fw:github-image-upload`
 skill (public URLs; never for anything sensitive).
 
-Then report back, in Korean: issue key + URL, category, which fields you had to
-mark Unknown, and any duplicate/related links you made.
+Then report back, in the reporter's language: issue key + URL, category, which
+fields you had to mark Unknown, and any duplicate/related links you made.
 
 ## Quality bar
 

--- a/.claude/skills/astryx-bug-report/SKILL.md
+++ b/.claude/skills/astryx-bug-report/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: astryx-bug-report
+description: >
+  File a UI/UX defect observed on the Astryx UI as a Jira Bug under the
+  reporting epic FR-3491 — capture only, never fix. Classifies the report as
+  visual (layout/spacing/color drift on a page) or behavioral (a component
+  does not work), enforces the minimum context (where + observed + expected),
+  asks the reporter once for anything missing, does a strictly bounded
+  read-only lookup, scans for duplicates and links related reports with
+  "relates to". Use whenever someone reports something wrong with the UI and
+  wants it recorded rather than fixed — "이거 리포팅해줘", "버그 등록해줘",
+  "이 페이지 UI가 틀어졌어", "이 버튼이 안 눌려", "astryx 버그", "file this UI
+  bug", "log this regression", "/astryx-bug-report". If the user instead wants
+  the defect *fixed now*, use the `astryx-fix` skill.
+---
+
+# astryx-bug-report — capture an Astryx UI/UX defect
+
+Post-migration QA turns up more defects than anyone can fix one at a time. This
+skill exists to make each report **cheap to file and expensive-free to
+investigate**: it collects exactly the context a later batch fix will need, and
+stops there. The batch fix comes later, over many issues at once, through
+`astryx-fix`.
+
+## Hard boundaries
+
+**Do:** ask, classify, look up where things live, search for duplicates, write
+the issue.
+
+**Do not:**
+
+- diagnose root cause, read Astryx internals, probe computed styles, or compare
+  theme artifacts — that is `astryx-fix`'s "measure before you fix" step, and it
+  belongs at fix time, not report time;
+- propose or apply a fix, edit any file, create a branch, or open a PR;
+- run `scripts/verify.sh`, tests, or a build;
+- launch a browser to reproduce, unless the user explicitly asks for it.
+
+A report that says "Unknown" in a field is fine. A report that cost twenty
+tool calls is not.
+
+## Step 0 — Setup
+
+```bash
+FW_JIRA=$(find ~/.claude/plugins -path '*fw*/skills/jira-workflow/scripts/jira.sh' 2>/dev/null | head -1)
+EPIC=FR-3491   # "Astryx UI/UX regression reports"
+```
+
+If `$EPIC` no longer resolves, find it instead of inventing one:
+
+```bash
+$FW_JIRA search "project = FR AND issuetype = Epic AND summary ~ 'Astryx UI/UX regression'" --limit 5
+```
+
+Jira is the system of record. **Do not create a GitHub issue** — Jira automation
+clones every FR issue to `lablup/backend.ai-webui` on its own (it lands in the
+issue's `github_issue_url` within a minute or two).
+
+## Step 1 — Classify
+
+| Category | Label | It is this when… | Location is pinned by |
+|---|---|---|---|
+| **Visual** | `astryx-visual` | spacing, alignment, size, color, typography, border, truncation, overflow, dark-mode drift — it *looks* wrong | the **page** (route + menu path) and the region inside it |
+| **Behavioral** | `astryx-behavior` | no response, wrong state, broken keyboard/focus, stale value, opens/closes wrongly, validation misfires — it *acts* wrong | the **component** and at least one page where it is reachable |
+
+A report that is both (e.g. "the dropdown is too narrow *and* it does not close
+on Escape") is **two issues**, filed separately and linked with `relates`. Say so
+before filing.
+
+Several defects reported in one message → one issue each, but batch the intake
+questions into a single round.
+
+## Step 2 — Intake gate
+
+These are required. Anything else is a bonus.
+
+**Both categories**
+
+1. **Observed** — what is actually happening/showing.
+2. **Expected** — what should happen/show instead. If the reporter only says
+   "it's broken", ask; do not invent the expectation.
+
+**Visual, additionally**
+
+3. **Page** — the route or the menu path ("Admin → Users", `/admin/users`).
+4. **Region** — which part of the page (card title, table header, modal footer,
+   sidebar item). "The page is broken" is not a region.
+
+**Behavioral, additionally**
+
+3. **Component** — a `BAI*` name, an Astryx name, or a plain description
+   ("the project selector in the header") that you can resolve to a file.
+4. **A page where it happens** — at least one route where the reporter saw it.
+
+### Asking
+
+Ask **once**, batching every missing field into a single `AskUserQuestion` call
+(≤4 questions; use options where the answer is a choice — category, page from
+the route list, light/dark/both — and let free text come through "Other").
+
+Do not ask for anything you can determine yourself (Step 3), and do not ask for
+the optional fields below. If a required field is still missing after that one
+round, file the issue anyway with `**Missing:** <field>` in the description and
+the `needs-info` label — a thin report in Jira beats a lost one.
+
+Optional, recorded when volunteered, never demanded: screenshot, light/dark,
+viewport, browser/OS, branch or release version, repro steps beyond "open the
+page", how often it happens.
+
+## Step 3 — Bounded lookup
+
+Budget: **≤6 read-only tool calls.** Stop when the budget is out and write
+"Unknown".
+
+Allowed, because it makes the issue actionable later:
+
+- resolve the menu path the reporter used to a real route in
+  `react/src/routes.tsx`, and the route to its page component;
+- locate the component file (`react/src/components/**`,
+  `packages/backend.ai-ui/src/components/**`) and note the Astryx primitive it
+  renders, if it is visible in the first screenful;
+- count how many files import that component (`grep -rl`), to tell "one page" from
+  "everywhere" — list up to 5 of them;
+- look up the exact UI string in `resources/i18n/en.json` when the reporter
+  paraphrased a label.
+
+Everything else is out of scope at report time.
+
+## Step 4 — Duplicate and related scan
+
+Run before creating. Search the epic's children and the wider project:
+
+```bash
+$FW_JIRA subtasks "$EPIC"
+$FW_JIRA search "project = FR AND labels = astryx-report AND text ~ '<keyword>'" --limit 20
+$FW_JIRA search "project = FR AND text ~ '<component or page>' AND created > -180d" --limit 20
+```
+
+Use two or three keywords: the component name, the page name, and the symptom
+noun ("overflow", "dark mode", "not clickable").
+
+Then decide:
+
+- **Same page/component + same element + same symptom → duplicate.** Do not file.
+  Add the new evidence as a comment on the existing issue
+  (`$FW_JIRA comment KEY "..."`) and tell the user which issue absorbed it.
+- **Same component, or same page, or the same plausible surface (a shared
+  wrapper, the same token, the same layout primitive) but a different symptom →
+  related.** File the new issue, then link it (Step 6).
+- Nothing matches → file it clean.
+
+Related links are for batching, so keep them meaningful: **at most 5** per issue,
+and skip a link whose only commonality is "also an Astryx bug".
+
+## Step 5 — Create the issue
+
+Title and description in **English** (project rule), even when the report came in
+Korean. Reply to the user in Korean.
+
+**Title:** `<Page or Component>: <the defect in one line>`
+
+- ✅ `Admin → Users: table header labels overflow their column at ≤1280px`
+- ✅ `BAISelect: dropdown stays open after selecting an option (Sessions page)`
+- ❌ `UI broken` · ❌ `Fix the user table` (a title is an observation, not a task)
+
+Description: use the matching template in
+`references/issue-templates.md` — read it before writing.
+
+```bash
+$FW_JIRA create --type Bug --parent "$EPIC" \
+  --title "<title>" \
+  --desc "$(cat <path-to-description.md>)" \
+  --labels "astryx-report,frontend,astryx-visual"     # or astryx-behavior
+```
+
+Write the description to a scratchpad file first and pass it with `$(cat …)` —
+the templates are long and quoting them inline breaks on backticks.
+
+## Step 6 — After creating
+
+```bash
+$FW_JIRA link --from <NEW-KEY> --to <RELATED-KEY> --type relates     # per related issue
+$FW_JIRA weblink <NEW-KEY> --url "<teams/github/PR url>" --title "Original report"
+```
+
+Add the weblink whenever the report originated from a Teams message, a GitHub
+comment, or a PR review thread.
+
+Screenshots: the CLI cannot attach files. If the reporter gave you an image,
+record its path/URL in the **Evidence** section and hand them the issue URL so
+they can drop it in — or, for a shareable link, use the `fw:github-image-upload`
+skill (public URLs; never for anything sensitive).
+
+Then report back, in Korean: issue key + URL, category, which fields you had to
+mark Unknown, and any duplicate/related links you made.
+
+## Quality bar
+
+Before `create`, re-read the description and confirm:
+
+- someone who has never seen the UI could get to the defect from the **Where**
+  section alone;
+- **Expected** is stated, not implied;
+- no root-cause claim, no proposed fix, no file-level "the bug is in X" —
+  observations only (a *suspicion* may live in **Notes**, one line, hedged);
+- title names the page or component, not "the UI";
+- parent is `$EPIC` and the category label is present.
+
+## Related
+
+- `astryx-fix` — the fixing counterpart. Reach for it when the ask is "fix this",
+  not "record this".
+- `fw:jira-workflow` — full `$FW_JIRA` command reference.
+- FR-3482 — the Ant Design → Astryx migration.
+- FR-3486 — an example of a report that outgrew a QA-sized fix and was split out
+  of this epic. Reports that clearly need architecture work still get filed here
+  first; splitting them out is a triage decision, not a reporting one.

--- a/.claude/skills/astryx-bug-report/references/issue-templates.md
+++ b/.claude/skills/astryx-bug-report/references/issue-templates.md
@@ -108,6 +108,11 @@ Optional, hedged, ≤3 lines. No fix proposal.
   actionable in six weeks. Spend the effort there, not on prose.
 - **Expected** must be concrete enough to test against. "Should look right" is
   not an expectation; "same height as the other admin tables" is.
+- **Scope** comes from the reporter, **Also used in** comes from a `grep`. They
+  are different claims: the importer list is usage breadth, and never on its own
+  evidence that the defect reproduces at every usage. When the reporter saw it in
+  one place only, `Scope` is `this page only` even if the component has 12
+  importers.
 - **Impact** is inferred, not asked. Three values only: blocks the task /
   workaround exists / cosmetic.
 - **Missing** — when a required field survived the one intake round unanswered,

--- a/.claude/skills/astryx-bug-report/references/issue-templates.md
+++ b/.claude/skills/astryx-bug-report/references/issue-templates.md
@@ -1,0 +1,117 @@
+# Issue description templates
+
+Both templates are Markdown — `$FW_JIRA create --desc` converts them to ADF.
+Keep the headings; drop a bullet only when it is genuinely not applicable.
+Unknown values are written as `Unknown`, never omitted silently, so triage can
+see what still needs chasing.
+
+---
+
+## Visual report (`astryx-visual`)
+
+```markdown
+## Where
+
+- **Page**: `/admin/users` (menu: Admin → Users)
+- **Region**: the credentials table header
+- **Component** (if identified): `BAITableAstryx` (`packages/backend.ai-ui/src/components/Table/`)
+
+## Observed
+
+Column labels wrap onto a second line and the header row grows to 64px, so the
+header no longer aligns with the toolbar above it.
+
+## Expected
+
+Single-line header at the same height as every other admin table (40px), labels
+truncated with an ellipsis when they do not fit.
+
+## Environment
+
+- **Mode**: light / dark / both
+- **Viewport**: ~1280px
+- **Browser/OS**: Chrome 141 / macOS
+- **Build**: `main` @ 2026-08-11 (or release v26.4.8-rc.3)
+
+## Reproduction
+
+1. Log in as an admin.
+2. Open Admin → Users.
+3. Narrow the window to 1280px.
+
+## Evidence
+
+- Screenshot: `~/Desktop/users-header.png` (to be attached in Jira)
+
+## Notes
+
+Optional. At most three lines of observation — e.g. "the same header looks
+correct on Admin → Resource Policy". No root-cause analysis.
+```
+
+---
+
+## Behavioral report (`astryx-behavior`)
+
+```markdown
+## Component
+
+- **Name**: `BAISelect` (`packages/backend.ai-ui/src/components/BAISelect.tsx`)
+- **Astryx primitive**: `Select`
+- **Scope**: this page only / every usage / Unknown
+
+## Where it is reachable
+
+- `/session/start` (menu: Sessions → Start) — the "Environment" selector
+- Also used in: 12 files (e.g. `SessionLauncherPage.tsx`, `ImageEnvironmentSelectFormItems.tsx`, `AgentSelect.tsx`)
+
+## Steps to reproduce
+
+1. Open Sessions → Start.
+2. Click the Environment selector.
+3. Click any option.
+
+## Observed
+
+The option is selected, but the dropdown stays open and swallows the next click.
+
+## Expected
+
+The dropdown closes on selection, and focus returns to the trigger — as it did
+before the migration and as the Image selector on the same page still does.
+
+## Environment
+
+- **Mode**: light / dark / both
+- **Viewport**: ~1440px
+- **Browser/OS**: Chrome 141 / macOS
+- **Build**: `main` @ 2026-08-11
+
+## Impact
+
+Blocks the task / workaround exists (click outside first) / cosmetic.
+
+## Evidence
+
+- Screen recording: none
+
+## Notes
+
+Optional, hedged, ≤3 lines. No fix proposal.
+```
+
+---
+
+## Field notes
+
+- **Where / Reachable** is the section that decides whether the issue is
+  actionable in six weeks. Spend the effort there, not on prose.
+- **Expected** must be concrete enough to test against. "Should look right" is
+  not an expectation; "same height as the other admin tables" is.
+- **Impact** is inferred, not asked. Three values only: blocks the task /
+  workaround exists / cosmetic.
+- **Missing** — when a required field survived the one intake round unanswered,
+  add a line at the top: `**Missing:** expected behaviour — ask <reporter>.` and
+  put `needs-info` in the labels.
+- Anything that reads like "the cause is …" belongs in **Notes**, hedged, or
+  nowhere. This epic collects symptoms; mechanisms are derived at fix time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Production build (`pnpm run build`) runs these steps sequentially:
 - **Documentation**: `docs-writing-guide` skill (fw plugin; user manual structure, terminology, multilingual rules)
 - **Relay**: `relay-patterns` skill (fragment architecture, naming conventions, query optimization)
 - **Astryx UI fixes**: `astryx-fix` skill (measure-before-you-fix, theme-defaults-first procedure, known traps, verification bar)
+- **Astryx UI bug reporting**: `astryx-bug-report` skill (capture-only intake for visual / behavioral defects, files them as Jira Bugs under epic FR-3491, duplicate + relates scan). Use it when the ask is "record this", `astryx-fix` when it is "fix this".
 
 ### Terminology Precedence
 


### PR DESCRIPTION
Resolves #8659 (FR-3492)

Post-migration QA turns up more UI defects than can be fixed one at a time, and the reports that arrive usually miss the one thing a later fix needs: **where**. At the same time, an agent handed a defect tends to slide straight into root-cause analysis, which is wasted effort while the intent is only to record the observation.

This adds a skill that files each observation as a Jira Bug under the epic that collects them — [FR-3491 "Astryx UI/UX regression reports"](https://lablup.atlassian.net/browse/FR-3491), created as part of this work — and stops there. The fixing counterpart stays `astryx-fix`.

## What the skill does

- **Classifies** the report as **visual** (`astryx-visual` — page + region required) or **behavioral** (`astryx-behavior` — component + at least one host page required). A report that is both is filed as two issues, linked.
- **Requires** observed *and* expected behaviour. Missing required context is asked for **exactly once**, batched into a single `AskUserQuestion`; a still-incomplete report is filed with `needs-info` rather than dropped, so nothing is lost to a question loop.
- **Caps investigation** at ≤6 read-only calls — resolving the menu path to a route in `react/src/routes.tsx`, locating the component file, counting importers to tell "one page" from "everywhere", checking the i18n label. Root-cause digging, computed-style probes, fixes, branches, PRs and `verify.sh` runs are explicitly out of scope at report time.
- **Deduplicates**: same page/component + same element + same symptom becomes a comment on the existing issue instead of a new one; a different symptom on a shared surface gets filed and linked with `relates`, so the later batch triage has the grouping already done.
- Files to Jira only — Jira automation clones FR issues to this repo on its own.

## Files

- `.claude/skills/astryx-bug-report/SKILL.md` — workflow, hard boundaries, intake gate, dedup rules, quality bar.
- `.claude/skills/astryx-bug-report/references/issue-templates.md` — the visual and behavioral description templates.
- `AGENTS.md` — one line in **On-Demand Skills** pointing "record this" at this skill and "fix this" at `astryx-fix`.

## Verification

Docs and skill definition only — no application code, so `scripts/verify.sh` has nothing to exercise here. Verified instead by running the skill's own commands against Jira: `$FW_JIRA` discovery, `subtasks FR-3491`, and the `labels = astryx-report` search all resolve. FR-3491 is linked to FR-3482 (the migration) and FR-3486 (a report that outgrew a QA-sized fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
