### PR TITLE
fix(FR-3523): stop the accelerator form-watch loop that freezes Relay selects

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -347,7 +347,14 @@ const ResourceAllocationFormItems: React.FC<
         allocationPreset: 'auto-select',
       });
     }
-    if (supportedAcceleratorTypesInRGByImage?.length === 0) {
+    // Write only on an actual change: `setFieldsValue` rebuilds `resource`,
+    // so `Form.useWatch(['resource'])` returns a new reference and re-triggers
+    // this effect. Unguarded, that self-feeding loop never settles and starves
+    // React's transition lanes, freezing every `useDeferredValue` on the page.
+    if (
+      supportedAcceleratorTypesInRGByImage?.length === 0 &&
+      currentResourceValue?.accelerator !== 0
+    ) {
       form.setFieldsValue({
         resource: {
           accelerator: 0,
@@ -411,11 +418,17 @@ const ResourceAllocationFormItems: React.FC<
       ? currentAcceleratorType
       : _.first(_.keys(acceleratorSlotsInRG));
 
-    form.setFieldsValue({
-      resource: {
-        acceleratorType: nextAcceleratorType || currentAcceleratorType,
-      },
-    });
+    const resolvedAcceleratorType =
+      nextAcceleratorType || currentAcceleratorType;
+    // Write only on an actual change — see the accelerator effect above for
+    // why an unconditional `setFieldsValue` here never settles.
+    if (resolvedAcceleratorType !== currentAcceleratorType) {
+      form.setFieldsValue({
+        resource: {
+          acceleratorType: resolvedAcceleratorType,
+        },
+      });
+    }
     // The accelerator type may have changed; clear the accelerator field if
     // the resolved type is a unified slot.
     syncUnifiedAcceleratorIfNeeded();


### PR DESCRIPTION
Resolves #8716 (FR-3523)

## Symptom


In **Deployments → (a deployment) → Add Revision → Advanced Mode**, the **Runtime Variant** select renders "No results" although the manager returns 8 runtime variants. The **Model Folder** select in the same modal is empty too, and **no GraphQL request is ever issued** for either list.

Verified against manager 26.8.0 — `runtimeVariants(limit: 20)` returns `count: 8` (cmd, custom, huggingface-tgi, llama-cpp, modular-max, nim, sglang, vllm).

The same `BAIRuntimeVariantSelectAstryx` works in both admin surfaces (Admin → Deployments → *Runtime Variant Presets* → Create Preset, and *Deployment Presets* → Create), so the select itself was never the defect.

## Mechanism

`ResourceAllocationFormItems` performs two **unconditional** form writes:

1. the mount effect's `form.setFieldsValue({ resource: { accelerator: 0 } })`, taken whenever the image has no supported accelerator in the resource group, and
2. `ensureValidAcceleratorType()`'s `form.setFieldsValue({ resource: { acceleratorType } })`.

Each `setFieldsValue` **rebuilds the `resource` object**, so `Form.useWatch(['resource'])` returns a new reference. That watch value is in those effects' dependency arrays, so the effect re-runs and writes again — a cycle that never settles.

Measured with a `FiberRootNode.pendingLanes` setter probe in the live app: **489 DefaultLane (32) updates in a 12-second idle window** (~40/s, indefinitely), alternating between `FormStore.notifyObservers → Field.reRender` and `useWatch`.

That endless stream of default-priority work **starves React's transition lanes**. The root ends up with `pendingLanes == expiredLanes` and a live `callbackNode`, and those lanes are never rendered — so `useDeferredValue` stops advancing anywhere on the page (confirmed: still frozen after a 35 s wait; `MessageChannel` and timers were verified alive, so it is lane starvation, not a dead host scheduler).

Every `BAIComplexSelect`-based Relay select gates its Relay `fetchPolicy` on exactly such a deferred value:

```ts
const deferredOpen = useDeferredValue(controllableOpen);
// …
fetchPolicy: deferredOpen ? 'network-only' : 'store-only'
```

`controllableOpen` flips to `true` when the popup opens, but `deferredOpen` never follows, so the query stays on `store-only`, no request is sent, and the popup shows "No results". Bisection confirmed the chain: removing `ResourceAllocationFormItems` from the modal made the select work; re-adding it broke it again; guarding both writes fixes it with the component in place.

## Fix

Both writes are now conditional on an actual value change, so the watch/effect cycle converges.

## Scope

This is **not** a `BAIRuntimeVariantSelectAstryx` bug and is unrelated to FR-3476 — the file is untouched by that branch, and this PR branches off `main`. Any page mounting `ResourceAllocationFormItems` was affected, including the session launcher.

## Evidence

| | before | after |
|---|---|---|
| Add Revision → Advanced → Runtime Variant options | 0 ("No results") | **8** |
| Add Revision → Advanced → Model Folder options | 0 ("No results") | **1** |
| root `pendingLanes` after opening the select | `2097664` (expired, never flushed) | `0` |
| lane updates during a 12 s idle window | 489 | 9 |
| `/session/start` `pendingLanes` | `25165824` | `0` |
| `pageerror` count | 0 | 0 |

Light and dark both measured, dark asserted via `document.documentElement.dataset.theme === 'dark'`.

### Add Revision → Advanced Mode — Runtime Variant select (light)

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3523/20260812-041750-fr-rv-before-light.png" width="440"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3523/20260812-041750-fr-rv-after-light.png" width="440"> |

### Same, dark

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3523/20260812-041750-fr-rv-before-dark.png" width="440"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3523/20260812-041750-fr-rv-after-dark.png" width="440"> |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → **66 files, 1166 tests passed**
- `pnpm --filter backend.ai-ui exec vitest run` → **41 files passed / 1 skipped, 583 tests passed / 1 skipped**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1, **pre-existing**: the only finding is `packages/backend.ai-ui/src/components/BAIText.tsx:230 var(--font-family-mono)`, untouched here. Confirmed identical exit status with this branch's change stashed.

## Residue

- The fragile idiom itself is left in place: ~17 `BAI*SelectAstryx` wrappers make *data loading* depend on a **deferred render landing** (`fetchPolicy: deferredOpen ? 'network-only' : 'store-only'`). That is an optimization gating correctness — any future transition-starving loop will silently empty every select again. Worth revisiting separately (e.g. `controllableOpen || deferredOpen`); deliberately out of scope here so this PR stays a one-component root-cause fix.
- No test is added: reproducing lane starvation needs a live React root and a `pendingLanes` probe, which the jsdom/vitest setup cannot express meaningfully.
