### PR TITLE
fix(FR-3544): restore tag info on the image version select's closed trigger

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.css
+++ b/packages/backend.ai-ui/src/components/BAISelect.css
@@ -65,16 +65,6 @@
   min-width: 0;
 }
 
-/* antd's vertical divider metrics (0.9em, centered, breathing room) — full
-   stretch reads as a cell border inside the compact trigger. */
-.bai-select-rich-trigger
-  > .bai-select-rich-value
-  [role='separator'][aria-orientation='vertical'] {
-  align-self: center;
-  height: 0.9em;
-  margin-inline: var(--spacing-2);
-}
-
 /* The trigger button spans the whole control so its focus, click and
    voice-control target stays full-size (the container is position:relative).
    Sibling clear/status buttons become positioned so DOM order keeps them

--- a/packages/backend.ai-ui/src/components/BAISelect.css
+++ b/packages/backend.ai-ui/src/components/BAISelect.css
@@ -47,36 +47,41 @@
   border-color: var(--color-error);
 }
 
-/* optionLabelProp="children" (FR-3544): the selected option's rich node
-   renders in `Selector`'s pass-through icon slot; the trigger button keeps
-   only the visually-hidden string label (still the accessible name), so it
-   collapses and the node takes the label's flex share. Structural child
-   selectors, matching the ghost rules above, so an Astryx class rename
-   cannot silently break it. */
-/* `stretch`, not `center`: vertical Dividers inside the node size themselves
-   by stretching, and the option rows render under the same default. */
+/* optionLabelProp="children" (FR-3544): the rich node sits in `Selector`'s
+   icon slot and takes the label's flex share; a bridge until Astryx `Selector`
+   grows `ComplexSelector`'s `triggerLabel` slot. Centering would collapse the
+   node's vertical Dividers to 0 height — keep default stretch. */
 .bai-select-rich-trigger > .bai-select-rich-value {
   display: flex;
-  align-items: stretch;
   flex: 1 1 0;
   min-width: 0;
   overflow: hidden;
 }
 
 /* The node fills the label area so a row's `justify="between"` keeps pushing
-   its trailing badges to the trigger's right edge, as antd rendered it. */
+   its trailing badges to the trigger's right edge. */
 .bai-select-rich-trigger > .bai-select-rich-value > * {
   flex: 1 1 auto;
   min-width: 0;
 }
