### PR TITLE
fix(FR-3520): surface review-step validation errors on the failing cards and stepper

### DIFF
--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -7,7 +7,6 @@ import { resolvesReadsVfolderConfigFiles } from '../helper/modelServiceCommand';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useAdminImageReference } from '../hooks/hooksUsingRelay';
 import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
-import { theme } from '../theme-shim';
 import type {
   AdminDeploymentPresetFormValue,
   ModelServiceFormValue,
@@ -43,12 +42,21 @@ import { useTranslation } from 'react-i18next';
 // and is DROPPED everywhere below — the Astryx default density is the design.
 
 const BASIC_INFO_FIELDS = ['name', 'runtimeVariantId', 'imageId'] as const;
-const RESOURCES_FIELDS = ['cpu', 'mem', 'clusterMode', 'clusterSize'] as const;
+const RESOURCES_FIELDS = [
+  'cpu',
+  'mem',
+  'clusterMode',
+  'clusterSize',
+  'resourceOpts',
+] as const;
 const DEPLOYMENT_FIELDS = ['replicaCount'] as const;
+// `environ` and `resourceOpts` are Form.Lists whose rows carry their own
+// required rules, so they report errors under the list's own name.
 const STEP2_FIELDS = [
   'startupCommand',
   'bootstrapScript',
   'modelDefinition',
+  'environ',
 ] as const;
 
 interface PresetReviewSummaryProps {
@@ -80,7 +88,6 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const baiClient = useSuspendedBackendaiClient();
   /**
    * FR-3481: mirrors the input form's placement of Service

--- a/react/src/components/AdminDeploymentPresetReviewSummary.tsx
+++ b/react/src/components/AdminDeploymentPresetReviewSummary.tsx
@@ -30,6 +30,7 @@ import {
   toLocalId,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { CircleX } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -248,17 +249,26 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
     </>
   );
 
+  // `status="error"` only tints the border. These cards pass a custom `extra`,
+  // so they never reach BAICard's own error glyph — reuse its class hook.
+  const extraSlot = (stepIndex: number, cardId: string, hasError: boolean) =>
+    hasError ? (
+      <BAIFlex gap="xs" align="center" className="bai-card-extra--error">
+        <CircleX size="1em" aria-label={t('dialog.error.Error')} />
+        {editLink(stepIndex, cardId)}
+      </BAIFlex>
+    ) : (
+      editLink(stepIndex, cardId)
+    );
+
   return (
     <BAIFlex direction="column" gap="md" align="stretch">
       {/* Basic Info */}
       <BAICard
         size="small"
-        className={basicInfoHasError ? 'bai-card-error' : ''}
-        style={
-          basicInfoHasError ? { borderColor: token.colorError } : undefined
-        }
+        status={basicInfoHasError ? 'error' : undefined}
         title={t('adminDeploymentPreset.step.BasicInfo')}
-        extra={editLink(0, 'preset-form-card-basic')}
+        extra={extraSlot(0, 'preset-form-card-basic', basicInfoHasError)}
       >
         {/* Field order below mirrors the Basic Info step's actual input
             order (name → description → runtime → runtime params → service
@@ -313,12 +323,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
       {/* Resources */}
       <BAICard
         size="small"
-        className={resourcesHasError ? 'bai-card-error' : ''}
-        style={
-          resourcesHasError ? { borderColor: token.colorError } : undefined
-        }
+        status={resourcesHasError ? 'error' : undefined}
         title={t('adminDeploymentPreset.step.Resources')}
-        extra={editLink(0, 'preset-form-card-resources')}
+        extra={extraSlot(0, 'preset-form-card-resources', resourcesHasError)}
       >
         <MetadataList columns={1}>
           <MetadataListItem label={t('adminDeploymentPreset.ResourceSlots')}>
@@ -369,12 +376,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
       {/* Deployment */}
       <BAICard
         size="small"
-        className={deploymentHasError ? 'bai-card-error' : ''}
-        style={
-          deploymentHasError ? { borderColor: token.colorError } : undefined
-        }
+        status={deploymentHasError ? 'error' : undefined}
         title={t('adminDeploymentPreset.step.Deployment')}
-        extra={editLink(0, 'preset-form-card-deployment')}
+        extra={extraSlot(0, 'preset-form-card-deployment', deploymentHasError)}
       >
         {/* Multi-column MetadataList defaults its labels to position: top,
             which reads as a different (vertical) layout from every other
@@ -401,10 +405,9 @@ const PresetReviewSummary: React.FC<PresetReviewSummaryProps> = ({
       {/* Model & Execution */}
       <BAICard
         size="small"
-        className={step2HasError ? 'bai-card-error' : ''}
-        style={step2HasError ? { borderColor: token.colorError } : undefined}
+        status={step2HasError ? 'error' : undefined}
         title={t('adminDeploymentPreset.step.ModelAndExecution')}
-        extra={editLink(1, 'preset-form-card-model')}
+        extra={extraSlot(1, 'preset-form-card-model', step2HasError)}
       >
         <MetadataList columns={1}>
           <MetadataListItem label={t('adminDeploymentPreset.StartupCommand')}>

--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -786,9 +786,14 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
       'clusterMode',
       'clusterSize',
       'replicaCount',
+      'resourceOpts',
     ]),
