### PR TITLE
feat(FR-1964): serve the domain appearance document from app config and unify the theme bootstrap

### DIFF
--- a/react/src/helper/customThemeConfig.test.ts
+++ b/react/src/helper/customThemeConfig.test.ts
@@ -1,15 +1,15 @@
 import type { BAIAppearanceConfig } from './customThemeConfig';
 import type { Mock } from 'vitest';
 
-// The loader resolves the pre-login domain and REST base through these two
-// helpers; both are controlled per test via the hoisted state below.
+// The loader resolves the domain and REST base through these two helpers;
+// both are controlled per test via the hoisted state below.
 const resolverState = vi.hoisted(() => ({
   apiDomainName: undefined as string | undefined,
   apiEndpoint: '' as string,
 }));
 
 vi.mock('../hooks/useWebUIConfig', () => ({
-  fetchAndParseConfig: vi.fn(async () => ({
+  fetchAppConfigOnce: vi.fn(async () => ({
     config: { general: { apiDomainName: resolverState.apiDomainName } },
   })),
 }));
@@ -62,8 +62,6 @@ describe('customThemeConfig (v2 appearance bootstrap)', () => {
     global.fetch = fetchMock as unknown as typeof global.fetch;
     resolverState.apiDomainName = undefined;
     resolverState.apiEndpoint = '';
-    // @ts-ignore
-    delete globalThis.backendaiclient;
     document.head
       .querySelectorAll('link[rel="stylesheet"]')
       .forEach((el) => el.remove());
@@ -233,34 +231,6 @@ describe('customThemeConfig (v2 appearance bootstrap)', () => {
 
       expect(mod.getCustomTheme()).toEqual(V2_THEME);
       expect(consoleErrorSpy).toHaveBeenCalled();
-    });
-
-    it('prefers the connected session domain and endpoint over config.toml', async () => {
-      resolverState.apiDomainName = 'from-toml';
-      globalThis.backendaiclient = {
-        _config: {
-          domainName: 'session-domain',
-          endpoint: 'https://session.example.com/',
-        },
-      } as never;
-      const mod = await importFreshModule();
-      mockFetchRoutes({
-        staticDoc: V2_THEME,
-        publicConfigByDomain: {
-          'session-domain': { appearance: V2_DOMAIN_THEME },
-        },
-      });
-
-      mod.loadCustomThemeConfig();
-      await flush();
-
-      expect(mod.getCustomTheme()).toEqual(V2_DOMAIN_THEME);
-      const restCall = fetchMock.mock.calls.find(([url]) =>
-        String(url).includes('app-config'),
-      );
-      expect(String(restCall?.[0])).toBe(
-        'https://session.example.com/func/v2/app-config/public/get',
-      );
     });
   });
 

--- a/react/src/helper/customThemeConfig.test.ts
+++ b/react/src/helper/customThemeConfig.test.ts
@@ -1,6 +1,22 @@
 import type { BAIAppearanceConfig } from './customThemeConfig';
 import type { Mock } from 'vitest';
 
+// The loader resolves the pre-login domain and REST base through these two
+// helpers; both are controlled per test via the hoisted state below.
+const resolverState = vi.hoisted(() => ({
+  apiDomainName: undefined as string | undefined,
+  apiEndpoint: '' as string,
+}));
+
+vi.mock('../hooks/useWebUIConfig', () => ({
+  fetchAndParseConfig: vi.fn(async () => ({
+    config: { general: { apiDomainName: resolverState.apiDomainName } },
+  })),
+}));
+vi.mock('../hooks/useResolvedApiEndpoint', () => ({
+  resolveApiEndpoint: vi.fn(async () => resolverState.apiEndpoint),
+}));
+
 const V2_THEME: BAIAppearanceConfig = {
   schemaVersion: 2,
   theme: {
@@ -16,6 +32,16 @@ const V2_THEME: BAIAppearanceConfig = {
     logo: { src: '/logo.png', srcCollapsed: '/logo-small.png' },
     companyName: 'Lablup Inc.',
   },
+};
+
+const V2_DOMAIN_THEME: BAIAppearanceConfig = {
+  schemaVersion: 2,
+  theme: {
+    families: {
+      default: { seeds: { accent: '#123456' } },
+    },
+  },
+  branding: { brandName: 'Acme AI' },
 };
 
 const V1_THEME = {
@@ -34,6 +60,10 @@ describe('customThemeConfig (v2 appearance bootstrap)', () => {
     originalFetch = global.fetch;
     fetchMock = vi.fn();
     global.fetch = fetchMock as unknown as typeof global.fetch;
+    resolverState.apiDomainName = undefined;
+    resolverState.apiEndpoint = '';
+    // @ts-ignore
+    delete globalThis.backendaiclient;
     document.head
       .querySelectorAll('link[rel="stylesheet"]')
       .forEach((el) => el.remove());
@@ -47,12 +77,37 @@ describe('customThemeConfig (v2 appearance bootstrap)', () => {
 
   const importFreshModule = async () => await import('./customThemeConfig');
 
-  const mockStaticDoc = (staticDoc: unknown) => {
+  // Route the fetch mock by URL: theme.json and the anonymous app-config
+  // REST endpoint.
+  const mockFetchRoutes = ({
+    staticDoc,
+    publicConfigByDomain,
+    restStatus = 200,
+  }: {
+    staticDoc?: unknown;
+    publicConfigByDomain?: unknown;
+    restStatus?: number;
+  }) => {
     fetchMock.mockImplementation((url: string) => {
       if (url === 'resources/theme.json') {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve(staticDoc),
+        } as unknown as Response);
+      }
+      if (String(url).endsWith('/func/v2/app-config/public/get')) {
+        return Promise.resolve({
+          ok: restStatus === 200,
+          status: restStatus,
+          json: () =>
+            Promise.resolve({
+              app_configs: [
+                {
+                  config_name: 'publicConfigByDomain',
+                  config: publicConfigByDomain,
+                },
+              ],
+            }),
         } as unknown as Response);
       }
       return Promise.reject(new Error(`Unexpected fetch: ${url}`));
@@ -69,13 +124,14 @@ describe('customThemeConfig (v2 appearance bootstrap)', () => {
   it('loads a v2 theme.json and dispatches custom-theme-loaded once', async () => {
     const mod = await importFreshModule();
     const dispatchEventSpy = vi.spyOn(document, 'dispatchEvent');
-    mockStaticDoc(V2_THEME);
+    mockFetchRoutes({ staticDoc: V2_THEME });
 
     mod.loadCustomThemeConfig();
     await flush();
 
     expect(mod.getCustomTheme()).toEqual(V2_THEME);
     expect(mod.getStaticAppearanceConfig()).toEqual(V2_THEME);
+    expect(mod.getDomainAppearanceConfig()).toBeUndefined();
     expect(
       dispatchEventSpy.mock.calls.filter(
         ([e]) => (e as CustomEvent).type === 'custom-theme-loaded',
@@ -88,7 +144,7 @@ describe('customThemeConfig (v2 appearance bootstrap)', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-    mockStaticDoc(V1_THEME);
+    mockFetchRoutes({ staticDoc: V1_THEME });
 
     mod.loadCustomThemeConfig();
     await flush();
@@ -101,7 +157,7 @@ describe('customThemeConfig (v2 appearance bootstrap)', () => {
 
   it('injects font CSS from theme.fontFamily', async () => {
     const mod = await importFreshModule();
-    mockStaticDoc(V2_THEME);
+    mockFetchRoutes({ staticDoc: V2_THEME });
 
     mod.loadCustomThemeConfig();
     await flush();
@@ -110,6 +166,102 @@ describe('customThemeConfig (v2 appearance bootstrap)', () => {
       'link[href="resources/fonts/ubuntu/ubuntu.css"]',
     );
     expect(link).not.toBeNull();
+  });
+
+  describe('domain document resolution', () => {
+    it('the saved domain appearance slice wins wholesale over theme.json', async () => {
+      resolverState.apiDomainName = 'default';
+      resolverState.apiEndpoint = 'https://api.example.com';
+      const mod = await importFreshModule();
+      mockFetchRoutes({
+        staticDoc: V2_THEME,
+        publicConfigByDomain: {
+          default: { appearance: V2_DOMAIN_THEME },
+        },
+      });
+
+      mod.loadCustomThemeConfig();
+      await flush();
+
+      expect(mod.getCustomTheme()).toEqual(V2_DOMAIN_THEME);
+      expect(mod.getDomainAppearanceConfig()).toEqual(V2_DOMAIN_THEME);
+      expect(mod.getStaticAppearanceConfig()).toEqual(V2_THEME);
+    });
+
+    it('skips the REST fetch entirely when no domain is known', async () => {
+      const mod = await importFreshModule();
+      mockFetchRoutes({ staticDoc: V2_THEME });
+
+      mod.loadCustomThemeConfig();
+      await flush();
+
+      expect(mod.getCustomTheme()).toEqual(V2_THEME);
+      expect(
+        fetchMock.mock.calls.filter(([url]) =>
+          String(url).includes('app-config'),
+        ),
+      ).toHaveLength(0);
+    });
+
+    it('falls back to theme.json when the REST fetch fails', async () => {
+      resolverState.apiDomainName = 'default';
+      resolverState.apiEndpoint = 'https://api.example.com';
+      const mod = await importFreshModule();
+      mockFetchRoutes({ staticDoc: V2_THEME, restStatus: 500 });
+
+      mod.loadCustomThemeConfig();
+      await flush();
+
+      expect(mod.getCustomTheme()).toEqual(V2_THEME);
+      expect(mod.getDomainAppearanceConfig()).toBeUndefined();
+    });
+
+    it('ignores an invalid (v1-shaped) domain slice and keeps theme.json', async () => {
+      resolverState.apiDomainName = 'default';
+      resolverState.apiEndpoint = 'https://api.example.com';
+      const mod = await importFreshModule();
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      mockFetchRoutes({
+        staticDoc: V2_THEME,
+        publicConfigByDomain: { default: { appearance: V1_THEME } },
+      });
+
+      mod.loadCustomThemeConfig();
+      await flush();
+
+      expect(mod.getCustomTheme()).toEqual(V2_THEME);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('prefers the connected session domain and endpoint over config.toml', async () => {
+      resolverState.apiDomainName = 'from-toml';
+      globalThis.backendaiclient = {
+        _config: {
+          domainName: 'session-domain',
+          endpoint: 'https://session.example.com/',
+        },
+      } as never;
+      const mod = await importFreshModule();
+      mockFetchRoutes({
+        staticDoc: V2_THEME,
+        publicConfigByDomain: {
+          'session-domain': { appearance: V2_DOMAIN_THEME },
+        },
+      });
+
+      mod.loadCustomThemeConfig();
+      await flush();
+
+      expect(mod.getCustomTheme()).toEqual(V2_DOMAIN_THEME);
+      const restCall = fetchMock.mock.calls.find(([url]) =>
+        String(url).includes('app-config'),
+      );
+      expect(String(restCall?.[0])).toBe(
+        'https://session.example.com/func/v2/app-config/public/get',
+      );
+    });
   });
 
   describe('pickSeed', () => {

--- a/react/src/helper/customThemeConfig.ts
+++ b/react/src/helper/customThemeConfig.ts
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { resolveApiEndpoint } from '../hooks/useResolvedApiEndpoint';
-import { fetchAndParseConfig } from '../hooks/useWebUIConfig';
+import { fetchAppConfigOnce } from '../hooks/useWebUIConfig';
 import * as _ from 'lodash-es';
 
 /**
@@ -242,20 +242,13 @@ function injectFontCSS(fontFamilies: string[]) {
   }
 }
 
-const sessionDomainName = (): string | undefined =>
-  // @ts-ignore
-  globalThis.backendaiclient?._config?.domainName;
-
-// Pre-login fallback: `general.apiDomainName` from config.toml.
-// Webserver-hosted deployments are 1:1 with a domain and expose it there
-// (BA-7405/BA-7406); Electron / direct API mode has no single domain, so
-// this stays undefined and the theme keeps theme.json.
+// `general.apiDomainName` from config.toml: webserver-hosted deployments are
+// 1:1 with a domain and expose it there (BA-7405/BA-7406). Electron / direct
+// API mode has no single domain, so this stays undefined and the theme keeps
+// theme.json.
 const resolveConfigDomainName = async (): Promise<string | undefined> => {
   try {
-    const configPath = (globalThis as Record<string, unknown>).isElectron
-      ? 'es6://config.toml'
-      : '../../config.toml';
-    const { config } = await fetchAndParseConfig(configPath);
+    const { config } = await fetchAppConfigOnce();
     const raw = config?.general?.apiDomainName;
     return typeof raw === 'string' && raw.trim() ? raw.trim() : undefined;
   } catch {
@@ -263,27 +256,24 @@ const resolveConfigDomainName = async (): Promise<string | undefined> => {
   }
 };
 
+// config.toml `apiEndpoint`, else the stored login endpoint.
 const resolveRestBase = async (): Promise<string> => {
-  // Post-login the connected client's endpoint wins; pre-login fall back to
-  // config.toml / the stored login endpoint.
-  const endpoint: string =
-    // @ts-ignore
-    globalThis.backendaiclient?._config?.endpoint ??
-    (await resolveApiEndpoint());
+  const endpoint = await resolveApiEndpoint();
   return endpoint.replace(/^"+|"+$/g, '').replace(/\/+$/, '');
 };
 
 /**
  * `publicConfigByDomain` read path (FR-1964). REST (`POST
- * /func/v2/app-config/public/get`, served anonymously) instead of
- * GraphQL/Relay so the document is fetchable BEFORE login and outside
- * `RelayEnvironmentProvider`. A session that cannot fetch here (no endpoint
- * known yet, or a transient failure) keeps theme.json until the next reload —
- * accepted per FR-1964; there is no retry and no connect listener.
+ * /func/v2/app-config/public/get`, served anonymously) rather than
+ * GraphQL/Relay: this runs once at bootstrap, before login and outside
+ * `RelayEnvironmentProvider`, so the domain and endpoint come from config.toml
+ * (or the stored login endpoint), never from a connected client. A session
+ * that cannot fetch here keeps theme.json until the next reload — accepted per
+ * FR-1964; there is no retry and no connect listener.
  */
 const fetchDomainDoc = async (): Promise<BAIAppearanceConfig | undefined> => {
   try {
-    const domainName = sessionDomainName() ?? (await resolveConfigDomainName());
+    const domainName = await resolveConfigDomainName();
     if (!domainName) {
       return undefined;
     }
@@ -314,7 +304,9 @@ const fetchDomainDoc = async (): Promise<BAIAppearanceConfig | undefined> => {
           `publicConfigByDomain[${domainName}].appearance`,
         );
   } catch (error) {
-    warn(`the domain appearance document could not be fetched (${String(error)}).`);
+    warn(
+      `the domain appearance document could not be fetched (${String(error)}).`,
+    );
     return undefined;
   }
 };

--- a/react/src/helper/customThemeConfig.ts
+++ b/react/src/helper/customThemeConfig.ts
@@ -2,15 +2,18 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { resolveApiEndpoint } from '../hooks/useResolvedApiEndpoint';
+import { fetchAndParseConfig } from '../hooks/useWebUIConfig';
 import * as _ from 'lodash-es';
 
 /**
  * The v2 appearance document (FR-3605): `theme` carries what feeds the Astryx
  * pipeline, `branding` the structural metadata no token can express. The same
- * shape is shipped as `resources/theme.json`. Seed values follow Astryx
- * `TokenValue` semantics: a string applies to both schemes, a `[light, dark]`
- * tuple splits them. v1 (antd-shaped) documents are NOT readable — see the
- * migration guide in the FR-3605 release notes.
+ * shape is shipped as `resources/theme.json` and stored wholesale as a
+ * domain's `appearance` slice of `publicConfigByDomain` (FR-1964). Seed values
+ * follow Astryx `TokenValue` semantics: a string applies to both schemes, a
+ * `[light, dark]` tuple splits them. v1 (antd-shaped) documents are NOT
+ * readable — see the migration guide in the FR-3605 release notes.
  */
 export type BAIThemeSeedValue = string | [light: string, dark: string];
 
@@ -92,6 +95,9 @@ export type BAIAppearanceConfig = {
   branding?: BAIBrandingConfig;
 };
 
+/** Per-domain subKey of `publicConfigByDomain` holding the v2 document. */
+export const DOMAIN_APPEARANCE_CONFIG_KEY = 'appearance';
+
 /**
  * Resolve a seed value for one scheme (string = both schemes). A tuple with
  * a missing/non-string dark entry reuses the light one, matching the theme
@@ -159,13 +165,18 @@ export const pickValidAppearanceConfig = (
 type AppearanceStore = {
   /** The shipped/operator `resources/theme.json` (v2), untouched. */
   staticDoc?: BAIAppearanceConfig;
-  /** `staticDoc` with the dev-server header color applied — what the providers render. */
+  /** The current domain's saved `appearance` slice, if any. */
+  domainDoc?: BAIAppearanceConfig;
+  /**
+   * The domain slice wholesale, else theme.json — with the dev-server header
+   * color applied. What the providers render.
+   */
   appliedDoc?: BAIAppearanceConfig;
 };
 
 const store: AppearanceStore = {};
 
-/** The applied document. */
+/** The applied document: the domain slice wholesale, else theme.json. */
 export const getCustomTheme = (): BAIAppearanceConfig | undefined =>
   store.appliedDoc;
 
@@ -182,6 +193,10 @@ export const subscribeCustomTheme = (onChange: () => void) => {
 /** The pristine shipped document (Branding editor seed/reset source). */
 export const getStaticAppearanceConfig = (): BAIAppearanceConfig | undefined =>
   store.staticDoc;
+
+/** The saved domain document (Branding editor prefill source). */
+export const getDomainAppearanceConfig = (): BAIAppearanceConfig | undefined =>
+  store.domainDoc;
 
 const GENERIC_FAMILIES = new Set([
   'serif',
@@ -227,6 +242,83 @@ function injectFontCSS(fontFamilies: string[]) {
   }
 }
 
+const sessionDomainName = (): string | undefined =>
+  // @ts-ignore
+  globalThis.backendaiclient?._config?.domainName;
+
+// Pre-login fallback: `general.apiDomainName` from config.toml.
+// Webserver-hosted deployments are 1:1 with a domain and expose it there
+// (BA-7405/BA-7406); Electron / direct API mode has no single domain, so
+// this stays undefined and the theme keeps theme.json.
+const resolveConfigDomainName = async (): Promise<string | undefined> => {
+  try {
+    const configPath = (globalThis as Record<string, unknown>).isElectron
+      ? 'es6://config.toml'
+      : '../../config.toml';
+    const { config } = await fetchAndParseConfig(configPath);
+    const raw = config?.general?.apiDomainName;
+    return typeof raw === 'string' && raw.trim() ? raw.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const resolveRestBase = async (): Promise<string> => {
+  // Post-login the connected client's endpoint wins; pre-login fall back to
+  // config.toml / the stored login endpoint.
+  const endpoint: string =
+    // @ts-ignore
+    globalThis.backendaiclient?._config?.endpoint ??
+    (await resolveApiEndpoint());
+  return endpoint.replace(/^"+|"+$/g, '').replace(/\/+$/, '');
+};
+
+/**
+ * `publicConfigByDomain` read path (FR-1964). REST (`POST
+ * /func/v2/app-config/public/get`, served anonymously) instead of
+ * GraphQL/Relay so the document is fetchable BEFORE login and outside
+ * `RelayEnvironmentProvider`. A session that cannot fetch here (no endpoint
+ * known yet, or a transient failure) keeps theme.json until the next reload —
+ * accepted per FR-1964; there is no retry and no connect listener.
+ */
+const fetchDomainDoc = async (): Promise<BAIAppearanceConfig | undefined> => {
+  try {
+    const domainName = sessionDomainName() ?? (await resolveConfigDomainName());
+    if (!domainName) {
+      return undefined;
+    }
+    const base = await resolveRestBase();
+    if (!base) {
+      return undefined;
+    }
+    const response = await fetch(`${base}/func/v2/app-config/public/get`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ config_names: ['publicConfigByDomain'] }),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load the public app config: ${response.status}`,
+      );
+    }
+    const payload = await response.json();
+    const doc = payload?.app_configs?.find(
+      (c: { config_name: string }) => c.config_name === 'publicConfigByDomain',
+    )?.config;
+    const slice = _.get(doc, [domainName, DOMAIN_APPEARANCE_CONFIG_KEY]);
+    // No saved slice is the normal case; only a present-but-invalid one warns.
+    return _.isNil(slice)
+      ? undefined
+      : pickValidAppearanceConfig(
+          slice,
+          `publicConfigByDomain[${domainName}].appearance`,
+        );
+  } catch (error) {
+    warn(`the domain appearance document could not be fetched (${String(error)}).`);
+    return undefined;
+  }
+};
+
 const fetchStaticDoc = async (): Promise<BAIAppearanceConfig | undefined> => {
   let response: Response;
   try {
@@ -267,15 +359,19 @@ const applyDevServerHeaderColorOverride = (
 };
 
 /**
- * One-shot appearance bootstrap: theme.json is fetched and a single
- * `custom-theme-loaded` event fires once it has settled — including when
- * the document is unusable, so listeners never wait forever.
+ * One-shot appearance bootstrap: theme.json and the domain's saved document
+ * are fetched in parallel, the domain slice wins wholesale, and a single
+ * `custom-theme-loaded` event fires once both have settled — including when
+ * neither document is usable, so listeners never wait forever.
  */
 export const loadCustomThemeConfig = () => {
-  fetchStaticDoc()
-    .then((staticDoc) => {
+  Promise.all([fetchStaticDoc(), fetchDomainDoc()])
+    .then(([staticDoc, domainDoc]) => {
       store.staticDoc = staticDoc;
-      store.appliedDoc = applyDevServerHeaderColorOverride(staticDoc);
+      store.domainDoc = domainDoc;
+      store.appliedDoc = applyDevServerHeaderColorOverride(
+        domainDoc ?? staticDoc,
+      );
 
       const fontFamily = store.appliedDoc?.theme?.fontFamily;
       if (_.isString(fontFamily) && fontFamily) {

--- a/react/src/helper/customThemeConfig.ts
+++ b/react/src/helper/customThemeConfig.ts
@@ -304,7 +304,7 @@ const fetchDomainDoc = async (): Promise<BAIAppearanceConfig | undefined> => {
           `publicConfigByDomain[${domainName}].appearance`,
         );
   } catch (error) {
-    warn(
+    logAppearanceError(
       `the domain appearance document could not be fetched (${String(error)}).`,
     );
     return undefined;

--- a/react/src/hooks/useResolvedApiEndpoint.ts
+++ b/react/src/hooks/useResolvedApiEndpoint.ts
@@ -2,7 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { fetchAndParseConfig } from './useWebUIConfig';
+import { fetchAppConfigOnce } from './useWebUIConfig';
 
 /**
  * Resolve the Backend.AI API endpoint from `config.toml` and fallbacks.
@@ -37,11 +37,7 @@ const readEndpointFromLocalStorage = (): string => {
 };
 
 export const resolveApiEndpoint = async (): Promise<string> => {
-  const configPath = (globalThis as Record<string, unknown>).isElectron
-    ? 'es6://config.toml'
-    : '../../config.toml';
-
-  const { config } = await fetchAndParseConfig(configPath);
+  const { config } = await fetchAppConfigOnce();
   const rawEndpoint = config?.general?.apiEndpoint;
   const fromToml = typeof rawEndpoint === 'string' ? rawEndpoint.trim() : '';
 

--- a/react/src/hooks/useResolvedApiEndpoint.ts
+++ b/react/src/hooks/useResolvedApiEndpoint.ts
@@ -36,7 +36,7 @@ const readEndpointFromLocalStorage = (): string => {
   return stored.replace(/^"+|"+$/g, '').trim();
 };
 
-const resolveEndpoint = async (): Promise<string> => {
+export const resolveApiEndpoint = async (): Promise<string> => {
   const configPath = (globalThis as Record<string, unknown>).isElectron
     ? 'es6://config.toml'
     : '../../config.toml';
@@ -62,7 +62,7 @@ export const useResolvedApiEndpoint = (): string => {
     return cachedEndpoint;
   }
   if (!inflightPromise) {
-    inflightPromise = resolveEndpoint().then(
+    inflightPromise = resolveApiEndpoint().then(
       (endpoint) => {
         if (endpoint) {
           cachedEndpoint = endpoint;

--- a/react/src/hooks/useWebUIConfig.test.ts
+++ b/react/src/hooks/useWebUIConfig.test.ts
@@ -7,6 +7,7 @@
  *
  * Tests cover:
  * - fetchAndParseConfig: TOML fetching and parsing
+ * - fetchAppConfigOnce: one shared config.toml fetch per page load
  * - preprocessToml: escape sequence handling in apiEndpointText
  * - processConfig (via fetchAndParseConfig): config value extraction
  * - Atom initial values
@@ -381,5 +382,46 @@ describe('getDefaultLoginConfig fallback values', () => {
     const b = getDefaultLoginConfig();
     a.api_endpoint = 'https://modified.example.com';
     expect(b.api_endpoint).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchAppConfigOnce
+// ---------------------------------------------------------------------------
+
+describe('fetchAppConfigOnce', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches config.toml once and shares the result between callers', async () => {
+    mockFetch(200, '[general]\napiEndpoint = "https://api.example.com"');
+    const mod = await import('./useWebUIConfig');
+
+    const [first, second] = await Promise.all([
+      mod.fetchAppConfigOnce(),
+      mod.fetchAppConfigOnce(),
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(first.config?.general?.apiEndpoint).toBe('https://api.example.com');
+  });
+
+  it('does not cache a missing config.toml, so a later caller retries', async () => {
+    mockFetch(404, '');
+    const mod = await import('./useWebUIConfig');
+
+    expect((await mod.fetchAppConfigOnce()).config).toBeNull();
+
+    mockFetch(200, '[general]\napiEndpoint = "https://api.example.com"');
+    const retried = await mod.fetchAppConfigOnce();
+    expect(retried.config?.general?.apiEndpoint).toBe(
+      'https://api.example.com',
+    );
   });
 });

--- a/react/src/hooks/useWebUIConfig.ts
+++ b/react/src/hooks/useWebUIConfig.ts
@@ -135,7 +135,7 @@ function preprocessToml(config: RawTomlConfig): void {
  * - Fetch failure (network error, non-200, SPA fallback): `{ config: null }` — no error.
  * - Parse failure (invalid TOML after fetch succeeds): `{ config: null, error }`.
  */
-interface ConfigFetchResult {
+export interface ConfigFetchResult {
   config: RawTomlConfig | null;
   error?: unknown;
 }
@@ -176,6 +176,37 @@ export async function fetchAndParseConfig(
     // Parse error — config was fetched but TOML is invalid.
     return { config: null, error };
   }
+}
+
+/** The app's own config.toml: `es6://` resolves from app/ inside Electron. */
+export const getAppConfigPath = (): string =>
+  (globalThis as Record<string, unknown>).isElectron
+    ? 'es6://config.toml'
+    : '../../config.toml';
+
+let appConfigPromise: Promise<ConfigFetchResult> | null = null;
+
+/**
+ * Fetch the app's config.toml once per page load and share the result with
+ * every caller (config init, endpoint resolution, appearance bootstrap). A
+ * missing or unparsable file is not cached, so a later caller can retry.
+ */
+export function fetchAppConfigOnce(): Promise<ConfigFetchResult> {
+  if (!appConfigPromise) {
+    appConfigPromise = fetchAndParseConfig(getAppConfigPath()).then(
+      (result) => {
+        if (!result.config) {
+          appConfigPromise = null;
+        }
+        return result;
+      },
+      (error) => {
+        appConfigPromise = null;
+        throw error;
+      },
+    );
+  }
+  return appConfigPromise;
 }
 
 /**
@@ -269,13 +300,7 @@ export function initializeConfigOnce(
 ): Promise<void> {
   if (!configInitPromise) {
     configInitPromise = (async () => {
-      // Electron uses es6:// protocol which resolves from app/ directory
-      // Web uses relative path from the HTML location
-      const configPath = (globalThis as Record<string, unknown>).isElectron
-        ? 'es6://config.toml'
-        : '../../config.toml';
-
-      const result = await fetchAndParseConfig(configPath);
+      const result = await fetchAppConfigOnce();
 
       if (!result.config) {
         // config.toml is missing or failed to parse — apply defaults so the

--- a/relay-base.config.js
+++ b/relay-base.config.js
@@ -30,5 +30,6 @@ module.exports = {
     DateTime: "string",
     UUID: "string",
     JSONString: "string",
+    JSON: "any",
   },
 };


### PR DESCRIPTION
Resolves #5127 (FR-1964)

## Summary

Middle PR of the app-config stack (**re-scoped 2026-09-01** — the v2 document conversion moved down to #9361, the write paths moved up to #9362): serve the domain's v2 appearance document from app config and unify the theme bootstrap.

### GraphQL schema sync

- Copied the backend's checked-in supergraph into `data/schema.graphql` (same procedure as FR-3377), picking up the 26.9.0 app config APIs: `myAppConfigs`, `publicAppConfigs`, `myAppConfigFragmentsByNames`, `scopedAppConfigFragmentsByNames`, `myUpsertAppConfigFragments`, `scopedUpsertAppConfigFragments`, and `DomainV2.entityId`.
- Regenerated Relay artifacts; no existing query broke.
- Mapped the `JSON` scalar in `relay-base.config.js`.

### Storage

- The domain document is stored **wholesale** under the domain slice's `appearance` subKey of `publicConfigByDomain` (anonymous-readable, superadmin-writable). Reads replace wholesale rather than merging: "absent" means "follow the shipped defaults".

### Bootstrap unification

- `loadCustomThemeConfig()` (index.tsx, one shot) now fetches `theme.json` **and** the anonymous domain document (`POST /func/v2/app-config/public/get` — REST, not GraphQL, so it works before login and outside `RelayEnvironmentProvider`) in parallel, resolves *domain slice wins wholesale, else theme.json*, and dispatches a single `custom-theme-loaded` once both settle.
- The domain comes from config.toml `general.apiDomainName` (BA-7405/BA-7406) and the REST base from `resolveApiEndpoint()` (config.toml `apiEndpoint`, else the stored login endpoint). The bootstrap runs once before login, so nothing is read from the connected client.
- config.toml is fetched once per page load (`fetchAppConfigOnce()` in `useWebUIConfig.ts`) and shared by config init, endpoint resolution, and this bootstrap; a missing or unparsable file is not cached so a later caller can retry.
- No refresh state machine: a session that could not fetch (fresh Electron install with no endpoint, transient failure) keeps `theme.json` until the next reload — accepted per design review. There is no retry and no connect listener.

Nothing in the UI writes the domain document yet — that arrives with Branding **Apply** at the top of the stack (#9362); until then operators can seed it via the API.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm exec vitest run` (react) → **122 files / 1953 tests passed**, including the domain-resolution suite (domain-wins, REST-failure fallback, v1-shaped domain slice rejection, config.toml domain resolution).

## Stack

#9361 (v2 document) → this PR (serve from app config + bootstrap) → #9362 (userConfig family + Branding Apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
