### PR TITLE
fix(FR-3601): give the Container Logs modal a height budget that fits

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -26,11 +26,19 @@ interface ContainerLogModalProps extends BAIModalProps {
   defaultKernelId?: string;
 }
 
-// Astryx `Dialog` caps its height at 75vh unless given `maxHeight`, so the tall
-// body this viewer asks for overflowed into a scrollbar. The two budgets must
-// stay in step: the body plus the header chrome has to fit the cap (FR-3601).
-const MODAL_MAX_HEIGHT = 'calc(100vh - 64px)';
-const LOG_BODY_HEIGHT = 'calc(100vh - 160px)';
+/**
+ * Height cap for the log dialog — the `95vh` the sibling full-height viewers
+ * use (`VFolderTextFileEditorModal`, `FolderExplorerModalV2`). Astryx `Dialog`
+ * otherwise caps itself at 75vh, well under the body this viewer asks for.
+ *
+ * The body is measured against that same cap rather than the viewport, so the
+ * two cannot cross over on a tall screen. It subtracts only the chrome above
+ * it: the dialog's own block padding (a published theme token) and the header
+ * row (measured 52px; this modal renders `footer={null}`).
+ */
+const LOG_MODAL_MAX_HEIGHT = '95vh';
+const LOG_MODAL_HEADER_HEIGHT = '52px';
+const LOG_BODY_HEIGHT = `calc(${LOG_MODAL_MAX_HEIGHT} - ${LOG_MODAL_HEADER_HEIGHT} - var(--astryx-dialog-padding-block-start) - var(--astryx-dialog-padding-block-end))`;
 
 const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
   sessionFrgmt,
@@ -149,7 +157,7 @@ const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
         </BAIFlex>
       }
       width={'100%'}
