### PR TITLE
fix(FR-3590): contain the folder explorer's split panes so they cannot overlap

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -349,7 +349,9 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
         gap="md"
         style={{ height: '100%', ...style }}
       >
-        <BAIFlex align="center" justify="between">
+        {/* Wraps so a narrow container stacks the path above the actions
+            instead of pushing them out of a clipped pane (FR-3590). */}
+        <BAIFlex align="center" justify="between" wrap="wrap" gap="xs">
           <Breadcrumbs
             label={t('comp:FileExplorer.Path')}
             style={{

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -78,6 +78,10 @@ const EXPLORER_MAX_HEIGHT = '95vh';
 // 419px and the whole toolbar 437px (viewport 1600, `xl` two-pane layout).
 const EXPLORER_MIN_WIDTH = 440;
 
+// The row's non-panel width: `--spacing-2` on each side of the 1px handle.
+// Measured 1392 - 655 - 720 = 17 at viewport 1600.
+const SPLIT_HANDLE_WIDTH = 17;
+
 export interface FolderExplorerElement extends HTMLDivElement {
   _fetchVFolder: () => void;
   _openDeleteMultipleFileDialog: () => void;
@@ -134,10 +138,30 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
   const fileExplorerRef = useRef<BAIFileExplorerRef>(null);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
+  // Observed so the drag can be clamped against the real row width. Without a
+  // `maxSizePx` the resizable's size keeps growing past what flexbox renders,
+  // and dragging back has to unwind that dead travel first (measured 685px).
+  const [splitRowWidth, setSplitRowWidth] = useState(0);
+  const observeSplitRow = (node: HTMLDivElement | null) => {
+    if (!node) return;
+    // `offsetWidth`, not `getBoundingClientRect()`: the latter is scaled by the
+    // dialog's entrance transform, so the first read lands at 95% and the
+    // observer never corrects it (the layout box never changed).
+    const measure = () => setSplitRowWidth(node.offsetWidth);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(node);
+    return () => ro.disconnect();
+  };
+
   // The info panel keeps its antd-Splitter geometry: default 45%, min 550px.
   const infoPanel = useResizable({
     defaultSize: '45%',
     minSizePx: 550,
+    maxSizePx:
+      splitRowWidth > 0
+        ? Math.max(550, splitRowWidth - EXPLORER_MIN_WIDTH - SPLIT_HANDLE_WIDTH)
+        : undefined,
   });
 
   const deferredOpen = useDeferredValue(modalProps.open);
@@ -522,6 +546,7 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
                 // `gap` applies on BOTH sides of the handle, so half the legacy
                 // `Splitter style={{ gap: token.size }}` reproduces 8 + 1 + 8.
                 <div
+                  ref={observeSplitRow}
                   style={{
                     display: 'flex',
                     flex: 1,

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -73,6 +73,11 @@ import { graphql, useLazyLoadQuery, useQueryLoader } from 'react-relay';
  */
 const EXPLORER_MAX_HEIGHT = '95vh';
 
+// Floor for the explorer pane, so the drag cannot shrink it until `overflow:
+// hidden` clips its toolbar out of reach. Measured: the action group needs
+// 419px and the whole toolbar 437px (viewport 1600, `xl` two-pane layout).
+const EXPLORER_MIN_WIDTH = 440;
+
 export interface FolderExplorerElement extends HTMLDivElement {
   _fetchVFolder: () => void;
   _openDeleteMultipleFileDialog: () => void;
@@ -524,7 +529,13 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
                     gap: 'var(--spacing-2)',
                   }}
                 >
-                  <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+                  <div
+                    style={{
+                      flex: 1,
+                      minWidth: EXPLORER_MIN_WIDTH,
+                      overflow: 'hidden',
+                    }}
+                  >
                     {fileExplorerElement}
                   </div>
                   {/* The handle's own `height: 100%` resolves to `auto` here —

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -511,14 +511,11 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
 
             {vfolderNode && !hasNoPermissions ? (
               xl ? (
-                // antd `Splitter` → Astryx `useResizable` + `ResizeHandle`:
-                // explorer fills the remaining space, the info panel keeps a
-                // drag-resizable width (default 45%, min 550px). `gap` restores
-                // the legacy `Splitter style={{ gap: token.size }}` — 16px of
-                // total separation between the two panes, which the conversion
-                // dropped (the 1px handle sat flush against both). The flex gap
-                // applies on BOTH sides of the handle, so half the legacy value
-                // (`--spacing-2`) reproduces it: 8 + 1 + 8 = 17px.
+                // antd `Splitter` owned containment — panel sizes always summed
+                // to the container and each panel clipped. `useResizable` only
+                // yields a number, so the panes carry it themselves (FR-3590).
+                // `gap` applies on BOTH sides of the handle, so half the legacy
+                // `Splitter style={{ gap: token.size }}` reproduces 8 + 1 + 8.
                 <div
                   style={{
                     display: 'flex',
@@ -527,7 +524,7 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
                     gap: 'var(--spacing-2)',
                   }}
                 >
-                  <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
                     {fileExplorerElement}
                   </div>
                   {/* The handle's own `height: 100%` resolves to `auto` here —
@@ -544,7 +541,14 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
                       resizable={infoPanel.props}
                     />
                   </div>
-                  <div style={{ width: infoPanel.size, flexShrink: 0 }}>
+                  <div
+                    style={{
+                      width: infoPanel.size,
+                      flexShrink: 1,
+                      minWidth: 0,
+                      overflow: 'hidden',
+                    }}
+                  >
                     {vFolderInfoPanelElement}
                   </div>
                 </div>


### PR DESCRIPTION
Resolves #8886 (FR-3590)

Dragging the divider between the folder explorer's file list and its metadata
panel left the two panes overlapping: the explorer's toolbar painted across the
metadata panel, on top of its tab strip.

## Mechanism

antd `Splitter` owned **containment** — panel sizes always summed to the
container, and each `Splitter.Panel` clipped its own content:

```jsx
<Splitter style={{ flex: 1, gap: token.size }} orientation="horizontal">
  <Splitter.Panel resizable>{fileExplorerElement}</Splitter.Panel>
  <Splitter.Panel defaultSize="45%" min={550}>{vFolderInfoPanelElement}</Splitter.Panel>
</Splitter>
```

The Astryx conversion replaced it with `useResizable` + a hand-rolled flex row.
`useResizable` only produces a number, and nothing took the containment over, so
both ends were left unbounded:

- `useResizable` defaults `maxSizePx` to `Infinity` and the call site passes only
  `minSizePx: 550`. With the info panel at `flexShrink: 0`, its width could grow
  past the row and push its right edge outside the modal.
- The explorer pane is `flex: 1; min-width: 0` with `overflow: visible`, so it
  collapsed toward zero while its toolbar kept painting at its natural width
  (measured 437px) — straight across the info panel.

Measured on the live app (viewport 1600, `xl` two-pane layout, row 1392px). At
the fully collapsed position, hit-testing the info-panel band at the toolbar's
y showed the explorer's own `Create File` and `Upload` buttons as the topmost
paint inside the metadata panel — which is exactly what the report's screenshot
shows.

## Fix

Restore the two properties antd `Splitter` supplied, in
`react/src/components/FolderExplorerModalV2.tsx`:

- `overflow: hidden` on both panes, so neither can paint outside its own box;
- `flexShrink: 1` + `minWidth: 0` on the info panel, so when `infoPanel.size`
  exceeds the available width flexbox absorbs it there instead of overflowing
  the row.

No new geometry constants, no measurement hook, no change to the drag behaviour.

## Measured before / after

Same DOM, same collapsed divider position, styles toggled in place.

| | info panel width | overflow past the row | explorer elements hit inside the info-panel band |
|---|---|---|---|
| before | 1730px | **+355px** | **2** — x=381 `Create File`, x=500 `Upload` |
| after | 1375px | **0px** | **0** |

Divider still behaves, both directions:

| state | explorer | info panel | sums to row (1392px) |
|---|---|---|---|
| default | 655px | 720px | ✔ |
| dragged right to the limit | 825px | **550px** (`minSizePx` still enforced) | ✔ |
| dragged fully left | 0px | 1375px | ✔ |
| dragged back | 275px | 1100px | ✔ |

Light and dark both re-measured (dark entered via the header button, with
`document.documentElement.dataset.theme === 'dark'` asserted): `explorerHits 0`
and `0px` overflow in both. Zero `pageerror` in both passes.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (TypeScript, Vite warmup paths,
  StyleX `cssInjectionTarget`, Astryx theme build, Terminology)
- `pnpm --prefix ./react exec vitest run` → **88 files, 1406 tests passed**
- `pnpm --filter backend.ai-ui exec vitest run` → **47 files, 616 passed, 1 skipped**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared
  `var(--x)` at `packages/backend.ai-ui/src/components/BAIText.css:28`.
  **Pre-existing** — it is the gate matching that file's own doc comment, and it
  is present unchanged on `origin/main`. No file I touched contributes a token.
- The first `verify.sh` run failed at `Astryx theme build` because this fresh
  worktree had no `backend.ai-ui` `dist` yet; `pnpm --filter backend.ai-ui build`
  then a re-run gives the `ALL PASS` above.

## Residue

- The explorer's own minimum is now set and the drag is clamped to the row (see
  the review follow-up below); the earlier draft left it collapsible to 0px.
- In that collapsed regime `infoPanel.size` keeps growing past the rendered
  clamp, so dragging back has to unwind the excess (measured ~175px of
  overshoot). Self-correcting, and invisible short of the collapse.
- `react/src/components/FolderExplorerModal.tsx` (V1) carries the same unbounded
  pattern, but `FolderExplorerOpener` lazy-imports **V2** only and nothing else
  imports V1, so it is unreachable and left untouched.
- Does not subsume FR-3575 (the drag-and-drop upload overlay) — a different
  symptom on the same screen, linked as related.

## Review follow-up (@ironAiken2)

> As the button is simply set to `display: hidden`, it is hidden and cannot be
> clicked. Previously, when the view size was reduced, the layout would adjust
> vertically, but it seems that feature is no longer available.

Confirmed and fixed. `overflow: hidden` gave containment, but the drag could
still take the explorer pane to 0px, so the clip hid its toolbar rather than
reflowing it.

Reproduced at the collapsed position (viewport 1600, row 1392px): explorer pane
**0px**, and all four action buttons — `Create Folder`, `Create File`,
`Upload`, `Refresh` — outside the pane's box, i.e. unclickable.

Two changes, both measured:

- `EXPLORER_MIN_WIDTH` (440px) floors the explorer pane. The info panel already
  carries `flexShrink: 1` + `minWidth: 0`, so flexbox absorbs the excess there
  instead of overflowing the row — no measurement hook, no `maxSizePx`. Sized
  from the measurement: the action group needs 419px, the whole toolbar 437px.
- The explorer's breadcrumb/actions row now **wraps**, so a narrow pane stacks
  the path above the actions instead of pushing them past the clip. This is the
  "adjust vertically" behaviour, and it keeps the pane's requirement at the
  action group's width no matter how deep the current path is.

### Measured after

| viewport | state | explorer | info panel | overflow past row | action buttons clipped |
|---|---|---|---|---|---|
| 1600 | default | 655px | 720px | 0px | 0 |
| 1600 | dragged fully left | **440px** | 935px | 0px | **0** |
| 1600 | dragged fully right | 654px | 721px | 0px | 0 |
| 1200 | dragged fully left | **440px** | 575px | 0px | **0** |

Toolbar height goes 32px → 54px at the floor, i.e. it wrapped to two rows.
Dark re-measured identical to light. Zero `pageerror` in every pass.

The only elements still clipped at the floor are the table's own `Created At` /
`Modified At` **column-header** sort buttons — present identically at viewport
1200 in the *default* state, so that is pre-existing `BAITable` horizontal
overflow, not this change.

### Re-verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → **93 files, 1472 tests passed**
- `pnpm --filter backend.ai-ui exec vitest run` → **52 passed, 1 skipped, 677 tests passed**

### Follow-up: the floor also had to clamp the drag

The first pass set the floor with flexbox only. `useResizable` still had
`maxSizePx: Infinity`, so past the floor the drag kept growing the panel's
stored size while the rendered widths stood still — and dragging back had to
unwind all of it before anything moved.

| dragging fully left, then back (viewport 1600, row 1392px) | rendered info | stored size | dead travel |
|---|---|---|---|
| flexbox floor only | 935px | 1620px | **685px** |
| **+ `maxSizePx` clamp** | 935px | **935px** | **0px** |

A `ResizeObserver` on the split row feeds `maxSizePx = row - 440 - 17`, so the
stored size can never exceed what the row can show. Every drag step now moves
1:1 in both directions, and `aria-valuemax` reports the real limit (935 at
viewport 1600, 575 at 1200) where before it was absent.

The observer reads `offsetWidth`, not `getBoundingClientRect()`: the dialog
animates in at 0.95 scale, so a rect-based first read landed at 1322 of 1392
and the observer never corrected it (the layout box never changed), leaving the
floor 70px too generous.


## Screenshots

**Before** — dark, divider dragged left. The explorer's `Create F…` and `…oad`
(Upload) buttons paint on top of the tab strip, garbling `Audit Log`.

![before, dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8887/20260819-064715-fr3590-before-dark.png)

**After** — dark, same divider position. The toolbar is clipped at the pane
boundary; `Metadata` and `Audit Log` sit side by side.

![after, dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8887/20260819-064715-fr3590-after-dark.png)

**After** — light, same position.

![after, light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8887/20260819-064715-fr3590-after-light.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)