### PR TITLE
chore(FR-3492): add a discussion category to astryx-bug-report and an assignee gate to astryx-fix

### DIFF
--- a/.claude/skills/astryx-bug-report/SKILL.md
+++ b/.claude/skills/astryx-bug-report/SKILL.md
@@ -1,24 +1,27 @@
 ---
 name: astryx-bug-report
 description: >
-  File a UI/UX defect observed on the Astryx UI as a Jira Bug under the
-  reporting epic FR-3491 — capture only, never fix. Classifies the report as
-  visual (layout/spacing/color drift on a page) or behavioral (a component
-  does not work), enforces the minimum context (where + observed + expected),
-  asks the reporter once for anything missing, does a strictly bounded
-  read-only lookup, scans for duplicates and links related reports with
-  "relates to". Use whenever someone reports something wrong with the UI and
-  wants it recorded rather than fixed — "이거 리포팅해줘", "버그 등록해줘",
-  "이 페이지 UI가 틀어졌어", "이 버튼이 안 눌려", "astryx 버그", "file this UI
-  bug", "log this regression", "/astryx-bug-report". If the user instead wants
-  the defect *fixed now*, use the `astryx-fix` skill.
+  File a UI/UX observation about the Astryx UI into the reporting epic FR-3491
+  — capture only, never fix. Classifies it as visual (layout/spacing/color
+  drift), behavioral (a component does not work), or discussion (it may be
+  intended, or a better alternative is proposed — needs a team decision),
+  enforces the minimum context (where + observed + expected, or the open
+  question), asks the reporter once for anything missing, does a bounded
+  read-only lookup, scans for duplicates and links related reports. Use when
+  someone reports something wrong with — or questionable about — the UI and
+  wants it recorded rather than fixed: "이거 리포팅해줘", "버그 등록해줘",
+  "이 페이지 UI가 틀어졌어", "이 버튼이 안 눌려", "이거 원래 이런 건가요?",
+  "이게 맞는 동작인지 논의하고 싶어요", "astryx 버그", "file this UI bug",
+  "log this regression", "open a discussion about this UI",
+  "/astryx-bug-report". If the ask is to fix it *now*, use `astryx-fix`.
 ---
 
-# astryx-bug-report — capture an Astryx UI/UX defect
+# astryx-bug-report — capture an Astryx UI/UX observation
 
-Post-migration QA turns up more defects than anyone can fix one at a time. This
-skill exists to make each report **cheap to file and expensive-free to
-investigate**: it collects exactly the context a later batch fix will need, and
+Post-migration QA turns up more defects than anyone can fix one at a time, plus
+a steady stream of "is this even wrong?" questions. This skill exists to make
+each report **cheap to file and expensive-free to investigate**: it collects
+exactly the context a later batch fix — or a later decision — will need, and
 stops there. The batch fix comes later, over many issues at once, through
 `astryx-fix`.
 
@@ -36,7 +39,11 @@ the issue.
   open a PR — the only file you write is the scratchpad the description is
   drafted in (Step 5);
 - run `scripts/verify.sh`, tests, or a build;
-- launch a browser to reproduce, unless the user explicitly asks for it.
+- launch a browser to reproduce, unless the user explicitly asks for it;
+- **settle a discussion report yourself.** Recording "is this intended?" or "we
+  should do X instead" is the whole job; ruling on it is the team's. Do not
+  answer the question in the issue, and do not downgrade it to "not a bug" and
+  drop it.
 
 A report that says "Unknown" in a field is fine. A report that cost twenty
 tool calls is not.
@@ -60,14 +67,51 @@ issue's `github_issue_url` within a minute or two).
 
 ## Step 1 — Classify
 
