### PR TITLE
style(FR-3572): give the deployment Scheduling History controls the accent icon-button treatment

### DIFF
--- a/react/src/components/DeploymentBasicInfoCard.tsx
+++ b/react/src/components/DeploymentBasicInfoCard.tsx
@@ -16,8 +16,8 @@ import DeploymentSchedulingHistoryModal, {
 } from './DeploymentSchedulingHistoryModal';
 import DeploymentSettingModal from './DeploymentSettingModal';
 import { ButtonGroup } from '@astryxdesign/core/ButtonGroup';
-import { Divider } from '@astryxdesign/core/Divider';
 import { DropdownMenu } from '@astryxdesign/core/DropdownMenu';
+import { IconButton } from '@astryxdesign/core/IconButton';
 import {
   MetadataList,
   MetadataListItem,
@@ -95,20 +95,19 @@ const DeploymentOverviewContent: React.FC<{
               status={deployment.metadata.status as BAIDeploymentStatus}
             />
             {onClickSchedulingHistory && (
-              <>
-                <Divider orientation="vertical" />
-                <BAIButton
-                  type="link"
-                  size="small"
-                  icon={<History size="1em" />}
-                  style={{ padding: 0 }}
-                  action={async () => {
-                    await onClickSchedulingHistory();
-                  }}
-                >
-                  {t('deployment.SchedulingHistory')}
-                </BAIButton>
-              </>
+              // Same control as the session drawer's Status row: an accent
+              // icon button, not a default-tinted link (FR-3482 Q-37 / FR-3572).
+              <IconButton
+                className="bai-action-accent"
+                variant="ghost"
+                size="sm"
+                icon={<History size="1em" />}
+                label={t('deployment.SchedulingHistory')}
+                tooltip={t('deployment.SchedulingHistory')}
+                clickAction={async () => {
+                  await onClickSchedulingHistory();
+                }}
+              />
             )}
           </BAIFlex>
         ) : (

--- a/react/src/components/DeploymentReplicasCard.tsx
+++ b/react/src/components/DeploymentReplicasCard.tsx
@@ -22,12 +22,12 @@ import RouteSchedulingHistoryModal, {
   RouteSchedulingHistoryQuery,
 } from './RouteSchedulingHistoryModal';
 import SessionDetailDrawer from './SessionDetailDrawer';
+import { IconButton } from '@astryxdesign/core/IconButton';
 import { Link } from '@astryxdesign/core/Link';
 import { Text } from '@astryxdesign/core/Text';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { BAISkeleton } from 'backend.ai-ui';
 import {
-  BAIButton,
   BAICard,
   BAIColumnType,
   BAIFlex,
@@ -377,13 +377,17 @@ const DeploymentReplicasCardContent: React.FC<DeploymentReplicasCardProps> = ({
         <BAIFlex align="center" gap="xs">
           <ReplicaStatusTag status={toReplicaTagStatus(value)} />
           {supportsRouteSchedulingHistory && (
-            <Tooltip content={t('route.RouteSchedulingHistory')}>
-              <BAIButton
-                type="link"
-                icon={<History size="1em" />}
-                size="small"
-                style={{ padding: 0 }}
-                action={async () => {
+            // `IconButton`'s own `label`/`tooltip` — the wrapping `Tooltip` left
+            // the button with no accessible name (it resolved to "Action"),
+            // and `type="link"` lost the accent tint (FR-3572).
+            <IconButton
+              className="bai-action-accent"
+              variant="ghost"
+              size="sm"
+              icon={<History size="1em" />}
+              label={t('route.RouteSchedulingHistory')}
+              tooltip={t('route.RouteSchedulingHistory')}
+              clickAction={async () => {
                   const id = safeDecodeUuid(record.id) ?? record.id;
                   // Render-as-you-fetch: start the request in the open event.
                   loadRouteHistoryQuery(
@@ -397,10 +401,9 @@ const DeploymentReplicasCardContent: React.FC<DeploymentReplicasCardProps> = ({
                       fetchPolicy: 'store-and-network',
                     },
                   );
-                  setIsRouteHistoryOpen(true);
-                }}
-              />
-            </Tooltip>
+                setIsRouteHistoryOpen(true);
+              }}
+            />
           )}
         </BAIFlex>
       ),


### PR DESCRIPTION
Resolves #8841 (FR-3572)

## Problem

The two **Scheduling History** openers on the deployment detail page were still antd-era `BAIButton type="link"`. The Astryx conversion drops that tint to `--color-text-primary`, so they read as plain non-interactive text — the same defect the session drawer's Status row already fixed as **FR-3482 QA finding Q-37**, which restores it with `.bai-action-accent` (`--color-text-accent`).

After — the Lifecycle row now matches the session drawer's status row (badge + accent history icon):

<img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0-unlinked/20260818-004108-fr3572-after.png" width="260">

## Measured, in the real app (deployment detail, dark)

| | before | after | session drawer (reference) |
|---|---|---|---|
| Lifecycle row control | **145 × 24**, visible `Scheduling History` text | **24 × 24**, icon-only | 24 × 24, icon-only |
| computed `color` | `rgb(255,255,255)` (default) | **`rgb(190,94,6)`** | `rgb(190,94,6)` |
| `.bai-action-accent` | absent | **present** | present |
| tooltip | none | **yes** | yes |
| replica-row accessible name | **`"Action"`** | **`"Replica Scheduling History"`** | — |

`--color-text-accent` is `light-dark(#FF7A00, #be5e06)`, so `rgb(190,94,6)` is exactly its dark half.

## Changes

- **Basic Information → Lifecycle**: drop the text label and the leading vertical `Divider`; render the accent `IconButton` with a `tooltip`.
- **Replicas table → Lifecycle cell**: same treatment. The button was already icon-only but wrapped in a bare `Tooltip`, which left it with **no accessible name** — its computed name resolved to `"Action"`. `IconButton`'s own `label` / `tooltip` fix both the tint and the a11y name.
- `action` → Astryx's `clickAction`, which preserves the async pending state both call sites relied on (the replica one kicks off a render-as-you-fetch query).
- `Divider` and `BAIButton` imports dropped where they became unused.

## Verification

- `bash scripts/verify.sh` — **`=== ALL PASS ===`**
- `pnpm --filter backend.ai-ui build` — built
- `pnpm --prefix ./react exec vitest run` — **1405 passed** (88 files)
- Live probe on the deployment detail page; both controls measured as in the table above

## Scope

Only the two deployment-page openers. The modal they open is untouched here — its chevron is fixed separately in #8803 (FR-3556 / FR-3557).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
