### PR TITLE
fix(FR-3519): stop clipping the Access Key copy button in the keypair modal

### DIFF
--- a/react/src/components/GeneratedKeypairListModal.tsx
+++ b/react/src/components/GeneratedKeypairListModal.tsx
@@ -77,7 +77,10 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
   return (
     <BAIModal
       title={t('credential.NewCredentialCreated')}
-      width={600}
+      // 600 left the three columns at 200px each, one of which cannot fit an
+      // access key plus its copy button; 780 clears the table's natural width
+      // so the default view needs no horizontal scroll (FR-3519).
+      width={780}
       destroyOnHidden
       okText={t('button.Download')}
       onOk={handleDownload}
@@ -98,10 +101,13 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
           title={t('credential.GeneratedKeypairWarning')}
         />
         <BAIText>{t('credential.GeneratedKeypairInfo')}</BAIText>
+        {/* No `scroll` prop: BAITableAstryx accepts and ignores it, so the
+            antd-era `x: 'max-content'` never sized these columns and its
+            presence only suggested otherwise. Astryx's scroll wrapper owns
+            overflow; column floors come from `minWidth`. */}
         <BAITableAstryx<KeypairType>
           size="small"
-          style={{ overflowX: 'auto' }}
-          scroll={{ x: 'max-content', y: 500 }}
+          resizable
           pagination={false}
           dataSource={keypairData}
           rowKey={(record) => record?.keypair?.accessKey ?? ''}
@@ -121,6 +127,10 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
               title: t('credential.AccessKey'),
               dataIndex: ['keypair', 'accessKey'],
               key: 'access_key',
+              // Widest cell in the table: 20 monospace chars plus the copy
+              // button. Without a floor it takes an equal third and clips the
+              // button, since `<td>` is `overflow: hidden` (FR-3519).
+              minWidth: 240,
               render: (value) => (
                 <BAIText copyable monospace>
                   {value}


### PR DESCRIPTION
Resolves #8708 (FR-3519)

## Summary

The "Keypair for new users" modal (`/admin/users` → Create User / Bulk Create Users / Bulk Create Users from CSV) sliced the **Access Key** copy button in half at the column edge. That button is the primary affordance for a credential the UI shows exactly once, so the alternative was noticing the Download button.

## Mechanism

Not the modal width on its own. The call site passed `scroll={{ x: 'max-content', y: 500 }}`, but `BAITableAstryx` **accepts and ignores `scroll`** — a documented migration PILOT-DECISION, since Astryx's own scroll wrapper owns overflow. So the antd-era `max-content` sizing never applied, and the three columns fell back to `proportional(1)`: an equal third of the 600px modal each.

200px does not fit a 20-character monospace access key plus a 24px copy button (content measured **197px** inside a **184px** padded box). `<td>` is `overflow: hidden`, so the 5px overhang was clipped — and the scroll container reported `scrollWidth == clientWidth`, so there was no scrollbar to reveal it either.

Column floors come from `minWidth`, which this call site never set.

## Changes

- **`minWidth: 240` on the Access Key column** — the actual fix. A floor the column can never be squeezed below, independent of modal width or sibling columns.
- **Modal `width` 600 → 780** — with the floor in place the table's natural width is 720; 780 clears it so the default view needs no horizontal scroll.
- **`resizable`** — the columns can now be dragged, so a longer-than-expected key or email is adjustable by hand.
- **Dropped the dead `scroll` prop** rather than leave it implying a sizing mode that is not in effect.

## Measured before / after

Live app, 1600×1100 viewport, first data row. Light and dark are identical — this is geometry, not colour.

| Measure | Before | After |
|---|---|---|
| Column widths | 200 / 200 / 200 | 260 / 260 / 260 |
| Access Key cell | 200px | 260px |
| **Copy button vs cell right edge** | **+5px (clipped)** | **−55px (inside)** |
| Modal scroller `clientWidth` / `scrollWidth` | 600 / 600 | 780 / 780 |
| Resize handles in the dialog | 2 | 4 |
| `pageerror` count | 0 | 0 |

## Screenshots

| | Before | After |
|---|---|---|
| **Light** | ![before light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3519/20260812-004834-before-light.png) | ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3519/20260812-004834-after-light.png) |
| **Dark** | ![before dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3519/20260812-004834-before-dark.png) | ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3519/20260812-004834-after-dark.png) |

Dark was entered through the header control with `document.documentElement.dataset.theme` asserted `'dark'` (poking the dataset alone does not restyle a native `<dialog>` in the top layer).

## Verification

```
bash scripts/verify.sh                          → === ALL PASS ===
pnpm --prefix ./react exec vitest run           → 66 files, 1166 tests passed
node scripts/migration-gates/astryx-token-gate.mjs --strict
                                                → no new findings (the two
                                                  dynamic var() constructions it
                                                  reports are pre-existing in
                                                  theme-shim/astryxVars.ts)
```

Live probe in both modes, 0 `pageerror`. This change adds no token or CSS.

## Residue

- **Not addressed here:** in dark mode the modal surface renders light while the page around it is dark (visible in the dark screenshots, in the *before* shot too). It predates this PR and is untouched by it — this change only moves widths. Worth its own report if it is not intentional.
- The `minWidth` floor is on the Access Key column only. Email and Secret Key keep pure proportional sizing; neither overflowed at any width measured.
