### PR TITLE
fix(FR-3594): restore compiler memoization on admin/project-admin list surfaces

### DIFF
--- a/react/src/__generated__/AdminComputeSessionListPageQuery.graphql.ts
+++ b/react/src/__generated__/AdminComputeSessionListPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5cd4a94f9a2089a82f2810de0e978003>>
+ * @generated SignedSource<<1dac9fcf4fe49833725628c52c60a88f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,11 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs, Result } from "relay-runtime";
 export type AdminComputeSessionListPageQuery$variables = {
   filter?: string | null | undefined;
+  filterForAllCount?: string | null | undefined;
+  filterForBatchCount?: string | null | undefined;
+  filterForInferenceCount?: string | null | undefined;
+  filterForInteractiveCount?: string | null | undefined;
+  filterForSystemCount?: string | null | undefined;
   first?: number | null | undefined;
   offset?: number | null | undefined;
   order?: string | null | undefined;
@@ -55,21 +60,46 @@ var v0 = {
   "name": "filter"
 },
 v1 = {
-  "defaultValue": 20,
+  "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "first"
+  "name": "filterForAllCount"
 },
 v2 = {
-  "defaultValue": 0,
+  "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "offset"
+  "name": "filterForBatchCount"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "filterForInferenceCount"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filterForInteractiveCount"
+},
+v5 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filterForSystemCount"
+},
+v6 = {
+  "defaultValue": 20,
+  "kind": "LocalArgument",
+  "name": "first"
+},
+v7 = {
+  "defaultValue": 0,
+  "kind": "LocalArgument",
+  "name": "offset"
+},
+v8 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "order"
 },
