### PR TITLE
fix(FR-3540): use the declared --font-family-code token for BAIText monospace

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -220,7 +220,7 @@ const BAIText: React.FC<BAITextProps> = ({
   const anchorRef = useRef<HTMLElement | null>(null);
 
   const decorationStyle: CSSProperties = {
-    ...(monospace && { fontFamily: 'var(--font-family-mono, monospace)' }),
+    ...(monospace && { fontFamily: 'var(--font-family-code, monospace)' }),
     ...(italic && { fontStyle: 'italic' }),
     ...(underline && deleteProp
       ? { textDecoration: 'underline line-through' }


### PR DESCRIPTION
Resolves #8768 (FR-3540)

## Bug

`packages/backend.ai-ui/src/components/BAIText.tsx` referenced `var(--font-family-mono, monospace)` for the `monospace` prop's font family. `--font-family-mono` was never declared anywhere in the theme — the declared font tokens are `--font-family-body`, `--font-family-code`, and `--font-family-heading`. Since the custom property never resolved, the `monospace` literal fallback always won silently, so `BAIText monospace` never actually rendered the theme's code font.

## Fix

One-line change: `var(--font-family-mono, monospace)` → `var(--font-family-code, monospace)`, using the token that is actually declared.

## Verification

- `pnpm install --prefer-offline`
- `pnpm --filter backend.ai-ui build` — succeeds
- `bash scripts/verify.sh` — ends `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, StyleX cssInjectionTarget, Astryx theme build, Terminology all pass)
- `pnpm --filter backend.ai-ui exec vitest run` — 611 passed, 1 skipped (46 test files passed, 1 skipped)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` — undeclared findings dropped from **2 → 1**. The one remaining finding (`packages/backend.ai-ui/src/components/BAIText.css:28 var(--x) [fallback 'literal' wins forever]`) is a known false positive: it's a `var(--x)` reference inside a comment, not real usage, and is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

