### PR TITLE
fix(FR-3610): keep the notification badge on the app theme, not the band's

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIBadgeCount.css
+++ b/packages/backend.ai-ui/src/components/BAIBadgeCount.css
@@ -25,6 +25,17 @@
   pointer-events: none;
 }
 
+/* The overlay paints in `light-dark()` tokens, so it would otherwise inherit an
+   inverted ancestor's scheme — the header band gave the alert dot the red meant
+   for the opposite surface (FR-3610). Mirrors the theme's own `html[data-theme]`
+   mapping so a status accent always tracks the app mode. */
+html[data-theme='light'] .bai-badge-count-overlay {
+  color-scheme: light;
+}
+html[data-theme='dark'] .bai-badge-count-overlay {
+  color-scheme: dark;
+}
+
 /* antd `size="small"`: a denser pill for tab rails and table headers. Astryx
    `Badge` has no size prop, so the override targets the single child BY
    POSITION — not by an Astryx class name, which would be the P6 failure mode

--- a/packages/backend.ai-ui/src/components/BAIBadgeCount.css
+++ b/packages/backend.ai-ui/src/components/BAIBadgeCount.css
@@ -25,17 +25,6 @@
   pointer-events: none;
 }
 
-/* The overlay paints in `light-dark()` tokens, so it would otherwise inherit an
-   inverted ancestor's scheme — the header band gave the alert dot the red meant
-   for the opposite surface (FR-3610). Mirrors the theme's own `html[data-theme]`
-   mapping so a status accent always tracks the app mode. */
-html[data-theme='light'] .bai-badge-count-overlay {
-  color-scheme: light;
-}
-html[data-theme='dark'] .bai-badge-count-overlay {
-  color-scheme: dark;
-}
-
 /* antd `size="small"`: a denser pill for tab rails and table headers. Astryx
    `Badge` has no size prop, so the override targets the single child BY
    POSITION — not by an Astryx class name, which would be the P6 failure mode

--- a/packages/backend.ai-ui/src/components/BAIBadgeCount.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBadgeCount.test.tsx
@@ -1,0 +1,36 @@
+import BAIBadgeCount from './BAIBadgeCount';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+// `className` lands on the WRAPPER, which is what lets a call site scope a rule
+// at the overlay (FR-3610: undoing an inverted band's `color-scheme` on the
+// badge). jsdom cannot compute `color-scheme`, so the selector shape is the part
+// worth pinning.
+describe('BAIBadgeCount', () => {
+  it('puts className on the wrapper, an ancestor of the overlay', () => {
+    const { container } = render(
+      <BAIBadgeCount className="scoping-hook" hasDot variant="error">
+        <span>anchor</span>
+      </BAIBadgeCount>,
+    );
+
+    expect(
+      container.querySelector('.scoping-hook .bai-badge-count-overlay'),
+    ).toBeInTheDocument();
+    expect(container.querySelector('.scoping-hook')).toHaveClass(
+      'bai-badge-count',
+    );
+  });
+
+  it('renders no overlay when there is nothing to show', () => {
+    const { container } = render(
+      <BAIBadgeCount className="scoping-hook">
+        <span>anchor</span>
+      </BAIBadgeCount>,
+    );
+
+    expect(
+      container.querySelector('.bai-badge-count-overlay'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/react/src/components/BAINotificationButton.css
+++ b/react/src/components/BAINotificationButton.css
@@ -1,0 +1,21 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+
+ The trigger carries the band's inverted media scope so the bell glyph contrasts
+ the orange band, but `data-astryx-media` sets `color-scheme`, so the badge
+ overlay's `light-dark()` tokens flipped too and the alert dot took the red meant
+ for the opposite surface (FR-3610). The overlay is a status accent, not a
+ foreground that needs to contrast the band, so this re-declares the app mode on
+ that subtree — mirroring the theme's own `html[data-theme]` -> `color-scheme`
+ mapping. Scoped to this call site rather than to `BAIBadgeCount` in BUI:
+ `html[data-theme]` is the host theme artifact's selector, and a deliberately
+ inverted call site must stay able to opt in.
+*/
+html[data-theme='light'] .bai-notification-badge .bai-badge-count-overlay {
+  color-scheme: light;
+}
+
+html[data-theme='dark'] .bai-notification-badge .bai-badge-count-overlay {
+  color-scheme: dark;
+}

