### PR TITLE
feat(FR-3571): add the resource grid view to the superadmin session page

### DIFF
--- a/react/src/helper/adminSessionProjectLift.test.ts
+++ b/react/src/helper/adminSessionProjectLift.test.ts
@@ -1,0 +1,80 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  liftProjectPredicate,
+  splitTopLevelAnd,
+} from './adminSessionProjectLift';
+
+describe('splitTopLevelAnd', () => {
+  test('splits on top-level & only', () => {
+    expect(splitTopLevelAnd('(a)&(b | c)')).toEqual(['(a)', '(b | c)']);
+    expect(splitTopLevelAnd('a & b')).toEqual(['a', 'b']);
+  });
+
+  test('ignores & inside quotes and parentheses', () => {
+    expect(splitTopLevelAnd('name == "a&b" & x')).toEqual([
+      'name == "a&b"',
+      'x',
+    ]);
+    expect(splitTopLevelAnd('(a & b) & c')).toEqual(['(a & b)', 'c']);
+  });
+});
+
+describe('liftProjectPredicate', () => {
+  test('lifts a single == predicate and strips it from the remainder', () => {
+    expect(liftProjectPredicate('project_id == "uuid-1"')).toEqual({
+      projectId: 'uuid-1',
+      remainder: undefined,
+    });
+    expect(
+      liftProjectPredicate('(project_id == "uuid-1")&(name ilike "%a%")'),
+    ).toEqual({ projectId: 'uuid-1', remainder: '(name ilike "%a%")' });
+  });
+
+  test('lifts ilike and the no-space form', () => {
+    expect(liftProjectPredicate('project_id ilike "%uuid-2%"').projectId).toBe(
+      'uuid-2',
+    );
+    expect(liftProjectPredicate('project_id=="uuid-3"').projectId).toBe(
+      'uuid-3',
+    );
+  });
+
+  test('does not lift when two project predicates exist', () => {
+    const filter = '(project_id == "a")&(project_id == "b")';
+    expect(liftProjectPredicate(filter)).toEqual({
+      projectId: undefined,
+      remainder: filter,
+    });
+  });
+
+  test('does not lift across a top-level |', () => {
+    const filter =
+      'project_id == "a" & name ilike "%x%" | scaling_group == "sg"';
+    expect(liftProjectPredicate(filter)).toEqual({
+      projectId: undefined,
+      remainder: filter,
+    });
+  });
+
+  test('leaves a compound segment mentioning project_id untouched', () => {
+    const filter = '(name == "job" & project_id == "a")';
+    expect(liftProjectPredicate(filter)).toEqual({
+      projectId: undefined,
+      remainder: filter,
+    });
+  });
+
+  test('passes through filters without a project predicate', () => {
+    expect(liftProjectPredicate('name ilike "%a%"')).toEqual({
+      projectId: undefined,
+      remainder: 'name ilike "%a%"',
+    });
+    expect(liftProjectPredicate('')).toEqual({
+      projectId: undefined,
+      remainder: undefined,
+    });
+  });
+});

