### PR TITLE
fix(FR-3609): make the deployment card-title help tooltips hoverable

### DIFF
--- a/react/src/components/DeploymentAccessTokensCard.tsx
+++ b/react/src/components/DeploymentAccessTokensCard.tsx
@@ -8,13 +8,11 @@ import { DeploymentAccessTokensCardListQuery } from '../__generated__/Deployment
 import { DeploymentAccessTokensCard_deployment$key } from '../__generated__/DeploymentAccessTokensCard_deployment.graphql';
 import { App } from '../app-shim';
 import { Form } from '../form-engine';
-import { theme } from '../theme-shim';
 import BAIFormItem from './BAIFormItem';
 import { AstryxFormSelector } from './astryxFormControls';
 import { DateTimeInput } from '@astryxdesign/core/DateTimeInput';
 import type { ISODateTimeString } from '@astryxdesign/core/DateTimeInput';
 import { Text } from '@astryxdesign/core/Text';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAISkeleton,
   BAIButton,
@@ -24,6 +22,7 @@ import {
   BAIFlex,
   BAIModal,
   BAINameActionCell,
+  BAIQuestionIconWithTooltip,
   BAITable,
   BAIText,
   BAIUnmountAfterClose,
@@ -36,7 +35,7 @@ import {
   useMutationWithPromise,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
-import { Trash2, CircleHelp, PlusIcon } from 'lucide-react';
+import { Trash2, PlusIcon } from 'lucide-react';
 import React, {
   Suspense,
   useDeferredValue,
@@ -77,7 +76,6 @@ const DeploymentAccessTokensCard: React.FC<DeploymentAccessTokensCardProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const { message } = App.useApp();
   const { logger } = useBAILogger();
   const [isPendingRefetch, startRefetchTransition] = useTransition();
@@ -147,12 +145,9 @@ const DeploymentAccessTokensCard: React.FC<DeploymentAccessTokensCardProps> = ({
         title={
           <BAIFlex gap="xs" align="center">
             {t('deployment.tab.AccessTokens')}
-            <Tooltip content={t('deployment.tab.description.AccessTokens')}>
-              <CircleHelp
-                style={{ color: token.colorTextDescription }}
-                size="1em"
-              />
-            </Tooltip>
+            <BAIQuestionIconWithTooltip
+              title={t('deployment.tab.description.AccessTokens')}
+            />
           </BAIFlex>
         }
         extra={

--- a/react/src/components/DeploymentAutoScalingCard.tsx
+++ b/react/src/components/DeploymentAutoScalingCard.tsx
@@ -13,10 +13,8 @@ import { App } from '../app-shim';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
-import { theme } from '../theme-shim';
 import AutoScalingRuleEditorModal from './AutoScalingRuleEditorModal';
 import AutoScalingRuleListNodes from './AutoScalingRuleListNodes';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import {
   BAISkeleton,
   BAIButton,
@@ -25,6 +23,7 @@ import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
+  BAIQuestionIconWithTooltip,
   BAIUnmountAfterClose,
   filterOutNullAndUndefined,
   isDeploymentInStoppedCategory,
@@ -33,7 +32,7 @@ import {
   useMutationWithPromise,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { CircleHelp, PlusIcon } from 'lucide-react';
+import { PlusIcon } from 'lucide-react';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, {
   Suspense,
@@ -64,7 +63,6 @@ const DeploymentAutoScalingCard: React.FC<DeploymentAutoScalingCardProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const [currentUser] = useCurrentUserInfo();
 
   const deployment = useFragment(
@@ -99,12 +97,9 @@ const DeploymentAutoScalingCard: React.FC<DeploymentAutoScalingCardProps> = ({
       title={
         <BAIFlex gap="xs" align="center">
           {t('deployment.tab.AutoScaling')}
-          <Tooltip content={t('deployment.tab.description.AutoScaling')}>
-            <CircleHelp
-              style={{ color: token.colorTextDescription }}
-              size="1em"
-            />
-          </Tooltip>
+          <BAIQuestionIconWithTooltip
+            title={t('deployment.tab.description.AutoScaling')}
+          />
         </BAIFlex>
       }
       styles={{ body: { paddingTop: 0 } }}

--- a/react/src/components/DeploymentReplicasCard.tsx
+++ b/react/src/components/DeploymentReplicasCard.tsx
@@ -11,7 +11,6 @@ import type { DeploymentRevisionDetail_revision$key } from '../__generated__/Dep
 import { RouteSchedulingHistoryModalQuery } from '../__generated__/RouteSchedulingHistoryModalQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
-import { theme } from '../theme-shim';
 import { ProjectContextOrNull } from '../types/projectContext';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import BAIErrorBoundary from './BAIErrorBoundary';
@@ -25,7 +24,6 @@ import SessionDetailDrawer from './SessionDetailDrawer';
 import { IconButton } from '@astryxdesign/core/IconButton';
 import { Link } from '@astryxdesign/core/Link';
 import { Text } from '@astryxdesign/core/Text';
-import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { BAISkeleton } from 'backend.ai-ui';
 import {
   BAICard,
@@ -47,7 +45,7 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
-import { History, CircleHelp } from 'lucide-react';
+import { History } from 'lucide-react';
 import {
   parseAsInteger,
   parseAsString,
@@ -123,19 +121,15 @@ const DeploymentReplicasCard: React.FC<DeploymentReplicasCardProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
 
   return (
     <BAICard
       title={
         <BAIFlex gap="xs" align="center">
           {t('deployment.tab.Replicas')}
-          <Tooltip content={t('deployment.tab.description.Replicas')}>
-            <CircleHelp
-              style={{ color: token.colorTextDescription }}
-              size="1em"
-            />
-          </Tooltip>
+          <BAIQuestionIconWithTooltip
+            title={t('deployment.tab.description.Replicas')}
+          />
         </BAIFlex>
       }
       styles={{ body: { paddingTop: 0 } }}


### PR DESCRIPTION
Resolves #8924 (FR-3609)

## Problem

On the deployment detail page the help "?" icons beside the **Replicas**,
**AutoScaling** and **Access Tokens** card titles never show their tooltip —
by hover or by keyboard.

All three passed a bare lucide `<svg>` straight to Astryx `Tooltip`:

```tsx
<Tooltip content={t('deployment.tab.description.Replicas')}>
  <CircleHelp style={{ color: token.colorTextDescription }} size="1em" />
</Tooltip>
```

Astryx wraps a non-text child in a `display: contents` div and attaches its
`mouseenter` / `mouseleave` listeners to `wrapper.firstElementChild` — here, the
`<svg>` itself. lucide renders `fill="none"`, and SVG hit-testing defaults to
`pointer-events: visiblePainted`, so only the glyph's ~1.5px stroke is
hoverable; the pointer never "enters" the element. `useTooltip`'s `isFocusable()`
accepts only `A/BUTTON/INPUT/SELECT/TEXTAREA`, `[tabindex]` or contenteditable,
so with the default `focusTrigger="auto"` there is no focus fallback either.

The wiring is otherwise correct — the elements do get `anchor-name` and
`aria-describedby` — which is why this reads as "the tooltip is missing" rather
than "the tooltip is broken".

Regression origin: 7d7b42388 (`feat(FR-3482): migrate the WebUI from Ant Design
to Astryx`) swapped antd's `QuestionCircleOutlined` (a real `<span role="img">`,
with handlers attached via `cloneElement`) for the lucide `<svg>`.

## Evidence

Measured against a running dev server, hovering each trigger's centre and
reading back the open `[popover]` elements:

| Trigger shape | Where | computed `cursor` | Tooltip on hover |
|---|---|---|---|
| bare `<svg>` in a `display:contents` wrapper | Dashboard board items (`BAIBoardItemTitle`) | `auto` | 0 / 6 |
| glyph wrapped in a real element (`BAIQuestionIconWithTooltip`) | Admin → Resource Policy column header | `help` | 1 / 1 |

The deployment detail page itself could not be exercised end to end — the shared
test backend currently has no deployments — so the reproduction above uses the
identical trigger shape on a reachable page. Note the same page already renders
four *working* "?" icons (Replica Lifecycle / Health / Traffic / Revision column
headers) through `BAIQuestionIconWithTooltip`, so the working and broken shapes
sat side by side on one screen.

## Change

Converge the three card titles onto `BAIQuestionIconWithTooltip`, the shared BUI
component (63 call sites) that wraps the glyph in a `Text` element with
`cursor: help` and `display: inline-flex`:

```tsx
<BAIQuestionIconWithTooltip title={t('deployment.tab.description.Replicas')} />
```

This also drops each file's `theme.useToken()` read, the `Tooltip` /
`CircleHelp` imports and the hand-rolled tint — the component takes its colour
from `Text color="placeholder"`, which is that shim's intended end state.

Net: 14 insertions, 30 deletions across 3 files.

## Scope

Deliberately limited to the three cards named in the issue. The same bare-`<svg>`
trigger shape is confirmed broken elsewhere (`BAIBoardItemTitle`,
`BAIAlertIconWithTooltip`, `ClusterModeFormItems`, `ResourceAllocationFormItems`,
`SessionDetailContent`, `ResourcePresetSelect`, `UserInfoModal`); that sweep is
filed separately rather than folded in here.

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript,
Vite warmup paths, StyleX cssInjectionTarget, Astryx theme build, Terminology).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
