### PR TITLE
feat(FR-3558): add palette actions — create shortcuts, appearance, panels and help

### DIFF
--- a/react/src/components/BAIContentWithDrawerArea.tsx
+++ b/react/src/components/BAIContentWithDrawerArea.tsx
@@ -2,9 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { notificationDrawerOpenState } from '../hooks/useShellPanels';
 import { useBAIBreakpoint } from '../theme-shim';
 import './BAIContentWithDrawerArea.css';
-import { isOpenDrawerState } from './BAINotificationButton';
 import { useAtomValue } from 'jotai';
 import React from 'react';
 
@@ -29,7 +29,7 @@ const BAIContentWithDrawerArea: React.FC<Props> = ({
   drawerWidth = 256,
   ...contextProps
 }) => {
-  const isOpenDrawer = useAtomValue(isOpenDrawerState);
+  const isOpenDrawer = useAtomValue(notificationDrawerOpenState);
   // Responsive policy (ticket 14): JS behaviour branch — the drawer style is
   // a layout MODE, not a track layout, so it stays on the JS-side hook.
   const { xl } = useBAIBreakpoint();

--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -4,6 +4,7 @@
  */
 import { useBAINotificationState } from '../hooks/useBAINotification';
 import useKeyboardShortcut from '../hooks/useKeyboardShortcut';
+import { useNotificationDrawerState } from '../hooks/useShellPanels';
 import { useThemeMode } from '../hooks/useThemeMode';
 import WEBUINotificationDrawer from './WEBUINotificationDrawer';
 import BAIBadgeCountAstryx from './astryx-bui/BAIBadgeCountAstryx';
@@ -12,12 +13,9 @@ import { Kbd } from '@astryxdesign/core/Kbd';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { MediaTheme } from '@astryxdesign/core/theme';
 import { t } from 'i18next';
-import { atom, useAtom } from 'jotai';
 import * as _ from 'lodash-es';
 import { Bell } from 'lucide-react';
 import React from 'react';
-
-export const isOpenDrawerState = atom(false);
 
 // Pure UI: badge + drawer toggle. Notification event handling and toast
 // rendering live in the app-wide <NotificationHost /> (DefaultProviders),
@@ -38,7 +36,7 @@ const BAINotificationButton: React.FC<BAINotificationButtonProps> = ({
   const [notifications] = useBAINotificationState();
   const { isDarkMode } = useThemeMode();
 
-  const [isOpenDrawer, setIsOpenDrawer] = useAtom(isOpenDrawerState);
+  const [isOpenDrawer, setIsOpenDrawer] = useNotificationDrawerState();
 
   useKeyboardShortcut(
     (event) => {

--- a/react/src/components/GlobalSearchPalette/GlobalSearchPalette.test.tsx
+++ b/react/src/components/GlobalSearchPalette/GlobalSearchPalette.test.tsx
@@ -40,6 +40,11 @@ const suspension = vi.hoisted(() => {
 
 const navigate = vi.fn();
 const pushRecent = vi.fn();
+const runAction = vi.fn();
+const setThemeMode = vi.fn();
+const openNotifications = vi.fn();
+const toggleSider = vi.fn();
+const openHelp = vi.fn();
 
 const makeHit = (hit: Partial<SearchHit> & Pick<SearchHit, 'id'>): SearchHit =>
   ({
@@ -80,7 +85,17 @@ const bodyHit = makeHit({
   target: { path: '/summary' },
 });
 
-const hits = [sessionsHit, settingHit, bodyHit];
+const actionHit = makeHit({
+  id: 'action:toggle-sidebar',
+  kind: 'action',
+  label: 'Toggle sidebar',
+  target: undefined,
+  run: runAction,
+  group: 'Panels & help',
+  auxiliaryData: { group: 'Panels & help' },
+});
+
+const hits = [sessionsHit, settingHit, bodyHit, actionHit];
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>();
@@ -95,10 +110,24 @@ vi.mock('react-i18next', async (importOriginal) => {
 
 vi.mock('../../hooks', () => ({
   useWebUINavigate: () => navigate,
+  useSuspendedBackendaiClient: () => ({ _config: {} }),
+}));
+
+vi.mock('../../hooks/useRouteScope', () => ({
+  useActiveProjectName: () => 'my project',
+}));
+
+vi.mock('../../hooks/useHelpURL', () => ({
+  useOpenHelp: () => openHelp,
+}));
+
+vi.mock('../../hooks/useShellPanels', () => ({
+  useNotificationDrawerState: () => [false, openNotifications],
+  useSiderCollapsedState: () => [false, toggleSider],
 }));
 
 vi.mock('../../hooks/useThemeMode', () => ({
-  useThemeMode: () => ({ isDarkMode: false }),
+  useThemeMode: () => ({ isDarkMode: false, setThemeMode }),
 }));
 
 vi.mock('./useRecentSearchHits', () => ({
@@ -130,8 +159,7 @@ const openPalette = async () => {
 
 describe('GlobalSearchPalette', () => {
   beforeEach(() => {
-    navigate.mockClear();
-    pushRecent.mockClear();
+    vi.clearAllMocks();
     suspension.release();
   });
 
@@ -219,5 +247,26 @@ describe('GlobalSearchPalette', () => {
     await waitFor(() =>
       expect(screen.queryByText('Auto logout')).not.toBeInTheDocument(),
     );
+  });
+
+  it('runs an action hit with the assembled context instead of navigating', async () => {
+    const user = await openPalette();
+
+    await user.click(screen.getByText('Toggle sidebar'));
+
+    await waitFor(() => expect(runAction).toHaveBeenCalledTimes(1));
+    expect(navigate).not.toHaveBeenCalled();
+    expect(pushRecent).toHaveBeenCalledWith(actionHit);
+
+    const ctx = runAction.mock.calls[0][0];
+    expect(ctx.projectName).toBe('my project');
+    ctx.openNotifications();
+    ctx.toggleSider();
+    ctx.openHelp();
+    ctx.setThemeMode('dark');
+    expect(openNotifications).toHaveBeenCalledWith(true);
+    expect(toggleSider).toHaveBeenCalledTimes(1);
+    expect(openHelp).toHaveBeenCalledTimes(1);
+    expect(setThemeMode).toHaveBeenCalledWith('dark');
   });
 });

--- a/react/src/components/GlobalSearchPalette/GlobalSearchPalette.tsx
+++ b/react/src/components/GlobalSearchPalette/GlobalSearchPalette.tsx
@@ -2,9 +2,16 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useWebUINavigate } from '../../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
+import { useOpenHelp } from '../../hooks/useHelpURL';
+import { useActiveProjectName } from '../../hooks/useRouteScope';
+import {
+  useNotificationDrawerState,
+  useSiderCollapsedState,
+} from '../../hooks/useShellPanels';
+import { useThemeMode } from '../../hooks/useThemeMode';
 import { plainText } from './rank';
-import type { SearchHit } from './types';
+import type { PaletteActionContext, SearchHit } from './types';
 import { toTranslator, useGlobalSearchSource } from './useGlobalSearchSource';
 import { useRecentSearchHits } from './useRecentSearchHits';
 import {
@@ -51,11 +58,32 @@ const GlobalSearchPalette: React.FC<GlobalSearchPaletteProps> = ({
   const { t } = useTranslation();
   const { logger } = useBAILogger();
   const navigate = useWebUINavigate();
+  const baiClient = useSuspendedBackendaiClient();
+  const projectName = useActiveProjectName();
+  const { setThemeMode } = useThemeMode();
+  const [, setNotificationDrawerOpen] = useNotificationDrawerState();
+  const [, setSiderCollapsed] = useSiderCollapsedState();
+  const openHelp = useOpenHelp();
   // Deliberately undebounced: the index is in-memory and `search()` is
   // synchronous, so Astryx commits its optimistic narrowing and the ranked
   // rows in one paint. A delay splits that into a visible two-phase jump.
   const searchSource = useGlobalSearchSource();
   const [, { push }] = useRecentSearchHits();
+
+  const actionContext: PaletteActionContext = {
+    navigate,
+    projectName: projectName ?? null,
+    config: {
+      hideAgents: baiClient?._config?.hideAgents ?? true,
+      enableReservoir: !!baiClient?._config?.enableReservoir,
+      fasttrackEndpoint: baiClient?._config?.fasttrackEndpoint ?? null,
+      allowThemeMode: !!baiClient?._config?.allowThemeMode,
+    },
+    setThemeMode,
+    openNotifications: () => setNotificationDrawerOpen(true),
+    toggleSider: () => setSiderCollapsed((collapsed) => !collapsed),
+    openHelp,
+  };
 
   const translate = toTranslator(t);
 
@@ -91,10 +119,16 @@ const GlobalSearchPalette: React.FC<GlobalSearchPaletteProps> = ({
           return;
         }
         push(hit);
-        navigate({
-          pathname: hit.target.path,
-          search: new URLSearchParams(hit.target.search ?? {}).toString(),
-        });
+        if (hit.run) {
+          Promise.resolve(hit.run(actionContext)).catch((error) =>
+            logger.error('GlobalSearchPalette: action failed', hit.id, error),
+          );
+        } else if (hit.target) {
+          navigate({
+            pathname: hit.target.path,
+            search: new URLSearchParams(hit.target.search ?? {}).toString(),
+          });
+        }
         onRequestClose();
       }}
       renderItem={(hit: SearchHit) => {

--- a/react/src/components/GlobalSearchPalette/GlobalSearchPalette.tsx
+++ b/react/src/components/GlobalSearchPalette/GlobalSearchPalette.tsx
@@ -77,7 +77,6 @@ const GlobalSearchPalette: React.FC<GlobalSearchPaletteProps> = ({
       hideAgents: baiClient?._config?.hideAgents ?? true,
       enableReservoir: !!baiClient?._config?.enableReservoir,
       fasttrackEndpoint: baiClient?._config?.fasttrackEndpoint ?? null,
-      allowThemeMode: !!baiClient?._config?.allowThemeMode,
     },
     setThemeMode,
     openNotifications: () => setNotificationDrawerOpen(true),

--- a/react/src/components/GlobalSearchPalette/actions.test.ts
+++ b/react/src/components/GlobalSearchPalette/actions.test.ts
@@ -1,0 +1,226 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * Contract of the static action registry: what each entry does when it runs,
+ * and which entries a given deployment is allowed to see.
+ */
+import { PALETTE_ACTIONS } from './actions';
+import { buildActionHits } from './buildHits';
+import type { PaletteActionContext, SearchContext, SearchHit } from './types';
+import { isHitVisible } from './visibility';
+import * as _ from 'lodash-es';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const groupLabels = {
+  create: 'Create',
+  appearance: 'Appearance',
+  panels: 'Panels & help',
+};
+
+const hits = (): Array<SearchHit> =>
+  buildActionHits({ groupLabels, t: (key) => key });
+
+const makeSearchContext = (
+  overrides: Partial<SearchContext> = {},
+): SearchContext => ({
+  projectName: 'my project',
+  isSuperAdmin: false,
+  isAdmin: false,
+  supports: () => true,
+  config: {
+    hideAgents: false,
+    enableReservoir: false,
+    fasttrackEndpoint: null,
+    allowThemeMode: false,
+  },
+  visibleMenuKeys: new Set(['session', 'data', 'deployments']),
+  disabledMenuKeys: new Set(),
+  t: (key) => key,
+  tEn: (key) => key,
+  ...overrides,
+});
+
+const visibleIds = (ctx: SearchContext) =>
+  _.map(
+    _.filter(hits(), (hit) => isHitVisible(hit, ctx)),
+    'id',
+  );
+
+const navigate = vi.fn();
+const setThemeMode = vi.fn();
+const openNotifications = vi.fn();
+const toggleSider = vi.fn();
+const openHelp = vi.fn();
+const windowOpen = vi.fn();
+
+const makeActionContext = (
+  overrides: Partial<PaletteActionContext> = {},
+): PaletteActionContext => ({
+  navigate,
+  projectName: 'my project',
+  config: {
+    hideAgents: false,
+    enableReservoir: false,
+    fasttrackEndpoint: 'https://fasttrack.example.com',
+    allowThemeMode: true,
+  },
+  setThemeMode,
+  openNotifications,
+  toggleSider,
+  openHelp,
+  ...overrides,
+});
+
+const run = (id: string, ctx = makeActionContext()) => {
+  const action = _.find(PALETTE_ACTIONS, { id });
+  expect(action, `no action ${id}`).toBeTruthy();
+  action?.run(ctx);
+};
+
+describe('PALETTE_ACTIONS gates', () => {
+  it('hides the theme actions unless the deployment allows theme mode', () => {
+    expect(visibleIds(makeSearchContext())).not.toContain('action:theme-light');
+
+    const allowed = visibleIds(
+      makeSearchContext({
+        config: {
+          ...makeSearchContext().config,
+          allowThemeMode: true,
+        },
+      }),
+    );
+    expect(allowed).toEqual(
+      expect.arrayContaining([
+        'action:theme-light',
+        'action:theme-dark',
+        'action:theme-system',
+      ]),
+    );
+  });
+
+  it('hides FastTrack until an endpoint is configured', () => {
+    expect(visibleIds(makeSearchContext())).not.toContain(
+      'action:open-fasttrack',
+    );
+    expect(
+      visibleIds(
+        makeSearchContext({
+          config: {
+            ...makeSearchContext().config,
+            fasttrackEndpoint: 'https://fasttrack.example.com',
+          },
+        }),
+      ),
+    ).toContain('action:open-fasttrack');
+  });
+
+  it('hides a create action when its page is not in the menu', () => {
+    const ids = visibleIds(makeSearchContext({ visibleMenuKeys: new Set() }));
+    expect(ids).not.toContain('action:start-session');
+    expect(ids).not.toContain('action:create-folder');
+    expect(ids).not.toContain('action:create-deployment');
+  });
+
+  it('keeps the ungated panel actions on every deployment', () => {
+    expect(
+      visibleIds(makeSearchContext({ visibleMenuKeys: new Set() })),
+    ).toEqual(
+      expect.arrayContaining([
+        'action:open-notifications',
+        'action:toggle-sidebar',
+        'action:open-manual',
+        'action:open-user-settings',
+        'action:change-language',
+      ]),
+    );
+  });
+});
+
+describe('PALETTE_ACTIONS run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('open', windowOpen);
+  });
+
+  it('navigates to the launcher in the current project', () => {
+    run('action:start-session');
+    expect(navigate).toHaveBeenCalledWith(
+      '/project/my%20project/session/start',
+    );
+  });
+
+  it('opens the create modal on the data page', () => {
+    run('action:create-folder');
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/project/my%20project/data',
+      search: 'action=add',
+    });
+  });
+
+  it('opens the create modal on the deployments page', () => {
+    run('action:create-deployment');
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/project/my%20project/deployments',
+      search: 'action=add',
+    });
+  });
+
+  it('opens the FastTrack endpoint in a new tab', () => {
+    run('action:open-fasttrack');
+    expect(windowOpen).toHaveBeenCalledWith(
+      'https://fasttrack.example.com',
+      '_blank',
+      'noopener noreferrer',
+    );
+  });
+
+  it('sets each theme mode', () => {
+    run('action:theme-light');
+    run('action:theme-dark');
+    run('action:theme-system');
+    expect(setThemeMode.mock.calls).toEqual([['light'], ['dark'], ['system']]);
+  });
+
+  it('deep-links to the language setting', () => {
+    run('action:change-language');
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/usersettings',
+      search: 'tab=general&setting=userSettings.Language',
+    });
+  });
+
+  it('drives the two shell panels and the manual', () => {
+    run('action:open-notifications');
+    run('action:toggle-sidebar');
+    run('action:open-manual');
+    expect(openNotifications).toHaveBeenCalledTimes(1);
+    expect(toggleSider).toHaveBeenCalledTimes(1);
+    expect(openHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates to user settings', () => {
+    run('action:open-user-settings');
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/usersettings',
+      search: '',
+    });
+  });
+});
+
+describe('buildActionHits', () => {
+  it('builds one hit per registry entry, in the registry order', () => {
+    expect(_.map(hits(), 'id')).toEqual(_.map(PALETTE_ACTIONS, 'id'));
+    expect(_.every(hits(), (hit) => hit.kind === 'action')).toBe(true);
+    expect(_.every(hits(), (hit) => !hit.target && !!hit.run)).toBe(true);
+  });
+
+  it('groups the hits into the three trailing headings', () => {
+    expect(_.uniq(_.map(hits(), (hit) => hit.auxiliaryData?.group))).toEqual([
+      'Create',
+      'Appearance',
+      'Panels & help',
+    ]);
+  });
+});

--- a/react/src/components/GlobalSearchPalette/actions.test.ts
+++ b/react/src/components/GlobalSearchPalette/actions.test.ts
@@ -33,7 +33,6 @@ const makeSearchContext = (
     hideAgents: false,
     enableReservoir: false,
     fasttrackEndpoint: null,
-    allowThemeMode: false,
   },
   visibleMenuKeys: new Set(['session', 'data', 'deployments']),
   disabledMenuKeys: new Set(),
@@ -64,7 +63,6 @@ const makeActionContext = (
     hideAgents: false,
     enableReservoir: false,
     fasttrackEndpoint: 'https://fasttrack.example.com',
-    allowThemeMode: true,
   },
   setThemeMode,
   openNotifications,
@@ -80,18 +78,12 @@ const run = (id: string, ctx = makeActionContext()) => {
 };
 
 describe('PALETTE_ACTIONS gates', () => {
-  it('hides the theme actions unless the deployment allows theme mode', () => {
-    expect(visibleIds(makeSearchContext())).not.toContain('action:theme-light');
-
-    const allowed = visibleIds(
-      makeSearchContext({
-        config: {
-          ...makeSearchContext().config,
-          allowThemeMode: true,
-        },
-      }),
-    );
-    expect(allowed).toEqual(
+  // The header's `WebUIThemeToggleButton` is mounted unconditionally, so the
+  // palette must not invent a stricter condition for the same capability.
+  it('offers the theme actions wherever the header toggle is offered', () => {
+    expect(
+      visibleIds(makeSearchContext({ visibleMenuKeys: new Set() })),
+    ).toEqual(
       expect.arrayContaining([
         'action:theme-light',
         'action:theme-dark',

--- a/react/src/components/GlobalSearchPalette/actions.ts
+++ b/react/src/components/GlobalSearchPalette/actions.ts
@@ -112,7 +112,6 @@ export const PALETTE_ACTIONS: ReadonlyArray<PaletteAction> = [
     icon: Sun,
     group: 'appearance',
     keywords: ['theme', 'light', 'mode', 'appearance'],
-    gate: (ctx) => ctx.config.allowThemeMode,
     run: (ctx) => ctx.setThemeMode('light'),
   },
   {
@@ -121,7 +120,6 @@ export const PALETTE_ACTIONS: ReadonlyArray<PaletteAction> = [
     icon: Moon,
     group: 'appearance',
     keywords: ['theme', 'dark', 'mode', 'appearance'],
-    gate: (ctx) => ctx.config.allowThemeMode,
     run: (ctx) => ctx.setThemeMode('dark'),
   },
   {
@@ -130,7 +128,6 @@ export const PALETTE_ACTIONS: ReadonlyArray<PaletteAction> = [
     icon: SunMoon,
     group: 'appearance',
     keywords: ['theme', 'system', 'mode', 'appearance'],
-    gate: (ctx) => ctx.config.allowThemeMode,
     run: (ctx) => ctx.setThemeMode('system'),
   },
   {

--- a/react/src/components/GlobalSearchPalette/actions.ts
+++ b/react/src/components/GlobalSearchPalette/actions.ts
@@ -3,6 +3,10 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { buildPath } from '../../helper/pathBuilder';
+import {
+  CREATE_ACTION_PARAM,
+  CREATE_ACTION_VALUE,
+} from '../../hooks/useCreateActionArrival';
 import { SETTING_ARRIVAL_PARAM } from '../../hooks/useSettingArrival';
 import type { PaletteActionContext, SearchContext } from './types';
 import {
@@ -36,7 +40,7 @@ export interface PaletteAction {
 }
 
 /** The one URL-openable modal convention in the app (`credentials?action=add`). */
-const OPEN_CREATE_SEARCH = 'action=add';
+const OPEN_CREATE_SEARCH = `${CREATE_ACTION_PARAM}=${CREATE_ACTION_VALUE}`;
 
 const userSettingsTarget = (settingKey?: string) => ({
   pathname: '/usersettings',

--- a/react/src/components/GlobalSearchPalette/actions.ts
+++ b/react/src/components/GlobalSearchPalette/actions.ts
@@ -1,0 +1,176 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { buildPath } from '../../helper/pathBuilder';
+import { SETTING_ARRIVAL_PARAM } from '../../hooks/useSettingArrival';
+import type { PaletteActionContext, SearchContext } from './types';
+import {
+  Bell,
+  BookOpen,
+  FolderPlus,
+  Languages,
+  Moon,
+  PanelLeft,
+  Play,
+  Rocket,
+  Settings,
+  Sun,
+  SunMoon,
+  Workflow,
+} from 'lucide-react';
+import type { ComponentType } from 'react';
+
+/** Trailing palette groups, in the order they are shown. */
+export type PaletteActionGroup = 'create' | 'appearance' | 'panels';
+
+export interface PaletteAction {
+  id: string;
+  labelKey: string;
+  icon: ComponentType<{ size?: string | number }>;
+  group: PaletteActionGroup;
+  /** Literal terms matched verbatim, in English (the always-searched locale). */
+  keywords?: Array<string>;
+  gate?: (ctx: SearchContext) => boolean;
+  run: (ctx: PaletteActionContext) => void | Promise<void>;
+}
+
+/** The one URL-openable modal convention in the app (`credentials?action=add`). */
+const OPEN_CREATE_SEARCH = 'action=add';
+
+const userSettingsTarget = (settingKey?: string) => ({
+  pathname: '/usersettings',
+  search: settingKey
+    ? new URLSearchParams({
+        tab: 'general',
+        [SETTING_ARRIVAL_PARAM]: settingKey,
+      }).toString()
+    : '',
+});
+
+/**
+ * The v1 action catalogue. Static by construction: other pages are not mounted
+ * when the palette opens, so nothing can register itself at mount time.
+ */
+export const PALETTE_ACTIONS: ReadonlyArray<PaletteAction> = [
+  {
+    id: 'action:start-session',
+    labelKey: 'session.launcher.StartNewSession',
+    icon: Play,
+    group: 'create',
+    keywords: ['session', 'launch', 'new'],
+    gate: (ctx) => ctx.visibleMenuKeys.has('session'),
+    run: (ctx) =>
+      ctx.navigate(`${buildPath('project', 'session', ctx.projectName)}/start`),
+  },
+  {
+    id: 'action:create-folder',
+    labelKey: 'data.CreateFolder',
+    icon: FolderPlus,
+    group: 'create',
+    keywords: ['folder', 'vfolder', 'storage', 'data'],
+    gate: (ctx) => ctx.visibleMenuKeys.has('data'),
+    run: (ctx) =>
+      ctx.navigate({
+        pathname: buildPath('project', 'data', ctx.projectName),
+        search: OPEN_CREATE_SEARCH,
+      }),
+  },
+  {
+    id: 'action:create-deployment',
+    labelKey: 'deployment.CreateDeployment',
+    icon: Rocket,
+    group: 'create',
+    keywords: ['deployment', 'serving', 'model', 'inference'],
+    gate: (ctx) => ctx.visibleMenuKeys.has('deployments'),
+    run: (ctx) =>
+      ctx.navigate({
+        pathname: buildPath('project', 'deployments', ctx.projectName),
+        search: OPEN_CREATE_SEARCH,
+      }),
+  },
+  {
+    id: 'action:open-fasttrack',
+    labelKey: 'webui.menu.FastTrack',
+    icon: Workflow,
+    group: 'create',
+    keywords: ['fasttrack', 'pipeline', 'mlops'],
+    gate: (ctx) => !!ctx.config.fasttrackEndpoint,
+    run: (ctx) => {
+      if (ctx.config.fasttrackEndpoint) {
+        window.open(
+          ctx.config.fasttrackEndpoint,
+          '_blank',
+          'noopener noreferrer',
+        );
+      }
+    },
+  },
+  {
+    id: 'action:theme-light',
+    labelKey: 'webui.search.action.SwitchToLightMode',
+    icon: Sun,
+    group: 'appearance',
+    keywords: ['theme', 'light', 'mode', 'appearance'],
+    gate: (ctx) => ctx.config.allowThemeMode,
+    run: (ctx) => ctx.setThemeMode('light'),
+  },
+  {
+    id: 'action:theme-dark',
+    labelKey: 'webui.search.action.SwitchToDarkMode',
+    icon: Moon,
+    group: 'appearance',
+    keywords: ['theme', 'dark', 'mode', 'appearance'],
+    gate: (ctx) => ctx.config.allowThemeMode,
+    run: (ctx) => ctx.setThemeMode('dark'),
+  },
+  {
+    id: 'action:theme-system',
+    labelKey: 'webui.search.action.UseSystemTheme',
+    icon: SunMoon,
+    group: 'appearance',
+    keywords: ['theme', 'system', 'mode', 'appearance'],
+    gate: (ctx) => ctx.config.allowThemeMode,
+    run: (ctx) => ctx.setThemeMode('system'),
+  },
+  {
+    id: 'action:change-language',
+    labelKey: 'webui.search.action.ChangeLanguage',
+    icon: Languages,
+    group: 'appearance',
+    keywords: ['language', 'locale', 'i18n'],
+    run: (ctx) => ctx.navigate(userSettingsTarget('userSettings.Language')),
+  },
+  {
+    id: 'action:open-notifications',
+    labelKey: 'webui.search.action.OpenNotifications',
+    icon: Bell,
+    group: 'panels',
+    keywords: ['notification', 'alert', 'bell', 'task'],
+    run: (ctx) => ctx.openNotifications(),
+  },
+  {
+    id: 'action:toggle-sidebar',
+    labelKey: 'webui.search.action.ToggleSidebar',
+    icon: PanelLeft,
+    group: 'panels',
+    keywords: ['sidebar', 'sider', 'menu', 'collapse'],
+    run: (ctx) => ctx.toggleSider(),
+  },
+  {
+    id: 'action:open-manual',
+    labelKey: 'webui.search.action.OpenManual',
+    icon: BookOpen,
+    group: 'panels',
+    keywords: ['manual', 'help', 'docs', 'documentation'],
+    run: (ctx) => ctx.openHelp(),
+  },
+  {
+    id: 'action:open-user-settings',
+    labelKey: 'webui.search.action.OpenUserSettings',
+    icon: Settings,
+    group: 'panels',
+    keywords: ['settings', 'preferences', 'account'],
+    run: (ctx) => ctx.navigate(userSettingsTarget()),
+  },
+];

--- a/react/src/components/GlobalSearchPalette/buildHits.test.ts
+++ b/react/src/components/GlobalSearchPalette/buildHits.test.ts
@@ -52,7 +52,7 @@ describe('buildHits', () => {
   it('drops pages the menu does not show, but keeps whitelisted /usersettings', () => {
     const hits = build([]);
     expect(_.uniq(_.map(hits, 'menuKey'))).toEqual(['usersettings']);
-    expect(_.find(hits, { kind: 'page' })?.target.path).toBe('/usersettings');
+    expect(_.find(hits, { kind: 'page' })?.target?.path).toBe('/usersettings');
   });
 
   it('keeps twin pages apart and gives each its own scope and group', () => {
@@ -78,7 +78,7 @@ describe('buildHits', () => {
     const sessions = _.find(build(), {
       id: 'page:/project/:projectName/session',
     });
-    expect(sessions?.target.path).toBe('/project/my%20project/session');
+    expect(sessions?.target?.path).toBe('/project/my%20project/session');
     expect(fillProjectName('/project/:projectName/data', null)).toBe(
       '/project//data',
     );
@@ -88,7 +88,7 @@ describe('buildHits', () => {
     const hit = _.find(build(), {
       id: 'tab:/project/:projectName/statistics?tab=user-session-history',
     });
-    expect(hit?.target.search).toEqual({ tab: 'user-session-history' });
+    expect(hit?.target?.search).toEqual({ tab: 'user-session-history' });
     expect(hit?.tab).toEqual({ param: 'tab', key: 'user-session-history' });
     expect(hit?.breadcrumbKeys).toEqual(['webui.menu.Statistics']);
     expect(hit?.label).toBe('User Session History');

--- a/react/src/components/GlobalSearchPalette/buildHits.ts
+++ b/react/src/components/GlobalSearchPalette/buildHits.ts
@@ -2,6 +2,8 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { PALETTE_ACTIONS } from './actions';
+import type { PaletteAction, PaletteActionGroup } from './actions';
 import { getSearchIndex } from './searchIndex.types';
 import type {
   SearchIndex,
@@ -12,6 +14,7 @@ import type {
 import type { HitTranslator, SearchHit } from './types';
 import { ALWAYS_VISIBLE_MENU_KEYS } from './visibility';
 import * as _ from 'lodash-es';
+import { createElement } from 'react';
 import type { ReactNode } from 'react';
 
 /** A menu row flattened out of `useWebUIMenuItems()`'s grouped output. */
@@ -216,3 +219,39 @@ export const buildHits = ({
 
   return hits;
 };
+
+export interface BuildActionHitsParams {
+  actions?: ReadonlyArray<PaletteAction>;
+  /** Translated heading per group, in `CommandPalette` insertion order. */
+  groupLabels: Record<PaletteActionGroup, string>;
+  t: HitTranslator;
+}
+
+/**
+ * Turns the static registry into trailing hits. Gates are carried, not applied:
+ * `isHitVisible` is the single place that decides what the user may see.
+ */
+export const buildActionHits = ({
+  actions = PALETTE_ACTIONS,
+  groupLabels,
+  t,
+}: BuildActionHitsParams): Array<SearchHit> =>
+  _.map(actions, (action) => {
+    const group = groupLabels[action.group];
+    return {
+      id: action.id,
+      kind: 'action' as const,
+      label: t(action.labelKey),
+      labelKey: action.labelKey,
+      menuKey: null,
+      scope: null,
+      breadcrumbKeys: [],
+      icon: createElement(action.icon, { size: '1em' }),
+      group,
+      keywords: action.keywords ?? [],
+      bodyKeys: [],
+      gate: action.gate,
+      run: action.run,
+      auxiliaryData: { group },
+    };
+  });

--- a/react/src/components/GlobalSearchPalette/types.ts
+++ b/react/src/components/GlobalSearchPalette/types.ts
@@ -4,6 +4,7 @@
  */
 import type { SearchableItem } from '@astryxdesign/core/Typeahead';
 import type { ReactNode } from 'react';
+import type { To } from 'react-router-dom';
 
 /** The four things v1 can honestly deep-link to. */
 export type SearchHitKind = 'page' | 'tab' | 'settingItem' | 'action';
@@ -40,7 +41,8 @@ export interface SearchHit extends SearchableItem<SearchHitAuxiliaryData> {
   icon?: ReactNode;
   /** Sidebar group label; admin groups are prefixed "Administration › ". */
   group: string;
-  target: SearchHitTarget;
+  /** Where the hit navigates. Actions run instead, so they carry none. */
+  target?: SearchHitTarget;
   /** Set on a body-key match: the page hit gains a "found in" line. */
   matchedIn?: { key: string; kind: 'body' };
   /** Literal terms (menu key, tab key, testid) matched verbatim. */
@@ -49,14 +51,30 @@ export interface SearchHit extends SearchableItem<SearchHitAuxiliaryData> {
   bodyKeys: Array<string>;
   /** The tab this hit addresses, for the `TAB_GATES` override map. */
   tab?: { param: string; key: string };
-  /** Actions declare their own runtime gate (registry lands in PR ⑤). */
+  /** Actions declare their own runtime gate. */
   gate?: (ctx: SearchContext) => boolean;
+  /** Action hits do this instead of navigating. */
+  run?: (ctx: PaletteActionContext) => void | Promise<void>;
 }
 
 export interface SearchConfigFlags {
   hideAgents: boolean;
   enableReservoir: boolean;
   fasttrackEndpoint: string | null;
+  allowThemeMode: boolean;
+}
+
+export type ThemeModeValue = 'system' | 'light' | 'dark';
+
+/** The handles an action's `run` may use, assembled by the palette. */
+export interface PaletteActionContext {
+  navigate: (to: To) => void;
+  projectName: string | null;
+  config: SearchConfigFlags;
+  setThemeMode: (mode: ThemeModeValue) => void;
+  openNotifications: () => void;
+  toggleSider: () => void;
+  openHelp: () => void;
 }
 
 /** Everything `isHitVisible` and the ranker need that is not in the index. */

--- a/react/src/components/GlobalSearchPalette/types.ts
+++ b/react/src/components/GlobalSearchPalette/types.ts
@@ -61,7 +61,6 @@ export interface SearchConfigFlags {
   hideAgents: boolean;
   enableReservoir: boolean;
   fasttrackEndpoint: string | null;
-  allowThemeMode: boolean;
 }
 
 export type ThemeModeValue = 'system' | 'light' | 'dark';

--- a/react/src/components/GlobalSearchPalette/useGlobalSearchSource.ts
+++ b/react/src/components/GlobalSearchPalette/useGlobalSearchSource.ts
@@ -75,7 +75,6 @@ export const useGlobalSearchSource = (): GlobalSearchSource => {
       hideAgents: baiClient?._config?.hideAgents ?? true,
       enableReservoir: !!baiClient?._config?.enableReservoir,
       fasttrackEndpoint: baiClient?._config?.fasttrackEndpoint ?? null,
-      allowThemeMode: !!baiClient?._config?.allowThemeMode,
     },
     visibleMenuKeys: new Set(
       _.map([...generalMenu, ...adminMenu], (item) => item.key as string),

--- a/react/src/components/GlobalSearchPalette/useGlobalSearchSource.ts
+++ b/react/src/components/GlobalSearchPalette/useGlobalSearchSource.ts
@@ -7,7 +7,7 @@ import { useCurrentUserRole } from '../../hooks/backendai';
 import { useEffectiveAdminRole } from '../../hooks/useCurrentUserProjectRoles';
 import { useActiveProjectName } from '../../hooks/useRouteScope';
 import { useWebUIMenuItems } from '../../hooks/useWebUIMenuItems';
-import { buildHits, toMenuSources } from './buildHits';
+import { buildActionHits, buildHits, toMenuSources } from './buildHits';
 import type { GroupedMenuNode } from './buildHits';
 import { RECENT_HIT_ID_PREFIX, baseHitId, rankHits } from './rank';
 import type { HitTranslator, SearchContext, SearchHit } from './types';
@@ -75,6 +75,7 @@ export const useGlobalSearchSource = (): GlobalSearchSource => {
       hideAgents: baiClient?._config?.hideAgents ?? true,
       enableReservoir: !!baiClient?._config?.enableReservoir,
       fasttrackEndpoint: baiClient?._config?.fasttrackEndpoint ?? null,
+      allowThemeMode: !!baiClient?._config?.allowThemeMode,
     },
     visibleMenuKeys: new Set(
       _.map([...generalMenu, ...adminMenu], (item) => item.key as string),
@@ -90,12 +91,24 @@ export const useGlobalSearchSource = (): GlobalSearchSource => {
   };
 
   const hits = _.filter(
-    buildHits({
-      menuSources,
-      projectName,
-      t: translate,
-      fallbackGroup: translate('webui.menu.groupName.General'),
-    }),
+    [
+      ...buildHits({
+        menuSources,
+        projectName,
+        t: translate,
+        fallbackGroup: translate('webui.menu.groupName.General'),
+      }),
+      // Actions come last so their groups trail the sidebar's in the empty
+      // state, which is the order `CommandPalette` renders headings in.
+      ...buildActionHits({
+        t: translate,
+        groupLabels: {
+          create: translate('webui.search.group.Create'),
+          appearance: translate('webui.search.group.Appearance'),
+          panels: translate('webui.search.group.PanelsAndHelp'),
+        },
+      }),
+    ],
     (hit) => isHitVisible(hit, ctx),
   );
   const hitById = _.keyBy(hits, 'id');
@@ -115,6 +128,7 @@ export const useGlobalSearchSource = (): GlobalSearchSource => {
     }),
   );
   const pageRows = _.filter(hits, (hit) => hit.kind === 'page');
+  const actionRows = _.filter(hits, (hit) => hit.kind === 'action');
 
   // Index drift is silent otherwise: a menu page with no indexed entry simply
   // never appears in the palette.
@@ -123,7 +137,7 @@ export const useGlobalSearchSource = (): GlobalSearchSource => {
       `[global-search] ${missing.length} menu key(s) have no search-index entry: ${missing.join(', ')}`,
     );
   });
-  const indexedMenuKeys = new Set(_.map(hits, 'menuKey'));
+  const indexedMenuKeys = new Set(_.compact(_.map(hits, 'menuKey')));
   const missingMenuKeys = _.filter(
     [...ctx.visibleMenuKeys],
     (key) => !indexedMenuKeys.has(key),
@@ -142,7 +156,7 @@ export const useGlobalSearchSource = (): GlobalSearchSource => {
         tEn: translateEn,
         recentIds,
       }),
-    bootstrap: () => [...recentRows, ...pageRows],
+    bootstrap: () => [...recentRows, ...pageRows, ...actionRows],
     getHit: (id: string) => hitById[baseHitId(id)],
   };
 };

--- a/react/src/components/GlobalSearchPalette/visibility.test.ts
+++ b/react/src/components/GlobalSearchPalette/visibility.test.ts
@@ -34,7 +34,12 @@ const makeCtx = (overrides: Partial<SearchContext> = {}): SearchContext => ({
   isSuperAdmin: false,
   isAdmin: true,
   supports: () => false,
-  config: { hideAgents: true, enableReservoir: false, fasttrackEndpoint: null },
+  config: {
+    hideAgents: true,
+    enableReservoir: false,
+    fasttrackEndpoint: null,
+    allowThemeMode: false,
+  },
   visibleMenuKeys: new Set(allMenuKeys),
   disabledMenuKeys: new Set(),
   t: tEn,

--- a/react/src/components/GlobalSearchPalette/visibility.test.ts
+++ b/react/src/components/GlobalSearchPalette/visibility.test.ts
@@ -38,7 +38,6 @@ const makeCtx = (overrides: Partial<SearchContext> = {}): SearchContext => ({
     hideAgents: true,
     enableReservoir: false,
     fasttrackEndpoint: null,
-    allowThemeMode: false,
   },
   visibleMenuKeys: new Set(allMenuKeys),
   disabledMenuKeys: new Set(),

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -10,6 +10,7 @@ import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import { useLogoutEventListeners } from '../../hooks/useLogout';
 import { useRouteAccessDecision } from '../../hooks/useRouteAccess';
 import { useCurrentMenuKey, useRouteScope } from '../../hooks/useRouteScope';
+import { useSiderCollapsedState } from '../../hooks/useShellPanels';
 import { useSetupWebUIPluginEffect } from '../../hooks/useWebUIPluginState';
 import { theme } from '../../theme-shim';
 import BAIContentWithDrawerArea from '../BAIContentWithDrawerArea';
@@ -55,8 +56,9 @@ function MainLayout() {
   'use memo';
   const navigate = useWebUINavigate();
   const [compactSidebarActive] = useBAISettingUserState('compact_sidebar');
-  const [sideCollapsed, setSideCollapsed] =
-    useState<boolean>(!!compactSidebarActive);
+  // Lifted to Jotai so the search palette's "Toggle sidebar" action drives the
+  // same state as the `[` shortcut.
+  const [sideCollapsed, setSideCollapsed] = useSiderCollapsedState();
 
   const matches = useMatches();
   // @ts-ignore

--- a/react/src/components/WEBUIHelpButton.tsx
+++ b/react/src/components/WEBUIHelpButton.tsx
@@ -2,121 +2,11 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useCurrentMenuKey } from '../hooks/useRouteScope';
-import { useCurrentLanguage } from './DefaultProviders';
+import { useOpenHelp } from '../hooks/useHelpURL';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { CircleHelp } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
-
-// Languages the hosted user manual (https://webui.docs.backend.ai) is
-// published in. Any other WebUI locale falls back to English.
-const DOCS_LANGUAGES = ['en', 'ko', 'ja', 'th'];
-
-// Maps the first path segment of the current route to the matching page in
-// the hosted user manual. Since the multi-version migration (FR-2729) the
-// manual is a flat, versioned static site served as
-// `https://webui.docs.backend.ai/{version}/{lang}/{page}.html`, so the values
-// below are flat `*.html` page slugs (optionally with an in-page anchor).
-// Admin / project-admin routes point to their dedicated admin manual sections
-// (`admin_menu.html`, `project_admin.html`) rather than the general-user page.
-// Keep the keys in sync with the route segments in `routes.tsx`; unmapped
-// routes fall back to the per-language index page.
-const URLMatchingTable: Record<string, string> = {
-  // General user pages
-  '': 'dashboard.html',
-  start: 'start.html',
-  dashboard: 'dashboard.html',
-  summary: 'dashboard.html', // legacy → /dashboard
-  session: 'sessions_all.html',
-  job: 'sessions_all.html', // legacy → /session
-  deployments: 'deployment.html',
-  serving: 'deployment.html', // legacy → /deployments
-  service: 'deployment.html', // legacy → /deployments
-  'model-store': 'deployment.html#deployment-model-store',
-  import: 'start.html', // legacy → /start
-  github: 'start.html', // legacy → /start
-  chat: 'chat.html',
-  data: 'vfolder.html',
-  'my-environment': 'my_environments.html',
-  'agent-summary': 'agent_summary.html',
-  statistics: 'statistics.html',
-  usersettings: 'user_settings.html',
-  // Admin pages → dedicated admin manual sections (not the general-user pages).
-  // The admin-scoped Users / Projects / Data / Sessions / Deployments pages are
-  // documented under `project_admin.html`; infrastructure / admin-only features
-  // live under `admin_menu.html`.
-  'admin-dashboard': 'dashboard.html',
-  'admin-session': 'project_admin.html#project_admin-sessions',
-  'admin-deployments': 'project_admin.html#project_admin-deployments',
-  'admin-serving': 'project_admin.html#project_admin-deployments', // legacy → /admin-deployments
-  'admin-data': 'project_admin.html#project_admin-data',
-  credential: 'project_admin.html#project_admin-users',
-  environment: 'admin_menu.html#admin_menu-manage-images',
-  scheduler: 'admin_menu.html#admin_menu-fair-share-scheduler',
-  agent: 'admin_menu.html#admin_menu-manage-agent-nodes',
-  'resource-policy': 'admin_menu.html#admin_menu-manage-resource-policies',
-  'storage-settings': 'admin_menu.html#admin_menu-storages',
-  settings: 'admin_menu.html#admin_menu-system-settings',
-  maintenance: 'admin_menu.html#admin_menu-server-management',
-  diagnostics: 'admin_menu.html#admin_menu-diagnostics',
-  branding: 'admin_menu.html#admin_menu-branding',
-  information: 'admin_menu.html#admin_menu-detailed-information',
-  rbac: 'rbac_management.html',
-  project: 'project_admin.html',
-  // Project-admin pages → project_admin manual sections
-  'project-admin-users': 'project_admin.html#project_admin-users',
-  'project-data': 'project_admin.html#project_admin-data',
-  'project-admin-session': 'project_admin.html#project_admin-sessions',
-  'project-admin-deployments': 'project_admin.html#project_admin-deployments',
-};
-
-// Tab-level overrides. Many pages carry the active tab in the URL as
-// `?tab=<key>`; where a tab maps to a more specific manual section than the
-// page default, list it here as `route → { tabKey → page#anchor }`. Keep the
-// tab keys in sync with each page's `Tabs` `items[].key` / `?tab=` values.
-// Pages whose tab has no distinct manual section are omitted and fall back to
-// the page-level mapping above.
-const TabMatchingTable: Record<string, Record<string, string>> = {
-  agent: {
-    agents: 'admin_menu.html#admin_menu-manage-agent-nodes',
-    storages: 'admin_menu.html#admin_menu-storages',
-    resourceGroup: 'admin_menu.html#admin_menu-manage-resource-group',
-  },
-  environment: {
-    image: 'admin_menu.html#admin_menu-manage-images',
-    preset: 'admin_menu.html#admin_menu-manage-resource-preset',
-    registry: 'admin_menu.html#admin_menu-manage-docker-registry',
-  },
-  usersettings: {
-    general: 'user_settings.html#user_settings-general-tab',
-    logs: 'user_settings.html#user_settings-logs-tab',
-  },
-  'resource-policy': {
-    keypair: 'admin_menu.html#admin_menu-keypair-resource-policy',
-    user: 'admin_menu.html#admin_menu-user-resource-policy',
-    project: 'admin_menu.html#admin_menu-project-resource-policy',
-  },
-  'admin-deployments': {
-    // Main list follows the page-level project_admin mapping; the
-    // admin-only sub-tabs are documented only under admin_menu.
-    deployments: 'project_admin.html#project_admin-deployments',
-    'model-store-management':
-      'admin_menu.html#admin_menu-admin-model-store-management',
-    'prometheus-preset': 'admin_menu.html#admin_menu-prometheus-query-presets',
-    'deployment-presets': 'admin_menu.html#admin_menu-deployment-presets',
-  },
-  credential: {
-    users: 'project_admin.html#project_admin-users',
-    // Keypairs/credentials tab is documented only under admin_menu.
-    credentials: 'admin_menu.html#admin_menu-manage-user39s-keypairs',
-  },
-  statistics: {
-    'allocation-history': 'statistics.html#statistics-allocation-history',
-    'user-session-history': 'statistics.html#statistics-user-session-history',
-  },
-};
 
 // PILOT-DECISION: antd `Button type="text" icon href target="_blank"` →
 // Astryx `IconButton variant="ghost"` + `window.open` (MAPPING §3.3).
@@ -131,45 +21,14 @@ interface WEBUIHelpButtonProps {
 const WEBUIHelpButton: React.FC<WEBUIHelpButtonProps> = ({ ...props }) => {
   'use memo';
   const { t } = useTranslation();
-  const [lang] = useCurrentLanguage();
-  const location = useLocation();
-
-  const docsLang = DOCS_LANGUAGES.includes(lang) ? lang : 'en';
-  // The manual is published as a versioned static site (FR-2729): stable
-  // releases live under their `major.minor` (e.g. "26.7") and the
-  // in-development tip lives under the `next` channel. Map the running WebUI
-  // build to the matching docs channel so the "?" opens docs for this build:
-  //   - a prerelease build (e.g. "26.5.0-alpha.0") tracks the workspace tip
-  //     and there is no numbered docs site for it yet → use `next`;
-  //   - a stable release → its `major.minor`.
-  // Fall back to `next` when the version is unknown (numbered docs may not
-  // exist, but `next` is rebuilt on every commit and always present).
-  const rawVersion = globalThis.packageVersion ?? '';
-  const docsVersion = rawVersion.includes('-')
-    ? 'next'
-    : rawVersion.split('.').slice(0, 2).filter(Boolean).join('.') || 'next';
-  const manualURL = `https://webui.docs.backend.ai/${docsVersion}/${docsLang}/`;
-
-  // Scope-aware menu key (route handle): under the `/admin/<feature>` and
-  // `/project/:name/<feature>` URLs the first pathname segment is the scope
-  // prefix, so the help-anchor lookup uses the matched route's menu key.
-  const matchingKey = useCurrentMenuKey() || '';
-  // Prefer a tab-specific manual section when the active tab (`?tab=…`) has
-  // one, otherwise use the page-level mapping.
-  const activeTab = new URLSearchParams(location.search).get('tab');
-  const tabTarget = activeTab
-    ? TabMatchingTable[matchingKey]?.[activeTab]
-    : undefined;
-  const URL = manualURL + (tabTarget ?? URLMatchingTable[matchingKey] ?? '');
+  const openHelp = useOpenHelp();
 
   return (
     <IconButton
       variant="ghost"
       label={t('webui.menu.Help')}
       icon={<CircleHelp size="1em" />}
-      onClick={() => {
-        window.open(URL, '_blank', 'noopener noreferrer');
-      }}
+      onClick={openHelp}
       {...props}
     />
   );

--- a/react/src/hooks/useCreateActionArrival.ts
+++ b/react/src/hooks/useCreateActionArrival.ts
@@ -1,0 +1,29 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { parseAsString, useQueryState } from 'nuqs';
+import { useEffect, useEffectEvent } from 'react';
+
+/** Deep-link param the credentials page established and the palette reuses. */
+export const CREATE_ACTION_PARAM = 'action';
+export const CREATE_ACTION_VALUE = 'add';
+
+/**
+ * Arrival half of the `?action=add` contract: opens the page's create modal
+ * once and strips the param, so a reload is not a second arrival.
+ */
+export const useCreateActionArrival = (open: () => void): void => {
+  'use memo';
+
+  const [action, setAction] = useQueryState(CREATE_ACTION_PARAM, parseAsString);
+
+  const arrive = useEffectEvent(() => {
+    open();
+    setAction(null);
+  });
+
+  useEffect(() => {
+    if (action === CREATE_ACTION_VALUE) arrive();
+  }, [action]);
+};

--- a/react/src/hooks/useHelpURL.ts
+++ b/react/src/hooks/useHelpURL.ts
@@ -1,0 +1,154 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useCurrentLanguage } from '../components/DefaultProviders';
+import { useWebUILocation } from './index';
+import { useCurrentMenuKey } from './useRouteScope';
+
+// Languages the hosted user manual (https://webui.docs.backend.ai) is
+// published in. Any other WebUI locale falls back to English.
+const DOCS_LANGUAGES = ['en', 'ko', 'ja', 'th'];
+
+// Maps the first path segment of the current route to the matching page in
+// the hosted user manual. Since the multi-version migration (FR-2729) the
+// manual is a flat, versioned static site served as
+// `https://webui.docs.backend.ai/{version}/{lang}/{page}.html`, so the values
+// below are flat `*.html` page slugs (optionally with an in-page anchor).
+// Admin / project-admin routes point to their dedicated admin manual sections
+// (`admin_menu.html`, `project_admin.html`) rather than the general-user page.
+// Keep the keys in sync with the route segments in `routes.tsx`; unmapped
+// routes fall back to the per-language index page.
+const URLMatchingTable: Record<string, string> = {
+  // General user pages
+  '': 'dashboard.html',
+  start: 'start.html',
+  dashboard: 'dashboard.html',
+  summary: 'dashboard.html', // legacy → /dashboard
+  session: 'sessions_all.html',
+  job: 'sessions_all.html', // legacy → /session
+  deployments: 'deployment.html',
+  serving: 'deployment.html', // legacy → /deployments
+  service: 'deployment.html', // legacy → /deployments
+  'model-store': 'deployment.html#deployment-model-store',
+  import: 'start.html', // legacy → /start
+  github: 'start.html', // legacy → /start
+  chat: 'chat.html',
+  data: 'vfolder.html',
+  'my-environment': 'my_environments.html',
+  'agent-summary': 'agent_summary.html',
+  statistics: 'statistics.html',
+  usersettings: 'user_settings.html',
+  // Admin pages → dedicated admin manual sections (not the general-user pages).
+  // The admin-scoped Users / Projects / Data / Sessions / Deployments pages are
+  // documented under `project_admin.html`; infrastructure / admin-only features
+  // live under `admin_menu.html`.
+  'admin-dashboard': 'dashboard.html',
+  'admin-session': 'project_admin.html#project_admin-sessions',
+  'admin-deployments': 'project_admin.html#project_admin-deployments',
+  'admin-serving': 'project_admin.html#project_admin-deployments', // legacy → /admin-deployments
+  'admin-data': 'project_admin.html#project_admin-data',
+  credential: 'project_admin.html#project_admin-users',
+  environment: 'admin_menu.html#admin_menu-manage-images',
+  scheduler: 'admin_menu.html#admin_menu-fair-share-scheduler',
+  agent: 'admin_menu.html#admin_menu-manage-agent-nodes',
+  'resource-policy': 'admin_menu.html#admin_menu-manage-resource-policies',
+  'storage-settings': 'admin_menu.html#admin_menu-storages',
+  settings: 'admin_menu.html#admin_menu-system-settings',
+  maintenance: 'admin_menu.html#admin_menu-server-management',
+  diagnostics: 'admin_menu.html#admin_menu-diagnostics',
+  branding: 'admin_menu.html#admin_menu-branding',
+  information: 'admin_menu.html#admin_menu-detailed-information',
+  rbac: 'rbac_management.html',
+  project: 'project_admin.html',
+  // Project-admin pages → project_admin manual sections
+  'project-admin-users': 'project_admin.html#project_admin-users',
+  'project-data': 'project_admin.html#project_admin-data',
+  'project-admin-session': 'project_admin.html#project_admin-sessions',
+  'project-admin-deployments': 'project_admin.html#project_admin-deployments',
+};
+
+// Tab-level overrides. Many pages carry the active tab in the URL as
+// `?tab=<key>`; where a tab maps to a more specific manual section than the
+// page default, list it here as `route → { tabKey → page#anchor }`. Keep the
+// tab keys in sync with each page's `Tabs` `items[].key` / `?tab=` values.
+// Pages whose tab has no distinct manual section are omitted and fall back to
+// the page-level mapping above.
+const TabMatchingTable: Record<string, Record<string, string>> = {
+  agent: {
+    agents: 'admin_menu.html#admin_menu-manage-agent-nodes',
+    storages: 'admin_menu.html#admin_menu-storages',
+    resourceGroup: 'admin_menu.html#admin_menu-manage-resource-group',
+  },
+  environment: {
+    image: 'admin_menu.html#admin_menu-manage-images',
+    preset: 'admin_menu.html#admin_menu-manage-resource-preset',
+    registry: 'admin_menu.html#admin_menu-manage-docker-registry',
+  },
+  usersettings: {
+    general: 'user_settings.html#user_settings-general-tab',
+    logs: 'user_settings.html#user_settings-logs-tab',
+  },
+  'resource-policy': {
+    keypair: 'admin_menu.html#admin_menu-keypair-resource-policy',
+    user: 'admin_menu.html#admin_menu-user-resource-policy',
+    project: 'admin_menu.html#admin_menu-project-resource-policy',
+  },
+  'admin-deployments': {
+    // Main list follows the page-level project_admin mapping; the
+    // admin-only sub-tabs are documented only under admin_menu.
+    deployments: 'project_admin.html#project_admin-deployments',
+    'model-store-management':
+      'admin_menu.html#admin_menu-admin-model-store-management',
+    'prometheus-preset': 'admin_menu.html#admin_menu-prometheus-query-presets',
+    'deployment-presets': 'admin_menu.html#admin_menu-deployment-presets',
+  },
+  credential: {
+    users: 'project_admin.html#project_admin-users',
+    // Keypairs/credentials tab is documented only under admin_menu.
+    credentials: 'admin_menu.html#admin_menu-manage-user39s-keypairs',
+  },
+  statistics: {
+    'allocation-history': 'statistics.html#statistics-allocation-history',
+    'user-session-history': 'statistics.html#statistics-user-session-history',
+  },
+};
+
+/** The hosted manual page for the current route (and `?tab=` when it has one). */
+export const useHelpURL = (): string => {
+  'use memo';
+
+  const [lang] = useCurrentLanguage();
+  const location = useWebUILocation();
+
+  const docsLang = DOCS_LANGUAGES.includes(lang) ? lang : 'en';
+  // The manual is a versioned static site (FR-2729): a prerelease build has no
+  // numbered docs site yet, so it tracks the `next` channel that every commit
+  // rebuilds; a stable release uses its own `major.minor`.
+  const rawVersion = globalThis.packageVersion ?? '';
+  const docsVersion = rawVersion.includes('-')
+    ? 'next'
+    : rawVersion.split('.').slice(0, 2).filter(Boolean).join('.') || 'next';
+  const manualURL = `https://webui.docs.backend.ai/${docsVersion}/${docsLang}/`;
+
+  // Scope-aware menu key (route handle): under `/admin/<feature>` and
+  // `/project/:name/<feature>` the first pathname segment is the scope prefix,
+  // so the lookup uses the matched route's menu key, not the pathname.
+  const matchingKey = useCurrentMenuKey() || '';
+  const activeTab = new URLSearchParams(location.search).get('tab');
+  const tabTarget = activeTab
+    ? TabMatchingTable[matchingKey]?.[activeTab]
+    : undefined;
+
+  return manualURL + (tabTarget ?? URLMatchingTable[matchingKey] ?? '');
+};
+
+/** Opens the current page's manual in a new tab. */
+export const useOpenHelp = (): (() => void) => {
+  'use memo';
+
+  const url = useHelpURL();
+  return () => {
+    window.open(url, '_blank', 'noopener noreferrer');
+  };
+};

--- a/react/src/hooks/useShellPanels.test.tsx
+++ b/react/src/hooks/useShellPanels.test.tsx
@@ -1,0 +1,72 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * The lift itself is the contract: the `[` / `]` owners and the search palette
+ * are separate components, so both must see one state.
+ */
+import {
+  useNotificationDrawerState,
+  useSiderCollapsedState,
+} from './useShellPanels';
+import { act, renderHook } from '@testing-library/react';
+import { Provider } from 'jotai';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let compactSidebar = false;
+
+vi.mock('./useBAISetting', () => ({
+  useBAISettingUserState: () => [compactSidebar, vi.fn()],
+}));
+
+/** Two consumers of the same store — the layout and the palette. */
+const renderPair = <T,>(hook: () => T) => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider>{children}</Provider>
+  );
+  const shared = renderHook(() => ({ owner: hook(), palette: hook() }), {
+    wrapper,
+  });
+  return shared;
+};
+
+describe('useNotificationDrawerState', () => {
+  it('shares the drawer state between two consumers', () => {
+    const { result } = renderPair(useNotificationDrawerState);
+    expect(result.current.owner[0]).toBe(false);
+
+    act(() => result.current.palette[1](true));
+    expect(result.current.owner[0]).toBe(true);
+
+    act(() => result.current.owner[1]((open) => !open));
+    expect(result.current.palette[0]).toBe(false);
+  });
+});
+
+describe('useSiderCollapsedState', () => {
+  beforeEach(() => {
+    compactSidebar = false;
+  });
+
+  it('follows the compact_sidebar setting until something toggles it', () => {
+    compactSidebar = true;
+    const { result } = renderPair(useSiderCollapsedState);
+    expect(result.current.owner[0]).toBe(true);
+
+    act(() => result.current.palette[1]((collapsed) => !collapsed));
+    expect(result.current.owner[0]).toBe(false);
+  });
+
+  it('shares the toggle between two consumers', () => {
+    const { result } = renderPair(useSiderCollapsedState);
+    expect(result.current.owner[0]).toBe(false);
+
+    act(() => result.current.palette[1]((collapsed) => !collapsed));
+    expect(result.current.owner[0]).toBe(true);
+
+    act(() => result.current.owner[1](false));
+    expect(result.current.palette[0]).toBe(false);
+  });
+});

--- a/react/src/hooks/useShellPanels.ts
+++ b/react/src/hooks/useShellPanels.ts
@@ -1,0 +1,40 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useBAISettingUserState } from './useBAISetting';
+import { atom, useAtom } from 'jotai';
+import type { SetStateAction } from 'react';
+
+/**
+ * Open/closed state of the two app-shell panels. Both used to live inside the
+ * component that owns the `[` / `]` shortcut, which left the global search
+ * palette unable to drive them from outside the layout.
+ */
+export const notificationDrawerOpenState = atom(false);
+
+export const useNotificationDrawerState = () =>
+  useAtom(notificationDrawerOpenState);
+
+/** `null` follows the `compact_sidebar` setting; a boolean is a manual choice. */
+const siderCollapsedOverrideState = atom<boolean | null>(null);
+
+export const useSiderCollapsedState = (): [
+  boolean,
+  (value: SetStateAction<boolean>) => void,
+] => {
+  'use memo';
+
+  const [compactSidebarActive] = useBAISettingUserState('compact_sidebar');
+  const [override, setOverride] = useAtom(siderCollapsedOverrideState);
+
+  return [
+    override ?? !!compactSidebarActive,
+    (value) =>
+      setOverride((prev) =>
+        typeof value === 'function'
+          ? value(prev ?? !!compactSidebarActive)
+          : value,
+      ),
+  ];
+};

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -48,8 +48,14 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { Trash2, SquarePenIcon } from 'lucide-react';
-import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
-import React, { Suspense, useDeferredValue, useState } from 'react';
+import {
+  parseAsJson,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryState,
+  useQueryStates,
+} from 'nuqs';
+import React, { Suspense, useDeferredValue, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
@@ -64,6 +70,10 @@ const DeploymentListPageContent: React.FC = () => {
   const buildProjectPath = useProjectPath();
   const [isCreating, { setLeft: closeCreate, setRight: openCreate }] =
     useToggle(false);
+
+  // `?action=add` opens the create modal, the same deep-link shape the
+  // credentials page uses — it is how the search palette's action arrives.
+  const [action, setAction] = useQueryState('action', parseAsString);
 
   const [editingDeploymentId, setEditingDeploymentId] = useState<string | null>(
     null,
@@ -101,6 +111,13 @@ const DeploymentListPageContent: React.FC = () => {
   );
 
   const [fetchKey, updateFetchKey] = useFetchKey();
+
+  useEffect(() => {
+    if (action === 'add') {
+      openCreate();
+      setAction(null);
+    }
+  }, [action, setAction, openCreate]);
 
   const currentProject = useCurrentProjectValue();
   const pageProject = toProjectContext(currentProject);

--- a/react/src/pages/DeploymentListPage.tsx
+++ b/react/src/pages/DeploymentListPage.tsx
@@ -19,6 +19,7 @@ import { convertToOrderBy } from '../helper';
 import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCreateActionArrival } from '../hooks/useCreateActionArrival';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useProjectPath } from '../hooks/useRouteScope';
 import { toProjectContext } from '../types/projectContext';
@@ -48,14 +49,8 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { Trash2, SquarePenIcon } from 'lucide-react';
-import {
-  parseAsJson,
-  parseAsString,
-  parseAsStringLiteral,
-  useQueryState,
-  useQueryStates,
-} from 'nuqs';
-import React, { Suspense, useDeferredValue, useEffect, useState } from 'react';
+import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
+import React, { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
@@ -71,9 +66,7 @@ const DeploymentListPageContent: React.FC = () => {
   const [isCreating, { setLeft: closeCreate, setRight: openCreate }] =
     useToggle(false);
 
-  // `?action=add` opens the create modal, the same deep-link shape the
-  // credentials page uses — it is how the search palette's action arrives.
-  const [action, setAction] = useQueryState('action', parseAsString);
+  useCreateActionArrival(openCreate);
 
   const [editingDeploymentId, setEditingDeploymentId] = useState<string | null>(
     null,
@@ -111,13 +104,6 @@ const DeploymentListPageContent: React.FC = () => {
   );
 
   const [fetchKey, updateFetchKey] = useFetchKey();
-
-  useEffect(() => {
-    if (action === 'add') {
-      openCreate();
-      setAction(null);
-    }
-  }, [action, setAction, openCreate]);
 
   const currentProject = useCurrentProjectValue();
   const pageProject = toProjectContext(currentProject);

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -100,6 +100,9 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     'invitation',
     parseAsString.withOptions({ history: 'replace' }),
   );
+  // `?action=add` opens the create-folder modal, the same deep-link shape the
+  // credentials page uses — it is how the search palette's action arrives.
+  const [action, setAction] = useQueryState('action', parseAsString);
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.VFolderNodeListPage',
@@ -116,7 +119,10 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     setSelectedFolderList([]);
   }
 
-  const [isOpenCreateModal, { toggle: toggleCreateModal }] = useToggle(false);
+  const [
+    isOpenCreateModal,
+    { toggle: toggleCreateModal, setRight: openCreateModal },
+  ] = useToggle(false);
   const [isOpenDeleteModal, { toggle: toggleDeleteModal }] = useToggle(false);
   const [isOpenRestoreModal, { toggle: toggleRestoreModal }] = useToggle(false);
 
@@ -193,6 +199,13 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     // Update fetchKey when invitation count changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [invitations.length]);
+
+  useEffect(() => {
+    if (action === 'add') {
+      openCreateModal();
+      setAction(null);
+    }
+  }, [action, setAction, openCreateModal]);
 
   const { vfolder_nodes, ...folderCounts } =
     useLazyLoadQuery<VFolderNodeListPageQuery>(

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -21,6 +21,7 @@ import { handleRowSelectionChange } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
+import { useCreateActionArrival } from '../hooks/useCreateActionArrival';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
 import { toProjectContext } from '../types/projectContext';
@@ -100,9 +101,6 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     'invitation',
     parseAsString.withOptions({ history: 'replace' }),
   );
-  // `?action=add` opens the create-folder modal, the same deep-link shape the
-  // credentials page uses — it is how the search palette's action arrives.
-  const [action, setAction] = useQueryState('action', parseAsString);
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.VFolderNodeListPage',
@@ -200,12 +198,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [invitations.length]);
 
-  useEffect(() => {
-    if (action === 'add') {
-      openCreateModal();
-      setAction(null);
-    }
-  }, [action, setAction, openCreateModal]);
+  useCreateActionArrival(openCreateModal);
 
   const { vfolder_nodes, ...folderCounts } =
     useLazyLoadQuery<VFolderNodeListPageQuery>(

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -3750,7 +3750,22 @@
       "FoundIn": "Gefunden in {{text}}",
       "NoResults": "Keine Ergebnisse",
       "Placeholder": "Seiten, Tabs und Einstellungen durchsuchen",
-      "Recent": "Zuletzt verwendet"
+      "Recent": "Zuletzt verwendet",
+      "action": {
+        "ChangeLanguage": "UI-Sprache ändern",
+        "OpenManual": "Handbuch zu dieser Seite öffnen",
+        "OpenNotifications": "Benachrichtigungen öffnen",
+        "OpenUserSettings": "Benutzereinstellungen öffnen",
+        "SwitchToDarkMode": "Zum Dunkelmodus wechseln",
+        "SwitchToLightMode": "Zum Hellmodus wechseln",
+        "ToggleSidebar": "Seitenleiste ein-/ausklappen",
+        "UseSystemTheme": "Systemeinstellung verwenden"
+      },
+      "group": {
+        "Appearance": "Darstellung",
+        "Create": "Erstellen",
+        "PanelsAndHelp": "Panels & Hilfe"
+      }
     }
   }
 }

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -3748,7 +3748,22 @@
       "FoundIn": "Βρέθηκε σε {{text}}",
       "NoResults": "Χωρίς αποτελέσματα",
       "Placeholder": "Αναζήτηση σελίδων, καρτελών και ρυθμίσεων",
-      "Recent": "Πρόσφατα"
+      "Recent": "Πρόσφατα",
+      "action": {
+        "ChangeLanguage": "Αλλαγή γλώσσας διεπαφής",
+        "OpenManual": "Άνοιγμα εγχειριδίου αυτής της σελίδας",
+        "OpenNotifications": "Άνοιγμα ειδοποιήσεων",
+        "OpenUserSettings": "Άνοιγμα ρυθμίσεων χρήστη",
+        "SwitchToDarkMode": "Εναλλαγή σε σκοτεινή λειτουργία",
+        "SwitchToLightMode": "Εναλλαγή σε φωτεινή λειτουργία",
+        "ToggleSidebar": "Εμφάνιση ή απόκρυψη πλαϊνής γραμμής",
+        "UseSystemTheme": "Χρήση ρύθμισης συστήματος"
+      },
+      "group": {
+        "Appearance": "Εμφάνιση",
+        "Create": "Δημιουργία",
+        "PanelsAndHelp": "Πίνακες και βοήθεια"
+      }
     }
   }
 }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -3735,7 +3735,22 @@
       "FoundIn": "Found in {{text}}",
       "NoResults": "No results",
       "Placeholder": "Search pages, tabs, and settings",
-      "Recent": "Recent"
+      "Recent": "Recent",
+      "action": {
+        "ChangeLanguage": "Change UI language",
+        "OpenManual": "Open manual for this page",
+        "OpenNotifications": "Open notifications",
+        "OpenUserSettings": "Open user settings",
+        "SwitchToDarkMode": "Switch to dark mode",
+        "SwitchToLightMode": "Switch to light mode",
+        "ToggleSidebar": "Toggle sidebar",
+        "UseSystemTheme": "Use system theme"
+      },
+      "group": {
+        "Appearance": "Appearance",
+        "Create": "Create",
+        "PanelsAndHelp": "Panels & help"
+      }
     }
   }
 }

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -3748,7 +3748,22 @@
       "FoundIn": "Encontrado en {{text}}",
       "NoResults": "Sin resultados",
       "Placeholder": "Buscar páginas, pestañas y ajustes",
-      "Recent": "Recientes"
+      "Recent": "Recientes",
+      "action": {
+        "ChangeLanguage": "Cambiar el idioma de la interfaz",
+        "OpenManual": "Abrir el manual de esta página",
+        "OpenNotifications": "Abrir notificaciones",
+        "OpenUserSettings": "Abrir ajustes de usuario",
+        "SwitchToDarkMode": "Cambiar al modo oscuro",
+        "SwitchToLightMode": "Cambiar al modo claro",
+        "ToggleSidebar": "Mostrar u ocultar la barra lateral",
+        "UseSystemTheme": "Usar configuración del sistema"
+      },
+      "group": {
+        "Appearance": "Apariencia",
+        "Create": "Crear",
+        "PanelsAndHelp": "Paneles y ayuda"
+      }
     }
   }
 }

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -3749,7 +3749,22 @@
       "FoundIn": "Löytyi kohteesta {{text}}",
       "NoResults": "Ei tuloksia",
       "Placeholder": "Hae sivuja, välilehtiä ja asetuksia",
-      "Recent": "Viimeisimmät"
+      "Recent": "Viimeisimmät",
+      "action": {
+        "ChangeLanguage": "Vaihda käyttöliittymän kieli",
+        "OpenManual": "Avaa tämän sivun käyttöohje",
+        "OpenNotifications": "Avaa ilmoitukset",
+        "OpenUserSettings": "Avaa käyttäjäasetukset",
+        "SwitchToDarkMode": "Vaihda tummaan tilaan",
+        "SwitchToLightMode": "Vaihda vaaleaan tilaan",
+        "ToggleSidebar": "Näytä tai piilota sivupalkki",
+        "UseSystemTheme": "Käytä järjestelmäasetuksia"
+      },
+      "group": {
+        "Appearance": "Ulkoasu",
+        "Create": "Luo",
+        "PanelsAndHelp": "Paneelit ja ohje"
+      }
     }
   }
 }

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -3751,7 +3751,22 @@
       "FoundIn": "Trouvé dans {{text}}",
       "NoResults": "Aucun résultat",
       "Placeholder": "Rechercher des pages, des onglets et des paramètres",
-      "Recent": "Récents"
+      "Recent": "Récents",
+      "action": {
+        "ChangeLanguage": "Changer la langue de l'interface",
+        "OpenManual": "Ouvrir le manuel de cette page",
+        "OpenNotifications": "Ouvrir les notifications",
+        "OpenUserSettings": "Ouvrir les paramètres utilisateur",
+        "SwitchToDarkMode": "Passer en mode sombre",
+        "SwitchToLightMode": "Passer en mode clair",
+        "ToggleSidebar": "Afficher ou masquer la barre latérale",
+        "UseSystemTheme": "Utiliser les paramètres du système"
+      },
+      "group": {
+        "Appearance": "Apparence",
+        "Create": "Créer",
+        "PanelsAndHelp": "Panneaux et aide"
+      }
     }
   }
 }

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -3752,7 +3752,22 @@
       "FoundIn": "Ditemukan di {{text}}",
       "NoResults": "Tidak ada hasil",
       "Placeholder": "Cari halaman, tab, dan pengaturan",
-      "Recent": "Terbaru"
+      "Recent": "Terbaru",
+      "action": {
+        "ChangeLanguage": "Ubah bahasa antarmuka",
+        "OpenManual": "Buka manual untuk halaman ini",
+        "OpenNotifications": "Buka pemberitahuan",
+        "OpenUserSettings": "Buka pengaturan pengguna",
+        "SwitchToDarkMode": "Beralih ke Mode Gelap",
+        "SwitchToLightMode": "Beralih ke Mode Terang",
+        "ToggleSidebar": "Tampilkan atau sembunyikan sidebar",
+        "UseSystemTheme": "Gunakan Pengaturan Sistem"
+      },
+      "group": {
+        "Appearance": "Tampilan",
+        "Create": "Buat",
+        "PanelsAndHelp": "Panel & bantuan"
+      }
     }
   }
 }

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -3748,7 +3748,22 @@
       "FoundIn": "Trovato in {{text}}",
       "NoResults": "Nessun risultato",
       "Placeholder": "Cerca pagine, schede e impostazioni",
-      "Recent": "Recenti"
+      "Recent": "Recenti",
+      "action": {
+        "ChangeLanguage": "Cambia la lingua dell'interfaccia",
+        "OpenManual": "Apri il manuale di questa pagina",
+        "OpenNotifications": "Apri le notifiche",
+        "OpenUserSettings": "Apri le impostazioni utente",
+        "SwitchToDarkMode": "Passa alla modalità scura",
+        "SwitchToLightMode": "Passa alla modalità chiara",
+        "ToggleSidebar": "Mostra o nascondi la barra laterale",
+        "UseSystemTheme": "Utilizza le impostazioni di sistema"
+      },
+      "group": {
+        "Appearance": "Aspetto",
+        "Create": "Crea",
+        "PanelsAndHelp": "Pannelli e aiuto"
+      }
     }
   }
 }

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -3750,7 +3750,22 @@
       "FoundIn": "{{text}}内で見つかりました",
       "NoResults": "検索結果がありません",
       "Placeholder": "ページ、タブ、設定を検索",
-      "Recent": "最近の項目"
+      "Recent": "最近の項目",
+      "action": {
+        "ChangeLanguage": "UI言語を変更",
+        "OpenManual": "このページのマニュアルを開く",
+        "OpenNotifications": "お知らせを開く",
+        "OpenUserSettings": "ユーザー設定を開く",
+        "SwitchToDarkMode": "ダークモードに切り替え",
+        "SwitchToLightMode": "ライトモードに切り替え",
+        "ToggleSidebar": "サイドバーの開閉",
+        "UseSystemTheme": "システム設定を使用する"
+      },
+      "group": {
+        "Appearance": "表示",
+        "Create": "作成",
+        "PanelsAndHelp": "パネルとヘルプ"
+      }
     }
   }
 }

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -3752,7 +3752,22 @@
       "FoundIn": "{{text}}에서 찾음",
       "NoResults": "검색 결과 없음",
       "Placeholder": "페이지, 탭, 설정 검색",
-      "Recent": "최근 항목"
+      "Recent": "최근 항목",
+      "action": {
+        "ChangeLanguage": "UI 언어 변경",
+        "OpenManual": "현재 페이지 매뉴얼 열기",
+        "OpenNotifications": "알림 열기",
+        "OpenUserSettings": "사용자 설정 열기",
+        "SwitchToDarkMode": "다크 모드로 전환",
+        "SwitchToLightMode": "라이트 모드로 전환",
+        "ToggleSidebar": "사이드바 접기/펼치기",
+        "UseSystemTheme": "시스템 설정 사용"
+      },
+      "group": {
+        "Appearance": "화면",
+        "Create": "만들기",
+        "PanelsAndHelp": "패널 및 도움말"
+      }
     }
   }
 }

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -3750,7 +3750,22 @@
       "FoundIn": "{{text}} дотроос олдсон",
       "NoResults": "Үр дүн олдсонгүй",
       "Placeholder": "Хуудас, таб, тохиргоо хайх",
-      "Recent": "Сүүлийн үеийн"
+      "Recent": "Сүүлийн үеийн",
+      "action": {
+        "ChangeLanguage": "Интерфейсийн хэлийг өөрчлөх",
+        "OpenManual": "Энэ хуудасны гарын авлагыг нээх",
+        "OpenNotifications": "Мэдэгдлийг нээх",
+        "OpenUserSettings": "Хэрэглэгчийн тохиргоог нээх",
+        "SwitchToDarkMode": "Харанхуй горим руу шилжих",
+        "SwitchToLightMode": "Цайвар горим руу шилжих",
+        "ToggleSidebar": "Хажуугийн самбарыг нээх/хаах",
+        "UseSystemTheme": "Системийн тохиргоог ашиглах"
+      },
+      "group": {
+        "Appearance": "Харагдац",
+        "Create": "Үүсгэх",
+        "PanelsAndHelp": "Самбар ба тусламж"
+      }
     }
   }
 }

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -3748,7 +3748,22 @@
       "FoundIn": "Ditemui dalam {{text}}",
       "NoResults": "Tiada keputusan",
       "Placeholder": "Cari halaman, tab dan tetapan",
-      "Recent": "Terkini"
+      "Recent": "Terkini",
+      "action": {
+        "ChangeLanguage": "Tukar bahasa antara muka",
+        "OpenManual": "Buka manual untuk halaman ini",
+        "OpenNotifications": "Buka pemberitahuan",
+        "OpenUserSettings": "Buka tetapan pengguna",
+        "SwitchToDarkMode": "Tukar ke Mod Gelap",
+        "SwitchToLightMode": "Tukar ke Mod Terang",
+        "ToggleSidebar": "Tunjuk atau sembunyikan bar sisi",
+        "UseSystemTheme": "Gunakan Tetapan Sistem"
+      },
+      "group": {
+        "Appearance": "Paparan",
+        "Create": "Buat",
+        "PanelsAndHelp": "Panel & bantuan"
+      }
     }
   }
 }

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -3751,7 +3751,22 @@
       "FoundIn": "Znaleziono w {{text}}",
       "NoResults": "Brak wyników",
       "Placeholder": "Szukaj stron, kart i ustawień",
