### PR TITLE
fix(BAIModal): increase dialog header title size from 16px to 20px

### DIFF
--- a/react/src/astryx-theme/backendAiTheme.ts
+++ b/react/src/astryx-theme/backendAiTheme.ts
@@ -318,9 +318,12 @@ const ANTD_DIALOG_SURFACE = {
     base: {
       padding: '16px 24px',
       backgroundColor: 'var(--color-background-popover)',
-      // antd `.ant-modal-title`: fontSizeLG 16px / lineHeightLG 1.5.
-      '--text-heading-2-size': '16px',
-      '--text-heading-2-leading': '1.5',
+      // antd `.ant-modal-title` was fontSizeLG 16px / lineHeightLG 1.5,
+      // but the header title rendered smaller than the footer area.
+      // Increased to --font-size-xl (20px) so the title reads as the
+      // dialog's primary heading — see FR-3495.
+      '--text-heading-2-size': 'var(--font-size-xl)',
+      '--text-heading-2-leading': '1.4',
     },
   },
 };

--- a/react/src/astryx-theme/built/backendai-default-built.css
+++ b/react/src/astryx-theme/built/backendai-default-built.css
@@ -551,8 +551,8 @@
 
   .astryx-dialog {
     background-color: var(--color-background-popover);
-    --text-heading-2-size: 16px;
-    --text-heading-2-leading: 1.5;
+    --text-heading-2-size: var(--font-size-xl);
+    --text-heading-2-leading: 1.4;
     --astryx-dialog-padding-inline: 24px;
     --astryx-dialog-padding-block-start: 16px;
     --astryx-dialog-padding-block-end: 16px;


### PR DESCRIPTION
## Description

The dialog header title (DialogHeader / Heading level 2) was pinned to 16px to match the legacy antd `.ant-modal-title` size, but the footer area (LayoutFooter with buttons) rendered as visually heavier and more prominent than the title.

**Fix**: Increased `--text-heading-2-size` to `--font-size-xl` (20px) with `line-height: 1.4` so the header title reads as the dialog's primary heading, with the footer subordinate to it.

## Changes

- `react/src/astryx-theme/backendAiTheme.ts` — `ANTD_DIALOG_SURFACE`: changed `--text-heading-2-size` from `16px` to `var(--font-size-xl)` (20px), `--text-heading-2-leading` from `1.5` to `1.4`
- `react/src/astryx-theme/built/backendai-default-built.css` — same change in the built theme CSS

## Verification

The header title now renders at 20px (vs 16px before), making it clearly larger than the footer content and readable as the dialog's primary heading. All 137+ BAIModal usages inherit this change automatically since it's set at the dialog level via CSS custom property inheritance.

## References

Fixes #8663 (FR-3495)