### PR TITLE
style(FR-3512): restore the sider footer's supporting size and muted rest tone

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -30,6 +30,8 @@ import { Link } from '@astryxdesign/core/Link';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
 import { useTheme } from '@astryxdesign/core/theme';
+import { colorVars } from '@astryxdesign/core/theme/tokens.stylex';
+import * as stylex from '@stylexjs/stylex';
 import {
   filterOutEmpty,
   useHover,
@@ -40,6 +42,17 @@ import { ArrowLeftIcon, ShieldUserIcon } from 'lucide-react';
 import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+
+const styles = stylex.create({
+  // `Link`'s own `color` lands on the inner `Text` too, so a rest/hover pair
+  // needs `color="inherit"` plus this override on the anchor. FR-3512.
+  footerLink: {
+    color: {
+      default: colorVars['--color-text-secondary'],
+      ':hover': colorVars['--color-text-accent'],
+    },
+  },
+});
 
 interface WebUISiderProps {
   collapsed?: boolean;
@@ -275,13 +288,8 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       }
       footer={
         props.collapsed ? undefined : (
-          // PILOT-DECISION: the footer used to be a `Typography.Text
-          // type="secondary"` wrapping a `<div class="terms-of-use">` with
-          // three `Typography.Link type="secondary"` entries at a hand-set
-          // 11px. Astryx `Link` has no `type="secondary"` and no font-size
-          // prop (closed enums, P5), so the links take the default link
-          // treatment and the block keeps only its `supporting` text tone.
-          // The `data-testid`s are preserved — the e2e suite anchors on them.
+          // Chrome-level block: links stay at `supporting` size and secondary
+          // tone at rest, taking the accent only on hover. FR-3512.
           <VStack
             gap={2}
             align="center"
@@ -292,6 +300,9 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
             <HStack gap={1} justify="center" wrap="wrap">
               <Link
                 data-testid="button-terms-of-service"
+                type="supporting"
+                color="inherit"
+                xstyle={styles.footerLink}
                 href="#"
                 onClick={(e) => {
                   e.preventDefault();
@@ -303,6 +314,9 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
               <Text type="supporting">·</Text>
               <Link
                 data-testid="button-privacy-policy"
+                type="supporting"
+                color="inherit"
+                xstyle={styles.footerLink}
                 href="#"
                 onClick={(e) => {
                   e.preventDefault();
@@ -314,6 +328,9 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
               <Text type="supporting">·</Text>
               <Link
                 data-testid="button-about-backend-ai"
+                type="supporting"
+                color="inherit"
+                xstyle={styles.footerLink}
                 href="#"
                 onClick={(e) => {
                   e.preventDefault();
@@ -327,6 +344,9 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
                   <Text type="supporting">·</Text>
                   <Link
                     data-testid="button-leave-service"
+                    type="supporting"
+                    color="inherit"
+                    xstyle={styles.footerLink}
                     href="#"
                     onClick={(e) => {
                       e.preventDefault();
@@ -338,7 +358,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
                 </>
               )}
             </HStack>
-            <Text type="supporting" as="div">
+            <Text type="supporting" size="xsm" as="div">
               <address className="sidebar-footer">
                 {themeConfig?.branding?.companyName || 'Lablup Inc.'}
                 &nbsp;


### PR DESCRIPTION
Resolves #8688 (FR-3512)

## Mechanism

Not a missing capability — a **doc gap that the migration trusted**.

The `PILOT-DECISION` comment this PR deletes claimed:

> Astryx `Link` has no `type="secondary"` and no font-size prop (closed enums, P5)

That is false. `Link` declares `type` / `size` / `weight` / `color` and forwards
all four to the inner `Text`
(`@astryxdesign/core/src/Link/Link.tsx:230-252` and `:339-345`; shipped types at
`dist/Link/Link.d.ts:110-123`). They are simply **absent from
`pnpm exec astryx component Link`'s props table**, which is what the migration
author read. So the footer links silently fell back to the defaults:

| | pre-migration | after migration (the bug) |
|---|---|---|
| size | hand-set `11px` (`style={{ fontSize: 11 }}`) | `type='body'` → `--text-body-size` → `--font-size-base` = **14px** |
| rest colour | `type="secondary"` → antd `colorTextDescription` | `color='accent'` (Link.tsx:311) → `--color-text-accent` = **brand orange** |

Pre-migration source recovered with
`git show 7d7b42388^:react/src/components/MainLayout/WebUISider.tsx` (7d7b42388 =
the antd→Astryx migration, the only commit that touched this footer).

**Why `color="inherit"` + `xstyle` rather than just `color="secondary"`.**
`Link` passes its `color` to *both* the anchor (`linkColorStyles`) and the inner
`Text` (`colorStyles`), and `Text`'s variants set a **hard colour on the span**
(`text.stylex.ts:30-32`). A hover colour declared on the anchor therefore never
reaches the label. `color="inherit"` is the only variant that makes the span
transparent to inheritance (`text.stylex.ts:42-43`), after which a StyleX
`xstyle` rest/hover pair on the anchor drives both. `xstyle` is the **last**
argument to `stylex.props` in every `Link` branch, so it needs no cascade fight.

`--color-text-tertiary` does not exist in Astryx's ramp (primary / secondary /
disabled / placeholder / accent + named hues), so `secondary` **is** the weakest
legitimate text tier — that is why the rest tone is `secondary` and not
something fainter.

## Before / after

Sider surface is `--color-background-surface` = `#FFFFFF` light / `#141414` dark
(`SIDE_NAV_DENSITY`, `backendAiTheme.ts:519-522`).

### Size — static (token arithmetic; root is 16px, no `html { font-size }`
override exists in the repo)

| element | before | after | token |
|---|---|---|---|
| 4 footer links | 14px | **12px** | `type="supporting"` → `--text-supporting-size` → `--font-size-sm` (0.75rem) |
| `·` separators | 12px | 12px (unchanged) | already `type="supporting"` |
| company / version `address` | 12px | **10px** | `size="xsm"` → `--font-size-xs` (0.625rem) |

There is **no 11px rung** on Astryx's size ladder — the neighbours are
`--font-size-xs` (10px) and `--font-size-sm` (12px). 12px was chosen because it
is the *semantic* type for low-emphasis chrome and it already matches the `·`
separators; the **+1px vs the pre-migration 11px is recorded as residue, not
rounded away**.

### Colour + contrast — static (WCAG 2.x sRGB, computed from the built theme
artifact `react/src/astryx-theme/built/backendai-default-built.css`)

| state | light | dark |
|---|---|---|
| **rest — before** (`--color-text-accent`) | `#FF7A00` on `#FFFFFF` = **2.61:1** ❌ AA | `#be5e06` on `#141414` = **4.20:1** ❌ AA (normal text) |
| **rest — after** (`--color-text-secondary`) | `#595959` on `#FFFFFF` = **7.00:1** ✅ AA + AAA | `#ADADAD` on `#141414` = **8.21:1** ✅ AA + AAA |
| **hover — after** (`--color-text-accent` + underline) | 2.61:1 | 4.20:1 |
| *(reference)* legacy antd `type="secondary"` rgba(0,0,0,0.45) | 3.36:1 | 4.54:1 |

So the rest state is not merely "more muted" — it goes from **failing** AA to
passing AAA in both modes, and it is also stronger than the pre-migration antd
tone it replaces (which itself failed AA in light). That is why the target tone
is `secondary` and not a faithful copy of `rgba(0,0,0,0.45)`.

**Hover** is `underline` (already in `Link`'s `styles.base`, `:hover`) **+ the
link colour**, per the issue's stated Expected. Its 2.61:1 / 4.20:1 is *lower*
than the rest state — deliberately called out rather than buried: hover is
transient, it is the same accent every other link in the app uses, and the
underline is a non-colour affordance that carries the "clickable" signal on its
own. If a reviewer would rather the hover kept AA, the one-word change is
`--color-text-accent` → `--color-text-primary` in the `xstyle` block; say so and
I will flip it.

### The mechanism verified in the **shipped bundle**, not just in the diff

`pnpm run build:react-only`, then grepping the entry stylesheet
`react/build/assets/index-DxqfnmqT.css` for the two compiled atomics:

```
.xv1l7n4:not(#\#):not(#\#) { color: var(--color-text-secondary); }
.x41ne37:hover:not(#\#):not(#\#) { color: var(--color-text-accent); }
```

Both are present, unlayered, in the entry CSS — i.e. the rest/hover pair
survives the production StyleX pipeline and is not a dev-only artifact. (This
matters here: `react/vite.config.ts` runs `@stylexjs/unplugin` with
`useCSSLayers: false`, and a theme-layer approach to the same problem would have
been outranked by the unlayered copy — the trap already written up in
`react/src/components/BAISider.css:180-232`.)

## Verification bar — actual output

| command | result |
|---|---|
| `bash scripts/verify.sh` | `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, StyleX `cssInjectionTarget`, Astryx theme build, Terminology 0 blocking / 0 warn, self-test `PASS — 409 assertion(s) hold`) |
| `pnpm --prefix ./react exec vitest run` | `Test Files 66 passed (66)` · `Tests 1166 passed (1166)` |
| `pnpm --filter backend.ai-ui exec vitest run` | `Test Files 41 passed \| 1 skipped (42)` · `Tests 583 passed \| 1 skipped (584)` |
| `node scripts/migration-gates/astryx-token-gate.mjs --strict` | `declared 259 \| checked 760 \| undeclared: 2` — **both pre-existing on `main`**: `BAIText.css:27 var(--x)` and `BAIText.tsx:230 var(--font-family-mono)`. Neither is in this diff; this PR touches no BUI file. |
| `pnpm --filter backend.ai-ui build` | `✓ built in 28.48s`. **Not** required by this change (nothing under `packages/backend.ai-ui/src` is touched) — it was needed only because this is a fresh worktree and `verify.sh`'s `astryx theme build --check` imports the *built* `backend.ai-ui`. First run without it failed with `No "exports" main defined in .../backend.ai-ui/package.json`; that failure was environmental, not this edit. |
| `pnpm run build:react-only` | `✓ built in 2m` (used for the compiled-CSS check above) |

No theme edit. `THEME_NAME_REV` stays at **11** and the committed
`bai-r11-default-brand-h165tsmd.*` artifacts are untouched — every value here
comes from props that already exist on Astryx `Link` plus two token references.

## Residue

- **No live app probe.** There is no Backend.AI endpoint or credentials on this
  box (`e2e/envs/.env.playwright` absent, no `config.toml`, no reachable
  cluster), and the sider footer only renders after login. Storybook does not
  cover it either — `WebUISider` lives in `react/src`, not
  `packages/backend.ai-ui`. **Every number above is static**: token values read
  from the built theme artifact, sizes from the token ladder, contrast computed
  with the WCAG 2.x sRGB formula, and the rest/hover rules grepped out of the
  production bundle. A reviewer with a cluster should confirm on screen in
  **both** modes and attach a screenshot; I have not claimed one.
- **+1px vs pre-migration.** Links land on 12px where the antd original hand-set
  11px. 11px is not on Astryx's ladder; see the size table.
- **The `·` separators are unchanged at 12px.** They were 8px pre-migration
  (`token.sizeXS`). They now match the links exactly, which reads better than
  restoring the old mismatch — flagging it as a deliberate deviation, not an
  oversight. `size="2xs"` (8px) is available if the reviewer prefers parity.
- **Hover contrast is below AA** (2.61:1 light / 4.20:1 dark) — see the colour
  table for why that is the accepted trade and how to flip it.
- **Sider under `AstryxReverseTheme`.** When the operator sets `sider.theme` in
  `theme.json`, the sider renders inverted (`WebUISider.tsx:418-434`). Both
  tones are token-driven so they invert cleanly, but that configuration was not
  probed.
- **Does NOT subsume FR-3495** ("BAIModal: header title renders smaller than the
  modal footer area"), the linked sibling. FR-3512's own report hedged that the
  two "may share a surface with typography scale drift" — they do not: this was
  a wrong `PILOT-DECISION` about one component's props, entirely local to
  `WebUISider.tsx`. FR-3495 needs its own diagnosis.
- **The doc gap itself is not closed.** `astryx component Link` still omits
  `type` / `size` / `weight` / `color`, so the next reader can make the same
  mistake on a different component. Worth an upstream report against
  `@astryxdesign/cli`; out of scope here.

## Files changed

- `react/src/components/MainLayout/WebUISider.tsx` — 4 `<Link>` get
  `type="supporting" color="inherit" xstyle={styles.footerLink}`, the `address`
  `<Text>` gets `size="xsm"`, a module-scope `stylex.create` block is added, and
  the stale 7-line `PILOT-DECISION` becomes 2 lines
  (`.claude/rules/comment-density.md`).

All four `data-testid`s (`button-terms-of-service`, `button-privacy-policy`,
`button-about-backend-ai`, `button-leave-service`) are preserved.
