### PR TITLE
fix(FR-3503): own the table empty state so it is iconed and localized

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.emptyState.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.emptyState.test.tsx
@@ -1,0 +1,86 @@
+/*
+ FR-3503 — the empty state BAITableAstryx renders when it has no rows.
+
+ Astryx's `Table` falls back to its OWN catalog (`@astryx.table.noData`), which
+ ships en/fr only, so a Korean UI showed a bare English "No data". Owning the
+ node moved the copy onto BUI's catalog and restored the icon.
+
+ `resolvedEmptyState` has four branches behind ~80 call sites, and nothing
+ asserted them: `false` renders nothing, nullish takes the localized default, a
+ string is WRAPPED in `EmptyState`, and any other ReactNode passes through
+ unwrapped. The legacy `locale.emptyText` feeds the same resolution.
+
+ Structural, not visual — jsdom's lack of layout does not matter.
+*/
+import BAITableAstryx from './BAITableAstryx';
+import type { BAIColumnsType } from './tableTypes';
+import { render, screen } from '@testing-library/react';
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const COLUMNS: BAIColumnsType<Row> = [
+  { key: 'name', title: 'Name', dataIndex: 'name' },
+];
+
+const renderEmpty = (
+  props: Partial<React.ComponentProps<typeof BAITableAstryx<Row>>> = {},
+) =>
+  render(
+    <BAITableAstryx<Row>
+      rowKey="id"
+      dataSource={[]}
+      columns={COLUMNS}
+      {...props}
+    />,
+  );
+
+describe('BAITableAstryx empty state (FR-3503)', () => {
+  it('renders the localized default when no override is given', () => {
+    renderEmpty();
+    // The copy comes from BUI's catalog, NOT Astryx's `@astryx.table.noData`.
+    expect(screen.getByText('No data to display')).toBeInTheDocument();
+    expect(screen.queryByText('No data')).not.toBeInTheDocument();
+  });
+
+  it('wraps a string override in the same empty state', () => {
+    renderEmpty({ emptyState: 'Nothing deployed yet' });
+    expect(screen.getByText('Nothing deployed yet')).toBeInTheDocument();
+    expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+  });
+
+  it('passes a ReactNode override through unwrapped', () => {
+    renderEmpty({
+      emptyState: <div data-testid="custom-empty">custom</div>,
+    });
+    expect(screen.getByTestId('custom-empty')).toBeInTheDocument();
+    expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+  });
+
+  it('renders no empty state at all when given false', () => {
+    renderEmpty({ emptyState: false });
+    expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+  });
+
+  it('still honours the legacy locale.emptyText', () => {
+    renderEmpty({ locale: { emptyText: 'Legacy copy' } });
+    expect(screen.getByText('Legacy copy')).toBeInTheDocument();
+  });
+
+  it('lets emptyState win over locale.emptyText', () => {
+    renderEmpty({
+      emptyState: 'Explicit wins',
+      locale: { emptyText: 'Legacy copy' },
+    });
+    expect(screen.getByText('Explicit wins')).toBeInTheDocument();
+    expect(screen.queryByText('Legacy copy')).not.toBeInTheDocument();
+  });
+
+  it('does not render the empty state when rows are present', () => {
+    renderEmpty({ dataSource: [{ id: '1', name: 'alpha' }] });
+    expect(screen.queryByText('No data to display')).not.toBeInTheDocument();
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+  });
+});

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
@@ -95,6 +95,8 @@ import {
   isColumnVisible,
   renderColumnTitle,
 } from './tableTypes';
+import { EmptyState } from '@astryxdesign/core/EmptyState';
+import { Icon } from '@astryxdesign/core/Icon';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { Pagination } from '@astryxdesign/core/Pagination';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
@@ -117,7 +119,13 @@ import type {
 import { Text } from '@astryxdesign/core/Text';
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
-import { ChevronDown, ChevronRight, FileDown, Settings } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  FileDown,
+  Inbox,
+  Settings,
+} from 'lucide-react';
 import React, { useMemo, useState, type ReactNode } from 'react';
 
 /** Internal row shape Astryx's generic constraint requires. */
