### PR TITLE
fix(FR-3616): upgrade markdown-to-jsx to 9.x to fix the GFM-alert crash

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,8 +872,8 @@ importers:
         specifier: 'catalog:'
         version: 1.29.0(react@19.2.8)
       markdown-to-jsx:
-        specifier: ^7.7.17
-        version: 7.7.17(react@19.2.8)
+        specifier: ^9.10.2
+        version: 9.10.2(react@19.2.8)
       marked:
         specifier: 'catalog:'
         version: 16.4.2
@@ -8392,13 +8392,22 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
-  markdown-to-jsx@7.7.17:
-    resolution: {integrity: sha512-7mG/1feQ0TX5I7YyMZVDgCC/y2I3CiEhIRQIhyov9nGBP5eoVrOXXHuL5ZP8GRfxVZKRiXWJgwXkb9It+nQZfQ==}
-    engines: {node: '>= 10'}
+  markdown-to-jsx@9.10.2:
+    resolution: {integrity: sha512-iR9GadlIox0q1uXnpqdxpF02Vb1WDmZ/QIXWjBR5htzjUEEhyIWbM65LuVKavdwJaVo4q95C/F2OOyNjWe91ig==}
+    engines: {node: '>= 18'}
     peerDependencies:
-      react: '>= 0.14.0'
+      react: '>= 16.0.0'
+      react-native: '*'
+      solid-js: '>=1.0.0'
+      vue: '>=3.0.0'
     peerDependenciesMeta:
       react:
+        optional: true
+      react-native:
+        optional: true
+      solid-js:
+        optional: true
+      vue:
         optional: true
 
   marked@12.0.2:
@@ -19626,7 +19635,7 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
-  markdown-to-jsx@7.7.17(react@19.2.8):
+  markdown-to-jsx@9.10.2(react@19.2.8):
     optionalDependencies:
       react: 19.2.8
 
@@ -23528,7 +23537,7 @@ time:
   lodash-es@4.18.1: '2026-04-01T21:04:15.518Z'
   lodash@4.18.1: '2026-04-01T21:01:20.458Z'
   lucide-react@1.29.0: '2026-08-06T11:51:53.703Z'
-  markdown-to-jsx@7.7.17: '2025-10-24T03:49:28.787Z'
+  markdown-to-jsx@9.10.2: '2026-08-03T17:49:48.169Z'
   marked@12.0.2: '2024-04-19T05:13:06.397Z'
   marked@16.4.2: '2025-11-06T22:29:20.004Z'
   mime-types@2.1.35: '2022-03-12T18:04:43.042Z'

--- a/react/package.json
+++ b/react/package.json
@@ -54,7 +54,7 @@
     "lexical": "0.46.0",
     "lodash-es": "catalog:",
     "lucide-react": "catalog:",
-    "markdown-to-jsx": "^7.7.17",
+    "markdown-to-jsx": "^9.10.2",
     "marked": "catalog:",
     "monaco-editor": "^0.55.1",
     "nanoid": "^5.1.16",


### PR DESCRIPTION
Resolves #8947 (FR-3616)

## Problem

Opening a model card in the Model Store crashed to the error boundary with `TypeError: Cannot read properties of undefined (reading 'l')` at `ModelCardDrawer.tsx:317`.

Root cause is an upstream bug in **markdown-to-jsx 7.7.17** (the last 7.x release): when the markdown contains a GitHub alert blockquote (`> [!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`) **and** `disableParsingRawHTML: true` is set, the blockquote renderer injects a synthetic `htmlBlock` AST node whose rule was deleted by that very option, so rendering dereferences `rules[type]` as `undefined`:

```js
compiler('> [!NOTE]\n> text', { disableParsingRawHTML: true }) // → TypeError (reading 'l')
```

HuggingFace-style model READMEs commonly contain these alert blocks, so any such model card crashed the drawer. `renderRule` cannot work around it — the rule lookup throws before `renderRule` is consulted.

## Fix

Upgrade `markdown-to-jsx` to **9.10.2**, where the combination is fixed upstream. No source change: both call sites (`ModelCardDrawer.tsx`, `ImportFromHuggingFaceModal.tsx`) and the `disableParsingRawHTML` semantics (raw HTML rendered as escaped text) are unchanged in 9.x, and the default export is the same.

An Astryx-`Markdown` replacement was tried first and reverted: full-document READMEs exercise far more of the markdown surface (setext headings, indented code blocks, footnotes, linked images, native GFM alerts) than Astryx's minimal renderer covers. Astryx `Markdown` remains the choice for simple renderers (announcements).

## Verification

- Node repro: 7.7.17 crashes on alert + `disableParsingRawHTML`; installed 9.10.2 renders the same input fine (checked against the seeded "Markdown Torture Test" model card).
- `bash scripts/verify.sh` → `=== ALL PASS ===`
- 9.10.2 (2026-08-03) clears the workspace `minimumReleaseAge` 7-day quarantine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
