### PR TITLE
fix(FR-3531): hug the cluster-mode segmented control and trail its help glyph

### DIFF
--- a/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
+++ b/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
@@ -8,19 +8,29 @@ import { useSuspendedBackendaiClient } from '../../hooks';
 import { useCurrentKeyPairResourcePolicyLazyLoadQuery } from '../../hooks/hooksUsingRelay';
 import { RemainingSlots } from '../../hooks/useResourceLimitAndRemaining';
 import InputNumberWithSlider from '../InputNumberWithSlider';
+import BAISegmentedControlItemAstryx from '../astryx-bui/BAISegmentedControlItemAstryx';
 import RemainingMark from './RemainingMark';
 // FRONTIER (ticket 17): the form ENGINE is self-hosted since ticket 34 (live
 // again since ticket 35). The CONTROLS are Astryx now.
-import {
-  SegmentedControl,
-  SegmentedControlItem,
-} from '@astryxdesign/core/SegmentedControl';
+import { SegmentedControl } from '@astryxdesign/core/SegmentedControl';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
+import { spacingVars } from '@astryxdesign/core/theme/tokens.stylex';
+import * as stylex from '@stylexjs/stylex';
 import { BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { CircleHelp } from 'lucide-react';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+
+// FR-3531: hug the content instead of stretching to the parent's width.
+const clusterModeSegmentedStyles = stylex.create({
+  control: { alignSelf: 'flex-start' },
+  label: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+  },
+});
 
 /**
  * The cluster-mode segmented control. A local adapter rather than the shared
@@ -45,20 +55,25 @@ const ClusterModeSegmented: React.FC<{
       label={label}
       isDisabled={isDisabled}
       value={value ?? items[0]?.value ?? ''}
+      xstyle={clusterModeSegmentedStyles.control}
       onChange={(next) => {
         onChange?.(next);
         onValueChange();
       }}
     >
       {items.map((item) => (
-        <SegmentedControlItem
+        // FR-3531: the help affordance is a small view that trails the label,
+        // not a leading `icon` — Astryx renders the `icon` slot first.
+        <BAISegmentedControlItemAstryx
           key={item.value}
           value={item.value}
-          label={item.label}
-          icon={
-            <Tooltip content={item.tooltip}>
-              <CircleHelp size="1em" />
-            </Tooltip>
+          label={
+            <span {...stylex.props(clusterModeSegmentedStyles.label)}>
+              {item.label}
+              <Tooltip content={item.tooltip}>
+                <CircleHelp size="1em" />
+              </Tooltip>
+            </span>
           }
         />
       ))}
@@ -103,13 +118,8 @@ const ClusterModeFormItems: React.FC<ClusterModeFormItemsProps> = ({
             <BAIFlex direction="column" align="stretch">
               {/* MAPPING §3.10: `Radio.Group` whose children are
                   `Radio.Button` -> `SegmentedControl` + `SegmentedControlItem`.
-                  PILOT-DECISION: `SegmentedControlItem.label` is a required
-                  STRING (P2), so the per-option help tooltip cannot stay
-                  inside the label. It moves to the item's `icon` slot — the
-                  same `CircleHelp` glyph and the same `Trans` copy, now
-                  leading the label instead of trailing it (the only visual
-                  change) and with the manual `marginLeft` gone, since the
-                  slot owns its spacing. */}
+                  The per-option help tooltip stays inside the label (FR-3531),
+                  which `BAISegmentedControlItemAstryx` widens to a ReactNode. */}
               <Form.Item name={'cluster_mode'} required noStyle>
                 <ClusterModeSegmented
                   label={t('session.launcher.ClusterMode')}

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -29,6 +29,7 @@ import {
 } from '../ImageEnvironmentSelectFormItems';
 import InputNumberWithSlider from '../InputNumberWithSlider';
 import ResourcePresetSelect from '../ResourcePresetSelect';
+import BAISegmentedControlItemAstryx from '../astryx-bui/BAISegmentedControlItemAstryx';
 import RemainingMark from './RemainingMark';
 import SharedMemoryFormItems from './SharedMemoryFormItems';
 // FRONTIER (ticket 17): the launcher's form-visual core. The Form ENGINE and
