### PR TITLE
fix/FR 3568 session detail drawer transition delay

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-08-11
+> **Last Updated:** 2026-08-18
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 313 / 458 features covered (68%)**
+**Overall (in-scope routes): 314 / 459 features covered (68%)**
 
 | Page                     | Route                                  | Features | Covered | Status  |
 | ------------------------ | -------------------------------------- | :------: | :-----: | :-----: |
@@ -20,7 +20,7 @@
 | Change Password          | `/change-password`                     |    9     |    9    | ✅ 100% |
 | Start Page               | `/start`                               |    8     |    6    | 🔶 75%  |
 | Dashboard                | `/dashboard`                           |    9     |    7    | 🔶 78%  |
-| Session List             | `/session`                             |    22    |   14    | 🔶 64%  |
+| Session List             | `/session`                             |    23    |   15    | 🔶 65%  |
 | Session Launcher         | `/session/start`                       |    14    |    3    | 🔶 21%  |
 | Serving                  | `/serving`                             |    7     |    2    | 🔶 29%  |
 | Endpoint Detail          | `/serving/:serviceId`                  |    20    |    9    | 🔶 45%  |
@@ -176,38 +176,39 @@
 
 ### 4. Session List (`/session`)
 
-**Test files:** [`e2e/session/session-creation.spec.ts`](session/session-creation.spec.ts), [`e2e/session/session-lifecycle.spec.ts`](session/session-lifecycle.spec.ts), [`e2e/session/session-scheduling-history-modal.spec.ts`](session/session-scheduling-history-modal.spec.ts), [`e2e/session/session-dependency.spec.ts`](session/session-dependency.spec.ts)
+**Test files:** [`e2e/session/session-creation.spec.ts`](session/session-creation.spec.ts), [`e2e/session/session-lifecycle.spec.ts`](session/session-lifecycle.spec.ts), [`e2e/session/session-scheduling-history-modal.spec.ts`](session/session-scheduling-history-modal.spec.ts), [`e2e/session/session-dependency.spec.ts`](session/session-dependency.spec.ts), [`e2e/session/session-detail-drawer-transition-delay.spec.ts`](session/session-detail-drawer-transition-delay.spec.ts)
 
 **Tabs:** `all` | `interactive` | `batch` | `inference` | `system`
 **Sub-tabs:** Running | Finished
 **Modals/Drawers:** `TerminateSessionModal`, `SessionDetailDrawer` (via name click), `SessionSchedulingHistoryModal`
 
