### PR TITLE
refactor(FR-3509): draw the notification tooltip's shortcut badge with Astryx Kbd

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIText.css
+++ b/packages/backend.ai-ui/src/components/BAIText.css
@@ -6,18 +6,19 @@
  component itself (P17), so the rules travel with it and cannot rot in an app
  stylesheet.
 
- JUSTIFICATION for per-component CSS (the policy asks for one). Three of antd
+ JUSTIFICATION for per-component CSS (the policy asks for one). Two of antd
  `Typography.Text`'s decorations have NO Astryx counterpart and no theme knob:
 
-   `keyboard` (9 sites)  Astryx `Kbd` takes a `keys: string` shortcut spec
-                         ("mod+k") and renders ITS OWN glyphs. Our call sites
-                         pass arbitrary children (a token, a path fragment),
-                         so `Kbd` cannot carry them — the box is rebuilt here.
    `mark` (4 sites)      no Astryx equivalent at all (MAPPING §3.4: "NONE —
                          self-build").
    `code` box padding    Astryx `Code` styles the glyph run; the surrounding
                          chip padding antd drew is added back so the 16 `code`
                          sites keep their footprint.
+
+ `keyboard` used to be a third: its box was rebuilt here because Astryx `Kbd`
+ takes a `keys: string` spec rather than children. FR-3509 retired the prop —
+ the one production call site passed a single literal key, which `Kbd` renders
+ verbatim — so shortcut badges are `Kbd` at the call site now.
 
  The copy-control row is layout, not decoration: the text must still measure
  its own ellipsis box, so the control is a sibling in an inline flex row.
@@ -43,34 +44,6 @@
 /* The copy glyph rides with the text; it must not stretch the row. */
 .bai-text-row > .bai-text-copy {
   flex-shrink: 0;
-}
-
-/* antd `Typography.Text keyboard` — the <kbd> chip. */
-.bai-text-kbd {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.15em 0.4em;
-  font-family: var(--font-family-code);
-  font-size: 0.9em;
-  background-color: var(--color-background-muted);
-  border: 1px solid var(--color-border-emphasized);
-  border-radius: var(--radius-inner);
-  box-shadow: 0 2px 0 var(--color-border);
-}
-
-/*
- The light-bordered variant used on the dark notification surface, where the
- chip sits on an inverted background and must borrow the surrounding color.
- antd expressed it as an inline `rgba(255,255,255,0.6)` border; the token
- counterpart on an inverted surface is the on-dark text color at the same
- role.
-*/
-.bai-text-kbd--light {
-  color: inherit;
-  margin: 0;
-  background-color: transparent;
-  border-color: var(--color-on-dark);
-  box-shadow: none;
 }
 
 /* antd `Typography.Text mark` — the highlighter. */

--- a/packages/backend.ai-ui/src/components/BAIText.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.stories.tsx
@@ -1,11 +1,12 @@
 import BAICard from './BAICard';
 import BAIFlex from './BAIFlex';
 import BAIText from './BAIText';
+import { Kbd } from '@astryxdesign/core/Kbd';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 /**
  * BAIText keeps an Ant Design Typography.Text-shaped prop surface (`type`,
- * `strong`, `ellipsis`, `copyable`, `code`, `keyboard`, ...) for call-site
+ * `strong`, `ellipsis`, `copyable`, `code`, `mark`, ...) for call-site
  * compatibility, but renders through Astryx's `Text` primitive internally.
  *
  * Key features:
@@ -25,7 +26,7 @@ const meta: Meta<typeof BAIText> = {
     docs: {
       description: {
         component: `
-**BAIText** keeps an [Ant Design Typography.Text](https://ant.design/components/typography)-shaped prop surface for call-site compatibility, and renders through Astryx's \`Text\` primitive (\`@astryxdesign/core/Text\`) internally — with \`code\`/\`keyboard\`/\`mark\` box treatments, an \`ellipsis\`-driven tooltip, and a self-built \`copyable\` control (\`IconButton\` + \`navigator.clipboard\`) layered on top.
+**BAIText** keeps an [Ant Design Typography.Text](https://ant.design/components/typography)-shaped prop surface for call-site compatibility, and renders through Astryx's \`Text\` primitive (\`@astryxdesign/core/Text\`) internally — with \`code\`/\`mark\` box treatments, an \`ellipsis\`-driven tooltip, and a self-built \`copyable\` control (\`IconButton\` + \`navigator.clipboard\`) layered on top.
 
 ## BAI-Specific Props
 | Prop | Type | Default | Description |
@@ -143,14 +144,6 @@ For all other props, see \`BAIText.tsx\` — the antd-shaped types (\`BAITextEll
     code: {
       control: { type: 'boolean' },
       description: 'Inline code styling with background and border',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-    keyboard: {
-      control: { type: 'boolean' },
-      description: 'Keyboard shortcut styling with shadow effect',
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'false' },
@@ -575,23 +568,25 @@ export const Interactive: Story = {
 export const Keyboard: Story = {
   name: 'KeyboardShortcuts',
   render: () => (
-    <BAIFlex direction="column">
+    <BAIFlex direction="column" gap="md" align="start">
       <div>
-        <BAIText keyboard>Ctrl</BAIText> + <BAIText keyboard>C</BAIText>
+        <BAIText type="secondary">Copy: </BAIText> <Kbd keys="mod+c" />
       </div>
       <div>
-        <BAIText keyboard>Cmd</BAIText> + <BAIText keyboard>Shift</BAIText> +{' '}
-        <BAIText keyboard>P</BAIText>
+        <BAIText type="secondary">Quick open: </BAIText>{' '}
+        <Kbd keys="mod+shift+p" />
       </div>
       <div>
-        Press <BAIText keyboard>Enter</BAIText> to submit
+        <BAIText type="secondary">A single literal key: </BAIText>{' '}
+        <Kbd keys="]" />
       </div>
     </BAIFlex>
   ),
   parameters: {
     docs: {
       description: {
-        story: 'Display keyboard shortcuts with keyboard styling.',
+        story:
+          'Shortcut badges are Astryx `Kbd`, not a `BAIText` prop — `keyboard` / `keyboardWithLightBorder` were retired in FR-3509. `Kbd` takes a `keys` spec rather than children; a key it does not know (`]`) is rendered verbatim. On an inverted surface such as a tooltip, wrap the tooltip\'s CONTENT — never the whole `Tooltip` — in `MediaTheme mode="dark"`, or `Kbd` resolves its tokens against the page surface and disappears (see `SiderToggleButton` / `BAINotificationButton`).',
       },
     },
   },
@@ -742,18 +737,14 @@ export const RealWorldExamples: Story = {
         styles={{ body: { paddingTop: 0 } }}
       >
         <BAIText type="secondary">To copy the command: </BAIText>
-        <BAIText keyboard>Ctrl</BAIText>
-        <BAIText type="secondary"> + </BAIText>
-        <BAIText keyboard>C</BAIText>
+        <Kbd keys="mod+c" />
         <br />
         <BAIText code copyable>
           git clone repository.git
         </BAIText>
         <br />
         <BAIText type="secondary">Quick Open: </BAIText>
-        <BAIText keyboard copyable ellipsis>
-          Ctrl+Shift+P+Alt+Meta+Super
-        </BAIText>
+        <Kbd keys="mod+shift+p" />
       </BAICard>
 
       <BAICard

--- a/packages/backend.ai-ui/src/components/BAIText.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.stories.tsx
@@ -586,7 +586,7 @@ export const Keyboard: Story = {
     docs: {
       description: {
         story:
-          'Shortcut badges are Astryx `Kbd`, not a `BAIText` prop — `keyboard` / `keyboardWithLightBorder` were retired in FR-3509. `Kbd` takes a `keys` spec rather than children; a key it does not know (`]`) is rendered verbatim. On an inverted surface such as a tooltip, wrap the tooltip\'s CONTENT — never the whole `Tooltip` — in `MediaTheme mode="dark"`, or `Kbd` resolves its tokens against the page surface and disappears (see `SiderToggleButton` / `BAINotificationButton`).',
+          'Shortcut badges are Astryx `Kbd`, not a `BAIText` prop — `keyboard` / `keyboardWithLightBorder` were retired in FR-3509. `Kbd` takes a `keys` spec rather than children; a key it does not know (`]`) is rendered verbatim. Match the `MediaTheme` to the surface the badge actually sits on, rather than assuming one: `useTooltip` hardcodes its bubble colours without flipping token context, so on a DARK bubble the content must be wrapped in `MediaTheme mode="dark"` (never the whole `Tooltip`) or `Kbd` resolves against the page surface and disappears. The host app pins its tooltip dark in BOTH modes via `ANTD_HOVER_PARITY`, which is why `SiderToggleButton` / `BAINotificationButton` do exactly that; this Storybook has no such pin, so its own tooltip is light and the same wrapper would be wrong here.',
       },
     },
   },

--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -6,7 +6,7 @@
 
  FRONTIER COMPONENT. 276 call sites in 62 files pass antd `Typography.Text`
  props (`type`, `strong`, `ellipsis={{rows,tooltip}}`, `copyable`, `code`,
- `keyboard`, `mark`, `delete`, `monospace`, …). Per the frontier rule the
+ `mark`, `delete`, `monospace`, …). Per the frontier rule the
  PUBLIC prop surface stays antd-SHAPED so none of those files change; only the
  internals move to Astryx. The antd *import* is gone though — the prop types
  are declared locally here (`BAITextEllipsisConfig`, `BAITextCopyConfig`)
@@ -27,8 +27,8 @@
    delete                          -> hasStrikethrough
    ellipsis / ellipsis={{rows}}    -> maxLines (+ hasTruncateTooltip)
    code                            -> <Code>
-   keyboard                        -> <Kbd> when the content is a shortcut
-                                      string, else the Kbd-ish box below
+   keyboard                        -> RETIRED (FR-3509). Shortcut badges are
+                                      Astryx `Kbd` at the call site.
    copyable                        -> self-built (Astryx has no `copyable`);
                                       IconButton + navigator.clipboard, the
                                       same shape the pilot's BAICopyableText
@@ -93,14 +93,11 @@ export interface BAITextProps extends Omit<
   delete?: boolean;
   mark?: boolean;
   code?: boolean;
-  keyboard?: boolean;
   disabled?: boolean;
   monospace?: boolean;
   /** CSS-based ellipsis (multi-line via `rows`), with an optional tooltip. */
   ellipsis?: boolean | BAITextEllipsisConfig;
   copyable?: boolean | BAITextCopyConfig;
-  /** Legacy variant used by the notification/keyboard-hint surfaces. */
-  keyboardWithLightBorder?: boolean;
 }
 
 const TYPE_TO_COLOR: Record<BAITextType, NonNullable<TextProps['color']>> = {
@@ -197,8 +194,6 @@ const BAIText: React.FC<BAITextProps> = ({
   delete: deleteProp,
   mark,
   code,
-  keyboard,
-  keyboardWithLightBorder,
   disabled,
   type,
   ...restProps
@@ -263,22 +258,11 @@ const BAIText: React.FC<BAITextProps> = ({
     </Text>
   );
 
-  // `code` / `keyboard` / `mark` are box treatments antd painted around the
-  // text. `Code` is Astryx-native; `keyboard` and `mark` have no counterpart
-  // and are rendered by the two co-located classes in BAIText.css (tokens
-  // only, justified there).
+  // `code` / `mark` are box treatments antd painted around the text. `Code` is
+  // Astryx-native; `mark` has no counterpart and is rendered by a co-located
+  // class in BAIText.css (tokens only, justified there).
   const boxed = code ? (
     <Code className="bai-text-code">{textNode}</Code>
-  ) : keyboard || keyboardWithLightBorder ? (
-    <span
-      className={
-        keyboardWithLightBorder
-          ? 'bai-text-kbd bai-text-kbd--light'
-          : 'bai-text-kbd'
-      }
-    >
-      {textNode}
-    </span>
   ) : mark ? (
     <mark className="bai-text-mark">{textNode}</mark>
   ) : (

--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -7,9 +7,9 @@ import useKeyboardShortcut from '../hooks/useKeyboardShortcut';
 import WEBUINotificationDrawer from './WEBUINotificationDrawer';
 import BAIBadgeCountAstryx from './astryx-bui/BAIBadgeCountAstryx';
 import { IconButton } from '@astryxdesign/core/IconButton';
+import { Kbd } from '@astryxdesign/core/Kbd';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { MediaTheme } from '@astryxdesign/core/theme';
-import { BAIText } from 'backend.ai-ui';
 import { t } from 'i18next';
 import { atom, useAtom } from 'jotai';
 import * as _ from 'lodash-es';
@@ -54,53 +54,19 @@ const BAINotificationButton: React.FC<BAINotificationButtonProps> = ({
     return n.backgroundTask?.status === 'pending';
   });
 
-  // This button only ever renders on `WebUIHeader`'s brand-accent band. The
-  // three nested `ReverseThemeProvider`s here were the legacy way to force the
-  // bell to the OPPOSITE polarity of the page so it read white on the orange —
-  // but "opposite of the page" only coincides with white in light mode: in dark
-  // mode the flip resolves to the LIGHT palette and painted the bell near-black
-  // (measured `rgb(20,20,20)`) on a still-orange band.
+  // TRAP (measured, twice). `MediaTheme` must wrap the tooltip CONTENT, never
+  // the whole `Tooltip`: `Tooltip` renders trigger and `[popover]` panel as
+  // SIBLINGS, so wrapping it pinned `color-scheme: dark` on the panel in both
+  // app modes and Astryx's inverted tooltip surface then resolved to WHITE —
+  // white on white (`bg rgb(255,255,255)` / `color rgb(255,255,255)`).
+  // The mode is the CONSTANT "dark", not the opposite of the app's:
+  // `ANTD_HOVER_PARITY` pins the bubble to `colorBgSpotlight`
+  // (`rgba(0,0,0,0.85)` / `#424242`), dark in BOTH schemes. QA-FINDINGS Q-10.
   //
-  // The band is a dark surface in BOTH modes, so the glyph is simply "on dark".
-  // Naming that directly (`--color-on-dark`, `#ffffff` in both modes) drops two
-  // of the three providers and the `Typography.Text` whose only job was to
-  // supply a colour, and matches what `WebUIHeader` now does for the rest of
-  // the band.
-  //
-  // The last provider is gone too (final switch). It was still an antd
-  // `ConfigProvider`, and by then nothing under it was an antd component —
-  // the tooltip, the button and the badge are all Astryx — so it re-themed
-  // exactly nothing. `MediaTheme mode="dark"` is the live replacement and the
-  // same primitive `WebUIHeader` wraps the sibling band controls
-  // (`WebUIThemeToggleButton`, `WEBUIHelpButton`) in, so the tooltip panel now
-  // matches theirs instead of following the page polarity.
-  //
-  // It wraps ONLY the trigger. `WEBUINotificationDrawer` stays outside on
-  // purpose: Astryx renders overlays as inline siblings rather than through a
-  // portal (measured — see `UserDropdownMenu.tsx`), so a drawer inside this
-  // context would paint as a dark surface in light mode.
-  //
-  // ...and the TOOLTIP is such an overlay too. `Tooltip` renders
-  // `<div display:contents>{trigger}</div>` and its `[popover]` panel as
-  // SIBLINGS, so a `MediaTheme` wrapped around the whole `Tooltip` reached the
-  // panel as well and pinned `color-scheme: dark` on it in BOTH app modes.
-  // Astryx's tooltip surface is deliberately INVERTED (`light-dark()` the other
-  // way round), so the forced dark scheme resolved it to WHITE while the
-  // on-dark tokens painted the content `--color-on-dark` — white text on a
-  // white tooltip, illegible in light *and* dark mode (measured
-  // `bg rgb(255,255,255)` / `color rgb(255,255,255)`).
-  //
-  // So the on-dark context now sits on the trigger BUTTON itself
-  // (`data-astryx-media="dark"` is exactly what `MediaTheme` renders — a
-  // wrapper is only needed when several elements share the context), and the
-  // tooltip CONTENT takes the tooltip surface's own luminance, the same recipe
-  // `SiderToggleButton` uses.
-  //
-  // That luminance is now CONSTANT. The theme pins the bubble to antd's
-  // `colorBgSpotlight` (`rgba(0,0,0,0.85)` / `#424242` — dark in both schemes,
-  // `ANTD_HOVER_PARITY`), so it no longer follows the app polarity and the
-  // content mode is a plain `"dark"` rather than the opposite of the app's.
-  // QA-FINDINGS Q-10.
+  // The band's on-dark context sits on the trigger BUTTON via
+  // `data-astryx-media` (MediaTheme's own mechanism, at element scope) so the
+  // sibling panel does not inherit it; `WEBUINotificationDrawer` stays outside
+  // for the same reason — Astryx overlays are inline siblings, not portalled.
   return (
     <>
       {/* antd `Tooltip title` -> `content`; `placement="left"` -> `"start"`
@@ -108,8 +74,7 @@ const BAINotificationButton: React.FC<BAINotificationButtonProps> = ({
       <Tooltip
         content={
           <MediaTheme mode="dark">
-            {t('notification.Notifications')}{' '}
-            <BAIText keyboardWithLightBorder>{']'}</BAIText>
+            {t('notification.Notifications')} <Kbd keys="]" />
           </MediaTheme>
         }
         placement="start"


### PR DESCRIPTION
Resolves #8683 (FR-3509)

## Mechanism

`BAIText`'s own header stated the intent as "`keyboard` -> `<Kbd>` when the
content is a shortcut string, else the Kbd-ish box below" — but the
implementation rendered the hand-rolled `<span class="bai-text-kbd">`
unconditionally. The reason is recorded in `BAIText.css`'s header:

> `keyboard` (9 sites)  Astryx `Kbd` takes a `keys: string` shortcut spec
> ("mod+k") and renders ITS OWN glyphs. Our call sites pass arbitrary children
> (a token, a path fragment), so `Kbd` cannot carry them — the box is rebuilt here.

**That justification had expired, and the "9 sites" was the load-bearing error.**
Measured across the whole repo:

| | production call sites | Storybook-only |
|---|---|---|
| `keyboardWithLightBorder` | **1** — `BAINotificationButton.tsx:112`, content `']'` | 0 |
| `keyboard` | **0** | 9 usages + 1 `argTypes` entry |

The issue body's "~9 components" list (`VFolderTextFileEditorModal`,
`LoginFormPanel`, `ProjectSelect`, `MyKeypairManagementModal`,
`FolderExplorerModal`, `AssignRoleModal`, `BAIQuestionIconWithTooltipAstryx`)
is a grep artifact: **every one** of those is `BAIModal`'s unrelated `keyboard`
prop (close-on-Escape) or the word "keyboard" in a comment. None is a shortcut
badge. Verified individually — none was touched.

So the single production call site passed **one literal key**, and `Kbd` renders
any key absent from `KEY_DISPLAY` verbatim (`Kbd.tsx:83-88`,
`KEY_DISPLAY[key] ?? key.toUpperCase()` — `']'` is not in the map, exactly as
`'['` is not, which is what `SiderToggleButton.tsx:87` already relies on). The
stated blocker did not apply to any live code.

With that call site converted, both props have **zero** consumers, so they and
their two now-dead CSS classes are retired rather than left as a second way to
draw a badge — that being the whole point of the ticket. This is
**option 1** from the issue. Option 2 (keep the props, render `Kbd` internally)
is not coherent: `Kbd` takes `keys: string` and no children, so
`<BAIText keyboard>Ctrl</BAIText>` would render `CTRL`, and the composed
`<BAIText keyboard copyable ellipsis>` case is inexpressible.

## The `MediaTheme` trap — already remedied, verified not re-broken

The brief flagged this as "expect to hit this": `Tooltip` renders trigger and
`[popover]` panel as **siblings** with `display: contents`, and `useTooltip`
inverts its surface by hardcoding colours **without** flipping the token
context — so a nested `Kbd` resolves `--color-neutral` / `--color-text-secondary`
against the *page* and can come out invisible.

Both header sites already carry the remedy (`MediaTheme mode="dark"` around the
tooltip **CONTENT**, never the whole `Tooltip`), so this PR **did not need to add
it** — only to not break it. Two specifics deliberately left alone:

- the wrapper stays on the CONTENT. Hoisting it to the `Tooltip` pins
  `color-scheme: dark` on the panel in both app modes and produced measured
  white-on-white (`bg rgb(255,255,255)` / `color rgb(255,255,255)`).
- the mode is the **constant** `'dark'`, *not* "opposite of the app mode" as the
  `astryx-fix` skill's generic row says. `ANTD_HOVER_PARITY.tooltip`
  (`backendAiTheme.ts:731-737`) pins the bubble to antd's `colorBgSpotlight`
  `light-dark(rgba(0,0,0,0.85), #424242)` — **dark in BOTH schemes**. The skill's
  row is superseded here (QA-FINDINGS Q-10).

## Before / after — measured

**How.** `pnpm --filter backend.ai-ui run storybook` (port 4533), driven with
Playwright, reading `getComputedStyle` off the real `<kbd>` element in **light
and dark**, toggling Storybook's theme via the dark-mode addon and asserting
`documentElement.colorScheme` actually flipped. Zero `pageerror` in both passes.
(First pass measured `.astryx-kbd` — that class is on the `Kbd` **wrapper**, not
the chip; the numbers below are from the `<kbd>` chips.)

### `Kbd` chip, measured directly

| | light page | dark page |
|---|---|---|
| background | `rgba(33, 26, 22, 0.1)` | `rgba(235, 224, 218, 0.2)` |
| color | `rgba(0, 0, 0, 0.65)` | `rgba(255, 255, 255, 0.65)` |
| border-bottom | `2px rgb(157, 142, 133)` | `2px rgb(116, 101, 93)` |
| font-size / height | 12px / 20px | 12px / 20px |

Inside the tooltip (`MediaTheme mode="dark"`), the chip resolves to the
dark-scheme column in **both** app modes — measured, `data-astryx-media="dark"`
confirmed present on an ancestor. That is the fix working: without the wrapper
it would take the light column and vanish on the dark bubble.

### On the app's pinned bubble — CORRECTED, measured live in the app

> **The table that stood here was wrong and has been replaced.** It composited
> Storybook chip values onto the app's bubble colour, i.e. mixed two themes, and
> concluded the badge lands at 4.78:1 / 3.64:1. A Backend.AI endpoint became
> available after this PR was opened, so the surface was measured in the running
> app instead (manager 26.7.0, superadmin, dark entered through the header
> toggle). **There is no filled chip on this surface — in either version.**

| | before — `.bai-text-kbd.bai-text-kbd--light` | after — `.astryx-kbd` |
|---|---|---|
| chip background | `rgba(0,0,0,0)` | `rgba(0,0,0,0)` |
| **border-width** | **`1px`** | **`0px`** |
| border colour | `rgb(255,255,255)` | `rgb(255,255,255)` (inert at 0 width) |
| text colour | `rgb(255,255,255)` | `rgb(255,255,255)` |
| font-size | `12.6px` | `14px` |
| tooltip bubble | `rgba(0,0,0,0.85)` light / `rgb(66,66,66)` dark | identical |

The badge is white text directly on the bubble, so the real contrast is
≈**19:1** light and ≈**7.6:1** dark — comfortably above AA, and **better** than
this PR originally claimed. There is no dark-mode AA concern on this surface.

**What the change does cost is the key-cap box, not contrast.** The previous
treatment drew a 1px white border; `Kbd` computes `border-width: 0` here, so `]`
now renders as plain 14px text inside "Notifications ]". Visibility is fine; the
*affordance* is what was lost, and that affordance is the reason a `Kbd` element
exists. Left open on the review thread as a design call: accept the flatter
treatment, or make `Kbd`'s chip paint inside a `MediaTheme mode="dark"` tooltip.

The `astryx-fix` §5 trap — `useTooltip` hardcoding bubble colours without
flipping token context, so a nested `Kbd` resolves against the page surface and
disappears — **does not bite here**; the badge is legible in both modes, and the
already-correct sibling call site (`SiderToggleButton`, `Collapse [`) measures
the same.

## Verification bar — actual output

| command | result |
|---|---|
| `pnpm --filter backend.ai-ui build` | `✓ built in 25.25s` (**mandatory** — `packages/backend.ai-ui/src` changed) |
| `bash scripts/verify.sh` | `=== ALL PASS ===` — Relay PASS, Lint PASS, Format PASS, TypeScript PASS, Vite warmup paths PASS, StyleX cssInjectionTarget PASS, Astryx theme build PASS, Terminology PASS (0 blocking / 0 warn) |
| `pnpm --prefix ./react exec vitest run` | `Test Files 66 passed (66)` · `Tests 1166 passed (1166)` |
| `pnpm --filter backend.ai-ui exec vitest run` | `Test Files 41 passed \| 1 skipped (42)` · `Tests 583 passed \| 1 skipped (584)` |
| `node scripts/migration-gates/astryx-token-gate.mjs --strict` | `declared 259 \| checked 754 \| undeclared: 2` |

**Token gate — the two known findings are NOT closed by this PR.** They survive
at shifted line numbers because the file shrank:

- `BAIText.css:27` → **`BAIText.css:28`**, still `var(--x)`. It is a **false
  positive on prose** — the header sentence "No `var(--x, literal)` fallbacks".
  I rewrote a *different* paragraph of that header (the `keyboard` justification)
  and deliberately left this line intact, so the finding is unchanged, not
  "fixed by deleting the prose that tripped it".
- `BAIText.tsx:230` → **`BAIText.tsx:225`**, still `var(--font-family-mono)`. Driven
  by the `monospace` prop; the gate's own suggestion is `--font-family-code`. Out
  of scope here.

`var()` usages checked drops 760 → **754**: the 6 removed are the declarations in
the two deleted CSS classes. No theme edit — `THEME_NAME_REV` stays at **11**,
committed `bai-r11-*` artifacts untouched.

## Residue

- **No live app probe.** No Backend.AI endpoint or credentials on this box
  (`e2e/envs/.env.playwright` absent, no `config.toml`); the header notification
  tooltip is a logged-in surface. The Playwright MCP seed was attempted and
  failed on `getByLabel('Email or Username')` — confirming it. Everything above
  was measured in **BUI Storybook**, which renders the same `Kbd` +
  `MediaTheme mode="dark"` composition, plus static compositing onto the app's
  pinned bubble colour. **A reviewer with a cluster should confirm the header
  tooltip in both modes and screenshot the `[` and `]` badges side by side** —
  I have not claimed that probe.
- **Storybook's theme diverges from the app's, and it bit this measurement.** In
  Storybook **dark** mode the tooltip panel measured `rgb(255,255,255)` — white —
  because `ANTD_HOVER_PARITY` lives in `react/src/astryx-theme/backendAiTheme.ts`
  and BUI's `.storybook/` theme files carry **no** `tooltip` entry (grepped). So
  Storybook's bubble follows Astryx's default inversion while the app's is pinned
  dark. **The app is unaffected**; but it means a Storybook story showing `Kbd`
  inside a tooltip would render white-on-white in Storybook's dark mode. I dropped
  that row from the story for exactly this reason and kept the plain `Kbd` rows,
  which render correctly in both. **Worth its own ticket** — Storybook is the
  team's only backend-free probe surface, and it currently misrepresents every
  tooltip.
- **`BAIText` is a declared FRONTIER COMPONENT** with a deliberately frozen
  antd-shaped surface (file header; `.claude/rules/component-props-extension.md`).
  Removing `keyboard` / `keyboardWithLightBorder` is a **removal of two
  zero-call-site props**, not the "rename to modernize" that rule forbids — but it
  is still a public-surface change to a frozen component and **wants explicit
  sign-off**. Minimal-blast-radius fallback if preferred: drop
  `keyboardWithLightBorder` only and keep `keyboard` + `.bai-text-kbd`. Say the
  word and I will re-cut it.
- **The `<BAIText keyboard copyable ellipsis>` composite** (a Storybook demo, no
  production use) has no `Kbd` equivalent — `Kbd` takes no children and has no
  copy/ellipsis. It was not ported; the `keyboard` prop was simply dropped from
  that story.
- **Does not subsume FR-3512** (sider footer typography), the sibling in this
  round. Disjoint files, different mechanism.
- **The rest of the "app-wide sweep"** the issue asked for is complete in the
  sense that matters: after this PR the repo contains **no** hand-rolled keyboard
  badge and exactly one mechanism (`Kbd`, 2 importers). No further call sites
  remain to convert.

## Files changed (4)

- `react/src/components/BAINotificationButton.tsx` — `<BAIText
  keyboardWithLightBorder>{']'}</BAIText>` → `<Kbd keys="]" />`; `BAIText` import
  dropped (it was the file's only use); the 44-line migration-travelogue comment
  trimmed to the two load-bearing traps per `.claude/rules/comment-density.md`.
- `packages/backend.ai-ui/src/components/BAIText.tsx` — both props removed from
  the interface, destructuring and the `boxed` ternary; header mapping line marked
  RETIRED rather than deleted (`astryx-fix` §7).
- `packages/backend.ai-ui/src/components/BAIText.css` — `.bai-text-kbd` and
  `.bai-text-kbd--light` deleted; the header's expired `keyboard` justification
  replaced with why it expired.
- `packages/backend.ai-ui/src/components/BAIText.stories.tsx` — `keyboard`
  `argTypes` entry and all 9 usages removed; the `KeyboardShortcuts` story
  re-pointed at `Kbd` so it stays a live signpost for anyone looking for the
  retired prop.

