### PR TITLE
docs(FR-3539): point THEME_NAME_REV at its source instead of a stale literal

### DIFF
--- a/.claude/skills/astryx-fix/SKILL.md
+++ b/.claude/skills/astryx-fix/SKILL.md
@@ -150,7 +150,9 @@ none.
      `ANTD_BOX_SHADOW_SECONDARY`, …). BUI cannot import from `react/src`, so the
      measured tables live there and are re-exported.
 
-2. **Bump `THEME_NAME_REV`** (`backendAiTheme.ts`, currently **10**) whenever
+2. **Bump `THEME_NAME_REV`** (read the current value from
+   `react/src/astryx-theme/backendAiTheme.ts` — do not trust any number quoted
+   in docs, it goes stale on every theme fix) whenever
    the *static recipe* changes, and add any new keys to the seed-hash array.
    The theme's `name` **is** its identity — it becomes the `data-astryx-theme`
    attribute, and when two `defineTheme()` calls share a name the **first


### PR DESCRIPTION
Resolves #8767 (FR-3539)

## Summary

The astryx-fix skill's theme procedure (step 2) quoted the current `THEME_NAME_REV` as **10**. The actual value on main is **15**, and the literal has drifted twice already — #8727 corrected it to 12 shortly before being closed, and it went stale again the same day. A wrong "current value" here can mislead the next fixer into computing the wrong next REV.

This replaces the literal with an instruction to read the current value from `react/src/astryx-theme/backendAiTheme.ts` (the single source of truth), so the sentence can never go stale again.

## Verification

Docs-only change to `.claude/skills/astryx-fix/SKILL.md` — no runtime code touched; nothing to build or test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)