### PR TITLE
fix(FR-3496): adopt BAIMetadataList bordered in the agent detail drawer

### DIFF
--- a/react/src/components/AgentDetailDrawerContent.tsx
+++ b/react/src/components/AgentDetailDrawerContent.tsx
@@ -11,16 +11,14 @@ import AgentResources from './AgentNodeItems/AgentResources';
 import AgentStatusTag from './AgentNodeItems/AgentStatusTag';
 import BAIErrorBoundary from './BAIErrorBoundary';
 import BAICopyableText from './astryx-bui/BAICopyableText';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import { Tab, TabList } from '@astryxdesign/core/TabList';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAIDoubleTag,
   BAIFlex,
   BAIIntervalView,
+  BAIMetadataList,
   toLocalId,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
@@ -100,14 +98,9 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
         <AgentActionButtons agentNodeFrgmt={agent} size="lg" />
       </BAIFlex>
 
-      {/* antd Descriptions bordered → MetadataList (MAPPING §4). `bordered` /
-          per-item `span` have no destination and are dropped (PILOT-DECISION,
-          established ticket 15/18 project-wide); the `md`-driven column count
-          survives via useBAIBreakpoint (R3). */}
-      <MetadataList
-        columns={md ? 2 : 1}
-        label={{ position: 'start', width: md ? 160 : 120 }}
-      >
+      {/* SUPERSEDED (FR-3496): `bordered` now has a destination — BAIMetadataList.
+          Still dropped: per-item `span`. Column count is `md`-driven (R3). */}
+      <BAIMetadataList bordered columns={md ? 2 : 1}>
         <MetadataListItem label={t('agent.ResourceGroup')}>
           {agent?.scaling_group}
         </MetadataListItem>
@@ -157,7 +150,7 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
             )}
           </BAIFlex>
         </MetadataListItem>
-      </MetadataList>
+      </BAIMetadataList>
 
       {/* antd Tabs → TabList + Tab (MAPPING §4): navigation only, panel is
           self-rendered below. */}

--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -8,12 +8,10 @@ import AgentDetailModal from '../AgentDetailModal';
 import SimpleProgressWithLabel from '../SimpleProgressWithLabel';
 import { Grid } from '@astryxdesign/core/Grid';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  MetadataList,