--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -5,6 +5,7 @@
 import { useBAINotificationState } from '../hooks/useBAINotification';
 import useKeyboardShortcut from '../hooks/useKeyboardShortcut';
 import { useThemeMode } from '../hooks/useThemeMode';
+import './BAINotificationButton.css';
 import WEBUINotificationDrawer from './WEBUINotificationDrawer';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { Kbd } from '@astryxdesign/core/Kbd';
@@ -94,6 +95,8 @@ const BAINotificationButton: React.FC<BAINotificationButtonProps> = ({
           label={t('notification.Notifications')}
           icon={
             <BAIBadgeCount
+              // The band's inversion stops at the overlay — see the .css.
+              className="bai-notification-badge"
               hasDot={hasRunningBackgroundTask}
               variant="error"
               title={t('notification.Notifications')}


### PR DESCRIPTION
Resolves #8926 (FR-3610)

The header's notification badge dot does not carry the app theme's error red. In **light** mode it renders in the dark-scheme red on the orange band, so it reads as a dull maroon hole rather than an alert.

## Mechanism

`BAINotificationButton` puts the band's inverted media scope on the trigger with `data-astryx-media={isDarkMode ? 'light' : 'dark'}`. That is what makes the bell glyph contrast the orange band, and it is correct for the glyph — but `data-astryx-media` sets `color-scheme`, so **every** `light-dark()` token in that subtree flips, including the badge overlay's `--color-error` and its `--color-background-surface` ring. A status accent should track the app mode wherever it is mounted; it is not a foreground that needs to contrast the band.

Measured on the running app at 1440px, reading `getComputedStyle` on the shipped `.bai-badge-count-dot[data-variant="error"]` markup inside the real header button:

| App mode | band `data-astryx-media` | bell glyph | dot **before** | ring **before** | dot **after** | ring **after** |
|---|---|---|---|---|---|---|
| light | `dark` | `rgb(255,255,255)` | `rgb(190,61,63)` | `rgb(20,20,20)` | **`rgb(255,77,79)`** | **`rgb(255,255,255)`** |
| dark | `light` | `rgb(23,23,23)` | `rgb(255,77,79)` | `rgb(255,255,255)` | **`rgb(190,61,63)`** | **`rgb(20,20,20)`** |

Both "after" rows now equal the same token measured on the page surface (`rgb(255,77,79)` light / `rgb(190,61,63)` dark) — the badge stopped taking the branch meant for the opposite surface. The glyph is untouched and still inverts against the band.

## The change

Two declarations re-state the app mode on the badge subtree, mirroring the theme's own `html[data-theme]` → `color-scheme` mapping, **scoped to this call site**:

```css
/* react/src/components/BAINotificationButton.css */
html[data-theme='light'] .bai-notification-badge .bai-badge-count-overlay { color-scheme: light; }
html[data-theme='dark']  .bai-notification-badge .bai-badge-count-overlay { color-scheme: dark; }
```

`BAINotificationButton` passes `className="bai-notification-badge"` to the badge. `BAIBadgeCount` puts `className` on its wrapper, which is the overlay's parent, so the rule reaches the overlay without BUI changing at all. No prop, no call-site branch, no JS.

Because the declaration lands **on** the overlay, it beats the `color-scheme` the overlay would otherwise inherit from the trigger — cascade order and layers never come into it, since the theme's `[data-astryx-media]` rule targets a different element.

### Why not in `BAIBadgeCount` (revision 2 → 3)

Revision 2 did this from BUI, as an unconditional `html[data-theme] .bai-badge-count-overlay` rule. Per review — "let the consuming component handle the inversion" — it moved here. Three reasons the BUI home was the wrong one:

- **It keys on the host's selector.** `html[data-theme]` → `color-scheme` is declared by the *app theme build artifact* (`react/src/astryx-theme/built/backendai-default-built.css`), not by BUI. A shared component keyed on it silently no-ops in Storybook or in any other host that does not ship that artifact — so the "reusable" version was in fact the non-portable one.
- **It removed the escape hatch.** An unconditional reset leaves no way for a call site that *deliberately* inverts a subtree (a dark brand card, a `MediaTheme mode="dark"` panel) to opt its badge back in.
- **It only half-restored.** The `[data-astryx-media]` scope re-declares `--color-text-primary` / `--color-icon-primary` / `--color-accent` as well as `color-scheme`. Resetting only `color-scheme` would have left the dot on the app theme while the numeric-pill path's neutral text still took the band's — one component, two surfaces. Scoping to the one call site that needs it keeps that asymmetry out of the shared component.

Revision 1 used an `overlayMedia` prop plus `isDarkMode ? 'dark' : 'light'` at the call site. It measured the same, but re-derived in JS what `html[data-theme]` already states in the DOM. Not revisited.

## Screenshots (after)

| light mode | dark mode |
|---|---|
| ![light after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8928/20260821-031156-light-after.png) | ![dark after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-8928/20260821-031156-dark-after.png) |

Before — light mode is the reported defect; dark mode was already carrying the light-scheme red:

| light before | dark before |
|---|---|
| ![light before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0-unlinked/20260820-091800-light-before.png) | ![dark before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-0-unlinked/20260820-091800-dark-before.png) |

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- `pnpm --filter backend.ai-ui exec vitest run` → **681 passed**, 1 skipped, 54 files (679 + the 2 added below)
- `pnpm --prefix ./react exec vitest run` → **1520 passed**, 93 files
- `pnpm --filter backend.ai-ui build` → confirmed the revision-2 rule is **gone** from `dist/backend.ai-ui.css`
- `node scripts/migration-gates/astryx-token-gate.mjs --strict` → 1 undeclared `var()`, `BAIText.css:28` `var(--x)`. **Pre-existing false positive** — line 28 is prose inside that file's header comment ("No `var(--x, literal)` fallbacks"), the file is not touched by this PR, and `git show origin/main:…/BAIText.css` has the same line.
- **New**: `BAIBadgeCount.test.tsx` (the component had no test) pins the contract the scoped rule depends on — `className` lands on the wrapper, an ancestor of `.bai-badge-count-overlay`, and no overlay renders when there is nothing to show.

## Rebase note

Rebased onto `main` after FR-3655 (#9015) dropped the migration-era `Astryx` suffix. `BAIBadgeCountAstryx` is now `BAIBadgeCount`; the call site and the test file added here follow the new name (`BAIBadgeCount.test.tsx`). The CSS class the rule targets (`.bai-badge-count-overlay`) was not renamed, so `BAINotificationButton.css` is unchanged. Net diff is still the same three files, additions only.

## Residue

- **Dark mode changes too**, deliberately: the dot moves from `rgb(255,77,79)` to `rgb(190,61,63)`. That is the app theme's own error red, and matching the page is the rule this PR settles on — but it is a visible change on a screen that was not part of the original report.
- **The measurement table is from revision 2**, which carried the identical two declarations on the identical element from a broader selector. The move to a call-site scope was **not** re-measured live: reaching the header needs a logged-in session against a backend, and this PR names no test server. What the move can change is only whether the selector still matches, and that is covered by the added unit test plus `BAIBadgeCount`'s own render (`className` → wrapper → overlay). Flagging it rather than implying a fresh probe.
- The original measurement injects the component's own overlay markup into the live header, because the dot only renders while a background task is pending.
- No unit test for the colour itself: `color-scheme` / `light-dark()` resolution is not computed by jsdom. The live probe above is that evidence.
- Sibling header reports FR-3502 (band content inversion, Done) and FR-3553 (notification `]` shortcut) are **not** subsumed by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

