### PR TITLE
feat(FR-3500): revive the antd scroll={{x,y}} contract on BAITableAstryx

### DIFF
--- a/packages/backend.ai-ui/.storybook/astryxBrandTheme.ts
+++ b/packages/backend.ai-ui/.storybook/astryxBrandTheme.ts
@@ -83,13 +83,11 @@ export const astryxBrandTheme = defineTheme({
     '--font-family-body': fontFamily,
     '--font-family-heading': fontFamily,
     ...ANTD_ALIGN_TOKENS,
-    // KEEP IN SYNC with `ANTD_NEUTRAL_TEXT` in
-    // `react/src/astryx-theme/backendAiTheme.ts` (audit 1, catalog G-1).
-    // The surface/border families are NOT mirrored here (Storybook renders on
-    // its own canvas, where the accent-derived neutrals never bothered
-    // anyone), but the TEXT ramp is: a story that reads as brown-on-white in
-    // Storybook and neutral in the app is exactly the divergence this mirror
-    // exists to prevent, and it is what reviewers screenshot.
+    // KEEP IN SYNC with `ANTD_NEUTRAL_TEXT`, `ANTD_NEUTRAL_SURFACES` and
+    // `ANTD_NEUTRAL_BORDERS` in `react/src/astryx-theme/backendAiTheme.ts`.
+    // All three neutral families are mirrored: unpinned, Astryx derives them
+    // from the accent and stories render on a warm pink-beige canvas the app
+    // never shows (FR-3500 review, 2026-08-12).
     '--color-text-primary': ['#141414', '#FFFFFF'] as [string, string],
     '--color-text-secondary': ['rgba(0,0,0,0.65)', 'rgba(255,255,255,0.65)'] as [
       string,
@@ -108,6 +106,25 @@ export const astryxBrandTheme = defineTheme({
       string,
       string,
     ],
+    '--color-background-body': ['#F7F7F6', '#191919'] as [string, string],
+    '--color-background-surface': ['#FFFFFF', '#141414'] as [string, string],
+    '--color-background-card': ['#FFFFFF', '#141414'] as [string, string],
+    '--color-background-popover': ['#FFFFFF', '#1F1F1F'] as [string, string],
+    '--color-background-muted': [
+      'rgba(0,0,0,0.04)',
+      'rgba(255,255,255,0.08)',
+    ] as [string, string],
+    '--color-neutral': ['rgba(0,0,0,0.06)', '#262626'] as [string, string],
+    '--color-overlay': ['rgba(0,0,0,0.45)', 'rgba(0,0,0,0.45)'] as [
+      string,
+      string,
+    ],
+    '--color-skeleton': ['rgba(0,0,0,0.15)', 'rgba(255,255,255,0.18)'] as [
+      string,
+      string,
+    ],
+    '--color-border': ['#F0F0F0', '#303030'] as [string, string],
+    '--color-border-emphasized': ['#D9D9D9', '#424242'] as [string, string],
     // KEEP IN SYNC with the interaction fills in `ANTD_NEUTRAL_SURFACES`
     // (catalog G-4) — without them dark-mode stories have no hover state.
     '--color-overlay-hover': ['rgba(0,0,0,0.06)', '#262626'] as [string, string],

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
@@ -84,8 +84,10 @@
    antd `scroll={{ x }}` as rc-table writes it: `width: <x>; min-width: 100%`.
    `table-layout: auto` is required for content-driven widths — the switch
    rc-table itself makes for 'max-content' (ant-design#25227).
+   `:not(table table)` keeps the rule (and the inherited custom property) off
+   tables nested inside cells / expandedRowRender.
   */
-  .bai-table-astryx-scroll-x table {
+  .bai-table-astryx-scroll-x table:not(table table) {
     table-layout: auto;
     width: var(--bai-table-scroll-x);
     /* !important: BaseTable writes a structural inline min-width whenever any
@@ -101,8 +103,10 @@
    whose direct child is the table" — its DEPTH varies: `useTableColumnResize`
    (on by default) wraps the whole table in a `display: contents` measuring div,
    so a `> div` child selector lands on that boxless wrapper and caps nothing.
+   `:not(table div)` keeps wrappers of nested tables (inside cells /
+   expandedRowRender) uncapped.
   */
-  .bai-table-astryx-scroll-y div:has(> table) {
+  .bai-table-astryx-scroll-y div:has(> table):not(table div) {
     max-height: var(--bai-table-scroll-y);
     overflow-y: auto;
   }
@@ -119,8 +123,9 @@
    COLLAPSED table border and cannot travel with a sticky cell, so it vanishes
    while scrolled. Candidate fix: `box-shadow: inset 0 -1px 0
    var(--color-border)` here — unmeasured against the sticky-column shadows.
+   `:not(table table)` keeps nested tables' headers non-sticky, as above.
   */
-  .bai-table-astryx-scroll-y thead th {
+  .bai-table-astryx-scroll-y table:not(table table) > thead th {
     position: sticky;
     top: 0;
     z-index: 2;

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
@@ -78,3 +78,18 @@
     min-width: 0;
   }
 }
+
+@layer components {
+  /*
+   antd `scroll={{ x }}` as rc-table writes it: `width: <x>; min-width: 100%`.
+   `table-layout: auto` is required for content-driven widths — the switch
+   rc-table itself makes for 'max-content' (ant-design#25227).
+  */
+  .bai-table-astryx-scroll-x table {
+    table-layout: auto;
+    width: var(--bai-table-scroll-x);
+    /* !important: BaseTable writes a structural inline min-width whenever any
+       pixel column exists (the injected selection column is pixel 52). */
+    min-width: 100% !important;
+  }
+}

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
@@ -93,3 +93,40 @@
     min-width: 100% !important;
   }
 }
+
+@layer components {
+  /*
+   antd `scroll={{ y }}`: cap the body and stick the header. The capped element
+   is Astryx's scroll wrapper (already `overflow-x: auto`), matched as "the div
+   whose direct child is the table" — its DEPTH varies: `useTableColumnResize`
+   (on by default) wraps the whole table in a `display: contents` measuring div,
+   so a `> div` child selector lands on that boxless wrapper and caps nothing.
+  */
+  .bai-table-astryx-scroll-y div:has(> table) {
+    max-height: var(--bai-table-scroll-y);
+    overflow-y: auto;
+  }
+
+  /*
+   Astryx paints no background on `th`, so a sticky header needs its own opaque
+   base — the same token the sticky-column plugin uses, so a pinned corner
+   matches. z-index 2 clears pinned BODY cells (z 1); this layer outranks the
+   plugin's `astryx-base` z 3 on pinned HEADER cells, which BAITableAstryx
+   restores inline. `overflow` is untouched: the resize drag handle needs
+   `visible` to reach through the body.
+
+   Known limit, deliberately deferred: the header's bottom rule belongs to the
+   COLLAPSED table border and cannot travel with a sticky cell, so it vanishes
+   while scrolled. Candidate fix: `box-shadow: inset 0 -1px 0
+   var(--color-border)` here — unmeasured against the sticky-column shadows.
+  */
+  .bai-table-astryx-scroll-y thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: var(
+      --table-sticky-background,
+      var(--color-background-card)
+    );
+  }
+}

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.scrollTestFixtures.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.scrollTestFixtures.tsx
@@ -1,0 +1,44 @@
+/*
+ Shared fixture for the scroll.x / scroll.y test pair — each file asserts the
+ NEGATIVE of the other's axis, so they must agree on the render shape.
+*/
+import BAITableAstryx from './BAITableAstryx';
+import type { BAIColumnsType } from './tableTypes';
+import { render } from '@testing-library/react';
+
+export interface ScrollTestRow {
+  id: string;
+  name: string;
+  note: string;
+}
+
+export const SCROLL_COLUMNS: BAIColumnsType<ScrollTestRow> = [
+  { key: 'name', title: 'Name', dataIndex: 'name', width: 120 },
+  { key: 'note', title: 'Note', dataIndex: 'note' },
+];
+
+export const SCROLL_PINNED_COLUMNS: BAIColumnsType<ScrollTestRow> = [
+  { ...SCROLL_COLUMNS[0], fixed: 'left' },
+  SCROLL_COLUMNS[1],
+];
+
+export const SCROLL_ROWS: Array<ScrollTestRow> = [
+  { id: '1', name: 'alpha', note: 'a long note' },
+];
+
+export const renderScrollTable = (
+  props: Partial<
+    React.ComponentProps<typeof BAITableAstryx<ScrollTestRow>>
+  > = {},
+) =>
+  render(
+    <BAITableAstryx<ScrollTestRow>
+      rowKey="id"
+      dataSource={SCROLL_ROWS}
+      columns={SCROLL_COLUMNS}
+      {...props}
+    />,
+  );
+
+export const dimLayerOf = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>('.bai-table-astryx-dim-layer')!;

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.scrollX.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.scrollX.test.tsx
@@ -3,37 +3,10 @@
  value mapping, and the PER-COLUMN max-width release — a table-wide release
  would let auto layout push a resized column back to its content width.
 */
-import BAITableAstryx from './BAITableAstryx';
-import type { BAIColumnsType } from './tableTypes';
-import { render } from '@testing-library/react';
-
-interface Row {
-  id: string;
-  name: string;
-  note: string;
-}
-
-const COLUMNS: BAIColumnsType<Row> = [
-  { key: 'name', title: 'Name', dataIndex: 'name', width: 120 },
-  { key: 'note', title: 'Note', dataIndex: 'note' },
-];
-
-const ROWS: Array<Row> = [{ id: '1', name: 'alpha', note: 'a long note' }];
-
-const renderTable = (
-  props: Partial<React.ComponentProps<typeof BAITableAstryx<Row>>> = {},
-) =>
-  render(
-    <BAITableAstryx<Row>
-      rowKey="id"
-      dataSource={ROWS}
-      columns={COLUMNS}
-      {...props}
-    />,
-  );
-
-const dimLayerOf = (container: HTMLElement) =>
-  container.querySelector<HTMLElement>('.bai-table-astryx-dim-layer')!;
+import {
+  dimLayerOf,
+  renderScrollTable,
+} from './BAITableAstryx.scrollTestFixtures';
 
 describe('BAITableAstryx scroll.x', () => {
   it.each([
@@ -41,26 +14,26 @@ describe('BAITableAstryx scroll.x', () => {
     [800 as const, '800px'],
     [true as const, 'auto'],
   ])('maps scroll.x=%s onto the CSS variable as %s', (x, expected) => {
-    const { container } = renderTable({ scroll: { x } });
+    const { container } = renderScrollTable({ scroll: { x } });
     const layer = dimLayerOf(container);
     expect(layer).toHaveClass('bai-table-astryx-scroll-x');
     expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe(expected);
   });
 
   it('stays off when scroll is absent or carries no x', () => {
-    const { container: withoutScroll } = renderTable();
+    const { container: withoutScroll } = renderScrollTable();
     expect(dimLayerOf(withoutScroll)).not.toHaveClass(
       'bai-table-astryx-scroll-x',
     );
 
-    const { container: yOnly } = renderTable({ scroll: { y: 500 } });
+    const { container: yOnly } = renderScrollTable({ scroll: { y: 500 } });
     const layer = dimLayerOf(yOnly);
     expect(layer).not.toHaveClass('bai-table-astryx-scroll-x');
     expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe('');
   });
 
   it('releases max-width on auto columns only', () => {
-    const { container } = renderTable({ scroll: { x: 'max-content' } });
+    const { container } = renderScrollTable({ scroll: { x: 'max-content' } });
     const [nameCell, noteCell] =
       container.querySelectorAll<HTMLTableCellElement>('tbody td');
 
@@ -77,7 +50,7 @@ describe('BAITableAstryx scroll.x', () => {
   });
 
   it('leaves every cell clipped when x mode is off', () => {
-    const { container } = renderTable();
+    const { container } = renderScrollTable();
     const cells = container.querySelectorAll<HTMLTableCellElement>('tbody td');
     expect([...cells].every((cell) => cell.style.maxWidth === '')).toBe(true);
   });

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.scrollX.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.scrollX.test.tsx
@@ -1,0 +1,84 @@
+/*
+ Pins the `scroll.x` contract structurally (jsdom has no layout): the rc-table
+ value mapping, and the PER-COLUMN max-width release — a table-wide release
+ would let auto layout push a resized column back to its content width.
+*/
+import BAITableAstryx from './BAITableAstryx';
+import type { BAIColumnsType } from './tableTypes';
+import { render } from '@testing-library/react';
+
+interface Row {
+  id: string;
+  name: string;
+  note: string;
+}
+
+const COLUMNS: BAIColumnsType<Row> = [
+  { key: 'name', title: 'Name', dataIndex: 'name', width: 120 },
+  { key: 'note', title: 'Note', dataIndex: 'note' },
+];
+
+const ROWS: Array<Row> = [{ id: '1', name: 'alpha', note: 'a long note' }];
+
+const renderTable = (
+  props: Partial<React.ComponentProps<typeof BAITableAstryx<Row>>> = {},
+) =>
+  render(
+    <BAITableAstryx<Row>
+      rowKey="id"
+      dataSource={ROWS}
+      columns={COLUMNS}
+      {...props}
+    />,
+  );
+
+const dimLayerOf = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>('.bai-table-astryx-dim-layer')!;
+
+describe('BAITableAstryx scroll.x', () => {
+  it.each([
+    ['max-content' as const, 'max-content'],
+    [800 as const, '800px'],
+    [true as const, 'auto'],
+  ])('maps scroll.x=%s onto the CSS variable as %s', (x, expected) => {
+    const { container } = renderTable({ scroll: { x } });
+    const layer = dimLayerOf(container);
+    expect(layer).toHaveClass('bai-table-astryx-scroll-x');
+    expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe(expected);
+  });
+
+  it('stays off when scroll is absent or carries no x', () => {
+    const { container: withoutScroll } = renderTable();
+    expect(dimLayerOf(withoutScroll)).not.toHaveClass(
+      'bai-table-astryx-scroll-x',
+    );
+
+    const { container: yOnly } = renderTable({ scroll: { y: 500 } });
+    const layer = dimLayerOf(yOnly);
+    expect(layer).not.toHaveClass('bai-table-astryx-scroll-x');
+    expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe('');
+  });
+
+  it('releases max-width on auto columns only', () => {
+    const { container } = renderTable({ scroll: { x: 'max-content' } });
+    const [nameCell, noteCell] =
+      container.querySelectorAll<HTMLTableCellElement>('tbody td');
+
+    // `name` declares width: 120 — it must keep Astryx's clip so it truncates.
+    expect(nameCell.style.maxWidth).toBe('');
+    expect(noteCell.style.maxWidth).toBe('none');
+
+    const [nameHeader, noteHeader] =
+      container.querySelectorAll<HTMLTableCellElement>('thead th');
+    expect(nameHeader.style.maxWidth).toBe('');
+    expect(noteHeader.style.maxWidth).toBe('none');
+    // Cancels the percentage width `resolveColumnWidths` still emits.
+    expect(noteHeader.style.width).toBe('auto');
+  });
+
+  it('leaves every cell clipped when x mode is off', () => {
+    const { container } = renderTable();
+    const cells = container.querySelectorAll<HTMLTableCellElement>('tbody td');
+    expect([...cells].every((cell) => cell.style.maxWidth === '')).toBe(true);
+  });
+});

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.scrollY.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.scrollY.test.tsx
@@ -1,0 +1,107 @@
+/*
+ Pins the `scroll.y` contract structurally (jsdom has no layout): the value
+ mapping onto the height variable, and the PINNED-header z-order restore that
+ keeps a `fixed` column's header above the plain sticky ones.
+*/
+import {
+  SCROLL_PINNED_COLUMNS,
+  dimLayerOf,
+  renderScrollTable,
+} from './BAITableAstryx.scrollTestFixtures';
+
+describe('BAITableAstryx scroll.y', () => {
+  it.each([
+    [500 as const, '500px'],
+    ['60vh' as const, '60vh'],
+  ])('maps scroll.y=%s onto the CSS variable as %s', (y, expected) => {
+    const { container } = renderScrollTable({ scroll: { y } });
+    const layer = dimLayerOf(container);
+    expect(layer).toHaveClass('bai-table-astryx-scroll-y');
+    expect(layer.style.getPropertyValue('--bai-table-scroll-y')).toBe(expected);
+  });
+
+  it('stays off when scroll is absent or carries no y', () => {
+    const { container: withoutScroll } = renderScrollTable();
+    expect(dimLayerOf(withoutScroll)).not.toHaveClass(
+      'bai-table-astryx-scroll-y',
+    );
+
+    const { container: xOnly } = renderScrollTable({
+      scroll: { x: 'max-content' },
+    });
+    const layer = dimLayerOf(xOnly);
+    expect(layer).not.toHaveClass('bai-table-astryx-scroll-y');
+    expect(layer.style.getPropertyValue('--bai-table-scroll-y')).toBe('');
+  });
+
+  it('carries both axes at once', () => {
+    const { container } = renderScrollTable({
+      scroll: { x: 'max-content', y: 500 },
+    });
+    const layer = dimLayerOf(container);
+    expect(layer).toHaveClass('bai-table-astryx-scroll-x');
+    expect(layer).toHaveClass('bai-table-astryx-scroll-y');
+    expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe(
+      'max-content',
+    );
+    expect(layer.style.getPropertyValue('--bai-table-scroll-y')).toBe('500px');
+  });
+
+  it('restores the pinned header cell above the plain sticky ones', () => {
+    const { container } = renderScrollTable({
+      columns: SCROLL_PINNED_COLUMNS,
+      scroll: { x: 'max-content', y: 500 },
+    });
+    const [pinnedHeader, plainHeader] =
+      container.querySelectorAll<HTMLTableCellElement>('thead th');
+
+    expect(pinnedHeader.style.zIndex).toBe('3');
+    expect(plainHeader.style.zIndex).toBe('');
+    // The plugin's own inline sticky offset must survive the merge.
+    expect(pinnedHeader.style.insetInlineStart).toBe('0px');
+  });
+
+  it('lifts no header when nothing is pinned (selection-only shape)', () => {
+    // The VFolderTable-style call site: rowSelection, no `fixed` column. The
+    // z plugin must stay unregistered; the sticky header is CSS alone.
+    const { container } = renderScrollTable({
+      rowSelection: { selectedRowKeys: [], onChange: () => {} },
+      scroll: { x: 'max-content', y: 300 },
+    });
+    for (const th of container.querySelectorAll<HTMLTableCellElement>(
+      'thead th',
+    )) {
+      expect(th.style.zIndex).toBe('');
+    }
+  });
+
+  it('keeps the capped element reachable at either DOM depth', () => {
+    // `div:has(> table)`, not `> div`: resize (default on) inserts a
+    // `display: contents` wrapper that would swallow a child cap.
+    const withResize = renderScrollTable({ scroll: { y: 500 } }).container;
+    const resizeLayer = dimLayerOf(withResize);
+    expect(resizeLayer.querySelector('div:has(> table)')).not.toBeNull();
+    expect(resizeLayer.querySelector('div:has(> table)')).not.toBe(
+      resizeLayer.firstElementChild,
+    );
+
+    const withoutResize = renderScrollTable({
+      scroll: { y: 500 },
+      resizable: false,
+    }).container;
+    const plainLayer = dimLayerOf(withoutResize);
+    expect(plainLayer.querySelector('div:has(> table)')).toBe(
+      plainLayer.firstElementChild,
+    );
+  });
+
+  it('leaves header z-order to the sticky plugin when y mode is off', () => {
+    const { container } = renderScrollTable({
+      columns: SCROLL_PINNED_COLUMNS,
+      scroll: { x: 'max-content' },
+    });
+    const [pinnedHeader] =
+      container.querySelectorAll<HTMLTableCellElement>('thead th');
+    expect(pinnedHeader.style.zIndex).toBe('');
+  });
+});

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
@@ -195,6 +195,26 @@ const scrollData = [
   },
 ];
 
+export const Default: Story = {
+  name: 'Basic Table',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Basic table with sample data. `department` and `email` are hidden by default (`defaultHidden: true`) — open the settings gear to reveal them.',
+      },
+    },
+  },
+  args: {
+    columns: sampleColumns,
+    dataSource: sampleData,
+    pagination: {
+      total: sampleData.length,
+      pageSize: 10,
+    },
+  },
+};
+
 export const HorizontalScroll: Story = {
   name: 'Horizontal Scroll (scroll.x)',
   parameters: {
@@ -215,26 +235,6 @@ export const HorizontalScroll: Story = {
       />
     </div>
   ),
-};
-
-export const Default: Story = {
-  name: 'Basic Table',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Basic table with sample data. `department` and `email` are hidden by default (`defaultHidden: true`) — open the settings gear to reveal them.',
-      },
-    },
-  },
-  args: {
-    columns: sampleColumns,
-    dataSource: sampleData,
-    pagination: {
-      total: sampleData.length,
-      pageSize: 10,
-    },
-  },
 };
 
 export const WithColumnSettings: Story = {

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
@@ -32,10 +32,11 @@ const meta: Meta<typeof BAITableAstryx> = {
 - **Server-side pagination** — a custom bottom bar (not antd's pager)
 
 - **Horizontal scroll** via antd-shaped \`scroll={{ x }}\` — width-less columns take their content's intrinsic width (FR-3500)
+- **Vertical scroll** via \`scroll={{ y }}\` — the body is capped at \`y\` and the header row sticks (FR-3500)
 
 ## Dropped vs BAITable (see ticket 25 "Feature matrix" for the full list)
-- \`scroll.y\` (sticky-header body scroll)
 - \`loading\` dims rows but shows no spinner
+- \`scroll.y\`'s sticky header loses its bottom rule while scrolled (a collapsed-border rule cannot travel with a sticky cell)
 - Column groups (\`columns[].children\`) are flattened, not spanned
 - Row virtualization (deferred, explicit product decision)
         `,
@@ -195,6 +196,12 @@ const scrollData = [
   },
 ];
 
+// Enough rows in the same shape to overflow a 240px body cap.
+const verticalScrollData = Array.from({ length: 15 }, (_unused, index) => ({
+  ...scrollData[index % scrollData.length],
+  key: `n${index + 1}`,
+}));
+
 export const Default: Story = {
   name: 'Basic Table',
   parameters: {
@@ -232,6 +239,28 @@ export const HorizontalScroll: Story = {
         columns={scrollColumns}
         dataSource={scrollData}
         pagination={{ total: scrollData.length, pageSize: 10 }}
+      />
+    </div>
+  ),
+};
+
+export const VerticalScroll: Story = {
+  name: 'Vertical Scroll (scroll.y)',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`scroll={{ x: 'max-content', y: 240 }}` — the shape an `x`+`y` call site passes. `y` caps the scroll container at 240px and sticks the header row over an opaque base, so all 15 rows render inside a fixed-height body instead of growing the page. Both axes scroll in the same container: the `Name` column stays pinned while scrolling sideways, and its header stays put while scrolling down.",
+      },
+    },
+  },
+  render: () => (
+    <div style={{ width: 560 }}>
+      <BAITableAstryx
+        scroll={{ x: 'max-content', y: 240 }}
+        columns={scrollColumns}
+        dataSource={verticalScrollData}
+        pagination={{ total: verticalScrollData.length, pageSize: 20 }}
       />
     </div>
   ),

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
@@ -206,12 +206,12 @@ export const HorizontalScroll: Story = {
     },
   },
   render: () => (
-    <div style={{ width: 560, border: '1px dashed #999' }}>
+    <div style={{ width: 560 }}>
       <BAITableAstryx
         scroll={{ x: 'max-content' }}
         columns={scrollColumns}
         dataSource={scrollData}
-        pagination={false}
+        pagination={{ total: scrollData.length, pageSize: 10 }}
       />
     </div>
   ),

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
@@ -31,6 +31,8 @@ const meta: Meta<typeof BAITableAstryx> = {
 - **Sorting** via \`order\`/\`onChangeOrder\` order strings (unchanged from \`BAITable\`)
 - **Server-side pagination** — a custom bottom bar (not antd's pager)
 
+- **Horizontal scroll** via antd-shaped \`scroll={{ x }}\` — width-less columns take their content's intrinsic width (FR-3500)
+
 ## Dropped vs BAITable (see ticket 25 "Feature matrix" for the full list)
 - \`scroll.y\` (sticky-header body scroll)
 - \`loading\` dims rows but shows no spinner
@@ -160,6 +162,60 @@ const sampleData = [
     department: 'Engineering',
   },
 ];
+
+// The FR-3500 shape: long unwrapped resource labels in width-less columns,
+// inside a container far narrower than the content (the dashboard card).
+const scrollColumns: BAIColumnsType<any> = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name',
+    width: 120,
+    fixed: 'left',
+  },
+  { title: 'Allocation', dataIndex: 'allocation', key: 'allocation' },
+  { title: 'Usage', dataIndex: 'usage', key: 'usage' },
+  { title: 'Status', dataIndex: 'status', key: 'status' },
+];
+
+const scrollData = [
+  {
+    key: 'a1',
+    name: 'agent-node-with-a-deliberately-long-name-01',
+    allocation: 'CPU 126.9 / 128 cores · MEM 972.3 / 1024 GiB',
+    usage: 'CPU 87% (111.4 cores) · MEM 63% (645.1 GiB) · GPU 4/8 (fGPU 3.5)',
+    status: 'ALIVE (schedulable)',
+  },
+  {
+    key: 'a2',
+    name: 'agent-node-02',
+    allocation: 'CPU 12 / 64 cores · MEM 96 / 512 GiB',
+    usage: 'CPU 12% (7.7 cores) · MEM 18% (92.2 GiB) · GPU 0/4 (fGPU 0)',
+    status: 'ALIVE (schedulable)',
+  },
+];
+
+export const HorizontalScroll: Story = {
+  name: 'Horizontal Scroll (scroll.x)',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "antd-shaped `scroll={{ x: 'max-content' }}` inside a 560px container: width-less columns (Allocation / Usage / Status) take their content's intrinsic width and the table scrolls horizontally; the pixel-width `Name` column stays 120px and still truncates. Without `scroll.x` the same table squeezes every column into the container and clips the labels (FR-3500).",
+      },
+    },
+  },
+  render: () => (
+    <div style={{ width: 560, border: '1px dashed #999' }}>
+      <BAITableAstryx
+        scroll={{ x: 'max-content' }}
+        columns={scrollColumns}
+        dataSource={scrollData}
+        pagination={false}
+      />
+    </div>
+  ),
+};
 
 export const Default: Story = {
   name: 'Basic Table',

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.stories.tsx
@@ -66,6 +66,11 @@ const meta: Meta<typeof BAITableAstryx> = {
       description:
         'Sort order string (e.g. "name" ascending, "-name" descending)',
     },
+    scroll: {
+      control: { type: 'object' },
+      description:
+        'antd-shaped `{ x?, y? }` — `x` sizes the table from its content, `y` caps the body height with a sticky header',
+    },
   },
 };
 

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
@@ -38,11 +38,12 @@
    sticky          column-level `fixed: 'left' | 'right' | true`
    expansion       antd `expandedRowRender` (local plugin, see below)
    cellRow         antd `onCell` / `onRow` escape hatches (local plugin)
+   scrollX         x mode's per-column `max-width` release (local plugin)
 
  Astryx's canonical plugin order is columnSettings -> sort -> tree ->
  selection -> pagination, with unknown names appended in insertion order — so
- `resize` / `sticky` / `cellRow` / `expansion` run last, which is what they
- want (they read the FINAL column list).
+ `resize` / `sticky` / `scrollX` / `cellRow` / `expansion` run last, which is
+ what they want (they read the FINAL column list).
 
  Pagination is deliberately NOT the `useTablePagination` plugin: BUI's tables
  are server-paginated (the data is already sliced) and BUI renders its own
@@ -62,9 +63,11 @@
  - **`loading`** — antd dims the existing rows under a centred spinner. Astryx
    has no table loading state; the dim + `pointer-events: none` wrapper is
    reproduced, the spinner is not.
- - **`scroll`** is accepted and ignored — Astryx's own scroll wrapper already
-   handles horizontal overflow. `scroll.y` (sticky-header body scrolling) is
-   DROPPED.
+ - **`scroll.x`** IS wired, as rc-table wires it: width-less columns drop their
+   proportional width so their content defines them, and the table switches to
+   `table-layout: auto` with `width: <x>; min-width: 100%`. Columns with a
+   numeric/resized width stay pixel-fixed and keep truncating.
+   **`scroll.y`** (sticky-header body scrolling) is still not implemented.
  - **Column-level `fixed`** IS wired, via `useTableStickyColumns` — 40 of the
    74 call sites use it. antd pins per column; Astryx pins a contiguous RUN
    from each edge, so the adapter derives the run from the LEADING
@@ -161,6 +164,28 @@ const isDetailRow = (item: unknown): item is Record<string, unknown> =>
   typeof item === 'object' &&
   DETAIL_ROW_MARKER in (item as Record<string, unknown>);
 
+/** x-mode cell styles; module-scope so unstyled cells keep a stable identity. */
+const X_HEADER_RELEASE: React.CSSProperties = {
+  width: 'auto',
+  maxWidth: 'none',
+};
+const X_BODY_RELEASE: React.CSSProperties = { maxWidth: 'none' };
+
+const releaseCellClip = <
+  P extends { htmlProps: { style?: React.CSSProperties } },
+>(
+  props: P,
+  release: React.CSSProperties,
+): P => ({
+  ...props,
+  htmlProps: {
+    ...props.htmlProps,
+    style: props.htmlProps.style
+      ? { ...props.htmlProps.style, ...release }
+      : release,
+  },
+});
+
 /* -------------------------------------------------------------------------- */
 /* Public prop contract                                                        */
 /* -------------------------------------------------------------------------- */
@@ -228,7 +253,7 @@ export interface BAIAstryxTableProps<RecordType extends AnyRecord = AnyRecord> {
   loading?: boolean;
   /** Kept for prop parity with `BAITable`; behaves like `loading` here. */
   spinnerLoading?: boolean;
-  /** Drag-to-resize column borders. */
+  /** Drag-to-resize column borders. Defaults to on; pass `false` to opt out. */
   resizable?: boolean;
   /** Backend.AI order string, e.g. `-created_at`. */
   order?: string | null;
@@ -263,8 +288,11 @@ export interface BAIAstryxTableProps<RecordType extends AnyRecord = AnyRecord> {
   isStriped?: boolean;
   hasHover?: boolean;
   textOverflow?: 'wrap' | 'truncate';
-  /** Accepted and ignored — Astryx's scroll wrapper owns overflow. */
-  scroll?: unknown;
+  /**
+   * antd `scroll`. `x` is wired — see the file-header PILOT-DECISION for the
+   * semantics; `y` is accepted for parity but NOT implemented yet.
+   */
+  scroll?: { x?: number | string | true; y?: number | string };
   /**
    * Hide the header row. Astryx's `Table` has no such prop (its header carries
    * the sort controls and the select-all checkbox), so this is done in CSS:
@@ -404,7 +432,7 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
   size = 'small',
   loading,
   spinnerLoading,
-  resizable = false,
+  resizable = true,
   order,
   onChangeOrder,
   rowSelection,
@@ -420,6 +448,7 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
   isStriped,
   hasHover = true,
   textOverflow = 'truncate',
+  scroll,
   showHeader = true,
   className,
   style,
@@ -427,6 +456,17 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
   'use memo';
   const { t } = useBAIi18n();
   const { token } = theme.useToken();
+
+  // rc-table's own mapping of `scroll.x` onto the table's CSS width.
+  const scrollXWidth =
+    scroll?.x == null
+      ? undefined
+      : scroll.x === true
+        ? 'auto'
+        : typeof scroll.x === 'number'
+          ? `${scroll.x}px`
+          : scroll.x;
+  const isScrollX = scrollXWidth !== undefined;
 
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
@@ -690,21 +730,27 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
         </span>
       );
 
+      // x mode: a width-less column carries NO width so its content sizes it;
+      // `column.minWidth` is deliberately ignored there (FR-3500).
+      const astryxWidth =
+        numericWidth != null
+          ? pixel(numericWidth)
+          : isScrollX
+            ? undefined
+            : proportional(
+                1,
+                typeof column.minWidth === 'number'
+                  ? { minWidth: column.minWidth }
+                  : undefined,
+              );
+
       built.push({
         key,
         header,
         align: toAstryxAlign(column.align),
         sortable: column.sorter ? { sortKey: sortKeyOf(column, key) } : false,
         resizable: resizable,
-        width:
-          numericWidth != null
-            ? pixel(numericWidth)
-            : proportional(
-                1,
-                typeof column.minWidth === 'number'
-                  ? { minWidth: column.minWidth }
-                  : undefined,
-              ),
+        width: astryxWidth,
         renderCell: (item) => {
           if (isDetailRow(item)) return null;
           const record = item as RecordType;
@@ -767,6 +813,7 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
   }, [
     flatColumns,
     columnWidths,
+    isScrollX,
     resizable,
     hasExpandable,
     expandable,
@@ -903,6 +950,21 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [flatColumns, onRow, rowIndexByKey, rowKey],
+  );
+
+  /* ---- x-mode per-column max-width release ------------------------------- */
+
+  // Astryx clips cells with `max-width: 0`; x mode releases width-LESS columns
+  // only, so pixel/resized columns keep truncating (the header release also
+  // cancels the stray % width `resolveColumnWidths` hands width-less columns).
+  const scrollXPlugin: TablePlugin<AnyRow> = useMemo(
+    () => ({
+      transformHeaderCell: (props, column) =>
+        column.width != null ? props : releaseCellClip(props, X_HEADER_RELEASE),
+      transformBodyCell: (props, column) =>
+        column.width != null ? props : releaseCellClip(props, X_BODY_RELEASE),
+    }),
+    [],
   );
 
   /* ---- sorting ----------------------------------------------------------- */
@@ -1077,6 +1139,8 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
     }
     if (resizable) next.resize = resizePlugin;
     next.sticky = stickyPlugin;
+    // Before `cellRow`, so a consumer's `onCell` style still has the last word.
+    if (isScrollX) next.scrollX = scrollXPlugin;
     next.cellRow = cellRowPlugin;
     if (hasExpandable) next.expansion = expansionPlugin;
     return next;
@@ -1089,6 +1153,8 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
     resizable,
     resizePlugin,
     stickyPlugin,
+    isScrollX,
+    scrollXPlugin,
     cellRowPlugin,
     hasExpandable,
     expansionPlugin,
@@ -1157,15 +1223,14 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
           // its pagination bar by 24px.
           'bai-table-astryx-dim-layer',
           !showHeader && 'bai-table-astryx-no-header',
+          isScrollX && 'bai-table-astryx-scroll-x',
         )}
         style={
-          isDimmed
-            ? {
-                opacity: 0.5,
-                pointerEvents: 'none',
-                transition: 'opacity .2s ease',
-              }
-            : { transition: 'opacity .2s ease' }
+          {
+            transition: 'opacity .2s ease',
+            ...(isDimmed ? { opacity: 0.5, pointerEvents: 'none' } : null),
+            ...(isScrollX ? { '--bai-table-scroll-x': scrollXWidth } : null),
+          } as React.CSSProperties
         }
       >
         <Table<AnyRow>

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
@@ -39,11 +39,13 @@
    expansion       antd `expandedRowRender` (local plugin, see below)
    cellRow         antd `onCell` / `onRow` escape hatches (local plugin)
    scrollX         x mode's per-column `max-width` release (local plugin)
+   scrollY         y mode's pinned-header z-order restore (local plugin)
 
  Astryx's canonical plugin order is columnSettings -> sort -> tree ->
  selection -> pagination, with unknown names appended in insertion order — so
- `resize` / `sticky` / `scrollX` / `cellRow` / `expansion` run last, which is
- what they want (they read the FINAL column list).
+ `resize` / `sticky` / `scrollX` / `scrollY` / `cellRow` / `expansion` run
+ last, which is what they want: most read the FINAL column list, and `scrollY`
+ (which reads only pinned-ness) must run before `cellRow` so `onCell` wins.
 
  Pagination is deliberately NOT the `useTablePagination` plugin: BUI's tables
  are server-paginated (the data is already sliced) and BUI renders its own
@@ -67,7 +69,10 @@
    proportional width so their content defines them, and the table switches to
    `table-layout: auto` with `width: <x>; min-width: 100%`. Columns with a
    numeric/resized width stay pixel-fixed and keep truncating.
-   **`scroll.y`** (sticky-header body scrolling) is still not implemented.
+   **`scroll.y`** IS wired too: the scroll wrapper is capped at
+   `max-height: <y>` and every `<th>` goes `position: sticky; top: 0` over an
+   opaque base. The header's bottom rule belongs to the COLLAPSED table border,
+   not to the cell, so it scrolls away with the rows.
  - **Column-level `fixed`** IS wired, via `useTableStickyColumns` — 40 of the
    74 call sites use it. antd pins per column; Astryx pins a contiguous RUN
    from each edge, so the adapter derives the run from the LEADING
@@ -164,25 +169,33 @@ const isDetailRow = (item: unknown): item is Record<string, unknown> =>
   typeof item === 'object' &&
   DETAIL_ROW_MARKER in (item as Record<string, unknown>);
 
-/** x-mode cell styles; module-scope so unstyled cells keep a stable identity. */
+/** Scroll-mode cell styles; module-scope so cells keep a stable identity. */
 const X_HEADER_RELEASE: React.CSSProperties = {
   width: 'auto',
   maxWidth: 'none',
 };
 const X_BODY_RELEASE: React.CSSProperties = { maxWidth: 'none' };
+// Inline beats every @layer, restoring the pinned header's z 3 over the
+// sticky-header rule. Why: BAITableAstryx.css.
+const Y_PINNED_HEADER_STACK: React.CSSProperties = { zIndex: 3 };
 
-const releaseCellClip = <
+/** antd scroll values: numbers are px, strings pass through. */
+const toCssLength = (value: number | string): string =>
+  typeof value === 'number' ? `${value}px` : value;
+
+/** Merges inline style onto a cell's html props, keeping what plugins set. */
+const mergeCellStyle = <
   P extends { htmlProps: { style?: React.CSSProperties } },
 >(
   props: P,
-  release: React.CSSProperties,
+  extra: React.CSSProperties,
 ): P => ({
   ...props,
   htmlProps: {
     ...props.htmlProps,
     style: props.htmlProps.style
-      ? { ...props.htmlProps.style, ...release }
-      : release,
+      ? { ...props.htmlProps.style, ...extra }
+      : extra,
   },
 });
 
@@ -289,8 +302,9 @@ export interface BAIAstryxTableProps<RecordType extends AnyRecord = AnyRecord> {
   hasHover?: boolean;
   textOverflow?: 'wrap' | 'truncate';
   /**
-   * antd `scroll`. `x` is wired — see the file-header PILOT-DECISION for the
-   * semantics; `y` is accepted for parity but NOT implemented yet.
+   * antd `scroll`. Both axes are wired — see the file-header PILOT-DECISION:
+   * `x` sizes the table from its content, `y` caps the body height and sticks
+   * the header row.
    */
   scroll?: { x?: number | string | true; y?: number | string };
   /**
@@ -457,16 +471,16 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
   const { t } = useBAIi18n();
   const { token } = theme.useToken();
 
-  // rc-table's own mapping of `scroll.x` onto the table's CSS width.
+  // rc-table's own mapping of `scroll` onto CSS lengths (`y` has no `true`).
   const scrollXWidth =
     scroll?.x == null
       ? undefined
       : scroll.x === true
         ? 'auto'
-        : typeof scroll.x === 'number'
-          ? `${scroll.x}px`
-          : scroll.x;
+        : toCssLength(scroll.x);
   const isScrollX = scrollXWidth !== undefined;
+  const scrollYHeight = scroll?.y == null ? undefined : toCssLength(scroll.y);
+  const isScrollY = scrollYHeight !== undefined;
 
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
@@ -960,12 +974,29 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
   const scrollXPlugin: TablePlugin<AnyRow> = useMemo(
     () => ({
       transformHeaderCell: (props, column) =>
-        column.width != null ? props : releaseCellClip(props, X_HEADER_RELEASE),
+        column.width != null ? props : mergeCellStyle(props, X_HEADER_RELEASE),
       transformBodyCell: (props, column) =>
-        column.width != null ? props : releaseCellClip(props, X_BODY_RELEASE),
+        column.width != null ? props : mergeCellStyle(props, X_BODY_RELEASE),
     }),
     [],
   );
+
+  /* ---- y-mode pinned-header z-order restore ------------------------------ */
+
+  const hasPinnedColumns = !!(stickyConfig.startKeys || stickyConfig.endKeys);
+
+  const scrollYPlugin: TablePlugin<AnyRow> = useMemo(() => {
+    const pinned = new Set([
+      ...(stickyConfig.startKeys ?? []),
+      ...(stickyConfig.endKeys ?? []),
+    ]);
+    return {
+      transformHeaderCell: (props, column) =>
+        pinned.has(column.key)
+          ? mergeCellStyle(props, Y_PINNED_HEADER_STACK)
+          : props,
+    };
+  }, [stickyConfig]);
 
   /* ---- sorting ----------------------------------------------------------- */
 
@@ -1141,6 +1172,9 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
     next.sticky = stickyPlugin;
     // Before `cellRow`, so a consumer's `onCell` style still has the last word.
     if (isScrollX) next.scrollX = scrollXPlugin;
+    // Without pinned columns the y plugin has nothing to lift; the sticky
+    // header itself is pure CSS.
+    if (isScrollY && hasPinnedColumns) next.scrollY = scrollYPlugin;
     next.cellRow = cellRowPlugin;
     if (hasExpandable) next.expansion = expansionPlugin;
     return next;
@@ -1155,6 +1189,9 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
     stickyPlugin,
     isScrollX,
     scrollXPlugin,
+    isScrollY,
+    hasPinnedColumns,
+    scrollYPlugin,
     cellRowPlugin,
     hasExpandable,
     expansionPlugin,
@@ -1224,12 +1261,14 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
           'bai-table-astryx-dim-layer',
           !showHeader && 'bai-table-astryx-no-header',
           isScrollX && 'bai-table-astryx-scroll-x',
+          isScrollY && 'bai-table-astryx-scroll-y',
         )}
         style={
           {
             transition: 'opacity .2s ease',
             ...(isDimmed ? { opacity: 0.5, pointerEvents: 'none' } : null),
             ...(isScrollX ? { '--bai-table-scroll-x': scrollXWidth } : null),
+            ...(isScrollY ? { '--bai-table-scroll-y': scrollYHeight } : null),
           } as React.CSSProperties
         }
       >


### PR DESCRIPTION
Resolves #8668 (FR-3500)

## What

`BAITableAstryx`'s `scroll` prop was accepted-and-ignored since the Astryx table flip, leaving no table-level way to say "let content size the columns and scroll sideways" — on the Active Agents card the Allocation/Usage labels clipped with no scrollbar to reach them. This PR wires `scroll.x` back with antd's exact semantics, and defaults `resizable` to on so every table has the per-column width escape hatch.

## How `scroll.x` works

rc-table's own recipe (`@rc-component/table@1.10.2`):

- `<table>` gets `width: <x>; min-width: 100%` inside the always-present Astryx scroll wrapper (`x: true` → `auto`, number → px, string — including `'max-content'` — passes through).
- `table-layout: auto` — Astryx's data-driven table is `fixed`, where content never sizes a column; this is the same switch rc-table makes for `'max-content'` (ant-design#25227).
- Width-less columns drop their `proportional()` width so their content defines them. Declared-numeric and user-resized columns stay `pixel()`-fixed **and keep truncating**: the `max-width: 0` clip release is per column (inline styles via a `scrollX` plugin), because a table-wide release would let auto layout push a resized column back out to its content width.
- `column.minWidth` is ignored in x mode.

## How `scroll.y` works

- The scroll wrapper (already `overflow-x: auto`) is capped at `max-height: <y>` and every header cell goes `position: sticky; top: 0` over an opaque base — the sticky-column plugin's own background token, so a pinned corner matches. Matched as `div:has(> table)` because the resize plugin's `display: contents` measuring div changes the wrapper's DOM depth.
- Pinned header cells get their `z-index: 3` restored inline by a `scrollY` plugin (our `@layer components` rule would otherwise outrank the plugin's `astryx-base` z), registered only when a pinned column exists. Both axes scroll in one container; measured on the Vertical Scroll story (`x: 'max-content', y: 240`): clientHeight 225 / scrollHeight 479, corner sticky on both axes.
- Known limit (documented in the CSS): the header's bottom rule belongs to the collapsed table border and vanishes while scrolled; an inset `box-shadow` is the candidate follow-up.
- The two live `scroll.y` call sites — `GeneratedKeypairListModal` (`y: 500`, pinned column) and `DeploymentAddRevisionModal` → `VFolderTable` (`y: 300`, selection column) — now get their height cap back.

## Measurements (new `Horizontal Scroll` story, 560px container)

| | value |
|---|---|
| table width | 998px (container 558px) → horizontal scroll active |
| pixel column `Name` (120) | 120px, ellipsis intact |
| auto columns | 303 / 434 / 142px — content-sized, unclipped |

## Screenshots

Storybook `Horizontal Scroll` story — 560px container, 998px table.

| light (initial, neutral canvas) | dark (scrolled 440px; pre-canvas-fix capture) |
|---|---|
| ![light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8726/20260812-170752-scrollx-story-light-final.png) | ![dark scrolled](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8726/20260812-164258-scrollx-story-dark-scrolled.png) |

### scroll.y — Vertical Scroll story, both axes scrolled (↓120px, →150px)

![scroll.y sticky header]( create mode 100644 screenshots/pr-8726/20260813-035433-scrolly-story-scrolled.png)

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm exec vitest run src/components/Table` → 4 files, 25 tests passed (incl. new `BAITableAstryx.scrollX.test.tsx` pinning the value mapping and the per-column release)

## Notes for review

- Call-site adoption (Active Agents card, `ActiveAgents.tsx`'s `overflowX: hidden`, stale comments in `AdminUserManagement` / `SessionSlotCell` / `BAIUserNodes`) is deliberately out of scope — follow-up per FR-3500.
- `resizable` default flip: explicit `resizable={false}` call sites keep their opt-out; ~30 bare `resizable` props become redundant but harmless (no sweep).
