### PR TITLE
style(FR-3566): give table headers a background band and header-only column splits

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
@@ -157,8 +157,13 @@
   /*
    Only where a resize handle actually exists — the injected selection column
    and the last column render none, so they get no split (FR-3566 follow-up).
+   `:not(table table)` keeps the split off tables nested inside cells /
+   expandedRowRender (whose own wrapper may be bordered), as above.
   */
-  .bai-table-astryx-header-split thead th:has([role='separator']) {
+  .bai-table-astryx-header-split
+    table:not(table table)
+    > thead
+    th:has([role='separator']) {
     background-image:
       linear-gradient(
         var(--color-border-emphasized),

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
@@ -135,3 +135,41 @@
     );
   }
 }
+
+@layer components {
+  /*
+   antd-style header band. The wash is painted card-base + muted-overlay so it
+   stays opaque under the scroll-y sticky header (--color-background-muted
+   alone is semi-transparent). The between-columns split is a background layer,
+   not a `th::after` (collides with the sticky-columns plugin's edge-shadow
+   pseudo) and not a positioned child (a positioned `th` would fight the
+   scroll-y `position: sticky` above). 1.6em inset height = antd's
+   `headerSplitColor` rule.
+  */
+  .bai-table-astryx-dim-layer thead th {
+    background-color: var(--color-background-card);
+    background-image: linear-gradient(
+      var(--color-background-muted),
+      var(--color-background-muted)
+    );
+  }
+
+  .bai-table-astryx-header-split thead th:not(:last-child) {
+    background-image:
+      linear-gradient(
+        var(--color-border-emphasized),
+        var(--color-border-emphasized)
+      ),
+      linear-gradient(
+        var(--color-background-muted),
+        var(--color-background-muted)
+      );
+    background-repeat: no-repeat;
+    background-position:
+      right center,
+      0 0;
+    background-size:
+      var(--border-width) 1.6em,
+      100% 100%;
+  }
+}

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.css
@@ -154,7 +154,11 @@
     );
   }
 
