### PR TITLE
fix(FR-3576): size width-less table columns from their content

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.scrollX.test.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.scrollX.test.tsx
@@ -17,16 +17,43 @@ describe('BAITable scroll.x', () => {
     expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe(expected);
   });
 
-  it('stays off when scroll is absent or carries no x', () => {
-    const { container: withoutScroll } = renderScrollTable();
+  it.each([[undefined], [{ y: 500 }]])(
+    'content-fits by default when scroll carries no x (%s)',
+    (scroll) => {
+      const { container } = renderScrollTable(scroll ? { scroll } : {});
+      const layer = dimLayerOf(container);
+      expect(layer).toHaveClass('bai-table-astryx-scroll-x');
+      expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe(
+        'max-content',
+      );
+    },
+  );
+
+  it('stays off when columnFit is equal', () => {
+    const { container: withoutScroll } = renderScrollTable({
+      columnFit: 'equal',
+    });
     expect(dimLayerOf(withoutScroll)).not.toHaveClass(
       'bai-table-astryx-scroll-x',
     );
 
-    const { container: yOnly } = renderScrollTable({ scroll: { y: 500 } });
+    const { container: yOnly } = renderScrollTable({
+      columnFit: 'equal',
+      scroll: { y: 500 },
+    });
     const layer = dimLayerOf(yOnly);
     expect(layer).not.toHaveClass('bai-table-astryx-scroll-x');
     expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe('');
+  });
+
+  it('explicit scroll.x still wins over the columnFit default', () => {
+    const { container } = renderScrollTable({
+      columnFit: 'equal',
+      scroll: { x: 800 },
+    });
+    const layer = dimLayerOf(container);
+    expect(layer).toHaveClass('bai-table-astryx-scroll-x');
+    expect(layer.style.getPropertyValue('--bai-table-scroll-x')).toBe('800px');
   });
 
   it('releases max-width on auto columns only', () => {
@@ -47,8 +74,23 @@ describe('BAITable scroll.x', () => {
   });
 
   it('leaves every cell clipped when x mode is off', () => {
-    const { container } = renderScrollTable();
+    const { container } = renderScrollTable({ columnFit: 'equal' });
     const cells = container.querySelectorAll<HTMLTableCellElement>('tbody td');
     expect([...cells].every((cell) => cell.style.maxWidth === '')).toBe(true);
+  });
+
+  // The `<td>`'s own max-width is ignored by the automatic table layout, so
+  // the cap that stops a long cell from eating the table has to sit on the
+  // content wrapper — and only on the columns the content is sizing.
+  it('caps content-sized columns at the wrapper, not the pixel ones', () => {
+    const { container } = renderScrollTable();
+    const [nameCell, noteCell] =
+      container.querySelectorAll<HTMLTableCellElement>('tbody td');
+
+    // `name` declares width: 120 — pixel-pinned, so no cap and no release.
+    expect((nameCell.firstElementChild as HTMLElement).style.maxWidth).toBe('');
+    expect((noteCell.firstElementChild as HTMLElement).style.maxWidth).toBe(
+      '400px',
+    );
   });
 });

--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -30,9 +30,9 @@
 
  Each is documented where it happens: multi-level headers (`flattenColumns`),
  `expandedRowRender` (`astryxData`), `loading`'s spinner (the dim wrapper),
- column-level `fixed` (`stickyConfig`), `scroll.x`/`.y` (the `scroll` prop).
- Row virtualization is DEFERRED by an explicit product decision (2026-08-07) —
- do not add it without re-opening that decision.
+ column-level `fixed` (`stickyConfig`), `scroll.x`/`.y` (the `scroll` prop),
+ width-less column sizing (`columnFit`). Row virtualization is DEFERRED by an
+ explicit product decision (2026-08-07) — do not add it without re-opening it.
 */
 import { useControllableValue } from '../../hooks';
 import { useBAIi18n } from '../../hooks/useBAIi18n';
@@ -129,6 +129,16 @@ const X_HEADER_RELEASE: React.CSSProperties = {
   maxWidth: 'none',
 };
 const X_BODY_RELEASE: React.CSSProperties = { maxWidth: 'none' };
+/**
+ * Ceiling for a content-sized column, applied to the cell's content wrapper
+ * (a `<td>`'s own `max-width` is ignored by the automatic table layout, a
+ * block child's is not). Without it one free-text column — an error message,
+ * a start command — takes the viewport and starves the rest.
+ *
+ * 400px clears the widest measured id+tag+actions cell in the app (Revision
+ * (ID) on the deployment detail page needs 362px at 1632px table width).
+ */
+const CONTENT_FIT_MAX_COLUMN_WIDTH = 400;
 // Inline beats every @layer, restoring the pinned header's z 3 over the
 // sticky-header rule. Why: BAITable.css.
 const Y_PINNED_HEADER_STACK: React.CSSProperties = { zIndex: 3 };
@@ -320,6 +330,17 @@ export interface BAITableProps<
    */
   scroll?: { x?: number | string | true; y?: number | string };
   /**
+   * How width-LESS columns claim horizontal space.
+   *
+   * `'content'` (default) sizes each one from what it actually renders, so a
+   * cell that packs an id + a tag + action buttons is not handed the same
+   * share as a one-word status. `'equal'` restores the flat 1/N split for a
+   * table that wants uniform columns regardless of content.
+   *
+   * Columns with a numeric `width` are pixel-pinned either way.
+   */
+  columnFit?: 'content' | 'equal';
+  /**
    * Hide the header row. Astryx's `Table` has no such prop (its header carries
    * the sort controls and the select-all checkbox), so this is done in CSS:
    * a wrapper class collapses `thead`. Only use it for list-shaped tables with
@@ -470,6 +491,7 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   textOverflow = 'truncate',
   verticalAlign,
   scroll,
+  columnFit = 'content',
   showHeader = true,
   className,
   style,
@@ -480,9 +502,14 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
   const { token } = theme.useToken();
 
   // rc-table's own mapping of `scroll` onto CSS lengths (`y` has no `true`).
+  // `columnFit: 'content'` is the same machinery antd reached through
+  // `scroll={{ x: 'max-content' }}`, so it defaults `x` rather than opening a
+  // second layout path.
   const scrollXWidth =
     scroll?.x == null
-      ? undefined
+      ? columnFit === 'content'
+        ? 'max-content'
+        : undefined
       : scroll.x === true
         ? 'auto'
         : toCssLength(scroll.x);
@@ -753,6 +780,18 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
             ? width
             : undefined;
 
+      // Under the automatic layout a content-sized column takes its width from
+      // these wrappers, so they carry the column's bounds: `minWidth` keeps an
+      // explicit floor reachable (Astryx drops `proportional`'s own minimum in
+      // this mode) and the cap stops one long cell from eating the table.
+      const contentFitBounds: React.CSSProperties =
+        isScrollX && numericWidth == null
+          ? {
+              minWidth: column.minWidth,
+              maxWidth: CONTENT_FIT_MAX_COLUMN_WIDTH,
+            }
+          : { minWidth: 0 };
+
       // Header text is clipped, not overflowed. Astryx puts a plain-string
       // `header` straight into the `<th>` (which is `overflow: visible`), so a
       // label longer than its column — `Sudo Session Enabled` in a 120px
@@ -763,10 +802,10 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
         <span
           style={{
             display: 'block',
-            minWidth: 0,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
+            ...contentFitBounds,
           }}
         >
           {groupTitle == null ? (
@@ -782,8 +821,9 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
         </span>
       );
 
-      // x mode: a width-less column carries NO width so its content sizes it;
-      // `column.minWidth` is deliberately ignored there (FR-3500).
+      // Content-fit / x mode: a width-less column carries NO width so its
+      // content sizes it. `column.minWidth` cannot ride on `proportional` here
+      // (FR-3500) — `contentFitBounds` above puts it on the wrapper instead.
       const astryxWidth =
         numericWidth != null
           ? pixel(numericWidth)
@@ -847,10 +887,10 @@ const BAITable = <RecordType extends AnyRecord = AnyRecord>({
             <span
               style={{
                 display: 'block',
-                minWidth: 0,
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
+                ...contentFitBounds,
               }}
             >
               {content}


### PR DESCRIPTION
Resolves #8853 (FR-3576)

## The mechanism

A `BAITableAstryx` column that declares neither `width` nor `minWidth` was handed Astryx `proportional(1)` — **a flat 1/N split of the table with only a 120px floor**. Nothing measured what a cell renders, so a column packing `#1 (uuid) [copy] [Current] [apply] [⋮]` got exactly the same share as a one-word status column.

The original report guessed that React-node cells are *measured badly*. They are not measured **at all** — and neither is plain text. Rich cells are simply the ones that need the most room, so they are where the flat split shows.

Measured on the deployment-detail **Replicas** table at a 1632px table width, before the fix:

| Column | allotted | natural content width |
|---|---|---|
| Replica ID | 233 | 347 |
| Lifecycle | 233 | 110 |
| Health Status | 233 | 130 |
| Traffic Status | 233 | 129 |
| Session | 233 | 361 |
| Revision (ID) | 233 | 378 |
| Created At | 233 | 175 |
| **total** | **1631** | **1630** |

The space was already there. It was just handed out equally instead of by need.

A sweep of every `BAITableAstryx` call site found **~55 production tables** in this state, so this is a component-level defect, not a per-page one — per-column pixel widths across 55 files would be neither tractable nor maintainable.

## The fix

`columnFit` now defaults to `'content'`. It reuses the **`scroll.x` machinery that antd reached through `scroll={{ x: 'max-content' }}`** rather than opening a second layout path: the table goes `table-layout: auto` with `min-width: 100%`, and the browser sizes each width-less column from what it actually renders — React nodes included. Columns with a numeric or drag-resized `width` stay pixel-pinned exactly as before.

Two bounds ride on the cell's **content wrapper**, because a `<td>`'s own `max-width` is ignored by the automatic table layout while a block child's is not:

- a **400px cap**, so one free-text column (an error message, a start command) cannot take the viewport and starve the rest;
- `column.minWidth`, which `proportional` can no longer carry in this mode (FR-3500).

`columnFit="equal"` restores the old flat split for any table that wants uniform columns.

## Measured after

Same table, same 1632px width — space moved from the three status columns to the three rich ones, with **no horizontal scrollbar introduced**:

| Column | before | after |
|---|---|---|
| Replica ID | 233 | 252 |
| Lifecycle | 233 | 173 |
| Health Status | 233 | 195 |
| Traffic Status | 233 | 197 |
| Session | 233 | 277 |
| Revision (ID) | 233 | 274 |
| Created At | 233 | 264 |

Revision History tab (the reported table), 4 visible columns: `Revision (ID)` **408 → 741**, so the `Current` tag — previously clipped to `Cu` — is fully readable.

### Regression probes on wide tables

| Page | cols | table width | h-scroll | widest column |
|---|---|---|---|---|
| Sessions | 10 | 1632 = viewport | no | 500 |
| Data (folders) | 7 | 1632 = viewport | no | 610 |
| Admin → Users | 21 | 3198 vs 1632 | **yes** | 352 |

Admin → Users already scrolled horizontally before this change (21 columns pinned to the 120px floor = 2452px), so the scrollbar is not new — the columns are simply readable now instead of all being 120px. The 400px cap held everywhere: no column's intrinsic contribution exceeded it.

**Drag-to-resize still works** under the automatic layout: dragging `Revision (ID)`'s handle 200px left moved the columns `[741, 332, …] → [541, 532, …]`.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built, 0 errors
- `pnpm --filter backend.ai-ui exec vitest run` → **617 passed**, 1 skipped (48 files)
- `pnpm --prefix ./react exec vitest run` → **1405 passed** (88 files)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared `var(--x)` in `BAIText.css:28`. **Pre-existing** — verified identical with these changes stashed on `HEAD`.
- Live probe on the dev server, **light and dark** (`document.documentElement.dataset.theme === 'dark'` asserted), zero new `pageerror`.

`BAITableAstryx.scrollX.test.tsx` gained coverage for the new default, for `columnFit="equal"`, for explicit `scroll.x` still winning, and for the cap landing on the wrapper of content-sized columns only.

## Screenshots

**Before** — as reported. `Revision (ID)` clips the uuid *and* the `Current` tag (to `Cu`), and the action buttons are squeezed; `Runtime` and `Cluster Mode` sit half empty:

![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8854/20260818-024106-before-report.png)

**After** — Revision History, light. The `Current` tag and both action buttons are fully readable:

![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8854/20260818-024106-after-revision-history.png)

**After** — same table, dark:

![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8854/20260818-024106-after-revision-history-dark.png)

**After** — Replicas card. `#1 (0cc64c83-b… [copy] )` now reads complete instead of `#1 (…`:

![after replicas](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8854/20260818-024106-after-replicas.png)

## Residue

- **`BAIId`'s own `maxWidth: 100`** still truncates the uuid inside the cell (`0cc64c83-b…`). That is deliberate and unchanged — this PR makes the surrounding tag/actions visible, not the full uuid.
- **No call sites were touched.** The three existing `minWidth` declarations keep working (they now ride on the wrapper). The `minWidth: 320` override in `AdminUserManagement.tsx` is now redundant rather than wrong — left in place to keep this diff to the mechanism.
- The 400px cap is a single measured constant, not a per-column knob. A column that genuinely needs more should declare a numeric `width`.
