### PR TITLE
fix(BAITable): render localized empty state with Inbox icon (Closes #8672)

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
@@ -114,10 +114,11 @@ import type {
   TablePlugin,
   TableSortState,
 } from '@astryxdesign/core/Table';
+import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { Text } from '@astryxdesign/core/Text';
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
-import { ChevronDown, ChevronRight, FileDown, Settings } from 'lucide-react';
+import { ChevronDown, ChevronRight, FileDown, Inbox, Settings } from 'lucide-react';
 import React, { useMemo, useState, type ReactNode } from 'react';
 
 /** Internal row shape Astryx's generic constraint requires. */
@@ -1151,7 +1152,8 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
           isStriped={isStriped}
           hasHover={hasHover}
           textOverflow={textOverflow}
-          emptyState={emptyState ?? locale?.emptyText}
+          emptyState={emptyState ?? locale?.emptyText
+            ?? <EmptyState icon={<Inbox size="2em" />} title={String(t('comp:BAITable.NoData'))} isCompact />}
           rowCount={total || undefined}
           rowIndexStart={
             pagination !== false

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -475,7 +475,8 @@
     "Pagination": "Seitennummerierung",
     "SearchTableColumn": "Suchtabellenspalten",
     "SelectColumnToDisplay": "Wählen Sie Spalten aus, um angezeigt zu werden",
-    "SettingTable": "Tabelleneinstellungen"
+    "SettingTable": "Tabelleneinstellungen",
+    "NoData": "Keine Daten"
   },
   "comp:BAITestButton": {
     "Test": "test"

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -475,7 +475,8 @@
     "Pagination": "Σελιδοποίηση",
     "SearchTableColumn": "Στήλες πίνακα αναζήτησης",
     "SelectColumnToDisplay": "Επιλέξτε στήλες για εμφάνιση",
-    "SettingTable": "Ρυθμίσεις πίνακα"
+    "SettingTable": "Ρυθμίσεις πίνακα",
+    "NoData": "Χωρίς δεδομένα"
   },
   "comp:BAITestButton": {
     "Test": "δοκιμή"

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -499,7 +499,8 @@
     "Pagination": "Pagination",
     "SearchTableColumn": "Search table columns",
     "SelectColumnToDisplay": "Select columns to display",
-    "SettingTable": "Table Settings"
+    "SettingTable": "Table Settings",
+    "NoData": "No data"
   },
   "comp:BAITestButton": {
     "Test": "Test"

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -475,7 +475,8 @@
     "Pagination": "Paginación",
     "SearchTableColumn": "Columnas de la tabla de búsqueda",
     "SelectColumnToDisplay": "Seleccionar columnas para mostrar",
-    "SettingTable": "Configuración de tabla"
+    "SettingTable": "Configuración de tabla",
+    "NoData": "Sin datos"
   },
   "comp:BAITestButton": {
     "Test": "prueba"

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -475,7 +475,8 @@
     "Pagination": "Sivutus",
     "SearchTableColumn": "Hakutaulukon sarakkeet",
     "SelectColumnToDisplay": "Valitse näytettävä sarakkeet",
-    "SettingTable": "Taulukon asetukset"
+    "SettingTable": "Taulukon asetukset",
+    "NoData": "Ei tietoja"
   },
   "comp:BAITestButton": {
     "Test": "testi"

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -475,7 +475,8 @@
     "Pagination": "Pagination",
     "SearchTableColumn": "Colonnes de table de recherche",
     "SelectColumnToDisplay": "Sélectionnez des colonnes à afficher",
-    "SettingTable": "Paramètres de la table"
+    "SettingTable": "Paramètres de la table",
+    "NoData": "Aucune donnée"
   },
   "comp:BAITestButton": {
     "Test": "test"

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -475,7 +475,8 @@
     "Pagination": "Penomoran halaman",
     "SearchTableColumn": "Kolom Tabel Cari",
     "SelectColumnToDisplay": "Pilih kolom untuk ditampilkan",
-    "SettingTable": "Pengaturan Tabel"
+    "SettingTable": "Pengaturan Tabel",
+    "NoData": "Tidak ada data"
   },
   "comp:BAITestButton": {
     "Test": "tes"

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -475,7 +475,8 @@
     "Pagination": "Impaginazione",
     "SearchTableColumn": "Colonne della tabella di ricerca",
     "SelectColumnToDisplay": "Seleziona le colonne da visualizzare",
-    "SettingTable": "Impostazioni della tabella"
+    "SettingTable": "Impostazioni della tabella",
+    "NoData": "Nessun dato"
   },
   "comp:BAITestButton": {
     "Test": "test"

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -475,7 +475,8 @@
     "Pagination": "ページネーション",
     "SearchTableColumn": "テーブル列を検索します",
     "SelectColumnToDisplay": "表示する列を選択します",
-    "SettingTable": "テーブル設定"
+    "SettingTable": "テーブル設定",
+    "NoData": "データなし"
   },
   "comp:BAITestButton": {
     "Test": "テスト"

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -475,7 +475,8 @@
     "Pagination": "페이지 나누기",
     "SearchTableColumn": "표시할 열 검색",
     "SelectColumnToDisplay": "표시할 열 선택",
-    "SettingTable": "표 설정"
+    "SettingTable": "표 설정",
+    "NoData": "데이터 없음"
   },
   "comp:BAITestButton": {
     "Test": "테스트"

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -475,7 +475,8 @@
     "Pagination": "Хуудаслалт",
     "SearchTableColumn": "Хүснэгтийн баганыг хайх",
     "SelectColumnToDisplay": "Дэлгэцийн баганыг сонгоно уу",
-    "SettingTable": "Хүснэгтийн тохиргоо"
+    "SettingTable": "Хүснэгтийн тохиргоо",
+    "NoData": "Өгөгдөл байхгүй"
   },
   "comp:BAITestButton": {
     "Test": "турших"

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -475,7 +475,8 @@
     "Pagination": "Penomboran halaman",
     "SearchTableColumn": "Lajur jadual carian",
     "SelectColumnToDisplay": "Pilih lajur untuk dipaparkan",
-    "SettingTable": "Tetapan Jadual"
+    "SettingTable": "Tetapan Jadual",
+    "NoData": "Tiada data"
   },
   "comp:BAITestButton": {
     "Test": "ujian"

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -475,7 +475,8 @@
     "Pagination": "Paginacja",
     "SearchTableColumn": "Wyszukaj kolumny tabeli",
     "SelectColumnToDisplay": "Wybierz kolumny do wyświetlenia",
-    "SettingTable": "Ustawienia tabeli"
+    "SettingTable": "Ustawienia tabeli",
+    "NoData": "Brak danych"
   },
   "comp:BAITestButton": {
     "Test": "test"

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -481,7 +481,8 @@
     "Pagination": "Paginação",
     "SearchTableColumn": "Pesquisar colunas da tabela",
     "SelectColumnToDisplay": "Selecione colunas para exibir",
-    "SettingTable": "Configurações da tabela"
+    "SettingTable": "Configurações da tabela",
+    "NoData": "Sem dados"
   },
   "comp:BAITestButton": {
     "Test": "teste"

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -475,7 +475,8 @@
     "Pagination": "Paginação",
     "SearchTableColumn": "Pesquisar colunas da tabela",
     "SelectColumnToDisplay": "Selecione colunas para exibir",
-    "SettingTable": "Configurações da tabela"
+    "SettingTable": "Configurações da tabela",
+    "NoData": "Sem dados"
   },
   "comp:BAITestButton": {
     "Test": "teste"

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -475,7 +475,8 @@
     "Pagination": "Разбиение на страницы",
     "SearchTableColumn": "Поиск таблицы столбцов",
     "SelectColumnToDisplay": "Выберите столбцы, чтобы отобразить",
-    "SettingTable": "Настройки таблицы"
+    "SettingTable": "Настройки таблицы",
+    "NoData": "Нет данных"
   },
   "comp:BAITestButton": {
     "Test": "тест"

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -475,7 +475,8 @@
     "Pagination": "การแบ่งหน้า",
     "SearchTableColumn": "คอลัมน์ตารางค้นหา",
     "SelectColumnToDisplay": "เลือกคอลัมน์ที่จะแสดง",
-    "SettingTable": "การตั้งค่าตาราง"
+    "SettingTable": "การตั้งค่าตาราง",
+    "NoData": "ไม่มีข้อมูล"
   },
   "comp:BAITestButton": {
     "Test": "ทดสอบ"

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -475,7 +475,8 @@
     "Pagination": "Sayfalama",
     "SearchTableColumn": "Arama Tablosu sütunları",
     "SelectColumnToDisplay": "Görüntülemek için sütunları seçin",
-    "SettingTable": "Masa Ayarları"
+    "SettingTable": "Masa Ayarları",
+    "NoData": "Veri yok"
   },
   "comp:BAITestButton": {
     "Test": "test"

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -475,7 +475,8 @@
     "Pagination": "Phân trang",
     "SearchTableColumn": "Các cột bảng tìm kiếm",
     "SelectColumnToDisplay": "Chọn các cột để hiển thị",
-    "SettingTable": "Cài đặt bảng"
+    "SettingTable": "Cài đặt bảng",
+    "NoData": "Không có dữ liệu"
   },
   "comp:BAITestButton": {
     "Test": "kiểm tra"

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -475,7 +475,8 @@
     "Pagination": "分页",
     "SearchTableColumn": "搜索表列",
     "SelectColumnToDisplay": "选择要显示的列",
-    "SettingTable": "表设置"
+    "SettingTable": "表设置",
+    "NoData": "暂无数据"
   },
   "comp:BAITestButton": {
     "Test": "测试"

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -475,7 +475,8 @@
     "Pagination": "分頁",
     "SearchTableColumn": "搜索表列",
     "SelectColumnToDisplay": "選擇要顯示的列",
-    "SettingTable": "表設置"
+    "SettingTable": "表設置",
+    "NoData": "暫無數據"
   },
   "comp:BAITestButton": {
     "Test": "測試"


### PR DESCRIPTION
## Summary

Fixes #8672 — the Astryx-table empty state regressed from the antd version in two ways:

1. **No icon.** When a `BAITableAstryx` has zero rows and neither `emptyState` nor `locale.emptyText` is supplied, Astryx `Table` falls through to its built-in empty state — a single bold English **"No data"** line with no illustration. The previous antd empty state showed an empty-box / inbox glyph above a muted caption.
2. **Not localized.** The built-in label stays English regardless of the UI language (e.g. shows "No data" under a Korean UI even though every other string on the card is Korean).

## Change

Extend the `emptyState` fallback chain in `BAITableAstryx.tsx` to end in a default `EmptyState`:

```tsx
emptyState={emptyState ?? locale?.emptyText
  ?? <EmptyState icon={<Inbox size="2em" />} title={String(t('comp:BAITable.NoData'))} isCompact />}
```

- Uses Astryx `EmptyState` (`@astryxdesign/core/EmptyState`) with an `Inbox` glyph and the **localized** `comp:BAITable.NoData` caption, compact variant.
- Adds the `NoData` key to the `comp:BAITable` namespace across all **21** locale bundles (`en`, `ko`, `zh-CN`, `zh-TW`, `ja`, `de`, `fr`, `es`, …), following the existing app-side `autoScalingRule.NoDataAvailable` translations.
- Consumers that already pass a custom `emptyState` or `locale.emptyText` are unaffected — the default only kicks in when neither is provided.

## Test plan

- [ ] Table with zero rows shows an inbox icon above a muted, language-aware caption (e.g. "데이터 없음" / "暂无数据" under those UIs).
- [ ] Tables that pass a custom `emptyState` keep their custom empty state.
- [ ] Full `BAITableAstryx` type-check passes (no new imports break the build).

Closes #8672