### PR TITLE
fix(FR-3530): fire Form.Provider onFormChange for unnamed forms

### DIFF
--- a/packages/backend.ai-ui/src/form-engine/Form.tsx
+++ b/packages/backend.ai-ui/src/form-engine/Form.tsx
@@ -292,11 +292,11 @@ const Form = React.forwardRef(InternalForm) as <Values = any>(
 export interface FormProviderProps {
   validateMessages?: ValidateMessages;
   onFormChange?: (
-    name: string,
+    name: string | undefined,
     info: { changedFields: FieldData[]; forms: Record<string, FormInstance> },
   ) => void;
   onFormFinish?: (
-    name: string,
+    name: string | undefined,
     info: { values: Store; forms: Record<string, FormInstance> },
   ) => void;
   children?: React.ReactNode;
@@ -323,16 +323,14 @@ export const FormProvider: React.FC<FormProviderProps> = ({
       ...parent.validateMessages,
       ...validateMessages,
     },
+    // Unnamed forms fire too, with `name` undefined — rc-field-form parity.
+    // Guarding on the name silenced SessionLauncherPage's URL sync (FR-3530).
     triggerFormChange: (formName, changedFields) => {
-      if (onFormChange && formName) {
-        onFormChange(formName, { changedFields, forms: formsRef.current });
-      }
+      onFormChange?.(formName, { changedFields, forms: formsRef.current });
       parent.triggerFormChange(formName, changedFields);
     },
     triggerFormFinish: (formName, values) => {
-      if (onFormFinish && formName) {
-        onFormFinish(formName, { values, forms: formsRef.current });
-      }
+      onFormFinish?.(formName, { values, forms: formsRef.current });
       parent.triggerFormFinish(formName, values);
     },
     registerForm: (formName, formInstance) => {

--- a/react/src/form-engine/formEngineAcceptance.test.tsx
+++ b/react/src/form-engine/formEngineAcceptance.test.tsx
@@ -1314,6 +1314,55 @@ describe.each(IMPLEMENTATIONS)('form engine acceptance [%s]', (_name, Form) => {
     expect(onValuesChange).not.toHaveBeenCalled();
   });
 
+  // 25b. FR-3530 — SessionLauncherPage's real `<Form>` carries NO `name`, and
+  //      its URL sync rides `Form.Provider onFormChange`. rc-field-form fires
+  //      the callback for unnamed forms too (`name` undefined); a name guard
+  //      here silently killed the page's `formValues` query-param sync.
+  it('25b. Form.Provider onFormChange fires for unnamed forms, with name undefined', async () => {
+    const user = userEvent.setup();
+    let form!: FormInstance;
+    const captureForm = (instance: FormInstance) => {
+      form = instance;
+    };
+    const onFormChange = vi.fn();
+    const Demo = () => {
+      const instance = useTestForm(captureForm);
+      return (
+        <Form.Provider onFormChange={onFormChange}>
+          <Form form={instance} initialValues={{ a: '1' }}>
+            {/* Rule required: the programmatic leg reaches onFieldsChange via
+                validation, and a rule-less field is skipped there (test 1). */}
+            <Form.Item
+              name="a"
+              rules={[{ required: true, message: 'a required' }]}
+            >
+              <Input data-testid="a" />
+            </Form.Item>
+          </Form>
+        </Form.Provider>
+      );
+    };
+    render(<Demo />);
+    await settle();
+    onFormChange.mockClear();
+
+    // User input fires the channel even without a form name.
+    await user.type(screen.getByTestId('a'), '2');
+    await settle();
+    expect(onFormChange).toHaveBeenCalled();
+    expect(onFormChange.mock.calls[0][0]).toBeUndefined();
+
+    onFormChange.mockClear();
+
+    // So does a programmatic edit — the path SessionLauncherPage depends on.
+    await act(async () => {
+      form.setFieldValue('a', 'programmatic');
+    });
+    await form.validateFields().catch(() => undefined);
+    await settle();
+    expect(onFormChange).toHaveBeenCalled();
+  });
+
   // ==========================================================================
   // G. error channels
   // ==========================================================================


### PR DESCRIPTION
Resolves #8733 (FR-3530)

## Mechanism

The self-hosted form engine's `FormProvider` (`packages/backend.ai-ui/src/form-engine/Form.tsx`) guarded `triggerFormChange` / `triggerFormFinish` with `onFormChange && formName`, so a `<Form>` without a `name` prop never reached `Form.Provider onFormChange`. rc-field-form — the engine's oracle — fires the callback unconditionally, passing `name` as `undefined` for unnamed forms.

SessionLauncherPage's debounced `formValues` URL sync (`syncFormToURLWithDebounce`) rides `Form.Provider onFormChange` on a **nameless** `<Form form={form}>`, so the guard silently killed the sync after the antd → engine switch. Acceptance test 25 was written for this exact page but its fixture used `name="launcher"`, which is why the suite stayed green.

Fix: drop the name guard (both channels, for parity), widen the callback types to `name: string | undefined`, and pin the unnamed case with acceptance test **25b**.

## Before / after

| Probe | Before (main) | After (this branch) |
|---|---|---|
| Acceptance test 25b (unnamed form → `onFormChange`) | **fails** (`expected "vi.fn()" to be called at least once`) | passes (30/30) |
| `/session/start`: type session name | URL unchanged (reported symptom) | `"sessionName":"fr3530-probe"` appears in `formValues` after the 500ms debounce |
| Switch session type to Batch | URL unchanged | `"sessionType":"batch"` + batch subtree appear immediately |
| Reload the synced URL | entered state lost | session name, Batch type, and batch config all restored |

Live probe on the shared test backend (`10.82.0.130:8090`), non-destructively (no session launched). The fix is form-event plumbing with no theme/mode interaction; light/dark parity is unaffected by construction.

![reload restores the synced form — session name, Batch type, batch config](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8753/20260813-091303-after-reload-restore.png)

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → 88 files, **1406 passed** (includes the new 25b)
- `pnpm --filter backend.ai-ui build` → OK; `pnpm --filter backend.ai-ui exec vitest run` → **611 passed**, 1 skipped
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 2 findings in `BAIText` (**pre-existing on main**, verified by stashing this diff and re-running; untouched by this PR)

## Residue

- The related report FR-3499 (image environment selector) is already Done and not touched here.
- While probing, the e2e login helper (`test-util.ts login()`) could not find the `Endpoint` field after clicking `Advanced` on the login screen, and does not tolerate an already-authenticated storage state — pre-existing harness friction, not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