-      "Recent": "Ostatnie"
+      "Recent": "Ostatnie",
+      "action": {
+        "ChangeLanguage": "Zmień język interfejsu",
+        "OpenManual": "Otwórz podręcznik tej strony",
+        "OpenNotifications": "Otwórz powiadomienia",
+        "OpenUserSettings": "Otwórz ustawienia użytkownika",
+        "SwitchToDarkMode": "Przełącz na tryb ciemny",
+        "SwitchToLightMode": "Przełącz na tryb jasny",
+        "ToggleSidebar": "Pokaż lub ukryj pasek boczny",
+        "UseSystemTheme": "Użyj ustawień systemowych"
+      },
+      "group": {
+        "Appearance": "Wygląd",
+        "Create": "Utwórz",
+        "PanelsAndHelp": "Panele i wsparcie"
+      }
     }
   }
 }

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -3748,7 +3748,22 @@
       "FoundIn": "Encontrado em {{text}}",
       "NoResults": "Sem resultados",
       "Placeholder": "Pesquisar páginas, abas e definições",
-      "Recent": "Recentes"
+      "Recent": "Recentes",
+      "action": {
+        "ChangeLanguage": "Alterar a língua da interface",
+        "OpenManual": "Abrir o manual desta página",
+        "OpenNotifications": "Abrir notificações",
+        "OpenUserSettings": "Abrir definições do usuário",
+        "SwitchToDarkMode": "Mudar para o modo escuro",
+        "SwitchToLightMode": "Mudar para o modo claro",
+        "ToggleSidebar": "Mostrar ou ocultar a barra lateral",
+        "UseSystemTheme": "Usar configuração do sistema"
+      },
+      "group": {
+        "Appearance": "Aparência",
+        "Create": "Criar",
+        "PanelsAndHelp": "Painéis e ajuda"
+      }
     }
   }
 }

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -3750,7 +3750,22 @@
       "FoundIn": "Encontrado em {{text}}",
       "NoResults": "Sem resultados",
       "Placeholder": "Pesquisar páginas, separadores e definições",
