### PR TITLE
fix(FR-3580): keep the session action buttons on the brand accent inside a notice

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -353,12 +353,21 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
 
   return session ? (
     <>
+      {/* These are the app's own controls, so the primary one keeps the brand
+          accent even on a status-coloured surface (the notification Banner
+          rebinds `--color-accent`). Rule in `index.css`. FR-3580. */}
       {compact ? (
-        <ButtonGroup label={t('data.explorer.Actions')} size={astryxSize}>
+        <ButtonGroup
+          className="bai-accent-pinned"
+          label={t('data.explorer.Actions')}
+          size={astryxSize}
+        >
           {buttons}
         </ButtonGroup>
       ) : (
-        <HStack gap={1}>{buttons}</HStack>
+        <HStack className="bai-accent-pinned" gap={1}>
+          {buttons}
+        </HStack>
       )}
 
       <Suspense fallback={null}>

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -19,6 +19,19 @@
 @import '@astryxdesign/lab/lab.css';
 @import '@astryxdesign/theme-neutral/theme.css';
 
+/* FR-3580: Astryx recolours a Banner's whole subtree to its status hue —
+   `.astryx-banner.info` rebinds `--color-accent` to the info blue, which is
+   right for the banner's own prose but not for a control that is deliberately
+   brand-primary (the session notice's app launcher, drawn in the `content`
+   slot). Bank the nearest theme's accent, where no component-status scope can
+   reach it, and restore it on those controls only. */
+[data-astryx-theme] {
+  --bai-theme-accent: var(--color-accent);
+}
+.bai-accent-pinned {
+  --color-accent: var(--bai-theme-accent);
+}
+
 /* FR-3506: secondary buttons are outlined (theme `variant:secondary`). Inside a
    ButtonGroup the outline moves to the GROUP: per-member borders double at
    seams and leave half-open chips when a disabled member renders ghost. The


### PR DESCRIPTION
Resolves #8870 (FR-3580)

The app launcher button in the session-creation toast rendered in a different
colour than the same button in the session detail drawer and the notifications
drawer list.

## Mechanism

The toast is `BAINotificationStackAstryx`, which renders every notice as an
Astryx `Banner`. `@astryxdesign/theme-neutral`'s `banner['status:info']` rebinds
the accent and text families **for the banner's whole subtree**:

```
.astryx-banner.info {
  --color-text-primary:   var(--color-text-blue);
  --color-text-secondary: var(--color-text-blue);
  --color-accent:         var(--color-text-blue);
}
```

Recolouring the banner's own prose is intended. The problem is that a notice
with a `content` slot draws a **complete app notice body** there — session link,
status tag and `SessionActionButtons` — and the app launcher is deliberately
`variant="primary"`, whose fill is `--color-accent`. So inside the toast it
painted info blue. The notifications drawer list and the session detail drawer
render the same component outside any Banner, so they kept the brand accent —
hence "only in the toast".

Fix: bank the nearest theme's accent on the theme root, where no
component-status scope can reach it, and restore it on the session action button
group alone. Everything else in the notice — title, description, status tag —
keeps the banner's info colouring, which is what a status surface is for.

```css
[data-astryx-theme] { --bai-theme-accent: var(--color-accent); }
.bai-accent-pinned  { --color-accent: var(--bai-theme-accent); }
```

## Measured

Reporter's screenshots (dominant fill of the app launcher cell):

| Surface | app launcher fill |
|---|---|
| Toast (defect) | `rgb(201,211,252)` |
| Session detail drawer | `rgb(178,99,37)` |
| Notifications drawer list | `rgb(178,99,37)` |

Live probe on this branch — `--color-accent` resolved inside a real
`.astryx-banner.info` vs. inside the pinned group; dark entered through the
header toggle with `documentElement.dataset.theme === 'dark'`:

| Scope | light | dark |
|---|---|---|
| theme root (reference) | `#FF7A00` | `#be5e06` |
| inside `.astryx-banner.info` | `#00458c` | `#c7d3ff` |
| inside `.bai-accent-pinned` | `#FF7A00` | `#be5e06` |

The dark banner value `#c7d3ff` matches the reporter's screenshot pixel
(`rgb(201,211,252)` after PNG blending), so the mechanism is confirmed end to end.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → 88 files / 1406 tests passed
- `pnpm --filter backend.ai-ui exec vitest run` → 47 passed, 1 skipped / 613 passed, 1 skipped
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → exits 1 on one
  **pre-existing** finding, `packages/backend.ai-ui/src/components/BAIText.css:28`,
  where the gate matches the words `var(--x, literal)` inside a prose comment.
  Verified unchanged on `main`; not touched by this PR.
- Live probe on the real notification stack, light and dark, zero uncaught
  `pageerror`. The console `ERROR` lines are environmental: react-grab's
  Google-Fonts stylesheet blocked by CSP, a backend `404 /func/totp`, and Relay
  `Group`/`UserGroup` `__typename` warnings from the test cluster.
- No `packages/backend.ai-ui/src` change, so no BUI rebuild was required.

## Screenshots

Two real notification toasts on the Sessions page, each carrying the **real**
`SessionActionButtons` group taken from the session detail drawer. The upper one
has `.bai-accent-pinned` removed to show the pre-fix state; the lower one is as
shipped. Same page, same theme, same button.

| Dark | Light |
|---|---|
| ![dark before/after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8877/20260819-053140-toast-dark.png) | ![light before/after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8877/20260819-053145-toast-light.png) |

App launcher fill measured in the same run — before `rgb(199,211,255)` /
`rgb(0,69,140)`, after `rgb(190,94,6)` / `rgb(255,122,0)` (dark / light).

### Every other info notice is untouched

The pin is scoped to the session action button group, so no other notice changes.
Five info variants on the same stack — plain, determinate background task with
Cancel, indeterminate background task with Retry, a `to`/`toText` navigation
link, and an expanded `extraDescription` disclosure. Titles, descriptions,
progress bars and all three action buttons stay in the banner's info hue; no
brand accent appears anywhere.

| Dark | Light |
|---|---|
| ![info variants dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8877/20260819-053710-variants-dark.png) | ![info variants light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8877/20260819-053715-variants-light.png) |

## Residue

- The screenshots are not a session-creation toast: raising one needs a real
  session, i.e. a mutation on the shared test cluster. They are real toasts
  (raised through the app's own `add-bai-notification` event) holding the real
  action-button group, so the Banner scope and the button are both genuine —
  only their pairing is staged.
- The pin sits on the whole `SessionActionButtons` group rather than on the one
  button. The group is the app's own control cluster, and the primary button is
  the only member that reads `--color-accent`, so this is the smallest edit that
  states the intent once instead of per call site.
- `variantWhenEnabled` (FR-3506) is left alone. A disabled action still falls
  back to `ghost`, and it now behaves the same in the toast as in the drawer.
- A sibling report filed during this work — the dark toast card being
  translucent so page content read through it (FR-3586) — turned out to be a
  duplicate of FR-3554, already merged in #8806. This branch is rebased onto
  that fix; no change here addresses it.