-| Category | Label | It is this when… | Location is pinned by |
-|---|---|---|---|
-| **Visual** | `astryx-visual` | spacing, alignment, size, color, typography, border, truncation, overflow, dark-mode drift — it *looks* wrong | the **page** (route + menu path) and the region inside it |
-| **Behavioral** | `astryx-behavior` | no response, wrong state, broken keyboard/focus, stale value, opens/closes wrongly, validation misfires — it *acts* wrong | the **component** and at least one page where it is reachable |
+| Category | Issue type | Label | It is this when… | Location is pinned by |
+|---|---|---|---|---|
+| **Visual** | Bug | `astryx-visual` | spacing, alignment, size, color, typography, border, truncation, overflow, dark-mode drift — it *looks* wrong | the **page** (route + menu path) and the region inside it |
+| **Behavioral** | Bug | `astryx-behavior` | no response, wrong state, broken keyboard/focus, stale value, opens/closes wrongly, validation misfires — it *acts* wrong | the **component** and at least one page where it is reachable |
+| **Discussion** | Task | `astryx-discussion` | nobody can say it is *wrong* yet: it may be intended and the reporter wants that confirmed, or it works as designed but a better alternative is being proposed — it needs a **decision**, not a fix | whatever the reporter saw it on: a page, a component, or a pattern that recurs across several |
+
+### Bug or discussion?
+
+The dividing line is **whether the expectation is established**, not how
+confident the reporter sounds and not how big the change would be.
+
+- The reporter can name what it *should* do, and that comes from somewhere
+  outside their preference — a prior release, a design spec, a sibling screen
+  that still does it right, a plain functional contract ("a dropdown closes when
+  you pick an option") → **Bug** (visual or behavioral).
+- The expectation is the thing in question — "is this intended?", "which of
+  these two is right?", "I'd rather it worked like X" — → **Discussion**.
+
+Signals in the report itself: "원래 이런 건가요", "이게 맞나요", "의도된 건지",
+"이렇게 하는 게 낫지 않나", "is this intended", "should this be…", "I'd prefer",
+"we might want to". A bug report states a defect; a discussion asks a question
+or makes a proposal.
+
+Two ways to get this wrong, both worth avoiding:
+
+- **Filing a real regression as a discussion** because the reporter hedged
+  ("이거 좀 이상한 것 같은데…"). If a prior release or a sibling screen settles
+  it, it is a Bug — say so and file it as one.
+- **Filing a design proposal as a Bug** because it is easier. That puts a
+  decision into a queue that is triaged for fixes, and it gets closed as
+  "works as designed" instead of being decided.
+
+If it is genuinely a coin flip after one clarifying question, file it as a
+**discussion** — a Task that turns out to be a defect is re-typed in one
+command, while a Bug that was never a defect burns triage time.
+
+### Mixed and multiple reports
 
 A report that is both (e.g. "the dropdown is too narrow *and* it does not close
 on Escape") is **two issues**, filed separately and linked with `relates`. Say so
 before filing.
+
+The same split applies across categories: "the header is 64px tall *and* by the
+way, should this even be a table?" is one visual Bug plus one discussion Task,
+linked with `relates` — not one issue carrying both.
 
 Several defects reported in one message → one issue each, but batch the intake
 questions into a single round.
@@ -76,29 +120,53 @@ questions into a single round.
 
 These are required. Anything else is a bonus.
 
-**Both categories**
+**All three categories**
 
-1. **Observed** — what is actually happening/showing.
-2. **Expected** — what should happen/show instead. If the reporter only says
-   "it's broken", ask; do not invent the expectation.
+1. **Observed** — what is actually happening/showing *today*. For a discussion
+   this is the current behaviour, stated neutrally, not as a complaint.
 
 **Visual, additionally**
 
+2. **Expected** — what should show instead. If the reporter only says "it's
+   broken", ask; do not invent the expectation.
 3. **Page** — the route or the menu path ("Admin → Users", `/admin/users`).
 4. **Region** — which part of the page (card title, table header, modal footer,
    sidebar item). "The page is broken" is not a region.
 
 **Behavioral, additionally**
 
+2. **Expected** — what should happen instead, same rule as above.
 3. **Component** — a `BAI*` name, an Astryx name, or a plain description
    ("the project selector in the header") that you can resolve to a file.
 4. **A page where it happens** — at least one route where the reporter saw it.
+
+**Discussion, additionally**
+
+2. **The question or the proposal** — stated as one sentence the team can answer
+   yes/no or pick a side on. "Is the checkbox intentional here, or should it be
+   a switch?" / "Propose: move the refresh button into the card header." A
+   discussion with no answerable question is a complaint, and it will sit in the
+   epic forever — this field is the one that cannot be `Unknown`.
+3. **Why it is being raised** — one line: what made the reporter stop on it
+   (inconsistent with another screen, differs from the legacy UI, slows a task,
+   looked accidental). This is what a decision-maker needs and it is the field
+   reporters most often omit.
+4. **Where** — a page, a component, or "several places" with at least one
+   concrete example. A discussion may legitimately be about a pattern rather
+   than one screen; it still needs one place someone can go look at.
+
+Note what is *not* required for a discussion: **Expected**. If the reporter can
+state a settled expectation, re-check Step 1 — it is probably a Bug.
 
 ### Asking
 
 Ask **once**, batching every missing field into a single `AskUserQuestion` call
 (≤4 questions; use options where the answer is a choice — category, page from
 the route list, light/dark/both — and let free text come through "Other").
+
+When the category itself is unclear, make that one of the questions and offer
+the three options in the reporter's own terms — "동작이 잘못됐다 / 보이는 게
+틀어졌다 / 이게 맞는지 논의하고 싶다" — rather than the label names.
 
 Do not ask for anything you can determine yourself (Step 3), and do not ask for
 the optional fields below. If a required field is still missing after that one
@@ -131,6 +199,14 @@ Allowed, because it makes the issue actionable later:
 
 Everything else is out of scope at report time.
 
+**A discussion does not raise the budget.** The temptation is to go and find the
+answer — read the component, check `git log` for whether the current shape was
+deliberate, compare three sibling screens. That is the decision work, and it
+belongs to whoever picks the issue up. Record the question; do not pre-answer
+it. The one exception is the cheap version of "where else does this pattern
+appear", which is already allowed above and makes the decision's blast radius
+visible.
+
 ## Step 4 — Duplicate and related scan
 
 Run before creating. Search the epic's children and the wider project:
@@ -154,8 +230,23 @@ Then decide:
   related.** File the new issue, then link it (Step 6).
 - Nothing matches → file it clean.
 
+Two extra checks when the new report is a **discussion**:
+
+- **An open discussion asking the same question → duplicate**, even when the
+  wording differs a lot; two people asking "should this be a switch?" about the
+  same control is one decision, not two. Comment the second reporter's reasoning
+  onto the existing Task.
+- **A *decided* discussion (Done/Closed) that already answered it → do not
+  re-file.** Tell the user the decision and point at the key. If they disagree
+  with the outcome, that is a new discussion that `relates` to the closed one —
+  filed on that basis, not as a fresh question.
+
+And when a discussion turns out to overlap an open **Bug** on the same surface,
+link them rather than merging: the fix and the decision have different owners
+and different done-conditions.
+
 Related links are for batching, so keep them meaningful: **at most 5** per issue,
-and skip a link whose only commonality is "also an Astryx bug".
+and skip a link whose only commonality is "also an Astryx report".
 
 ## Step 5 — Create the issue
 
@@ -163,21 +254,40 @@ Title and description in **English** (project rule), whatever language the repor
 came in. Talk to the reporter in *their* language — the questions in Step 2 and
 the wrap-up in Step 6 follow the language they reported in.
 
-**Title:** `<Page or Component>: <the defect in one line>`
+**Title (Bug):** `<Page or Component>: <the defect in one line>`
 
 - ✅ `Admin → Users: table header labels overflow their column at ≤1280px`
 - ✅ `BAISelect: dropdown stays open after selecting an option (Sessions page)`
 - ❌ `UI broken` · ❌ `Fix the user table` (a title is an observation, not a task)
 
+**Title (Discussion):** `<Page, Component, or pattern>: <the question or the
+proposal in one line>` — phrased as the question, or as `Proposal: …`.
+
+- ✅ `Admin → Configurations: should boolean settings be switches or checkboxes?`
+- ✅ `BAICard: proposal — move the refresh button into the header extra slot`
+- ❌ `Checkbox weirdness` (names no decision) · ❌ `Change it to a switch`
+  (an instruction, not a question the team can answer)
+
 Description: use the matching template in
 `references/issue-templates.md` — read it before writing.
 
 ```bash
+# Visual / behavioral → a Bug
 $FW_JIRA create --type Bug --parent "$EPIC" \
   --title "<title>" \
   --desc "$(cat <path-to-description.md>)" \
   --labels "astryx-report,frontend,astryx-visual"     # or astryx-behavior
+
+# Discussion → a Task, same epic
+$FW_JIRA create --type Task --parent "$EPIC" \
+  --title "<title>" \
+  --desc "$(cat <path-to-description.md>)" \
+  --labels "astryx-report,frontend,astryx-discussion"
 ```
+
+The `astryx-report` label stays on all three, so the epic's queue and every
+duplicate scan keep working across categories; the category label and the issue
+type are what separate a fix queue from a decision queue.
 
 Write the description to a scratchpad file first and pass it with `$(cat …)` —
 the templates are long and quoting them inline breaks on backticks.
@@ -200,22 +310,34 @@ skill (public URLs; never for anything sensitive).
 Then report back, in the reporter's language: issue key + URL, category, which
 fields you had to mark Unknown, and any duplicate/related links you made.
 
+For a discussion, add one line setting the expectation: it is recorded as a
+**decision** to be made, not as work queued for a fix, and the reporter is the
+person best placed to push it onto a sync agenda if it matters soon.
+
 ## Quality bar
 
 Before `create`, re-read the description and confirm:
 
 - someone who has never seen the UI could get to the defect from the **Where**
   section alone;
-- **Expected** is stated, not implied;
+- **Expected** is stated, not implied (Bug), or **the question is answerable as
+  written** (Discussion — read it back as if you had to reply "yes" or "option
+  B" to it);
 - no root-cause claim, no proposed fix, no file-level "the bug is in X" —
-  observations only (a *suspicion* may live in **Notes**, one line, hedged);
+  observations only (a *suspicion* may live in **Notes**, one line, hedged). On
+  a discussion, a *proposal* is the point and belongs in **Proposal**, but the
+  issue still must not decide the outcome or start listing implementation steps;
 - title names the page or component, not "the UI";
-- parent is `$EPIC` and the category label is present.
+- parent is `$EPIC`, the issue type matches the category (Bug / Bug / Task), and
+  the category label is present alongside `astryx-report`.
 
 ## Related
 
 - `astryx-fix` — the fixing counterpart. Reach for it when the ask is "fix this",
-  not "record this".
+  not "record this". A `astryx-discussion` Task is **not** fix-ready: it goes to
+  `astryx-fix` only after the team has answered it, at which point the decision
+  is usually written into the Task and either that Task or a spun-off Bug
+  carries the work.
 - `fw:jira-workflow` — full `$FW_JIRA` command reference.
 - FR-3482 — the Ant Design → Astryx migration.
 - FR-3486 — an example of a report that outgrew a QA-sized fix and was split out

--- a/.claude/skills/astryx-bug-report/references/issue-templates.md
+++ b/.claude/skills/astryx-bug-report/references/issue-templates.md
@@ -1,9 +1,15 @@
 # Issue description templates
 
-Both templates are Markdown — `$FW_JIRA create --desc` converts them to ADF.
+All three templates are Markdown — `$FW_JIRA create --desc` converts them to ADF.
 Keep the headings; drop a bullet only when it is genuinely not applicable.
 Unknown values are written as `Unknown`, never omitted silently, so triage can
 see what still needs chasing.
+
+| Category | Template | Issue type | Label |
+|---|---|---|---|
+| Visual | [Visual report](#visual-report-astryx-visual) | Bug | `astryx-visual` |
+| Behavioral | [Behavioral report](#behavioral-report-astryx-behavior) | Bug | `astryx-behavior` |
+| Discussion | [Discussion](#discussion-astryx-discussion) | Task | `astryx-discussion` |
 
 ---
 
@@ -102,6 +108,76 @@ Optional, hedged, ≤3 lines. No fix proposal.
 
 ---
 
+## Discussion (`astryx-discussion`)
+
+Filed as a **Task**, not a Bug. The issue exists to get an answer; it is done
+when the team has decided, not when code changed.
+
+```markdown
+## Question
+
+Should boolean settings on Admin → Configurations be switches, or is the
+checkbox the intended control?
+
+## Where
+
+- **Page**: `/admin/configurations` (menu: Admin → Configurations)
+- **Component** (if identified): `CheckboxInput` via `BAIConfigItem` (`react/src/components/…`)
+- **Recurs in**: Admin → Resource Policy uses a switch for the same kind of
+  on/off setting — 2 screens differ. (Or `this screen only` / `Unknown`.)
+
+## Current behaviour
+
+Each boolean row renders a checkbox with the label to its right. Toggling it
+saves immediately, with no confirm step.
+
+## Why this is being raised
+
+The two admin screens disagree, so an admin toggling settings across both sees
+two different affordances for the same kind of change.
+
+## Proposal
+
+Optional — present only when the reporter had one. State it as one option, not
+as a decision:
+
+> Use a switch for every immediate-effect boolean, and keep checkboxes for
+> booleans that are only applied on Save.
+
+## Options considered
+
+Optional. When the reporter (or the intake round) surfaced more than one way
+out, list them plainly — no recommendation, no scoring.
+
+1. Switch everywhere.
+2. Checkbox everywhere.
+3. Split by whether the change applies immediately.
+
+## Impact if it stays as-is
+
+Cosmetic inconsistency / confusing but workable / actively causes mistakes.
+
+## Environment
+
+- **Mode**: light / dark / both
+- **Build**: `main` @ 2026-08-11 (or release v26.4.8-rc.3)
+
+Only when the observation is mode- or version-specific; a design question
+usually is not, and `Unknown` is fine here.
+
+## Evidence
+
+- Screenshot: `~/Desktop/config-booleans.png` (to be attached in Jira)
+- Legacy comparison: none
+
+## Notes
+
+Optional, ≤3 lines. Prior art, a linked decision, an "asked in the 8/11 sync"
+pointer. Not an answer to the question.
+```
+
+---
+
 ## Field notes
 
 - **Where / Reachable** is the section that decides whether the issue is
@@ -115,6 +191,17 @@ Optional, hedged, ≤3 lines. No fix proposal.
   importers.
 - **Impact** is inferred, not asked. Three values only: blocks the task /
   workaround exists / cosmetic.
+- **Question** (discussion) is the one field that may never be `Unknown` — an
+  issue that does not ask anything cannot be closed by answering it. If the
+  intake round did not produce one, you are probably holding a Bug report or a
+  vent, not a discussion; re-check Step 1 before filing.
+- **Why this is being raised** is what turns a preference into a decidable
+  question. "Two admin screens disagree" is decidable; "I don't like it" is not.
+- **Proposal / Options considered** stay descriptive. Recording that the
+  reporter would prefer a switch is capture; arguing that a switch is correct is
+  the decision, and this skill does not make it.
+- A discussion carries **no Expected section**. If you find yourself writing
+  one, the expectation is settled and the issue is a Bug.
 - **Missing** — when a required field survived the one intake round unanswered,
   add a line at the top: `**Missing:** expected behaviour — ask <reporter>.` and
   put `needs-info` in the labels.

--- a/.claude/skills/astryx-fix/SKILL.md
+++ b/.claude/skills/astryx-fix/SKILL.md
@@ -2,7 +2,9 @@
 name: astryx-fix
 description: >
   Standing rules for fixing a visual or behavioural regression on the Astryx
-  UI: measure before you fix, theme-defaults-first (with the exact
+  UI: check the tracked issue's assignee before starting (proceed only when it
+  is you or nobody — claim an unassigned one, stop and report when someone else
+  holds it), measure before you fix, theme-defaults-first (with the exact
   THEME_NAME_REV bump + `astryx theme build` artifact regeneration + wrapper
   and mirror updates), Astryx-canonical composition over hand-rolled CSS,
   `astryx component <Name>` discovery over guessing, tokens-only enforced by
@@ -21,6 +23,63 @@ source file imports it, and the workspace pins exact dependency versions so
 nothing reintroduces it transitively. A `from 'antd'` import is not migration
 debt; it fails `tsc` immediately, which is what keeps it out. Everything below
 assumes `@astryxdesign/core` is the only component system.
+
+## Before anything — the assignee gate
+
+**Run this first, before §0.** Two people measuring, branching and PR-ing the
+same regression is the one waste this skill can prevent outright, and it is only
+preventable *before* the work, not after.
+
+The gate applies whenever the fix is tied to a tracked issue — a `FR-XXXX` key
+in the request, in the branch name, in a linked GitHub issue, or the issue you
+were handed.
+
+```bash
+FW_JIRA=$(find ~/.claude/plugins -path '*fw*/skills/jira-workflow/scripts/jira.sh' 2>/dev/null | head -1)
+
+$FW_JIRA myself                       # → {accountId, name, email}
+$FW_JIRA get FR-XXXX | jq '{key, status, assignee, summary}'
+```
+
+`assignee` comes back as a **display name**, and literally `"Unassigned"` when
+the field is empty. Compare it against `myself`'s `name` (the account the CLI is
+authenticated as *is* "you" — do not infer identity from the git author or the
+branch name).
+
+| `assignee` | What to do |
+|---|---|
+| **You** | Proceed to §0. |
+| **`Unassigned`** | Claim it, then proceed: `$FW_JIRA update FR-XXXX --assignee me`. Say in your reply that you assigned it to yourself. |
+| **Someone else** | **Stop.** Report, do not fix. |
+
+### When someone else holds it
+
+Do **not** measure, reproduce, branch, edit, or open a PR — stopping after
+"just a quick look" still means two people looked. Instead, reply with:
+
+- the holder's name, the issue's current status, and the key as a link
+  (`https://lablup.atlassian.net/browse/FR-XXXX` — `get` returns no URL field);
+- one line on what you were about to do, so they can judge overlap;
+- the choices: hand it back and pick something else / ask the holder / take it
+  over / file a separate issue for the part that is genuinely distinct.
+
+**Reassignment is the user's call, not yours.** Never run
+`--assignee me` on an issue held by someone else. An explicit "그래도 진행해" /
+"take it over" from the user unblocks you — record in your reply that you
+proceeded on their instruction, and leave the assignee field alone unless they
+also asked you to change it.
+
+### Edge cases
+
+- **The key does not resolve, or the CLI errors.** Resolve toward stopping: say
+  the check failed and ask, rather than treating an error as "Unassigned".
+- **Status is Done / Closed.** Cheap signal that the fix already landed — check
+  before redoing it, whoever the assignee is.
+- **No tracked issue at all** (an ad-hoc "이거 좀 고쳐줘"). No gate; proceed. If
+  the fix will end up in a PR, find or file the issue first — `astryx-bug-report`
+  handles the filing, and then this gate applies to what it created.
+- **Several issues in one request.** Gate each one. A blocked issue does not
+  block the others; do the ones you hold and report the rest.
 
 ## 0. Measure before you fix
 
@@ -233,6 +292,11 @@ Terminology.
 
 ## Related
 
+- `astryx-bug-report` — the capture-only counterpart, and where an untracked
+  regression gets its issue before this skill's assignee gate can apply. Its
+  `astryx-discussion` Tasks are not fix-ready until the team has answered them.
+- `fw:jira-workflow` — full `$FW_JIRA` command reference (`myself`, `get`,
+  `update --assignee me`).
 - `dev-server`, `webui-connection-info` — running the app and logging in.
 - `.specs/FR-3482-astryx-migration/CONVERSION-IDIOMS.md`,
   `.specs/FR-3482-astryx-migration/RESPONSIVE-POLICY.md` — ratified conversion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,8 @@ read `package.json` / `pnpm-workspace.yaml` / `ls` rather than expecting a list 
 - **Storybook**: `storybook-patterns` skill (fw plugin; CSF 3, meta config, story patterns, checklists)
 - **i18n**: `i18n-patterns` skill (fw plugin; translation keys, casing rules, language-specific guidelines)
 - **Documentation**: `docs-writing-guide` skill (fw plugin; user manual structure, terminology, multilingual rules)
-- **Astryx UI fixes**: `astryx-fix` skill (measure-before-you-fix, theme-defaults-first procedure, known traps, verification bar)
-- **Astryx UI bug reporting**: `astryx-bug-report` skill (capture-only intake for visual / behavioral defects, files them as Jira Bugs under epic FR-3491, duplicate + relates scan). Use it when the ask is "record this", `astryx-fix` when it is "fix this".
+- **Astryx UI fixes**: `astryx-fix` skill (assignee gate before starting, measure-before-you-fix, theme-defaults-first procedure, known traps, verification bar)
+- **Astryx UI bug reporting**: `astryx-bug-report` skill (capture-only intake for visual / behavioral defects and `discussion` items — "is this intended?" / "propose X instead" — filed under epic FR-3491 as Bugs and Tasks respectively, duplicate + relates scan). Use it when the ask is "record this", `astryx-fix` when it is "fix this".
 
 Component-authoring patterns (Relay tables, selects, modals, forms, layout) have no
 dedicated skills: read `react.instructions.md` for the project deltas, then copy the


### PR DESCRIPTION
Follow-up to #8660 (FR-3492) — no new issue was filed for this; it is a skill-definition change only.

Two independent asks, both about the Astryx post-migration skills.

## 1. `astryx-bug-report` gains a **discussion** category

The skill classified every report as **visual** or **behavioral**. A steady share of what actually arrives is neither: "is this intended?", "should this be a switch?", "I'd move this into the header instead". Filed as a Bug, those get closed as *works as designed* without anyone deciding anything; not filed at all, they are lost.

So there is now a third category — **discussion** — filed as a **Task** under the same epic [FR-3491](https://lablup.atlassian.net/browse/FR-3491) with the label `astryx-discussion`. All three categories keep the `astryx-report` label, so the epic queue and every duplicate scan still work across categories, while the issue type separates a fix queue from a decision queue.

| Category | Issue type | Label |
|---|---|---|
| Visual | Bug | `astryx-visual` |
| Behavioral | Bug | `astryx-behavior` |
| Discussion | Task | `astryx-discussion` |

What the skill now does with it:

- **A test for the boundary.** The dividing line is *whether the expectation is established* — not how confident the reporter sounds, and not how big the change would be. If a prior release, a design spec, a sibling screen, or a plain functional contract settles what it should do, it is a Bug. If the expectation itself is the question, it is a discussion. Both failure directions are called out: filing a real regression as a discussion because the reporter hedged, and filing a design proposal as a Bug because that is easier. Genuine coin flips go to discussion — re-typing a Task is one command, a Bug that was never a defect burns triage time.
- **A different intake gate.** A discussion requires an *answerable question or proposal* and a one-line *why it is being raised*; it explicitly does **not** require **Expected**, since having a settled expectation means it is a Bug. The question is the one field that may never be `Unknown`.
- **The same investigation budget.** Stated explicitly, because the temptation with a discussion is to go find the answer — read the component, check `git log`, compare siblings. That is the decision work and it belongs to whoever picks it up.
- **Dedup for decisions.** Two people asking the same question is one decision, not two. An already-decided discussion is not re-filed — the reporter is pointed at the outcome, and disagreeing with it is a *new* discussion that `relates` to the closed one. A discussion overlapping an open Bug on the same surface is linked, not merged: different owners, different done-conditions.
- **Its own title convention and template.** Titles are phrased as the question or as `Proposal: …`. The new template is Question / Where / Current behaviour / Why raised / Proposal / Options considered / Impact — no **Expected** section, and no answer to the question.

The skill still never rules on a discussion: recording it is the whole job.

## 2. `astryx-fix` gains an **assignee gate**

Two people measuring, branching and PR-ing the same regression is only preventable *before* the work. A new section runs ahead of the measure step whenever the fix is tied to a tracked issue (a key in the request, in the branch name, or in a linked GitHub issue):

| `assignee` | Action |
|---|---|
| You | Proceed. |
| `Unassigned` | Claim it (`jira update KEY --assignee me`), say so in the reply, proceed. |
| Someone else | **Stop** — no measuring, no branch, no edit. Report the holder, status, and issue link, plus the options (hand back / ask them / take over / file a separate issue). |

Reassignment stays the user's call: the skill never runs `--assignee me` on someone else's issue, and only an explicit go-ahead unblocks it. Edge cases covered: an unresolvable key or CLI error resolves *toward stopping* rather than being read as unassigned; a Done/Closed issue is a cheap signal the fix already landed; no tracked issue means no gate; several issues are gated one by one.

## Files

- `.claude/skills/astryx-bug-report/SKILL.md` — category table, the bug-or-discussion test, per-category intake gate, dedup rules, create commands split by issue type, quality bar.
- `.claude/skills/astryx-bug-report/references/issue-templates.md` — the discussion template and its field notes.
- `.claude/skills/astryx-fix/SKILL.md` — the assignee gate ahead of §0, and the `astryx-bug-report` / `fw:jira-workflow` cross-links.
- `AGENTS.md` — the two On-Demand Skills lines, which still described the old two-category split.

## Verification

Skill definitions and docs only — no application code, so `scripts/verify.sh` has nothing to exercise. Verified instead by:

- parsing both `SKILL.md` frontmatter blocks as YAML (descriptions are 879 and 955 characters, inside the 1024 limit) and confirming the section structure is intact;
- running the commands the new text tells an agent to run: `jira myself` returns the display name to compare against, `jira get FR-3491` returns `assignee` as a display name or the literal string `"Unassigned"`, and `project = FR AND issuetype = Task AND parent is not EMPTY` confirms Task-under-Epic parenting is already in use, so `create --type Task --parent FR-3491` is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FR-3491]: https://lablup.atlassian.net/browse/FR-3491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