### PR TITLE
style(FR-3529): give the Runtime Parameters category tabs room and a rail

### DIFF
--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -23,10 +23,21 @@ import { Collapsible } from '@astryxdesign/core/Collapsible';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { Tab, TabList } from '@astryxdesign/core/TabList';
 import { Text } from '@astryxdesign/core/Text';
+import { spacingVars } from '@astryxdesign/core/theme/tokens.stylex';
+import * as stylex from '@stylexjs/stylex';
 import { BAIFlex, toLocalId } from 'backend.ai-ui';
 import { Undo2 } from 'lucide-react';
 import React, { useEffect, useEffectEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const styles = stylex.create({
+  // The tab strip is a bare sibling of the Banner and the first field, so its
+  // breathing room has to come from the strip itself. FR-3529.
+  categoryTabs: {
+    marginBlockStart: spacingVars['--spacing-4'],
+    marginBlockEnd: spacingVars['--spacing-4'],
+  },
+});
 
 /** Convert category slug to a display-friendly label. */
 function formatCategoryLabel(category: string): string {
@@ -272,6 +283,8 @@ const RuntimeParameterFormSection: React.FC<
           already is. */}
       <TabList
         size="sm"
+        hasDivider
+        xstyle={styles.categoryTabs}
         value={effectiveActiveTab}
         onChange={(key) => setActiveTab(key)}
       >


### PR DESCRIPTION
Resolves #8723 (FR-3529)

> Stacked on #8717 (FR-3523). That PR is what makes the Runtime Variant select
> in this modal populate at all — without it you cannot pick a non-`custom`
> runtime, and the Runtime Parameters section this PR touches never renders.

## Symptom

In **Deployments → (a deployment) → Add Revision → Advanced Mode**, with a
non-`custom` runtime selected, the **Runtime Parameters** section's category tab
strip (`E2e Category` / `General`) is wedged between the warning banner above it
and the first parameter field below it: no vertical gap on either side, and no
rail under the tabs. It does not read as a tab bar.

## Mechanism

`RuntimeParameterFormSection` renders the Astryx `TabList` primitive directly.
Astryx's `hasDivider` defaults to `false`, so no rail is drawn — the BUI wrapper
`BAITabList` defaults it to `true`, but this call site does not go through the
wrapper. The strip is also a bare sibling of the `Banner` and the panel `div`s
inside `Collapsible`, which lay their children out with no gap container, so
there is nothing to supply vertical spacing either.

Both knobs are first-class Astryx props, so the fix stays at the component-prop
level — no CSS file, no wrapper swap:

- `hasDivider` draws the rail;
- `xstyle` carries a `marginBlock` pair built from `spacingVars['--spacing-4']`
  (tokens only; `stylex.create`, per the repo's existing `xstyle` idiom in
  `WebUISider.tsx`).

The nav already spans the full content width (672px measured), so `BAITabList`'s
block-level-nav rule was not needed here — the rail spans the bar as-is.

## Measured

Computed style on the `nav.astryx-tab-list`, live in the Add Revision modal with
runtime `cmd` selected:

| | before (light) | after (light) | before (dark) | after (dark) |
|---|---|---|---|---|
| `margin-top` | 0px | **16px** | 0px | **16px** |
| `margin-bottom` | 0px | **16px** | 0px | **16px** |
| `border-bottom` | `0px` | **`1px solid rgb(240,240,240)`** | `0px` | **`1px solid rgb(48,48,48)`** |
| gap to previous sibling | 0px | **16px** | 0px | **16px** |
| gap to next sibling | 0px | **16px** | 0px | **16px** |
| nav width | 672px | 672px | 672px | 672px |
| `pageerror` | 0 | 0 | 0 | 0 |

The rail colour differs between modes (`#F0F0F0` vs `#303030`), i.e. it resolves
through the theme rather than being hardcoded.

Dark mode was entered via the OS `prefers-color-scheme` the app's `system` theme
mode follows, with `document.documentElement.dataset.theme` asserted `'dark'`
before measuring. (Setting that attribute by hand does **not** re-theme the app —
an earlier pass that did so produced a light-looking "dark" screenshot and was
discarded.)

### Light

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8724/20260812-060826-tabs-before-light.png" width="420"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8724/20260812-060826-tabs-after-light.png" width="420"> |

### Dark

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8724/20260812-060826-tabs-before-dark.png" width="420"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8724/20260812-060826-tabs-after-dark.png" width="420"> |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → **66 files, 1166 tests passed**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1,
  **pre-existing**: the sole finding is
  `packages/backend.ai-ui/src/components/BAIText.tsx:230 var(--font-family-mono)`,
  untouched here. No finding names `RuntimeParameterFormSection`.
- No `packages/backend.ai-ui/src` change, so no BUI rebuild was required.

## Residue

- **Only this call site.** Four other `TabList` call sites render without
  `hasDivider` too — `SessionDetailContent`, `AgentDetailDrawerContent`,
  `StorageHostDetailDrawerContent`, `RoleDetailDrawerContent`. They were not
  touched and not reproduced; whether they *want* a rail is a per-surface
  decision, not something to sweep from one report. Worth a follow-up if the
  team wants the rail to be the default everywhere (i.e. route those call sites
  through `BAITabList`).
- The same section also renders on **Admin → Deployments → Deployment Presets →
  New/Edit**; it gets the fix for free but was not separately re-measured.
- The 16px value is a plain `--spacing-4` pick, not derived from a legacy
  reference — there is no pre-migration screenshot of this section to match
  against.