@@ -36,12 +37,11 @@ import SharedMemoryFormItems from './SharedMemoryFormItems';
 // and every control and every piece of chrome below is Astryx now.
 import { Card } from '@astryxdesign/core/Card';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import {
-  SegmentedControl,
-  SegmentedControlItem,
-} from '@astryxdesign/core/SegmentedControl';
+import { SegmentedControl } from '@astryxdesign/core/SegmentedControl';
 import { VStack } from '@astryxdesign/core/Stack';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
+import { spacingVars } from '@astryxdesign/core/theme/tokens.stylex';
+import * as stylex from '@stylexjs/stylex';
 import {
   BAIFlex,
   useEventNotStable,
@@ -162,6 +162,16 @@ interface ResourceAllocationFormItemsProps {
   }>;
 }
 
+// FR-3531: hug the content instead of stretching to the parent's width.
+const clusterModeSegmentedStyles = stylex.create({
+  control: { alignSelf: 'flex-start' },
+  label: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+  },
+});
+
 /**
  * Cluster-mode segmented control — the twin of the one in
  * `ClusterModeFormItems`, declared locally for the same reason: each option
@@ -184,20 +194,25 @@ const ClusterModeSegmented: React.FC<{
       label={label}
       isDisabled={isDisabled}
       value={value ?? items[0]?.value ?? ''}
+      xstyle={clusterModeSegmentedStyles.control}
       onChange={(next) => {
         onChange?.(next);
         onValueChange();
       }}
     >
       {items.map((item) => (
-        <SegmentedControlItem
+        // FR-3531: the help affordance is a small view that trails the label,
+        // not a leading `icon` — Astryx renders the `icon` slot first.
+        <BAISegmentedControlItemAstryx
           key={item.value}
           value={item.value}
-          label={item.label}
-          icon={
-            <Tooltip content={item.tooltip}>
-              <CircleHelp size="1em" />
-            </Tooltip>
+          label={
+            <span {...stylex.props(clusterModeSegmentedStyles.label)}>
+              {item.label}
+              <Tooltip content={item.tooltip}>
+                <CircleHelp size="1em" />
+              </Tooltip>
+            </span>
           }
         />
       ))}
@@ -1550,9 +1565,7 @@ const ResourceAllocationFormItems: React.FC<
                     this one is `VStack gap`. No `xs`-driven reflow is lost:
                     both columns already spanned the full 24.
                     The Radio.Group -> SegmentedControl move mirrors
-                    `ClusterModeFormItems` exactly (same PILOT-DECISION: the
-                    per-option help tooltip becomes the item's `icon`, since
-                    `SegmentedControlItem.label` is a required string). */}
+                    `ClusterModeFormItems` exactly. */}
                 <VStack gap={5} align="stretch">
                   <Form.Item name={'cluster_mode'} required noStyle>
                     <ClusterModeSegmented

--- a/react/src/components/astryx-bui/BAISegmentedControlItemAstryx.tsx
+++ b/react/src/components/astryx-bui/BAISegmentedControlItemAstryx.tsx
@@ -1,0 +1,30 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ Astryx types `SegmentedControlItem.label` as `string` but renders it straight
+ through as children; it only reaches an attribute via `isLabelHidden`, which
+ this wrapper drops so a ReactNode label can never become an `aria-label`.
+*/
+import type { SegmentedControlItemProps } from '@astryxdesign/core/SegmentedControl';
+import { SegmentedControlItem } from '@astryxdesign/core/SegmentedControl';
+import React from 'react';
+
+export interface BAISegmentedControlItemAstryxProps extends Omit<
+  SegmentedControlItemProps,
+  'label' | 'isLabelHidden'
+> {
+  /** Widened from Astryx's `string` — see the file header. */
+  label: React.ReactNode;
+}
+
+const BAISegmentedControlItemAstryx: React.FC<
+  BAISegmentedControlItemAstryxProps
+> = ({ label, ...itemProps }) => {
+  'use memo';
+  return (
+    <SegmentedControlItem {...itemProps} label={label as unknown as string} />
+  );
+};
+
+export default BAISegmentedControlItemAstryx;


