### PR TITLE
fix(FR-3598): widen the Start from URL modal so the tab strip fits

### DIFF
--- a/react/src/components/StartFromURLModal.tsx
+++ b/react/src/components/StartFromURLModal.tsx
@@ -51,7 +51,9 @@ const StartFromURLModal: React.FC<StartFromURLModalProps> = ({
   return (
     <BAIModal
       title={t('start.StartFromURL')}
-      width={800}
+      // The four import tabs lay out on one row and do not shrink; at 800 the
+      // strip needed 867px and the modal body became an x-scroller (FR-3598).
+      width={1000}
       footer={null}
       {...modalProps}
     >


### PR DESCRIPTION
Resolves #8903 (FR-3598)

The `Start from URL` modal rendered a horizontal scrollbar at its default size
and clipped the fourth tab (`Import GitLab Repository`) mid-label.

## Mechanism

The four import tabs lay out on one row in Astryx's flex `nav`, whose items do
not shrink. At `width={800}` the strip's intrinsic width is **867px** against a
**752px** body content box (800 − 2×24px padding). The `nav` itself is
`overflow-x: visible`, so the overflow fell through to the modal's
`astryx-layout-content`, which *is* `overflow-x: auto` — so the whole modal
body became the horizontal scroller, dragging the form fields sideways with it.

The cause is the fixed 800px budget, not the tab strip. `width={1000}` gives the
nav a 952px content box.

## Measured, live, both colour modes

Admin on `/start`, 1600×1000 viewport, HF tab enabled. Numbers are
`nav.scrollWidth / nav.clientWidth`, and whether any descendant of the dialog is
an `overflow-x: auto` scroller.

| Locale | Before (`width=800`) | After (`width=1000`) |
|---|---|---|
| en (light) | 867 / 752 — body scroller **891 / 800** | 952 / 952 — **no scroller** |
| en (dark) | 867 / 752 — body scroller **891 / 800** | 952 / 952 — **no scroller** |
| ja (light) | — | 952 / 952 — **no scroller** (tabs total 898) |
| ko (light) | — | 952 / 952 — **no scroller** (tabs total 801) |

Per-tab widths, en: `[237, 172, 227, 225]` = 861px + 3×2px gaps = 867px.
`pageerror` count: **0** in every pass.

### Before → after (light)

| Before | After |
|---|---|
| ![before light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3598/20260820-024004-before-light.png) | ![after light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3598/20260820-024004-after-en-light.png) |

### Before → after (dark)

| Before | After |
|---|---|
| ![before dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3598/20260820-024004-before-dark.png) | ![after dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-3598/20260820-024004-after-en-dark.png) |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --prefix ./react exec vitest run` → **93 files, 1472 tests, all passing**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 288 declared
  properties, 921 `var()` usages, **1 undeclared**:
  `packages/backend.ai-ui/src/components/BAIText.css:28`. **Pre-existing and not
  a real finding** — the gate is matching the words `var(--x, literal)` inside
  that file's doc comment. It is untouched by this PR and present on `main`
  (last changed by `0038e925f`, FR-3518); verified with `git show main:…`.
- No `backend.ai-ui` source changed, so no BUI rebuild was needed.

## Residue — what this does *not* close

A fixed width cannot guarantee "no horizontal scroll" for all 22 locales at all
viewports, and 1000px does not. Measured at `width=1000`, **ru** still overflows:
nav `1100 / 952`, i.e. it would need a ~1148px dialog. The same is expected for
the other long-label locales (de, mn, el, tr, es, pl — estimated 1000–1100px of
strip). I sized for the reported case plus the primary shipped locales
(en / ko / ja), rather than pushing every user to an ~1150px modal for a
four-field form.

The durable fix for the long locales is to let the tab strip scroll on its own
instead of the modal body — that touches shared `BAITabList` behaviour app-wide,
so it is deliberately **not** in this PR. Worth a follow-up if the long locales
matter.

No sibling report is subsumed by this change; FR-3519 and FR-3590 are different
surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
