### PR TITLE
style(FR-3543): mute placeholders to the antd quaternary strength

### DIFF
--- a/packages/backend.ai-ui/src/styles/backend.ai-ui.css
+++ b/packages/backend.ai-ui/src/styles/backend.ai-ui.css
@@ -122,11 +122,11 @@
   }
 
   /* Astryx paints placeholders with `--color-text-secondary`, which this theme
-     pins at entered-text strength; dark keeps 0.65 for legibility (FR-3543). */
+     pins at entered-text strength (FR-3543). */
   :root {
     --bai-color-text-placeholder: light-dark(
       rgba(0, 0, 0, 0.45),
-      rgba(255, 255, 255, 0.65)
+      rgba(255, 255, 255, 0.45)
     );
   }
 

--- a/packages/backend.ai-ui/src/styles/backend.ai-ui.css
+++ b/packages/backend.ai-ui/src/styles/backend.ai-ui.css
@@ -121,32 +121,17 @@
     );
   }
 
-  /* ======================== Placeholder strength (FR-3543) ================
-
-     Astryx paints every placeholder with the SECONDARY text token, and the
-     antd-parity theme pins that token at 0.65 alpha — nearly entered-text
-     strength, so empty and filled fields read the same. Placeholders get
-     their own strength token instead: antd's colorTextTertiary step (0.45),
-     picked over strict placeholder parity (antd's colorTextPlaceholder was
-     0.25, the quaternary/disabled step) so an empty field still reads as a
-     hint but does not look disabled.
-
-     The compiled StyleX placeholder rule is unlayered with id-level
-     specificity, so it is not overridable — but it only READS
-     `--color-text-secondary`, so the token is remapped on the
-     placeholder-bearing element instead. `:placeholder-shown` scopes the
-     remap to empty fields (NumberInput colors its invalid VALUE with the
-     secondary token); `.astryx-selector`'s popover is a DOM sibling of the
-     root, so its option list is out of reach; the chat composer's overlay
-     `<div>` is its own only secondary consumer. MultiSelector's trigger is
-     deliberately left out — its "+N" overflow count shares the token. */
+  /* Astryx paints placeholders with `--color-text-secondary`, which this theme
+     pins at entered-text strength; dark keeps 0.65 for legibility (FR-3543). */
   :root {
     --bai-color-text-placeholder: light-dark(
       rgba(0, 0, 0, 0.45),
-      rgba(255, 255, 255, 0.45)
+      rgba(255, 255, 255, 0.65)
     );
   }
 
+  /* `:placeholder-shown` only — NumberInput paints its invalid VALUE with the
+     same token. */
   input:placeholder-shown,
   textarea:placeholder-shown,
   .astryx-selector,

--- a/packages/backend.ai-ui/src/styles/backend.ai-ui.css
+++ b/packages/backend.ai-ui/src/styles/backend.ai-ui.css
@@ -120,6 +120,39 @@
         var(--text-supporting-leading)
     );
   }
