### PR TITLE
fix: reset automount folder list when switching projects (Closes #7993)

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -299,20 +299,26 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   );
 
   useEffect(() => {
+    // Only reset selectedRowKeys when currentProject changes if there are no controlled selectedRowKeys
+    if (!controlledSelectedRowKeys || controlledSelectedRowKeys.length === 0) {
+      setSelectedRowKeys([]);
+    }
+    // Clear stale automount data when project changes, so the
+    // autoMountedFolderNames effect below re-populates with the new
+    // project's dot files rather than keeping the previous project's.
+    if (_.isFunction(onChangeAutoMountedFolders)) {
+      onChangeAutoMountedFolders([]);
+    }
+    // Reset selectedRowKeys when currentProject changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentProject.id]);
+
+  useEffect(() => {
     _.isFunction(onChangeAutoMountedFolders) &&
       onChangeAutoMountedFolders(autoMountedFolderNames);
     // Omit `onChangeAutoMountedFolders` from deps so a parent re-render doesn't retrigger this effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoMountedFolderNames]);
-
-  useEffect(() => {
-    // Only reset selectedRowKeys when currentProject changes if there are no controlled selectedRowKeys
-    if (!controlledSelectedRowKeys || controlledSelectedRowKeys.length === 0) {
-      setSelectedRowKeys([]);
-    }
-    // Reset selectedRowKeys when currentProject changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentProject.id]);
 
   const [searchKey, setSearchKey] = useState('');
   const displayingFolders = _.filter(mountableFoldersByPermission, (vf) => {


### PR DESCRIPTION
## Description

Fixes #7993

When switching projects via the global project selector while the Start Session dialog is open, the previous project's dot-file VFolders (folders whose name starts with `.`) remained in the automount list instead of being replaced with the new project's dot files.

### Root Cause

The `useEffect([currentProject.id])` that resets `selectedRowKeys` on project change ran **after** the `useEffect([autoMountedFolderNames])` that calls `onChangeAutoMountedFolders`. When `autoMountedFolderNames` reference did not change (e.g. new project has no dot files), the `autoMountedFolderNames` effect skipped rendering, leaving stale data from the previous project.

### Fix

1. Move the `useEffect([currentProject.id])` **before** the `useEffect([autoMountedFolderNames])` — effects run in declaration order
2. Explicitly call `onChangeAutoMountedFolders([])` from the project-change effect to clear stale automount data
3. The `autoMountedFolderNames` effect then re-populates the field with the new project's dot files on the next render

### Test Plan

1. Open the Start Session dialog and navigate to the Storage step
2. Note the Automount Folders section (dot-file folders for the current project)
3. Switch to a different project using the global project selector in the header
4. Verify automount folder list updates to reflect the new project's dot files only
