### PR TITLE
fix(FR-3499): stop the image selector clearing itself on re-select

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
@@ -1,0 +1,96 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Pins FR-3499 for the `<Select.Option>` children API: the option label Astryx
+ * receives is the DISPLAY text, never the synthetic search key.
+ *
+ * Astryx's `Selector` spends `SelectorOptionData.label` twice — the dropdown
+ * filters on it, and the closed trigger renders it — so folding an option's
+ * `filterValue` into that label leaked the search key onto the control. The
+ * image environment selector (`ImageEnvironmentSelectFormItems`, which is the
+ * repo's real user of this children API and the only place `filterValue` is
+ * set) rendered `PyTorch PyTorch` and a tab-separated version string on the
+ * Session Launcher and the deployment Add-Revision modal.
+ *
+ * The fixture below mirrors that call site's shape exactly: an OptGroup of
+ * rich-JSX option rows, each carrying a `filterValue` whose text overlaps the
+ * visible label. jsdom sees the trigger's text content the same way a browser
+ * does, so the assertion is the same thing that was measured live.
+ */
+import BAISelect, {
+  BAISelectOptionGroup as SelectOptGroup,
+  BAISelectOptionItem as SelectOption,
+} from './BAISelect';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+// The popup keeps the keyboard highlight in view; jsdom has no layout, so it
+// does not implement `scrollIntoView`. Unrelated to what is asserted.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const ImageSelect = ({
+  value,
+  onChange,
+}: {
+  value?: string;
+  onChange?: (next: unknown) => void;
+}) => (
+  <BAISelect label="Environments" value={value} onChange={onChange}>
+    <SelectOptGroup key="ml" label="Machine Learning / Deep Learning">
+      <SelectOption
+        key="cr.backend.ai/stable/pytorch"
+        value="cr.backend.ai/stable/pytorch"
+        filterValue={'PyTorch\tstable\tGPU'}
+      >
+        <span>PyTorch</span>
+      </SelectOption>
+      <SelectOption
+        key="cr.backend.ai/stable/tensorflow"
+        value="cr.backend.ai/stable/tensorflow"
+        filterValue={'TensorFlow\tstable\tGPU'}
+      >
+        <span>TensorFlow</span>
+      </SelectOption>
+    </SelectOptGroup>
+  </BAISelect>
+);
+
+const triggerText = () =>
+  screen.getAllByRole('button')[0]?.textContent?.trim() ?? '';
+
+describe('BAISelect children-option trigger label (FR-3499)', () => {
+  it('shows the option text alone, not the folded-in filterValue', () => {
+    render(<ImageSelect value="cr.backend.ai/stable/pytorch" />);
+    expect(triggerText()).toBe('PyTorch');
+  });
+
+  it('never leaks the search key separators onto the trigger', () => {
+    render(<ImageSelect value="cr.backend.ai/stable/tensorflow" />);
+    const text = triggerText();
+    expect(text).not.toContain('\t');
+    expect(text).not.toContain('stable');
+    // The defect rendered the name twice ("TensorFlow TensorFlow").
+    expect(text.match(/TensorFlow/g)).toHaveLength(1);
+  });
+
+  it('still selects a grouped option and reports the caller value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ImageSelect value="cr.backend.ai/stable/pytorch" onChange={onChange} />,
+    );
+
+    await user.click(screen.getAllByRole('button')[0]);
+    await user.click(screen.getByRole('option', { name: 'TensorFlow' }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      'cr.backend.ai/stable/tensorflow',
+      expect.anything(),
+    );
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -290,9 +290,11 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
   // Astryx's `Selector` is `options`-driven only, so the element tree is
   // flattened into the same option model — the group's `label` becomes a
   // `{type: 'section'}` entry (Astryx's native grouping), each option's JSX
-  // body is kept for `renderOption`, and `filterValue` (the synthetic search
-  // key `ImageEnvironmentSelectFormItems` sets) is folded into the searchable
-  // label. Two call sites use this form; both nest options inside OptGroups.
+  // body is kept for `renderOption`, and the option's flattened text becomes
+  // its label. `filterValue` (the synthetic search key
+  // `ImageEnvironmentSelectFormItems` sets) is NOT folded in — see FR-3499 at
+  // the leaf branch below. Two call sites use this form; both nest options
+  // inside OptGroups.
   const childOptions: Array<BAISelectOption> = [];
   const childSections: Array<SelectorOptionType> = [];
   if (options === undefined && children !== undefined) {
@@ -326,22 +328,31 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
           });
           return;
         }
-        const searchable =
-          [
-            nodeToAccessibleLabel(childProps.children),
-            childProps.filterValue ?? '',
-          ]
-            .filter(Boolean)
-            .join(' ') || toOptionKey(childProps.value);
+        // FR-3499 — the option label is the DISPLAY text, never the search key.
+        // Astryx's `Selector` spends `SelectorOptionData.label` twice: the
+        // dropdown filters on it AND the closed trigger renders it
+        // (`selectedItem?.label`). There is no separate search field on the
+        // option model. Folding `filterValue` in therefore printed the
+        // synthetic search key onto the control itself — measured live on the
+        // Session Launcher and the deployment Add-Revision modal, the trigger
+        // read `PyTorch PyTorch` and
+        // `2.1.0 x86_64 2.1.0\tPython 3.10\tx86_64\tGPU\tCUDA12.1\tUbuntu 22.04`,
+        // tab separators and all. Search now filters on the text the user is
+        // reading, which is exactly what the `optionFilterProp` PILOT-DECISION
+        // above already specifies for the `options`-prop path; this makes the
+        // two option APIs agree instead of only one of them corrupting itself.
+        const displayLabel =
+          nodeToAccessibleLabel(childProps.children) ||
+          toOptionKey(childProps.value);
         into.push({
           value: childProps.value as BAISelectOption['value'],
           label: childProps.children,
           disabled: childProps.disabled,
-          title: searchable,
+          title: displayLabel,
         });
         out.push({
           value: toOptionKey(childProps.value),
-          label: searchable,
+          label: displayLabel,
           disabled: childProps.disabled,
         });
       });

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -600,8 +600,10 @@ export interface BAISelectOptionProps {
   value?: BAISelectOption['value'];
   disabled?: boolean;
   /**
-   * Extra text folded into the option's search key, on top of the flattened
-   * children. antd's `optionFilterProp="filterValue"` convention.
+   * Accepted and IGNORED, for antd's `optionFilterProp="filterValue"` call
+   * sites. Search matches the option's visible text only — Astryx renders the
+   * option label on the trigger too, so a search key folded into it leaks
+   * there (FR-3499).
    */
   filterValue?: string;
   /** The option row. May be rich JSX — it survives via `renderOption`. */

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -460,16 +460,31 @@ const ImageEnvironmentSelectFormItems: React.FC<
               });
             } else {
               // NOTE: when user set environment only then set the version to the first item
-              const firstInListImage: Image = imageGroups
-                .flatMap((group) => group.environmentGroups)
-                .filter((envGroup) => envGroup.environmentName === value)[0]
-                .images[0];
+              //
+              // FR-3499 — write the OPTION's own key back, not the image's
+              // bare namespace. Every option in this select is keyed by
+              // `environmentGroup.environmentName`, i.e. `registry/namespace`,
+              // and the rest of the component agrees: the version select finds
+              // `selectedEnvironmentGroup` by `environmentName`, and the
+              // auto-select effect stores `nextEnvironment.environmentName`.
+              // Storing the registry-less `namespace` produced a value no
+              // option matched, so Astryx `Selector` fell back to its
+              // placeholder — the environment trigger read "Select…" and the
+              // version select, keyed off the same field, emptied with it.
+              // Choosing a DIFFERENT environment masked this, because the
+              // resulting `version` change re-ran the effect and it rewrote the
+              // field correctly; choosing the environment that was already
+              // selected left the broken value in place, so on a cluster with a
+              // single environment no image could be selected at all.
+              const selectedEnvironmentGroup = _.find(
+                _.flatMap(imageGroups, (group) => group.environmentGroups),
+                (envGroup) => envGroup.environmentName === value,
+              );
+              const firstInListImage: Image | undefined =
+                selectedEnvironmentGroup?.images[0];
               form.setFieldsValue({
                 environments: {
-                  environment:
-                    (supportExtendedImageInfo
-                      ? firstInListImage?.namespace
-                      : firstInListImage?.name) || '',
+                  environment: selectedEnvironmentGroup?.environmentName ?? '',
                   version: getImageFullName(firstInListImage),
                   image: firstInListImage,
                 },


### PR DESCRIPTION
Resolves #8667 (FR-3499)

## Summary

The image environment selector cleared its own value when the user clicked an option, on the Session Launcher and in the deployment **Add Revision** modal alike.

**Root cause.** Every option in the environment select is keyed by `environmentGroup.environmentName` — `registry/namespace` — but its `onChange` wrote back the image's bare `namespace`:

```tsx
environment: (supportExtendedImageInfo ? firstInListImage?.namespace : firstInListImage?.name) || '',
```

Nothing downstream matches that shorter form. The version select resolves its group by `environmentName`, and Astryx `Selector` renders its **placeholder** when no option carries the current value — so the environment trigger went blank and the version select emptied with it.

**Why it looked intermittent.** Choosing a *different* environment masked the bug: the resulting `version` change re-ran the auto-select effect, which rewrote the field with the correct `environmentName`. Choosing the environment that was **already selected** changes no version, so the effect never ran and the broken value survived. On a cluster with a single installed environment that is *every* click — which is why it presents as "이미지를 아예 선택할 수 없다".

The fix writes the option's own key back, and looks the group up with `_.find` so a miss can no longer throw on `[0].images[0]`.

## Also fixed — the trigger printed its own search key

Found while measuring the above. `BAISelect` folded an option's `filterValue` into the `label` it hands Astryx, but `Selector` spends `SelectorOptionData.label` **twice**: the dropdown filters on it *and* the closed trigger renders it (`selectedItem?.label`). The synthetic search key was therefore painted onto the control:

| | before | after |
|---|---|---|
| Environments trigger | `Python Python` | `Python` |
| Version trigger | `3.9 x86_64 3.9 Ubuntu 20.04 x86_64` | `3.9 x86_64` |
| Version trigger (multi-image cluster) | `2.1.0 x86_64 2.1.0⇥Python 3.10⇥x86_64⇥GPU⇥CUDA12.1⇥Ubuntu 22.04` | `2.1.0 x86_64 Python 3.10 GPU:CUDA12.1 Ubuntu 22.04` |

The label is now the display text alone. Search filters on the text the user is reading — which is exactly what this module's existing `optionFilterProp` PILOT-DECISION already specifies for the `options`-prop path, so the two option APIs now agree instead of only one of them corrupting itself.

**Trade-off worth a reviewer's eye:** extras that appeared only in `filterValue` and not in the visible row (e.g. an environment's `prefix` tag) are no longer searchable. Astryx's option model has no separate search field, so a clean trigger and an extended search key are mutually exclusive here.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Vite warmup / StyleX / Astryx theme build / Terminology)
- `pnpm --filter backend.ai-ui exec vitest run` → 586 passed, 1 skipped
- `pnpm --prefix ./react exec vitest run` → 1162 passed
- `pnpm --filter backend.ai-ui build` → OK
- New regression test `BAISelect.triggerLabel.test.tsx` (3 cases). Confirmed it **fails without** the fix with the exact string measured live: `expected 'PyTorch PyTorch\tstable\tGPU' to be 'PyTorch'`.
- **Live probe** against a real backend, Session Launcher + deployment Add-Revision modal: clicking the already-selected environment used to blank both selects (`Select…` / `Select…`); it now keeps `Python` / `3.9 x86_64`. Selecting a different environment (ngc-vllm → PyTorch → TensorFlow) still updates both. No new `pageerror`.

**Checklist:**

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review
- [x] Minimum requirements to check during review: re-select the environment that is already selected — the value must survive; and confirm the search trade-off above is acceptable
- [x] Test case(s) to demonstrate the difference of before/after
