### PR TITLE
fix(FR-3602): enter a directory when its name is clicked in the file explorer

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -255,8 +255,11 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
             }}
             onClick={(e) => {
               e.stopPropagation();
-              const targetEl = e.target as HTMLElement;
-              if (targetEl.closest('button')) return;
+              // The directory name itself is an Astryx `Link` <button> (no
+              // href), so excluding every <button> swallowed the navigating
+              // click; the rename trigger stops propagation on its own, and
+              // only its inline <form> has to be excluded here (FR-3602).
+              if ((e.target as HTMLElement).closest('form')) return;
               if (record.type === 'DIRECTORY') {
                 navigateDown(name);
                 setSelectedItems([]);


### PR DESCRIPTION
Resolves #8910 (FR-3602)

## Mechanism

The file-list **Name** cell suppressed navigation whenever the click landed inside a `<button>`:

```tsx
if (targetEl.closest('button')) return;
```

That guard predates the Astryx migration, when the directory name rendered as an `<a>`. Today `BAILink` without a `to` falls through to Astryx `Link`, and Astryx `Link` without an `href` renders `<button type="button">` (`Link.tsx`: *"When undefined, renders as a `<button>` with link styling"*). So the guard matched **the folder name itself** and swallowed the very click it exists to serve. Row selection did not happen either — the cell calls `e.stopPropagation()` before the guard — so clicking a directory did nothing at all.

The same guard did **not** match the inline rename `<form>`, so clicking into the rename text field navigated into the directory and discarded the edit.

The fix matches on the rename form instead. The rename trigger (`IconButton`) already calls `e.stopPropagation()` in its own handler, so the form is the only descendant whose clicks must not navigate.

## Measured before/after

Probed live against the same cluster (`10.82.130.172:8090`), admin, Chromium. `crumb` = the explorer's `nav[aria-label="Path"]` text; the target is an empty subdirectory `probe-nav-dir` inside the `test` folder.

| Gesture | Before (`main`, build 8646) | After (this branch) |
|---|---|---|
| Click the directory **name** | crumb `""` → `""`, list unchanged, row not selected — nothing happens | crumb `""` → `"/ probe-nav-dir"`, subdirectory contents shown |
| Click the **Rename** pencil | crumb unchanged, editor opens | crumb unchanged, editor opens (unchanged) |
| Click **inside the rename field** | crumb `""` → `"/ probe-nav-dir"`, editor destroyed, rename lost | crumb `""` → `""`, editor stays open |

Both modes on the fixed build, dark entered through the header button with `document.documentElement.dataset.theme` asserted:

| Mode | `data-theme` | Click directory name |
|---|---|---|
| Light | `light` | crumb `""` → `"/ probe-nav-dir"`, 0 `pageerror` |
| Dark | `dark` | crumb `""` → `"/ probe-nav-dir"`, 0 `pageerror` |

DOM confirmation of the mechanism, measured in the running app:
`tagName = "BUTTON"`, `class = "astryx-link accent … bai-link-hover"` on the directory-name element.

No screenshots: the change is behavioural, not visual — nothing in the rendered frame moves, so a before/after image pair would be identical.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript, Vite warmup paths, StyleX sentinel, Astryx theme build `--check`, Terminology)
- `pnpm --filter backend.ai-ui build` → built (required after a BUI source change)
- `pnpm --filter backend.ai-ui exec vitest run` → 52 passed | 1 skipped files, 677 passed | 1 skipped tests
- `pnpm --prefix ./react exec vitest run` → 93 files, 1472 tests passed
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared (`BAIText.css:28  var(--x)`). **Pre-existing on `main`** — verified by re-running the gate with this change stashed; identical output. This PR touches no CSS.

## Residue

- **Not covered:** the same `BAIFileExplorer` name cell is reused by the directory-picker mode (`BAIVFolderPathPicker` → `BAIDirectoryPickerModal`). That mode has its own `onRow` click that calls `navigateDown`, so it was never affected by this bug and is unchanged here.
- **No related report subsumed:** FR-3590 (divider drag) and FR-3575 (drag-drop overlay) are separate folder-explorer issues on other mechanisms; neither is touched.
- The `<form>` match is a DOM check, like the guard it replaces. Binding the navigation to the name element itself would be structurally cleaner but changes `EditableFileName`'s single-`onClick` contract, which also carries the `stopPropagation` that suppresses row selection — out of scope for a fix this size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
