### PR TITLE
style(FR-3555): re-anchor the primary button fill so an info banner cannot repaint it

### DIFF
--- a/packages/backend.ai-ui/.storybook/astryxBrandTheme.ts
+++ b/packages/backend.ai-ui/.storybook/astryxBrandTheme.ts
@@ -141,6 +141,14 @@ export const astryxBrandTheme = defineTheme({
   // Storybook while looking correct in the app, which is exactly the kind of
   // silent divergence this mirror file exists to prevent.
   components: {
+    // KEEP IN SYNC with `ANTD_HOVER_PARITY.button` in
+    // `react/src/astryx-theme/backendAiTheme.ts` — without it Storybook keeps
+    // rendering the FR-3555 defect the app no longer has.
+    button: {
+      'variant:primary': {
+        '--color-accent': 'var(--color-text-accent)',
+      },
+    },
     text: {
       'color:danger': { color: 'var(--color-error)' },
       'color:warning': { color: 'var(--color-warning)' },

--- a/react/src/astryx-theme/backendAiTheme.ts
+++ b/react/src/astryx-theme/backendAiTheme.ts
@@ -802,6 +802,11 @@ const ANTD_HOVER_PARITY = {
   button: {
     'variant:primary': {
       '--color-overlay-hover': 'rgba(255,255,255,0.16)',
+      // An info Banner re-points `--color-accent` at its blue status hue so
+      // its own icon reads blue — which also repainted this button's fill,
+      // leaving a white label on pale blue. `--color-text-accent` is the same
+      // accent, and no component scope re-points it. FR-3555.
+      '--color-accent': 'var(--color-text-accent)',
     },
     'variant:destructive': {
       '--color-overlay-hover': 'rgba(255,255,255,0.16)',

--- a/react/src/astryx-theme/built/backendai-default-built.css
+++ b/react/src/astryx-theme/built/backendai-default-built.css
@@ -399,6 +399,7 @@
 
   .astryx-button.primary {
     --color-overlay-hover: rgba(255,255,255,0.16);
+    --color-accent: var(--color-text-accent);
   }
 
   .astryx-button.secondary {

--- a/react/src/astryx-theme/built/bai-r18-default-brand-h161l5oh.js
+++ b/react/src/astryx-theme/built/bai-r18-default-brand-h161l5oh.js
@@ -312,7 +312,8 @@ export const baiR18DefaultBrandH161l5ohTheme = {
         "--color-overlay-hover": "rgba(255,255,255,0.16)"
       },
       "variant:primary": {
-        "--color-overlay-hover": "rgba(255,255,255,0.16)"
+        "--color-overlay-hover": "rgba(255,255,255,0.16)",
+        "--color-accent": "var(--color-text-accent)"
       },
       "variant:secondary": {
         "--color-neutral": "var(--color-background-surface)",


### PR DESCRIPTION
Resolves #8800 (FR-3555)

In dark mode the "Add Access Token" button on a private deployment's info banner
renders as a pale periwinkle block with a white label — glaring against the dark
band and effectively unreadable.

**Before / after** — the banner as it actually appears on the deployment detail
page (dark mode, real `BAIAlert` + `BAIButton type="primary"`):

| | |
|---|---|
| **Before** | ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8804/20260818-001758-fr3555-v2-before-dark.png) |
| **After** | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8804/20260818-001758-fr3555-v2-after-dark.png) |

Note what does **not** change: the banner keeps its blue band, blue status icon
and blue title. Only the button's fill returns to the brand accent.

## Mechanism

`@astryxdesign/theme-neutral` re-points `--color-accent` at `--color-text-blue`
inside `.astryx-banner.info` (`dist/source.js:544`), so the banner's status glyph
reads blue — Astryx's `Banner` renders it as `<Icon color="accent">`, which
resolves `--color-accent`.

`--color-accent` is also the **fill** of `Button variant="primary"`, and the
paired `--color-on-accent` label is left at `#ffffff`. So an accent-filled button
in the banner's `endContent` inherits the pale status hue as its background and
keeps a white label. Astryx's own `BannerWithActionButton` template uses
`variant="secondary"`, which is why the upstream recipe never hit this.

Only `status="info"` is affected: the `success` / `warning` / `error` scopes
re-point `--color-success` / `--color-warning` / `--color-error`, and no BAI
button variant fills from those. This is a measured claim, not a guess — see the
probe table below, where a primary button outside any banner and inside a
non-info banner both resolve to the brand accent unchanged.

## Fix

Declare `--color-accent: var(--color-text-accent)` on the button itself, in the
theme's existing `button` → `variant:primary` block. A declaration on the element
beats an inherited value regardless of specificity or `@layer`, so no ancestor
status scope can repaint a filled button while leaving its `--color-on-*` label
untouched.

`--color-text-accent` is set to the same accent as `--color-accent` in **every**
role theme (brand / admin / secondary) and no component scope re-points it, so
the anchor stays role-safe and survives a runtime `theme.json` rebrand.

`packages/backend.ai-ui/.storybook/astryxBrandTheme.ts` is a hand-maintained
mirror of the app theme and carried none of the app's `button` overrides, so
Storybook rendered the defect. The same key is added there with a KEEP-IN-SYNC
note — that is what the screenshots above are captured from (the "before" shot is
the same story with that one key removed).

## Was this the pre-migration look?

The call site has been `<Alert type="info" action={<BAIButton type="primary">}>`
since it was introduced in `2bd349213` (2026-07-27), two weeks before the Astryx
migration `7d7b42388`. **This PR does not touch the call site** — the only files
it changes are the theme and its regenerated artifacts.

Evidence that antd painted that button with the brand accent, stated at the
strength it actually has:

- **Direct, but for a sibling case.** `packages/backend.ai-webui-docs/src/en/images/endpoint_detail_ready_alert.png`
  is an antd-era capture of the *same page*: a `success` alert whose
  `<Button type="primary">` ("Test in Chat") is fully brand orange. antd's
  `Alert` demonstrably did not tint a nested primary button toward the alert hue.
- **Structural.** antd's `cssVar` mode was never enabled (`git grep cssVar 7d7b42388^`
  over `react/src` + BUI src returns only a comment), so antd colors were
  cssinjs-computed **literals** from the `ConfigProvider` context. An ancestor
  `Alert` had no CSS-custom-property channel through which to repaint a
  descendant `Button`. Astryx's tokens *do* inherit through DOM ancestors — that
  difference is precisely what turned this into a regression.
- **Gap, stated plainly.** There is **no** antd-era screenshot of `info` + `primary`
  specifically. The one info-alert capture in the docs
  (`endpoint_detail_private_alert.png`) is stale: it predates this button and
  shows a white default button labeled "Manage Access Tokens".

The conclusion does not rest on that gap alone: independently of any antd
question, the `success` and `warning` banners on this same page render their
primary buttons in brand orange **today** (measured), so before this fix the info
banner was the sole inconsistent one.

## Measured — live probe on the running dev server, both modes

Resolved on the FR-3555 dev server, entering each mode via
`documentElement.dataset.theme` and reading the tokens through a real color
property. Zero `pageerror` in both passes.

**Dark** (the reported case)

| | fill | label | label contrast |
|---|---|---|---|
| before | `#C7D3FF` | `#FFFFFF` | **1.48:1** |
| after | `#BE5E06` | `#FFFFFF` | **4.38:1** |

The reporter's screenshot measures `#C7D3FF` fill / `#FFFFFF` label / 1.47:1 —
the probe reproduces it to within rounding.

**Light**

| | fill | label | label contrast |
|---|---|---|---|
| before | `#00458C` | `#FFFFFF` | 9.42:1 |
| after | `#FF7A00` | `#FFFFFF` | 2.61:1 |

⚠️ **Read this one deliberately.** In light mode the change *lowers* the measured
contrast at this call site, because the button stops being an accidental navy and
becomes the brand orange — which is exactly what every other primary button in
the app renders in light mode (probe: a primary button outside any banner is
`#FF7A00` / `#FFFFFF`, the same 2.61:1). So this is not a new defect introduced
here; it is this surface rejoining the app-wide primary-button treatment
(white-on-orange, inherited from antd). If we want to raise that number, it is an
app-wide `--color-on-accent` decision and deserves its own issue — fixing it only
inside info banners would re-introduce the inconsistency this PR removes.

Also verified: a primary button **outside** a banner resolves identically before
and after (`#FF7A00` / `#BE5E06`), i.e. nothing else moves.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript,
  Vite warmup, StyleX sentinel, **Astryx theme build `--check`**, Terminology)
- `pnpm --prefix ./react exec vitest run` → **88 files, 1405 tests passed**
- `pnpm --filter backend.ai-ui exec vitest run` → **47 files passed, 1 skipped;
  613 tests passed, 1 skipped**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 268 declared,
  768 `var()` usages checked, **1 undeclared: `BAIText.css:28 var(--x)`**.
  Pre-existing — that file was last touched by #8730 on `main` and this branch
  changes nothing under `packages/backend.ai-ui/src`.
- `THEME_NAME_REV` 15 → 16, artifacts regenerated with `astryx theme build`, the
  wrapper re-exported, and the stale `bai-r15-*` files deleted.

## Notes for the reviewer

- **`THEME_NAME_REV` collision.** #8756 also bumps the rev to 16 (its artifact
  hash differs, so the filenames do not collide). Whichever of the two merges
  second needs to re-bump and regenerate. This branch is based on `main`, not
  stacked on #8756, because the two fixes are unrelated and stacking would tie
  this merge to that review.
- **Residue — not covered here.** `EduAppLauncher.tsx:913` puts a
  `variant="destructive"` button in a `status="error"` banner, where the same
  scope re-points `--color-error`. That path is a *different* pairing —
  theme-neutral gives `variant:destructive` a `--color-error-muted` background
  and `--color-error` **text** — so it needs its own measurement rather than the
  same one-liner. Not measured, not changed.
- The screenshots come from Storybook rather than a live private deployment:
  reproducing that banner in the app needs a deployment with no access token,
  which would mean mutating the shared cluster. The components, copy and theme in
  the captures are the real ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
