### PR TITLE
fix(FR-3486): keep notices above modal backdrops and drop the backdrop blur

### DIFF
--- a/packages/backend.ai-ui/src/app-shim/appShim.test.tsx
+++ b/packages/backend.ai-ui/src/app-shim/appShim.test.tsx
@@ -17,8 +17,8 @@ import { BAIAppProvider } from './index';
 import { message } from './message';
 import { modal } from './modal';
 import type { ShowToastFn, ToastOptions } from '@astryxdesign/core/Toast';
-import { cleanup, render } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 interface ShownToast {
   options: ToastOptions;
@@ -121,71 +121,80 @@ describe('app-shim message', () => {
 });
 
 describe('app-shim top-layer re-entry (FR-3486)', () => {
-  // jsdom has neither the Popover API nor the `:modal` / `:popover-open`
-  // selectors, so the fixtures carry instance-level stand-ins. The Astryx
-  // toast viewport BAIAppProvider mounts has no stubs, which also exercises
-  // the listener's `typeof showPopover` guard.
-  function mountNotice({ isPopoverOpen }: { isPopoverOpen: boolean }) {
+  // jsdom lacks the Popover API and the `:modal` / `:popover-open` selectors,
+  // so fixtures carry instance-level stand-ins. Never hoist them into a
+  // setupTests prototype polyfill: the listener branches on the method's
+  // ABSENCE, and a global polyfill would make that branch untestable.
+  const fixtures: HTMLElement[] = [];
+
+  function mountNotice({ isPopoverOpen = false, hasPopoverApi = true } = {}) {
     const el = document.createElement('div');
     el.setAttribute('popover', 'manual');
     el.setAttribute('data-bai-top-layer', '');
-    const showPopover = vi.fn();
-    const hidePopover = vi.fn();
-    Object.assign(el, { showPopover, hidePopover });
-    const nativeMatches = el.matches.bind(el);
     el.matches = (selector: string) =>
-      selector === ':popover-open' ? isPopoverOpen : nativeMatches(selector);
+      selector === ':popover-open' && isPopoverOpen;
+    const calls: string[] = [];
+    if (hasPopoverApi) {
+      Object.assign(el, {
+        showPopover: () => calls.push('show'),
+        hidePopover: () => calls.push('hide'),
+      });
+    }
     document.body.appendChild(el);
-    return { showPopover, hidePopover };
+    fixtures.push(el);
+    return calls;
   }
 
-  function dispatchToggle(
-    target: HTMLElement,
-    { isModal = true, newState = 'open' } = {},
-  ) {
-    if (target instanceof HTMLDialogElement) {
-      const nativeMatches = target.matches.bind(target);
-      target.matches = (selector: string) =>
-        selector === ':modal' ? isModal : nativeMatches(selector);
-    }
+  function dispatchToggle({
+    tag = 'dialog',
+    isModal = true,
+    newState = 'open',
+  } = {}) {
+    const target = document.createElement(tag);
+    target.matches = (selector: string) => selector === ':modal' && isModal;
     document.body.appendChild(target);
+    fixtures.push(target);
     const event = new Event('toggle');
     Object.assign(event, { newState });
     target.dispatchEvent(event);
   }
 
+  beforeEach(() => {
+    render(<BAIAppProvider />);
+  });
+
   afterEach(() => {
-    cleanup();
-    document.body.innerHTML = '';
+    fixtures.splice(0).forEach((el) => el.remove());
   });
 
   it('re-enters an open notice surface when a modal dialog opens', () => {
-    render(<BAIAppProvider />);
-    const notice = mountNotice({ isPopoverOpen: true });
-    dispatchToggle(document.createElement('dialog'));
-    expect(notice.hidePopover).toHaveBeenCalledTimes(1);
-    expect(notice.showPopover).toHaveBeenCalledTimes(1);
-    expect(notice.hidePopover.mock.invocationCallOrder[0]).toBeLessThan(
-      notice.showPopover.mock.invocationCallOrder[0],
-    );
+    const calls = mountNotice({ isPopoverOpen: true });
+    dispatchToggle();
+    expect(calls).toEqual(['hide', 'show']);
   });
 
   it('shows a not-yet-promoted notice without hiding it first', () => {
-    render(<BAIAppProvider />);
-    const notice = mountNotice({ isPopoverOpen: false });
-    dispatchToggle(document.createElement('dialog'));
-    expect(notice.hidePopover).not.toHaveBeenCalled();
-    expect(notice.showPopover).toHaveBeenCalledTimes(1);
+    const calls = mountNotice();
+    dispatchToggle();
+    expect(calls).toEqual(['show']);
   });
 
-  it('ignores dialog close, non-modal dialogs, and non-dialog toggles', () => {
-    render(<BAIAppProvider />);
-    const notice = mountNotice({ isPopoverOpen: true });
-    dispatchToggle(document.createElement('dialog'), { newState: 'closed' });
-    dispatchToggle(document.createElement('dialog'), { isModal: false });
-    dispatchToggle(document.createElement('div'));
-    expect(notice.hidePopover).not.toHaveBeenCalled();
-    expect(notice.showPopover).not.toHaveBeenCalled();
+  it('skips a notice without the Popover API instead of throwing', () => {
+    const bare = mountNotice({ isPopoverOpen: true, hasPopoverApi: false });
+    const stubbed = mountNotice({ isPopoverOpen: true });
+    dispatchToggle();
+    expect(bare).toEqual([]);
+    expect(stubbed).toEqual(['hide', 'show']);
+  });
+
+  it.each([
+    { name: 'dialog close', options: { newState: 'closed' } },
+    { name: 'a non-modal dialog', options: { isModal: false } },
+    { name: 'a non-dialog toggle', options: { tag: 'div' } },
+  ])('ignores $name', ({ options }) => {
+    const calls = mountNotice({ isPopoverOpen: true });
+    dispatchToggle(options);
+    expect(calls).toEqual([]);
   });
 });
 

--- a/packages/backend.ai-ui/src/app-shim/appShim.test.tsx
+++ b/packages/backend.ai-ui/src/app-shim/appShim.test.tsx
@@ -127,12 +127,18 @@ describe('app-shim top-layer re-entry (FR-3486)', () => {
   // ABSENCE, and a global polyfill would make that branch untestable.
   const fixtures: HTMLElement[] = [];
 
+  // TS 6 types `matches` with `this`-based predicate overloads, so a plain
+  // boolean stub only assigns through `unknown`.
+  const stubMatches = (fn: (selector: string) => boolean) =>
+    fn as unknown as Element['matches'];
+
   function mountNotice({ isPopoverOpen = false, hasPopoverApi = true } = {}) {
     const el = document.createElement('div');
     el.setAttribute('popover', 'manual');
     el.setAttribute('data-bai-top-layer', '');
-    el.matches = (selector: string) =>
-      selector === ':popover-open' && isPopoverOpen;
+    el.matches = stubMatches(
+      (selector) => selector === ':popover-open' && isPopoverOpen,
+    );
     const calls: string[] = [];
     if (hasPopoverApi) {
       Object.assign(el, {
@@ -151,7 +157,9 @@ describe('app-shim top-layer re-entry (FR-3486)', () => {
     newState = 'open',
   } = {}) {
     const target = document.createElement(tag);
-    target.matches = (selector: string) => selector === ':modal' && isModal;
+    target.matches = stubMatches(
+      (selector) => selector === ':modal' && isModal,
+    );
     document.body.appendChild(target);
     fixtures.push(target);
     const event = new Event('toggle');

--- a/packages/backend.ai-ui/src/app-shim/appShim.test.tsx
+++ b/packages/backend.ai-ui/src/app-shim/appShim.test.tsx
@@ -13,9 +13,11 @@ import {
   registerBridge,
   setMessageConfig,
 } from './bridge';
+import { BAIAppProvider } from './index';
 import { message } from './message';
 import { modal } from './modal';
 import type { ShowToastFn, ToastOptions } from '@astryxdesign/core/Toast';
+import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 interface ShownToast {
@@ -115,6 +117,75 @@ describe('app-shim message', () => {
   it('keeps unsupported antd APIs loud instead of silently dropping', () => {
     expect(() => message.loading()).toThrow(/not implemented/);
     expect(() => message.destroy()).toThrow(/not implemented/);
+  });
+});
+
+describe('app-shim top-layer re-entry (FR-3486)', () => {
+  // jsdom has neither the Popover API nor the `:modal` / `:popover-open`
+  // selectors, so the fixtures carry instance-level stand-ins. The Astryx
+  // toast viewport BAIAppProvider mounts has no stubs, which also exercises
+  // the listener's `typeof showPopover` guard.
+  function mountNotice({ isPopoverOpen }: { isPopoverOpen: boolean }) {
+    const el = document.createElement('div');
+    el.setAttribute('popover', 'manual');
+    el.setAttribute('data-bai-top-layer', '');
+    const showPopover = vi.fn();
+    const hidePopover = vi.fn();
+    Object.assign(el, { showPopover, hidePopover });
+    const nativeMatches = el.matches.bind(el);
+    el.matches = (selector: string) =>
+      selector === ':popover-open' ? isPopoverOpen : nativeMatches(selector);
+    document.body.appendChild(el);
+    return { showPopover, hidePopover };
+  }
+
+  function dispatchToggle(
+    target: HTMLElement,
+    { isModal = true, newState = 'open' } = {},
+  ) {
+    if (target instanceof HTMLDialogElement) {
+      const nativeMatches = target.matches.bind(target);
+      target.matches = (selector: string) =>
+        selector === ':modal' ? isModal : nativeMatches(selector);
+    }
+    document.body.appendChild(target);
+    const event = new Event('toggle');
+    Object.assign(event, { newState });
+    target.dispatchEvent(event);
+  }
+
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+  });
+
+  it('re-enters an open notice surface when a modal dialog opens', () => {
+    render(<BAIAppProvider />);
+    const notice = mountNotice({ isPopoverOpen: true });
+    dispatchToggle(document.createElement('dialog'));
+    expect(notice.hidePopover).toHaveBeenCalledTimes(1);
+    expect(notice.showPopover).toHaveBeenCalledTimes(1);
+    expect(notice.hidePopover.mock.invocationCallOrder[0]).toBeLessThan(
+      notice.showPopover.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('shows a not-yet-promoted notice without hiding it first', () => {
+    render(<BAIAppProvider />);
+    const notice = mountNotice({ isPopoverOpen: false });
+    dispatchToggle(document.createElement('dialog'));
+    expect(notice.hidePopover).not.toHaveBeenCalled();
+    expect(notice.showPopover).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores dialog close, non-modal dialogs, and non-dialog toggles', () => {
+    render(<BAIAppProvider />);
+    const notice = mountNotice({ isPopoverOpen: true });
+    dispatchToggle(document.createElement('dialog'), { newState: 'closed' });
+    dispatchToggle(document.createElement('dialog'), { isModal: false });
+    dispatchToggle(document.createElement('div'));
+    expect(notice.hidePopover).not.toHaveBeenCalled();
+    expect(notice.showPopover).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend.ai-ui/src/app-shim/index.tsx
+++ b/packages/backend.ai-ui/src/app-shim/index.tsx
@@ -23,6 +23,7 @@
  Astryx's `LayerProvider` (toast viewport + layer stacking), the toast bridge
  registration, and the imperative-modal host.
 */
+import useEventListener from '../hooks/useEventListener';
 import {
   registerBridge,
   setMessageConfig,
@@ -86,6 +87,38 @@ const BAIAppBridgeMount: React.FC<{
     registerBridge({ showToast });
     return () => registerBridge(null);
   }, [showToast]);
+
+  // The CSS top layer stacks by entry order, so a `showModal()` backdrop
+  // paints over notice popovers that entered earlier; re-enter them on each
+  // modal open. Notices stay inert while a modal is open (FR-3486).
+  // `[role="region"][popover="manual"]` is Astryx 0.4.0 ToastViewport's
+  // internal DOM (src/Toast/ToastViewport.tsx) — no refresh hook is exposed.
+  useEventListener(
+    'toggle',
+    (e) => {
+      const dialog = e.target;
+      if (
+        !(dialog instanceof HTMLDialogElement) ||
+        (e as ToggleEvent).newState !== 'open' ||
+        !dialog.matches(':modal')
+      ) {
+        return;
+      }
+      document
+        .querySelectorAll<HTMLElement>(
+          '[popover="manual"]:is([role="region"], [data-bai-top-layer])',
+        )
+        .forEach((el) => {
+          try {
+            if (el.matches(':popover-open')) el.hidePopover();
+            el.showPopover();
+          } catch {
+            /* disconnected mid-toggle */
+          }
+        });
+    },
+    { target: () => document, capture: true },
+  );
 
   return null;
 };

--- a/packages/backend.ai-ui/src/app-shim/index.tsx
+++ b/packages/backend.ai-ui/src/app-shim/index.tsx
@@ -109,11 +109,12 @@ const BAIAppBridgeMount: React.FC<{
           '[popover="manual"]:is([role="region"], [data-bai-top-layer])',
         )
         .forEach((el) => {
+          if (typeof el.showPopover !== 'function') return;
           try {
             if (el.matches(':popover-open')) el.hidePopover();
             el.showPopover();
           } catch {
-            /* disconnected mid-toggle */
+            /* a beforetoggle handler flipped the popover mid-re-entry */
           }
         });
     },

--- a/packages/backend.ai-ui/src/styles/backend.ai-ui.css
+++ b/packages/backend.ai-ui/src/styles/backend.ai-ui.css
@@ -120,6 +120,16 @@
         var(--text-supporting-leading)
     );
   }
+
+  /* A modal backdrop dims but never blurs — blur makes notices behind the
+     top-most dialog unreadable (FR-3486). Astryx hardcodes `blur(2px)` in
+     `astryx-base` with no token or stable class hook, so the selector is
+     deliberately un-scoped; `components` outranks `astryx-base` by layer
+     order. */
+  dialog::backdrop {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
 }
 
 /* Keyframes are not layerable — `@keyframes` inside `@layer` is legal but the

--- a/react/src/components/astryx-bui/BAINotificationStackAstryx.tsx
+++ b/react/src/components/astryx-bui/BAINotificationStackAstryx.tsx
@@ -323,6 +323,24 @@ const BAINotificationStackAstryx: React.FC<BAINotificationStackAstryxProps> = ({
 
   return (
     <div
+      // A manual popover, so the stack enters the CSS top layer — a fixed
+      // div's z-index cannot compete with a modal <dialog>'s backdrop there.
+      // `data-bai-top-layer` opts into the app-shim's re-promotion on modal
+      // open; notices stay inert while a modal is open (FR-3486). Mirrors
+      // Astryx ToastViewport's own top-layer promotion.
+      popover="manual"
+      data-bai-top-layer=""
+      ref={(el) => {
+        // API guard first: `:popover-open` throws in matches() where the
+        // Popover API is missing (the CSS fallback keeps the stack visible).
+        if (
+          el &&
+          typeof el.showPopover === 'function' &&
+          !el.matches(':popover-open')
+        ) {
+          el.showPopover();
+        }
+      }}
       className="bai-notification-stack"
       // e2e anchor: the stack, each notice, and each notice's status are
       // addressable without reaching into Astryx's own class names (P7).

--- a/react/src/components/astryx-bui/astryxBui.css
+++ b/react/src/components/astryx-bui/astryxBui.css
@@ -119,6 +119,15 @@
    bars, retry/cancel actions and a link, and they stack. */
 .bai-notification-stack {
   position: fixed;
+  /* Neutralize the UA popover defaults — the stack is a `popover="manual"`
+     so it renders in the CSS top layer above modal backdrops (FR-3486). */
+  inset: auto;
+  margin: 0;
+  border: none;
+  padding: 0;
+  overflow: visible;
+  background: transparent;
+  color: inherit;
   /* `--spacing-6` = 24px, antd's own notification inset. */
   inset-block-end: var(--spacing-6);
   inset-inline-end: var(--spacing-6);
@@ -129,9 +138,9 @@
   gap: var(--spacing-3);
   width: 384px; /* antd's notification width; not on the spacing scale. */
   max-width: calc(100vw - var(--spacing-6) * 2);
-  /* The theme-shim owns `zIndexPopupBase` (verdict `self`, value 1000) because
-     Astryx layering is a LayerProvider concern with no token. Kept in one
-     place here rather than repeated per item. */
+  /* Only used where the Popover API is unavailable (`display: flex` keeps the
+     stack rendered as a plain fixed element there); the top layer ignores it.
+     1000 = the theme-shim's `zIndexPopupBase`. */
   z-index: 1000;
   pointer-events: none;
 }

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -179,7 +179,9 @@ check_astryx_theme_built() {
 run_check "Relay" check_relay_drift
 run_check "Lint" pnpm -r --stream lint
 run_check "Format" pnpm run format
-run_check "TypeScript" pnpm --prefix ./react exec tsc --noEmit
+
+run_check "TypeScript (react)" pnpm --prefix ./react exec tsc --noEmit
+run_check "TypeScript (backend.ai-ui)" pnpm --filter backend.ai-ui exec tsc --noEmit
 run_check "Vite warmup paths" check_warmup_paths
 run_check "StyleX cssInjectionTarget" check_stylex_injection
 run_check "Astryx theme build" check_astryx_theme_built


### PR DESCRIPTION
Resolves #8636 (FR-3486)

## Mechanism

The CSS top layer stacks **by entry order**, so a native `<dialog>` promoted with `showModal()` paints its `::backdrop` above the whole document and above every top-layer element that entered earlier:

- `.bai-notification-stack` was a normal-flow `div` — its `z-index: 1000` cannot compete with the top layer at all.
- Astryx's `ToastViewport` (`popover="manual"`) enters the top layer **on mount**, i.e. always before any dialog, so it lands under the backdrop just the same.
- Astryx hardcodes `backdrop-filter: blur(2px)` on the backdrop (compiled StyleX inside `@layer astryx-base`, not tokenized), which is what made the buried notices unreadable.

## Fix

1. **`BAINotificationStackAstryx`** becomes a `popover="manual"` that shows itself on attach, entering the top layer. A `data-bai-top-layer` attribute opts it into re-promotion. CSS fallback (`display: flex` + `z-index: 1000`) keeps it rendered where the Popover API is unavailable.
2. **`BAIAppProvider`'s bridge mount** (BUI app-shim — the owner of the toast viewport, so Storybook surfaces get the fix too) listens for the capturing `toggle` event; when a dialog opens modally (`:modal`), it re-enters both notice surfaces (`hidePopover()` → `showPopover()`) so they stack above the newest backdrop. The toast viewport selector `[role="region"][popover="manual"]` is Astryx 0.4.0 `ToastViewport` internal DOM — no refresh hook is exposed upstream; the coupling is pinned in a comment.
3. **`backend.ai-ui.css`** drops the backdrop blur inside `@layer components`, which outranks `astryx-base` by layer order. The dim mask (`rgba(0,0,0,0.45)`) is kept — exact parity with the antd-era `BAIModal` mask (catalogued as O-5).

## Measured before/after (live dev server, login screen, `modal.confirm` + notification + `message.error`)

| Property | Before (issue-measured) | After (light) | After (dark) |
|---|---|---|---|
| `::backdrop` `backdrop-filter` | `blur(2px)` | `none` | `none` |
| `::backdrop` `background-color` | `rgba(0,0,0,0.45)` | `rgba(0,0,0,0.45)` (unchanged) | same |
| Notification stack | normal-flow, under backdrop | `:popover-open`, **above** backdrop | same |
| Toast viewport (shown before modal) | under backdrop | re-promoted on modal open, **above** backdrop | same |
| Notice buttons after modal closes | — | hit-testable again (`elementFromPoint` ✓) | same |
| `pageerror` | — | 0 (only a pre-existing CSP font warning) | 0 |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built (dist regenerated)
- react vitest: **88 files / 1405 tests passed**
- BUI vitest: **46 files passed, 1 skipped / 611 passed, 1 skipped**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 finding, **pre-existing on main** (`BAIText.css:28 var(--x)`, FR-3540 leftover — verified identical on a clean `origin/main` checkout, unrelated to this diff)

## Residue

- **Notices above an open modal are still inert** (visible and legible, but Close/Retry/Cancel are unclickable until the modal closes). `showModal()` makes everything outside the dialog inert by spec; lifting that requires changing the dialog/notification hosting model — explicitly left as the team decision FR-3486 names ("interactive notifications over modals"). This PR delivers the issue's stage 1 (blur removal, O-5) + stage 2 (top-layer re-entry).
- The toast viewport and the notification stack both anchor bottom-right and can overlap; pre-existing layout, unchanged here.
- Browsers without the dialog `toggle` event degrade to the status quo (notices below the backdrop), never an error; the app's effective floor (Astryx requires the Popover API + CSS anchor positioning) already implies `toggle` support.

## Screenshots

### Light — notification + modal open (notice crisp above the dimmed page)
![notices above backdrop, light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8782/20260814-141215-notices-above-backdrop-light.png)

### Dark — notification shown before the modal, re-promoted above the backdrop
![notice above backdrop, dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8782/20260814-141210-notice-above-backdrop-dark.png)

### Dark — `message.error` toast shown before the modal, re-promoted above the backdrop
![toast above backdrop, dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8782/20260814-141213-toast-above-backdrop-dark.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FysW3SbMGEsgTm4rG9vnhU
