### PR TITLE
fix(FR-3181): reset auto-mounted folders when switching projects (Closes #7992)

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -303,7 +303,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
       onChangeAutoMountedFolders(autoMountedFolderNames);
     // Omit `onChangeAutoMountedFolders` from deps so a parent re-render doesn't retrigger this effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoMountedFolderNames]);
+  }, [autoMountedFolderNames, currentProject.id]);
 
   useEffect(() => {
     // Only reset selectedRowKeys when currentProject changes if there are no controlled selectedRowKeys

--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -12,6 +12,7 @@ import VFolderTable, {
   vFolderAliasNameRegExp,
 } from './VFolderTable';
 import { useEventNotStable } from 'backend.ai-ui';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import * as _ from 'lodash-es';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -39,6 +40,7 @@ const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
 }) => {
   const form = Form.useFormInstance();
   const { t } = useTranslation();
+  const currentProject = useCurrentProjectValue();
 
   const { message } = App.useApp();
   return (
@@ -108,7 +110,7 @@ const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
         trigger="onChangeSelectedRowKeys"
       >
         <VFolderTable
-          key={tableProps?.ownerEmail}
+          key={`${tableProps?.ownerEmail}-${currentProject.id}`}
           rowKey={rowKey}
           showAliasInput
           aliasMap={form.getFieldValue('mount_id_map')}


### PR DESCRIPTION
## Fix: Reset auto-mounted folders when switching projects

### Problem

When switching projects via the global project selector in the UI header while the **Start Session** dialog is open, the previous project's dot-folder VFolders (folders whose name starts with `.`) remain in the automount list instead of being replaced with the new project's dot files.

### Root cause

`VFolderTableFormItem` keyed the `VFolderTable` component only by `ownerEmail`. Switching projects (same owner) did **not** remount the table, so:

1. The `allFolderList` query was not re-fetched for the new project.
2. The `autoMountedFolderNames` effect did not re-fire on project change, so the hidden `autoMountedFolderNames` form field kept the previous project's dot-folder names.

### Fix

- **`VFolderTableFormItem.tsx`**: Key `VFolderTable` by `ownerEmail` **and** `currentProject.id`. This forces the table to fully remount (and refetch) when the project changes.
- **`VFolderTable.tsx`**: Add `currentProject.id` to the `autoMountedFolderNames` effect dependencies so the parent form's hidden field is updated on project switch.

### Test plan

1. Open Start Session dialog -> Storage step.
2. Note the automount folders listed for the current project.
3. Switch to a different project via the header selector while the dialog is open.
4. The automount section now shows the new project's dot files (old project's dot files are gone).

Closes #7992