### PR TITLE
fix(FR-3606): adapt the folder explorer to live viewport resizes

### DIFF
--- a/packages/backend.ai-ui/src/theme-shim/breakpoints.test.tsx
+++ b/packages/backend.ai-ui/src/theme-shim/breakpoints.test.tsx
@@ -46,13 +46,16 @@ beforeAll(() => {
       matches: evaluateQuery(query, viewportWidth),
       evaluate: () => evaluateQuery(query, viewportWidth),
       listeners,
-      addEventListener: (_type: string, cb: () => void) => listeners.add(cb),
-      removeEventListener: (_type: string, cb: () => void) =>
-        listeners.delete(cb),
+      addEventListener: (_type: string, cb: () => void) => {
+        listeners.add(cb);
+      },
+      removeEventListener: (_type: string, cb: () => void) => {
+        listeners.delete(cb);
+      },
     };
     mockLists.push(list);
     return list;
-  }) as typeof window.matchMedia;
+  }) as unknown as typeof window.matchMedia;
 });
 
 const Probe: React.FC<{ id: string }> = ({ id }) => {

--- a/packages/backend.ai-ui/src/theme-shim/breakpoints.test.tsx
+++ b/packages/backend.ai-ui/src/theme-shim/breakpoints.test.tsx
@@ -1,0 +1,92 @@
+import { useBAIBreakpoint } from './breakpoints';
+import { act, render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * matchMedia mock with a mutable viewport width: `matches` follows the query,
+ * and crossing a boundary fires that list's 'change' listeners — the part of
+ * the real MediaQueryList the store subscribes to.
+ */
+type MockMQL = {
+  matches: boolean;
+  media: string;
+  addEventListener: (type: string, cb: () => void) => void;
+  removeEventListener: (type: string, cb: () => void) => void;
+};
+
+let viewportWidth = 1600;
+const mockLists: Array<
+  MockMQL & { listeners: Set<() => void>; evaluate: () => boolean }
+> = [];
+
+function evaluateQuery(query: string, width: number): boolean {
+  const min = query.match(/min-width:\s*([\d.]+)px/);
+  if (min) return width >= parseFloat(min[1]);
+  const max = query.match(/max-width:\s*([\d.]+)px/);
+  if (max) return width <= parseFloat(max[1]);
+  throw new Error(`unsupported query: ${query}`);
+}
+
+function setViewportWidth(width: number) {
+  viewportWidth = width;
+  mockLists.forEach((list) => {
+    const next = list.evaluate();
+    if (next !== list.matches) {
+      list.matches = next;
+      list.listeners.forEach((cb) => cb());
+    }
+  });
+}
+
+beforeAll(() => {
+  window.matchMedia = ((query: string) => {
+    const listeners = new Set<() => void>();
+    const list = {
+      media: query,
+      matches: evaluateQuery(query, viewportWidth),
+      evaluate: () => evaluateQuery(query, viewportWidth),
+      listeners,
+      addEventListener: (_type: string, cb: () => void) => listeners.add(cb),
+      removeEventListener: (_type: string, cb: () => void) =>
+        listeners.delete(cb),
+    };
+    mockLists.push(list);
+    return list;
+  }) as typeof window.matchMedia;
+});
+
+const Probe: React.FC<{ id: string }> = ({ id }) => {
+  const { xl } = useBAIBreakpoint();
+  return <span data-testid={id}>{xl ? 'xl' : 'not-xl'}</span>;
+};
+
+describe('useBAIBreakpoint', () => {
+  it('reflects the current viewport on first render', () => {
+    act(() => setViewportWidth(1600));
+    render(<Probe id="first" />);
+    expect(screen.getByTestId('first')).toHaveTextContent('xl');
+  });
+
+  // FR-3606: with a per-subscriber handler comparing against the shared
+  // cache, only the FIRST subscriber was notified per flip — every other
+  // component kept the stale snapshot until reload.
+  it('notifies every subscriber when a breakpoint flips', () => {
+    act(() => setViewportWidth(1600));
+    render(
+      <>
+        <Probe id="a" />
+        <Probe id="b" />
+        <Probe id="c" />
+      </>,
+    );
+    act(() => setViewportWidth(1000));
+    expect(screen.getByTestId('a')).toHaveTextContent('not-xl');
+    expect(screen.getByTestId('b')).toHaveTextContent('not-xl');
+    expect(screen.getByTestId('c')).toHaveTextContent('not-xl');
+
+    act(() => setViewportWidth(1600));
+    expect(screen.getByTestId('a')).toHaveTextContent('xl');
+    expect(screen.getByTestId('b')).toHaveTextContent('xl');
+    expect(screen.getByTestId('c')).toHaveTextContent('xl');
+  });
+});

--- a/packages/backend.ai-ui/src/theme-shim/breakpoints.ts
+++ b/packages/backend.ai-ui/src/theme-shim/breakpoints.ts
@@ -128,23 +128,45 @@ function getServerSnapshot(): BAIScreenMap {
   return SERVER_SNAPSHOT;
 }
 
+/**
+ * One shared media-query handler fanning out to every subscriber. A
+ * per-subscriber handler comparing against the shared `cachedSnapshot` would
+ * notify only the FIRST subscriber per flip — the first handler updates the
+ * cache, so every later handler sees "no change" and skips its own component
+ * (FR-3606: the folder explorer stayed in a stale layout until reload).
+ */
+const storeListeners = new Set<() => void>();
+
+function handleMediaChange() {
+  const next = computeSnapshot();
+  // Keep the object identity stable unless a boolean actually flipped, so the
+  // 2nd..6th `change` events of one crossing don't re-render subscribers.
+  const changed =
+    !cachedSnapshot ||
+    BAI_BREAKPOINT_KEYS.some((key) => cachedSnapshot?.[key] !== next[key]);
+  if (changed) {
+    cachedSnapshot = next;
+    storeListeners.forEach((listener) => listener());
+  }
+}
+
 function subscribe(onStoreChange: () => void): () => void {
-  const handler = () => {
-    const next = computeSnapshot();
-    // Only publish a new object identity when a boolean actually flipped, so a
-    // resize inside one step does not re-render 18 components for nothing.
-    const changed =
-      !cachedSnapshot ||
-      BAI_BREAKPOINT_KEYS.some((key) => cachedSnapshot?.[key] !== next[key]);
-    if (changed) {
-      cachedSnapshot = next;
-      onStoreChange();
-    }
-  };
-  const lists = getMediaQueryLists();
-  lists.forEach((list) => list.addEventListener('change', handler));
+  if (storeListeners.size === 0) {
+    getMediaQueryLists().forEach((list) =>
+      list.addEventListener('change', handleMediaChange),
+    );
+    // The cache is not maintained while nothing is attached — refresh it (and
+    // notify, via React's post-subscribe re-check) in case it went stale.
+    handleMediaChange();
+  }
+  storeListeners.add(onStoreChange);
   return () => {
-    lists.forEach((list) => list.removeEventListener('change', handler));
+    storeListeners.delete(onStoreChange);
+    if (storeListeners.size === 0) {
+      getMediaQueryLists().forEach((list) =>
+        list.removeEventListener('change', handleMediaChange),
+      );
+    }
   };
 }
 

--- a/react/src/components/FolderExplorerHeaderV2.tsx
+++ b/react/src/components/FolderExplorerHeaderV2.tsx
@@ -67,14 +67,18 @@ const FolderExplorerHeaderV2: React.FC<FolderExplorerHeaderV2Props> = ({
       // The conversion had landed on step 5 (20px).
       gap={4}
       width="100%"
+      // Wraps so the FileBrowser/SFTP groups drop under the title instead of
+      // clipping into the modal's close button at narrow widths (FR-3606).
+      wrap="wrap"
       {...({ 'data-testid': 'folder-explorer-header' } as object)}
     >
       <HStack
         align="center"
         // Legacy `BAIFlex gap="xs"` = antd `sizeXS` = 8px = step 2.
         gap={2}
-        // reset font weight set by the modal header
-        style={{ flex: 1, fontWeight: 'normal', ...titleStyle }}
+        // reset font weight set by the modal header; the min width keeps a
+        // readable slice of the name and is the wrap trigger for the actions
+        style={{ flex: 1, minWidth: 180, fontWeight: 'normal', ...titleStyle }}
         {...({ 'data-testid': 'folder-explorer-title' } as object)}
       >
         {vfolderNode ? (
@@ -117,6 +121,8 @@ const FolderExplorerHeaderV2: React.FC<FolderExplorerHeaderV2Props> = ({
         // Legacy `BAIFlex gap={token.marginSM}` = 12px = `--spacing-3` (step 3).
         // The conversion had landed on step 2 (8px), crowding the two buttons.
         gap={3}
+        // Keeps the group right-aligned on its own row once wrapped.
+        style={{ marginLeft: 'auto' }}
         {...({ 'data-testid': 'folder-explorer-actions' } as object)}
       >
         {vfolderNode && !vfolderNode?.unmanagedPath ? (

--- a/react/src/components/FolderExplorerModalV2.tsx
+++ b/react/src/components/FolderExplorerModalV2.tsx
@@ -82,6 +82,12 @@ const EXPLORER_MIN_WIDTH = 440;
 // Measured 1392 - 655 - 720 = 17 at viewport 1600.
 const SPLIT_HANDLE_WIDTH = 17;
 
+// Stacked (< xl) info panel height: default fits the metadata list without an
+// inner scroll (measured 430px at viewport 800); min keeps the tab strip and
+// a few rows reachable.
+const STACKED_INFO_PANEL_DEFAULT_HEIGHT = 440;
+const STACKED_INFO_PANEL_MIN_HEIGHT = 160;
+
 export interface FolderExplorerElement extends HTMLDivElement {
   _fetchVFolder: () => void;
   _openDeleteMultipleFileDialog: () => void;
@@ -162,6 +168,15 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
       splitRowWidth > 0
         ? Math.max(550, splitRowWidth - EXPLORER_MIN_WIDTH - SPLIT_HANDLE_WIDTH)
         : undefined,
+  });
+
+  // Below `xl` the panes stack, so the split flips to the block axis: the
+  // handle sits above the info panel and drags its HEIGHT (FR-3516). A pixel
+  // default — useResizable resolves '%' against window.innerWidth, the wrong
+  // axis here.
+  const stackedInfoPanel = useResizable({
+    defaultSize: STACKED_INFO_PANEL_DEFAULT_HEIGHT,
+    minSizePx: STACKED_INFO_PANEL_MIN_HEIGHT,
   });
 
   const deferredOpen = useDeferredValue(modalProps.open);
@@ -595,7 +610,25 @@ const FolderExplorerModalV2: React.FC<FolderExplorerProps> = ({
               ) : (
                 <VStack align="stretch" gap={6}>
                   {fileExplorerElement}
-                  {vFolderInfoPanelElement}
+                  <ResizeHandle
+                    direction="vertical"
+                    isReversed
+                    hasDivider
+                    // `center` routes the grab zone away from `hitAreaOffsetY`,
+                    // the inline-axis mirror of the FR-3591 offset bug.
+                    pillPlacement="center"
+                    label={t('explorer.Metadata')}
+                    resizable={stackedInfoPanel.props}
+                  />
+                  <div
+                    style={{
+                      height: stackedInfoPanel.size,
+                      flexShrink: 0,
+                      overflow: 'auto',
+                    }}
+                  >
+                    {vFolderInfoPanelElement}
+                  </div>
                 </VStack>
               )
             ) : null}


### PR DESCRIPTION
Resolves #8920 (FR-3606)

The folder explorer froze in whatever breakpoint state it first rendered in: growing the window back past `xl` left it stacked (no split, no divider) until a full reload, and crossing breakpoints sometimes left a broken mixed state (overlapping toolbar buttons, mid-word label wraps).

## Mechanism

`useBAIBreakpoint`'s store (`packages/backend.ai-ui/src/theme-shim/breakpoints.ts`) registered one `MediaQueryList` handler **per subscriber**, all sharing the module-level `cachedSnapshot`. On a flip, the first handler to run updated the cache and notified its own component; every later handler then computed "no change" against the already-updated cache and never called its `onStoreChange`. Net effect: exactly one subscriber in the whole app reacted to any breakpoint flip. (Shrinking sometimes worked in the explorer only by accident — the split row's `ResizeObserver` forced a re-render; that observer is unmounted in the stacked layout, so growing back never recovered.)

The store now attaches **one shared handler** and fans out to a listener set, so every subscriber re-renders on a flip. The cache is refreshed on first subscribe in case it went stale while detached. The regression test renders three subscribers and asserts all of them flip — it fails against the old implementation (verified by stashing the fix: `1 failed | 1 passed`).

## Stacked-layout divider (FR-3516)

Below `xl` the two panes stack, and the split now flips to the block axis: a horizontal `ResizeHandle direction="vertical"` sits above the metadata panel and drags its height (default 440px, min 160px). `pillPlacement="center"` routes the grab zone away from `hitAreaOffsetY` — the inline-axis mirror of the FR-3591 offset bug — so the drag engages across the handle's full width (verified at x=100 and x=400 of a 672px handle).

The toolbar-overlap half of the report is already handled one PR down (FR-3590 added `wrap="wrap"` to the breadcrumb/actions row); with the store fixed, the `lg` icon-only button switch now also happens live.

## Evidence (measured on this branch's dev build)

1600 → 1000 → 1600, modal open the whole time:

| before: stuck stacked after growing back to 1600 | after: split restored at 1600 |
|---|---|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8921/20260820-061637-before-stuck-stacked-at-1600.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8921/20260820-061642-after-split-restored-at-1600.png) |

| after: live shrink to 1000 — stacked + horizontal divider | after: live shrink to 800 — icon-only buttons, no overlap |
|---|---|
| ![stacked](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8921/20260820-061647-after-stacked-divider-1000.png) | ![narrow](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8921/20260820-061653-after-icononly-800.png) |

- xl divider still drags after breakpoint round-trips, including low on the handle (FR-3591 intact): `aria-valuenow` 720 → 800.
- Vertical handle drag: 440 → 540 (up), 540 → 490 (down).

## Follow-up: header wrap at very narrow widths

Reported during review: at ~430px the FileBrowser/SFTP groups overflowed the header row and clipped into the modal's close button. The header row now wraps — the groups drop under the title, right-aligned (`margin-left: auto`), with a 180px readable title slice as the wrap trigger. Wide layout unchanged (title and actions measured on one row at 1600px).

| after: header wrapped at 430px |
|---|
| <img src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8921/20260820-063410-after-header-wrap-430.png" width="320" /> |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- BUI vitest: 53 files / 679 tests passed (incl. the new `breakpoints.test.tsx`)
- `react` vitest `FolderExplorerModalV2.test.tsx`: 3 passed

**Checklist:**

- [x] Test case(s) to demonstrate the difference of before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