-    stepHasError(['startupCommand', 'bootstrapScript']) ||
-      errorFieldNames.includes('modelDefinition'),
+    stepHasError([
+      'startupCommand',
+      'bootstrapScript',
+      'modelDefinition',
+      'environ',
+    ]),
     reviewHasError,
   ];
 

--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -767,8 +767,14 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
     }
   };
 
+  // `getFieldError` only reports MOUNTED fields, so a step the user has
+  // navigated away from always read as clean; `errorFieldNames` comes from the
+  // full `validateFields()` sweep and covers every step (FR-3520).
   const stepHasError = (fields: string[]) =>
-    fields.some((f) => form.getFieldError(f as never).length > 0);
+    fields.some(
+      (f) =>
+        form.getFieldError(f as never).length > 0 || errorFieldNames.includes(f),
+    );
 
   const stepErrors = [
     stepHasError([


### PR DESCRIPTION
Resolves #8710 (FR-3520)

## Summary

On the deployment preset **Review** step, a failed validation was almost invisible: the only cue was a bare 1px red border on the failing cards, and the stepper showed a **completion checkmark** next to the very step holding the failing fields.

## Mechanism

Two separate causes, both named below rather than guessed at.

**1. The stepper — `getFieldError` only sees mounted fields.**
`stepHasError` was `fields.some((f) => form.getFieldError(f).length > 0)`. `getFieldError` reports only fields that are currently **mounted**, so every step except the one on screen measured as clean and rendered `status="completed"`. It now also consults `errorFieldNames`, which is populated from the full `validateFields()` sweep and covers every step — the same source `AdminDeploymentPresetReviewSummary` already matched its per-card flags against, so no new plumbing.

**2. The cards hand-rolled the tint instead of using the design system.**
They passed `className="bai-card-error"` + inline `style={{ borderColor: token.colorError }}`. `.bai-card-error` has **zero CSS rules** — `BAICard` *emits* it as an OUTPUT of `status="error"` for the two validation tours to anchor on — so only the inline style painted anything. They now pass `status="error"` and pick up `bai-card--error`.

**3. The error glyph never rendered.** `BAICard` draws its error icon only in the `extraButtonTitle` branch; these cards supply a custom `extra` (the Edit link), so that branch is never taken. The action slot now renders a `CircleX` through `BAICard`'s existing `.bai-card-extra--error` hook (`color: var(--color-error)`), so the icon is themed, not hardcoded.

### Correction — this is not a colour fix

The issue as filed claimed the hardcoded `rgb(255,77,79)` did not follow dark mode. **That was wrong**, and I measured it on `main` before writing this: `theme.useToken()`'s `colorError` carries `[light, dark]` pairs, so the pre-fix inline style already resolved to `rgb(255,77,79)` light / `rgb(190,61,63)` dark. The border colour is **identical before and after**. Switching to `status="error"` is an API/consistency change (per `use-bai-card.md` rule 4), not a visual one. The user-visible wins are the stepper and the new glyph. FR-3520 carries a comment with the same correction.

## Measured, in the real app (light + dark)

Repro: `/admin/deployments/deployment-presets/new?step=review` with an empty form.

| | Before | After |
|---|---|---|
| Card classes | `bai-card--compact, bai-card-error` | `bai-card--compact, **bai-card--error**, bai-card-error` |
| Card inline style | `border-color: rgb(255,77,79)` | *(none)* |
| Computed border — light | `rgb(255, 77, 79)` | `rgb(255, 77, 79)` *(unchanged, by design)* |
| Computed border — dark | `rgb(190, 61, 63)` | `rgb(190, 61, 63)` *(unchanged, by design)* |
| Error glyph in action slot | absent | 3 × `rgb(255, 77, 79)` (`var(--color-error)`) |
| Stepper step 1 (holds the failing fields) | `Go to step 1: Basic Info, **completed**` | `Go to step 1: Basic Info, **error**` |
| Stepper step 2 — empty form (no failing fields) | `…, completed` | `…, completed` *(correct — genuinely clean)* |
| Stepper step 2 — **env var row with an empty value** | `…, **completed**` | `…, **error**` |
| Error cards — env var case | 3 | 4 (Model & Execution now included) |
| Stepper step 3 | `…, error` | `…, error` |
| `pageerror` count | — | 0 (both modes) |

Dark mode was entered through the header toggle with `document.documentElement.dataset.theme === 'dark'` asserted.

## Screenshots

After
 ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0/20260812-010951-fr3520-after-light.png) 
 ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0/20260812-011002-fr3520-after-dark.png) 

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup, StyleX, Astryx theme build, Terminology)
- `pnpm exec vitest run` in `react/` → **66 files, 1166 tests passed**
- `pnpm exec vitest run` in `packages/backend.ai-ui/` → **41 passed / 1 skipped, 583 tests passed / 1 skipped**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → **fails with `undeclared: 2` — pre-existing.** Verified by `git stash`-ing this diff and re-running on the clean tree: identical exit code and identical `undeclared: 2`. Neither undeclared token is in a file this PR touches.
- Live probe in both modes, 0 `pageerror`.