-  .bai-table-astryx-header-split thead th:not(:last-child) {
+  /*
+   Only where a resize handle actually exists — the injected selection column
+   and the last column render none, so they get no split (FR-3566 follow-up).
+  */
+  .bai-table-astryx-header-split thead th:has([role='separator']) {
     background-image:
       linear-gradient(
         var(--color-border-emphasized),
@@ -171,5 +175,17 @@
     background-size:
       var(--border-width) 1.6em,
       100% 100%;
+  }
+
+  /*
+   On a SORTABLE header Astryx anchors the resize handle (`right: 0`) to the
+   inner flex wrapper around the sort button, which sits one cell-padding
+   (8px measured) inside the `<th>` — so the whole 8px hit zone misses the
+   actual column boundary. Un-positioning that wrapper re-anchors the handle
+   to the `<th>` (always positioned: relative, or sticky under scroll-y),
+   identical to non-sortable headers. FR-3566.
+  */
+  .bai-table-astryx-dim-layer thead th > div:has(> [role='separator']) {
+    position: static;
   }
 }

--- a/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableAstryx.tsx
@@ -1260,6 +1260,9 @@ const BAITableAstryx = <RecordType extends AnyRecord = AnyRecord>({
           // its pagination bar by 24px.
           'bai-table-astryx-dim-layer',
           !showHeader && 'bai-table-astryx-no-header',
+          // dividers="grid" already draws real column borders; the header
+          // split would double them. See BAITableAstryx.css.
+          !bordered && 'bai-table-astryx-header-split',
           isScrollX && 'bai-table-astryx-scroll-x',
           isScrollY && 'bai-table-astryx-scroll-y',
         )}


### PR DESCRIPTION
Resolves #8828 (FR-3566)

## What

The default table (`BAITableAstryx`, `dividers="rows"`) drew no vertical line between columns, so there was no visual cue for where to grab when resizing a column. Header cells now get an antd-style band:

- a subtle background wash on every header cell (light **and** dark), and
- a short inset vertical split between header cells — header only, never after the last column, never in the body.

Requested with a reference screenshot; the result matches it.

## Why not the Astryx theme

`defineTheme({ components })` accepts CSS **properties** per semantic key only — it cannot express the `:not(:last-child)` exclusion or the 1.6em inset shape of the split. The change therefore lives in `BAITableAstryx.css` (scoped, element-selector discipline, Astryx tokens only). Since `BAITableAstryx` is the **only** consumer of Astryx `Table` in the repo, this still covers every table in the app.

## Mechanism

- **Wash**: `--color-background-muted` is semi-transparent (`rgba(0,0,0,0.04)` / `rgba(255,255,255,0.08)`), which would let scrolled rows show through the scroll-y sticky header. So the wash is painted as `background-color: var(--color-background-card)` + a muted gradient layer → opaque composite, and the existing sticky-header rule (which only overrides `background-color`) keeps compositing correctly.
- **Split**: a `background-image` layer (`var(--border-width)` × 1.6em, `--color-border-emphasized`, right-center) instead of
  - `th::after` — collides with the sticky-columns plugin's edge-shadow pseudo-element;
  - a positioned child — `position` on `th` would fight the scroll-y `position: sticky` rule (higher specificity, same layer).
- **Bordered tables**: `dividers="grid"` already draws real column borders, so the split would double up. A `bai-table-astryx-header-split` wrapper class is added only when `bordered` is falsy.
- **Split only where a handle exists** (review follow-up): the split targets `th:has([role='separator'])` instead of `:not(:last-child)`, so the injected selection-checkbox column — which has no resize handle — no longer draws a false affordance. The last column keeps rendering no split (it has no handle either).
- **Sortable-header handle re-anchoring** (review follow-up): Astryx positions the resize handle (`position: absolute; right: 0`, 8px hit zone) against whatever its offsetParent is. On a plain header that is the `<th>`; on a **sortable** header the handle lives inside the positioned flex wrapper around the sort button, which is inset by the cell's 8px padding — so the whole hit zone sat at `th.right − 16px … th.right − 8px`, missing the column boundary (and the split drawn at the boundary). Measured on `/admin/users`: handle right edge at `th.right − 8` for E-Mail/Username/Domain vs exactly `th.right` for User ID/Full Name/Integration Name. `position: static` on that wrapper (`th > div:has(> [role='separator'])`) re-anchors the handle to the `<th>`, unifying all handles at the boundary; a real drag at the boundary was exercised after the change (E-Mail column 320px → 260px). This is arguably an Astryx upstream quirk (the drag zone on sortable columns cannot reach the visible boundary at all) — candidate for an `astryx-bug-report` filing.

## Measured (live app, Users / Sessions / Agent Summary pages)

| Property | Light | Dark (`data-theme="dark"` asserted) |
|---|---|---|
| Header cell background | `rgb(255,255,255)` + `rgba(0,0,0,0.04)` wash | `rgb(20,20,20)` + `rgba(255,255,255,0.08)` wash |
| Split color / size | `#D9D9D9`, `1px × 22.4px` (1.6em @ 14px) | `#424242`, `1px × 22.4px` |
| Last header cell / selection column | wash only, no split | wash only, no split |
| Resize handle right edge vs th right edge | 0px on **every** column (was −8px on sortable ones) | 0px |
| Bordered table (Agent Summary) | split class absent; grid border `1px solid #F0F0F0` intact | — |

Console: only pre-existing entries (RelayResponseNormalizer warnings, `func/totp` 404, react-grab external font) — none attributable to this CSS/className-only change.

### Screenshots

| Light | Dark |
|---|---|
| ![light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/fr-3566/table-header-light.png) | ![dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/fr-3566/table-header-dark.png) |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → OK
- `pnpm --prefix ./react exec vitest run` → 88 files, 1405 passed
- `pnpm --filter backend.ai-ui exec vitest run` → 47 passed / 1 skipped files, 613 passed / 1 skipped tests
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → same single pre-existing finding as `main` (`BAIText.css:28`, a `var(--x)` inside a doc comment); nothing new flagged

## Residue

- The split is drawn at `background-position: right center` (physical), so it would sit on the wrong side under an RTL direction — the app does not currently flip `dir`.
- The sortable-header handle offset is patched locally; the underlying anchoring quirk still exists in Astryx `Table` and is worth an upstream report (FR-3491 family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