-      maxHeight={MODAL_MAX_HEIGHT}
+      maxHeight={LOG_MODAL_MAX_HEIGHT}
       styles={{
         header: {
           width: '100%',

--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -26,6 +26,12 @@ interface ContainerLogModalProps extends BAIModalProps {
   defaultKernelId?: string;
 }
 
+// Astryx `Dialog` caps its height at 75vh unless given `maxHeight`, so the tall
+// body this viewer asks for overflowed into a scrollbar. The two budgets must
+// stay in step: the body plus the header chrome has to fit the cap (FR-3601).
+const MODAL_MAX_HEIGHT = 'calc(100vh - 64px)';
+const LOG_BODY_HEIGHT = 'calc(100vh - 160px)';
+
 const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
   sessionFrgmt,
   defaultKernelId,
@@ -143,13 +149,13 @@ const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
         </BAIFlex>
       }
       width={'100%'}
+      maxHeight={MODAL_MAX_HEIGHT}
       styles={{
         header: {
           width: '100%',
         },
         body: {
-          height: 'calc(100vh - 100px)',
-          maxHeight: 'calc(100vh - 100px)',
+          height: LOG_BODY_HEIGHT,
         },
       }}
       {...modalProps}


### PR DESCRIPTION
Resolves #8906 (FR-3601)

## Mechanism

Astryx `Dialog` caps its own height at its `maxHeight` prop, which **defaults to `75vh`** (`@astryxdesign/core/src/Dialog/Dialog.tsx`, `maxHeight = '75vh'`).

`ContainerLogModal` never passed a `maxHeight`, but asked for a body of `calc(100vh - 100px)`. At a 950px viewport that is an 850px body inside a dialog clamped to 712.5px — so the body overflowed the dialog's content area, and Astryx `LayoutContent` (`overflow-y: auto`) turned the excess into a permanent vertical scrollbar.

This is migration residue: antd's `Modal` had no such cap, so `calc(100vh - 100px)` used to size the body directly.

## Approach — follow the existing full-height-viewer idiom

The two sibling viewers already solved this. Both cap at **`95vh`**:

| Component | cap | content box |
|---|---|---|
| `VFolderTextFileEditorModal` (Monaco file viewer) | `maxHeight={'95vh'}` | `height: calc(100vh - 220px)` |
| `FolderExplorerModalV2` | `maxHeight={EXPLORER_MAX_HEIGHT}` = `'95vh'` | `minHeight: calc(95vh - var(--astryx-dialog-padding-block-start) - var(--astryx-dialog-padding-block-end))` |

This PR takes `95vh` from both, and the **token-based chrome subtraction** from `FolderExplorerModalV2` — the dialog's own block padding is published by the theme as `--astryx-dialog-padding-block-*`, so it is not re-measured as a literal here.

Two things it deliberately does *not* copy:

- **`FolderExplorerModalV2`'s `minHeight`-only fill.** Tried and measured: with no definite height on the body, `height: 100%` does not resolve through `LayoutContent`, the log pane collapsed to 120px and `react-lazylog` rendered blank.
- **`VFolderTextFileEditorModal`'s `calc(100vh - 220px)`.** Its 220px reserves space for a Save/Cancel footer that this modal does not have (`footer={null}`), so copying it wastes ~88px. It is also viewport-relative while the cap is proportional, and the two cross over above ~1120px of viewport height.

So the body is measured against **the cap** rather than the viewport. Only the header row stays a literal (52px, measured).

## Measured before / after

Live app, `hf-model-to-Qwen2-5-0-5B-Instruct-vPK` → Container Logs. `LayoutContent` is the box that was scrolling; `lazyLog` is the visible log pane:

| Viewport | | dialog height | LayoutContent scrollH / clientH | scrollbar | visible log |
|---|---|---|---|---|---|
| 1600×950 | before | 713px (75vh cap) | 882 / 661 → **221px overflow** | yes | ~629px |
| 1600×950 | after | 902px (95%) | 762 / 762 | **no** | **724px** |
| 1600×700 | after | 665px (95%) | — | **no** | 486px |
| 1600×1080 | after | 1026px (95%) | — | **no** | 847px |
| 1600×1440 | after | 1368px (95%) | — | **no** | 1189px |

The dialog lands at exactly 95% of the viewport at all four heights, so the fix scales instead of drifting.

Dark mode re-measured at 1600×950 (`document.documentElement.dataset.theme === 'dark'`): identical numbers, `scrolls: false`, visible log 724px. Zero `pageerror` in both passes.

### Before

The log pane runs past the modal's bottom edge and the modal body scrolls:

<img width="1600" alt="Container Logs modal before the fix" src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8909/20260820-030754-before-scrollbar.png" />

### After

The modal fits the viewport and the log pane ends inside it:

<img width="1600" alt="Container Logs modal after the fix" src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8909/20260820-043157-after-95vh.png" />

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup, StyleX sentinel, Astryx theme build, Terminology)
  - `Astryx theme build` failed on the first run in a fresh worktree with `No "exports" main defined in .../backend.ai-ui/package.json` — the known stale-BUI-dist trap, not this change. `pnpm --filter backend.ai-ui build`, then `ALL PASS`.
- `pnpm --prefix ./react exec vitest run` → 93 files, **1472 passed**
- `pnpm --filter backend.ai-ui exec vitest run` → 52 files, **677 passed, 1 skipped**
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared `var()`, in `packages/backend.ai-ui/src/components/BAIText.css:28`. **Pre-existing** — verified by running the gate on `main`, where it fails identically. The two `--astryx-dialog-padding-block-*` tokens this PR adds are declared and pass.

## Residue

- `LOG_MODAL_HEADER_HEIGHT` (52px) is still a literal — there is no published token for the `DialogHeader` row. If the title ever wraps to a second line (very narrow viewports; the modal is `width: 100%`, so this needs a phone-width screen) the body overshoots by one row and `LayoutContent` scrolls, which is the same graceful degradation as today.
- The `react-lazylog` pane keeps its own inner scrollbar. That is the log *content* being longer than the pane — inherent to a log viewer, and not what the report was about.
- **Does not** address FR-3600 (#8905), the sibling report that this modal's text/button colors differ when opened from a notification action button. Not reproduced: reaching the notification path needs a session-creation mutation on the shared cluster, and two cheap proxies (tinting the mount-point ancestor; opening the modal under the admin/blue `AstryxAdminTheme` route scope) both left the colors unchanged — so it is neither plain `color` inheritance nor the route theme scope. It looks specific to the Astryx `Banner` surface the notification renders on, which FR-3580 (#8870, In Review) already covers.
