### PR TITLE
fix(FR-3614): run the react vitest suite without per-file isolation

### DIFF
--- a/packages/backend.ai-ui/setupTests.ts
+++ b/packages/backend.ai-ui/setupTests.ts
@@ -44,6 +44,74 @@ if (typeof document !== 'undefined') {
   sessionStorage.clear();
 }
 
+// window/document listeners registered by one file would otherwise run with
+// stale module state during later files' events. Wrap add/removeEventListener
+// once per worker to track live registrations; each per-file re-run of this
+// setup disposes the leftovers. Only project-code registrations are tracked:
+// node_modules registrants (e.g. react-dom's once-per-document
+// `selectionchange`) stay cached across files and would not re-register
+// after removal.
+type TrackedListener = {
+  type: string;
+  listener: EventListenerOrEventListenerObject | null;
+  options?: boolean | AddEventListenerOptions;
+  remove: EventTarget['removeEventListener'];
+};
+const listenerTracker: { installed: boolean; live: TrackedListener[] } = ((
+  globalThis as any
+).__baiTestListenerTracker ??= { installed: false, live: [] });
+if (!listenerTracker.installed && typeof document !== 'undefined') {
+  listenerTracker.installed = true;
+  const captureOf = (options?: boolean | AddEventListenerOptions) =>
+    typeof options === 'boolean' ? options : !!options?.capture;
+  // globalThis and window can hold distinct copies of the same methods.
+  for (const holder of new Set<EventTarget>([
+    globalThis as unknown as EventTarget,
+    window,
+    document,
+  ])) {
+    const originalAdd = holder.addEventListener.bind(holder);
+    const originalRemove = holder.removeEventListener.bind(holder);
+    holder.addEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions,
+    ) => {
+      // Stack frame 0 is "Error", 1 is this wrapper; 2 is the registrant.
+      const caller = (new Error().stack ?? '').split('\n')[2] ?? '';
+      if (!caller.includes('node_modules')) {
+        listenerTracker.live.push({
+          type,
+          listener,
+          options,
+          remove: originalRemove,
+        });
+      }
+      originalAdd(type, listener, options);
+    };
+    holder.removeEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | EventListenerOptions,
+    ) => {
+      const index = listenerTracker.live.findIndex(
+        (entry) =>
+          entry.remove === originalRemove &&
+          entry.type === type &&
+          entry.listener === listener &&
+          captureOf(entry.options) === captureOf(options),
+      );
+      if (index !== -1) {
+        listenerTracker.live.splice(index, 1);
+      }
+      originalRemove(type, listener, options);
+    };
+  }
+}
+for (const entry of listenerTracker.live.splice(0)) {
+  entry.remove(entry.type, entry.listener, entry.options);
+}
+
 // The `@rc-component/motion` transitionend auto-completer that used to live
 // here is gone (to-astryx final switch).
 //

--- a/packages/backend.ai-ui/setupTests.ts
+++ b/packages/backend.ai-ui/setupTests.ts
@@ -11,7 +11,38 @@ import '@testing-library/jest-dom';
 // polling uses `setTimeout`, which never fires under faked timers.
 // (None of our test code references `jest.*` directly anymore; this is
 // purely a `@testing-library/dom` integration hook.)
