### PR TITLE
fix(FR-3574): draw the fetch-key countdown border in the current menu's accent

### DIFF
--- a/packages/backend.ai-ui/src/components/BAICountdownBorder.tsx
+++ b/packages/backend.ai-ui/src/components/BAICountdownBorder.tsx
@@ -28,7 +28,8 @@ export interface BAICountdownBorderProps {
   /**
    * Style for the wrapper element. The border's own appearance is taken from
    * the same object via standard CSS properties:
-   * - `stroke` — border color (default `colorPrimaryHover`)
+   * - `stroke` — border color (default `var(--color-accent)`, so it follows the
+   *   accent of whichever Astryx theme subtree the border is rendered in)
    * - `strokeWidth` — border thickness (default `1.5`)
    * - `borderRadius` — corner radius (default the `borderRadius` token)
    */
@@ -41,7 +42,7 @@ export interface BAICountdownBorderProps {
  * each cycle — a countdown progress border. Used like antd's `BorderBeam`:
  *
  * ```tsx
- * <BAICountdownBorder durationMs={5000} style={{ stroke: token.colorPrimary }}>
+ * <BAICountdownBorder durationMs={5000} style={{ stroke: 'var(--color-error)' }}>
  *   <SomeControl />
  * </BAICountdownBorder>
  * ```
@@ -76,7 +77,9 @@ const BAICountdownBorder: React.FC<BAICountdownBorderProps> = ({
   // Border appearance is read from `style` (CSS props), the rest passes through
   // to the wrapper element.
   const {
-    stroke = token.colorPrimaryHover,
+    // The accent CSS var, not a `theme.useToken()` read: per-menu accents come
+    // from a nested Astryx <Theme> subtree the shim's static seeds never see.
+    stroke = 'var(--color-accent)',
     strokeWidth = 1.5,
     borderRadius = token.borderRadius,
     ...wrapperStyle
@@ -120,12 +123,14 @@ const BAICountdownBorder: React.FC<BAICountdownBorderProps> = ({
             rx={borderRadius}
             ry={borderRadius}
             fill="none"
-            stroke={stroke}
             strokeWidth={strokeWidth}
             pathLength={100}
             strokeDasharray={100}
             className="bai-countdown-border-fill"
             style={{
+              // As a CSS property, not the `stroke` presentation attribute —
+              // `var()` does not substitute in presentation attributes.
+              stroke,
               animationDuration: `${durationMs}ms`,
               animationPlayState: paused ? 'paused' : 'running',
             }}


### PR DESCRIPTION
Resolves #8844 (FR-3574)

## Mechanism

`BAICountdownBorder` defaulted its stroke to `theme.useToken().colorPrimaryHover`.

That token never follows the per-menu accent, and cannot:

- the per-menu accent is applied as a **nested Astryx `<Theme>` subtree** —
  `AutoAdminPrimaryColorProvider` (`react/src/components/MainLayout/MainLayout.tsx`)
  wraps the page outlet in `AstryxAdminTheme` whenever `useRouteScope() !== 'project'`.
  A nested `<Theme>` publishes itself only as CSS custom properties on its own
  wrapper `div` (`data-astryx-theme`); it does **not** sync onto `<html>`.
- `theme.useToken()` resolves `colorPrimary` from the theme-shim's **static JS seed
  bag** (`packages/backend.ai-ui/src/theme-shim/mapping.ts` — `colorPrimary` has no
  `var:` entry, so it is never probed from the DOM), seeded once app-wide from
  `resources/theme.json`. `colorPrimaryHover` is `palette(colorPrimary)(5)`.

So inside `/admin/*` the element sat in a subtree whose `--color-accent` was already
the admin blue, while the stroke kept resolving to the brand orange.

The fix defaults the stroke to `var(--color-accent)`, which resolves against the
element the border is actually drawn on, and applies it as a **CSS property instead
of the `stroke` presentation attribute** — `var()` does not substitute in
presentation attributes.

## Measured before/after

Live app, `/project/default/session` (user scope) and `/admin/agent` (admin scope),
auto-refresh on, computed `stroke` read off `.bai-countdown-border-fill`.
`--color-accent` is read **at the rect**, not at `documentElement`.

| Page | Mode | `--color-accent` at the rect | stroke before | stroke after |
|---|---|---|---|---|
| user Sessions | light | `#FF7A00` | `rgb(255, 151, 41)` `#ff9729` | `rgb(255, 122, 0)` `#FF7A00` |
| user Sessions | dark | `#be5e06` | `rgb(211, 127, 37)` `#d37f25` | `rgb(190, 94, 6)` `#be5e06` |
| **admin Agent** | light | **`#028DF2`** | `rgb(255, 151, 41)` `#ff9729` | **`rgb(2, 141, 242)` `#028DF2`** |
| **admin Agent** | dark | **`#0387bf`** | `rgb(211, 127, 37)` `#d37f25` | **`rgb(3, 135, 191)` `#0387bf`** |

DOM confirms the admin subtree was present and correct all along — `themeNodes` on
`/admin/agent` = `['bai-r15-default-brand-hc43dtt', 'bai-r15-default-admin-h38a01g']`
— i.e. the theme was never the problem, only the JS token read was.

`pageerror` count: **0** in both modes, both pages, before and after.

## Screenshots

Auto-refresh countdown border, frozen mid-cycle (`stroke-dashoffset: 35`).

### Admin scope (`/admin/agent`) — the reported defect

| | Before | After |
|---|---|---|
| light | ![](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8846/20260818-011421-before-admin-agent-light.png) | ![](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8846/20260818-011442-after-admin-agent-light.png) |
| dark | ![](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8846/20260818-011426-before-admin-agent-dark.png) | ![](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8846/20260818-011447-after-admin-agent-dark.png) |

### User scope (`/project/default/session`) — unchanged hue family

| | Before | After |
|---|---|---|
| light | ![](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8846/20260818-011410-before-user-sessions-light.png) | ![](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8846/20260818-011431-after-user-sessions-light.png) |
| dark | ![](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8846/20260818-011415-before-user-sessions-dark.png) | ![](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8846/20260818-011436-after-user-sessions-dark.png) |

## Verification

| Check | Result |
|---|---|
| `bash scripts/verify.sh` | `=== ALL PASS ===` |
| `pnpm --filter backend.ai-ui build` | built OK (run after every source edit) |
| `pnpm --filter backend.ai-ui exec vitest run` | 47 files passed, 1 skipped · **613 passed**, 1 skipped |
| `pnpm --prefix ./react exec vitest run` | 88 files passed · **1405 passed** |
| `node scripts/migration-gates/astryx-token-gate.mjs --strict` | 1 undeclared `var()` — **pre-existing**, `BAIText.css:28 var(--x)`, untouched by this PR (last changed in #8730) |
| Live probe, light + dark | table above, 0 `pageerror` |

## Residue

- **The user-scope hue shifts one step**, from the `colorPrimaryHover` shade
  (`#ff9729` / `#d37f25`) to the base accent (`#FF7A00` / `#be5e06`). Astryx exposes
  no accent-hover variable — only `--color-accent` and `--color-accent-muted` (a
  20–25% mix, far too pale for a 1.5px border) — and the base accent is what every
  other accent surface on the page already uses (`.bai-action-accent` →
  `--color-text-accent`). Treated as a deliberate convergence, not a regression.
- **Consumer overrides are unaffected.** `style.stroke` still wins; only the default
  changed. `BAIFetchKeyButton`, the sole in-tree consumer, passes no `stroke`.
- **Not touched:** the secondary (teal) theme role. It gets the same fix for free
  because the fix is generic to `--color-accent`, but no page using it was probed.
- `theme.useToken()` is still used in this component for `borderRadius`, which is
  not accent-scoped and needs a number for the SVG `rx`/`ry`.
- **Not addressed here:** the wider question of which other components read
  `token.colorPrimary*` and therefore also miss the per-menu accent. This PR fixes
  only the countdown border reported in FR-3574.

## Related

FR-3300 (added the countdown border), FR-3354 (countdown/interval desync) — same
component, different defects; neither is subsumed by this change.

## Does this still follow a rebranded `theme.json`?

Yes — per role, which the previous code could not do.

`AstryxBrandTheme` / `AstryxAdminTheme` both hand the **live** `useCustomThemeConfig()`
document to `resolveRoleTheme(config, role, family)`
(`react/src/astryx-theme/resolveRoleTheme.ts`):

```ts
const options = themeOptionsFromConfig(config ?? {}, role, family);
if (computeThemeName(options) === builtBackendAiBrandTheme.name) {
  return builtBackendAiBrandTheme;   // only when the seeds are byte-identical to the baked ones
}
return buildBackendAiTheme(options); // any override → runtime defineTheme()
```

A theme's name is a pure function of its CSS-affecting seeds, so the moment an
operator (or the end-user accent picker) changes a colour, the computed name stops
matching the prebuilt artifact and the runtime `defineTheme()` path takes over — and
that is what emits `--color-accent`. `themeOptionsFromConfig` maps the roles
brand→`colorPrimary`, admin→`colorInfo`, secondary→`colorSuccess`.

| | reflects a `theme.json` rebrand | role-aware |
|---|---|---|
| before — `token.colorPrimaryHover` | `colorPrimary` only | no; one value app-wide |
| after — `var(--color-accent)` | per role | brand / admin / secondary |

`colorPrimaryHover` was never operator-declarable in the first place: the theme-shim
marks it `verdict: 'derive'` from the `colorPrimary` seed (palette key 5), so no
`theme.json` document could ever set it directly. Nothing that was configurable
before became unconfigurable.
