### PR TITLE
refactor(FR-3564): rename BAITableAstryx to BAITable and inherit Astryx's TableProps

### DIFF
--- a/.claude/rules/use-bai-card.md
+++ b/.claude/rules/use-bai-card.md
@@ -71,7 +71,7 @@ import { BAICard } from 'backend.ai-ui';
 >
   <BAIFlex direction="column" align="stretch" gap="sm">
     <BAIGraphQLPropertyFilter style={{ flex: 1 }} {...filterProps} />
-    <BAITableAstryx {...tableProps} />
+    <BAITable {...tableProps} />
   </BAIFlex>
 </BAICard>
 ```

--- a/.claude/skills/astryx-bug-report/references/issue-templates.md
+++ b/.claude/skills/astryx-bug-report/references/issue-templates.md
@@ -20,7 +20,7 @@ see what still needs chasing.
 
 - **Page**: `/admin/users` (menu: Admin → Users)
 - **Region**: the credentials table header
-- **Component** (if identified): `BAITableAstryx` (`packages/backend.ai-ui/src/components/Table/`)
+- **Component** (if identified): `BAITable` (`packages/backend.ai-ui/src/components/Table/`)
 
 ## Observed
 

--- a/.claude/skills/astryx-fix/SKILL.md
+++ b/.claude/skills/astryx-fix/SKILL.md
@@ -132,7 +132,7 @@ engine — nothing injects `<style>` at runtime any more.
 
 **Do not reproduce a retired engine's quirk inside the one that replaced it.**
 `rc-table` returned the whole record from an empty `dataIndex` path, so
-`render: (row) =>` worked under it; teaching `BAITableAstryx` the same trick
+`render: (row) =>` worked under it; teaching `BAITable` the same trick
 would carry the old engine's accidents forward permanently. The contract is
 `render(value, record, index)` and call sites use `(_value, row) =>` (see
 `.specs/FR-3482-astryx-migration/CONVERSION-IDIOMS.md` §2).
@@ -243,7 +243,7 @@ re-invent.
 | **Stale built theme artifact** | The recipe changed but the committed `bai-r*` CSS did not, or an old artifact is still present — the first registration for a `data-astryx-theme` name wins, so your change silently does nothing. | §2 steps 2 + 4, in full. |
 | **Stale BUI `dist`** | `verify.sh`'s `astryx theme build --check` depends on the built `backend.ai-ui`, so it can fail for a reason unrelated to your edit. | `pnpm --filter backend.ai-ui build` after **any** `packages/backend.ai-ui/src` change, then re-run verify. |
 | **`Grid` child overflow** | CSS grid items default to `min-width: auto`, so a `width: 100%` Astryx field pushes its track past the container and the right-hand column gets clipped at the modal edge. | `width="100%"` on the `Grid` **plus** `style={{ minWidth: 0 }}` on every direct grid child. Every grid-of-fields conversion needs it. |
-| **Astryx Table bleed** | The table can paint outside its own layout box — the pagination row lays out as if the table ended slightly earlier and overlaps the last row. | Do not "fix" it with a margin at one call site. If it recurs, the root cause is in `BAITableAstryx` itself — check whether it is already fixed upstream before patching around it locally. |
+| **Astryx Table bleed** | The table can paint outside its own layout box — the pagination row lays out as if the table ended slightly earlier and overlaps the last row. | Do not "fix" it with a margin at one call site. If it recurs, the root cause is in `BAITable` itself — check whether it is already fixed upstream before patching around it locally. |
 | **`Tooltip` / `MediaTheme` `display: contents`** | Both render zero-layout wrappers — good (no layout cost), but they are still **DOM ancestors**, so token context inherits through them. `useTooltip` inverts its surface by hardcoding colours *without* flipping the token context, so nested content (e.g. `Kbd`) resolves against the page surface and comes out invisible. | Wrap tooltip content in `<MediaTheme mode={opposite of app mode}>` — the surface is inverted, so the media mode is too. |
 | **`MediaTheme` leaking into a native `<dialog>`** | Astryx `Dialog` is a **native, non-portalled `<dialog>`** promoted with `showModal()`; the top layer does not change DOM ancestry. A `MediaTheme` ancestor therefore keeps forcing its surface tokens inside every modal mounted under it — e.g. a dark header band forcing dark text onto a light modal surface, or vice versa. | Scope the `MediaTheme` to the content actually on the band; mount modals outside it. Do not wrap modals in a counter-`MediaTheme` (it declares *surface luminance*, not app mode) and do not portal the dialog (non-portalled is deliberate). |
 | **`ButtonGroup` with a non-Astryx child** | Joining is context-based and only Astryx `Button`/`IconButton`/`ToggleButton` read it; any other child keeps its own pill and leaves a notch. | Make every group child an Astryx button. |

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -29,7 +29,7 @@ canonical reference, and each BAI wrapper's file header documents its deliberate
 ## Component system: BAI first, Astryx second, antd never
 
 - **Reach for a `backend.ai-ui` component first** — `BAIFlex`, `BAIButton`, `BAIModal`,
-  `BAICard`, `BAIText`, `BAITableAstryx`, … They own this project's defaults and wrap the
+  `BAICard`, `BAIText`, `BAITable`, … They own this project's defaults and wrap the
   Astryx internals.
 - When no BAI equivalent exists, use **Astryx** (`@astryxdesign/core`) directly. Discover
   before writing: `astryx search "<thing>"`, `astryx component <Name>`. The CLI lives in

--- a/packages/backend.ai-ui/.storybook/astryxBrandTheme.ts
+++ b/packages/backend.ai-ui/.storybook/astryxBrandTheme.ts
@@ -2,7 +2,7 @@
  * Backend.AI brand Astryx theme for Storybook (to-astryx ticket 32).
  *
  * Before this file, no `<Theme>` from `@astryxdesign/core/theme` was ever
- * mounted in the preview — Astryx-native components (`BAITableAstryx`,
+ * mounted in the preview — Astryx-native components (`BAITable`,
  * `BAIComplexSelect`, PowerSearch, …) fell back to `@astryxdesign/theme-
  * neutral`'s default palette (imported globally in `astryx.css`), not the
  * Backend.AI brand. `ThemeShimProvider` (ticket 10) only feeds antd-shaped

--- a/packages/backend.ai-ui/.storybook/decorators.tsx
+++ b/packages/backend.ai-ui/.storybook/decorators.tsx
@@ -88,7 +88,7 @@ const GlobalConfigProvider: React.FC<StorybookProviderProps> = ({
     // Astryx brand theme (ticket 32, mirrors the app's always-on
     // `AstryxBrandTheme` — see DefaultProviders.tsx). Mounted unconditionally
     // (not gated by the antd-only "Theme Style" toolbar below) so
-    // Astryx-native components (BAITableAstryx, BAIComplexSelect,
+    // Astryx-native components (BAITable, BAIComplexSelect,
     // PowerSearch, …) render the real Backend.AI palette instead of Astryx's
     // theme-neutral default, in both light and dark.
     <AstryxThemeProvider

--- a/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
@@ -2,7 +2,7 @@ import {
   BAIColumnType,
   BAIFlex,
   BAIQuestionIconWithTooltip,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAITagList,
   BAIText,
@@ -321,7 +321,7 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx<UserV2InList>
+    <BAITable<UserV2InList>
       resizable
       rowKey="id"
       size="small"

--- a/packages/backend.ai-ui/src/components/BAIBulkErrorModal.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBulkErrorModal.stories.tsx
@@ -55,7 +55,7 @@ const meta: Meta<typeof BAIBulkErrorModal> = {
 - The title defaults to a localized "Action execution failed" with an error icon; pass \`title\` for operation-specific copy.
 - Purely informational: there is no footer — dismissal happens through the header X (or mask / Esc) and is reported through \`onRequestClose\` so the caller decides what happens next (typically keeping its own form open for a retry).
 - Client-side pagination shows at most 10 rows per page; the pager is hidden while the failures fit on a single page.
-- Built on \`BAIModal\` and \`BAITableAstryx\`.
+- Built on \`BAIModal\` and \`BAITable\`.
         `,
       },
     },

