### PR TITLE
fix(FR-3585): render scrimmed drawers through a portal so a modal opened from a drawer is reachable

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIDrawerAstryx.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerAstryx.tsx
@@ -9,6 +9,7 @@ import { Heading } from '@astryxdesign/core/Heading';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { HStack, StackItem, VStack } from '@astryxdesign/core/Stack';
 import { Drawer } from '@astryxdesign/lab';
+import classNames from 'classnames';
 import { X } from 'lucide-react';
 import React, { type ReactNode } from 'react';
 
@@ -31,7 +32,12 @@ export interface BAIDrawerAstryxProps {
   size?: number | string;
   /** Edge the panel slides from. @default 'end' */
   side?: 'start' | 'end' | 'top' | 'bottom';
-  /** Modal scrim. antd `Drawer`'s `mask`. @default true */
+  /**
+   * Modal scrim, and with it the modality switch: `true` renders through
+   * `BAIDrawerPortal` (modal band level + focus containment), `false` keeps
+   * lab's native non-modal `show()` overlay.
+   * antd `Drawer`'s `mask`. @default true
+   */
   hasScrim?: boolean;
   /**
    * Body padding. antd's drawer body was `paddingLG` (24px) and a few call
@@ -85,9 +91,7 @@ const BAIDrawerAstryx: React.FC<BAIDrawerAstryxProps> = ({
     <VStack gap={0} align="stretch" height="100%">
       {hasHeader ? (
         <HStack
-          className={['bai-drawer-header', headerClassName]
-            .filter(Boolean)
-            .join(' ')}
+          className={classNames('bai-drawer-header', headerClassName)}
           align="center"
           gap={0}
           wrap="nowrap"
@@ -128,12 +132,10 @@ const BAIDrawerAstryx: React.FC<BAIDrawerAstryxProps> = ({
       ) : null}
       <StackItem size="fill" isScrollable>
         <div
-          className={[
+          className={classNames(
             hasBodyPadding ? 'bai-drawer-body' : 'bai-drawer-body-flush',
             bodyClassName,
-          ]
-            .filter(Boolean)
-            .join(' ')}
+          )}
         >
           {children}
         </div>

--- a/packages/backend.ai-ui/src/components/BAIDrawerAstryx.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerAstryx.tsx
@@ -4,6 +4,7 @@
  */
 import { useBAIi18n } from '../hooks/useBAIi18n';
 import './BAIDrawerAstryx.css';
+import BAIDrawerPortal from './BAIDrawerPortal';
 import { Heading } from '@astryxdesign/core/Heading';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { HStack, StackItem, VStack } from '@astryxdesign/core/Stack';
@@ -50,38 +51,12 @@ export interface BAIDrawerAstryxProps {
 }
 
 /**
- * The project's drawer shell: lab `Drawer` plus the header arrangement the
- * antd `Drawer` produced, so every detail drawer reads the same way it did
- * before the Astryx migration.
- *
- * WHY THIS EXISTS (qa2-c). lab `Drawer` has no title bar at all — it only
- * offers `hasCloseButton`, which paints a ghost icon button ABSOLUTELY
- * POSITIONED in the top-trailing corner, floating over whatever the content
- * renders first. Each converted drawer therefore hand-rolled its own
- * `HStack justify="between"` title row inside the body, which put the page's
- * own action buttons underneath (or overlapping) that floating close button
- * and produced a different header on every drawer.
- *
- * The legacy arrangement, read off antd 6.5.0's `DrawerPanel` and its style
- * module (and confirmed by rendering it):
- *
- *   .ant-drawer-header        display:flex; align-items:center;
- *                             padding: `padding` `paddingLG` (16px 24px);
- *                             border-bottom: 1px solid colorSplit
- *     .ant-drawer-header-title  flex:1; display:flex; align-items:center
- *       button.ant-drawer-close   margin-inline-end: marginXS (8px)
- *       .ant-drawer-title         flex:1; font-weight:600; font-size:fontSizeLG
- *     .ant-drawer-extra         flex:none
- *   .ant-drawer-body          flex:1; padding: paddingLG (24px); overflow:auto
- *
- * i.e. `[X] Title …………… [extra]` on one row, a divider, then a padded
- * scrollable body. `closable.placement` was never overridden anywhere in the
- * app (`ConfigProvider drawer={{ mask: { blur: false } }}` is the only drawer
- * config), so antd's default `'start'` placement applies and the close button
- * sits BEFORE the title, not at the far edge.
- *
- * This component reproduces that exactly and turns lab's floating button off
- * (`hasCloseButton={false}`) so there is only one close affordance.
+ * The project's drawer shell: lab `Drawer` plus the header arrangement antd's
+ * `Drawer` produced — `[X] Title …… [extra]`, a divider, then a padded
+ * scrollable body — so every detail drawer reads the way it did before the
+ * Astryx migration. lab has no title bar of its own, only a floating
+ * `hasCloseButton` glyph that overlaps whatever the content renders first;
+ * that button is turned off here so there is one close affordance (qa2-c).
  */
 const BAIDrawerAstryx: React.FC<BAIDrawerAstryxProps> = ({
   open = false,
@@ -106,28 +81,22 @@ const BAIDrawerAstryx: React.FC<BAIDrawerAstryxProps> = ({
 
   const hasHeader = title !== undefined || extra !== undefined;
 
-  return (
-    <Drawer
-      isOpen={open}
-      onClose={() => onClose?.()}
-      side={side}
-      size={size}
-      label={accessibleName}
-      hasScrim={hasScrim}
-      // The header below owns the close affordance, at antd's `start`
-      // placement. Leaving lab's own button on would paint a second, floating
-      // one over the content.
-      hasCloseButton={false}
-    >
-      <VStack gap={0} align="stretch" height="100%">
-        {hasHeader ? (
+  const panel = (
+    <VStack gap={0} align="stretch" height="100%">
+      {hasHeader ? (
+        <HStack
+          className={['bai-drawer-header', headerClassName]
+            .filter(Boolean)
+            .join(' ')}
+          align="center"
+          gap={0}
+          wrap="nowrap"
+        >
           <HStack
-            className={['bai-drawer-header', headerClassName]
-              .filter(Boolean)
-              .join(' ')}
             align="center"
             gap={0}
             wrap="nowrap"
+            className="bai-drawer-header-title"
           >
             <HStack
               align="center"
@@ -152,20 +121,46 @@ const BAIDrawerAstryx: React.FC<BAIDrawerAstryxProps> = ({
               <div className="bai-drawer-extra">{extra}</div>
             ) : null}
           </HStack>
-        ) : null}
-        <StackItem size="fill" isScrollable>
-          <div
-            className={[
-              hasBodyPadding ? 'bai-drawer-body' : 'bai-drawer-body-flush',
-              bodyClassName,
-            ]
-              .filter(Boolean)
-              .join(' ')}
-          >
-            {children}
-          </div>
-        </StackItem>
-      </VStack>
+          {extra !== undefined ? (
+            <div className="bai-drawer-extra">{extra}</div>
+          ) : null}
+        </HStack>
+      ) : null}
+      <StackItem size="fill" isScrollable>
+        <div
+          className={[
+            hasBodyPadding ? 'bai-drawer-body' : 'bai-drawer-body-flush',
+            bodyClassName,
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {children}
+        </div>
+      </StackItem>
+    </VStack>
+  );
+
+  const drawerProps = {
+    isOpen: open,
+    onClose: () => onClose?.(),
+    side,
+    size,
+    label: accessibleName,
+    // The header above owns the close affordance, at antd's `start` placement.
+    // Leaving lab's own button on would paint a second, floating one over the
+    // content.
+    hasCloseButton: false,
+  };
+
+  // A scrimmed lab `Drawer` would `showModal()` and inert every portalled modal
+  // opened from inside it; the portal keeps the modality without the top layer
+  // (FR-3585). Non-scrim drawers already use `show()` and stay native.
+  return hasScrim ? (
+    <BAIDrawerPortal {...drawerProps}>{panel}</BAIDrawerPortal>
+  ) : (
+    <Drawer {...drawerProps} hasScrim={false}>
+      {panel}
     </Drawer>
   );
 };

--- a/packages/backend.ai-ui/src/components/BAIDrawerAstryx.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerAstryx.tsx
@@ -102,27 +102,17 @@ const BAIDrawerAstryx: React.FC<BAIDrawerAstryxProps> = ({
             wrap="nowrap"
             className="bai-drawer-header-title"
           >
-            <HStack
-              align="center"
-              gap={0}
-              wrap="nowrap"
-              className="bai-drawer-header-title"
-            >
-              <IconButton
-                icon={<X size="1em" />}
-                label={t('general.button.Close')}
-                variant="ghost"
-                size="sm"
-                onClick={() => onClose?.()}
-              />
-              {title !== undefined ? (
-                <Heading level={5} className="bai-drawer-title">
-                  {title}
-                </Heading>
-              ) : null}
-            </HStack>
-            {extra !== undefined ? (
-              <div className="bai-drawer-extra">{extra}</div>
+            <IconButton
+              icon={<X size="1em" />}
+              label={t('general.button.Close')}
+              variant="ghost"
+              size="sm"
+              onClick={() => onClose?.()}
+            />
+            {title !== undefined ? (
+              <Heading level={5} className="bai-drawer-title">
+                {title}
+              </Heading>
             ) : null}
           </HStack>
           {extra !== undefined ? (

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
@@ -9,17 +9,13 @@
 */
 
 @layer components {
-  /* Same band and step as `BAIDialog` (`backend.ai-ui/src/styles/
-     zIndexLadder.css`), so a modal opened later claims a level above the
-     drawer and paints over it. */
+  /* One stack with `BAIDialog`: `dialogLevelStack.ts` resolves and writes
+     `--bai-dialog-z` on this root too, so a modal opened later paints over the
+     drawer. The band base is the fallback for a root that has not claimed. */
   .bai-drawer-portal {
-    --bai-drawer-portal-level: 0;
     position: fixed;
     inset: 0;
-    z-index: calc(
-      var(--bai-z-modal-base) + var(--bai-drawer-portal-level) *
-        var(--bai-z-modal-level-step)
-    );
+    z-index: var(--bai-dialog-z, var(--bai-z-modal-base));
   }
 
   /* Closed but still rendered: lab keeps the panel sliding out for one

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
@@ -34,12 +34,12 @@
     display: none;
   }
 
-  /* Same look as lab's `::backdrop` scrim, on the same duration. */
+  /* lab's `::backdrop` overlay color on the same duration — minus its
+     blur, dropped on request (FR-3585). */
   .bai-drawer-portal__mask {
     position: absolute;
     inset: 0;
     background-color: var(--color-overlay);
-    backdrop-filter: blur(2px);
     transition: opacity var(--duration-medium) var(--ease-standard);
   }
 

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
@@ -9,7 +9,7 @@
 */
 
 @layer components {
-  /* Same band and step as `BAIDialogPortal` (`backend.ai-ui/src/styles/
+  /* Same band and step as `BAIDialog` (`backend.ai-ui/src/styles/
      zIndexLadder.css`), so a modal opened later claims a level above the
      drawer and paints over it. */
   .bai-drawer-portal {

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
@@ -1,0 +1,71 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ Co-located styles for <BAIDrawerPortal> — the scrim and stacking a scrimmed
+ lab `Drawer` used to get from the top layer, restated for a portalled tree
+ (FR-3585). The panel geometry stays lab's: the inner <dialog> is
+ `position: fixed` and anchors itself to its own edge.
+*/
+
+@layer components {
+  /* Same band and step as `BAIDialogPortal` (`backend.ai-ui/src/styles/
+     zIndexLadder.css`), so a modal opened later claims a level above the
+     drawer and paints over it. */
+  .bai-drawer-portal {
+    --bai-drawer-portal-level: 0;
+    position: fixed;
+    inset: 0;
+    z-index: calc(
+      var(--bai-z-modal-base) + var(--bai-drawer-portal-level) *
+        var(--bai-z-modal-level-step)
+    );
+  }
+
+  /* Closed but still rendered: lab keeps the panel sliding out for one
+     `--duration-medium` before its delayed `dialog.close()`. */
+  .bai-drawer-portal--closed {
+    pointer-events: none;
+  }
+
+  /* Set by the component once that slide-out is over. Children stay mounted,
+     as the native drawer's did. */
+  .bai-drawer-portal[data-bai-drawer-hidden] {
+    display: none;
+  }
+
+  /* No box of its own: the focus trap needs an element, the panel inside is
+     `position: fixed` and lab anchors it. */
+  .bai-drawer-portal__wrap {
+    display: contents;
+  }
+
+  /* Same look as lab's `::backdrop` scrim, on the same duration. */
+  .bai-drawer-portal__mask {
+    position: absolute;
+    inset: 0;
+    background-color: var(--color-overlay);
+    backdrop-filter: blur(2px);
+    opacity: 1;
+    transition: opacity var(--duration-medium) var(--ease-standard);
+  }
+
+  /* The scrim fades in on the frame the root leaves `display: none`; a plain
+     transition cannot start from an unrendered element. */
+  @starting-style {
+    .bai-drawer-portal__mask {
+      opacity: 0;
+    }
+  }
+
+  .bai-drawer-portal--closed .bai-drawer-portal__mask {
+    opacity: 0;
+  }
+
+  /* lab's own reduced-motion duration, so scrim and panel stay in step. */
+  @media (prefers-reduced-motion: reduce) {
+    .bai-drawer-portal__mask {
+      transition-duration: 0.01s;
+    }
+  }
+}

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.css
@@ -34,19 +34,12 @@
     display: none;
   }
 
-  /* No box of its own: the focus trap needs an element, the panel inside is
-     `position: fixed` and lab anchors it. */
-  .bai-drawer-portal__wrap {
-    display: contents;
-  }
-
   /* Same look as lab's `::backdrop` scrim, on the same duration. */
   .bai-drawer-portal__mask {
     position: absolute;
     inset: 0;
     background-color: var(--color-overlay);
     backdrop-filter: blur(2px);
-    opacity: 1;
     transition: opacity var(--duration-medium) var(--ease-standard);
   }
 

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
@@ -51,6 +51,7 @@ const Nested: React.FC<{
   onDrawerClose: () => void;
   onModalOpenChange: (isOpen: boolean) => void;
 }> = ({ onDrawerClose, onModalOpenChange }) => {
+  'use memo';
   const [isModalOpen, setIsModalOpen] = useState(false);
   return (
     <BAIDrawerPortal isOpen onClose={onDrawerClose} label="Details">

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
@@ -1,0 +1,197 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ The FR-3585 contract: a scrimmed drawer promotes nothing to the top layer, so
+ a modal opened from inside it is reachable — and inerts the drawer instead of
+ being inerted by it.
+
+ NOTE: `setupTests` polyfills showModal/show/close, so a `showModal()` would NOT
+ fail on its own — the two calls are spied on explicitly.
+*/
+import BAIDrawerAstryx from './BAIDrawerAstryx';
+import BAIDrawerPortal from './BAIDrawerPortal';
+import { Theme, defineTheme } from '@astryxdesign/core/theme';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BAIDialogPortal from './BAIDialogPortal';
+import { BAI_MODAL_OPEN_ATTRIBUTE } from './dialogLevelStack';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>();
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+const renderDrawer = (
+  props: Partial<React.ComponentProps<typeof BAIDrawerPortal>> = {},
+) => {
+  const onClose = vi.fn();
+  const result = render(
+    <BAIDrawerPortal isOpen onClose={onClose} label="Details" {...props}>
+      <button type="button">Inside</button>
+    </BAIDrawerPortal>,
+  );
+  return { ...result, onClose };
+};
+
+const getRoot = () =>
+  document.body.querySelector<HTMLElement>('.bai-drawer-portal');
+const getMask = () =>
+  document.querySelector<HTMLElement>(
+    '.bai-drawer-portal__mask',
+  ) as HTMLElement;
+
+// A nested `<Theme>` is the app's admin/reverse region: a wrapper element the
+// portal is not a descendant of.
+const outerTheme = defineTheme({ name: 'drawer-outer', tokens: {} });
+const innerTheme = defineTheme({ name: 'drawer-inner', tokens: {} });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('BAIDrawerPortal', () => {
+  it('portals to document.body and opens the inner dialog with show()', () => {
+    const showModal = vi.spyOn(HTMLDialogElement.prototype, 'showModal');
+    const show = vi.spyOn(HTMLDialogElement.prototype, 'show');
+
+    renderDrawer();
+
+    const root = getRoot();
+    expect(root?.parentElement).toBe(document.body);
+    expect(root?.hasAttribute(BAI_MODAL_OPEN_ATTRIBUTE)).toBe(true);
+    // `show()` is the whole fix: no top layer, so nothing outside is inerted.
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(showModal).not.toHaveBeenCalled();
+  });
+
+  it('restores the modality lab drops with the scrim', () => {
+    renderDrawer();
+
+    expect(screen.getByRole('dialog', { name: 'Details' })).toHaveAttribute(
+      'aria-modal',
+      'true',
+    );
+    expect(getMask()).not.toBeNull();
+  });
+
+  it('moves focus into the panel, which `show()` does not do', () => {
+    renderDrawer();
+
+    expect(getRoot()?.contains(document.activeElement)).toBe(true);
+  });
+
+  it('bypasses the portal entirely for a non-scrim drawer', () => {
+    render(
+      <BAIDrawerAstryx open hasScrim={false} title="Notifications">
+        <span>notices</span>
+      </BAIDrawerAstryx>,
+    );
+
+    expect(getRoot()).toBeNull();
+    expect(document.querySelector(`[${BAI_MODAL_OPEN_ATTRIBUTE}]`)).toBeNull();
+    expect(document.querySelector('dialog')?.open).toBe(true);
+  });
+
+  // The regression FR-3585 exists for: a `showModal()` drawer inerted the
+  // portalled modal instead, leaving it unclickable and untabbable.
+  it('lets a modal opened inside it take the level above and inert it', async () => {
+    const user = userEvent.setup();
+    const Nested: React.FC = () => {
+      const [isModalOpen, setIsModalOpen] = useState(false);
+      return (
+        <BAIDrawerPortal isOpen onClose={vi.fn()} label="Details">
+          <button type="button" onClick={() => setIsModalOpen(true)}>
+            Deploy
+          </button>
+          <BAIDialogPortal
+            isOpen={isModalOpen}
+            onOpenChange={vi.fn()}
+            aria-label="deploy"
+          >
+            <button type="button">Confirm</button>
+          </BAIDialogPortal>
+        </BAIDrawerPortal>
+      );
+    };
+    render(<Nested />);
+
+    await user.click(screen.getByRole('button', { name: 'Deploy' }));
+
+    const drawerRoot = getRoot() as HTMLElement;
+    const modalRoot = document.querySelector<HTMLElement>(
+      '.bai-dialog-portal',
+    ) as HTMLElement;
+    expect(drawerRoot.style.getPropertyValue('--bai-drawer-portal-level')).toBe(
+      '0',
+    );
+    expect(modalRoot.style.getPropertyValue('--bai-dialog-portal-level')).toBe(
+      '1',
+    );
+    expect(drawerRoot.hasAttribute('inert')).toBe(true);
+    expect(modalRoot.hasAttribute('inert')).toBe(false);
+    expect(
+      screen.getByRole('button', { name: 'Confirm' }).closest('[inert]'),
+    ).toBeNull();
+  });
+
+  it('closes on a mask click, but not on a drag that started inside', () => {
+    const { onClose } = renderDrawer();
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Inside' }));
+    fireEvent.click(getMask());
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(getMask());
+    fireEvent.click(getMask());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // Hiding the root the moment `isOpen` flips would cut lab's slide-out off.
+  it('keeps the root rendered through lab’s exit delay', () => {
+    vi.useFakeTimers();
+    const drawer = (isOpen: boolean) => (
+      <BAIDrawerPortal isOpen={isOpen} onClose={vi.fn()} label="Details">
+        <button type="button">Inside</button>
+      </BAIDrawerPortal>
+    );
+    const { rerender } = render(drawer(true));
+
+    rerender(drawer(false));
+    expect(getRoot()?.className).toContain('bai-drawer-portal--closed');
+    expect(getRoot()?.hasAttribute('data-bai-drawer-hidden')).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(getRoot()?.hasAttribute('data-bai-drawer-hidden')).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('keeps children mounted but unmarked while closed', () => {
+    renderDrawer({ isOpen: false });
+
+    expect(getRoot()?.hasAttribute(BAI_MODAL_OPEN_ATTRIBUTE)).toBe(false);
+    expect(getRoot()?.hasAttribute('data-bai-drawer-hidden')).toBe(true);
+    expect(screen.getByText('Inside')).toBeInTheDocument();
+  });
+
+  it('re-emits the nearest theme name so @scope’d theme CSS reaches the portal', () => {
+    render(
+      <Theme theme={outerTheme} mode="light">
+        <Theme theme={innerTheme} mode="light">
+          <BAIDrawerPortal isOpen onClose={vi.fn()} label="Details">
+            <span>body</span>
+          </BAIDrawerPortal>
+        </Theme>
+      </Theme>,
+    );
+
+    expect(getRoot()?.getAttribute('data-astryx-theme')).toBe(innerTheme.name);
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
@@ -133,10 +133,14 @@ describe('BAIDrawerPortal', () => {
     const modalRoot = document.querySelector<HTMLElement>(
       '.bai-dialog',
     ) as HTMLElement;
-    expect(drawerRoot.style.getPropertyValue('--bai-drawer-portal-level')).toBe(
-      '0',
-    );
+    expect(drawerRoot.style.getPropertyValue('--bai-dialog-level')).toBe('0');
     expect(modalRoot.style.getPropertyValue('--bai-dialog-level')).toBe('1');
+    // One stack, so the later claim also paints higher.
+    expect(
+      Number(modalRoot.style.getPropertyValue('--bai-dialog-z')),
+    ).toBeGreaterThan(
+      Number(drawerRoot.style.getPropertyValue('--bai-dialog-z')),
+    );
     expect(drawerRoot.hasAttribute('inert')).toBe(true);
     expect(modalRoot.hasAttribute('inert')).toBe(false);
 

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
@@ -9,13 +9,13 @@
  NOTE: `setupTests` polyfills showModal/show/close, so a `showModal()` would NOT
  fail on its own — the two calls are spied on explicitly.
 */
+import BAIDialog from './BAIDialog';
 import BAIDrawerAstryx from './BAIDrawerAstryx';
 import BAIDrawerPortal from './BAIDrawerPortal';
+import { BAI_MODAL_OPEN_ATTRIBUTE } from './dialogLevelStack';
 import { Theme, defineTheme } from '@astryxdesign/core/theme';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import BAIDialogPortal from './BAIDialogPortal';
-import { BAI_MODAL_OPEN_ATTRIBUTE } from './dialogLevelStack';
 import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -58,13 +58,13 @@ const Nested: React.FC<{
       <button type="button" onClick={() => setIsModalOpen(true)}>
         Deploy
       </button>
-      <BAIDialogPortal
+      <BAIDialog
         isOpen={isModalOpen}
         onOpenChange={onModalOpenChange}
         aria-label="deploy"
       >
         <button type="button">Confirm</button>
-      </BAIDialogPortal>
+      </BAIDialog>
     </BAIDrawerPortal>
   );
 };
@@ -131,14 +131,12 @@ describe('BAIDrawerPortal', () => {
 
     const drawerRoot = getRoot() as HTMLElement;
     const modalRoot = document.querySelector<HTMLElement>(
-      '.bai-dialog-portal',
+      '.bai-dialog',
     ) as HTMLElement;
     expect(drawerRoot.style.getPropertyValue('--bai-drawer-portal-level')).toBe(
       '0',
     );
-    expect(modalRoot.style.getPropertyValue('--bai-dialog-portal-level')).toBe(
-      '1',
-    );
+    expect(modalRoot.style.getPropertyValue('--bai-dialog-level')).toBe('1');
     expect(drawerRoot.hasAttribute('inert')).toBe(true);
     expect(modalRoot.hasAttribute('inert')).toBe(false);
 

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
@@ -152,8 +152,9 @@ describe('BAIDrawerPortal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  // Hiding the root the moment `isOpen` flips would cut lab's slide-out off.
-  it('keeps the root rendered through lab’s exit delay', () => {
+  // Hiding the root the moment `isOpen` flips would cut lab's slide-out off;
+  // the root waits for the inner dialog's `close`, which lab delays by 250ms.
+  it('keeps the root rendered until lab closes the inner dialog', () => {
     vi.useFakeTimers();
     const drawer = (isOpen: boolean) => (
       <BAIDrawerPortal isOpen={isOpen} onClose={vi.fn()} label="Details">

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.test.tsx
@@ -46,6 +46,28 @@ const getMask = () =>
     '.bai-drawer-portal__mask',
   ) as HTMLElement;
 
+// A drawer with a modal opened from inside it — the FR-3585 arrangement.
+const Nested: React.FC<{
+  onDrawerClose: () => void;
+  onModalOpenChange: (isOpen: boolean) => void;
+}> = ({ onDrawerClose, onModalOpenChange }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  return (
+    <BAIDrawerPortal isOpen onClose={onDrawerClose} label="Details">
+      <button type="button" onClick={() => setIsModalOpen(true)}>
+        Deploy
+      </button>
+      <BAIDialogPortal
+        isOpen={isModalOpen}
+        onOpenChange={onModalOpenChange}
+        aria-label="deploy"
+      >
+        <button type="button">Confirm</button>
+      </BAIDialogPortal>
+    </BAIDrawerPortal>
+  );
+};
+
 // A nested `<Theme>` is the app's admin/reverse region: a wrapper element the
 // portal is not a descendant of.
 const outerTheme = defineTheme({ name: 'drawer-outer', tokens: {} });
@@ -102,24 +124,7 @@ describe('BAIDrawerPortal', () => {
   // portalled modal instead, leaving it unclickable and untabbable.
   it('lets a modal opened inside it take the level above and inert it', async () => {
     const user = userEvent.setup();
-    const Nested: React.FC = () => {
-      const [isModalOpen, setIsModalOpen] = useState(false);
-      return (
-        <BAIDrawerPortal isOpen onClose={vi.fn()} label="Details">
-          <button type="button" onClick={() => setIsModalOpen(true)}>
-            Deploy
-          </button>
-          <BAIDialogPortal
-            isOpen={isModalOpen}
-            onOpenChange={vi.fn()}
-            aria-label="deploy"
-          >
-            <button type="button">Confirm</button>
-          </BAIDialogPortal>
-        </BAIDrawerPortal>
-      );
-    };
-    render(<Nested />);
+    render(<Nested onDrawerClose={vi.fn()} onModalOpenChange={vi.fn()} />);
 
     await user.click(screen.getByRole('button', { name: 'Deploy' }));
 
@@ -135,9 +140,46 @@ describe('BAIDrawerPortal', () => {
     );
     expect(drawerRoot.hasAttribute('inert')).toBe(true);
     expect(modalRoot.hasAttribute('inert')).toBe(false);
-    expect(
-      screen.getByRole('button', { name: 'Confirm' }).closest('[inert]'),
-    ).toBeNull();
+
+    // jsdom does not enforce `inert`, so also assert reachability the way a user
+    // meets it: the control takes focus when asked.
+    const confirm = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirm.closest('[inert]')).toBeNull();
+    act(() => confirm.focus());
+    expect(document.activeElement).toBe(confirm);
+  });
+
+  // The other half of the goal: the modal is reachable AND owns Escape, so one
+  // press dismisses it without also collapsing the drawer underneath.
+  it('routes Escape to the modal above it, leaving the drawer open', async () => {
+    const user = userEvent.setup();
+    const onDrawerClose = vi.fn();
+    const onModalOpenChange = vi.fn();
+    render(
+      <Nested
+        onDrawerClose={onDrawerClose}
+        onModalOpenChange={onModalOpenChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Deploy' }));
+    act(() => screen.getByRole('button', { name: 'Confirm' }).focus());
+    await user.keyboard('{Escape}');
+
+    expect(onModalOpenChange).toHaveBeenCalledWith(false);
+    expect(onDrawerClose).not.toHaveBeenCalled();
+  });
+
+  // lab listens for Escape on its `<dialog>`, so the press has to bubble out of
+  // the panel — which it still does through the portal.
+  it('closes on Escape pressed inside the drawer panel', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderDrawer();
+
+    act(() => screen.getByRole('button', { name: 'Inside' }).focus());
+    await user.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('closes on a mask click, but not on a drag that started inside', () => {

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
@@ -1,0 +1,172 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ `BAIDrawerPortal` — a scrimmed lab `Drawer` rendered through a `document.body`
+ portal instead of `showModal()`. A `showModal()` dialog inerts everything
+ outside its flat tree, which included the portalled modals FR-3578 introduced;
+ the inner drawer therefore takes `hasScrim={false}` and opens with `show()`,
+ which promotes nothing (FR-3585).
+*/
+import './BAIDrawerPortal.css';
+import { useFocusTrap, useScrollLock } from '@astryxdesign/core/hooks';
+import { dataAttr } from '@astryxdesign/core/naming';
+import { useThemeName } from '@astryxdesign/core/theme';
+import { Drawer, type DrawerProps } from '@astryxdesign/lab';
+import {
+  BAI_MODAL_OPEN_ATTRIBUTE,
+  claimDialogLevel,
+  releaseDialogLevel,
+} from './dialogLevelStack';
+import classNames from 'classnames';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+// lab delays its own `dialog.close()` by these to let the panel slide out
+// (`@astryxdesign/lab/src/Drawer/Drawer.tsx`); the portal root has to outlive
+// `isOpen` by the same amount or the exit is cut off.
+const EXIT_DURATION_MS = 250;
+const REDUCED_MOTION_EXIT_DURATION_MS = 10;
+
+/** Hides the root once the slide-out is over. Driven from the DOM, not React,
+    so a closing drawer does not re-render its whole subtree a frame later. */
+const HIDDEN_ATTRIBUTE = 'data-bai-drawer-hidden';
+
+/** Everything lab `Drawer` takes; the portal owns the scrim, so not `hasScrim`. */
+export type BAIDrawerPortalProps = Omit<DrawerProps, 'hasScrim'>;
+
+const BAIDrawerPortal: React.FC<BAIDrawerPortalProps> = ({
+  isOpen,
+  onClose,
+  children,
+  ...rest
+}) => {
+  'use memo';
+
+  // Theme CSS is `@scope`d to `[data-astryx-theme]`, and the portal escapes DOM
+  // ancestry — re-emit the nearest theme's NAME as `BAIDialogPortal` does.
+  const themeName = useThemeName();
+
+  // Modality restored by hand: `show()` traps nothing. Escape stays lab's — its
+  // dialog `keydown` already closes the top drawer, and a second handler here
+  // would call `onClose` twice.
+  // A covered surface drops its trap; see `syncCoveredDialogs`.
+  const [isTopmost, setIsTopmost] = useState(true);
+
+  const { containerRef, focusFirst } = useFocusTrap<HTMLDivElement>({
+    isActive: isOpen && isTopmost,
+  });
+
+  // lab runs `useScrollLock(isOpen && hasScrim)`, and its scrim is off now.
+  useScrollLock(isOpen);
+
+  const rootRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const level = claimDialogLevel(rootRef.current, setIsTopmost);
+    rootRef.current?.style.setProperty(
+      '--bai-drawer-portal-level',
+      String(level),
+    );
+    return () => {
+      releaseDialogLevel(level);
+    };
+  }, [isOpen]);
+
+  const hasBeenOpenRef = useRef(false);
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      return;
+    }
+    if (isOpen) {
+      hasBeenOpenRef.current = true;
+      root.removeAttribute(HIDDEN_ATTRIBUTE);
+      return;
+    }
+    if (!hasBeenOpenRef.current) {
+      root.setAttribute(HIDDEN_ATTRIBUTE, '');
+      return;
+    }
+    const timer = setTimeout(
+      () => root.setAttribute(HIDDEN_ATTRIBUTE, ''),
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        ? REDUCED_MOTION_EXIT_DURATION_MS
+        : EXIT_DURATION_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  // `show()` moves focus nowhere, unlike `showModal()`. lab has already honoured
+  // `[data-autofocus]`; otherwise land on its `tabindex="-1"` panel body, where
+  // the dialog focusing steps used to put us.
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!isOpen || !node || node.querySelector('[data-autofocus]')) {
+      return;
+    }
+    const panel = node.querySelector<HTMLElement>('dialog > [tabindex="-1"]');
+    if (panel) {
+      panel.focus();
+    } else {
+      focusFirst();
+    }
+  }, [isOpen, containerRef, focusFirst]);
+
+  const maskRef = useRef<HTMLDivElement>(null);
+  const isPointerDownOnMaskRef = useRef(false);
+  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    isPointerDownOnMaskRef.current = event.target === maskRef.current;
+  };
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    // A drag that started inside the panel must not dismiss it.
+    const isMaskClick =
+      isPointerDownOnMaskRef.current && event.target === maskRef.current;
+    isPointerDownOnMaskRef.current = false;
+    if (isMaskClick) {
+      onClose();
+    }
+  };
+
+  return createPortal(
+    <div
+      ref={rootRef}
+      className={classNames(
+        'bai-drawer-portal',
+        !isOpen && 'bai-drawer-portal--closed',
+      )}
+      onMouseDown={handleMouseDown}
+      onClick={handleClick}
+      {...{
+        [BAI_MODAL_OPEN_ATTRIBUTE]: isOpen ? '' : undefined,
+        [dataAttr('theme')]: themeName ?? undefined,
+      }}
+    >
+      <div ref={maskRef} className="bai-drawer-portal__mask" />
+      <div ref={containerRef} className="bai-drawer-portal__wrap">
+        <Drawer
+          {...rest}
+          isOpen={isOpen}
+          onClose={onClose}
+          hasScrim={false}
+          // lab omits it without a scrim, but the portal restores modality.
+          aria-modal={isOpen ? 'true' : undefined}
+        >
+          {children}
+        </Drawer>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+BAIDrawerPortal.displayName = 'BAIDrawerPortal';
+
+export default BAIDrawerPortal;

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
@@ -9,12 +9,12 @@
  which promotes nothing (FR-3585).
 */
 import './BAIDrawerPortal.css';
+import { BAI_MODAL_OPEN_ATTRIBUTE, useDialogLevel } from './dialogLevelStack';
 import { useFocusTrap, useScrollLock } from '@astryxdesign/core/hooks';
 import { dataAttr } from '@astryxdesign/core/naming';
 import { useThemeName } from '@astryxdesign/core/theme';
 import { mergeRefs } from '@astryxdesign/core/utils';
 import { Drawer, type DrawerProps } from '@astryxdesign/lab';
-import { BAI_MODAL_OPEN_ATTRIBUTE, useDialogLevel } from './dialogLevelStack';
 import classNames from 'classnames';
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
@@ -39,7 +39,7 @@ const BAIDrawerPortal: React.FC<BAIDrawerPortalProps> = ({
   'use memo';
 
   // Theme CSS is `@scope`d to `[data-astryx-theme]`, and the portal escapes DOM
-  // ancestry — re-emit the nearest theme's NAME as `BAIDialogPortal` does.
+  // ancestry — re-emit the nearest theme's NAME as `BAIDialog` does.
   const themeName = useThemeName();
 
   // Modality restored by hand: `show()` traps nothing. Escape stays lab's — its

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
@@ -23,8 +23,12 @@ import { createPortal } from 'react-dom';
     so a closing drawer does not re-render its whole subtree a frame later. */
 const HIDDEN_ATTRIBUTE = 'data-bai-drawer-hidden';
 
-/** Everything lab `Drawer` takes; the portal owns the scrim, so not `hasScrim`. */
-export type BAIDrawerPortalProps = Omit<DrawerProps, 'hasScrim'>;
+/** Everything lab `Drawer` takes; the portal owns the scrim, so not `hasScrim`
+    — nor the collapse-to-rail pair its `hasScrim={false}` silently unlocks. */
+export type BAIDrawerPortalProps = Omit<
+  DrawerProps,
+  'hasScrim' | 'isCollapsed' | 'onCollapsedChange'
+>;
 
 const BAIDrawerPortal: React.FC<BAIDrawerPortalProps> = ({
   isOpen,

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
@@ -46,11 +46,7 @@ const BAIDrawerPortal: React.FC<BAIDrawerPortalProps> = ({
   // dialog `keydown` already closes the top drawer, and a second handler here
   // would call `onClose` twice.
   const rootRef = useRef<HTMLDivElement>(null);
-  const isTopmost = useDialogLevel(
-    rootRef,
-    isOpen,
-    '--bai-drawer-portal-level',
-  );
+  const isTopmost = useDialogLevel(rootRef, isOpen);
 
   const { containerRef, focusFirst } = useFocusTrap<HTMLDivElement>({
     isActive: isOpen && isTopmost,

--- a/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDrawerPortal.tsx
@@ -12,26 +12,12 @@ import './BAIDrawerPortal.css';
 import { useFocusTrap, useScrollLock } from '@astryxdesign/core/hooks';
 import { dataAttr } from '@astryxdesign/core/naming';
 import { useThemeName } from '@astryxdesign/core/theme';
+import { mergeRefs } from '@astryxdesign/core/utils';
 import { Drawer, type DrawerProps } from '@astryxdesign/lab';
-import {
-  BAI_MODAL_OPEN_ATTRIBUTE,
-  claimDialogLevel,
-  releaseDialogLevel,
-} from './dialogLevelStack';
+import { BAI_MODAL_OPEN_ATTRIBUTE, useDialogLevel } from './dialogLevelStack';
 import classNames from 'classnames';
-import React, {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-
-// lab delays its own `dialog.close()` by these to let the panel slide out
-// (`@astryxdesign/lab/src/Drawer/Drawer.tsx`); the portal root has to outlive
-// `isOpen` by the same amount or the exit is cut off.
-const EXIT_DURATION_MS = 250;
-const REDUCED_MOTION_EXIT_DURATION_MS = 10;
 
 /** Hides the root once the slide-out is over. Driven from the DOM, not React,
     so a closing drawer does not re-render its whole subtree a frame later. */
@@ -55,8 +41,12 @@ const BAIDrawerPortal: React.FC<BAIDrawerPortalProps> = ({
   // Modality restored by hand: `show()` traps nothing. Escape stays lab's — its
   // dialog `keydown` already closes the top drawer, and a second handler here
   // would call `onClose` twice.
-  // A covered surface drops its trap; see `syncCoveredDialogs`.
-  const [isTopmost, setIsTopmost] = useState(true);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const isTopmost = useDialogLevel(
+    rootRef,
+    isOpen,
+    '--bai-drawer-portal-level',
+  );
 
   const { containerRef, focusFirst } = useFocusTrap<HTMLDivElement>({
     isActive: isOpen && isTopmost,
@@ -65,51 +55,33 @@ const BAIDrawerPortal: React.FC<BAIDrawerPortalProps> = ({
   // lab runs `useScrollLock(isOpen && hasScrim)`, and its scrim is off now.
   useScrollLock(isOpen);
 
-  const rootRef = useRef<HTMLDivElement>(null);
-  useLayoutEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const level = claimDialogLevel(rootRef.current, setIsTopmost);
-    rootRef.current?.style.setProperty(
-      '--bai-drawer-portal-level',
-      String(level),
-    );
-    return () => {
-      releaseDialogLevel(level);
-    };
-  }, [isOpen]);
-
-  const hasBeenOpenRef = useRef(false);
+  // lab delays its own `dialog.close()` to let the panel slide out, so the
+  // portal root outlives `isOpen` until that close lands — no copied duration.
   useLayoutEffect(() => {
     const root = rootRef.current;
     if (!root) {
       return;
     }
     if (isOpen) {
-      hasBeenOpenRef.current = true;
       root.removeAttribute(HIDDEN_ATTRIBUTE);
       return;
     }
-    if (!hasBeenOpenRef.current) {
-      root.setAttribute(HIDDEN_ATTRIBUTE, '');
+    const hide = () => root.setAttribute(HIDDEN_ATTRIBUTE, '');
+    const dialog = root.querySelector('dialog');
+    if (!dialog?.open) {
+      hide();
       return;
     }
-    const timer = setTimeout(
-      () => root.setAttribute(HIDDEN_ATTRIBUTE, ''),
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches
-        ? REDUCED_MOTION_EXIT_DURATION_MS
-        : EXIT_DURATION_MS,
-    );
-    return () => clearTimeout(timer);
+    dialog.addEventListener('close', hide, { once: true });
+    return () => dialog.removeEventListener('close', hide);
   }, [isOpen]);
 
-  // `show()` moves focus nowhere, unlike `showModal()`. lab has already honoured
-  // `[data-autofocus]`; otherwise land on its `tabindex="-1"` panel body, where
-  // the dialog focusing steps used to put us.
+  // `show()` moves focus nowhere, unlike `showModal()`. lab may already have
+  // focused `[data-autofocus]`; otherwise land on its `tabindex="-1"` panel
+  // body, where the dialog focusing steps used to put us.
   useEffect(() => {
     const node = containerRef.current;
-    if (!isOpen || !node || node.querySelector('[data-autofocus]')) {
+    if (!isOpen || !node || node.contains(document.activeElement)) {
       return;
     }
     const panel = node.querySelector<HTMLElement>('dialog > [tabindex="-1"]');
@@ -137,7 +109,7 @@ const BAIDrawerPortal: React.FC<BAIDrawerPortalProps> = ({
 
   return createPortal(
     <div
-      ref={rootRef}
+      ref={mergeRefs<HTMLDivElement>(rootRef, containerRef)}
       className={classNames(
         'bai-drawer-portal',
         !isOpen && 'bai-drawer-portal--closed',
@@ -150,18 +122,16 @@ const BAIDrawerPortal: React.FC<BAIDrawerPortalProps> = ({
       }}
     >
       <div ref={maskRef} className="bai-drawer-portal__mask" />
-      <div ref={containerRef} className="bai-drawer-portal__wrap">
-        <Drawer
-          {...rest}
-          isOpen={isOpen}
-          onClose={onClose}
-          hasScrim={false}
-          // lab omits it without a scrim, but the portal restores modality.
-          aria-modal={isOpen ? 'true' : undefined}
-        >
-          {children}
-        </Drawer>
-      </div>
+      <Drawer
+        {...rest}
+        isOpen={isOpen}
+        onClose={onClose}
+        hasScrim={false}
+        // lab omits it without a scrim, but the portal restores modality.
+        aria-modal={isOpen ? 'true' : undefined}
+      >
+        {children}
+      </Drawer>
     </div>,
     document.body,
   );

--- a/packages/backend.ai-ui/src/components/BAINotificationStackAstryx.css
+++ b/packages/backend.ai-ui/src/components/BAINotificationStackAstryx.css
@@ -17,8 +17,9 @@
   width: 384px; /* antd's notification width; not on the spacing scale. */
   max-width: calc(100vw - var(--spacing-6) * 2);
   /* Top of the ladder (`../styles/zIndexLadder.ts`), so a notice clears every
-     layer on it — including the whole modal band. It does NOT clear the CSS top
-     layer: lab `Drawer` is still a native `<dialog>` and paints over notices. */
+     layer on it — the modal band included, and since FR-3585 the scrimmed
+     drawers that joined it. It does NOT clear the CSS top layer: tours and
+     non-scrim drawers are still native and paint over notices. */
   z-index: var(--bai-z-notification);
   pointer-events: none;
 }

--- a/packages/backend.ai-ui/src/components/BAINotificationStackAstryx.css
+++ b/packages/backend.ai-ui/src/components/BAINotificationStackAstryx.css
@@ -17,9 +17,9 @@
   width: 384px; /* antd's notification width; not on the spacing scale. */
   max-width: calc(100vw - var(--spacing-6) * 2);
   /* Top of the ladder (`../styles/zIndexLadder.ts`), so a notice clears every
-     layer on it — the modal band included, and since FR-3585 the scrimmed
-     drawers that joined it. It does NOT clear the CSS top layer: tours and
-     non-scrim drawers are still native and paint over notices. */
+     layer on it — the modal band and, since FR-3585, the scrimmed drawers. Not
+     the CSS top layer: tours use the popover API and paint over notices.
+     Non-scrim drawers `show()` at 1000, below this — they do not. */
   z-index: var(--bai-z-notification);
   pointer-events: none;
 }

--- a/packages/backend.ai-ui/src/components/dialogLevelStack.test.ts
+++ b/packages/backend.ai-ui/src/components/dialogLevelStack.test.ts
@@ -119,6 +119,24 @@ describe('dialogLevelStack', () => {
     expect(entry.zIndex).toBe(BAI_Z_INDEX.modalBase);
   });
 
+  // The focus trap gates on this flag, not on `inert`: Astryx >=0.4.4 drops
+  // `inert` subtrees from its focusables, so a covered trap left active sees
+  // none and swallows Tab instead of letting the top one cycle (FR-3578).
+  it('tells each entry whether it is the topmost one', () => {
+    const lowerFlags: Array<boolean> = [];
+    const upperFlags: Array<boolean> = [];
+
+    claim(makeRoot(), (isTopmost) => lowerFlags.push(isTopmost));
+    expect(lowerFlags).toEqual([true]);
+
+    const upper = claim(makeRoot(), (isTopmost) => upperFlags.push(isTopmost));
+    expect(lowerFlags.at(-1)).toBe(false);
+    expect(upperFlags.at(-1)).toBe(true);
+
+    releaseDialogLevel(upper);
+    expect(lowerFlags.at(-1)).toBe(true);
+  });
+
   // Past the ceiling the level repeats, so a release resolved by level would
   // splice — and un-inert — the wrong, still-open entry.
   it('releases by identity when two entries share the clamped level', () => {

--- a/packages/backend.ai-ui/src/components/dialogLevelStack.test.ts
+++ b/packages/backend.ai-ui/src/components/dialogLevelStack.test.ts
@@ -119,24 +119,6 @@ describe('dialogLevelStack', () => {
     expect(entry.zIndex).toBe(BAI_Z_INDEX.modalBase);
   });
 
-  // The focus trap gates on this flag, not on `inert`: Astryx >=0.4.4 drops
-  // `inert` subtrees from its focusables, so a covered trap left active sees
-  // none and swallows Tab instead of letting the top one cycle (FR-3578).
-  it('tells each entry whether it is the topmost one', () => {
-    const lowerFlags: Array<boolean> = [];
-    const upperFlags: Array<boolean> = [];
-
-    claim(makeRoot(), (isTopmost) => lowerFlags.push(isTopmost));
-    expect(lowerFlags).toEqual([true]);
-
-    const upper = claim(makeRoot(), (isTopmost) => upperFlags.push(isTopmost));
-    expect(lowerFlags.at(-1)).toBe(false);
-    expect(upperFlags.at(-1)).toBe(true);
-
-    releaseDialogLevel(upper);
-    expect(lowerFlags.at(-1)).toBe(true);
-  });
-
   // Past the ceiling the level repeats, so a release resolved by level would
   // splice — and un-inert — the wrong, still-open entry.
   it('releases by identity when two entries share the clamped level', () => {

--- a/packages/backend.ai-ui/src/styles/zIndexLadder.ts
+++ b/packages/backend.ai-ui/src/styles/zIndexLadder.ts
@@ -13,10 +13,10 @@
  | `splash` | 900 | `index.html` `#splash`, which stays mounted as the logged-out backdrop. It sits BELOW `modalBase` deliberately: every dialog is a `document.body` portal now, so no login-screen wrapper can lift one over a splash that outranks the band |
  | `loginHost` | 950 | `InteractiveLoginPage`'s full-viewport card host |
  | (theme-shim) | 1000–1002 | a SECOND vocabulary this ladder does not own: `theme-shim`'s `zIndexPopupBase` (1000, operator-settable through `resources/antdThemeConfig.schema.json`), read by `FolderExplorerModal` (`+ 2`); lab `Drawer`'s non-modal base is 1000 too, and `DragAndDrop` sits at 1001 |
- | `modalBase` | 1100 | `BAIDialog`, plus `BAI_Z_INDEX_MODAL_LEVEL_STEP` per nesting level |
+ | `modalBase` | 1100 | `BAIDialog` and `BAIDrawerPortal` (the scrimmed drawer), plus `BAI_Z_INDEX_MODAL_LEVEL_STEP` per level of the stack they share |
  | `loginSideHelp` | 1101 | `LoginFormPanel`'s side help panel — a fixed sibling anchored to the base modal's edge, so it clears that modal's mask but not a modal opened on top of it |
  | `notification` | 11000 | `.bai-notification-stack` |
- | (CSS top layer) | above all | Astryx `Toast`/`Popover`/`DropdownMenu`/`Tooltip`, lab `Drawer` — not stackable against this ladder |
+ | (CSS top layer) | above all | Astryx `Toast`/`Popover`/`DropdownMenu`/`Tooltip`, `BAITourAstryx` — not stackable against this ladder. A NON-SCRIM lab `Drawer` is not here either: it opens with `show()`, so it stacks at the theme-shim 1000 band above |
  | context-local stacking | off the ladder at any magnitude | `BAIBoard.css`, `BAITableAstryx*`, `BAICompactGroup.css` — local to a subtree |
 */
 import './zIndexLadder.css';
@@ -35,5 +35,5 @@ export const BAI_Z_INDEX = {
   notification: 11000,
 } as const;
 
-/** Each nested `BAIDialog` claims one step above `modalBase`. */
+/** Each nested portal — dialog or scrimmed drawer — claims one step above `modalBase`. */
 export const BAI_Z_INDEX_MODAL_LEVEL_STEP = 10;

--- a/react/src/components/BAIContentWithDrawerArea.css
+++ b/react/src/components/BAIContentWithDrawerArea.css
@@ -17,11 +17,12 @@
  sets inline on its own element (`--bai-drawer-area-width`).
 
  `drawerStyle` used to select whether the drawer-panel rule was emitted at all.
- The drawer panel lives in the TOP LAYER (a native `<dialog>`; modals are
- portalled since FR-3578), so it cannot read a custom property set on the
- content div — the rule keys off the content div's own `margin-style` class
- through `:has()` instead (Chromium 105+/Safari 15.4+/Firefox 121+). It fires
- only while the notification drawer holds the layout in margin-style.
+ The drawer panel is never a descendant of the content div — non-scrim drawers
+ are top-layer-free native `<dialog>`s and scrimmed ones are `document.body`
+ portals (FR-3585) — so it cannot read a custom property set there. The rule
+ keys off the content div's own `margin-style` class through `:has()` instead
+ (Chromium 105+/Safari 15.4+/Firefox 121+). It fires only while the
+ notification drawer holds the layout in margin-style.
 
  Token mapping (P19-checked): theme.colorBorder -> var(--color-border-emphasized).
 */

--- a/react/src/helper/openModalRoot.ts
+++ b/react/src/helper/openModalRoot.ts
@@ -5,13 +5,14 @@
 import { BAI_MODAL_OPEN_ATTRIBUTE } from 'backend.ai-ui';
 
 // A portal root (`BAIDialog`, the `BAIModal` app launcher among them, and
-// `BAIDrawerPortal` since FR-3585), or an open native `<dialog>` — which since
-// FR-3585 is only the two non-scrim drawers. Tours are popovers, not dialogs.
-// `:not([inert])` drops the roots the level stack covered, whose contents no
-// one can reach.
+// `BAIDrawerPortal` since FR-3585), or an open native `<dialog>` that is
+// actually MODAL. `[aria-modal="true"]` stands in for `:modal` (jsdom cannot
+// match it) and keeps the non-scrim `show()` drawers out — an open
+// notification drawer must not suppress its own `]` toggle (FR-3619).
+// `:not([inert])` drops the roots the level stack covered.
 const OPEN_MODAL_ROOTS = [
   `[${BAI_MODAL_OPEN_ATTRIBUTE}]:not([inert])`,
-  'dialog[open]:not([inert])',
+  'dialog[open][aria-modal="true"]:not([inert])',
 ] as const;
 
 export const OPEN_MODAL_ROOT_SELECTOR = OPEN_MODAL_ROOTS.join(', ');

--- a/react/src/helper/openModalRoot.ts
+++ b/react/src/helper/openModalRoot.ts
@@ -4,8 +4,9 @@
 */
 import { BAI_MODAL_OPEN_ATTRIBUTE } from 'backend.ai-ui';
 
-// A portal root (`BAIDialog`, and `BAIDrawerPortal` since FR-3585), or any
-// open native `<dialog>` — tours, the launcher, non-scrim drawers.
+// A portal root (`BAIDialog`, the `BAIModal` app launcher among them, and
+// `BAIDrawerPortal` since FR-3585), or an open native `<dialog>` — which since
+// FR-3585 is only the two non-scrim drawers. Tours are popovers, not dialogs.
 // `:not([inert])` drops the roots the level stack covered, whose contents no
 // one can reach.
 const OPEN_MODAL_ROOTS = [

--- a/react/src/helper/openModalRoot.ts
+++ b/react/src/helper/openModalRoot.ts
@@ -4,9 +4,10 @@
 */
 import { BAI_MODAL_OPEN_ATTRIBUTE } from 'backend.ai-ui';
 
-// A `BAIDialog` root, or any open native `<dialog>` — after FR-3578 that
-// is drawers, plus anything opened with `.show()`. `:not([inert])` drops the
-// roots the level stack covered, whose contents no one can reach.
+// A portal root (`BAIDialog`, and `BAIDrawerPortal` since FR-3585), or any
+// open native `<dialog>` — tours, the launcher, non-scrim drawers.
+// `:not([inert])` drops the roots the level stack covered, whose contents no
+// one can reach.
 const OPEN_MODAL_ROOTS = [
   `[${BAI_MODAL_OPEN_ATTRIBUTE}]:not([inert])`,
   'dialog[open]:not([inert])',

--- a/react/src/hooks/useKeyboardShortcut.test.ts
+++ b/react/src/hooks/useKeyboardShortcut.test.ts
@@ -120,11 +120,12 @@ describe('useKeyboardShortcut', () => {
   });
 
   describe('Modal detection', () => {
-    // Both roots the selector covers: BAIDialog's marked div, and the lab
-    // `Drawer`'s still-native `<dialog>`.
+    // Both roots the selector covers: a portal root (BAIDialog, and since
+    // FR-3585 the scrimmed drawer), and the native `<dialog>` tours, the
+    // launcher and non-scrim drawers still open.
     it.each([
       ['a portal modal', 'div', BAI_MODAL_OPEN_ATTRIBUTE],
-      ['a native dialog (drawer)', 'dialog', 'open'],
+      ['a native dialog', 'dialog', 'open'],
     ])(
       'should not trigger handler when %s is open',
       (_label, tagName, attribute) => {

--- a/react/src/hooks/useKeyboardShortcut.test.ts
+++ b/react/src/hooks/useKeyboardShortcut.test.ts
@@ -44,10 +44,16 @@ describe('useKeyboardShortcut', () => {
     return event;
   };
 
-  const appendOpenModalRoot = (tagName: string, attribute: string) => {
+  const appendOpenModalRoot = (
+    tagName: string,
+    attributes: Record<string, string>,
+  ) => {
     const root = document.createElement(tagName);
-    root.setAttribute(attribute, '');
+    Object.entries(attributes).forEach(([name, value]) =>
+      root.setAttribute(name, value),
+    );
     document.body.appendChild(root);
+    return root;
   };
 
   describe('Basic functionality', () => {
@@ -121,15 +127,15 @@ describe('useKeyboardShortcut', () => {
 
   describe('Modal detection', () => {
     // Both roots the selector covers: a portal root (BAIDialog, the
-    // BAIModal launcher, and since FR-3585 the scrimmed drawer), and the native
-    // `<dialog>` the two non-scrim drawers still open.
+    // BAIModal launcher, and since FR-3585 the scrimmed drawer), and a native
+    // `<dialog>` that is actually modal (`aria-modal`).
     it.each([
-      ['a portal modal', 'div', BAI_MODAL_OPEN_ATTRIBUTE],
-      ['a native dialog', 'dialog', 'open'],
-    ])(
+      ['a portal modal', 'div', { [BAI_MODAL_OPEN_ATTRIBUTE]: '' }],
+      ['a modal native dialog', 'dialog', { open: '', 'aria-modal': 'true' }],
+    ] as const)(
       'should not trigger handler when %s is open',
-      (_label, tagName, attribute) => {
-        appendOpenModalRoot(tagName, attribute);
+      (_label, tagName, attributes) => {
+        appendOpenModalRoot(tagName, attributes);
 
         renderHook(() => useKeyboardShortcut(mockHandler));
         triggerKeydown({ key: 'a' });
@@ -137,6 +143,18 @@ describe('useKeyboardShortcut', () => {
         expect(mockHandler).not.toHaveBeenCalled();
       },
     );
+
+    // The non-scrim drawers open with `show()`: page interactive, shortcuts
+    // too — an open notification drawer must not eat its own `]` toggle
+    // (FR-3619).
+    it('should trigger handler when only a non-modal dialog is open', () => {
+      appendOpenModalRoot('dialog', { open: '' });
+
+      renderHook(() => useKeyboardShortcut(mockHandler));
+      triggerKeydown({ key: 'a' });
+
+      expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
 
     it('should trigger handler when a dialog is present but closed', () => {
       document.body.appendChild(document.createElement('dialog'));
@@ -278,7 +296,7 @@ describe('useKeyboardShortcut', () => {
       document.body.appendChild(input);
       input.focus();
 
-      appendOpenModalRoot('div', BAI_MODAL_OPEN_ATTRIBUTE);
+      appendOpenModalRoot('div', { [BAI_MODAL_OPEN_ATTRIBUTE]: '' });
 
       renderHook(() => useKeyboardShortcut(mockHandler));
       triggerKeydown({ key: 'a' });

--- a/react/src/hooks/useKeyboardShortcut.test.ts
+++ b/react/src/hooks/useKeyboardShortcut.test.ts
@@ -120,9 +120,9 @@ describe('useKeyboardShortcut', () => {
   });
 
   describe('Modal detection', () => {
-    // Both roots the selector covers: a portal root (BAIDialog, and since
-    // FR-3585 the scrimmed drawer), and the native `<dialog>` tours, the
-    // launcher and non-scrim drawers still open.
+    // Both roots the selector covers: a portal root (BAIDialog, the
+    // BAIModal launcher, and since FR-3585 the scrimmed drawer), and the native
+    // `<dialog>` the two non-scrim drawers still open.
     it.each([
       ['a portal modal', 'div', BAI_MODAL_OPEN_ATTRIBUTE],
       ['a native dialog', 'dialog', 'open'],

--- a/scripts/migration-gates/z-index-ladder-gate.mjs
+++ b/scripts/migration-gates/z-index-ladder-gate.mjs
@@ -17,7 +17,9 @@
  * Also pinned: `@astryxdesign/lab`'s non-modal `Drawer` / `BottomSheet` base of
  * 1000 — the one off-ladder value the ladder must not collide with. It sits
  * between `loginHost` (950) and `modalBase` (1100), so an upstream bump moving
- * it lands inside the ladder's range with nothing else to notice.
+ * it lands inside the ladder's range with nothing else to notice. Still live
+ * after FR-3585: `ChatPage`, the notification drawer, and the inner `<dialog>`
+ * of every portalled drawer all open with `show()` and take this base.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";


### PR DESCRIPTION
Resolves #8878 (FR-3585)
Resolves #8955 (FR-3619)

## Mechanism

A scrimmed lab `Drawer` is a native `<dialog>` promoted with `showModal()`, and per the [HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#modal-dialogs-and-inert-subtrees) that inerts everything outside its flat-tree descendants. Since FR-3578 moved modals onto a `document.body` portal, a modal opened from inside a drawer sat *outside* that flat tree — unclickable, untabbable, unfocusable, with Escape closing the invisible modal.

`hasScrim` never decides *whether* a `<dialog>` renders — only `showModal()` vs `show()` (`lab/src/Drawer/Drawer.tsx:521-538`), and `show()` promotes nothing. So `BAIDrawerAstryx`'s scrimmed path now renders through a new **`BAIDrawerPortal`**: `createPortal(root > mask + wrap > <Drawer hasScrim={false}>)` into `document.body`. The portal restores exactly what dropping the scrim loses — mask (pointer modality + outside-click-to-close with FR-3578's drag-out guard), `useFocusTrap`, `useScrollLock`, `aria-modal` — and the panel geometry, slide animation, and `[data-autofocus]` contract stay lab's own. None of the 8 `BAIDrawerAstryx` call sites changed; `hasScrim={false}` consumers (`WEBUINotificationDrawer`, `ChatPage`) are untouched on the native `show()` path.

## One level stack, shared

The stacking machinery FR-3578 built into `BAIDialogPortal` is extracted to `packages/backend.ai-ui/src/components/dialogLevelStack.ts` and both portals join it through one `useDialogLevel` hook: scrimmed drawers claim a level in the modal band (`--bai-z-modal-base` 1100 + level × 10), so a modal opened later claims the next level, paints above, and `inert`s the drawer root — the semantics `showModal()` chronology used to give. No new ladder band. `releaseDialogLevel` clears `inert` on the departing root (a root can outlive its stack entry), the covered-root sync writes attributes only on transitions, and the stack has its own unit tests.

Two deliberate deltas, recorded here rather than as code comments:

- **Escape stays lab's.** Its LIFO registry already closes the top drawer via a `keydown` on the dialog element; a second `onEscape` handler on the trap would double-fire `onClose`. With a modal above, focus is inside the modal, so the drawer's listener never fires and the modal's trap wins — measured below.
- **Focus on open is placed by hand** at lab's `tabindex="-1"` panel body (where the dialog focusing steps used to land), because `show()` moves focus nowhere. `[data-autofocus]` still wins when present.

The exit animation is lab's own, and so is its timing: the portal root hides (a DOM attribute → `display: none`) on the inner dialog's `close` event, which lab fires at the exact end of its 250 ms / reduced-motion 10 ms slide-out delay — self-synchronizing by construction, with no copied duration constants to drift on an Astryx bump. Driving the hide through the DOM instead of state avoids re-rendering the closing subtree (and the `react-hooks/set-state-in-effect` lint error the state version trips).

## Measured — live, both modes

Dev server against a real cluster, Admin → RBAC → role detail drawer → 역할 수정 modal (the worst case: the modal is a DOM **descendant** of the drawer). The FR-3585 issue's "before" numbers are from the same probe on the base branch.

| | before (FR-3578) | light | dark |
|---|---|---|---|
| drawer promoted to top layer (`:modal`) | true | **false** | **false** |
| drawer / modal z-index | top layer / 1100 | 1100 / **1110** | 1100 / **1110** |
| drawer root `inert` while modal open | n/a (modal inert instead) | **true** | **true** |
| `elementFromPoint` at modal's first control | `DIALOG#probe-drawer` | **inside the modal** | **inside the modal** |
| `.focus()` on the modal control | refused | **accepted** | **accepted** |
| typing into the modal's input | impossible | **works** | **works** |
| Escape #1 / #2 | closes invisible modal | **modal, then drawer** | **modal, then drawer** |
| drawer `inert` cleared after modal closes | — | **yes** | **yes** |
| `duration: 0` notice over the open drawer | drawer paints over it | **11000 > 1100, dismiss 1 → 0** | **11000 > 1100, dismiss 1 → 0** |
| `pageerror` | — | **0** | **0** |

Also verified live: theme re-emission (`data-astryx-theme="bai-r15-default-admin-…"` on the portal root — the modal's primary button keeps the admin `#028DF2` accent over the drawer), mask fade-in via `@starting-style`, exit timing (root visible at close+100 ms, hidden at +400 ms), and the mask absorbing clicks aimed at the header while the drawer is open.

The notice row closes the FR-3578 residue "drawers still paint over the notice stack" for scrimmed drawers; the `astryxBui.css` comment now says so.

## Bundled: FR-3619 — the `]` toggle could not close the notification drawer

The global-shortcut guard suppressed every handler whenever an open native `<dialog>` existed — and the non-scrim notification drawer is itself one (lab renders a `<dialog>` regardless of `hasScrim`; the non-scrim path just opens it with `show()`). So the `]` that opened the drawer was suppressed by the drawer it opened: a one-way toggle, with every other global shortcut dead while it was open. Pre-existing on `main` (its inline check is `document.querySelector('dialog[open]')`), surfaced by this PR's re-audit of the layer inventory.

Fix: the dialog arm of `OPEN_MODAL_ROOT_SELECTOR` now requires `[aria-modal="true"]` — a stand-in for `:modal` that jsdom can match. lab sets `aria-modal` only on the `showModal()` path, and `BAIDrawerPortal` passes it explicitly, so scrimmed surfaces keep suppressing while the non-scrim drawers stop. Deliberate behaviour change: while the notification drawer (or ChatPage history) is open, other global shortcuts now work too — consistent with a non-modal overlay leaving the page interactive. Known gap, accepted: a raw `showModal()` dialog without `aria-modal` would escape the arm; no such consumer exists.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → ok
- `pnpm --filter backend.ai-ui exec vitest run` → **644 passed / 1 skipped** (51 files) — `BAIDialogPortal.test.tsx` and `zIndexLadder.test.ts` green after the extraction, +4 new `dialogLevelStack` tests (incl. a ceiling regression for identity-based release)
- `pnpm --prefix ./react exec vitest run` → **1422 passed** (90 files; +11 new `BAIDrawerPortal` tests, incl. the core regression — a modal opened inside the drawer claims level 1 and the drawer root goes `inert` — and both halves of the Escape ordering)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared, `BAIText.css:28` — **pre-existing on the base branch**, untouched here

## Residue

- **Verified live on one of the three affected screens** (RBAC role edit — the worst case, a DOM-descendant modal). `ModelCardDrawer` and `SessionDetailDrawer` could not be probed on this cluster (empty model store, no sessions); they take the identical `BAIDrawerAstryx` scrimmed path and are covered by the unit test asserting the drawer→modal level/inert contract.
- **The two non-scrim drawers (`WEBUINotificationDrawer`, `ChatPage` history) stay native `show()` dialogs** — they are all `openModalRoot.ts`'s `dialog[open]` arm matches now (tours are popovers, the app launcher is a `BAIModal` portal), and at z 1000 they sit *below* the notice stack. Tours' popover layer is the one surface notices still cannot clear. Converting the non-scrim drawers is FR-3585's option 2 tail, deliberately not taken (they host no modals).
- The `z-index-ladder-gate.mjs` pin on lab's `NON_MODAL_BASE_Z = 1000` stays: `ChatPage`, the notification drawer, and every portalled drawer's inner `show()` dialog still rely on it (the inner value resolves inside the portal root's stacking context, so it cannot collide with the ladder).
- **The drawer mask drops lab's `::backdrop` blur on request**, keeping only the overlay color — matching the base branch, which dropped the modal mask's blur the same way. Both portal masks now agree: overlay color, no blur.
- `BAIContentWithDrawerArea.css`'s `body:has(...)` workaround remains — a portal under `document.body` is still not a descendant of the content div — with its comment corrected to say why.
- **The portal shell is now written twice** (theme re-emission, mask look, `data-bai-modal-open` root, mask drag-guard) — once in `BAIDialogPortal`, once in `BAIDrawerPortal`, in two packages. A simplify pass folded the small shared pieces (`useDialogLevel`, transition-guarded inert sync) into `dialogLevelStack.ts`; extracting the full shell into one BUI `BAIPortalSurface` is deliberately left for a follow-up — it would rewrite FR-3578's shipped portal in the same PR that depends on it.

<sub>Live-probe screenshots (light + dark) captured; attaching pending write access to the assets branch — the probe is reproducible on any cluster with an admin account: RBAC → create a custom role → open it → 역할 수정.</sub>