-      "Recent": "Recentes"
+      "Recent": "Recentes",
+      "action": {
+        "ChangeLanguage": "Alterar a língua da interface",
+        "OpenManual": "Abrir o manual desta página",
+        "OpenNotifications": "Abrir notificações",
+        "OpenUserSettings": "Abrir definições do utilizador",
+        "SwitchToDarkMode": "Mudar para o modo escuro",
+        "SwitchToLightMode": "Mudar para o modo claro",
+        "ToggleSidebar": "Mostrar ou ocultar a barra lateral",
+        "UseSystemTheme": "Usar configuração do sistema"
+      },
+      "group": {
+        "Appearance": "Aparência",
+        "Create": "Criar",
+        "PanelsAndHelp": "Painéis e ajuda"
+      }
     }
   }
 }

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -3748,7 +3748,22 @@
       "FoundIn": "Найдено в {{text}}",
       "NoResults": "Ничего не найдено",
       "Placeholder": "Поиск по страницам, вкладкам и настройкам",
-      "Recent": "Недавние"
+      "Recent": "Недавние",
+      "action": {
+        "ChangeLanguage": "Изменить язык интерфейса",
+        "OpenManual": "Открыть руководство для этой страницы",
+        "OpenNotifications": "Открыть уведомления",
+        "OpenUserSettings": "Открыть настройки пользователя",
+        "SwitchToDarkMode": "Переключиться на тёмный режим",
+        "SwitchToLightMode": "Переключиться на светлый режим",
+        "ToggleSidebar": "Показать или скрыть боковую панель",
+        "UseSystemTheme": "Использовать настройки системы"
+      },
+      "group": {
+        "Appearance": "Оформление",
+        "Create": "Создать",
+        "PanelsAndHelp": "Панели и справка"
+      }
     }
   }
 }

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -3750,7 +3750,22 @@
       "FoundIn": "พบใน {{text}}",
       "NoResults": "ไม่พบผลลัพธ์",
       "Placeholder": "ค้นหาหน้า แท็บ และการตั้งค่า",
