### PR TITLE
fix(FR-3633): keep the runtime variant preset UI option fields inside the modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetSettingModal.tsx
@@ -725,7 +725,12 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
               />
             </Form.Item>
             {uiType === 'SLIDER' ? (
-              <BAIFlex gap="sm" align="start" style={{ width: '100%' }}>
+              <BAIFlex
+                gap="sm"
+                align="start"
+                wrap="wrap"
+                style={{ width: '100%' }}
+              >
                 <Form.Item
                   label={t(
                     'comp:BAIRuntimeVariantPresetSettingModal.SliderMin',
@@ -739,7 +744,7 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
                       ),
                     },
                   ]}
-                  style={{ flex: 1 }}
+                  style={{ flex: 1, minWidth: 0 }}
                 >
                   <AstryxFormNumberInput
                     label={t(
@@ -784,7 +789,7 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
                       },
                     }),
                   ]}
-                  style={{ flex: 1 }}
+                  style={{ flex: 1, minWidth: 0 }}
                 >
                   <AstryxFormNumberInput
                     label={t(
@@ -820,7 +825,7 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
                       },
                     },
                   ]}
-                  style={{ flex: 1 }}
+                  style={{ flex: 1, minWidth: 0 }}
                 >
                   <AstryxFormNumberInput
                     label={t(
@@ -832,13 +837,18 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
               </BAIFlex>
             ) : null}
             {uiType === 'NUMBER_INPUT' ? (
-              <BAIFlex gap="sm" align="start" style={{ width: '100%' }}>
+              <BAIFlex
+                gap="sm"
+                align="start"
+                wrap="wrap"
+                style={{ width: '100%' }}
+              >
                 <Form.Item
                   label={t(
                     'comp:BAIRuntimeVariantPresetSettingModal.NumberMin',
                   )}
                   name="numberMin"
-                  style={{ flex: 1 }}
+                  style={{ flex: 1, minWidth: 0 }}
                 >
                   <AstryxFormNumberInput
                     label={t(
@@ -877,7 +887,7 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
                       },
                     }),
                   ]}
-                  style={{ flex: 1 }}
+                  style={{ flex: 1, minWidth: 0 }}
                 >
                   <AstryxFormNumberInput
                     label={t(
@@ -918,7 +928,7 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
                           <Form.Item
                             {...restField}
                             name={[name, 'value']}
-                            style={{ marginBottom: 0, flex: 1 }}
+                            style={{ marginBottom: 0, flex: 1, minWidth: 0 }}
                             rules={[
                               {
                                 required: true,
@@ -940,7 +950,7 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
                           <Form.Item
                             {...restField}
                             name={[name, 'label']}
-                            style={{ marginBottom: 0, flex: 1 }}
+                            style={{ marginBottom: 0, flex: 1, minWidth: 0 }}
                             rules={[
                               {
                                 required: true,
@@ -964,6 +974,7 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
                             danger
                             icon={<Trash2 />}
                             aria-label={t('general.button.Delete')}
+                            style={{ flexShrink: 0 }}
                             onClick={() => remove(name)}
                           />
                         </BAIFlex>


### PR DESCRIPTION
Resolves #8975 (FR-3633)

Stacked on #8614 (FR-3476).

## Summary

Choosing a `UI Type` in **Admin > Deployments > Runtime Variant Presets > Create/Edit Preset** rendered configuration fields that overflowed the modal horizontally and were clipped outside it.

## Measured before

| | |
|---|---|
| Dialog | 520px wide, right edge at x=1060 |
| Form content | `scrollWidth` **714px** inside a **472px** content box |
| `UI Type = Slider` | the **Step** field's box is x=1048..1278 — ~95% outside the modal. Its label, its value and its `Step must be greater than 0.` message are all unreachable; the control can only be focused by tabbing into it blind. |
| `UI Type = Select` | Choices rows overflow; the row delete button is half-clipped. |

## Mechanism

`flex: 1` expands to `1 1 0%` — it sets `flex-basis`, not `min-width`. Each `Form.Item` root therefore keeps the flex default `min-width: auto` and cannot shrink below its content's min-content width. `BAIFlex` sets `minWidth: 0` on its **own** root only, never on its children, and defaults to `wrap: nowrap`.

Three 230px inputs plus two 12px `gap="sm"` (`sizeSM`) steps is 714px — exactly the measured `scrollWidth`.

## Change

- `minWidth: 0` alongside `flex: 1` on the Slider (min/max/step), Number (min/max) and Choices (value/label) `Form.Item`s.
- `wrap="wrap"` on the two numeric rows.
- `flexShrink: 0` on the Choices row delete button so it is never squeezed.

This is the existing precedent in this repo for side-by-side fields inside a modal — see `AnnouncementEditModal.tsx` (`wrap="wrap"` + `style={{ flex: 1, minWidth: 0 }}`).

## Measured after

Live in the browser on all three affected UI types:

- No `input`/`button` bounding box escapes the dialog (`escaped: []`).
- Form `scrollWidth` == `clientWidth` == **472px** (was 714px).
- Validation behaviour unchanged — `Maximum must be greater than minimum.`, `Step must be greater than 0.`, `At least one choice is required.` all still fire, and Choices add/remove still works.

## Test plan

- [x] `bash scripts/verify.sh` — ALL PASS
- [x] `backend.ai-ui` vitest — 752 passed / 1 skipped
- [x] `react` vitest — 1571 passed
- [x] Live browser probe of Slider / Number Input / Select in light theme

**Checklist:**

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review
- [x] Minimum requirements to check during review: open Create Preset and switch UI Type through Slider / Number Input / Select — every field and the Choices delete button must sit fully inside the modal.
- [ ] Test case(s) to demonstrate the difference of before/after