### PR DESCRIPTION
Resolves #8735 (FR-3531)

The cluster-mode segmented control on `/session/start?step=1` stretched to its parent's full width, and each option's help tooltip rendered to the **left** of the option label.

## Mechanism

**(a) Help glyph on the wrong side — `SegmentedControlItem.icon` renders before the label.**
The tooltip was passed through the item's `icon` slot, and Astryx renders `{iconElement}` before `{label}` (`SegmentedControlItem.tsx:253-254`). There is no icon-side prop.

The `?` is not conceptually an icon — it is a small view that belongs after the label. Astryx **types** `label` as `string` (`SegmentedControlItem.tsx:46`) but **renders it straight through as children** (`<span>{label}</span>`, line 254) with no coercion, and the only path where `label` reaches an HTML attribute is `aria-label={isLabelHidden ? label : undefined}` (line 226). So `label: string` is a type-level declaration, not a structural constraint. The tooltip moves into the label node, after the text.

The cast lives in **one** place — a new `BAISegmentedControlItemAstryx` wrapper (`.claude/rules/component-props-extension.md`) that extends `Omit<SegmentedControlItemProps, 'label' | 'isLabelHidden'>` and widens `label` to `ReactNode`. `isLabelHidden` is dropped deliberately: it is the only path that would turn the node into an `aria-label`. No CSS ordering rule, and the `icon` slot stays free for a real icon.

**(b) Full-width stretch — inherited cross-axis stretch, not a component default.**
`SegmentedControl`'s container is `display: inline-flex` with no `flex-grow`, but it sits in a `VStack` / `BAIFlex direction="column"` whose `align-items: stretch` sizes it on the cross axis. Measured: `align-self: auto`, `flex-grow: 0`, width `676px` = parent width. `layout="hug"` already defaults on and only sizes the *segments*, so this is call-site containment. Closed with the documented `xstyle` prop → `alignSelf: 'flex-start'`.

## Measured before / after

Live, `/session/start?step=1`, 1600×1000, same base commit for both columns. Light and dark are **identical** on every geometry number (this is a layout fix; no colour token is touched).

| Property | Before (light / dark) | After (light / dark) |
|---|---|---|
| `astryx-segmented-control` width | **676 px** / 676 px | **241 px** / 241 px |
| `align-self` | `auto` / `auto` | `flex-start` / `flex-start` |
| parent width (unchanged) | 676 px | 676 px |
| "Multi Node" glyph vs. label | icon `x=290`, label `x=310` → **LEFT** | label `x=290..364`, icon `x=368` → **RIGHT** |
| "Single Node" glyph vs. label | icon `x=410`, label `x=430` → **LEFT** | label `x=408..485`, icon `x=489` → **RIGHT** |
| glyph gap from label | n/a (leading) | 4 px (`--spacing-1`) |
| accessible names (aria snapshot) | `radio "Multi Node"`, `radio "Single Node"` | **unchanged** |
| tooltip surface | `rgb(255,255,255)` on `rgba(0,0,0,0.85)` light, `rgb(66,66,66)` dark | **unchanged** |
| `pageerror` count | 0 | 0 |

### Accessibility, verified not merely asserted

The label is now a `ReactNode` containing the tooltip, so the accessible name was re-measured rather than assumed:

- Playwright aria snapshot is byte-identical before and after: `radio "Multi Node" [checked]` / `radio "Single Node"`. `getByRole('radio', { name: 'Multi Node', exact: true })` matches exactly 1 node in both. The tooltip content sits in a closed popover (`display:none`), so it never entered the name — the pre-existing `textContent` noise is not the accessible name.
- No focusable descendant inside `role="radio"` (measured: `[]`), so the radiogroup's roving tabindex is intact. Arrow-key navigation re-verified: click "Single Node" → selected, `ArrowLeft` → back to "Multi Node", in both modes.
- Hover still opens the help tooltip on **both** options, in both modes.

