### PR TITLE
fix(FR-3553): let non-modal dialogs keep global keyboard shortcuts

### DIFF
--- a/react/src/hooks/useKeyboardShortcut.test.ts
+++ b/react/src/hooks/useKeyboardShortcut.test.ts
@@ -146,7 +146,7 @@ describe('useKeyboardShortcut', () => {
 
     // The non-scrim drawers open with `show()`: page interactive, shortcuts
     // too — an open notification drawer must not eat its own `]` toggle
-    // (FR-3619).
+    // (FR-3553 / FR-3619).
     it('should trigger handler when only a non-modal dialog is open', () => {
       appendOpenModalRoot('dialog', { open: '' });
 
@@ -163,6 +163,16 @@ describe('useKeyboardShortcut', () => {
       triggerKeydown({ key: 'a' });
 
       expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not trigger handler when a modal and a non-modal dialog are both open', () => {
+      appendOpenModalRoot('dialog', { open: '' });
+      appendOpenModalRoot('dialog', { open: '', 'aria-modal': 'true' });
+
+      renderHook(() => useKeyboardShortcut(mockHandler));
+      triggerKeydown({ key: 'a' });
+
+      expect(mockHandler).not.toHaveBeenCalled();
     });
 
     it('should trigger handler when no modal is open', () => {


### PR DESCRIPTION
Resolves #8797 (FR-3553)

> [!NOTE]
> **Scope update (2026-08-24, after rebase onto main):** main's FR-3619
> (`openModalRoot.ts`, `OPEN_MODAL_ROOT_SELECTOR`) landed a superseding
> implementation of this fix — it covers the same `show()`-vs-`showModal()`
> distinction via `dialog[open][aria-modal="true"]`, plus portal modal roots
> and `inert` roots. After rebasing, the hook change here is gone (identical
> to main) and this PR now carries **only a regression test**: modal + non-modal
> dialog open together → shortcuts stay suppressed (+11/−1 in
> `useKeyboardShortcut.test.ts`). The analysis below documents the original
> bug and is kept for context.


`]` opened the notification drawer but could never close it again. The same
guard also silently killed `[` (sider collapse) for as long as the drawer was
open.

## Mechanism

`useKeyboardShortcut` skipped the handler whenever `document.querySelector('dialog[open]')`
matched anything. That selector was written when every `<dialog>` in the app
was a modal opened with `showModal()`.

Since the Astryx migration it is not. The notification drawer is
`BAIDrawerAstryx` → lab `Drawer`, and lab `Drawer` opens the native `<dialog>`
with **`show()`** rather than `showModal()` when `hasScrim={false}` — which is
exactly how `WEBUINotificationDrawer` configures it, deliberately, so the page
behind the drawer stays interactive:

```js
// @astryxdesign/lab/dist/Drawer/Drawer.js
if (hasScrim) { dialog.showModal(); } else { dialog.show(); }
```

`show()` still sets the `open` attribute. So the first `]` opened the drawer,
and from that moment the drawer itself matched the "a modal is open, ignore
shortcuts" guard — the second `]` never reached the toggle.

The fix narrows the guard from "any open dialog" to "any *modal* open dialog"
using the `:modal` pseudo-class, which is precisely the distinction between
`showModal()` and `show()`.

## Measured, in the app (Chromium, dev server on this branch)

Confirming the premise — after pressing `]` once, on `main`:

| Query | Result |
|---|---|
| `document.querySelectorAll('dialog[open]').length` | **1** |
| `…filter(d => d.matches(':modal')).length` | **0** |

The drawer is open but *not* modal, so the old guard misclassified it.
`BAIModal` (Create Folder) measures `dialog[open]` = 1, `:modal` = **1**, so
the two are genuinely distinguishable at runtime.

Behaviour, same steps on both builds:

| Step | Before (main) | After (this branch) |
|---|---|---|
| `]` — open drawer | opens | opens |
| `]` again — close drawer | **stays open** | **closes** (0 open dialogs) |
| `[` while drawer open | sider stays 240px | sider 240px → **74px** |
| `]` while a `BAIModal` is open | ignored | ignored (unchanged) |
| Dark mode (`data-theme="dark"`) open → close | n/a | opens, then closes |

Light and dark passes both ran; zero `pageerror`, and no new console errors.
The errors present are pre-existing and unrelated (react-grab's Google-Fonts
CSP block, the backend's `400 /server/login` and `404 /func/totp`, Relay's
`Group` vs `UserGroup` `__typename` warning, and the create-folder modal's
`afterClose` / `afterOpenChange` DOM-prop warnings).

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format,
  TypeScript, Vite warmup, StyleX, Astryx theme build, Terminology).
  Note: in a fresh worktree the theme-build step fails until
  `pnpm --filter backend.ai-ui build` has run; it passes after that.
- `pnpm --prefix ./react exec vitest run` → **1407 passed / 88 files**
  (25 in `useKeyboardShortcut.test.ts`, including the 2 new cases).
- `pnpm --filter backend.ai-ui exec vitest run` → **613 passed, 1 skipped**.
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared
  `var(--x)` in `packages/backend.ai-ui/src/components/BAIText.css:28`.
  **Pre-existing on `main`** — this branch touches no CSS; verified by the diff
  being two `.ts` files.

## Test changes

`useKeyboardShortcut.test.ts` builds real `<dialog>` fixtures, but jsdom
implements neither `HTMLDialogElement.showModal()` nor the `:modal`
pseudo-class, so the fixture helper stubs the modal state on the element. Two
cases added: a non-modal open dialog must **not** suppress the shortcut, and a
modal alongside a non-modal one must still suppress it.

## Residue

- The fix is in the shared hook, so it also restores `[` (sider collapse) and
  any future `useKeyboardShortcut` consumer while a non-modal drawer is open.
  `WebUISpotlight` uses Astryx `useHotkeys`, not this hook, and is unaffected.
- Not addressed here: whether a non-modal drawer *should* capture Escape or
  focus differently. This change is only about the global-shortcut guard.

