### PR TITLE
fix(FR-3525): keep the lab Tour callout above its spotlight backdrop

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,7 @@ overrides:
   lodash: ^4.18.0
 
 patchedDependencies:
+  '@astryxdesign/lab@0.3.0-canary.12db2a1': 0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08
   '@cloudscape-design/board-components@3.0.176': 06f6366f1016801dd543a4b968e088fbcbf34ee1a4473bc09a07e35206597a98
   ansi_up@6.0.6: 99856fc7fa4571c6ef4716cfd2dbf1151a025690c737775e248e8b7fe08a4459
   relay-runtime@20.1.1: cc791a2ea160bc7c87571401d2f1430d50527847c44039d45579a5bfa60effa6
@@ -716,7 +717,7 @@ importers:
         version: 0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@astryxdesign/lab':
         specifier: 0.3.0-canary.12db2a1
-        version: 0.3.0-canary.12db2a1(@astryxdesign/core@0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@astryxdesign/theme-neutral':
         specifier: 0.3.0
         version: 0.3.0(@astryxdesign/core@0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -957,7 +958,7 @@ importers:
     devDependencies:
       '@astryxdesign/cli':
         specifier: 0.3.0
-        version: 0.3.0(8681d4eefeacb7448bddfd79b6dea792)
+        version: 0.3.0(7899de1701eda587c13ad081945d384b)
       '@babel/core':
         specifier: 'catalog:'
         version: 7.29.7
@@ -11332,7 +11333,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@astryxdesign/cli@0.3.0(8681d4eefeacb7448bddfd79b6dea792)':
+  '@astryxdesign/cli@0.3.0(7899de1701eda587c13ad081945d384b)':
     dependencies:
       commander: 12.1.0
       gpt-tokenizer: 3.4.0
@@ -11341,7 +11342,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@astryxdesign/core': 0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@astryxdesign/lab': 0.3.0-canary.12db2a1(@astryxdesign/core@0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@astryxdesign/lab': 0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@astryxdesign/theme-neutral': 0.3.0(@astryxdesign/core@0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -11354,7 +11355,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@astryxdesign/lab@0.3.0-canary.12db2a1(@astryxdesign/core@0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@astryxdesign/lab@0.3.0-canary.12db2a1(patch_hash=0e5e0cbe89a52670bf3b7b7324794cf671a257ce501858d58f346a993af51e08)(@astryxdesign/core@0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@lexical/code@0.46.0(typescript@6.0.3))(@lexical/headless@0.46.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(@lexical/html@0.46.0(typescript@6.0.3))(@lexical/link@0.46.0(typescript@6.0.3))(@lexical/list@0.46.0(typescript@6.0.3))(@lexical/markdown@0.46.0(typescript@6.0.3))(@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31))(@lexical/rich-text@0.46.0(typescript@6.0.3))(@lexical/selection@0.46.0(typescript@6.0.3))(@lexical/utils@0.46.0(typescript@6.0.3))(@stylexjs/stylex@0.19.0)(lexical@0.46.0(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@astryxdesign/core': 0.3.0(@stylexjs/stylex@0.19.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@stylexjs/stylex': 0.19.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -151,6 +151,7 @@ overrides:
   lodash: ^4.18.0 # _.template RCE + _.unset prototype pollution (#321, #322 high)
 
 patchedDependencies:
+  "@astryxdesign/lab@0.3.0-canary.12db2a1": react/patches/@astryxdesign__lab@0.3.0-canary.12db2a1.patch
   "@cloudscape-design/board-components@3.0.176": react/patches/@cloudscape-design__board-components@3.0.176.patch
   ansi_up@6.0.6: react/patches/ansi_up@6.0.6.patch
   relay-runtime@20.1.1: react/patches/relay-runtime@20.1.1.patch

--- a/react/patches/@astryxdesign__lab@0.3.0-canary.12db2a1.patch
+++ b/react/patches/@astryxdesign__lab@0.3.0-canary.12db2a1.patch
@@ -1,0 +1,48 @@
+diff --git a/dist/Tour/TourStep.js b/dist/Tour/TourStep.js
+index 19c803aa98debc29728cbc69065f9144adb67ca8..3719b7865f676a90877986778577d546d0123818 100644
+--- a/dist/Tour/TourStep.js
++++ b/dist/Tour/TourStep.js
+@@ -102,12 +102,13 @@ function TourHighlight({
+     if (el == null || typeof el.showPopover !== 'function') {
+       return;
+     }
+-    el.showPopover();
+-    return () => {
+-      if (el.isConnected && typeof el.hidePopover === 'function') {
+-        el.hidePopover();
+-      }
+-    };
++    // Promote exactly once, and never hide-then-reshow: top-layer order is
++    // promotion order, so a re-promotion (React StrictMode's dev double-invoke
++    // of this effect) would move the overlay ABOVE the callout and paint the
++    // spotlight dim over it. Detaching the node drops it from the top layer.
++    if (!el.matches(':popover-open')) {
++      el.showPopover();
++    }
+   }, []);
+   return /*#__PURE__*/_jsx("div", {
+     ref: ref,
+diff --git a/src/Tour/TourStep.tsx b/src/Tour/TourStep.tsx
+index 1b98f09f5a487a690dcc35315b25e55b82cd93e1..56fcd7bd60fb6b07318ec676a1afc08d7ca52ebd 100644
+--- a/src/Tour/TourStep.tsx
++++ b/src/Tour/TourStep.tsx
+@@ -168,12 +168,13 @@ function TourHighlight({
+     if (el == null || typeof el.showPopover !== 'function') {
+       return;
+     }
+-    el.showPopover();
+-    return () => {
+-      if (el.isConnected && typeof el.hidePopover === 'function') {
+-        el.hidePopover();
+-      }
+-    };
++    // Promote exactly once, and never hide-then-reshow: top-layer order is
++    // promotion order, so a re-promotion (React StrictMode's dev double-invoke
++    // of this effect) would move the overlay ABOVE the callout and paint the
++    // spotlight dim over it. Detaching the node drops it from the top layer.
++    if (!el.matches(':popover-open')) {
++      el.showPopover();
++    }
+   }, []);
+ 
+   return (


### PR DESCRIPTION
Resolves #8719 (FR-3525)

## Mechanism — top-layer promotion order, inverted by StrictMode's double-invoke

The tour draws two things: a **spotlight overlay** (`TourHighlight` in
`@astryxdesign/lab/src/Tour/TourStep.tsx`, a `popover="manual"` div whose inner
`[data-testid="tour-highlight"]` box carries
`box-shadow: … , 0 0 0 9999px var(--color-overlay)` — that 9999px spread *is*
the dim) and the **callout** (a core `Popover`). Both are promoted into the
browser top layer with `showPopover()`, and **top-layer paint order is
promotion order**, not z-index — neither element has a z-index at all
(`z-index: auto` measured on both). The file's own comment states the intended
invariant: the highlight is "promoted once (never re-promoted) so that ordering
holds", with the callout promoted after it.

It was not promoted once. The promotion lived in a mount layout effect whose
cleanup called `hidePopover()`. React StrictMode (this app mounts under
`<React.StrictMode>`, `react/src/index.tsx`) double-invokes effects in dev:
cleanup-all, then re-run-all. The callout's `useLayer.show()` is guarded by its
own `isOpenRef` and does **not** re-promote, so the highlight came back **last**
and its dim painted over the callout.

Instrumenting `HTMLElement.prototype.showPopover` on the live page, before the
fix:

```
SHOWPOPOVER #1 tour-backdrop
SHOWPOPOVER #2 <callout "Input field validation errors…">
SHOWPOPOVER #3 tour-backdrop      ← StrictMode re-run; overlay now on top
```

Two controls confirm the mechanism rather than a look-alike:

- **Remove StrictMode locally** (temporary, reverted): only `#1` + `#2` fire and
  the callout renders at full contrast.
- **Re-promote the callout by hand** (`hidePopover(); showPopover()` on the
  callout, backdrop untouched): the callout surface goes from `rgb(140,140,140)`
  back to `rgb(255,255,255)` while the page stays dimmed at `rgb(140,140,140)`.

It is *not* an opacity or isolation problem: `opacity: 1` and
`isolation: auto` on the callout throughout. And the card stays clickable
because the overlay root sizes to **0×0** — `inset: 0` cannot beat the UA
popover rule's `width/height: fit-content`, and its only child is
`position: absolute` — so it captures no pointer events even though it paints
across the viewport.

## The fix

A pnpm patch on `@astryxdesign/lab@0.3.0-canary.12db2a1` (the repo already
carries three such patches under `react/patches/`): promote the overlay only
when it is not already open, and drop the `hidePopover()` cleanup — detaching
the node removes it from the top layer on its own. That makes the code do what
its comment already claimed.

```diff
-    el.showPopover();
-    return () => {
-      if (el.isConnected && typeof el.hidePopover === 'function') {
-        el.hidePopover();
-      }
-    };
+    if (!el.matches(':popover-open')) {
+      el.showPopover();
+    }
```

There is no fix available at the theme / prop / composition level: `hasBackdrop`
is the only knob, and turning it off drops the spotlight entirely. **This should
go upstream to facebook/astryx** (lab `Tour`); the patch is the diff to send.

## Measured before / after

Live on the dev server, `/admin/deployments/deployment-presets/new?step=review`
with an empty form, 1600×1000. Values are screenshot pixel samples (sRGB) at the
callout's bottom-left interior, with two references in the same frame.

| Sample | Light before | Light after | Dark before | Dark after |
|---|---|---|---|---|
| **Callout surface** | `rgb(140,140,140)` ❌ | `rgb(255,255,255)` ✅ | `rgb(17,17,17)` ❌ | `rgb(31,31,31)` ✅ |
| Spotlighted target (undimmed reference) | `rgb(255,255,255)` | `rgb(255,255,255)` | `rgb(20,20,20)` | `rgb(20,20,20)` |
| Plain page (dimmed reference) | `rgb(140,140,140)` | `rgb(140,140,140)` | `rgb(11,11,11)` | `rgb(11,11,11)` |

Before, the callout surface is pixel-identical to the dimmed page. After, it
matches the untinted surface token, and the backdrop still dims everything else
— `0.55 × 255 = 140` and `0.55 × 31 = 17` are exactly the
`--color-overlay: rgba(0,0,0,0.45)` composites, so the "before" numbers are the
dim landing on the card and nothing else.

Interaction re-exercised after the fix (light): all three steps, Next → Next,
callout surface `rgb(255,255,255)` on every step against a `rgb(140,140,140)`
page, `body.dark-theme` asserted for the dark pass, **0 pageerrors** in every
run.

Screenshots were not attached: the shared `assets/images` branch is checked out
by a concurrent agent worktree and `img.sh` could not commit. The pixel samples
above are the same evidence in numeric form.

## Verification

| Check | Result |
|---|---|
| `bash scripts/verify.sh` | `=== ALL PASS ===` |
| `pnpm --filter backend.ai-ui build` | built (required first — the fresh worktree had no `dist`, which fails `astryx theme build --check`) |
| `pnpm --prefix ./react exec vitest run` | 66 files, **1166 passed** |
| `pnpm --filter backend.ai-ui exec vitest run` | 42 files + 1 skipped, **590 passed / 1 skipped** |
| `node scripts/migration-gates/astryx-token-gate.mjs --strict` | exit 1 — **2 pre-existing findings**, both in `packages/backend.ai-ui/src/components/BAIText.{css,tsx}` (`var(--x)`, `var(--font-family-mono)`), untouched by this PR |
| `pnpm install --frozen-lockfile` | clean (patch path lives in `react/patches/` next to the existing three; the lockfile records the content hash, not the path) |

## Residue

- **This is a development-build defect.** StrictMode's effect double-invoke is
  dev-only, so a production bundle promoted the two layers in the right order
  already. The report came from a dev server, and the patch also removes the
  latent fragility for any future re-promotion (remount, fast refresh) —
  but do not read it as a production regression fix.
- **`SessionLauncherErrorTourProps.tsx` is fixed by the same change.** It uses
  the identical `<Tour hasBackdrop>` composition, and both the defect and the
  fix live in lab's shared `TourHighlight`, not at the call site. It could not
  be re-measured live: the session launcher's default form validates clean, so
  its validation tour never opens on an untouched cluster.
- **Not closed: FR-3526** (off-viewport spotlight targets not scrolled into view
  on step change). Different mechanism, untouched here.
- **Not closed: a tour-open race in our own call sites.** Both tour components
  resolve their targets in a single `requestAnimationFrame` after `isActive`
  flips and give up permanently if `.bai-card-error` has not painted yet, so the
  tour silently does not appear on a slow load. It cost several probe retries to
  reproduce. Pre-existing, out of scope, worth its own issue.
- The patch pins `0.3.0-canary.12db2a1`; the next `@astryxdesign/lab` bump will
  need it re-applied or dropped if upstream lands the fix.