-v4 = [
+v9 = [
   {
     "kind": "Variable",
     "name": "filter",
@@ -91,159 +121,159 @@ v4 = [
     "variableName": "order"
   }
 ],
-v5 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "count",
   "storageKey": null
 },
-v8 = {
+v13 = {
   "kind": "Literal",
   "name": "first",
   "value": 0
 },
-v9 = {
+v14 = {
   "kind": "Literal",
   "name": "offset",
   "value": 0
 },
-v10 = [
-  (v7/*: any*/)
+v15 = [
+  (v12/*: any*/)
 ],
-v11 = {
+v16 = {
   "alias": "all",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\""
+      "variableName": "filterForAllCount"
     },
-    (v8/*: any*/),
-    (v9/*: any*/)
+    (v13/*: any*/),
+    (v14/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v10/*: any*/),
-  "storageKey": "compute_session_nodes(filter:\"status != \"TERMINATED\" & status != \"CANCELLED\"\",first:0,offset:0)"
+  "selections": (v15/*: any*/),
+  "storageKey": null
 },
-v12 = {
+v17 = {
   "alias": "interactive",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
+      "variableName": "filterForInteractiveCount"
     },
-    (v8/*: any*/),
-    (v9/*: any*/)
+    (v13/*: any*/),
+    (v14/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v10/*: any*/),
-  "storageKey": "compute_session_nodes(filter:\"status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\"\",first:0,offset:0)"
+  "selections": (v15/*: any*/),
+  "storageKey": null
 },
-v13 = {
+v18 = {
   "alias": "inference",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
+      "variableName": "filterForInferenceCount"
     },
-    (v8/*: any*/),
-    (v9/*: any*/)
+    (v13/*: any*/),
+    (v14/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v10/*: any*/),
-  "storageKey": "compute_session_nodes(filter:\"status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\"\",first:0,offset:0)"
+  "selections": (v15/*: any*/),
+  "storageKey": null
 },
-v14 = {
+v19 = {
   "alias": "batch",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
+      "variableName": "filterForBatchCount"
     },
-    (v8/*: any*/),
-    (v9/*: any*/)
+    (v13/*: any*/),
+    (v14/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v10/*: any*/),
-  "storageKey": "compute_session_nodes(filter:\"status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\"\",first:0,offset:0)"
+  "selections": (v15/*: any*/),
+  "storageKey": null
 },
-v15 = {
+v20 = {
   "alias": "system",
   "args": [
     {
-      "kind": "Literal",
+      "kind": "Variable",
       "name": "filter",
-      "value": "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
+      "variableName": "filterForSystemCount"
     },
-    (v8/*: any*/),
-    (v9/*: any*/)
+    (v13/*: any*/),
+    (v14/*: any*/)
   ],
   "concreteType": "ComputeSessionConnection",
   "kind": "LinkedField",
   "name": "compute_session_nodes",
   "plural": false,
-  "selections": (v10/*: any*/),
-  "storageKey": "compute_session_nodes(filter:\"status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\"\",first:0,offset:0)"
+  "selections": (v15/*: any*/),
+  "storageKey": null
 },
-v16 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "row_id",
   "storageKey": null
 },
-v17 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status",
   "storageKey": null
 },
-v18 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status_info",
   "storageKey": null
 },
-v19 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "tag",
   "storageKey": null
 },
-v20 = [
+v25 = [
   {
     "alias": null,
     "args": null,
@@ -259,14 +289,14 @@ v20 = [
     "storageKey": null
   }
 ],
-v21 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "idle_checks",
   "storageKey": null
 },
-v22 = [
+v27 = [
   {
     "alias": null,
     "args": null,
@@ -283,17 +313,17 @@ v22 = [
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v16/*: any*/),
-          (v6/*: any*/),
-          (v17/*: any*/)
+          (v10/*: any*/),
+          (v21/*: any*/),
+          (v11/*: any*/),
+          (v22/*: any*/)
         ],
         "storageKey": null
       }
     ],
     "storageKey": null
   },
-  (v7/*: any*/)
+  (v12/*: any*/)
 ];
 return {
   "fragment": {
@@ -301,7 +331,12 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/)
+      (v3/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -311,7 +346,7 @@ return {
         "kind": "CatchField",
         "field": {
           "alias": "computeSessionNodeResult",
-          "args": (v4/*: any*/),
+          "args": (v9/*: any*/),
           "concreteType": "ComputeSessionConnection",
           "kind": "LinkedField",
           "name": "compute_session_nodes",
@@ -339,12 +374,12 @@ return {
                       "selections": [
                         {
                           "kind": "RequiredField",
-                          "field": (v5/*: any*/),
+                          "field": (v10/*: any*/),
                           "action": "THROW"
                         },
                         {
                           "kind": "RequiredField",
-                          "field": (v6/*: any*/),
+                          "field": (v11/*: any*/),
                           "action": "THROW"
                         },
                         {
@@ -367,17 +402,17 @@ return {
               },
               "action": "THROW"
             },
-            (v7/*: any*/)
+            (v12/*: any*/)
           ],
           "storageKey": null
         },
         "to": "RESULT"
       },
-      (v11/*: any*/),
-      (v12/*: any*/),
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v15/*: any*/)
+      (v16/*: any*/),
+      (v17/*: any*/),
+      (v18/*: any*/),
+      (v19/*: any*/),
+      (v20/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -385,17 +420,22 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v1/*: any*/),
-      (v2/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
       (v0/*: any*/),
-      (v3/*: any*/)
+      (v8/*: any*/),
+      (v1/*: any*/),
+      (v4/*: any*/),
+      (v3/*: any*/),
+      (v2/*: any*/),
+      (v5/*: any*/)
     ],
     "kind": "Operation",
     "name": "AdminComputeSessionListPageQuery",
     "selections": [
       {
         "alias": "computeSessionNodeResult",
-        "args": (v4/*: any*/),
+        "args": (v9/*: any*/),
         "concreteType": "ComputeSessionConnection",
         "kind": "LinkedField",
         "name": "compute_session_nodes",
@@ -417,10 +457,10 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/),
-                  (v6/*: any*/),
-                  (v16/*: any*/),
-                  (v17/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v21/*: any*/),
+                  (v22/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -449,7 +489,7 @@ return {
                     "name": "agent_ids",
                     "storageKey": null
                   },
-                  (v18/*: any*/),
+                  (v23/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -499,7 +539,7 @@ return {
                     "name": "requested_slots",
                     "storageKey": null
                   },
-                  (v19/*: any*/),
+                  (v24/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -538,7 +578,7 @@ return {
                                 "name": "cluster_role",
                                 "storageKey": null
                               },
-                              (v5/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -568,7 +608,7 @@ return {
                                     "name": "architecture",
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -576,7 +616,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "tags",
                                     "plural": true,
-                                    "selections": (v20/*: any*/),
+                                    "selections": (v25/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -586,7 +626,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "labels",
                                     "plural": true,
-                                    "selections": (v20/*: any*/),
+                                    "selections": (v25/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -603,12 +643,12 @@ return {
                                     "name": "namespace",
                                     "storageKey": null
                                   },
-                                  (v19/*: any*/),
-                                  (v5/*: any*/)
+                                  (v24/*: any*/),
+                                  (v10/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v16/*: any*/),
+                              (v21/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -623,8 +663,8 @@ return {
                                 "name": "cluster_idx",
                                 "storageKey": null
                               },
-                              (v17/*: any*/),
-                              (v18/*: any*/),
+                              (v22/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -648,7 +688,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v21/*: any*/),
+                  (v26/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -671,7 +711,7 @@ return {
                         "name": "email",
                         "storageKey": null
                       },
-                      (v5/*: any*/)
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -713,16 +753,16 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
-                              (v6/*: any*/),
-                              (v5/*: any*/)
+                              (v21/*: any*/),
+                              (v11/*: any*/),
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v7/*: any*/)
+                      (v12/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -733,7 +773,7 @@ return {
                     "name": "scaling_group",
                     "storageKey": null
                   },
-                  (v21/*: any*/),
+                  (v26/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -748,7 +788,7 @@ return {
                     "kind": "LinkedField",
                     "name": "dependees",
                     "plural": false,
-                    "selections": (v22/*: any*/),
+                    "selections": (v27/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -758,7 +798,7 @@ return {
                     "kind": "LinkedField",
                     "name": "dependents",
                     "plural": false,
-                    "selections": (v22/*: any*/),
+                    "selections": (v27/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -802,28 +842,28 @@ return {
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v12/*: any*/)
         ],
         "storageKey": null
       },
-      (v11/*: any*/),
-      (v12/*: any*/),
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v15/*: any*/)
+      (v16/*: any*/),
+      (v17/*: any*/),
+      (v18/*: any*/),
+      (v19/*: any*/),
+      (v20/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "b3b5faa20af0e10a6e9f82769480a697",
+    "cacheID": "748f595116bcd4321d1f9dda3757091b",
     "id": null,
     "metadata": {},
     "name": "AdminComputeSessionListPageQuery",
     "operationKind": "query",
-    "text": "query AdminComputeSessionListPageQuery(\n  $first: Int = 20\n  $offset: Int = 0\n  $filter: String\n  $order: String\n) {\n  computeSessionNodeResult: compute_session_nodes(first: $first, offset: $offset, filter: $filter, order: $order) {\n    edges {\n      node {\n        id\n        name\n        ...SessionNodesFragment\n        ...TerminateSessionModalFragment\n      }\n    }\n    count\n  }\n  all: compute_session_nodes(first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\"\") {\n    count\n  }\n  interactive: compute_session_nodes(first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"interactive\\\"\") {\n    count\n  }\n  inference: compute_session_nodes(first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"inference\\\"\") {\n    count\n  }\n  batch: compute_session_nodes(first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"batch\\\"\") {\n    count\n  }\n  system: compute_session_nodes(first: 0, offset: 0, filter: \"status != \\\"TERMINATED\\\" & status != \\\"CANCELLED\\\" & type == \\\"system\\\"\") {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusCellFragment\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionReclamationStatusCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReclamationStatusCellFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusPopoverFragment\n}\n\nfragment SessionReclamationStatusPopoverFragment on ComputeSessionNode {\n  id\n  idle_checks\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query AdminComputeSessionListPageQuery(\n  $first: Int = 20\n  $offset: Int = 0\n  $filter: String\n  $order: String\n  $filterForAllCount: String\n  $filterForInteractiveCount: String\n  $filterForInferenceCount: String\n  $filterForBatchCount: String\n  $filterForSystemCount: String\n) {\n  computeSessionNodeResult: compute_session_nodes(first: $first, offset: $offset, filter: $filter, order: $order) {\n    edges {\n      node {\n        id\n        name\n        ...SessionNodesFragment\n        ...TerminateSessionModalFragment\n      }\n    }\n    count\n  }\n  all: compute_session_nodes(first: 0, offset: 0, filter: $filterForAllCount) {\n    count\n  }\n  interactive: compute_session_nodes(first: 0, offset: 0, filter: $filterForInteractiveCount) {\n    count\n  }\n  inference: compute_session_nodes(first: 0, offset: 0, filter: $filterForInferenceCount) {\n    count\n  }\n  batch: compute_session_nodes(first: 0, offset: 0, filter: $filterForBatchCount) {\n    count\n  }\n  system: compute_session_nodes(first: 0, offset: 0, filter: $filterForSystemCount) {\n    count\n  }\n}\n\nfragment AppLaunchConfirmationModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment AppLauncherModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  service_ports\n  access_key\n  ...useBackendAIAppLauncherFragment\n  ...SFTPConnectionInfoModalFragment\n  ...TensorboardPathModalFragment\n  ...AppLaunchConfirmationModalFragment\n}\n\nfragment BAISessionAgentIdsFragment on ComputeSessionNode {\n  agent_ids\n}\n\nfragment BAISessionClusterModeFragment on ComputeSessionNode {\n  cluster_mode\n  cluster_size\n}\n\nfragment BAISessionTypeTagFragment on ComputeSessionNode {\n  type\n}\n\nfragment ConnectedKernelListFragment on KernelNode {\n  id\n  row_id\n  cluster_hostname\n  cluster_idx\n  cluster_role\n  status\n  status_info\n  agent_id\n  container_id\n}\n\nfragment ContainerCommitModalFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n}\n\nfragment ContainerLogModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  access_key\n  kernel_nodes {\n    edges {\n      node {\n        id\n        row_id\n        container_id\n        cluster_idx\n        cluster_role\n        cluster_hostname\n      }\n    }\n  }\n}\n\nfragment EditableSessionNameFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  priority\n  user_id\n  status\n  project_id\n}\n\nfragment FolderLink_vfolderNode on VirtualFolderNode {\n  row_id\n  name\n  ...VFolderNodeIdenticonFragment\n}\n\nfragment ImageNodeSimpleTagFragment on ImageNode {\n  base_image_name\n  version\n  architecture\n  name\n  tags {\n    key\n    value\n  }\n  labels {\n    key\n    value\n  }\n  registry\n  namespace\n  tag\n}\n\nfragment MountedVFolderLinksFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n  }\n  ...MountedVFolderLinksLegacyLazyFolderLinkFragment\n}\n\nfragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {\n  row_id\n  vfolder_mounts\n}\n\nfragment SFTPConnectionInfoModalFragment on ComputeSessionNode {\n  row_id\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment SessionActionButtonsFragment on ComputeSessionNode {\n  id\n  name\n  row_id\n  type\n  status\n  access_key\n  service_ports\n  commit_status\n  user_id\n  ...TerminateSessionModalFragment\n  ...ContainerLogModalFragment\n  ...ContainerCommitModalFragment\n  ...AppLauncherModalFragment\n  ...SFTPConnectionInfoModalFragment\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment SessionDetailContentFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  project_id\n  user_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  resource_opts\n  status\n  status_data\n  vfolder_mounts\n  vfolder_nodes @since(version: \"25.4.0\") {\n    edges {\n      node {\n        ...FolderLink_vfolderNode\n        id\n      }\n    }\n    count\n  }\n  created_at\n  terminated_at\n  scaling_group\n  agent_ids\n  requested_slots\n  occupied_slots\n  tag\n  idle_checks @since(version: \"24.12.0\")\n  type\n  startup_command\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        ...ConnectedKernelListFragment\n        id\n      }\n    }\n  }\n  dependees {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        id\n        row_id\n        name\n        status\n      }\n    }\n    count\n  }\n  ...SessionStatusTagFragment\n  ...SessionActionButtonsFragment\n  ...BAISessionTypeTagFragment\n  ...EditableSessionNameFragment\n  ...SessionReservationFragment\n  ...ContainerLogModalFragment\n  ...SessionUsageMonitorFragment\n  ...ContainerCommitModalFragment\n  ...SessionIdleChecksNodeFragment\n  ...SessionStatusDetailModalFragment\n  ...AppLauncherModalFragment\n  ...MountedVFolderLinksFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionClusterModeFragment\n}\n\nfragment SessionDetailDrawerFragment on ComputeSessionNode {\n  id\n  project_id\n  ...SessionDetailContentFragment\n}\n\nfragment SessionIdleChecksNodeFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusCellFragment\n}\n\nfragment SessionNodesFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  status\n  type\n  service_ports\n  user_id\n  agent_ids\n  ...SessionStatusTagFragment\n  ...SessionReservationFragment\n  ...SessionSlotCellFragment\n  ...SessionReclamationStatusCellFragment\n  ...SessionUsageMonitorFragment\n  ...SessionDetailDrawerFragment\n  ...BAISessionAgentIdsFragment\n  ...BAISessionTypeTagFragment\n  ...BAISessionClusterModeFragment\n  ...AppLauncherModalFragment\n  ...TerminateSessionModalFragment\n  kernel_nodes {\n    edges {\n      node {\n        image {\n          ...ImageNodeSimpleTagFragment\n          id\n        }\n        id\n      }\n    }\n  }\n  created_at\n  scaling_group\n  project_id\n  owner @since(version: \"25.13.0\") {\n    email\n    id\n  }\n  dependees {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n  dependents {\n    edges {\n      node {\n        row_id\n        name\n        id\n      }\n    }\n    count\n  }\n}\n\nfragment SessionReclamationStatusCellFragment on ComputeSessionNode {\n  id\n  idle_checks\n  ...SessionReclamationStatusPopoverFragment\n}\n\nfragment SessionReclamationStatusPopoverFragment on ComputeSessionNode {\n  id\n  idle_checks\n}\n\nfragment SessionReservationFragment on ComputeSessionNode {\n  id\n  created_at\n  starts_at\n  terminated_at\n}\n\nfragment SessionSlotCellFragment on ComputeSessionNode {\n  id\n  status\n  occupied_slots\n  requested_slots\n  tag\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment SessionStatusDetailModalFragment on ComputeSessionNode {\n  id\n  name\n  status\n  status_info\n  status_data\n  starts_at\n  ...SessionStatusTagFragment\n}\n\nfragment SessionStatusTagFragment on ComputeSessionNode {\n  id\n  status\n  status_info\n  status_data\n  queue_position @since(version: \"25.13.0\")\n}\n\nfragment SessionUsageMonitorFragment on ComputeSessionNode {\n  occupied_slots\n  ...useSessionNodeLiveStatSessionFragment\n}\n\nfragment TensorboardPathModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  ...useBackendAIAppLauncherFragment\n}\n\nfragment TerminateSessionModalFragment on ComputeSessionNode {\n  id\n  row_id\n  name\n  scaling_group\n  access_key\n  project_id\n  kernel_nodes {\n    edges {\n      node {\n        container_id\n        agent_id\n        id\n      }\n    }\n  }\n}\n\nfragment VFolderNodeIdenticonFragment on VirtualFolderNode {\n  id\n}\n\nfragment useBackendAIAppLauncherFragment on ComputeSessionNode {\n  name\n  row_id\n  vfolder_mounts\n  scaling_group\n  project_id\n  service_ports\n}\n\nfragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {\n  id\n  kernel_nodes {\n    edges {\n      node {\n        live_stat\n        cluster_role\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "20511d2ccabe11df1c413275a52a3443";
+(node as any).hash = "7c8dbadc30e34da0dc4a5dd7f6c4a230";
 
 export default node;

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -58,6 +58,7 @@ type Keypair = NonNullable<
 >;
 
 const AdminUserCredentialList: React.FC = () => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message, modal } = App.useApp();

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -60,6 +60,7 @@ export type ContainerRegistry = NonNullable<
 const ContainerRegistryList: React.FC<{
   style?: React.CSSProperties;
 }> = ({ style }) => {
+  'use memo';
   const { logger } = useBAILogger();
   const baiClient = useSuspendedBackendaiClient();
   const [fetchKey, updateFetchKey] = useFetchKey();

--- a/react/src/pages/AdminComputeSessionListPage.tsx
+++ b/react/src/pages/AdminComputeSessionListPage.tsx
@@ -62,6 +62,18 @@ type ComputeSessionNodesData = ExtractResultValue<
 
 type SessionNode = NonNullableNodeOnEdges<ComputeSessionNodesData>;
 
+// Passed as query variables: inlining these in the graphql tag needs `\"`
+// escapes, and a tagged template whose cooked text differs from its raw text
+// makes the React Compiler bail out of the whole component (FR-3510 symptom).
+const NOT_FINISHED_FILTER = 'status != "TERMINATED" & status != "CANCELLED"';
+const COUNT_FILTERS = {
+  all: NOT_FINISHED_FILTER,
+  interactive: `${NOT_FINISHED_FILTER} & type == "interactive"`,
+  inference: `${NOT_FINISHED_FILTER} & type == "inference"`,
+  batch: `${NOT_FINISHED_FILTER} & type == "batch"`,
+  system: `${NOT_FINISHED_FILTER} & type == "system"`,
+};
+
 const AdminComputeSessionListPage = () => {
   'use memo';
 
@@ -128,7 +140,7 @@ const AdminComputeSessionListPage = () => {
   const statusFilter =
     queryParams.statusCategory === 'running' ||
     queryParams.statusCategory === undefined
-      ? 'status != "TERMINATED" & status != "CANCELLED"'
+      ? NOT_FINISHED_FILTER
       : 'status == "TERMINATED" | status == "CANCELLED"';
 
   const isNotRunningCategory = (status?: string | null) => {
@@ -143,6 +155,11 @@ const AdminComputeSessionListPage = () => {
     first: baiPaginationOption.first,
     filter: mergeFilterValues([statusFilter, queryParams.filter, typeFilter]),
     order: queryParams.order || '-created_at',
+    filterForAllCount: COUNT_FILTERS.all,
+    filterForInteractiveCount: COUNT_FILTERS.interactive,
+    filterForInferenceCount: COUNT_FILTERS.inference,
+    filterForBatchCount: COUNT_FILTERS.batch,
+    filterForSystemCount: COUNT_FILTERS.system,
   };
 
   const deferredQueryVariables = useDeferredValue(queryVariables);
@@ -150,65 +167,70 @@ const AdminComputeSessionListPage = () => {
 
   const queryRef = useLazyLoadQuery<AdminComputeSessionListPageQuery>(
     graphql`
-        query AdminComputeSessionListPageQuery(
-          $first: Int = 20
-          $offset: Int = 0
-          $filter: String
-          $order: String
-        ) {
-          computeSessionNodeResult: compute_session_nodes(
-            first: $first
-            offset: $offset
-            filter: $filter
-            order: $order
-          ) @catch(to: RESULT) {
-            edges @required(action: THROW) {
-              node @required(action: THROW) {
-                id @required(action: THROW)
-                name @required(action: THROW)
-                ...SessionNodesFragment
-                ...TerminateSessionModalFragment
-              }
+      query AdminComputeSessionListPageQuery(
+        $first: Int = 20
+        $offset: Int = 0
+        $filter: String
+        $order: String
+        $filterForAllCount: String
+        $filterForInteractiveCount: String
+        $filterForInferenceCount: String
+        $filterForBatchCount: String
+        $filterForSystemCount: String
+      ) {
+        computeSessionNodeResult: compute_session_nodes(
+          first: $first
+          offset: $offset
+          filter: $filter
+          order: $order
+        ) @catch(to: RESULT) {
+          edges @required(action: THROW) {
+            node @required(action: THROW) {
+              id @required(action: THROW)
+              name @required(action: THROW)
+              ...SessionNodesFragment
+              ...TerminateSessionModalFragment
             }
-            count
           }
-          all: compute_session_nodes(
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\""
-          ) {
-            count
-          }
-          interactive: compute_session_nodes(
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
-          ) {
-            count
-          }
-          inference: compute_session_nodes(
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
-          ) {
-            count
-          }
-          batch: compute_session_nodes(
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
-          ) {
-            count
-          }
-          system: compute_session_nodes(
-            first: 0
-            offset: 0
-            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
-          ) {
-            count
-          }
+          count
         }
-      `,
+        all: compute_session_nodes(
+          first: 0
+          offset: 0
+          filter: $filterForAllCount
+        ) {
+          count
+        }
+        interactive: compute_session_nodes(
+          first: 0
+          offset: 0
+          filter: $filterForInteractiveCount
+        ) {
+          count
+        }
+        inference: compute_session_nodes(
+          first: 0
+          offset: 0
+          filter: $filterForInferenceCount
+        ) {
+          count
+        }
+        batch: compute_session_nodes(
+          first: 0
+          offset: 0
+          filter: $filterForBatchCount
+        ) {
+          count
+        }
+        system: compute_session_nodes(
+          first: 0
+          offset: 0
+          filter: $filterForSystemCount
+        ) {
+          count
+        }
+      }
+    `,
     deferredQueryVariables,
     {
       fetchPolicy:
@@ -253,15 +275,15 @@ const AdminComputeSessionListPage = () => {
             inference: t('session.Inference'),
             system: t('session.System'),
           },
-          (label, key) => ({
-            key,
-            label: (
-              <BAIFlex justify="center" gap={10}>
-                {label}
-                {
-                  // display badge only if count is greater than 0
-                  // @ts-ignore
-                  (sessionCounts[key]?.count || 0) > 0 && (
+          (label, key) => {
+            const count =
+              sessionCounts[key as keyof typeof sessionCounts]?.count ?? 0;
+            return {
+              key,
+              label: (
+                <BAIFlex justify="center" gap={10}>
+                  {label}
+                  {count > 0 && (
                     <Badge
                       // PILOT-DECISION: antd count Badge (brand color when the
                       // tab is active, gray otherwise) -> Astryx Badge pill.
@@ -275,16 +297,13 @@ const AdminComputeSessionListPage = () => {
                           ? PRIMARY_TAG_VARIANT
                           : 'neutral'
                       }
-                      label={
-                        // @ts-ignore
-                        sessionCounts[key].count
-                      }
+                      label={count}
                     />
-                  )
-                }
-              </BAIFlex>
-            ),
-          }),
+                  )}
+                </BAIFlex>
+              ),
+            };
+          },
         )}
       />
       <BAIFlex direction="column" align="stretch" gap={'sm'}>

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -39,7 +39,7 @@ import {
 import * as _ from 'lodash-es';
 import { PlusIcon, RotateCcwIcon } from 'lucide-react';
 import { parseAsString, useQueryStates } from 'nuqs';
-import React, { useDeferredValue, useRef, useState } from 'react';
+import React, { useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -106,11 +106,16 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
     [queryParams.statusCategory]: { queryParams, tablePaginationOption },
   });
 
-  // eslint-disable-next-line react-hooks/refs
-  queryMapRef.current[queryParams.statusCategory] = {
-    queryParams,
-    tablePaginationOption,
-  };
+  // Written in an effect: a render-phase ref write is a react-hooks/refs
+  // violation that made the React Compiler bail out of this component, which
+  // re-created `queryVariables` every render and flashed the deferred-value
+  // loading states on unrelated re-renders (same symptom as FR-3510).
+  useEffect(() => {
+    queryMapRef.current[queryParams.statusCategory] = {
+      queryParams,
+      tablePaginationOption,
+    };
+  }, [queryParams, tablePaginationOption]);
 
   function getUsageModeFilter(mode: string) {
     switch (mode) {
@@ -250,28 +255,31 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
                 active: t('data.Active'),
                 deleted: t('data.folders.TrashBin'),
               },
-              (label, key) => ({
-                key,
-                // Astryx `Tab` takes a STRING label plus a native `endContent`
-                // slot, so the original's BAIFlex-wrapped JSX label is split in
-                // two. This also restores a correct `aria-label` on the tab.
-                label,
-                endContent:
-                  // display badge only if count is greater than 0
-                  // @ts-ignore
-                  (folderCounts[key]?.count || 0) > 0 ? (
-                    // PILOT-DECISION: antd's Badge took an arbitrary `color`
-                    // (brand accent when selected, disabled grey otherwise).
-                    // Astryx's Badge exposes only a closed `variant` set.
-                    <Badge
-                      // @ts-ignore
-                      label={folderCounts[key].count}
-                      variant={
-                        queryParams.statusCategory === key ? 'info' : 'neutral'
-                      }
-                    />
-                  ) : undefined,
-              }),
+              (label, key) => {
+                const count =
+                  folderCounts[key as keyof typeof folderCounts]?.count ?? 0;
+                return {
+                  key,
+                  // Astryx `Tab` takes a STRING label plus a native `endContent`
+                  // slot, so the original's BAIFlex-wrapped JSX label is split in
+                  // two. This also restores a correct `aria-label` on the tab.
+                  label,
+                  endContent:
+                    count > 0 ? (
+                      // PILOT-DECISION: antd's Badge took an arbitrary `color`
+                      // (brand accent when selected, disabled grey otherwise).
+                      // Astryx's Badge exposes only a closed `variant` set.
+                      <Badge
+                        label={count}
+                        variant={
+                          queryParams.statusCategory === key
+                            ? 'info'
+                            : 'neutral'
+                        }
+                      />
+                    ) : undefined,
+                };
+              },
             )}
           />
           <VStack align="stretch" gap={3}>

--- a/react/src/pages/ProjectAdminDataPage.tsx
+++ b/react/src/pages/ProjectAdminDataPage.tsx
@@ -50,7 +50,13 @@ import {
 import * as _ from 'lodash-es';
 import { PlusIcon, RotateCcwIcon, Trash2Icon } from 'lucide-react';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
-import React, { Suspense, useDeferredValue, useRef, useState } from 'react';
+import React, {
+  Suspense,
+  useDeferredValue,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -154,11 +160,16 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
     [queryParams.statusCategory]: { queryParams, tablePaginationOption },
   });
 
-  // eslint-disable-next-line react-hooks/refs
-  queryMapRef.current[queryParams.statusCategory] = {
-    queryParams,
-    tablePaginationOption,
-  };
+  // Written in an effect: a render-phase ref write is a react-hooks/refs
+  // violation that made the React Compiler bail out of this component, which
+  // re-created `queryVariables` every render and flashed the deferred-value
+  // loading states on unrelated re-renders (same symptom as FR-3510).
+  useEffect(() => {
+    queryMapRef.current[queryParams.statusCategory] = {
+      queryParams,
+      tablePaginationOption,
+    };
+  }, [queryParams, tablePaginationOption]);
 
   const usageModeFilter = getUsageModeFilter(queryParams.mode);
 

--- a/react/src/pages/ProjectAdminDataPage.tsx
+++ b/react/src/pages/ProjectAdminDataPage.tsx
@@ -86,27 +86,23 @@ const STATUS_FILTER_DELETED = {
 const statusCategoryValues = ['active', 'deleted'] as const;
 const modeValues = ['all', 'general', 'data', 'automount', 'model'] as const;
 
-function getUsageModeFilter(mode: (typeof modeValues)[number]) {
-  switch (mode) {
-    case 'all':
-      return undefined;
-    case 'general':
-      return {
-        AND: [
-          { name: { iNotStartsWith: '.' } },
-          { usageMode: { equals: 'GENERAL' } },
-        ],
-      } as const;
-    case 'data':
-      return { usageMode: { equals: 'DATA' } } as const;
-    case 'automount':
-      return { name: { iStartsWith: '.' } } as const;
-    case 'model':
-      return { usageMode: { equals: 'MODEL' } } as const;
-    default:
-      return undefined;
-  }
-}
+// Module constants so each mode's filter keeps a stable identity: the compiler
+// cannot skip calls that take fresh mutable arguments, and an unstable object
+// here cascades into a new `queryVariables` identity on every render, which
+// flashes the deferred-value loading states (FR-3594).
+const USAGE_MODE_FILTERS: Partial<
+  Record<(typeof modeValues)[number], VFolderFilter>
+> = {
+  general: {
+    AND: [
+      { name: { iNotStartsWith: '.' } },
+      { usageMode: { equals: 'GENERAL' } },
+    ],
+  },
+  data: { usageMode: { equals: 'DATA' } },
+  automount: { name: { iStartsWith: '.' } },
+  model: { usageMode: { equals: 'MODEL' } },
+};
 
 interface ProjectAdminDataContentProps {
   project: ProjectContext;
@@ -171,7 +167,7 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
     };
   }, [queryParams, tablePaginationOption]);
 
-  const usageModeFilter = getUsageModeFilter(queryParams.mode);
+  const usageModeFilter = USAGE_MODE_FILTERS[queryParams.mode];
 
   const [fetchKey, updateFetchKey] = useFetchKey();
 
@@ -180,12 +176,15 @@ const ProjectAdminDataContent: React.FC<ProjectAdminDataContentProps> = ({
       ? STATUS_FILTER_DELETED
       : STATUS_FILTER_ACTIVE;
 
-  const combinedFilter = {
-    AND: filterOutEmpty([
+  // Built from literals and stable references only (no helper call): the
+  // compiler keeps unknown calls with mutable arguments un-memoized, and any
+  // per-render identity here re-fires the deferred-value loading flash.
+  const combinedFilter: VFolderFilter = {
+    AND: [
       statusFilter,
-      usageModeFilter,
-      queryParams.filter ?? undefined,
-    ]),
+      ...(usageModeFilter ? [usageModeFilter] : []),
+      ...(queryParams.filter ? [queryParams.filter] : []),
+    ],
   };
 
   const queryVariables = {


### PR DESCRIPTION
Resolves #8893 (FR-3594)

Sibling of #8752 (FR-3510) — same symptom, three different React Compiler bailout causes. Stacked on that PR.

## Mechanism

FR-3510 established the chain: the React Compiler skips a component → `queryVariables` (a plain object literal) gets a new identity every render → any unrelated state update (row selection) makes `useDeferredValue` return the previous object for one urgent render pass → `deferredQueryVariables !== queryVariables` flashes `true` → `BAIFetchKeyButton`'s 700ms anti-flicker hold amplifies it into a visible, unclickable loading state.

A compiler sweep over all 48 pages plus the 93 risky components (files using `useDeferredValue` / `FetchKeyButton` / react-hooks suppressions) found the admin/project-admin surfaces where that chain is live, with three distinct bailout causes:

| File | Bailout cause | Fix |
|---|---|---|
| `AdminVFolderNodeListPage` (/admin/data) | render-phase `queryMapRef.current[…] = …` write → `CompileError: Cannot access refs during render` | move the write into a `useEffect` (the tab-change handler only reads the map on user interaction) |
| `ProjectAdminDataPage` | **two defects**: (1) identical render-phase ref write; (2) even with compiler memoization restored, `combinedFilter` was rebuilt through `filterOutEmpty([...])` / a switch returning fresh literals — the compiler keeps calls with fresh **mutable** arguments un-memoized, so the object filter (and `queryVariables`) changed identity every render. String-filter pages are immune because the memo guard compares strings by value. | (1) same; (2) hoist usage-mode filters to module constants and build `combinedFilter` from literals only, which the compiler memoizes |
| `AdminComputeSessionListPage` (/admin/session) | inline count-filter strings need `\"` escapes in the `graphql` tag; cooked ≠ raw tagged template is a compiler Todo bailout | pass count filters as query variables (the `filterForActiveCount` precedent) |
| `AdminUserCredentialList` | no `'use memo'` directive — compiler never ran | add the directive (compiles cleanly) |
| `ContainerRegistryList` | no `'use memo'` directive — compiler never ran | add the directive (compiles cleanly) |

Also replaced the `@ts-ignore` badge-count suppressions in the touched files with `keyof` narrowing, per the FR-3510 review direction of removing suppressions rather than adding them.

## Verification

- Per-file annotation-mode compile check (`babel-plugin-react-compiler`): all five files now report `CompileSuccess` (before: `CompileError`/never compiled)
- **Live probe** (headless Chromium against the dev server, 50ms sampling for 1.5s after clicking a row checkbox):

  | Probe | Before | After |
  |---|---|---|
  | `/project/default/admin/data` — refresh button loading after row select | **8/20 samples, 0–599ms window** | **0/22 samples** |
  | `/admin-data` — same | (fixed by commit 1) | **0/20 samples** |
  | Selection toolbar appears | works | works |
  | Manual refresh click still shows loading | — | yes, 0–592ms window (legit loading intact) |
  | `pageerror` count | 0 | 0 |
- `bash scripts/verify.sh` → `=== ALL PASS ===` (the earlier Relay drift was the regenerated `AdminComputeSessionListPageQuery` artifact, committed here)
- `pnpm --prefix ./react exec vitest run` → 88 files, **1405 passed** (0 failed)

## Residue (recorded in FR-3594 for follow-up triage)

The same sweep found bailouts **without** a deferred-comparison flash surface (no user-visible bug known, memoization only): `AdminDeploymentPresetSettingPage` (try/finally), `DeploymentAddRevisionModal`, `ChatCard`, and several others. And bailouts **with** a deferred surface but outside the admin scope of this issue: `AssignRoleModal`, `ProjectAdminSettingModal`, `UserSettingModal`, `FolderExplorerModal`/`V2`, `LoginSession`, plus missing-directive files `DashboardPage`, `ReservoirArtifactDetailPage`, `MyResourceWithinResourceGroup`, `TotalResourceWithinResourceGroup`, `PendingSessionNodeList`. Those need per-file restructuring (try/finally, optional-chaining-in-try, TSAsExpression keys) and are listed in the Jira issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

