### PR TITLE
fix(FR-3546): retry tour target resolution until the anchors exist

### DIFF
--- a/react/src/components/AdminDeploymentPresetValidationTour.tsx
+++ b/react/src/components/AdminDeploymentPresetValidationTour.tsx
@@ -4,8 +4,9 @@
  */
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import BAITourAstryx from './astryx-bui/BAITourAstryx';
+import { useTourTargets } from './astryx-bui/useTourTargets';
 import { TourStep } from '@astryxdesign/lab';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -39,45 +40,30 @@ const PresetValidationTour: React.FC<PresetValidationTourProps> = ({
 
   // PILOT-DECISION: antd Tour took lazy function targets
   // (`target: () => HTMLElement`); lab `TourStep` anchors through a
-  // `targetRef` whose element must already exist when the step renders. The
-  // same DOM queries now run once in an effect when the tour opens, and the
-  // resolved elements are handed to the steps as literal ref objects. Each
-  // target contains a real `<button>` (the review card's Modify link / the
-  // footer nav buttons), satisfying the Popover anchor contract. The
-  // The action-slot anchor is `.bai-card__extra`. It was `.ant-card-extra`,
-  // which stopped existing when `BAICard` was rebuilt on Astryx — the query
-  // returned null and this step silently lost its anchor. `BAICard` now emits
-  // a BAI-namespaced class for exactly this purpose (see the comment on its
+  // `targetRef` whose element must already exist when the step renders, so the
+  // DOM queries run in an effect and the resolved elements are handed to the
+  // steps as literal ref objects. Each target contains a real `<button>` (the
+  // review card's Modify link / the footer nav buttons), satisfying the
+  // Popover anchor contract.
+  // The action-slot anchor is `.bai-card__extra` — `BAICard` emits a
+  // BAI-namespaced class for exactly this purpose (see the comment on its
   // header row).
-  const [targets, setTargets] = useState<TourTargets | null>(null);
-
   const isActive = !!open && !hasOpened;
 
-  useEffect(() => {
-    // Resolve targets on the next frame (never synchronously in the effect —
-    // react-hooks/set-state-in-effect): the error-card DOM this queries is
-    // painted by the same commit that flips `isActive`.
-    const frame = requestAnimationFrame(() => {
-      if (!isActive) {
-        setTargets(null);
-        return;
-      }
-      const card = document.getElementsByClassName('bai-card-error')?.[0] as
-        HTMLElement | undefined;
-      if (!card) {
-        setTargets(null);
-        return;
-      }
-      setTargets({
-        card,
-        extra: card.querySelector<HTMLElement>('.bai-card__extra'),
-        nav: document.querySelector<HTMLElement>(
-          '[data-test-id="deployment-preset-step-navigation"]',
-        ),
-      });
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [isActive]);
+  const targets = useTourTargets<TourTargets>(isActive, () => {
+    const card = document.getElementsByClassName('bai-card-error')?.[0] as
+      HTMLElement | undefined;
+    if (!card) {
+      return null;
+    }
+    return {
+      card,
+      extra: card.querySelector<HTMLElement>('.bai-card__extra'),
+      nav: document.querySelector<HTMLElement>(
+        '[data-test-id="deployment-preset-step-navigation"]',
+      ),
+    };
+  });
 
   if (!isActive || !targets) return null;
 

--- a/react/src/components/SessionLauncherErrorTourProps.tsx
+++ b/react/src/components/SessionLauncherErrorTourProps.tsx
@@ -3,13 +3,12 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { useBAISettingUserState } from '../hooks/useBAISetting';
-// Ticket 17's FRONTIER note is discharged: ticket 18 pinned
-// `@astryxdesign/lab@0.3.0-canary.12db2a1`, so the Astryx Tour is available.
-// This file follows `AdminDeploymentPresetValidationTour` — the same
-// three-step "you have a validation error" tour — verbatim.
+// Mirrors `AdminDeploymentPresetValidationTour` — the same three-step
+// "you have a validation error" tour.
 import BAITourAstryx from './astryx-bui/BAITourAstryx';
+import { useTourTargets } from './astryx-bui/useTourTargets';
 import { TourStep } from '@astryxdesign/lab';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -44,46 +43,27 @@ const SessionLauncherValidationTour: React.FC<
   const [hasOpenedValidationTour, setHasOpenedValidationTour] =
     useBAISettingUserState('has_opened_tour_neo_session_validation');
 
-  // PILOT-DECISION: antd Tour took lazy function targets
-  // (`target: () => HTMLElement`); lab `TourStep` anchors through a
-  // `targetRef` whose element must already exist when the step renders. The
-  // same DOM queries now run once in an effect when the tour opens, and the
-  // resolved elements are handed to the steps as literal ref objects. The
-  // The header anchor is `.bai-card__head`. It was `.ant-card-head`, on the
-  // then-true premise that `BAICard` was an unconverted frontier component
-  // still rendering antd Card DOM. It converted; the class went with it, the
-  // query started returning null, and this step lost its anchor without
-  // failing. `BAICard` now emits a BAI-namespaced class for exactly this
-  // purpose (see the comment on its header row).
-  const [targets, setTargets] = useState<TourTargets | null>(null);
-
+  // lab `TourStep` anchors through a `targetRef` whose element must already
+  // exist when the step renders, so the DOM queries run in an effect and the
+  // resolved elements are handed to the steps as literal ref objects.
+  // The header anchor is `.bai-card__head` — `BAICard` emits a BAI-namespaced
+  // class for exactly this purpose (see the comment on its header row).
   const isActive = !!open && !hasOpenedValidationTour;
 
-  useEffect(() => {
-    // Resolve targets on the next frame (never synchronously in the effect —
-    // react-hooks/set-state-in-effect): the error-card DOM this queries is
-    // painted by the same commit that flips `isActive`.
-    const frame = requestAnimationFrame(() => {
-      if (!isActive) {
-        setTargets(null);
-        return;
-      }
-      const card = document.getElementsByClassName('bai-card-error')?.[0] as
-        HTMLElement | undefined;
-      if (!card) {
-        setTargets(null);
-        return;
-      }
-      setTargets({
-        card,
-        head: card.querySelector<HTMLElement>('.bai-card__head'),
-        nav: document.querySelector<HTMLElement>(
-          '[data-test-id="neo-session-launcher-tour-step-navigation"]',
-        ),
-      });
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [isActive]);
+  const targets = useTourTargets<TourTargets>(isActive, () => {
+    const card = document.getElementsByClassName('bai-card-error')?.[0] as
+      HTMLElement | undefined;
+    if (!card) {
+      return null;
+    }
+    return {
+      card,
+      head: card.querySelector<HTMLElement>('.bai-card__head'),
+      nav: document.querySelector<HTMLElement>(
+        '[data-test-id="neo-session-launcher-tour-step-navigation"]',
+      ),
+    };
+  });
 
   if (!isActive || !targets) return null;
 

--- a/react/src/components/astryx-bui/useTourTargets.ts
+++ b/react/src/components/astryx-bui/useTourTargets.ts
@@ -1,0 +1,75 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useEffect, useEffectEvent, useState } from 'react';
+
+/**
+ * Resolve a tour's DOM anchors once `isActive` turns on.
+ *
+ * A tour can activate before the DOM it points at exists — the review summary
+ * suspends on a Relay query, so `.bai-card-error` lands after the commit that
+ * flips the tour on. The first attempt is retried on every DOM mutation until
+ * it succeeds, so the wait is bounded by the anchor appearing rather than by a
+ * wall-clock guess that a slow backend would blow through (FR-3546).
+ *
+ * `resolve` must return `null` while the DOM is not ready yet; anything
+ * non-null ends the search.
+ */
+export const useTourTargets = <T>(
+  isActive: boolean,
+  resolve: () => T | null,
+): T | null => {
+  'use memo';
+  const [targets, setTargets] = useState<T | null>(null);
+  const resolveTargets = useEffectEvent(() => resolve());
+
+  useEffect(() => {
+    let observer: MutationObserver | null = null;
+
+    // Returns true when the search is over — resolved, or not wanted at all.
+    const attempt = () => {
+      if (!isActive) {
+        setTargets(null);
+        return true;
+      }
+      const next = resolveTargets();
+      if (!next) {
+        return false;
+      }
+      setTargets(next);
+      return true;
+    };
+
+    // Never set state synchronously in the effect
+    // (react-hooks/set-state-in-effect) — the first attempt is a frame away.
+    const frame = requestAnimationFrame(() => {
+      if (attempt()) {
+        return;
+      }
+      observer = new MutationObserver(() => {
+        if (attempt()) {
+          observer?.disconnect();
+          observer = null;
+        }
+      });
+      // `.bai-card-error` arrives either with the card (childList) or as a
+      // class added to one already mounted (attributes).
+      observer.observe(document.body, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: ['class'],
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer?.disconnect();
+    };
+  }, [isActive]);
+
+  return targets;
+};
+
+export default useTourTargets;


### PR DESCRIPTION
Resolves #8784 (FR-3546)

## Mechanism

Both validation tours resolved their DOM anchors inside a **single**
`requestAnimationFrame`, in an effect that depends only on `isActive`:

```tsx
useEffect(() => {
  const frame = requestAnimationFrame(() => {
    const card = document.getElementsByClassName('bai-card-error')?.[0];
    if (!card) { setTargets(null); return; }   // ← gives up forever
    setTargets({ card, … });
  });
  return () => cancelAnimationFrame(frame);
}, [isActive]);
```

On the **first** entry into the Review step that frame runs before the review
summary has painted — `AdminDeploymentPresetReviewSummary` suspends on a Relay
query (`useAdminImageReference`) — so `.bai-card-error` is not in the DOM yet.
`targets` is set to `null`, and because `isActive` stays `true` the effect never
re-runs. The tour is silently dropped.

Entering the step a **second** time worked only because the Relay cache was warm
by then, so the summary painted in the same commit that flipped the tour on.
That is why "Previous → Next" appeared to fix it.

Instrumented log from the repro, first entry (before this change):

```
[TOURDBG] render open=true isActive=true targets=null
[TOURDBG] rAF isActive=true cardFound=false cardCount=0    ← one shot, missed
```

versus the second entry:

```
[TOURDBG] rAF isActive=true cardFound=true cardCount=3
[TOURDBG] render open=true isActive=true targets=set
```

## Change

- **`react/src/components/astryx-bui/useTourTargets.ts`** (new): resolves a
  tour's anchors once `isActive` turns on and, if they are not there yet,
  re-runs the resolver on **every DOM mutation** until it succeeds, then
  disconnects. A `null` return now means "not ready yet" instead of "give up".
- **`AdminDeploymentPresetValidationTour.tsx`** / **`SessionLauncherErrorTourProps.tsx`**:
  use the hook instead of their own single-shot `rAF`. Both files carried the
  identical defect, so the resolution lives in one place rather than a third copy.

**Why a MutationObserver and not a timeout.** The first version of this fix
retried each frame for 3s. That is a wall-clock guess about how long a Relay
query takes: a slow backend blows through it and the tour is lost again — the
same bug, just with a different threshold. Waiting on the anchor itself has no
such tunable, and it matches the actual intent ("show the tour once the error
cards exist"). The observer only lives while a tour is pending and disconnects
the moment it resolves.

Per `comment-density.md` ("touch it, trim it"), the two migration-travelogue
comment blocks in the files being edited were shortened to the constraint they
still carry.

## Measured before/after

Playwright repro against a dev server, polling `.bai-card-error` count (`c`) and
whether the tour callout is present (`tour`):

| Scenario | Before | After |
|---|---|---|
| 1st entry — **Skip to Review** | `0ms c=3 tour=0` — **stays 0 for the full 4s** | `0ms c=0 tour=0` → `100ms c=3 tour=1` |
| 2nd entry — Previous → Next | `0ms c=3 tour=1` | `0ms c=3 tour=1` (unchanged) |
| 1st entry, **GraphQL delayed 6s** | n/a — would miss any deadline under 6s | `0ms c=0 tour=0` → `6000ms c=3 tour=1` |

The third row is the one that justifies the observer: with all `**/admin/gql`
responses stalled by 6s, the anchors land far past any 3s deadline and the tour
still appears **in the same poll sample the cards do**.

Before the fix the error cards were present in *both* of the first two rows —
the tour was the only thing missing, which rules out "the cards were not
rendered".

## Verification

- `bash scripts/verify.sh` → Relay / Lint / Format / TypeScript / Vite warmup /
  StyleX sentinel / Terminology all **PASS**.
  `Astryx theme build` **FAILs**, but it fails identically on a clean `main`
  checkout with this branch's changes stashed — pre-existing, not from this change.
- `pnpm --prefix ./react exec vitest run` → 88 files, **1405 passed**
- Live repro on the dev server (table above), both the normal and the
  6s-stalled-backend path. The session-launcher tour shares the same code path
  but was verified statically only.

## Residue

- The two tour components remain near-verbatim copies of each other (same
  three-step structure, differing only in identifiers, i18n keys, and the
  second-step anchor). This change removes one copy of the resolution logic;
  merging the components themselves is a separate refactor.
