### PR TITLE
fix(FR-3479): give start-service its own 60s request timeout

### DIFF
--- a/packages/backend.ai-client/src/resources/compute-session.ts
+++ b/packages/backend.ai-client/src/resources/compute-session.ts
@@ -214,7 +214,10 @@ export class ComputeSession {
         arguments: JSON.stringify(args) || undefined,
       },
     );
-    return this.client._wrapWithPromise(rqst);
+    // App launch traverses webserver → manager RPC → agent → krunner; the
+    // backend-side budget (BA-7258) can exceed the client-wide 30s default,
+    // so give start-service its own longer timeout (FR-3479).
+    return this.client._wrapWithPromise(rqst, false, null, 60_000);
   }
 
   /**


### PR DESCRIPTION
Resolves [FR-3479](https://lablup.atlassian.net/browse/FR-3479)

> The GitHub clone of FR-3479 has not been created by the Jira webhook yet; this reference will be updated to `Resolves #N (FR-3479)` once it appears.

## Problem

`startService()` calls `_wrapWithPromise(rqst)` without a timeout argument, so the client-wide `requestTimeout` of 30s applies to `POST /session/{id}/start-service`. BA-7258 raises the agent-side app-launch budget (browser → webserver → manager RPC → agent → krunner); with the browser aborting at 30s, any backend budget at or above ~25s would just move the failure into the browser instead of fixing it.

## Changes

- `packages/backend.ai-client/src/resources/compute-session.ts` — `startService()` now passes an explicit `60_000` ms timeout as `_wrapWithPromise`'s 4th argument, so start-service outlives the backend budget while every other request keeps the 30s default.

## Why no UI change (relation to #8640)

FR-3479's second acceptance criterion — a genuine client-side timeout must be displayed as a timeout, not a generic fetch failure — is already satisfied by the PR below this one in the stack, #8640 (FR-3478): its `_resolveV2ProxyUri` catch resolves the client's plain-object rejection via `getErrorMessage`, which surfaces the timeout payload's `No response returned within timeout` message. This PR therefore only needs the client-side timeout bump, and stacks on #8640.

## Acceptance criteria (from FR-3479)

- [x] start-service requests are not aborted by the client before the backend budget configured in BA-7258 elapses — 60s per-request timeout.
- [x] A genuine client-side timeout is displayed as a timeout, not as "Failed to fetch" — via #8640's `getErrorMessage` path.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, i18n structure, terminology)

Depends on: BA-7258 (backend budget; this change is harmless if it lands first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FR-3479]: https://lablup.atlassian.net/browse/FR-3479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