+
+  /* ======================== Placeholder strength (FR-3543) ================
+
+     Astryx paints every placeholder with the SECONDARY text token, and the
+     antd-parity theme pins that token at 0.65 alpha — nearly entered-text
+     strength, so empty and filled fields read the same. Placeholders get
+     their own strength token instead: antd's colorTextTertiary step (0.45),
+     picked over strict placeholder parity (antd's colorTextPlaceholder was
+     0.25, the quaternary/disabled step) so an empty field still reads as a
+     hint but does not look disabled.
+
+     The compiled StyleX placeholder rule is unlayered with id-level
+     specificity, so it is not overridable — but it only READS
+     `--color-text-secondary`, so the token is remapped on the
+     placeholder-bearing element instead. `:placeholder-shown` scopes the
+     remap to empty fields (NumberInput colors its invalid VALUE with the
+     secondary token); `.astryx-selector`'s popover is a DOM sibling of the
+     root, so its option list is out of reach; the chat composer's overlay
+     `<div>` is its own only secondary consumer. MultiSelector's trigger is
+     deliberately left out — its "+N" overflow count shares the token. */
+  :root {
+    --bai-color-text-placeholder: light-dark(
+      rgba(0, 0, 0, 0.45),
+      rgba(255, 255, 255, 0.45)
+    );
+  }
+
+  input:placeholder-shown,
+  textarea:placeholder-shown,
+  .astryx-selector,
+  .astryx-chat-composer-input > [aria-hidden='true'] {
+    --color-text-secondary: var(--bai-color-text-placeholder);
+  }
 }
 
 /* Keyframes are not layerable — `@keyframes` inside `@layer` is legal but the


### PR DESCRIPTION
Resolves #8776 (FR-3543)

Placeholder text rendered at nearly entered-text strength across every input in the app, so empty and filled fields were hard to tell apart at a glance.

## Mechanism

Astryx's entire input family (`TextInput`, `TextArea`, `NumberInput`, the date/time inputs, `Typeahead`/`CommandPalette` search fields) paints `::placeholder` with `var(--color-text-secondary)`, and `Selector`'s trigger and the chat composer's overlay placeholder use the same token. The antd-parity theme (FR-3482 audit 1) pins `--color-text-secondary` at `rgba(0,0,0,0.65)` / `rgba(255,255,255,0.65)` — antd's *body-secondary* strength — so placeholders inherited it.

Placeholders now get their own strength token, `--bai-color-text-placeholder`, set in both modes to **antd's `colorTextTertiary` step (0.45)**. This is a deliberate departure from strict legacy placeholder parity (antd's `colorTextPlaceholder` was `colorTextQuaternary` = 0.25, the same value as the disabled step): at 0.25 an empty field reads as *disabled*; at 0.45 it reads as a hint — fainter than entered text (`#141414` in light, pure white in dark) but clearly stronger than disabled.

The compiled StyleX placeholder rule is **unlayered with id-level specificity** (`.xeyghm5:not(#\#)×7::placeholder`), so it cannot be out-cascaded. But it only *reads* the token — so the fix remaps `--color-text-secondary → var(--bai-color-text-placeholder)` on the placeholder-bearing elements themselves, in `backend.ai-ui.css` (`@layer components`), with no specificity fight and no `!important`:

- `input:placeholder-shown` / `textarea:placeholder-shown` — scoped to the **empty** state, because `NumberInput` paints its *invalid typed value* with the same secondary token (unconditional remap would fade real text).
- `.astryx-selector` — safe unconditionally: its popover (option list, empty state) is a DOM **sibling** of the root, and the trigger's other consumers use icon tokens.
- `.astryx-chat-composer-input > [aria-hidden='true']` — the composer's overlay placeholder `<div>`, its own only secondary consumer.

## Measured before/after (live app, dev server `fr-3543`)

| Surface | Mode | Before | After | Entered text (unchanged) |
|---|---|---|---|---|
| `input`/`textarea` `::placeholder` (login, session search) | light | `rgba(0,0,0,0.65)` | `rgba(0,0,0,0.45)` | `rgb(20,20,20)` |
| same | dark | `rgba(255,255,255,0.65)` | `rgba(255,255,255,0.45)` | `rgb(255,255,255)` |
| Chat composer overlay placeholder | light / dark | 0.65 alpha | `rgba(0,0,0,0.45)` / `rgba(255,255,255,0.45)` | — |
| `.astryx-selector` root token | both | `light-dark(rgba(0,0,0,0.65), rgba(255,255,255,0.65))` | the placeholder token (0.45 pair) | filled trigger stays `--color-text-primary` (measured `rgb(20,20,20)`) |

"Before" values are the un-remapped `--color-text-secondary` measured on `document.body` of the same build; the before screenshots recreate it by re-pinning the token at 0.65 via an injected style, since the CSS change is branch-wide.

## Screenshots

### Light — before (0.65) → after (0.45)

| Before (0.65) | After (0.45) |
|---|---|
| ![login light before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8777/20260814-033300-login-light-before.png) | ![login light after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8777/20260814-041811-login-light-after-045.png) |

### Dark — after (0.45)

Create Preset, dark mode: `Name`, `Description`, `Runtime`, `Image` and the resource-slot fields all render their placeholders at 0.45, legible but plainly weaker than the entered `1` in Cluster Size.

![create preset dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8777/20260819-013500-create-preset-dark-045.png)

> The chat-page dark capture that circulated during review is not a fair sample: that composer was **disabled** (the deployment could not respond), and Astryx dims a disabled composer with nested opacity — `.astryx-chat-composer-input` `0.5` inside `.astryx-chat-composer` `0.6`. Its placeholder therefore rendered at an effective alpha of ~`0.135`, well below even the disabled step (0.25), rather than the 0.45 this PR sets.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built OK (BUI src changed)
- `pnpm --filter backend.ai-ui exec vitest run` → 611 passed | 1 skipped (612)
- `pnpm --prefix ./react exec vitest run` → 1405 passed (88 files)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → the new `--bai-color-text-placeholder` counts as declared (268 → 269); the single remaining finding is `BAIText.css:28 var(--x)`, a **pre-existing false positive** (the literal string `var(--x, literal)` inside a comment shipped by FR-3518 #8730) — verified failing identically on a clean `origin/main` checkout with this change stashed.
- Live probe: light and dark both measured on the running app (`document.body.classList.contains('dark-theme')` asserted). Console shows only the pre-existing environment noise every dev server against this backend emits (mixed-content warnings, Relay normalizer warnings, `/func/totp` 404) — none introduced by this change.

## Residue

- **MultiSelector's trigger placeholder still renders at 0.65** — deliberately excluded because its "+N" overflow count shares the secondary token on the same subtree; a remap would fade it to placeholder strength. Fixing it cleanly needs either an upstream placeholder token in Astryx or a stable class on the placeholder span.
- Upstream, Astryx has no dedicated placeholder token (its own theme generator maps the `Text` `placeholder` color variant to `--color-text-secondary` too) — this fix is downstream compensation, worth an upstream report.

## Dev server

`https://fr-3543.localhost:1336` (serving this branch from a worktree, backend `http://10.82.130.172:8090` pre-filled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
