### PR TITLE
feat(FR-3533): close BUI twin gaps ahead of the astryx-bui fold

### DIFF
--- a/packages/backend.ai-ui/src/components/BAICard.tsx
+++ b/packages/backend.ai-ui/src/components/BAICard.tsx
@@ -160,6 +160,10 @@ export interface BAICardProps extends Omit<
   /** Callback function triggered when the extra button is clicked */
   onClickExtraButton?: () => void;
   size?: 'default' | 'small';
+  /** Astryx `Card` padding step; overrides the `size`-derived default (6, or 3 for `size="small"`). */
+  padding?: React.ComponentProps<typeof Card>['padding'];
+  /** Astryx `Card` width passthrough. */
+  width?: React.ComponentProps<typeof Card>['width'];
   /** antd's nested/inner card treatment. */
   type?: 'inner';
   /** antd v5 `bordered` / antd v6 `variant` — both mean the same thing here. */
@@ -189,6 +193,8 @@ const BAICard: React.FC<BAICardProps> = ({
   extra,
   title,
   size,
+  padding,
+  width,
   type,
   bordered: _bordered,
   variant: _variant,
@@ -260,7 +266,8 @@ const BAICard: React.FC<BAICardProps> = ({
         .filter(Boolean)
         .join(' ')}
       variant={type === 'inner' ? 'muted' : 'default'}
-      padding={size === 'small' ? 3 : 6}
+      padding={padding ?? (size === 'small' ? 3 : 6)}
+      width={width}
     >
       <VStack gap={4} align="stretch">
         {cover}

--- a/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.tsx
@@ -112,6 +112,8 @@ export interface BAIDeleteConfirmModalProps extends Omit<
   inputProps?: BAIDeleteConfirmModalInputProps;
   /** Content rendered between the input field and "cannot be undone" text (e.g. checkboxes). */
   extraContent?: React.ReactNode;
+  /** Override for "This action cannot be undone." Defaults to the localized string. */
+  cannotBeUndoneText?: string;
   /** Max height (px) of the scrollable item list. Default: 200. Set 0 for no limit. */
   itemListMaxHeight?: number;
   /**
@@ -152,6 +154,7 @@ const BAIDeleteConfirmModal: React.FC<BAIDeleteConfirmModalProps> = ({
   inputLabel,
   inputProps,
   extraContent,
+  cannotBeUndoneText,
   itemListMaxHeight = 200,
   plainItems = false,
   onOk,
@@ -174,8 +177,6 @@ const BAIDeleteConfirmModal: React.FC<BAIDeleteConfirmModalProps> = ({
     if (isOpen) setTypedText('');
   }
 
-  const needsInput = !reversible && (items.length > 1 || requireConfirmInput);
-
   const resolvedTitle =
     title ??
     (items.length > 1
@@ -189,6 +190,16 @@ const BAIDeleteConfirmModal: React.FC<BAIDeleteConfirmModalProps> = ({
     (items.length === 1
       ? (extractTextFromNode(items[0]?.label) ?? t('general.button.Delete'))
       : t('general.button.Delete'));
+
+  // An explicitly empty `confirmText` (e.g. the target row is not resolved yet)
+  // must not arm the gate with an already-satisfied empty comparison.
+  const needsInput =
+    !reversible &&
+    (items.length > 1 || requireConfirmInput) &&
+    !!resolvedConfirmText;
+
+  const resolvedWarning =
+    cannotBeUndoneText ?? t('comp:BAIDeleteConfirmModal.CannotBeUndone');
 
   const resolvedDescription =
     description ??
@@ -299,15 +310,18 @@ const BAIDeleteConfirmModal: React.FC<BAIDeleteConfirmModalProps> = ({
               hasClear
               htmlName="confirmText"
             />
+            {/* QA-FINDINGS Q-17: with the input present the warning is a danger
+                Text directly under it (legacy position), not a trailing Banner
+                below the option checkboxes. */}
+            <Text color="danger">{resolvedWarning}</Text>
           </VStack>
         ) : null}
-        {!reversible ? (
-          <Banner
-            status="error"
-            title={t('comp:BAIDeleteConfirmModal.CannotBeUndone')}
-          />
-        ) : null}
         {extraContent}
+        {/* A reversible-tier modal never had a warning; a non-input one has no
+            input to sit under, so it keeps the banner. */}
+        {!needsInput && !reversible ? (
+          <Banner status="error" title={resolvedWarning} />
+        ) : null}
       </VStack>
     </BAIModal>
   );


### PR DESCRIPTION
References #8739 (FR-3533)

First PR of the FR-3533 stack (consolidate `react/src/components/astryx-bui/` into `backend.ai-ui`). Closes the two BUI-twin capability gaps the fold in the next PR depends on:

**`BAIDeleteConfirmModal`**
- New `cannotBeUndoneText` prop (host twin had it; all 3 host call sites pass `t('dialog.warning.CannotBeUndone')`).
- QA-FINDINGS Q-17 warning placement ported from the host twin: with the typed-confirm input present, the warning renders as `Text color="danger"` directly under the input (legacy position); the `Banner status="error"` is kept only for the no-input variant and now renders after `extraContent` instead of before it (it used to sit above the option checkboxes — after the thing it warns about, on `PurgeUsersModal`).
- `needsInput` now also requires a non-empty resolved `confirmText`, so an explicitly empty `confirmText` (target row not yet resolved) cannot arm the gate pre-satisfied.

**`BAICard`**
- `padding` / `width` passthrough to the Astryx `Card`. `use-bai-card.md` already documents `padding` as the supported per-card inset knob; the prop now exists. Needed by `AllocationHistoryStatistics`'s `GraphCard` (`padding={4}`, `width="100%"`).

**Behavior note**: the Q-17 placement applies to every existing `BAIDeleteConfirmModal` call site — input-gated delete modals now show the danger text under the input instead of a trailing banner. This is the layout the QA report asked for and what the host-side variant already shipped on the VFolder pages.

**Verification**
- `bash scripts/verify.sh` → `=== ALL PASS ===`
- BUI vitest: 611 passed, 1 skipped (incl. `destructiveConfirmFlow.test.tsx`, the typed-confirm gate contract)
