### PR TITLE
e2e(FR-3558): cover the global search palette

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 340 / 497 features covered (68%)**
+**Overall (in-scope routes): 348 / 505 features covered (69%)**
 
 | Page                     | Route                                            | Features | Covered | Status  |
 | ------------------------ | ------------------------------------------------ | :------: | :-----: | :-----: |
@@ -53,8 +53,8 @@
 | Admin Deployment Preset  | `/admin/deployments/deployment-presets/new`      |    4     |    4    | ✅ 100% |
 | Runtime Parameters       | `/admin/deployments?tab=runtime-variant-presets` |    5     |    5    | ✅ 100% |
 | Project-Agnostic Scope   | `/admin/*` (except `admin-dashboard`)            |    5     |    5    | ✅ 100% |
-| Global Search Palette    | (header, every route)                            |    7     |    7    | ✅ 100% |
-| **Total**                |                                                  | **504**  | **347** | **69%** |
+| Global Search Palette    | (header, every route)                            |    8     |    8    | ✅ 100% |
+| **Total**                |                                                  | **505**  | **348** | **69%** |
 
 ---
 
@@ -1284,20 +1284,20 @@ is deliberately out of scope — operate above project scope — the header proj
 
 ### 33. Global Search Palette (header, every route)
 
-**Test files:** [`e2e/global-search-palette.spec.ts`](global-search-palette.spec.ts)
+**Test files:** [`e2e/global-search/global-search-palette.spec.ts`](global-search/global-search-palette.spec.ts)
 
-| Feature                                        | Status | Test                                                                    |
-| ---------------------------------------------- | ------ | ----------------------------------------------------------------------- |
-| Open from the header button                    | ✅     | `user can open the palette from the header button and close it with Escape` |
-| Open with `mod+k`                              | ✅     | `user can open the palette with the keyboard shortcut`                  |
-| Escape closes                                  | ✅     | `user can open the palette from the header button and close it with Escape` |
-| Page hit → route                               | ✅     | `user can arrow-select a page hit and land on that page`                |
-| Tab hit → `?tab=`                              | ✅     | `user can select a tab hit and land on the deep-linked tab`             |
-| Setting hit → `?setting=` arrival + highlight  | ✅     | `user can select a setting hit and arrive on the highlighted item`      |
-| Action hit (theme) → effect                    | ✅     | `user can run the theme action from the palette`                        |
-| Recents in the empty state                     | ✅     | `user sees the pages they picked under Recent when reopening`           |
+| Feature                                       | Status | Test                                                                        |
+| --------------------------------------------- | ------ | --------------------------------------------------------------------------- |
+| Open from the header button                   | ✅     | `user can open the palette from the header button and close it with Escape` |
+| Open with `mod+k`                             | ✅     | `user can open the palette with the keyboard shortcut`                      |
+| Escape closes                                 | ✅     | `user can open the palette from the header button and close it with Escape` |
+| Page hit → route                              | ✅     | `user can arrow-select a page hit and land on that page`                    |
+| Tab hit → `?tab=`                             | ✅     | `user can select a tab hit and land on the deep-linked tab`                 |
+| Setting hit → `?setting=` arrival + highlight | ✅     | `user can select a setting hit and arrive on the highlighted item`          |
+| Action hit (theme) → effect                   | ✅     | `user can run the theme action from the palette`                            |
+| Recents in the empty state                    | ✅     | `user sees the pages they picked under Recent when reopening`               |
 
-**Coverage: ✅ 7/7 features**
+**Coverage: ✅ 8/8 features**
 
 ---
 

--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -53,7 +53,8 @@
 | Admin Deployment Preset  | `/admin/deployments/deployment-presets/new`      |    4     |    4    | ✅ 100% |
 | Runtime Parameters       | `/admin/deployments?tab=runtime-variant-presets` |    5     |    5    | ✅ 100% |
 | Project-Agnostic Scope   | `/admin/*` (except `admin-dashboard`)            |    5     |    5    | ✅ 100% |
-| **Total**                |                                                  | **497**  | **340** | **68%** |
+| Global Search Palette    | (header, every route)                            |    7     |    7    | ✅ 100% |
+| **Total**                |                                                  | **504**  | **347** | **69%** |
 
 ---
 
@@ -1278,6 +1279,25 @@ is deliberately out of scope — operate above project scope — the header proj
 | Folder created from admin Data page lands in the in-modal chosen project |   ✅    | `folder created from the admin Data page lands in the project chosen in the modal` |
 
 **Coverage: 5 / 5 features (100%)**