--- a/react/src/helper/adminSessionProjectLift.ts
+++ b/react/src/helper/adminSessionProjectLift.ts
@@ -1,0 +1,79 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ Lifts a project condition out of the admin session filter for the grid's
+ legacy `compute_session_list` query, which has no `project_id` queryfilter
+ field but does take a `group_id` argument (FR-3571).
+ */
+
+/** Splits on top-level `&` only (never inside quotes or parentheses). */
+export const splitTopLevelAnd = (filter: string): string[] => {
+  const segments: string[] = [];
+  let depth = 0;
+  let inQuote = false;
+  let current = '';
+  for (const ch of filter) {
+    if (ch === '"') {
+      inQuote = !inQuote;
+    } else if (!inQuote && ch === '(') {
+      depth += 1;
+    } else if (!inQuote && ch === ')') {
+      depth -= 1;
+    }
+    if (ch === '&' && depth === 0 && !inQuote) {
+      segments.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  segments.push(current);
+  return segments.map((s) => s.trim()).filter(Boolean);
+};
+
+const hasTopLevelOr = (filter: string): boolean => {
+  let depth = 0;
+  let inQuote = false;
+  for (const ch of filter) {
+    if (ch === '"') {
+      inQuote = !inQuote;
+    } else if (!inQuote && ch === '(') {
+      depth += 1;
+    } else if (!inQuote && ch === ')') {
+      depth -= 1;
+    } else if (ch === '|' && depth === 0 && !inQuote) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// A segment that IS a bare project predicate (optionally parenthesized).
+// `ilike` counts as equality: the value always comes from the project
+// select, so it is a full UUID.
+const BARE_PROJECT_PREDICATE =
+  /^\(*\s*project_id\s*(?:==|ilike)\s*"%?([^"%]+)%?"\s*\)*$/;
+
+/**
+ * Lift the filter's project condition to a `group_id` value — but only when
+ * that is provably semantics-preserving: no top-level `|` (removing a
+ * conjunct would change the result set) and exactly one bare project
+ * predicate. Anything else passes through unchanged; a filter the legacy
+ * list rejects then surfaces as the grid's error banner instead of
+ * silently showing the wrong sessions.
+ */
+export const liftProjectPredicate = (
+  filter: string,
+): { projectId: string | undefined; remainder: string | undefined } => {
+  const passthrough = { projectId: undefined, remainder: filter || undefined };
+  if (!filter || hasTopLevelOr(filter)) return passthrough;
+  const segments = splitTopLevelAnd(filter);
+  const bare = segments.filter((seg) => BARE_PROJECT_PREDICATE.test(seg));
+  if (bare.length !== 1) return passthrough;
+  const kept = segments.filter((seg) => !BARE_PROJECT_PREDICATE.test(seg));
+  return {
+    projectId: BARE_PROJECT_PREDICATE.exec(bare[0])?.[1],
+    remainder: kept.join('&') || undefined,
+  };
+};

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -33,9 +33,9 @@ import {
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAIAdminProjectSelectAstryx,
-  BAICard,
   BAIFlex,
   BAIPropertyFilter,
+  BAIResourceUnitGridSkeleton,
   BAISelectionLabel,
   filterOutEmpty,
   filterOutNullAndUndefined,
@@ -112,6 +112,9 @@ const AdminComputeSessionListPage = () => {
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.AdminComputeSessionListPage',
+  );
+  const [experimentalSessionResourceGrid] = useBAISettingUserState(
+    'experimental_session_resource_grid',
   );
 
   const { supportedFields, exportCSV } = useCSVExport('sessions');
@@ -449,30 +452,32 @@ const AdminComputeSessionListPage = () => {
                 />
               </>
             )}
-            <SegmentedControl
-              label={t('session.resourceGrid.ViewMode')}
-              value={queryParams.view}
-              onChange={(value) =>
-                setQueryParams({ view: value as 'table' | 'grid' })
-              }
-            >
-              <Tooltip content={t('session.resourceGrid.TableView')}>
-                <SegmentedControlItem
-                  value="table"
-                  label={t('session.resourceGrid.TableView')}
-                  isLabelHidden
-                  icon={<TableIcon size="1em" />}
-                />
-              </Tooltip>
-              <Tooltip content={t('session.resourceGrid.GridView')}>
-                <SegmentedControlItem
-                  value="grid"
-                  label={t('session.resourceGrid.GridView')}
-                  isLabelHidden
-                  icon={<LayoutGridIcon size="1em" />}
-                />
-              </Tooltip>
-            </SegmentedControl>
+            {experimentalSessionResourceGrid && (
+              <SegmentedControl
+                label={t('session.resourceGrid.ViewMode')}
+                value={queryParams.view}
+                onChange={(value) =>
+                  setQueryParams({ view: value as 'table' | 'grid' })
+                }
+              >
+                <Tooltip content={t('session.resourceGrid.TableView')}>
+                  <SegmentedControlItem
+                    value="table"
+                    label={t('session.resourceGrid.TableView')}
+                    isLabelHidden
+                    icon={<TableIcon size="1em" />}
+                  />
+                </Tooltip>
+                <Tooltip content={t('session.resourceGrid.GridView')}>
+                  <SegmentedControlItem
+                    value="grid"
+                    label={t('session.resourceGrid.GridView')}
+                    isLabelHidden
+                    icon={<LayoutGridIcon size="1em" />}
+                  />
+                </Tooltip>
+              </SegmentedControl>
+            )}
             <AutoUpdateFetchKeyButton
               settingId="admin-session-list"
               defaultAutoUpdateDelay={15_000}
@@ -487,16 +492,14 @@ const AdminComputeSessionListPage = () => {
             />
           </BAIFlex>
         </BAIFlex>
-        {queryParams.view === 'grid' ? (
+        {experimentalSessionResourceGrid && queryParams.view === 'grid' ? (
           // Keyed by the UNdeferred filter/order: a change remounts the
           // boundary so its fallback shows immediately, instead of the
           // refetch being held hidden until the next poll commit. The
           // fetchKey stays deferred so poll refreshes never flash.
           <Suspense
             key={`${gridFilter ?? ''}:${gridProjectId ?? ''}:${queryVariables.order ?? ''}`}
-            fallback={
-              <BAICard style={{ width: '100%' }} loading variant="borderless" />
-            }
+            fallback={<BAIResourceUnitGridSkeleton />}
           >
             <SessionResourceGrid
               filter={gridFilter}

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -17,6 +17,7 @@ import SessionNodes, {
 } from '../components/SessionNodes';
 import SessionResourceGrid from '../components/SessionResourceGrid';
 import { handleRowSelectionChange } from '../helper';
+import { liftProjectPredicate } from '../helper/adminSessionProjectLift';
 import { ExtractResultValue } from '../helper/resultTypes';
 import { useWebUINavigate } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';
@@ -69,32 +70,6 @@ type ComputeSessionNodesData = ExtractResultValue<
 
 type SessionNode = NonNullableNodeOnEdges<ComputeSessionNodesData>;
 
-// Splits a queryfilter string on top-level `&` only (never inside quotes or
-// parentheses), so `(a)&(b | c)` stays two segments.
-const splitTopLevelAnd = (filter: string): string[] => {
-  const segments: string[] = [];
-  let depth = 0;
-  let inQuote = false;
-  let current = '';
-  for (const ch of filter) {
-    if (ch === '"') {
-      inQuote = !inQuote;
-    } else if (!inQuote && ch === '(') {
-      depth += 1;
-    } else if (!inQuote && ch === ')') {
-      depth -= 1;
-    }
-    if (ch === '&' && depth === 0 && !inQuote) {
-      segments.push(current);
-      current = '';
-    } else {
-      current += ch;
-    }
-  }
-  segments.push(current);
-  return segments.map((s) => s.trim()).filter(Boolean);
-};
-
 const AdminComputeSessionListPage = () => {
   'use memo';
 
@@ -143,16 +118,18 @@ const AdminComputeSessionListPage = () => {
     },
   );
 
+  // `view` is page-level state, not per-tab — excluded from the snapshots
+  // and re-applied on tab change so switching tabs cannot flip the mode.
   const queryMapRef = useRef({
     [queryParams.type]: {
-      queryParams,
+      queryParams: _.omit(queryParams, ['view']),
       tablePaginationOption,
     },
   });
 
   useEffect(() => {
     queryMapRef.current[queryParams.type] = {
-      queryParams,
+      queryParams: _.omit(queryParams, ['view']),
       tablePaginationOption,
     };
   }, [queryParams, tablePaginationOption]);
@@ -184,26 +161,14 @@ const AdminComputeSessionListPage = () => {
 
   // The grid's legacy compute_session_list has no `project_id` queryfilter
   // field — lift the filter UI's project condition to the query's group_id
-  // argument. Only a segment that IS a bare project predicate is lifted and
-  // stripped; a compound segment mentioning project_id is passed through
-  // untouched (the grid then surfaces the backend error) rather than
-  // silently narrowing the result set. The UUID comes from the project
-  // select, so an `ilike "%uuid%"` predicate is equality in practice.
-  let gridProjectId: string | undefined;
-  const keptSegments: string[] = [];
-  for (const seg of splitTopLevelAnd(queryParams.filter ?? '')) {
-    const m = /^\(*\s*project_id\s+(?:==|ilike)\s+"%?([^"%]+)%?"\s*\)*$/.exec(
-      seg,
-    );
-    if (m) {
-      gridProjectId ??= m[1];
-    } else {
-      keptSegments.push(seg);
-    }
-  }
+  // argument when that is provably semantics-preserving; anything else
+  // passes through and surfaces as the grid's error banner (see
+  // helper/adminSessionProjectLift.ts).
+  const { projectId: gridProjectId, remainder: gridUserFilter } =
+    liftProjectPredicate(queryParams.filter ?? '');
   const gridFilter = mergeFilterValues([
     statusFilter,
-    keptSegments.join('&') || undefined,
+    gridUserFilter,
     typeFilter,
   ]);
 
@@ -301,6 +266,7 @@ const AdminComputeSessionListPage = () => {
           setQueryParams({
             ...storedQuery.queryParams,
             type: key as TypeFilterType,
+            view: queryParams.view,
           });
           setTablePaginationOption(
             storedQuery.tablePaginationOption || { current: 1 },

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -15,6 +15,7 @@ import TerminateSessionModal from '../components/ComputeSessionNodeItems/Termina
 import SessionNodes, {
   availableSessionSorterValues,
 } from '../components/SessionNodes';
+import SessionResourceGrid from '../components/SessionResourceGrid';
 import { handleRowSelectionChange } from '../helper';
 import { ExtractResultValue } from '../helper/resultTypes';
 import { useWebUINavigate } from '../hooks';
@@ -26,7 +27,13 @@ import { Badge } from '@astryxdesign/core/Badge';
 import { Banner } from '@astryxdesign/core/Banner';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@astryxdesign/core/SegmentedControl';
+import { Tooltip } from '@astryxdesign/core/Tooltip';
+import {
   BAIAdminProjectSelectAstryx,
+  BAICard,
   BAIFlex,
   BAIPropertyFilter,
   BAISelectionLabel,
@@ -39,9 +46,9 @@ import {
   useFetchKey,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { PowerOffIcon } from 'lucide-react';
+import { LayoutGridIcon, PowerOffIcon, TableIcon } from 'lucide-react';
 import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
-import { useDeferredValue, useEffect, useRef, useState } from 'react';
+import { Suspense, useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useLocation } from 'react-router-dom';
@@ -61,6 +68,32 @@ type ComputeSessionNodesData = ExtractResultValue<
 >;
 
 type SessionNode = NonNullableNodeOnEdges<ComputeSessionNodesData>;
+
+// Splits a queryfilter string on top-level `&` only (never inside quotes or
+// parentheses), so `(a)&(b | c)` stays two segments.
+const splitTopLevelAnd = (filter: string): string[] => {
+  const segments: string[] = [];
+  let depth = 0;
+  let inQuote = false;
+  let current = '';
+  for (const ch of filter) {
+    if (ch === '"') {
+      inQuote = !inQuote;
+    } else if (!inQuote && ch === '(') {
+      depth += 1;
+    } else if (!inQuote && ch === ')') {
+      depth -= 1;
+    }
+    if (ch === '&' && depth === 0 && !inQuote) {
+      segments.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  segments.push(current);
+  return segments.map((s) => s.trim()).filter(Boolean);
+};
 
 const AdminComputeSessionListPage = () => {
   'use memo';
@@ -100,6 +133,7 @@ const AdminComputeSessionListPage = () => {
       statusCategory: parseAsStringLiteral(['running', 'finished']).withDefault(
         'running',
       ),
+      view: parseAsStringLiteral(['table', 'grid']).withDefault('table'),
     },
     {
       history: 'replace',
@@ -144,6 +178,31 @@ const AdminComputeSessionListPage = () => {
     filter: mergeFilterValues([statusFilter, queryParams.filter, typeFilter]),
     order: queryParams.order || '-created_at',
   };
+
+  // The grid's legacy compute_session_list has no `project_id` queryfilter
+  // field — lift the filter UI's project condition to the query's group_id
+  // argument. Only a segment that IS a bare project predicate is lifted and
+  // stripped; a compound segment mentioning project_id is passed through
+  // untouched (the grid then surfaces the backend error) rather than
+  // silently narrowing the result set. The UUID comes from the project
+  // select, so an `ilike "%uuid%"` predicate is equality in practice.
+  let gridProjectId: string | undefined;
+  const keptSegments: string[] = [];
+  for (const seg of splitTopLevelAnd(queryParams.filter ?? '')) {
+    const m = /^\(*\s*project_id\s+(?:==|ilike)\s+"%?([^"%]+)%?"\s*\)*$/.exec(
+      seg,
+    );
+    if (m) {
+      gridProjectId ??= m[1];
+    } else {
+      keptSegments.push(seg);
+    }
+  }
+  const gridFilter = mergeFilterValues([
+    statusFilter,
+    keptSegments.join('&') || undefined,
+    typeFilter,
+  ]);
 
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);
@@ -390,6 +449,30 @@ const AdminComputeSessionListPage = () => {
                 />
               </>
             )}
+            <SegmentedControl
+              label={t('session.resourceGrid.ViewMode')}
+              value={queryParams.view}
+              onChange={(value) =>
+                setQueryParams({ view: value as 'table' | 'grid' })
+              }
+            >
+              <Tooltip content={t('session.resourceGrid.TableView')}>
+                <SegmentedControlItem
+                  value="table"
+                  label={t('session.resourceGrid.TableView')}
+                  isLabelHidden
+                  icon={<TableIcon size="1em" />}
+                />
+              </Tooltip>
+              <Tooltip content={t('session.resourceGrid.GridView')}>
+                <SegmentedControlItem
+                  value="grid"
+                  label={t('session.resourceGrid.GridView')}
+                  isLabelHidden
+                  icon={<LayoutGridIcon size="1em" />}
+                />
+              </Tooltip>
+            </SegmentedControl>
             <AutoUpdateFetchKeyButton
               settingId="admin-session-list"
               defaultAutoUpdateDelay={15_000}
@@ -404,7 +487,34 @@ const AdminComputeSessionListPage = () => {
             />
           </BAIFlex>
         </BAIFlex>
-        {computeSessionNodeResult.ok ? (
+        {queryParams.view === 'grid' ? (
+          // Keyed by the UNdeferred filter/order: a change remounts the
+          // boundary so its fallback shows immediately, instead of the
+          // refetch being held hidden until the next poll commit. The
+          // fetchKey stays deferred so poll refreshes never flash.
+          <Suspense
+            key={`${gridFilter ?? ''}:${gridProjectId ?? ''}:${queryVariables.order ?? ''}`}
+            fallback={
+              <BAICard style={{ width: '100%' }} loading variant="borderless" />
+            }
+          >
+            <SessionResourceGrid
+              filter={gridFilter}
+              projectId={gridProjectId}
+              order={queryVariables.order ?? undefined}
+              fetchKey={deferredFetchKey}
+              onClickSession={(sessionId) => {
+                const newSearchParams = new URLSearchParams(location.search);
+                newSearchParams.set('sessionDetail', sessionId);
+                webUINavigate({
+                  pathname: location.pathname,
+                  hash: location.hash,
+                  search: newSearchParams.toString(),
+                });
+              }}
+            />
+          </Suspense>
+        ) : computeSessionNodeResult.ok ? (
           <SessionNodes
             order={queryParams.order}
             onClickSessionName={(session) => {


### PR DESCRIPTION
Resolves #8840 (FR-3571)

## Summary

Mounts the same Table|Grid toggle and `SessionResourceGrid` wrapper on the superadmin session page (`/admin/session`), completing the production effort of map #8786. The grid is unscoped by default, matching the admin table's intentionally omitted scope. Because the grid's legacy `compute_session_list` query has no `project_id` queryfilter field, a project condition set through the filter UI is lifted to the query's `group_id` argument by a tested helper (`helper/adminSessionProjectLift.ts`) that lifts **only when provably semantics-preserving** — no top-level `|`, exactly one bare `project_id` predicate (`==`/`ilike`); anything else passes through and a legacy-rejected filter surfaces as the grid's error banner rather than a silently different result set.

All grid behavior (modes, popover, drawer navigation, URL persistence, cap banner, keyed-undeferred Suspense) is shared with the user page through the same wrapper; no duplicated wiring.

Added during review (driving dev feedback): the admin page mirrors the user page's **experimental gating** (`experimental_session_resource_grid`, opt-in, default off — toggle hidden and table forced when off) and adopts the **grid-shaped `BAIResourceUnitGridSkeleton`** as the Suspense fallback, unwrapped from the card. Verified live in both flag states.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`; react vitest 1443 green.
- Live probes against a real cluster:
  - Unscoped set — multi-core sessions as merged serpentine plates (dashed = not yet allocated).
  - Hover popover on a plate; dark theme parity.
  - **Project filter lift verified live**: selecting a project through the filter UI produced `filter=project_id == "<uuid>"` in the URL, the grid re-rendered scoped (14 → 11 plates) with no backend error — the condition was lifted to `group_id` and stripped from the legacy filter string.

| | |
|---|---|
| ![admin grid](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/pr-8850/07-admin-grid.png) | ![admin popover](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/pr-8850/09-admin-popover.png) |
| ![admin dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/pr-8850/10-admin-dark.png) | ![admin project filter](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/pr-8850/13-admin-project-filter.png) |
