### PR TITLE
fix(FR-3608): stop copyable text painting over the copy button

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAdminUserV2Table.tsx
@@ -135,7 +135,12 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
         title: t('comp:UserNodes.UserID'),
         exportKey: 'uuid',
         render: (__, record) => (
-          <BAIText copyable ellipsis monospace style={{ maxWidth: 100 }}>
+          <BAIText
+            copyable
+            ellipsis={{ tooltip: true }}
+            monospace
+            style={{ maxWidth: 100 }}
+          >
             {toLocalId(record.id)}
           </BAIText>
         ),
@@ -185,7 +190,12 @@ const BAIAdminUserV2Table: React.FC<BAIAdminUserV2TableProps> = ({
         exportKey: 'main_access_key',
         render: (__, record) =>
           record.organization?.mainAccessKey ? (
-            <BAIText copyable ellipsis monospace style={{ maxWidth: 120 }}>
+            <BAIText
+              copyable
+              ellipsis={{ tooltip: true }}
+              monospace
+              style={{ maxWidth: 120 }}
+            >
               {record.organization.mainAccessKey}
             </BAIText>
           ) : (

--- a/packages/backend.ai-ui/src/components/BAIId.tsx
+++ b/packages/backend.ai-ui/src/components/BAIId.tsx
@@ -21,7 +21,9 @@ const BAIId: React.FC<BAIIdProps> = ({
   uuid,
   globalId,
   copyable = true,
-  ellipsis = true,
+  // An id is clamped to 100px, so it is almost always truncated; without the
+  // tooltip slot there is no way to read the value it holds (FR-3608).
+  ellipsis = { tooltip: true },
   monospace = true,
   style,
   ...restProps

--- a/packages/backend.ai-ui/src/components/BAIText.css
+++ b/packages/backend.ai-ui/src/components/BAIText.css
@@ -60,6 +60,16 @@
   text-overflow: ellipsis;
 }
 
+/* `code` nests the text INSIDE the chip, and the chip is a flex box, where
+   `text-overflow` has no effect — so the value was hard-cut with no ellipsis.
+   The chip still clips (its background must not spill); the ellipsis belongs
+   on the text itself, which needs `min-width: 0` to shrink as a flex item. */
+.bai-text-row > .bai-text-code > .astryx-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* antd `Typography.Text mark` — the highlighter. */
 .bai-text-mark {
   padding: 0 0.2em;

--- a/packages/backend.ai-ui/src/components/BAIText.css
+++ b/packages/backend.ai-ui/src/components/BAIText.css
@@ -47,11 +47,17 @@
 }
 
 /* Flex min-width defaults to `auto`, so a long unbreakable value would drag
-   the copy control out of a fixed cell instead of wrapping. */
+   the copy control out of a fixed cell instead of wrapping. `overflow-wrap`
+   only fires where wrapping is allowed: Astryx's own `astryx-table-cell` is
+   `white-space: nowrap`, which inherits in, so inside a table the text keeps
+   its single line and must clip to its own box instead of painting over the
+   copy control (FR-3608). */
 .bai-text-row > .astryx-text,
 .bai-text-row > .bai-text-code {
   min-width: 0;
   overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* antd `Typography.Text mark` — the highlighter. */

--- a/packages/backend.ai-ui/src/components/BAIUserNodes.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUserNodes.tsx
@@ -122,7 +122,7 @@ const BAIUserNodes: React.FC<BAIUserNodesProps> = ({
         render: (__, record) => (
           <BAIText
             copyable
-            ellipsis
+            ellipsis={{ tooltip: true }}
             monospace
             style={{
               maxWidth: 100,

--- a/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIModelDeploymentNodes.tsx
@@ -336,7 +336,12 @@ const BAIModelDeploymentNodes: React.FC<BAIModelDeploymentNodesProps> = ({
         defaultHidden: true,
         render: (__, record) =>
           record.currentRevisionId ? (
-            <BAIText copyable ellipsis monospace style={{ maxWidth: 160 }}>
+            <BAIText
+              copyable
+              ellipsis={{ tooltip: true }}
+              monospace
+              style={{ maxWidth: 160 }}
+            >
               {record.currentRevisionId}
             </BAIText>
           ) : (

--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetTable.tsx
@@ -175,7 +175,7 @@ const BAIRuntimeVariantPresetTable = ({
         sorter: isEnableSorter('key'),
         render: (__, record) =>
           record.targetSpec?.key ? (
-            <BAIText code copyable>
+            <BAIText code copyable ellipsis={{ tooltip: true }}>
               {record.targetSpec.key}
             </BAIText>
           ) : (

--- a/react/src/components/AdminDeploymentPresetTable.tsx
+++ b/react/src/components/AdminDeploymentPresetTable.tsx
@@ -167,7 +167,7 @@ const AdminDeploymentPresetTable: React.FC<AdminDeploymentPresetTableProps> = ({
             : record.execution?.imageId;
           if (!label) return '-';
           return (
-            <BAIText copyable style={{ wordBreak: 'break-all' }}>
+            <BAIText copyable ellipsis={{ tooltip: true }}>
               {label}
             </BAIText>
           );

--- a/react/src/components/AdminModelCard.tsx
+++ b/react/src/components/AdminModelCard.tsx
@@ -296,7 +296,11 @@ const AdminModelCard: React.FC<AdminModelCardProps> = ({
       title: t('adminModelCard.Project'),
       dataIndex: 'projectId',
       render: (projectId) => (
-        <BAIText copyable ellipsis style={{ maxWidth: 150 }}>
+        <BAIText
+          copyable
+          ellipsis={{ tooltip: true }}
+          style={{ maxWidth: 150 }}
+        >
           {projectId}
         </BAIText>
       ),

--- a/react/src/components/DeploymentAccessTokensCard.tsx
+++ b/react/src/components/DeploymentAccessTokensCard.tsx
@@ -246,7 +246,11 @@ const DeploymentAccessTokensCard: React.FC<DeploymentAccessTokensCardProps> = ({
           <BAIFlex direction="column" align="stretch" gap="sm">
             <Text>{t('deployment.accessToken.Created')}</Text>
             {createdToken ? (
-              <BAIText copyable={{ text: createdToken.token }} ellipsis code>
+              <BAIText
+                copyable={{ text: createdToken.token }}
+                ellipsis={{ tooltip: true }}
+                code
+              >
                 {createdToken.token}
               </BAIText>
             ) : null}
@@ -371,7 +375,7 @@ const DeploymentAccessTokensTable: React.FC<
                   title={
                     <BAIText
                       copyable={{ text: row.token }}
-                      ellipsis
+                      ellipsis={{ tooltip: true }}
                       style={{ maxWidth: 200 }}
                     >
                       {row.token}

--- a/react/src/components/PrometheusQueryPresetTable.tsx
+++ b/react/src/components/PrometheusQueryPresetTable.tsx
@@ -136,7 +136,7 @@ const PrometheusQueryPresetTable: React.FC<PrometheusQueryPresetTableProps> = ({
       sorter: isEnableSorter('id'),
       onCell: () => ({ style: { maxWidth: 120 } }),
       render: (id: string) => (
-        <BAIText copyable ellipsis monospace title={toLocalId(id)}>
+        <BAIText copyable ellipsis={{ tooltip: true }} monospace>
           {toLocalId(id)}
         </BAIText>
       ),
@@ -182,7 +182,7 @@ const PrometheusQueryPresetTable: React.FC<PrometheusQueryPresetTableProps> = ({
       sorter: isEnableSorter('categoryId'),
       onCell: () => ({ style: { maxWidth: 120 } }),
       render: (_value: unknown, row) => (
-        <BAIText ellipsis copyable monospace title={row.category?.id ?? '-'}>
+        <BAIText ellipsis={{ tooltip: true }} copyable monospace>
           {row.category?.id ?? '-'}
         </BAIText>
       ),


### PR DESCRIPTION
Resolves #8923 (FR-3608)

On **Admin → Serving → Deployment Presets**, the Image column's copy button was drawn on top of the image name instead of beside it.

## Mechanism

`BAIText`'s copy control is a **flex sibling** of the text (it is self-built in `BAIText` — Astryx has no `copyable`). `BAIText.css` gave the text `min-width: 0` and `overflow-wrap: anywhere` so a long unbreakable value would wrap instead of dragging the control out of a fixed cell.

`overflow-wrap` only fires **where wrapping is allowed**. Astryx's own `astryx-table-cell` sets `white-space: nowrap`, and `white-space` inherits — measured down the chain: `td (nowrap) → .bai-text-row (nowrap) → .astryx-text (nowrap)`. So inside *any* table the text kept a single line, shrank to its `min-width: 0` flex box, and — being `overflow: visible` — painted its remaining glyphs straight over the copy button.

The fix clips the text to its own box with an ellipsis. Where wrapping *is* allowed nothing overflows horizontally, so the rule is inert there.

## Measured — `/admin/deployments`, Deployment Presets, 1600×1000

Light and dark were **identical** in every number, before and after.

| | before | after |
|---|---|---|
| text span `overflow` | `visible` | `hidden` |
| text box width | 175px | 175px |
| text content width (`scrollWidth`) | 330 / 523 / 371px | 330 / 523 / 371px |
| **row `scrollWidth`** (row width = 203px) | **330 / 523 / 371px** — overflows | **203px** — fits |
| glyphs paint to x= | 1039 / 1232 / 1080 | clipped at 885 |
| copy button spans x= | 888–912 | 888–912 |
| **text painting under the copy button** | **151 / 344 / 192px** | **0** |

`<td>` is `overflow: hidden` with its right edge at x=920, so before the fix the tail was clipped at the column edge *and* ran under the button.

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8927/20260820-090558-before-light.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8927/20260820-090603-after-light.png) |

Hover tooltip on the truncated name:

![tooltip](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8927/20260820-090609-after-tooltip.png)

## Scope

- `packages/backend.ai-ui/src/components/BAIText.css` — the actual fix, so it holds for **every** `BAIText copyable` in a table, not just this one column.
- `react/src/components/AdminDeploymentPresetTable.tsx` — the Image cell drops a now-dead `wordBreak: 'break-all'` (inert under the inherited `nowrap`) for `ellipsis={{ tooltip: true }}`, matching the Startup Command cell beside it, so the truncated image name stays readable on hover.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui build` → built (required after the BUI change)
- `pnpm --filter backend.ai-ui exec vitest run` → **677 passed**, 1 skipped (52 files)
- `pnpm --prefix ./react exec vitest run` → **1522 passed** (94 files)
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared, `BAIText.css:28 var(--x)`. **Pre-existing on `main`** — verified by re-running the gate with these changes stashed, byte-identical output — and a false positive: that string is prose inside the file's header comment, not a declaration.
- Live probe on `/admin/deployments`, light **and** dark (`data-theme` asserted `dark`): geometry above, **zero `pageerror`** in both passes. Interactions exercised — the hover tooltip reveals the full name (`…ngc-vllm:26.07-cuda13.3-ubuntu24.04-solaropen2@x86_64`), and the copy button puts the **full** label on the clipboard, not the truncated text.

## Second commit — truncated `copyable` text that could not be read

Reviewing the fix surfaced a separate defect in the same family. `BAIText`'s tooltip is driven **only** by the `ellipsis` prop's `tooltip` slot — `resolveTooltipContent` returns early for a non-object `ellipsis`, and `copyable` has no influence on it:

```ts
if (!ellipsis || typeof ellipsis !== 'object') return undefined;   // `ellipsis` (boolean) -> no tooltip
if (tooltip === undefined || tooltip === false) return undefined;  // `{ rows: 1 }` -> no tooltip either
```

Surveying all 99 `BAIText copyable` call sites: **21** already pass `ellipsis={{ tooltip: true }}`, **66** pass no `ellipsis` at all, and **12** ask for truncation with `ellipsis` (boolean) and therefore truncate with no way to read the value. Ten of those 12 are product UI and are fixed here; the remaining two are Storybook demos (one of which uses `expandable`, so its full text is already reachable).

The widest one is **`BAIId`**, which defaulted to `ellipsis = true` with `maxWidth: 100` — so *every* id rendered through it was clamped to 100px with no tooltip. Its default is now `{ tooltip: true }`; callers passing their own `ellipsis` are unaffected.

The two `PrometheusQueryPresetTable` cells had a hand-written `title` attribute doing this job. They now get the same content through Astryx's truncate tooltip, matching the `QueryTemplate` column beside them, and the duplicated attribute is dropped.

Verified live on **Admin → Users**, User ID column (`/admin/users`, 1600×1000): the cell clamps to 100px against 302px of content, the row no longer overflows (`scrollWidth` 128 = its width), and hovering the text resolves `aria-describedby` to a **visible `role="tooltip"` carrying the full UUID** (`090317fa-…-4206cf128648`). Zero `pageerror`.

### Still open after this commit

The **66 `copyable`-without-`ellipsis`** sites are untouched. Inside a table they now truncate (via the CSS rule above) with no tooltip; outside one they wrap and are unaffected. Fixing those means deciding whether `ellipsis` should imply a tooltip by default — a change to the frozen antd-shaped contract across ~204 `ellipsis` usages — which is a team decision, not this PR's call.

## Third commit — `code`-wrapped values were hard-cut, not ellipsized

Reported against **Runtime Variant Presets → Key**: `--enable-prompt-tokens-details` rendered as `--enable-promp` with no ellipsis.

The first commit's rule only matched **direct** children of `.bai-text-row`. With `code`, `BAIText` nests the text *inside* the chip (`<Code class="bai-text-code">{textNode}</Code>`), so the inner span was never covered — and the chip is `display: flex`, where `text-overflow` has no effect at all. Measured before: chip 120px wide against 203px of content, inner text `min-width: auto` / `overflow: visible` at 195px, hard-cut by the chip. After: inner text shrinks to 112px and ellipsizes, chip `scrollWidth` = its width (120px).

The Key cell also gains `ellipsis={{ tooltip: true }}` — it truncates inside a 120px column, so without it the key was unreadable. Verified live: hovering resolves `aria-describedby` to a visible `role="tooltip"` carrying `--enable-prompt-tokens-details`. Zero `pageerror`.

This is a CSS-level fix, so it covers **every** `code` + `copyable` cell, not just this column.

## Residue

- The CSS rule changes rendering for every `BAIText copyable` call site inside a table: long values now truncate with an ellipsis rather than painting outside their box. That is the intended behaviour, but it is broader than this one page — flagging it explicitly for review.
- **FR-3519** (keypair modal: Access Key copy button clipped at the column edge) is the same `BAIText copyable`-in-a-table-cell family and is linked as `relates`. Its root cause is column *sizing* (`BAITableAstryx` accepts and ignores `scroll`), not this overflow, and I did **not** verify whether this change closes it. It stays open.
- The 66 `copyable`-without-`ellipsis` call sites are deliberately left alone (see above).