-| Feature                                                  | Status | Test                                                                                                   |
-| -------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------ |
-| Create interactive session (Start page)                  | ✅     | `User can create interactive session on the Start page`                                                |
-| Create batch session (Start page)                        | ✅     | `User can create batch session on the Start page`                                                      |
-| Create interactive session (Session page)                | ✅     | `User can create interactive session from the quick-action card`                                       |
-| Create batch session (Session page)                      | ✅     | Via session creation tests                                                                             |
-| Session lifecycle (create/monitor/terminate)             | ✅     | `Create, monitor, and terminate interactive session`                                                   |
-| Batch session auto-completion                            | ✅     | `Create and wait for batch session completion`                                                         |
-| View container logs                                      | ✅     | `View session container logs`                                                                          |
-| Monitor resource usage                                   | ✅     | `Monitor session resource usage`                                                                       |
-| Status transitions                                       | ✅     | `Session status transitions are correct`                                                               |
-| Bulk terminate disabled for terminated                   | ✅     | `Cannot select terminated sessions for bulk operations`                                                |
-| Sensitive env vars cleared on reload                     | ✅     | `Sensitive environment variables are cleared`                                                          |
-| Scheduling history modal                                 | ✅     | `Session Scheduling History Modal` (via mocked GraphQL)                                                |
-| Session name click → SessionDetailDrawer                 | 🚧     | `Session detail drawer renders correctly and can show dependency info` (fixme: requires running agent) |
-| Dependencies column toggle                               | ✅     | `Dependencies column can be enabled via table settings`                                                |
-| Session type filtering (interactive/batch/inference)     | ❌     | -                                                                                                      |
-| Running/Finished status toggle                           | ❌     | -                                                                                                      |
-| Property filtering (name, resource group, agent)         | ❌     | -                                                                                                      |
-| Session table sorting                                    | ❌     | -                                                                                                      |
-| Pagination                                               | ❌     | -                                                                                                      |
-| Batch terminate → TerminateSessionModal                  | ❌     | -                                                                                                      |
-| Scheduling history modal → SessionSchedulingHistoryModal | ✅     | `Admin can see the scheduling history button` + 18 more tests                                          |
-| Resource policy warnings                                 | 🚧     | Skipped: `superadmin to modify keypair resource policy`                                                |
+| Feature                                                  | Status | Test                                                                                                                                                 |
+| -------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Create interactive session (Start page)                  | ✅     | `User can create interactive session on the Start page`                                                                                              |
+| Create batch session (Start page)                        | ✅     | `User can create batch session on the Start page`                                                                                                    |
+| Create interactive session (Session page)                | ✅     | `User can create interactive session from the quick-action card`                                                                                     |
+| Create batch session (Session page)                      | ✅     | Via session creation tests                                                                                                                           |
+| Session lifecycle (create/monitor/terminate)             | ✅     | `Create, monitor, and terminate interactive session`                                                                                                 |
+| Batch session auto-completion                            | ✅     | `Create and wait for batch session completion`                                                                                                       |
+| View container logs                                      | ✅     | `View session container logs`                                                                                                                        |
+| Monitor resource usage                                   | ✅     | `Monitor session resource usage`                                                                                                                     |
+| Status transitions                                       | ✅     | `Session status transitions are correct`                                                                                                             |
+| Bulk terminate disabled for terminated                   | ✅     | `Cannot select terminated sessions for bulk operations`                                                                                              |
+| Sensitive env vars cleared on reload                     | ✅     | `Sensitive environment variables are cleared`                                                                                                        |
+| Scheduling history modal                                 | ✅     | `Session Scheduling History Modal` (via mocked GraphQL)                                                                                              |
+| Session name click → SessionDetailDrawer                 | 🚧     | `Session detail drawer renders correctly and can show dependency info` (fixme: requires running agent)                                               |
+| Drawer opens promptly under held refetch (FR-3568)       | ✅     | `User can open the session detail drawer promptly while a session-list refetch is held in flight` (`session-detail-drawer-transition-delay.spec.ts`) |
+| Dependencies column toggle                               | ✅     | `Dependencies column can be enabled via table settings`                                                                                              |
+| Session type filtering (interactive/batch/inference)     | ❌     | -                                                                                                                                                    |
+| Running/Finished status toggle                           | ❌     | -                                                                                                                                                    |
+| Property filtering (name, resource group, agent)         | ❌     | -                                                                                                                                                    |
+| Session table sorting                                    | ❌     | -                                                                                                                                                    |
+| Pagination                                               | ❌     | -                                                                                                                                                    |
+| Batch terminate → TerminateSessionModal                  | ❌     | -                                                                                                                                                    |
+| Scheduling history modal → SessionSchedulingHistoryModal | ✅     | `Admin can see the scheduling history button` + 18 more tests                                                                                        |
+| Resource policy warnings                                 | 🚧     | Skipped: `superadmin to modify keypair resource policy`                                                                                              |
 
-**Coverage: 🔶 14/22 features**
+**Coverage: 🔶 15/23 features**
 
 ---
 

--- a/e2e/session/session-detail-drawer-transition-delay.spec.ts
+++ b/e2e/session/session-detail-drawer-transition-delay.spec.ts
@@ -28,8 +28,8 @@ import { sessionDetailMockResponse } from './mocking/session-detail-mock';
 import { sessionListMockResponse } from './mocking/session-list-mock';
 import { test, expect, type Route } from '@playwright/test';
 
-// Fires once on page load, then again (network-only) when Refresh is
-// clicked -- the second firing is the one we hold open.
+// Fires during page load (possibly more than once) and again when Refresh
+// is clicked -- the armed firing after the click is the one we hold open.
 const SESSION_LIST_QUERY = 'ComputeSessionListPageQuery';
 // Not expected to fire for this flow (the clicked row already carries a fresh
 // fragment via router state, so SessionDetailContent reads it store-only),
