### PR TITLE
fix(FR-3599): apply the deployment card's secondary accent to its icon and title

### DIFF
--- a/react/src/components/ActionItemContent.tsx
+++ b/react/src/components/ActionItemContent.tsx
@@ -19,7 +19,6 @@ interface StartItemContentProps {
   onClick?: () => void;
   to?: To;
   themeColor?: string;
-  itemRole?: 'user' | 'admin';
   type?: 'simple' | 'default';
   style?: React.CSSProperties;
 }
@@ -33,13 +32,11 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
   to,
   themeColor,
   type = 'default',
-  itemRole = 'user',
   style,
 }) => {
   const { token } = theme.useToken();
   const containerRef = useRef<HTMLDivElement>(null);
-  const accentColor =
-    themeColor ?? (itemRole === 'user' ? token.colorPrimary : token.colorInfo);
+  const accentColor = themeColor ?? token.colorPrimary;
   const accentColorWithAlpha = `rgba(${parseInt(accentColor.slice(1, 3), 16)}, ${parseInt(accentColor.slice(3, 5), 16)}, ${parseInt(accentColor.slice(5, 7), 16)}, 0.15)`;
 
   // PILOT-DECISION: antd `Button type="primary"` hand-painted with

--- a/react/src/components/ActionItemContent.tsx
+++ b/react/src/components/ActionItemContent.tsx
@@ -38,7 +38,9 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
 }) => {
   const { token } = theme.useToken();
   const containerRef = useRef<HTMLDivElement>(null);
-  const colorPrimaryWithAlpha = `rgba(${parseInt(token.colorPrimary.slice(1, 3), 16)}, ${parseInt(token.colorPrimary.slice(3, 5), 16)}, ${parseInt(token.colorPrimary.slice(5, 7), 16)}, 0.15)`;
+  const accentColor =
+    themeColor ?? (itemRole === 'user' ? token.colorPrimary : token.colorInfo);
+  const accentColorWithAlpha = `rgba(${parseInt(accentColor.slice(1, 3), 16)}, ${parseInt(accentColor.slice(3, 5), 16)}, ${parseInt(accentColor.slice(5, 7), 16)}, 0.15)`;
 
   // PILOT-DECISION: antd `Button type="primary"` hand-painted with
   // `backgroundColor` (accent for user items, info blue for admin items) →
@@ -92,8 +94,8 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
             width: 50,
             height: 50,
             fontSize: token.fontSizeHeading3,
-            color: token.colorPrimary,
-            backgroundColor: colorPrimaryWithAlpha,
+            color: accentColor,
+            backgroundColor: accentColorWithAlpha,
           }}
         >
           {icon}
@@ -113,13 +115,7 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
               type="large"
               size="xl"
               weight="semibold"
-              style={{
-                color: themeColor
-                  ? themeColor
-                  : itemRole === 'user'
-                    ? token.colorPrimary
-                    : token.colorInfo,
-              }}
+              style={{ color: accentColor }}
             >
               {title}
             </Text>

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -2,12 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { AstryxSecondaryTheme } from '../astryx-theme';
 import ActionItemContent from '../components/ActionItemContent';
 import AnnouncementAlert from '../components/AnnouncementAlert';
 import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
 import FolderCreateModalV2 from '../components/FolderCreateModalV2';
 import StartFromURLModal from '../components/StartFromURLModal';
-import { AstryxSecondaryTheme } from '../astryx-theme';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
@@ -15,6 +15,7 @@ import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useProjectPath } from '../hooks/useRouteScope';
 import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
 import { MenuKeys } from '../hooks/useWebUIMenuItems';
+import { theme } from '../theme-shim';
 import { toProjectContext } from '../types/projectContext';
 import { SessionLauncherFormValue } from './SessionLauncherPage';
 import {
@@ -41,6 +42,7 @@ interface StartPageBoardItem extends BAIBoardItem {
 const StartPage: React.FC = () => {
   const { t } = useTranslation();
 
+  const { token } = theme.useToken();
   const baiClient = useSuspendedBackendaiClient();
   const currentProject = useCurrentProjectValue();
   const blockList = baiClient?._config?.blockList ?? [];
@@ -220,14 +222,10 @@ const StartPage: React.FC = () => {
       columnSpan: 1,
       columnOffset: { 6: 0, 4: 0 },
       data: {
-        // The deployment card takes the SECONDARY accent. This was
-        // `ThemeSecondaryProvider`, an antd `ConfigProvider` overriding
-        // `colorPrimary` — dead since `ActionItemContent` became Astryx.
-        // `AstryxSecondaryTheme` is the counterpart that reaches the Astryx
-        // `Button` again (ticket 02). The card's title/icon colours still come
-        // from the app-level theme-shim token object, which is not
-        // per-subtree, so they keep the brand accent — recorded in
-        // MERGE-CHECKLIST as a known partial-fidelity item.
+        // The deployment card takes the SECONDARY accent. `AstryxSecondaryTheme`
+        // reaches the Astryx `Button`; the title/icon read the app-level
+        // theme-shim token object instead (not per-subtree), so they need the
+        // accent passed explicitly via `themeColor`.
         content: (
           <AstryxSecondaryTheme>
             <ActionItemContent
@@ -235,6 +233,7 @@ const StartPage: React.FC = () => {
               description={t('start.StartDeploymentDesc')}
               buttonText={t('start.button.StartDeployment')}
               icon={<Grid2x2Plus size="1em" />}
+              themeColor={token.colorSuccess}
               onClick={() => webuiNavigate(buildProjectPath('deployments'))}
             />
           </AstryxSecondaryTheme>


### PR DESCRIPTION
Resolves #8904 (FR-3599)

## Summary

- The Start page's "Start Deployment" card wraps itself in `AstryxSecondaryTheme`, which correctly gives its button the SECONDARY (green) accent. Its icon and title, however, kept the PRIMARY (orange) accent — the same defect on every other card — because `ActionItemContent` reads icon/title colour from `theme.useToken()`, the app-root `theme-shim`, which is not aware of nested Astryx `<Theme>` subtrees.
- `ActionItemContent`: consolidated the icon and title color logic into a single `accentColor`/`accentColorWithAlpha` derivation, so the icon now honours `themeColor` (it previously ignored it and always used `token.colorPrimary`).
- `StartPage`: passes `themeColor={token.colorSuccess}` to the deployment card's `ActionItemContent`, matching the pre-migration antd `ThemeSecondaryProvider` behavior where one accent override covered button, icon, and title together.
- Dropped the `itemRole` (`'user' | 'admin'`) prop from `ActionItemContent`. It switched icon/title colour between `colorPrimary`/`colorInfo`, but no call site has passed `itemRole="admin"` since FR-587 (Feb 2025) moved the deployment card onto an explicit secondary-theme wrapper instead of the role-based blue/orange split — it was dead code, confirmed by a full-repo grep. `themeColor` is the only live colour override now.

This was already flagged as a known partial-fidelity gap in a code comment on `StartPage.tsx` left over from the Ant Design → Astryx migration (FR-3482); this PR closes it.

## Test plan

- [x] `bash scripts/verify.sh` → `=== ALL PASS ===`
- [ ] Visual check: Start page → Start Deployment card icon/title render in green, matching the button