### PR TITLE
fix(BAISelect): disable Astryx internal search when showSearch is an object (Fixes #8667)

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -492,7 +492,7 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
     // `baseShowSearch ?? true`, so a `BAISelect` that says nothing about
     // search was type-to-filter. Treating `undefined` as "no search" turned
     // that off on every call site that omitted the prop.
-    hasSearch: showSearch !== false,
+    hasSearch: showSearch === true,
     status:
       status === 'error' || status === 'warning' ? { type: status } : undefined,
     size:


### PR DESCRIPTION
## Summary

When `showSearch` is passed as an object (antd compatibility mode with `searchValue`/`onSearch`/`optionFilterProp`), the `hasSearch` prop was incorrectly set to `true` via the `showSearch !== false` condition. This activated the Astryx Selector's internal search mode, which:

- Intercepts option clicks, making them unselectable
- Leaves the popup open after clicking an option
- Prevents the image selection from being reflected in the form field

## Fix

Changed `hasSearch: showSearch !== false` to `hasSearch: showSearch === true`. This ensures the Astryx internal search is only enabled when `showSearch` is explicitly a boolean `true`. When it's an object, the calling component manages its own external search via `searchValue`/`onSearch`, and the Astryx internal search is not needed.

## Related Issue

Fixes #8667