-      "Recent": "ล่าสุด"
+      "Recent": "ล่าสุด",
+      "action": {
+        "ChangeLanguage": "เปลี่ยนภาษาของอินเทอร์เฟซ",
+        "OpenManual": "เปิดคู่มือของหน้านี้",
+        "OpenNotifications": "เปิดการแจ้งเตือน",
+        "OpenUserSettings": "เปิดการตั้งค่าผู้ใช้",
+        "SwitchToDarkMode": "สลับเป็นโหมดมืด",
+        "SwitchToLightMode": "สลับเป็นโหมดสว่าง",
+        "ToggleSidebar": "แสดงหรือซ่อนแถบด้านข้าง",
+        "UseSystemTheme": "ใช้การตั้งค่าระบบ"
+      },
+      "group": {
+        "Appearance": "การแสดงผล",
+        "Create": "สร้าง",
+        "PanelsAndHelp": "แผงและความช่วยเหลือ"
+      }
     }
   }
 }

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -3748,7 +3748,22 @@
       "FoundIn": "{{text}} içinde bulundu",
       "NoResults": "Sonuç yok",
       "Placeholder": "Sayfalarda, sekmelerde ve ayarlarda ara",
-      "Recent": "Son kullanılanlar"
+      "Recent": "Son kullanılanlar",
+      "action": {
+        "ChangeLanguage": "Arayüz dilini değiştir",
+        "OpenManual": "Bu sayfanın el kitabını aç",
+        "OpenNotifications": "Bildirimleri aç",
+        "OpenUserSettings": "Kullanıcı ayarlarını aç",
+        "SwitchToDarkMode": "Karanlık Moda geç",
+        "SwitchToLightMode": "Açık Moda geç",
+        "ToggleSidebar": "Kenar çubuğunu aç/kapat",
+        "UseSystemTheme": "Sistem Ayarını Kullan"
+      },
+      "group": {
+        "Appearance": "Görünüm",
+        "Create": "Oluştur",
+        "PanelsAndHelp": "Paneller ve yardım"
+      }
     }
   }
 }

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -3750,7 +3750,22 @@
       "FoundIn": "Tìm thấy trong {{text}}",
       "NoResults": "Không có kết quả",
       "Placeholder": "Tìm kiếm trang, tab và cài đặt",