-import { vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+
+// RTL's auto-cleanup registers its afterEach at module-import time, which the
+// shared module registry of `isolate: false` only executes for the first test
+// file per worker — register it explicitly so every file unmounts its DOM.
+afterEach(() => {
+  cleanup();
+});
+
+// `isolate: false` shares the source-module registry across test files, so a
+// file's `vi.mock` never reaches an importer another file already evaluated.
+// This setup file re-runs before each test file: dropping the source-module
+// cache here restores per-file mock semantics while keeping the shared jsdom
+// environment and transform caches that make no-isolate fast.
+vi.resetModules();
+
+// Non-React residue survives RTL cleanup in the shared environment (Astryx's
+// live-region singleton nodes, scroll-lock leftovers on <body>): start each
+// file with the pristine body a fresh jsdom would give it. Astryx re-attaches
+// its live regions on the next announcement, so removal is safe.
+if (typeof document !== 'undefined') {
+  document.body.replaceChildren();
+  for (const el of [document.body, document.documentElement]) {
+    for (const { name } of Array.from(el.attributes)) {
+      el.removeAttribute(name);
+    }
+  }
+  // Web storage is per-jsdom under isolation; keep that per-file guarantee.
+  localStorage.clear();
+  sessionStorage.clear();
+}
 
 // The `@rc-component/motion` transitionend auto-completer that used to live
 // here is gone (to-astryx final switch).

--- a/packages/backend.ai-ui/vitest.config.ts
+++ b/packages/backend.ai-ui/vitest.config.ts
@@ -45,6 +45,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // Reuse the worker environment across test files; setupTests.ts restores
+    // per-file DOM and source-module freshness. Escape hatch: `vitest run --isolate`.
+    isolate: false,
     setupFiles: [
       resolve(__dirname, 'setupTests.ts'),
     ],

--- a/react/src/components/NetworkStatusBanner.test.tsx
+++ b/react/src/components/NetworkStatusBanner.test.tsx
@@ -94,7 +94,12 @@ describe('NetworkStatusBanner offline gating', () => {
     renderBanner();
 
     expect(screen.queryByText(OFFLINE_TEXT)).not.toBeInTheDocument();
-    expect(fetchSpy).not.toHaveBeenCalled();
+    // Assert on the probe itself, not global fetch quiescence — deferred app
+    // bootstrap fetches (i18n, image metadata) may land in this window.
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      'https://api.test/health',
+      expect.anything(),
+    );
   });
 
   it('shows the offline banner when the browser is offline AND the probe is non-OK', async () => {

--- a/react/src/global-stores.test.ts
+++ b/react/src/global-stores.test.ts
@@ -250,14 +250,17 @@ describe('BackendAIMetadataStore', () => {
     } as unknown as Response);
 
     const events: Event[] = [];
-    document.addEventListener('backend-ai-metadata-image-loaded', (e) =>
-      events.push(e),
+    const onImageLoaded = (e: Event) => events.push(e);
+    document.addEventListener(
+      'backend-ai-metadata-image-loaded',
+      onImageLoaded,
     );
 
     await backendaiMetadata.readImageMetadata();
 
-    document.removeEventListener('backend-ai-metadata-image-loaded', (e) =>
-      events.push(e),
+    document.removeEventListener(
+      'backend-ai-metadata-image-loaded',
+      onImageLoaded,
     );
 
     expect(events).toHaveLength(1);
@@ -289,15 +292,12 @@ describe('BackendAITasker', () => {
   describe('add()', () => {
     it('dispatches add-bai-notification event with pending status', () => {
       const events: CustomEvent[] = [];
-      document.addEventListener('add-bai-notification', (e) =>
-        events.push(e as CustomEvent),
-      );
+      const onNotification = (e: Event) => events.push(e as CustomEvent);
+      document.addEventListener('add-bai-notification', onNotification);
 
       backendaiTasker.add('Test Task', null, 'task-001');
 
-      document.removeEventListener('add-bai-notification', (e) =>
-        events.push(e as CustomEvent),
-      );
+      document.removeEventListener('add-bai-notification', onNotification);
 
       expect(events.length).toBeGreaterThanOrEqual(1);
       const firstEvent = events[0];
@@ -320,9 +320,8 @@ describe('BackendAITasker', () => {
 
     it('sets open=false when hiddenNotification is true', () => {
       const events: CustomEvent[] = [];
-      document.addEventListener('add-bai-notification', (e) =>
-        events.push(e as CustomEvent),
-      );
+      const onNotification = (e: Event) => events.push(e as CustomEvent);
+      document.addEventListener('add-bai-notification', onNotification);
 
       backendaiTasker.add(
         'Hidden Task',
@@ -335,9 +334,7 @@ describe('BackendAITasker', () => {
         true,
       );
 
-      document.removeEventListener('add-bai-notification', (e) =>
-        events.push(e as CustomEvent),
-      );
+      document.removeEventListener('add-bai-notification', onNotification);
 
       const firstEvent = events[0];
       expect(firstEvent.detail.open).toBe(false);
@@ -345,24 +342,20 @@ describe('BackendAITasker', () => {
 
     it('dispatches resolved notification when promise resolves', async () => {
       const resolvedEvents: CustomEvent[] = [];
-      document.addEventListener('add-bai-notification', (e) => {
+      const onResolved = (e: Event) => {
         const ce = e as CustomEvent;
         if (ce.detail?.backgroundTask?.status === 'resolved') {
           resolvedEvents.push(ce);
         }
-      });
+      };
+      document.addEventListener('add-bai-notification', onResolved);
 
       const task = Promise.resolve();
       backendaiTasker.add('Async Task', task, 'task-async');
 
       await task;
 
-      document.removeEventListener('add-bai-notification', (e) => {
-        const ce = e as CustomEvent;
-        if (ce.detail?.backgroundTask?.status === 'resolved') {
-          resolvedEvents.push(ce);
-        }
-      });
+      document.removeEventListener('add-bai-notification', onResolved);
 
       expect(resolvedEvents).toHaveLength(1);
       expect(resolvedEvents[0].detail.key).toBe('task:task-async');
@@ -370,24 +363,20 @@ describe('BackendAITasker', () => {
 
     it('dispatches rejected notification when promise rejects', async () => {
       const rejectedEvents: CustomEvent[] = [];
-      document.addEventListener('add-bai-notification', (e) => {
+      const onRejected = (e: Event) => {
         const ce = e as CustomEvent;
         if (ce.detail?.backgroundTask?.status === 'rejected') {
           rejectedEvents.push(ce);
         }
-      });
+      };
+      document.addEventListener('add-bai-notification', onRejected);
 
       const task = Promise.reject(new Error('fail'));
       backendaiTasker.add('Failing Task', task, 'task-fail');
 
       await task.catch(() => {});
 
-      document.removeEventListener('add-bai-notification', (e) => {
-        const ce = e as CustomEvent;
-        if (ce.detail?.backgroundTask?.status === 'rejected') {
-          rejectedEvents.push(ce);
-        }
-      });
+      document.removeEventListener('add-bai-notification', onRejected);
 
       expect(rejectedEvents).toHaveLength(1);
       expect(rejectedEvents[0].detail.key).toBe('task:task-fail');
@@ -404,15 +393,12 @@ describe('BackendAITasker', () => {
   describe('signal()', () => {
     it('dispatches backend-ai-task-changed event with tasks', () => {
       const events: CustomEvent[] = [];
-      document.addEventListener('backend-ai-task-changed', (e) =>
-        events.push(e as CustomEvent),
-      );
+      const onTaskChanged = (e: Event) => events.push(e as CustomEvent);
+      document.addEventListener('backend-ai-task-changed', onTaskChanged);
 
       backendaiTasker.signal();
 
-      document.removeEventListener('backend-ai-task-changed', (e) =>
-        events.push(e as CustomEvent),
-      );
+      document.removeEventListener('backend-ai-task-changed', onTaskChanged);
 
       expect(events).toHaveLength(1);
       expect(events[0].detail.tasks).toBeDefined();

--- a/react/src/setupTests.ts
+++ b/react/src/setupTests.ts
@@ -15,9 +15,40 @@ import '@testing-library/jest-dom';
 // polling uses `setTimeout`, which never fires under faked timers.
 // (None of our test code references `jest.*` directly anymore; this is
 // purely a `@testing-library/dom` integration hook.)
-import { vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
 
 (globalThis as any).jest = vi;
+
+// `isolate: false` shares the source-module registry across test files, so a
+// file's `vi.mock` never reaches an importer another file already evaluated.
+// This setup file re-runs before each test file: dropping the source-module
+// cache here restores per-file mock semantics while keeping the shared jsdom
+// environment and transform caches that make no-isolate fast.
+vi.resetModules();
+
+// Non-React residue survives RTL cleanup in the shared environment (Astryx's
+// live-region singleton nodes, scroll-lock leftovers, body/html attributes):
+// start each file with the pristine document a fresh jsdom would give it.
+// Astryx re-attaches its live regions on the next announcement, so removal is safe.
+if (typeof document !== 'undefined') {
+  document.body.replaceChildren();
+  for (const el of [document.body, document.documentElement]) {
+    for (const { name } of Array.from(el.attributes)) {
+      el.removeAttribute(name);
+    }
+  }
+  // Web storage is per-jsdom under isolation; keep that per-file guarantee.
+  localStorage.clear();
+  sessionStorage.clear();
+}
+
+// RTL's auto-cleanup registers its afterEach at module-import time, which the
+// shared module registry of `isolate: false` only executes for the first test
+// file per worker — register it explicitly so every file unmounts its DOM.
+afterEach(() => {
+  cleanup();
+});
 
 // jsdom implements `<dialog>` as an element but not its modal API, so any
 // component built on Astryx `Dialog` (every `BAIModalAstryx`, drawer and

--- a/react/src/setupTests.ts
+++ b/react/src/setupTests.ts
@@ -43,6 +43,74 @@ if (typeof document !== 'undefined') {
   sessionStorage.clear();
 }
 
+// window/document listeners registered by one file (e.g. TabCount's anonymous
+// `beforeunload`) would otherwise run with stale module state during later
+// files' events. Wrap add/removeEventListener once per worker to track live
+// registrations; each per-file re-run of this setup disposes the leftovers.
+// Only project-code registrations are tracked: node_modules registrants (e.g.
+// react-dom's once-per-document `selectionchange`) stay cached across files
+// and would not re-register after removal.
+type TrackedListener = {
+  type: string;
+  listener: EventListenerOrEventListenerObject | null;
+  options?: boolean | AddEventListenerOptions;
+  remove: EventTarget['removeEventListener'];
+};
+const listenerTracker: { installed: boolean; live: TrackedListener[] } = ((
+  globalThis as any
+).__baiTestListenerTracker ??= { installed: false, live: [] });
+if (!listenerTracker.installed && typeof document !== 'undefined') {
+  listenerTracker.installed = true;
+  const captureOf = (options?: boolean | AddEventListenerOptions) =>
+    typeof options === 'boolean' ? options : !!options?.capture;
+  // globalThis and window can hold distinct copies of the same methods.
+  for (const holder of new Set<EventTarget>([
+    globalThis as unknown as EventTarget,
+    window,
+    document,
+  ])) {
+    const originalAdd = holder.addEventListener.bind(holder);
+    const originalRemove = holder.removeEventListener.bind(holder);
+    holder.addEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions,
+    ) => {
+      // Stack frame 0 is "Error", 1 is this wrapper; 2 is the registrant.
+      const caller = (new Error().stack ?? '').split('\n')[2] ?? '';
+      if (!caller.includes('node_modules')) {
+        listenerTracker.live.push({
+          type,
+          listener,
+          options,
+          remove: originalRemove,
+        });
+      }
+      originalAdd(type, listener, options);
+    };
+    holder.removeEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | EventListenerOptions,
+    ) => {
+      const index = listenerTracker.live.findIndex(
+        (entry) =>
+          entry.remove === originalRemove &&
+          entry.type === type &&
+          entry.listener === listener &&
+          captureOf(entry.options) === captureOf(options),
+      );
+      if (index !== -1) {
+        listenerTracker.live.splice(index, 1);
+      }
+      originalRemove(type, listener, options);
+    };
+  }
+}
+for (const entry of listenerTracker.live.splice(0)) {
+  entry.remove(entry.type, entry.listener, entry.options);
+}
+
 // RTL's auto-cleanup registers its afterEach at module-import time, which the
 // shared module registry of `isolate: false` only executes for the first test
 // file per worker — register it explicitly so every file unmounts its DOM.

--- a/react/vitest.config.ts
+++ b/react/vitest.config.ts
@@ -105,6 +105,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // Reuse the worker environment across test files; setupTests.ts restores
+    // per-file DOM and source-module freshness. Escape hatch: `vitest run --isolate`.
+    isolate: false,
     setupFiles: [
       resolve(__dirname, 'src/setupTests.ts'),
     ],


### PR DESCRIPTION
Resolves #8937 (FR-3614)

## What

Fixes the cross-test state leakage that made both vitest suites fail under `--no-isolate`, then enables `isolate: false` unconditionally in `react/vitest.config.ts` and `packages/backend.ai-ui/vitest.config.ts` so local and CI runs exercise the same shared-environment path. Escape hatch: `vitest run --isolate`.

Per-test-file environment isolation was the largest remaining cost in the react-vitest CI job (transform/import-bound). CI picks this up through the existing `vitest run --coverage` invocation — no workflow change.

## Leak inventory

Measured baseline under `--no-isolate`: react 25–27 failed files / 118–145 failed tests (the set varies with worker scheduling), BUI 18 files / 92 tests.

| Leak | Class | Affected (examples) | Fix |
|---|---|---|---|
| RTL auto-cleanup registers its `afterEach` at module-import time; the shared module registry executes it only for the first test file per worker | DOM residue | ~20 react files + most BUI failures ("Found multiple elements …"), `useKeyboardShortcut` (leftover open `<dialog>` suppressed shortcuts) | Explicit `afterEach(cleanup)` in each suite's `setupTests` (re-run per test file) |
| `vi.mock` factories never reach importer modules another file already evaluated in the shared registry | module cache vs. mocks | `useHighlight`, `useCustomThemeConfig`, `useBrowserPopstateEffect`, `useUrlProjectValidity`, `SFTPServerButtonV2` — and potentially any of the 33 react test files mocking source modules, depending on scheduling | `vi.resetModules()` per file in `setupTests`: restores per-file mock semantics while keeping the shared jsdom environment and transform/node_modules caches |
| Non-React DOM residue that outlives RTL cleanup: Astryx's live-region singleton appends `[data-astryx-live-region]` nodes to `<body>` outside any React root; body/html attributes and web storage persist | environment residue | `BAIFlex` `baseElement` snapshots (flaky), theme/body-attribute tests | Per-file pristine reset in `setupTests`: `body.replaceChildren()`, strip body/html attributes, `localStorage`/`sessionStorage` clear. Astryx re-attaches its live regions on the next announcement, so removal is safe |
| Deferred app-bootstrap fetches (i18next backend load, `image_metadata.json`) scheduled by an earlier file's module evaluation land in a later test's global-fetch spy window | async residue | `NetworkStatusBanner.test.tsx` ("never probes" flaked ~1/8 runs) | Narrowed the blanket `expect(fetchSpy).not.toHaveBeenCalled()` to `not.toHaveBeenCalledWith('https://api.test/health', …)` — the probe contract the test owns; the sibling test still pins the exact health URL |

No test was skipped and no product code was changed.

## Measured times (local, warm)

| Suite / command | isolate on | isolate off |
|---|---|---|
| react `vitest run` | 118.1s | 70.6 / 68.0 / 70.5s (3 runs) |
| react `vitest run --coverage` (CI command) | 156.5s | 111.3s |
| BUI `vitest run` | 51.4s | ~37s |
| BUI `vitest run --coverage` (CI command) | 59.9s | 42.8s |

## Stability

- react: **6 consecutive** clean full runs with `isolate: false` (93 files / 1520 tests each).
- BUI: **5 consecutive** clean full runs (53 files / 679 tests + 1 skipped).
- Both suites also pass with the `--isolate` escape hatch (fixes are isolation-neutral).

## verify.sh

```
=== Relay ===            PASS
=== Lint ===             PASS
=== Format ===           PASS
=== TypeScript ===       PASS
=== Vite warmup paths ===        PASS
=== StyleX cssInjectionTarget == PASS
=== Astryx theme build ===       PASS
=== Terminology ===              PASS
=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