@@ -230,9 +238,13 @@ export interface BAIAstryxTableProps<RecordType extends AnyRecord = AnyRecord> {
   tableSettings?: BAITableSettings;
   exportSettings?: BAIExportSettings;
   expandable?: BAIAstryxExpandable<RecordType>;
-  /** Rendered in place of the body when `dataSource` is empty. */
+  /**
+   * Rendered in place of the body when `dataSource` is empty. A string is
+   * wrapped in the default `EmptyState` (icon + padding); any other node is
+   * rendered as-is; `false` renders nothing.
+   */
   emptyState?: ReactNode | false;
-  /** antd parity shim — only `emptyText` is honoured. */
+  /** antd parity shim — only `emptyText` is honoured, same wrapping rules. */
   locale?: { emptyText?: ReactNode };
   /** antd `onRow` — only the returned handlers/style/className are applied. */
   onRow?: (
@@ -1107,6 +1119,24 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
 
   const hasBottomBar = isPagerVisible || !!tableSettings || !!exportSettings;
 
+  // Astryx's built-in empty state reads from ITS OWN message catalog
+  // (`@astryx.table.noData`), which ships en/fr only — hence English under a
+  // Korean UI. Owning the node moves the copy onto BUI's catalog and restores
+  // the icon. `false` opts out; a ReactNode override passes through unwrapped.
+  const resolvedEmptyState = emptyState ?? locale?.emptyText;
+  const emptyStateNode =
+    resolvedEmptyState === false ? (
+      false
+    ) : resolvedEmptyState == null || typeof resolvedEmptyState === 'string' ? (
+      <EmptyState
+        isCompact
+        icon={<Icon icon={Inbox} size="lg" color="secondary" />}
+        title={resolvedEmptyState ?? String(t('comp:BAITable.NoDataToDisplay'))}
+      />
+    ) : (
+      resolvedEmptyState
+    );
+
   return (
     <div className={className} style={style}>
       {/* PILOT-DECISION: antd's loading overlay (dim + centred spinner over the
@@ -1151,7 +1181,7 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
           isStriped={isStriped}
           hasHover={hasHover}
           textOverflow={textOverflow}
-          emptyState={emptyState ?? locale?.emptyText}
+          emptyState={emptyStateNode}
           rowCount={total || undefined}
           rowIndexStart={
             pagination !== false

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Als CSV exportieren",
     "GoToFirstPage": "Zur ersten Seite",
     "InvalidPageNumber": "Ungültige Seitenzahl",
+    "NoDataToDisplay": "Keine Daten zum Anzeigen",
     "Pagination": "Seitennummerierung",
     "SearchTableColumn": "Suchtabellenspalten",
     "SelectColumnToDisplay": "Wählen Sie Spalten aus, um angezeigt zu werden",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Εξαγωγή CSV",
     "GoToFirstPage": "Μετάβαση στην πρώτη σελίδα",
     "InvalidPageNumber": "Μη έγκυρος αριθμός σελίδας",
+    "NoDataToDisplay": "Δεν υπάρχουν δεδομένα για εμφάνιση",
     "Pagination": "Σελιδοποίηση",
     "SearchTableColumn": "Στήλες πίνακα αναζήτησης",
     "SelectColumnToDisplay": "Επιλέξτε στήλες για εμφάνιση",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -496,6 +496,7 @@
     "ExportCSV": "Export CSV",
     "GoToFirstPage": "Go to first page",
     "InvalidPageNumber": "Invalid page number",
+    "NoDataToDisplay": "No data to display",
     "Pagination": "Pagination",
     "SearchTableColumn": "Search table columns",
     "SelectColumnToDisplay": "Select columns to display",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Exportar CSV",
     "GoToFirstPage": "Ir a la primera página",
     "InvalidPageNumber": "Número de página no válido",
+    "NoDataToDisplay": "No hay datos para mostrar",
     "Pagination": "Paginación",
     "SearchTableColumn": "Columnas de la tabla de búsqueda",
     "SelectColumnToDisplay": "Seleccionar columnas para mostrar",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Vie CSV",
     "GoToFirstPage": "Siirry ensimmäiselle sivulle",
     "InvalidPageNumber": "Virheellinen sivunumero",
+    "NoDataToDisplay": "Ei näytettäviä tietoja",
     "Pagination": "Sivutus",
     "SearchTableColumn": "Hakutaulukon sarakkeet",
     "SelectColumnToDisplay": "Valitse näytettävä sarakkeet",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Exporter en CSV",
     "GoToFirstPage": "Aller à la première page",
     "InvalidPageNumber": "Numéro de page invalide",
+    "NoDataToDisplay": "Aucune donnée à afficher",
     "Pagination": "Pagination",
     "SearchTableColumn": "Colonnes de table de recherche",
     "SelectColumnToDisplay": "Sélectionnez des colonnes à afficher",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Ekspor CSV",
     "GoToFirstPage": "Ke halaman pertama",
     "InvalidPageNumber": "Nomor halaman tidak valid",
+    "NoDataToDisplay": "Tidak ada data untuk ditampilkan",
     "Pagination": "Penomoran halaman",
     "SearchTableColumn": "Kolom Tabel Cari",
     "SelectColumnToDisplay": "Pilih kolom untuk ditampilkan",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Esporta CSV",
     "GoToFirstPage": "Vai alla prima pagina",
     "InvalidPageNumber": "Numero di pagina non valido",
+    "NoDataToDisplay": "Nessun dato da visualizzare",
     "Pagination": "Impaginazione",
     "SearchTableColumn": "Colonne della tabella di ricerca",
     "SelectColumnToDisplay": "Seleziona le colonne da visualizzare",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -472,6 +472,7 @@
     "ExportCSV": "CSV をエクスポート",
     "GoToFirstPage": "最初のページへ",
     "InvalidPageNumber": "無効なページ番号です",
+    "NoDataToDisplay": "表示するデータがありません",
     "Pagination": "ページネーション",
     "SearchTableColumn": "テーブル列を検索します",
     "SelectColumnToDisplay": "表示する列を選択します",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -472,6 +472,7 @@
     "ExportCSV": "CSV로 내보내기",
     "GoToFirstPage": "첫 페이지로 이동하기",
     "InvalidPageNumber": "유효하지 않은 페이지 번호입니다",
+    "NoDataToDisplay": "표시할 데이터가 없습니다",
     "Pagination": "페이지 나누기",
     "SearchTableColumn": "표시할 열 검색",
     "SelectColumnToDisplay": "표시할 열 선택",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -472,6 +472,7 @@
     "ExportCSV": "CSV экспортлах",
     "GoToFirstPage": "Эх хуудас руу шилжих",
     "InvalidPageNumber": "Хуудасны дугаар буруу байна",
+    "NoDataToDisplay": "Харуулах өгөгдөл алга",
     "Pagination": "Хуудаслалт",
     "SearchTableColumn": "Хүснэгтийн баганыг хайх",
     "SelectColumnToDisplay": "Дэлгэцийн баганыг сонгоно уу",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Eksport CSV",
     "GoToFirstPage": "Pergi ke halaman pertama",
     "InvalidPageNumber": "Nombor halaman tidak sah",
+    "NoDataToDisplay": "Tiada data untuk dipaparkan",
     "Pagination": "Penomboran halaman",
     "SearchTableColumn": "Lajur jadual carian",
     "SelectColumnToDisplay": "Pilih lajur untuk dipaparkan",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Eksportuj do CSV",
     "GoToFirstPage": "Przejdź do pierwszej strony",
     "InvalidPageNumber": "Nieprawidłowy numer strony",
+    "NoDataToDisplay": "Brak danych do wyświetlenia",
     "Pagination": "Paginacja",
     "SearchTableColumn": "Wyszukaj kolumny tabeli",
     "SelectColumnToDisplay": "Wybierz kolumny do wyświetlenia",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -478,6 +478,7 @@
     "ExportCSV": "Exportar CSV",
     "GoToFirstPage": "Ir para a primeira página",
     "InvalidPageNumber": "Número de página inválido",
+    "NoDataToDisplay": "Nenhum dado para exibir",
     "Pagination": "Paginação",
     "SearchTableColumn": "Pesquisar colunas da tabela",
     "SelectColumnToDisplay": "Selecione colunas para exibir",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Exportar CSV",
     "GoToFirstPage": "Ir para a primeira página",
     "InvalidPageNumber": "Número de página inválido",
+    "NoDataToDisplay": "Nenhum dado para apresentar",
     "Pagination": "Paginação",
     "SearchTableColumn": "Pesquisar colunas da tabela",
     "SelectColumnToDisplay": "Selecione colunas para exibir",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Экспорт в CSV",
     "GoToFirstPage": "Перейти на первую страницу",
     "InvalidPageNumber": "Неверный номер страницы",
+    "NoDataToDisplay": "Нет данных для отображения",
     "Pagination": "Разбиение на страницы",
     "SearchTableColumn": "Поиск таблицы столбцов",
     "SelectColumnToDisplay": "Выберите столбцы, чтобы отобразить",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -472,6 +472,7 @@
     "ExportCSV": "ส่งออก CSV",
     "GoToFirstPage": "ไปยังหน้าแรก",
     "InvalidPageNumber": "หมายเลขหน้าไม่ถูกต้อ",
+    "NoDataToDisplay": "ไม่มีข้อมูลที่จะแสดง",
     "Pagination": "การแบ่งหน้า",
     "SearchTableColumn": "คอลัมน์ตารางค้นหา",
     "SelectColumnToDisplay": "เลือกคอลัมน์ที่จะแสดง",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -472,6 +472,7 @@
     "ExportCSV": "CSV Dışa Aktar",
     "GoToFirstPage": "İlk sayfaya git",
     "InvalidPageNumber": "Geçersiz sayfa numarası",
+    "NoDataToDisplay": "Görüntülenecek veri yok",
     "Pagination": "Sayfalama",
     "SearchTableColumn": "Arama Tablosu sütunları",
     "SelectColumnToDisplay": "Görüntülemek için sütunları seçin",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -472,6 +472,7 @@
     "ExportCSV": "Xuất CSV",
     "GoToFirstPage": "Đến trang đầu",
     "InvalidPageNumber": "Số trang không hợp lệ",
+    "NoDataToDisplay": "Không có dữ liệu để hiển thị",
     "Pagination": "Phân trang",
     "SearchTableColumn": "Các cột bảng tìm kiếm",
     "SelectColumnToDisplay": "Chọn các cột để hiển thị",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -472,6 +472,7 @@
     "ExportCSV": "导出 CSV",
     "GoToFirstPage": "转到第一页",
     "InvalidPageNumber": "无效的页码",
+    "NoDataToDisplay": "暂无数据",
     "Pagination": "分页",
     "SearchTableColumn": "搜索表列",
     "SelectColumnToDisplay": "选择要显示的列",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -472,6 +472,7 @@
     "ExportCSV": "匯出 CSV",
     "GoToFirstPage": "跳到第一頁",
     "InvalidPageNumber": "無效的頁碼",
+    "NoDataToDisplay": "暫無資料",
     "Pagination": "分頁",
     "SearchTableColumn": "搜索表列",
     "SelectColumnToDisplay": "選擇要顯示的列",


### PR DESCRIPTION
Resolves #8672 (FR-3503)

An empty table rendered a bold English **"No data"** with no icon, under a Korean UI.

## Mechanism

Not "the table isn't using an empty state" — it already was, just not ours.

Astryx's `BaseTable` renders its own documented default when `emptyState` is nullish
(`packages/backend.ai-ui/node_modules/@astryxdesign/core/src/Table/BaseTable.tsx:567-577`):

```tsx
{emptyState ?? <EmptyState title={t('@astryx.table.noData')} isCompact />}
```

Two independent consequences, both confirmed by reading the shipped source:

1. **English under Korean.** That `t` is **Astryx's own** i18n runtime — a third catalog,
   neither the host's `react-i18next` nor BUI's `i18next`. It is correctly wired
   (`BAIConfigProvider.tsx:123-127` passes `locale` + `overrides`), but
   `@astryxdesign/core/locales/` ships **en.json / fr-FR.json / pseudo.json only**, and the
   app's override channel — the reserved `astryx` subtree that `astryxOverrides.ts:68-85`
   reads — is **empty in all 21 BUI locale files** (`'astryx' in en.json` → `False`). So the
   key falls through to Astryx's shipped English. The reporter's own suspicion in the issue
   ("appears to come from Astryx's own catalog") was exactly right.
2. **No icon.** The built-in default passes no `icon`, and `EmptyState.icon` is optional with
   **no fallback** (`EmptyState.tsx:100`). There is no way to inject a glyph from the outside
   without supplying our own node.

A third, quieter defect surfaced while measuring: of the 6 call sites that already override via
`locale.emptyText`, **4 pass a bare string**, which landed raw in the `<td>` with no
`EmptyState` frame at all — unpadded, uncentered, no icon.

**Fix level: component code** (astryx-fix §1 step 4). Steps 1–3 do not reach it: a theme
`components: { 'empty-state': … }` block cannot add an `icon` (it is a prop, not a style) and
would repaint all 22 existing `EmptyState` call sites app-wide; there is no prop on
`Table`/`BaseTable` that supplies only an icon or only a string.

`BAITableAstryx` now owns the node. The **`emptyState` / `locale.emptyText` props already
existed** (`BAITableAstryx.tsx:234-236`) — no new prop was added; **6 call sites** use them
today, and the normalization preserves every existing contract:

| override value | before | after |
|---|---|---|
| `false` | empty `<tbody>` | unchanged — empty `<tbody>` |
| `ReactNode` | rendered as-is | unchanged — rendered as-is (no double-wrap) |
| `string` | **raw text in the `<td>`** | wrapped in the same default `EmptyState` |
| nothing | Astryx's English default | `comp:BAITable.NoDataToDisplay` + `Inbox` glyph |

Per the TRAP note ("Astryx Table bleed"): the empty state lives inside Astryx's own
`<td colSpan>`, so this is fixed **only** in `BAITableAstryx` — no call site got a margin.

## Copy decision

Astryx's own guidance explicitly forbids the generic string ("Don't: Use a generic message like
'No data'"), while the reporter's stated Expected is the antd-parity label "데이터 없음".
`BAITableAstryx` is generic infrastructure behind **81 call sites** (53 in `react/src`, 28 in
`packages/backend.ai-ui/src`) and cannot know *what* is empty, so a generic default is the only
correct thing at this level — specificity belongs at call sites, through the `emptyState` prop
that already exists.

Compromise shipped: **`No data to display` / `표시할 데이터가 없습니다`** — more specific than a
bare "No data", still generic enough for infrastructure. The Korean follows the project's
established idiom per Terminology Precedence (`resources/i18n/ko.json`:
`rbac.NoPermissionsToDisplay` = "표시할 세부 권한이 없습니다",
`rbac.NoRolesToDisplay` = "표시할 역할이 없습니다"), and the English follows the matching
`No permissions to display` / `No roles to display`. Key added to **all 21** BUI locale files as
`comp:BAITable.NoDataToDisplay` (PascalCase leaf under an existing 15-key namespace).

**This is the one taste call in the PR** — if the PO prefers exact antd parity ("데이터 없음" /
"No data"), it is a one-line change per locale file.

## Measured before/after

**Live-probed** in `packages/backend.ai-ui` Storybook (`Table/BAITableAstryx` → `Empty State`,
the pre-existing `dataSource: []` story at `BAITableAstryx.stories.tsx:284`) — no backend needed.
Headless Chromium, 1000×520, computed styles read off the DOM. Before/after taken from the same
running Storybook by stashing only `BAITableAstryx.tsx` and letting HMR reload.

| Property | Before (light) | After (light) | Before (dark) | After (dark) |
|---|---|---|---|---|
| Title text (locale `ko`) | `No data` | **`표시할 데이터가 없습니다`** | `No data` | **`표시할 데이터가 없습니다`** |
| Title text (locale `en`) | `No data` | **`No data to display`** | — | — |
| Icon present | **no** | **yes** (`Inbox`) | **no** | **yes** (`Inbox`) |
| Icon box | — | `24px × 24px` | — | `24px × 24px` |
| Icon color | — | `rgba(0, 0, 0, 0.45)` | — | `rgba(255, 255, 255, 0.45)` |
| EmptyState height | `52px` | **`84px`** | `52px` | **`84px`** |
| `<td>` height | `54px` | **`86px`** | `54px` | **`86px`** |
| Container padding | `16px` all round | `16px` all round (unchanged) | same | same |
| Container gap | `8px` | `8px` (unchanged) | same | same |
| Title color | `rgb(20,20,20)` | `rgb(20,20,20)` (unchanged) | `rgb(255,255,255)` | `rgb(255,255,255)` (unchanged) |
| Title size / weight | `14px` / `600` | `14px` / `600` (unchanged) | same | same |
| `role="status"` | present | present | present | present |
| `pageerror` count | 0 | **0** | 0 | **0** |

**Correcting the report on one point, honestly:** the issue says "very little vertical space
around the label". Padding was **not** the problem — it measured `16px` on all four sides both
before and after, because Astryx's default already passed `isCompact`. The cramped look came
entirely from the missing glyph; adding it takes the block from 52px to 84px. `isCompact` is
**kept** — non-compact would be `--spacing-8` block / `--spacing-6` inline (32/24px) with a
`--text-large-size` title, which is out of proportion inside a table body, and compact is what
Astryx's own default used.

Icon form is Astryx-canonical `<Icon icon={Inbox} size="lg" color="secondary" />` — the exact
shape in `EmptyState.tsx:136`'s own example. `size="lg"` is `1.5rem` (rem, so it tracks the root
font size) and `color="secondary"` is `--color-icon-secondary`, i.e. muted. This **deviates**
from the 6 existing icon-passing `EmptyState` call sites in `react/src`, which use a bare lucide
glyph with a raw `size={40}` (`BAIErrorBoundary.tsx:118,310`, `StorageHostFetchErrorBoundary.tsx:41`,
`SchedulerPage.tsx:122`, `DeploymentDetailPage.tsx:505`, `ImportFromHuggingFaceModal.tsx:417`).
Those are full-page error states where 40px is proportionate; 40px in a compact table body is not,
and the raw px slips past the token gate only because it is a React prop rather than CSS. Those 6
were **not** swept.

### Screenshots

Light (ko) and dark (ko), Storybook `Table/BAITableAstryx → Empty State`, after the fix:

| light (`ko`) | dark (`ko`) |
|---|---|
| <img width="480" alt="empty state, light mode, Korean" src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8694/20260811-131401-empty-state-after-light-ko.png" /> | <img width="480" alt="empty state, dark mode, Korean" src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8694/20260811-131401-empty-state-after-dark-ko.png" /> |

(The "before" is one line of bold `No data` with no glyph in the same frame — see the measured
table above; the visual delta is entirely the glyph and the 52px → 84px block height.)

## Verification

Actual output, in the order the astryx-fix §6 bar requires:

```
pnpm --filter backend.ai-ui build      → ✓ built in 36.72s
                                         dist/backend.ai-ui.js  1,877.57 kB │ gzip: 455.08 kB
                                         (mandatory — this PR touches packages/backend.ai-ui/src)

bash scripts/verify.sh                 → === ALL PASS ===
                                         TypeScript PASS · Vite warmup PASS · StyleX
                                         cssInjectionTarget PASS · Astryx theme build PASS
                                         ("Theme outputs are up to date") · Terminology PASS
                                         (0 blocking, 0 warn-only) · self-test 409 assertions hold

pnpm --filter backend.ai-ui exec vitest run
                                       → Test Files 41 passed | 1 skipped (42)
                                         Tests 583 passed | 1 skipped (584)   [46.95s]

pnpm --prefix ./react exec vitest run  → Test Files 66 passed (66)
                                         Tests 1166 passed (1166)             [111.05s]

node scripts/migration-gates/astryx-token-gate.mjs --strict
                                       → declared 259 | checked 760 | undeclared 2
                                         BAIText.css:27   var(--x)
                                         BAIText.tsx:230  var(--font-family-mono)
```

Both token-gate findings are **pre-existing on `main`**, not introduced here. Checked by
`git stash push -u` on this worktree and re-running the gate on the clean tree: byte-identical
output (`declared 259 | checked 760 | undeclared 2`, same two lines), then `git stash pop`.
Neither file is touched by this PR.

No theme edit and **no `THEME_NAME_REV` bump** — it stays at **11** and
`react/src/astryx-theme/built/bai-r11-default-brand-h165tsmd.*` is untouched. WS-1 owns the theme
this round. `verify.sh`'s `astryx theme build --check` passes, confirming no artifact drift.

## Residue

What this PR does **not** close:

- **The title is still semibold `--color-text-primary`, not muted.** The reporter asked for a
  muted caption. `EmptyState` hardcodes `--font-weight-semibold` + `--color-text-primary` in
  StyleX (`EmptyState.tsx:45-52`) with no prop to override it. The only lever is a
  `components: { 'empty-state': … }` theme block, which would restyle **all 22** `EmptyState`
  call sites in the app for one table cosmetic — deliberately not done here. Worth its own
  ticket if the team wants it. (Partial mitigation shipped: the *icon* is `secondary`/muted.)
- **Other Astryx built-in strings remain English.** The reporter's broader suspicion is
  confirmed — the `astryx` override subtree is empty in all 21 BUI locale files, so any other
  Astryx built-in chrome string is in the same position. `astryxOverrides.ts:44-46` already names
  the deferred candidates (PowerSearch / Typeahead chrome, token remove, clear-all, date editor
  labels, operator menu aria). This PR fixes **only** the table empty state, by owning the node
  rather than by populating that subtree — populating it would have fixed the string but never
  the icon. Tracked as **FR-3511** (#8687, "maintain machine-translated catalogs for all 21
  languages") and **FR-3507** (#8679, "should the astryx override channel be removed?"), both
  already linked to FR-3503 in Jira and both untouched here.
- **4 of the 6 `locale.emptyText` call sites change appearance** — from bare unstyled text to an
  iconed compact `EmptyState`. This is a fix, not a regression, but it is a visible change nobody
  asked for on those screens:
  `KeypairResourcePolicyStoragePermissionTableV2.tsx:220`, `DomainStoragePermissionTable.tsx:160`,
  `UserFolderPermissionPanel.tsx:122`, `ProjectStoragePermissionTable.tsx:366` (a conditional —
  **both** branches are strings, so both wrap). The other 2 pass a full `<EmptyState>` node and
  are byte-for-byte unaffected: `QuotaScopeTable.tsx:192`, `MyKeypairManagementModal.tsx:646`.
  Not individually screenshotted — they are logged-in admin surfaces and there is no backend on
  this box.
- **No live app probe.** No Backend.AI endpoint or credentials are configured here
  (`e2e/envs/.env.playwright` absent, no `config.toml`, no reachable cluster), and the reported
  surface — the Deployment detail "Traffic status" card
  (`react/src/components/DeploymentReplicasCard.tsx:574`) — is a logged-in view. It has **no**
  `emptyState` override, so it takes the new default with zero call-site edits, but that specific
  card was **not** verified on screen. Everything in the before/after table above was measured in
  Storybook, which renders the identical `BAITableAstryx` component.

Sibling reports:

- **Subsumes FR-3504 (#8673)**, already closed as Not Planned as a duplicate — its symptom
  ("table empty state reads 'No data' in English while the UI language is Korean") is the exact
  localization half fixed here, and it is closed by this change.
- **Does not subsume FR-3511 (#8687) or FR-3507 (#8679)** — see the second residue item.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