**Honest residue on keyboard:** the help tooltip is hover-only, and *was already hover-only before this PR* — measured, not assumed. Focusing a segment opens Astryx's keyboard hint (`←→to navigate`), not the help tooltip, because `Tooltip`'s `focusTrigger: 'auto'` only attaches focus listeners to naturally-focusable children and the trigger is an `<svg>`. Making it focusable would require an interactive element nested inside `role="radio"` — invalid HTML, and it would inject a second tab stop into the roving-tabindex group. That needs an upstream Astryx affordance (a non-focusable-anchor focus trigger), not a call-site hack, so this PR preserves the existing behaviour rather than regressing structure to fake an improvement.

## Screenshots

| | Before | After |
|---|---|---|
| **Light** | ![before light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8737/20260813-030923-up-before-light.png) | ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8737/20260813-030923-up-after-light.png) |
| **Dark** | ![before dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8737/20260813-030923-up-before-dark.png) | ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8737/20260813-030923-up-after-dark.png) |

## Scope — which surfaces this reaches

| Surface | Renders `ClusterModeSegmented`? | Fixed? |
|---|---|---|
| Session launcher, `/session/start?step=1` | yes (`ResourceAllocationFormItems`) | **yes** — measured live |
| Deployment revision form (`DeploymentAddRevisionModal`) | yes — renders `ResourceAllocationFormItems` and does not pass `hideClusterFormItems` | **yes**, same component instance |
| Admin deployment preset form (`AdminDeploymentPresetSettingPageContent:934-957`) | **no** — that field is an `AstryxFormSelector` dropdown, not a segmented control | not applicable, nothing to fix |

`ClusterModeFormItems.tsx` holds a hand-maintained **twin** of `ClusterModeSegmented`. It currently has **no importers** in the app (only e2e comments reference it), so it renders nowhere and could not be measured. It is fixed identically anyway, because both files' comments declare them mirrors and leaving the twin behind would reintroduce the bug the moment it is wired up. Say the word and I will drop that half.

Per instruction, tooltip **colours** are untouched — #8727 owns tooltip token context. The only tooltip-adjacent change here is which DOM slot the trigger lives in.

## Verification

| Check | Result |
|---|---|
| `bash scripts/verify.sh` | `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup, StyleX sentinel, Astryx theme build, Terminology 0 blocking / 0 warn) |
| `pnpm --prefix ./react exec vitest run` | **66 files, 1166 tests passed**, 0 failed |
| `pnpm --filter backend.ai-ui exec vitest run` | **42 passed / 1 skipped (43 files), 590 passed / 1 skipped (591 tests)**, 0 failed |
| `pnpm --filter backend.ai-ui build` | built (no `packages/backend.ai-ui/src` change in this PR; needed only because `verify.sh`'s `astryx theme build --check` reads the BUI dist) |
| `node scripts/migration-gates/astryx-token-gate.mjs --strict` | **2 undeclared**, both **pre-existing on `main`** in `BAIText.css:28` and `BAIText.tsx:225`. Verified pre-existing: `git diff origin/main -- <those two files>` is empty — this branch does not touch them. Not fixed here. |
| Live probe, light **and** dark | both defects closed, 0 `pageerror` in every pass |

Tokens only: the one new length is `spacingVars['--spacing-1']`; no raw hex, no raw px.

## Residue

- **Below ~900 px the field is already broken, before and after.** Measured with a runtime counterfactual (toggling `align-self` on the live node): at 900 px the fix hugs cleanly (241 px control in a 280 px parent, no clipping, no overflow). At 768 px the parent column has *already* collapsed to 148 px — narrower than the control's 166 px min-content — so the old code clipped the segments inside the box and the new code overflows it. At 480 px the parent is 26 px and the entire launcher form is unreadable in both variants (see the pre-existing collapse). This is a separate, pre-existing responsive defect in the launcher's form column, not caused or worsened in kind by this change; it is not fixed here.
- Keyboard-focus tooltip trigger — see the accessibility note above; needs upstream Astryx.
- The two `ClusterModeSegmented` twins are still hand-duplicated. Deduplicating them is a separate refactor and is deliberately not attempted in a visual-fix PR.
