### PR TITLE
fix(FR-3619): suppress global shortcuts only for modal surfaces, not show() dialogs

### DIFF
--- a/react/src/helper/openModalRoot.ts
+++ b/react/src/helper/openModalRoot.ts
@@ -5,13 +5,14 @@
 import { BAI_MODAL_OPEN_ATTRIBUTE } from 'backend.ai-ui';
 
 // A portal root (`BAIDialog`, the `BAIModal` app launcher among them, and
-// `BAIDrawerPortal` since FR-3585), or an open native `<dialog>` — which since
-// FR-3585 is only the two non-scrim drawers. Tours are popovers, not dialogs.
-// `:not([inert])` drops the roots the level stack covered, whose contents no
-// one can reach.
+// `BAIDrawerPortal` since FR-3585), or an open native `<dialog>` that is
+// actually MODAL. `[aria-modal="true"]` stands in for `:modal` (jsdom cannot
+// match it) and keeps the non-scrim `show()` drawers out — an open
+// notification drawer must not suppress its own `]` toggle (FR-3619).
+// `:not([inert])` drops the roots the level stack covered.
 const OPEN_MODAL_ROOTS = [
   `[${BAI_MODAL_OPEN_ATTRIBUTE}]:not([inert])`,
-  'dialog[open]:not([inert])',
+  'dialog[open][aria-modal="true"]:not([inert])',
 ] as const;
 
 export const OPEN_MODAL_ROOT_SELECTOR = OPEN_MODAL_ROOTS.join(', ');

--- a/react/src/hooks/useKeyboardShortcut.test.ts
+++ b/react/src/hooks/useKeyboardShortcut.test.ts
@@ -44,10 +44,16 @@ describe('useKeyboardShortcut', () => {
     return event;
   };
 
-  const appendOpenModalRoot = (tagName: string, attribute: string) => {
+  const appendOpenModalRoot = (
+    tagName: string,
+    attributes: Record<string, string>,
+  ) => {
     const root = document.createElement(tagName);
-    root.setAttribute(attribute, '');
+    Object.entries(attributes).forEach(([name, value]) =>
+      root.setAttribute(name, value),
+    );
     document.body.appendChild(root);
+    return root;
   };
 
   describe('Basic functionality', () => {
@@ -121,15 +127,15 @@ describe('useKeyboardShortcut', () => {
 
   describe('Modal detection', () => {
     // Both roots the selector covers: a portal root (BAIDialog, the
-    // BAIModal launcher, and since FR-3585 the scrimmed drawer), and the native
-    // `<dialog>` the two non-scrim drawers still open.
+    // BAIModal launcher, and since FR-3585 the scrimmed drawer), and a native
+    // `<dialog>` that is actually modal (`aria-modal`).
     it.each([
-      ['a portal modal', 'div', BAI_MODAL_OPEN_ATTRIBUTE],
-      ['a native dialog', 'dialog', 'open'],
-    ])(
+      ['a portal modal', 'div', { [BAI_MODAL_OPEN_ATTRIBUTE]: '' }],
+      ['a modal native dialog', 'dialog', { open: '', 'aria-modal': 'true' }],
+    ] as const)(
       'should not trigger handler when %s is open',
-      (_label, tagName, attribute) => {
-        appendOpenModalRoot(tagName, attribute);
+      (_label, tagName, attributes) => {
+        appendOpenModalRoot(tagName, attributes);
 
         renderHook(() => useKeyboardShortcut(mockHandler));
         triggerKeydown({ key: 'a' });
@@ -137,6 +143,18 @@ describe('useKeyboardShortcut', () => {
         expect(mockHandler).not.toHaveBeenCalled();
       },
     );
+
+    // The non-scrim drawers open with `show()`: page interactive, shortcuts
+    // too — an open notification drawer must not eat its own `]` toggle
+    // (FR-3619).
+    it('should trigger handler when only a non-modal dialog is open', () => {
+      appendOpenModalRoot('dialog', { open: '' });
+
+      renderHook(() => useKeyboardShortcut(mockHandler));
+      triggerKeydown({ key: 'a' });
+
+      expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
 
     it('should trigger handler when a dialog is present but closed', () => {
       document.body.appendChild(document.createElement('dialog'));
@@ -278,7 +296,7 @@ describe('useKeyboardShortcut', () => {
       document.body.appendChild(input);
       input.focus();
 
-      appendOpenModalRoot('div', BAI_MODAL_OPEN_ATTRIBUTE);
+      appendOpenModalRoot('div', { [BAI_MODAL_OPEN_ATTRIBUTE]: '' });
 
       renderHook(() => useKeyboardShortcut(mockHandler));
       triggerKeydown({ key: 'a' });


### PR DESCRIPTION
Resolves #8955 (FR-3619)

## Mechanism

The global-shortcut guard (`useKeyboardShortcut` → `OPEN_MODAL_ROOT_SELECTOR`) suppressed every handler whenever an open native `<dialog>` existed. The notification drawer is itself such a `<dialog>` — lab `Drawer` renders one regardless of `hasScrim`, and the non-scrim path just opens it with `show()` (`lab/src/Drawer/Drawer.tsx:521-528`). So the `]` that opens the drawer was suppressed by the drawer it opened: a one-way toggle, and every other global shortcut dead while it was open. Reproduces on `main` too (its inline check is `document.querySelector('dialog[open]')`) — this predates FR-3578/FR-3585.

The fix narrows the dialog arm to surfaces that are actually **modal**:

```
dialog[open][aria-modal="true"]:not([inert])
```

`[aria-modal="true"]` stands in for the `:modal` pseudo-class (jsdom cannot match it): lab sets `aria-modal` only on the `showModal()` path, and `BAIDrawerPortal` passes it explicitly on its inner dialog since it restores modality by hand. Matching table:

| Open surface | marker arm | dialog arm | shortcuts |
|---|---|---|---|
| notification drawer / ChatPage history (non-scrim, `show()`) | ✗ | ✗ (no `aria-modal`) | **alive — `]` toggles both ways** |
| scrimmed drawer (`BAIDrawerPortal`) | ✓ (root marker) | ✓ (inner dialog `aria-modal`) | suppressed, as before |
| modals (`BAIDialogPortal`) | ✓ | — | suppressed, as before |

Known gap, accepted: a hypothetical raw `showModal()` dialog without `aria-modal` would escape the narrowed arm. No such consumer exists (the only native dialogs left in the app are the two non-scrim drawers), and `:modal` — the airtight form — cannot run in jsdom.

`queryWithinOpenModal`'s one consumer (`DeploymentAddRevisionModal` scroll-to-error) targets a portal modal, matched by the marker arm — unaffected.

## Verification

- `pnpm --prefix ./react exec vitest run` → **1560 passed** (96 files) — the touched suite gains a negative case (an open non-modal dialog does not suppress) and the modal-dialog case now carries `aria-modal`
- `bash scripts/verify.sh` → `=== ALL PASS ===`
- BUI untouched.

## Residue

- The behaviour change is deliberate and user-visible: while the notification drawer (or ChatPage history) is open, **other** global shortcuts now work too. A non-modal overlay leaves the page interactive by design, so shortcuts follow — but it is a call a reviewer may want to weigh.