-      "Recent": "Gần đây"
+      "Recent": "Gần đây",
+      "action": {
+        "ChangeLanguage": "Thay đổi ngôn ngữ giao diện",
+        "OpenManual": "Mở hướng dẫn cho trang này",
+        "OpenNotifications": "Mở thông báo",
+        "OpenUserSettings": "Mở cài đặt người dùng",
+        "SwitchToDarkMode": "Chuyển sang chế độ tối",
+        "SwitchToLightMode": "Chuyển sang chế độ sáng",
+        "ToggleSidebar": "Ẩn hoặc hiện thanh bên",
+        "UseSystemTheme": "Sử dụng cài đặt hệ thống"
+      },
+      "group": {
+        "Appearance": "Giao diện",
+        "Create": "Tạo",
+        "PanelsAndHelp": "Bảng điều khiển và trợ giúp"
+      }
     }
   }
 }

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -3750,7 +3750,22 @@
       "FoundIn": "在 {{text}} 中找到",
       "NoResults": "无结果",
       "Placeholder": "搜索页面、标签页和设置",
-      "Recent": "最近使用"
+      "Recent": "最近使用",
+      "action": {
+        "ChangeLanguage": "更改界面语言",
+        "OpenManual": "打开本页手册",
+        "OpenNotifications": "打开通知",
+        "OpenUserSettings": "打开用户设置",
+        "SwitchToDarkMode": "切换到深色模式",
+        "SwitchToLightMode": "切换到浅色模式",
+        "ToggleSidebar": "折叠/展开侧边栏",
+        "UseSystemTheme": "使用系统设置"
+      },
+      "group": {
+        "Appearance": "外观",
+        "Create": "创建",
+        "PanelsAndHelp": "面板与帮助"
+      }
     }
   }
 }

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -3752,7 +3752,22 @@
       "FoundIn": "在 {{text}} 中找到",
       "NoResults": "無結果",
       "Placeholder": "搜尋頁面、分頁與設置",
