### PR TITLE
style(FR-3588): drop the result count from Power search on the folder lists

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPowerSearchAdapters.tsx
@@ -202,6 +202,9 @@ export interface BAIPowerSearchChromeProps {
   /**
    * Pre-formatted result count. Passed to PowerSearch as a STRING so the host's
    * own pluralisation wins over Astryx's "N results".
+   *
+   * @deprecated FR-3588 — Power search shows no result count. Kept only so the
+   * published API stays source-compatible; drop it in the next major.
    */
   resultCount?: string;
   /**

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -320,9 +320,6 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
                   placeholder={t('data.SearchByName')}
                   applyLabel={t('button.Apply')}
                   contentSearchFieldKey="name"
-                  resultCount={t('general.TotalItems', {
-                    total: vfolder_nodes?.count ?? 0,
-                  })}
                   filterProperties={[
                     {
                       key: 'name',

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -383,9 +383,6 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                 applyLabel={t('button.Apply')}
                 // Free text with no field prefix becomes a `name ilike` token.
                 contentSearchFieldKey="name"
-                resultCount={t('general.TotalItems', {
-                  total: vfolder_nodes?.count ?? 0,
-                })}
                 filterProperties={[
                   {
                     key: 'name',


### PR DESCRIPTION
Resolves #8882 (FR-3588)

## Mechanism

`BAIPropertyFilter` destructures `resultCount` (`BAIPropertyFilter.tsx:455`) and
forwards it verbatim to Astryx `PowerSearch` (`:534`), which renders it inside
the search field. Two host call sites fed it `general.TotalItems`:

- `react/src/pages/VFolderNodeListPage.tsx` (`/data`)
- `react/src/pages/AdminVFolderNodeListPage.tsx` (`/admin/data`)

So the folder lists carried a `Total N items` string on the search control while
the table's own pagination row already reported the same figure
(`1 - 10 of 11 items`) a few hundred pixels below it.

`resultCount` has **no default** on `PowerSearch` (`astryx component
PowerSearch`), so omitting the prop renders nothing — no suppression flag or
override is needed.

## Measured, in the running app

Dev server on this branch (`https://fr-3588.localhost:1357`) against
`http://10.82.0.130:8090`, headless Chromium at 1440×900. Light and dark are
separate browser contexts with `colorScheme` set, so the app takes its real
`prefers-color-scheme` → `themeMode` path; `document.documentElement.dataset.theme`
was asserted per pass. The value below is the full `.astryx-power-search`
`innerText`.

| Route | Mode | `dataset.theme` | Before | After |
|---|---|---|---|---|
| `/data` | light | `light` | `Search \| Total 11 items` | `Search` |
| `/data` | dark | `dark` | `Search \| Total 11 items` | `Search` |
| `/admin/data` | light | `light` | `Search \| Total 14 items` | `Search` |
| `/admin/data` | dark | `dark` | `Search \| Total 14 items` | `Search` |

`pageerror` count: **0** in every pass, before and after.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built (run before verify, since
  `astryx theme build --check` reads the BUI dist)
- `pnpm --filter backend.ai-ui exec vitest run` → **616 passed**, 1 skipped (48 files)
- `pnpm --prefix ./react exec vitest run` → **1406 passed** (88 files)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 277 declared,
  897 usages, **1 undeclared**: `BAIText.css:28 var(--x)`. Pre-existing — that
  line is inside the file's header comment explaining the no-fallback rule, and
  it is present verbatim on `origin/main`. Not touched by this PR.

## Residue

- **The count is not lost.** The table's pagination row still reports
  `1 - 10 of N items` on both pages; only the duplicate inside the search
  control is gone.
- **The `resultCount` prop stays on the API.** `BAIPropertyFilter` /
  `BAIGraphQLPropertyFilter` and their props types are exported from the
  published `backend.ai-ui` package, so removing `resultCount` from
  `BAIPowerSearchChromeProps` would be a breaking change. It is marked
  `@deprecated` pointing at FR-3588 instead, to be dropped in the next major.
  No call site in this repository passes it after this PR.
- **No sibling report is subsumed.** These were the only two call sites in the
  tree that fed a result count into Power search.

## Screenshots

The `.astryx-power-search` element, cropped from the live probe above.

| Route | Mode | Before | After |
|---|---|---|---|
| `/data` | light | ![before light-data](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8885/20260819-before-light-data-powersearch.png) | ![after light-data](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8885/20260819-after-light-data-powersearch.png) |
| `/data` | dark | ![before dark-data](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8885/20260819-before-dark-data-powersearch.png) | ![after dark-data](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8885/20260819-after-dark-data-powersearch.png) |
| `/admin/data` | light | ![before light-admin-data](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8885/20260819-before-light-admin-data-powersearch.png) | ![after light-admin-data](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8885/20260819-after-light-admin-data-powersearch.png) |
| `/admin/data` | dark | ![before dark-admin-data](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8885/20260819-before-dark-admin-data-powersearch.png) | ![after dark-admin-data](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8885/20260819-after-dark-admin-data-powersearch.png) |