@@ -59,7 +59,11 @@ test.describe(
       // test needs no live session/cluster -- only fault-injects a delay on
       // the second list refetch. Set up before login/navigation so it is in
       // place before any query fires.
-      let sessionListQueryCount = 0;
+      // Armed explicitly right before the Refresh click — an ordinal
+      // ("2nd query") arm can be spent by an extra list query during
+      // initial load, letting the spec pass without a held transition.
+      let holdArmed = false;
+      let heldRefetchCount = 0;
       let signalHeldRefetchStarted: () => void = () => {};
       const heldRefetchStarted = new Promise<void>((resolve) => {
         signalHeldRefetchStarted = resolve;
@@ -72,8 +76,9 @@ test.describe(
         const body = req.postData() ?? '';
 
         if (body.includes(SESSION_LIST_QUERY)) {
-          sessionListQueryCount += 1;
-          if (sessionListQueryCount === 2) {
+          if (holdArmed) {
+            holdArmed = false;
+            heldRefetchCount += 1;
             signalHeldRefetchStarted();
             await new Promise((resolve) =>
               setTimeout(resolve, HELD_TRANSITION_DELAY_MS),
@@ -106,8 +111,10 @@ test.describe(
       });
       await expect(sessionNameButton).toBeVisible({ timeout: 15000 });
 
-      // Click Refresh to start the held (delayed) refetch -- the concurrently
-      // pending transition the drawer mount must not entangle with.
+      // Arm the hold only now, then click Refresh to start the held (delayed)
+      // refetch -- the concurrently pending transition the drawer mount must
+      // not entangle with.
+      holdArmed = true;
       await getTableRefreshButton(page).click();
 
       // The refresh click only schedules the deferred refetch; wait until the
@@ -135,9 +142,9 @@ test.describe(
       // exercised the entanglement window, so a passing drawer would prove
       // nothing.
       expect(
-        sessionListQueryCount,
-        `${SESSION_LIST_QUERY} should have fired at least twice (initial load + refresh)`,
-      ).toBeGreaterThanOrEqual(2);
+        heldRefetchCount,
+        `${SESSION_LIST_QUERY} should have been held exactly once (armed refresh)`,
+      ).toBe(1);
 
       // Close clears the param; the drawer must not be left poisoned for a
       // re-open.

--- a/e2e/session/session-detail-drawer-transition-delay.spec.ts
+++ b/e2e/session/session-detail-drawer-transition-delay.spec.ts
@@ -1,0 +1,150 @@
+// spec: regression guard for FR-3568
+//
+// Bug: `SessionDetailAndContainerLogOpenerLegacy` used to read the
+// `sessionDetail` URL param via nuqs `useQueryState`, which applies EXTERNAL
+// URL changes (a plain history push via `useWebUINavigate`, as
+// `ComputeSessionListPage` does when a row's name is clicked -- not nuqs' own
+// setter) inside `startTransition`. When another transition is concurrently
+// pending on the same root -- e.g. the session list's own
+// `useDeferredValue`-driven refetch, suspended in flight without a fallback
+// -- React entangles the drawer's param-driven mount with that other
+// transition and delays it by seconds. Reading the param from
+// `useLocation()` instead (the fix) is a plain render, not entangled with any
+// pending transition, so the drawer opens immediately regardless.
+//
+// This test makes the entanglement window deterministic: it holds the
+// session list's own refetch transition open by delaying the *second*
+// `ComputeSessionListPageQuery` response (the one triggered by clicking
+// Refresh), then opens the session detail drawer while that refetch is still
+// in flight. On the unpatched build the drawer mount is entangled with the
+// pending refetch and the tight visibility bound below times out; the fix
+// keeps the mount independent of it.
+import {
+  getTableRefreshButton,
+  loginAsUser,
+  navigateTo,
+} from '../utils/test-util';
+import { sessionDetailMockResponse } from './mocking/session-detail-mock';
+import { sessionListMockResponse } from './mocking/session-list-mock';
+import { test, expect, type Route } from '@playwright/test';
+
+// Fires once on page load, then again (network-only) when Refresh is
+// clicked -- the second firing is the one we hold open.
+const SESSION_LIST_QUERY = 'ComputeSessionListPageQuery';
+// Not expected to fire for this flow (the clicked row already carries a fresh
+// fragment via router state, so SessionDetailContent reads it store-only),
+// but mocked defensively so the route never falls through to a live backend.
+const SESSION_DETAIL_QUERY = 'SessionDetailContentQuery';
+// Deliberate latency injection (see header) -- not an arbitrary flake wait.
+const HELD_TRANSITION_DELAY_MS = 4000;
+// The drawer must mount well under the injected delay, proving it did not
+// wait on the held refetch. A cold mount is comfortably sub-second.
+const DRAWER_OPEN_BOUND_MS = 1500;
+
+const MOCK_SESSION_NAME = 'mock-session-for-scheduling-history';
+
+test.describe(
+  'Session Detail Drawer - transition-delay regression (FR-3568)',
+  { tag: ['@critical', '@session', '@regression'] },
+  () => {
+    test.describe.configure({ mode: 'default' });
+
+    test('User can open the session detail drawer promptly while a session-list refetch is held in flight', async ({
+      page,
+      request,
+    }) => {
+      test.setTimeout(60000);
+
+      // Mock the session list (and, defensively, the detail query) so the
+      // test needs no live session/cluster -- only fault-injects a delay on
+      // the second list refetch. Set up before login/navigation so it is in
+      // place before any query fires.
+      let sessionListQueryCount = 0;
+      let signalHeldRefetchStarted: () => void = () => {};
+      const heldRefetchStarted = new Promise<void>((resolve) => {
+        signalHeldRefetchStarted = resolve;
+      });
+      await page.route('**/admin/gql', async (route: Route) => {
+        const req = route.request();
+        if (req.method() !== 'POST') {
+          return route.continue();
+        }
+        const body = req.postData() ?? '';
+
+        if (body.includes(SESSION_LIST_QUERY)) {
+          sessionListQueryCount += 1;
+          if (sessionListQueryCount === 2) {
+            signalHeldRefetchStarted();
+            await new Promise((resolve) =>
+              setTimeout(resolve, HELD_TRANSITION_DELAY_MS),
+            );
+          }
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: sessionListMockResponse() }),
+          });
+        }
+
+        if (body.includes(SESSION_DETAIL_QUERY)) {
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: sessionDetailMockResponse({}) }),
+          });
+        }
+
+        return route.continue();
+      });
+
+      await loginAsUser(page, request);
+      await navigateTo(page, 'session');
+
+      const sessionNameButton = page.getByRole('button', {
+        name: MOCK_SESSION_NAME,
+        exact: true,
+      });
+      await expect(sessionNameButton).toBeVisible({ timeout: 15000 });
+
+      // Click Refresh to start the held (delayed) refetch -- the concurrently
+      // pending transition the drawer mount must not entangle with.
+      await getTableRefreshButton(page).click();
+
+      // The refresh click only schedules the deferred refetch; wait until the
+      // delayed request has actually STARTED so the held transition is
+      // guaranteed to be in flight when the drawer opens.
+      await heldRefetchStarted;
+
+      // Without waiting for that refetch to resolve, open the drawer via an
+      // in-app click (the path that triggers `webUINavigate`, i.e. the
+      // "external" URL change nuqs used to pick up).
+      await sessionNameButton.click();
+
+      // The URL updates immediately regardless of the bug -- `webUINavigate`
+      // pushes the param synchronously.
+      await expect(page).toHaveURL(/[?&]sessionDetail=/, { timeout: 2000 });
+
+      // The drawer must actually mount, and quickly -- well under
+      // HELD_TRANSITION_DELAY_MS. On the unpatched build the param read was
+      // entangled with the still-pending refetch transition, so this timed
+      // out instead.
+      const drawer = page.getByRole('dialog', { name: 'Session Info' });
+      await expect(drawer).toBeVisible({ timeout: DRAWER_OPEN_BOUND_MS });
+
+      // Guard against a false green: if the held refetch never fired we never
+      // exercised the entanglement window, so a passing drawer would prove
+      // nothing.
+      expect(
+        sessionListQueryCount,
+        `${SESSION_LIST_QUERY} should have fired at least twice (initial load + refresh)`,
+      ).toBeGreaterThanOrEqual(2);
+
+      // Close clears the param; the drawer must not be left poisoned for a
+      // re-open.
+      await drawer.getByRole('button', { name: 'Close' }).click();
+      await expect(page).not.toHaveURL(/[?&]sessionDetail=/, {
+        timeout: 5000,
+      });
+    });
+  },
+);