-.bai-select-rich-trigger > button {
+
+/* Only the trigger combobox button — the container also hosts the clear and
+   status-tooltip buttons, whose glyphs must not be clipped. */
+.bai-select-rich-trigger > button[aria-haspopup='listbox'] {
   flex: 0 0 auto;
 }
-.bai-select-rich-trigger > button > span {
+
+/* @astryxdesign/core `VisuallyHidden`'s recipe, inlined — the label span is
+   Selector-internal, still the accessible selected-value text. */
+.bai-select-rich-trigger > button[aria-haspopup='listbox'] > span {
   position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 0;
   width: 1px;
   height: 1px;
+  margin: -1px;
   overflow: hidden;
-  clip-path: inset(50%);
+  clip: rect(0 0 0 0);
   white-space: nowrap;
+  pointer-events: none;
 }

--- a/packages/backend.ai-ui/src/components/BAISelect.css
+++ b/packages/backend.ai-ui/src/components/BAISelect.css
@@ -75,10 +75,16 @@
   margin-inline: var(--spacing-2);
 }
 
-/* Only the trigger combobox button — the container also hosts the clear and
-   status-tooltip buttons, whose glyphs must not be clipped. */
+/* The trigger button spans the whole control so its focus, click and
+   voice-control target stays full-size (the container is position:relative).
+   Sibling clear/status buttons become positioned so DOM order keeps them
+   painted — and clickable — above it. */
 .bai-select-rich-trigger > button[aria-haspopup='listbox'] {
-  flex: 0 0 auto;
+  position: absolute;
+  inset: 0;
+}
+.bai-select-rich-trigger > button:not([aria-haspopup='listbox']) {
+  position: relative;
 }
 
 /* @astryxdesign/core `VisuallyHidden`'s recipe, inlined — the label span is

--- a/packages/backend.ai-ui/src/components/BAISelect.css
+++ b/packages/backend.ai-ui/src/components/BAISelect.css
@@ -46,3 +46,37 @@
 .bai-select-ghost [aria-invalid='true'] {
   border-color: var(--color-error);
 }
+
+/* optionLabelProp="children" (FR-3544): the selected option's rich node
+   renders in `Selector`'s pass-through icon slot; the trigger button keeps
+   only the visually-hidden string label (still the accessible name), so it
+   collapses and the node takes the label's flex share. Structural child
+   selectors, matching the ghost rules above, so an Astryx class rename
+   cannot silently break it. */
+/* `stretch`, not `center`: vertical Dividers inside the node size themselves
+   by stretching, and the option rows render under the same default. */
+.bai-select-rich-trigger > .bai-select-rich-value {
+  display: flex;
+  align-items: stretch;
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* The node fills the label area so a row's `justify="between"` keeps pushing
+   its trailing badges to the trigger's right edge, as antd rendered it. */
+.bai-select-rich-trigger > .bai-select-rich-value > * {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.bai-select-rich-trigger > button {
+  flex: 0 0 auto;
+}
+.bai-select-rich-trigger > button > span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}

--- a/packages/backend.ai-ui/src/components/BAISelect.css
+++ b/packages/backend.ai-ui/src/components/BAISelect.css
@@ -65,6 +65,16 @@
   min-width: 0;
 }
 
+/* antd's vertical divider metrics (0.9em, centered, breathing room) — full
+   stretch reads as a cell border inside the compact trigger. */
+.bai-select-rich-trigger
+  > .bai-select-rich-value
+  [role='separator'][aria-orientation='vertical'] {
+  align-self: center;
+  height: 0.9em;
+  margin-inline: var(--spacing-2);
+}
+
 /* Only the trigger combobox button — the container also hosts the clear and
    status-tooltip buttons, whose glyphs must not be clipped. */
 .bai-select-rich-trigger > button[aria-haspopup='listbox'] {

--- a/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
@@ -78,6 +78,27 @@ describe('BAISelect children-option trigger label (FR-3499)', () => {
     expect(text.match(/TensorFlow/g)).toHaveLength(1);
   });
 
+  it('prefers an explicit option label over the flattened children text (FR-3544)', () => {
+    // The image version rows carry their tag facts in Badge/BAIDoubleTag
+    // PROPS, which the text flattener cannot see — the call site names the
+    // trigger text explicitly instead.
+    render(
+      <BAISelect label="Version" value="cr.backend.ai/stable/pytorch:2.1.0">
+        <SelectOptGroup key="v" label="Versions">
+          <SelectOption
+            key="cr.backend.ai/stable/pytorch:2.1.0"
+            value="cr.backend.ai/stable/pytorch:2.1.0"
+            label={'2.1.0 | x86_64 | CUDA 12.1'}
+          >
+            <span>2.1.0</span>
+            <span>x86_64</span>
+          </SelectOption>
+        </SelectOptGroup>
+      </BAISelect>,
+    );
+    expect(triggerText()).toBe('2.1.0 | x86_64 | CUDA 12.1');
+  });
+
   it('still selects a grouped option and reports the caller value', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
@@ -108,7 +108,7 @@ describe('BAISelect children-option trigger label (FR-3499)', () => {
           <SelectOption
             key="cr.backend.ai/stable/pytorch"
             value="cr.backend.ai/stable/pytorch"
-            label="PyTorch"
+            label="PyTorch (GPU)"
           >
             <span data-testid="rich-row">PyTorch</span>
             <span>GPU</span>
@@ -118,8 +118,38 @@ describe('BAISelect children-option trigger label (FR-3499)', () => {
     );
     const richValue = container.querySelector('.bai-select-rich-value');
     expect(richValue?.querySelector('[data-testid="rich-row"]')).not.toBeNull();
-    // The string label survives as the trigger button's accessible text.
-    expect(triggerText()).toBe('PyTorch');
+    // The string label stays the trigger button's accessible text — the rich
+    // node must not leak into it.
+    expect(triggerText()).toBe('PyTorch (GPU)');
+  });
+
+  it('keeps the plain trigger when nothing is selected or without the opt-in', () => {
+    const richless = render(
+      <BAISelect label="Environments" value="a">
+        <SelectOptGroup key="g" label="G">
+          <SelectOption key="a" value="a" label="A">
+            <span>A</span>
+          </SelectOption>
+        </SelectOptGroup>
+      </BAISelect>,
+    );
+    expect(
+      richless.container.querySelector('.bai-select-rich-trigger'),
+    ).toBeNull();
+    richless.unmount();
+
+    const empty = render(
+      <BAISelect label="Environments" optionLabelProp="children">
+        <SelectOptGroup key="g" label="G">
+          <SelectOption key="a" value="a" label="A">
+            <span>A</span>
+          </SelectOption>
+        </SelectOptGroup>
+      </BAISelect>,
+    );
+    expect(
+      empty.container.querySelector('.bai-select-rich-trigger'),
+    ).toBeNull();
   });
 
   it('still selects a grouped option and reports the caller value', async () => {

--- a/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
@@ -97,6 +97,31 @@ describe('BAISelect children-option trigger label (FR-3499)', () => {
     expect(triggerText()).toBe('2.1.0 | x86_64 | CUDA 12.1');
   });
 
+  it('renders the option node on the trigger with optionLabelProp="children" (FR-3544)', () => {
+    const { container } = render(
+      <BAISelect
+        label="Environments"
+        optionLabelProp="children"
+        value="cr.backend.ai/stable/pytorch"
+      >
+        <SelectOptGroup key="ml" label="Machine Learning">
+          <SelectOption
+            key="cr.backend.ai/stable/pytorch"
+            value="cr.backend.ai/stable/pytorch"
+            label="PyTorch"
+          >
+            <span data-testid="rich-row">PyTorch</span>
+            <span>GPU</span>
+          </SelectOption>
+        </SelectOptGroup>
+      </BAISelect>,
+    );
+    const richValue = container.querySelector('.bai-select-rich-value');
+    expect(richValue?.querySelector('[data-testid="rich-row"]')).not.toBeNull();
+    // The string label survives as the trigger button's accessible text.
+    expect(triggerText()).toBe('PyTorch');
+  });
+
   it('still selects a grouped option and reports the caller value', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.triggerLabel.test.tsx
@@ -79,9 +79,7 @@ describe('BAISelect children-option trigger label (FR-3499)', () => {
   });
 
   it('prefers an explicit option label over the flattened children text (FR-3544)', () => {
-    // The image version rows carry their tag facts in Badge/BAIDoubleTag
-    // PROPS, which the text flattener cannot see — the call site names the
-    // trigger text explicitly instead.
+    // The flattener cannot see Badge/tag props, so the call site names the text.
     render(
       <BAISelect label="Version" value="cr.backend.ai/stable/pytorch:2.1.0">
         <SelectOptGroup key="v" label="Versions">

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -503,23 +503,29 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
 
   const singleValue = toOptionKey(value ?? defaultValue);
   const resolvedSingleValue =
-    singleValue === '' && autoSelectOption
+    mode === undefined && singleValue === '' && autoSelectOption
       ? toOptionKey(
           _.isFunction(autoSelectOption)
             ? autoSelectOption(options)
             : rawOptions[0]?.value,
         )
       : singleValue;
-  // antd `optionLabelProp="children"` — the selected option's rich node
-  // renders on the closed trigger (via `Selector`'s pass-through icon slot);
-  // the string label stays the accessible name and search key (FR-3544).
   const richTriggerNode =
-    mode === undefined && optionLabelProp === 'children'
+    mode === undefined &&
+    resolvedSingleValue !== '' &&
+    optionLabelProp === 'children'
       ? nodeLabels.get(resolvedSingleValue)
       : undefined;
 
   const shared = {
     ...restProps,
+    // `nodeLabels` holds non-string labels only, so `renderIconSlot` renders
+    // this node as-is instead of wrapping it in an `Icon` (FR-3544).
+    ...(richTriggerNode !== undefined && {
+      startIcon: (
+        <span className="bai-select-rich-value">{richTriggerNode}</span>
+      ),
+    }),
     className: classNames(
       className,
       'bai-select',
@@ -602,11 +608,6 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
       {...shared}
       options={optionsWithSlots}
       hasClear={allowClear}
-      startIcon={
-        richTriggerNode !== undefined ? (
-          <span className="bai-select-rich-value">{richTriggerNode}</span>
-        ) : undefined
-      }
       // `autoSelectOption` is honoured without the antd layout effect: when
       // nothing is selected the resolved first (or caller-chosen) option is
       // the rendered value, and the caller is told on mount by the same

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -522,8 +522,12 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
     // `nodeLabels` holds non-string labels only, so `renderIconSlot` renders
     // this node as-is instead of wrapping it in an `Icon` (FR-3544).
     ...(richTriggerNode !== undefined && {
+      // The clone is decorative; the trigger button's visually-hidden string
+      // label stays the single accessible selected value.
       startIcon: (
-        <span className="bai-select-rich-value">{richTriggerNode}</span>
+        <span className="bai-select-rich-value" aria-hidden="true">
+          {richTriggerNode}
+        </span>
       ),
     }),
     className: classNames(

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -341,7 +341,13 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
         // reading, which is exactly what the `optionFilterProp` PILOT-DECISION
         // above already specifies for the `options`-prop path; this makes the
         // two option APIs agree instead of only one of them corrupting itself.
+        //
+        // FR-3544 — an explicit string `label` wins over the flattened
+        // children text: rich option rows carry their key facts in Badge/tag
+        // PROPS the flattener cannot see, so the call site names what the
+        // closed trigger should say.
         const displayLabel =
+          (_.isString(childProps.label) && childProps.label) ||
           nodeToAccessibleLabel(childProps.children) ||
           toOptionKey(childProps.value);
         into.push({
@@ -598,6 +604,13 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
  */
 export interface BAISelectOptionProps {
   value?: BAISelectOption['value'];
+  /**
+   * antd's `optionLabelProp="label"` slot: the string the closed trigger
+   * shows (and search matches) when `children` is rich JSX whose key facts
+   * live in props the text flattener cannot reach (FR-3544). Must accompany
+   * `value` — a label-only element is read as an OptGroup.
+   */
+  label?: string;
   disabled?: boolean;
   /**
    * Accepted and IGNORED, for antd's `optionFilterProp="filterValue"` call

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -200,6 +200,11 @@ export interface BAISelectProps<ValueType = any, OptionType = BAISelectOption> {
   triggerDisplay?: 'count' | 'labels' | 'badges';
   /** Badges shown before "+N". Only meaningful with `triggerDisplay="badges"`. */
   maxBadges?: number;
+  /**
+   * antd's trigger-label source selector. Only `'children'` is honoured: the
+   * selected option's rich node renders on the closed trigger (FR-3544).
+   * Other values fall back to the flattened text label.
+   */
   optionLabelProp?: string;
   filterOption?: boolean | ((input: string, option?: any) => boolean);
   defaultActiveFirstOption?: boolean;
@@ -276,7 +281,7 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
   labelRender: _labelRender,
   maxTagCount: _maxTagCount,
   maxTagPlaceholder: _maxTagPlaceholder,
-  optionLabelProp: _optionLabelProp,
+  optionLabelProp,
   filterOption: _filterOption,
   defaultActiveFirstOption: _defaultActiveFirstOption,
   open: _open,
@@ -496,9 +501,31 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
   const accessibleLabel =
     label ?? nodeToAccessibleLabel(placeholder) ?? t('general.Select');
 
+  const singleValue = toOptionKey(value ?? defaultValue);
+  const resolvedSingleValue =
+    singleValue === '' && autoSelectOption
+      ? toOptionKey(
+          _.isFunction(autoSelectOption)
+            ? autoSelectOption(options)
+            : rawOptions[0]?.value,
+        )
+      : singleValue;
+  // antd `optionLabelProp="children"` — the selected option's rich node
+  // renders on the closed trigger (via `Selector`'s pass-through icon slot);
+  // the string label stays the accessible name and search key (FR-3544).
+  const richTriggerNode =
+    mode === undefined && optionLabelProp === 'children'
+      ? nodeLabels.get(resolvedSingleValue)
+      : undefined;
+
   const shared = {
     ...restProps,
-    className: classNames(className, 'bai-select', ghost && 'bai-select-ghost'),
+    className: classNames(
+      className,
+      'bai-select',
+      ghost && 'bai-select-ghost',
+      richTriggerNode !== undefined && 'bai-select-rich-trigger',
+    ),
     label: accessibleLabel || t('general.Select'),
     isLabelHidden: isLabelHidden ?? label === undefined,
     // `tooltip` was an antd `Tooltip` WRAPPING the whole control; Astryx
@@ -557,7 +584,6 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
     );
   }
 
-  const singleValue = toOptionKey(value ?? defaultValue);
   return (
     <Selector
       // QA-FINDINGS Q-34 — `placement` is the documented opt-out from
@@ -576,19 +602,16 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
       {...shared}
       options={optionsWithSlots}
       hasClear={allowClear}
+      startIcon={
+        richTriggerNode !== undefined ? (
+          <span className="bai-select-rich-value">{richTriggerNode}</span>
+        ) : undefined
+      }
       // `autoSelectOption` is honoured without the antd layout effect: when
       // nothing is selected the resolved first (or caller-chosen) option is
       // the rendered value, and the caller is told on mount by the same
       // `onChange` it used to receive.
-      value={
-        singleValue === '' && autoSelectOption
-          ? toOptionKey(
-              _.isFunction(autoSelectOption)
-                ? autoSelectOption(options)
-                : rawOptions[0]?.value,
-            )
-          : singleValue
-      }
+      value={resolvedSingleValue}
       onChange={(next: string | null) => emitChange(next)}
     />
   );

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -312,7 +312,15 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
           filterValue?: string;
           children?: ReactNode;
         };
-        if (childProps.value === undefined && childProps.label !== undefined) {
+        // The BUI carriers are discriminated by TYPE; the prop-shape test only
+        // remains for foreign elements, since options may carry `label` too
+        // (FR-3544).
+        const isOptGroup =
+          child.type === BAISelectOptionGroup ||
+          (child.type !== BAISelectOptionItem &&
+            childProps.value === undefined &&
+            childProps.label !== undefined);
+        if (isOptGroup) {
           // OptGroup
           const groupOptions: Array<BAISelectOption> = [];
           collect(childProps.children, groupOptions);
@@ -342,12 +350,10 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
         // above already specifies for the `options`-prop path; this makes the
         // two option APIs agree instead of only one of them corrupting itself.
         //
-        // FR-3544 — an explicit string `label` wins over the flattened
-        // children text: rich option rows carry their key facts in Badge/tag
-        // PROPS the flattener cannot see, so the call site names what the
-        // closed trigger should say.
+        // FR-3544 — rich rows keep their key facts in Badge/tag PROPS the
+        // flattener cannot see, so an explicit `label` wins when provided.
         const displayLabel =
-          (_.isString(childProps.label) && childProps.label) ||
+          nodeToAccessibleLabel(childProps.label) ||
           nodeToAccessibleLabel(childProps.children) ||
           toOptionKey(childProps.value);
         into.push({
@@ -596,8 +602,9 @@ function BAISelect<ValueType = any, OptionType = BAISelectOption>({
  * `options` model — but the elements themselves were still antd's
  * `Select.Option` / `Select.OptGroup`, which kept three otherwise-converted
  * files importing antd for a component that is never rendered. The flattener
- * reads PROPS only and never looks at the element type (see `collect` above),
- * so a render-null marker is a complete replacement.
+ * discriminates these carriers by element type (falling back to the antd
+ * prop-shape test for foreign elements), so a render-null marker is a
+ * complete replacement.
  *
  * These do NOT render. They exist to be walked by `BAISelect`; putting one
  * anywhere else produces nothing.
@@ -607,8 +614,7 @@ export interface BAISelectOptionProps {
   /**
    * antd's `optionLabelProp="label"` slot: the string the closed trigger
    * shows (and search matches) when `children` is rich JSX whose key facts
-   * live in props the text flattener cannot reach (FR-3544). Must accompany
-   * `value` — a label-only element is read as an OptGroup.
+   * live in props the text flattener cannot reach (FR-3544).
    */
   label?: string;
   disabled?: boolean;

--- a/packages/backend.ai-ui/src/helper/astryxLabel.ts
+++ b/packages/backend.ai-ui/src/helper/astryxLabel.ts
@@ -16,6 +16,10 @@
  A node built only from non-textual leaves (an icon, an `<img>`) yields `''`,
  which callers must treat as "no name available" — either `isLabelHidden` plus
  an `endContent` render (Token/Badge), or an explicit translated fallback.
+
+ The walk also cannot see PROP-carried text (`Badge label=`, `BAIDoubleTag
+ values=`) — such call sites name the text explicitly instead (`title` on
+ `BAISelect`'s options path, `label` on its children carrier — FR-3544).
 */
 import React from 'react';
 import type { ReactNode } from 'react';

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -429,6 +429,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
       >
         <BAISelect
           ref={envSelectRef}
+          optionLabelProp="children"
           open={envSelectOpen}
           onOpenChange={(visible) => {
             // Return to uncontrolled mode once the user interacts
@@ -669,6 +670,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
             >
               <BAISelect
                 ref={versionSelectRef}
+                optionLabelProp="children"
                 popupMatchSelectWidth={false}
                 onChange={(value) => {
                   const selectedImage = _.find(images, (image) => {

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -92,7 +92,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
   );
   const [versionSearch, setVersionSearch] = useState('');
   const { t } = useTranslation();
-  const [metadata, { getBaseVersion, getImageMeta, tagAlias }] =
+  const [metadata, { getBaseVersion, getImageMeta, getTags, tagAlias }] =
     useBackendAIImageMetaData();
   const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
@@ -789,10 +789,64 @@ const ImageEnvironmentSelectFormItems: React.FC<
                         );
                       }
                     }
+                    // The closed trigger renders a plain string (BAISelect
+                    // FR-3544), so the row's version | arch | tag facts are
+                    // restated as text here, mirroring the JSX below.
+                    const selectedLabel = _.compact(
+                      supportExtendedImageInfo
+                        ? [
+                            image?.version,
+                            image?.architecture,
+                            ..._.map(
+                              image?.tags,
+                              (tag: { key: string; value: string }) => {
+                                const isCustomized = _.includes(
+                                  tag.key,
+                                  'customized_',
+                                );
+                                const tagValue = isCustomized
+                                  ? _.find(image?.labels, {
+                                      key: 'ai.backend.customized-image.name',
+                                    })?.value
+                                  : tag.value;
+                                const aliasedTag = tagAlias(tag.key + tagValue);
+                                return _.isEqual(
+                                  aliasedTag,
+                                  preserveDotStartCase(tag.key + tagValue),
+                                ) || isCustomized
+                                  ? _.trim(
+                                      `${tagAlias(tag.key)} ${tagValue ?? ''}`,
+                                    )
+                                  : aliasedTag;
+                              },
+                            ),
+                          ]
+                        : [
+                            getBaseVersion(getImageFullName(image) || ''),
+                            image?.architecture,
+                            ..._.map(
+                              getTags(
+                                image?.tag || '',
+                                (image?.labels ?? []) as Array<{
+                                  key: string;
+                                  value: string;
+                                }>,
+                              ),
+                              (tag) =>
+                                _.isEqual(
+                                  tagAlias(tag.key + tag.value),
+                                  preserveDotStartCase(tag.key + tag.value),
+                                )
+                                  ? _.trim(`${tagAlias(tag.key)} ${tag.value}`)
+                                  : tagAlias(tag.key + tag.value),
+                            ),
+                          ],
+                    ).join(' | ');
                     return (
                       <SelectOption
                         key={image?.id}
                         value={getImageFullName(image)}
+                        label={selectedLabel}
                         filterValue={[
                           version,
                           metadataTagAlias,

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -13,7 +13,6 @@ import {
   isPrivateImage,
   localeCompare,
   parseImageString,
-  preserveDotStartCase,
   removeArchitectureFromImageFullName,
 } from '../helper';
 import {
@@ -24,7 +23,13 @@ import { useThemeMode } from '../hooks/useThemeMode';
 import { theme } from '../theme-shim';
 // @ts-ignore
 import ImageMetaIcon from './ImageMetaIcon';
-import { imageTagFacts, ImageTags } from './ImageTags';
+import {
+  imageNodeTagFacts,
+  imageTagFacts,
+  ImageMetaDivider,
+  ImageTagBadges,
+  ImageTags,
+} from './ImageTags';
 import TextHighlighter from './TextHighlighter';
 import { AstryxFormTextInput } from './astryxFormControls';
 import { Badge } from '@astryxdesign/core/Badge';
@@ -93,13 +98,6 @@ const ImageEnvironmentSelectFormItems: React.FC<
     useBackendAIImageMetaData();
   const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
-  // Astryx's vertical Divider is `height: 100%`, which a centered flex row
-  // collapses to 0; antd's metrics keep the row and the trigger identical.
-  const versionDividerStyle: React.CSSProperties = {
-    alignSelf: 'center',
-    height: '0.9em',
-    marginInline: token.marginXXS,
-  };
 
   // antd `RefSelectProps` restated as the one method these two refs ever
   // called. `BAISelect` accepts `ref` and never attaches it (P26-8 — Astryx's
@@ -409,563 +407,507 @@ const ImageEnvironmentSelectFormItems: React.FC<
 
   return (
     <>
-      <Form.Item
-        className="image-environment-select-form-item"
-        name={['environments', 'environment']}
-        label={
-          <BAIText
-            copyable={{
-              text: getImageFullName(
-                form.getFieldValue(['environments', 'image']),
-              ),
-            }}
-          >
-            {t('session.launcher.Environments')} /{' '}
-            {t('session.launcher.Version')}
-          </BAIText>
-        }
-        rules={[
-          {
-            required: _.isEmpty(environments?.manual),
-            message: t('general.ValueRequired', {
-              name: t('session.launcher.Environments'),
-            }),
-          },
-        ]}
-        style={{ marginBottom: 10 }}
-      >
-        <BAISelect
-          ref={envSelectRef}
-          optionLabelProp="children"
-          open={envSelectOpen}
-          onOpenChange={(visible) => {
-            // Return to uncontrolled mode once the user interacts
-            if (!visible) {
-              setEnvSelectOpen(undefined);
-            }
-          }}
-          showSearch={{
-            searchValue: environmentSearch,
-            onSearch: setEnvironmentSearch,
-            optionFilterProp: 'filterValue',
-          }}
-          popupMatchSelectWidth={false}
-          defaultActiveFirstOption={true}
-          onChange={(value) => {
-            if (fullNameMatchedImage) {
-              form.setFieldsValue({
-                environments: {
-                  environment:
-                    (supportExtendedImageInfo
-                      ? fullNameMatchedImage?.namespace
-                      : fullNameMatchedImage?.name) || '',
-                  version: getImageFullName(fullNameMatchedImage),
-                  image: fullNameMatchedImage,
-                },
-              });
-            } else {
-              // NOTE: when user set environment only then set the version to the first item
-              //
-              // FR-3499 — write the OPTION's own key back, not the image's
-              // bare namespace. Every option in this select is keyed by
-              // `environmentGroup.environmentName`, i.e. `registry/namespace`,
-              // and the rest of the component agrees: the version select finds
-              // `selectedEnvironmentGroup` by `environmentName`, and the
-              // auto-select effect stores `nextEnvironment.environmentName`.
-              // Storing the registry-less `namespace` produced a value no
-              // option matched, so Astryx `Selector` fell back to its
-              // placeholder — the environment trigger read "Select…" and the
-              // version select, keyed off the same field, emptied with it.
-              // Choosing a DIFFERENT environment masked this, because the
-              // resulting `version` change re-ran the effect and it rewrote the
-              // field correctly; choosing the environment that was already
-              // selected left the broken value in place, so on a cluster with a
-              // single environment no image could be selected at all.
-              const selectedEnvironmentGroup = _.find(
-                _.flatMap(imageGroups, (group) => group.environmentGroups),
-                (envGroup) => envGroup.environmentName === value,
-              );
-              const firstInListImage: Image | undefined =
-                selectedEnvironmentGroup?.images[0];
-              form.setFieldsValue({
-                environments: {
-                  environment: selectedEnvironmentGroup?.environmentName ?? '',
-                  version: getImageFullName(firstInListImage),
-                  image: firstInListImage,
-                },
-              });
-            }
-          }}
-          disabled={
-            baiClient._config.allow_manual_image_name_for_session &&
-            !_.isEmpty(environments?.manual)
+      {/* The environment and version selects are one field. */}
+      <BAIFlex direction="column" align="stretch" gap="xs">
+        <Form.Item
+          className="image-environment-select-form-item"
+          // The wrapper's gap is the pair's spacing.
+          style={{ marginBottom: 0 }}
+          name={['environments', 'environment']}
+          label={
+            <BAIText
+              copyable={{
+                text: getImageFullName(
+                  form.getFieldValue(['environments', 'image']),
+                ),
+              }}
+            >
+              {t('session.launcher.Environments')} /{' '}
+              {t('session.launcher.Version')}
+            </BAIText>
           }
+          rules={[
+            {
+              required: _.isEmpty(environments?.manual),
+              message: t('general.ValueRequired', {
+                name: t('session.launcher.Environments'),
+              }),
+            },
+          ]}
         >
-          {fullNameMatchedImage ? (
-            <SelectOption
-              value={
-                supportExtendedImageInfo
-                  ? fullNameMatchedImage?.namespace
-                  : fullNameMatchedImage?.name
+          <BAISelect
+            ref={envSelectRef}
+            optionLabelProp="children"
+            open={envSelectOpen}
+            onOpenChange={(visible) => {
+              // Return to uncontrolled mode once the user interacts
+              if (!visible) {
+                setEnvSelectOpen(undefined);
               }
-              filterValue={getImageFullName(fullNameMatchedImage)}
-            >
-              <BAIFlex
-                direction="row"
-                align="center"
-                gap="xs"
-                style={{ display: 'inline-flex' }}
-              >
-                <ImageMetaIcon
-                  image={getImageFullName(fullNameMatchedImage) || ''}
-                  style={{
-                    width: 15,
-                    height: 15,
-                  }}
-                />
-                {getImageFullName(fullNameMatchedImage)}
-              </BAIFlex>
-            </SelectOption>
-          ) : (
-            _.map(imageGroups, (group) => {
-              return (
-                <SelectOptGroup key={group.groupName} label={group.groupName}>
-                  {_.map(group.environmentGroups, (environmentGroup) => {
-                    const firstImage = environmentGroup.images[0];
-                    const currentMetaImageInfo =
-                      metadata?.imageInfo[
-                        environmentGroup.environmentName.split('/')?.[2]
-                      ];
-
-                    const extraFilterValues: string[] = [];
-                    let environmentPrefixTag = null;
-                    if (
-                      environmentGroup.prefix &&
-                      !['lablup', 'cloud', 'stable'].includes(
-                        environmentGroup.prefix,
-                      )
-                    ) {
-                      extraFilterValues.push(environmentGroup.prefix);
-                      // antd `Tag color` → Astryx `Badge variant` through the
-                      // repo-global lookup (ticket 13). Never a raw hue/hex.
-                      environmentPrefixTag = (
-                        <Badge
-                          variant={badgeVariantForTagColor('purple')}
-                          label={
-                            <TextHighlighter keyword={environmentSearch}>
-                              {environmentGroup.prefix}
-                            </TextHighlighter>
-                          }
-                        />
-                      );
-                    }
-
-                    const tagsFromMetaImageInfoLabel = _.map(
-                      currentMetaImageInfo?.label,
-                      (label) => {
-                        if (
-                          _.isUndefined(label.category) &&
-                          label.tag &&
-                          label.color
-                        ) {
-                          extraFilterValues.push(label.tag);
-                          // `label.color` is a runtime-arbitrary string from
-                          // the image metadata JSON; the lookup normalises it
-                          // and falls back to `neutral` for anything it does
-                          // not recognise (ticket 13 §5).
-                          return (
-                            <Badge
-                              key={label.tag}
-                              variant={badgeVariantForTagColor(label.color)}
-                              label={
-                                <TextHighlighter
-                                  keyword={environmentSearch}
-                                  key={label.tag}
-                                >
-                                  {label.tag}
-                                </TextHighlighter>
-                              }
-                            />
-                          );
-                        }
-                        return null;
-                      },
-                    );
-                    return (
-                      <SelectOption
-                        key={environmentGroup.environmentName}
-                        value={environmentGroup.environmentName}
-                        // The prefix/meta badge texts live in Badge props, so
-                        // the accessible/search label restates them (FR-3544).
-                        label={_.compact([
-                          environmentGroup.displayName,
-                          ...extraFilterValues,
-                        ]).join(' | ')}
-                        filterValue={
-                          environmentGroup.displayName +
-                          '\t' +
-                          extraFilterValues.join('\t')
-                        }
-                      >
-                        <BAIFlex direction="row" justify="between">
-                          <BAIFlex direction="row" align="center" gap="xs">
-                            <ImageMetaIcon
-                              image={getImageFullName(firstImage) || ''}
-                              style={{
-                                width: 15,
-                                height: 15,
-                              }}
-                            />
-                            <TextHighlighter keyword={environmentSearch}>
-                              {environmentGroup.displayName}
-                            </TextHighlighter>
-                          </BAIFlex>
-                          <BAIFlex
-                            direction="row"
-                            // set specific class name to handle flex wrap using css
-                            className={
-                              isDarkMode ? 'tag-wrap-dark' : 'tag-wrap-light'
-                            }
-                            // style={{ flex: 1 }}
-                            style={{
-                              marginLeft: token.marginXS,
-                              flexShrink: 1,
-                            }}
-                            gap="xs"
-                          >
-                            {environmentPrefixTag}
-                            {tagsFromMetaImageInfoLabel}
-                          </BAIFlex>
-                        </BAIFlex>
-                      </SelectOption>
-                    );
-                  })}
-                </SelectOptGroup>
-              );
-            })
-          )}
-        </BAISelect>
-      </Form.Item>
-      <Form.Item
-        noStyle
-        shouldUpdate={(prev, cur) =>
-          prev.environments?.environment !== cur.environments?.environment
-        }
-      >
-        {({ getFieldValue }) => {
-          let selectedEnvironmentGroup:
-            ImageGroup['environmentGroups'][0] | undefined;
-          _.find(imageGroups, (group) => {
-            return _.find(group.environmentGroups, (environment) => {
-              if (
-                environment.environmentName ===
-                getFieldValue('environments')?.environment
-              ) {
-                selectedEnvironmentGroup = environment;
-                return true;
+            }}
+            showSearch={{
+              searchValue: environmentSearch,
+              onSearch: setEnvironmentSearch,
+              optionFilterProp: 'filterValue',
+            }}
+            popupMatchSelectWidth={false}
+            defaultActiveFirstOption={true}
+            onChange={(value) => {
+              if (fullNameMatchedImage) {
+                form.setFieldsValue({
+                  environments: {
+                    environment:
+                      (supportExtendedImageInfo
+                        ? fullNameMatchedImage?.namespace
+                        : fullNameMatchedImage?.name) || '',
+                    version: getImageFullName(fullNameMatchedImage),
+                    image: fullNameMatchedImage,
+                  },
+                });
               } else {
-                return false;
+                // NOTE: when user set environment only then set the version to the first item
+                //
+                // FR-3499 — write the OPTION's own key back, not the image's
+                // bare namespace. Every option in this select is keyed by
+                // `environmentGroup.environmentName`, i.e. `registry/namespace`,
+                // and the rest of the component agrees: the version select finds
+                // `selectedEnvironmentGroup` by `environmentName`, and the
+                // auto-select effect stores `nextEnvironment.environmentName`.
+                // Storing the registry-less `namespace` produced a value no
+                // option matched, so Astryx `Selector` fell back to its
+                // placeholder — the environment trigger read "Select…" and the
+                // version select, keyed off the same field, emptied with it.
+                // Choosing a DIFFERENT environment masked this, because the
+                // resulting `version` change re-ran the effect and it rewrote the
+                // field correctly; choosing the environment that was already
+                // selected left the broken value in place, so on a cluster with a
+                // single environment no image could be selected at all.
+                const selectedEnvironmentGroup = _.find(
+                  _.flatMap(imageGroups, (group) => group.environmentGroups),
+                  (envGroup) => envGroup.environmentName === value,
+                );
+                const firstInListImage: Image | undefined =
+                  selectedEnvironmentGroup?.images[0];
+                form.setFieldsValue({
+                  environments: {
+                    environment:
+                      selectedEnvironmentGroup?.environmentName ?? '',
+                    version: getImageFullName(firstInListImage),
+                    image: firstInListImage,
+                  },
+                });
               }
-            });
-          });
-          return (
-            <Form.Item
-              className="image-environment-select-form-item"
-              name={['environments', 'version']}
-              rules={[
-                {
-                  required: _.isEmpty(environments?.manual),
-                  message: t('general.ValueRequired', {
-                    name: t('session.launcher.Version'),
-                  }),
-                },
-              ]}
-            >
-              <BAISelect
-                ref={versionSelectRef}
-                optionLabelProp="children"
-                popupMatchSelectWidth={false}
-                onChange={(value) => {
-                  const selectedImage = _.find(images, (image) => {
-                    return getImageFullName(image) === value;
-                  });
-                  form.setFieldValue(['environments', 'image'], selectedImage);
-                }}
-                showSearch={{
-                  searchValue: versionSearch,
-                  onSearch: setVersionSearch,
-                  optionFilterProp: 'filterValue',
-                }}
-                popupRender={(menu) => (
-                  <>
-                    <BAIFlex
-                      style={{
-                        fontWeight: token.fontWeightStrong,
-                        paddingLeft: token.paddingSM,
-                      }}
-                    >
-                      {t('session.launcher.Version')}
-                      <Divider orientation="vertical" />
-                      {t('session.launcher.Architecture')}
-                      <Divider orientation="vertical" />
-                      {t('session.launcher.Tags')}
-                    </BAIFlex>
-                    <Divider style={{ margin: '8px 0' }} />
-                    {menu}
-                  </>
-                )}
-                disabled={
-                  baiClient._config.allow_manual_image_name_for_session &&
-                  !_.isEmpty(environments?.manual)
+            }}
+            disabled={
+              baiClient._config.allow_manual_image_name_for_session &&
+              !_.isEmpty(environments?.manual)
+            }
+          >
+            {fullNameMatchedImage ? (
+              <SelectOption
+                value={
+                  supportExtendedImageInfo
+                    ? fullNameMatchedImage?.namespace
+                    : fullNameMatchedImage?.name
                 }
+                filterValue={getImageFullName(fullNameMatchedImage)}
               >
-                {_.map(
-                  _.uniqBy(selectedEnvironmentGroup?.images, 'id'),
+                <BAIFlex
+                  direction="row"
+                  align="center"
+                  gap="xs"
+                  style={{ display: 'inline-flex' }}
+                >
+                  <ImageMetaIcon
+                    image={getImageFullName(fullNameMatchedImage) || ''}
+                    style={{
+                      width: 15,
+                      height: 15,
+                    }}
+                  />
+                  {getImageFullName(fullNameMatchedImage)}
+                </BAIFlex>
+              </SelectOption>
+            ) : (
+              _.map(imageGroups, (group) => {
+                return (
+                  <SelectOptGroup key={group.groupName} label={group.groupName}>
+                    {_.map(group.environmentGroups, (environmentGroup) => {
+                      const firstImage = environmentGroup.images[0];
+                      const currentMetaImageInfo =
+                        metadata?.imageInfo[
+                          environmentGroup.environmentName.split('/')?.[2]
+                        ];
 
-                  (image) => {
-                    const imageFullName = getImageFullName(image);
-                    const [version, tag, ...requirements] = image?.tag?.split(
-                      '-',
-                    ) || ['', '', ''];
-
-                    let metadataTagAlias = metadata?.tagAlias[tag];
-                    if (!metadataTagAlias) {
-                      for (const [key, replaceString] of Object.entries(
-                        metadata?.tagReplace || {},
-                      )) {
-                        const pattern = new RegExp(key);
-                        if (pattern.test(tag)) {
-                          metadataTagAlias = tag?.replace(
-                            pattern,
-                            replaceString,
-                          );
-                        }
-                      }
-                      if (!metadataTagAlias) {
-                        metadataTagAlias = tag;
-                      }
-                    }
-
-                    const extraFilterValues: string[] = [];
-                    const requirementTags = _.map(
-                      _.filter(
-                        requirements,
-                        (requirement) => !requirement.startsWith('customized_'),
-                      ),
-                      (requirement, idx) => (
-                        <BAIDoubleTag
-                          key={idx}
-                          values={_.split(
-                            metadata?.tagAlias[requirement] || requirement,
-                            ':',
-                          ).map((str) => {
-                            extraFilterValues.push(str);
-                            return {
-                              label: str,
-                              highlightKeyword: versionSearch,
-                            };
-                          })}
-                        />
-                      ),
-                    );
-                    const imageLabels = image?.labels;
-                    if (imageLabels) {
-                      const customizedImageNameLabelIdx = _.findIndex(
-                        imageLabels,
-                        (item) =>
-                          item !== null &&
-                          item?.key === 'ai.backend.customized-image.name',
-                      );
+                      const extraFilterValues: string[] = [];
+                      let environmentPrefixTag = null;
                       if (
-                        customizedImageNameLabelIdx &&
-                        imageLabels[customizedImageNameLabelIdx]
+                        environmentGroup.prefix &&
+                        !['lablup', 'cloud', 'stable'].includes(
+                          environmentGroup.prefix,
+                        )
                       ) {
-                        const tag =
-                          imageLabels[customizedImageNameLabelIdx]?.value || '';
-                        extraFilterValues.push('Customized');
-                        extraFilterValues.push(tag);
-                        requirementTags.push(
-                          <BAIDoubleTag
-                            key={requirementTags.length + 1}
-                            highlightKeyword={versionSearch}
-                            values={[
-                              {
-                                label: 'Customized',
-                                color: 'cyan',
-                              },
-                              {
-                                label: tag ?? '',
-                                color: 'cyan',
-                              },
-                            ]}
-                          />,
+                        extraFilterValues.push(environmentGroup.prefix);
+                        // antd `Tag color` → Astryx `Badge variant` through the
+                        // repo-global lookup (ticket 13). Never a raw hue/hex.
+                        environmentPrefixTag = (
+                          <Badge
+                            variant={badgeVariantForTagColor('purple')}
+                            label={
+                              <TextHighlighter keyword={environmentSearch}>
+                                {environmentGroup.prefix}
+                              </TextHighlighter>
+                            }
+                          />
                         );
                       }
-                    }
-                    // The closed trigger renders a plain string (BAISelect
-                    // FR-3544): compute each tag's display facts once, then
-                    // derive both the trigger text and the option row from them.
-                    const customizedImageName = _.find(image?.labels, {
-                      key: 'ai.backend.customized-image.name',
-                    })?.value;
-                    const tagFacts = supportExtendedImageInfo
-                      ? _.map(
-                          (image?.tags ?? []) as Array<{
-                            key: string;
-                            value: string;
-                          }>,
-                          (imageTag) => {
-                            const isCustomized = _.includes(
-                              imageTag.key,
-                              'customized_',
+
+                      const tagsFromMetaImageInfoLabel = _.map(
+                        currentMetaImageInfo?.label,
+                        (label) => {
+                          if (
+                            _.isUndefined(label.category) &&
+                            label.tag &&
+                            label.color
+                          ) {
+                            extraFilterValues.push(label.tag);
+                            // `label.color` is a runtime-arbitrary string from
+                            // the image metadata JSON; the lookup normalises it
+                            // and falls back to `neutral` for anything it does
+                            // not recognise (ticket 13 §5).
+                            return (
+                              <Badge
+                                key={label.tag}
+                                variant={badgeVariantForTagColor(label.color)}
+                                label={
+                                  <TextHighlighter
+                                    keyword={environmentSearch}
+                                    key={label.tag}
+                                  >
+                                    {label.tag}
+                                  </TextHighlighter>
+                                }
+                              />
                             );
-                            const value = isCustomized
-                              ? customizedImageName
-                              : imageTag.value;
-                            const aliasedTag = tagAlias(imageTag.key + value);
-                            const isDouble =
-                              _.isEqual(
-                                aliasedTag,
-                                preserveDotStartCase(imageTag.key + value),
-                              ) || isCustomized;
-                            return {
-                              key: imageTag.key,
-                              value,
-                              isCustomized,
-                              aliasedTag,
-                              isDouble,
-                              keyAlias: isDouble
-                                ? tagAlias(imageTag.key)
-                                : undefined,
-                            };
-                          },
-                        )
-                      : imageTagFacts(
-                          getTags(
-                            image?.tag || '',
+                          }
+                          return null;
+                        },
+                      );
+                      return (
+                        <SelectOption
+                          key={environmentGroup.environmentName}
+                          value={environmentGroup.environmentName}
+                          // The prefix/meta badge texts live in Badge props, so
+                          // the accessible/search label restates them (FR-3544).
+                          label={_.compact([
+                            environmentGroup.displayName,
+                            ...extraFilterValues,
+                          ]).join(' | ')}
+                          filterValue={
+                            environmentGroup.displayName +
+                            '\t' +
+                            extraFilterValues.join('\t')
+                          }
+                        >
+                          <BAIFlex direction="row" justify="between">
+                            <BAIFlex direction="row" align="center" gap="xs">
+                              <ImageMetaIcon
+                                image={getImageFullName(firstImage) || ''}
+                                style={{
+                                  width: 15,
+                                  height: 15,
+                                }}
+                              />
+                              <TextHighlighter keyword={environmentSearch}>
+                                {environmentGroup.displayName}
+                              </TextHighlighter>
+                            </BAIFlex>
+                            <BAIFlex
+                              direction="row"
+                              // set specific class name to handle flex wrap using css
+                              className={
+                                isDarkMode ? 'tag-wrap-dark' : 'tag-wrap-light'
+                              }
+                              // style={{ flex: 1 }}
+                              style={{
+                                marginLeft: token.marginXS,
+                                flexShrink: 1,
+                              }}
+                              gap="xs"
+                            >
+                              {environmentPrefixTag}
+                              {tagsFromMetaImageInfoLabel}
+                            </BAIFlex>
+                          </BAIFlex>
+                        </SelectOption>
+                      );
+                    })}
+                  </SelectOptGroup>
+                );
+              })
+            )}
+          </BAISelect>
+        </Form.Item>
+        <Form.Item
+          noStyle
+          shouldUpdate={(prev, cur) =>
+            prev.environments?.environment !== cur.environments?.environment
+          }
+        >
+          {({ getFieldValue }) => {
+            let selectedEnvironmentGroup:
+              ImageGroup['environmentGroups'][0] | undefined;
+            _.find(imageGroups, (group) => {
+              return _.find(group.environmentGroups, (environment) => {
+                if (
+                  environment.environmentName ===
+                  getFieldValue('environments')?.environment
+                ) {
+                  selectedEnvironmentGroup = environment;
+                  return true;
+                } else {
+                  return false;
+                }
+              });
+            });
+            return (
+              <Form.Item
+                className="image-environment-select-form-item"
+                name={['environments', 'version']}
+                rules={[
+                  {
+                    required: _.isEmpty(environments?.manual),
+                    message: t('general.ValueRequired', {
+                      name: t('session.launcher.Version'),
+                    }),
+                  },
+                ]}
+              >
+                <BAISelect
+                  ref={versionSelectRef}
+                  optionLabelProp="children"
+                  popupMatchSelectWidth={false}
+                  onChange={(value) => {
+                    const selectedImage = _.find(images, (image) => {
+                      return getImageFullName(image) === value;
+                    });
+                    form.setFieldValue(
+                      ['environments', 'image'],
+                      selectedImage,
+                    );
+                  }}
+                  showSearch={{
+                    searchValue: versionSearch,
+                    onSearch: setVersionSearch,
+                    optionFilterProp: 'filterValue',
+                  }}
+                  popupRender={(menu) => (
+                    <>
+                      <BAIFlex
+                        style={{
+                          fontWeight: token.fontWeightStrong,
+                          paddingLeft: token.paddingSM,
+                        }}
+                      >
+                        {t('session.launcher.Version')}
+                        <Divider orientation="vertical" />
+                        {t('session.launcher.Architecture')}
+                        <Divider orientation="vertical" />
+                        {t('session.launcher.Tags')}
+                      </BAIFlex>
+                      <Divider style={{ margin: '8px 0' }} />
+                      {menu}
+                    </>
+                  )}
+                  disabled={
+                    baiClient._config.allow_manual_image_name_for_session &&
+                    !_.isEmpty(environments?.manual)
+                  }
+                >
+                  {_.map(
+                    _.uniqBy(selectedEnvironmentGroup?.images, 'id'),
+
+                    (image) => {
+                      const imageFullName = getImageFullName(image);
+                      const [version, tag, ...requirements] = image?.tag?.split(
+                        '-',
+                      ) || ['', '', ''];
+
+                      let metadataTagAlias = metadata?.tagAlias[tag];
+                      if (!metadataTagAlias) {
+                        for (const [key, replaceString] of Object.entries(
+                          metadata?.tagReplace || {},
+                        )) {
+                          const pattern = new RegExp(key);
+                          if (pattern.test(tag)) {
+                            metadataTagAlias = tag?.replace(
+                              pattern,
+                              replaceString,
+                            );
+                          }
+                        }
+                        if (!metadataTagAlias) {
+                          metadataTagAlias = tag;
+                        }
+                      }
+
+                      const extraFilterValues: string[] = [];
+                      const requirementTags = _.map(
+                        _.filter(
+                          requirements,
+                          (requirement) =>
+                            !requirement.startsWith('customized_'),
+                        ),
+                        (requirement, idx) => (
+                          <BAIDoubleTag
+                            key={idx}
+                            values={_.split(
+                              metadata?.tagAlias[requirement] || requirement,
+                              ':',
+                            ).map((str) => {
+                              extraFilterValues.push(str);
+                              return {
+                                label: str,
+                                highlightKeyword: versionSearch,
+                              };
+                            })}
+                          />
+                        ),
+                      );
+                      const imageLabels = image?.labels;
+                      if (imageLabels) {
+                        const customizedImageNameLabelIdx = _.findIndex(
+                          imageLabels,
+                          (item) =>
+                            item !== null &&
+                            item?.key === 'ai.backend.customized-image.name',
+                        );
+                        if (
+                          customizedImageNameLabelIdx &&
+                          imageLabels[customizedImageNameLabelIdx]
+                        ) {
+                          const tag =
+                            imageLabels[customizedImageNameLabelIdx]?.value ||
+                            '';
+                          extraFilterValues.push('Customized');
+                          extraFilterValues.push(tag);
+                          requirementTags.push(
+                            <BAIDoubleTag
+                              key={requirementTags.length + 1}
+                              highlightKeyword={versionSearch}
+                              values={[
+                                {
+                                  label: 'Customized',
+                                  color: 'cyan',
+                                },
+                                {
+                                  label: tag ?? '',
+                                  color: 'cyan',
+                                },
+                              ]}
+                            />,
+                          );
+                        }
+                      }
+                      // The closed trigger renders a plain string (BAISelect
+                      // FR-3544): compute each tag's display facts once, then
+                      // derive both the trigger text and the option row from them.
+                      const tagFacts = supportExtendedImageInfo
+                        ? imageNodeTagFacts(
+                            image?.tags as Array<{
+                              key: string;
+                              value: string;
+                            }>,
                             image?.labels as Array<{
                               key: string;
                               value: string;
                             }>,
-                          ),
-                          tagAlias,
-                        );
-                    const selectedLabel = _.compact([
-                      supportExtendedImageInfo
-                        ? image?.version
-                        : getBaseVersion(imageFullName || ''),
-                      image?.architecture,
-                      ..._.map(tagFacts, (fact) =>
-                        fact.isDouble
-                          ? _.trim(`${fact.keyAlias ?? ''} ${fact.value ?? ''}`)
-                          : fact.aliasedTag,
-                      ),
-                    ]).join(' | ');
-                    return (
-                      <SelectOption
-                        key={image?.id}
-                        value={imageFullName}
-                        label={selectedLabel}
-                        filterValue={[
-                          version,
-                          metadataTagAlias,
-                          image?.architecture,
-                          ...extraFilterValues,
-                        ].join('\t')}
-                      >
-                        {supportExtendedImageInfo ? (
-                          <BAIFlex direction="row">
-                            <TextHighlighter keyword={versionSearch}>
-                              {image?.version}
-                            </TextHighlighter>
-                            <Divider
-                              orientation="vertical"
-                              style={versionDividerStyle}
-                            />
-                            <TextHighlighter keyword={versionSearch}>
-                              {image?.architecture}
-                            </TextHighlighter>
-                            <Divider
-                              orientation="vertical"
-                              style={versionDividerStyle}
-                            />
-                            <BAIFlex direction="row" align="start" gap="xxs">
-                              {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
-                              {_.map(tagFacts, (fact) =>
-                                fact.isDouble ? (
-                                  <BAIDoubleTag
-                                    key={fact.key}
-                                    highlightKeyword={versionSearch}
-                                    values={[
-                                      {
-                                        label: fact.keyAlias ?? '',
-                                        color: fact.isCustomized
-                                          ? 'cyan'
-                                          : 'blue',
-                                      },
-                                      {
-                                        label: fact.value ?? '',
-                                        color: fact.isCustomized
-                                          ? 'cyan'
-                                          : 'blue',
-                                      },
-                                    ]}
-                                  />
-                                ) : (
-                                  <Badge
-                                    key={fact.key}
-                                    variant={badgeVariantForTagColor(
-                                      fact.isCustomized ? 'cyan' : 'blue',
-                                    )}
-                                    label={
-                                      <TextHighlighter keyword={versionSearch}>
-                                        {fact.aliasedTag}
-                                      </TextHighlighter>
-                                    }
-                                  />
-                                ),
-                              )}
-                            </BAIFlex>
-                          </BAIFlex>
-                        ) : (
-                          <BAIFlex direction="row" justify="between">
-                            <BAIFlex direction="row" gap="xxs">
+                            tagAlias,
+                          )
+                        : imageTagFacts(
+                            getTags(
+                              image?.tag || '',
+                              image?.labels as Array<{
+                                key: string;
+                                value: string;
+                              }>,
+                            ),
+                            tagAlias,
+                          );
+                      const selectedLabel = _.compact([
+                        supportExtendedImageInfo
+                          ? image?.version
+                          : getBaseVersion(imageFullName || ''),
+                        image?.architecture,
+                        ..._.map(tagFacts, (fact) =>
+                          fact.isDouble
+                            ? _.trim(
+                                `${fact.keyAlias ?? ''} ${fact.value ?? ''}`,
+                              )
+                            : fact.aliasedTag,
+                        ),
+                      ]).join(' | ');
+                      return (
+                        <SelectOption
+                          key={image?.id}
+                          value={imageFullName}
+                          label={selectedLabel}
+                          filterValue={[
+                            version,
+                            metadataTagAlias,
+                            image?.architecture,
+                            ...extraFilterValues,
+                          ].join('\t')}
+                        >
+                          {supportExtendedImageInfo ? (
+                            <BAIFlex direction="row">
                               <TextHighlighter keyword={versionSearch}>
-                                {getBaseVersion(imageFullName || '')}
+                                {image?.version}
                               </TextHighlighter>
-                              <Divider
-                                orientation="vertical"
-                                style={versionDividerStyle}
-                              />
+                              <ImageMetaDivider />
                               <TextHighlighter keyword={versionSearch}>
                                 {image?.architecture}
                               </TextHighlighter>
-                              <Divider
-                                orientation="vertical"
-                                style={versionDividerStyle}
-                              />
-                              <ImageTags
-                                tag={image?.tag || ''}
+                              <ImageMetaDivider />
+                              <ImageTagBadges
+                                facts={tagFacts}
                                 highlightKeyword={versionSearch}
-                                labels={
-                                  image?.labels as Array<{
-                                    key: string;
-                                    value: string;
-                                  }>
-                                }
                               />
                             </BAIFlex>
-                          </BAIFlex>
-                        )}
-                      </SelectOption>
-                    );
-                  },
-                )}
-              </BAISelect>
-            </Form.Item>
-          );
-        }}
-      </Form.Item>
+                          ) : (
+                            <BAIFlex direction="row" justify="between">
+                              <BAIFlex direction="row" gap="xxs">
+                                <TextHighlighter keyword={versionSearch}>
+                                  {getBaseVersion(imageFullName || '')}
+                                </TextHighlighter>
+                                <ImageMetaDivider />
+                                <TextHighlighter keyword={versionSearch}>
+                                  {image?.architecture}
+                                </TextHighlighter>
+                                <ImageMetaDivider />
+                                <ImageTags
+                                  tag={image?.tag || ''}
+                                  highlightKeyword={versionSearch}
+                                  labels={
+                                    image?.labels as Array<{
+                                      key: string;
+                                      value: string;
+                                    }>
+                                  }
+                                />
+                              </BAIFlex>
+                            </BAIFlex>
+                          )}
+                        </SelectOption>
+                      );
+                    },
+                  )}
+                </BAISelect>
+              </Form.Item>
+            );
+          }}
+        </Form.Item>
+      </BAIFlex>
       <Form.Item
         label={t('session.launcher.ManualImageName')}
         name={['environments', 'manual']}

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -588,6 +588,12 @@ const ImageEnvironmentSelectFormItems: React.FC<
                       <SelectOption
                         key={environmentGroup.environmentName}
                         value={environmentGroup.environmentName}
+                        // The prefix/meta badge texts live in Badge props, so
+                        // the accessible/search label restates them (FR-3544).
+                        label={_.compact([
+                          environmentGroup.displayName,
+                          ...extraFilterValues,
+                        ]).join(' | ')}
                         filterValue={
                           environmentGroup.displayName +
                           '\t' +

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -93,6 +93,13 @@ const ImageEnvironmentSelectFormItems: React.FC<
     useBackendAIImageMetaData();
   const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
+  // Astryx's vertical Divider is `height: 100%`, which a centered flex row
+  // collapses to 0; antd's metrics keep the row and the trigger identical.
+  const versionDividerStyle: React.CSSProperties = {
+    alignSelf: 'center',
+    height: '0.9em',
+    marginInline: token.marginXXS,
+  };
 
   // antd `RefSelectProps` restated as the one method these two refs ever
   // called. `BAISelect` accepts `ref` and never attaches it (P26-8 — Astryx's
@@ -871,12 +878,18 @@ const ImageEnvironmentSelectFormItems: React.FC<
                             <TextHighlighter keyword={versionSearch}>
                               {image?.version}
                             </TextHighlighter>
-                            <Divider orientation="vertical" />
+                            <Divider
+                              orientation="vertical"
+                              style={versionDividerStyle}
+                            />
                             <TextHighlighter keyword={versionSearch}>
                               {image?.architecture}
                             </TextHighlighter>
-                            <Divider orientation="vertical" />
-                            <BAIFlex direction="row" align="start" gap="xs">
+                            <Divider
+                              orientation="vertical"
+                              style={versionDividerStyle}
+                            />
+                            <BAIFlex direction="row" align="start" gap="xxs">
                               {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
                               {_.map(tagFacts, (fact) =>
                                 fact.isDouble ? (
@@ -916,15 +929,21 @@ const ImageEnvironmentSelectFormItems: React.FC<
                           </BAIFlex>
                         ) : (
                           <BAIFlex direction="row" justify="between">
-                            <BAIFlex direction="row">
+                            <BAIFlex direction="row" gap="xxs">
                               <TextHighlighter keyword={versionSearch}>
                                 {getBaseVersion(imageFullName || '')}
                               </TextHighlighter>
-                              <Divider orientation="vertical" />
+                              <Divider
+                                orientation="vertical"
+                                style={versionDividerStyle}
+                              />
                               <TextHighlighter keyword={versionSearch}>
                                 {image?.architecture}
                               </TextHighlighter>
-                              <Divider orientation="vertical" />
+                              <Divider
+                                orientation="vertical"
+                                style={versionDividerStyle}
+                              />
                               <ImageTags
                                 tag={image?.tag || ''}
                                 highlightKeyword={versionSearch}

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -24,7 +24,7 @@ import { useThemeMode } from '../hooks/useThemeMode';
 import { theme } from '../theme-shim';
 // @ts-ignore
 import ImageMetaIcon from './ImageMetaIcon';
-import { ImageTags } from './ImageTags';
+import { imageTagFacts, ImageTags } from './ImageTags';
 import TextHighlighter from './TextHighlighter';
 import { AstryxFormTextInput } from './astryxFormControls';
 import { Badge } from '@astryxdesign/core/Badge';
@@ -34,11 +34,8 @@ import {
   BAIDoubleTag,
   BAIFlex,
   BAISelect,
-  // `BAISelect` was rebuilt on Astryx in wave 2 and still accepts antd's
-  // children option API — it flattens the element tree by reading PROPS, never
-  // the element type. So `Select.Option` / `Select.OptGroup` are replaced by
-  // BUI's own render-null carriers, and the rich JSX option rows below (image
-  // icon + highlighted name + metadata badges) stay exactly as they are.
+  // BAISelect still accepts antd's children option API via BUI's render-null
+  // carriers; the rich JSX option rows below survive through `renderOption`.
   BAISelectOptionItem as SelectOption,
   BAISelectOptionGroup as SelectOptGroup,
   BAIText,
@@ -711,6 +708,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                   _.uniqBy(selectedEnvironmentGroup?.images, 'id'),
 
                   (image) => {
+                    const imageFullName = getImageFullName(image);
                     const [version, tag, ...requirements] = image?.tag?.split(
                       '-',
                     ) || ['', '', ''];
@@ -790,62 +788,68 @@ const ImageEnvironmentSelectFormItems: React.FC<
                       }
                     }
                     // The closed trigger renders a plain string (BAISelect
-                    // FR-3544), so the row's version | arch | tag facts are
-                    // restated as text here, mirroring the JSX below.
-                    const selectedLabel = _.compact(
+                    // FR-3544): compute each tag's display facts once, then
+                    // derive both the trigger text and the option row from them.
+                    const customizedImageName = _.find(image?.labels, {
+                      key: 'ai.backend.customized-image.name',
+                    })?.value;
+                    const tagFacts = supportExtendedImageInfo
+                      ? _.map(
+                          (image?.tags ?? []) as Array<{
+                            key: string;
+                            value: string;
+                          }>,
+                          (imageTag) => {
+                            const isCustomized = _.includes(
+                              imageTag.key,
+                              'customized_',
+                            );
+                            const value = isCustomized
+                              ? customizedImageName
+                              : imageTag.value;
+                            const aliasedTag = tagAlias(imageTag.key + value);
+                            const isDouble =
+                              _.isEqual(
+                                aliasedTag,
+                                preserveDotStartCase(imageTag.key + value),
+                              ) || isCustomized;
+                            return {
+                              key: imageTag.key,
+                              value,
+                              isCustomized,
+                              aliasedTag,
+                              isDouble,
+                              keyAlias: isDouble
+                                ? tagAlias(imageTag.key)
+                                : undefined,
+                            };
+                          },
+                        )
+                      : imageTagFacts(
+                          getTags(
+                            image?.tag || '',
+                            image?.labels as Array<{
+                              key: string;
+                              value: string;
+                            }>,
+                          ),
+                          tagAlias,
+                        );
+                    const selectedLabel = _.compact([
                       supportExtendedImageInfo
-                        ? [
-                            image?.version,
-                            image?.architecture,
-                            ..._.map(
-                              image?.tags,
-                              (tag: { key: string; value: string }) => {
-                                const isCustomized = _.includes(
-                                  tag.key,
-                                  'customized_',
-                                );
-                                const tagValue = isCustomized
-                                  ? _.find(image?.labels, {
-                                      key: 'ai.backend.customized-image.name',
-                                    })?.value
-                                  : tag.value;
-                                const aliasedTag = tagAlias(tag.key + tagValue);
-                                return _.isEqual(
-                                  aliasedTag,
-                                  preserveDotStartCase(tag.key + tagValue),
-                                ) || isCustomized
-                                  ? _.trim(
-                                      `${tagAlias(tag.key)} ${tagValue ?? ''}`,
-                                    )
-                                  : aliasedTag;
-                              },
-                            ),
-                          ]
-                        : [
-                            getBaseVersion(getImageFullName(image) || ''),
-                            image?.architecture,
-                            ..._.map(
-                              getTags(
-                                image?.tag || '',
-                                (image?.labels ?? []) as Array<{
-                                  key: string;
-                                  value: string;
-                                }>,
-                              ),
-                              (tag) =>
-                                _.isEqual(
-                                  tagAlias(tag.key + tag.value),
-                                  preserveDotStartCase(tag.key + tag.value),
-                                )
-                                  ? _.trim(`${tagAlias(tag.key)} ${tag.value}`)
-                                  : tagAlias(tag.key + tag.value),
-                            ),
-                          ],
-                    ).join(' | ');
+                        ? image?.version
+                        : getBaseVersion(imageFullName || ''),
+                      image?.architecture,
+                      ..._.map(tagFacts, (fact) =>
+                        fact.isDouble
+                          ? _.trim(`${fact.keyAlias ?? ''} ${fact.value ?? ''}`)
+                          : fact.aliasedTag,
+                      ),
+                    ]).join(' | ');
                     return (
                       <SelectOption
                         key={image?.id}
-                        value={getImageFullName(image)}
+                        value={imageFullName}
                         label={selectedLabel}
                         filterValue={[
                           version,
@@ -866,55 +870,39 @@ const ImageEnvironmentSelectFormItems: React.FC<
                             <Divider orientation="vertical" />
                             <BAIFlex direction="row" align="start" gap="xs">
                               {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
-                              {_.map(
-                                image?.tags,
-                                (tag: { key: string; value: string }) => {
-                                  const isCustomized = _.includes(
-                                    tag.key,
-                                    'customized_',
-                                  );
-                                  const tagValue = isCustomized
-                                    ? _.find(image?.labels, {
-                                        key: 'ai.backend.customized-image.name',
-                                      })?.value
-                                    : tag.value;
-                                  const aliasedTag = tagAlias(
-                                    tag.key + tagValue,
-                                  );
-                                  return _.isEqual(
-                                    aliasedTag,
-                                    preserveDotStartCase(tag.key + tagValue),
-                                  ) || isCustomized ? (
-                                    <BAIDoubleTag
-                                      key={tag.key}
-                                      highlightKeyword={versionSearch}
-                                      values={[
-                                        {
-                                          label: tagAlias(tag.key),
-                                          color: isCustomized ? 'cyan' : 'blue',
-                                        },
-                                        {
-                                          label: tagValue ?? '',
-                                          color: isCustomized ? 'cyan' : 'blue',
-                                        },
-                                      ]}
-                                    />
-                                  ) : (
-                                    <Badge
-                                      key={tag.key}
-                                      variant={badgeVariantForTagColor(
-                                        isCustomized ? 'cyan' : 'blue',
-                                      )}
-                                      label={
-                                        <TextHighlighter
-                                          keyword={versionSearch}
-                                        >
-                                          {aliasedTag}
-                                        </TextHighlighter>
-                                      }
-                                    />
-                                  );
-                                },
+                              {_.map(tagFacts, (fact) =>
+                                fact.isDouble ? (
+                                  <BAIDoubleTag
+                                    key={fact.key}
+                                    highlightKeyword={versionSearch}
+                                    values={[
+                                      {
+                                        label: fact.keyAlias ?? '',
+                                        color: fact.isCustomized
+                                          ? 'cyan'
+                                          : 'blue',
+                                      },
+                                      {
+                                        label: fact.value ?? '',
+                                        color: fact.isCustomized
+                                          ? 'cyan'
+                                          : 'blue',
+                                      },
+                                    ]}
+                                  />
+                                ) : (
+                                  <Badge
+                                    key={fact.key}
+                                    variant={badgeVariantForTagColor(
+                                      fact.isCustomized ? 'cyan' : 'blue',
+                                    )}
+                                    label={
+                                      <TextHighlighter keyword={versionSearch}>
+                                        {fact.aliasedTag}
+                                      </TextHighlighter>
+                                    }
+                                  />
+                                ),
                               )}
                             </BAIFlex>
                           </BAIFlex>
@@ -922,7 +910,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                           <BAIFlex direction="row" justify="between">
                             <BAIFlex direction="row">
                               <TextHighlighter keyword={versionSearch}>
-                                {getBaseVersion(getImageFullName(image) || '')}
+                                {getBaseVersion(imageFullName || '')}
                               </TextHighlighter>
                               <Divider orientation="vertical" />
                               <TextHighlighter keyword={versionSearch}>

--- a/react/src/components/ImageTags.tsx
+++ b/react/src/components/ImageTags.tsx
@@ -9,6 +9,7 @@ import { theme } from '../theme-shim';
 import ImageMetaIcon from './ImageMetaIcon';
 import TextHighlighter from './TextHighlighter';
 import { Badge } from '@astryxdesign/core/Badge';
+import { Divider } from '@astryxdesign/core/Divider';
 import {
   BAIDoubleTag,
   BAIFlex,
@@ -116,38 +117,93 @@ interface ImageTagsProps extends ImageTagColorProps {
   highlightKeyword?: string;
 }
 
-// One rule for "how does a parsed image tag display" — the tag row (below)
-// and the version select's trigger text (FR-3544) both read these facts.
+// One rule for "how does a parsed image tag display" — every surface that
+// shows image tags (select rows, the closed trigger's text, the launcher
+// review step) reads these facts (FR-3544).
+export interface ImageTagFact {
+  key: string;
+  value?: string;
+  isCustomized: boolean;
+  aliasedTag: string;
+  isDouble: boolean;
+  keyAlias?: string;
+}
+
+const toFact = (
+  key: string,
+  value: string | undefined,
+  isCustomized: boolean,
+  tagAlias: (tag: string) => string,
+): ImageTagFact => {
+  const aliasedTag = tagAlias(key + value);
+  const isDouble =
+    _.isEqual(aliasedTag, preserveDotStartCase(key + value)) || isCustomized;
+  return {
+    key,
+    value,
+    isCustomized,
+    aliasedTag,
+    isDouble,
+    keyAlias: isDouble ? tagAlias(key) : undefined,
+  };
+};
+
+/** Facts from `getTags`-parsed tags (servers without extended image info). */
 export const imageTagFacts = (
   tags: Array<{ key: string; value: string }>,
   tagAlias: (tag: string) => string,
-) =>
-  _.map(tags, (tag) => {
-    const aliasedTag = tagAlias(tag.key + tag.value);
-    const isDouble = _.isEqual(
-      aliasedTag,
-      preserveDotStartCase(tag.key + tag.value),
-    );
-    return {
-      ...tag,
-      isCustomized: tag.key === 'Customized',
-      aliasedTag,
-      isDouble,
-      keyAlias: isDouble ? tagAlias(tag.key) : undefined,
-    };
+): Array<ImageTagFact> =>
+  _.map(tags, (tag) =>
+    toFact(tag.key, tag.value, tag.key === 'Customized', tagAlias),
+  );
+
+/** Facts from an image node's own `tags` (extended image info). */
+export const imageNodeTagFacts = (
+  tags: Array<{ key: string; value: string }> | null | undefined,
+  labels: Array<{ key: string; value: string }> | null | undefined,
+  tagAlias: (tag: string) => string,
+): Array<ImageTagFact> =>
+  _.map(tags ?? [], (tag) => {
+    const isCustomized = _.includes(tag.key, 'customized_');
+    // A customized tag's value is a hash; the readable name is in the labels.
+    const value = isCustomized
+      ? _.find(labels ?? [], { key: 'ai.backend.customized-image.name' })?.value
+      : tag.value;
+    return toFact(tag.key, value, isCustomized, tagAlias);
   });
 
-export const ImageTags: React.FC<ImageTagsProps> = ({
-  tag,
-  labels,
-  highlightKeyword,
-  ...props
-}) => {
-  labels = labels || [];
-  const [, { getTags, tagAlias }] = useBackendAIImageMetaData();
+/**
+ * Astryx's vertical `Divider` is `height: 100%`, which a centered flex row
+ * collapses to 0; these are antd's metrics, shared by every image meta row.
+ */
+export const ImageMetaDivider: React.FC = () => {
+  'use memo';
+  const { token } = theme.useToken();
   return (
-    <React.Fragment {...props}>
-      {_.map(imageTagFacts(getTags(tag, labels), tagAlias), (fact, index) =>
+    <Divider
+      orientation="vertical"
+      style={{
+        alignSelf: 'center',
+        height: '0.9em',
+        marginInline: token.marginXXS,
+      }}
+    />
+  );
+};
+
+interface ImageTagBadgesProps {
+  facts: Array<ImageTagFact>;
+  highlightKeyword?: string;
+}
+/** The badge row every image meta surface renders from {@link ImageTagFact}s. */
+export const ImageTagBadges: React.FC<ImageTagBadgesProps> = ({
+  facts,
+  highlightKeyword,
+}) => {
+  'use memo';
+  return (
+    <BAIFlex direction="row" align="center" gap="xxs" wrap="wrap">
+      {_.map(facts, (fact) =>
         fact.isDouble ? (
           <BAIDoubleTag
             key={fact.key}
@@ -158,7 +214,7 @@ export const ImageTags: React.FC<ImageTagsProps> = ({
                 color: fact.isCustomized ? 'cyan' : 'blue',
               },
               {
-                label: fact.value,
+                label: fact.value ?? '',
                 color: fact.isCustomized ? 'cyan' : 'blue',
               },
             ]}
@@ -170,14 +226,32 @@ export const ImageTags: React.FC<ImageTagsProps> = ({
               fact.isCustomized ? 'cyan' : 'blue',
             )}
             label={
-              <TextHighlighter keyword={highlightKeyword} key={index}>
+              <TextHighlighter keyword={highlightKeyword}>
                 {fact.aliasedTag}
               </TextHighlighter>
             }
           />
         ),
       )}
-    </React.Fragment>
+    </BAIFlex>
+  );
+};
+
+export const ImageTags: React.FC<ImageTagsProps> = ({
+  tag,
+  labels,
+  highlightKeyword,
+  ...props
+}) => {
+  labels = labels || [];
+  const [, { getTags, tagAlias }] = useBackendAIImageMetaData();
+  return (
+    <span {...props}>
+      <ImageTagBadges
+        facts={imageTagFacts(getTags(tag, labels), tagAlias)}
+        highlightKeyword={highlightKeyword}
+      />
+    </span>
   );
 };
 

--- a/react/src/components/ImageTags.tsx
+++ b/react/src/components/ImageTags.tsx
@@ -115,6 +115,28 @@ interface ImageTagsProps extends ImageTagColorProps {
   labels: Array<{ key: string; value: string }>;
   highlightKeyword?: string;
 }
+
+// One rule for "how does a parsed image tag display" — the tag row (below)
+// and the version select's trigger text (FR-3544) both read these facts.
+export const imageTagFacts = (
+  tags: Array<{ key: string; value: string }>,
+  tagAlias: (tag: string) => string,
+) =>
+  _.map(tags, (tag) => {
+    const aliasedTag = tagAlias(tag.key + tag.value);
+    const isDouble = _.isEqual(
+      aliasedTag,
+      preserveDotStartCase(tag.key + tag.value),
+    );
+    return {
+      ...tag,
+      isCustomized: tag.key === 'Customized',
+      aliasedTag,
+      isDouble,
+      keyAlias: isDouble ? tagAlias(tag.key) : undefined,
+    };
+  });
+
 export const ImageTags: React.FC<ImageTagsProps> = ({
   tag,
   labels,
@@ -123,42 +145,38 @@ export const ImageTags: React.FC<ImageTagsProps> = ({
 }) => {
   labels = labels || [];
   const [, { getTags, tagAlias }] = useBackendAIImageMetaData();
-  const tags = getTags(tag, labels);
   return (
     <React.Fragment {...props}>
-      {_.map(tags, (tag: { key: string; value: string }, index) => {
-        const isCustomized = tag.key === 'Customized';
-        const aliasedTag = tagAlias(tag.key + tag.value);
-        return _.isEqual(
-          aliasedTag,
-          preserveDotStartCase(tag.key + tag.value),
-        ) ? (
+      {_.map(imageTagFacts(getTags(tag, labels), tagAlias), (fact, index) =>
+        fact.isDouble ? (
           <BAIDoubleTag
-            key={tag.key}
+            key={fact.key}
             highlightKeyword={highlightKeyword}
             values={[
               {
-                label: tagAlias(tag.key),
-                color: isCustomized ? 'cyan' : 'blue',
+                label: fact.keyAlias ?? '',
+                color: fact.isCustomized ? 'cyan' : 'blue',
               },
               {
-                label: tag.value,
-                color: isCustomized ? 'cyan' : 'blue',
+                label: fact.value,
+                color: fact.isCustomized ? 'cyan' : 'blue',
               },
             ]}
           />
         ) : (
           <Badge
-            key={tag.key}
-            variant={badgeVariantForTagColor(isCustomized ? 'cyan' : 'blue')}
+            key={fact.key}
+            variant={badgeVariantForTagColor(
+              fact.isCustomized ? 'cyan' : 'blue',
+            )}
             label={
               <TextHighlighter keyword={highlightKeyword} key={index}>
-                {aliasedTag}
+                {fact.aliasedTag}
               </TextHighlighter>
             }
           />
-        );
-      })}
+        ),
+      )}
     </React.Fragment>
   );
 };

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -6,7 +6,7 @@ import { App } from '../app-shim';
 // FRONTIER (ticket 17 / ticket 34): `Form.useFormInstance` / `Form.useWatch`
 // keep reading the antd form engine (locked SHIM decision).
 import { Form } from '../form-engine';
-import { preserveDotStartCase, getImageFullName } from '../helper';
+import { getImageFullName } from '../helper';
 import {
   useBackendAIImageMetaData,
   useSuspendedBackendaiClient,
@@ -18,7 +18,12 @@ import {
   SessionLauncherStepKey,
 } from '../pages/SessionLauncherPage';
 import ImageMetaIcon from './ImageMetaIcon';
-import { ImageTags } from './ImageTags';
+import {
+  imageNodeTagFacts,
+  ImageMetaDivider,
+  ImageTagBadges,
+  ImageTags,
+} from './ImageTags';
 import { PortTag } from './PortSelectFormItem';
 import { SessionOwnerSetterPreviewCard } from './SessionOwnerSetterCard';
 import SourceCodeView from './SourceCodeView';
@@ -26,7 +31,6 @@ import { Badge } from '@astryxdesign/core/Badge';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { Card } from '@astryxdesign/core/Card';
-import { Divider } from '@astryxdesign/core/Divider';
 import { Heading } from '@astryxdesign/core/Heading';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import {
@@ -34,13 +38,7 @@ import {
   MetadataListItem,
 } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
-import {
-  BAICard,
-  BAIDoubleTag,
-  BAIFlex,
-  BAITableAstryx,
-  BAIText,
-} from 'backend.ai-ui';
+import { BAICard, BAIFlex, BAITableAstryx, BAIText } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { CheckIcon, CopyIcon } from 'lucide-react';
@@ -218,14 +216,14 @@ const SessionLauncherPreview: React.FC<{
           </MetadataListItem>
           <MetadataListItem label={t('general.Image')}>
             {supportExtendedImageInfo ? (
-              <BAIFlex direction="row" align="start" gap="xs" wrap="nowrap">
+              <BAIFlex direction="row" align="center" gap="xs" wrap="nowrap">
                 <ImageMetaIcon
                   image={
                     form.getFieldValue('environments')?.version ||
                     form.getFieldValue('environments')?.manual
                   }
                 />
-                <BAIFlex direction="row" wrap="wrap">
+                <BAIFlex direction="row" align="center" gap="xxs" wrap="wrap">
                   {form.getFieldValue('environments')?.manual ? (
                     <BAIText code copyable>
                       {form.getFieldValue('environments')?.manual}
@@ -238,63 +236,27 @@ const SessionLauncherPreview: React.FC<{
                             ?.base_image_name,
                         )}
                       </Text>
-                      <Divider orientation="vertical" />
+                      <ImageMetaDivider />
                       <Text>
                         {form.getFieldValue('environments')?.image?.version}
                       </Text>
-                      <Divider orientation="vertical" />
+                      <ImageMetaDivider />
                       <Text>
                         {
                           form.getFieldValue('environments')?.image
                             ?.architecture
                         }
                       </Text>
-                      <Divider orientation="vertical" />
+                      <ImageMetaDivider />
                       {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
-                      <BAIFlex gap={'xxs'}>
-                        {_.map(
+                      <ImageTagBadges
+                        facts={imageNodeTagFacts(
                           form.getFieldValue('environments')?.image?.tags,
-                          (tag: { key: string; value: string }) => {
-                            const isCustomized = _.includes(
-                              tag.key,
-                              'customized_',
-                            );
-                            const tagValue = isCustomized
-                              ? _.find(
-                                  form.getFieldValue('environments')?.image
-                                    ?.labels,
-                                  {
-                                    key: 'ai.backend.customized-image.name',
-                                  },
-                                )?.value
-                              : tag.value;
-                            const aliasedTag = tagAlias(tag.key + tagValue);
-                            return _.isEqual(
-                              aliasedTag,
-                              preserveDotStartCase(tag.key + tagValue),
-                            ) || isCustomized ? (
-                              <BAIDoubleTag
-                                key={tag.key}
-                                values={[
-                                  {
-                                    label: tagAlias(tag.key),
-                                    color: isCustomized ? 'cyan' : 'blue',
-                                  },
-                                  {
-                                    label: tagValue,
-                                    color: isCustomized ? 'cyan' : 'blue',
-                                  },
-                                ]}
-                              />
-                            ) : (
-                              <Badge
-                                key={tag.key}
-                                variant={isCustomized ? 'cyan' : 'blue'}
-                                label={aliasedTag}
-                              />
-                            );
-                          },
+                          form.getFieldValue('environments')?.image?.labels,
+                          tagAlias,
                         )}
+                      />
+                      <BAIFlex gap={'xxs'}>
                         <CopyValueIconButton
                           label={t('button.CopySomething', {
                             name: t('general.Image'),
@@ -311,14 +273,14 @@ const SessionLauncherPreview: React.FC<{
                 </BAIFlex>
               </BAIFlex>
             ) : (
-              <BAIFlex direction="row" align="start" gap="xs" wrap="nowrap">
+              <BAIFlex direction="row" align="center" gap="xs" wrap="nowrap">
                 <ImageMetaIcon
                   image={
                     form.getFieldValue('environments')?.version ||
                     form.getFieldValue('environments')?.manual
                   }
                 />
-                <BAIFlex direction="row" wrap="wrap">
+                <BAIFlex direction="row" align="center" gap="xxs" wrap="wrap">
                   {form.getFieldValue('environments')?.manual ? (
                     <BAIText code copyable>
                       {form.getFieldValue('environments')?.manual}
@@ -332,20 +294,20 @@ const SessionLauncherPreview: React.FC<{
                           ),
                         )}
                       </Text>
-                      <Divider orientation="vertical" />
+                      <ImageMetaDivider />
                       <Text>
                         {getBaseVersion(
                           form.getFieldValue('environments')?.version,
                         )}
                       </Text>
-                      <Divider orientation="vertical" />
+                      <ImageMetaDivider />
                       <Text>
                         {
                           form.getFieldValue('environments')?.image
                             ?.architecture
                         }
                       </Text>
-                      <Divider orientation="vertical" />
+                      <ImageMetaDivider />
                       <ImageTags
                         tag={form.getFieldValue([
                           'environments',


### PR DESCRIPTION
Resolves #8780 (FR-3544)

## Mechanism

Astryx `Selector` renders a **plain string** in the closed trigger (`selectedItem?.label`), and `BAISelect`'s children-API flattener derives that string from the option's rendered text via `nodeToAccessibleLabel`, which walks `children` only. The Session Launcher's option rows carry their key facts in `Badge label=` / `BAIDoubleTag values=` **props** — invisible to the walker — so a selected image's trigger read `3.9 x86_64` with the image icon and every tag badge dropped. The popup rows were unaffected (rich JSX survives via `renderOption`); only the selected-value display lost them.

## Fix (three layers)

1. **String label restored as the accessible/search surface** — `BAISelectOptionItem` accepts antd's option-`label` string; the version options build `version | arch | tags` from the same facts the row renders. This is the trigger's accessible name and the search key, so searching by tag text ("ubuntu", "cuda") works again.
2. **Rich node restored as the visual surface** — `BAISelect` now honours antd's `optionLabelProp="children"`: the selected option's rich node (icon + badges) renders on the closed trigger through `Selector`'s pass-through icon slot (`renderIconSlot` returns arbitrary elements untouched), while the trigger button keeps the string label visually hidden. Co-located CSS (P17, structural selectors like the existing ghost rules) gives the node the label's flex share; `align-items: stretch` keeps vertical `Divider`s visible; the node fills the label area so a row's `justify="between"` keeps trailing badges at the trigger's right edge — the antd-era look, byte for byte at the call sites (zero option-JSX changes).
3. **Shared tag facts** — each version option computes its tag display facts once (`imageTagFacts`, shared with `ImageTags`) and both the trigger text and the rendered tag row read them, so trigger and row cannot drift. The children-API carriers are now discriminated by element type, so an option carrying `label` can never be misread as an OptGroup.

## Measured before/after (live dev server, light and dark, `data-theme` asserted)

| Property | Before | After |
|---|---|---|
| Environment trigger | plain text `python-tcp-app` | image icon + name, meta badges right-aligned (e.g. `PyTorch (NGC)` + `testing` `NVIDIA GPU Cloud`) |
| Version trigger | `3.9 x86_64` (tags dropped) | `26.06 │ aarch64 │` + `PyTorch 2.13` `Python 3.12` `GPU:CUDA13.3` badge chips |
| Vertical dividers (trigger **and** dropdown row) | trigger: full stretch; row: 0px | 0.9em, centered, `marginXXS` side margins on both — one style on the option JSX |
| Popup option rows | unchanged | unchanged (same node, same facts) |
| Search "ubuntu"/"pytorch" | no match on tag text | matches (label string carries tags) |
| Selecting/re-selecting options | value kept | value kept; trigger updates (exercised live on both selects) |
| `pageerror` count, both modes | — | 0 new (only the pre-existing Relay `Group`/`UserGroup` id-collision warnings) |

Verified against two backends: the e2e cluster (10.82.0.6, legacy image-info branch) and dogbowl (extended-image-info branch).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built
- `pnpm --prefix ./react exec vitest run` → 88 files, 1405 passed
- `pnpm --filter backend.ai-ui exec vitest run` → 613 passed, 1 skipped (new trigger-label + rich-trigger tests included; FR-3499's text-leak pins still pass)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 finding: `BAIText.css:28 var(--x)` — **pre-existing on `main`** (the gate flags the literal `var(--x, literal)` example inside that file's header comment; confirmed identical via `git show main:...`, untouched by this diff)

## Residue

- `optionLabelProp="children"` is opt-in; only the image environment/version selects (Session Launcher + `DeploymentAddRevisionModal`, shared component) use it. Other `BAISelect` call sites keep their text triggers.
- The `Arm` `64` double chip in the version trigger renders the same as in the option row (pre-existing `BAIDoubleTag` output for `image.tags`, unchanged by this PR).
- ~~Vertical dividers inside popup option rows collapsed to 0px~~ — folded in (`d2fc666bc`): the divider metrics now live on the option JSX itself, so the trigger and the dropdown row render identically (measured: 12px dividers with 4px side margins, 4px badge gaps on both).

## Screenshots

Trigger vs dropdown row after `d2fc666bc` (identical metrics):

![trigger vs row](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8783/20260818-123326-trigger-vs-row-match.png)

antd-era parity (rich trigger — icon, name, badge chips):

| Light | Dark |
|---|---|
| ![rich trigger light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8783/20260814-161527-divider-fix-light.jpg) | ![rich trigger dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8783/20260814-161527-divider-fix-dark.jpg) |

Original defect vs first (text-only) stage, on the e2e cluster:

| | Before | Text stage |
|---|---|---|
| Light | ![before light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8783/20260814-144103-before-light.jpg) | ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8783/20260814-144103-after-light.jpg) |
| Dark | ![before dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8783/20260814-144103-before-dark.jpg) | ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8783/20260814-144103-after-dark.jpg) |