### Field-list coverage

The step/card error lists are hand-maintained, and the first cut missed the two `Form.List`s whose **rows** carry the required rules — `environ` (Environment Variables) and `resourceOpts` (Resource Options). Both report row errors under the list's own name, so an empty env var value failed validation while the Model & Execution card and its stepper entry still rendered complete. Both are now listed.

Audited every `name=` on the form against the lists; the remaining uncovered fields (`description`, `openToPublic`, `revisionHistoryLimit`, `resourceSlots`) carry no `rules`, so they cannot produce an error.

**No manager-version branching is needed.** The two `@since` directives on this form (`presetValues`, `healthCheck.enable`) hydrate initial values from an existing preset — they do not gate whether a field renders or validates, and the top-level field names are static JSX. `errorFieldNames` only ever contains fields that actually mounted and validated, so a list entry for a field an older manager does not render is inert; the lists are safe as supersets. Nested paths collapse to their first segment, so `modelDefinition.*` (which contains the version-gated `enable`) is already covered by the `modelDefinition` entry.

## Residue — deliberately not closed here

- **No list of *which* fields failed.** The cards say *that* a section failed, not which input. That was raised as an option and deferred as a separate design decision.
- **`AdminDeploymentPresetValidationTour` is untouched.** It spotlights the error card, but is gated on the `has_opened_tour_deployment_preset_validation` user setting and fires **once per user, ever** — so for anyone past their first run it contributes nothing. Whether that gate is right is a separate question.
- **`SessionLauncherErrorTourProps` uses the same `.bai-card-error` anchor** and is **not** covered by this PR; I did not audit whether the session launcher has the same card/stepper symptom.
- `.bai-card-error` is left emitted by `BAICard` — both tours query it, so removing it would be a silent contract change.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
