### PR TITLE
fix(FR-3500): distinguish disabled action buttons on info notification card background

### DIFF
--- a/react/src/components/astryx-bui/astryxBui.css
+++ b/react/src/components/astryx-bui/astryxBui.css
@@ -303,3 +303,13 @@
   min-width: 0;
   overflow-wrap: anywhere;
 }
+
+/* #8676 — Session notification card: disabled action buttons indistinguishable
+   from enabled ones on the info background.
+   Astryx Button already applies `opacity: 0.5` when disabled, but on the
+   info (light blue) background the icon still reads as enabled. Reduce opacity
+   further so the disabled state is visually distinct. */
+.bai-notification-stack-item[data-status="info"]
+  button:where([disabled], [aria-disabled="true"]) {
+  opacity: 0.25;
+}


### PR DESCRIPTION
## Summary

Session notification cards render with an info (light blue) background. On that background, disabled action icon-buttons (app dialog / terminal / log / terminate) inside a session notification card look the same as enabled ones — the reporter's screenshot of two PENDING session notifications showed the 1st and 2nd buttons from the left disabled but visually identical to the enabled buttons next to them.

**Root cause.** Astryx `Button` applies `opacity: 0.5` when disabled, but on the info (light blue) background the icon still reads as enabled.

## Fix

Add a local CSS rule in `react/src/components/astryx-bui/astryxBui.css` that reduces the disabled opacity to `0.25` when the button sits inside an info-status notification stack item (`.bai-notification-stack-item[data-status="info"]`), so the disabled state is clearly distinguishable.

The selector targets both native `[disabled]` and `[aria-disabled="true"]` (used when a tooltip keeps the button focusable). It only applies inside the notification stack, so no other surface changes.

Closes #8676