+
+---
+
+### 33. Global Search Palette (header, every route)
+
+**Test files:** [`e2e/global-search-palette.spec.ts`](global-search-palette.spec.ts)
+
+| Feature                                        | Status | Test                                                                    |
+| ---------------------------------------------- | ------ | ----------------------------------------------------------------------- |
+| Open from the header button                    | ✅     | `user can open the palette from the header button and close it with Escape` |
+| Open with `mod+k`                              | ✅     | `user can open the palette with the keyboard shortcut`                  |
+| Escape closes                                  | ✅     | `user can open the palette from the header button and close it with Escape` |
+| Page hit → route                               | ✅     | `user can arrow-select a page hit and land on that page`                |
+| Tab hit → `?tab=`                              | ✅     | `user can select a tab hit and land on the deep-linked tab`             |
+| Setting hit → `?setting=` arrival + highlight  | ✅     | `user can select a setting hit and arrive on the highlighted item`      |
+| Action hit (theme) → effect                    | ✅     | `user can run the theme action from the palette`                        |
+| Recents in the empty state                     | ✅     | `user sees the pages they picked under Recent when reopening`           |
+
+**Coverage: ✅ 7/7 features**
 
 ---
 

--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1440,6 +1440,7 @@ To efficiently build new E2E tests, these POMs should be created:
 | `/chat/:id?`                           |        ✅        |      ✅      |    -     |
 | App Launcher (modal)                   |        🔶        |      ❌      |    -     |
 | `/applauncher`, `/edu-applauncher`     |        🔶        |      ❌      |    -     |
+| Global Search Palette (header)         |        ✅        |      ❌      |    -     |
 | Plugin System (config-based)           |        ✅        |      ❌      |    -     |
 | `/admin-serving?tab=auto-scaling-rule` |        🔶        |      ❌      |    -     |
 

--- a/e2e/global-search-palette.spec.ts
+++ b/e2e/global-search-palette.spec.ts
@@ -23,11 +23,27 @@ const search = async (page: Page, query: string) => {
   await searchInput(page).fill(query);
 };
 
