### PR TITLE
fix(FR-3526): scroll off-viewport tour spotlight targets into view on step change

### DIFF
--- a/react/src/components/AdminDeploymentPresetValidationTour.tsx
+++ b/react/src/components/AdminDeploymentPresetValidationTour.tsx
@@ -3,7 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useBAISettingUserState } from '../hooks/useBAISetting';
-import { Tour, TourStep } from '@astryxdesign/lab';
+import BAITourAstryx from './astryx-bui/BAITourAstryx';
+import { TourStep } from '@astryxdesign/lab';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -67,8 +68,6 @@ const PresetValidationTour: React.FC<PresetValidationTourProps> = ({
         setTargets(null);
         return;
       }
-      // antd `scrollIntoViewOptions` parity: bring the first target on screen.
-      card.scrollIntoView({ block: 'center' });
       setTargets({
         card,
         extra: card.querySelector<HTMLElement>('.bai-card__extra'),
@@ -88,7 +87,16 @@ const PresetValidationTour: React.FC<PresetValidationTourProps> = ({
   };
 
   return (
-    <Tour isActive hasBackdrop isStepCountShown onDismiss={handleDismiss}>
+    <BAITourAstryx
+      isActive
+      hasBackdrop
+      isStepCountShown
+      onDismiss={handleDismiss}
+      // One entry per rendered step, in step order (nulls are skipped below).
+      scrollTargets={[targets.card, targets.extra, targets.nav].filter(
+        (el): el is HTMLElement => el != null,
+      )}
+    >
       <TourStep
         targetRef={{ current: targets.card }}
         heading={t('tourGuide.deploymentPreset.ValidationErrorTitle')}
@@ -111,7 +119,7 @@ const PresetValidationTour: React.FC<PresetValidationTourProps> = ({
           {t('tourGuide.deploymentPreset.FixErrorAndTryAgainText')}
         </TourStep>
       ) : null}
-    </Tour>
+    </BAITourAstryx>
   );
 };
 

--- a/react/src/components/SessionLauncherErrorTourProps.tsx
+++ b/react/src/components/SessionLauncherErrorTourProps.tsx
@@ -7,7 +7,8 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 // `@astryxdesign/lab@0.3.0-canary.12db2a1`, so the Astryx Tour is available.
 // This file follows `AdminDeploymentPresetValidationTour` — the same
 // three-step "you have a validation error" tour — verbatim.
-import { Tour, TourStep } from '@astryxdesign/lab';
+import BAITourAstryx from './astryx-bui/BAITourAstryx';
+import { TourStep } from '@astryxdesign/lab';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -18,14 +19,14 @@ import { useTranslation } from 'react-i18next';
  * surface is entirely different, so the blanket antd-prop passthrough
  * (`{...otherProps}`) had nothing left to carry. `onClose` loses antd's mouse
  * event — the consumer ignores it. antd's `scrollIntoViewOptions` (passed as a
- * bare boolean at the call site) becomes an explicit `scrollIntoView` on the
- * first target, matching the preset tour.
+ * bare boolean at the call site) is handled per step by `BAITourAstryx`
+ * (FR-3526), matching the preset tour.
  */
 interface SessionLauncherValidationTourProps {
   open?: boolean;
   onClose?: () => void;
   /** Accepted for source compatibility with the existing call site; the
-   *  scroll behaviour is now unconditional on the first step. */
+   *  scroll behaviour is unconditional, per step, via `BAITourAstryx`. */
   scrollIntoViewOptions?: boolean;
 }
 
@@ -73,8 +74,6 @@ const SessionLauncherValidationTour: React.FC<
         setTargets(null);
         return;
       }
-      // antd `scrollIntoViewOptions` parity: bring the first target on screen.
-      card.scrollIntoView({ block: 'center' });
       setTargets({
         card,
         head: card.querySelector<HTMLElement>('.bai-card__head'),
@@ -94,7 +93,16 @@ const SessionLauncherValidationTour: React.FC<
   };
 
   return (
-    <Tour isActive hasBackdrop isStepCountShown onDismiss={handleDismiss}>
+    <BAITourAstryx
+      isActive
+      hasBackdrop
+      isStepCountShown
+      onDismiss={handleDismiss}
+      // One entry per rendered step, in step order (nulls are skipped below).
+      scrollTargets={[targets.card, targets.head, targets.nav].filter(
+        (el): el is HTMLElement => el != null,
+      )}
+    >
       <TourStep
         targetRef={{ current: targets.card }}
         heading={t('tourGuide.neoSessionLauncher.ValidationErrorTitle')}
@@ -117,7 +125,7 @@ const SessionLauncherValidationTour: React.FC<
           {t('tourGuide.neoSessionLauncher.FixErrorAndTryAgainText')}
         </TourStep>
       ) : null}
-    </Tour>
+    </BAITourAstryx>
   );
 };
 

