### PR TITLE
fix(FR-3617): give waitFor enough headroom for the CI runner

### DIFF
--- a/react/src/components/FolderExplorerModalV2.test.tsx
+++ b/react/src/components/FolderExplorerModalV2.test.tsx
@@ -158,6 +158,8 @@ vi.mock('../hooks/useDefaultImagesWithFallback', () => ({
   useDefaultSystemSSHImageWithFallback: () => ({
     systemSSHImage: 'cr.backend.ai/stable/ssh:latest@x86_64',
   }),
+  // Fixtures are already fully qualified, which the real hook passes through.
+  useResolveImageReference: () => async (imageString?: string) => imageString,
 }));
 
 vi.mock('./FolderExplorerOpener', () => ({

--- a/react/src/setupTests.ts
+++ b/react/src/setupTests.ts
@@ -15,10 +15,20 @@ import '@testing-library/jest-dom';
 // polling uses `setTimeout`, which never fires under faked timers.
 // (None of our test code references `jest.*` directly anymore; this is
 // purely a `@testing-library/dom` integration hook.)
-import { cleanup } from '@testing-library/react';
+import { cleanup, configure } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 
 (globalThis as any).jest = vi;
+
+// `waitFor`'s 1000ms default leaves almost no headroom: the ADR-0001
+// project-prop-contract tests (`DeploymentSettingModal`, `FolderCreateModalV2`)
+// measure 621–787ms on an idle 8-core dev box and 1502ms on a CI runner, where
+// they intermittently failed with `expected [] to have a length of 1` — the
+// Relay mutation had simply not been dispatched inside the window. Raising the
+// budget cannot mask a real defect: a mutation that never fires still fails,
+// just 5s later. `testTimeout` in vitest.config.ts is raised past this so the
+// assertion's own diff surfaces instead of a bare test timeout. FR-3617.
+configure({ asyncUtilTimeout: 5000 });
 
 // `isolate: false` shares the source-module registry across test files, so a
 // file's `vi.mock` never reaches an importer another file already evaluated.

--- a/react/vitest.config.ts
+++ b/react/vitest.config.ts
@@ -105,6 +105,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // Must stay above `setupTests.ts`'s 5s `asyncUtilTimeout`, or a `waitFor`
+    // that exhausts its budget is cut off by the runner and reports a bare
+    // timeout instead of the assertion diff that names the cause. FR-3617.
+    testTimeout: 15_000,
     // Reuse the worker environment across test files; setupTests.ts restores
     // per-file DOM and source-module freshness. Escape hatch: `vitest run --isolate`.
     isolate: false,


### PR DESCRIPTION
Resolves #8950 (FR-3617)

## What

`waitFor`'s **1000ms default** was the real ceiling on every async assertion in the react suite, and the ADR-0001 project-prop-contract tests sat right under it. `setupTests.ts` now raises the budget to 5s, and `vitest.config.ts` raises `testTimeout` past it so an exhausted `waitFor` reports its assertion diff instead of being cut off by a bare runner timeout.

A second, unrelated defect found in the same CI log is fixed alongside: `FolderExplorerModalV2.test.tsx` mocked `useDefaultImagesWithFallback` with two of its three exports, logging `[vitest] No "useResolveImageReference" export is defined on the mock` on every render.

## Measurements

| | idle 8-core dev box | CI runner | `waitFor` budget |
|---|---|---|---|
| `DeploymentSettingModal` > project prop contract | 787ms | **1502ms** | 1000ms |
| `FolderCreateModalV2` > project prop contract | 621ms | — | 1000ms |

213ms of headroom on a fast machine; none on CI.

## Reproduction

The failure does **not** reproduce from a single-file run, nor from the full suite at default parallelism, nor with `CI=1` (which is what flips on the CI-only `experimental.fsModuleCache`) — all green locally, cold and warm.

It reproduces by pinning the **whole suite** to two cores, which is the contention a CI runner has:

```bash
CI=1 taskset -c 0,1 pnpm exec vitest run
```

That run failed `VFolderNodes.test.tsx > keeps the deploy action enabled…` the same way — and that test **already declared `testTimeout: 10000`**, which bought it nothing, because the 1s `waitFor` budget expired first. That is the shape of the bug: a per-test timeout cannot rescue an assertion whose own polling window is the constraint.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===`
- Post-fix, same contended condition (`CI=1 taskset -c 0,1`, full suite) **×3**: the ADR-0001 tests that failed on CI passed in **all three** runs.
- `react/src/components/VFolderNodes.test.tsx` single-file, pinned to **one** core, ×5: all pass.

## Residue

Run 3 of the post-fix contended runs still failed `VFolderNodes.test.tsx > keeps the deploy action enabled and fires its handler when noDeployTooltip is absent` — with a 5s budget, so the wait window is **not** its constraint. It passes 5/5 when run alone under harsher (single-core) contention, which points at cross-file interaction in the shared worker environment (`isolate: false`) rather than timing. It has not been observed failing on real CI. Deliberately not chased here: it needs its own investigation, and widening this change to cover it would mean guessing.

Raising the budget cannot mask a real defect — an operation that never fires still fails, five seconds later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtQwQxoK9ZVx4ryiJC65dr
