### PR TITLE
chore(FR-3646): bump actions/upload-artifact to v7 so release builds stop forcing Node 20

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -77,7 +77,7 @@ jobs:
 
       # Share build artifacts with downstream desktop jobs
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: web-build
           path: |
@@ -352,7 +352,7 @@ jobs:
       # (handy during dry runs and when debugging the release path).
       - name: Upload PDFs as workflow artifact
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: webui-docs-pdfs
           path: packages/backend.ai-webui-docs/dist/*.pdf


### PR DESCRIPTION
Resolves #8997 (FR-3646)

## Problem

The `v26.9.0-rc.0` release run ([32682472444](https://github.com/lablup/backend.ai-webui/actions/runs/32682472444)) still warns on `build_web`:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/upload-artifact@v5`.

## Why the previous fix missed it

FR-2621 (#6837) swept the workflows for Node 20 actions and bumped `actions/upload-artifact` from `@v4` to `@v5`, taking v5 for the Node 24-compatible major. It is not. From the upstream v6.0.0 notes:

> `actions/upload-artifact@v6` now runs on Node.js 24 (`runs.using: node24`) [...] v5 had preliminary support for Node.js 24, however this action was by default still running on Node.js 20.

Verified against the tag this PR pins — `actions/upload-artifact@v7` resolves to `043fb46` (v7.0.1), whose `action.yml` declares `runs.using: 'node24'`.

Every sibling action from the FR-2621 batch is already clear: `checkout@v7`, `setup-node@v6.4.0`, `download-artifact@v8`, `pnpm/action-setup@v5`. `upload-artifact` was the only straggler.

## Why not just merge dependabot #8126

#8126 ("bump actions/upload-artifact from 5 to 7", opened 2026-07-02) is still open and `CONFLICTING`. Beyond the two lines in `package.yml`, it also rewrites pinned SHAs inside four gh-aw generated `*.lock.yml` files (v7.0.0 → v7.0.1). Those are regenerated by the gh-aw compiler and keep drifting out from under the PR, so it stays dirty. They already pin a Node 24 build, so they were never part of the problem. This PR touches only the hand-maintained file; #8126 should be closed as superseded.

## Change

Two lines in `.github/workflows/package.yml`:

| Job | Step | Before | After |
| --- | --- | --- | --- |
| `build_web` | Upload build artifacts | `actions/upload-artifact@v5` | `actions/upload-artifact@v7` |
| `build_docs` | Upload PDFs as workflow artifact | `actions/upload-artifact@v5` | `actions/upload-artifact@v7` |

Floating major matches the surrounding style (`checkout@v7`, `download-artifact@v8`) and pairs `upload-artifact@v7` with the `download-artifact@v8` already in the file.

## Compatibility

Checked `action.yml` at `043fb46` against every input in use:

- `name`, `path`, `retention-days`, `compression-level`, `if-no-files-found` — all present, semantics unchanged.
- New `archive` input defaults to `true`, i.e. the v5 behaviour; not set here.
- v6 raises the minimum runner to 2.327.1; GitHub-hosted runners exceed it.

## Verification

- `.github/workflows/package.yml` re-parsed after the edit — 5 jobs intact, artifact steps resolve to `upload-artifact@v7` (`build_web`, `build_docs`) and `download-artifact@v8` (`build_mac`, `build_desktop`).
- No `actions/upload-artifact@v5` remains anywhere under `.github/workflows/`.
- `scripts/verify.sh` not run: this PR changes no TypeScript, Relay, or lint-visible source.
- The real proof is a release/dry-run of `package.yml` showing no Node 20 warning on `build_web` and `build_docs`, plus an intact `build_web` → `build_mac`/`build_desktop` artifact hand-off. Worth a `workflow_dispatch` dry run before merge.

## Out of scope

`.github/workflows/e2e-healer.md` still contains `actions/setup-node@v4`, `actions/cache@v4`, and `actions/upload-artifact@v4`. Those strings are cosmetic — the gh-aw compiler rewrites them to current pinned SHAs in `e2e-healer.lock.yml` (setup-node v6.4.0, cache v5.0.3, upload-artifact v7.0.0). Tidying them changes nothing that runs, so it is left for a separate pass.