### PR TITLE
style(FR-3596): draw the pinned step rails with the on-track indicator

### DIFF
--- a/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
+++ b/react/src/components/AdminDeploymentPresetSettingPageContent.tsx
@@ -1216,6 +1216,9 @@ const AdminDeploymentPresetSettingPageContent: React.FC<
             activeStep={currentStepIndex}
             orientation="vertical"
             density="compact"
+            // FR-3596: on-track puts each indicator on the connector line.
+            // Keep in sync with the Session Launcher rail this one mirrors.
+            indicatorPosition="on-track"
             onStepClick={(nextIndex) => goToStep(nextIndex)}
           >
             {stepTitles.map((title, idx) => (

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1548,6 +1548,9 @@ const SessionLauncherPage = () => {
             <Stepper
               orientation="vertical"
               density="compact"
+              // FR-3596: on-track puts each indicator on the connector line.
+              // Keep in sync with the deployment preset rail, which mirrors this one.
+              indicatorPosition="on-track"
               activeStep={currentStep}
               // `Stepper.label` names the whole sequence for assistive tech;
               // antd's `Steps` had none. Reuses the page's own existing title


### PR DESCRIPTION
Resolves #8897 (FR-3596)

Both sticky right-column step rails now render the lab `Stepper` with
`indicatorPosition="on-track"`.

## Mechanism

The lab `Stepper` defaults to `indicatorPosition="separated"`, which lays the
progress track out as its own **4px `astryx-step-bar` column to the left of the
label row** — the indicator sits *beside* the track, not on it. `"on-track"`
slots each indicator into the connector line as a node, with the label beside it
(the vertical arm of the lab layout; the horizontal arm puts the label below).

That is the whole change: the separate bar column disappears, which is exactly
where the measured **14px narrowing of both rails** comes from. No theme edit, no
CSS authored on our side, no DOM restructuring by us — a prop the component
already exposes (`@astryxdesign/lab@0.3.0-canary.12db2a1`,
`StepperIndicatorPosition = 'separated' | 'on-track'`).

Scope is the two rails FR-3596 named: `SessionLauncherPage.tsx` and
`AdminDeploymentPresetSettingPageContent.tsx`, which are the only two places in
the app that pin a `Stepper` in a `position: sticky; top: 80` right column behind
a `screens.lg` gate. The other two `Stepper` usages are a different pattern and
are deliberately untouched — see Residue.

## Measured before/after — live app, both modes

Chromium 1440×1000, dev server against a live cluster. Dark entered through the
Playwright context `colorScheme: 'dark'` (setting `documentElement.dataset.theme`
alone darkens the page but leaves Astryx card surfaces light), with
`document.documentElement.dataset.theme` asserted `'dark'` in the probe.

**Session Launcher — `/session/start`, 5 steps**

| | before (`separated`) | after (`on-track`) |
|---|---|---|
| `ol[data-indicator-position]` | `separated` | `on-track` |
| rail box | 280 × 157.9 | 266 × 156 |
| step `<li>` direct children | `div.astryx-step-bar` (4×30) + label `div` | single `<button>` filling the step |
| step heights | 30 / 30 / 30 / 30 / 30 | 30 / 32 / 32 / 32 / 30 |
| `pageerror` | 0 | 0 |

Identical geometry in light and dark.

**Deployment preset setting — `/admin/deployments/deployment-presets/new`, 3 steps**

| | before (`separated`) | after (`on-track`) |
|---|---|---|
| `ol[data-indicator-position]` | `separated` | `on-track` |
| rail box | 169 × 94 | 155 × 94 |
| step `<li>` direct children | `div.astryx-step-bar` (4×30) + label `div` | single `<button>` filling the step |
| `pageerror` | 0 | 0 |

Same −14px rail delta as the launcher, from the same removed bar column.

### No behavioural delta

`on-track` promotes the step `<button>` to a *direct* child of the `<li>`, but
the button was always there under `separated` (nested one level deeper inside the
label `div`). Running the same interaction probe against both states returned
**byte-identical** results:

- all 5 steps expose a `<button>`, `disabled=false`, `tabIndex=0`, no `aria-disabled`;
- clicking a `not-started` step navigates to it (0 → 2) — **in both states**;
- `Next` advances, and clicking a `completed` step navigates back (3 → 0) — in both;
- 0 `pageerror` in both.

Worth flagging because the `PILOT-DECISION` comment in
`AdminDeploymentPresetSettingPageContent.tsx` claims "Astryx only makes
completed/current steps clickable — forward jumps go through the Next /
Skip-to-Review buttons instead of the rail." The live probe contradicts that on
`main`, i.e. **before** this PR. It is a pre-existing inaccuracy in a comment, not
something this change introduces, and it is left alone here rather than silently
widened into a behaviour fix.

## Verification

| check | result |
|---|---|
| `bash scripts/verify.sh` | `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup, StyleX sentinel, Astryx theme build, Terminology) |
| `pnpm --prefix ./react exec vitest run` | 90 files, **1415 passed** |
| `pnpm --filter backend.ai-ui exec vitest run` | 50 files, **634 passed, 1 skipped** |
| `node scripts/migration-gates/astryx-token-gate.mjs --strict` | 1 undeclared — **pre-existing** |
| `pnpm --filter backend.ai-ui build` | ok (needed once in a fresh worktree — see below) |

The token gate's single finding is `packages/backend.ai-ui/src/components/BAIText.css:28`
`var(--x)`. It is inside a **comment** (`No var(--x, literal) fallbacks: …` in the
file header prose), not a live declaration, and `git show origin/main:` on that
path shows the identical lines — unrelated to this PR.

First `verify.sh` run in a fresh worktree failed at `Astryx theme build` with
`No "exports" main defined in … node_modules/backend.ai-ui/package.json`. That is
the known stale/absent BUI `dist` trap, not a defect in this change;
`pnpm --filter backend.ai-ui build` then `verify.sh` → ALL PASS.

## Screenshots

### Session Launcher rail — `/session/start`

| light — before (`separated`) | light — after (`on-track`) |
|---|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8901/launcher-before-light.png" width="280"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8901/launcher-after-light.png" width="280"> |

| dark — before (`separated`) | dark — after (`on-track`) |
|---|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8901/launcher-before-dark.png" width="280"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8901/launcher-after-dark.png" width="280"> |

The separate track column at the far left of the "before" shots is the
`astryx-step-bar`; in the "after" shots the connector runs through the
indicators instead.

### Deployment preset setting rail — `/admin/deployments/deployment-presets/new`

| dark — before (`separated`) | dark — after (`on-track`) |
|---|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8901/preset-before-dark.png" width="200"> | <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8901/preset-after-dark.png" width="200"> |

Light-mode after, for completeness (its matching *before* capture is the one
missing item noted under Residue):

<img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8901/preset-after-light.png" width="200">

## Residue

- **Not changed: the two non-pinned `Stepper` usages.** `EduAppLauncher.tsx`
  (vertical, inside a centred `BAICard`) and `FairShareList.tsx` (in the page
  body) are a different pattern and were explicitly out of the reporter's scope.
  FR-3596's "Options considered" keeps "apply everywhere" and "make it a theme
  default for `Stepper`" open; this PR implements option 1 only.
- **Not changed: the stale `PILOT-DECISION` claim** about forward-jump
  clickability described above.
- **Not changed:** `AdminDeploymentPresetSettingPageContent.tsx`'s comment says
  the rail "mirrors `DeploymentLauncherPageContent`", a file that no longer
  exists in the tree.
- The light-mode capture of the deployment preset rail's *before* state is
  missing (its probe run was interrupted); the dark-mode before is included and
  the geometry table above is measured, not inferred.