--- a/react/src/components/astryx-bui/BAITourAstryx.tsx
+++ b/react/src/components/astryx-bui/BAITourAstryx.tsx
@@ -1,0 +1,64 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { Tour, type TourProps, useTour } from '@astryxdesign/lab';
+import React, { useEffect, useEffectEvent } from 'react';
+
+export interface BAITourAstryxProps extends TourProps {
+  /**
+   * Ordered scroll targets, one per RENDERED `TourStep` (skip steps that are
+   * not rendered). When a step activates and its target sits outside the
+   * viewport, it is scrolled into view — antd Tour `scrollIntoViewOptions`
+   * parity (FR-3526).
+   */
+  scrollTargets?: Array<HTMLElement | null | undefined>;
+}
+
+// lab TourStep spotlights the target at its current box but never scrolls it
+// on screen, so an off-viewport step points at nothing (FR-3526).
+const ActiveTargetScroller: React.FC<{
+  targets: Array<HTMLElement | null | undefined>;
+}> = ({ targets }) => {
+  'use memo';
+  const tour = useTour();
+  const activeStepIndex = tour?.activeStepIndex ?? -1;
+
+  const scrollActiveTargetIntoView = useEffectEvent(() => {
+    const el = activeStepIndex >= 0 ? targets[activeStepIndex] : null;
+    if (!el) {
+      return;
+    }
+    const box = el.getBoundingClientRect();
+    const isInViewport =
+      box.top >= 0 &&
+      box.left >= 0 &&
+      box.bottom <= window.innerHeight &&
+      box.right <= window.innerWidth;
+    if (!isInViewport) {
+      el.scrollIntoView({ block: 'center' });
+    }
+  });
+
+  useEffect(() => {
+    scrollActiveTargetIntoView();
+  }, [activeStepIndex]);
+
+  return null;
+};
+
+const BAITourAstryx: React.FC<BAITourAstryxProps> = ({
+  scrollTargets,
+  children,
+  ...tourProps
+}) => {
+  'use memo';
+  return (
+    <Tour {...tourProps}>
+      {scrollTargets ? <ActiveTargetScroller targets={scrollTargets} /> : null}
+      {children}
+    </Tour>
+  );
+};
+
+export default BAITourAstryx;


### PR DESCRIPTION
Resolves #8720 (FR-3526)

## Mechanism

The lab `TourStep` (`@astryxdesign/lab`) draws its spotlight at the target's *current* box and re-measures on scroll/resize, but never scrolls the target on screen when the step activates. Both migrated validation tours only compensated with a one-shot `scrollIntoView` on the **first** target at mount, so advancing to a step whose target sat below the fold left the user staring at a dimmed page with the spotlight (and callout) rendered off-viewport.

The lab package publicly exports `useTour()` with `activeStepIndex`, so the fix is an app-side wrapper — no lab patch needed:

- **`react/src/components/astryx-bui/BAITourAstryx.tsx`** (new): wraps lab `Tour`; a render-null child observes `useTour().activeStepIndex` and, when a step activates with its target outside the viewport, calls `target.scrollIntoView({ block: 'center' })`. Skips the scroll when the target is already fully visible — the same if-needed semantics antd's rc-tour applied with its `scrollIntoViewOptions` default (`isInViewPort` check + `scrollIntoView`).
- **`AdminDeploymentPresetValidationTour.tsx`** / **`SessionLauncherErrorTourProps.tsx`**: render `BAITourAstryx` with `scrollTargets` (one entry per rendered step, nulls filtered in step order). The wrapper also covers step 0, so each file's one-shot mount scroll is removed.

## Measured before/after

Live probe on the dev server (`/admin/deployments/deployment-presets/new?step=review`, empty form, viewport 1280×600 so the step-navigation bar starts below the fold at `top: 940`):

| Step (target) | Before — nav rect | After — nav rect |
|---|---|---|
| 1 (error card) | card `top:174` in viewport; nav `top:940` off-viewport | same (no scroll needed) |
| 2 (card `extra`) | nav `top:940` off-viewport | same (target already visible → no scroll, if-needed) |
| **3 (step navigation)** | **nav stays `top:940` — spotlight points off-screen** | **page scrolls, nav at `top:540` (centered, in viewport)** |

Dark mode (entered via the header toggle, `document.documentElement.dataset.theme === 'dark'` asserted): identical measurements (nav 940 → 540). Zero `pageerror` in all passes (light before/after, dark after).

### Screenshots

| Before — step 3 (light) | After — step 3 (light) |
|---|---|
| ![before step3](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8754/20260813-091831-before-light-step3.png) | ![after step3](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8754/20260813-091842-after-light-step3.png) |

| After — step 1 (light, unchanged) | After — step 3 (dark) |
|---|---|
| ![after step1](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8754/20260813-091836-after-light-step1.png) | ![after dark step3](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8754/20260813-091848-after-dark-step3.png) |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript / Vite warmup / StyleX sentinel / Astryx theme build / Terminology)
- `pnpm --prefix ./react exec vitest run` → 88 files, 1405 passed
- `pnpm --filter backend.ai-ui exec vitest run` → 611 passed, 1 skipped
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1 with the same 2 pre-existing `BAIText.css`/`BAIText.tsx` findings as `main` (verified by running the gate on `main`); this change adds no CSS/tokens

## Residue

- The session-launcher validation tour (`SessionLauncherErrorTourProps.tsx`) gets the identical wrapper + `scrollTargets` conversion but was verified statically only (verify.sh + vitest); the live probe exercised the deployment-preset tour. Both tours share the same three-step structure and the same scroller code path.
- The lab `Tour` itself still doesn't scroll; if more lab Tour usages appear they must use `BAITourAstryx` (or the lab component should grow the behavior upstream).