--- a/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
+++ b/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
@@ -2,13 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { ProjectContextOrNull } from '../types/projectContext';
 import ContainerLogModalWithLazyQueryLoader from './ComputeSessionNodeItems/ContainerLogModalWithLazyQueryLoader';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import { BAIUnmountAfterClose } from 'backend.ai-ui';
-import { parseAsString, useQueryState } from 'nuqs';
 import { useState, useEffect, useTransition } from 'react';
+import { useLocation } from 'react-router-dom';
 
 interface SessionDetailAndContainerLogOpenerLegacyProps {
   /**
@@ -23,10 +23,27 @@ interface SessionDetailAndContainerLogOpenerLegacyProps {
 const SessionDetailAndContainerLogOpenerLegacy: React.FC<
   SessionDetailAndContainerLogOpenerLegacyProps
 > = ({ project }) => {
-  const [sessionId, setSessionId] = useQueryState(
-    'sessionDetail',
-    parseAsString.withOptions({ history: 'replace' }),
-  );
+  // Read `sessionDetail` from the router location, NOT nuqs — nuqs applies
+  // external URL changes inside startTransition, which entangles the drawer
+  // mount with any concurrently held transition (e.g. a page poll refetch
+  // suspended without a fallback) and delays it by seconds. Same pattern and
+  // reasoning as `useTabQuerySnapshot` (react/src/hooks/index.tsx).
+  const location = useLocation();
+  const webUINavigate = useWebUINavigate();
+  const sessionId = new URLSearchParams(location.search).get('sessionDetail');
+  const setSessionId = (value: string | null) => {
+    const params = new URLSearchParams(location.search);
+    if (value === null) params.delete('sessionDetail');
+    else params.set('sessionDetail', value);
+    webUINavigate(
+      {
+        pathname: location.pathname,
+        hash: location.hash,
+        search: params.toString(),
+      },
+      { replace: true },
+    );
+  };
   const [containerLogModalSessionId, setContainerLogModalSessionId] =
     useState<string>();
   const [isPendingLogModalOpen, startLogModalOpenTransition] = useTransition();


### PR DESCRIPTION
Resolves #8837 (FR-3568)

## Summary

The legacy session-detail opener read the `sessionDetail` URL param through nuqs `useQueryState`, which applies external URL changes inside `startTransition`. Any concurrently held transition — most commonly the session list's suspended poll refetch — therefore delayed the drawer mount by several seconds after a click. The opener now reads the param from the router location and writes it via `webUINavigate(..., { replace: true })`, keeping the drawer mount out of transition entanglement (probed at <0.7s after click on the prototype branch).

The opener is mounted on the session list route, the scheduler page, and the admin session page, so every current session-detail surface benefits.

Discovered and fixed during the session resource-grid prototyping (map #8786, decision #8790); ships ahead of the grid feature per spec #8832. The hand-off spec named a second nuqs fix (filter-change hold); investigation showed that bug only exists inside the grid's own Suspense architecture, so it ships within the grid PR (#8849) instead of standalone.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`; react workspace vitest 1443 green.
- New e2e regression spec `e2e/session/session-detail-drawer-transition-delay.spec.ts` following the FR-3358 fault-injection prior art: deterministically holds the session-list refetch open and asserts the drawer still mounts within 1.5s (vs a 4s injected delay), using existing session list/detail mocks — no live session required. Runs under the cluster-backed e2e suite (not executed in CI-less environment).
- Live probe on the dev server against a real cluster: drawer opens promptly from the table view; deep-linking and close/param-clear behavior unchanged.
