### PR TITLE
fix(FR-3615): use session UUID instead of session name in session REST API calls

### DIFF
--- a/packages/backend.ai-client/src/client.ts
+++ b/packages/backend.ai-client/src/client.ts
@@ -1707,12 +1707,12 @@ export class Client {
   /**
    * Rename session to another name.
    *
-   * @param {string} sessionId - current session name
-   * @param {string} newId - new session name
+   * @param {string} sessionId - ID (UUID) of the session
+   * @param {string} newName - new session name
    */
-  async rename(sessionId: string, newId: string): Promise<any> {
+  async rename(sessionId: string, newName: string): Promise<any> {
     let params = {
-      name: newId,
+      name: newName,
     };
     let rqst = this.newSignedRequest(
       'POST',

--- a/packages/backend.ai-client/src/resources/compute-session.ts
+++ b/packages/backend.ai-client/src/resources/compute-session.ts
@@ -223,12 +223,12 @@ export class ComputeSession {
   /**
    * Request container commit for corresponding session in agent node
    *
-   * @param sessionName - name of the session
+   * @param sessionId - ID (UUID) of the session
    */
-  async commitSession(sessionName: string = ''): Promise<any> {
+  async commitSession(sessionId: string): Promise<any> {
     const rqst = this.client.newSignedRequest(
       'POST',
-      `/session/${sessionName}/commit`,
+      `/session/${sessionId}/commit`,
       null,
     );
     return this.client._wrapWithPromise(rqst);
@@ -237,15 +237,15 @@ export class ComputeSession {
   /**
    * Request container commit for corresponding session in agent node
    *
-   * @param sessionName - name of the session
+   * @param sessionId - ID (UUID) of the session
    */
   async convertSessionToImage(
-    sessionName: string,
+    sessionId: string,
     newImageName: string,
   ): Promise<any> {
     const rqst = this.client.newSignedRequest(
       'POST',
-      `/session/${sessionName}/imagify`,
+      `/session/${sessionId}/imagify`,
       { image_name: newImageName },
     );
     return this.client._wrapWithPromise(rqst);
@@ -254,12 +254,12 @@ export class ComputeSession {
   /**
    * Get status of requested container commit on agent node (ongoing / finished / failed)
    *
-   * @param sessionName - name of the session
+   * @param sessionId - ID (UUID) of the session
    */
-  async getCommitSessionStatus(sessionName: string = ''): Promise<any> {
+  async getCommitSessionStatus(sessionId: string): Promise<any> {
     const rqst = this.client.newSignedRequest(
       'GET',
-      `/session/${sessionName}/commit`,
+      `/session/${sessionId}/commit`,
     );
     return this.client._wrapWithPromise(rqst);
   }

--- a/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
@@ -61,7 +61,7 @@ const ContainerCommitModal: React.FC<ContainerCommitModalProps> = ({
           backgroundTask: {
             status: 'pending',
             promise: baiClient.computeSession.convertSessionToImage(
-              session?.name ?? '',
+              session?.row_id ?? '',
               values.imageName,
             ),
             onChange: {

--- a/react/src/components/ComputeSessionNodeItems/EditableSessionName.tsx
+++ b/react/src/components/ComputeSessionNodeItems/EditableSessionName.tsx
@@ -6,7 +6,7 @@ import { EditableSessionNameFragment$key } from '../../__generated__/EditableSes
 import { EditableSessionNameRefetchQuery } from '../../__generated__/EditableSessionNameRefetchQuery.graphql';
 import { App } from '../../app-shim';
 import { Form } from '../../form-engine';
-import { useBaiSignedRequestWithPromise } from '../../helper';
+import { useSuspendedBackendaiClient } from '../../hooks';
 import { useCurrentUserInfo } from '../../hooks/backendai';
 import { useTanMutation } from '../../hooks/reactQueryAlias';
 import { useValidateSessionName } from '../../hooks/useValidateSessionName';
@@ -76,16 +76,10 @@ const EditableSessionName: React.FC<EditableSessionNameProps> = ({
   const validationRules = useValidateSessionName(optimisticName);
   const [userInfo] = useCurrentUserInfo();
 
-  const baiRequestWithPromise = useBaiSignedRequestWithPromise();
+  const baiClient = useSuspendedBackendaiClient();
   const renameSessionMutation = useTanMutation({
     mutationFn: (newName: string) => {
-      return baiRequestWithPromise({
-        method: 'POST',
-        url: `/session/${session.name}/rename`,
-        body: {
-          name: newName,
-        },
-      });
+      return baiClient.rename(session.row_id, newName);
     },
   });
 


### PR DESCRIPTION
Resolves #8945 (FR-3615)

## Summary

Two frontend session REST calls still used the session **name** as the path identifier. Session names are unique only per-user and only for the session's lifetime, so a name-based call can resolve to the wrong session (e.g. a recreated session reusing a name). The manager already accepts the session **UUID** on these routes — existing production calls (`startService(session.row_id)`, `destroy(session.row_id)`, `get_logs(session.row_id)`) prove it — so both call sites now pass `session.row_id`.

Both Relay fragments already selected `row_id`, so no GraphQL change and no regenerated Relay artifacts were needed.

A repo-wide sweep found **no other name-based session REST calls in the React app**. The only other rename call site, `react/src/components/SessionListColums/SessionInfoCell.tsx`, is unused dead code (no importers) and already passes the UUID on API >= v5; the legacy Electron wsproxy client (`src/lib/backend.ai-client-node.ts`) is out of scope. `commitSession` / `getCommitSessionStatus` have no callers in `react/src/**`.

User-facing display of the session name (the notification text and the metadata rows in the commit modal) is unchanged — only the API identifier moved.

## Changes

- `react/src/components/ComputeSessionNodeItems/EditableSessionName.tsx` — the rename mutation now calls the existing `baiClient.rename(session.row_id, newName)` wrapper instead of hand-building `/session/${session.name}/rename` with `useBaiSignedRequestWithPromise`, so the identifier semantics live in one place and the call inherits the client's kernel-prefix handling.
- `react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx` — `convertSessionToImage()` is called with `session?.row_id ?? ''` instead of the name. The notification message and the `SessionName` metadata row still show the name.
- `packages/backend.ai-client/src/resources/compute-session.ts` — renamed the `sessionName` parameter of `commitSession`, `convertSessionToImage`, and `getCommitSessionStatus` to `sessionId`, corrected their JSDoc to say "ID (UUID) of the session", and dropped the `= ''` defaults on the two caller-less methods (an empty identifier could only produce a malformed `/session//commit` request).
- `packages/backend.ai-client/src/client.ts` — `rename()`'s JSDoc said `@param sessionId - current session name`; corrected to "ID (UUID) of the session". Its second parameter `newId` is renamed to `newName` to match what it actually is (the new session name).

## Verification

`bash scripts/verify.sh`:

```
=== Astryx theme build ===
✓ Theme outputs are up to date with src/astryx-theme/built/backendai-default.ts.
--- Astryx theme build: PASS ---

=== Terminology ===
  CHECK 1 summary: 0 blocking, 1 warn-only.

=== TERMINOLOGY SUMMARY ===
  blocking terminology findings: 0
  warn-only terminology findings: 1
  near-duplicate findings (report): 0
  unknown-noun findings (report): 0
--- Terminology: PASS ---

=== Terminology self-test (report-only here; hard gate in CI) ===
  PASS — 409 assertion(s) hold.

=== ALL PASS ===
```

(The one warn-only terminology finding is pre-existing and unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143Hcm1saTLNK3CNk8p5E3o