+/**
+ * The palette is behind the `experimental_global_search` user setting, which is
+ * off by default. `addInitScript` runs before every document — including the
+ * reloads `loginAsAdmin` / `navigateTo` trigger — so the flag is already in
+ * `localStorage` by the time the settings atom first reads it.
+ */
+const enableGlobalSearchSetting = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'backendaiwebui.settings.user.experimental_global_search',
+      'true',
+    );
+  });
+};
+
 test.describe(
   'Global Search Palette - Navigation',
   { tag: ['@regression', '@global-search', '@functional'] },
   () => {
     test.beforeEach(async ({ page, request }) => {
+      await enableGlobalSearchSetting(page);
       await loginAsAdmin(page, request);
       await navigateTo(page, 'summary');
     });

--- a/e2e/global-search-palette.spec.ts
+++ b/e2e/global-search-palette.spec.ts
@@ -1,0 +1,137 @@
+// spec: global search palette (FR-3558) — open, search, and arrive
+import { loginAsAdmin, navigateTo } from './utils/test-util';
+import { test, expect, type Page } from '@playwright/test';
+
+const palette = (page: Page) => page.getByRole('dialog', { name: 'Search' });
+
+const searchInput = (page: Page) => palette(page).getByRole('combobox');
+
+/** A result row, ignoring the body-match rows that repeat a page's own title. */
+const resultRow = (page: Page, text: string) =>
+  palette(page)
+    .getByRole('option')
+    .filter({ hasText: text })
+    .filter({ hasNotText: 'Found in' })
+    .first();
+
+const openPalette = async (page: Page) => {
+  await page.getByTestId('button-global-search').click();
+  await expect(palette(page)).toBeVisible();
+};
+
+const search = async (page: Page, query: string) => {
+  await searchInput(page).fill(query);
+};
+
+test.describe(
+  'Global Search Palette - Navigation',
+  { tag: ['@regression', '@global-search', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+      await navigateTo(page, 'summary');
+    });
+
+    test('user can open the palette from the header button and close it with Escape', async ({
+      page,
+    }) => {
+      await openPalette(page);
+
+      await expect(
+        palette(page).getByPlaceholder('Search pages, tabs, and settings'),
+      ).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await expect(palette(page)).toBeHidden();
+    });
+
+    test('user can open the palette with the keyboard shortcut', async ({
+      page,
+    }) => {
+      await page.keyboard.press('ControlOrMeta+k');
+
+      await expect(palette(page)).toBeVisible();
+    });
+
+    test('user can arrow-select a page hit and land on that page', async ({
+      page,
+    }) => {
+      await openPalette(page);
+      await search(page, 'Statistics');
+      await expect(resultRow(page, 'Statistics')).toBeVisible();
+
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('Enter');
+
+      await expect(page).toHaveURL(/\/statistics/);
+      await expect(palette(page)).toBeHidden();
+    });
+
+    test('user can select a tab hit and land on the deep-linked tab', async ({
+      page,
+    }) => {
+      await openPalette(page);
+      await search(page, 'Registries');
+
+      await resultRow(page, 'Registries').click();
+
+      await expect(page).toHaveURL(/\/admin\/environment\?.*tab=registry/);
+      await expect(page.getByRole('tab', { selected: true })).toContainText(
+        'Registries',
+      );
+    });
+
+    test('user can select a setting hit and arrive on the highlighted item', async ({
+      page,
+    }) => {
+      await openPalette(page);
+      await search(page, 'Auto Logout');
+
+      await resultRow(page, 'Auto Logout').click();
+
+      await expect(page).toHaveURL(/setting=userSettings.AutoLogout/);
+      // The param IS the highlight: it marks the item, then strips itself.
+      await expect(page.getByTestId('items-auto-logout')).toHaveAttribute(
+        'data-arrival',
+        'true',
+      );
+      await expect(page).not.toHaveURL(/setting=/);
+      await expect(page.getByTestId('items-auto-logout')).toBeVisible();
+    });
+
+    test('user can run the theme action from the palette', async ({ page }) => {
+      const themeButton = page.getByTestId('button-theme');
+      const wasDark =
+        (await themeButton.getAttribute('aria-label')) === 'Light mode';
+
+      await openPalette(page);
+      await search(page, wasDark ? 'Switch to light mode' : 'Switch to dark');
+
+      await resultRow(page, wasDark ? 'light mode' : 'dark mode').click();
+
+      await expect(palette(page)).toBeHidden();
+      await expect(themeButton).toHaveAttribute(
+        'aria-label',
+        wasDark ? 'Dark mode' : 'Light mode',
+      );
+    });
+
+    test('user sees the pages they picked under Recent when reopening', async ({
+      page,
+    }) => {
+      await openPalette(page);
+      await search(page, 'Statistics');
+      await resultRow(page, 'Statistics').click();
+      await expect(page).toHaveURL(/\/statistics/);
+
+      await page.keyboard.press('ControlOrMeta+k');
+
+      await expect(
+        palette(page)
+          .getByRole('group', { name: 'Recent' })
+          .getByRole('option')
+          .filter({ hasText: 'Statistics' }),
+      ).toBeVisible();
+    });
+  },
+);

--- a/e2e/global-search/global-search-palette.spec.ts
+++ b/e2e/global-search/global-search-palette.spec.ts
@@ -1,5 +1,5 @@
 // spec: global search palette (FR-3558) — open, search, and arrive
-import { loginAsAdmin, navigateTo } from './utils/test-util';
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
 import { test, expect, type Page } from '@playwright/test';
 
 const palette = (page: Page) => page.getByRole('dialog', { name: 'Search' });
@@ -13,6 +13,24 @@ const resultRow = (page: Page, text: string) =>
     .filter({ hasText: text })
     .filter({ hasNotText: 'Found in' })
     .first();
+
+/**
+ * `data-value` on a row is the hit id, which is the only text-free handle on
+ * exactly which row is which — "Statistics" also appears in the breadcrumb of
+ * that page's tab hits.
+ */
+const STATISTICS_PAGE_HIT = 'page:/project/:projectName/statistics';
+
+/**
+ * The hit id of the row the arrow keys are currently on. The highlight lives
+ * on the input as `aria-activedescendant`, not on the row itself.
+ */
+const highlightedHit = (page: Page) =>
+  expect.poll(async () => {
+    const id = await searchInput(page).getAttribute('aria-activedescendant');
+    if (!id) return null;
+    return palette(page).locator(`[id="${id}"]`).getAttribute('data-value');
+  });
 
 const openPalette = async (page: Page) => {
   await page.getByTestId('button-global-search').click();
@@ -64,6 +82,10 @@ test.describe(
     test('user can open the palette with the keyboard shortcut', async ({
       page,
     }) => {
+      // The header trigger is the same component that registers `mod+k`, so
+      // its presence is the readiness signal the bare press otherwise races.
+      await expect(page.getByTestId('button-global-search')).toBeVisible();
+
       await page.keyboard.press('ControlOrMeta+k');
 
       await expect(palette(page)).toBeVisible();
@@ -77,9 +99,12 @@ test.describe(
       await expect(resultRow(page, 'Statistics')).toBeVisible();
 
       await page.keyboard.press('ArrowDown');
+      await highlightedHit(page).toBe(STATISTICS_PAGE_HIT);
+
       await page.keyboard.press('Enter');
 
-      await expect(page).toHaveURL(/\/statistics/);
+      // Anchored: the tab hits of this same page land on /statistics?tab=….
+      await expect(page).toHaveURL(/\/statistics$/);
       await expect(palette(page)).toBeHidden();
     });
 
@@ -105,14 +130,14 @@ test.describe(
 
       await resultRow(page, 'Auto Logout').click();
 
-      await expect(page).toHaveURL(/setting=userSettings.AutoLogout/);
       // The param IS the highlight: it marks the item, then strips itself.
+      // Asserting the un-stripped URL first would race that same window, so
+      // the mark and the stripped URL are all this test looks at.
       await expect(page.getByTestId('items-auto-logout')).toHaveAttribute(
         'data-arrival',
         'true',
       );
-      await expect(page).not.toHaveURL(/setting=/);
-      await expect(page.getByTestId('items-auto-logout')).toBeVisible();
+      await expect(page).not.toHaveURL(/setting=userSettings\.AutoLogout/);
     });
 
     test('user can run the theme action from the palette', async ({ page }) => {
@@ -121,9 +146,16 @@ test.describe(
         (await themeButton.getAttribute('aria-label')) === 'Light mode';
 
       await openPalette(page);
-      await search(page, wasDark ? 'Switch to light mode' : 'Switch to dark');
+      await search(
+        page,
+        wasDark ? 'Switch to light mode' : 'Switch to dark mode',
+      );
 
-      await resultRow(page, wasDark ? 'light mode' : 'dark mode').click();
+      await palette(page)
+        .locator(
+          `[data-value="${wasDark ? 'action:theme-light' : 'action:theme-dark'}"]`,
+        )
+        .click();
 
       await expect(palette(page)).toBeHidden();
       await expect(themeButton).toHaveAttribute(

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -142,10 +142,14 @@ export async function login(
   await page.getByLabel('Password').fill(password);
   // Astryx Button exposes no aria-label — its accessible name is the visible text.
   const loginButton = page.getByRole('button', { name: 'Login', exact: true });
-  // Expand the endpoint section if it's not already visible. Must be the role
-  // locator: getByLabel('Endpoint') also matches the 'Endpoint History' /
-  // 'About Endpoint' controls once the section is open.
-  const endpointInput = page.getByRole('textbox', { name: 'Endpoint' });
+  // Expand the endpoint section if it's not already visible.
+  // `getByLabel('Endpoint')` matches on substring, so it also picks up the
+  // "Endpoint History" trigger and the "About Endpoint" button — three
+  // elements, so it throws. `exact` pins the role lookup to the input alone.
+  const endpointInput = page.getByRole('textbox', {
+    name: 'Endpoint',
+    exact: true,
+  });
   if (!(await endpointInput.isVisible({ timeout: 500 }).catch(() => false))) {
     await page.getByText('Advanced').click();
   }


### PR DESCRIPTION
Resolves #8807 (FR-3558)

## What

- `e2e/global-search/global-search-palette.spec.ts` — 7 cases: open from the header button, open with `mod+k`, Escape closes, a page hit navigates (arrow-selected), a tab hit lands on `?tab=`, a setting hit arrives with `data-arrival` set and then strips `?setting=`, the theme action flips the header toggle, and a selected hit comes back under "Recent".
- `e2e/utils/test-util.ts`: `login()`'s `getByLabel('Endpoint')` also matched the "Endpoint History" trigger and the "About Endpoint" button — three elements, so every login threw a strict-mode violation. Narrowed to `getByRole('textbox', { name: 'Endpoint', exact: true })`. **This is the shared login helper: it runs in the `beforeEach` of every spec in the suite, so this one-line change is on the blast radius of the whole e2e run, not just this spec.**
- `e2e/E2E_COVERAGE_REPORT.md` updated (new section, summary row, totals, date).

## Why

The palette's value is the arrival — the URL it produces and the state it leaves behind — which only an end-to-end run can assert.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (on this branch and on all four below it)
- vitest: 77 tests across the stack
- **Playwright run blocked by the environment, not by the spec.** Against `https://fr-3558.localhost:1355` + webserver `http://10.82.0.6:8090`, the UI login never completes: `POST /server/login` returns `400 {"title": "You must provide the username field."}` — the webserver cannot read the client's AES-encoded login payload, while a direct API login with the same credentials returns `200 authenticated: true`. An existing untouched spec (`e2e/information/information.spec.ts`) fails identically on the same host pair, so the spec still needs a run against a cluster where UI login succeeds.