-      "Recent": "最近使用"
+      "Recent": "最近使用",
+      "action": {
+        "ChangeLanguage": "變更介面語言",
+        "OpenManual": "開啟本頁手冊",
+        "OpenNotifications": "開啟通知",
+        "OpenUserSettings": "開啟使用者設置",
+        "SwitchToDarkMode": "切換至深色模式",
+        "SwitchToLightMode": "切換至淺色模式",
+        "ToggleSidebar": "收合/展開側邊欄",
+        "UseSystemTheme": "使用系統設定"
+      },
+      "group": {
+        "Appearance": "外觀",
+        "Create": "建立",
+        "PanelsAndHelp": "面板與幫助"
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves #8807 (FR-3558)

## What

- `actions.ts`: the v1 action catalogue — Create (start session, create folder, start deployment, FastTrack), Appearance (light / dark / system theme, UI language), Panels & help (notifications, sidebar, manual for this page, user settings). Each action declares its own gate and `run(ctx)`.
- `hooks/useShellPanels.ts` lifts the sider and notification-drawer state to Jotai so an action can toggle them; the `[` / `]` shortcuts are unchanged.
- `hooks/useHelpURL.ts` extracts the docs-URL mapping out of `WEBUIHelpButton`; `hooks/useCreateActionArrival.ts` owns the `?action=add` contract, now used by Data and Deployments instead of a per-page copy.
- Theme actions are **ungated**: the header's `WebUIThemeToggleButton` is mounted unconditionally, so gating the palette's equivalents on `_config.allowThemeMode` hid a capability the toolbar beside it still offers.

## Why

Other pages are not mounted when the palette opens, so nothing can register an action at mount time — the catalogue is static by construction.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- vitest: 77 tests (actions gates + run effects, shell panels, plus the layers below)
- Every action was live-verified in en + ko on the FR-3558 dev server.
