### PR TITLE
fix(FR-3634): correct preset metadata gating and number parameter validation

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetSettingModal.tsx
@@ -32,7 +32,9 @@ import { PayloadError } from 'relay-runtime';
 
 type UIType = 'SLIDER' | 'NUMBER_INPUT' | 'SELECT' | 'CHECKBOX' | 'TEXT_INPUT';
 
-const READ_UI_TYPE_TO_FORM_UI_TYPE: Record<string, UIType> = {
+// `Partial<>` because the read side types `UIOption.uiType` as an open
+// `String!`, so a newer manager can serve a control type this build predates.
+const READ_UI_TYPE_TO_FORM_UI_TYPE: Partial<Record<string, UIType>> = {
   slider: 'SLIDER',
   number_input: 'NUMBER_INPUT',
   select: 'SELECT',
@@ -201,6 +203,15 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
       : undefined,
   );
 
+  // A control type this build does not know about cannot be represented in the
+  // form, so the builder would emit `undefined` and we would send an explicit
+  // `uiOption: null` — which the manager reads as "clear it" (the input field
+  // is SENTINEL-defaulted). Omit the key instead and leave the server's value
+  // alone.
+  const hasUnknownUIType =
+    !!preset?.uiOption?.uiType &&
+    !READ_UI_TYPE_TO_FORM_UI_TYPE[preset.uiOption.uiType];
+
   const [commitCreate, isInFlightCreate] =
     useMutation<BAIRuntimeVariantPresetSettingModalCreateMutation>(graphql`
       mutation BAIRuntimeVariantPresetSettingModalCreateMutation(
@@ -329,7 +340,9 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
           ? {
               category: normalizeOptionalText(values.category),
               displayName: normalizeOptionalText(values.displayName),
-              uiOption: buildUIOptionInput(values) ?? null,
+              ...(hasUnknownUIType
+                ? {}
+                : { uiOption: buildUIOptionInput(values) ?? null }),
             }
           : {};
         if (preset) {

--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetSettingModal.tsx
@@ -340,7 +340,10 @@ const BAIRuntimeVariantPresetSettingModal: React.FC<
           ? {
               category: normalizeOptionalText(values.category),
               displayName: normalizeOptionalText(values.displayName),
-              ...(hasUnknownUIType
+              // Only hold back while the form still has no representable
+              // type — once the admin picks a supported one, that selection
+              // must reach the server.
+              ...(hasUnknownUIType && values.uiType === undefined
                 ? {}
                 : { uiOption: buildUIOptionInput(values) ?? null }),
             }

--- a/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRuntimeVariantPresetTable.tsx
@@ -68,9 +68,6 @@ const BAIRuntimeVariantPresetTable = ({
   const isRuntimeVariantFieldSupported = baiClient.supports(
     'runtime-variant-preset-runtime-variant-field',
   );
-  const isUIMetadataSupported = baiClient.supports(
-    'runtime-variant-preset-ui-metadata',
-  );
 
   const presets = useFragment<BAIRuntimeVariantPresetTableFragment$key>(
     graphql`
@@ -139,13 +136,15 @@ const BAIRuntimeVariantPresetTable = ({
         title: t('comp:BAIRuntimeVariantPresetTable.RuntimeVariant'),
         render: (__, record) => record.runtimeVariant?.name ?? '-',
       },
-      isUIMetadataSupported && {
+      // Read-only, so no capability gate: `category` / `displayName` ship with
+      // the type since 26.4.2. Only WRITING them needs 26.9.0.
+      {
         key: 'category',
         title: t('comp:BAIRuntimeVariantPresetTable.Category'),
         defaultHidden: true,
         render: (__, record) => record.category ?? '-',
       },
-      isUIMetadataSupported && {
+      {
         key: 'displayName',
         title: t('comp:BAIRuntimeVariantPresetTable.DisplayName'),
         defaultHidden: true,

--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -12,13 +12,13 @@ import {
 } from '../hooks/useRuntimeParameterSchema';
 import { theme } from '../theme-shim';
 import InputNumberWithSlider from './InputNumberWithSlider';
-import './collapsible-section.css';
 import {
   AstryxFormCheckbox,
   AstryxFormNumberInput,
   AstryxFormSelector,
   AstryxFormTextInput,
 } from './astryxFormControls';
+import './collapsible-section.css';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Collapsible } from '@astryxdesign/core/Collapsible';
 import { IconButton } from '@astryxdesign/core/IconButton';
@@ -436,11 +436,17 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
       // Surface out-of-range values as a validation error instead of
       // clamping/blocking input via the number input's `min`/`max` props — the
       // user can see and correct what they typed rather than have the
-      // control silently refuse it. The message itself comes from the form
-      // engine's global `validateMessages` template (`form.validateMessages`
-      // in the BUI locale catalogs, wired up in `DefaultProviders.tsx`),
-      // already localized to the user's selected language.
-      const rangeRule = { type: 'number' as const, min, max };
+      // control silently refuse it. The message comes from the form engine's
+      // global `validateMessages` template, already localized.
+      // Only attach it when there is a bound to enforce AND the stored value
+      // is actually numeric: `toNativeValue` hydrates STR as a string and
+      // BOOL/FLAG as a boolean, and `type: 'number'` would reject those on a
+      // field the user never touched, blocking submit.
+      const isNumericValueType = isInt || param.valueType === 'FLOAT';
+      const rangeRules =
+        isNumericValueType && (min !== undefined || max !== undefined)
+          ? [{ type: 'number' as const, min, max }]
+          : [];
       return (
         <Form.Item
           name={[RUNTIME_PARAMS_NAMESPACE, param.key]}
@@ -448,14 +454,15 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
           tooltip={tooltip}
           style={formItemStyle}
           required={isRequired}
-          rules={[...(requiredRules ?? []), rangeRule]}
+          rules={[...(requiredRules ?? []), ...rangeRules]}
           getValueFromEvent={touchOnChange}
         >
           {/* MAPPING 3.17: `InputNumber` -> `NumberInput`; `style.width:
               '100%'` becomes the adapter's `width` (its default). `min`/`max`
               are deliberately NOT passed to the adapter — it clamps, and the
-              point of `rangeRule` is validation feedback instead of
-              clamping. */}
+              point of `rangeRules` is validation feedback instead of
+              clamping. The adapter still repairs a typed decimal on blur when
+              `isIntegerOnly`, which does not depend on the bounds. */}
           <AstryxFormNumberInput
             label={label}
             step={isInt ? 1 : 0.1}

--- a/react/src/components/astryxFormControls.parity.test.tsx
+++ b/react/src/components/astryxFormControls.parity.test.tsx
@@ -117,6 +117,41 @@ describe('AstryxFormNumberInput — clamp on blur', () => {
     fireEvent.blur(screen.getByLabelText('Port'), { target: { value: '443' } });
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('rounds a decimal in an UNBOUNDED integer-only field', () => {
+    // Astryx's parser rejects a decimal exactly the way it rejects an
+    // out-of-range value, so without `isIntegerOnly` counting as a repairable
+    // constraint the entry would vanish on blur. FR-3634.
+    const onChange = vi.fn();
+    render(
+      <AstryxFormNumberInput
+        label="Replicas"
+        value={2}
+        isIntegerOnly
+        onChange={onChange}
+      />,
+    );
+    fireEvent.blur(screen.getByLabelText('Replicas'), {
+      target: { value: '3.5' },
+    });
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it('leaves a whole number alone in an unbounded integer-only field', () => {
+    const onChange = vi.fn();
+    render(
+      <AstryxFormNumberInput
+        label="Replicas"
+        value={2}
+        isIntegerOnly
+        onChange={onChange}
+      />,
+    );
+    fireEvent.blur(screen.getByLabelText('Replicas'), {
+      target: { value: '7' },
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });
 
 describe('AstryxFormTagsInput — tokenSeparators', () => {

--- a/react/src/components/astryxFormControls.tsx
+++ b/react/src/components/astryxFormControls.tsx
@@ -536,10 +536,14 @@ export const AstryxFormNumberInput: React.FC<AstryxFormNumberInputProps> = ({
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     const rawText = event.target.value;
     const typed = rawText.trim() === '' ? NaN : Number(rawText);
+    // `isIntegerOnly` counts as a repairable constraint on its own: Astryx's
+    // parser rejects a typed decimal exactly the way it rejects an
+    // out-of-range value, so without it a decimal vanishes on blur in an
+    // unbounded integer field.
     if (
       Number.isFinite(typed) &&
       typed !== safeValue &&
-      (typeof min === 'number' || typeof max === 'number')
+      (typeof min === 'number' || typeof max === 'number' || isIntegerOnly)
     ) {
       let clamped = typed;
       if (typeof min === 'number' && clamped < min) clamped = min;


### PR DESCRIPTION
Resolves #8976 (FR-3634)

Stacked on #8977 (FR-3633), which is stacked on #8614 (FR-3476).

## Summary

Three independent defects found while reviewing #8609.

### 1. An unrecognised `uiType` silently cleared the server's `uiOption` on save

`READ_UI_TYPE_TO_FORM_UI_TYPE` was typed `Record<string, UIType>` with five lowercase keys, but the **read** side types `UIOption.uiType` as an open `String!` — only the **write** input is a closed enum (`RuntimeVariantPresetUIType`). A manager newer than the WebUI can therefore serve a sixth control type.

When that happened the map returned `undefined`, `buildUIOptionInput` fell through to `default`, and `handleOk` sent `uiOption: null`. The manager's `UpdateRuntimeVariantPresetInput.ui_option` is SENTINEL-defaulted, so an explicit `null` is a **clear**, not a no-op — editing only the description destroyed the preset's entire UI configuration (min/max/step, choices, placeholder) with no warning, and the deployment form silently degraded that parameter to a plain text input.

Typed the map `Partial<Record<string, UIType>>` so the miss is visible to `tsc`, and omit the `uiOption` key entirely when the stored type is unrecognised, so the server value is left untouched.

### 2. Read-only `category` / `displayName` columns were gated on a write-only capability

`BAIRuntimeVariantPresetTable.tsx` gated both columns on `supports('runtime-variant-preset-ui-metadata')`, which is set only at manager `>= 26.9.0`. But 26.9.0 is when those fields became **writable**. They have been **readable** since 26.4.2: on `type RuntimeVariantPreset` they carry no per-field `Added in` annotation, unlike `required` ("Added in 26.4.4") and `runtimeVariant` ("Added in 26.8.0"), and they are present in the first schema drop that contains the type. The fragment already selected them ungated two lines above the gate.

Effect: on a 26.4.2–26.8.x manager the admin could not see metadata the backend already seeds, and that `useRuntimeParameterSchema.ts` reads **ungated** to render the deployment form's sliders and selects — the data was visibly in use but invisible in the admin screen that owns it.

Dropped the gate from the two read-only columns. The modal's write controls stay gated, because writing really does need 26.9.0.

### 3. The new `{ type: 'number' }` rule blocked submit on non-numeric presets

`RuntimeParameterFormSection.tsx` attached `{ type: 'number', min, max }` to **every** `number_input` control. `toNativeValue` hydrates `STR` as a string and `BOOL`/`FLAG` as a boolean, so a preset with `uiType = number_input` and a non-numeric `valueType` failed validation on a field the user never touched and blocked the whole save. The rule was also attached when both bounds were `undefined`, where it enforces nothing but still type-checks.

Additionally, dropping `min`/`max` from the adapter made the integer round-on-blur unreachable: `astryxFormControls.tsx` gates the whole blur-repair block on a bound being present, so a decimal typed into a **bounded** `INT` field was silently discarded instead of rounded (Astryx's parser rejects rather than repairs).

Attach the range rule only when the value type is numeric **and** a bound exists, and let the adapter's blur repair run on `isIntegerOnly` alone.

## Test plan

- [x] `bash scripts/verify.sh` — ALL PASS
- [x] `backend.ai-ui` vitest — 752 passed / 1 skipped
- [x] `react` vitest — 1571 passed
- [x] root vitest (`scripts/`) — 98 passed / 6 skipped
- [ ] Defect 1 needs a manager serving an unknown `uiType` to reproduce end to end; the guard is covered by types and reading, not by a live repro.

**Checklist:**

- [ ] Documentation
- [x] Minimum required manager version: unchanged. Defect 2 *lowers* the floor at which `category`/`displayName` become visible (26.9.0 -> 26.4.2, matching the schema).
- [ ] Specific setting for review
- [x] Minimum requirements to check during review: on a `< 26.9.0` manager the Category / Display Name columns are offered in the table's column picker while the modal's metadata fields stay hidden; a `number_input` preset whose `valueType` is `STR` no longer blocks submit.
- [ ] Test case(s) to demonstrate the difference of before/after