--- a/packages/backend.ai-ui/src/components/BAIBulkErrorModal.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBulkErrorModal.test.tsx
@@ -52,7 +52,7 @@ describe('BAIBulkErrorModal', () => {
       />,
     );
 
-    // Caller-defined column headers (BAITableAstryx renders a hidden measurement
+    // Caller-defined column headers (BAITable renders a hidden measurement
     // header alongside the visible one, so use getAllByText)
     expect(screen.getAllByText('Target').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Error Message').length).toBeGreaterThan(0);

--- a/packages/backend.ai-ui/src/components/BAIBulkErrorModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBulkErrorModal.tsx
@@ -7,7 +7,7 @@ import { theme } from '../theme-shim';
 import BAIAlert from './BAIAlert';
 import BAIFlex from './BAIFlex';
 import BAIModal, { type BAIModalProps } from './BAIModal';
-import { BAITableAstryx, type BAIColumnsType } from './Table';
+import { BAITable, type BAIColumnsType } from './Table';
 import { TriangleAlert } from 'lucide-react';
 import type { ReactNode } from 'react';
 
@@ -94,7 +94,7 @@ const BAIBulkErrorModal = <RecordType extends AnyObject = AnyObject>({
             description={alertDescription}
           />
         )}
-        <BAITableAstryx<RecordType>
+        <BAITable<RecordType>
           columns={columns}
           dataSource={dataSource}
           // Client-side pagination: 10 rows per page, hidden entirely while

--- a/packages/backend.ai-ui/src/components/BAILoginHistoryTable.tsx
+++ b/packages/backend.ai-ui/src/components/BAILoginHistoryTable.tsx
@@ -1,7 +1,7 @@
 import {
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAITag,
   filterOutEmpty,
@@ -179,7 +179,7 @@ const BAILoginHistoryTable = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       resizable
       rowKey="id"
       size="small"

--- a/packages/backend.ai-ui/src/components/BAILoginSessionTable.tsx
+++ b/packages/backend.ai-ui/src/components/BAILoginSessionTable.tsx
@@ -1,7 +1,7 @@
 import {
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAIText,
   filterOutEmpty,
@@ -133,7 +133,7 @@ const BAILoginSessionTable = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       resizable
       rowKey="id"
       size="small"

--- a/packages/backend.ai-ui/src/components/BAISessionNodesV2.tsx
+++ b/packages/backend.ai-ui/src/components/BAISessionNodesV2.tsx
@@ -10,7 +10,7 @@ import {
   BAIIntervalView,
   BAISessionClusterModeV2,
   BAISessionTypeTagV2,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAITag,
   filterOutEmpty,
@@ -382,7 +382,7 @@ const BAISessionNodesV2: React.FC<BAISessionNodesV2Props> = ({
 
   return (
     <BAIFlex direction="column" align="stretch">
-      <BAITableAstryx
+      <BAITable
         resizable
         rowKey="id"
         size="small"

--- a/packages/backend.ai-ui/src/components/BAIUserNodes.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUserNodes.stories.tsx
@@ -42,7 +42,7 @@ const meta: Meta<typeof BAIUserNodes> = {
 'totp_activated', 'created_at', 'modified_at', 'status'
 \`\`\`
 
-For inherited BAITableAstryx props, refer to [BAITableAstryx component](?path=/docs/table-baitable--docs).
+For inherited BAITable props, refer to [BAITable component](?path=/docs/table-baitable--docs).
 
 ## Usage with Relay Query
 
@@ -89,7 +89,7 @@ const { users } = useLazyLoadQuery(
     },
     loading: {
       control: { type: 'boolean' },
-      description: 'Shows loading skeleton (inherited from BAITableAstryx)',
+      description: 'Shows loading skeleton (inherited from BAITable)',
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'false' },

--- a/packages/backend.ai-ui/src/components/BAIUserNodes.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUserNodes.tsx
@@ -1,6 +1,6 @@
 import {
-  BAITableAstryx,
-  BAIAstryxTableProps,
+  BAITable,
+  BAITableProps,
   BAIColumnType,
   BAIText,
   BooleanTag,
@@ -45,7 +45,7 @@ const isEnableSorter = (key: string) => {
 };
 
 interface BAIUserNodesProps extends Omit<
-  BAIAstryxTableProps<UserNodeInList>,
+  BAITableProps<UserNodeInList>,
   'dataSource' | 'columns' | 'onChangeOrder'
 > {
   usersFrgmt: BAIUserNodesFragment$key;
@@ -298,7 +298,7 @@ const BAIUserNodes: React.FC<BAIUserNodesProps> = ({
     // to-astryx ticket 25: migrated to the Astryx engine. antd's
     // `scroll={{ x: 'max-content' }}` is gone — Astryx's own scroll wrapper
     // already handles horizontal overflow.
-    <BAITableAstryx
+    <BAITable
       resizable
       rowKey={'id'}
       size="small"

--- a/packages/backend.ai-ui/src/components/BAIUserResourcePolicyV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUserResourcePolicyV2Table.tsx
@@ -1,7 +1,7 @@
 import {
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   convertToDecimalUnit,
   filterOutEmpty,
@@ -149,7 +149,7 @@ const BAIUserResourcePolicyV2Table = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       resizable
       rowKey="id"
       dataSource={filterOutNullAndUndefined(userResourcePolicies)}

--- a/packages/backend.ai-ui/src/components/Table/BAITable.cellValue.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.cellValue.test.tsx
@@ -1,5 +1,5 @@
 /*
- approved-2: the value `BAITableAstryx` hands to a column's `render`.
+ approved-2: the value `BAITable` hands to a column's `render`.
 
  The contract is Astryx/antd's `render(value, record, index)`, nothing more.
  A column with no `dataIndex` has NO cell value, so `value` is `undefined` and
@@ -14,7 +14,7 @@
 
  They are structural, not visual, so jsdom's lack of layout does not matter.
 */
-import BAITableAstryx from './BAITableAstryx';
+import BAITable from './BAITable';
 import type { BAIColumnsType } from './tableTypes';
 import { render, screen } from '@testing-library/react';
 
@@ -33,11 +33,9 @@ const ROWS: Array<Row> = [
 const fullPath = (row: Row) => `${row.registry}/${row.name}:${row.tag}`;
 
 const renderTable = (columns: BAIColumnsType<Row>) =>
-  render(
-    <BAITableAstryx<Row> rowKey="id" dataSource={ROWS} columns={columns} />,
-  );
+  render(<BAITable<Row> rowKey="id" dataSource={ROWS} columns={columns} />);
 
-describe('BAITableAstryx cell values', () => {
+describe('BAITable cell values', () => {
   it('should reach the record through `render`s SECOND argument on a column with no dataIndex', () => {
     renderTable([
       {
@@ -109,7 +107,7 @@ describe('BAITableAstryx cell values', () => {
 
   it('should resolve a nested dataIndex path', () => {
     render(
-      <BAITableAstryx<{ id: string; meta: { owner: string } }>
+      <BAITable<{ id: string; meta: { owner: string } }>
         rowKey="id"
         dataSource={[{ id: '1', meta: { owner: 'admin' } }]}
         columns={[

--- a/packages/backend.ai-ui/src/components/Table/BAITable.columnLabel.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.columnLabel.test.tsx
@@ -15,7 +15,7 @@
 
  Structural, not visual — jsdom's lack of layout does not matter.
 */
-import BAITableAstryx from './BAITableAstryx';
+import BAITable from './BAITable';
 import type { BAIColumnsType } from './tableTypes';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -29,7 +29,7 @@ const ROWS: Array<Row> = [{ id: '1', cpu: '2' }];
 
 const openSettings = async (columns: BAIColumnsType<Row>) => {
   render(
-    <BAITableAstryx<Row>
+    <BAITable<Row>
       rowKey="id"
       dataSource={ROWS}
       columns={columns}
@@ -39,7 +39,7 @@ const openSettings = async (columns: BAIColumnsType<Row>) => {
   await userEvent.click(screen.getByRole('button', { name: /setting/i }));
 };
 
-describe('BAITableAstryx column labels in the settings modal', () => {
+describe('BAITable column labels in the settings modal', () => {
   it('uses the text of an ELEMENT title instead of stringifying the element', async () => {
     await openSettings([
       {

--- a/packages/backend.ai-ui/src/components/Table/BAITable.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.css
@@ -2,7 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- Co-located styles for <BAITableAstryx> (to-astryx ticket 30-D). Replaces
+ Co-located styles for <BAITable> (to-astryx ticket 30-D). Replaces
  `BAITable.css`, which is gone with the antd engine.
 
  Two rules survive the engine swap.
@@ -24,7 +24,7 @@
     so a table that really IS the card's only content sits flush against the
     card's top/bottom edges, and a table with siblings does not.
 
-    `BAITableAstryx` wraps Astryx's `<Table>` in its own dim layer (the
+    `BAITable` wraps Astryx's `<Table>` in its own dim layer (the
     loading-state opacity wrapper) and renders the pagination bar as a SIBLING
     of that layer. That makes Astryx's scroll wrapper the ONLY child of the dim
     layer, so it matches BOTH `:first-child` AND `:last-child` regardless of
@@ -57,7 +57,7 @@
   /*
    Unblock the header's clip wrapper inside Astryx's sort button.
 
-   `BAITableAstryx` already wraps every header label in an
+   `BAITable` already wraps every header label in an
    `overflow: hidden; text-overflow: ellipsis` span, because Astryx's own
    `overflowStyles.cell` clip is cancelled on the `<th>` by
    `useTableColumnResize` (which needs `overflow: visible` so its drag handle
@@ -115,7 +115,7 @@
    Astryx paints no background on `th`, so a sticky header needs its own opaque
    base — the same token the sticky-column plugin uses, so a pinned corner
    matches. z-index 2 clears pinned BODY cells (z 1); this layer outranks the
-   plugin's `astryx-base` z 3 on pinned HEADER cells, which BAITableAstryx
+   plugin's `astryx-base` z 3 on pinned HEADER cells, which BAITable
    restores inline. `overflow` is untouched: the resize drag handle needs
    `visible` to reach through the body.
 

--- a/packages/backend.ai-ui/src/components/Table/BAITable.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.css
@@ -2,8 +2,8 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- Co-located styles for <BAITable> (to-astryx ticket 30-D). Replaces
- `BAITable.css`, which is gone with the antd engine.
+ Co-located styles for <BAITable>. Renamed from `BAITableAstryx.css` in
+ FR-3564; the antd engine's own stylesheet is gone.
 
  Two rules survive the engine swap.
 

--- a/packages/backend.ai-ui/src/components/Table/BAITable.emptyState.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.emptyState.test.tsx
@@ -1,5 +1,5 @@
 /*
- FR-3503 — the empty state BAITableAstryx renders when it has no rows.
+ FR-3503 — the empty state BAITable renders when it has no rows.
 
  Astryx's `Table` falls back to its OWN catalog (`@astryx.table.noData`), which
  ships en/fr only, so a Korean UI showed a bare English "No data". Owning the
@@ -12,7 +12,7 @@
 
  Structural, not visual — jsdom's lack of layout does not matter.
 */
-import BAITableAstryx from './BAITableAstryx';
+import BAITable from './BAITable';
 import type { BAIColumnsType } from './tableTypes';
 import { render, screen } from '@testing-library/react';
 
@@ -26,18 +26,13 @@ const COLUMNS: BAIColumnsType<Row> = [
 ];
 
 const renderEmpty = (
-  props: Partial<React.ComponentProps<typeof BAITableAstryx<Row>>> = {},
+  props: Partial<React.ComponentProps<typeof BAITable<Row>>> = {},
 ) =>
   render(
-    <BAITableAstryx<Row>
-      rowKey="id"
-      dataSource={[]}
-      columns={COLUMNS}
-      {...props}
-    />,
+    <BAITable<Row> rowKey="id" dataSource={[]} columns={COLUMNS} {...props} />,
   );
 
-describe('BAITableAstryx empty state (FR-3503)', () => {
+describe('BAITable empty state (FR-3503)', () => {
   it('renders the localized default when no override is given', () => {
     renderEmpty();
     // The copy comes from BUI's catalog, NOT Astryx's `@astryx.table.noData`.

--- a/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
@@ -2,7 +2,7 @@
  Client-side slicing, plus the server-sliced case it must not re-slice.
  Mechanism + affected call sites: FR-3563.
 */
-import BAITableAstryx from './BAITableAstryx';
+import BAITable from './BAITable';
 import type { BAIColumnsType } from './tableTypes';
 import { render, screen } from '@testing-library/react';
 
@@ -22,10 +22,10 @@ const makeRows = (count: number): Array<Row> =>
   }));
 
 const renderTable = (
-  props: Partial<React.ComponentProps<typeof BAITableAstryx<Row>>> = {},
-) => render(<BAITableAstryx<Row> rowKey="id" columns={COLUMNS} {...props} />);
+  props: Partial<React.ComponentProps<typeof BAITable<Row>>> = {},
+) => render(<BAITable<Row> rowKey="id" columns={COLUMNS} {...props} />);
 
-describe('BAITableAstryx pagination (FR-3563)', () => {
+describe('BAITable pagination (FR-3563)', () => {
   it('slices a client-side list to the default page size', () => {
     renderTable({ dataSource: makeRows(25), pagination: {} });
 

--- a/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
@@ -78,13 +78,16 @@ describe('BAITable pagination (FR-3563)', () => {
   });
 
   it('clamps a page that a shrinking list left stranded', () => {
-    // The user paged to 3, then a filter cut the list down to 4 rows.
+    // Paged to 5, then a filter cut the list to 25 rows — still longer than a
+    // page, so this exercises the slice with a clamped page rather than
+    // short-circuiting on `length <= pageSize`.
     renderTable({
-      dataSource: makeRows(4),
-      pagination: { current: 3, pageSize: 10 },
+      dataSource: makeRows(25),
+      pagination: { current: 5, pageSize: 10 },
     });
 
-    expect(screen.getByText('row-1')).toBeInTheDocument();
-    expect(screen.getByText('row-4')).toBeInTheDocument();
+    expect(screen.queryByText('row-20')).not.toBeInTheDocument();
+    expect(screen.getByText('row-21')).toBeInTheDocument();
+    expect(screen.getByText('row-25')).toBeInTheDocument();
   });
 });

--- a/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.pagination.test.tsx
@@ -78,9 +78,8 @@ describe('BAITable pagination (FR-3563)', () => {
   });
 
   it('clamps a page that a shrinking list left stranded', () => {
-    // Paged to 5, then a filter cut the list to 25 rows — still longer than a
-    // page, so this exercises the slice with a clamped page rather than
-    // short-circuiting on `length <= pageSize`.
+    // Still longer than a page after the filter, so this reaches the slice
+    // instead of short-circuiting on `length <= pageSize` (which made it vacuous).
     renderTable({
       dataSource: makeRows(25),
       pagination: { current: 5, pageSize: 10 },

--- a/packages/backend.ai-ui/src/components/Table/BAITable.scrollTestFixtures.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.scrollTestFixtures.tsx
@@ -2,7 +2,7 @@
  Shared fixture for the scroll.x / scroll.y test pair — each file asserts the
  NEGATIVE of the other's axis, so they must agree on the render shape.
 */
-import BAITableAstryx from './BAITableAstryx';
+import BAITable from './BAITable';
 import type { BAIColumnsType } from './tableTypes';
 import { render } from '@testing-library/react';
 
@@ -27,12 +27,10 @@ export const SCROLL_ROWS: Array<ScrollTestRow> = [
 ];
 
 export const renderScrollTable = (
-  props: Partial<
-    React.ComponentProps<typeof BAITableAstryx<ScrollTestRow>>
-  > = {},
+  props: Partial<React.ComponentProps<typeof BAITable<ScrollTestRow>>> = {},
 ) =>
   render(
-    <BAITableAstryx<ScrollTestRow>
+    <BAITable<ScrollTestRow>
       rowKey="id"
       dataSource={SCROLL_ROWS}
       columns={SCROLL_COLUMNS}

--- a/packages/backend.ai-ui/src/components/Table/BAITable.scrollX.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.scrollX.test.tsx
@@ -3,12 +3,9 @@
  value mapping, and the PER-COLUMN max-width release — a table-wide release
  would let auto layout push a resized column back to its content width.
 */
-import {
-  dimLayerOf,
-  renderScrollTable,
-} from './BAITableAstryx.scrollTestFixtures';
+import { dimLayerOf, renderScrollTable } from './BAITable.scrollTestFixtures';
 
-describe('BAITableAstryx scroll.x', () => {
+describe('BAITable scroll.x', () => {
   it.each([
     ['max-content' as const, 'max-content'],
     [800 as const, '800px'],

--- a/packages/backend.ai-ui/src/components/Table/BAITable.scrollY.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.scrollY.test.tsx
@@ -7,9 +7,9 @@ import {
   SCROLL_PINNED_COLUMNS,
   dimLayerOf,
   renderScrollTable,
-} from './BAITableAstryx.scrollTestFixtures';
+} from './BAITable.scrollTestFixtures';
 
-describe('BAITableAstryx scroll.y', () => {
+describe('BAITable scroll.y', () => {
   it.each([
     [500 as const, '500px'],
     ['60vh' as const, '60vh'],

--- a/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
@@ -1,30 +1,30 @@
 import BAITag from '../BAITag';
-import BAITableAstryx from './BAITableAstryx';
+import BAITable from './BAITable';
 import { BAITableColumnOverrideItem, BAIColumnsType } from './tableTypes';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState, type Key } from 'react';
 
 /**
- * BAITableAstryx is the Astryx-native successor to BAITable (to-astryx
+ * BAITable is the Astryx-native successor to BAITable (to-astryx
  * ticket 25). It keeps the SAME antd/BUI-shaped `columns`/`dataSource`
  * contract as the legacy `BAITable` — a consumer migrates by swapping the
- * import (`BAITable` -> `BAITableAstryx`), not by rewriting its column
+ * import (`BAITable` -> `BAITable`), not by rewriting its column
  * model — but renders through Astryx's `Table` primitive + plugin pipeline
  * instead of antd's `Table`.
  *
  * The antd engine (and its `BAITable.stories.tsx`) was deleted in ticket 30-D
  * once the last consumer flipped; these are now the table's only stories.
  */
-const meta: Meta<typeof BAITableAstryx> = {
-  title: 'Table/BAITableAstryx',
-  component: BAITableAstryx,
+const meta: Meta<typeof BAITable> = {
+  title: 'Table/BAITable',
+  component: BAITable,
   tags: ['autodocs'],
   parameters: {
     layout: 'padded',
     docs: {
       description: {
         component: `
-**BAITableAstryx** is the Astryx-engine successor to \`BAITable\` (ticket 25). Same public contract, different renderer:
+**BAITable** is the Astryx-engine successor to \`BAITable\` (ticket 25). Same public contract, different renderer:
 
 - **Column visibility** via \`tableSettings\` (Astryx \`Dialog\` settings modal, not the antd one)
 - **Resizable columns** — drag-to-resize, persisted into \`columnOverrides[key].width\`
@@ -76,7 +76,7 @@ const meta: Meta<typeof BAITableAstryx> = {
 
 export default meta;
 
-type Story = StoryObj<typeof BAITableAstryx>;
+type Story = StoryObj<typeof BAITable>;
 
 const sampleColumns: BAIColumnsType<any> = [
   {
@@ -264,7 +264,7 @@ export const HorizontalScroll: Story = {
   },
   render: () => (
     <div style={{ width: 560 }}>
-      <BAITableAstryx
+      <BAITable
         scroll={{ x: 'max-content' }}
         columns={scrollColumns}
         dataSource={scrollData}
@@ -286,7 +286,7 @@ export const VerticalScroll: Story = {
   },
   render: () => (
     <div style={{ width: 560 }}>
-      <BAITableAstryx
+      <BAITable
         scroll={{ x: 'max-content', y: 240 }}
         columns={scrollColumns}
         dataSource={verticalScrollData}
@@ -312,7 +312,7 @@ export const WithColumnSettings: Story = {
     >({});
 
     return (
-      <BAITableAstryx
+      <BAITable
         columns={sampleColumns}
         dataSource={sampleData}
         resizable
@@ -342,7 +342,7 @@ export const WithSorting: Story = {
   render: () => {
     const [order, setOrder] = useState<string | null>('name');
     return (
-      <BAITableAstryx
+      <BAITable
         columns={sampleColumns}
         dataSource={sampleData}
         order={order}
@@ -364,7 +364,7 @@ export const RowSelection: Story = {
   render: () => {
     const [selectedRowKeys, setSelectedRowKeys] = useState<Array<Key>>([]);
     return (
-      <BAITableAstryx
+      <BAITable
         columns={sampleColumns}
         dataSource={sampleData}
         rowKey="key"

--- a/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.stories.tsx
@@ -5,15 +5,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState, type Key } from 'react';
 
 /**
- * BAITable is the Astryx-native successor to BAITable (to-astryx
- * ticket 25). It keeps the SAME antd/BUI-shaped `columns`/`dataSource`
- * contract as the legacy `BAITable` — a consumer migrates by swapping the
- * import (`BAITable` -> `BAITable`), not by rewriting its column
- * model — but renders through Astryx's `Table` primitive + plugin pipeline
- * instead of antd's `Table`.
- *
- * The antd engine (and its `BAITable.stories.tsx`) was deleted in ticket 30-D
- * once the last consumer flipped; these are now the table's only stories.
+ * `BAITable` renders through Astryx's `Table` primitive + plugin pipeline,
+ * behind the antd-shaped `columns` / `dataSource` contract the retired antd
+ * engine had. That engine and its stories were deleted in to-astryx ticket
+ * 30-D, so these are the table's only stories.
  */
 const meta: Meta<typeof BAITable> = {
   title: 'Table/BAITable',
@@ -24,11 +19,11 @@ const meta: Meta<typeof BAITable> = {
     docs: {
       description: {
         component: `
-**BAITable** is the Astryx-engine successor to \`BAITable\` (ticket 25). Same public contract, different renderer:
+**BAITable** renders through Astryx instead of the retired antd engine, keeping the same public contract:
 
 - **Column visibility** via \`tableSettings\` (Astryx \`Dialog\` settings modal, not the antd one)
 - **Resizable columns** — drag-to-resize, persisted into \`columnOverrides[key].width\`
-- **Sorting** via \`order\`/\`onChangeOrder\` order strings (unchanged from \`BAITable\`)
+- **Sorting** via \`order\`/\`onChangeOrder\` order strings
 - **Pagination** — a custom bottom bar (not antd's pager). Client-side data is sliced here; a \`total\` larger than \`dataSource\` means the caller already sliced server-side (FR-3563)
 
 - **Horizontal scroll** via antd-shaped \`scroll={{ x }}\` — width-less columns take their content's intrinsic width (FR-3500)

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -262,6 +262,10 @@ type InheritedTableProps = Omit<
   | 'style'
   // Owned here: the pipeline is assembled below and its order is load-bearing
   | 'plugins'
+  // Not offered: antd's `onChange(pagination, filters, sorter)` habit would
+  // otherwise compile as a form handler on the `<table>`. Sorting and paging
+  // report through `onChangeOrder` / `pagination.onChange`.
+  | 'onChange'
 >;
 
 export interface BAITableProps<

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -263,8 +263,7 @@ type InheritedTableProps = Omit<
   // Owned here: the pipeline is assembled below and its order is load-bearing
   | 'plugins'
   // Not offered: antd's `onChange(pagination, filters, sorter)` habit would
-  // otherwise compile as a form handler on the `<table>`. Sorting and paging
-  // report through `onChangeOrder` / `pagination.onChange`.
+  // otherwise compile as a form handler on the `<table>`.
   | 'onChange'
 >;
 

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -292,7 +292,7 @@ export interface BAITableProps<
   size?: 'small' | 'middle' | 'large';
   /** Dims the rows while a refetch is in flight (no spinner — see header). */
   loading?: boolean;
-  /** Kept for prop parity with `BAITable`; behaves like `loading` here. */
+  /** Kept for parity with the retired antd engine; behaves like `loading`. */
   spinnerLoading?: boolean;
   /** Drag-to-resize column borders. Defaults to on; pass `false` to opt out. */
   resizable?: boolean;
@@ -857,7 +857,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
           // identically sized NON-pinned cell with 255px of overflow escaped by
           // 0. Same on `/agent`'s pinned `row_id`. Legacy antd clipped both
           // faces unconditionally — `.ant-table-cell { overflow: hidden }` in
-          // `BAITable`'s `resizableTable` block matched `<th>`, `<td>` and
+          // the antd table's `resizableTable` block matched `<th>`, `<td>` and
           // `.ant-table-cell-fix-left` alike.
           //
           // Wrapping the CONTENT rather than re-clipping the cell keeps the

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -1236,7 +1236,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
           'bai-table-astryx-dim-layer',
           !showHeader && 'bai-table-astryx-no-header',
           // dividers="grid" already draws real column borders; the header
-          // split would double them. See BAITableAstryx.css.
+          // split would double them. See BAITable.css.
           !bordered && 'bai-table-astryx-header-split',
           isScrollX && 'bai-table-astryx-scroll-x',
           isScrollY && 'bai-table-astryx-scroll-y',

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -1216,22 +1216,21 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
     return next;
   })();
 
-  // Split the BUI-only keys out so the inherited Astryx ones can be forwarded
-  // as-is; anything left in `paginationRest` is a real `Pagination` prop.
+  // Split the BUI-only keys out; anything left in `paginationRest` is a real
+  // `Pagination` prop and is forwarded as-is. The keys this bar computes
+  // itself (`pageSize`, `pageSizeOptions`, `size`) stay in — the explicit
+  // props after the spread win.
   const {
     current: _current,
     defaultCurrent: _defaultCurrent,
     defaultPageSize: _defaultPageSize,
     total: _total,
     onChange: _onChange,
-    pageSize: _pageSize,
-    pageSizeOptions: _pageSizeOptions,
-    size: _size,
     showSizeChanger: _showSizeChanger,
     hideOnSinglePage: _hideOnSinglePage,
     extraContent: _extraContent,
     ...paginationRest
-  } = pagination === false || !pagination ? {} : pagination;
+  } = pagination || {};
 
   const rangeStart = total === 0 ? 0 : (activePage - 1) * currentPageSize + 1;
   const rangeEnd = Math.min(activePage * currentPageSize, total);

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -2,32 +2,27 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- to-astryx TICKET 25 — the Astryx-native successor to `BAITable`.
+ The project's table: Astryx's `Table` primitive plus a plugin pipeline,
+ behind an antd/BUI-shaped prop contract.
 
- `BAITable` (antd) is a MONOLITH: `columns` / `dataSource` / `rowSelection` /
- `pagination` / `expandable` / sorting are all internal to one component.
- Astryx's `Table` is a PRIMITIVE plus a plugin pipeline — selection, sorting,
- column settings and resizing are each an opt-in hook whose state the CONSUMER
- owns. Nothing here is "ported"; the behaviour is re-assembled.
+ Astryx's `Table` is a PRIMITIVE — selection, sorting, column settings and
+ resizing are each an opt-in hook whose state the CONSUMER owns. Nothing here
+ is "ported" from the antd table that preceded it; the behaviour is
+ re-assembled.
 
- ## The migration seam (read this before touching a call site)
+ ## The prop contract (read this before touching a call site)
 
- The public prop contract is deliberately kept **antd/BUI-shaped**:
- `columns` (`BAIColumnsType`, i.e. `title`/`dataIndex`/`render`/`sorter`/
- `required`/`defaultHidden`), `dataSource`, `rowKey`, `rowSelection`,
+ The public surface is deliberately kept **antd-v6-shaped**: `columns`
+ (`BAIColumnsType`, i.e. `title`/`dataIndex`/`render`/`sorter`/`required`/
+ `defaultHidden`), `dataSource`, `rowKey`, `size`, `bordered`, `rowSelection`,
  `pagination`, `expandable`, `order`/`onChangeOrder`, `tableSettings`,
- `exportSettings`. That is the whole point of this file: a consumer moves off
- the antd table by swapping ONE import, not by rewriting its column model.
+ `exportSettings`. Several hundred call sites carried over from the antd era
+ use those names; renaming them buys nothing and breaks all of them. See
+ `.claude/rules/component-props-extension.md` ("Frozen antd-v6-shaped prop
+ vocabulary").
 
-   - import { BAITable }       from 'backend.ai-ui';  // antd engine (legacy)
-   + import { BAITableAstryx } from 'backend.ai-ui';  // Astryx engine
-
- **Ticket 30-D completed that flip.** All 71 consumers are across, the antd
- engine (`BAITable.tsx` / `BAITableSettingModal.tsx` / `BAITable.css`) is
- deleted, and this is the only table engine in the package. `BAITableProps` is
- kept as an alias of `BAIAstryxTableProps` because ~30 components embed it in
- their own public prop interfaces; the column model and the persisted-override
- shape moved to the engine-neutral `tableTypes.ts`.
+ Everything Astryx exposes that this file does NOT rename is inherited rather
+ than restated — see `InheritedTableProps` below (FR-3564).
 
  ## The plugin composition
 
@@ -50,7 +45,7 @@
  Pagination is deliberately NOT the `useTablePagination` plugin: BUI renders
  its own bottom bar next to the settings gear, and the plugin hides itself on a
  single page, which antd never does. Client-vs-server slicing is documented on
- `BAIAstryxPaginationConfig.total` (FR-3563).
+ `BAITablePaginationConfig.total` (FR-3563).
 
  ## PILOT-DECISIONs (see the ticket file for the full list)
 
@@ -87,7 +82,7 @@ import { useBAIi18n } from '../../hooks/useBAIi18n';
 import { theme } from '../../theme-shim';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
 import BAIPaginationInfoText from './BAIPaginationInfoText';
-import './BAITableAstryx.css';
+import './BAITable.css';
 import BAITableAstryxSettingModal from './BAITableAstryxSettingModal';
 import BAITableColumnCSVExportModal from './BAITableColumnCSVExportModal';
 import type {
@@ -122,6 +117,7 @@ import type {
   TableColumn,
   TableDensity,
   TablePlugin,
+  TableProps,
   TableSortState,
 } from '@astryxdesign/core/Table';
 import { Text } from '@astryxdesign/core/Text';
@@ -139,10 +135,10 @@ import React, { useState, type ReactNode } from 'react';
 /** Internal row shape Astryx's generic constraint requires. */
 type AnyRow = Record<string, unknown>;
 /**
- * PUBLIC record constraint. Deliberately looser than `AnyRow`: it is the same
- * shape antd's `AnyObject` had, so the ~70 consumers that write
- * `BAITableProps<SomeRelayNode>` keep type-checking unchanged after the flip.
- * Rows are cast to `AnyRow` at the Astryx boundary.
+ * PUBLIC record constraint. Deliberately looser than `AnyRow` so the ~70
+ * consumers that write `BAITableProps<SomeRelayNode>` type-check — a Relay
+ * node interface does not satisfy Astryx's `Record<string, unknown>`. Rows are
+ * cast to `AnyRow` at the Astryx boundary.
  */
 type AnyRecord = BAIAnyObject;
 
@@ -176,7 +172,7 @@ const X_HEADER_RELEASE: React.CSSProperties = {
 };
 const X_BODY_RELEASE: React.CSSProperties = { maxWidth: 'none' };
 // Inline beats every @layer, restoring the pinned header's z 3 over the
-// sticky-header rule. Why: BAITableAstryx.css.
+// sticky-header rule. Why: BAITable.css.
 const Y_PINNED_HEADER_STACK: React.CSSProperties = { zIndex: 3 };
 
 /** antd scroll values: numbers are px, strings pass through. */
@@ -203,7 +199,7 @@ const mergeCellStyle = <
 /* Public prop contract                                                        */
 /* -------------------------------------------------------------------------- */
 
-export interface BAIAstryxRowSelection<RecordType> {
+export interface BAITableRowSelection<RecordType> {
   /** Only `'checkbox'` is implemented; `'radio'` is dropped (see ticket 25). */
   type?: 'checkbox';
   selectedRowKeys?: ReadonlyArray<React.Key>;
@@ -219,7 +215,7 @@ export interface BAIAstryxRowSelection<RecordType> {
   getRowLabel?: (record: RecordType) => string;
 }
 
-export interface BAIAstryxPaginationConfig {
+export interface BAITablePaginationConfig {
   current?: number;
   defaultCurrent?: number;
   pageSize?: number;
@@ -250,7 +246,7 @@ export interface BAIAstryxPaginationConfig {
   extraContent?: ReactNode;
 }
 
-export interface BAIAstryxExpandable<RecordType> {
+export interface BAITableExpandable<RecordType> {
   expandedRowRender?: (record: RecordType, index: number) => ReactNode;
   rowExpandable?: (record: RecordType) => boolean;
   expandedRowKeys?: ReadonlyArray<React.Key>;
@@ -261,7 +257,34 @@ export interface BAIAstryxExpandable<RecordType> {
   columnWidth?: number;
 }
 
-export interface BAIAstryxTableProps<RecordType extends AnyRecord = AnyRecord> {
+/**
+ * Astryx's own props, minus everything this wrapper renames or owns. The
+ * renamed ones (`data`/`columns`/`idKey`) are also the only generic-in-`T`
+ * props, so the remainder is instantiated at `AnyRow` — which keeps the public
+ * `RecordType` constraint loose enough for the Relay node types call sites
+ * pass, while Astryx's own is `Record<string, unknown>`.
+ */
+type InheritedTableProps = Omit<
+  TableProps<AnyRow>,
+  // Renamed by the frozen antd-v6-shaped vocabulary
+  | 'data' // -> dataSource
+  | 'columns' // -> BAIColumnsType, not TableColumn[]
+  | 'idKey' // -> rowKey
+  | 'density' // -> size
+  | 'dividers' // -> bordered
+  // Owned here: derived from `pagination`, or fixed internally
+  | 'rowIndexStart'
+  | 'rowCount'
+  | 'children'
+  | 'scrollWrapper'
+  | 'ref'
+  // Owned here: a string is wrapped in the default EmptyState (see below)
+  | 'emptyState'
+>;
+
+export interface BAITableProps<
+  RecordType extends AnyRecord = AnyRecord,
+> extends InheritedTableProps {
   columns?: BAIColumnsType<RecordType>;
   dataSource?: ReadonlyArray<RecordType>;
   rowKey?: string | ((record: RecordType) => React.Key);
@@ -276,11 +299,11 @@ export interface BAIAstryxTableProps<RecordType extends AnyRecord = AnyRecord> {
   /** Backend.AI order string, e.g. `-created_at`. */
   order?: string | null;
   onChangeOrder?: (order?: string) => void;
-  rowSelection?: BAIAstryxRowSelection<RecordType>;
-  pagination?: false | BAIAstryxPaginationConfig;
+  rowSelection?: BAITableRowSelection<RecordType>;
+  pagination?: false | BAITablePaginationConfig;
   tableSettings?: BAITableSettings;
   exportSettings?: BAIExportSettings;
-  expandable?: BAIAstryxExpandable<RecordType>;
+  expandable?: BAITableExpandable<RecordType>;
   /**
    * Rendered in place of the body when `dataSource` is empty. A string is
    * wrapped in the default `EmptyState` (icon + padding); any other node is
@@ -303,9 +326,6 @@ export interface BAIAstryxTableProps<RecordType extends AnyRecord = AnyRecord> {
   sticky?: boolean;
   /** antd `bordered` -> Astryx `dividers="grid"`. */
   bordered?: boolean;
-  isStriped?: boolean;
-  hasHover?: boolean;
-  textOverflow?: 'wrap' | 'truncate';
   /**
    * antd `scroll`. Both axes are wired — see the file-header PILOT-DECISION:
    * `x` sizes the table from its content, `y` caps the body height and sticks
@@ -359,7 +379,7 @@ const columnKeyOf = (column: BAIColumnType<any>, index: number) =>
  * `getPathValue` returns the whole RECORD when `path` is empty, which makes
  * `render: (row) => …` work under antd); that quirk is deliberately NOT
  * re-implemented. Call sites that need the record write
- * `render: (_value, row) => …`. See `BAITableAstryx.cellValue.test.tsx`,
+ * `render: (_value, row) => …`. See `BAITable.cellValue.test.tsx`,
  * which pins this in both directions.
  */
 const readDataIndex = (record: AnyRow, dataIndex: unknown): unknown => {
@@ -444,7 +464,7 @@ const columnPlainLabel = <RecordType extends AnyRecord>({
 /* Component                                                                   */
 /* -------------------------------------------------------------------------- */
 
-const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
+const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   columns,
   dataSource,
   rowKey = 'id',
@@ -467,11 +487,12 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
   isStriped,
   hasHover = true,
   textOverflow = 'truncate',
+  verticalAlign,
   scroll,
   showHeader = true,
   className,
   style,
-}: BAIAstryxTableProps<RecordType>): React.ReactElement => {
+}: BAITableProps<RecordType>): React.ReactElement => {
   'use memo';
   const { t } = useBAIi18n();
   const { token } = theme.useToken();
@@ -1220,12 +1241,12 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
 
           qa2-c: holding only the table also makes Astryx's scroll wrapper the
           wrapper's ONLY child, which is why it needs the block-bleed reset
-          below — see BAITableAstryx.css. */}
+          below — see BAITable.css. */}
       <div
         aria-busy={isDimmed || undefined}
         className={classNames(
           // Cancels Astryx's BLOCK-axis container bleed. See
-          // BAITableAstryx.css for why this dim wrapper makes the bleed
+          // BAITable.css for why this dim wrapper makes the bleed
           // misfire; without it every table page overlaps its filter row and
           // its pagination bar by 24px.
           'bai-table-astryx-dim-layer',
@@ -1258,6 +1279,7 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
           isStriped={isStriped}
           hasHover={hasHover}
           textOverflow={textOverflow}
+          verticalAlign={verticalAlign}
           emptyState={emptyStateNode}
           rowCount={total || undefined}
           rowIndexStart={
@@ -1398,7 +1420,7 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
   );
 };
 
-export default BAITableAstryx;
+export default BAITable;
 
 /** Re-exported so a migrated call site does not need a second import. */
 export type { BAIColumnType, BAIColumnsType };

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -102,6 +102,7 @@ import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { Icon } from '@astryxdesign/core/Icon';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { Pagination } from '@astryxdesign/core/Pagination';
+import type { PaginationProps } from '@astryxdesign/core/Pagination';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import {
   Table,
@@ -215,10 +216,27 @@ export interface BAITableRowSelection<RecordType> {
   getRowLabel?: (record: RecordType) => string;
 }
 
-export interface BAITablePaginationConfig {
+/**
+ * Astryx's `Pagination` props, minus what the bottom bar renames or owns.
+ * `pageSize` / `pageSizeOptions` / `size` / `variant` and the rest are
+ * inherited and forwarded, so the bar gains Astryx's knobs without restating
+ * them (FR-3564).
+ */
+type InheritedPaginationProps = Omit<
+  PaginationProps,
+  // Renamed by the frozen antd vocabulary
+  | 'page' // -> current
+  | 'totalItems' // -> total
+  | 'onChange' // -> onChange(page, pageSize)
+  // Owned by the bottom bar: derived from the table's own state
+  | 'onPageSizeChange'
+  | 'label'
+  | 'ref'
+>;
+
+export interface BAITablePaginationConfig extends InheritedPaginationProps {
   current?: number;
   defaultCurrent?: number;
-  pageSize?: number;
   defaultPageSize?: number;
   /**
    * Omit it and the table slices `dataSource` itself. Pass a `total` greater
@@ -226,9 +244,7 @@ export interface BAITablePaginationConfig {
    * and the table leaves them alone (antd's `pageData` rule).
    */
   total?: number;
-  pageSizeOptions?: Array<number>;
   onChange?: (page: number, pageSize: number) => void;
-  size?: 'sm' | 'md';
   /**
    * antd parity. Astryx's `Pagination` renders the size selector exactly when
    * `pageSizeOptions` is passed, so `false` here simply withholds them — the
@@ -1200,6 +1216,23 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
     return next;
   })();
 
+  // Split the BUI-only keys out so the inherited Astryx ones can be forwarded
+  // as-is; anything left in `paginationRest` is a real `Pagination` prop.
+  const {
+    current: _current,
+    defaultCurrent: _defaultCurrent,
+    defaultPageSize: _defaultPageSize,
+    total: _total,
+    onChange: _onChange,
+    pageSize: _pageSize,
+    pageSizeOptions: _pageSizeOptions,
+    size: _size,
+    showSizeChanger: _showSizeChanger,
+    hideOnSinglePage: _hideOnSinglePage,
+    extraContent: _extraContent,
+    ...paginationRest
+  } = pagination === false || !pagination ? {} : pagination;
+
   const rangeStart = total === 0 ? 0 : (activePage - 1) * currentPageSize + 1;
   const rangeEnd = Math.min(activePage * currentPageSize, total);
 
@@ -1312,6 +1345,8 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
                 />
               </Text>
               <Pagination
+                variant="pages"
+                {...paginationRest}
                 page={activePage}
                 pageSize={currentPageSize}
                 totalItems={total}
@@ -1323,7 +1358,6 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
                     : (pagination?.pageSizeOptions ?? [10, 20, 50])
                 }
                 size={pagination?.size ?? 'sm'}
-                variant="pages"
                 label={String(t('comp:BAITable.Pagination'))}
                 onChange={(page) => {
                   setCurrentPage(page);

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -2,80 +2,37 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- The project's table: Astryx's `Table` primitive plus a plugin pipeline,
- behind an antd/BUI-shaped prop contract.
-
- Astryx's `Table` is a PRIMITIVE — selection, sorting, column settings and
- resizing are each an opt-in hook whose state the CONSUMER owns. Nothing here
- is "ported" from the antd table that preceded it; the behaviour is
- re-assembled.
+ The project's table: Astryx's `Table` primitive plus a plugin pipeline, behind
+ an antd-v6-shaped prop contract.
 
  ## The prop contract (read this before touching a call site)
 
- The public surface is deliberately kept **antd-v6-shaped**: `columns`
- (`BAIColumnsType`, i.e. `title`/`dataIndex`/`render`/`sorter`/`required`/
- `defaultHidden`), `dataSource`, `rowKey`, `size`, `bordered`, `rowSelection`,
- `pagination`, `expandable`, `order`/`onChangeOrder`, `tableSettings`,
- `exportSettings`. Several hundred call sites carried over from the antd era
- use those names; renaming them buys nothing and breaks all of them. See
+ The public surface is deliberately antd-v6-shaped — `dataSource`, `rowKey`,
+ `size`, `bordered`, `columns` (`BAIColumnsType`) and friends. Several hundred
+ call sites carried over from the antd era use those names; renaming them buys
+ nothing and breaks all of them. See
  `.claude/rules/component-props-extension.md` ("Frozen antd-v6-shaped prop
- vocabulary").
+ vocabulary"). Everything Astryx exposes that this file does NOT rename is
+ inherited rather than restated — `InheritedTableProps` (FR-3564).
 
- Everything Astryx exposes that this file does NOT rename is inherited rather
- than restated — see `InheritedTableProps` below (FR-3564).
+ ## Plugin order is load-bearing
 
- ## The plugin composition
+ Astryx runs columnSettings -> sort -> tree -> selection -> pagination, then
+ unknown names in insertion order. `resize` / `sticky` / `scrollX` / `scrollY` /
+ `cellRow` / `expansion` must stay last: most read the FINAL column list, and
+ `scrollY` must run before `cellRow` so a consumer's `onCell` wins.
 
-   columnSettings  visibility + display order (BUI `columnOverrides`)
-   sort            header sort controls  <-> the `-field` order string
-   selection       checkbox column       <-> antd `rowSelection`
-   resize          drag-to-resize widths (persisted into `columnOverrides`)
-   sticky          column-level `fixed: 'left' | 'right' | true`
-   expansion       antd `expandedRowRender` (local plugin, see below)
-   cellRow         antd `onCell` / `onRow` escape hatches (local plugin)
-   scrollX         x mode's per-column `max-width` release (local plugin)
-   scrollY         y mode's pinned-header z-order restore (local plugin)
+ Pagination is deliberately NOT the `useTablePagination` plugin: BUI renders its
+ own bottom bar next to the settings gear, and the plugin hides itself on a
+ single page, which antd never does.
 
- Astryx's canonical plugin order is columnSettings -> sort -> tree ->
- selection -> pagination, with unknown names appended in insertion order — so
- `resize` / `sticky` / `scrollX` / `scrollY` / `cellRow` / `expansion` run
- last, which is what they want: most read the FINAL column list, and `scrollY`
- (which reads only pinned-ness) must run before `cellRow` so `onCell` wins.
+ ## Deliberate capability drops
 
- Pagination is deliberately NOT the `useTablePagination` plugin: BUI renders
- its own bottom bar next to the settings gear, and the plugin hides itself on a
- single page, which antd never does. Client-vs-server slicing is documented on
- `BAITablePaginationConfig.total` (FR-3563).
-
- ## PILOT-DECISIONs (see the ticket file for the full list)
-
- - **Multi-level headers** (`columns[].children`) have NO Astryx counterpart —
-   there is no `colSpan` header contract. Column groups are FLATTENED and each
-   child header renders the group title above it in muted small text. The
-   information survives; the spanning cell does not.
- - **`expandedRowRender`** has no Astryx counterpart either (`useTableTreeData`
-   / `useTableRowExpansion` only do *inherited-column* child rows). Rebuilt as
-   a local plugin: detail rows are interleaved into `data` and the plugin
-   replaces that row's cells with a single full-span `<td>`.
- - **`loading`** — antd dims the existing rows under a centred spinner. Astryx
-   has no table loading state; the dim + `pointer-events: none` wrapper is
-   reproduced, the spinner is not.
- - **`scroll.x`** IS wired, as rc-table wires it: width-less columns drop their
-   proportional width so their content defines them, and the table switches to
-   `table-layout: auto` with `width: <x>; min-width: 100%`. Columns with a
-   numeric/resized width stay pixel-fixed and keep truncating.
-   **`scroll.y`** IS wired too: the scroll wrapper is capped at
-   `max-height: <y>` and every `<th>` goes `position: sticky; top: 0` over an
-   opaque base. The header's bottom rule belongs to the COLLAPSED table border,
-   not to the cell, so it scrolls away with the rows.
- - **Column-level `fixed`** IS wired, via `useTableStickyColumns` — 40 of the
-   74 call sites use it. antd pins per column; Astryx pins a contiguous RUN
-   from each edge, so the adapter derives the run from the LEADING
-   `fixed: 'left' | true` columns and the TRAILING `fixed: 'right'` ones. A
-   `fixed` column in the middle of the table silently stops pinning; no call
-   site does that today.
- - **Virtualization is DEFERRED** by an explicit product decision (2026-08-07).
-   Do not add it here without re-opening that decision.
+ Each is documented where it happens: multi-level headers (`flattenColumns`),
+ `expandedRowRender` (`astryxData`), `loading`'s spinner (the dim wrapper),
+ column-level `fixed` (`stickyConfig`), `scroll.x`/`.y` (the `scroll` prop).
+ Row virtualization is DEFERRED by an explicit product decision (2026-08-07) —
+ do not add it without re-opening that decision.
 */
 import { useControllableValue } from '../../hooks';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
@@ -343,9 +300,11 @@ export interface BAITableProps<
   /** antd `bordered` -> Astryx `dividers="grid"`. */
   bordered?: boolean;
   /**
-   * antd `scroll`. Both axes are wired — see the file-header PILOT-DECISION:
-   * `x` sizes the table from its content, `y` caps the body height and sticks
-   * the header row.
+   * antd `scroll`, both axes. `x`: width-less columns drop their proportional
+   * width so content defines them and the table goes `table-layout: auto`;
+   * pixel/resized columns stay fixed and keep truncating. `y`: the wrapper is
+   * capped at `y` and every `<th>` sticks. The header's bottom rule belongs to
+   * the COLLAPSED table border, so it scrolls away with the rows.
    */
   scroll?: { x?: number | string | true; y?: number | string };
   /**
@@ -386,17 +345,11 @@ const columnKeyOf = (column: BAIColumnType<any>, index: number) =>
   (column.dataIndex ? String(column.dataIndex) : `index_${index}`);
 
 /**
- * The cell VALUE for a column, read out of the record.
- *
- * POLICY (to-astryx approved-2, per user direction): a column with no
- * `dataIndex` has no value, so this returns `undefined` — the record reaches
- * `render` through its SECOND argument, which is the Astryx/antd render
- * contract `(value, record, index)`. rc-table has a quirk here (its
- * `getPathValue` returns the whole RECORD when `path` is empty, which makes
- * `render: (row) => …` work under antd); that quirk is deliberately NOT
- * re-implemented. Call sites that need the record write
- * `render: (_value, row) => …`. See `BAITable.cellValue.test.tsx`,
- * which pins this in both directions.
+ * The cell VALUE for a column. A column with no `dataIndex` has no value, so
+ * this returns `undefined`; the record reaches `render` through its SECOND
+ * argument (`(value, record, index)`). Do NOT re-implement rc-table's quirk of
+ * returning the whole record for an empty path — call sites write
+ * `render: (_value, row) => …`. Pinned by `BAITable.cellValue.test.tsx`.
  */
 const readDataIndex = (record: AnyRow, dataIndex: unknown): unknown => {
   if (dataIndex == null) return undefined;
@@ -586,13 +539,10 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   /* ---- row keys ---------------------------------------------------------- */
 
   /**
-   * Row identity. `rowKey` defaults to `'id'` here, but antd's `Table`
-   * defaulted to `'key'` — and 10 call sites relied on that default rather
-   * than declaring one. A missing key is not a cosmetic problem: every row
-   * would resolve to the string `"undefined"`, which collapses React's
-   * reconciliation keys, row selection and expansion onto a single identity
-   * (observed live on `ErrorLogList`). So an unresolved lookup falls back to
-   * antd's `key`, then `id`, and finally to the row's position.
+   * Row identity. Falls back `rowKey` -> `key` -> `id` -> position: 10 call
+   * sites declare none and relied on antd's `'key'` default. Without the
+   * fallback every row keys to `"undefined"`, collapsing reconciliation,
+   * selection and expansion onto one identity (seen live on `ErrorLogList`).
    */
   const getRowKey = (record: RecordType): string => {
     if (typeof rowKey === 'function') return String(rowKey(record));
@@ -853,6 +803,9 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
             : value == null || value === ''
               ? null
               : String(value);
+          // Over budget deliberately: external constraint (Astryx's own plugin
+          // CSS) + a measured value. See comment-density.md.
+          //
           // Body cells are clipped by the same wrapper the header above uses,
           // and for the same reason one rung down (FR-3482 QA finding Q-18).
           //
@@ -871,10 +824,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
           // Measured on the session scheduling-history nested table: the pinned
           // `step` cell escaped its box by +30px onto `result`, while an
           // identically sized NON-pinned cell with 255px of overflow escaped by
-          // 0. Same on `/agent`'s pinned `row_id`. Legacy antd clipped both
-          // faces unconditionally — `.ant-table-cell { overflow: hidden }` in
-          // the antd table's `resizableTable` block matched `<th>`, `<td>` and
-          // `.ant-table-cell-fix-left` alike.
+          // 0. Same on `/agent`'s pinned `row_id`.
           //
           // Wrapping the CONTENT rather than re-clipping the cell keeps the
           // plugins' bleed working: the shadow and the drag handle are painted
@@ -1169,20 +1119,12 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   /* ---- plugin record ----------------------------------------------------- */
 
   /**
-   * Give the injected selection column room for its own checkbox.
+   * Give the injected selection column room for its checkbox: the plugin's
+   * default 36px leaves 4px of content box, so the 20px checkbox overhangs
+   * 8px each side. Measured on sessions / admin-users: checkbox left 280 vs a
+   * card content edge of 287 (FR-3482 QA finding Q-14).
    *
-   * Astryx insets the FIRST column by 24px so a bleeding table's content still
-   * lines up with its card's content edge — that is what makes a normal first
-   * cell start exactly there. The selection plugin injects its column without a
-   * width, and the default lands at 36px, of which the first-column inset takes
-   * 24 and the trailing pad 8: the 20px checkbox is centred in the 4px that is
-   * left and overhangs 8px each side. Measured on the sessions and admin-users
-   * tables during the FR-3482 Astryx migration: checkbox left
-   * 280 against a card content edge of 287, while the same table's first data
-   * column starts at 288. That 7-8px is "첫 row의 시작점은 다듬어야" in the
-   * report (FR-3482 QA finding Q-14).
-   *
-   * 24 (inset) + 20 (checkbox) + 8 (trailing pad) = 52.
+   * 24 (Astryx first-column inset) + 20 (checkbox) + 8 (trailing pad) = 52.
    */
   const selectionWidthPlugin: TablePlugin<AnyRow> = {
     transformColumns: (cols) =>

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -189,6 +189,10 @@ type InheritedPaginationProps = Omit<
   | 'onPageSizeChange'
   | 'label'
   | 'ref'
+  // Unsupported: slicing, range text and row indices all derive from `total`,
+  // which the bar always passes as `totalItems`, so neither can drive anything
+  | 'totalPages'
+  | 'hasMore'
 >;
 
 export interface BAITablePaginationConfig extends InheritedPaginationProps {
@@ -256,6 +260,8 @@ type InheritedTableProps = Omit<
   // Owned here: these land on the dim/scroll WRAPPER, not on the `<table>`
   | 'className'
   | 'style'
+  // Owned here: the pipeline is assembled below and its order is load-bearing
+  | 'plugins'
 >;
 
 export interface BAITableProps<

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -253,6 +253,9 @@ type InheritedTableProps = Omit<
   | 'ref'
   // Owned here: a string is wrapped in the default EmptyState (see below)
   | 'emptyState'
+  // Owned here: these land on the dim/scroll WRAPPER, not on the `<table>`
+  | 'className'
+  | 'style'
 >;
 
 export interface BAITableProps<
@@ -461,6 +464,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   showHeader = true,
   className,
   style,
+  ...restTableProps
 }: BAITableProps<RecordType>): React.ReactElement => {
   'use memo';
   const { t } = useBAIi18n();
@@ -1241,6 +1245,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
         }
       >
         <Table<AnyRow>
+          {...restTableProps}
           data={astryxData}
           columns={astryxColumns}
           idKey={(item: AnyRow) =>

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryxSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryxSettingModal.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  to-astryx TICKET 25 — Astryx-native column-settings modal for
- `BAITableAstryx`.
+ `BAITable`.
 
  The antd version (`BAITableSettingModal`) renders a whole antd `Table` inside
  an antd `Modal`, with `Form`, `Checkbox`, `Input.Search` and a dnd-kit
@@ -16,7 +16,7 @@
  the working set is ordinary component state seeded from props on open, and
  `onRequestClose` is called with `undefined` on cancel / the new
  `{selectedColumnKeys, columnOrder}` on apply. That is the same contract the
- caller already handled, so `BAITableAstryx`'s projection back into
+ caller already handled, so `BAITable`'s projection back into
  `columnOverrides` is unchanged.
 
  Drag-to-reorder still uses dnd-kit (already a BUI dependency); Astryx ships no

--- a/packages/backend.ai-ui/src/components/Table/BAITableColumnCSVExportModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableColumnCSVExportModal.tsx
@@ -2,7 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
- to-astryx TICKET 30-D — Astryx-native CSV column picker for `BAITableAstryx`.
+ to-astryx TICKET 30-D — Astryx-native CSV column picker for `BAITable`.
 
  The antd version rendered an antd `Table` (one column, a `Checkbox` per row)
  inside an antd `Modal` wrapped in a `Form` whose only field was the search

--- a/packages/backend.ai-ui/src/components/Table/index.ts
+++ b/packages/backend.ai-ui/src/components/Table/index.ts
@@ -1,23 +1,16 @@
 /**
- * to-astryx TICKET 30-D — the BAITable seam, closed.
+ * `BAITable` is the one table implementation: Astryx `Table` + plugin
+ * pipeline. The antd engine was deleted in to-astryx ticket 30-D, and
+ * FR-3564 dropped the `Astryx` suffix the two-engine era needed.
  *
- * Ticket 25 shipped `BAITableAstryx` next to the antd `BAITable` and moved
- * three `*Nodes` across. Ticket 30-D moved the remaining 71 consumers and
- * deleted the antd engine, so there is exactly ONE table implementation now:
- *
- *   `BAITableAstryx`  Astryx `Table` + plugin pipeline
- *
- * The names that survive from the antd era are types, not components:
- * `BAITableProps` (~30 components embed it in their own public prop
- * interfaces) is an alias of `BAIAstryxTableProps`, and the column model
- * (`BAIColumnsType`) plus the persisted-override shape (`BAITableSettings`,
- * `BAITableColumnOverrideItem`) live in the engine-neutral `tableTypes`
- * module, which imports no table implementation at all.
+ * The column model (`BAIColumnsType`) and the persisted-override shape
+ * (`BAITableSettings`, `BAITableColumnOverrideItem`) live in the
+ * engine-neutral `tableTypes` module, which imports no table implementation.
  */
-export { default as BAITableAstryx } from './BAITableAstryx';
+export { default as BAITable } from './BAITable';
 /**
  * Exported for the app's own `TableColumnsSettingModal`, which serves the five
- * tables that predate `BAITableAstryx`'s built-in `tableSettings` and keep
+ * tables that predate `BAITable`'s built-in `tableSettings` and keep
  * their own `useHiddenColumnKeysSetting` persistence. It delegates its
  * rendering here so those tables' column settings look like every other
  * table's (QA-FINDINGS Q-13) without migrating their storage shape.
@@ -34,12 +27,11 @@ export type {
   BAINameActionCellProps,
 } from './BAINameActionCell';
 export type {
-  BAIAstryxTableProps,
-  BAIAstryxTableProps as BAITableProps,
-  BAIAstryxRowSelection,
-  BAIAstryxPaginationConfig,
-  BAIAstryxExpandable,
-} from './BAITableAstryx';
+  BAITableProps,
+  BAITableRowSelection,
+  BAITablePaginationConfig,
+  BAITableExpandable,
+} from './BAITable';
 export type {
   BAIAnyObject,
   BAIColumnType,

--- a/packages/backend.ai-ui/src/components/Table/tableTypes.ts
+++ b/packages/backend.ai-ui/src/components/Table/tableTypes.ts
@@ -5,7 +5,7 @@
  to-astryx TICKET 30-D — the engine-neutral half of the BAITable contract.
 
  These types and helpers used to live inside `BAITable.tsx` (the antd engine),
- which is why ticket 30 could not delete that file: `BAITableAstryx` imported
+ which is why ticket 30 could not delete that file: `BAITable` imported
  `isColumnVisible` from it, and every consumer imported `BAIColumnsType` /
  `BAITableSettings` from it. Extracting them here breaks that cycle — the
  column model, the persisted-override shape and the visibility rules are
@@ -75,7 +75,7 @@ export interface BAITableColumnOverrideItem {
    */
   order?: number;
   /**
-   * Persisted column width in pixels. Written by `BAITableAstryx` when the
+   * Persisted column width in pixels. Written by `BAITable` when the
    * user drags a column border, so a resize survives a reload exactly like a
    * visibility toggle (ticket 25).
    */
@@ -119,7 +119,7 @@ export interface BAIExportSettings {
 }
 
 /**
- * Column model for BAITable / BAITableAstryx.
+ * Column model for BAITable / BAITable.
  *
  * antd-shaped (see the file header) but antd-free.
  */

--- a/packages/backend.ai-ui/src/components/Table/tableTypes.ts
+++ b/packages/backend.ai-ui/src/components/Table/tableTypes.ts
@@ -119,7 +119,7 @@ export interface BAIExportSettings {
 }
 
 /**
- * Column model for BAITable / BAITable.
+ * Column model for `BAITable`.
  *
  * antd-shaped (see the file header) but antd-free.
  */

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -8,7 +8,7 @@ import { theme } from '../../../theme-shim';
 import BAIFetchKeyButton from '../../BAIFetchKeyButton';
 import BAIFlex from '../../BAIFlex';
 import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
-import { BAIColumnsType, BAITableAstryx, BAITableProps } from '../../Table';
+import { BAIColumnsType, BAITable, BAITableProps } from '../../Table';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
 import { VFolderFile } from '../../provider/BAIClientProvider/types';
 import DeleteSelectedItemsModal from './DeleteSelectedItemsModal';
@@ -449,7 +449,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
           />
         </BAIFlex>
 
-        <BAITableAstryx
+        <BAITable
           rowKey="name"
           dataSource={files?.items}
           columns={tableColumns}

--- a/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.stories.tsx
@@ -67,7 +67,7 @@ Use with prefix \`-\` for descending order (e.g., \`'-first_contact'\`).
 - **Status**: Agent status, CUDA version, plugin info
 - **Schedulable**: Whether agent can schedule new sessions
 
-For other props (loading, pagination, etc.), refer to [BAITableAstryx](?path=/docs/table-baitable--docs).
+For other props (loading, pagination, etc.), refer to [BAITable](?path=/docs/table-baitable--docs).
         `,
       },
     },

--- a/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
@@ -23,7 +23,7 @@ import BAIText from '../BAIText';
 import {
   BAIColumnType,
   BAIColumnsType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
 } from '../Table';
 import {
@@ -773,7 +773,7 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
   const mergedColumns = customizeColumns ? customizeColumns(columns) : columns;
 
   return (
-    <BAITableAstryx<AgentNodeInList>
+    <BAITable<AgentNodeInList>
       {...tableProps}
       rowKey={(record) => record.id}
       dataSource={agents}

--- a/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
@@ -7,7 +7,7 @@ import { theme } from '../../theme-shim';
 import BAIFlex from '../BAIFlex';
 import BAILink from '../BAILink';
 import BAIModal from '../BAIModal';
-import { BAITableAstryx } from '../Table';
+import { BAITable } from '../Table';
 import * as _ from 'lodash-es';
 import { CircleCheck, Ban, LockIcon, LockOpenIcon } from 'lucide-react';
 import React from 'react';
@@ -133,7 +133,7 @@ const BAIAllowedVfolderHostsWithPermission: React.FC<
         onCancel={() => setStorageHost(null)}
         footer={null}
       >
-        <BAITableAstryx
+        <BAITable
           pagination={false}
           size="small"
           dataSource={_.map(

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionTable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionTable.stories.tsx
@@ -52,7 +52,7 @@ const meta: Meta<typeof BAIArtifactRevisionTable> = {
 - **Size**: Revision size in human-readable format
 - **Updated**: Time since last update (relative time)
 
-For other props (loading, pagination, etc.), refer to [BAITableAstryx](?path=/docs/table-baitable--docs).
+For other props (loading, pagination, etc.), refer to [BAITable](?path=/docs/table-baitable--docs).
         `,
       },
     },

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactRevisionTable.tsx
@@ -12,7 +12,7 @@ import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIFlex from '../BAIFlex';
 import BAITag from '../BAITag';
 import BAIText from '../BAIText';
-import { BAIColumnType, BAITableAstryx, BAITableProps } from '../Table';
+import { BAIColumnType, BAITable, BAITableProps } from '../Table';
 import BAIArtifactStatusTag from './BAIArtifactStatusTag';
 import { Badge } from '@astryxdesign/core/Badge';
 import dayjs from 'dayjs';
@@ -144,13 +144,13 @@ const BAIArtifactRevisionTable = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx<ArtifactRevision>
+    <BAITable<ArtifactRevision>
       rowKey={(record) => record.id}
       resizable
       columns={allColumns}
       dataSource={artifactRevision}
       {...tableProps}
-    ></BAITableAstryx>
+    ></BAITable>
   );
 };
 

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactTable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactTable.stories.tsx
@@ -53,7 +53,7 @@ const meta: Meta<typeof BAIArtifactTable> = {
 - **Registry**: Registry name and URL (hidden by default)
 - **Source**: Source repository link (hidden by default)
 
-For other props (loading, pagination, etc.), refer to [BAITableAstryx](?path=/docs/table-baitable--docs).
+For other props (loading, pagination, etc.), refer to [BAITable](?path=/docs/table-baitable--docs).
         `,
       },
     },

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactTable.tsx
@@ -13,7 +13,7 @@ import BAIButton from '../BAIButton';
 import BAIFlex from '../BAIFlex';
 import BAILink from '../BAILink';
 import BAIText from '../BAIText';
-import { BAIColumnType, BAITableAstryx, BAITableProps } from '../Table';
+import { BAIColumnType, BAITable, BAITableProps } from '../Table';
 import BAIArtifactRevisionDownloadButton from './BAIArtifactRevisionDownloadButton';
 import BAIArtifactStatusTag from './BAIArtifactStatusTag';
 import BAIArtifactTypeTag from './BAIArtifactTypeTag';
@@ -171,7 +171,7 @@ const BAIArtifactTable = ({
       // HISTORY (to-astryx W2-D): this column declared `render: (record) => …`
       // and every row threw `Cannot read properties of undefined (reading
       // 'availability')`. Under rc-table a `dataIndex`-less column happens to
-      // receive the RECORD as `render`'s first argument; `BAITableAstryx` does
+      // receive the RECORD as `render`'s first argument; `BAITable` does
       // not reproduce that quirk, so the record must be taken from the SECOND
       // argument — the Astryx/antd `(value, record, index)` contract. This is
       // the canonical form for every computed column in this codebase.
@@ -309,12 +309,12 @@ const BAIArtifactTable = ({
   ];
 
   return (
-    <BAITableAstryx<Artifact>
+    <BAITable<Artifact>
       rowKey={(record) => record.id}
       columns={filterOutEmpty(columns)}
       dataSource={filterOutNullAndUndefined(artifact)}
       {...tableProps}
-    ></BAITableAstryx>
+    ></BAITable>
   );
 };
 

--- a/packages/backend.ai-ui/src/components/fragments/BAIAuditLogNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAuditLogNodes.tsx
@@ -10,7 +10,7 @@ import BAIText from '../BAIText';
 import {
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
 } from '../Table';
 import dayjs from 'dayjs';
@@ -208,7 +208,7 @@ const BAIAuditLogNodes = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       resizable
       rowKey="id"
       size="small"

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
@@ -18,7 +18,7 @@ import BAIFlex from '../BAIFlex';
 import BAIModal, { type BAIModalProps } from '../BAIModal';
 import BAIText from '../BAIText';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
-import { BAIColumnsType, BAITableAstryx } from '../Table';
+import { BAIColumnsType, BAITable } from '../Table';
 import BAIArtifactDescriptions from './BAIArtifactDescriptions';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import * as _ from 'lodash-es';
@@ -209,7 +209,7 @@ const BAIDeleteArtifactRevisionsModal = ({
           {selectedArtifact && (
             <BAIArtifactDescriptions artifactFrgmt={selectedArtifact} />
           )}
-          <BAITableAstryx<ArtifactRevision>
+          <BAITable<ArtifactRevision>
             columns={filterOutEmpty(columns)}
             dataSource={filterOutNullAndUndefined(selectedArtifactRevision)}
             pagination={{

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSchedulingHistoryNodes.tsx
@@ -15,7 +15,7 @@ import BAIText from '../BAIText';
 import {
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
 } from '../Table';
 import dayjs from 'dayjs';
@@ -179,7 +179,7 @@ const BAIDeploymentSchedulingHistoryNodes = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       rowKey={'id'}
       dataSource={filterOutNullAndUndefined(histories)}
       columns={allColumns}

--- a/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
@@ -18,7 +18,7 @@ import BAIFlex from '../BAIFlex';
 import BAIModal, { type BAIModalProps } from '../BAIModal';
 import BAIText from '../BAIText';
 import BAIUnmountAfterClose from '../BAIUnmountAfterClose';
-import { BAIColumnsType, BAITableAstryx } from '../Table';
+import { BAIColumnsType, BAITable } from '../Table';
 import BAIArtifactDescriptions from './BAIArtifactDescriptions';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import * as _ from 'lodash-es';
@@ -240,7 +240,7 @@ const BAIImportArtifactModal = ({
           {selectedArtifact && (
             <BAIArtifactDescriptions artifactFrgmt={selectedArtifact} />
           )}
-          <BAITableAstryx<ArtifactRevision>
+          <BAITable<ArtifactRevision>
             columns={filterOutEmpty(columns)}
             dataSource={filterOutNullAndUndefined(filteredSelectedRevisions)}
             pagination={{

--- a/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
@@ -15,7 +15,7 @@ import {
   BAIColumnType,
   BAIColumnsType,
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
 } from '../Table';
 import BAIDeploymentOwnerInfo from './BAIDeploymentOwnerInfo';
@@ -427,7 +427,7 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx<ModelDeploymentNodeInList>
+    <BAITable<ModelDeploymentNodeInList>
       resizable
       rowKey="id"
       size="small"

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.stories.tsx
@@ -64,7 +64,7 @@ const meta: Meta<typeof BAIProjectTable> = {
 - **Project ID**: Global ID (sortable, copyable)
 - **Integration ID**: External integration ID
 
-For other props (loading, pagination, etc.), refer to [BAITableAstryx](?path=/docs/table-baitable--docs).
+For other props (loading, pagination, etc.), refer to [BAITable](?path=/docs/table-baitable--docs).
         `,
       },
     },

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx
@@ -6,7 +6,7 @@ import { badgeVariantForTagColor, toLocalId } from '../../helper';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
 import BAIResourceNumberWithIcon from '../BAIResourceNumberWithIcon';
 import BAIText from '../BAIText';
-import { BAIColumnsType, BAITableAstryx, BAITableProps } from '../Table';
+import { BAIColumnsType, BAITable, BAITableProps } from '../Table';
 import AllowedVfolderHostsWithPermission from './BAIAllowedVfolderHostsWithPermission';
 import { Badge } from '@astryxdesign/core/Badge';
 import dayjs from 'dayjs';
@@ -200,7 +200,7 @@ const BAIProjectTable = ({
   const allColumns = customizeColumns ? customizeColumns(columns) : columns;
 
   return (
-    <BAITableAstryx<ProjectInList>
+    <BAITable<ProjectInList>
       {...tableProps}
       rowKey={(record) => record.id}
       dataSource={projects}

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
@@ -20,7 +20,7 @@ import BAIText from '../BAIText';
 import {
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
 } from '../Table';
 import useConnectedBAIClient from '../provider/BAIClientProvider/hooks/useConnectedBAIClient';
@@ -261,7 +261,7 @@ const BAIRouteNodes = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       rowKey={'id'}
       dataSource={filterOutNullAndUndefined(routes)}
       columns={allColumns}

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryNodeTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteSchedulingHistoryNodeTable.tsx
@@ -15,7 +15,7 @@ import BAIText from '../BAIText';
 import {
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
 } from '../Table';
 import dayjs from 'dayjs';
@@ -178,7 +178,7 @@ const BAIRouteSchedulingHistoryNodeTable = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       rowKey={'id'}
       dataSource={filterOutNullAndUndefined(histories)}
       columns={allColumns}

--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetTable.tsx
@@ -12,7 +12,7 @@ import BooleanTag from '../BooleanTag';
 import {
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
 } from '../Table';
 import useConnectedBAIClient from '../provider/BAIClientProvider/hooks/useConnectedBAIClient';
@@ -240,7 +240,7 @@ const BAIRuntimeVariantPresetTable = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       rowKey="id"
       dataSource={filterOutNullAndUndefined(presets)}
       columns={allColumns}

--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
@@ -13,10 +13,10 @@ import BAISchedulingResultBadge, {
 } from '../BAISchedulingResultBadge';
 import BAIText from '../BAIText';
 import {
-  BAIAstryxTableProps,
+  BAITableProps,
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
 } from '../Table';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
@@ -38,7 +38,7 @@ const isEnableSorter = (key: string) => {
 };
 
 export interface BAISchedulingHistoryNodesProps extends Omit<
-  BAIAstryxTableProps<SchedulingHistoryNodeInList>,
+  BAITableProps<SchedulingHistoryNodeInList>,
   'dataSource' | 'onChangeOrder' | 'columns'
 > {
   schedulingHistoryFrgmt: BAISchedulingHistoryNodesFragment$key;
@@ -161,7 +161,7 @@ const BAISchedulingHistoryNodes = ({
     // to-astryx ticket 25: migrated to the Astryx engine — this is the
     // expandable-row proving ground (`expandable` arrives from
     // `BAISchedulingHistoryTable` and renders a nested `BAISubStepNodes`).
-    <BAITableAstryx
+    <BAITable
       rowKey={'id'}
       dataSource={filterOutNullAndUndefined(histories)}
       columns={allColumns}

--- a/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISubStepNodes.tsx
@@ -14,10 +14,10 @@ import BAISchedulingResultBadge, {
 } from '../BAISchedulingResultBadge';
 import BAIText from '../BAIText';
 import {
-  BAIAstryxTableProps,
+  BAITableProps,
   BAIColumnsType,
   BAIColumnType,
-  BAITableAstryx,
+  BAITable,
 } from '../Table';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
@@ -43,7 +43,7 @@ const isEnableSorter = (key: string) => {
 };
 
 export interface BAISubStepNodesProps extends Omit<
-  BAIAstryxTableProps<SubStepInList>,
+  BAITableProps<SubStepInList>,
   'dataSource' | 'columns' | 'onChangeOrder'
 > {
   subStepsFrgmt: BAISubStepNodesFragment$key;
@@ -180,7 +180,7 @@ const BAISubStepNodes = ({
     // to-astryx ticket 25: migrated to the Astryx engine. This table renders
     // INSIDE an expanded row of `BAISchedulingHistoryNodes`, so it also proves
     // the nested-table case (`onCell` cell styles, `fixed: 'left'`).
-    <BAITableAstryx
+    <BAITable
       rowKey="step"
       size="small"
       dataSource={dataSource}

--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -10,7 +10,7 @@ export * from './astryxTagVariant';
  It adapted the `sorter` argument of antd `Table.onChange` into the Backend.AI
  `-field` order string, and the antd `BAITable` was its only caller. With that
  engine deleted the function had no consumer left (the Astryx engine builds
- the order string directly from `TableSortState` in `BAITableAstryx`), and its
+ the order string directly from `TableSortState` in `BAITable`), and its
  `SorterResult` parameter was the SOLE antd import in this module — which the
  import-graph gate ranks as a 606-file taint hub. Dropping it makes
  `helper/index.ts` antd-free.

--- a/packages/backend.ai-ui/src/hooks/useControllableValue.ts
+++ b/packages/backend.ai-ui/src/hooks/useControllableValue.ts
@@ -18,7 +18,7 @@ import { useReducer, useRef, useState, type SetStateAction } from 'react';
  *   resolved value plus any extra arguments, in both modes. When the value is
  *   controlled the internal state is *not* written — the parent owns it.
  * - A `trigger` naming a prop that does not exist (the `'no-trigger'` idiom
- *   used by `BAITableAstryx`) simply means "notify nobody".
+ *   used by `BAITable`) simply means "notify nobody".
  * - The setter identity is stable for the component's whole lifetime.
  */
 export interface UseControllableValueOptions<T> {

--- a/react/src/components/AdminDeploymentPresetTable.tsx
+++ b/react/src/components/AdminDeploymentPresetTable.tsx
@@ -10,7 +10,7 @@ import {
   BAIColumnType,
   BAINameActionCell,
   BAISessionClusterMode,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAIText,
   BooleanTag,
@@ -257,7 +257,7 @@ const AdminDeploymentPresetTable: React.FC<AdminDeploymentPresetTableProps> = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       rowKey="id"
       dataSource={filteredPresets}
       columns={allColumns}

--- a/react/src/components/AdminModelCard.tsx
+++ b/react/src/components/AdminModelCard.tsx
@@ -36,7 +36,7 @@ import {
   BAINameActionCell,
   BAISelectionLabel,
   BAIStorageHostSelectAstryx,
-  BAITableAstryx,
+  BAITable,
   type BAITableSettings,
   BAIText,
   BAITag,
@@ -399,7 +399,7 @@ const AdminModelCard: React.FC<AdminModelCardProps> = ({
           </BAIButton>
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx<ModelCardNode>
+      <BAITable<ModelCardNode>
         rowKey="id"
         dataSource={modelCards as ModelCardNode[]}
         columns={columns}

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -23,7 +23,7 @@ import {
   filterOutEmpty,
   filterOutNullAndUndefined,
   BAIButton,
-  BAITableAstryx,
+  BAITable,
   BAIFlex,
   BAIPropertyFilter,
   BAINameActionCell,
@@ -376,7 +376,7 @@ const AdminUserCredentialList: React.FC = () => {
           </BAIButton>
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx<Keypair>
+      <BAITable<Keypair>
         rowKey={'id'}
         loading={deferredQueryVariables !== queryVariables}
         dataSource={filterOutNullAndUndefined(keypair_list?.items)}

--- a/react/src/components/AdminUserManagement.tsx
+++ b/react/src/components/AdminUserManagement.tsx
@@ -567,7 +567,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
               //
               // Reported as "default email column width 가 좁아서 컨트롤 버튼이
               // 모두 보이지 않음" (QA-FINDINGS Q-16). The column carries no
-              // width, so `BAITableAstryx` falls through to `proportional(1)`,
+              // width, so `BAITable` falls through to `proportional(1)`,
               // whose documented minimum is 120px; with 21 columns that is
               // 2452px against a 1600px viewport, so the flex share never
               // activates and EVERY column pins to that 120px floor. 120 minus
@@ -579,7 +579,7 @@ const AdminUserManagement: React.FC<AdminUserManagementProps> = () => {
               // Legacy sized this column to its content: the antd table ran
               // `scroll={{ x: 'max-content' }}`, which puts rc-table in `auto`
               // layout (`git show origin/main:packages/backend.ai-ui/src/
-              // components/BAIAdminUserV2Table.tsx`), and `BAITableAstryx`
+              // components/BAIAdminUserV2Table.tsx`), and `BAITable`
               // accepts-and-ignores `scroll` by PILOT-DECISION. 320 = 200px of
               // email text + 8 gap + four 24px buttons with 2px gaps (102) +
               // 16 padding. The table already scrolls, so this takes nothing

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -25,7 +25,7 @@ import {
   BAIFlex,
   BAIProgressWithLabel,
   BAIPropertyFilter,
-  BAITableAstryx,
+  BAITable,
   INITIAL_FETCH_KEY,
   ResourceTypeIcon,
   filterOutNullAndUndefined,
@@ -427,7 +427,7 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
           />
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         bordered
         rowKey={'id'}
         dataSource={filterOutNullAndUndefined(agent_summary_list?.items)}

--- a/react/src/components/AutoScalingRuleListLegacy.tsx
+++ b/react/src/components/AutoScalingRuleListLegacy.tsx
@@ -18,7 +18,7 @@ import {
   BAICard,
   BAIDeleteConfirmModal,
   BAIFlex,
-  BAITableAstryx,
+  BAITable,
   BAIUnmountAfterClose,
 } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
@@ -148,7 +148,7 @@ const AutoScalingRuleListLegacy: React.FC<AutoScalingRuleListLegacyProps> = ({
         }
         styles={{ body: { paddingTop: 0 } }}
       >
-        <BAITableAstryx
+        <BAITable
           rowKey={'id'}
           columns={[
             {
@@ -294,7 +294,7 @@ const AutoScalingRuleListLegacy: React.FC<AutoScalingRuleListLegacyProps> = ({
           ]}
           pagination={false}
           dataSource={autoScalingRules}
-        ></BAITableAstryx>
+        ></BAITable>
       </BAICard>
       <BAIUnmountAfterClose>
         <AutoScalingRuleEditorModalLegacy

--- a/react/src/components/AutoScalingRuleListNodes.tsx
+++ b/react/src/components/AutoScalingRuleListNodes.tsx
@@ -13,7 +13,7 @@ import {
   BAIQuestionIconWithTooltip,
   BAIFlex,
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   filterOutNullAndUndefined,
 } from 'backend.ai-ui';
 import type { BAITableProps } from 'backend.ai-ui';
@@ -148,7 +148,7 @@ const AutoScalingRuleListNodes: React.FC<AutoScalingRuleListNodesProps> = ({
   );
 
   return (
-    <BAITableAstryx<AutoScalingRuleNode>
+    <BAITable<AutoScalingRuleNode>
       rowKey="id"
       columns={[
         {

--- a/react/src/components/BulkCreateUserFromCSVModal.tsx
+++ b/react/src/components/BulkCreateUserFromCSVModal.tsx
@@ -56,7 +56,7 @@ import {
   BAIModalProps,
   BAIQuestionIconWithTooltip,
   BAIRowWrapWithDividers,
-  BAITableAstryx,
+  BAITable,
   BAIText,
   badgeVariantForTagColor,
   useBAILogger,
@@ -680,7 +680,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
   // error/mask cell renderer, per-field `onCell` background styling) and the
   // failed-rows grid as a raw antd `Table` island, because no Astryx-backed
   // table existed in that ticket's scope. Ticket 30-D closed that frontier:
-  // both grids now render through `BAITableAstryx`, which accepts this exact
+  // both grids now render through `BAITable`, which accepts this exact
   // antd-shaped column model (`render` / `onCell` / `width` / `dataIndex`)
   // unchanged. The cell renderers' last two antd primitives closed in
   // final-A: `Typography.Text` -> `BAIText` (a rename — BAIText's public prop
@@ -985,7 +985,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
               failCount: failedRows.length,
             })}
           />
-          <BAITableAstryx
+          <BAITable
             size="small"
             rowKey="index"
             dataSource={failedRows}
@@ -1463,7 +1463,7 @@ const BulkCreateUserFromCSVModal: React.FC<BulkCreateUserFromCSVModalProps> = ({
                 for that class exists anywhere in the repo, and the invalid
                 state is already carried by the validity icon column plus the
                 per-cell error background that `onCell` paints. */}
-            <BAITableAstryx<ValidatedRow>
+            <BAITable<ValidatedRow>
               size="small"
               rowKey="key"
               dataSource={displayRows}

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -16,7 +16,7 @@ import {
   badgeVariantForStatus,
   filterOutEmpty,
   filterOutNullAndUndefined,
-  BAITableAstryx,
+  BAITable,
   BAIUnmountAfterClose,
   BAIDoubleTag,
   BAIId,
@@ -178,7 +178,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
           });
         }}
       /> */}
-      <BAITableAstryx
+      <BAITable
         bordered
         // loading={isPendingFilter}
         rowKey="id"

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -25,7 +25,7 @@ import {
   BAIFlex,
   BAINameActionCell,
   BAIPropertyFilter,
-  BAITableAstryx,
+  BAITable,
   INITIAL_FETCH_KEY,
   badgeVariantForTagColor,
   filterOutNullAndUndefined,
@@ -479,7 +479,7 @@ const ContainerRegistryList: React.FC<{
           />
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         rowKey={(record) => record.id}
         pagination={{
           pageSize: tablePaginationOption.pageSize,

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -26,7 +26,7 @@ import { TextInput } from '@astryxdesign/core/TextInput';
 import {
   BAIDeleteConfirmModal,
   BAIFlex,
-  BAITableAstryx,
+  BAITable,
   BAIText,
   filterOutEmpty,
   filterOutNullAndUndefined,
@@ -427,7 +427,7 @@ const CustomizedImageList: React.FC = () => {
             }}
           />
         </BAIFlex>
-        <BAITableAstryx
+        <BAITable
           resizable
           loading={isPendingSearchTransition}
           columns={

--- a/react/src/components/DeploymentAccessTokensCard.tsx
+++ b/react/src/components/DeploymentAccessTokensCard.tsx
@@ -24,7 +24,7 @@ import {
   BAIFlex,
   BAIModal,
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   BAIText,
   BAIUnmountAfterClose,
   INITIAL_FETCH_KEY,
@@ -353,7 +353,7 @@ const DeploymentAccessTokensTable: React.FC<
 
   return (
     <>
-      <BAITableAstryx<AccessTokenNode>
+      <BAITable<AccessTokenNode>
         rowKey="id"
         loading={isPendingRefetch || isDeletingToken}
         dataSource={accessTokens}

--- a/react/src/components/DeploymentAutoScalingCard.tsx
+++ b/react/src/components/DeploymentAutoScalingCard.tsx
@@ -151,7 +151,7 @@ const DeploymentAutoScalingCardContent: React.FC<
     'table_column_overrides.AutoScalingRuleList',
   );
 
-  // BAITableAstryx order string: "createdAt" (ASC) | "-createdAt" (DESC)
+  // BAITable order string: "createdAt" (ASC) | "-createdAt" (DESC)
   const [queryParams, setQueryParams] = useQueryStates(
     {
       order: parseAsStringLiteral([

--- a/react/src/components/DeploymentReplicasCard.tsx
+++ b/react/src/components/DeploymentReplicasCard.tsx
@@ -11,8 +11,8 @@ import type { DeploymentRevisionDetail_revision$key } from '../__generated__/Dep
 import { RouteSchedulingHistoryModalQuery } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
-import { ProjectContextOrNull } from '../types/projectContext';
 import { theme } from '../theme-shim';
+import { ProjectContextOrNull } from '../types/projectContext';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from './BAIErrorBoundary';
 import BAIRadioGroup from './BAIRadioGroup';
@@ -34,7 +34,7 @@ import {
   BAIGraphQLPropertyFilter,
   BAIId,
   BAIQuestionIconWithTooltip,
-  BAITableAstryx,
+  BAITable,
   BAITag,
   BAIUnmountAfterClose,
   INITIAL_FETCH_KEY,
@@ -584,7 +584,7 @@ const DeploymentReplicasCardContent: React.FC<DeploymentReplicasCardProps> = ({
           }}
         />
       </BAIFlex>
-      <BAITableAstryx<ReplicaNode>
+      <BAITable<ReplicaNode>
         rowKey={(record) => record.id}
         dataSource={replicas}
         columns={columns}

--- a/react/src/components/DeploymentRevisionHistoryTab.tsx
+++ b/react/src/components/DeploymentRevisionHistoryTab.tsx
@@ -28,7 +28,7 @@ import {
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
   BAIQuestionIconWithTooltip,
-  BAITableAstryx,
+  BAITable,
   BAITag,
   BAIUnmountAfterClose,
   BAIId,
@@ -725,7 +725,7 @@ const DeploymentRevisionHistoryTab: React.FC<
           onChange={() => handleRefresh()}
         />
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         rowKey="id"
         dataSource={revisions}
         columns={columns}

--- a/react/src/components/DomainStoragePermissionTable.tsx
+++ b/react/src/components/DomainStoragePermissionTable.tsx
@@ -16,7 +16,7 @@ import StoragePermissionEditModal from './StoragePermissionEditModal';
 import { Text } from '@astryxdesign/core/Text';
 import {
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   type BAITableProps,
   BAIUnmountAfterClose,
 } from 'backend.ai-ui';
@@ -154,7 +154,7 @@ const DomainStoragePermissionTable: React.FC<
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         size="small"
         {...tableProps}
         locale={{ emptyText: t('storageHost.permission.NoDomainSelected') }}

--- a/react/src/components/ErrorLogList.tsx
+++ b/react/src/components/ErrorLogList.tsx
@@ -14,7 +14,7 @@ import { TextInput } from '@astryxdesign/core/TextInput';
 import {
   BAIFlex,
   BAIModal,
-  BAITableAstryx,
+  BAITable,
   type BAIColumnsType,
   useUpdatableState,
 } from 'backend.ai-ui';
@@ -253,7 +253,7 @@ const ErrorLogList: React.FC<{
           </BAIFlex>
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         pagination={{
           showSizeChanger: false,
         }}

--- a/react/src/components/FairShareItems/DomainFairShareTable.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareTable.tsx
@@ -16,7 +16,7 @@ import {
   BAIFlex,
   BAINameActionCell,
   BAIResourceNumberWithIcon,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   toFixedFloorWithoutTrailingZeros,
 } from 'backend.ai-ui';
@@ -214,16 +214,12 @@ const DomainFairShareTable: React.FC<DomainFairShareTableProps> = ({
               entries,
               (entry: { resourceType: string; quantity: number }, index) => (
                 <BAIFlex key={entry.resourceType} gap="sm" align="center">
-                  {index > 0 && (
-                    <Divider orientation="vertical" />
-                  )}
+                  {index > 0 && <Divider orientation="vertical" />}
                   <BAIResourceNumberWithIcon
                     type={entry.resourceType}
                     value={toFixedFloorWithoutTrailingZeros(entry.quantity, 2)}
                     extra={
-                      <Text color="secondary">
-                        / {t('fairShare.DayUnit')}
-                      </Text>
+                      <Text color="secondary">/ {t('fairShare.DayUnit')}</Text>
                     }
                   />
                 </BAIFlex>
@@ -249,7 +245,7 @@ const DomainFairShareTable: React.FC<DomainFairShareTableProps> = ({
   ];
 
   return (
-    <BAITableAstryx
+    <BAITable
       rowKey={'domainName'}
       {...tableProps}
       dataSource={domain || []}

--- a/react/src/components/FairShareItems/ProjectFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareTable.tsx
@@ -16,7 +16,7 @@ import {
   BAIFlex,
   BAINameActionCell,
   BAIResourceNumberWithIcon,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   toFixedFloorWithoutTrailingZeros,
 } from 'backend.ai-ui';
@@ -204,16 +204,12 @@ const ProjectFairShareTable: React.FC<ProjectFairShareTableProps> = ({
               entries,
               (entry: { resourceType: string; quantity: number }, index) => (
                 <BAIFlex key={entry.resourceType} gap="sm" align="center">
-                  {index > 0 && (
-                    <Divider orientation="vertical" />
-                  )}
+                  {index > 0 && <Divider orientation="vertical" />}
                   <BAIResourceNumberWithIcon
                     type={entry.resourceType}
                     value={toFixedFloorWithoutTrailingZeros(entry.quantity, 2)}
                     extra={
-                      <Text color="secondary">
-                        / {t('fairShare.DayUnit')}
-                      </Text>
+                      <Text color="secondary">/ {t('fairShare.DayUnit')}</Text>
                     }
                   />
                 </BAIFlex>
@@ -240,7 +236,7 @@ const ProjectFairShareTable: React.FC<ProjectFairShareTableProps> = ({
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         rowKey={'id'}
         {...tableProps}
         dataSource={projectFairShares || []}

--- a/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
@@ -15,7 +15,7 @@ import {
   BAIQuestionIconWithTooltip,
   BAIFlex,
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAIUnmountAfterClose,
   convertToBinaryUnit,
@@ -164,7 +164,10 @@ const ResourceGroupFairShareTable: React.FC<
                           ? `${convertToBinaryUnit(usedEntries?.find((e) => e.resourceType === resourceType)?.quantity ?? 0, 'g', 0)?.numberFixed ?? 0} / ${convertToBinaryUnit(quantity, 'g', 0)?.numberFixed ?? 0}`
                           : `${usedEntries?.find((e) => e.resourceType === resourceType)?.quantity ?? 0} / ${quantity}`}
                       </Text>
-                      <Text color="secondary" style={{ fontSize: token.sizeXS }}>
+                      <Text
+                        color="secondary"
+                        style={{ fontSize: token.sizeXS }}
+                      >
                         {mergedResourceSlots?.[resourceType]?.display_unit}
                       </Text>
                     </BAIFlex>
@@ -215,7 +218,10 @@ const ResourceGroupFairShareTable: React.FC<
                       }}
                     />
                     {rw.weight}
-                    <Text color="secondary" style={{ fontSize: token.fontSizeSM }}>
+                    <Text
+                      color="secondary"
+                      style={{ fontSize: token.fontSizeSM }}
+                    >
                       {rw.usesDefault ? `(${t('fairShare.UsingDefault')})` : ''}
                     </Text>
                   </BAIFlex>
@@ -287,7 +293,7 @@ const ResourceGroupFairShareTable: React.FC<
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         rowKey={'id'}
         {...tableProps}
         dataSource={resourceGroups || []}

--- a/react/src/components/FairShareItems/UserFairShareTable.tsx
+++ b/react/src/components/FairShareItems/UserFairShareTable.tsx
@@ -14,7 +14,7 @@ import {
   BAIFlex,
   BAINameActionCell,
   BAIResourceNumberWithIcon,
-  BAITableAstryx,
+  BAITable,
   BAIText,
   BAITableProps,
   toFixedFloorWithoutTrailingZeros,
@@ -244,7 +244,7 @@ const UserFairShareTable: React.FC<UserFairShareTableProps> = ({
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         rowKey={'userUuid'}
         {...tableProps}
         dataSource={userFairShares || []}

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -342,7 +342,7 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
       enableEdit={hasUploadContentPermission}
       // NOTE: the legacy `tableProps.scroll` ({x:'max-content'} at `xl`,
       // plus a `y: calc(100vh - 400px)` body cap below it) is gone on purpose:
-      // `BAITableAstryx` accepts and ignores `scroll` (Astryx's own scroll
+      // `BAITable` accepts and ignores `scroll` (Astryx's own scroll
       // wrapper owns horizontal overflow), and the dialog body is the scroll
       // container for the vertical axis now.
       style={{

--- a/react/src/components/GeneratedKeypairListModal.tsx
+++ b/react/src/components/GeneratedKeypairListModal.tsx
@@ -13,7 +13,7 @@ import {
   BAIFlex,
   BAIModal,
   BAIModalProps,
-  BAITableAstryx,
+  BAITable,
   BAIText,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
@@ -98,7 +98,7 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
           title={t('credential.GeneratedKeypairWarning')}
         />
         <BAIText>{t('credential.GeneratedKeypairInfo')}</BAIText>
-        <BAITableAstryx<KeypairType>
+        <BAITable<KeypairType>
           size="small"
           style={{ overflowX: 'auto' }}
           scroll={{ x: 'max-content', y: 500 }}

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -33,7 +33,7 @@ import {
   BAIFlex,
   BAIPropertyFilter,
   BAIResourceNumberWithIcon,
-  BAITableAstryx,
+  BAITable,
   BAIUnmountAfterClose,
   INITIAL_FETCH_KEY,
   badgeVariantForTagColor,
@@ -319,7 +319,7 @@ const ImageListInScope: React.FC<ImageListInScopeProps> = ({
       // The record arrives as `render`'s SECOND argument — this column is
       // computed and has no `dataIndex`, so the first argument (the cell
       // value) is `undefined`. Reading the row off the first argument is an
-      // rc-table quirk that `BAITableAstryx` does not reproduce; taking it
+      // rc-table quirk that `BAITable` does not reproduce; taking it
       // from the second is the Astryx/antd `(value, record, index)` contract.
       render: (_value, row) => (
         // `maxLines={1}` for the same reason as the Digest column below:
@@ -597,7 +597,7 @@ const ImageListInScope: React.FC<ImageListInScopeProps> = ({
             />
           </BAIFlex>
         </BAIFlex>
-        <BAITableAstryx
+        <BAITable
           resizable
           rowKey="id"
           pagination={{

--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -6,7 +6,7 @@
  decision); its controls become Astryx via the `astryxFormControls` adapters
  and `BAIFormItem` carries the visuals. The invite row's `Descriptions title`
  wrapper (used purely as a section heading) becomes a `Heading`; the invitee
- table is `BAITableAstryx` (Astryx engine since ticket 30-D) with Astryx cells.
+ table is `BAITable` (Astryx engine since ticket 30-D) with Astryx cells.
 
  PILOT-DECISIONs:
  - antd `Input.onPressEnter` has no `TextInput` equivalent — Enter-to-invite
@@ -31,7 +31,7 @@ import { IconButton } from '@astryxdesign/core/IconButton';
 import { Selector } from '@astryxdesign/core/Selector';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Heading } from '@astryxdesign/core/Text';
-import { BAITableAstryx, useErrorMessageResolver } from 'backend.ai-ui';
+import { BAITable, useErrorMessageResolver } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { CircleXIcon } from 'lucide-react';
 import React, { useRef } from 'react';
@@ -257,7 +257,7 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
             />
           </HStack>
 
-          <BAITableAstryx<Invitee>
+          <BAITable<Invitee>
             bordered
             pagination={false}
             loading={isFetching}

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -21,7 +21,7 @@ import {
   useUpdatableState,
   filterOutEmpty,
   BAIButton,
-  BAITableAstryx,
+  BAITable,
   BAIFlex,
   BAIAllowedVfolderHostsWithPermission,
   BAIResourceNumberWithIcon,
@@ -363,7 +363,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
           </BAIButton>
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         columns={columns as BAIColumnType<AnyObject>[]}
         dataSource={
           keypair_resource_policies as readonly AnyObject[] | undefined

--- a/react/src/components/KeypairResourcePolicyStoragePermissionTable.tsx
+++ b/react/src/components/KeypairResourcePolicyStoragePermissionTable.tsx
@@ -13,7 +13,7 @@ import { theme } from '../theme-shim';
 import StoragePermissionEditModal from './StoragePermissionEditModal';
 import {
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   type BAITableProps,
   BAIUnmountAfterClose,
   BAIText,
@@ -199,7 +199,7 @@ const KeypairResourcePolicyStoragePermissionTable: React.FC<
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         size="small"
         {...tableProps}
         rowKey="id"

--- a/react/src/components/KeypairResourcePolicyStoragePermissionTableV2.tsx
+++ b/react/src/components/KeypairResourcePolicyStoragePermissionTableV2.tsx
@@ -19,7 +19,7 @@ import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAIFlex,
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   type BAITableProps,
   BAITag,
   BAIUnmountAfterClose,
@@ -210,7 +210,7 @@ const KeypairResourcePolicyStoragePermissionTableV2: React.FC<
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         size="small"
         {...tableProps}
         rowKey="id"

--- a/react/src/components/LegacyRolePermissionTab.tsx
+++ b/react/src/components/LegacyRolePermissionTab.tsx
@@ -24,7 +24,7 @@ import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   BAIUnmountAfterClose,
   INITIAL_FETCH_KEY,
   toLocalId,
@@ -399,7 +399,7 @@ const LegacyRolePermissionTab: React.FC<LegacyRolePermissionTabProps> = ({
           </BAIButton>
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         rowKey="id"
         dataSource={permissions}
         loading={isLoading}
@@ -512,7 +512,7 @@ const LegacyRolePermissionTab: React.FC<LegacyRolePermissionTabProps> = ({
                 {
                   key: deletingPermission.id,
                   label: (
-                    <BAITableAstryx
+                    <BAITable
                       rowKey="id"
                       size="small"
                       resizable={false}

--- a/react/src/components/LegacyRoleScopeTab.tsx
+++ b/react/src/components/LegacyRoleScopeTab.tsx
@@ -17,7 +17,7 @@ import {
   BAIFlex,
   BAIGraphQLPropertyFilter,
   BAIId,
-  BAITableAstryx,
+  BAITable,
   filterOutEmpty,
   INITIAL_FETCH_KEY,
   useFetchKey,
@@ -215,7 +215,7 @@ const LegacyRoleScopeTab: React.FC<LegacyRoleScopeTabProps> = ({ roleId }) => {
           onChange={updateFetchKey}
         />
       </BAIFlex>
-      <BAITableAstryx<ScopeNode>
+      <BAITable<ScopeNode>
         rowKey={(record) => `${record.scopeType}|${record.scopeId}`}
         dataSource={scopeNodes as ScopeNode[]}
         columns={columns}

--- a/react/src/components/MyKeypairInfoModalLegacy.tsx
+++ b/react/src/components/MyKeypairInfoModalLegacy.tsx
@@ -13,7 +13,7 @@ import {
   BAIFlex,
   BAIModal,
   BAIModalProps,
-  BAITableAstryx,
+  BAITable,
   badgeVariantForTagColor,
   BAIText,
 } from 'backend.ai-ui';
@@ -80,7 +80,7 @@ const MyKeypairInfoModalLegacy: React.FC<MyKeypairInfoModalLegacyProps> = ({
         />,
       ]}
     >
-      <BAITableAstryx
+      <BAITable
         rowKey={'access_key'}
         dataSource={keypairs}
         columns={[

--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -31,7 +31,7 @@ import {
   BAIGraphQLPropertyFilter,
   BAIModal,
   BAIModalProps,
-  BAITableAstryx,
+  BAITable,
   BAIText,
   filterOutEmpty,
   filterOutNullAndUndefined,
@@ -448,7 +448,7 @@ const MyKeypairManagementModal: React.FC<MyKeypairManagementModalProps> = ({
               />
             </BAIFlex>
           </BAIFlex>
-          <BAITableAstryx<KeypairNode>
+          <BAITable<KeypairNode>
             rowKey="id"
             loading={deferredQueryVariables !== queryVariables}
             dataSource={keypairNodes}

--- a/react/src/components/ProjectAdminSettingModal.tsx
+++ b/react/src/components/ProjectAdminSettingModal.tsx
@@ -18,7 +18,7 @@ import {
   BAIModal,
   BAIModalProps,
   BAISelect,
-  BAITableAstryx,
+  BAITable,
   BAIUserSelectAstryx,
   filterOutNullAndUndefined,
   toLocalId,
@@ -294,7 +294,7 @@ const ProjectAdminSettingModal = ({
             </BAIButton>
           </BAIFlex>
         </Form>
-        <BAITableAstryx
+        <BAITable
           rowKey="id"
           size="small"
           dataSource={assignments}

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -23,7 +23,7 @@ import {
   filterOutEmpty,
   filterOutNullAndUndefined,
   BAIButton,
-  BAITableAstryx,
+  BAITable,
   BAIFlex,
   useUpdatableState,
   BAINameActionCell,
@@ -243,7 +243,7 @@ const ProjectResourcePolicyList: React.FC<
           </BAIButton>
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         rowKey="id"
         columns={columns}
         dataSource={filterOutNullAndUndefined(project_resource_policies)}

--- a/react/src/components/ProjectStoragePermissionTable.tsx
+++ b/react/src/components/ProjectStoragePermissionTable.tsx
@@ -31,7 +31,7 @@ import {
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
   BAISelectionLabel,
-  BAITableAstryx,
+  BAITable,
   type BAITableProps,
   BAIUnmountAfterClose,
   toLocalId,
@@ -357,7 +357,7 @@ const ProjectStoragePermissionTable: React.FC<
           />
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         size="small"
         {...tableProps}
         locale={{

--- a/react/src/components/PrometheusQueryPresetTable.tsx
+++ b/react/src/components/PrometheusQueryPresetTable.tsx
@@ -11,7 +11,7 @@ import {
   BAIColumnsType,
   BAIFlex,
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAIText,
   badgeVariantForTagColor,
@@ -290,7 +290,7 @@ const PrometheusQueryPresetTable: React.FC<PrometheusQueryPresetTableProps> = ({
     : baseColumns;
 
   return (
-    <BAITableAstryx
+    <BAITable
       size="small"
       rowKey="id"
       dataSource={filterOutNullAndUndefined(presets)}

--- a/react/src/components/QuotaScopeTable.tsx
+++ b/react/src/components/QuotaScopeTable.tsx
@@ -10,7 +10,7 @@ import QuotaSettingModal from './QuotaSettingModal';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import {
   BAINameActionCell,
-  BAITableAstryx,
+  BAITable,
   BAIUnmountAfterClose,
 } from 'backend.ai-ui';
 import { X, SquarePenIcon } from 'lucide-react';
@@ -112,7 +112,7 @@ const QuotaScopeTable: React.FC<Props> = ({ scopeId, hostName }) => {
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         rowKey="id"
         pagination={false}
         loading={queryVariables !== deferredQueryVariables}

--- a/react/src/components/ReservoirAuditLogList.tsx
+++ b/react/src/components/ReservoirAuditLogList.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@astryxdesign/core/Badge';
 import {
   BAIPropertyFilter,
   BAIFlex,
-  BAITableAstryx,
+  BAITable,
   BAIText,
   badgeVariantForTagColor,
 } from 'backend.ai-ui';
@@ -95,7 +95,7 @@ const ReservoirAuditLogList: React.FC<ReservoirAuditLogListProps> = ({
           onChange={onFilterChange}
         />
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         size="small"
         dataSource={auditLogs}
         rowKey="id"

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -28,7 +28,7 @@ import {
   BAINameActionCell,
   BAIQuestionIconWithTooltip,
   BAISelectionLabel,
-  BAITableAstryx,
+  BAITable,
   BAIUnmountAfterClose,
   filterOutEmpty,
   filterOutNullAndUndefined,
@@ -385,7 +385,7 @@ const ResourceGroupList: React.FC = () => {
         </BAIFlex>
       </BAIFlex>
 
-      <BAITableAstryx
+      <BAITable
         rowKey={'name'}
         resizable
         size="small"

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -17,7 +17,7 @@ import { IconButton } from '@astryxdesign/core/IconButton';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
-  BAITableAstryx,
+  BAITable,
   BAIFlex,
   BAINumberWithUnit,
   useUpdatableState,
@@ -185,7 +185,7 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
           />
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         rowKey={'name'}
         dataSource={filterOutNullAndUndefined(resource_presets)}
         columns={columns}

--- a/react/src/components/RoleAssignmentTab.tsx
+++ b/react/src/components/RoleAssignmentTab.tsx
@@ -24,7 +24,7 @@ import {
   BAIGraphQLPropertyFilter,
   BAINameActionCell,
   BAISelectionLabel,
-  BAITableAstryx,
+  BAITable,
   BAIUnmountAfterClose,
   toLocalId,
   useBAILogger,
@@ -286,7 +286,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
           )}
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         rowKey="id"
         dataSource={assignments}
         loading={isPendingRefetch}

--- a/react/src/components/RoleNodes.tsx
+++ b/react/src/components/RoleNodes.tsx
@@ -17,7 +17,7 @@ import {
   BAIDoubleTag,
   BAIFlex,
   BAIId,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   badgeVariantForStatus,
   badgeVariantForTagColor,
@@ -243,7 +243,7 @@ const RoleNodes: React.FC<RoleNodesProps> = ({
 
   return (
     <>
-      <BAITableAstryx<RoleNodeInList>
+      <BAITable<RoleNodeInList>
         rowKey="id"
         dataSource={roles as RoleNodeInList[]}
         columns={displayedColumns}

--- a/react/src/components/RoleScopePermissionEditModal.tsx
+++ b/react/src/components/RoleScopePermissionEditModal.tsx
@@ -36,7 +36,7 @@ import {
   BAIListAlert,
   BAIModal,
   type BAIModalProps,
-  BAITableAstryx,
+  BAITable,
   toLocalId,
   useBAILogger,
   useMutationWithPromise,
@@ -848,7 +848,7 @@ const RoleScopePermissionEditModal: React.FC<
             // required `title` (MAPPING §4).
             <EmptyState title={t('rbac.NoPermissionsToDisplay')} />
           ) : (
-            <BAITableAstryx
+            <BAITable
               rowKey="entityType"
               columns={columns}
               dataSource={entities}

--- a/react/src/components/ScopedRolePermissionCard.tsx
+++ b/react/src/components/ScopedRolePermissionCard.tsx
@@ -30,7 +30,7 @@ import {
   BAIId,
   BAINameActionCell,
   BAISelectionLabel,
-  BAITableAstryx,
+  BAITable,
   BAIUnmountAfterClose,
   INITIAL_FETCH_KEY,
   badgeVariantForStatus,
@@ -460,7 +460,7 @@ const ScopedRolePermissionCard: React.FC<ScopedRolePermissionCardProps> = ({
             />
           </BAIFlex>
         </BAIFlex>
-        <BAITableAstryx<(typeof scopeRows)[number]>
+        <BAITable<(typeof scopeRows)[number]>
           rowKey="scopeId"
           dataSource={scopeRows}
           columns={columns}

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -38,7 +38,7 @@ import {
   MetadataListItem,
 } from '@astryxdesign/core/MetadataList';
 import { Text } from '@astryxdesign/core/Text';
-import { BAICard, BAIFlex, BAITableAstryx, BAIText } from 'backend.ai-ui';
+import { BAICard, BAIFlex, BAITable, BAIText } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { CheckIcon, CopyIcon } from 'lucide-react';
@@ -480,7 +480,7 @@ const SessionLauncherPreview: React.FC<{
       >
         <BAIFlex direction="column" align="stretch" gap={'xs'}>
           {form.getFieldValue('mount_ids')?.length > 0 ? (
-            <BAITableAstryx
+            <BAITable
               rowKey="name"
               size="small"
               pagination={false}

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -24,7 +24,7 @@ import {
   filterOutNullAndUndefined,
   BAIColumnType,
   BAIFlex,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAISessionAgentIds,
   BAIAppIcon,
@@ -415,7 +415,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         resizable
         rowKey={'id'}
         size="small"

--- a/react/src/components/SessionTemplateModal.tsx
+++ b/react/src/components/SessionTemplateModal.tsx
@@ -22,7 +22,7 @@ import {
   BAIQuestionIconWithTooltip,
   BAIModal,
   BAIModalProps,
-  BAITableAstryx,
+  BAITable,
   BAIFlex,
   BAILink,
 } from 'backend.ai-ui';
@@ -114,7 +114,7 @@ const SessionTemplateModal: React.FC<SessionTemplateModalProps> = ({
             Astryx owns its checkbox column and has no such hook, so the
             highlight is applied directly through `onRow` instead, which is
             what the hack was emulating. */}
-        <BAITableAstryx<ParsedSessionHistory>
+        <BAITable<ParsedSessionHistory>
           dataSource={parsedSessionHistory}
           pagination={false}
           onRow={(record) => ({

--- a/react/src/components/SharedFolderPermissionInfoModal.tsx
+++ b/react/src/components/SharedFolderPermissionInfoModal.tsx
@@ -29,7 +29,7 @@ import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Heading, Text } from '@astryxdesign/core/Text';
 import {
   filterOutNullAndUndefined,
-  BAITableAstryx,
+  BAITable,
   BAIText,
   useErrorMessageResolver,
   toGlobalId,
@@ -125,7 +125,7 @@ const SharedFolderPermissionInfoModal: React.FC<
         {vfolder?.ownership_type === 'user' ? (
           <VStack align="stretch" gap={4}>
             <Heading level={5}>{t('data.folders.Permission')}</Heading>
-            <BAITableAstryx
+            <BAITable
               bordered
               pagination={false}
               dataSource={filterOutNullAndUndefined([vfolder])}

--- a/react/src/components/SharedFolderPermissionInfoModalV2.tsx
+++ b/react/src/components/SharedFolderPermissionInfoModalV2.tsx
@@ -27,7 +27,7 @@ import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Heading, Text } from '@astryxdesign/core/Text';
 import {
   filterOutNullAndUndefined,
-  BAITableAstryx,
+  BAITable,
   BAIText,
   useErrorMessageResolver,
   toLocalId,
@@ -133,7 +133,7 @@ const SharedFolderPermissionInfoModalV2: React.FC<
         {isUserOwned ? (
           <VStack align="stretch" gap={4}>
             <Heading level={5}>{t('data.folders.Permission')}</Heading>
-            <BAITableAstryx
+            <BAITable
               bordered
               pagination={false}
               dataSource={filterOutNullAndUndefined([vfolder])}

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -21,7 +21,7 @@ import {
   BAIFlex,
   BAILink,
   BAIPureStorageIcon,
-  BAITableAstryx,
+  BAITable,
   BAIProgressWithLabel,
   BAIDoubleTag,
   BAIUnmountAfterClose,
@@ -276,7 +276,7 @@ const StorageProxyList = () => {
           }}
         />
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         resizable
         size="small"
         rowKey={'id'}

--- a/react/src/components/TableColumnsSettingModal.tsx
+++ b/react/src/components/TableColumnsSettingModal.tsx
@@ -7,7 +7,7 @@
  수정이 필요합니다."
 
  There are two column-settings surfaces in the app. Most tables use the one
- `BAITableAstryx` renders for its `tableSettings` prop
+ `BAITable` renders for its `tableSettings` prop
  (`BAITableAstryxSettingModal`): a `Dialog` with a title+subtitle header, an
  unlabelled search field, drag-to-reorder handles, locked required columns and
  Cancel/Apply. The five tables that predate that prop — `RoleNodes` (RBAC

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -23,7 +23,7 @@ import {
   filterOutEmpty,
   filterOutNullAndUndefined,
   BAIButton,
-  BAITableAstryx,
+  BAITable,
   BAIFlex,
   BAINameActionCell,
   BAIDeleteConfirmModal,
@@ -244,7 +244,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
           </BAIButton>
         </BAIFlex>
       </BAIFlex>
-      <BAITableAstryx
+      <BAITable
         rowKey="id"
         columns={columns}
         dataSource={filterOutNullAndUndefined(user_resource_policies)}

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Ticket 16 — converted to Astryx; the table itself crossed in ticket 30-D
- (`BAITableAstryx`, Astryx engine). Everything rendered AROUND and INSIDE the table's
+ (`BAITable`, Astryx engine). Everything rendered AROUND and INSIDE the table's
  cells is Astryx: `BAINameActionCellAstryx` (name + row actions),
  `Badge` + the repo-global status lookup (ticket 13) for the status tag,
  `Text` for text cells, `BAIText copyable` for the copyable id, and
@@ -39,7 +39,7 @@ import { Link } from '@astryxdesign/core/Link';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { Text } from '@astryxdesign/core/Text';
 import {
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAIUnmountAfterClose,
   badgeVariantForStatus,
@@ -421,7 +421,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         resizable
         rowKey={(record) => record.id}
         size="small"

--- a/react/src/components/VFolderNodesV2.tsx
+++ b/react/src/components/VFolderNodesV2.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
 
  Ticket 16 — converted to Astryx; the table itself crossed in ticket 30-D
- (`BAITableAstryx`, Astryx engine). Cells and satellites are Astryx:
+ (`BAITable`, Astryx engine). Cells and satellites are Astryx:
  `BAINameActionCellAstryx`, `Badge` + the ticket-13 status lookup, `Text`,
  `BAIText copyable`, `BAIModalAstryx` (host-quota modal), `BAISkeleton`.
 */
@@ -45,7 +45,7 @@ import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAISkeleton,
   BAIAlertIconWithTooltip,
-  BAITableAstryx,
+  BAITable,
   BAITableProps,
   BAIUnmountAfterClose,
   StorageUsageBadge,
@@ -637,7 +637,7 @@ const VFolderNodesV2: React.FC<VFolderNodesV2Props> = ({
 
   return (
     <>
-      <BAITableAstryx
+      <BAITable
         resizable
         rowKey={(record) => record.id}
         size="small"

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -31,7 +31,7 @@ import {
   BAIUserUnionIcon,
   BAIFlex,
   BAILink,
-  BAITableAstryx,
+  BAITable,
   useEventNotStable,
   useUpdatableState,
   type BAIColumnsType,
@@ -674,7 +674,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
         </ButtonGroup>
       </BAIFlex>
       <Form form={internalForm} component={false}>
-        <BAITableAstryx
+        <BAITable
           // size="small"
           rowKey={getRowKey}
           rowSelection={{

--- a/react/src/diagnostics/TableAstryxProbe.tsx
+++ b/react/src/diagnostics/TableAstryxProbe.tsx
@@ -8,7 +8,7 @@
  harness page (`react/theme-probe/table25.tsx`) mounts these against a
  relay-test-utils mock environment; they render nothing in the app itself.
 
- Each case exercises a different corner of the Astryx-native `BAITableAstryx`:
+ Each case exercises a different corner of the Astryx-native `BAITable`:
 
    users       BAIUserNodes  — sorting, resize, row selection, column settings,
                                CSV export, pagination bar

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -1108,7 +1108,7 @@ export const convertToOrderBy = <
 
 /**
  * Reverses `convertToOrderBy`: converts the first entry of a GraphQL v2
- * OrderBy array back to a UI order string (e.g., for a `BAITableAstryx`'s `order`
+ * OrderBy array back to a UI order string (e.g., for a `BAITable`'s `order`
  * prop, or to persist the current sort to the URL).
  *
  * @param orderBy - An OrderBy array (or its first entry's `field`/`direction`).

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -25,7 +25,7 @@ import { Heading, Text } from '@astryxdesign/core/Text';
 import { TextInput } from '@astryxdesign/core/TextInput';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { Drawer } from '@astryxdesign/lab';
-import { BAIFlex, BAITableAstryx, toLocalId } from 'backend.ai-ui';
+import { BAIFlex, BAITable, toLocalId } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { HistoryIcon, PencilIcon, PlusIcon, TrashIcon } from 'lucide-react';
@@ -145,7 +145,7 @@ const ChatHistoryDrawer = ({
     >
       <VStack gap={4} align="stretch" style={{ padding: 'var(--spacing-6)' }}>
         <Heading level={5}>{t('chatui.History')}</Heading>
-        <BAITableAstryx
+        <BAITable
           showHeader={false}
           dataSource={history.map((item) => ({
             title: item.label,


### PR DESCRIPTION
Resolves #8822 (FR-3564)

Names and types only. **No runtime behaviour change**, and no call site needed an
edit beyond the identifier.

## 1. The suffix outlived its purpose

`BAITableAstryx` was named that so the Astryx engine could sit next to the antd
one during to-astryx ticket 25. Ticket 30-D deleted the antd engine, so the
suffix distinguished the component from nothing — while the barrel already
re-exported its props as `BAITableProps`, leaving the **type** and the
**component it types** under different names.

| before | after |
|---|---|
| `BAITableAstryx` | `BAITable` |
| `BAIAstryxTableProps` (aliased to `BAITableProps`) | `BAITableProps`, alias removed |
| `BAIAstryxRowSelection` | `BAITableRowSelection` |
| `BAIAstryxPaginationConfig` | `BAITablePaginationConfig` |
| `BAIAstryxExpandable` | `BAITableExpandable` |

Files renamed to match (`BAITable.tsx`, `.css`, `.stories.tsx`, and the six test
files). `BAITableAstryxSettingModal` **keeps its name** — its props are a
separate contract, and it is out of scope here.

## 2. The props now extend Astryx's

`BAIAstryxTableProps` extended nothing, which
`.claude/rules/component-props-extension.md` forbids for a wrapper around one
Astryx primitive ("must extend the props type of whatever it actually wraps" —
this was case 1, the default case, standing as a live exception).

```ts
type InheritedTableProps = Omit<
  TableProps<AnyRow>,
  // Renamed by the frozen antd-v6-shaped vocabulary
  'data' | 'columns' | 'idKey' | 'density' | 'dividers'
  // Owned here: derived from `pagination`, or fixed internally
  | 'rowIndexStart' | 'rowCount' | 'children' | 'scrollWrapper' | 'ref'
  // Owned here: a string is wrapped in the default EmptyState
  | 'emptyState'
>;
```

**Why `TableProps<AnyRow>` and not `TableProps<RecordType>`.** Astryx constrains
its generic to `Record<string, unknown>`; BUI's public `AnyRecord` is
deliberately looser (`Record<PropertyKey, any>`) because ~70 call sites write
`BAITableProps<SomeRelayNode>`, and a Relay node interface does not satisfy
Astryx's constraint. The props that are generic in `T` — `data`, `columns`,
`idKey` — are **exactly** the ones the frozen vocabulary renames and this Omit
list removes, so the inherited remainder carries no `T` at all and instantiating
it at `AnyRow` is exact rather than a widening.

**What changed as a result:** `isStriped` / `hasHover` / `textOverflow` stop
being hand-restated and come from Astryx. `verticalAlign` is newly available —
and is **forwarded to the Astryx `Table`**, not just declared. (Declared-but-
ignored props are a live trap in this file; the PR below this one fixes two of
them, `defaultCurrent` / `defaultPageSize`.)

The frozen antd-v6 vocabulary is untouched: `dataSource`, `rowKey`, `size`,
`bordered`, `columns` (`BAIColumnsType`) all keep their names.

## 3. …and so does the pagination config

`BAITablePaginationConfig` was standalone for the same reason, and configures
the Astryx `Pagination` the bottom bar renders. It now extends
`Omit<PaginationProps, …>`:

| omitted | why |
|---|---|
| `page`, `totalItems`, `onChange` | renamed by the antd vocabulary to `current`, `total`, and `onChange(page, pageSize)` |
| `onPageSizeChange`, `label`, `ref` | owned by the bar (`label` is i18n'd) |

`pageSize` / `pageSizeOptions` / `size` stop being hand-restated. `variant`,
`changeAction`, `totalPages`, `hasMore`, `pageLabel`, `hasFirstLast`, `step`,
`siblingCount`, `isDisabled` and `xstyle` become reachable — and are
**forwarded through a rest spread**, not merely declared: the BUI-only keys are
destructured out first, so what remains is by construction a real `Pagination`
prop. `variant="pages"` moves ahead of the spread, so it stays the default
while becoming overridable.

## 4. Copilot review round

Three findings worth recording, all applied:

- **Inherited props were advertised but dropped.** `BAITableProps` promised
  everything `TableProps` carries — including `BaseProps`' `xstyle`, `data-*`
  and the table's HTML attributes — while the component destructured named keys
  only. The remainder is now captured and spread onto the Astryx `Table`.
  `className` / `style` are omitted instead: they target the dim/scroll
  wrapper, not the `<table>`.
- **Props the wrapper cannot honour are omitted, not decorated.** `plugins` is
  on `TableProps` after all (a type probe settled it) and would have been
  overwritten by the internal pipeline; `totalPages` / `hasMore` cannot drive a
  bar whose slicing, clamp, range text and row indices all derive from `total`.
- **Stale guidance.** `.claude/rules/use-bai-card.md` carried a `BAITableAstryx`
  example that would no longer compile, and `react.instructions.md` still
  listed the old name.

Five docs left describing `BAITable` as the successor to itself were fixed too.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup, StyleX, Astryx theme build, Terminology)
- `pnpm --filter backend.ai-ui build` → OK
- `pnpm --filter backend.ai-ui exec vitest run` → **619 passed | 1 skipped (620)**, 48 files
- `pnpm --prefix ./react exec vitest run` → **1406 passed (1406)**, 88 files
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared
  `var(--x)` in `BAIText.css:28`. **Pre-existing** — reproduced on a clean tree
  earlier in this stack; no CSS is touched here.
- `grep -r 'BAITableAstryx'` → only `BAITableAstryxSettingModal`, as intended.
- No `BAITableAstryx` / `bai-table-astryx` selector appears in `e2e/`, so no
  e2e selector was invalidated. (The CSS *class* names keep the
  `bai-table-astryx-*` spelling — renaming them is cosmetic and would enlarge
  the diff for no behavioural gain.)

**Live probe** (Storybook, zero console errors): sidebar entry renders as
`BAITable`; client-side pagination still pages (3 → rows 21–30 of 42); the
column-settings modal opens and lists the columns. Behaviour is identical to
the branch below.

## Residue

- `BAITableAstryxSettingModal` still carries the old suffix. Renaming it is a
  separate, smaller change — worth a follow-up issue if wanted.
- CSS class names (`bai-table-astryx-dim-layer`, …) unchanged, as above.
- `verticalAlign` and the newly-inherited `Pagination` knobs are reachable
  but no call site uses them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKvxBYgqPLuXq1dfXXpaZq