-  MetadataListItem,
-} from '@astryxdesign/core/MetadataList';
+import { MetadataListItem } from '@astryxdesign/core/MetadataList';
 import {
   BAIFlex,
+  BAIMetadataList,
   BAIText,
   convertToBinaryUnit,
   convertToDecimalUnit,
@@ -64,11 +62,9 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
 
   return (
     <>
-      {/* antd Descriptions bordered column={1} → MetadataList (MAPPING §4).
-          `bordered`/`labelStyle` have no destination and are dropped
-          (PILOT-DECISION, project-wide). Content is block-level (progress
-          grids), so the label sits above rather than beside it. */}
-      <MetadataList columns="single" label={{ position: 'top' }}>
+      {/* SUPERSEDED (FR-3497): `bordered` now has a destination — BAIMetadataList,
+          which implies side labels. Still dropped: `labelStyle` word-break. */}
+      <BAIMetadataList bordered columns="single">
         <MetadataListItem label={t('agent.ResourceAllocation')}>
           {/* antd Row gutter={[16,16]} + Col xs={24} sm={12} (uniform 2-up
               from 576px) → Grid columns={{minWidth:280, max:2}} gap={4}
@@ -401,7 +397,7 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
             </Grid>
           )}
         </MetadataListItem>
-      </MetadataList>
+      </BAIMetadataList>
       <AgentDetailModal
         agentNodeFrgmt={agent}
         open={openInfoModal}


### PR DESCRIPTION
Resolves #8664 (FR-3496)
Resolves #8665 (FR-3497)

One PR: same component, same drawer, one mechanism closes both.

## Mechanism

Both reports blame Astryx `MetadataList`. The component is fine — **the fix
already shipped and was never adopted.**

Under antd both surfaces were `Descriptions bordered`:

```
AgentDetailDrawerContent.tsx  <Descriptions bordered column={md ? 2 : 1} labelStyle={{wordBreak:'keep-all'}}>
AgentResources.tsx            <Descriptions bordered column={1}          labelStyle={{wordBreak:'keep-all'}}>
```
(`git show 7d7b42388^:<path>`)

The conversion mapped them to Astryx `MetadataList`, which has no `bordered`
counterpart, so each call site dropped the prop with a PILOT-DECISION note
reading *"`bordered` … have no destination and are dropped"*. That statement
went stale in the very commit that wrote it: **`BAIMetadataList` — the BUI
wrapper that restores the bordered look — landed in the same PR (#8626)**,
complete with `BAIMetadataList.css` (token-only), `BAIMetadataList.stories.tsx`
(6 stories incl. `Bordered`, `Sizes`, `MultiColumn`), and the `bordered` /
`size` props. `grep -rn BAIMetadataList react/src` on `main` returns **zero
call sites** — the wrapper has been sitting unused, so every converted surface
renders the plain variant.

So this is not "add a feature", it is "wire up the one that exists":

- **FR-3496 (no label/value divider)** — `bordered` paints the frame + cell
  lattice as the `<dl>` grid gap.
- **FR-3497 (labels above content)** — `BAIMetadataList` defaults `bordered`
  lists to `label={{ position: 'start' }}`, so the same prop flips the
  Resources tab back to side labels. `AgentResources.tsx` had an explicit
  `label={{ position: 'top' }}` override; removing it is the whole FR-3497 fix.

### The label-width finding

`AgentDetailDrawerContent` passed `label={{ position: 'start', width: md ? 160 : 120 }}`
— raw px the antd original never had. Astryx **ignores** `label.width` whenever
`columns` is a number > 1:

```ts
// @astryxdesign/core/src/MetadataList/MetadataList.tsx:264
if (typeof columns === 'number' && columns > 1)
  return isStacked ? `repeat(${columns}, 1fr)` : `repeat(${columns}, auto 1fr)`;
// ...only below this does labelConfig.width get read
```

Measured confirmation: at `md` (`columns={2}`) the before-state grid template is
`109px 326.5px 58px 326.5px` — auto-sized label tracks, **not** 160px. So the
prop was dead at `md` and live only below it. Dropped rather than tokenised: it
has no antd reference to preserve, and keeping it would have meant inventing a
size token for a value that was never measured from anything.

## Blast radius — measured

`@astryxdesign/core/MetadataList` is imported by **41 files** (39 in
`react/src`, 2 in `packages/backend.ai-ui/src`). This PR changes **2** of them —
the two named in the two reports.

**Per-call-site opt-in, not a default change.** `bordered` is opt-in by
construction (`BAIMetadataList.css` header: a theme `components:` variant is
impossible because `metadata-list` reflects only `columns`/`orientation`, and
`metadata-list-item.base` is flat per-component so it would repaint all 41).
Confirmed against `astryx component MetadataList` → Theming table:
`data-columns`, `data-orientation` only. The other 39 surfaces keep the plain
variant until someone reports them.

## Measured before / after

Storybook probe, Chromium, 900px viewport, `colorScheme` light and dark, DOM
`data-theme` asserted per pass. Values are `getComputedStyle` on the
`<dl>` / `<dt>` / `<dd>`.

### FR-3496 — drawer header list (`columns={2}`)

| Property | Before (light) | After (light) | Before (dark) | After (dark) |
|---|---|---|---|---|
| `dl` grid template | `109px 326.5px 58px 326.5px` | `157px 300px 106px 300px` | `109px 326.5px 58px 326.5px` | `157px 300px 106px 300px` |
| `dl` gap (row/col) | `16px / 16px` | `1px / 1px` | `16px / 16px` | `1px / 1px` |
| `dl` background | `rgba(0,0,0,0)` | `rgba(33,26,22,0.1)` | `rgba(0,0,0,0)` | `rgba(250,239,233,0.1)` |
| `dl` border-radius | `0px` | `8px` | `0px` | `8px` |
| `dl` align-items | `normal` | `stretch` | `normal` | `stretch` |
| `dt`/`dd` padding | `0px` | `16px 24px` | `0px` | `16px 24px` |
| `dd` background | `rgba(0,0,0,0)` | `rgb(255,251,248)` | `rgba(0,0,0,0)` | `rgb(33,26,22)` |
| `dt` label wash | `none` | `linear-gradient(rgba(33,26,22,0.05) ×2)` | `none` | `linear-gradient(rgba(33,26,22,0.5) ×2)` |

Before: transparent `<dl>`, 16px gaps, no rules — the reported "labels and
values float in plain whitespace". After: 1px lattice + 1px frame + 8px radius,
label column on a muted wash. Label track grows 109→157 / 58→106 = exactly the
2×24px cell padding.

### FR-3497 — Resources tab list (`columns="single"`)

| Property | Before (light) | After (light) | Before (dark) | After (dark) |
|---|---|---|---|---|
| `dl` grid template | `868px` | `177px 688px` | `868px` | `177px 688px` |
| `dt` top / `dd` top | `16` / `40` | `17` / `17` | `16` / `40` | `17` / `17` |
| **label beside value** | **false** | **true** | **false** | **true** |
| `dl` gap | `12px / 12px` | `1px / 1px` | `12px / 12px` | `1px / 1px` |
| `dt`/`dd` padding | `0px` | `16px 24px` | `0px` | `16px 24px` |

`dtTop === ddTop` after, `dtTop + 24 === ddTop` before — that is literally the
reported "label renders above its content", measured.

Zero `pageerror` across all 8 passes (2 modes × 4 stories).

### Probe caveat — read this before trusting the hex values

Storybook renders under its own seed theme (`data-astryx-theme="storybook-bai-brand"`,
`--color-background-card: light-dark(#FFFBF8, #211A16)`), **not** the app's
committed default. The *mechanism* is identical — same tokens, same CSS — but
the resolved colours differ from what ships. Resolved **statically** from the
committed artifact (`react/src/astryx-theme/built/bai-r11-default-brand-h165tsmd.js`):

| Token | Light | Dark |
|---|---|---|
| `--color-background-card` (cell fill) | `#FFFFFF` | `#141414` |
| `--color-background-surface` (drawer body, `@astryxdesign/lab/Drawer:121`) | `#FFFFFF` | `#141414` |
| `--color-background-muted` (label wash) | `rgba(0,0,0,0.04)` | `rgba(255,255,255,0.08)` |
| `--color-border` (frame + rules) | `#F0F0F0` | `#303030` |
| `--radius-element` | `8px` | `8px` |

Two things this settles: the default cell fill (`--color-background-card`) is
**byte-identical to the drawer's own surface** in both modes, so no
`--bai-metadata-list-cell-bg` override is needed here; and in the app theme the
dark label wash is white@8% (label column reads *lighter* than the cells),
whereas Storybook's brand seeds make it read *darker*. Both are visible; the
direction differs by theme.

**A live in-app probe was NOT performed** — no Backend.AI backend or credentials
are configured on this box (`e2e/envs/.env.playwright` absent, no `config.toml`,
no reachable cluster), so `/admin/agent` cannot be reached. Everything above is
Storybook-live for layout/geometry and static for the app's colour resolution.

### Screenshots (Storybook seeds, see caveat)

<details><summary>After — header list, light / dark</summary>

Light: 3 rows × (label | value | label | value), 1px rules, 8px frame, muted
label columns. Dark: same lattice, `rgb(33,26,22)` cells on `rgb(24,15,8)` page.
</details>

## Verification

| Command | Result |
|---|---|
| `bash scripts/verify.sh` | `=== ALL PASS ===` — Relay PASS, Lint PASS, Format PASS, TypeScript PASS, Vite warmup PASS, StyleX cssInjectionTarget PASS, Astryx theme build PASS, Terminology PASS (0 blocking, 0 warn), self-test 409 assertions hold |
| `pnpm --filter backend.ai-ui build` | exit 0 — `dist/backend.ai-ui.css 52.77 kB`, `dist/backend.ai-ui.js 1,875.71 kB`; `bai-metadata-list--bordered{,-middle,-small}` + `>dl`, `>dl>dt`, `>dl>dd` all present in the emitted CSS |
| `pnpm --prefix ./react exec vitest run` | **66 files passed, 1166 tests passed** |
| `pnpm --filter backend.ai-ui exec vitest run` | **41 passed / 1 skipped (42 files), 583 passed / 1 skipped (584 tests)** |
| `node scripts/migration-gates/astryx-token-gate.mjs --strict` | 259 declared props, 760 var() usages, **2 undeclared — both pre-existing on `main`**: `BAIText.css:27`, `BAIText.tsx:230`. Not mine; this PR adds no CSS and touches no BUI source. |

## Residue

**Not closed by this PR:**

- **The other 39 `MetadataList` call sites.** `UserInfoModal`,
  `ResourceGroupInfoModal`, `VFolderNodeDescription`, `KeypairInfoModal`,
  `SessionDetailContent`, … all still render the plain variant, and many were
  `Descriptions bordered` under antd too. Deliberate: `bordered` is opt-in, and
  both reports scoped themselves to this drawer ("Scope as reported: this
  drawer only"). Anyone wanting a project-wide sweep should open a separate
  issue — the mechanism is now a one-word prop change per site.
- **`labelStyle={{ wordBreak: 'keep-all' }}`** — both antd originals carried it,
  for CJK label wrapping. `MetadataListItem` has no equivalent slot and neither
  report mentions it. Still dropped; the PILOT-DECISION comments say so.
- **Per-item `span`** (`AgentDetailDrawerContent` had `span={md ? 2 : 1}` on 4 of
  6 items). Astryx `MetadataListItem` has no column-span. Still dropped, still
  noted at the call site. Visible consequence: items that used to run full-width
  at `md` now occupy one of the two column pairs.
- **The label-column width below `md`.** Removing the dead `width` also removes
  the live `120px` at narrow widths; the label track is now content-sized. This
  matches antd (which had no fixed width) but is a real, if small, change under
  `md`. Not separately probed at a narrow viewport.
- **No live in-app probe** — see the caveat above.

**Sibling reports — subsumption:**

- **Subsumes FR-3497 (#8665) fully.** Same drawer, same component; `bordered`
  implying side labels closes it in the same prop, hence one PR.
- **Does NOT subsume any other FR-3491 report.** In particular this touches no
  theme file — `react/src/astryx-theme/backendAiTheme.ts` and
  `packages/backend.ai-ui/src/theme-shim/antdParity.ts` are untouched,
  `THEME_NAME_REV` stays at 11, and the built artifact
  `bai-r11-default-brand-h165tsmd.*` is unchanged. If a sibling workstream
  concluded a theme custom-variant was the answer here: it is not available —
  `astryx component MetadataList` reports the component reflects only
  `data-columns` / `data-orientation`, so a `variant:bordered` key would never
  render. The CSS wrapper is the only route, and it already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
